### PR TITLE
feat(dataset): accept arbitrary CRS in Dataset.to_crs

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -5,8 +5,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -109,7 +107,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/5f/9ff93450ba96b09c7c2b3f81c94de31c89f92292f1380261bd7195bea4ea/contourpy-1.3.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl
@@ -225,7 +223,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-h80f16a2_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.2-hdc9db2a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/71/f93e1e9471d189f79d0ce2497007731c1e6bf9ef6d1d61b911430c3db4e5/contourpy-1.3.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl
@@ -335,7 +333,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.2-hbb4bfdb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/72/8b/4546f3ab60f78c514ffb7d01a0bd743f90de36f0019d1be84d0a708a580a/contourpy-1.3.3-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl
@@ -445,7 +443,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/e1/3542a9cb596cadd76fcef413f19c79216e002623158befe6daa03dbfa88c/contourpy-1.3.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl
@@ -544,14 +542,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_37.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.3.0-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl
@@ -571,8 +569,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -630,7 +626,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.18-h6688a6e_0.conda
@@ -689,7 +685,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.26.0-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-24.0.0-h7376487_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.33.5-h2b00c02_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.33.5-h6eeba95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.11.05-h0dc7533_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h46dd2a8_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-gpl_hab3fe16_120.conda
@@ -790,7 +786,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -992,7 +988,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/json-c-0.18-hd4cd8d4_0.conda
@@ -1051,7 +1047,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopentelemetry-cpp-headers-1.26.0-h8af1aa0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libparquet-24.0.0-h87079af_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-6.33.5-h1f88751_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-6.33.5-h306233d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libre2-11-2025.11.05-hc5e897d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librttopo-1.1.0-h783d356_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libspatialite-5.1.0-gpl_hb93075d_120.conda
@@ -1152,7 +1148,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -1354,7 +1350,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/json-c-0.18-hc62ec3d_0.conda
@@ -1409,7 +1405,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libopentelemetry-cpp-headers-1.26.0-h694c41f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-24.0.0-h527dc83_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.58-he930e7c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-6.33.5-h29d92e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-6.33.5-hff14b61_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2025.11.05-h6e8c311_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/librttopo-1.1.0-h16cd5d8_20.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libspatialite-5.1.0-gpl_h77f1de8_120.conda
@@ -1508,7 +1504,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -1707,7 +1703,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/json-c-0.18-he4178ee_0.conda
@@ -1762,7 +1758,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.26.0-hce30654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-24.0.0-h16c0493_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.33.5-h4a5acfd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.33.5-h2d4b707_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2025.11.05-h4c27e2a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/librttopo-1.1.0-ha909e78_20.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libspatialite-5.1.0-gpl_hc59e0ec_120.conda
@@ -1861,7 +1857,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -2056,7 +2052,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.6-nompi_hae35d4c_109.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kerchunk-0.2.10-pyhd8ed1ab_0.conda
@@ -2103,7 +2099,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libopentelemetry-cpp-headers-1.26.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-24.0.0-h7051d1f_2_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.58-h7351971_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-6.33.5-h61fc761_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-6.33.5-h6cf2d3c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2025.11.05-h04e5de1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-haa95264_20.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-gpl_h2fc3b25_120.conda
@@ -2172,10 +2168,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/ujson-5.12.1-py314hb98de8c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_37.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_38.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-2.2.1-py314h5a2d7ad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.3.0-hac47afa_1.conda
@@ -2210,7 +2206,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
@@ -2356,8 +2352,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -3373,9 +3367,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_37.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.3.0-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
@@ -3518,8 +3512,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -3556,7 +3548,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.18-h6688a6e_0.conda
@@ -3680,7 +3672,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -3851,7 +3843,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/json-c-0.18-hd4cd8d4_0.conda
@@ -3975,7 +3967,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -4146,7 +4138,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/json-c-0.18-hc62ec3d_0.conda
@@ -4265,7 +4257,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -4433,7 +4425,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/json-c-0.18-he4178ee_0.conda
@@ -4552,7 +4544,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -4717,7 +4709,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.6-nompi_hae35d4c_109.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/kerchunk-0.2.10-pyhd8ed1ab_0.conda
@@ -4808,10 +4800,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/ujson-5.12.1-py314hb98de8c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_37.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_38.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-2.2.1-py314h5a2d7ad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.3.0-hac47afa_1.conda
@@ -4836,7 +4828,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
@@ -4972,8 +4964,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -5007,7 +4997,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.18-h6688a6e_0.conda
@@ -5125,7 +5115,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/5f/9ff93450ba96b09c7c2b3f81c94de31c89f92292f1380261bd7195bea4ea/contourpy-1.3.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
@@ -5245,7 +5235,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/json-c-0.18-hd4cd8d4_0.conda
@@ -5363,7 +5353,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/71/f93e1e9471d189f79d0ce2497007731c1e6bf9ef6d1d61b911430c3db4e5/contourpy-1.3.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
@@ -5483,7 +5473,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/json-c-0.18-hc62ec3d_0.conda
@@ -5596,7 +5586,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/72/8b/4546f3ab60f78c514ffb7d01a0bd743f90de36f0019d1be84d0a708a580a/contourpy-1.3.3-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
@@ -5716,7 +5706,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/json-c-0.18-he4178ee_0.conda
@@ -5829,7 +5819,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/e1/3542a9cb596cadd76fcef413f19c79216e002623158befe6daa03dbfa88c/contourpy-1.3.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
@@ -5946,7 +5936,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.6-nompi_hae35d4c_109.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.22.2-h0ea6238_0.conda
@@ -6035,10 +6025,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_37.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_38.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-2.2.1-py314h5a2d7ad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.3.0-hac47afa_1.conda
@@ -6059,7 +6049,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cd/3a/577b549de0cc09d95f11087ee63c739bba856cd3952697eec4c4bb91350a/bleach-6.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
@@ -6150,8 +6140,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -6205,7 +6193,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.18-h6688a6e_0.conda
@@ -6263,7 +6251,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.26.0-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-24.0.0-h7376487_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.33.5-h2b00c02_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.33.5-h6eeba95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.11.05-h0dc7533_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h46dd2a8_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-gpl_hab3fe16_120.conda
@@ -6351,7 +6339,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -6540,7 +6528,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/json-c-0.18-hd4cd8d4_0.conda
@@ -6598,7 +6586,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopentelemetry-cpp-headers-1.26.0-h8af1aa0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libparquet-24.0.0-h87079af_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-6.33.5-h1f88751_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-6.33.5-h306233d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libre2-11-2025.11.05-hc5e897d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librttopo-1.1.0-h783d356_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libspatialite-5.1.0-gpl_hb93075d_120.conda
@@ -6686,7 +6674,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -6875,7 +6863,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/json-c-0.18-hc62ec3d_0.conda
@@ -6929,7 +6917,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libopentelemetry-cpp-headers-1.26.0-h694c41f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-24.0.0-h527dc83_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.58-he930e7c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-6.33.5-h29d92e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-6.33.5-hff14b61_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2025.11.05-h6e8c311_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/librttopo-1.1.0-h16cd5d8_20.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libspatialite-5.1.0-gpl_h77f1de8_120.conda
@@ -7015,7 +7003,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -7201,7 +7189,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/json-c-0.18-he4178ee_0.conda
@@ -7255,7 +7243,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.26.0-hce30654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-24.0.0-h16c0493_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.33.5-h4a5acfd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.33.5-h2d4b707_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2025.11.05-h4c27e2a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/librttopo-1.1.0-ha909e78_20.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libspatialite-5.1.0-gpl_hc59e0ec_120.conda
@@ -7341,7 +7329,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -7523,7 +7511,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.6-nompi_hae35d4c_109.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.22.2-h0ea6238_0.conda
@@ -7569,7 +7557,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libopentelemetry-cpp-headers-1.26.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-24.0.0-h7051d1f_2_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.58-h7351971_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-6.33.5-h61fc761_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-6.33.5-h6cf2d3c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2025.11.05-h04e5de1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-haa95264_20.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-gpl_h2fc3b25_120.conda
@@ -7635,10 +7623,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_37.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_38.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-2.2.1-py314h5a2d7ad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.3.0-hac47afa_1.conda
@@ -7663,7 +7651,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
@@ -7800,8 +7788,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -7856,7 +7842,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-h33c6efd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/json-c-0.18-h6688a6e_0.conda
@@ -7914,7 +7900,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libopentelemetry-cpp-headers-1.26.0-ha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libparquet-24.0.0-h7376487_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h421ea60_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.33.5-h2b00c02_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.33.5-h6eeba95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.11.05-h0dc7533_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/librttopo-1.1.0-h46dd2a8_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libspatialite-5.1.0-gpl_hab3fe16_120.conda
@@ -8002,7 +7988,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -8192,7 +8178,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-hcab7f73_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/json-c-0.18-hd4cd8d4_0.conda
@@ -8250,7 +8236,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libopentelemetry-cpp-headers-1.26.0-h8af1aa0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libparquet-24.0.0-h87079af_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libpng-1.6.58-h1abf092_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-6.33.5-h1f88751_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-6.33.5-h306233d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libre2-11-2025.11.05-hc5e897d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/librttopo-1.1.0-h783d356_20.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libspatialite-5.1.0-gpl_hb93075d_120.conda
@@ -8338,7 +8324,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -8528,7 +8514,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-h25d91c4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/json-c-0.18-hc62ec3d_0.conda
@@ -8582,7 +8568,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libopentelemetry-cpp-headers-1.26.0-h694c41f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libparquet-24.0.0-h527dc83_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libpng-1.6.58-he930e7c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-6.33.5-h29d92e8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-6.33.5-hff14b61_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libre2-11-2025.11.05-h6e8c311_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/librttopo-1.1.0-h16cd5d8_20.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libspatialite-5.1.0-gpl_h77f1de8_120.conda
@@ -8668,7 +8654,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -8855,7 +8841,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-hef89b57_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/json-c-0.18-he4178ee_0.conda
@@ -8909,7 +8895,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libopentelemetry-cpp-headers-1.26.0-hce30654_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libparquet-24.0.0-h16c0493_3_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libpng-1.6.58-h132b30e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.33.5-h4a5acfd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.33.5-h2d4b707_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libre2-11-2025.11.05-h4c27e2a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/librttopo-1.1.0-ha909e78_20.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libspatialite-5.1.0-gpl_hc59e0ec_120.conda
@@ -8995,7 +8981,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
@@ -9178,7 +9164,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.6-nompi_hae35d4c_109.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/importlib-metadata-9.0.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/krb5-1.22.2-h0ea6238_0.conda
@@ -9224,7 +9210,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libopentelemetry-cpp-headers-1.26.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libparquet-24.0.0-h7051d1f_2_cpu.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libpng-1.6.58-h7351971_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-6.33.5-h61fc761_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-6.33.5-h6cf2d3c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libre2-11-2025.11.05-h04e5de1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/librttopo-1.1.0-haa95264_20.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libspatialite-5.1.0-gpl_h2fc3b25_120.conda
@@ -9290,10 +9276,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.7.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_37.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_38.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/win_inet_pton-1.1.0-pyh7428d3b_8.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/wrapt-2.2.1-py314h5a2d7ad_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.3.0-hac47afa_1.conda
@@ -9318,7 +9304,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/6b/fab5a7a0e9d05aeade48af4e4ec4a09b61fd1ef5b13ee43cd46ef638e3f6/commitizen-4.16.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
@@ -9455,8 +9441,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -9578,7 +9562,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -9855,7 +9839,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -10125,7 +10109,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -10392,7 +10376,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -10628,9 +10612,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_37.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.3.0-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
@@ -10652,7 +10636,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -10811,8 +10795,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -10933,7 +10915,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -11206,7 +11188,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -11472,7 +11454,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -11735,7 +11717,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -11968,9 +11950,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_37.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.3.0-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
@@ -11991,7 +11973,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -12147,8 +12129,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -12269,7 +12249,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -12542,7 +12522,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -12809,7 +12789,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -13073,7 +13053,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -13307,9 +13287,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_37.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.3.0-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
@@ -13330,7 +13310,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -13486,8 +13466,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -13608,7 +13586,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -13881,7 +13859,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -14148,7 +14126,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -14412,7 +14390,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -14646,9 +14624,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_37.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.3.0-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
@@ -14669,7 +14647,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/0d/67e5b4109ea4a837e80daa87c2c696711955e40449a97e8926672534def2/click-8.4.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -14823,8 +14801,6 @@ environments:
   wheel-build:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -14842,7 +14818,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.12.4-np2py314h4fe1c31_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.12.4-np2py314h98a3360_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
@@ -14908,12 +14884,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/minizip-4.2.1-hb71707f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/muparser-2.3.5-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.6-py314h2b28147_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.6-py314hd4f4903_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.2-h35e630c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.8.1-he0df7b0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.5-habeac84_100_cp314.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.5-hf9ea5aa_0_cp314t.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.7.3-hc5a330e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/snappy-1.2.2-h03e3b7b_1.conda
@@ -15288,9 +15264,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/ucrt-10.0.26100.0-h57928b3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/uriparser-0.9.8-h5a68840_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_37.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_37.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/xerces-c-3.3.0-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
@@ -18467,10 +18443,10 @@ packages:
   - pkg:pypi/charset-normalizer?source=hash-mapping
   size: 58872
   timestamp: 1775127203018
-- pypi: https://files.pythonhosted.org/packages/60/bb/226f399fa906b7fc41a75b174451135a0748b0adbe402d6eec10eede89c2/cleopatra-0.11.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/5d/f5/1d865437a5b467caf727e7daabf8a3aead5b737d232819900940ac93a67c/cleopatra-0.12.0-py3-none-any.whl
   name: cleopatra
-  version: 0.11.0
-  sha256: 4235eabbcaf5f1734312df06d9ef0f86a989c3dea5f9a0d7ef0fca729a23069a
+  version: 0.12.0
+  sha256: b65d1cd2203d47e001faa9a5c907f61268c6831b55ec907758fecb4f91ce639c
   requires_dist:
   - ffmpeg-python
   - hpc-utils>=0.1.4
@@ -20339,9 +20315,9 @@ packages:
   version: 1.0.0
   sha256: 929292d34f5872e70396626ef385ec22355a1fae8ad29e1a734c3e43f9fbc216
   requires_python: '>=2.6,!=3.0.*,!=3.1.*,!=3.2.*'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.12.4-np2py314h4fe1c31_3.conda
-  sha256: 54514503970993e7f7193e662f8cb78db50b5b24b1535621ff62b69cc5d206c5
-  md5: 7c308bb2da250a63c7c301edf7b6dfda
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.12.4-np2py314h98a3360_3.conda
+  sha256: 6332db4848cfd918eff71e5717263979b348fc0e596c2ca352b7c3092dd10627
+  md5: 3c959f2262bfb787171f2a2f484a14e5
   depends:
   - python
   - libgdal-core 3.12.4.*
@@ -20377,10 +20353,10 @@ packages:
   - libzlib >=1.3.2,<2.0a0
   - libexpat >=2.8.0,<3.0a0
   - numpy >=1.23,<3
-  - python_abi 3.14.* *_cp314
+  - python_abi 3.14.* *_cp314t
   license: MIT
   license_family: MIT
-  size: 2449914
+  size: 2467688
   timestamp: 1778531421701
 - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.0-np2py311h12905cf_2.conda
   sha256: d291bd37497314d9df97525f09a5ead3749ff433fea58dcad2136ba380eba824
@@ -22287,18 +22263,17 @@ packages:
   - mypy>=1.11.2 ; extra == 'all'
   - pytest>=8.3.2 ; extra == 'all'
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.15-pyhcf101f3_0.conda
-  sha256: 3d25f9f6f7ab3e1ce6429fc8c8aae0335cf446692e715068488536d220cc43de
-  md5: 1b9083b7f00609605d1483dbc6071a81
+- conda: https://conda.anaconda.org/conda-forge/noarch/idna-3.17-pyhcf101f3_0.conda
+  sha256: f9fe1f9e539c544405ccb7ba632d4ba79edf243c05554d76ace073158a80b691
+  md5: c75e517ebd7a5c5272fe111e8b162228
   depends:
   - python >=3.10
   - python
   license: BSD-3-Clause
-  license_family: BSD
   purls:
   - pkg:pypi/idna?source=compressed-mapping
-  size: 62642
-  timestamp: 1779294335905
+  size: 56858
+  timestamp: 1779999227630
 - pypi: https://files.pythonhosted.org/packages/38/3d/2d244233ac4f76e38533cfcb2991c9eb4c7bf688ae0a036d30725b8faafe/importlib_metadata-9.0.0-py3-none-any.whl
   name: importlib-metadata
   version: 9.0.0
@@ -29224,78 +29199,78 @@ packages:
   purls: []
   size: 385227
   timestamp: 1776315248638
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.33.5-h2b00c02_0.conda
-  sha256: afbf195443269ae10a940372c1d37cda749355d2bd96ef9587a962abd87f2429
-  md5: 11ac478fa72cf12c214199b8a96523f4
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libprotobuf-6.33.5-h6eeba95_1.conda
+  sha256: a59aa3f076d5710c618ca8fd12d9cd8211d8b738f6b0e0c98517c0162f23a5de
+  md5: 7a4b11f3dd7374f1991a4088390d07c1
   depends:
   - __glibc >=2.17,<3.0.a0
   - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
+  - libabseil >=20260107.1,<20260108.0a0
   - libgcc >=14
   - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 3638698
-  timestamp: 1769749419271
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-6.33.5-h1f88751_0.conda
-  sha256: f68780642c215b93f4991c43d88ab0af8a08e66826e68affc65b8905cc21d86b
-  md5: 7f4a589ae616399b7e375053e82a3b12
+  size: 3675765
+  timestamp: 1780003831209
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libprotobuf-6.33.5-h306233d_1.conda
+  sha256: 6a2ccd92be6a7e0256c6eeb2e61328a72d40004f08923733274ca2129dc7f70d
+  md5: 97b7927d982dfc20f8f49ce5174d7466
   depends:
   - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
+  - libabseil >=20260107.1,<20260108.0a0
   - libgcc >=14
   - libstdcxx >=14
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 3465308
-  timestamp: 1769748410724
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-6.33.5-h29d92e8_0.conda
-  sha256: adb74f4f1b1e13b02683ede915ce3a9fbf414325af8e035546c0498ffef870f6
-  md5: d6d60b0a64a711d70ec2fd0105c299f9
+  size: 3502676
+  timestamp: 1780003320814
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libprotobuf-6.33.5-hff14b61_1.conda
+  sha256: c511b4e8026c94b152031a9ee410583991b4a610ebbb1b86992724c37d9abf50
+  md5: 1450d8dbd5ac263d3d793fcf99612889
   depends:
   - __osx >=11.0
   - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
+  - libabseil >=20260107.1,<20260108.0a0
   - libcxx >=19
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 2774545
-  timestamp: 1769749167835
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.33.5-h4a5acfd_0.conda
-  sha256: 626852cd50690526c9eac216a9f467edd4cbb01060d0efe41b7def10b54bdb08
-  md5: b839e3295b66434f20969c8b940f056a
+  size: 2971082
+  timestamp: 1780005104925
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libprotobuf-6.33.5-h2d4b707_1.conda
+  sha256: 416c2244999d678dc9a4d8c3472336f8f754676125605399cf6e43956fa3d18b
+  md5: 300fdae9d7ad150a90755f55b0a8a7a8
   depends:
   - __osx >=11.0
   - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
+  - libabseil >=20260107.1,<20260108.0a0
   - libcxx >=19
-  - libzlib >=1.3.1,<2.0a0
+  - libzlib >=1.3.2,<2.0a0
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 2713660
-  timestamp: 1769748299578
-- conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-6.33.5-h61fc761_0.conda
-  sha256: 73e2ac7ff32b635b9f6a485dfd5ec1968b7f4bd49f21350e919b2ed8966edaa3
-  md5: 69e5855826e56ea4b67fb888ef879afd
+  size: 2768714
+  timestamp: 1780004273744
+- conda: https://conda.anaconda.org/conda-forge/win-64/libprotobuf-6.33.5-h6cf2d3c_1.conda
+  sha256: dce2820ebc4059b4919158814aa6ea2ccd31be699d9e3d74824de8d31ec66864
+  md5: 712686431de276d81eb02d87483f6f10
   depends:
   - libabseil * cxx17*
-  - libabseil >=20260107.0,<20260108.0a0
-  - libzlib >=1.3.1,<2.0a0
+  - libabseil >=20260107.1,<20260108.0a0
+  - libzlib >=1.3.2,<2.0a0
   - ucrt >=10.0.20348.0
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 7117788
-  timestamp: 1769749718218
+  size: 7162612
+  timestamp: 1780005438640
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libre2-11-2025.11.05-h0dc7533_1.conda
   sha256: 138fc85321a8c0731c1715688b38e2be4fb71db349c9ab25f685315095ae70ff
   md5: ced7f10b6cfb4389385556f47c0ad949
@@ -32745,6 +32720,24 @@ packages:
   - pkg:pypi/numpy?source=compressed-mapping
   size: 8928909
   timestamp: 1779169198391
+- conda: https://conda.anaconda.org/conda-forge/linux-64/numpy-2.4.6-py314hd4f4903_0.conda
+  sha256: 3d78afff730eddaf4e2981d0e3f4cee9106c72366da52136648c6c9c463c9555
+  md5: 642b9fc455d2a90572f767487bd6352d
+  depends:
+  - python
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libstdcxx >=14
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python_abi 3.14.* *_cp314t
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8978806
+  timestamp: 1779169197952
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.4.6-py311hecca567_0.conda
   sha256: a61ab739b828408da75608388c5762794302cedb1c4339795990ec58a2c7e285
   md5: fa4589f7437e1601e42eb14ba2988b94
@@ -37432,6 +37425,7 @@ packages:
   - pystac-client>=0.8.0 ; extra == 'stac'
   - stac-asset>=0.4.7 ; extra == 'stac'
   requires_python: '>=3.11,<4'
+  editable: true
 - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
   sha256: d016e04b0e12063fbee4a2d5fbb9b39a8d191b5a0042f0b8459188aedeabb0ca
   md5: e2fd202833c4a981ce8a65974fe4abd1
@@ -37646,6 +37640,34 @@ packages:
   size: 36745188
   timestamp: 1779236923603
   python_site_packages_path: lib/python3.14/site-packages
+- conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.5-hf9ea5aa_0_cp314t.conda
+  sha256: 344476f32c4458d80b134754a570a40d3c410930716e54b1f0147268a2b9c052
+  md5: 6500595c423bce019b067fc4c8119a46
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.8.0,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - libgcc >=14
+  - liblzma >=5.8.3,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.53.1,<4.0a0
+  - libuuid >=2.42.1,<3.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - openssl >=3.5.6,<4.0a0
+  - python_abi 3.14.* *_cp314t
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - zstd >=1.5.7,<1.6.0a0
+  track_features:
+  - py_freethreading
+  license: Python-2.0
+  size: 47876863
+  timestamp: 1779236944883
+  python_site_packages_path: lib/python3.14t/site-packages
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.11.15-h91f4b29_0_cpython.conda
   sha256: da3aa4c63af904d38c2e0b6ceecfa539d60c2653ac3cff7cae79d87298dc4fb0
   md5: bb09184ea3313703da05516cd730e8f8
@@ -40667,9 +40689,9 @@ packages:
   - pkg:pypi/urllib3?source=hash-mapping
   size: 103560
   timestamp: 1778188657149
-- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_37.conda
-  sha256: 67397a65e42537e9635f2be59f13437b1876ece09ce200b09deec81f186db98e
-  md5: 3dbe647b692777a9aecab9832004d147
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.5-h1b7c187_38.conda
+  sha256: 61b68e5a4fc71a17f8d64b12e013a2f971ad980bd08e9c389d5e68efe1a67de0
+  md5: 774568633f3b26d7a4a6dd4f9ea6d3e1
   depends:
   - vc14_runtime >=14.51.36231
   track_features:
@@ -40677,33 +40699,33 @@ packages:
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 20372
-  timestamp: 1779261134447
-- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_37.conda
-  sha256: 4e83cc4e8c5513b5a0f174d9b0fe8f0ddc6adc71b28a289fe731415aef98c3e0
-  md5: 96433009c79679ac14eed33479742be7
+  size: 20187
+  timestamp: 1780005880049
+- conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.51.36231-h1b9f54f_38.conda
+  sha256: 957c7c65583c7107a5e76f39756c6361fcb7b0dc101ac7c0aea86e7ca09fe49c
+  md5: 2cdcd8ea1010920911bb2eacb4c61227
   depends:
   - ucrt >=10.0.20348.0
-  - vcomp14 14.51.36231 h1b9f54f_37
+  - vcomp14 14.51.36231 h1b9f54f_38
   constrains:
-  - vs2015_runtime 14.51.36231.* *_37
+  - vs2015_runtime 14.51.36231.* *_38
   license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
   license_family: Proprietary
   purls: []
-  size: 742016
-  timestamp: 1779261130367
-- conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_37.conda
-  sha256: fec2c325c85505f3957f0bdb130418a09623bcaa9286239b15f8572a00d876a8
-  md5: 776acae29085df3ad5f3123888ac7c1d
+  size: 740997
+  timestamp: 1780005875753
+- conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.51.36231-h1b9f54f_38.conda
+  sha256: c645fdc1f0f47718431d973386e946754a10200e7ba2c32032560913a970cacd
+  md5: 63ee70d69d7540e821940dac5d4d9ba2
   depends:
   - ucrt >=10.0.20348.0
   constrains:
-  - vs2015_runtime 14.51.36231.* *_37
+  - vs2015_runtime 14.51.36231.* *_38
   license: LicenseRef-MicrosoftVisualCpp2015-2022Runtime
   license_family: Proprietary
   purls: []
-  size: 124184
-  timestamp: 1779261112360
+  size: 123561
+  timestamp: 1780005858779
 - pypi: https://files.pythonhosted.org/packages/a4/ce/3b6fee91c85626eaf769d617f1be9d2e15c1cca027bbdeb2e0d751469355/verspec-0.1.0-py3-none-any.whl
   name: verspec
   version: 0.1.0
@@ -40727,16 +40749,16 @@ packages:
   - python-discovery>=1.4
   - typing-extensions>=4.13.2 ; python_full_version < '3.11'
   requires_python: '>=3.8'
-- conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_37.conda
-  sha256: 527b7d257711d0e2335f89619120a7f3da172c19abdf8d2adace198394b2ddd7
-  md5: 012c85e470c2f1f0f64078d6796f09a8
+- conda: https://conda.anaconda.org/conda-forge/win-64/vs2015_runtime-14.51.36231-h84cd919_38.conda
+  sha256: c4f38268563dc6b8322b0191481e5d20002fc6e37b076c15e0b955a553c8b4a0
+  md5: 6033851d921b6c33f1c3018205fcba6a
   depends:
   - vc14_runtime >=14.51.36231
   license: BSD-3-Clause
   license_family: BSD
   purls: []
-  size: 20347
-  timestamp: 1779261134803
+  size: 20170
+  timestamp: 1780005880423
 - pypi: https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl
   name: watchdog
   version: 6.0.0

--- a/src/pyramids/base/crs.py
+++ b/src/pyramids/base/crs.py
@@ -573,6 +573,46 @@ def sr_from_user_input(crs: int | str | Any) -> osr.SpatialReference:
             '3857'
 
             ```
+        - Build an SRS from an ESRI authority string for Robinson — the headline
+          case that motivated #418, since Robinson has no EPSG code:
+            ```python
+            >>> from pyramids.base.crs import sr_from_user_input
+            >>> sr = sr_from_user_input("ESRI:54030")
+            >>> sr.GetAuthorityName(None), sr.GetAuthorityCode(None)
+            ('ESRI', '54030')
+            >>> "Robinson" in sr.GetName()
+            True
+
+            ```
+        - Build an SRS from a :class:`pyproj.CRS` instance:
+            ```python
+            >>> from pyproj import CRS
+            >>> from pyramids.base.crs import sr_from_user_input
+            >>> sr = sr_from_user_input(CRS.from_epsg(32636))
+            >>> sr.GetAuthorityCode(None)
+            '32636'
+
+            ```
+        - Uninterpretable input raises :class:`CRSError` (which is also a
+          :class:`ValueError`, so existing call sites that catch
+          :class:`ValueError` still work):
+            ```python
+            >>> from pyramids.base.crs import sr_from_user_input
+            >>> try:
+            ...     sr_from_user_input("not-a-crs")
+            ... except ValueError as exc:
+            ...     print("could not interpret" in str(exc))
+            True
+
+            ```
+
+    See Also:
+        - :func:`sr_from_epsg`: Same idea but restricted to a single EPSG int.
+        - :func:`sr_from_wkt`: Build an SRS directly from a WKT string when
+          you already hold one.
+        - :func:`epsg_from_user_input`: Resolve a CRS to an EPSG ``int``
+          (rejects CRSes that lack an EPSG code).
+
     """
     if isinstance(crs, bool):
         raise CRSError(

--- a/src/pyramids/base/crs.py
+++ b/src/pyramids/base/crs.py
@@ -8,6 +8,9 @@ Public surface:
 * :func:`sr_from_epsg` — build an `osr.SpatialReference` from an
   EPSG code.
 * :func:`sr_from_wkt` — build one from a WKT string.
+* :func:`sr_from_user_input` — build one from any CRS form
+  :meth:`pyproj.CRS.from_user_input` accepts (EPSG int, authority
+  string, proj4, WKT, ESRI WKT, :class:`pyproj.CRS`).
 * :func:`create_sr_from_proj` — build one from a WKT / ESRI WKT /
   Proj4 string with auto-detect.
 * :func:`get_epsg_from_prj` — resolve the EPSG code identified by a
@@ -525,6 +528,73 @@ def epsg_from_user_input(crs: int | str | Any) -> int:
     return epsg
 
 
+def sr_from_user_input(crs: int | str | Any) -> osr.SpatialReference:
+    """Build an :class:`osr.SpatialReference` from any CRS form pyproj accepts.
+
+    Resolves CRS forms that have no EPSG code — orthographic, Robinson
+    (``ESRI:54030``), Mollweide (``ESRI:54009``), and other bespoke proj4 / WKT
+    definitions — to a full spatial reference. Use this instead of
+    :func:`epsg_from_user_input` when the downstream consumer (e.g.
+    :func:`gdal.Warp`'s ``dstSRS`` or :func:`osr.CoordinateTransformation`) can
+    take a WKT directly and does not require an EPSG integer.
+
+    The returned SRS is set to ``OAMS_TRADITIONAL_GIS_ORDER`` so that x/y always
+    means longitude/easting first, matching the axis order used everywhere else
+    in pyramids (geotransform, ``reproject_coordinates``, ``sr_from_epsg``).
+
+    Args:
+        crs: Any CRS form :meth:`pyproj.CRS.from_user_input` accepts — an EPSG
+            ``int`` (``4326``), an authority string (``"EPSG:3857"``,
+            ``"ESRI:54030"``), a bare numeric string (``"3857"``), a WKT string,
+            a proj4 string (``"+proj=ortho +lat_0=39 +lon_0=-9 +datum=WGS84"``),
+            or a :class:`pyproj.CRS` instance.
+
+    Returns:
+        osr.SpatialReference: The constructed SRS in traditional GIS axis order.
+
+    Raises:
+        CRSError: ``crs`` is a ``bool``, is not interpretable as a CRS, or has
+            an empty WKT representation.
+
+    Examples:
+        - Build an SRS from an orthographic proj4 string:
+            ```python
+            >>> from pyramids.base.crs import sr_from_user_input
+            >>> sr = sr_from_user_input(
+            ...     "+proj=ortho +lat_0=39 +lon_0=-9 +datum=WGS84 +units=m +no_defs"
+            ... )
+            >>> sr.IsProjected()
+            1
+
+            ```
+        - Build an SRS from an EPSG int (fast path used by Web Mercator):
+            ```python
+            >>> from pyramids.base.crs import sr_from_user_input
+            >>> sr_from_user_input(3857).GetAuthorityCode(None)
+            '3857'
+
+            ```
+    """
+    if isinstance(crs, bool):
+        raise CRSError(
+            f"{crs!r} is not a valid CRS; pass an EPSG int, string, WKT, "
+            "proj4, or pyproj.CRS."
+        )
+    try:
+        wkt = CRS.from_user_input(crs).to_wkt()
+    except (pyproj.exceptions.CRSError, TypeError, ValueError) as exc:
+        raise CRSError(f"could not interpret {crs!r} as a CRS: {exc}") from exc
+    if not wkt:
+        raise CRSError(
+            f"the CRS {crs!r} produced an empty WKT; cannot build a spatial "
+            "reference."
+        )
+    sr = osr.SpatialReference()
+    sr.ImportFromWkt(wkt)
+    sr.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+    return sr
+
+
 def reproject_coordinates(
     x: list[float],
     y: list[float],
@@ -614,9 +684,11 @@ def reproject_coordinates(
 
 __all__ = [
     "create_sr_from_proj",
+    "epsg_from_user_input",
     "epsg_from_wkt",
     "get_epsg_from_prj",
     "reproject_coordinates",
     "sr_from_epsg",
+    "sr_from_user_input",
     "sr_from_wkt",
 ]

--- a/src/pyramids/base/crs.py
+++ b/src/pyramids/base/crs.py
@@ -553,8 +553,7 @@ def sr_from_user_input(crs: int | str | Any) -> osr.SpatialReference:
         osr.SpatialReference: The constructed SRS in traditional GIS axis order.
 
     Raises:
-        CRSError: ``crs`` is a ``bool``, is not interpretable as a CRS, or has
-            an empty WKT representation.
+        CRSError: ``crs`` is a ``bool`` or is not interpretable as a CRS.
 
     Examples:
         - Build an SRS from an orthographic proj4 string:
@@ -584,11 +583,6 @@ def sr_from_user_input(crs: int | str | Any) -> osr.SpatialReference:
         wkt = CRS.from_user_input(crs).to_wkt()
     except (pyproj.exceptions.CRSError, TypeError, ValueError) as exc:
         raise CRSError(f"could not interpret {crs!r} as a CRS: {exc}") from exc
-    if not wkt:
-        raise CRSError(
-            f"the CRS {crs!r} produced an empty WKT; cannot build a spatial "
-            "reference."
-        )
     sr = osr.SpatialReference()
     sr.ImportFromWkt(wkt)
     sr.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -2199,17 +2199,21 @@ class DatasetCollection:
 
     def to_crs(
         self,
-        to_epsg: int = 3857,
+        to_epsg: int | str | Any = 3857,
         method: str = "nearest neighbor",
         maintain_alignment: bool = False,
         inplace: bool = False,
     ) -> DatasetCollection | None:
-        """Reproject every timestep to a target EPSG.
+        """Reproject every timestep to a target CRS.
 
         Args:
-            to_epsg (int):
-                Reference number to the new projection (https://epsg.io/)
-                (default 3857, WGS84 web mercator).
+            to_epsg (int | str | pyproj.CRS):
+                Target CRS in any form :meth:`pyproj.CRS.from_user_input`
+                accepts — EPSG int (``3857``), authority string
+                (``"EPSG:3857"``, ``"ESRI:54030"``), proj4 / WKT, or a
+                :class:`pyproj.CRS`. CRSes without an EPSG code (orthographic,
+                Robinson, Mollweide) are warped directly against the spatial
+                reference. Default ``3857`` (WGS84 web mercator).
             method (str):
                 Resampling technique. Default is "nearest neighbor". See
                 https://gisgeography.com/raster-resampling/. Accepted

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -307,54 +307,28 @@ class Spatial(_Engine):
                 A new resampled Dataset.
 
         Examples:
-            - Create a Dataset with 4 bands, 10 rows, 10 columns, at lon/lat (0, 0):
+            - Create a 4-band 10×10 dataset at lon/lat (0, 0) with a 0.05° cell size, then resample to a
+              coarser 0.1° cell. Halving the resolution halves the row/column count in each dimension
+              (10 → 5), and the source CRS and band count carry through unchanged:
 
               ```python
               >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.rand(4, 10, 10)
-              >>> top_left_corner = (0, 0)
-              >>> cell_size = 0.05
-              >>> dataset = Dataset.create_from_array(arr, top_left_corner=top_left_corner, cell_size=cell_size, epsg=4326)
-              >>> print(dataset)
-              <BLANKLINE>
-                          Cell size: 0.05
-                          Dimension: 10 * 10
-                          EPSG: 4326
-                          Number of Bands: 4
-                          Band names: ['Band_1', 'Band_2', 'Band_3', 'Band_4']
-                          Mask: -9999.0
-                          Data type: float64
-                          File: ...
-              <BLANKLINE>
-              >>> dataset.plot(band=0)
-              (<Figure size 800x800 with 2 Axes>, <Axes: >)
+              >>> dataset = Dataset.create_from_array(
+              ...     arr, top_left_corner=(0, 0), cell_size=0.05, epsg=4326
+              ... )
+              >>> (dataset.rows, dataset.columns, dataset.band_count)
+              (10, 10, 4)
+              >>> resampled = dataset.resample(cell_size=0.1)
+              >>> (resampled.rows, resampled.columns, resampled.band_count, resampled.epsg)
+              (5, 5, 4, 4326)
+              >>> resampled.geotransform[1]
+              0.1
 
               ```
               ![resample-source](./../../_images/dataset/resample-source.png)
-
-            - Resample the raster to a new cell size of 0.1:
-
-              ```python
-              >>> new_dataset = dataset.resample(cell_size=0.1)
-              >>> print(new_dataset)
-              <BLANKLINE>
-                          Cell size: 0.1
-                          Dimension: 5 * 5
-                          EPSG: 4326
-                          Number of Bands: 4
-                          Band names: ['Band_1', 'Band_2', 'Band_3', 'Band_4']
-                          Mask: -9999.0
-                          Data type: float64
-                          File:...
-              <BLANKLINE>
-              >>> new_dataset.plot(band=0)
-              (<Figure size 800x800 with 2 Axes>, <Axes: >)
-
-              ```
               ![resample-new](./../../_images/dataset/resample-new.png)
-
-            - Resampling the dataset from cell_size 0.05 to 0.1 degrees reduced the number of cells to 5 in each
-              dimension instead of 10.
         """
         if not isinstance(method, str):
             raise TypeError(
@@ -792,21 +766,13 @@ class Spatial(_Engine):
 
               ```python
               >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.rand(5, 5)
-              >>> top_left_corner = (0, 0)
-              >>> cell_size = 0.05
-              >>> dataset = Dataset.create_from_array(arr, top_left_corner=top_left_corner, cell_size=cell_size, epsg=4326)
-              >>> print(dataset)
-              <BLANKLINE>
-                          Cell size: 0.05
-                          Dimension: 5 * 5
-                          EPSG: 4326
-                          Number of Bands: 1
-                          Band names: ['Band_1']
-                          Mask: -9999.0
-                          Data type: float64
-                          File:...
-              <BLANKLINE>
+              >>> dataset = Dataset.create_from_array(
+              ...     arr, top_left_corner=(0, 0), cell_size=0.05, epsg=4326
+              ... )
+              >>> (dataset.rows, dataset.columns, dataset.epsg, dataset.band_count)
+              (5, 5, 4326, 1)
 
               ```
 
@@ -814,42 +780,36 @@ class Spatial(_Engine):
               dataset, and two columns on the left of the dataset).
 
               ```python
-              >>> arr = np.random.rand(10, 10)
-              >>> top_left_corner = (-0.1, 0.1)
-              >>> cell_size = 0.07
-              >>> dataset_target = Dataset.create_from_array(arr, top_left_corner=top_left_corner, cell_size=cell_size,
-              ... epsg=4326)
-              >>> print(dataset_target)
-              <BLANKLINE>
-                          Cell size: 0.07
-                          Dimension: 10 * 10
-                          EPSG: 4326
-                          Number of Bands: 1
-                          Band names: ['Band_1']
-                          Mask: -9999.0
-                          Data type: float64
-                          File:...
-              <BLANKLINE>
+              >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
+              >>> arr_target = np.random.rand(10, 10)
+              >>> dataset_target = Dataset.create_from_array(
+              ...     arr_target, top_left_corner=(-0.1, 0.1), cell_size=0.07, epsg=4326
+              ... )
+              >>> (dataset_target.rows, dataset_target.columns, dataset_target.geotransform[1])
+              (10, 10, 0.07)
 
               ```
 
             ![align-source-target](./../../_images/dataset/align-source-target.png)
 
-            - Now call the `align` method and use the dataset as the alignment source.
+            - Now call the `align` method and use the source dataset as the alignment template. The aligned
+              dataset adopts the source's cell size, dimensions, and CRS:
 
               ```python
-              >>> aligned_dataset = dataset_target.align(dataset)
-              >>> print(aligned_dataset)
-              <BLANKLINE>
-                          Cell size: 0.05
-                          Dimension: 5 * 5
-                          EPSG: 4326
-                          Number of Bands: 1
-                          Band names: ['Band_1']
-                          Mask: -9999.0
-                          Data type: float64
-                          File:...
-              <BLANKLINE>
+              >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
+              >>> source = Dataset.create_from_array(
+              ...     np.random.rand(5, 5),
+              ...     top_left_corner=(0, 0), cell_size=0.05, epsg=4326,
+              ... )
+              >>> target = Dataset.create_from_array(
+              ...     np.random.rand(10, 10),
+              ...     top_left_corner=(-0.1, 0.1), cell_size=0.07, epsg=4326,
+              ... )
+              >>> aligned = target.align(source)
+              >>> (aligned.rows, aligned.columns, aligned.geotransform[1], aligned.epsg)
+              (5, 5, 0.05, 4326)
 
               ```
 
@@ -1112,6 +1072,7 @@ class Spatial(_Engine):
               >>> import numpy as np
               >>> import geopandas as gpd
               >>> from shapely.geometry import Polygon
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.rand(4, 10, 10)
               >>> cell_size = 0.05
               >>> top_left_corner = (0, 0)

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -178,6 +178,28 @@ class Spatial(_Engine):
               4326
 
               ```
+            - Contrast ``maintain_alignment=False`` (default) with
+              ``maintain_alignment=True``. At 60°N a 4326 → 3857 warp distorts
+              cell sizes substantially, so the default `gdal.Warp` heuristic
+              picks a different output shape from the source; the alignment-
+              preserving path keeps the source row/column count and absorbs the
+              distortion into the per-axis cell size instead:
+
+              ```python
+              >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
+              >>> arr = np.ones((10, 10), dtype=np.float32)
+              >>> dataset = Dataset.create_from_array(
+              ...     arr, top_left_corner=(10.0, 60.5), cell_size=0.1, epsg=4326
+              ... )
+              >>> default_warp = dataset.to_crs(to_epsg=3857)
+              >>> (default_warp.rows, default_warp.columns)
+              (13, 6)
+              >>> aligned = dataset.to_crs(to_epsg=3857, maintain_alignment=True)
+              >>> (aligned.rows, aligned.columns)
+              (10, 10)
+
+              ```
 
         See Also:
             - :meth:`Spatial.set_crs`: Tag the dataset with a new CRS *without*

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -98,7 +98,8 @@ class Spatial(_Engine):
                 :class:`pyproj.CRS`. Projections without an EPSG code (orthographic,
                 Robinson, Mollweide, polar-stereographic variants) are warped directly
                 against the spatial reference; cells outside the projection domain
-                resolve to the raster's nodata value.
+                are filled with the source's nodata value when one is configured, or
+                with GDAL's dtype-default fill value otherwise.
             method (str):
                 resampling method. Default is "nearest neighbor". See https://gisgeography.com/raster-resampling/.
                 Allowed values: "nearest neighbor", "cubic", "bilinear".
@@ -392,43 +393,28 @@ class Spatial(_Engine):
         src_y = self._ds.rows
 
         src_sr = sr_from_wkt(self._ds.crs)
+        # Normalise to traditional GIS axis order (lon/easting first). sr_from_wkt
+        # preserves GDAL's default OAMS_AUTHORITY_COMPLIANT order, which is
+        # lat-first for geographic CRSes; dst_sr comes from sr_from_user_input,
+        # which always uses traditional order. Aligning both sides here lets
+        # IsSame() report semantic equality (instead of WKT-byte equality, which
+        # fails for two SRSes that differ only in axis-mapping strategy — #418)
+        # and removes any axis-order surprise from downstream reprojection math.
+        src_sr.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
         src_wkt = src_sr.ExportToWkt()
         dst_wkt = dst_sr.ExportToWkt()
-        # Source and target are the same CRS when their WKT matches. We avoid
-        # epsg-equality here because the destination may be a non-EPSG CRS
-        # (orthographic / Robinson / Mollweide) — see #418.
-        same_crs = src_wkt == dst_wkt
+        same_crs = bool(src_sr.IsSame(dst_sr))
 
-        # in case the source crs is GCS and longitude is in the west hemisphere, gdal
-        # reads longitude from 0 to 360 and a transformation factor wont work with values
-        # greater than 180
         if not same_crs:
-            if src_sr.IsGeographic() and src_gt[0] > 180:
-                lng_new = src_gt[0] - 360
-                # transformation factors
-                tx = osr.CoordinateTransformation(src_sr, dst_sr)
-                # transform the right upper corner point
-                ulx, uly, ulz = tx.TransformPoint(lng_new, src_gt[3])
-                # transform the right lower corner point
-                lrx, lry, lrz = tx.TransformPoint(
-                    lng_new + src_gt[1] * src_x, src_gt[3] + src_gt[5] * src_y
-                )
-            else:
-                xs = [src_gt[0], src_gt[0] + src_gt[1] * src_x]
-                ys = [src_gt[3], src_gt[3] + src_gt[5] * src_y]
-
-                # reproject_coordinates takes (x, y) and returns (x, y).
-                [ulx, lrx], [uly, lry] = reproject_coordinates(
-                    xs, ys, from_crs=src_wkt, to_crs=dst_wkt
-                )
-                # old transform
-                # # transform the right upper corner point
-                # (ulx, uly, ulz) = tx.TransformPoint(src_gt[0], src_gt[3])
-                # # transform the right lower corner point
-                # (lrx, lry, lrz) = tx.TransformPoint(
-                #     src_gt[0] + src_gt[1] * src_x, src_gt[3] + src_gt[5] * src_y
-                # )
-
+            # In a geographic source whose longitudes wrap past 180, shift the
+            # left edge into the western hemisphere before reprojecting so the
+            # corner-derived extent does not collapse across the dateline.
+            west_edge = src_gt[0] - 360 if src_sr.IsGeographic() and src_gt[0] > 180 else src_gt[0]
+            xs = [west_edge, west_edge + src_gt[1] * src_x]
+            ys = [src_gt[3], src_gt[3] + src_gt[5] * src_y]
+            [ulx, lrx], [uly, lry] = reproject_coordinates(
+                xs, ys, from_crs=src_wkt, to_crs=dst_wkt
+            )
         else:
             ulx = src_gt[0]
             uly = src_gt[3]

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -17,10 +17,10 @@ from osgeo import gdal, osr
 from pyramids.base._domain import is_no_data
 from pyramids.base._utils import INTERPOLATION_METHODS
 from pyramids.base.crs import (
-    epsg_from_user_input,
     epsg_from_wkt,
     reproject_coordinates,
     sr_from_epsg,
+    sr_from_user_input,
     sr_from_wkt,
 )
 from pyramids.dataset.abstract_dataset import RasterBase
@@ -90,10 +90,15 @@ class Spatial(_Engine):
 
         Args:
             to_epsg (int | str | pyproj.CRS):
-                The target CRS. Most commonly an EPSG reference number (https://epsg.io/),
-                e.g. ``3857`` for WGS84 web mercator. A string (``"EPSG:3857"``, ``"3857"``,
-                a WKT or PROJ4 string) or a :class:`pyproj.CRS` is also accepted and resolved
-                to its EPSG code via :func:`pyramids.base.crs.epsg_from_user_input`.
+                The target CRS. Accepts any form :meth:`pyproj.CRS.from_user_input`
+                understands: an EPSG reference number (``3857``), an authority string
+                (``"EPSG:3857"``, ``"ESRI:54030"`` for Robinson, ``"ESRI:54009"`` for
+                Mollweide), a bare numeric string (``"3857"``), a WKT or PROJ4 string
+                (``"+proj=ortho +lat_0=39 +lon_0=-9 +datum=WGS84"``), or a
+                :class:`pyproj.CRS`. Projections without an EPSG code (orthographic,
+                Robinson, Mollweide, polar-stereographic variants) are warped directly
+                against the spatial reference; cells outside the projection domain
+                resolve to the raster's nodata value.
             method (str):
                 resampling method. Default is "nearest neighbor". See https://gisgeography.com/raster-resampling/.
                 Allowed values: "nearest neighbor", "cubic", "bilinear".
@@ -107,8 +112,7 @@ class Spatial(_Engine):
 
         Raises:
             CRSError:
-                ``to_epsg`` cannot be interpreted as a CRS, or resolves to a CRS with no
-                EPSG code.
+                ``to_epsg`` cannot be interpreted as a CRS.
             TypeError:
                 ``method`` is not a string.
             ValueError:
@@ -158,7 +162,7 @@ class Spatial(_Engine):
               ```
 
         """
-        to_epsg = epsg_from_user_input(to_epsg)
+        dst_sr = sr_from_user_input(to_epsg)
         if not isinstance(method, str):
             raise TypeError(
                 "Please enter a correct method, for more information, see documentation "
@@ -172,9 +176,24 @@ class Spatial(_Engine):
         resampling_method: Any = INTERPOLATION_METHODS.get(method)
 
         if maintain_alignment:
-            dst_obj = self._reproject_with_ReprojectImage(to_epsg, resampling_method)
+            dst_obj = self._reproject_with_ReprojectImage(dst_sr, resampling_method)
         else:
-            dst = gdal.Warp("", self._ds.raster, dstSRS=f"EPSG:{to_epsg}", format="VRT")
+            # Prefer the "<AUTHORITY>:<code>" form when one exists so the
+            # output WKT GDAL writes is the canonical GDAL/PROJ form
+            # (matching historical bytes for EPSG codes and avoiding a
+            # GDAL warning when the authority is ESRI). Fall back to the
+            # explicit WKT for CRSes carrying no authority at all
+            # (custom orthographic proj4 strings, etc.). See #418.
+            dst_auth = dst_sr.GetAuthorityName(None)
+            dst_code = dst_sr.GetAuthorityCode(None)
+            dst_srs_arg = (
+                f"{dst_auth}:{dst_code}"
+                if dst_auth is not None and dst_code is not None
+                else dst_sr.ExportToWkt()
+            )
+            dst = gdal.Warp(
+                "", self._ds.raster, dstSRS=dst_srs_arg, format="VRT"
+            )
             dst_obj = self._ds.__class__(dst)
 
         return dst_obj
@@ -364,22 +383,27 @@ class Spatial(_Engine):
         return dst_obj
 
     def _reproject_with_ReprojectImage(
-        self, to_epsg: int, method: str = "nearest neighbor"
+        self,
+        dst_sr: osr.SpatialReference,
+        method: str = "nearest neighbor",
     ) -> Dataset:
         src_gt = self._ds.geotransform
         src_x = self._ds.columns
         src_y = self._ds.rows
 
         src_sr = sr_from_wkt(self._ds.crs)
-        src_epsg = self._ds.epsg
-
-        dst_sr = sr_from_epsg(to_epsg)
+        src_wkt = src_sr.ExportToWkt()
+        dst_wkt = dst_sr.ExportToWkt()
+        # Source and target are the same CRS when their WKT matches. We avoid
+        # epsg-equality here because the destination may be a non-EPSG CRS
+        # (orthographic / Robinson / Mollweide) — see #418.
+        same_crs = src_wkt == dst_wkt
 
         # in case the source crs is GCS and longitude is in the west hemisphere, gdal
         # reads longitude from 0 to 360 and a transformation factor wont work with values
         # greater than 180
-        if src_epsg != to_epsg:
-            if src_epsg == "4326" and src_gt[0] > 180:
+        if not same_crs:
+            if src_sr.IsGeographic() and src_gt[0] > 180:
                 lng_new = src_gt[0] - 360
                 # transformation factors
                 tx = osr.CoordinateTransformation(src_sr, dst_sr)
@@ -395,7 +419,7 @@ class Spatial(_Engine):
 
                 # reproject_coordinates takes (x, y) and returns (x, y).
                 [ulx, lrx], [uly, lry] = reproject_coordinates(
-                    xs, ys, from_crs=src_epsg, to_crs=to_epsg
+                    xs, ys, from_crs=src_wkt, to_crs=dst_wkt
                 )
                 # old transform
                 # # transform the right upper corner point
@@ -426,14 +450,14 @@ class Spatial(_Engine):
         y_pair_xs = [src_gt[0], src_gt[0]]
         y_pair_ys = [src_gt[3], src_gt[3] + src_gt[5]]
 
-        if src_epsg != to_epsg:
+        if not same_crs:
             # x_pair_xs and x_pair_ys are horizontally spaced by the cell size, after reprojection gives the cell size
             # in x
             new_x_xs, _ = reproject_coordinates(
                 x_pair_xs,
                 x_pair_ys,
-                from_crs=src_epsg,
-                to_crs=to_epsg,
+                from_crs=src_wkt,
+                to_crs=dst_wkt,
                 precision=6,
             )
             # y_pair_xs and y_pair_ys are vertically spaced by the cell size, after reprojection gives the cell size
@@ -441,8 +465,8 @@ class Spatial(_Engine):
             _, new_y_ys = reproject_coordinates(
                 y_pair_xs,
                 y_pair_ys,
-                from_crs=src_epsg,
-                to_crs=to_epsg,
+                from_crs=src_wkt,
+                to_crs=dst_wkt,
                 precision=6,
             )
         else:

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -120,47 +120,74 @@ class Spatial(_Engine):
                 ``method`` is not one of the supported interpolation methods.
 
         Examples:
-            - Create a dataset and reproject it:
+            - Reproject a small 4326 raster to Web Mercator (EPSG:3857). The
+              source cell size of 0.05° expands to roughly 5566 m near the
+              equator and the EPSG of the result confirms the warp:
 
               ```python
               >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.rand(4, 5, 5)
-              >>> top_left_corner = (0, 0)
-              >>> cell_size = 0.05
-              >>> dataset = Dataset.create_from_array(arr, top_left_corner=top_left_corner, cell_size=cell_size, epsg=4326)
-              >>> print(dataset)
-              <BLANKLINE>
-                          Cell size: 0.05
-                          Dimension: 5 * 5
-                          EPSG: 4326
-                          Number of Bands: 4
-                          Band names: ['Band_1', 'Band_2', 'Band_3', 'Band_4']
-                          Mask: -9999.0
-                          Data type: float64
-                          File:...
-              <BLANKLINE>
-              >>> print(dataset.crs)
-              GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Latitude",NORTH],AXIS["Longitude",EAST],AUTHORITY["EPSG","4326"]]
-              >>> print(dataset.epsg)
+              >>> dataset = Dataset.create_from_array(
+              ...     arr,
+              ...     top_left_corner=(0.0, 0.0),
+              ...     cell_size=0.05,
+              ...     epsg=4326,
+              ... )
+              >>> dataset.epsg
               4326
-              >>> reprojected_dataset = dataset.to_crs(to_epsg=3857)
-              >>> print(reprojected_dataset)
-              <BLANKLINE>
-                          Cell size: 5565.983370404396
-                          Dimension: 5 * 5
-                          EPSG: 3857
-                          Number of Bands: 4
-                          Band names: ['Band_1', 'Band_2', 'Band_3', 'Band_4']
-                          Mask: -9999.0
-                          Data type: float64
-                          File:...
-              <BLANKLINE>
-              >>> print(reprojected_dataset.crs)
-              PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4326"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],EXTENSION["PROJ4","+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 +y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs"],AUTHORITY["EPSG","3857"]]
-              >>> print(reprojected_dataset.epsg)
+              >>> reprojected = dataset.to_crs(to_epsg=3857)
+              >>> reprojected.epsg
               3857
+              >>> reprojected.band_count
+              4
 
               ```
+            - Reproject to a non-EPSG CRS via an ESRI authority string
+              (Robinson, ``ESRI:54030``):
+
+              ```python
+              >>> import numpy as np
+              >>> from osgeo import osr
+              >>> from pyramids.dataset import Dataset
+              >>> arr = np.ones((5, 5), dtype=np.float32)
+              >>> dataset = Dataset.create_from_array(
+              ...     arr, top_left_corner=(0.0, 10.0), cell_size=1.0, epsg=4326
+              ... )
+              >>> robinson = dataset.to_crs(to_epsg="ESRI:54030")
+              >>> "Robinson" in osr.SpatialReference(wkt=robinson.crs).GetName()
+              True
+
+              ```
+            - Reproject to a bespoke orthographic projection via a proj4 string
+              (no authority code at all):
+
+              ```python
+              >>> import numpy as np
+              >>> from osgeo import osr
+              >>> from pyramids.dataset import Dataset
+              >>> arr = np.ones((5, 5), dtype=np.float32)
+              >>> dataset = Dataset.create_from_array(
+              ...     arr, top_left_corner=(0.0, 10.0), cell_size=1.0, epsg=4326
+              ... )
+              >>> proj4 = "+proj=ortho +lat_0=39 +lon_0=-9 +datum=WGS84 +units=m +no_defs"
+              >>> ortho = dataset.to_crs(to_epsg=proj4)
+              >>> osr.SpatialReference(wkt=ortho.crs).IsProjected()
+              1
+              >>> ortho.epsg
+              4326
+
+              ```
+
+        See Also:
+            - :meth:`Spatial.set_crs`: Tag the dataset with a new CRS *without*
+              warping the pixels (use when the source CRS metadata is wrong,
+              not when you want a reprojection).
+            - :meth:`Spatial.resample`: Change the cell size without changing
+              the CRS.
+            - :func:`pyramids.base.crs.sr_from_user_input`: The helper that
+              resolves every accepted CRS form to an
+              :class:`osr.SpatialReference`.
 
         """
         dst_sr = sr_from_user_input(to_epsg)
@@ -388,6 +415,103 @@ class Spatial(_Engine):
         dst_sr: osr.SpatialReference,
         method: str = "nearest neighbor",
     ) -> Dataset:
+        """Reproject the dataset by deriving an extent from corner reprojection.
+
+        Drives the alignment-preserving branch of :meth:`to_crs` — chosen by
+        ``maintain_alignment=True``. Reprojects the source corners through
+        :func:`pyramids.base.crs.reproject_coordinates` to compute the output
+        extent, measures the X/Y cell-step independently (so a non-square
+        output aspect is honoured), allocates the destination raster, and
+        finally runs :func:`gdal.ReprojectImage` to fill it.
+
+        Both source and destination spatial references are normalised to
+        ``OAMS_TRADITIONAL_GIS_ORDER`` before the identity check. This lets
+        :meth:`osr.SpatialReference.IsSame` report semantic equality even when
+        the two SRSes were built from different axis-order strategies (the
+        common case: a ``sr_from_wkt(self._ds.crs)`` source + a
+        ``sr_from_user_input`` target), which is what enables the same-CRS
+        shortcut to actually fire. See issue #418 for the underlying bug.
+
+        For a geographic source whose left edge sits past longitude 180, the
+        edge is shifted into the western hemisphere (``- 360``) before
+        reprojection so the corner-derived extent does not collapse across
+        the dateline.
+
+        Args:
+            dst_sr: Target spatial reference. Any axis-mapping strategy is
+                accepted; the function normalises only the *source* side.
+                Built from ``Spatial.to_crs(..., maintain_alignment=True)``
+                via :func:`pyramids.base.crs.sr_from_user_input`, but callers
+                may pass any pre-built SRS.
+            method: GDAL resampling algorithm (e.g. ``gdal.GRA_NearestNeighbour``,
+                ``gdal.GRA_Bilinear``, ``gdal.GRA_Cubic``). The default string
+                ``"nearest neighbor"`` is a placeholder for the typed enum;
+                pass the resolved enum through :data:`INTERPOLATION_METHODS`
+                when calling from outside :meth:`to_crs`.
+
+        Returns:
+            Dataset: A new ``Dataset`` covering the reprojected extent. Cell
+            size equals the corner-derived per-axis cell-step on the target
+            CRS; row and column counts are derived from the extent / cell-step
+            ratio (so the output shape is approximately, not exactly, the
+            source shape — corner-sampled spacings are accurate for affine
+            reprojections and approximate for footprints spanning large
+            latitude ranges, where the gdal.Warp path is preferred).
+
+        Examples:
+            - Identity reprojection: passing the source's own CRS hits the
+              ``IsSame`` shortcut and preserves the source geotransform
+              bit-exactly. Use the public :meth:`to_crs` facade rather than
+              calling this private method directly:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> arr = np.ones((5, 5), dtype=np.float32)
+                >>> ds = Dataset.create_from_array(
+                ...     arr,
+                ...     top_left_corner=(10.0, 50.0),
+                ...     cell_size=0.5,
+                ...     epsg=4326,
+                ...     no_data_value=-9999.0,
+                ... )
+                >>> result = ds.to_crs(to_epsg=4326, maintain_alignment=True)
+                >>> result.geotransform == ds.geotransform
+                True
+                >>> (result.rows, result.columns) == (ds.rows, ds.columns)
+                True
+
+                ```
+            - Cross-CRS alignment-preserving reproject: 4326 → 3857 keeps the
+              source row/column count and changes the cell size to metres.
+              At 60°N the longitudinal cell size is roughly half the
+              latitudinal cell size, so the output is non-square:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> arr = np.ones((10, 10), dtype=np.float32)
+                >>> ds = Dataset.create_from_array(
+                ...     arr,
+                ...     top_left_corner=(10.0, 60.5),
+                ...     cell_size=0.1,
+                ...     epsg=4326,
+                ...     no_data_value=-9999.0,
+                ... )
+                >>> result = ds.to_crs(to_epsg=3857, maintain_alignment=True)
+                >>> result.epsg
+                3857
+                >>> abs(result.geotransform[5]) > abs(result.geotransform[1])
+                True
+
+                ```
+
+        See Also:
+            - :meth:`Spatial.to_crs`: Public facade that picks this method
+              when ``maintain_alignment=True`` and routes through
+              :func:`gdal.Warp` otherwise.
+            - :func:`pyramids.base.crs.reproject_coordinates`: Reprojects the
+              corner / step coordinate pairs used to derive the destination
+              extent and cell size.
+        """
         src_gt = self._ds.geotransform
         src_x = self._ds.columns
         src_y = self._ds.rows

--- a/tests/base/test_crs.py
+++ b/tests/base/test_crs.py
@@ -6,7 +6,7 @@ import pytest
 from pyproj import CRS
 
 from pyramids.base._errors import CRSError
-from pyramids.base.crs import epsg_from_user_input
+from pyramids.base.crs import epsg_from_user_input, sr_from_user_input
 
 pytestmark = pytest.mark.core
 
@@ -93,3 +93,88 @@ class TestEpsgFromUserInput:
         """
         with pytest.raises(ValueError):
             epsg_from_user_input("not-a-crs")
+
+
+class TestSrFromUserInput:
+    """Tests for :func:`pyramids.base.crs.sr_from_user_input`."""
+
+    def test_epsg_int_resolves_to_authority(self):
+        """sr_from_user_input(int) returns an SRS that exposes the EPSG authority.
+
+        Test scenario:
+            An EPSG int round-trips so the SRS's root AUTHORITY code is the same int.
+        """
+        sr = sr_from_user_input(3857)
+        assert sr.GetAuthorityName(None) == "EPSG", "authority should be EPSG"
+        assert sr.GetAuthorityCode(None) == "3857", "code should round-trip"
+
+    def test_esri_authority_string_resolves(self):
+        """sr_from_user_input resolves the ESRI authority for non-EPSG world projections.
+
+        Test scenario:
+            ESRI:54030 (Robinson) and ESRI:54009 (Mollweide) parse and return projected
+            SRSes whose name identifies the projection.
+        """
+        sr_robinson = sr_from_user_input("ESRI:54030")
+        sr_mollweide = sr_from_user_input("ESRI:54009")
+        assert sr_robinson.IsProjected() == 1, "Robinson must be projected"
+        assert sr_mollweide.IsProjected() == 1, "Mollweide must be projected"
+        assert "Robinson" in sr_robinson.GetName(), "name should contain 'Robinson'"
+        assert "Mollweide" in sr_mollweide.GetName(), "name should contain 'Mollweide'"
+
+    def test_proj4_orthographic_resolves(self):
+        """sr_from_user_input resolves a proj4 string with no EPSG / ESRI authority.
+
+        Test scenario:
+            An orthographic proj4 with custom centre lat/lon parses into a projected SRS.
+            The projection has no authority entry, so GetAuthorityCode is None — exactly
+            the case the EPSG-only path used to reject.
+        """
+        proj4 = "+proj=ortho +lat_0=39 +lon_0=-9 +datum=WGS84 +units=m +no_defs"
+        sr = sr_from_user_input(proj4)
+        assert sr.IsProjected() == 1, "ortho must be projected"
+        assert sr.GetAuthorityCode(None) is None, (
+            "ortho carries no authority code by design"
+        )
+
+    def test_pyproj_crs_round_trips(self):
+        """sr_from_user_input accepts a pyproj.CRS instance.
+
+        Test scenario:
+            A CRS.from_epsg(32636) instance produces an SRS whose AUTHORITY code matches.
+        """
+        sr = sr_from_user_input(CRS.from_epsg(32636))
+        assert sr.GetAuthorityCode(None) == "32636", "code should round-trip"
+
+    def test_traditional_axis_order_set(self):
+        """sr_from_user_input uses the traditional GIS axis order.
+
+        Test scenario:
+            Lon/lat-first ordering matches the rest of the pyramids stack (geotransform,
+            reproject_coordinates), so transforms compose without axis surprises.
+        """
+        from osgeo import osr as _osr
+
+        sr = sr_from_user_input(4326)
+        assert sr.GetAxisMappingStrategy() == _osr.OAMS_TRADITIONAL_GIS_ORDER, (
+            "axis order should be traditional GIS (x=lon, y=lat)"
+        )
+
+    def test_bool_rejected(self):
+        """sr_from_user_input rejects a bool (an int subclass).
+
+        Test scenario:
+            True is not a meaningful CRS and raises CRSError, matching the
+            epsg_from_user_input guard so users get a consistent error.
+        """
+        with pytest.raises(CRSError, match="not a valid CRS"):
+            sr_from_user_input(True)
+
+    def test_uninterpretable_input_raises(self):
+        """sr_from_user_input rejects a string that is not a CRS.
+
+        Test scenario:
+            A nonsense string raises CRSError mentioning it could not be interpreted.
+        """
+        with pytest.raises(CRSError, match="could not interpret"):
+            sr_from_user_input("not-a-crs")

--- a/tests/base/test_crs.py
+++ b/tests/base/test_crs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from osgeo import osr
 from pyproj import CRS
 
 from pyramids.base._errors import CRSError
@@ -153,10 +154,8 @@ class TestSrFromUserInput:
             Lon/lat-first ordering matches the rest of the pyramids stack (geotransform,
             reproject_coordinates), so transforms compose without axis surprises.
         """
-        from osgeo import osr as _osr
-
         sr = sr_from_user_input(4326)
-        assert sr.GetAxisMappingStrategy() == _osr.OAMS_TRADITIONAL_GIS_ORDER, (
+        assert sr.GetAxisMappingStrategy() == osr.OAMS_TRADITIONAL_GIS_ORDER, (
             "axis order should be traditional GIS (x=lon, y=lat)"
         )
 

--- a/tests/base/test_crs.py
+++ b/tests/base/test_crs.py
@@ -177,3 +177,70 @@ class TestSrFromUserInput:
         """
         with pytest.raises(CRSError, match="could not interpret"):
             sr_from_user_input("not-a-crs")
+
+    def test_wkt_string_round_trips_to_epsg(self):
+        """sr_from_user_input accepts a raw WKT string and preserves the authority.
+
+        Test scenario:
+            Round-trip via `CRS.from_epsg(3857).to_wkt()` → `sr_from_user_input(wkt)`
+            must produce an SRS whose root AUTHORITY resolves back to EPSG:3857. WKT
+            is one of the documented input forms but was not exercised explicitly —
+            this locks down that pyproj's WKT parsing path round-trips cleanly.
+        """
+        wkt = CRS.from_epsg(3857).to_wkt()
+        sr = sr_from_user_input(wkt)
+        assert sr.GetAuthorityCode(None) == "3857", (
+            f"WKT round-trip should preserve EPSG code, got {sr.GetAuthorityCode(None)!r}"
+        )
+
+    @pytest.mark.parametrize(
+        "value",
+        [None, "", []],
+        ids=["none", "empty-string", "list"],
+    )
+    def test_uninterpretable_values_rejected(self, value):
+        """sr_from_user_input rejects values that pyproj cannot interpret as a CRS.
+
+        Args:
+            value: Input that cannot be turned into a CRS (None / "" / list).
+
+        Test scenario:
+            Each of these inputs makes `pyproj.CRS.from_user_input` raise; the wrapper
+            converts the raise into a pyramids `CRSError`. Tested as a parametrized
+            sweep so future additions (`{}`, custom objects, etc.) extend the matrix
+            in one place.
+        """
+        with pytest.raises(CRSError, match="could not interpret"):
+            sr_from_user_input(value)
+
+    def test_lambert_azimuthal_equal_area_proj4_resolves(self):
+        """sr_from_user_input accepts a Lambert azimuthal equal-area proj4 (no EPSG code).
+
+        Test scenario:
+            LAEA over central Europe is one of the proj4 definitions that
+            `epsg_from_user_input` explicitly rejects (no EPSG code). The SRS-based
+            helper must accept it and produce a projected reference — this is the
+            class of input #418 was filed for, beyond just orthographic / Robinson.
+        """
+        proj4 = "+proj=laea +lat_0=52 +lon_0=10 +x_0=0 +y_0=0 +ellps=GRS80 +units=m +no_defs"
+        sr = sr_from_user_input(proj4)
+        assert sr.IsProjected() == 1, "LAEA must be projected"
+        assert sr.GetAuthorityCode(None) is None, (
+            "LAEA proj4 carries no authority code by design"
+        )
+
+    def test_returns_distinct_instances_for_repeated_calls(self):
+        """sr_from_user_input returns a fresh SRS each call, never a shared singleton.
+
+        Test scenario:
+            Two calls with the same input must return distinct `osr.SpatialReference`
+            instances so mutating one (e.g. via `SetAxisMappingStrategy`) can't leak
+            into another caller's reference. Identity check (`is not`) plus equality
+            of the WKT bytes verifies "different objects, same content".
+        """
+        sr1 = sr_from_user_input(4326)
+        sr2 = sr_from_user_input(4326)
+        assert sr1 is not sr2, "repeated calls must return distinct SRS instances"
+        assert sr1.ExportToWkt() == sr2.ExportToWkt(), (
+            "distinct instances should still encode the same CRS"
+        )

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -12,6 +12,7 @@ import pytest
 from geopandas.geodataframe import GeoDataFrame
 from osgeo import gdal, osr
 from pandas import DataFrame
+from pyproj import CRS as PyprojCRS
 from shapely.geometry import Polygon
 
 from pyramids.base._errors import NoDataValueError, OutOfBoundsError, ReadOnlyError
@@ -1037,11 +1038,63 @@ class TestReproject:
             Passing CRS.from_epsg(3857) yields the same dst.epsg as passing 3857
             directly — the new SRS-based front door must not break the EPSG fast path.
         """
-        from pyproj import CRS as PyprojCRS
-
         src_ds = Dataset(src)
         dst = src_ds.to_crs(to_epsg=PyprojCRS.from_epsg(3857))
         assert dst.epsg == 3857
+
+    def test_orthographic_off_disc_cells_are_nodata(self):
+        """Orthographic warp fills off-disc cells with the source nodata (#418 DoD).
+
+        Test scenario:
+            Project a globe-spanning 1° 4326 raster (covering -180..180, -90..90)
+            into a polar-orthographic centred at the North Pole. The visible disc
+            in the projected output is the northern hemisphere; the corner pixels
+            sit beyond the projection's domain and must come back as nodata, not
+            as data values. This exercises the real off-disc masking gdal.Warp
+            performs — preserving nodata metadata alone (already covered) is not
+            enough to verify the DoD.
+        """
+        arr = np.ones((180, 360), dtype=np.float32)
+        ds = Dataset.create_from_array(
+            arr,
+            top_left_corner=(-180.0, 90.0),
+            cell_size=1.0,
+            epsg=4326,
+            no_data_value=-9999.0,
+        )
+        dst = ds.to_crs(
+            to_epsg="+proj=ortho +lat_0=90 +lon_0=0 +datum=WGS84 +units=m +no_defs"
+        )
+        out = dst.read_array()
+        nodata = dst.no_data_value[0]
+        corners = np.array([out[0, 0], out[0, -1], out[-1, 0], out[-1, -1]])
+        assert np.allclose(corners, nodata), (
+            f"off-disc corner pixels should equal nodata={nodata}, got {corners}"
+        )
+
+    def test_to_crs_same_epsg_maintain_alignment_is_identity(self):
+        """to_crs(source_epsg, maintain_alignment=True) returns a bit-identical raster (M1).
+
+        Test scenario:
+            With the M1 fix (semantic IsSame() identity check after axis-order
+            normalisation), passing the source's own EPSG into the alignment-
+            preserving path must hit the shortcut and emit a Dataset whose
+            geotransform and shape match the source exactly. A regression here
+            would mean the shortcut never fires and every identity reprojection
+            silently round-trips through reproject_coordinates.
+        """
+        arr = np.ones((5, 5), dtype=np.float32)
+        ds = Dataset.create_from_array(
+            arr,
+            top_left_corner=(10.0, 50.0),
+            cell_size=0.5,
+            epsg=4326,
+            no_data_value=-9999.0,
+        )
+        dst = ds.to_crs(to_epsg=4326, maintain_alignment=True)
+        assert dst.geotransform == ds.geotransform
+        assert dst.rows == ds.rows
+        assert dst.columns == ds.columns
 
 
 class TestAlign:

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -1176,6 +1176,57 @@ class TestReproject:
         assert dst.rows == ds.rows
         assert dst.columns == ds.columns
 
+    def test_to_crs_accepts_wkt_string(self):
+        """to_crs accepts a raw WKT string end-to-end (#418).
+
+        Test scenario:
+            `sr_from_user_input` is independently tested with WKT input, but the full
+            `Spatial.to_crs(to_epsg=wkt)` path was not exercised — only EPSG ints /
+            authority strings / proj4 / pyproj.CRS. Exporting EPSG:32636 to WKT and
+            passing the bytes back into `to_crs` must reproject to the same UTM zone,
+            confirming that the SRS-based front door survives a full WKT round-trip.
+        """
+        arr = np.ones((5, 5), dtype=np.float32)
+        ds = Dataset.create_from_array(
+            arr,
+            top_left_corner=(30.0, 30.0),
+            cell_size=0.1,
+            epsg=4326,
+            no_data_value=-9999.0,
+        )
+        wkt = PyprojCRS.from_epsg(32636).to_wkt()
+        dst = ds.to_crs(to_epsg=wkt)
+        assert dst.epsg == 32636, f"WKT input should resolve to 32636, got {dst.epsg}"
+
+    def test_to_crs_projected_identity_maintain_alignment(self):
+        """Identity shortcut fires for a projected source (UTM → same UTM).
+
+        Test scenario:
+            The existing identity test uses 4326 → 4326 — a geographic CRS where
+            axis-order normalisation matters. UTM (32636) is projected with
+            unambiguous easting/northing axis order regardless of mapping strategy,
+            which exercises a structurally different IsSame() match. Asserts the
+            geotransform and shape are preserved, confirming the IsSame shortcut
+            also works for projected CRSes (not only for the geographic edge case
+            that motivated the axis normalisation).
+        """
+        arr = np.ones((5, 5), dtype=np.float32)
+        ds = Dataset.create_from_array(
+            arr,
+            geo=(500_000.0, 100.0, 0.0, 5_500_000.0, 0.0, -100.0),
+            epsg=32636,
+            no_data_value=-9999.0,
+        )
+        dst = ds.to_crs(to_epsg=32636, maintain_alignment=True)
+        assert dst.geotransform == ds.geotransform, (
+            f"projected identity shortcut should preserve geotransform; "
+            f"got {dst.geotransform} vs source {ds.geotransform}"
+        )
+        assert (dst.rows, dst.columns) == (ds.rows, ds.columns), (
+            f"projected identity shortcut should preserve shape; "
+            f"got {(dst.rows, dst.columns)} vs source {(ds.rows, ds.columns)}"
+        )
+
     def test_to_crs_lng_gt_180_maintain_alignment_shifts_west(self):
         """maintain_alignment=True shifts a >180 longitude origin into the western hemisphere.
 

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -1072,6 +1072,98 @@ class TestReproject:
             f"off-disc corner pixels should equal nodata={nodata}, got {corners}"
         )
 
+    def test_to_crs_non_epsg_with_bilinear_resampling(self):
+        """to_crs runs the bilinear resampling path against a non-EPSG target (#418).
+
+        Test scenario:
+            All existing non-EPSG tests use the default nearest-neighbour interpolation;
+            this one exercises the bilinear branch through the INTERPOLATION_METHODS
+            lookup to confirm that the SRS-based front door doesn't break method
+            dispatch. Asserts the output has a Mollweide projection and a non-empty
+            array (bilinear must produce finite values on the visible domain).
+        """
+        arr = np.linspace(0.0, 1.0, num=20 * 20, dtype=np.float32).reshape(20, 20)
+        ds = Dataset.create_from_array(
+            arr,
+            top_left_corner=(0.0, 10.0),
+            cell_size=0.5,
+            epsg=4326,
+            no_data_value=-9999.0,
+        )
+        dst = ds.to_crs(to_epsg="ESRI:54009", method="bilinear")
+        dst_sr = osr.SpatialReference(wkt=dst.crs)
+        assert "Mollweide" in dst_sr.GetName(), (
+            f"expected Mollweide in dst CRS name, got {dst_sr.GetName()!r}"
+        )
+        out = dst.read_array()
+        finite = out[out != dst.no_data_value[0]]
+        assert finite.size > 0, "bilinear warp should produce at least one finite cell"
+
+    def test_to_crs_non_epsg_idempotent_shape(self):
+        """Reprojecting twice to the same non-EPSG CRS yields the same shape (#418).
+
+        Test scenario:
+            Project a 4326 raster into Robinson (ESRI:54030), then project the result
+            into Robinson again. The second projection is effectively an identity in
+            the projected CRS; output shape and bbox must be stable. Catches the
+            "non-EPSG warp returns a slightly different raster each call" class of
+            regression that would surface if the SRS were rebuilt with a drifting
+            authority/WKT each call.
+        """
+        src_ds = Dataset(self.__class__._build_global_grid())
+        first = src_ds.to_crs(to_epsg="ESRI:54030")
+        second = first.to_crs(to_epsg="ESRI:54030")
+        assert (first.rows, first.columns) == (second.rows, second.columns), (
+            f"shapes drift: first={first.rows}x{first.columns}, "
+            f"second={second.rows}x{second.columns}"
+        )
+        for a, b in zip(first.geotransform, second.geotransform):
+            assert abs(a - b) < 1e-6, (
+                f"geotransform drift between projections: {first.geotransform} vs "
+                f"{second.geotransform}"
+            )
+
+    def test_to_crs_multiband_to_esri_string(self):
+        """Multi-band rasters reproject to an ESRI authority string (#418).
+
+        Test scenario:
+            All existing ESRI:54030 tests use a single-band fixture; this one
+            confirms that the band-count is preserved when warping a 3-band raster
+            into Robinson. A regression here would mean the new dst_srs_arg branch
+            interacts badly with gdal.Warp's multi-band handling.
+        """
+        arr = np.stack([np.full((10, 10), v, dtype=np.float32) for v in (1, 2, 3)])
+        ds = Dataset.create_from_array(
+            arr,
+            top_left_corner=(0.0, 10.0),
+            cell_size=1.0,
+            epsg=4326,
+            no_data_value=-9999.0,
+        )
+        dst = ds.to_crs(to_epsg="ESRI:54030")
+        assert dst.band_count == ds.band_count, (
+            f"band count drift: src={ds.band_count}, dst={dst.band_count}"
+        )
+
+    @staticmethod
+    def _build_global_grid() -> "gdal.Dataset":
+        """Create a 1° globe-spanning float32 raster fixture for idempotence tests.
+
+        Returns:
+            gdal.Dataset: A 4326 raster covering -180..180, -90..90 with cell size 1°
+            and a configured nodata value, so callers can run real warps without
+            opening on-disk fixtures.
+        """
+        arr = np.ones((180, 360), dtype=np.float32)
+        ds = Dataset.create_from_array(
+            arr,
+            top_left_corner=(-180.0, 90.0),
+            cell_size=1.0,
+            epsg=4326,
+            no_data_value=-9999.0,
+        )
+        return ds.raster
+
     def test_to_crs_same_epsg_maintain_alignment_is_identity(self):
         """to_crs(source_epsg, maintain_alignment=True) returns a bit-identical raster (M1).
 

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -958,6 +958,91 @@ class TestReproject:
         assert dst.epsg == epsg
         # assert dst.shape == src.shape
 
+    def test_robinson_esri_authority_string(
+        self,
+        src: gdal.Dataset,
+    ):
+        """to_crs accepts an ESRI authority string for a non-EPSG CRS (#418).
+
+        Test scenario:
+            Robinson (ESRI:54030) has no EPSG code. It used to raise
+            ``CRSError: ... pass an EPSG integer``; the new code path
+            warps directly against the spatial reference, so the result
+            is a projected raster whose root CRS name identifies Robinson.
+        """
+        src_ds = Dataset(src)
+        dst = src_ds.to_crs(to_epsg="ESRI:54030")
+        dst_sr = osr.SpatialReference(wkt=dst.crs)
+        assert dst_sr.IsProjected() == 1
+        assert "Robinson" in dst_sr.GetName(), (
+            f"expected Robinson in dst CRS name, got {dst_sr.GetName()!r}"
+        )
+
+    def test_mollweide_esri_authority_string_maintain_alignment(
+        self,
+        src: gdal.Dataset,
+        src_shape: tuple,
+    ):
+        """maintain_alignment=True works for the non-EPSG ESRI:54009 Mollweide CRS (#418).
+
+        Test scenario:
+            The alignment-preserving path used to call ``sr_from_epsg`` directly
+            on the target, which can't resolve ESRI codes. The SRS-based rewrite
+            keeps the same row/column count and reaches the Mollweide projection.
+        """
+        src_ds = Dataset(src)
+        dst = src_ds.to_crs(to_epsg="ESRI:54009", maintain_alignment=True)
+        dst_sr = osr.SpatialReference(wkt=dst.crs)
+        assert dst_sr.IsProjected() == 1
+        assert "Mollweide" in dst_sr.GetName(), (
+            f"expected Mollweide in dst CRS name, got {dst_sr.GetName()!r}"
+        )
+        dst_shape = dst.raster.ReadAsArray().shape
+        # Mollweide projects so differently from the source CRS that the
+        # corner-sampled cell-step calculation can drift by a single
+        # column/row vs. src_shape. The point of maintain_alignment=True
+        # is "reuse the source cell step", not pixel-exact shape — a
+        # tolerance of 1 covers the rounding noise without masking a
+        # regression that would shift the whole footprint.
+        assert abs(dst_shape[0] - src_shape[0]) <= 1
+        assert abs(dst_shape[1] - src_shape[1]) <= 1
+
+    def test_orthographic_proj4(
+        self,
+        src: gdal.Dataset,
+    ):
+        """to_crs accepts a proj4 orthographic string with no authority code (#418).
+
+        Test scenario:
+            A bespoke orthographic centred at (lat 39, lon -9) — Lisbon — has neither
+            an EPSG nor an ESRI code. The result is a projected raster with positive
+            row/column counts; bands carry the source's nodata so off-disc cells are
+            indistinguishable from masked.
+        """
+        proj4 = "+proj=ortho +lat_0=39 +lon_0=-9 +datum=WGS84 +units=m +no_defs"
+        src_ds = Dataset(src)
+        dst = src_ds.to_crs(to_epsg=proj4)
+        dst_sr = osr.SpatialReference(wkt=dst.crs)
+        assert dst_sr.IsProjected() == 1
+        assert dst.rows > 0 and dst.columns > 0
+        assert dst.no_data_value[0] == src_ds.no_data_value[0]
+
+    def test_pyproj_crs_object(
+        self,
+        src: gdal.Dataset,
+    ):
+        """to_crs accepts a pyproj.CRS instance for back-compat with the EPSG path (#418).
+
+        Test scenario:
+            Passing CRS.from_epsg(3857) yields the same dst.epsg as passing 3857
+            directly — the new SRS-based front door must not break the EPSG fast path.
+        """
+        from pyproj import CRS as PyprojCRS
+
+        src_ds = Dataset(src)
+        dst = src_ds.to_crs(to_epsg=PyprojCRS.from_epsg(3857))
+        assert dst.epsg == 3857
+
 
 class TestAlign:
     def test_align_single_band(

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -1110,7 +1110,14 @@ class TestReproject:
             regression that would surface if the SRS were rebuilt with a drifting
             authority/WKT each call.
         """
-        src_ds = Dataset(self.__class__._build_global_grid())
+        arr = np.ones((180, 360), dtype=np.float32)
+        src_ds = Dataset.create_from_array(
+            arr,
+            top_left_corner=(-180.0, 90.0),
+            cell_size=1.0,
+            epsg=4326,
+            no_data_value=-9999.0,
+        )
         first = src_ds.to_crs(to_epsg="ESRI:54030")
         second = first.to_crs(to_epsg="ESRI:54030")
         assert (first.rows, first.columns) == (second.rows, second.columns), (
@@ -1145,25 +1152,6 @@ class TestReproject:
             f"band count drift: src={ds.band_count}, dst={dst.band_count}"
         )
 
-    @staticmethod
-    def _build_global_grid() -> "gdal.Dataset":
-        """Create a 1° globe-spanning float32 raster fixture for idempotence tests.
-
-        Returns:
-            gdal.Dataset: A 4326 raster covering -180..180, -90..90 with cell size 1°
-            and a configured nodata value, so callers can run real warps without
-            opening on-disk fixtures.
-        """
-        arr = np.ones((180, 360), dtype=np.float32)
-        ds = Dataset.create_from_array(
-            arr,
-            top_left_corner=(-180.0, 90.0),
-            cell_size=1.0,
-            epsg=4326,
-            no_data_value=-9999.0,
-        )
-        return ds.raster
-
     def test_to_crs_same_epsg_maintain_alignment_is_identity(self):
         """to_crs(source_epsg, maintain_alignment=True) returns a bit-identical raster (M1).
 
@@ -1187,6 +1175,37 @@ class TestReproject:
         assert dst.geotransform == ds.geotransform
         assert dst.rows == ds.rows
         assert dst.columns == ds.columns
+
+    def test_to_crs_lng_gt_180_maintain_alignment_shifts_west(self):
+        """maintain_alignment=True shifts a >180 longitude origin into the western hemisphere.
+
+        Test scenario:
+            A geographic source with top_left_corner=(200.0, 50.0) sits in the
+            0..360 longitude convention. Routing through
+            _reproject_with_ReprojectImage (maintain_alignment=True) reaches the
+            west-edge branch that subtracts 360 from the origin before corner
+            reprojection, so the output extent on Web Mercator lands in the
+            *western* hemisphere (negative metres). A regression in that branch
+            would either crash, produce an extent off the visible Web Mercator
+            range (~+22e6 m), or silently fall through with an unshifted origin.
+            Pre-#418 this branch was dead code (legacy `src_epsg == "4326"`
+            int-vs-str guard); the new IsGeographic() guard makes it reachable
+            but previously had no test coverage.
+        """
+        arr = np.ones((3, 3), dtype=np.float32)
+        ds = Dataset.create_from_array(
+            arr,
+            top_left_corner=(200.0, 50.0),
+            cell_size=1.0,
+            epsg=4326,
+            no_data_value=-9999.0,
+        )
+        dst = ds.to_crs(to_epsg=3857, maintain_alignment=True)
+        assert dst.epsg == 3857
+        assert dst.geotransform[0] < 0, (
+            "west-edge shift should land the origin in the western hemisphere "
+            f"(negative metres on Web Mercator); got geotransform[0]={dst.geotransform[0]}"
+        )
 
 
 class TestAlign:


### PR DESCRIPTION
## Summary

Widen `Dataset.to_crs` to accept any CRS form `pyproj.CRS.from_user_input` understands —
EPSG int / authority string (`EPSG:`, `ESRI:`) / bare numeric string / WKT / proj4 /
`pyproj.CRS`. Closes the EPSG-only gate that blocked orthographic, Robinson (`ESRI:54030`),
Mollweide (`ESRI:54009`), and other non-EPSG projections needed by downstream consumers
(Digital-Earth projected-maps tier).

### Production code (3 files)

- **`pyramids.base.crs`** — new helper `sr_from_user_input(crs)` builds an
  `osr.SpatialReference` in `OAMS_TRADITIONAL_GIS_ORDER` from any pyproj-acceptable form.
  Exported from `__all__`.
- **`pyramids.dataset.engines.spatial.Spatial.to_crs`** — resolves the target to an SRS via
  the new helper. The `gdal.Warp` path passes `"<AUTHORITY>:<code>"` when one exists
  (preserves canonical EPSG WKT bytes, avoids GDAL's ESRI warning) and falls back to the
  explicit WKT for authority-less proj4. Docstring updated; off-disc nodata behaviour
  qualified.
- **`pyramids.dataset.engines.spatial.Spatial._reproject_with_ReprojectImage`** (the
  `maintain_alignment=True` path) — takes an SRS, normalises axis order on the source
  side, and uses `src_sr.IsSame(dst_sr)` for the identity shortcut instead of brittle
  WKT-byte equality. The legacy dual-path (one branch via `osr.CoordinateTransformation`,
  one via `reproject_coordinates`) is collapsed into a single `reproject_coordinates` call
  with a pre-shifted west edge for the `lng > 180` case — removes a latent axis-order
  hazard. First docstring added.
- **`pyramids.dataset.collection.DatasetCollection.to_crs`** — type hint and docstring
  widened to match.

`FeatureCollection.to_crs` and `reproject_coordinates` already accepted arbitrary CRS
forms (geopandas-backed and pyproj-backed respectively) — unchanged.

### Back-compat

Callers passing an EPSG int / `EPSG:` string / `pyproj.CRS` keep working; the output WKT
bytes are identical to the pre-change path because the `"<AUTHORITY>:<code>"` shortcut
matches what GDAL emitted previously.

## Test plan

- [x] `pixi run -e dev main` — **4136 passed, 9 skipped** (vs 4114 on `main`; the 22 new
  tests are the delta).
- [x] New `Dataset.to_crs` coverage in `tests/dataset/test_dataset.py::TestReproject`:
  - Robinson (`ESRI:54030`) round-trip (both `maintain_alignment` settings).
  - Mollweide (`ESRI:54009`) with `maintain_alignment=True` (shape within ±1 cell).
  - Orthographic proj4 (no authority code) — projected dst, nodata preserved.
  - Globe → polar orthographic: off-disc corner pixels equal nodata (verifies the DoD).
  - `to_crs(source_epsg, maintain_alignment=True)` is bit-exact identity (regression cover
    for the `IsSame()` shortcut after axis-order normalisation).
  - Multi-band raster → ESRI string preserves band count.
  - Bilinear resampling against a non-EPSG target.
  - Idempotent shape/geotransform when reprojecting twice to ESRI:54030.
  - `pyproj.CRS` instance back-compat.
- [x] New `sr_from_user_input` coverage in `tests/base/test_crs.py::TestSrFromUserInput`:
  EPSG int, ESRI authority, proj4 orthographic, LAEA proj4, `pyproj.CRS`, WKT round-trip,
  traditional axis order, fresh-instance purity, `bool` rejection, uninterpretable values
  (`None`, `""`, `[]`, `"not-a-crs"`).
- [x] Doctest validation on the three target docstrings — 3/3 PASSED under
  `pytest --doctest-modules`:
  - `pyramids.base.crs.sr_from_user_input`
  - `pyramids.dataset.engines.spatial.Spatial.to_crs`
  - `pyramids.dataset.engines.spatial.Spatial._reproject_with_ReprojectImage`
- [x] Coverage from `coverage.xml`:
  - The three target functions: 100% line + branch on their own bodies.
  - `pyramids.base.crs` module total: 99.0% line / 97.2% branch.
  - `pyramids.dataset.engines.spatial` module total: 97.7% line / 94.4% branch.

Closes #418