### PR TITLE
docs(errors): add conda-forge install instructions to optional-dependency messages

### DIFF
--- a/src/pyramids/base/_utils.py
+++ b/src/pyramids/base/_utils.py
@@ -394,9 +394,10 @@ class Catalog:
 
 
 _DEFAULT_CLEOPATRA_MSG = (
-    "The current operation uses the cleopatra package. Install it via the "
-    "[viz] extra (`pip install pyramids-gis[viz]`) or directly from "
-    "https://github.com/serapeum-org/cleopatra"
+    "The current operation uses the cleopatra package. Install with one of:\n"
+    "  - PyPI:        pip install 'pyramids-gis[viz]'\n"
+    "  - conda-forge: conda install -c conda-forge pyramids-viz\n"
+    "  - or directly: https://github.com/serapeum-org/cleopatra"
 )
 
 

--- a/src/pyramids/basemap/__init__.py
+++ b/src/pyramids/basemap/__init__.py
@@ -6,8 +6,11 @@ and :func:`~pyramids.basemap.get_provider` are thin wrappers over
 :mod:`cleopatra.tiles` (the cleopatra C-6 helpers) — cleopatra does the
 tile fetching, stitching, GDAL CRS warping, and rendering.
 
-Requires the cleopatra ``[tiles]`` extra. Install with: `pyramids-gis[viz]`
-(which pins `cleopatra[tiles]`).
+Requires the cleopatra ``[tiles]`` extra (which pins ``cleopatra[tiles]``).
+Install with one of:
+
+- PyPI: ``pip install 'pyramids-gis[viz]'``
+- conda-forge: ``conda install -c conda-forge pyramids-viz``
 """
 
 from pyramids.basemap.basemap import add_basemap, get_provider

--- a/src/pyramids/basemap/basemap.py
+++ b/src/pyramids/basemap/basemap.py
@@ -30,9 +30,10 @@ from pyramids.base._utils import import_basemap
 logger = logging.getLogger(__name__)
 
 _BASEMAP_MSG = (
-    "Basemap support requires the cleopatra [tiles] extra. Install it via "
-    "`pip install 'pyramids-gis[viz]'` (which pins `cleopatra[tiles]`), or "
-    "`pip install 'cleopatra[tiles]'` directly."
+    "Basemap support requires the cleopatra [tiles] extra. Install with one of:\n"
+    "  - PyPI:        pip install 'pyramids-gis[viz]' (which pins `cleopatra[tiles]`)\n"
+    "  - conda-forge: conda install -c conda-forge pyramids-viz\n"
+    "  - or directly: pip install 'cleopatra[tiles]'"
 )
 
 

--- a/src/pyramids/dataset/_reduce_ops.py
+++ b/src/pyramids/dataset/_reduce_ops.py
@@ -52,8 +52,9 @@ def resolve_dask_op(
     except ImportError as exc:  # pragma: no cover
         raise ImportError(
             "DatasetCollection reductions require the optional "
-            "'dask' dependency. Install with: "
-            "pip install 'pyramids-gis[lazy]'"
+            "'dask' dependency. Install with one of:\n"
+            "  - PyPI:        pip install 'pyramids-gis[lazy]'\n"
+            "  - conda-forge: conda install -c conda-forge pyramids-lazy"
         ) from exc
     name = _NAN_TABLE[op_name] if skipna else op_name
     return getattr(da, name), name

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -116,8 +116,10 @@ def _flox_groupby_reduce(
     importable so the caller falls back to the per-label loop.
     """
     import_flox(
-        "flox is required for grouped reductions over a DatasetCollection;"
-        " install it via `pip install pyramids-gis[lazy]`."
+        "flox is required for grouped reductions over a DatasetCollection. "
+        "Install with one of:\n"
+        "  - PyPI:        pip install 'pyramids-gis[lazy]'\n"
+        "  - conda-forge: conda install -c conda-forge pyramids-lazy"
     )
     from flox import groupby_reduce
 
@@ -740,7 +742,9 @@ class DatasetCollection:
         except ImportError as exc:
             raise ImportError(
                 "DatasetCollection.data requires the optional 'dask' "
-                "dependency. Install with: pip install 'pyramids-gis[lazy]'"
+                "dependency. Install with one of:\n"
+                "  - PyPI:        pip install 'pyramids-gis[lazy]'\n"
+                "  - conda-forge: conda install -c conda-forge pyramids-lazy"
             ) from exc
         meta = self._meta
         shape = meta.shape
@@ -869,7 +873,9 @@ class DatasetCollection:
             )
         import_zarr(
             "DatasetCollection.to_zarr requires the optional 'zarr' "
-            "dependency. Install with: pip install 'pyramids-gis[lazy]'"
+            "dependency. Install with one of:\n"
+            "  - PyPI:        pip install 'pyramids-gis[lazy]'\n"
+            "  - conda-forge: conda install -c conda-forge pyramids-lazy"
         )
         data = self.data
         resolved_store = _resolve_store(store, storage_options)
@@ -937,8 +943,9 @@ class DatasetCollection:
 
         Raises:
             OptionalPackageDoesNotExist: When ``xarray`` is not
-                installed. Install with ``pip install
-                'pyramids-gis[xarray]'``.
+                installed. Install with one of: PyPI
+                ``pip install 'pyramids-gis[xarray]'`` or conda-forge
+                ``conda install -c conda-forge pyramids-xarray``.
             ValueError: When ``len(time_coords) != self.time_length``.
             RuntimeError: When :meth:`NetCDF.from_xarray` fails to write
                 the file.
@@ -984,7 +991,9 @@ class DatasetCollection:
         except ImportError as exc:
             raise OptionalPackageDoesNotExist(
                 "DatasetCollection.to_netcdf requires the optional 'xarray' "
-                "dependency. Install with: pip install 'pyramids-gis[xarray]'"
+                "dependency. Install with one of:\n"
+                "  - PyPI:        pip install 'pyramids-gis[xarray]'\n"
+                "  - conda-forge: conda install -c conda-forge pyramids-xarray"
             ) from exc
 
         if time_coords is not None:

--- a/src/pyramids/dataset/ops/_focal.py
+++ b/src/pyramids/dataset/ops/_focal.py
@@ -33,8 +33,9 @@ if TYPE_CHECKING:
 
 
 _LAZY_IMPORT_ERROR = (
-    "chunks= requires the optional 'dask' dependency. "
-    "Install with: pip install 'pyramids-gis[lazy]'"
+    "chunks= requires the optional 'dask' dependency. Install with one of:\n"
+    "  - PyPI:        pip install 'pyramids-gis[lazy]'\n"
+    "  - conda-forge: conda install -c conda-forge pyramids-lazy"
 )
 
 

--- a/src/pyramids/dataset/ops/_zarr.py
+++ b/src/pyramids/dataset/ops/_zarr.py
@@ -32,7 +32,9 @@ if TYPE_CHECKING:
 
 _LAZY_IMPORT_ERROR = (
     "Zarr IO requires the optional 'dask' / 'zarr' dependencies. "
-    "Install them with: pip install 'pyramids-gis[lazy]'"
+    "Install with one of:\n"
+    "  - PyPI:        pip install 'pyramids-gis[lazy]'\n"
+    "  - conda-forge: conda install -c conda-forge pyramids-lazy"
 )
 
 

--- a/src/pyramids/dataset/ops/io.py
+++ b/src/pyramids/dataset/ops/io.py
@@ -22,8 +22,9 @@ if TYPE_CHECKING:
 
 
 _LAZY_IMPORT_ERROR = (
-    "Lazy reads require the optional 'dask' dependency. "
-    "Install it with: pip install 'pyramids-gis[lazy]'"
+    "Lazy reads require the optional 'dask' dependency. Install with one of:\n"
+    "  - PyPI:        pip install 'pyramids-gis[lazy]'\n"
+    "  - conda-forge: conda install -c conda-forge pyramids-lazy"
 )
 
 

--- a/src/pyramids/dataset/ops/reproject.py
+++ b/src/pyramids/dataset/ops/reproject.py
@@ -28,7 +28,9 @@ if TYPE_CHECKING:
 
 _LAZY_IMPORT_ERROR = (
     "Lazy reprojection (compute=False) requires the optional 'dask' "
-    "dependency. Install it with: pip install 'pyramids-gis[lazy]'"
+    "dependency. Install with one of:\n"
+    "  - PyPI:        pip install 'pyramids-gis[lazy]'\n"
+    "  - conda-forge: conda install -c conda-forge pyramids-lazy"
 )
 
 

--- a/src/pyramids/feature/__init__.py
+++ b/src/pyramids/feature/__init__.py
@@ -33,7 +33,9 @@ from pyramids.feature.geometry import (
 
 _LAZY_FC_INSTALL_HINT = (
     "LazyFeatureCollection requires the optional 'dask-geopandas' "
-    "dependency. Install with: pip install 'pyramids-gis[parquet-lazy]'"
+    "dependency. Install with one of:\n"
+    "  - PyPI:        pip install 'pyramids-gis[parquet-lazy]'\n"
+    "  - conda-forge: conda install -c conda-forge pyramids-parquet-lazy"
 )
 
 # LazyFeatureCollection is only available when the [parquet-lazy] extra

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -125,8 +125,9 @@ def _require_pyarrow() -> None:
     """
     import_pyarrow(
         "GeoParquet support requires the optional 'pyarrow' "
-        "dependency. Install with: pip install 'pyramids-gis[parquet]' "
-        "(or `pixi add pyarrow` in a pixi workspace)."
+        "dependency. Install with one of:\n"
+        "  - PyPI:        pip install 'pyramids-gis[parquet]'\n"
+        "  - conda-forge: conda install -c conda-forge pyramids-parquet"
     )
 
 
@@ -1006,8 +1007,9 @@ class FeatureCollection(GeoDataFrame):
             except ImportError as exc:
                 raise ImportError(
                     "backend='dask' requires the optional "
-                    "'dask-geopandas' dependency. Install with: "
-                    "pip install 'pyramids-gis[parquet-lazy]'"
+                    "'dask-geopandas' dependency. Install with one of:\n"
+                    "  - PyPI:        pip install 'pyramids-gis[parquet-lazy]'\n"
+                    "  - conda-forge: conda install -c conda-forge pyramids-parquet-lazy"
                 ) from exc
             # default npartitions from file size when neither
             # kwarg was supplied; one-partition fallback defeats the
@@ -1496,7 +1498,9 @@ class FeatureCollection(GeoDataFrame):
         except ImportError as exc:
             raise ImportError(
                 "open_arrow requires the optional 'pyogrio' dependency. "
-                "Install with: pip install pyogrio"
+                "Install with one of:\n"
+                "  - PyPI:        pip install pyogrio\n"
+                "  - conda-forge: conda install -c conda-forge pyogrio"
             ) from exc
         resolved = _pyramids_io._parse_path(path)
         kwargs: dict[str, Any] = {}
@@ -1537,9 +1541,10 @@ class FeatureCollection(GeoDataFrame):
         (`s3://`, `gs://`, `http(s)://`, …) resolve the same way
         they do in :meth:`read_file`.
 
-        Requires the optional :mod:`pyarrow` dependency. Install with
-        `pip install pyramids-gis[parquet]` or
-        `pixi add pyarrow`.
+        Requires the optional :mod:`pyarrow` dependency. Install with one of:
+
+        - PyPI: ``pip install 'pyramids-gis[parquet]'``
+        - conda-forge: ``conda install -c conda-forge pyramids-parquet``
 
         Args:
             path (str | Path):
@@ -1623,8 +1628,9 @@ class FeatureCollection(GeoDataFrame):
             except ImportError as exc:
                 raise ImportError(
                     "backend='dask' requires the optional "
-                    "'dask-geopandas' dependency. Install with: "
-                    "pip install 'pyramids-gis[parquet-lazy]'"
+                    "'dask-geopandas' dependency. Install with one of:\n"
+                    "  - PyPI:        pip install 'pyramids-gis[parquet-lazy]'\n"
+                    "  - conda-forge: conda install -c conda-forge pyramids-parquet-lazy"
                 ) from exc
             dask_kwargs: dict[str, Any] = {}
             if columns is not None:
@@ -1683,9 +1689,10 @@ class FeatureCollection(GeoDataFrame):
         that defaults :param:`compression` to `"snappy"` — the
         format-standard tradeoff between speed and size.
 
-        Requires the optional :mod:`pyarrow` dependency. Install with
-        `pip install pyramids-gis[parquet]` or
-        `pixi add pyarrow`.
+        Requires the optional :mod:`pyarrow` dependency. Install with one of:
+
+        - PyPI: ``pip install 'pyramids-gis[parquet]'``
+        - conda-forge: ``conda install -c conda-forge pyramids-parquet``
 
         Args:
             path (str | Path):

--- a/src/pyramids/io/sniff.py
+++ b/src/pyramids/io/sniff.py
@@ -79,8 +79,9 @@ _PRIMARY_EXTS = frozenset(
     }
 )
 _PARQUET_EXTRA_HINT = (
-    "Reading Parquet requires the optional 'pyarrow' dependency. Install "
-    "it with: pip install 'pyramids-gis[parquet]'"
+    "Reading Parquet requires the optional 'pyarrow' dependency. Install with one of:\n"
+    "  - PyPI:        pip install 'pyramids-gis[parquet]'\n"
+    "  - conda-forge: conda install -c conda-forge pyramids-parquet"
 )
 
 

--- a/src/pyramids/netcdf/_kerchunk.py
+++ b/src/pyramids/netcdf/_kerchunk.py
@@ -27,7 +27,9 @@ from typing import Any, Sequence
 
 _KERCHUNK_IMPORT_ERROR = (
     "kerchunk is required for NetCDF → Zarr reference manifests. "
-    "Install it with: pip install 'pyramids-gis[netcdf-lazy]'"
+    "Install with one of:\n"
+    "  - PyPI:        pip install 'pyramids-gis[netcdf-lazy]'\n"
+    "  - conda-forge: conda install -c conda-forge pyramids-netcdf-lazy"
 )
 
 

--- a/src/pyramids/netcdf/_lazy.py
+++ b/src/pyramids/netcdf/_lazy.py
@@ -42,7 +42,9 @@ from pyramids.base._locks import DummyLock, default_lock
 from pyramids.base._utils import import_dask
 
 _DASK_MISSING_MESSAGE = (
-    "dask is required for lazy NetCDF reads; install pyramids-gis[lazy]"
+    "dask is required for lazy NetCDF reads. Install with one of:\n"
+    "  - PyPI:        pip install 'pyramids-gis[lazy]'\n"
+    "  - conda-forge: conda install -c conda-forge pyramids-lazy"
 )
 
 

--- a/src/pyramids/netcdf/_mfdataset.py
+++ b/src/pyramids/netcdf/_mfdataset.py
@@ -32,8 +32,9 @@ if TYPE_CHECKING:
 
 
 _LAZY_IMPORT_ERROR = (
-    "open_mfdataset requires the optional 'dask' dependency. "
-    "Install it with: pip install 'pyramids-gis[lazy]'"
+    "open_mfdataset requires the optional 'dask' dependency. Install with one of:\n"
+    "  - PyPI:        pip install 'pyramids-gis[lazy]'\n"
+    "  - conda-forge: conda install -c conda-forge pyramids-lazy"
 )
 
 

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4038,9 +4038,10 @@ class NetCDF(Dataset):
         :meth:`read_array(chunks=...)` and wrap the result in
         :class:`xarray.DataArray` yourself.
 
-        Requires the optional `xarray` package. Install it with::
+        Requires the optional `xarray` package. Install with one of:
 
-            pip install 'pyramids-gis[xarray]'
+        - PyPI: ``pip install 'pyramids-gis[xarray]'``
+        - conda-forge: ``conda install -c conda-forge pyramids-xarray``
 
         Returns:
             xarray.Dataset: An xarray Dataset with the same
@@ -4064,8 +4065,9 @@ class NetCDF(Dataset):
             import xarray as xr
         except ImportError:
             raise OptionalPackageDoesNotExist(
-                "xarray is required for to_xarray(). "
-                "Install it with: pip install 'pyramids-gis[xarray]'"
+                "xarray is required for to_xarray(). Install with one of:\n"
+                "  - PyPI:        pip install 'pyramids-gis[xarray]'\n"
+                "  - conda-forge: conda install -c conda-forge pyramids-xarray"
             )
 
         rg = self._raster.GetRootGroup()
@@ -4146,7 +4148,10 @@ class NetCDF(Dataset):
             var = nc.get_variable("temperature")
             cropped = var.crop(mask)
 
-        Requires the optional `xarray` package.
+        Requires the optional `xarray` package. Install with one of:
+
+        - PyPI: ``pip install 'pyramids-gis[xarray]'``
+        - conda-forge: ``conda install -c conda-forge pyramids-xarray``
 
         Args:
             dataset: An `xarray.Dataset` instance.
@@ -4167,8 +4172,9 @@ class NetCDF(Dataset):
             import xarray as xr
         except ImportError:
             raise OptionalPackageDoesNotExist(
-                "xarray is required for from_xarray(). "
-                "Install it with: pip install 'pyramids-gis[xarray]'"
+                "xarray is required for from_xarray(). Install with one of:\n"
+                "  - PyPI:        pip install 'pyramids-gis[xarray]'\n"
+                "  - conda-forge: conda install -c conda-forge pyramids-xarray"
             )
 
         if not isinstance(dataset, xr.Dataset):

--- a/src/pyramids/netcdf/ugrid/plot.py
+++ b/src/pyramids/netcdf/ugrid/plot.py
@@ -2,7 +2,10 @@
 
 Thin wrapper around `cleopatra.mesh_glyph.MeshGlyph` that accepts
 pyramids `Mesh2d` objects and delegates all rendering to cleopatra.
-Requires the `viz` optional extra (`pip install pyramids-gis[viz]`).
+Requires the `viz` optional extra. Install with one of:
+
+- PyPI: ``pip install 'pyramids-gis[viz]'``
+- conda-forge: ``conda install -c conda-forge pyramids-viz``
 """
 
 from __future__ import annotations
@@ -13,9 +16,10 @@ from pyramids.base._utils import require_cleopatra
 from pyramids.netcdf.ugrid.mesh import Mesh2d
 
 _CLEOPATRA_MSG = (
-    "Mesh plotting requires the cleopatra package. "
-    "Install it with: pip install pyramids-gis[viz] "
-    "or see https://github.com/serapeum-org/cleopatra"
+    "Mesh plotting requires the cleopatra package. Install with one of:\n"
+    "  - PyPI:        pip install 'pyramids-gis[viz]'\n"
+    "  - conda-forge: conda install -c conda-forge pyramids-viz\n"
+    "  - or see https://github.com/serapeum-org/cleopatra"
 )
 
 

--- a/src/pyramids/netcdf/utils.py
+++ b/src/pyramids/netcdf/utils.py
@@ -514,7 +514,9 @@ def create_time_conversion_func(
     if calendar.lower() not in ("standard", "proleptic_gregorian", "gregorian"):
         import_cftime(
             f"Calendar '{calendar}' requires the cftime package. "
-            f"Install it with: pixi add cftime"
+            "Install with one of:\n"
+            "  - PyPI:        pip install cftime\n"
+            "  - conda-forge: conda install -c conda-forge cftime"
         )
         import cftime
 

--- a/src/pyramids/stac/client.py
+++ b/src/pyramids/stac/client.py
@@ -5,8 +5,10 @@ This thin wrapper attaches a :class:`~pyramids.stac.signers.Signer` to both
 `request_modifier` (pre-send HTTP request signing) — so the caller never has
 to remember which boundary a given signer cares about.
 
-`pystac-client` is an optional dependency; install it with the `[stac]`
-extra (`pip install pyramids-gis[stac]`).
+`pystac-client` is an optional dependency. Install with one of:
+
+- PyPI: ``pip install 'pyramids-gis[stac]'``
+- conda-forge: ``conda install -c conda-forge pyramids-stac``
 """
 
 from __future__ import annotations
@@ -18,7 +20,9 @@ from pyramids.stac.signers import AnonymousSigner, Signer
 
 _STAC_INSTALL_HINT = (
     "open_client requires the optional 'pystac-client' dependency. "
-    "Install it with: pip install 'pyramids-gis[stac]'"
+    "Install with one of:\n"
+    "  - PyPI:        pip install 'pyramids-gis[stac]'\n"
+    "  - conda-forge: conda install -c conda-forge pyramids-stac"
 )
 
 

--- a/src/pyramids/stac/download.py
+++ b/src/pyramids/stac/download.py
@@ -8,7 +8,12 @@ returning the local paths so they can feed
 
 `stac-asset` pulls heavy async dependencies (`aiohttp`, `aiobotocore`), so it is
 **not** a core dependency — it ships via the `[stac]` extra (alongside
-`pystac-client`): install with `pip install 'pyramids-gis[stac]'`.
+`pystac-client`). Install with one of:
+
+- PyPI: ``pip install 'pyramids-gis[stac]'``
+- conda-forge: ``conda install -c conda-forge pyramids-stac``
+  (stac-asset is not on conda-forge; install it alone with ``pip install stac-asset``)
+
 The per-protocol client (HTTP / S3 / Planetary Computer / Earthdata) is selected
 by `stac_asset` from each asset href.
 """
@@ -21,8 +26,10 @@ from typing import Any
 from pyramids.base._utils import import_stac_asset
 
 _STAC_ASSET_INSTALL_HINT = (
-    "download_item requires the optional 'stac-asset' dependency. "
-    "Install it with: pip install 'pyramids-gis[stac]'"
+    "download_item requires the optional 'stac-asset' dependency. Install with one of:\n"
+    "  - PyPI:        pip install 'pyramids-gis[stac]'\n"
+    "  - conda-forge: conda install -c conda-forge pyramids-stac\n"
+    "                 (stac-asset is not on conda-forge; install it alone: pip install stac-asset)"
 )
 
 

--- a/src/pyramids/stac/search.py
+++ b/src/pyramids/stac/search.py
@@ -14,8 +14,10 @@ AOI / time / cloud query one call and returns an ``ItemCollection`` ready for
   whose own ``bbox`` / ``max_items`` are *client-side post-filters* over an
   already-materialised item list.
 
-`pystac-client` is an optional dependency; install it with the ``[stac]`` extra
-(``pip install 'pyramids-gis[stac]'``).
+`pystac-client` is an optional dependency. Install with one of:
+
+- PyPI: ``pip install 'pyramids-gis[stac]'``
+- conda-forge: ``conda install -c conda-forge pyramids-stac``
 """
 
 from __future__ import annotations
@@ -26,8 +28,9 @@ from pyramids.base._utils import import_pystac_client
 from pyramids.stac.client import open_client
 
 _STAC_INSTALL_HINT = (
-    "search requires the optional 'pystac-client' dependency. "
-    "Install it with: pip install 'pyramids-gis[stac]'"
+    "search requires the optional 'pystac-client' dependency. Install with one of:\n"
+    "  - PyPI:        pip install 'pyramids-gis[stac]'\n"
+    "  - conda-forge: conda install -c conda-forge pyramids-stac"
 )
 
 


### PR DESCRIPTION
## Summary

Optional-dependency install hints previously showed only the PyPI command
(`pip install 'pyramids-gis[<extra>]'`). conda-forge users got no guidance. Every runtime error message
and docstring install hint now lists both install paths as a stacked list:

```
... Install with one of:
  - PyPI:        pip install 'pyramids-gis[<extra>]'
  - conda-forge: conda install -c conda-forge pyramids-<extra>
```

Extra → conda-forge metapackage: `viz`→`pyramids-viz`, `lazy`→`pyramids-lazy`, `xarray`→`pyramids-xarray`,
`netcdf-lazy`→`pyramids-netcdf-lazy`, `parquet`→`pyramids-parquet`, `parquet-lazy`→`pyramids-parquet-lazy`,
`stac`→`pyramids-stac`.

## Special cases

- **`stac-asset`** has no conda-forge package, so the `download_item` hint instructs installing it alone via
  `pip install stac-asset` after `conda install -c conda-forge pyramids-stac`.
- **`pyogrio`** and **`cftime`** are bare packages (not extras) and use their own names on both PyPI and
  conda-forge.

## Test plan

- [x] Smoke-imported all 21 touched modules with `MPLBACKEND=Agg` — no syntax/concatenation errors.
- [x] Rendered sample messages at runtime to confirm stacked-list spacing and the `stac-asset` note.
- [x] Verified every `pyramids-gis[...]` hint is paired with a conda-forge line.

# Issues

- Fixes #380
