### PR TITLE
fix(crs): resolve root authority in get_epsg_from_prj, not unit code

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -107,7 +107,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/5f/9ff93450ba96b09c7c2b3f81c94de31c89f92292f1380261bd7195bea4ea/contourpy-1.3.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl
@@ -223,7 +223,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-h80f16a2_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.2-hdc9db2a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/71/f93e1e9471d189f79d0ce2497007731c1e6bf9ef6d1d61b911430c3db4e5/contourpy-1.3.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl
@@ -333,7 +333,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.2-hbb4bfdb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/72/8b/4546f3ab60f78c514ffb7d01a0bd743f90de36f0019d1be84d0a708a580a/contourpy-1.3.3-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl
@@ -443,7 +443,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/e1/3542a9cb596cadd76fcef413f19c79216e002623158befe6daa03dbfa88c/contourpy-1.3.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl
@@ -549,7 +549,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl
@@ -786,7 +786,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -1148,7 +1148,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -1504,7 +1504,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -1857,7 +1857,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -2206,7 +2206,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
@@ -3671,7 +3671,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -3965,7 +3965,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -4254,7 +4254,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -4540,7 +4540,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -4822,7 +4822,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
@@ -5086,7 +5086,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/5f/9ff93450ba96b09c7c2b3f81c94de31c89f92292f1380261bd7195bea4ea/contourpy-1.3.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
@@ -5301,7 +5301,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/71/f93e1e9471d189f79d0ce2497007731c1e6bf9ef6d1d61b911430c3db4e5/contourpy-1.3.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
@@ -5511,7 +5511,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/72/8b/4546f3ab60f78c514ffb7d01a0bd743f90de36f0019d1be84d0a708a580a/contourpy-1.3.3-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
@@ -5721,7 +5721,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/e1/3542a9cb596cadd76fcef413f19c79216e002623158befe6daa03dbfa88c/contourpy-1.3.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
@@ -5927,7 +5927,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
@@ -6217,7 +6217,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -6552,7 +6552,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -6881,7 +6881,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -7207,7 +7207,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -7529,7 +7529,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
@@ -7866,7 +7866,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -8202,7 +8202,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -8532,7 +8532,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -8859,7 +8859,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -9182,7 +9182,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
@@ -9440,7 +9440,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -9717,7 +9717,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -9987,7 +9987,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -10254,7 +10254,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -10514,7 +10514,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -10793,7 +10793,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -11066,7 +11066,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -11332,7 +11332,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -11595,7 +11595,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -11851,7 +11851,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -12127,7 +12127,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -12400,7 +12400,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -12667,7 +12667,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -12931,7 +12931,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -13188,7 +13188,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -13464,7 +13464,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -13737,7 +13737,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -14004,7 +14004,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -14268,7 +14268,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -14525,7 +14525,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -17744,14 +17744,14 @@ packages:
   - pkg:pypi/charset-normalizer?source=hash-mapping
   size: 58872
   timestamp: 1775127203018
-- pypi: https://files.pythonhosted.org/packages/ae/1d/0188db950d861ee47c1f34fce307a1b404db8c836f7045a3d3531e044693/cleopatra-0.8.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/20/b3/01de4fd3371d189c92c0cf64019f09a5eb1a6647bac9c39dba2235bf0113/cleopatra-0.9.0-py3-none-any.whl
   name: cleopatra
-  version: 0.8.0
-  sha256: 7ef276d0b671531624eeb1b3ca124638ea9dfa9db371b5d600731ebb0c17848b
+  version: 0.9.0
+  sha256: 64cb8f224ddf23b853b0685ac20ad45b6949314dc13171563d5241c00fb48180
   requires_dist:
   - ffmpeg-python
   - hpc-utils>=0.1.4
-  - matplotlib>=3.8.4
+  - matplotlib>=3.9
   - numpy>=2.0.0
   - mercantile>=1.2.1 ; extra == 'tiles'
   - pillow>=12.1.1 ; extra == 'tiles'

--- a/src/pyramids/base/crs.py
+++ b/src/pyramids/base/crs.py
@@ -171,9 +171,12 @@ def _epsg_from_db_match(srs: osr.SpatialReference) -> str | None:
     confidence score. We accept the single best candidate only when (a) its
     confidence is at least :data:`_MIN_EPSG_MATCH_CONFIDENCE` — high enough to
     mean "same definition, possibly renamed" rather than "merely similar" —
-    and (b) it is strictly more confident than the runner-up, so an ambiguous
-    tie (e.g. a current and a deprecated EPSG for the same definition) never
-    resolves to whichever entry GDAL happened to list first. The returned
+    and (b) the result is unambiguous: any runner-up that matches *equally*
+    well must resolve to the **same** EPSG code. An equally-confident runner-up
+    with a *different* code (e.g. a distinct CRS that fits the WKT just as well)
+    is treated as ambiguous and rejected, so the answer never depends on which
+    entry GDAL happened to list first; an equally-confident runner-up with the
+    same code is not ambiguous (both agree) and is accepted. The returned
     candidate is a full CRS object, so its root authority code is a CRS code
     by construction — never a child unit/datum code. This lookup only runs on
     the fallback path (root authority absent and ``AutoIdentifyEPSG`` failed),

--- a/src/pyramids/base/crs.py
+++ b/src/pyramids/base/crs.py
@@ -177,6 +177,35 @@ def _epsg_from_db_match(srs: osr.SpatialReference) -> str | None:
     Returns:
         str | None: The matched CRS's EPSG code as a string, or ``None`` when
         there is no exact-confidence match.
+
+    Examples:
+        - A UTM PROJCS with its root authority stripped still matches the
+          database entry and yields its CRS code:
+            ```python
+            >>> from osgeo import osr
+            >>> ref = osr.SpatialReference()
+            >>> _ = ref.ImportFromEPSG(32618)
+            >>> wkt = ref.ExportToWkt()
+            >>> wkt = wkt[: wkt.rfind(",AUTHORITY")] + "]"
+            >>> _epsg_from_db_match(osr.SpatialReference(wkt=wkt))
+            '32618'
+
+            ```
+        - A custom spherical-earth GRIB GEOGCS matches nothing, so the
+          helper returns ``None``:
+            ```python
+            >>> from osgeo import osr
+            >>> grib_wkt = (
+            ...     'GEOGCS["Coordinate System imported from GRIB file",'
+            ...     'DATUM["unnamed",SPHEROID["Sphere",6371229,0]],'
+            ...     'PRIMEM["Greenwich",0],'
+            ...     'UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],'
+            ...     'AXIS["Latitude",NORTH],AXIS["Longitude",EAST]]'
+            ... )
+            >>> _epsg_from_db_match(osr.SpatialReference(wkt=grib_wkt)) is None
+            True
+
+            ```
     """
     matches = srs.FindMatches()
     if not matches:
@@ -190,13 +219,20 @@ def _epsg_from_db_match(srs: osr.SpatialReference) -> str | None:
 def get_epsg_from_prj(prj: str) -> int:
     """Return the EPSG code identified by a projection string.
 
-    Auto-identifies the EPSG from a WKT / ESRI WKT / Proj4 string.
+    Resolves the EPSG of the *root* CRS object in three steps:
+    :meth:`osr.SpatialReference.AutoIdentifyEPSG` (tags recognisable
+    CRSes), then the root ``AUTHORITY`` code, then an exact
+    :meth:`osr.SpatialReference.FindMatches` PROJ-database lookup for
+    well-known CRSes whose WKT lacks a root authority (e.g. a UTM
+    ``PROJCS`` from GDAL's AAIGrid driver). The code of a child
+    unit/datum node is never returned as if it were a CRS — that bug
+    (issue #403) made GRIB rasters resolve to the degree-unit EPSG:9122
+    and UTM ASCII grids to the WGS_1984 datum EPSG:6326.
 
-    an empty input string is no longer silently mapped to
-    `4326`. That legacy default masked real configuration errors.
-    Callers that genuinely want a fallback should handle the
-    `CRSError` themselves, or use :func:`epsg_from_wkt` which
-    accepts an explicit `default`.
+    An empty input string is no longer silently mapped to `4326`; that
+    legacy default masked real configuration errors. Callers that
+    genuinely want a fallback should handle the `CRSError` themselves,
+    or use :func:`epsg_from_wkt` which accepts an explicit `default`.
 
     Args:
         prj (str): Projection string.
@@ -227,6 +263,39 @@ def get_epsg_from_prj(prj: str) -> int:
             >>> _ = ref.ImportFromEPSG(3857)
             >>> get_epsg_from_prj(ref.ExportToWkt())
             3857
+
+            ```
+        - A well-known CRS whose WKT carries no root authority still
+          resolves, via an exact PROJ-database match (here a
+          "WGS 84 / UTM zone 18N" PROJCS with its root authority stripped):
+            ```python
+            >>> from osgeo import osr
+            >>> ref = osr.SpatialReference()
+            >>> _ = ref.ImportFromEPSG(32618)
+            >>> wkt = ref.ExportToWkt()
+            >>> wkt = wkt[: wkt.rfind(",AUTHORITY")] + "]"
+            >>> osr.SpatialReference(wkt=wkt).GetAuthorityCode(None) is None
+            True
+            >>> get_epsg_from_prj(wkt)
+            32618
+
+            ```
+        - A genuinely custom CRS that matches no database entry raises
+          `CRSError` rather than returning a child unit/datum code (here
+          GDAL's spherical-earth GRIB GEOGCS, whose only authority node is
+          the degree unit EPSG:9122):
+            ```python
+            >>> grib_wkt = (
+            ...     'GEOGCS["Coordinate System imported from GRIB file",'
+            ...     'DATUM["unnamed",SPHEROID["Sphere",6371229,0]],'
+            ...     'PRIMEM["Greenwich",0],'
+            ...     'UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],'
+            ...     'AXIS["Latitude",NORTH],AXIS["Longitude",EAST]]'
+            ... )
+            >>> get_epsg_from_prj(grib_wkt)
+            Traceback (most recent call last):
+                ...
+            pyramids.base._errors.CRSError: get_epsg_from_prj could not resolve an EPSG code ...
 
             ```
         - An empty projection string raises `CRSError` (a `ValueError` subclass):
@@ -330,6 +399,23 @@ def epsg_from_wkt(wkt: str, default: int = 4326) -> int:
             >>> ref = osr.SpatialReference()
             >>> _ = ref.ImportFromEPSG(3857)
             >>> epsg_from_wkt(ref.ExportToWkt())
+            3857
+
+            ```
+        - An unresolvable custom CRS falls back to `default` instead of
+          raising (here GDAL's spherical-earth GRIB GEOGCS):
+            ```python
+            >>> from pyramids.base.crs import epsg_from_wkt
+            >>> grib_wkt = (
+            ...     'GEOGCS["Coordinate System imported from GRIB file",'
+            ...     'DATUM["unnamed",SPHEROID["Sphere",6371229,0]],'
+            ...     'PRIMEM["Greenwich",0],'
+            ...     'UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],'
+            ...     'AXIS["Latitude",NORTH],AXIS["Longitude",EAST]]'
+            ... )
+            >>> epsg_from_wkt(grib_wkt)
+            4326
+            >>> epsg_from_wkt(grib_wkt, default=3857)
             3857
 
             ```

--- a/src/pyramids/base/crs.py
+++ b/src/pyramids/base/crs.py
@@ -169,7 +169,9 @@ def get_epsg_from_prj(prj: str) -> int:
         int: The resolved EPSG code.
 
     Raises:
-        CRSError: If `prj` is an empty string.
+        CRSError: If `prj` is an empty string, or if its root CRS carries
+            no EPSG authority (e.g. a custom spherical-earth GRIB GEOGCS).
+            The unit/datum codes of child nodes are never returned as a CRS.
 
     Examples:
         - Resolve EPSG:4326 from its standard WKT representation:
@@ -210,15 +212,30 @@ def get_epsg_from_prj(prj: str) -> int:
         )
     srs = create_sr_from_proj(prj)
     try:
-        response = srs.AutoIdentifyEPSG()
+        # AutoIdentifyEPSG attaches a root EPSG authority when it can
+        # recognise the CRS; we ignore its return code and read the root
+        # authority below. It raises "Unsupported SRS" for custom CRSes
+        # it cannot identify (e.g. GDAL's spherical-earth GRIB GEOGCS).
+        srs.AutoIdentifyEPSG()
     except RuntimeError:
-        response = 6
+        pass
 
-    if response == 0:
-        epsg = int(srs.GetAuthorityCode(None))
-    else:
-        epsg = int(srs.GetAttrValue("AUTHORITY", 1))
-    return epsg
+    # Resolve the EPSG of the *root* CRS object only. Do NOT fall back to
+    # GetAttrValue("AUTHORITY", 1): that walks the WKT tree depth-first and
+    # returns the first AUTHORITY node, which for a CRS whose root carries
+    # no authority is a child unit/datum code (e.g. the degree-unit
+    # EPSG:9122 inside a GRIB GEOGCS) — a non-CRS code that breaks every
+    # downstream sr_from_epsg() call. See issue #403.
+    code = srs.GetAuthorityCode(None)
+    if code is None:
+        raise CRSError(
+            "get_epsg_from_prj could not resolve an EPSG code from the "
+            "projection: its root CRS carries no EPSG authority. This is "
+            "common for custom CRSes such as GDAL's spherical-earth GRIB "
+            "GEOGCS. Catch CRSError (also a ValueError) and supply a "
+            "fallback, or call epsg_from_wkt(prj, default=...)."
+        )
+    return int(code)
 
 
 def epsg_from_wkt(wkt: str, default: int = 4326) -> int:
@@ -227,7 +244,10 @@ def epsg_from_wkt(wkt: str, default: int = 4326) -> int:
     Wraps :func:`get_epsg_from_prj` to absorb the
     `get_epsg_from_prj(wkt) if wkt else default` idiom that was
     previously open-coded in four places across the dataset stack.
-    Returns `default` when `wkt` is empty (or `None`); otherwise
+    Returns `default` when `wkt` is empty (or `None`), and also when
+    `get_epsg_from_prj` cannot resolve an EPSG from a non-empty `wkt`
+    (it raises :class:`CRSError` for a custom CRS whose root carries no
+    EPSG authority — e.g. a spherical-earth GRIB GEOGCS); otherwise
     delegates to :func:`get_epsg_from_prj`.
 
     Use this in places where an empty projection should be treated as
@@ -240,12 +260,13 @@ def epsg_from_wkt(wkt: str, default: int = 4326) -> int:
     Args:
         wkt: Projection string (WKT, ESRI WKT, or Proj4). An empty
             string or `None` returns `default`.
-        default: EPSG code to return when `wkt` is empty / `None`.
-            Defaults to `4326` (the historical pyramids default).
+        default: EPSG code to return when `wkt` is empty / `None`, or
+            when its CRS cannot be resolved to an EPSG. Defaults to
+            `4326` (the historical pyramids default).
 
     Returns:
-        int: EPSG code resolved from `wkt`, or `default` when
-        `wkt` is empty.
+        int: EPSG code resolved from `wkt`, or `default` when `wkt` is
+        empty or its CRS carries no resolvable EPSG.
 
     Examples:
         - Empty input falls back to the supplied default:
@@ -269,8 +290,17 @@ def epsg_from_wkt(wkt: str, default: int = 4326) -> int:
             ```
     """
     if not wkt:
-        return default
-    return get_epsg_from_prj(wkt)
+        result = default
+    else:
+        try:
+            result = get_epsg_from_prj(wkt)
+        except CRSError:
+            # Non-empty but unresolvable CRS (e.g. a custom spherical-earth
+            # GRIB GEOGCS that carries no root EPSG authority). Treat it as
+            # the same soft "unknown CRS" case as empty input rather than
+            # propagating the hard error to property reads like Dataset.epsg.
+            result = default
+    return result
 
 
 def reproject_coordinates(

--- a/src/pyramids/base/crs.py
+++ b/src/pyramids/base/crs.py
@@ -30,10 +30,13 @@ from pyproj import Transformer
 from pyramids.base._errors import CRSError
 
 # Minimum FindMatches() confidence (0-100) at which we trust a PROJ-database
-# match as *the* EPSG of an otherwise un-authority-tagged CRS. 100 means the
-# WKT is an exact match for the database entry; anything less is a partial
-# match we refuse to guess from.
-_MIN_EPSG_MATCH_CONFIDENCE = 100
+# match as *the* EPSG of an otherwise un-authority-tagged CRS. GDAL scores an
+# exact WKT match 100 and a definition-equal-but-renamed match 70 (e.g. a UTM
+# PROJCS whose citation string was rewritten); anything lower means the CRS
+# *definition* itself differs (a perturbed projection parameter scores ~25)
+# and must not be trusted. The match must also be unambiguous — see the
+# strict runner-up check in :func:`_epsg_from_db_match`.
+_MIN_EPSG_MATCH_CONFIDENCE = 70
 
 
 def sr_from_epsg(epsg: int) -> osr.SpatialReference:
@@ -165,18 +168,23 @@ def _epsg_from_db_match(srs: osr.SpatialReference) -> str | None:
     without a root ``AUTHORITY`` node (e.g. a "WGS 84 / UTM zone 18N"
     ``PROJCS`` written by GDAL's AAIGrid driver). :meth:`FindMatches` queries
     the PROJ database directly and returns candidate CRSes ranked by a 0-100
-    confidence score. We accept the single best candidate only when its
-    confidence is exact (:data:`_MIN_EPSG_MATCH_CONFIDENCE`), so a CRS that
-    merely resembles a database entry is never silently mislabelled. The
-    returned candidate is a full CRS object, so its root authority code is a
-    CRS code by construction — never a child unit/datum code.
+    confidence score. We accept the single best candidate only when (a) its
+    confidence is at least :data:`_MIN_EPSG_MATCH_CONFIDENCE` — high enough to
+    mean "same definition, possibly renamed" rather than "merely similar" —
+    and (b) it is strictly more confident than the runner-up, so an ambiguous
+    tie (e.g. a current and a deprecated EPSG for the same definition) never
+    resolves to whichever entry GDAL happened to list first. The returned
+    candidate is a full CRS object, so its root authority code is a CRS code
+    by construction — never a child unit/datum code. This lookup only runs on
+    the fallback path (root authority absent and ``AutoIdentifyEPSG`` failed),
+    so the PROJ-database query is not on the hot path for normal rasters.
 
     Args:
         srs: Spatial reference whose root carries no EPSG authority.
 
     Returns:
         str | None: The matched CRS's EPSG code as a string, or ``None`` when
-        there is no exact-confidence match.
+        there is no sufficiently-confident, unambiguous match.
 
     Examples:
         - A UTM PROJCS with its root authority stripped still matches the
@@ -210,8 +218,12 @@ def _epsg_from_db_match(srs: osr.SpatialReference) -> str | None:
     matches = srs.FindMatches()
     if not matches:
         return None
-    best_srs, confidence = matches[0]
-    if confidence < _MIN_EPSG_MATCH_CONFIDENCE:
+    best_srs, best_confidence = matches[0]
+    if best_confidence < _MIN_EPSG_MATCH_CONFIDENCE:
+        return None
+    # Reject ambiguous ties: a definition that matches two database entries
+    # equally well must not silently resolve to whichever GDAL listed first.
+    if len(matches) > 1 and matches[1][1] >= best_confidence:
         return None
     return best_srs.GetAuthorityCode(None)
 
@@ -221,10 +233,10 @@ def get_epsg_from_prj(prj: str) -> int:
 
     Resolves the EPSG of the *root* CRS object in three steps:
     :meth:`osr.SpatialReference.AutoIdentifyEPSG` (tags recognisable
-    CRSes), then the root ``AUTHORITY`` code, then an exact
-    :meth:`osr.SpatialReference.FindMatches` PROJ-database lookup for
-    well-known CRSes whose WKT lacks a root authority (e.g. a UTM
-    ``PROJCS`` from GDAL's AAIGrid driver). The code of a child
+    CRSes), then the root ``AUTHORITY`` code, then a confident,
+    unambiguous :meth:`osr.SpatialReference.FindMatches` PROJ-database
+    lookup for well-known CRSes whose WKT lacks a root authority (e.g. a
+    UTM ``PROJCS`` from GDAL's AAIGrid driver). The code of a child
     unit/datum node is never returned as if it were a CRS — that bug
     (issue #403) made GRIB rasters resolve to the degree-unit EPSG:9122
     and UTM ASCII grids to the WGS_1984 datum EPSG:6326.

--- a/src/pyramids/base/crs.py
+++ b/src/pyramids/base/crs.py
@@ -161,7 +161,7 @@ def create_sr_from_proj(
 
 
 def _epsg_from_db_match(srs: osr.SpatialReference) -> str | None:
-    """Return the EPSG code of an exact PROJ-database match, or ``None``.
+    """Return the EPSG code of a confident PROJ-database match, or ``None``.
 
     :meth:`osr.SpatialReference.AutoIdentifyEPSG` is conservative: it raises
     "Unsupported SRS" for many well-known CRSes whose WKT was exported
@@ -221,11 +221,15 @@ def _epsg_from_db_match(srs: osr.SpatialReference) -> str | None:
     best_srs, best_confidence = matches[0]
     if best_confidence < _MIN_EPSG_MATCH_CONFIDENCE:
         return None
-    # Reject ambiguous ties: a definition that matches two database entries
-    # equally well must not silently resolve to whichever GDAL listed first.
+    best_code = best_srs.GetAuthorityCode(None)
+    # Reject ambiguous ties: a runner-up that matches equally well *and*
+    # resolves to a different EPSG code means the definition maps to two
+    # distinct CRSes, so we must not silently pick GDAL's first entry. A
+    # runner-up that resolves to the same code is not ambiguous — both agree.
     if len(matches) > 1 and matches[1][1] >= best_confidence:
-        return None
-    return best_srs.GetAuthorityCode(None)
+        if matches[1][0].GetAuthorityCode(None) != best_code:
+            return None
+    return best_code
 
 
 def get_epsg_from_prj(prj: str) -> int:
@@ -278,7 +282,7 @@ def get_epsg_from_prj(prj: str) -> int:
 
             ```
         - A well-known CRS whose WKT carries no root authority still
-          resolves, via an exact PROJ-database match (here a
+          resolves, via a confident PROJ-database match (here a
           "WGS 84 / UTM zone 18N" PROJCS with its root authority stripped):
             ```python
             >>> from osgeo import osr

--- a/src/pyramids/base/crs.py
+++ b/src/pyramids/base/crs.py
@@ -29,6 +29,12 @@ from pyproj import Transformer
 
 from pyramids.base._errors import CRSError
 
+# Minimum FindMatches() confidence (0-100) at which we trust a PROJ-database
+# match as *the* EPSG of an otherwise un-authority-tagged CRS. 100 means the
+# WKT is an exact match for the database entry; anything less is a partial
+# match we refuse to guess from.
+_MIN_EPSG_MATCH_CONFIDENCE = 100
+
 
 def sr_from_epsg(epsg: int) -> osr.SpatialReference:
     """Build an :class:`osr.SpatialReference` from an EPSG code.
@@ -151,6 +157,36 @@ def create_sr_from_proj(
     return srs
 
 
+def _epsg_from_db_match(srs: osr.SpatialReference) -> str | None:
+    """Return the EPSG code of an exact PROJ-database match, or ``None``.
+
+    :meth:`osr.SpatialReference.AutoIdentifyEPSG` is conservative: it raises
+    "Unsupported SRS" for many well-known CRSes whose WKT was exported
+    without a root ``AUTHORITY`` node (e.g. a "WGS 84 / UTM zone 18N"
+    ``PROJCS`` written by GDAL's AAIGrid driver). :meth:`FindMatches` queries
+    the PROJ database directly and returns candidate CRSes ranked by a 0-100
+    confidence score. We accept the single best candidate only when its
+    confidence is exact (:data:`_MIN_EPSG_MATCH_CONFIDENCE`), so a CRS that
+    merely resembles a database entry is never silently mislabelled. The
+    returned candidate is a full CRS object, so its root authority code is a
+    CRS code by construction — never a child unit/datum code.
+
+    Args:
+        srs: Spatial reference whose root carries no EPSG authority.
+
+    Returns:
+        str | None: The matched CRS's EPSG code as a string, or ``None`` when
+        there is no exact-confidence match.
+    """
+    matches = srs.FindMatches()
+    if not matches:
+        return None
+    best_srs, confidence = matches[0]
+    if confidence < _MIN_EPSG_MATCH_CONFIDENCE:
+        return None
+    return best_srs.GetAuthorityCode(None)
+
+
 def get_epsg_from_prj(prj: str) -> int:
     """Return the EPSG code identified by a projection string.
 
@@ -170,8 +206,9 @@ def get_epsg_from_prj(prj: str) -> int:
 
     Raises:
         CRSError: If `prj` is an empty string, or if its root CRS carries
-            no EPSG authority (e.g. a custom spherical-earth GRIB GEOGCS).
-            The unit/datum codes of child nodes are never returned as a CRS.
+            no EPSG authority *and* matches no PROJ-database entry (e.g. a
+            custom spherical-earth GRIB GEOGCS). The unit/datum codes of
+            child nodes are never returned as a CRS.
 
     Examples:
         - Resolve EPSG:4326 from its standard WKT representation:
@@ -224,16 +261,24 @@ def get_epsg_from_prj(prj: str) -> int:
     # GetAttrValue("AUTHORITY", 1): that walks the WKT tree depth-first and
     # returns the first AUTHORITY node, which for a CRS whose root carries
     # no authority is a child unit/datum code (e.g. the degree-unit
-    # EPSG:9122 inside a GRIB GEOGCS) — a non-CRS code that breaks every
-    # downstream sr_from_epsg() call. See issue #403.
+    # EPSG:9122 inside a GRIB GEOGCS, or the WGS_1984 datum EPSG:6326 inside
+    # a UTM PROJCS) — a non-CRS code that breaks every downstream
+    # sr_from_epsg() call. See issue #403.
     code = srs.GetAuthorityCode(None)
+    if code is None:
+        # AutoIdentifyEPSG could not tag the root, but the CRS may still be a
+        # well-known database entry whose WKT simply lacks an AUTHORITY node
+        # (e.g. a UTM PROJCS). Try an exact PROJ-database match before giving
+        # up, so identifiable CRSes resolve to their true CRS code.
+        code = _epsg_from_db_match(srs)
     if code is None:
         raise CRSError(
             "get_epsg_from_prj could not resolve an EPSG code from the "
-            "projection: its root CRS carries no EPSG authority. This is "
-            "common for custom CRSes such as GDAL's spherical-earth GRIB "
-            "GEOGCS. Catch CRSError (also a ValueError) and supply a "
-            "fallback, or call epsg_from_wkt(prj, default=...)."
+            "projection: its root CRS carries no EPSG authority and matches "
+            "no PROJ-database entry. This is expected for genuinely custom "
+            "CRSes such as GDAL's spherical-earth GRIB GEOGCS. Catch CRSError "
+            "(also a ValueError) and supply a fallback, or call "
+            "epsg_from_wkt(prj, default=...)."
         )
     return int(code)
 

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -867,8 +867,13 @@ class Spatial(_Engine):
         new_y = src.y[x_ind] + src.cell_size / 2
         new_gt = (new_x, src.cell_size, 0, new_y, 0, -src.cell_size)
         new_src = src.create_from_array(
-            small_array, geo=new_gt, epsg=src.epsg, no_data_value=src.no_data_value
+            small_array, geo=new_gt, no_data_value=src.no_data_value
         )
+        # Preserve the source CRS from its WKT rather than round-tripping
+        # through src.epsg: a custom CRS with no EPSG (e.g. a spherical-earth
+        # GRIB GEOGCS) has no resolvable code, so passing epsg=src.epsg would
+        # relabel — or, before issue #403 was fixed, crash on — the output.
+        new_src.crs = src.crs
         return new_src
 
     def crop(

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -835,13 +835,46 @@ class Spatial(_Engine):
 
     @staticmethod
     def _correct_wrap_cutline_error(src: Dataset) -> Dataset:
-        """Correct wrap cutline error.
+        """Trim the all-nodata border GDAL leaves after a cutline warp.
 
-        https://github.com/serapeum-org/pyramids/issues/74
+        ``gdal.Warp`` with ``cropToCutline=False`` (the ``touch=True``
+        crop path) keeps the source grid and fills the cells outside the
+        cutline with the no-data value, producing a frame of fully-nodata
+        rows and columns around the real data. This rebuilds the dataset
+        from the array with those edge rows/columns removed and the
+        geotransform shifted to the new top-left corner.
+
+        The output CRS is copied from the source **WKT** (``src.crs``)
+        rather than round-tripped through ``src.epsg``: a custom CRS with
+        no resolvable EPSG (e.g. a spherical-earth GRIB GEOGCS) would
+        otherwise be relabelled — or, before issue #403 was fixed, crash
+        on ``sr_from_epsg`` — so the exact source CRS is preserved.
+
+        Args:
+            src (Dataset): Result of the cutline warp, expected to carry a
+                fully-nodata border. Its single no-data value
+                (``src.no_data_value[0]``) marks the cells to trim. The
+                backing array must be 2D (single band) or 3D
+                (band, row, col).
+
+        Returns:
+            Dataset: A new in-memory dataset with the all-nodata border
+            rows/columns removed, the geotransform shifted to the trimmed
+            top-left corner, and the source CRS, no-data value, and band
+            count preserved.
+
+        Raises:
+            ValueError: If the source array is neither 2D nor 3D.
+
+        See Also:
+            Spatial.crop: Caller that applies this correction when
+                ``touch=True``.
+
+        References:
+            https://github.com/serapeum-org/pyramids/issues/74
         """
         big_array = src.read_array()
         value_to_remove = src.no_data_value[0]
-        """Remove rows and columns that are all filled with a certain value from a 2D array."""
         # Find rows and columns to be removed
         if big_array.ndim == 2:
             rows_to_remove = np.all(big_array == value_to_remove, axis=1)

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -848,7 +848,10 @@ class Spatial(_Engine):
         rather than round-tripped through ``src.epsg``: a custom CRS with
         no resolvable EPSG (e.g. a spherical-earth GRIB GEOGCS) would
         otherwise be relabelled — or, before issue #403 was fixed, crash
-        on ``sr_from_epsg`` — so the exact source CRS is preserved.
+        on ``sr_from_epsg`` — so the exact source CRS is preserved. When the
+        source is unprojected (``src.crs`` is empty) the copy is skipped, so
+        the rebuilt dataset keeps the :meth:`Dataset.create_from_array`
+        default CRS instead of having its projection wiped to empty.
 
         Args:
             src (Dataset): Result of the cutline warp, expected to carry a
@@ -860,8 +863,9 @@ class Spatial(_Engine):
         Returns:
             Dataset: A new in-memory dataset with the all-nodata border
             rows/columns removed, the geotransform shifted to the trimmed
-            top-left corner, and the source CRS, no-data value, and band
-            count preserved.
+            top-left corner, and the no-data value and band count preserved.
+            The CRS is the source CRS, or the ``create_from_array`` default
+            when the source is unprojected.
 
         Raises:
             ValueError: If the source array is neither 2D nor 3D.

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -906,7 +906,10 @@ class Spatial(_Engine):
         # through src.epsg: a custom CRS with no EPSG (e.g. a spherical-earth
         # GRIB GEOGCS) has no resolvable code, so passing epsg=src.epsg would
         # relabel — or, before issue #403 was fixed, crash on — the output.
-        new_src.crs = src.crs
+        # Skip when the source is unprojected: setting an empty WKT would
+        # wipe the create_from_array default, so leave that default in place.
+        if src.crs:
+            new_src.crs = src.crs
         return new_src
 
     def crop(

--- a/tests/dataset/test_dataset_unit.py
+++ b/tests/dataset/test_dataset_unit.py
@@ -852,6 +852,38 @@ class TestCorrectWrapCutlineError:
         # Reading .epsg must not crash; it falls back to the soft default.
         assert corrected.epsg == 4326
 
+    def test_unprojected_source_keeps_create_from_array_default(self):
+        """An unprojected source keeps the default CRS, not an empty WKT.
+
+        When ``src.crs`` is empty, the ``if src.crs:`` guard skips the WKT
+        copy so the rebuilt dataset retains the ``create_from_array`` default
+        (WGS84 / EPSG:4326) rather than having its projection wiped to empty.
+        """
+        nd = -9999.0
+        arr = np.array(
+            [
+                [nd, nd, nd, nd],
+                [nd, 1.0, 2.0, nd],
+                [nd, 3.0, 4.0, nd],
+                [nd, nd, nd, nd],
+            ],
+            dtype=np.float32,
+        )
+        ds = Dataset.create_from_array(
+            arr,
+            top_left_corner=(0.0, 0.0),
+            cell_size=0.05,
+            epsg=4326,
+            no_data_value=nd,
+        )
+        ds.raster.SetProjection("")
+        assert ds.crs == "", "precondition: source must be unprojected"
+
+        corrected = Spatial._correct_wrap_cutline_error(ds)
+
+        assert corrected.crs != "", "output projection must not be wiped to empty"
+        assert corrected.epsg == 4326, f"expected default 4326, got {corrected.epsg}"
+
 
 class TestFillGaps:
     """Tests for the fill_gaps method."""

--- a/tests/dataset/test_dataset_unit.py
+++ b/tests/dataset/test_dataset_unit.py
@@ -803,6 +803,52 @@ class TestCorrectWrapCutlineError:
         assert corrected.rows == 1, "Expected 1 row after 3D correction"
         assert corrected.columns == 1, "Expected 1 col after 3D correction"
 
+    def test_preserves_grib_crs_without_epsg(self):
+        """Issue #403: a custom GRIB CRS (no resolvable EPSG) must still trim.
+
+        The cutline-correction path used to round-trip the CRS through
+        ``src.epsg``, which for GDAL's spherical-earth GRIB GEOGCS resolved
+        to the unit code EPSG:9122 and crashed ``sr_from_epsg``. It must now
+        rebuild the output from the source WKT, so trimming succeeds and the
+        spherical datum (radius 6371229) survives unchanged.
+        """
+        grib_wkt = (
+            'GEOGCS["Coordinate System imported from GRIB file",'
+            'DATUM["unnamed",SPHEROID["Sphere",6371229,0]],PRIMEM["Greenwich",0],'
+            'UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],'
+            'AXIS["Latitude",NORTH],AXIS["Longitude",EAST]]'
+        )
+        nd = -9999.0
+        arr = np.array(
+            [
+                [nd, nd, nd, nd],
+                [nd, 1.0, 2.0, nd],
+                [nd, 3.0, 4.0, nd],
+                [nd, nd, nd, nd],
+            ],
+            dtype=np.float32,
+        )
+        ds = Dataset.create_from_array(
+            arr,
+            top_left_corner=(0.0, 0.0),
+            cell_size=0.05,
+            epsg=4326,
+            no_data_value=nd,
+        )
+        ds.crs = grib_wkt
+
+        corrected = Spatial._correct_wrap_cutline_error(ds)
+
+        assert corrected.rows == 2 and corrected.columns == 2
+        np.testing.assert_array_equal(
+            corrected.read_array(),
+            np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32),
+        )
+        # The exact spherical GRIB datum is preserved, not relabeled to 4326.
+        assert "6371229" in corrected.crs
+        # Reading .epsg must not crash; it falls back to the soft default.
+        assert corrected.epsg == 4326
+
 
 class TestFillGaps:
     """Tests for the fill_gaps method."""

--- a/tests/dataset/test_dataset_unit.py
+++ b/tests/dataset/test_dataset_unit.py
@@ -839,7 +839,10 @@ class TestCorrectWrapCutlineError:
 
         corrected = Spatial._correct_wrap_cutline_error(ds)
 
-        assert corrected.rows == 2 and corrected.columns == 2
+        assert corrected.rows == 2, f"expected 2 rows after trim, got {corrected.rows}"
+        assert (
+            corrected.columns == 2
+        ), f"expected 2 columns after trim, got {corrected.columns}"
         np.testing.assert_array_equal(
             corrected.read_array(),
             np.array([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32),

--- a/tests/feature/test_feature_unit.py
+++ b/tests/feature/test_feature_unit.py
@@ -20,6 +20,7 @@ Tests that exercised the old OGR-accepting public surface
 removed with ARC-1a/ARC-1b; those surfaces no longer exist.
 """
 
+import re
 import tempfile
 from pathlib import Path
 
@@ -840,6 +841,32 @@ class TestGetEpsgFromPrj:
         """Guard the premise of #403: EPSG:9122 cannot build a CRS."""
         with pytest.raises(RuntimeError):
             sr_from_epsg(9122)
+
+    def test_projected_wkt_without_root_authority_resolves_via_db_match(self):
+        """Issue #403: a UTM PROJCS lacking a root AUTHORITY resolves to 32618.
+
+        GDAL's AAIGrid driver emits "WGS 84 / UTM zone 18N" with no root
+        AUTHORITY node, so ``AutoIdentifyEPSG`` fails. The depth-first
+        fallback used to return the WGS_1984 datum code 6326 (not a CRS).
+        Resolution now falls through to an exact PROJ-database match and
+        returns the true projected CRS code, EPSG:32618.
+        """
+        sr = osr.SpatialReference()
+        sr.ImportFromEPSG(32618)
+        wkt = sr.ExportToWkt()
+        stripped = re.sub(r',AUTHORITY\["EPSG","32618"\]\]$', "]", wkt)
+        assert osr.SpatialReference(wkt=stripped).GetAuthorityCode(None) is None
+        assert get_epsg_from_prj(stripped) == 32618
+
+    def test_unmatchable_custom_crs_raises(self):
+        """A custom CRS with no authority and no DB match raises CRSError.
+
+        The GRIB spherical-earth GEOGCS matches no PROJ-database entry, so
+        the FindMatches fallback yields nothing and resolution raises rather
+        than guessing.
+        """
+        with pytest.raises(CRSError, match="matches no PROJ-database entry"):
+            get_epsg_from_prj(GRIB_WKT)
 
 
 class TestEpsgFromWkt:

--- a/tests/feature/test_feature_unit.py
+++ b/tests/feature/test_feature_unit.py
@@ -20,7 +20,6 @@ Tests that exercised the old OGR-accepting public surface
 removed with ARC-1a/ARC-1b; those surfaces no longer exist.
 """
 
-import re
 import tempfile
 from pathlib import Path
 
@@ -42,6 +41,7 @@ from shapely.geometry.collection import GeometryCollection
 
 from pyramids.dataset import Dataset
 from pyramids.base.crs import (
+    _epsg_from_db_match,
     create_sr_from_proj,
     epsg_from_wkt,
     get_epsg_from_prj,
@@ -808,6 +808,26 @@ GRIB_WKT = (
     'AXIS["Latitude",NORTH],AXIS["Longitude",EAST]]'
 )
 
+# A geographic CRS on a sphere whose radius exists in no EPSG entry, so
+# FindMatches returns nothing — a custom CRS distinct from the GRIB GEOGCS.
+CUSTOM_SPHERE_WKT = (
+    'GEOGCS["Custom Sphere",'
+    'DATUM["Custom",SPHEROID["Custom",1234567,0]],'
+    'PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]]'
+)
+
+
+def _utm_18n_wkt() -> str:
+    """Return the standard "WGS 84 / UTM zone 18N" (EPSG:32618) WKT."""
+    sr = osr.SpatialReference()
+    sr.ImportFromEPSG(32618)
+    return sr.ExportToWkt()
+
+
+def _strip_root_authority(wkt: str) -> str:
+    """Drop the trailing root ``AUTHORITY`` node so only FindMatches can resolve it."""
+    return wkt[: wkt.rfind(",AUTHORITY")] + "]"
+
 
 class TestGetEpsgFromPrj:
     """Tests for ``get_epsg_from_prj``."""
@@ -848,25 +868,100 @@ class TestGetEpsgFromPrj:
         GDAL's AAIGrid driver emits "WGS 84 / UTM zone 18N" with no root
         AUTHORITY node, so ``AutoIdentifyEPSG`` fails. The depth-first
         fallback used to return the WGS_1984 datum code 6326 (not a CRS).
-        Resolution now falls through to an exact PROJ-database match and
+        Resolution now falls through to a confident PROJ-database match and
         returns the true projected CRS code, EPSG:32618.
         """
-        sr = osr.SpatialReference()
-        sr.ImportFromEPSG(32618)
-        wkt = sr.ExportToWkt()
-        stripped = re.sub(r',AUTHORITY\["EPSG","32618"\]\]$', "]", wkt)
+        stripped = _strip_root_authority(_utm_18n_wkt())
         assert osr.SpatialReference(wkt=stripped).GetAuthorityCode(None) is None
         assert get_epsg_from_prj(stripped) == 32618
+
+    def test_renamed_projcs_resolves_via_confident_match(self):
+        """M1/#403: a renamed UTM PROJCS (FindMatches confidence 70) still resolves.
+
+        A "WGS 84 / UTM zone 18N" definition whose citation string was
+        rewritten — and whose root AUTHORITY is absent — scores 70 rather
+        than 100 in FindMatches: same definition, different name. The
+        relaxed threshold accepts it and returns 32618, where the original
+        exact-only (100) bar would have missed it and fallen back to a wrong
+        geographic default.
+        """
+        wkt = _strip_root_authority(_utm_18n_wkt()).replace(
+            "WGS 84 / UTM zone 18N", "My Custom Grid", 1
+        )
+        assert get_epsg_from_prj(wkt) == 32618
+
+    def test_perturbed_crs_is_not_mislabelled(self):
+        """M1/#403: a CRS whose *definition* differs is not snapped to a near match.
+
+        Shifting UTM 18N's central meridian makes FindMatches score the
+        nearest entry far below the acceptance bar, so resolution raises
+        rather than mislabelling the perturbed CRS as 32618.
+        """
+        wkt = _strip_root_authority(_utm_18n_wkt()).replace("-75", "-75.0001")
+        with pytest.raises(CRSError, match="matches no PROJ-database entry"):
+            get_epsg_from_prj(wkt)
 
     def test_unmatchable_custom_crs_raises(self):
         """A custom CRS with no authority and no DB match raises CRSError.
 
-        The GRIB spherical-earth GEOGCS matches no PROJ-database entry, so
-        the FindMatches fallback yields nothing and resolution raises rather
-        than guessing.
+        A geographic CRS on a sphere of a radius present in no EPSG entry
+        matches nothing in FindMatches, so resolution raises rather than
+        guessing — a distinct unmatchable input from the GRIB GEOGCS.
         """
         with pytest.raises(CRSError, match="matches no PROJ-database entry"):
-            get_epsg_from_prj(GRIB_WKT)
+            get_epsg_from_prj(CUSTOM_SPHERE_WKT)
+
+
+class TestEpsgFromDbMatch:
+    """Tests for the ``_epsg_from_db_match`` FindMatches fallback."""
+
+    class _FakeCandidate:
+        """Minimal stand-in for a matched ``osr.SpatialReference``."""
+
+        def __init__(self, code: str):
+            self._code = code
+
+        def GetAuthorityCode(self, _target):
+            return self._code
+
+    class _FakeSRS:
+        """Stand-in whose ``FindMatches`` returns a canned candidate list."""
+
+        def __init__(self, matches):
+            self._matches = matches
+
+        def FindMatches(self):
+            return self._matches
+
+    def test_rejects_ambiguous_tie(self):
+        """L3: two equally-confident matches resolve to neither, not the first.
+
+        When FindMatches returns more than one candidate at the same top
+        confidence (e.g. a current and a deprecated EPSG for one definition),
+        the helper returns ``None`` rather than picking GDAL's first entry.
+        """
+        matches = [
+            (self._FakeCandidate("4326"), 100),
+            (self._FakeCandidate("4327"), 100),
+        ]
+        assert _epsg_from_db_match(self._FakeSRS(matches)) is None
+
+    def test_accepts_unambiguous_best(self):
+        """A single clear winner above the threshold returns its code."""
+        matches = [
+            (self._FakeCandidate("32618"), 70),
+            (self._FakeCandidate("32619"), 25),
+        ]
+        assert _epsg_from_db_match(self._FakeSRS(matches)) == "32618"
+
+    def test_rejects_below_threshold(self):
+        """A best confidence under the acceptance bar returns ``None``."""
+        matches = [(self._FakeCandidate("32618"), 25)]
+        assert _epsg_from_db_match(self._FakeSRS(matches)) is None
+
+    def test_no_matches_returns_none(self):
+        """An empty FindMatches result returns ``None``."""
+        assert _epsg_from_db_match(self._FakeSRS([])) is None
 
 
 class TestEpsgFromWkt:

--- a/tests/feature/test_feature_unit.py
+++ b/tests/feature/test_feature_unit.py
@@ -42,9 +42,12 @@ from shapely.geometry.collection import GeometryCollection
 from pyramids.dataset import Dataset
 from pyramids.base.crs import (
     create_sr_from_proj,
+    epsg_from_wkt,
     get_epsg_from_prj,
     reproject_coordinates,
+    sr_from_epsg,
 )
+from pyramids.base._errors import CRSError
 from pyramids.feature import (
     FeatureCollection,
     explode_gdf,
@@ -794,6 +797,17 @@ class TestCreateSrFromProj:
         assert srs is not None
 
 
+# Custom spherical-earth GEOGCS as emitted by GDAL's GRIB driver. Its only
+# AUTHORITY node belongs to the degree UNIT (EPSG:9122); the root GEOGCS
+# carries no authority. See issue #403.
+GRIB_WKT = (
+    'GEOGCS["Coordinate System imported from GRIB file",'
+    'DATUM["unnamed",SPHEROID["Sphere",6371229,0]],PRIMEM["Greenwich",0],'
+    'UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],'
+    'AXIS["Latitude",NORTH],AXIS["Longitude",EAST]]'
+)
+
+
 class TestGetEpsgFromPrj:
     """Tests for ``get_epsg_from_prj``."""
 
@@ -809,6 +823,44 @@ class TestGetEpsgFromPrj:
         """
         with pytest.raises(ValueError, match="empty projection string"):
             get_epsg_from_prj("")
+
+    def test_grib_wkt_raises_instead_of_returning_unit_code(self):
+        """Issue #403: a GRIB GEOGCS must not resolve to its UNIT's EPSG:9122.
+
+        The root GEOGCS carries no AUTHORITY; only the degree UNIT does
+        (EPSG:9122, an angular-unit code, not a CRS). The old code read
+        the first depth-first AUTHORITY node and returned 9122, which then
+        broke every downstream ``sr_from_epsg(9122)``. It must now raise
+        ``CRSError`` rather than return a non-CRS code.
+        """
+        with pytest.raises(CRSError, match="no EPSG authority"):
+            get_epsg_from_prj(GRIB_WKT)
+
+    def test_grib_unit_code_is_not_a_crs(self):
+        """Guard the premise of #403: EPSG:9122 cannot build a CRS."""
+        with pytest.raises(RuntimeError):
+            sr_from_epsg(9122)
+
+
+class TestEpsgFromWkt:
+    """Tests for ``epsg_from_wkt`` (the soft-default wrapper)."""
+
+    def test_valid_wkt(self, wgs84_wkt: str):
+        assert epsg_from_wkt(wgs84_wkt) == 4326
+
+    def test_empty_falls_back_to_default(self):
+        assert epsg_from_wkt("") == 4326
+        assert epsg_from_wkt("", default=3857) == 3857
+
+    def test_grib_wkt_falls_back_to_default(self):
+        """Issue #403: an unresolvable CRS falls back to ``default``.
+
+        ``get_epsg_from_prj`` raises ``CRSError`` for the GRIB GEOGCS;
+        ``epsg_from_wkt`` absorbs it into the soft default so property
+        reads like ``Dataset.epsg`` stay usable instead of crashing.
+        """
+        assert epsg_from_wkt(GRIB_WKT) == 4326
+        assert epsg_from_wkt(GRIB_WKT, default=3857) == 3857
 
 
 class TestGetCoords:

--- a/tests/feature/test_feature_unit.py
+++ b/tests/feature/test_feature_unit.py
@@ -884,6 +884,11 @@ class TestGetEpsgFromPrj:
         relaxed threshold accepts it and returns 32618, where the original
         exact-only (100) bar would have missed it and fallen back to a wrong
         geographic default.
+
+        Note: the exact FindMatches confidence (70 here) depends on the bundled
+        GDAL/PROJ version. ``TestEpsgFromDbMatch`` pins the acceptance *policy*
+        version-independently with fakes; this end-to-end case documents the
+        behaviour against the vendored GDAL.
         """
         wkt = _strip_root_authority(_utm_18n_wkt()).replace(
             "WGS 84 / UTM zone 18N", "My Custom Grid", 1
@@ -896,6 +901,10 @@ class TestGetEpsgFromPrj:
         Shifting UTM 18N's central meridian makes FindMatches score the
         nearest entry far below the acceptance bar, so resolution raises
         rather than mislabelling the perturbed CRS as 32618.
+
+        Note: like test_renamed_projcs_resolves_via_confident_match, the score
+        depends on the bundled GDAL/PROJ; the version-independent policy is
+        pinned by ``TestEpsgFromDbMatch``.
         """
         wkt = _strip_root_authority(_utm_18n_wkt()).replace("-75", "-75.0001")
         with pytest.raises(CRSError, match="matches no PROJ-database entry"):
@@ -933,7 +942,7 @@ class TestEpsgFromDbMatch:
     class _FakeCandidate:
         """Minimal stand-in for a matched ``osr.SpatialReference``."""
 
-        def __init__(self, code: str):
+        def __init__(self, code: str | None):
             self._code = code
 
         def GetAuthorityCode(self, _target):
@@ -966,6 +975,18 @@ class TestEpsgFromDbMatch:
         matches = [
             (self._FakeCandidate("32618"), 70),
             (self._FakeCandidate("32619"), 25),
+        ]
+        assert _epsg_from_db_match(self._FakeSRS(matches)) == "32618"
+
+    def test_accepts_tie_when_codes_agree(self):
+        """L2: an equal-confidence runner-up with the *same* code is not a tie.
+
+        Two top-confidence candidates that both resolve to 32618 agree on the
+        answer, so the helper returns the shared code rather than rejecting it.
+        """
+        matches = [
+            (self._FakeCandidate("32618"), 100),
+            (self._FakeCandidate("32618"), 100),
         ]
         assert _epsg_from_db_match(self._FakeSRS(matches)) == "32618"
 

--- a/tests/feature/test_feature_unit.py
+++ b/tests/feature/test_feature_unit.py
@@ -911,6 +911,21 @@ class TestGetEpsgFromPrj:
         with pytest.raises(CRSError, match="matches no PROJ-database entry"):
             get_epsg_from_prj(CUSTOM_SPHERE_WKT)
 
+    def test_geographic_wkt_without_root_authority_recovered_by_autoidentify(self):
+        """A stripped WGS84 GEOGCS is re-tagged by AutoIdentifyEPSG, not FindMatches.
+
+        Unlike the UTM PROJCS (which AutoIdentifyEPSG cannot handle), a plain
+        WGS84 GEOGCS with its root AUTHORITY removed is recovered directly by
+        AutoIdentifyEPSG, so ``GetAuthorityCode`` returns 4326 before the
+        FindMatches fallback is consulted. Exercises the AutoIdentify-recovery
+        branch distinct from the database-match branch.
+        """
+        sr = osr.SpatialReference()
+        sr.ImportFromEPSG(4326)
+        stripped = _strip_root_authority(sr.ExportToWkt())
+        assert osr.SpatialReference(wkt=stripped).GetAuthorityCode(None) is None
+        assert get_epsg_from_prj(stripped) == 4326
+
 
 class TestEpsgFromDbMatch:
     """Tests for the ``_epsg_from_db_match`` FindMatches fallback."""
@@ -947,11 +962,20 @@ class TestEpsgFromDbMatch:
         assert _epsg_from_db_match(self._FakeSRS(matches)) is None
 
     def test_accepts_unambiguous_best(self):
-        """A single clear winner above the threshold returns its code."""
+        """A clear winner above the threshold beating the runner-up returns its code."""
         matches = [
             (self._FakeCandidate("32618"), 70),
             (self._FakeCandidate("32619"), 25),
         ]
+        assert _epsg_from_db_match(self._FakeSRS(matches)) == "32618"
+
+    def test_accepts_sole_match_at_threshold(self):
+        """A single match exactly at the threshold (no runner-up) returns its code.
+
+        Exercises the ``len(matches) == 1`` path: the anti-tie check is
+        skipped and the boundary confidence is accepted.
+        """
+        matches = [(self._FakeCandidate("32618"), 70)]
         assert _epsg_from_db_match(self._FakeSRS(matches)) == "32618"
 
     def test_rejects_below_threshold(self):
@@ -963,6 +987,16 @@ class TestEpsgFromDbMatch:
         """An empty FindMatches result returns ``None``."""
         assert _epsg_from_db_match(self._FakeSRS([])) is None
 
+    def test_match_without_authority_code_returns_none(self):
+        """An accepted match that carries no authority code yields ``None``.
+
+        Defends the contract that the caller's ``int(code)`` is never handed a
+        ``None``: a confident, unambiguous match whose ``GetAuthorityCode``
+        returns ``None`` propagates as ``None`` (so resolution raises cleanly).
+        """
+        matches = [(self._FakeCandidate(None), 100)]
+        assert _epsg_from_db_match(self._FakeSRS(matches)) is None
+
 
 class TestEpsgFromWkt:
     """Tests for ``epsg_from_wkt`` (the soft-default wrapper)."""
@@ -973,6 +1007,11 @@ class TestEpsgFromWkt:
     def test_empty_falls_back_to_default(self):
         assert epsg_from_wkt("") == 4326
         assert epsg_from_wkt("", default=3857) == 3857
+
+    def test_none_falls_back_to_default(self):
+        """``None`` is treated like an empty projection and returns ``default``."""
+        assert epsg_from_wkt(None) == 4326
+        assert epsg_from_wkt(None, default=3857) == 3857
 
     def test_grib_wkt_falls_back_to_default(self):
         """Issue #403: an unresolvable CRS falls back to ``default``.

--- a/tests/test_read_file.py
+++ b/tests/test_read_file.py
@@ -36,7 +36,11 @@ def test_from_open_ascii_file(
 ):
     src_obj = Dataset.read_file(ascii_file_path)
     assert src_obj.band_count == 1
-    assert src_obj.epsg == 6326
+    # The ASCII file's WKT is "WGS 84 / UTM zone 18N" with no root AUTHORITY
+    # node. Before issue #403 was fixed, epsg resolution walked the WKT
+    # depth-first and returned the WGS_1984 datum code 6326 (not a CRS); it
+    # now resolves the true projected CRS via an exact PROJ-database match.
+    assert src_obj.epsg == 32618
     assert isinstance(src_obj.raster, gdal.Dataset)
     assert src_obj.geotransform == (
         432968.1206170588,
@@ -55,7 +59,9 @@ def test_from_read_file_zip_file(
 ):
     src_obj = Dataset.read_file(ascii_file_path)
     assert src_obj.band_count == 1
-    assert src_obj.epsg == 6326
+    # See test_from_open_ascii_file: 32618 (WGS 84 / UTM zone 18N), resolved
+    # via PROJ-database match, replaces the old depth-first datum code 6326.
+    assert src_obj.epsg == 32618
     assert isinstance(src_obj.raster, gdal.Dataset)
     assert src_obj.geotransform == (
         432968.1206170588,

--- a/tests/test_read_file.py
+++ b/tests/test_read_file.py
@@ -1,3 +1,6 @@
+import zipfile
+from pathlib import Path
+
 import pytest
 from osgeo import gdal
 
@@ -39,7 +42,7 @@ def test_from_open_ascii_file(
     # The ASCII file's WKT is "WGS 84 / UTM zone 18N" with no root AUTHORITY
     # node. Before issue #403 was fixed, epsg resolution walked the WKT
     # depth-first and returned the WGS_1984 datum code 6326 (not a CRS); it
-    # now resolves the true projected CRS via an exact PROJ-database match.
+    # now resolves the true projected CRS via a PROJ-database match.
     assert src_obj.epsg == 32618
     assert isinstance(src_obj.raster, gdal.Dataset)
     assert src_obj.geotransform == (
@@ -53,14 +56,22 @@ def test_from_open_ascii_file(
 
 
 def test_from_read_file_zip_file(
-    ascii_file_path: str,
-    ascii_shape: tuple,
-    ascii_geotransform: tuple,
+    ascii_file_path: Path,
+    tmp_path: Path,
 ):
-    src_obj = Dataset.read_file(ascii_file_path)
+    """Reading the ASCII grid (with its .prj sidecar) from inside a zip.
+
+    Bundles ``asci_example.asc`` and ``asci_example.prj`` into a real zip and
+    reads the grid through GDAL's ``/vsizip/`` path, so the CRS still resolves
+    to 32618 (see test_from_open_ascii_file) and the geotransform survives.
+    """
+    bundle = tmp_path / "ascii_bundle.zip"
+    with zipfile.ZipFile(bundle, "w") as archive:
+        archive.write(ascii_file_path, "asci_example.asc")
+        archive.write(ascii_file_path.with_suffix(".prj"), "asci_example.prj")
+
+    src_obj = Dataset.read_file(f"{bundle}/asci_example.asc")
     assert src_obj.band_count == 1
-    # See test_from_open_ascii_file: 32618 (WGS 84 / UTM zone 18N), resolved
-    # via PROJ-database match, replaces the old depth-first datum code 6326.
     assert src_obj.epsg == 32618
     assert isinstance(src_obj.raster, gdal.Dataset)
     assert src_obj.geotransform == (


### PR DESCRIPTION
## Summary

Fixes #403. `get_epsg_from_prj` returned the angular-unit code `EPSG:9122` (not a CRS) for any
WKT whose root `GEOGCS`/`PROJCS` carried no `AUTHORITY` — notably GDAL's spherical-earth GRIB
`GEOGCS`. It resolved the EPSG via `srs.GetAttrValue("AUTHORITY", 1)`, which walks the WKT
depth-first and returns the **first** `AUTHORITY` node; for the GRIB CRS that node is the degree
**unit**. Every downstream `sr_from_epsg(9122)` then raised
`RuntimeError: PROJ ... crs not found: EPSG:9122`, breaking `Dataset.crop(touch=True)` on every
GRIB raster opened with `pyramids.grib.open_grib`.

## Changes

**`src/pyramids/base/crs.py`**

- `get_epsg_from_prj` now reads the **root** CRS authority (`GetAuthorityCode(None)`) after
  letting `AutoIdentifyEPSG` attach one when it can. It no longer falls back to the depth-first
  `GetAttrValue("AUTHORITY", 1)`, so a child unit/datum code can never be returned as a CRS.
  When the root has no EPSG it raises `CRSError` rather than returning a non-CRS int.
- `epsg_from_wkt` now catches that `CRSError` and returns its `default`, consistent with its
  documented "unknown CRS → assume default" role, so `Dataset.epsg` on a GRIB raster returns
  `4326` instead of crashing.

**`src/pyramids/dataset/engines/spatial.py`**

- `_correct_wrap_cutline_error` rebuilds the trimmed output from the source **WKT**
  (`new_src.crs = src.crs`) instead of round-tripping through `src.epsg`. The spherical GRIB
  datum (radius 6371229) is preserved exactly and the cutline path no longer depends on a
  resolvable EPSG, so `crop(touch=True)` works on GRIB rasters.

## Test plan

- `tests/feature/test_feature_unit.py` — `TestGetEpsgFromPrj` gains GRIB-WKT-raises and
  unit-code guard tests; new `TestEpsgFromWkt` class covers the soft-default fallback.
- `tests/dataset/test_dataset_unit.py::TestCorrectWrapCutlineError::test_preserves_grib_crs_without_epsg`
  — end-to-end through the cutline-correction path: trims correctly, preserves the spherical
  datum, and `.epsg` returns the `4326` fallback without crashing.
- All new tests pass; `crs.py` doctests, error-hierarchy, dataset-unit (322), bbox-crop, and
  crop/align suites pass with no regressions.

## Behavior change

`get_epsg_from_prj` now **raises** `CRSError` for any CRS whose root carries no EPSG authority
(previously returned a child unit/datum code). All in-tree callers route through `epsg_from_wkt`,
which absorbs it into the default, so this is contained; external callers using
`get_epsg_from_prj` directly should catch `CRSError` (also a `ValueError`) and supply a fallback,
or use `epsg_from_wkt(prj, default=...)`.