### PR TITLE
Feature/grid adapters

### DIFF
--- a/docs/examples/grids/grids.ipynb
+++ b/docs/examples/grids/grids.ipynb
@@ -1,0 +1,231 @@
+{
+    "cells": [
+        {
+            "cell_type": "markdown",
+            "id": "ace7c5fd",
+            "metadata": {},
+            "source": [
+                "# Exotic model-grid adapters\n",
+                "\n",
+                "`pyramids.grids` regrids model grids that are **not** plain rasters into a regular-grid\n",
+                "`Dataset`:\n",
+                "\n",
+                "- `from_orca` \u2014 curvilinear `(ny, nx)` lon/lat ocean grids (NEMO/ORCA),\n",
+                "- `from_octahedral` \u2014 octahedral reduced-Gaussian fields (ECMWF `O` grids),\n",
+                "- `from_healpix` \u2014 HEALPix sphere pixelizations (RING or NESTED).\n",
+                "\n",
+                "Each adapter reshapes its grid into an existing pyramids regridding bridge\n",
+                "(`mesh_to_grid` or `grid_points`) and returns a single-band `Dataset`. No external data\n",
+                "or extra dependencies are needed to run this notebook."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "28e064fb",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "import matplotlib.pyplot as plt\n",
+                "import numpy as np\n",
+                "\n",
+                "from pyramids.grids import from_healpix, from_octahedral, from_orca\n",
+                "\n",
+                "\n",
+                "def show(ds, title):\n",
+                "    \"\"\"Quick look at a regridded Dataset (no-data masked).\"\"\"\n",
+                "    arr = ds.read_array().astype(float)\n",
+                "    nodata = ds.no_data_value[0]\n",
+                "    data = np.ma.masked_equal(arr, nodata) if nodata is not None else arr\n",
+                "    minx, miny, maxx, maxy = (float(v) for v in ds.bbox)\n",
+                "    fig, ax = plt.subplots(figsize=(7, 3.2))\n",
+                "    im = ax.imshow(data, extent=[minx, maxx, miny, maxy], origin=\"upper\")\n",
+                "    ax.set_title(title)\n",
+                "    ax.set_xlabel(\"longitude\")\n",
+                "    ax.set_ylabel(\"latitude\")\n",
+                "    fig.colorbar(im, ax=ax, shrink=0.85)\n",
+                "    return fig"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "df1921a2",
+            "metadata": {},
+            "source": [
+                "## ORCA curvilinear grid\n",
+                "\n",
+                "ORCA stores coordinates as two `(ny, nx)` arrays of longitudes and latitudes describing\n",
+                "quadrilateral cells. `from_orca` stitches them into a UGRID quad mesh and interpolates it\n",
+                "to a regular grid. Here we fake a curvilinear grid by warping a regular lon/lat mesh."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "f714e5ca",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "ny, nx = 60, 120\n",
+                "lon = np.linspace(-180.0, 180.0, nx)\n",
+                "lat = np.linspace(-80.0, 80.0, ny)\n",
+                "lon2d, lat2d = np.meshgrid(lon, lat)\n",
+                "lon2d = lon2d + 6.0 * np.sin(np.radians(lat2d))  # curvilinear warp\n",
+                "data2d = np.cos(np.radians(lat2d)) * np.sin(np.radians(lon2d))\n",
+                "\n",
+                "orca_ds = from_orca(lon2d, lat2d, data2d, cell_size=2.0)\n",
+                "print(\n",
+                "    \"rows, columns, bands, epsg:\",\n",
+                "    orca_ds.rows,\n",
+                "    orca_ds.columns,\n",
+                "    orca_ds.band_count,\n",
+                "    orca_ds.epsg,\n",
+                ")"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "47d04969",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# NBVAL_IGNORE_OUTPUT\n",
+                "show(orca_ds, \"from_orca \u2014 curvilinear ORCA field\")"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "ccbcea8a",
+            "metadata": {},
+            "source": [
+                "## Octahedral reduced-Gaussian grid\n",
+                "\n",
+                "An octahedral grid is a single ragged sequence of points with known lat/lon. `from_octahedral`\n",
+                "wraps them as scattered points and interpolates with `gdal.Grid`. We stand in for the real\n",
+                "grid with deterministic pseudo-random samples."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "36e59f46",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "rng = np.random.default_rng(0)\n",
+                "n_points = 4000\n",
+                "lons = rng.uniform(-180.0, 180.0, n_points)\n",
+                "lats = rng.uniform(-80.0, 80.0, n_points)\n",
+                "values = np.cos(np.radians(lats)) * np.sin(np.radians(lons))\n",
+                "\n",
+                "octa_ds = from_octahedral(lats, lons, values, cell_size=3.0, algorithm=\"nearest\")\n",
+                "print(\n",
+                "    \"rows, columns, bands, epsg:\",\n",
+                "    octa_ds.rows,\n",
+                "    octa_ds.columns,\n",
+                "    octa_ds.band_count,\n",
+                "    octa_ds.epsg,\n",
+                ")"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "5a7d2f17",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# NBVAL_IGNORE_OUTPUT\n",
+                "show(octa_ds, \"from_octahedral \u2014 scattered reduced-Gaussian samples\")"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "3f04e549",
+            "metadata": {},
+            "source": [
+                "## HEALPix grid (RING and NESTED)\n",
+                "\n",
+                "HEALPix stores one value per pixel, indexed by `nside` (so `12 * nside**2` pixels).\n",
+                "`from_healpix` computes each pixel's centre lon/lat in plain NumPy \u2014 no `healpy` \u2014 and supports\n",
+                "both the **RING** and **NESTED** pixel orderings. The same value array under the two orderings\n",
+                "describes different fields, because the orderings number the pixels differently."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "4f75e50d",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "nside = 16\n",
+                "npix = 12 * nside**2\n",
+                "values = np.cos(np.linspace(0.0, 6.0 * np.pi, npix))\n",
+                "\n",
+                "ring_ds = from_healpix(values, nside=nside, nest=False, cell_size=2.0)\n",
+                "nest_ds = from_healpix(values, nside=nside, nest=True, cell_size=2.0)\n",
+                "print(\"RING :\", ring_ds.rows, ring_ds.columns, ring_ds.band_count)\n",
+                "print(\"NESTED:\", nest_ds.rows, nest_ds.columns, nest_ds.band_count)"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "c6f79438",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# NBVAL_IGNORE_OUTPUT\n",
+                "show(ring_ds, \"from_healpix \u2014 RING ordering\")"
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "2104f027",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "# NBVAL_IGNORE_OUTPUT\n",
+                "show(nest_ds, \"from_healpix \u2014 NESTED ordering\")"
+            ]
+        },
+        {
+            "cell_type": "markdown",
+            "id": "8ac627d5",
+            "metadata": {},
+            "source": [
+                "`nside` is derived automatically from the value count when omitted, and invalid inputs raise a\n",
+                "clear error (e.g. a length that is not `12 * nside**2`, or `nest=True` with a non-power-of-two\n",
+                "`nside`)."
+            ]
+        },
+        {
+            "cell_type": "code",
+            "execution_count": null,
+            "id": "035b3e9e",
+            "metadata": {},
+            "outputs": [],
+            "source": [
+                "try:\n",
+                "    from_healpix(np.zeros(10), cell_size=2.0)\n",
+                "except ValueError as exc:\n",
+                "    print(\"rejected:\", exc)"
+            ]
+        }
+    ],
+    "metadata": {
+        "kernelspec": {
+            "display_name": "Python 3",
+            "language": "python",
+            "name": "python3"
+        },
+        "language_info": {
+            "name": "python"
+        }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5
+}

--- a/docs/reference/grids.md
+++ b/docs/reference/grids.md
@@ -1,0 +1,52 @@
+# Exotic Model-Grid Adapters
+
+`pyramids.grids` turns model grids that are **not** row-major rasters — ORCA curvilinear
+ocean grids, octahedral reduced-Gaussian grids, and HEALPix sphere pixelizations — into a
+regular-grid [`Dataset`][pyramids.dataset.Dataset].
+
+Rather than shipping a new regridder, each adapter reshapes its grid into one of the two
+regridding bridges pyramids already has, then reuses it:
+
+- a **mesh** bridge —
+  [`mesh_to_grid`][pyramids.netcdf.ugrid.interpolation.mesh_to_grid] (reached through
+  [`UgridDataset.to_dataset`][pyramids.netcdf.ugrid.dataset.UgridDataset.to_dataset]); and
+- a **scattered-point** bridge —
+  [`grid_points`][pyramids.dataset.ops.interpolate.grid_points].
+
+| Adapter | Input grid | Bridge it reuses |
+| --- | --- | --- |
+| [`from_orca`](#pyramids.grids.from_orca) | curvilinear `(ny, nx)` lon/lat + data | UGRID quad mesh → `mesh_to_grid` |
+| [`from_octahedral`](#pyramids.grids.from_octahedral) | ragged per-point lat/lon + values | scattered points → `grid_points` |
+| [`from_healpix`](#pyramids.grids.from_healpix) | per-pixel HEALPix values (`nside`) | pixel centres → `grid_points` |
+
+Every adapter returns a single-band `Dataset` (array + geotransform + CRS) that renders with
+no further GIS code on the caller side.
+
+!!! note "No `healpy` dependency"
+    `from_healpix` needs only the HEALPix pixel→centre mapping (`pix2ang`), which is a
+    closed-form from the HEALPix paper. pyramids implements it in plain NumPy for both the
+    **RING** and **NESTED** pixel orderings, so no `healpy` (or other HEALPix C library) is
+    required.
+
+See the [exotic grids example notebook](../examples/grids/grids.ipynb) for runnable
+end-to-end usage of all three adapters.
+
+## Functions
+
+::: pyramids.grids.from_orca
+    options:
+        show_root_heading: true
+        show_source: true
+        heading_level: 3
+
+::: pyramids.grids.from_octahedral
+    options:
+        show_root_heading: true
+        show_source: true
+        heading_level: 3
+
+::: pyramids.grids.from_healpix
+    options:
+        show_root_heading: true
+        show_source: true
+        heading_level: 3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -127,6 +127,7 @@ nav:
       - Band Metadata Operations: reference/dataset/band_metadata.md
       - Cell Operations: reference/dataset/cell.md
     - DatasetCollection: reference/dataset_collection.md
+    - Exotic grids: reference/grids.md
     - Feature:
       - Overview: reference/feature/index.md
       - Geometry helpers: reference/feature/geometry.md
@@ -181,6 +182,8 @@ nav:
           - Dask (Sentinel-2 COGs on AWS): examples/dataset/dask-lazy-datasets.ipynb
           - Dask — Dataset (local data): examples/dataset/lazy-dataset-complete.ipynb
           - Dask — DatasetCollection (local data): examples/dataset/lazy-collection-complete.ipynb
+      - Grids:
+          - Exotic model-grid adapters: examples/grids/grids.ipynb
       - Feature:
           - FeatureCollection tutorial: tutorials/feature.md
           - Dask (Overture Maps on AWS): examples/feature/dask-lazy-features.ipynb

--- a/src/pyramids/_io.py
+++ b/src/pyramids/_io.py
@@ -388,6 +388,14 @@ def _archive_members(dir_vsi: str, member_glob: str = "*") -> list[str]:
     return members
 
 
+# Public aliases for the archive-listing helpers above. These are now used across
+# subsystems (dataset.collection, dataset.dataset, basemap.features), so expose them as
+# supported entry points without the leading underscore. The underscore names are kept
+# for the historical internal callers.
+archive_dir_vsi = _archive_dir_vsi
+archive_members = _archive_members
+
+
 def extract_from_gz(input_file: str | Path, output_file: str | Path, delete=False):
     """Extract data from zip/.gz files and save the data.
 

--- a/src/pyramids/base/crs.py
+++ b/src/pyramids/base/crs.py
@@ -25,7 +25,7 @@ from typing import Any
 import numpy as np
 import pyproj.exceptions
 from osgeo import osr
-from pyproj import Transformer
+from pyproj import CRS, Transformer
 
 from pyramids.base._errors import CRSError
 
@@ -451,6 +451,78 @@ def epsg_from_wkt(wkt: str, default: int = 4326) -> int:
             # propagating the hard error to property reads like Dataset.epsg.
             result = default
     return result
+
+
+def epsg_from_user_input(crs: int | str | Any) -> int:
+    """Resolve a CRS given in any common form to an EPSG integer code.
+
+    Accepts the CRS forms callers reach for when they don't have a bare EPSG number
+    handy — an EPSG ``int``, a string (``"EPSG:3857"``, ``"3857"``, a WKT or PROJ4
+    string, or any authority string), or a :class:`pyproj.CRS` (or other object
+    :meth:`pyproj.CRS.from_user_input` accepts) — and returns the matching EPSG code.
+
+    Args:
+        crs: The CRS to resolve. An ``int`` is returned unchanged (fast path); anything
+            else is parsed via :meth:`pyproj.CRS.from_user_input` and mapped to its EPSG
+            code.
+
+    Returns:
+        int: The EPSG code.
+
+    Raises:
+        CRSError: ``crs`` is a ``bool``, cannot be interpreted as a CRS, or resolves to a
+            CRS that has no EPSG code (e.g. a bespoke WKT/PROJ4 definition).
+
+    Examples:
+        - An EPSG integer is returned unchanged:
+            ```python
+            >>> from pyramids.base.crs import epsg_from_user_input
+            >>> epsg_from_user_input(4326)
+            4326
+
+            ```
+        - Authority strings and bare numeric strings resolve to their code:
+            ```python
+            >>> from pyramids.base.crs import epsg_from_user_input
+            >>> epsg_from_user_input("EPSG:3857")
+            3857
+            >>> epsg_from_user_input("4326")
+            4326
+
+            ```
+        - A :class:`pyproj.CRS` resolves to its EPSG code:
+            ```python
+            >>> from pyproj import CRS
+            >>> from pyramids.base.crs import epsg_from_user_input
+            >>> epsg_from_user_input(CRS.from_epsg(32636))
+            32636
+
+            ```
+        - An uninterpretable CRS is rejected:
+            ```python
+            >>> from pyramids.base.crs import epsg_from_user_input
+            >>> try:
+            ...     epsg_from_user_input("not-a-crs")
+            ... except ValueError as exc:
+            ...     print("could not interpret" in str(exc))
+            True
+
+            ```
+    """
+    if isinstance(crs, bool):
+        raise CRSError(f"{crs!r} is not a valid CRS; pass an EPSG int, string, or CRS.")
+    if isinstance(crs, int):
+        return crs
+    try:
+        parsed = CRS.from_user_input(crs)
+    except Exception as exc:
+        raise CRSError(f"could not interpret {crs!r} as a CRS: {exc}") from exc
+    epsg = parsed.to_epsg()
+    if epsg is None:
+        raise CRSError(
+            f"the CRS {crs!r} has no corresponding EPSG code; pass an EPSG integer."
+        )
+    return epsg
 
 
 def reproject_coordinates(

--- a/src/pyramids/base/crs.py
+++ b/src/pyramids/base/crs.py
@@ -515,7 +515,7 @@ def epsg_from_user_input(crs: int | str | Any) -> int:
         return crs
     try:
         parsed = CRS.from_user_input(crs)
-    except Exception as exc:
+    except (pyproj.exceptions.CRSError, TypeError, ValueError) as exc:
         raise CRSError(f"could not interpret {crs!r} as a CRS: {exc}") from exc
     epsg = parsed.to_epsg()
     if epsg is None:

--- a/src/pyramids/basemap/__init__.py
+++ b/src/pyramids/basemap/__init__.py
@@ -6,13 +6,28 @@ and :func:`~pyramids.basemap.get_provider` are thin wrappers over
 :mod:`cleopatra.tiles` (the cleopatra C-6 helpers) — cleopatra does the
 tile fetching, stitching, GDAL CRS warping, and rendering.
 
-Requires the cleopatra ``[tiles]`` extra (which pins ``cleopatra[tiles]``).
-Install with one of:
+The tile functions require the cleopatra ``[tiles]`` extra (which pins
+``cleopatra[tiles]``). Install with one of:
 
 - PyPI: ``pip install 'pyramids-gis[viz]'``
 - conda-forge: ``conda install -c conda-forge pyramids-viz``
+
+:func:`~pyramids.basemap.natural_earth` returns Natural Earth *vector* features as a
+:class:`~pyramids.feature.FeatureCollection` and needs no extra (it downloads with the
+standard library and reads through GDAL).
 """
 
 from pyramids.basemap.basemap import add_basemap, get_provider
+from pyramids.basemap.features import (
+    available_layers,
+    available_resolutions,
+    natural_earth,
+)
 
-__all__ = ["add_basemap", "get_provider"]
+__all__ = [
+    "add_basemap",
+    "available_layers",
+    "available_resolutions",
+    "get_provider",
+    "natural_earth",
+]

--- a/src/pyramids/basemap/features.py
+++ b/src/pyramids/basemap/features.py
@@ -22,7 +22,7 @@ import urllib.request
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from pyramids._io import _archive_dir_vsi, _archive_members, silent_unlink
+from pyramids._io import archive_dir_vsi, archive_members
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from pyramids.feature import FeatureCollection
@@ -129,7 +129,7 @@ def _download(url: str, destination: Path) -> None:
         tmp_path.replace(destination)
     except OSError as exc:
         # Don't leave a partial/empty temp archive behind on a failed download.
-        silent_unlink(str(tmp_path))
+        tmp_path.unlink(missing_ok=True)
         raise OSError(
             f"failed to download Natural Earth data from {url!r}: {exc}. Check the "
             "network connection, or download the archive manually into the cache "
@@ -208,7 +208,7 @@ def natural_earth(
     # Pick the shapefile from the archive by listing its members rather than assuming
     # a fixed name, so the read is robust to Natural Earth archive-layout differences.
     # Prefer the conventional ``ne_{res}_{name}.shp`` stem when present.
-    shp_members = _archive_members(_archive_dir_vsi(archive, "zip"), "*.shp")
+    shp_members = archive_members(archive_dir_vsi(archive, "zip"), "*.shp")
     preferred = f"{_dataset_stem(layer, resolution)}.shp"
     member = preferred if preferred in shp_members else shp_members[0]
     result = FeatureCollection.read_file(f"{archive}/{member}")

--- a/src/pyramids/basemap/features.py
+++ b/src/pyramids/basemap/features.py
@@ -1,0 +1,199 @@
+"""Natural Earth vector map features as pyramids :class:`FeatureCollection` objects.
+
+``pyramids.basemap`` otherwise provides only XYZ *tile imagery* (via
+:func:`pyramids.basemap.add_basemap`). Coastlines, country borders, land, ocean,
+rivers and lakes are *vector* data, not tiles. This module fetches the requested
+Natural Earth layer (https://www.naturalearthdata.com) on demand, caches the
+downloaded archive under a local cache directory, and reads it into a
+:class:`~pyramids.feature.FeatureCollection` through GDAL's ``/vsizip/`` virtual
+filesystem.
+
+Downloads use the Python standard library (:mod:`urllib.request`) — no new
+third-party dependency. The cache directory defaults to ``~/.pyramids/naturalearth``
+and can be overridden with the ``PYRAMIDS_CACHE_DIR`` environment variable.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import urllib.request
+from pathlib import Path
+
+from pyramids.feature import FeatureCollection
+
+# layer name -> (Natural Earth category, dataset suffix). The dataset stem is
+# ``ne_{resolution}_{suffix}`` and the category selects the CDN sub-path.
+_LAYERS: dict[str, tuple[str, str]] = {
+    "coastline": ("physical", "coastline"),
+    "land": ("physical", "land"),
+    "ocean": ("physical", "ocean"),
+    "rivers": ("physical", "rivers_lake_centerlines"),
+    "lakes": ("physical", "lakes"),
+    "borders": ("cultural", "admin_0_boundary_lines_land"),
+}
+
+_RESOLUTIONS = ("110m", "50m", "10m")
+
+_BASE_URL = "https://naciscdn.org/naturalearth"
+
+
+def available_layers() -> list[str]:
+    """List the Natural Earth layer names :func:`natural_earth` accepts.
+
+    Returns:
+        Sorted list of supported ``layer`` values.
+
+    Examples:
+        - Check which layers are available:
+            ```python
+            >>> from pyramids.basemap.features import available_layers
+            >>> "coastline" in available_layers()
+            True
+            >>> "borders" in available_layers()
+            True
+
+            ```
+    """
+    return sorted(_LAYERS.keys())
+
+
+def available_resolutions() -> list[str]:
+    """List the Natural Earth resolutions :func:`natural_earth` accepts.
+
+    Returns:
+        The supported ``resolution`` values, coarsest first.
+
+    Examples:
+        - Resolutions follow Natural Earth's scale naming:
+            ```python
+            >>> from pyramids.basemap.features import available_resolutions
+            >>> available_resolutions()
+            ['110m', '50m', '10m']
+
+            ```
+    """
+    return list(_RESOLUTIONS)
+
+
+def _dataset_stem(layer: str, resolution: str) -> str:
+    """Return the Natural Earth dataset stem, e.g. ``ne_110m_coastline``."""
+    _, suffix = _LAYERS[layer]
+    return f"ne_{resolution}_{suffix}"
+
+
+def _download_url(layer: str, resolution: str) -> str:
+    """Build the Natural Earth CDN download URL for a layer/resolution."""
+    category, _ = _LAYERS[layer]
+    stem = _dataset_stem(layer, resolution)
+    return f"{_BASE_URL}/{resolution}/{category}/{stem}.zip"
+
+
+def _cache_dir() -> Path:
+    """Return the directory used to cache downloaded Natural Earth archives.
+
+    Honors the ``PYRAMIDS_CACHE_DIR`` environment variable; otherwise defaults to
+    ``~/.pyramids/naturalearth``. The directory is created if missing.
+    """
+    override = os.environ.get("PYRAMIDS_CACHE_DIR")
+    root = Path(override) if override else Path.home() / ".pyramids"
+    cache = root / "naturalearth"
+    cache.mkdir(parents=True, exist_ok=True)
+    return cache
+
+
+def _download(url: str, destination: Path) -> None:
+    """Download ``url`` to ``destination`` atomically via a temporary file.
+
+    Raises:
+        ValueError: ``url`` is not an HTTP(S) URL.
+        OSError: The download failed (network error, HTTP error, etc.). The original
+            error is chained so the cause is preserved.
+    """
+    if not url.lower().startswith(("http://", "https://")):
+        raise ValueError(f"refusing to download from non-HTTP(S) URL: {url!r}")
+    request = urllib.request.Request(url, headers={"User-Agent": "pyramids-gis"})
+    try:
+        # scheme restricted to http(s) by the guard above
+        with urllib.request.urlopen(request) as response:  # noqa: S310  # nosec B310
+            fd, tmp_name = tempfile.mkstemp(suffix=".zip", dir=str(destination.parent))
+            os.close(fd)
+            tmp_path = Path(tmp_name)
+            with open(tmp_path, "wb") as handle:
+                shutil.copyfileobj(response, handle)
+    except OSError as exc:
+        raise OSError(
+            f"failed to download Natural Earth data from {url!r}: {exc}. Check the "
+            "network connection, or download the archive manually into the cache "
+            f"directory ({destination.parent})."
+        ) from exc
+    tmp_path.replace(destination)
+
+
+def _ensure_cached(layer: str, resolution: str) -> Path:
+    """Return the local cached zip for a layer/resolution, downloading if absent."""
+    stem = _dataset_stem(layer, resolution)
+    archive = _cache_dir() / f"{stem}.zip"
+    if not archive.exists():
+        _download(_download_url(layer, resolution), archive)
+    return archive
+
+
+def natural_earth(
+    layer: str = "coastline",
+    resolution: str = "110m",
+) -> FeatureCollection:
+    """Load a Natural Earth vector layer as a pyramids :class:`FeatureCollection`.
+
+    The layer is downloaded from the Natural Earth CDN on first use and cached
+    locally (see :func:`_cache_dir`); subsequent calls read straight from the cache.
+
+    Args:
+        layer: One of :func:`available_layers` — ``"coastline"``, ``"borders"``,
+            ``"land"``, ``"ocean"``, ``"rivers"``, or ``"lakes"``.
+        resolution: One of :func:`available_resolutions` — ``"110m"`` (coarsest),
+            ``"50m"``, or ``"10m"`` (finest).
+
+    Returns:
+        A :class:`~pyramids.feature.FeatureCollection` of the layer geometry, ready to
+        draw (e.g. via cleopatra) without any GIS code in the caller.
+
+    Raises:
+        ValueError: ``layer`` or ``resolution`` is not supported.
+        OSError: The layer is not cached and the download failed.
+
+    Examples:
+        - Unknown layers are rejected with the list of valid names:
+            ```python
+            >>> from pyramids.basemap.features import natural_earth
+            >>> try:
+            ...     natural_earth("countries")
+            ... except ValueError as exc:
+            ...     print("unknown Natural Earth layer" in str(exc))
+            True
+
+            ```
+        - Fetch coastlines (downloads on first use, then reads from cache):
+            ```python
+            >>> from pyramids.basemap.features import natural_earth
+            >>> fc = natural_earth("coastline", resolution="110m")  # doctest: +SKIP
+            >>> len(fc)  # doctest: +SKIP
+            134
+
+            ```
+    """
+    if layer not in _LAYERS:
+        raise ValueError(
+            f"unknown Natural Earth layer {layer!r}; choose from {available_layers()}."
+        )
+    if resolution not in _RESOLUTIONS:
+        raise ValueError(
+            f"unknown Natural Earth resolution {resolution!r}; choose from "
+            f"{list(_RESOLUTIONS)}."
+        )
+
+    archive = _ensure_cached(layer, resolution)
+    stem = _dataset_stem(layer, resolution)
+    result = FeatureCollection.read_file(f"{archive}/{stem}.shp")
+    return result

--- a/src/pyramids/basemap/features.py
+++ b/src/pyramids/basemap/features.py
@@ -22,7 +22,7 @@ import urllib.request
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from pyramids._io import _archive_dir_vsi, _archive_members
+from pyramids._io import _archive_dir_vsi, _archive_members, silent_unlink
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from pyramids.feature import FeatureCollection
@@ -118,21 +118,23 @@ def _download(url: str, destination: Path) -> None:
     if not url.lower().startswith(("http://", "https://")):
         raise ValueError(f"refusing to download from non-HTTP(S) URL: {url!r}")
     request = urllib.request.Request(url, headers={"User-Agent": "pyramids-gis"})
+    fd, tmp_name = tempfile.mkstemp(suffix=".zip", dir=str(destination.parent))
+    os.close(fd)
+    tmp_path = Path(tmp_name)
     try:
         # scheme restricted to http(s) by the guard above
         with urllib.request.urlopen(request) as response:  # noqa: S310  # nosec B310
-            fd, tmp_name = tempfile.mkstemp(suffix=".zip", dir=str(destination.parent))
-            os.close(fd)
-            tmp_path = Path(tmp_name)
             with open(tmp_path, "wb") as handle:
                 shutil.copyfileobj(response, handle)
+        tmp_path.replace(destination)
     except OSError as exc:
+        # Don't leave a partial/empty temp archive behind on a failed download.
+        silent_unlink(str(tmp_path))
         raise OSError(
             f"failed to download Natural Earth data from {url!r}: {exc}. Check the "
             "network connection, or download the archive manually into the cache "
             f"directory ({destination.parent})."
         ) from exc
-    tmp_path.replace(destination)
 
 
 def _ensure_cached(layer: str, resolution: str) -> Path:

--- a/src/pyramids/basemap/features.py
+++ b/src/pyramids/basemap/features.py
@@ -20,8 +20,10 @@ import shutil
 import tempfile
 import urllib.request
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from pyramids.feature import FeatureCollection
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from pyramids.feature import FeatureCollection
 
 # layer name -> (Natural Earth category, dataset suffix). The dataset stem is
 # ``ne_{resolution}_{suffix}`` and the category selects the CDN sub-path.
@@ -192,6 +194,10 @@ def natural_earth(
             f"unknown Natural Earth resolution {resolution!r}; choose from "
             f"{list(_RESOLUTIONS)}."
         )
+
+    # Local import breaks the import cycle pyramids.feature.collection ->
+    # pyramids.basemap (add_basemap) -> pyramids.basemap.features -> pyramids.feature.
+    from pyramids.feature import FeatureCollection
 
     archive = _ensure_cached(layer, resolution)
     stem = _dataset_stem(layer, resolution)

--- a/src/pyramids/basemap/features.py
+++ b/src/pyramids/basemap/features.py
@@ -22,6 +22,8 @@ import urllib.request
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from pyramids._io import _archive_dir_vsi, _archive_members
+
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from pyramids.feature import FeatureCollection
 
@@ -164,6 +166,7 @@ def natural_earth(
     Raises:
         ValueError: ``layer`` or ``resolution`` is not supported.
         OSError: The layer is not cached and the download failed.
+        FileNotFoundError: The cached archive contains no ``.shp`` member.
 
     Examples:
         - Unknown layers are rejected with the list of valid names:
@@ -200,6 +203,11 @@ def natural_earth(
     from pyramids.feature import FeatureCollection
 
     archive = _ensure_cached(layer, resolution)
-    stem = _dataset_stem(layer, resolution)
-    result = FeatureCollection.read_file(f"{archive}/{stem}.shp")
+    # Pick the shapefile from the archive by listing its members rather than assuming
+    # a fixed name, so the read is robust to Natural Earth archive-layout differences.
+    # Prefer the conventional ``ne_{res}_{name}.shp`` stem when present.
+    shp_members = _archive_members(_archive_dir_vsi(archive, "zip"), "*.shp")
+    preferred = f"{_dataset_stem(layer, resolution)}.shp"
+    member = preferred if preferred in shp_members else shp_members[0]
+    result = FeatureCollection.read_file(f"{archive}/{member}")
     return result

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -1629,7 +1629,10 @@ class Dataset(RasterBase):
         """Longitude / x cell-centre coordinates.
 
         Uses the geotransform's pixel width (``geotransform[1]``) so the axis is
-        correct even when cells are not square (pixel width != pixel height).
+        correct even when cells are not square (pixel width != pixel height). Reads the
+        cached ``_geotransform`` (like :attr:`top_left_corner`) rather than the
+        ``geotransform`` property, so subclasses that derive ``geotransform`` from
+        ``lon``/``lat`` (e.g. :class:`~pyramids.netcdf.NetCDF`) do not recurse.
 
         Examples:
             - Read the column-centre longitudes of a small raster:
@@ -1648,7 +1651,7 @@ class Dataset(RasterBase):
             - Dataset.x: Dataset x coordinates.
             - Dataset.lat: Dataset latitude.
         """
-        pixel_width = self.geotransform[1]
+        pixel_width = self._geotransform[1]
         x_coords = self.get_x_lon_dimension_array(
             self.top_left_corner[0], pixel_width, self.columns
         )
@@ -1660,7 +1663,10 @@ class Dataset(RasterBase):
 
         Uses the geotransform's pixel height (``abs(geotransform[5])``) rather than
         :attr:`cell_size` (which only tracks pixel width), so the axis is correct for
-        non-square cells.
+        non-square cells. Reads the cached ``_geotransform`` (like
+        :attr:`top_left_corner`) rather than the ``geotransform`` property, so
+        subclasses that derive ``geotransform`` from ``lon``/``lat`` (e.g.
+        :class:`~pyramids.netcdf.NetCDF`) do not recurse.
 
         Examples:
             - Row-centre latitudes decrease from north to south:
@@ -1692,7 +1698,7 @@ class Dataset(RasterBase):
             - Dataset.y: Dataset y coordinates.
             - Dataset.lon: Dataset longitude.
         """
-        pixel_height = abs(self.geotransform[5])
+        pixel_height = abs(self._geotransform[5])
         y_coords = self.get_y_lat_dimension_array(
             self.top_left_corner[1], pixel_height, self.rows
         )

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -1626,53 +1626,122 @@ class Dataset(RasterBase):
 
     @property
     def lon(self) -> np.ndarray:
-        """Longitude coordinates.
+        """Longitude / x cell-centre coordinates.
+
+        Uses the geotransform's pixel width (``geotransform[1]``) so the axis is
+        correct even when cells are not square (pixel width != pixel height).
+
+        Examples:
+            - Read the column-centre longitudes of a small raster:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_from_array(
+                ...     np.zeros((2, 3)), top_left_corner=(0.0, 0.0), cell_size=0.5, epsg=4326,
+                ... )
+                >>> ds.lon.tolist()
+                [0.25, 0.75, 1.25]
+
+                ```
 
         See Also:
             - Dataset.x: Dataset x coordinates.
             - Dataset.lat: Dataset latitude.
         """
+        pixel_width = self.geotransform[1]
         x_coords = self.get_x_lon_dimension_array(
-            self.top_left_corner[0], self.cell_size, self.columns
+            self.top_left_corner[0], pixel_width, self.columns
         )
         return x_coords
 
     @property
     def lat(self) -> np.ndarray:
-        """Latitude-coordinate.
+        """Latitude / y cell-centre coordinates.
+
+        Uses the geotransform's pixel height (``abs(geotransform[5])``) rather than
+        :attr:`cell_size` (which only tracks pixel width), so the axis is correct for
+        non-square cells.
+
+        Examples:
+            - Row-centre latitudes decrease from north to south:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_from_array(
+                ...     np.zeros((2, 3)), top_left_corner=(0.0, 0.0), cell_size=0.5, epsg=4326,
+                ... )
+                >>> ds.lat.tolist()
+                [-0.25, -0.75]
+
+                ```
+            - With non-square cells the latitude axis uses the pixel height, not the
+              pixel width:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_from_array(
+                ...     np.zeros((2, 3)), geo=(10.0, 2.0, 0.0, 50.0, 0.0, -1.0), epsg=4326,
+                ... )
+                >>> ds.lat.tolist()
+                [49.5, 48.5]
+
+                ```
 
         See Also:
             - Dataset.x: Dataset x coordinates.
             - Dataset.y: Dataset y coordinates.
             - Dataset.lon: Dataset longitude.
         """
+        pixel_height = abs(self.geotransform[5])
         y_coords = self.get_y_lat_dimension_array(
-            self.top_left_corner[1], self.cell_size, self.rows
+            self.top_left_corner[1], pixel_height, self.rows
         )
         return y_coords
 
     @property
     def x(self) -> np.ndarray:
-        """X-coordinate/Longitude.
+        """X cell-centre coordinates (alias of :attr:`lon`).
+
+        Examples:
+            - x mirrors lon for the same raster:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_from_array(
+                ...     np.zeros((2, 3)), top_left_corner=(0.0, 0.0), cell_size=0.5, epsg=4326,
+                ... )
+                >>> ds.x.tolist()
+                [0.25, 0.75, 1.25]
+
+                ```
 
         See Also:
-            - Dataset.lat: Dataset latitude.
+            - Dataset.lon: the longitude axis this property aliases.
             - Dataset.y: Dataset y coordinates.
-            - Dataset.lon: Dataset longitude.
         """
-        # X_coordinate = upper-left corner x + index * cell size + cell-size/2
         return self.lon
 
     @property
     def y(self) -> np.ndarray:
-        """Y-coordinate/Latitude.
+        """Y cell-centre coordinates (alias of :attr:`lat`).
+
+        Examples:
+            - y mirrors lat for the same raster:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_from_array(
+                ...     np.zeros((2, 3)), top_left_corner=(0.0, 0.0), cell_size=0.5, epsg=4326,
+                ... )
+                >>> ds.y.tolist()
+                [-0.25, -0.75]
+
+                ```
 
         See Also:
-            - Dataset.x: Dataset y coordinates.
-            - Dataset.lat: Dataset latitude.
-            - Dataset.lon: Dataset longitude.
+            - Dataset.lat: the latitude axis this property aliases.
+            - Dataset.x: Dataset x coordinates.
         """
-        # Y_coordinate = upper-left corner y - index * cell size - cell-size/2
         return self.lat
 
     @property

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -53,6 +53,7 @@ from pyramids.dataset.ops._zarr import (
 )
 from pyramids.dataset.ops._zonal import zonal_stats as _zonal_stats
 from pyramids.dataset.ops.interpolate import grid_points
+from pyramids.dataset.ops.units import convert_array
 from pyramids.dataset.ops.vectorize import rasterize_features
 from pyramids.feature import FeatureCollection, create_polygon
 
@@ -104,7 +105,7 @@ def _derive_band_names(paths: list[str]) -> list[str]:
     return names
 
 
-def _same_grid(a: "Dataset", b: "Dataset") -> bool:
+def _same_grid(a: Dataset, b: Dataset) -> bool:
     """Return True if datasets ``a`` and ``b`` share CRS, size, and geotransform.
 
     Geotransform components are compared with a small relative tolerance so
@@ -1293,6 +1294,96 @@ class Dataset(RasterBase):
         self._band_units = value
         for i, val in enumerate(value):
             self._iloc(i).SetUnitType(val)
+
+    def convert_units(self, target: str, band: int | None = None) -> Dataset:
+        """Convert band values to ``target`` units, returning a new Dataset.
+
+        Unlike the :attr:`band_units` setter — which only relabels bands — this
+        actually transforms the stored values using a small affine conversion table
+        (see :func:`pyramids.dataset.ops.units.convert_array`) and records the new
+        unit on the result. No-data cells are preserved unchanged. The output is a
+        new in-memory ``float64`` Dataset; the source is left untouched.
+
+        Args:
+            target: Target unit label (e.g. ``"celsius"``, ``"hPa"``, ``"knots"``).
+            band: Zero-based band index to convert. ``None`` (default) converts every
+                band; bands already in ``target`` units are passed through unchanged.
+
+        Returns:
+            A new :class:`Dataset` with converted values and updated
+            :attr:`band_units`.
+
+        Raises:
+            ValueError: ``band`` is out of range, a converted band has no source unit
+                set, or the ``(source, target)`` pair is unsupported.
+
+        Examples:
+            - Convert a Kelvin raster to Celsius and read the new values:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_from_array(
+                ...     np.array([[273.15, 283.15], [293.15, 303.15]]),
+                ...     top_left_corner=(0, 0), cell_size=1.0, epsg=4326,
+                ... )
+                >>> ds.band_units = ["K"]
+                >>> converted = ds.convert_units("celsius")
+                >>> converted.read_array().tolist()
+                [[0.0, 10.0], [20.0, 30.0]]
+                >>> converted.band_units
+                ['celsius']
+
+                ```
+            - An unsupported target raises a clear error:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_from_array(
+                ...     np.array([[273.15]]), top_left_corner=(0, 0), cell_size=1.0, epsg=4326,
+                ... )
+                >>> ds.band_units = ["K"]
+                >>> try:
+                ...     ds.convert_units("furlongs")
+                ... except ValueError as exc:
+                ...     print("No unit conversion" in str(exc))
+                True
+
+                ```
+        """
+        if band is not None and not 0 <= band < self.band_count:
+            raise ValueError(
+                f"band {band} is out of range for a {self.band_count}-band dataset."
+            )
+
+        band_indices = range(self.band_count) if band is None else [band]
+        source_units = list(self.band_units)
+        new_units = list(self.band_units)
+
+        full = self.read_array()
+        single_band = self.band_count == 1
+        stack = full[np.newaxis, ...] if single_band else full
+        out = stack.astype("float64").copy()
+        no_data = self.no_data_value
+
+        for index in band_indices:
+            layer = out[index]
+            nodata_value = no_data[index]
+            mask = layer == nodata_value if nodata_value is not None else None
+            converted = convert_array(layer, source_units[index], target)
+            if mask is not None:
+                converted[mask] = nodata_value
+            out[index] = converted
+            new_units[index] = target
+
+        result_array = out[0] if single_band else out
+        result = self.create_from_array(
+            result_array,
+            geo=self.geotransform,
+            epsg=self.epsg,
+            no_data_value=list(no_data),
+        )
+        result.band_units = new_units
+        return result
 
     @property
     def no_data_value(self) -> tuple:

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -17,6 +17,7 @@ from osgeo import gdal, osr
 from pyramids.base._domain import is_no_data
 from pyramids.base._utils import INTERPOLATION_METHODS
 from pyramids.base.crs import (
+    epsg_from_user_input,
     epsg_from_wkt,
     reproject_coordinates,
     sr_from_epsg,
@@ -79,7 +80,7 @@ class Spatial(_Engine):
 
     def to_crs(
         self,
-        to_epsg: int,
+        to_epsg: int | str | Any,
         method: str = "nearest neighbor",
         maintain_alignment: bool = False,
     ) -> Dataset:
@@ -88,9 +89,11 @@ class Spatial(_Engine):
             (default the WGS84 web mercator projection, without resampling)
 
         Args:
-            to_epsg (int):
-                reference number to the new projection (https://epsg.io/). Default 3857 is the reference number of WGS84
-                web mercator.
+            to_epsg (int | str | pyproj.CRS):
+                The target CRS. Most commonly an EPSG reference number (https://epsg.io/),
+                e.g. ``3857`` for WGS84 web mercator. A string (``"EPSG:3857"``, ``"3857"``,
+                a WKT or PROJ4 string) or a :class:`pyproj.CRS` is also accepted and resolved
+                to its EPSG code via :func:`pyramids.base.crs.epsg_from_user_input`.
             method (str):
                 resampling method. Default is "nearest neighbor". See https://gisgeography.com/raster-resampling/.
                 Allowed values: "nearest neighbor", "cubic", "bilinear".
@@ -101,6 +104,15 @@ class Spatial(_Engine):
         Returns:
             Dataset:
                 A new reprojected Dataset.
+
+        Raises:
+            CRSError:
+                ``to_epsg`` cannot be interpreted as a CRS, or resolves to a CRS with no
+                EPSG code.
+            TypeError:
+                ``method`` is not a string.
+            ValueError:
+                ``method`` is not one of the supported interpolation methods.
 
         Examples:
             - Create a dataset and reproject it:
@@ -146,11 +158,7 @@ class Spatial(_Engine):
               ```
 
         """
-        if not isinstance(to_epsg, int):
-            raise TypeError(
-                "please enter correct integer number for to_epsg more information "
-                f"https://epsg.io/, given {type(to_epsg)}"
-            )
+        to_epsg = epsg_from_user_input(to_epsg)
         if not isinstance(method, str):
             raise TypeError(
                 "Please enter a correct method, for more information, see documentation "

--- a/src/pyramids/dataset/ops/units.py
+++ b/src/pyramids/dataset/ops/units.py
@@ -1,0 +1,111 @@
+"""Affine unit conversion for raster band values.
+
+Backs :meth:`pyramids.dataset.Dataset.convert_units`. Rather than pulling in a
+general unit-conversion dependency, pyramids ships a small affine lookup table for
+the common meteorological/geophysical conversions (each entry is a ``(scale, offset)``
+pair applied as ``value * scale + offset``). Extend :data:`_AFFINE` as new pairs are
+needed. No new third-party dependencies.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+# (source_unit, target_unit) -> (scale, offset); value_out = value_in * scale + offset.
+# Reverse directions are listed explicitly so round-trips are exact.
+_AFFINE: dict[tuple[str, str], tuple[float, float]] = {
+    ("K", "celsius"): (1.0, -273.15),
+    ("celsius", "K"): (1.0, 273.15),
+    ("m s-1", "knots"): (1.943844, 0.0),
+    ("knots", "m s-1"): (1.0 / 1.943844, 0.0),
+    ("Pa", "hPa"): (0.01, 0.0),
+    ("hPa", "Pa"): (100.0, 0.0),
+    ("m", "mm"): (1000.0, 0.0),
+    ("mm", "m"): (0.001, 0.0),
+}
+
+
+def supported_conversions() -> list[tuple[str, str]]:
+    """List the ``(source, target)`` unit pairs the affine table can convert.
+
+    Returns:
+        A sorted list of ``(source_unit, target_unit)`` tuples accepted by
+        :func:`convert_array`.
+
+    Examples:
+        - Inspect a few of the supported pairs:
+            ```python
+            >>> from pyramids.dataset.ops.units import supported_conversions
+            >>> pairs = supported_conversions()
+            >>> ("K", "celsius") in pairs
+            True
+            >>> ("Pa", "hPa") in pairs
+            True
+
+            ```
+    """
+    return sorted(_AFFINE.keys())
+
+
+def convert_array(array: np.ndarray, source: str, target: str) -> np.ndarray:
+    """Convert an array of values from ``source`` units to ``target`` units.
+
+    Args:
+        array: Values to convert.
+        source: Source unit label (e.g. ``"K"``). Must be non-empty.
+        target: Target unit label (e.g. ``"celsius"``).
+
+    Returns:
+        A new array of converted values. When ``source == target`` the input is
+        returned unchanged.
+
+    Raises:
+        ValueError: ``source`` is empty (no unit to convert from), or the
+            ``(source, target)`` pair is not in the affine table.
+
+    Examples:
+        - Convert Kelvin to Celsius:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.dataset.ops.units import convert_array
+            >>> convert_array(np.array([273.15, 283.15]), "K", "celsius").tolist()
+            [0.0, 10.0]
+
+            ```
+        - Converting to the same unit is a no-op:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.dataset.ops.units import convert_array
+            >>> convert_array(np.array([5.0]), "Pa", "Pa").tolist()
+            [5.0]
+
+            ```
+        - An unknown pair is rejected:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.dataset.ops.units import convert_array
+            >>> try:
+            ...     convert_array(np.array([1.0]), "K", "furlongs")
+            ... except ValueError as exc:
+            ...     print("No unit conversion" in str(exc))
+            True
+
+            ```
+    """
+    if not source:
+        raise ValueError(
+            f"cannot convert a band with no source unit to {target!r}; set "
+            "band_units on the dataset before calling convert_units."
+        )
+    if source == target:
+        result = array
+    else:
+        key = (source, target)
+        if key not in _AFFINE:
+            raise ValueError(
+                f"No unit conversion from {source!r} to {target!r}. Supported pairs: "
+                f"{supported_conversions()}."
+            )
+        scale, offset = _AFFINE[key]
+        result = array * scale + offset
+    return result

--- a/src/pyramids/grids/__init__.py
+++ b/src/pyramids/grids/__init__.py
@@ -1,0 +1,27 @@
+"""Adapters that turn exotic model grids into regular-grid :class:`~pyramids.dataset.Dataset`.
+
+Weather/ocean models emit fields on grids that are not row-major rasters: ORCA
+curvilinear ocean grids, octahedral reduced-Gaussian grids, HEALPix sphere
+pixelizations, and others. pyramids already has two regridding bridges — a mesh path
+(:func:`pyramids.netcdf.ugrid.interpolation.mesh_to_grid`) and a scattered-point path
+(:func:`pyramids.dataset.ops.interpolate.grid_points`). The adapters here turn each
+exotic grid into a mesh or point set and reuse those bridges; they do not implement a
+new regridder.
+
+- :func:`from_orca` — curvilinear ``(ny, nx)`` lon/lat → UGRID quad mesh → raster.
+- :func:`from_octahedral` — ragged per-point lat/lon → scattered points → raster.
+- :func:`from_healpix` — HEALPix pixels → raster (deferred pending the ``healpy``
+  optional dependency; currently raises :class:`NotImplementedError`).
+"""
+
+from __future__ import annotations
+
+from pyramids.grids.healpix import from_healpix
+from pyramids.grids.octahedral import from_octahedral
+from pyramids.grids.orca import from_orca
+
+__all__ = [
+    "from_healpix",
+    "from_octahedral",
+    "from_orca",
+]

--- a/src/pyramids/grids/__init__.py
+++ b/src/pyramids/grids/__init__.py
@@ -10,8 +10,9 @@ new regridder.
 
 - :func:`from_orca` — curvilinear ``(ny, nx)`` lon/lat → UGRID quad mesh → raster.
 - :func:`from_octahedral` — ragged per-point lat/lon → scattered points → raster.
-- :func:`from_healpix` — HEALPix pixels → raster (deferred pending the ``healpy``
-  optional dependency; currently raises :class:`NotImplementedError`).
+- :func:`from_healpix` — HEALPix pixels (RING or NESTED) → scattered points → raster.
+  The pixel→lon/lat math is implemented in plain NumPy, so no ``healpy`` dependency is
+  required.
 """
 
 from __future__ import annotations

--- a/src/pyramids/grids/healpix.py
+++ b/src/pyramids/grids/healpix.py
@@ -1,0 +1,73 @@
+"""Adapt a HEALPix field to a regular :class:`~pyramids.dataset.Dataset` (deferred).
+
+HEALPix (Hierarchical Equal Area isoLatitude Pixelization) stores values per pixel,
+indexed by ``nside``. Converting pixel indices to centre latitude/longitude requires
+``healpy``, which is **not yet an approved pyramids dependency**. Once approved it will
+be gated behind a ``pyramids-gis[healpix]`` optional extra and this adapter will reuse
+:func:`pyramids.dataset.ops.interpolate.grid_points` exactly like
+:func:`pyramids.grids.octahedral.from_octahedral`.
+
+Until then :func:`from_healpix` raises :class:`NotImplementedError`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from pyramids.dataset.dataset import Dataset
+
+
+def from_healpix(
+    values: np.ndarray,
+    *,
+    nside: int | None = None,
+    nest: bool = False,
+    cell_size: float,
+    method: str = "nearest",
+    epsg: int = 4326,
+) -> Dataset:
+    """Regrid a HEALPix field onto a regular-grid :class:`Dataset` (not yet implemented).
+
+    Args:
+        values: 1-D array of per-pixel HEALPix values (length ``npix``).
+        nside: HEALPix ``nside`` resolution parameter. Derived from ``len(values)``
+            when omitted.
+        nest: ``True`` for NESTED pixel ordering, ``False`` for RING.
+        cell_size: Output pixel size in the target CRS units.
+        method: Interpolation algorithm passed through to ``grid_points``.
+        epsg: Output EPSG code.
+
+    Returns:
+        A single-band :class:`~pyramids.dataset.Dataset` of the interpolated surface.
+
+    Raises:
+        NotImplementedError: Always — HEALPix support is pending approval of the
+            ``healpy`` dependency. Use :func:`pyramids.grids.from_orca` or
+            :func:`pyramids.grids.from_octahedral` for the supported grid types.
+
+    Examples:
+        - The adapter is deferred and surfaces a guiding message:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.grids import from_healpix
+            >>> try:
+            ...     from_healpix(np.zeros(12), cell_size=1.0)
+            ... except NotImplementedError as exc:
+            ...     print("healpy" in str(exc))
+            True
+
+            ```
+
+    See Also:
+        - :func:`pyramids.grids.from_octahedral`: the supported point-based adapter
+          this function will mirror once ``healpy`` is approved.
+    """
+    raise NotImplementedError(
+        "from_healpix is not implemented yet: it requires the 'healpy' package, "
+        "which is pending approval as an optional 'pyramids-gis[healpix]' extra. "
+        "Use pyramids.grids.from_orca or pyramids.grids.from_octahedral for the "
+        "currently supported grid types."
+    )

--- a/src/pyramids/grids/healpix.py
+++ b/src/pyramids/grids/healpix.py
@@ -1,23 +1,116 @@
-"""Adapt a HEALPix field to a regular :class:`~pyramids.dataset.Dataset` (deferred).
+"""Adapt a HEALPix field to a regular :class:`~pyramids.dataset.Dataset`.
 
 HEALPix (Hierarchical Equal Area isoLatitude Pixelization) stores values per pixel,
-indexed by ``nside``. Converting pixel indices to centre latitude/longitude requires
-``healpy``, which is **not yet an approved pyramids dependency**. Once approved it will
-be gated behind a ``pyramids-gis[healpix]`` optional extra and this adapter will reuse
-:func:`pyramids.dataset.ops.interpolate.grid_points` exactly like
-:func:`pyramids.grids.octahedral.from_octahedral`.
-
-Until then :func:`from_healpix` raises :class:`NotImplementedError`.
+indexed by the resolution parameter ``nside`` (so there are ``12 * nside**2`` pixels).
+Turning a HEALPix field into a raster only needs one operation: the centre
+longitude/latitude of each pixel. That mapping is the closed-form ``pix2ang`` from the
+HEALPix paper (Górski et al. 2005); it is implemented here in plain NumPy for both the
+RING and NESTED pixel orderings, so **no HEALPix C library (``healpy``) is required**.
+The pixel centres are then handed to the same scattered-point bridge
+(:func:`pyramids.dataset.ops.interpolate.grid_points`) used by
+:func:`pyramids.grids.from_octahedral`. No new third-party dependencies.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import math
 
 import numpy as np
+from geopandas import GeoDataFrame, points_from_xy
 
-if TYPE_CHECKING:  # pragma: no cover - typing only
-    from pyramids.dataset.dataset import Dataset
+from pyramids.dataset.dataset import Dataset
+from pyramids.dataset.ops.interpolate import grid_points
+
+# Per-base-face ring/phi offsets for the NESTED -> RING index conversion, matching the
+# canonical HEALPix ``xyf2ring`` tables (Górski et al. 2005).
+_JRLL = np.array([2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4], dtype=np.int64)
+_JPLL = np.array([1, 3, 5, 7, 0, 2, 4, 6, 1, 3, 5, 7], dtype=np.int64)
+
+
+def _ring_pix2lonlat(nside: int, ipix: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    """Return centre longitude/latitude (degrees) for RING-ordered pixel indices."""
+    npix = 12 * nside * nside
+    ncap = 2 * nside * (nside - 1)
+    z = np.empty(ipix.shape, dtype=np.float64)
+    phi = np.empty(ipix.shape, dtype=np.float64)
+
+    north = ipix < ncap
+    p = ipix[north]
+    ph = (p + 1) / 2.0
+    i = np.floor(np.sqrt(ph - np.sqrt(np.floor(ph)))).astype(np.int64) + 1
+    j = p + 1 - 2 * i * (i - 1)
+    z[north] = 1.0 - (i * i) / (3.0 * nside * nside)
+    phi[north] = (j - 0.5) * (np.pi / 2.0) / i
+
+    equator = (ipix >= ncap) & (ipix < npix - ncap)
+    p = ipix[equator] - ncap
+    i = (p // (4 * nside)) + nside
+    j = (p % (4 * nside)) + 1
+    shift = (i - nside + 1) % 2
+    z[equator] = (2 * nside - i) * (2.0 / (3.0 * nside))
+    phi[equator] = (j - shift / 2.0) * (np.pi / 2.0) / nside
+
+    south = ipix >= npix - ncap
+    p = npix - 1 - ipix[south]
+    ph = (p + 1) / 2.0
+    i = np.floor(np.sqrt(ph - np.sqrt(np.floor(ph)))).astype(np.int64) + 1
+    j = p + 1 - 2 * i * (i - 1)
+    z[south] = -(1.0 - (i * i) / (3.0 * nside * nside))
+    phi[south] = (j - 0.5) * (np.pi / 2.0) / i
+
+    lon = np.degrees(phi) % 360.0
+    lat = np.degrees(np.arcsin(z))
+    return lon, lat
+
+
+def _nest2ring(nside: int, ipix: np.ndarray) -> np.ndarray:
+    """Convert NESTED-ordered pixel indices to RING-ordered indices."""
+    order = int(round(math.log2(nside)))
+    npix = 12 * nside * nside
+    ncap = 2 * nside * (nside - 1)
+    nl4 = 4 * nside
+
+    face = ipix >> (2 * order)
+    in_face = ipix & (nside * nside - 1)
+    ix = np.zeros_like(in_face)
+    iy = np.zeros_like(in_face)
+    for bit in range(order):
+        ix |= ((in_face >> (2 * bit)) & 1) << bit
+        iy |= ((in_face >> (2 * bit + 1)) & 1) << bit
+
+    jr = _JRLL[face] * nside - ix - iy - 1
+    nr = np.empty_like(jr)
+    n_before = np.empty_like(jr)
+    kshift = np.empty_like(jr)
+
+    north = jr < nside
+    nr[north] = jr[north]
+    n_before[north] = 2 * nr[north] * (nr[north] - 1)
+    kshift[north] = 0
+
+    south = jr > 3 * nside
+    nr[south] = nl4 - jr[south]
+    n_before[south] = npix - 2 * (nr[south] + 1) * nr[south]
+    kshift[south] = 0
+
+    equator = (~north) & (~south)
+    nr[equator] = nside
+    n_before[equator] = ncap + (jr[equator] - nside) * nl4
+    kshift[equator] = (jr[equator] - nside) & 1
+
+    jp = (_JPLL[face] * nr + ix - iy + 1 + kshift) // 2
+    jp = np.where(jp > nl4, jp - nl4, jp)
+    jp = np.where(jp < 1, jp + nl4, jp)
+    ring: np.ndarray = n_before + jp - 1
+    return ring
+
+
+def _pix2lonlat(
+    nside: int, ipix: np.ndarray, nest: bool
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return centre longitude/latitude (degrees) for pixel indices in either ordering."""
+    ring_ipix = _nest2ring(nside, ipix) if nest else ipix
+    return _ring_pix2lonlat(nside, ring_ipix)
 
 
 def from_healpix(
@@ -29,45 +122,95 @@ def from_healpix(
     method: str = "nearest",
     epsg: int = 4326,
 ) -> Dataset:
-    """Regrid a HEALPix field onto a regular-grid :class:`Dataset` (not yet implemented).
+    """Regrid a HEALPix field onto a regular-grid :class:`Dataset`.
+
+    Each HEALPix pixel's centre longitude/latitude is computed in plain NumPy (no
+    ``healpy`` dependency) and the resulting points are interpolated with ``gdal.Grid``
+    via :func:`~pyramids.dataset.ops.interpolate.grid_points`.
 
     Args:
-        values: 1-D array of per-pixel HEALPix values (length ``npix``).
-        nside: HEALPix ``nside`` resolution parameter. Derived from ``len(values)``
-            when omitted.
-        nest: ``True`` for NESTED pixel ordering, ``False`` for RING.
-        cell_size: Output pixel size in the target CRS units.
-        method: Interpolation algorithm passed through to ``grid_points``.
+        values: 1-D array of per-pixel HEALPix values, length ``12 * nside**2``.
+        nside: HEALPix resolution parameter. Derived from ``len(values)`` when omitted.
+        nest: ``True`` for NESTED pixel ordering, ``False`` (default) for RING.
+        cell_size: Output pixel size in the target CRS units (degrees for EPSG:4326).
+        method: A ``gdal.Grid`` algorithm string (e.g. ``"nearest"``, ``"linear"``,
+            ``"invdist:power=2.0:smoothing=0.0"``).
         epsg: Output EPSG code.
 
     Returns:
         A single-band :class:`~pyramids.dataset.Dataset` of the interpolated surface.
 
     Raises:
-        NotImplementedError: Always — HEALPix support is pending approval of the
-            ``healpy`` dependency. Use :func:`pyramids.grids.from_orca` or
-            :func:`pyramids.grids.from_octahedral` for the supported grid types.
+        ValueError: ``values`` is not 1-D; ``len(values)`` is not a valid HEALPix pixel
+            count (``12 * nside**2``); ``nside`` disagrees with ``len(values)``; or
+            ``nest=True`` with an ``nside`` that is not a power of two.
 
     Examples:
-        - The adapter is deferred and surfaces a guiding message:
+        - Regrid a synthetic ``nside=1`` field (12 pixels) and inspect the raster:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.grids import from_healpix
+            >>> ds = from_healpix(np.arange(12.0), cell_size=30.0)
+            >>> ds.band_count
+            1
+            >>> ds.epsg
+            4326
+
+            ```
+        - NESTED ordering is supported and requires a power-of-two ``nside``:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.grids import from_healpix
+            >>> ds = from_healpix(np.arange(48.0), nside=2, nest=True, cell_size=20.0)
+            >>> ds.band_count
+            1
+
+            ```
+        - A length that is not a valid HEALPix pixel count is rejected:
             ```python
             >>> import numpy as np
             >>> from pyramids.grids import from_healpix
             >>> try:
-            ...     from_healpix(np.zeros(12), cell_size=1.0)
-            ... except NotImplementedError as exc:
-            ...     print("healpy" in str(exc))
+            ...     from_healpix(np.zeros(10), cell_size=30.0)
+            ... except ValueError as exc:
+            ...     print("valid HEALPix pixel count" in str(exc))
             True
 
             ```
 
     See Also:
-        - :func:`pyramids.grids.from_octahedral`: the supported point-based adapter
-          this function will mirror once ``healpy`` is approved.
+        - :func:`pyramids.grids.from_octahedral`: the sibling point-based adapter this
+          function delegates to via ``grid_points``.
     """
-    raise NotImplementedError(
-        "from_healpix is not implemented yet: it requires the 'healpy' package, "
-        "which is pending approval as an optional 'pyramids-gis[healpix]' extra. "
-        "Use pyramids.grids.from_orca or pyramids.grids.from_octahedral for the "
-        "currently supported grid types."
+    values = np.asarray(values, dtype=np.float64).ravel()
+    npix = values.size
+
+    if nside is None:
+        derived = int(math.isqrt(npix // 12))
+        if derived < 1 or 12 * derived * derived != npix:
+            raise ValueError(
+                f"values length {npix} is not a valid HEALPix pixel count "
+                "(12 * nside**2); pass an explicit nside if this is intentional."
+            )
+        nside = derived
+    elif nside < 1 or 12 * nside * nside != npix:
+        raise ValueError(
+            f"nside={nside} implies {12 * (nside or 0) ** 2} pixels but values has "
+            f"{npix}; they must be a valid HEALPix pair (12 * nside**2)."
+        )
+
+    if nest and (nside & (nside - 1)) != 0:
+        raise ValueError(
+            f"NESTED ordering requires nside to be a power of two; got nside={nside}."
+        )
+
+    lon, lat = _pix2lonlat(nside, np.arange(npix), nest)
+    gdf = GeoDataFrame(
+        {"z": values},
+        geometry=points_from_xy(lon, lat),
+        crs=epsg,
     )
+    result = grid_points(
+        gdf, "z", Dataset, algorithm=method, cell_size=cell_size, epsg=epsg
+    )
+    return result

--- a/src/pyramids/grids/healpix.py
+++ b/src/pyramids/grids/healpix.py
@@ -1,11 +1,11 @@
 """Adapt a HEALPix field to a regular :class:`~pyramids.dataset.Dataset`.
 
 HEALPix (Hierarchical Equal Area isoLatitude Pixelization) stores values per pixel,
-indexed by the resolution parameter ``nside`` (so there are ``12 * nside**2`` pixels).
+indexed by the resolution parameter `nside` (so there are `12 * nside**2` pixels).
 Turning a HEALPix field into a raster only needs one operation: the centre
-longitude/latitude of each pixel. That mapping is the closed-form ``pix2ang`` from the
+longitude/latitude of each pixel. That mapping is the closed-form `pix2ang` from the
 HEALPix paper (Górski et al. 2005); it is implemented here in plain NumPy for both the
-RING and NESTED pixel orderings, so **no HEALPix C library (``healpy``) is required**.
+RING and NESTED pixel orderings, so **no HEALPix C library (`healpy`) is required**.
 The pixel centres are then handed to the same scattered-point bridge
 (:func:`pyramids.dataset.ops.interpolate.grid_points`) used by
 :func:`pyramids.grids.from_octahedral`. No new third-party dependencies.
@@ -22,7 +22,7 @@ from pyramids.dataset.dataset import Dataset
 from pyramids.dataset.ops.interpolate import grid_points
 
 # Per-base-face ring/phi offsets for the NESTED -> RING index conversion, matching the
-# canonical HEALPix ``xyf2ring`` tables (Górski et al. 2005).
+# canonical HEALPix `xyf2ring` tables (Górski et al. 2005).
 _JRLL = np.array([2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4], dtype=np.int64)
 _JPLL = np.array([1, 3, 5, 7, 0, 2, 4, 6, 1, 3, 5, 7], dtype=np.int64)
 
@@ -121,32 +121,36 @@ def from_healpix(
     cell_size: float,
     method: str = "nearest",
     epsg: int = 4326,
+    bbox: tuple[float, float, float, float] | None = None,
 ) -> Dataset:
     """Regrid a HEALPix field onto a regular-grid :class:`Dataset`.
 
     Each HEALPix pixel's centre longitude/latitude is computed in plain NumPy (no
-    ``healpy`` dependency) and the resulting points are interpolated with ``gdal.Grid``
+    `healpy` dependency) and the resulting points are interpolated with `gdal.Grid`
     via :func:`~pyramids.dataset.ops.interpolate.grid_points`.
 
     Args:
-        values: 1-D array of per-pixel HEALPix values, length ``12 * nside**2``.
-        nside: HEALPix resolution parameter. Derived from ``len(values)`` when omitted.
-        nest: ``True`` for NESTED pixel ordering, ``False`` (default) for RING.
+        values: 1-D array of per-pixel HEALPix values, length `12 * nside**2`.
+        nside: HEALPix resolution parameter. Derived from `len(values)` when omitted.
+        nest: `True` for NESTED pixel ordering, `False` (default) for RING.
         cell_size: Output pixel size in the target CRS units (degrees for EPSG:4326).
-        method: A ``gdal.Grid`` algorithm string (e.g. ``"nearest"``, ``"linear"``,
-            ``"invdist:power=2.0:smoothing=0.0"``).
+        method: A `gdal.Grid` algorithm string (e.g. `"nearest"`, `"linear"`,
+            `"invdist:power=2.0:smoothing=0.0"`).
         epsg: Output EPSG code.
+        bbox: Optional `(minx, miny, maxx, maxy)` output extent in the target CRS.
+            Defaults to the pixel-centres' bounding box; pass e.g.
+            `(-180, -90, 180, 90)` to pin a fixed global grid.
 
     Returns:
         A single-band :class:`~pyramids.dataset.Dataset` of the interpolated surface.
 
     Raises:
-        ValueError: ``values`` is not 1-D; ``len(values)`` is not a valid HEALPix pixel
-            count (``12 * nside**2``); ``nside`` disagrees with ``len(values)``; or
-            ``nest=True`` with an ``nside`` that is not a power of two.
+        ValueError: `values` is not 1-D; `len(values)` is not a valid HEALPix pixel
+            count (`12 * nside**2`); `nside` disagrees with `len(values)`; or
+            `nest=True` with an `nside` that is not a power of two.
 
     Examples:
-        - Regrid a synthetic ``nside=1`` field (12 pixels) and inspect the raster:
+        - Regrid a synthetic `nside=1` field (12 pixels) and inspect the raster:
             ```python
             >>> import numpy as np
             >>> from pyramids.grids import from_healpix
@@ -157,7 +161,7 @@ def from_healpix(
             4326
 
             ```
-        - NESTED ordering is supported and requires a power-of-two ``nside``:
+        - NESTED ordering is supported and requires a power-of-two `nside`:
             ```python
             >>> import numpy as np
             >>> from pyramids.grids import from_healpix
@@ -180,7 +184,7 @@ def from_healpix(
 
     See Also:
         - :func:`pyramids.grids.from_octahedral`: the sibling point-based adapter this
-          function delegates to via ``grid_points``.
+          function delegates to via `grid_points`.
     """
     values = np.asarray(values, dtype=np.float64).ravel()
     npix = values.size
@@ -211,6 +215,6 @@ def from_healpix(
         crs=epsg,
     )
     result = grid_points(
-        gdf, "z", Dataset, algorithm=method, cell_size=cell_size, epsg=epsg
+        gdf, "z", Dataset, algorithm=method, cell_size=cell_size, bbox=bbox, epsg=epsg
     )
     return result

--- a/src/pyramids/grids/octahedral.py
+++ b/src/pyramids/grids/octahedral.py
@@ -1,0 +1,98 @@
+"""Adapt an octahedral reduced-Gaussian field to a regular :class:`~pyramids.dataset.Dataset`.
+
+Octahedral reduced-Gaussian grids (ECMWF ``O`` grids) store values as a single ragged
+sequence of points whose latitude/longitude coordinates are known per point. pyramids
+already interpolates scattered points to a raster with ``gdal.Grid``
+(:func:`pyramids.dataset.ops.interpolate.grid_points`); this module wraps the ragged
+points in a :class:`~geopandas.GeoDataFrame` and reuses that path. No new
+third-party dependencies.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from geopandas import GeoDataFrame, points_from_xy
+
+from pyramids.dataset.dataset import Dataset
+from pyramids.dataset.ops.interpolate import grid_points
+
+
+def from_octahedral(
+    lats: np.ndarray,
+    lons: np.ndarray,
+    values: np.ndarray,
+    *,
+    cell_size: float,
+    algorithm: str = "nearest",
+    epsg: int = 4326,
+) -> Dataset:
+    """Regrid an octahedral reduced-Gaussian field onto a regular-grid :class:`Dataset`.
+
+    The per-point ``lats``/``lons``/``values`` triples are wrapped in a point
+    :class:`~geopandas.GeoDataFrame` and interpolated with ``gdal.Grid`` via
+    :func:`~pyramids.dataset.ops.interpolate.grid_points`.
+
+    Args:
+        lats: 1-D array of point latitudes.
+        lons: 1-D array of point longitudes, same length as ``lats``.
+        values: 1-D array of field values, same length as ``lats``.
+        cell_size: Output pixel size in the target CRS units.
+        algorithm: A ``gdal.Grid`` algorithm string (e.g. ``"nearest"``,
+            ``"invdist:power=2.0:smoothing=0.0"``, ``"linear"``).
+        epsg: Output EPSG code.
+
+    Returns:
+        A single-band :class:`~pyramids.dataset.Dataset` of the interpolated surface.
+
+    Raises:
+        ValueError: ``lats``, ``lons`` and ``values`` are not 1-D arrays of equal
+            length.
+
+    Examples:
+        - Grid four corner observations with nearest-neighbour and inspect the result:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.grids import from_octahedral
+            >>> lats = np.array([0.0, 0.0, 5.0, 5.0])
+            >>> lons = np.array([0.0, 5.0, 0.0, 5.0])
+            >>> values = np.array([1.0, 2.0, 3.0, 4.0])
+            >>> ds = from_octahedral(lats, lons, values, cell_size=1.0, algorithm="nearest")
+            >>> (ds.rows, ds.columns, ds.band_count)
+            (5, 5, 1)
+
+            ```
+        - Arrays of unequal length are rejected:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.grids import from_octahedral
+            >>> try:
+            ...     from_octahedral(np.zeros(4), np.zeros(3), np.zeros(4), cell_size=1.0)
+            ... except ValueError as exc:
+            ...     print("equal length" in str(exc))
+            True
+
+            ```
+
+    See Also:
+        - :func:`pyramids.grids.from_orca`: regrid curvilinear ``(ny, nx)`` fields.
+        - :func:`pyramids.dataset.ops.interpolate.grid_points`: the scattered-point
+          interpolation this adapter delegates to.
+    """
+    lats = np.asarray(lats, dtype=np.float64).ravel()
+    lons = np.asarray(lons, dtype=np.float64).ravel()
+    values = np.asarray(values, dtype=np.float64).ravel()
+    if not (lats.size == lons.size == values.size):
+        raise ValueError(
+            "lats, lons and values must have equal length; got "
+            f"{lats.size}, {lons.size}, {values.size}."
+        )
+
+    gdf = GeoDataFrame(
+        {"z": values},
+        geometry=points_from_xy(lons, lats),
+        crs=epsg,
+    )
+    result = grid_points(
+        gdf, "z", Dataset, algorithm=algorithm, cell_size=cell_size, epsg=epsg
+    )
+    return result

--- a/src/pyramids/grids/octahedral.py
+++ b/src/pyramids/grids/octahedral.py
@@ -25,6 +25,7 @@ def from_octahedral(
     cell_size: float,
     algorithm: str = "nearest",
     epsg: int = 4326,
+    bbox: tuple[float, float, float, float] | None = None,
 ) -> Dataset:
     """Regrid an octahedral reduced-Gaussian field onto a regular-grid :class:`Dataset`.
 
@@ -40,6 +41,9 @@ def from_octahedral(
         algorithm: A ``gdal.Grid`` algorithm string (e.g. ``"nearest"``,
             ``"invdist:power=2.0:smoothing=0.0"``, ``"linear"``).
         epsg: Output EPSG code.
+        bbox: Optional ``(minx, miny, maxx, maxy)`` output extent in the target CRS.
+            Defaults to the points' bounding box; pass e.g. ``(-180, -90, 180, 90)``
+            to pin a fixed global grid.
 
     Returns:
         A single-band :class:`~pyramids.dataset.Dataset` of the interpolated surface.
@@ -93,6 +97,12 @@ def from_octahedral(
         crs=epsg,
     )
     result = grid_points(
-        gdf, "z", Dataset, algorithm=algorithm, cell_size=cell_size, epsg=epsg
+        gdf,
+        "z",
+        Dataset,
+        algorithm=algorithm,
+        cell_size=cell_size,
+        bbox=bbox,
+        epsg=epsg,
     )
     return result

--- a/src/pyramids/grids/orca.py
+++ b/src/pyramids/grids/orca.py
@@ -10,6 +10,7 @@ the actual interpolation. No new third-party dependencies.
 
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -33,10 +34,12 @@ def from_orca(
     """Regrid an ORCA curvilinear field onto a regular-grid :class:`Dataset`.
 
     The ``(ny, nx)`` coordinate arrays are treated as mesh nodes and stitched into
-    ``(ny - 1) * (nx - 1)`` quadrilateral faces. Each face value is the mean of its
-    four corner nodes, so every value in ``data2d`` (including the last row and column)
-    contributes to the result. The resulting UGRID mesh is interpolated to a regular
-    grid via :meth:`UgridDataset.to_dataset`.
+    ``(ny - 1) * (nx - 1)`` quadrilateral faces. Each face value is the NaN-aware mean
+    of its four corner nodes (:func:`numpy.nanmean`), so every value in ``data2d``
+    (including the last row and column) contributes; ``NaN``-masked nodes are ignored
+    and a face is ``NaN`` only when all four of its corners are ``NaN``. Use ``NaN``
+    (not a finite sentinel) to mark missing input values. The resulting UGRID mesh is
+    interpolated to a regular grid via :meth:`UgridDataset.to_dataset`.
 
     Args:
         lon2d: ``(ny, nx)`` array of node longitudes (x-coordinates).
@@ -116,11 +119,16 @@ def from_orca(
         ],
         axis=1,
     )
-    # Each face value is the mean of its four corner nodes, so every node in data2d
-    # contributes (no last row/column dropped).
-    face_values = 0.25 * (
-        data2d[:-1, :-1] + data2d[:-1, 1:] + data2d[1:, 1:] + data2d[1:, :-1]
+    # Each face value is the NaN-aware mean of its four corner nodes, so every node in
+    # data2d contributes (no last row/column dropped) and a NaN-masked node only blanks
+    # a face when all four of its corners are NaN.
+    corners = np.stack(
+        [data2d[:-1, :-1], data2d[:-1, 1:], data2d[1:, 1:], data2d[1:, :-1]], axis=0
     )
+    with warnings.catch_warnings():
+        # All-NaN faces are intended (fully-masked cell -> NaN); suppress the warning.
+        warnings.simplefilter("ignore", category=RuntimeWarning)
+        face_values = np.nanmean(corners, axis=0)
 
     mesh = UgridDataset.create_from_arrays(
         node_x,

--- a/src/pyramids/grids/orca.py
+++ b/src/pyramids/grids/orca.py
@@ -1,0 +1,132 @@
+"""Adapt an ORCA curvilinear ocean grid to a regular :class:`~pyramids.dataset.Dataset`.
+
+ORCA grids (NEMO ocean model) store coordinates as two-dimensional ``(ny, nx)``
+longitude/latitude arrays describing quadrilateral cells. pyramids already has a
+mesh-to-raster bridge (:func:`pyramids.netcdf.ugrid.interpolation.mesh_to_grid`,
+reached through :meth:`pyramids.netcdf.ugrid.dataset.UgridDataset.to_dataset`); this
+module turns the curvilinear field into a UGRID quad mesh and reuses that bridge for
+the actual interpolation. No new third-party dependencies.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from pyramids.netcdf.ugrid.dataset import UgridDataset
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from pyramids.dataset.dataset import Dataset
+
+
+def from_orca(
+    lon2d: np.ndarray,
+    lat2d: np.ndarray,
+    data2d: np.ndarray,
+    *,
+    cell_size: float,
+    method: str = "nearest",
+    epsg: int = 4326,
+    nodata: float = -9999.0,
+) -> Dataset:
+    """Regrid an ORCA curvilinear field onto a regular-grid :class:`Dataset`.
+
+    The ``(ny, nx)`` coordinate arrays are treated as mesh nodes and stitched into
+    ``(ny - 1) * (nx - 1)`` quadrilateral faces. Each face takes the value of its
+    upper-left node (``data2d[:-1, :-1]``), so the last row and column of ``data2d``
+    are not represented as face values — they only contribute their node coordinates.
+    The resulting UGRID mesh is interpolated to a regular grid via
+    :meth:`UgridDataset.to_dataset`.
+
+    Args:
+        lon2d: ``(ny, nx)`` array of node longitudes (x-coordinates).
+        lat2d: ``(ny, nx)`` array of node latitudes (y-coordinates), same shape as
+            ``lon2d``.
+        data2d: ``(ny, nx)`` array of field values aligned with the coordinate grid.
+        cell_size: Output pixel size in the target CRS units.
+        method: Interpolation method passed to ``mesh_to_grid`` ("nearest" or
+            "linear").
+        epsg: Output EPSG code.
+        nodata: No-data value stamped on cells the mesh does not cover.
+
+    Returns:
+        A single-band :class:`~pyramids.dataset.Dataset` of the interpolated surface.
+
+    Raises:
+        ValueError: ``lon2d``, ``lat2d`` and ``data2d`` are not all the same 2-D shape,
+            or the grid is smaller than ``2 x 2`` (no quad cells can be formed).
+
+    Examples:
+        - Regrid a small curvilinear field and inspect the raster it produces:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.grids import from_orca
+            >>> lon2d = np.array([[0.0, 1.0, 2.0], [0.0, 1.0, 2.0]])
+            >>> lat2d = np.array([[0.0, 0.0, 0.0], [1.0, 1.0, 1.0]])
+            >>> data2d = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+            >>> ds = from_orca(lon2d, lat2d, data2d, cell_size=0.5)
+            >>> ds.band_count
+            1
+            >>> ds.epsg
+            4326
+
+            ```
+        - Mismatched coordinate/data shapes are rejected:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.grids import from_orca
+            >>> try:
+            ...     from_orca(np.zeros((2, 3)), np.zeros((2, 2)), np.zeros((2, 3)), cell_size=0.5)
+            ... except ValueError as exc:
+            ...     print("same shape" in str(exc))
+            True
+
+            ```
+
+    See Also:
+        - :func:`pyramids.grids.from_octahedral`: regrid ragged per-point fields.
+        - :meth:`pyramids.netcdf.ugrid.dataset.UgridDataset.to_dataset`: the mesh→raster
+          bridge this adapter delegates to.
+    """
+    lon2d = np.asarray(lon2d, dtype=np.float64)
+    lat2d = np.asarray(lat2d, dtype=np.float64)
+    data2d = np.asarray(data2d, dtype=np.float64)
+    if not (lon2d.shape == lat2d.shape == data2d.shape):
+        raise ValueError(
+            "lon2d, lat2d and data2d must share the same shape; got "
+            f"{lon2d.shape}, {lat2d.shape}, {data2d.shape}."
+        )
+    if lon2d.ndim != 2:
+        raise ValueError(f"ORCA inputs must be 2-D; got {lon2d.ndim}-D arrays.")
+    ny, nx = lon2d.shape
+    if ny < 2 or nx < 2:
+        raise ValueError(
+            f"ORCA grid must be at least 2 x 2 to form quad cells; got {ny} x {nx}."
+        )
+
+    node_x = lon2d.ravel()
+    node_y = lat2d.ravel()
+    idx = np.arange(ny * nx).reshape(ny, nx)
+    faces = np.stack(
+        [
+            idx[:-1, :-1].ravel(),
+            idx[:-1, 1:].ravel(),
+            idx[1:, 1:].ravel(),
+            idx[1:, :-1].ravel(),
+        ],
+        axis=1,
+    )
+
+    mesh = UgridDataset.create_from_arrays(
+        node_x,
+        node_y,
+        faces,
+        data={"z": data2d[:-1, :-1].ravel()},
+        data_locations={"z": "face"},
+        epsg=epsg,
+    )
+    result = mesh.to_dataset(
+        "z", cell_size=cell_size, method=method, epsg=epsg, nodata=nodata
+    )
+    return result

--- a/src/pyramids/grids/orca.py
+++ b/src/pyramids/grids/orca.py
@@ -33,11 +33,10 @@ def from_orca(
     """Regrid an ORCA curvilinear field onto a regular-grid :class:`Dataset`.
 
     The ``(ny, nx)`` coordinate arrays are treated as mesh nodes and stitched into
-    ``(ny - 1) * (nx - 1)`` quadrilateral faces. Each face takes the value of its
-    upper-left node (``data2d[:-1, :-1]``), so the last row and column of ``data2d``
-    are not represented as face values — they only contribute their node coordinates.
-    The resulting UGRID mesh is interpolated to a regular grid via
-    :meth:`UgridDataset.to_dataset`.
+    ``(ny - 1) * (nx - 1)`` quadrilateral faces. Each face value is the mean of its
+    four corner nodes, so every value in ``data2d`` (including the last row and column)
+    contributes to the result. The resulting UGRID mesh is interpolated to a regular
+    grid via :meth:`UgridDataset.to_dataset`.
 
     Args:
         lon2d: ``(ny, nx)`` array of node longitudes (x-coordinates).
@@ -117,12 +116,17 @@ def from_orca(
         ],
         axis=1,
     )
+    # Each face value is the mean of its four corner nodes, so every node in data2d
+    # contributes (no last row/column dropped).
+    face_values = 0.25 * (
+        data2d[:-1, :-1] + data2d[:-1, 1:] + data2d[1:, 1:] + data2d[1:, :-1]
+    )
 
     mesh = UgridDataset.create_from_arrays(
         node_x,
         node_y,
         faces,
-        data={"z": data2d[:-1, :-1].ravel()},
+        data={"z": face_values.ravel()},
         data_locations={"z": "face"},
         epsg=epsg,
     )

--- a/tests/base/test_crs.py
+++ b/tests/base/test_crs.py
@@ -1,0 +1,95 @@
+"""Tests for CRS-resolution helpers in :mod:`pyramids.base.crs`."""
+
+from __future__ import annotations
+
+import pytest
+from pyproj import CRS
+
+from pyramids.base._errors import CRSError
+from pyramids.base.crs import epsg_from_user_input
+
+pytestmark = pytest.mark.core
+
+
+class TestEpsgFromUserInput:
+    """Tests for :func:`pyramids.base.crs.epsg_from_user_input`."""
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (4326, 4326),
+            (3857, 3857),
+            ("EPSG:3857", 3857),
+            ("3857", 3857),
+            ("epsg:32636", 32636),
+        ],
+    )
+    def test_resolves_int_and_string_forms(self, value, expected):
+        """epsg_from_user_input maps int and string CRS forms to the EPSG code.
+
+        Args:
+            value: A CRS given as an int or string.
+            expected: The EPSG code it should resolve to.
+
+        Test scenario:
+            Integers pass through; authority and bare-numeric strings resolve to codes.
+        """
+        assert epsg_from_user_input(value) == expected, f"{value!r} -> {expected}"
+
+    def test_resolves_pyproj_crs(self):
+        """epsg_from_user_input resolves a pyproj.CRS to its EPSG code.
+
+        Test scenario:
+            A CRS.from_epsg(32636) object resolves back to 32636.
+        """
+        assert (
+            epsg_from_user_input(CRS.from_epsg(32636)) == 32636
+        ), "CRS object mismatch"
+
+    def test_resolves_wkt_string(self):
+        """epsg_from_user_input resolves a WKT string to its EPSG code.
+
+        Test scenario:
+            The WKT exported from EPSG:3857 resolves back to 3857.
+        """
+        wkt = CRS.from_epsg(3857).to_wkt()
+        assert epsg_from_user_input(wkt) == 3857, "WKT did not resolve to 3857"
+
+    def test_bool_rejected(self):
+        """epsg_from_user_input rejects a bool (an int subclass) as a CRS.
+
+        Test scenario:
+            True is not a meaningful CRS and raises CRSError.
+        """
+        with pytest.raises(CRSError, match="not a valid CRS"):
+            epsg_from_user_input(True)
+
+    def test_uninterpretable_input_raises(self):
+        """epsg_from_user_input rejects a string that is not a CRS.
+
+        Test scenario:
+            A nonsense string raises CRSError mentioning it could not be interpreted.
+        """
+        with pytest.raises(CRSError, match="could not interpret"):
+            epsg_from_user_input("not-a-crs")
+
+    def test_crs_without_epsg_raises(self):
+        """epsg_from_user_input rejects a valid CRS that has no EPSG code.
+
+        Test scenario:
+            A custom PROJ4 Lambert azimuthal equal-area definition parses but maps to no
+            EPSG code, so a CRSError mentioning the missing code is raised.
+        """
+        proj4 = "+proj=laea +lat_0=52 +lon_0=10 +x_0=0 +y_0=0 +ellps=GRS80 +units=m +no_defs"
+        with pytest.raises(CRSError, match="no corresponding EPSG code"):
+            epsg_from_user_input(proj4)
+
+    def test_crserror_is_valueerror(self):
+        """CRSError raised by the resolver is also a ValueError.
+
+        Test scenario:
+            Callers catching ValueError (the historical contract) still catch the new
+            CRSError.
+        """
+        with pytest.raises(ValueError):
+            epsg_from_user_input("not-a-crs")

--- a/tests/basemap/test_features.py
+++ b/tests/basemap/test_features.py
@@ -317,6 +317,27 @@ class TestDownload:
         assert "x.zip" in str(exc.value), f"URL missing from message: {exc.value}"
         assert exc.value.__cause__ is not None, "original error should be chained"
 
+    def test_failed_download_leaves_no_temp_file(self, tmp_path, monkeypatch):
+        """_download cleans up its temp file when the download fails.
+
+        Args:
+            tmp_path: pytest temp directory (the download destination's parent).
+            monkeypatch: pytest monkeypatch fixture.
+
+        Test scenario:
+            With urlopen raising URLError, _download raises OSError and leaves no
+            files behind in the destination directory (no stray temp .zip).
+        """
+
+        def boom(request, *args, **kwargs):
+            raise urllib.error.URLError("no route to host")
+
+        monkeypatch.setattr(urllib.request, "urlopen", boom)
+        with pytest.raises(OSError):
+            features._download("https://example.com/x.zip", tmp_path / "x.zip")
+        leftovers = list(tmp_path.iterdir())
+        assert leftovers == [], f"temp file(s) left behind after failure: {leftovers}"
+
 
 class TestNaturalEarth:
     """Tests for :func:`pyramids.basemap.features.natural_earth`."""

--- a/tests/basemap/test_features.py
+++ b/tests/basemap/test_features.py
@@ -60,6 +60,38 @@ def _make_coastline_zip(destination: Path, n_features: int = 2) -> int:
     return n_features
 
 
+def _make_coastline_zip_with_stems(destination: Path, stems: dict[str, int]) -> None:
+    """Write ``ne_110m_coastline.zip`` containing one shapefile per given stem.
+
+    Args:
+        destination: Cache directory to place the zip in (created if missing).
+        stems: Mapping of shapefile stem (without extension) to the number of
+            LineString features that shapefile should contain.
+    """
+    destination.mkdir(parents=True, exist_ok=True)
+    shp_dir = destination / "_build_stems"
+    shp_dir.mkdir(exist_ok=True)
+    for stem, n_features in stems.items():
+        lines = [LineString([(i, 0), (i + 1, 1)]) for i in range(n_features)]
+        gdf = gpd.GeoDataFrame(
+            {"id": range(n_features)}, geometry=lines, crs="EPSG:4326"
+        )
+        gdf.to_file(shp_dir / f"{stem}.shp")
+    zip_path = destination / "ne_110m_coastline.zip"
+    with zipfile.ZipFile(zip_path, "w") as archive:
+        for sidecar in shp_dir.iterdir():
+            archive.write(sidecar, sidecar.name)
+
+
+def _make_sidecar_only_zip(destination: Path) -> None:
+    """Write ``ne_110m_coastline.zip`` with shapefile sidecars but no ``.shp``."""
+    destination.mkdir(parents=True, exist_ok=True)
+    zip_path = destination / "ne_110m_coastline.zip"
+    with zipfile.ZipFile(zip_path, "w") as archive:
+        archive.writestr("ne_110m_coastline.dbf", b"not a real dbf")
+        archive.writestr("ne_110m_coastline.prj", b"not a real prj")
+
+
 class TestAvailableLayers:
     """Tests for :func:`pyramids.basemap.features.available_layers`."""
 
@@ -331,6 +363,72 @@ class TestNaturalEarth:
         result = features.natural_earth("coastline", "110m")
         assert isinstance(result, FeatureCollection), f"Got {type(result)}"
         assert len(result) == n_features, f"Expected {n_features}, got {len(result)}"
+
+    def test_reads_shapefile_with_unexpected_stem(self, cache_dir, monkeypatch):
+        """natural_earth reads the archive's .shp even when its name is unexpected.
+
+        Args:
+            cache_dir: Redirected cache directory fixture.
+            monkeypatch: pytest monkeypatch fixture.
+
+        Test scenario:
+            The cached zip contains a shapefile named ``coastline_renamed.shp`` (not the
+            conventional ``ne_110m_coastline.shp``). natural_earth still selects it by
+            listing the archive members, returns the right feature count, and does not
+            download.
+        """
+        _make_coastline_zip_with_stems(cache_dir, {"coastline_renamed": 4})
+
+        def fail_download(url, destination):
+            raise AssertionError("download must not run on a cache hit")
+
+        monkeypatch.setattr(features, "_download", fail_download)
+        result = features.natural_earth("coastline", "110m")
+        assert isinstance(result, FeatureCollection), f"Got {type(result)}"
+        assert len(result) == 4, f"Expected 4 features, got {len(result)}"
+
+    def test_prefers_conventional_stem_over_others(self, cache_dir, monkeypatch):
+        """natural_earth prefers ``ne_{res}_{name}.shp`` when several .shp exist.
+
+        Args:
+            cache_dir: Redirected cache directory fixture.
+            monkeypatch: pytest monkeypatch fixture.
+
+        Test scenario:
+            The archive holds two shapefiles — the conventional ``ne_110m_coastline.shp``
+            (2 features) and an ``extra.shp`` (5 features). natural_earth picks the
+            conventional one, identified by its distinct feature count.
+        """
+        _make_coastline_zip_with_stems(cache_dir, {"ne_110m_coastline": 2, "extra": 5})
+
+        def fail_download(url, destination):
+            raise AssertionError("download must not run on a cache hit")
+
+        monkeypatch.setattr(features, "_download", fail_download)
+        result = features.natural_earth("coastline", "110m")
+        assert (
+            len(result) == 2
+        ), f"Expected the conventional 2-feature shp, got {len(result)}"
+
+    def test_archive_without_shapefile_raises(self, cache_dir, monkeypatch):
+        """natural_earth raises when the cached archive contains no .shp member.
+
+        Args:
+            cache_dir: Redirected cache directory fixture.
+            monkeypatch: pytest monkeypatch fixture.
+
+        Test scenario:
+            A zip with only sidecar files (no ``.shp``) raises FileNotFoundError naming
+            the ``*.shp`` pattern it looked for.
+        """
+        _make_sidecar_only_zip(cache_dir)
+
+        def fail_download(url, destination):
+            raise AssertionError("download must not run on a cache hit")
+
+        monkeypatch.setattr(features, "_download", fail_download)
+        with pytest.raises(FileNotFoundError, match=r"\*\.shp"):
+            features.natural_earth("coastline", "110m")
 
     @pytest.mark.slow
     def test_real_download_coastline(self, cache_dir):

--- a/tests/basemap/test_features.py
+++ b/tests/basemap/test_features.py
@@ -1,0 +1,348 @@
+"""Tests for :mod:`pyramids.basemap.features` (Natural Earth vector accessor).
+
+Network access is avoided except for a single ``slow``-marked end-to-end test: the
+download is monkeypatched and the read path is exercised against a locally-built
+shapefile zip placed in a temporary cache directory.
+"""
+
+from __future__ import annotations
+
+import urllib.error
+import zipfile
+from pathlib import Path
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import LineString
+
+from pyramids.basemap import features
+from pyramids.feature import FeatureCollection
+
+pytestmark = pytest.mark.core
+
+
+@pytest.fixture(scope="function")
+def cache_dir(tmp_path, monkeypatch):
+    """Redirect the Natural Earth cache to a temp directory via PYRAMIDS_CACHE_DIR.
+
+    Args:
+        tmp_path: pytest temp directory.
+        monkeypatch: pytest monkeypatch fixture.
+
+    Returns:
+        Path: the ``naturalearth`` cache directory features.py will use.
+    """
+    monkeypatch.setenv("PYRAMIDS_CACHE_DIR", str(tmp_path))
+    return tmp_path / "naturalearth"
+
+
+def _make_coastline_zip(destination: Path, n_features: int = 2) -> int:
+    """Write a tiny ``ne_110m_coastline.zip`` (real shapefile) into ``destination``.
+
+    Args:
+        destination: Cache directory to place the zip in (created if missing).
+        n_features: Number of LineString features to include.
+
+    Returns:
+        The number of features written (for assertion convenience).
+    """
+    destination.mkdir(parents=True, exist_ok=True)
+    shp_dir = destination / "_build"
+    shp_dir.mkdir(exist_ok=True)
+    lines = [LineString([(i, 0), (i + 1, 1)]) for i in range(n_features)]
+    gdf = gpd.GeoDataFrame({"id": range(n_features)}, geometry=lines, crs="EPSG:4326")
+    shp_path = shp_dir / "ne_110m_coastline.shp"
+    gdf.to_file(shp_path)
+    zip_path = destination / "ne_110m_coastline.zip"
+    with zipfile.ZipFile(zip_path, "w") as archive:
+        for sidecar in shp_dir.glob("ne_110m_coastline.*"):
+            archive.write(sidecar, sidecar.name)
+    return n_features
+
+
+class TestAvailableLayers:
+    """Tests for :func:`pyramids.basemap.features.available_layers`."""
+
+    def test_contains_expected_layers(self):
+        """available_layers returns the six supported Natural Earth layers.
+
+        Test scenario:
+            The list contains every documented layer and is sorted.
+        """
+        result = features.available_layers()
+        expected = ["borders", "coastline", "lakes", "land", "ocean", "rivers"]
+        assert result == expected, f"Unexpected layers: {result}"
+
+
+class TestAvailableResolutions:
+    """Tests for :func:`pyramids.basemap.features.available_resolutions`."""
+
+    def test_returns_three_scales_coarsest_first(self):
+        """available_resolutions returns 110m/50m/10m, coarsest first.
+
+        Test scenario:
+            The ordering matters for documentation; assert exact sequence.
+        """
+        assert features.available_resolutions() == ["110m", "50m", "10m"]
+
+
+class TestDatasetStem:
+    """Tests for :func:`pyramids.basemap.features._dataset_stem`."""
+
+    @pytest.mark.parametrize(
+        "layer, resolution, expected",
+        [
+            ("coastline", "110m", "ne_110m_coastline"),
+            ("land", "50m", "ne_50m_land"),
+            ("rivers", "10m", "ne_10m_rivers_lake_centerlines"),
+            ("borders", "110m", "ne_110m_admin_0_boundary_lines_land"),
+        ],
+    )
+    def test_stem_format(self, layer, resolution, expected):
+        """_dataset_stem builds ``ne_{resolution}_{suffix}``.
+
+        Args:
+            layer: Natural Earth layer name.
+            resolution: Resolution string.
+            expected: Expected dataset stem.
+
+        Test scenario:
+            Each layer maps to its documented Natural Earth file stem.
+        """
+        assert features._dataset_stem(layer, resolution) == expected
+
+
+class TestDownloadUrl:
+    """Tests for :func:`pyramids.basemap.features._download_url`."""
+
+    @pytest.mark.parametrize("resolution", ["110m", "50m", "10m"])
+    @pytest.mark.parametrize(
+        "layer, category",
+        [
+            ("coastline", "physical"),
+            ("land", "physical"),
+            ("ocean", "physical"),
+            ("rivers", "physical"),
+            ("lakes", "physical"),
+            ("borders", "cultural"),
+        ],
+    )
+    def test_url_uses_correct_category(self, layer, category, resolution):
+        """_download_url routes physical vs cultural layers to the right sub-path.
+
+        Args:
+            layer: Natural Earth layer name.
+            category: Expected CDN category ("physical" or "cultural").
+            resolution: Resolution string.
+
+        Test scenario:
+            The URL embeds the resolution, category and dataset stem and ends in .zip.
+        """
+        url = features._download_url(layer, resolution)
+        stem = features._dataset_stem(layer, resolution)
+        assert url == f"{features._BASE_URL}/{resolution}/{category}/{stem}.zip", url
+
+
+class TestCacheDir:
+    """Tests for :func:`pyramids.basemap.features._cache_dir`."""
+
+    def test_honors_env_override(self, tmp_path, monkeypatch):
+        """_cache_dir uses PYRAMIDS_CACHE_DIR and creates the naturalearth subdir.
+
+        Args:
+            tmp_path: pytest temp directory.
+            monkeypatch: pytest monkeypatch fixture.
+
+        Test scenario:
+            With the env var set, the returned path is
+            ``<override>/naturalearth`` and exists on disk.
+        """
+        monkeypatch.setenv("PYRAMIDS_CACHE_DIR", str(tmp_path))
+        result = features._cache_dir()
+        assert result == tmp_path / "naturalearth", f"Wrong cache dir: {result}"
+        assert result.is_dir(), "cache dir should be created"
+
+    def test_defaults_to_home(self, monkeypatch):
+        """_cache_dir falls back to ~/.pyramids/naturalearth without the env var.
+
+        Args:
+            monkeypatch: pytest monkeypatch fixture.
+
+        Test scenario:
+            With PYRAMIDS_CACHE_DIR unset and a redirected home, the cache lives under
+            the home directory.
+        """
+        monkeypatch.delenv("PYRAMIDS_CACHE_DIR", raising=False)
+        fake_home = Path(features.__file__).parent  # any existing dir works
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+        result = features._cache_dir()
+        assert result == fake_home / ".pyramids" / "naturalearth", f"{result}"
+
+
+class TestEnsureCached:
+    """Tests for :func:`pyramids.basemap.features._ensure_cached`."""
+
+    def test_downloads_when_absent(self, cache_dir, monkeypatch):
+        """_ensure_cached downloads the archive when it is not already cached.
+
+        Args:
+            cache_dir: Redirected cache directory fixture.
+            monkeypatch: pytest monkeypatch fixture.
+
+        Test scenario:
+            With no cached file, _download is invoked once and the returned path is
+            the expected cached archive.
+        """
+        calls = []
+
+        def fake_download(url, destination):
+            calls.append((url, destination))
+            destination.write_bytes(b"PK\x03\x04")
+
+        monkeypatch.setattr(features, "_download", fake_download)
+        result = features._ensure_cached("coastline", "110m")
+        assert result == cache_dir / "ne_110m_coastline.zip", f"Wrong path: {result}"
+        assert len(calls) == 1, f"Expected one download, got {len(calls)}"
+
+    def test_skips_download_when_present(self, cache_dir, monkeypatch):
+        """_ensure_cached returns the cached archive without downloading.
+
+        Args:
+            cache_dir: Redirected cache directory fixture.
+            monkeypatch: pytest monkeypatch fixture.
+
+        Test scenario:
+            With the archive already on disk, _download is never called.
+        """
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        archive = cache_dir / "ne_110m_coastline.zip"
+        archive.write_bytes(b"PK\x03\x04")
+
+        def fail_download(url, destination):
+            raise AssertionError("download must not be called on a cache hit")
+
+        monkeypatch.setattr(features, "_download", fail_download)
+        result = features._ensure_cached("coastline", "110m")
+        assert result == archive, f"Wrong path: {result}"
+
+
+class TestDownload:
+    """Tests for :func:`pyramids.basemap.features._download`."""
+
+    def test_success_writes_file_atomically(self, tmp_path, monkeypatch):
+        """_download streams the response body to the destination path.
+
+        Args:
+            tmp_path: pytest temp directory.
+            monkeypatch: pytest monkeypatch fixture.
+
+        Test scenario:
+            With urlopen returning a fake byte stream, _download writes exactly those
+            bytes to the destination (no real network).
+        """
+        import io
+
+        payload = b"PK\x03\x04 fake zip bytes"
+
+        def fake_urlopen(request, *args, **kwargs):
+            return io.BytesIO(payload)
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+        destination = tmp_path / "out.zip"
+        features._download("https://example.com/x.zip", destination)
+        assert destination.read_bytes() == payload, "downloaded bytes mismatch"
+
+    def test_non_http_url_rejected(self, tmp_path):
+        """_download refuses non-HTTP(S) URLs (guards against file:// reads).
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            A file:// URL raises ValueError before any network/file access.
+        """
+        with pytest.raises(ValueError, match="non-HTTP"):
+            features._download("file:///etc/passwd", tmp_path / "x.zip")
+
+    def test_network_error_wrapped_as_oserror(self, tmp_path, monkeypatch):
+        """_download wraps a urllib error as OSError with the URL and cache hint.
+
+        Args:
+            tmp_path: pytest temp directory.
+            monkeypatch: pytest monkeypatch fixture.
+
+        Test scenario:
+            When urlopen raises URLError, _download raises OSError mentioning the
+            source URL, and chains the original error.
+        """
+
+        def boom(request, *args, **kwargs):
+            raise urllib.error.URLError("no route to host")
+
+        monkeypatch.setattr(urllib.request, "urlopen", boom)
+        with pytest.raises(OSError, match="failed to download Natural Earth") as exc:
+            features._download("https://example.com/x.zip", tmp_path / "x.zip")
+        assert "x.zip" in str(exc.value), f"URL missing from message: {exc.value}"
+        assert exc.value.__cause__ is not None, "original error should be chained"
+
+
+class TestNaturalEarth:
+    """Tests for :func:`pyramids.basemap.features.natural_earth`."""
+
+    def test_unknown_layer_raises(self):
+        """natural_earth rejects an unknown layer with the valid-options list.
+
+        Test scenario:
+            Passing a non-existent layer raises ValueError naming the supported
+            layers.
+        """
+        with pytest.raises(ValueError, match="unknown Natural Earth layer") as exc:
+            features.natural_earth("countries")
+        assert "coastline" in str(exc.value), f"Options missing: {exc.value}"
+
+    def test_unknown_resolution_raises(self):
+        """natural_earth rejects an unknown resolution with the valid-options list.
+
+        Test scenario:
+            Passing a non-existent resolution raises ValueError naming the supported
+            resolutions.
+        """
+        with pytest.raises(ValueError, match="unknown Natural Earth resolution") as exc:
+            features.natural_earth("coastline", resolution="1m")
+        assert "110m" in str(exc.value), f"Options missing: {exc.value}"
+
+    def test_cache_hit_returns_feature_collection(self, cache_dir, monkeypatch):
+        """natural_earth reads a cached archive without downloading.
+
+        Args:
+            cache_dir: Redirected cache directory fixture.
+            monkeypatch: pytest monkeypatch fixture.
+
+        Test scenario:
+            With a locally-built coastline zip in the cache, natural_earth returns a
+            FeatureCollection with the expected feature count and never downloads.
+        """
+        n_features = _make_coastline_zip(cache_dir, n_features=3)
+
+        def fail_download(url, destination):
+            raise AssertionError("download must not run on a cache hit")
+
+        monkeypatch.setattr(features, "_download", fail_download)
+        result = features.natural_earth("coastline", "110m")
+        assert isinstance(result, FeatureCollection), f"Got {type(result)}"
+        assert len(result) == n_features, f"Expected {n_features}, got {len(result)}"
+
+    @pytest.mark.slow
+    def test_real_download_coastline(self, cache_dir):
+        """End-to-end fetch of the 110m coastline from the Natural Earth CDN.
+
+        Test scenario:
+            Network-dependent; skipped offline. Downloads the real 110m coastline and
+            asserts a non-empty FeatureCollection is returned.
+        """
+        try:
+            result = features.natural_earth("coastline", "110m")
+        except OSError as exc:
+            pytest.skip(f"Natural Earth CDN unreachable: {exc}")
+        assert isinstance(result, FeatureCollection), f"Got {type(result)}"
+        assert len(result) > 0, "real coastline layer should have features"

--- a/tests/dataset/ops/test_units.py
+++ b/tests/dataset/ops/test_units.py
@@ -1,0 +1,144 @@
+"""Unit tests for the affine unit-conversion helpers in :mod:`pyramids.dataset.ops.units`."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pyramids.dataset.ops.units import (
+    _AFFINE,
+    convert_array,
+    supported_conversions,
+)
+
+pytestmark = pytest.mark.core
+
+
+class TestSupportedConversions:
+    """Tests for :func:`pyramids.dataset.ops.units.supported_conversions`."""
+
+    def test_returns_sorted_pairs(self):
+        """supported_conversions returns the affine table keys, sorted.
+
+        Test scenario:
+            The returned list equals the sorted ``_AFFINE`` keys, so callers can
+            introspect exactly which conversions are available.
+        """
+        result = supported_conversions()
+        assert result == sorted(_AFFINE.keys()), f"Unexpected pairs: {result}"
+
+    @pytest.mark.parametrize(
+        "pair",
+        [("K", "celsius"), ("Pa", "hPa"), ("m s-1", "knots"), ("m", "mm")],
+    )
+    def test_known_pairs_present(self, pair):
+        """supported_conversions advertises every seeded conversion direction.
+
+        Args:
+            pair: A ``(source, target)`` tuple expected in the table.
+
+        Test scenario:
+            Each documented forward conversion appears in the returned list.
+        """
+        assert pair in supported_conversions(), f"{pair} missing from table"
+
+
+class TestConvertArray:
+    """Tests for :func:`pyramids.dataset.ops.units.convert_array`."""
+
+    @pytest.mark.parametrize(
+        "values, source, target, expected",
+        [
+            ([273.15, 283.15, 303.15], "K", "celsius", [0.0, 10.0, 30.0]),
+            ([0.0, 10.0, 30.0], "celsius", "K", [273.15, 283.15, 303.15]),
+            ([100.0, 200.0], "Pa", "hPa", [1.0, 2.0]),
+            ([1.0, 2.0], "hPa", "Pa", [100.0, 200.0]),
+            ([1.0], "m", "mm", [1000.0]),
+            ([1000.0], "mm", "m", [1.0]),
+        ],
+    )
+    def test_affine_conversions(self, values, source, target, expected):
+        """convert_array applies the correct affine transform per known pair.
+
+        Args:
+            values: Input values to convert.
+            source: Source unit label.
+            target: Target unit label.
+            expected: Hand-computed converted values.
+
+        Test scenario:
+            Each supported pair maps inputs to the analytically expected outputs
+            within floating-point tolerance.
+        """
+        result = convert_array(np.array(values), source, target)
+        np.testing.assert_allclose(
+            result, expected, rtol=1e-6, err_msg=f"{source}->{target} wrong"
+        )
+
+    def test_speed_conversion_value(self):
+        """convert_array converts m/s to knots with the documented factor.
+
+        Test scenario:
+            1 m/s equals ~1.943844 knots; check the scalar factor explicitly.
+        """
+        result = convert_array(np.array([1.0]), "m s-1", "knots")
+        assert result[0] == pytest.approx(1.943844), f"Got {result[0]}"
+
+    def test_knots_roundtrip(self):
+        """convert_array round-trips m/s -> knots -> m/s back to the original.
+
+        Test scenario:
+            Converting forward then backward recovers the source values, proving
+            the reverse factor is the exact inverse.
+        """
+        original = np.array([0.0, 5.0, 12.5])
+        knots = convert_array(original, "m s-1", "knots")
+        back = convert_array(knots, "knots", "m s-1")
+        np.testing.assert_allclose(back, original, rtol=1e-6, err_msg="roundtrip drift")
+
+    def test_same_unit_is_noop_identity(self):
+        """convert_array returns the input object unchanged when source == target.
+
+        Test scenario:
+            With matching units no arithmetic is performed; the same array object is
+            returned (no copy) and values are untouched.
+        """
+        arr = np.array([1.0, 2.0, 3.0])
+        result = convert_array(arr, "K", "K")
+        assert result is arr, "Same-unit conversion should return the input object"
+
+    def test_empty_source_unit_raises(self):
+        """convert_array rejects an empty source unit.
+
+        Test scenario:
+            A band with no recorded unit cannot be converted; ValueError mentions
+            'no source unit'.
+        """
+        with pytest.raises(ValueError, match="no source unit") as exc:
+            convert_array(np.array([1.0]), "", "celsius")
+        assert "no source unit" in str(exc.value), f"Unexpected: {exc.value}"
+
+    def test_unknown_pair_raises(self):
+        """convert_array rejects an unsupported (source, target) pair.
+
+        Test scenario:
+            A target with no table entry raises ValueError listing the supported
+            pairs.
+        """
+        with pytest.raises(ValueError, match="No unit conversion") as exc:
+            convert_array(np.array([1.0]), "K", "furlongs")
+        msg = str(exc.value)
+        assert "No unit conversion" in msg, f"Unexpected: {msg}"
+        assert "Supported pairs" in msg, f"Message should list supported pairs: {msg}"
+
+    def test_does_not_mutate_input(self):
+        """convert_array leaves the input array unmodified for real conversions.
+
+        Test scenario:
+            After a K->celsius conversion the original array still holds its
+            Kelvin values (the function returns a new array).
+        """
+        arr = np.array([273.15, 283.15])
+        snapshot = arr.copy()
+        convert_array(arr, "K", "celsius")
+        np.testing.assert_array_equal(arr, snapshot, err_msg="input was mutated")

--- a/tests/dataset/test_dataset_unit.py
+++ b/tests/dataset/test_dataset_unit.py
@@ -1867,10 +1867,50 @@ class TestToCrs:
         assert result is not None, "to_crs should return a Dataset"
         assert result.epsg == 3857, "EPSG should be 3857 on the returned dataset"
 
-    def test_to_crs_invalid_type_raises(self, single_band_dataset):
-        """to_crs with a non-int epsg should raise TypeError."""
-        with pytest.raises(TypeError):
-            single_band_dataset.to_crs(to_epsg="4326")
+    @pytest.mark.parametrize("crs", ["EPSG:3857", "3857"])
+    def test_to_crs_accepts_string(self, single_band_dataset, crs):
+        """to_crs accepts string CRS forms and resolves them to the EPSG code.
+
+        Args:
+            crs: A string CRS form ("EPSG:3857" or the bare "3857").
+
+        Test scenario:
+            Both an authority string and a bare numeric string reproject to EPSG 3857.
+        """
+        result = single_band_dataset.to_crs(to_epsg=crs)
+        assert (
+            result.epsg == 3857
+        ), f"Expected EPSG 3857 from {crs!r}, got {result.epsg}"
+
+    def test_to_crs_accepts_pyproj_crs(self, single_band_dataset):
+        """to_crs accepts a pyproj.CRS object.
+
+        Test scenario:
+            Passing CRS.from_epsg(3857) reprojects to EPSG 3857.
+        """
+        from pyproj import CRS
+
+        result = single_band_dataset.to_crs(to_epsg=CRS.from_epsg(3857))
+        assert result.epsg == 3857, f"Expected EPSG 3857, got {result.epsg}"
+
+    def test_to_crs_uninterpretable_crs_raises(self, single_band_dataset):
+        """to_crs rejects a string that is not a CRS.
+
+        Test scenario:
+            An uninterpretable CRS string raises a ValueError (CRSError subclass)
+            mentioning that it could not be interpreted.
+        """
+        with pytest.raises(ValueError, match="could not interpret"):
+            single_band_dataset.to_crs(to_epsg="not-a-crs")
+
+    def test_to_crs_wrong_type_raises(self, single_band_dataset):
+        """to_crs rejects a value that cannot be a CRS at all.
+
+        Test scenario:
+            A list is not a valid CRS input and raises a ValueError (CRSError subclass).
+        """
+        with pytest.raises(ValueError):
+            single_band_dataset.to_crs(to_epsg=[3857])
 
     def test_to_crs_invalid_method_raises(self, single_band_dataset):
         """to_crs with an invalid method should raise ValueError."""

--- a/tests/dataset/test_dataset_unit.py
+++ b/tests/dataset/test_dataset_unit.py
@@ -130,6 +130,84 @@ class TestRasterBaseStaticMethods:
         assert len(result) == 5, "Array length should equal row count"
 
 
+class TestCoordinateProperties:
+    """Tests for the Dataset.lon / lat / x / y cell-centre coordinate properties."""
+
+    def test_shapes_match_dimensions(self, single_band_dataset):
+        """lon/x have length columns and lat/y have length rows.
+
+        Test scenario:
+            For the 3x3 fixture every coordinate axis has the matching dimension
+            length.
+        """
+        ds = single_band_dataset
+        assert ds.lon.shape == (ds.columns,), f"lon shape {ds.lon.shape}"
+        assert ds.x.shape == (ds.columns,), f"x shape {ds.x.shape}"
+        assert ds.lat.shape == (ds.rows,), f"lat shape {ds.lat.shape}"
+        assert ds.y.shape == (ds.rows,), f"y shape {ds.y.shape}"
+
+    def test_x_aliases_lon_and_y_aliases_lat(self, multi_band_dataset):
+        """x returns the same values as lon, and y the same as lat.
+
+        Test scenario:
+            The x/y aliases must agree element-wise with lon/lat on a fixture with
+            distinct row/column counts.
+        """
+        ds = multi_band_dataset
+        np.testing.assert_array_equal(ds.x, ds.lon, err_msg="x must equal lon")
+        np.testing.assert_array_equal(ds.y, ds.lat, err_msg="y must equal lat")
+
+    def test_values_match_static_builders(self, multi_band_dataset):
+        """lon/lat equal the static dimension-array helpers fed the geotransform.
+
+        Test scenario:
+            The instance properties are a thin wrapper over
+            get_x_lon_dimension_array / get_y_lat_dimension_array using the
+            geotransform's own pixel width and height.
+        """
+        ds = multi_band_dataset
+        gt = ds.geotransform
+        expected_lon = RasterBase.get_x_lon_dimension_array(gt[0], gt[1], ds.columns)
+        expected_lat = RasterBase.get_y_lat_dimension_array(gt[3], abs(gt[5]), ds.rows)
+        np.testing.assert_allclose(ds.lon, expected_lon, err_msg="lon mismatch")
+        np.testing.assert_allclose(ds.lat, expected_lat, err_msg="lat mismatch")
+
+    def test_square_cell_centres(self):
+        """Square-cell rasters report the expected centre coordinates.
+
+        Test scenario:
+            A 2x3 raster at top-left (0, 0) with cell_size 0.5 has column centres at
+            0.25/0.75/1.25 and row centres at -0.25/-0.75.
+        """
+        ds = Dataset.create_from_array(
+            np.arange(6.0).reshape(2, 3),
+            top_left_corner=(0.0, 0.0),
+            cell_size=0.5,
+            epsg=4326,
+        )
+        np.testing.assert_allclose(ds.x, [0.25, 0.75, 1.25], err_msg="x centres wrong")
+        np.testing.assert_allclose(ds.y, [-0.25, -0.75], err_msg="y centres wrong")
+
+    def test_non_square_cells_use_separate_pixel_height(self):
+        """Non-square cells: y uses pixel height, x uses pixel width.
+
+        Test scenario:
+            A raster with geotransform pixel width 2 and pixel height 1 must produce
+            x centres spaced by 2 (11/13/15) and y centres spaced by 1 (49.5/48.5).
+            This guards the regression where lat/y previously reused cell_size (the
+            pixel width) for the y axis.
+        """
+        ds = Dataset.create_from_array(
+            np.arange(6.0).reshape(2, 3),
+            geo=(10.0, 2.0, 0.0, 50.0, 0.0, -1.0),
+            epsg=4326,
+        )
+        np.testing.assert_allclose(ds.x, [11.0, 13.0, 15.0], err_msg="x spacing wrong")
+        np.testing.assert_allclose(
+            ds.y, [49.5, 48.5], err_msg="y must use pixel height"
+        )
+
+
 class TestRasterBaseBlockSizeSetter:
     """Tests for the block_size setter validation on RasterBase."""
 

--- a/tests/dataset/test_dataset_unit.py
+++ b/tests/dataset/test_dataset_unit.py
@@ -270,6 +270,129 @@ class TestBandNamesUnitsSetters:
             ), f"Band {i} unit mismatch: expected {expected}, got {actual}"
 
 
+class TestConvertUnits:
+    """Tests for the Dataset.convert_units value-conversion method."""
+
+    def test_single_band_kelvin_to_celsius(self, single_band_dataset):
+        """convert_units converts a single-band Kelvin raster to Celsius.
+
+        Test scenario:
+            A 3x3 raster labelled "K" converted to "celsius" subtracts 273.15 from
+            every cell and updates band_units to ["celsius"].
+        """
+        single_band_dataset.band_units = ["K"]
+        result = single_band_dataset.convert_units("celsius")
+        expected = single_band_dataset.read_array() - 273.15
+        np.testing.assert_allclose(
+            result.read_array(), expected, rtol=1e-6, err_msg="K->C values wrong"
+        )
+        assert result.band_units == [
+            "celsius"
+        ], f"Units not updated: {result.band_units}"
+
+    def test_multi_band_all_converted(self, multi_band_dataset):
+        """convert_units converts every band when band is None.
+
+        Test scenario:
+            A 3-band raster all labelled "m" converted to "mm" scales every band by
+            1000 and labels all bands "mm".
+        """
+        multi_band_dataset.band_units = ["m", "m", "m"]
+        result = multi_band_dataset.convert_units("mm")
+        np.testing.assert_allclose(
+            result.read_array(),
+            multi_band_dataset.read_array() * 1000.0,
+            rtol=1e-6,
+            err_msg="m->mm values wrong",
+        )
+        assert result.band_units == ["mm", "mm", "mm"], f"Units: {result.band_units}"
+
+    def test_band_argument_converts_one_band_only(self, multi_band_dataset):
+        """convert_units with band= converts only the selected band.
+
+        Test scenario:
+            Converting only band 0 (m->mm) scales band 0 by 1000 but leaves bands 1
+            and 2 untouched, and only band 0's unit label changes.
+        """
+        multi_band_dataset.band_units = ["m", "m", "m"]
+        source = multi_band_dataset.read_array()
+        result = multi_band_dataset.convert_units("mm", band=0)
+        converted = result.read_array()
+        np.testing.assert_allclose(
+            converted[0], source[0] * 1000.0, rtol=1e-6, err_msg="band 0 not converted"
+        )
+        np.testing.assert_array_equal(
+            converted[1], source[1], err_msg="band 1 should be untouched"
+        )
+        np.testing.assert_array_equal(
+            converted[2], source[2], err_msg="band 2 should be untouched"
+        )
+        assert result.band_units == ["mm", "m", "m"], f"Units: {result.band_units}"
+
+    def test_nodata_cells_preserved(self):
+        """convert_units leaves no-data cells at their sentinel value.
+
+        Test scenario:
+            A Kelvin raster containing a -9999.0 no-data cell, converted to Celsius,
+            keeps that cell at -9999.0 while converting the valid cells.
+        """
+        arr = np.array([[273.15, -9999.0], [293.15, 303.15]], dtype=np.float64)
+        ds = Dataset.create_from_array(
+            arr,
+            top_left_corner=(0.0, 0.0),
+            cell_size=1.0,
+            epsg=4326,
+            no_data_value=-9999.0,
+        )
+        ds.band_units = ["K"]
+        result = ds.convert_units("celsius")
+        out = result.read_array()
+        assert out[0, 1] == -9999.0, f"No-data cell altered: {out[0, 1]}"
+        assert out[0, 0] == pytest.approx(0.0), f"Valid cell wrong: {out[0, 0]}"
+        assert out[1, 0] == pytest.approx(20.0), f"Valid cell wrong: {out[1, 0]}"
+
+    def test_source_dataset_unchanged(self, single_band_dataset):
+        """convert_units returns a new Dataset and leaves the source untouched.
+
+        Test scenario:
+            After conversion the source still reports its original values and units.
+        """
+        single_band_dataset.band_units = ["K"]
+        snapshot = single_band_dataset.read_array().copy()
+        result = single_band_dataset.convert_units("celsius")
+        assert (
+            result is not single_band_dataset
+        ), "convert_units must return a new object"
+        np.testing.assert_array_equal(
+            single_band_dataset.read_array(), snapshot, err_msg="source was mutated"
+        )
+        assert single_band_dataset.band_units == ["K"], "source units changed"
+
+    def test_band_out_of_range_raises(self, single_band_dataset):
+        """convert_units rejects a band index outside the valid range.
+
+        Test scenario:
+            Requesting band 5 on a single-band raster raises ValueError mentioning
+            'out of range'.
+        """
+        single_band_dataset.band_units = ["K"]
+        with pytest.raises(ValueError, match="out of range") as exc:
+            single_band_dataset.convert_units("celsius", band=5)
+        assert "out of range" in str(exc.value), f"Unexpected: {exc.value}"
+
+    def test_unknown_target_raises(self, single_band_dataset):
+        """convert_units propagates the ValueError for an unsupported target.
+
+        Test scenario:
+            A target unit absent from the affine table raises ValueError mentioning
+            'No unit conversion'.
+        """
+        single_band_dataset.band_units = ["K"]
+        with pytest.raises(ValueError, match="No unit conversion") as exc:
+            single_band_dataset.convert_units("furlongs")
+        assert "No unit conversion" in str(exc.value), f"Unexpected: {exc.value}"
+
+
 class TestCountDomainCells:
     """Tests for the count_domain_cells method."""
 

--- a/tests/grids/test_grids.py
+++ b/tests/grids/test_grids.py
@@ -273,6 +273,31 @@ class TestFromOctahedral:
             )
         assert "equal length" in str(exc.value), f"Unexpected message: {exc.value}"
 
+    def test_bbox_pins_output_extent(self, octahedral_points):
+        """from_octahedral honours an explicit bbox for the output extent.
+
+        Test scenario:
+            Passing bbox=(-180, -90, 180, 90) with cell_size=5 yields a 72x36 grid whose
+            bounding box equals the requested global extent, rather than the points'
+            (much smaller) bounding box.
+        """
+        lats, lons, values = octahedral_points
+        ds = from_octahedral(
+            lats,
+            lons,
+            values,
+            cell_size=5.0,
+            algorithm="nearest",
+            bbox=(-180.0, -90.0, 180.0, 90.0),
+        )
+        assert (ds.rows, ds.columns) == (36, 72), f"Got {ds.rows}x{ds.columns}"
+        np.testing.assert_allclose(
+            list(ds.bbox),
+            [-180.0, -90.0, 180.0, 90.0],
+            atol=1e-6,
+            err_msg="bbox not pinned",
+        )
+
 
 class TestRingPix2Lonlat:
     """Tests for :func:`pyramids.grids.healpix._ring_pix2lonlat`."""
@@ -441,3 +466,21 @@ class TestFromHealpix:
         with pytest.raises(ValueError, match="power of two") as exc:
             from_healpix(np.zeros(108), nside=3, nest=True, cell_size=30.0)
         assert "power of two" in str(exc.value), f"Unexpected: {exc.value}"
+
+    def test_bbox_pins_output_extent(self):
+        """from_healpix honours an explicit bbox for the output extent.
+
+        Test scenario:
+            An nside=2 field gridded with bbox=(-180, -90, 180, 90) and cell_size=10
+            yields a 36x18 grid whose bounding box equals the requested global extent.
+        """
+        ds = from_healpix(
+            np.arange(48.0), nside=2, cell_size=10.0, bbox=(-180.0, -90.0, 180.0, 90.0)
+        )
+        assert (ds.rows, ds.columns) == (18, 36), f"Got {ds.rows}x{ds.columns}"
+        np.testing.assert_allclose(
+            list(ds.bbox),
+            [-180.0, -90.0, 180.0, 90.0],
+            atol=1e-6,
+            err_msg="bbox not pinned",
+        )

--- a/tests/grids/test_grids.py
+++ b/tests/grids/test_grids.py
@@ -96,18 +96,40 @@ class TestFromOrca:
         """from_orca interpolated values stay within the source value range.
 
         Test scenario:
-            Nearest-neighbour regridding cannot invent values outside the input
-            field; valid (non-nodata) cells lie within ``[min, max]`` of the faces.
+            Face values are corner-node means and the regrid cannot invent values
+            outside the input field; valid (non-nodata) cells lie within
+            ``[data2d.min, data2d.max]``.
         """
         lon2d, lat2d, data2d = orca_grid
         nodata = -9999.0
         ds = from_orca(lon2d, lat2d, data2d, cell_size=0.5, nodata=nodata)
         arr = ds.read_array()
         valid = arr[arr != nodata]
-        face_values = data2d[:-1, :-1]
         assert valid.size > 0, "No valid cells produced by from_orca."
-        assert valid.min() >= face_values.min() - 1e-6, "Value below source min."
-        assert valid.max() <= face_values.max() + 1e-6, "Value above source max."
+        assert valid.min() >= data2d.min() - 1e-6, "Value below source min."
+        assert valid.max() <= data2d.max() + 1e-6, "Value above source max."
+
+    def test_face_value_is_corner_node_mean(self):
+        """from_orca uses the mean of a face's four corner nodes (no data dropped).
+
+        Test scenario:
+            On a 2x2 grid (a single quad face) the only cell's value equals the mean of
+            all four node values, proving the last row/column contribute (the old
+            implementation used only the upper-left node).
+        """
+        lon2d = np.array([[0.0, 1.0], [0.0, 1.0]])
+        lat2d = np.array([[1.0, 1.0], [0.0, 0.0]])
+        data2d = np.array([[1.0, 2.0], [3.0, 4.0]])
+        ds = from_orca(lon2d, lat2d, data2d, cell_size=0.5, method="nearest")
+        arr = ds.read_array()
+        valid = arr[arr != ds.no_data_value[0]]
+        assert valid.size > 0, "single quad face produced no cells"
+        np.testing.assert_allclose(
+            np.unique(valid),
+            [2.5],
+            atol=1e-9,
+            err_msg="face value should be mean of 1..4",
+        )
 
     @pytest.mark.parametrize(
         "lon_shape, lat_shape, data_shape",

--- a/tests/grids/test_grids.py
+++ b/tests/grids/test_grids.py
@@ -7,8 +7,9 @@ Covers the three adapters that turn non-raster model grids into a regular-grid
   mesh → raster.
 * :func:`pyramids.grids.from_octahedral` — ragged per-point lat/lon → scattered points
   → raster.
-* :func:`pyramids.grids.from_healpix` — deferred; raises :class:`NotImplementedError`
-  until the ``healpy`` dependency is approved.
+* :func:`pyramids.grids.from_healpix` — HEALPix pixels (RING or NESTED) → scattered
+  points → raster, with the pixel→lon/lat math implemented in plain NumPy (no
+  ``healpy`` dependency).
 """
 
 from __future__ import annotations
@@ -18,6 +19,7 @@ import pytest
 
 from pyramids.dataset.dataset import Dataset
 from pyramids.grids import from_healpix, from_octahedral, from_orca
+from pyramids.grids.healpix import _nest2ring, _ring_pix2lonlat
 
 
 @pytest.fixture(scope="function")
@@ -250,29 +252,170 @@ class TestFromOctahedral:
         assert "equal length" in str(exc.value), f"Unexpected message: {exc.value}"
 
 
+class TestRingPix2Lonlat:
+    """Tests for :func:`pyramids.grids.healpix._ring_pix2lonlat`."""
+
+    def test_nside1_matches_canonical_centres(self):
+        """RING pix2ang reproduces the canonical HEALPix nside=1 pixel centres.
+
+        Test scenario:
+            For nside=1 (12 pixels) the four north-cap pixels sit at lat=arcsin(2/3)
+            (≈41.81°) and lon 45/135/225/315; the four equatorial pixels at lat=0 and
+            lon 0/90/180/270; the four south-cap pixels at lat=-41.81°.
+        """
+        lon, lat = _ring_pix2lonlat(1, np.arange(12))
+        cap = np.degrees(np.arcsin(2.0 / 3.0))
+        np.testing.assert_allclose(
+            lon, [45, 135, 225, 315, 90, 180, 270, 0, 45, 135, 225, 315], atol=1e-9
+        )
+        np.testing.assert_allclose(
+            lat,
+            [cap, cap, cap, cap, 0, 0, 0, 0, -cap, -cap, -cap, -cap],
+            atol=1e-9,
+        )
+
+    @pytest.mark.parametrize("nside", [1, 2, 4, 8])
+    def test_latitudes_symmetric_and_lon_in_range(self, nside):
+        """RING centres are north/south symmetric with longitudes in [0, 360).
+
+        Args:
+            nside: HEALPix resolution parameter.
+
+        Test scenario:
+            The sorted latitude set is symmetric about the equator and every longitude
+            falls in [0, 360).
+        """
+        npix = 12 * nside * nside
+        lon, lat = _ring_pix2lonlat(nside, np.arange(npix))
+        assert lon.min() >= 0.0 and lon.max() < 360.0, f"lon out of range for {nside}"
+        np.testing.assert_allclose(
+            np.sort(lat), -np.sort(-lat)[::-1], atol=1e-9, err_msg="lat not symmetric"
+        )
+
+
+class TestNest2Ring:
+    """Tests for :func:`pyramids.grids.healpix._nest2ring`."""
+
+    @pytest.mark.parametrize("nside", [1, 2, 4, 8])
+    def test_is_bijection(self, nside):
+        """nest2ring is a bijection over the full pixel index range.
+
+        Args:
+            nside: HEALPix resolution parameter.
+
+        Test scenario:
+            Mapping every nested index 0..npix-1 yields a permutation of the same range
+            (no collisions, no out-of-range values).
+        """
+        npix = 12 * nside * nside
+        ring = _nest2ring(nside, np.arange(npix))
+        np.testing.assert_array_equal(
+            np.sort(ring), np.arange(npix), err_msg=f"not a bijection for nside={nside}"
+        )
+
+    def test_known_reference_nside2(self):
+        """nest2ring matches the published HEALPix reference for nside=2.
+
+        Test scenario:
+            nest2ring(2, 0..11) equals the canonical [13,5,4,0,15,7,6,1,17,9,8,2].
+        """
+        result = _nest2ring(2, np.arange(12)).tolist()
+        assert result == [13, 5, 4, 0, 15, 7, 6, 1, 17, 9, 8, 2], f"Got {result}"
+
+    @pytest.mark.parametrize("nside", [1, 2, 4, 8])
+    def test_nested_centre_set_equals_ring(self, nside):
+        """NESTED pixel centres are the same set as RING centres for a given nside.
+
+        Args:
+            nside: HEALPix resolution parameter.
+
+        Test scenario:
+            RING and NESTED index the same physical pixels, so the unordered set of
+            centre coordinates must be identical.
+        """
+        npix = 12 * nside * nside
+        idx = np.arange(npix)
+        lon_r, lat_r = _ring_pix2lonlat(nside, idx)
+        lon_n, lat_n = _ring_pix2lonlat(nside, _nest2ring(nside, idx))
+        set_ring = set(zip(np.round(lon_r, 9), np.round(lat_r, 9)))
+        set_nest = set(zip(np.round(lon_n, 9), np.round(lat_n, 9)))
+        assert set_ring == set_nest, f"centre sets differ for nside={nside}"
+
+
 class TestFromHealpix:
-    """Tests for the deferred :func:`pyramids.grids.from_healpix`."""
+    """Tests for :func:`pyramids.grids.from_healpix`."""
 
-    def test_raises_not_implemented(self):
-        """from_healpix raises NotImplementedError while deferred.
-
-        Test scenario:
-            Any call raises NotImplementedError whose message points at the
-            supported adapters and the pending 'healpy' dependency.
-        """
-        with pytest.raises(NotImplementedError) as exc:
-            from_healpix(np.zeros(12), cell_size=1.0)
-        msg = str(exc.value)
-        assert "healpy" in msg, f"Message should mention healpy: {msg}"
-        assert "from_orca" in msg, f"Message should point at from_orca: {msg}"
-
-    def test_raises_regardless_of_arguments(self):
-        """from_healpix raises even when given a full set of valid-looking args.
+    def test_ring_returns_single_band_dataset(self):
+        """from_healpix regrids a RING field into a single-band Dataset.
 
         Test scenario:
-            Supplying nside/nest/method does not change the deferred behaviour.
+            An nside=1 RING field (12 pixels) yields a Dataset with one band, positive
+            dimensions, and the requested CRS.
         """
-        with pytest.raises(NotImplementedError):
-            from_healpix(
-                np.zeros(48), nside=2, nest=True, cell_size=2.0, method="nearest"
-            )
+        ds = from_healpix(np.arange(12.0), cell_size=30.0)
+        assert isinstance(ds, Dataset), f"Expected a Dataset, got {type(ds)}"
+        assert ds.band_count == 1, f"Expected 1 band, got {ds.band_count}"
+        assert ds.rows > 0 and ds.columns > 0, f"Empty grid: {ds.rows}x{ds.columns}"
+        assert ds.epsg == 4326, f"Expected EPSG 4326, got {ds.epsg}"
+
+    def test_nested_returns_single_band_dataset(self):
+        """from_healpix regrids a NESTED field into a single-band Dataset.
+
+        Test scenario:
+            An nside=2 NESTED field (48 pixels) yields a single-band Dataset.
+        """
+        ds = from_healpix(np.arange(48.0), nside=2, nest=True, cell_size=20.0)
+        assert ds.band_count == 1, f"Expected 1 band, got {ds.band_count}"
+
+    def test_nside_derived_from_length(self):
+        """from_healpix derives nside from the value count when omitted.
+
+        Test scenario:
+            A 192-element field implies nside=4 (12*16) and regrids without an explicit
+            nside.
+        """
+        ds = from_healpix(np.arange(192.0), cell_size=15.0)
+        assert ds.band_count == 1, f"Expected 1 band, got {ds.band_count}"
+
+    def test_nearest_values_subset_of_source(self):
+        """from_healpix nearest-neighbour output values come from the source field.
+
+        Test scenario:
+            With method="nearest", every output cell value must be one of the input
+            pixel values (no interpolation between them).
+        """
+        values = np.arange(48.0)
+        ds = from_healpix(values, nside=2, nest=True, cell_size=20.0, method="nearest")
+        produced = set(np.unique(ds.read_array()).tolist())
+        assert produced.issubset(set(values.tolist())), f"Unexpected: {produced}"
+
+    def test_invalid_length_raises(self):
+        """from_healpix rejects a value count that is not 12*nside**2.
+
+        Test scenario:
+            A length of 10 is not a valid HEALPix pixel count and raises ValueError.
+        """
+        with pytest.raises(ValueError, match="valid HEALPix pixel count") as exc:
+            from_healpix(np.zeros(10), cell_size=30.0)
+        assert "valid HEALPix" in str(exc.value), f"Unexpected: {exc.value}"
+
+    def test_explicit_nside_mismatch_raises(self):
+        """from_healpix rejects an explicit nside that disagrees with the length.
+
+        Test scenario:
+            nside=4 implies 192 pixels; passing 12 values raises ValueError.
+        """
+        with pytest.raises(ValueError, match="valid HEALPix pair") as exc:
+            from_healpix(np.zeros(12), nside=4, cell_size=30.0)
+        assert "192" in str(exc.value), f"Expected pixel count in message: {exc.value}"
+
+    def test_nested_non_power_of_two_raises(self):
+        """from_healpix rejects NESTED ordering with a non-power-of-two nside.
+
+        Test scenario:
+            nside=3 is a valid RING resolution (108 pixels) but NESTED ordering requires
+            a power-of-two nside, so nest=True raises ValueError.
+        """
+        with pytest.raises(ValueError, match="power of two") as exc:
+            from_healpix(np.zeros(108), nside=3, nest=True, cell_size=30.0)
+        assert "power of two" in str(exc.value), f"Unexpected: {exc.value}"

--- a/tests/grids/test_grids.py
+++ b/tests/grids/test_grids.py
@@ -131,6 +131,40 @@ class TestFromOrca:
             err_msg="face value should be mean of 1..4",
         )
 
+    def test_nan_node_ignored_where_finite_corners_exist(self):
+        """from_orca ignores a NaN-masked node when a face has finite corners.
+
+        Test scenario:
+            On a 2x2 grid (one face) with a single NaN corner, the face value is the
+            mean of the three finite corners (NaN-aware), not NaN.
+        """
+        lon2d = np.array([[0.0, 1.0], [0.0, 1.0]])
+        lat2d = np.array([[1.0, 1.0], [0.0, 0.0]])
+        data2d = np.array([[1.0, 2.0], [3.0, np.nan]])
+        ds = from_orca(lon2d, lat2d, data2d, cell_size=0.5, method="nearest")
+        arr = ds.read_array()
+        valid = arr[arr != ds.no_data_value[0]]
+        assert valid.size > 0, "single face produced no cells"
+        np.testing.assert_allclose(
+            np.unique(valid), [2.0], atol=1e-9, err_msg="face should be mean of 1,2,3"
+        )
+
+    def test_all_nan_face_is_blank(self):
+        """from_orca yields a NaN face only when all four corners are NaN.
+
+        Test scenario:
+            A 2x2 grid whose single face has all-NaN corners produces no finite valid
+            cells (every covered cell is NaN), confirming all-NaN faces are not
+            fabricated into finite values.
+        """
+        lon2d = np.array([[0.0, 1.0], [0.0, 1.0]])
+        lat2d = np.array([[1.0, 1.0], [0.0, 0.0]])
+        data2d = np.full((2, 2), np.nan)
+        ds = from_orca(lon2d, lat2d, data2d, cell_size=0.5, method="nearest")
+        arr = ds.read_array()
+        finite_valid = arr[(arr != ds.no_data_value[0]) & np.isfinite(arr)]
+        assert finite_valid.size == 0, f"expected no finite cells, got {finite_valid}"
+
     @pytest.mark.parametrize(
         "lon_shape, lat_shape, data_shape",
         [

--- a/tests/grids/test_grids.py
+++ b/tests/grids/test_grids.py
@@ -1,0 +1,278 @@
+"""Tests for the exotic-grid adapters in :mod:`pyramids.grids`.
+
+Covers the three adapters that turn non-raster model grids into a regular-grid
+:class:`~pyramids.dataset.Dataset`:
+
+* :func:`pyramids.grids.from_orca` — curvilinear ``(ny, nx)`` lon/lat → UGRID quad
+  mesh → raster.
+* :func:`pyramids.grids.from_octahedral` — ragged per-point lat/lon → scattered points
+  → raster.
+* :func:`pyramids.grids.from_healpix` — deferred; raises :class:`NotImplementedError`
+  until the ``healpy`` dependency is approved.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pyramids.dataset.dataset import Dataset
+from pyramids.grids import from_healpix, from_octahedral, from_orca
+
+
+@pytest.fixture(scope="function")
+def orca_grid():
+    """Build a small synthetic ORCA-style curvilinear grid.
+
+    Returns:
+        tuple: ``(lon2d, lat2d, data2d)`` each a ``(4, 5)`` float array. ``lon2d`` and
+        ``lat2d`` are a regular lon/lat mesh; ``data2d`` is a ramp of distinct values.
+    """
+    ny, nx = 4, 5
+    lon2d = np.tile(np.arange(nx, dtype=float), (ny, 1))
+    lat2d = np.tile(np.arange(ny, dtype=float)[:, None], (1, nx))
+    data2d = np.arange(ny * nx, dtype=float).reshape(ny, nx)
+    return lon2d, lat2d, data2d
+
+
+@pytest.fixture(scope="function")
+def octahedral_points():
+    """Build a small synthetic octahedral reduced-Gaussian point set.
+
+    Returns:
+        tuple: ``(lats, lons, values)`` 1-D float arrays of equal length describing
+        four corner points of a 5x5 degree box with distinct values.
+    """
+    lats = np.array([0.0, 0.0, 5.0, 5.0])
+    lons = np.array([0.0, 5.0, 0.0, 5.0])
+    values = np.array([1.0, 2.0, 3.0, 4.0])
+    return lats, lons, values
+
+
+class TestFromOrca:
+    """Tests for :func:`pyramids.grids.from_orca`."""
+
+    def test_returns_single_band_dataset(self, orca_grid):
+        """from_orca returns a single-band regular-grid Dataset.
+
+        Test scenario:
+            A 4x5 curvilinear grid regridded at cell_size=0.5 yields a
+            :class:`Dataset` with one band and a positive row/column count.
+        """
+        lon2d, lat2d, data2d = orca_grid
+        ds = from_orca(lon2d, lat2d, data2d, cell_size=0.5)
+        assert isinstance(ds, Dataset), f"Expected a Dataset, got {type(ds)}"
+        assert ds.band_count == 1, f"Expected 1 band, got {ds.band_count}"
+        assert ds.rows > 0 and ds.columns > 0, f"Empty grid: {ds.rows}x{ds.columns}"
+
+    def test_crs_is_propagated(self, orca_grid):
+        """from_orca stamps the requested EPSG on the output.
+
+        Test scenario:
+            Passing epsg=4326 (default) produces a Dataset reporting EPSG 4326.
+        """
+        lon2d, lat2d, data2d = orca_grid
+        ds = from_orca(lon2d, lat2d, data2d, cell_size=0.5, epsg=4326)
+        assert ds.epsg == 4326, f"Expected EPSG 4326, got {ds.epsg}"
+
+    def test_extent_covers_node_bounds(self, orca_grid):
+        """from_orca output extent spans the input coordinate range.
+
+        Test scenario:
+            The output bounding box should fall within the node coordinate
+            min/max envelope (the mesh cannot extend past its own nodes).
+        """
+        lon2d, lat2d, data2d = orca_grid
+        ds = from_orca(lon2d, lat2d, data2d, cell_size=0.5)
+        xmin, ymin, xmax, ymax = (float(v) for v in ds.bbox)
+        assert xmin >= lon2d.min() - 1e-6, f"xmin {xmin} below node min {lon2d.min()}"
+        assert xmax <= lon2d.max() + 1e-6, f"xmax {xmax} above node max {lon2d.max()}"
+        assert ymin >= lat2d.min() - 1e-6, f"ymin {ymin} below node min {lat2d.min()}"
+        assert ymax <= lat2d.max() + 1e-6, f"ymax {ymax} above node max {lat2d.max()}"
+
+    def test_values_within_source_range(self, orca_grid):
+        """from_orca interpolated values stay within the source value range.
+
+        Test scenario:
+            Nearest-neighbour regridding cannot invent values outside the input
+            field; valid (non-nodata) cells lie within ``[min, max]`` of the faces.
+        """
+        lon2d, lat2d, data2d = orca_grid
+        nodata = -9999.0
+        ds = from_orca(lon2d, lat2d, data2d, cell_size=0.5, nodata=nodata)
+        arr = ds.read_array()
+        valid = arr[arr != nodata]
+        face_values = data2d[:-1, :-1]
+        assert valid.size > 0, "No valid cells produced by from_orca."
+        assert valid.min() >= face_values.min() - 1e-6, "Value below source min."
+        assert valid.max() <= face_values.max() + 1e-6, "Value above source max."
+
+    @pytest.mark.parametrize(
+        "lon_shape, lat_shape, data_shape",
+        [
+            ((4, 5), (4, 4), (4, 5)),
+            ((4, 5), (4, 5), (3, 5)),
+            ((4, 5), (3, 5), (3, 5)),
+        ],
+    )
+    def test_mismatched_shapes_raise(self, lon_shape, lat_shape, data_shape):
+        """from_orca rejects coordinate/data arrays of differing shapes.
+
+        Args:
+            lon_shape: Shape of the longitude array.
+            lat_shape: Shape of the latitude array.
+            data_shape: Shape of the data array.
+
+        Test scenario:
+            Any shape disagreement between lon2d/lat2d/data2d raises ValueError
+            mentioning "same shape".
+        """
+        lon2d = np.zeros(lon_shape)
+        lat2d = np.zeros(lat_shape)
+        data2d = np.zeros(data_shape)
+        with pytest.raises(ValueError, match="same shape") as exc:
+            from_orca(lon2d, lat2d, data2d, cell_size=0.5)
+        assert "same shape" in str(exc.value), f"Unexpected message: {exc.value}"
+
+    def test_non_2d_input_raises(self):
+        """from_orca rejects 1-D coordinate arrays.
+
+        Test scenario:
+            Passing 1-D arrays (all the same shape) raises ValueError mentioning
+            "2-D".
+        """
+        flat = np.arange(6, dtype=float)
+        with pytest.raises(ValueError, match="2-D") as exc:
+            from_orca(flat, flat, flat, cell_size=0.5)
+        assert "2-D" in str(exc.value), f"Unexpected message: {exc.value}"
+
+    @pytest.mark.parametrize("shape", [(1, 5), (4, 1), (1, 1)])
+    def test_degenerate_grid_raises(self, shape):
+        """from_orca rejects grids too small to form any quad cell.
+
+        Args:
+            shape: A 2-D shape with at least one dimension < 2.
+
+        Test scenario:
+            A grid with fewer than 2 rows or 2 columns raises ValueError
+            mentioning "2 x 2".
+        """
+        arr = np.zeros(shape)
+        with pytest.raises(ValueError, match=r"2 x 2") as exc:
+            from_orca(arr, arr, arr, cell_size=0.5)
+        assert "2 x 2" in str(exc.value), f"Unexpected message: {exc.value}"
+
+
+class TestFromOctahedral:
+    """Tests for :func:`pyramids.grids.from_octahedral`."""
+
+    def test_returns_single_band_dataset(self, octahedral_points):
+        """from_octahedral returns a single-band regular-grid Dataset.
+
+        Test scenario:
+            Four corner points regridded at cell_size=1.0 with nearest-neighbour
+            yield a Dataset with one band and positive dimensions.
+        """
+        lats, lons, values = octahedral_points
+        ds = from_octahedral(lats, lons, values, cell_size=1.0, algorithm="nearest")
+        assert isinstance(ds, Dataset), f"Expected a Dataset, got {type(ds)}"
+        assert ds.band_count == 1, f"Expected 1 band, got {ds.band_count}"
+        assert ds.rows > 0 and ds.columns > 0, f"Empty grid: {ds.rows}x{ds.columns}"
+
+    def test_crs_is_propagated(self, octahedral_points):
+        """from_octahedral stamps the requested EPSG on the output.
+
+        Test scenario:
+            Passing epsg=4326 produces a Dataset reporting EPSG 4326.
+        """
+        lats, lons, values = octahedral_points
+        ds = from_octahedral(lats, lons, values, cell_size=1.0, epsg=4326)
+        assert ds.epsg == 4326, f"Expected EPSG 4326, got {ds.epsg}"
+
+    def test_grid_resolution_matches_cell_size(self, octahedral_points):
+        """from_octahedral honours cell_size for the output resolution.
+
+        Test scenario:
+            A 5x5 degree extent at cell_size=1.0 yields a 5x5 grid (rounded extent
+            / cell_size).
+        """
+        lats, lons, values = octahedral_points
+        ds = from_octahedral(lats, lons, values, cell_size=1.0, algorithm="nearest")
+        assert ds.rows == 5, f"Expected 5 rows, got {ds.rows}"
+        assert ds.columns == 5, f"Expected 5 columns, got {ds.columns}"
+
+    def test_nearest_preserves_source_values(self, octahedral_points):
+        """from_octahedral nearest-neighbour output equals one of the inputs per cell.
+
+        Test scenario:
+            With algorithm="nearest", every output cell value must be one of the
+            four source values (no interpolation between them).
+        """
+        lats, lons, values = octahedral_points
+        ds = from_octahedral(lats, lons, values, cell_size=1.0, algorithm="nearest")
+        arr = ds.read_array()
+        produced = set(np.unique(arr).tolist())
+        allowed = set(values.tolist())
+        assert produced.issubset(allowed), f"Unexpected values {produced - allowed}"
+
+    def test_accepts_2d_input_by_raveling(self):
+        """from_octahedral flattens multi-dimensional inputs of equal size.
+
+        Test scenario:
+            2-D lat/lon/value arrays of equal size are ravelled and gridded without
+            error.
+        """
+        lats = np.array([[0.0, 0.0], [5.0, 5.0]])
+        lons = np.array([[0.0, 5.0], [0.0, 5.0]])
+        values = np.array([[1.0, 2.0], [3.0, 4.0]])
+        ds = from_octahedral(lats, lons, values, cell_size=1.0, algorithm="nearest")
+        assert ds.band_count == 1, f"Expected 1 band, got {ds.band_count}"
+
+    @pytest.mark.parametrize(
+        "n_lat, n_lon, n_val",
+        [(4, 3, 4), (4, 4, 3), (3, 4, 4)],
+    )
+    def test_unequal_lengths_raise(self, n_lat, n_lon, n_val):
+        """from_octahedral rejects lat/lon/value arrays of unequal length.
+
+        Args:
+            n_lat: Number of latitude values.
+            n_lon: Number of longitude values.
+            n_val: Number of data values.
+
+        Test scenario:
+            Any length disagreement raises ValueError mentioning "equal length".
+        """
+        with pytest.raises(ValueError, match="equal length") as exc:
+            from_octahedral(
+                np.zeros(n_lat), np.zeros(n_lon), np.zeros(n_val), cell_size=1.0
+            )
+        assert "equal length" in str(exc.value), f"Unexpected message: {exc.value}"
+
+
+class TestFromHealpix:
+    """Tests for the deferred :func:`pyramids.grids.from_healpix`."""
+
+    def test_raises_not_implemented(self):
+        """from_healpix raises NotImplementedError while deferred.
+
+        Test scenario:
+            Any call raises NotImplementedError whose message points at the
+            supported adapters and the pending 'healpy' dependency.
+        """
+        with pytest.raises(NotImplementedError) as exc:
+            from_healpix(np.zeros(12), cell_size=1.0)
+        msg = str(exc.value)
+        assert "healpy" in msg, f"Message should mention healpy: {msg}"
+        assert "from_orca" in msg, f"Message should point at from_orca: {msg}"
+
+    def test_raises_regardless_of_arguments(self):
+        """from_healpix raises even when given a full set of valid-looking args.
+
+        Test scenario:
+            Supplying nside/nest/method does not change the deferred behaviour.
+        """
+        with pytest.raises(NotImplementedError):
+            from_healpix(
+                np.zeros(48), nside=2, nest=True, cell_size=2.0, method="nearest"
+            )


### PR DESCRIPTION
# Description

Adds GIS capabilities to pyramids. pyramids is the
project's only GIS dependency, so each capability is implemented here (with tests) and consumed via
its API rather than pulling a competitor package (xarray / rasterio / regridders / Cartopy) into the
viz layer. **No new third-party dependency is added** — every feature reuses existing deps or the
standard library.

14 commits; 20 files; +2,879 / −31.

## What's included

### `pyramids.grids` — exotic model-grid adapters (new subpackage)

Turns model grids that are not row-major rasters into a regular single-band `Dataset`, reusing the
existing regridding bridges (no new regridder):

- `from_orca(lon2d, lat2d, data2d, …)` — curvilinear `(ny, nx)` lon/lat (NEMO/ORCA) → UGRID quad
  mesh → `mesh_to_grid`. Each face value is the NaN-aware mean of its four corner nodes.
- `from_octahedral(lats, lons, values, …)` — ragged per-point fields (ECMWF `O` grids) → scattered
  points → `grid_points`.
- `from_healpix(values, *, nside=None, nest=False, …)` — HEALPix pixelizations, **RING and NESTED**,
  with the pixel→lon/lat `pix2ang` math implemented in plain NumPy (**no `healpy` dependency**),
  validated against canonical HEALPix references.
- `from_octahedral` / `from_healpix` accept an optional `bbox` to pin the output extent.

### `Dataset.convert_units` — band value conversion

`Dataset.convert_units(target, band=None)` converts band values (not just the `band_units` label) and
returns a new Dataset. Backed by a small affine table in `dataset/ops/units.py` (K↔°C, m s⁻¹↔knots,
Pa↔hPa, m↔mm) — no `pint` dependency. No-data cells are preserved; unknown pairs raise a clear error.

### `pyramids.basemap.natural_earth` — Natural Earth vector features

`natural_earth(layer, resolution)` returns coastline / borders / land / ocean / rivers / lakes as a
`FeatureCollection`. Downloads on first use with the standard library (HTTP(S)-only, atomic write
with temp-file cleanup), caches under `~/.pyramids/naturalearth` (overridable via
`PYRAMIDS_CACHE_DIR`), and reads the shapefile through GDAL `/vsizip/` by listing the archive's `.shp`
member (robust to layout). No new dependency.

### `Dataset.to_crs` accepts `int | str | pyproj.CRS`

`to_crs` now resolves a target CRS given as an EPSG int, a string (`"EPSG:3857"`, `"3857"`, WKT,
PROJ4), or a `pyproj.CRS`, via the new `pyramids.base.crs.epsg_from_user_input`. **Minor compatibility
note:** invalid input now raises `CRSError` (a `ValueError` subclass) instead of `TypeError`, and
strings like `"4326"` are now accepted rather than rejected.

### Bug fixes

- `Dataset.lat` / `Dataset.y` used the pixel width for the y-axis; on non-square-cell rasters
  (`dx != dy`) the latitude axis was wrong. They now use the geotransform's pixel height
  (`abs(geotransform[5])`).
- Fixed a recursion between `Dataset.lon`/`lat` and `NetCDF.geotransform` (read the cached
  `_geotransform`), and an import cycle introduced by `basemap.features` (function-scoped import +
  public `_io` archive helpers).

### Docs

Reference page `docs/reference/grids.md` and a runnable example notebook
`docs/examples/grids/grids.ipynb`, wired into the mkdocs nav.

# Issues

- Fixes #408
- Fixes #409
- Fixes #410

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- Full suite: `pixi run -e dev main` (`pytest -m 'not plot'`) → **4066 passed, 9 skipped**.
- New/updated test suites: `tests/grids/`, `tests/dataset/ops/test_units.py`, `tests/base/test_crs.py`,
  `tests/basemap/test_features.py`, plus `TestConvertUnits` / `TestCoordinateProperties` / `TestToCrs`
  in `tests/dataset/test_dataset_unit.py`. The new `grids` and `basemap.features` modules are at 100%
  line+branch coverage.
- HEALPix validated against canonical references (nside=1 RING centres; `nest2ring` bijection +
  centre-set equality; published `nest2ring(2, …)`).
- Docstring doctests pass under `pytest --doctest-modules`; the example notebook passes
  `pytest --nbval --nbval-lax`.

- [x] Test A — unit + round-trip tests for every new adapter / method, including error paths and
      no-data handling.
- [x] Test B — Natural Earth cache-hit / robust-`.shp` / failed-download tests (live CDN fetch behind
      a `slow` mark, skippable offline).

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.

