### PR TITLE
feat(io): add decompress-aware resource reader (sniff → Dataset / FeatureCollection / DataFrame)

### DIFF
--- a/src/pyramids/__init__.py
+++ b/src/pyramids/__init__.py
@@ -25,9 +25,15 @@ except PackageNotFoundError:  # pragma: no cover
 
 Config()
 
+# Imported after Config() so the package (and GDAL) is fully initialised before
+# `_resource` pulls in the Dataset / FeatureCollection readers it dispatches to.
+from pyramids._resource import ResourceKind, read_resource, sniff_kind
 
 __all__ = [
     "configure",
     "configure_lazy_vector",
+    "read_resource",
+    "sniff_kind",
+    "ResourceKind",
     "__version__",
 ]

--- a/src/pyramids/__init__.py
+++ b/src/pyramids/__init__.py
@@ -25,9 +25,32 @@ except PackageNotFoundError:  # pragma: no cover
 
 Config()
 
-# Imported after Config() so the package (and GDAL) is fully initialised before
-# `_resource` pulls in the Dataset / FeatureCollection readers it dispatches to.
-from pyramids._resource import ResourceKind, read_resource, sniff_kind
+# `read_resource` / `sniff_kind` live in `pyramids._resource`, which imports the
+# Dataset and FeatureCollection readers (and, transitively, geopandas / dask).
+# Expose them lazily via PEP 562 module `__getattr__` so a bare `import pyramids`
+# stays light — that heavy stack is only pulled in when these symbols are first
+# accessed, not at package import time.
+_LAZY_RESOURCE_EXPORTS = frozenset({"read_resource", "sniff_kind", "ResourceKind"})
+
+
+def __getattr__(name: str):
+    """Lazily import the resource-reader exports on first access (PEP 562)."""
+    if name in _LAZY_RESOURCE_EXPORTS:
+        from pyramids._resource import ResourceKind, read_resource, sniff_kind
+
+        globals().update(
+            read_resource=read_resource,
+            sniff_kind=sniff_kind,
+            ResourceKind=ResourceKind,
+        )
+        return globals()[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Include the lazily-exported names in ``dir(pyramids)``."""
+    return sorted(set(globals()) | _LAZY_RESOURCE_EXPORTS)
+
 
 __all__ = [
     "configure",

--- a/src/pyramids/_resource.py
+++ b/src/pyramids/_resource.py
@@ -2,8 +2,8 @@
 
 A single entry point, :func:`read_resource`, that takes a local file path
 (optionally plus a format hint), sniffs the format, transparently handles
-``.gz`` / ``.zip`` / ``.tar`` containers, and returns the appropriate pyramids
-type:
+``.gz`` / ``.zip`` / ``.tar`` / ``.tar.gz`` containers, and returns the
+appropriate pyramids type:
 
 * raster  (``.tif`` / ``.tiff`` / ``.cog`` / ``.nc`` / ``.nc4`` / ``.vrt``)
   → :class:`pyramids.dataset.Dataset`
@@ -15,14 +15,19 @@ type:
 This is a thin sniff-and-dispatch shim over the existing per-family readers
 (:meth:`Dataset.read_file`, :meth:`FeatureCollection.read_file`) plus a
 :mod:`pandas` branch for tabular formats. Decompression is delegated to GDAL's
-virtual filesystem via :mod:`pyramids._io` — no new decompression code lives
-here.
+virtual filesystem via :mod:`pyramids._io` (for raster/vector) and to
+:mod:`pandas`' own compression inference (for tabular) — no new decompression
+code lives here.
+
+Note on ``.json``: a ``.json`` suffix is assumed to be GeoJSON and routed to the
+vector reader. For a non-spatial JSON table, pass ``kind="tabular"`` (or a
+tabular ``fmt``) explicitly.
 """
 from __future__ import annotations
 
 import warnings
 from pathlib import Path
-from typing import Literal, Union
+from typing import Literal
 
 import pandas as pd
 
@@ -33,11 +38,12 @@ from pyramids.feature import FeatureCollection
 
 ResourceKind = Literal["raster", "vector", "tabular"]
 
-# Compression extensions that wrap a single inner file — peel one layer to read
-# the inner suffix (e.g. ``kontur.gpkg.gz`` → ``.gpkg``).
+# Single-file compression layer — peel it to read the inner suffix
+# (e.g. ``kontur.gpkg.gz`` → ``.gpkg``).
 _GZIP_SUFFIXES = {".gz"}
-# Container extensions whose members must be inspected to know the family —
-# a bare ``.zip`` name does not say whether it holds a raster, vector, or table.
+# Container extensions whose members must be inspected to know the family and to
+# target the right member. ``.tar.gz`` is matched separately (its ``Path.suffix``
+# is ``.gz``) via :func:`_is_archive`.
 _ARCHIVE_SUFFIXES = {".zip", ".tar", ".tgz"}
 
 _RASTER_SUFFIXES = {".tif", ".tiff", ".cog", ".nc", ".nc4", ".vrt"}
@@ -51,7 +57,14 @@ _VECTOR_SUFFIXES = {
     ".fgb",
     ".gml",
 }
-_TABULAR_SUFFIXES = {".csv", ".tsv", ".txt", ".xlsx", ".xls", ".parquet", ".pq"}
+_TABULAR_SUFFIXES = {".csv", ".tsv", ".xlsx", ".xls", ".parquet", ".pq"}
+
+# kind → the suffix set used to pick the matching member inside an archive.
+_KIND_SUFFIXES: dict[ResourceKind, set[str]] = {
+    "raster": _RASTER_SUFFIXES,
+    "vector": _VECTOR_SUFFIXES,
+    "tabular": _TABULAR_SUFFIXES,
+}
 
 # CKAN / source format labels → family. Keys are lower-cased and stripped of any
 # leading dot; used as a tiebreaker when the suffix alone is ambiguous (notably
@@ -78,7 +91,6 @@ _FMT_TO_KIND: dict[str, ResourceKind] = {
     "gml": "vector",
     "csv": "tabular",
     "tsv": "tabular",
-    "txt": "tabular",
     "excel": "tabular",
     "xlsx": "tabular",
     "xls": "tabular",
@@ -86,21 +98,38 @@ _FMT_TO_KIND: dict[str, ResourceKind] = {
 }
 
 
-def _strip_compression(name: str) -> str:
-    """Peel one ``.gz`` layer so the inner suffix can be sniffed.
+def _is_archive(path: Path) -> bool:
+    """True when ``path`` is a multi-member container (``.zip``/``.tar``/…).
 
-    ``"kontur.gpkg.gz"`` → ``"kontur.gpkg"``; everything else is returned
-    unchanged (``.zip`` / ``.tar`` are containers, handled separately).
+    ``.tar.gz`` is included even though its :attr:`~pathlib.Path.suffix` is
+    ``.gz`` — GDAL's ``/vsitar/`` handler decompresses it inline.
     """
-    p = Path(name)
-    inner = p.stem if p.suffix.lower() in _GZIP_SUFFIXES else name
+    name = path.name.lower()
+    return name.endswith(".tar.gz") or Path(name).suffix in _ARCHIVE_SUFFIXES
+
+
+def _strip_compression(name: str) -> str:
+    """Peel one compression / container layer so the inner suffix can be sniffed.
+
+    ``"kontur.gpkg.gz"`` → ``"kontur.gpkg"``, ``"rivers.shp.zip"`` →
+    ``"rivers.shp"``, ``"noah.tif.tar.gz"`` → ``"noah.tif"``. A bare container
+    with no inner name (``"download.zip"``) peels to its stem (``"download"``),
+    which carries no usable suffix — the caller then leans on ``fmt`` or peeks
+    inside the archive.
+    """
+    low = name.lower()
+    if low.endswith(".tar.gz"):
+        inner = name[: -len(".tar.gz")]
+    else:
+        p = Path(name)
+        inner = p.stem if p.suffix.lower() in _GZIP_SUFFIXES | _ARCHIVE_SUFFIXES else name
     return inner
 
 
-def sniff_kind(path: Union[str, Path], fmt: str | None = None) -> ResourceKind:
+def sniff_kind(path: str | Path, fmt: str | None = None) -> ResourceKind:
     """Determine the resource family from a path (+ optional format hint).
 
-    Peels one ``.gz`` compression layer to read the inner suffix, maps that
+    Peels one compression / container layer to read the inner suffix, maps that
     suffix to ``"raster"`` / ``"vector"`` / ``"tabular"``, and falls back to the
     ``fmt`` label when the suffix is unknown or ambiguous (e.g. a bare ``.zip``,
     whose contents are not implied by the name).
@@ -133,12 +162,17 @@ def sniff_kind(path: Union[str, Path], fmt: str | None = None) -> ResourceKind:
             >>> sniff_kind("kontur.gpkg.gz")
             'vector'
 
+        - A zipped Shapefile whose name carries the inner suffix::
+
+            >>> sniff_kind("rivers.shp.zip")
+            'vector'
+
         - A bare ``.zip`` leans on the format label::
 
             >>> sniff_kind("meta_hrsl.zip", fmt="GeoTIFF")
             'raster'
     """
-    inner = Path(_strip_compression(str(path)))
+    inner = Path(_strip_compression(str(Path(path).name)))
     ext = inner.suffix.lower()
     kind: ResourceKind | None = None
     if ext in _RASTER_SUFFIXES:
@@ -158,15 +192,29 @@ def sniff_kind(path: Union[str, Path], fmt: str | None = None) -> ResourceKind:
     return kind
 
 
-def _sniff_from_archive(path: Path) -> ResourceKind | None:
-    """Peek inside a ``.zip`` / ``.tar`` and infer the family from its members.
+def _archive_members_for_kind(path: Path, kind: ResourceKind) -> list[str]:
+    """List archive members whose suffix matches ``kind`` (best-effort).
 
-    Best-effort: returns ``None`` (rather than raising) when the archive cannot
-    be listed or holds no member with a recognised suffix, so the caller can
-    surface a single, clear error.
+    Returns ``[]`` (rather than raising) when the archive cannot be listed, so
+    callers can fall back to the whole-archive path.
+    """
+    try:
+        members = _io.archive_members(_io.archive_dir_vsi(path, "auto"))
+    except (FileFormatNotSupportedError, FileNotFoundError, RuntimeError):
+        members = []
+    suffixes = _KIND_SUFFIXES[kind]
+    return [m for m in members if Path(m).suffix.lower() in suffixes]
+
+
+def _sniff_from_archive(path: Path) -> ResourceKind | None:
+    """Peek inside a container and infer the family from the first known member.
+
+    Best-effort: returns ``None`` when the archive cannot be listed or holds no
+    member with a recognised suffix, so the caller can surface a single, clear
+    error.
     """
     kind: ResourceKind | None = None
-    if path.suffix.lower() in _ARCHIVE_SUFFIXES:
+    if _is_archive(path):
         try:
             members = _io.archive_members(_io.archive_dir_vsi(path, "auto"))
         except (FileFormatNotSupportedError, FileNotFoundError, RuntimeError):
@@ -196,26 +244,32 @@ def _determine_kind(path: Path, fmt: str | None) -> ResourceKind:
     return kind
 
 
-def _warn_if_multilayer(path: Path) -> None:
-    """Warn when a vector source exposes more than one layer / vector member.
+def _read_raster(path: Path) -> Dataset:
+    """Read a raster, targeting the matching member when ``path`` is an archive.
 
-    Covers both multi-layer single files (GeoPackage, GDB, KML — via
-    :meth:`FeatureCollection.list_layers`) and archives bundling several vector
-    members (e.g. a HOTOSM ``.zip`` of Shapefiles — via the archive member list).
-    Never raises: the warning is advisory and must not block the read.
+    For a ``.zip`` / ``.tar`` / ``.tar.gz`` the raster member is selected
+    explicitly (``<archive>/<member>``) rather than relying on the archive
+    handler's first-member default — which, for a tar, would otherwise open the
+    container directory and fail.
     """
-    names: list[str] = []
-    if path.suffix.lower() in _ARCHIVE_SUFFIXES:
-        try:
-            members = _io.archive_members(_io.archive_dir_vsi(path, "auto"))
-            names = [m for m in members if Path(m).suffix.lower() in _VECTOR_SUFFIXES]
-        except (FileFormatNotSupportedError, FileNotFoundError, RuntimeError):
-            names = []
-    else:
-        try:
-            names = FeatureCollection.list_layers(str(path))
-        except Exception:  # noqa: BLE001 — advisory check, any failure → no warning
-            names = []
+    source = str(path)
+    if _is_archive(path):
+        members = _archive_members_for_kind(path, "raster")
+        if members:
+            source = f"{path}/{members[0]}"
+    return Dataset.read_file(source)
+
+
+def _warn_if_multilayer(path: Path) -> None:
+    """Warn when a single vector file exposes more than one layer (GPKG/GDB/KML).
+
+    Never raises: the warning is advisory and must not block the read. Archive
+    containers are handled separately by :func:`_select_vector_member`.
+    """
+    try:
+        names = FeatureCollection.list_layers(str(path))
+    except Exception:  # noqa: BLE001 — advisory check; any failure → no warning
+        names = []
     if len(names) > 1:
         warnings.warn(
             f"{str(path)!r} contains {len(names)} layers {names!r}; reading the "
@@ -225,41 +279,79 @@ def _warn_if_multilayer(path: Path) -> None:
         )
 
 
-def _read_vector(
-    path: Path, layer: Union[str, int, None]
-) -> FeatureCollection:
-    """Read a vector resource, applying the multi-layer policy.
+def _select_vector_member(
+    members: list[str], layer: str | int | None, path: Path
+) -> tuple[str, str | int | None]:
+    """Pick the archive member to read and the layer to forward to the reader.
 
-    When ``layer`` is not specified and the source exposes more than one layer,
-    warn and read the first (driver-default) layer — never silently drop data.
+    A vector archive may hold several vector files (e.g. a HOTOSM ``.zip`` of
+    Shapefiles). ``layer`` selects one by member stem (str) or index (int);
+    ``None`` reads the first and warns when more exist. When ``layer`` names a
+    member it is consumed here (the member *is* the selection), so ``None`` is
+    forwarded as the internal layer.
     """
-    if layer is None:
+    stems = {Path(m).stem: m for m in members}
+    member = members[0]
+    passthrough = layer
+    if isinstance(layer, str) and layer in stems:
+        member = stems[layer]
+        passthrough = None
+    elif isinstance(layer, int) and 0 <= layer < len(members):
+        member = members[layer]
+        passthrough = None
+    elif layer is None and len(members) > 1:
+        warnings.warn(
+            f"{str(path)!r} contains {len(members)} vector members {members!r}; "
+            f"reading the first ({members[0]!r}). Pass layer=<name|index> to "
+            "choose a specific one.",
+            stacklevel=3,
+        )
+    return member, passthrough
+
+
+def _read_vector(path: Path, layer: str | int | None) -> FeatureCollection:
+    """Read a vector resource, applying the multi-layer / multi-member policy.
+
+    Plain multi-layer files (GPKG/GDB) default to the first layer and warn;
+    ``layer=`` selects. Archive containers resolve to a specific vector member
+    (``<archive>/<member>``) so a zipped Shapefile reads its ``.shp`` rather than
+    an alphabetically-first sidecar.
+    """
+    source = str(path)
+    passthrough_layer = layer
+    if _is_archive(path):
+        members = _archive_members_for_kind(path, "vector")
+        if members:
+            member, passthrough_layer = _select_vector_member(members, layer, path)
+            source = f"{path}/{member}"
+    elif layer is None:
         _warn_if_multilayer(path)
-    return FeatureCollection.read_file(str(path), layer=layer)
+    return FeatureCollection.read_file(source, layer=passthrough_layer)
 
 
 def _read_tabular(path: Path) -> pd.DataFrame:
     """Read a tabular resource into a :class:`pandas.DataFrame`.
 
-    ``pandas`` infers ``.gz`` / ``.zip`` compression for CSV/TSV from the
-    suffix. ``.xlsx`` needs ``openpyxl`` and ``.parquet`` needs ``pyarrow`` —
-    when missing, the underlying :class:`ImportError` is re-raised with install
-    guidance.
+    ``pandas`` infers ``.gz`` / ``.zip`` / ``.tar`` compression from the suffix,
+    so the path is passed through verbatim. ``.xlsx`` needs ``openpyxl`` and
+    ``.parquet`` needs ``pyarrow`` — when missing, the underlying
+    :class:`ImportError` is re-raised with install guidance.
     """
     source = str(path)
     ext = Path(_strip_compression(path.name)).suffix.lower()
     result: pd.DataFrame
-    if ext in {".csv", ".txt"}:
+    if ext == ".csv":
         result = pd.read_csv(source)
     elif ext == ".tsv":
         result = pd.read_csv(source, sep="\t")
     elif ext in {".xlsx", ".xls"}:
         try:
             result = pd.read_excel(source)
-        except ImportError as exc:  # openpyxl / xlrd not installed
+        except ImportError as exc:  # openpyxl (.xlsx) / xlrd (.xls) not installed
             raise ImportError(
-                f"reading {ext} files needs an Excel engine (e.g. 'openpyxl'); "
-                "install it into the environment to read this resource."
+                f"reading {ext} files needs an Excel engine (openpyxl for .xlsx, "
+                "xlrd for legacy .xls); install it into the environment to read "
+                "this resource."
             ) from exc
     elif ext in {".parquet", ".pq"}:
         try:
@@ -278,17 +370,17 @@ def _read_tabular(path: Path) -> pd.DataFrame:
 
 
 def read_resource(
-    path: Union[str, Path],
+    path: str | Path,
     fmt: str | None = None,
     *,
     kind: ResourceKind | None = None,
-    layer: Union[str, int, None] = None,
-) -> Union[Dataset, FeatureCollection, pd.DataFrame]:
+    layer: str | int | None = None,
+) -> Dataset | FeatureCollection | pd.DataFrame:
     """Read a downloaded resource into the appropriate pyramids type.
 
     Sniffs the format (suffix + ``fmt``, peeking inside ``.zip`` / ``.tar`` when
-    needed), transparently handles ``.gz`` / ``.zip`` / ``.tar`` containers via
-    GDAL's virtual filesystem, and dispatches:
+    needed), transparently handles ``.gz`` / ``.zip`` / ``.tar`` / ``.tar.gz``
+    containers, and dispatches:
 
     * raster  → :class:`pyramids.dataset.Dataset`
     * vector  → :class:`pyramids.feature.FeatureCollection`
@@ -305,7 +397,8 @@ def read_resource(
         layer: For multi-layer vector containers (a ``.gpkg`` / ``.gdb`` with
             several layers, or a ``.zip`` of Shapefiles), select by name or
             index. ``None`` reads the first / default layer and warns when more
-            exist (data is never silently dropped).
+            exist (data is never silently dropped). Ignored — with a warning —
+            for raster and tabular resources.
 
     Returns:
         Dataset | FeatureCollection | pandas.DataFrame: The resource read into
@@ -335,10 +428,14 @@ def read_resource(
     """
     path = Path(path)
     resolved_kind = kind if kind is not None else _determine_kind(path, fmt)
-    if resolved_kind == "raster":
-        result: Union[Dataset, FeatureCollection, pd.DataFrame] = Dataset.read_file(
-            str(path)
+    if layer is not None and resolved_kind != "vector":
+        warnings.warn(
+            f"layer={layer!r} is ignored for {resolved_kind} resources; it only "
+            "applies to vector data.",
+            stacklevel=2,
         )
+    if resolved_kind == "raster":
+        result: Dataset | FeatureCollection | pd.DataFrame = _read_raster(path)
     elif resolved_kind == "vector":
         result = _read_vector(path, layer)
     elif resolved_kind == "tabular":

--- a/src/pyramids/_resource.py
+++ b/src/pyramids/_resource.py
@@ -296,7 +296,12 @@ def _select_vector_member(
     if isinstance(layer, str) and layer in stems:
         member = stems[layer]
         passthrough = None
-    elif isinstance(layer, int) and 0 <= layer < len(members):
+    elif isinstance(layer, int) and not isinstance(layer, bool):
+        if not 0 <= layer < len(members):
+            raise IndexError(
+                f"layer index {layer} is out of range for the {len(members)} "
+                f"vector member(s) in {str(path)!r}: {members!r}"
+            )
         member = members[layer]
         passthrough = None
     elif layer is None and len(members) > 1:

--- a/src/pyramids/_resource.py
+++ b/src/pyramids/_resource.py
@@ -1,0 +1,351 @@
+"""Decompress-aware resource reader.
+
+A single entry point, :func:`read_resource`, that takes a local file path
+(optionally plus a format hint), sniffs the format, transparently handles
+``.gz`` / ``.zip`` / ``.tar`` containers, and returns the appropriate pyramids
+type:
+
+* raster  (``.tif`` / ``.tiff`` / ``.cog`` / ``.nc`` / ``.nc4`` / ``.vrt``)
+  → :class:`pyramids.dataset.Dataset`
+* vector  (``.gpkg`` / ``.shp`` / ``.geojson`` / ``.gdb`` / ``.kml`` / …)
+  → :class:`pyramids.feature.FeatureCollection`
+* tabular (``.csv`` / ``.tsv`` / ``.xlsx`` / ``.xls`` / ``.parquet``)
+  → :class:`pandas.DataFrame`
+
+This is a thin sniff-and-dispatch shim over the existing per-family readers
+(:meth:`Dataset.read_file`, :meth:`FeatureCollection.read_file`) plus a
+:mod:`pandas` branch for tabular formats. Decompression is delegated to GDAL's
+virtual filesystem via :mod:`pyramids._io` — no new decompression code lives
+here.
+"""
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+from typing import Literal, Union
+
+import pandas as pd
+
+from pyramids import _io
+from pyramids.base._errors import FileFormatNotSupportedError
+from pyramids.dataset import Dataset
+from pyramids.feature import FeatureCollection
+
+ResourceKind = Literal["raster", "vector", "tabular"]
+
+# Compression extensions that wrap a single inner file — peel one layer to read
+# the inner suffix (e.g. ``kontur.gpkg.gz`` → ``.gpkg``).
+_GZIP_SUFFIXES = {".gz"}
+# Container extensions whose members must be inspected to know the family —
+# a bare ``.zip`` name does not say whether it holds a raster, vector, or table.
+_ARCHIVE_SUFFIXES = {".zip", ".tar", ".tgz"}
+
+_RASTER_SUFFIXES = {".tif", ".tiff", ".cog", ".nc", ".nc4", ".vrt"}
+_VECTOR_SUFFIXES = {
+    ".gpkg",
+    ".shp",
+    ".geojson",
+    ".json",
+    ".gdb",
+    ".kml",
+    ".fgb",
+    ".gml",
+}
+_TABULAR_SUFFIXES = {".csv", ".tsv", ".txt", ".xlsx", ".xls", ".parquet", ".pq"}
+
+# CKAN / source format labels → family. Keys are lower-cased and stripped of any
+# leading dot; used as a tiebreaker when the suffix alone is ambiguous (notably
+# a bare ``.zip``).
+_FMT_TO_KIND: dict[str, ResourceKind] = {
+    "geotiff": "raster",
+    "gtiff": "raster",
+    "tif": "raster",
+    "tiff": "raster",
+    "cog": "raster",
+    "netcdf": "raster",
+    "nc": "raster",
+    "vrt": "raster",
+    "geopackage": "vector",
+    "gpkg": "vector",
+    "shapefile": "vector",
+    "shp": "vector",
+    "geojson": "vector",
+    "json": "vector",
+    "kml": "vector",
+    "gdb": "vector",
+    "fgb": "vector",
+    "flatgeobuf": "vector",
+    "gml": "vector",
+    "csv": "tabular",
+    "tsv": "tabular",
+    "txt": "tabular",
+    "excel": "tabular",
+    "xlsx": "tabular",
+    "xls": "tabular",
+    "parquet": "tabular",
+}
+
+
+def _strip_compression(name: str) -> str:
+    """Peel one ``.gz`` layer so the inner suffix can be sniffed.
+
+    ``"kontur.gpkg.gz"`` → ``"kontur.gpkg"``; everything else is returned
+    unchanged (``.zip`` / ``.tar`` are containers, handled separately).
+    """
+    p = Path(name)
+    inner = p.stem if p.suffix.lower() in _GZIP_SUFFIXES else name
+    return inner
+
+
+def sniff_kind(path: Union[str, Path], fmt: str | None = None) -> ResourceKind:
+    """Determine the resource family from a path (+ optional format hint).
+
+    Peels one ``.gz`` compression layer to read the inner suffix, maps that
+    suffix to ``"raster"`` / ``"vector"`` / ``"tabular"``, and falls back to the
+    ``fmt`` label when the suffix is unknown or ambiguous (e.g. a bare ``.zip``,
+    whose contents are not implied by the name).
+
+    This is a pure, name-based helper — it performs no I/O. For an ambiguous
+    container with no usable ``fmt``, :func:`read_resource` peeks inside the
+    archive instead.
+
+    Args:
+        path: Path to the (possibly compressed) resource.
+        fmt: Optional source format label (e.g. a CKAN ``"Geopackage"`` /
+            ``"GeoTIFF"`` / ``"CSV"`` string) used as a tiebreaker.
+
+    Returns:
+        ResourceKind: ``"raster"``, ``"vector"``, or ``"tabular"``.
+
+    Raises:
+        ValueError: When the family cannot be determined from the suffix or
+            ``fmt``.
+
+    Examples:
+        - A GeoTIFF sniffs as raster::
+
+            >>> from pyramids._resource import sniff_kind
+            >>> sniff_kind("worldpop.tif")
+            'raster'
+
+        - A gzipped GeoPackage peels one layer to the inner ``.gpkg``::
+
+            >>> sniff_kind("kontur.gpkg.gz")
+            'vector'
+
+        - A bare ``.zip`` leans on the format label::
+
+            >>> sniff_kind("meta_hrsl.zip", fmt="GeoTIFF")
+            'raster'
+    """
+    inner = Path(_strip_compression(str(path)))
+    ext = inner.suffix.lower()
+    kind: ResourceKind | None = None
+    if ext in _RASTER_SUFFIXES:
+        kind = "raster"
+    elif ext in _VECTOR_SUFFIXES:
+        kind = "vector"
+    elif ext in _TABULAR_SUFFIXES:
+        kind = "tabular"
+    if kind is None and fmt is not None:
+        kind = _FMT_TO_KIND.get(fmt.strip().lower().lstrip("."))
+    if kind is None:
+        raise ValueError(
+            f"could not determine the resource kind from {str(path)!r}"
+            f"{'' if fmt is None else f' (fmt={fmt!r})'}; pass an explicit "
+            "kind='raster'|'vector'|'tabular' or a recognised fmt label."
+        )
+    return kind
+
+
+def _sniff_from_archive(path: Path) -> ResourceKind | None:
+    """Peek inside a ``.zip`` / ``.tar`` and infer the family from its members.
+
+    Best-effort: returns ``None`` (rather than raising) when the archive cannot
+    be listed or holds no member with a recognised suffix, so the caller can
+    surface a single, clear error.
+    """
+    kind: ResourceKind | None = None
+    if path.suffix.lower() in _ARCHIVE_SUFFIXES:
+        try:
+            members = _io.archive_members(_io.archive_dir_vsi(path, "auto"))
+        except (FileFormatNotSupportedError, FileNotFoundError, RuntimeError):
+            members = []
+        for member in members:
+            ext = Path(member).suffix.lower()
+            if ext in _RASTER_SUFFIXES:
+                kind = "raster"
+                break
+            if ext in _VECTOR_SUFFIXES:
+                kind = "vector"
+                break
+            if ext in _TABULAR_SUFFIXES:
+                kind = "tabular"
+                break
+    return kind
+
+
+def _determine_kind(path: Path, fmt: str | None) -> ResourceKind:
+    """Resolve the family from name + ``fmt``, peeking into archives as needed."""
+    try:
+        kind = sniff_kind(path, fmt=fmt)
+    except ValueError:
+        kind = _sniff_from_archive(path)
+        if kind is None:
+            raise
+    return kind
+
+
+def _warn_if_multilayer(path: Path) -> None:
+    """Warn when a vector source exposes more than one layer / vector member.
+
+    Covers both multi-layer single files (GeoPackage, GDB, KML — via
+    :meth:`FeatureCollection.list_layers`) and archives bundling several vector
+    members (e.g. a HOTOSM ``.zip`` of Shapefiles — via the archive member list).
+    Never raises: the warning is advisory and must not block the read.
+    """
+    names: list[str] = []
+    if path.suffix.lower() in _ARCHIVE_SUFFIXES:
+        try:
+            members = _io.archive_members(_io.archive_dir_vsi(path, "auto"))
+            names = [m for m in members if Path(m).suffix.lower() in _VECTOR_SUFFIXES]
+        except (FileFormatNotSupportedError, FileNotFoundError, RuntimeError):
+            names = []
+    else:
+        try:
+            names = FeatureCollection.list_layers(str(path))
+        except Exception:  # noqa: BLE001 — advisory check, any failure → no warning
+            names = []
+    if len(names) > 1:
+        warnings.warn(
+            f"{str(path)!r} contains {len(names)} layers {names!r}; reading the "
+            f"first ({names[0]!r}). Pass layer=<name|index> to choose a specific "
+            "one, or call FeatureCollection.list_layers(path) to enumerate them.",
+            stacklevel=3,
+        )
+
+
+def _read_vector(
+    path: Path, layer: Union[str, int, None]
+) -> FeatureCollection:
+    """Read a vector resource, applying the multi-layer policy.
+
+    When ``layer`` is not specified and the source exposes more than one layer,
+    warn and read the first (driver-default) layer — never silently drop data.
+    """
+    if layer is None:
+        _warn_if_multilayer(path)
+    return FeatureCollection.read_file(str(path), layer=layer)
+
+
+def _read_tabular(path: Path) -> pd.DataFrame:
+    """Read a tabular resource into a :class:`pandas.DataFrame`.
+
+    ``pandas`` infers ``.gz`` / ``.zip`` compression for CSV/TSV from the
+    suffix. ``.xlsx`` needs ``openpyxl`` and ``.parquet`` needs ``pyarrow`` —
+    when missing, the underlying :class:`ImportError` is re-raised with install
+    guidance.
+    """
+    source = str(path)
+    ext = Path(_strip_compression(path.name)).suffix.lower()
+    result: pd.DataFrame
+    if ext in {".csv", ".txt"}:
+        result = pd.read_csv(source)
+    elif ext == ".tsv":
+        result = pd.read_csv(source, sep="\t")
+    elif ext in {".xlsx", ".xls"}:
+        try:
+            result = pd.read_excel(source)
+        except ImportError as exc:  # openpyxl / xlrd not installed
+            raise ImportError(
+                f"reading {ext} files needs an Excel engine (e.g. 'openpyxl'); "
+                "install it into the environment to read this resource."
+            ) from exc
+    elif ext in {".parquet", ".pq"}:
+        try:
+            result = pd.read_parquet(source)
+        except ImportError as exc:  # pyarrow / fastparquet not installed
+            raise ImportError(
+                "reading .parquet files needs a parquet engine (e.g. 'pyarrow'); "
+                "install it into the environment to read this resource."
+            ) from exc
+    else:
+        raise ValueError(
+            f"unsupported tabular suffix {ext!r} for {source!r}; expected one of "
+            f"{sorted(_TABULAR_SUFFIXES)}."
+        )
+    return result
+
+
+def read_resource(
+    path: Union[str, Path],
+    fmt: str | None = None,
+    *,
+    kind: ResourceKind | None = None,
+    layer: Union[str, int, None] = None,
+) -> Union[Dataset, FeatureCollection, pd.DataFrame]:
+    """Read a downloaded resource into the appropriate pyramids type.
+
+    Sniffs the format (suffix + ``fmt``, peeking inside ``.zip`` / ``.tar`` when
+    needed), transparently handles ``.gz`` / ``.zip`` / ``.tar`` containers via
+    GDAL's virtual filesystem, and dispatches:
+
+    * raster  → :class:`pyramids.dataset.Dataset`
+    * vector  → :class:`pyramids.feature.FeatureCollection`
+    * tabular → :class:`pandas.DataFrame`
+
+    Args:
+        path: Local path to the (possibly compressed) resource.
+        fmt: Optional source format label (e.g. a CKAN ``"Geopackage"`` /
+            ``"GeoTIFF"`` / ``"CSV"`` string) used as a tiebreaker when the
+            suffix is ambiguous — notably a bare ``.zip`` whose contents are not
+            implied by the name.
+        kind: Optional explicit family override (``"raster"`` / ``"vector"`` /
+            ``"tabular"``) when both suffix and ``fmt`` are unreliable.
+        layer: For multi-layer vector containers (a ``.gpkg`` / ``.gdb`` with
+            several layers, or a ``.zip`` of Shapefiles), select by name or
+            index. ``None`` reads the first / default layer and warns when more
+            exist (data is never silently dropped).
+
+    Returns:
+        Dataset | FeatureCollection | pandas.DataFrame: The resource read into
+        its pyramids / pandas type.
+
+    Raises:
+        ValueError: When the format cannot be determined or is unsupported.
+
+    Examples:
+        - Read a WorldPop GeoTIFF as a raster ``Dataset``::
+
+            >>> from pyramids._resource import read_resource
+            >>> ds = read_resource("worldpop.tif")  # doctest: +SKIP
+
+        - Read a gzipped Kontur GeoPackage as a ``FeatureCollection``::
+
+            >>> fc = read_resource("kontur.gpkg.gz")  # doctest: +SKIP
+
+        - Read a zipped GeoTIFF, disambiguated by the CKAN format label::
+
+            >>> ds = read_resource("meta_hrsl.zip", fmt="GeoTIFF")  # doctest: +SKIP
+
+    See Also:
+        - :func:`sniff_kind`: the name-based family classifier used here.
+        - :meth:`pyramids.dataset.Dataset.read_file`: the raster reader.
+        - :meth:`pyramids.feature.FeatureCollection.read_file`: the vector reader.
+    """
+    path = Path(path)
+    resolved_kind = kind if kind is not None else _determine_kind(path, fmt)
+    if resolved_kind == "raster":
+        result: Union[Dataset, FeatureCollection, pd.DataFrame] = Dataset.read_file(
+            str(path)
+        )
+    elif resolved_kind == "vector":
+        result = _read_vector(path, layer)
+    elif resolved_kind == "tabular":
+        result = _read_tabular(path)
+    else:
+        raise ValueError(
+            f"unsupported resource kind {resolved_kind!r}; expected one of "
+            "'raster', 'vector', 'tabular'."
+        )
+    return result

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -1,0 +1,196 @@
+"""Tests for the decompress-aware resource reader (:mod:`pyramids._resource`)."""
+from __future__ import annotations
+
+import gzip
+import shutil
+import warnings
+import zipfile
+from pathlib import Path
+
+import geopandas as gpd
+import pandas as pd
+import pytest
+
+from pyramids import read_resource, sniff_kind
+from pyramids.dataset import Dataset
+from pyramids.feature import FeatureCollection
+
+RASTER_FILE = "tests/data/acc4000.tif"
+VECTOR_FILE = "tests/data/test_vector.geojson"
+
+
+def _gzip_file(src: str | Path, dst: Path) -> Path:
+    """Gzip ``src`` to ``dst`` (single-member gzip)."""
+    with open(src, "rb") as f_in, gzip.open(dst, "wb") as f_out:
+        shutil.copyfileobj(f_in, f_out)
+    return dst
+
+
+def _zip_file(src: str | Path, dst: Path, arcname: str | None = None) -> Path:
+    """Zip ``src`` into ``dst`` as a single member."""
+    with zipfile.ZipFile(dst, "w") as zf:
+        zf.write(src, arcname or Path(src).name)
+    return dst
+
+
+class TestSniffKind:
+    """Suffix + ``fmt`` classification, no I/O."""
+
+    @pytest.mark.parametrize(
+        "name, expected",
+        [
+            ("worldpop.tif", "raster"),
+            ("scene.tiff", "raster"),
+            ("cube.nc", "raster"),
+            ("noah.nc4", "raster"),
+            ("kontur.gpkg", "vector"),
+            ("admin.shp", "vector"),
+            ("aoi.geojson", "vector"),
+            ("export.gdb", "vector"),
+            ("survey.csv", "tabular"),
+            ("survey.tsv", "tabular"),
+            ("survey.xlsx", "tabular"),
+            ("survey.parquet", "tabular"),
+        ],
+    )
+    def test_suffix(self, name: str, expected: str):
+        assert sniff_kind(name) == expected
+
+    def test_gzip_layer_is_peeled(self):
+        assert sniff_kind("kontur.gpkg.gz") == "vector"
+        assert sniff_kind("chirps.tif.gz") == "raster"
+        assert sniff_kind("survey.csv.gz") == "tabular"
+
+    @pytest.mark.parametrize(
+        "fmt, expected",
+        [
+            ("GeoTIFF", "raster"),
+            ("Geopackage", "vector"),
+            ("SHP", "vector"),
+            ("CSV", "tabular"),
+            ("XLSX", "tabular"),
+            (".geojson", "vector"),
+        ],
+    )
+    def test_fmt_tiebreaker_on_bare_zip(self, fmt: str, expected: str):
+        # a bare `.zip` carries no inner suffix in its name; lean on `fmt`
+        assert sniff_kind("download.zip", fmt=fmt) == expected
+
+    def test_suffix_wins_over_fmt(self):
+        # an explicit, recognised suffix is authoritative; `fmt` is only a fallback
+        assert sniff_kind("admin.shp", fmt="GeoTIFF") == "vector"
+
+    def test_unknown_raises(self):
+        with pytest.raises(ValueError, match="could not determine"):
+            sniff_kind("mystery.dat")
+
+    def test_bare_zip_without_fmt_raises(self):
+        with pytest.raises(ValueError, match="could not determine"):
+            sniff_kind("download.zip")
+
+
+class TestReadPlain:
+    """Reading uncompressed resources of each family."""
+
+    def test_raster(self):
+        ds = read_resource(RASTER_FILE)
+        assert isinstance(ds, Dataset)
+
+    def test_vector(self):
+        fc = read_resource(VECTOR_FILE)
+        assert isinstance(fc, FeatureCollection)
+
+    def test_tabular_csv(self, tmp_path: Path):
+        csv = tmp_path / "survey.csv"
+        csv.write_text("a,b\n1,2\n3,4\n")
+        df = read_resource(csv)
+        assert isinstance(df, pd.DataFrame)
+        assert list(df.columns) == ["a", "b"]
+        assert len(df) == 2
+
+    def test_tabular_tsv(self, tmp_path: Path):
+        tsv = tmp_path / "survey.tsv"
+        tsv.write_text("a\tb\n1\t2\n")
+        df = read_resource(tsv)
+        assert list(df.columns) == ["a", "b"]
+
+
+class TestReadCompressed:
+    """Decompression round-trips via GDAL VSI / pandas."""
+
+    def test_gzipped_raster(self, tmp_path: Path):
+        gz = _gzip_file(RASTER_FILE, tmp_path / "acc4000.tif.gz")
+        ds = read_resource(gz)
+        assert isinstance(ds, Dataset)
+
+    def test_gzipped_vector(self, tmp_path: Path):
+        gz = _gzip_file(VECTOR_FILE, tmp_path / "test_vector.geojson.gz")
+        fc = read_resource(gz)
+        assert isinstance(fc, FeatureCollection)
+
+    def test_zipped_raster_sniffed_from_members(self, tmp_path: Path):
+        # bare `.zip`, no `fmt` -> the reader peeks inside and finds the .tif
+        zp = _zip_file(RASTER_FILE, tmp_path / "meta_hrsl.zip")
+        ds = read_resource(zp)
+        assert isinstance(ds, Dataset)
+
+    def test_zipped_raster_with_fmt(self, tmp_path: Path):
+        zp = _zip_file(RASTER_FILE, tmp_path / "meta_hrsl.zip")
+        ds = read_resource(zp, fmt="GeoTIFF")
+        assert isinstance(ds, Dataset)
+
+    def test_gzipped_csv(self, tmp_path: Path):
+        plain = tmp_path / "survey.csv"
+        plain.write_text("a,b\n1,2\n3,4\n")
+        gz = _gzip_file(plain, tmp_path / "survey.csv.gz")
+        df = read_resource(gz)
+        assert isinstance(df, pd.DataFrame)
+        assert len(df) == 2
+
+
+class TestExplicitOverrides:
+    """`kind` override and error surface."""
+
+    def test_kind_override(self):
+        ds = read_resource(RASTER_FILE, kind="raster")
+        assert isinstance(ds, Dataset)
+
+    def test_bad_kind_raises(self):
+        with pytest.raises(ValueError, match="unsupported resource kind"):
+            read_resource(RASTER_FILE, kind="bogus")  # type: ignore[arg-type]
+
+    def test_undeterminable_raises(self, tmp_path: Path):
+        mystery = tmp_path / "mystery.dat"
+        mystery.write_bytes(b"\x00\x01")
+        with pytest.raises(ValueError, match="could not determine"):
+            read_resource(mystery)
+
+
+class TestMultiLayerPolicy:
+    """Default-first-layer-and-warn policy for multi-layer containers."""
+
+    @pytest.fixture
+    def multilayer_gpkg(self, tmp_path: Path) -> Path:
+        gdf = gpd.read_file(VECTOR_FILE)
+        path = tmp_path / "multi.gpkg"
+        gdf.to_file(path, layer="alpha", driver="GPKG")
+        gdf.to_file(path, layer="beta", driver="GPKG")
+        FeatureCollection.list_layers_cache_clear()
+        return path
+
+    def test_warns_and_reads_first(self, multilayer_gpkg: Path):
+        with pytest.warns(UserWarning, match="contains 2 layers"):
+            fc = read_resource(multilayer_gpkg)
+        assert isinstance(fc, FeatureCollection)
+
+    def test_layer_selection_suppresses_warning(self, multilayer_gpkg: Path):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            fc = read_resource(multilayer_gpkg, layer="beta")
+        assert isinstance(fc, FeatureCollection)
+
+    def test_single_layer_does_not_warn(self):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            fc = read_resource(VECTOR_FILE)
+        assert isinstance(fc, FeatureCollection)

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import gzip
 import shutil
+import subprocess
+import sys
 import tarfile
 import warnings
 import zipfile
@@ -385,6 +387,51 @@ class TestSelectVectorMember:
         assert member == "city.gpkg"
         assert passthrough == "roads"
 
+    def test_out_of_range_index_raises(self):
+        with pytest.raises(IndexError, match="out of range"):
+            _select_vector_member(["a.shp", "b.shp"], 5, Path("x.zip"))
+
+    def test_bool_layer_is_not_used_as_index(self):
+        # bool subclasses int but must not be treated as a member index
+        member, passthrough = _select_vector_member(
+            ["a.shp", "b.shp"], True, Path("x.zip")
+        )
+        assert member == "a.shp"
+        assert passthrough is True
+
+
+class TestLazyImport:
+    """`import pyramids` must stay light (M1): no eager dataset/feature/dask."""
+
+    def test_import_pyramids_does_not_pull_heavy_stack(self):
+        code = (
+            "import sys, pyramids\n"
+            "assert 'pyramids.feature' not in sys.modules, 'feature eagerly imported'\n"
+            "assert 'pyramids.dataset' not in sys.modules, 'dataset eagerly imported'\n"
+            "assert 'dask_geopandas' not in sys.modules, 'dask_geopandas eagerly imported'\n"
+            "assert callable(pyramids.read_resource), 'lazy export not callable'\n"
+            "assert 'pyramids.feature' in sys.modules, 'access did not load feature'\n"
+            "print('LAZY_OK')\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True
+        )
+        assert result.returncode == 0, result.stderr
+        assert "LAZY_OK" in result.stdout, result.stdout
+
+    def test_unknown_attribute_raises(self):
+        import pyramids
+
+        with pytest.raises(AttributeError, match="has no attribute"):
+            pyramids.this_attribute_does_not_exist
+
+    def test_dir_includes_lazy_exports(self):
+        import pyramids
+
+        names = dir(pyramids)
+        assert "read_resource" in names
+        assert "sniff_kind" in names
+
 
 class TestHelperRobustness:
     """Defensive branches that must never raise or mis-dispatch."""
@@ -395,17 +442,19 @@ class TestHelperRobustness:
             _warn_if_multilayer(tmp_path / "missing.gpkg")
 
     def test_kind_raster_on_archive_without_raster_member_raises(self, tmp_path: Path):
+        # GDAL rejects the unreadable member with a RuntimeError.
         zp = tmp_path / "blob.zip"
         with zipfile.ZipFile(zp, "w") as zf:
             zf.writestr("blob.bin", "\x00\x01\x02")
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError):
             read_resource(zp, kind="raster")
 
     def test_kind_vector_on_archive_without_vector_member_raises(self, tmp_path: Path):
+        # pyogrio raises DataSourceError (a RuntimeError subclass) for the member.
         zp = tmp_path / "blob.zip"
         with zipfile.ZipFile(zp, "w") as zf:
             zf.writestr("blob.bin", "\x00\x01\x02")
-        with pytest.raises(Exception):
+        with pytest.raises(RuntimeError):
             read_resource(zp, kind="vector")
 
 

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import gzip
 import shutil
+import tarfile
 import warnings
 import zipfile
 from pathlib import Path
@@ -12,6 +13,15 @@ import pandas as pd
 import pytest
 
 from pyramids import read_resource, sniff_kind
+from pyramids._resource import (
+    _archive_members_for_kind,
+    _is_archive,
+    _read_tabular,
+    _select_vector_member,
+    _sniff_from_archive,
+    _strip_compression,
+    _warn_if_multilayer,
+)
 from pyramids.dataset import Dataset
 from pyramids.feature import FeatureCollection
 
@@ -194,3 +204,245 @@ class TestMultiLayerPolicy:
             warnings.simplefilter("error")
             fc = read_resource(VECTOR_FILE)
         assert isinstance(fc, FeatureCollection)
+
+
+def _shapefile_dir(tmp_path: Path) -> Path:
+    """Write ``VECTOR_FILE`` out as a Shapefile (a multi-file format)."""
+    out = tmp_path / "shp"
+    out.mkdir()
+    gpd.read_file(VECTOR_FILE).to_file(out / "aoi.shp")
+    return out
+
+
+def _zip_dir(src_dir: Path, dst: Path) -> Path:
+    """Zip every file in ``src_dir`` (flat) into ``dst``."""
+    with zipfile.ZipFile(dst, "w") as zf:
+        for f in sorted(src_dir.iterdir()):
+            zf.write(f, f.name)
+    return dst
+
+
+def _targz_file(src: str | Path, dst: Path, arcname: str | None = None) -> Path:
+    """Tar+gzip ``src`` into ``dst`` as a single member."""
+    with tarfile.open(dst, "w:gz") as tf:
+        tf.add(src, arcname=arcname or Path(src).name)
+    return dst
+
+
+class TestArchiveRegressions:
+    """Regressions for H1 (zipped Shapefile) and M1 (`.tar.gz`)."""
+
+    def test_zipped_shapefile_reads_shp_not_sidecar(self, tmp_path: Path):
+        # H1: a bare `.zip` of a Shapefile must resolve to the `.shp` member,
+        # not the alphabetically-first sidecar (`aoi.cpg` / `aoi.dbf`).
+        zp = _zip_dir(_shapefile_dir(tmp_path), tmp_path / "hotosm.zip")
+        fc = read_resource(zp)
+        assert isinstance(fc, FeatureCollection)
+        assert len(fc) > 0
+
+    def test_zipped_shapefile_named_inner_suffix(self, tmp_path: Path):
+        # COD-AB `.shp.zip` case: the inner suffix is in the name.
+        zp = _zip_dir(_shapefile_dir(tmp_path), tmp_path / "aoi.shp.zip")
+        assert sniff_kind(zp) == "vector"
+        fc = read_resource(zp)
+        assert isinstance(fc, FeatureCollection)
+
+    def test_targz_raster_via_member_resolution(self, tmp_path: Path):
+        # M1: `.tar.gz` raster must target the member; sniff peeks inside.
+        tgz = _targz_file(RASTER_FILE, tmp_path / "data.tar.gz")
+        ds = read_resource(tgz)
+        assert isinstance(ds, Dataset)
+
+    def test_targz_raster_with_fmt(self, tmp_path: Path):
+        tgz = _targz_file(RASTER_FILE, tmp_path / "data.tar.gz")
+        ds = read_resource(tgz, fmt="GeoTIFF")
+        assert isinstance(ds, Dataset)
+
+    def test_targz_sniffs_from_members(self, tmp_path: Path):
+        tgz = _targz_file(RASTER_FILE, tmp_path / "data.tar.gz")
+        # name alone is a container -> name-based sniff cannot classify it
+        with pytest.raises(ValueError, match="could not determine"):
+            sniff_kind(tgz)
+        # but read_resource peeks inside and dispatches correctly
+        assert isinstance(read_resource(tgz), Dataset)
+
+
+class TestUncoveredFormats:
+    """M2: formats named in the #447 acceptance criteria that lacked coverage."""
+
+    def test_gpkg_gz_vector(self, tmp_path: Path):
+        plain = tmp_path / "kontur.gpkg"
+        gpd.read_file(VECTOR_FILE).to_file(plain, driver="GPKG")
+        gz = _gzip_file(plain, tmp_path / "kontur.gpkg.gz")
+        fc = read_resource(gz)
+        assert isinstance(fc, FeatureCollection)
+
+    def test_xlsx_tabular(self, tmp_path: Path):
+        pytest.importorskip("openpyxl")
+        xlsx = tmp_path / "survey.xlsx"
+        pd.DataFrame({"a": [1, 2], "b": [3, 4]}).to_excel(xlsx, index=False)
+        df = read_resource(xlsx)
+        assert isinstance(df, pd.DataFrame)
+        assert list(df.columns) == ["a", "b"]
+
+
+class TestLayerOnNonVector:
+    """L4: `layer=` is ignored — with a warning — for non-vector resources."""
+
+    def test_layer_on_raster_warns(self):
+        with pytest.warns(UserWarning, match="ignored for raster"):
+            ds = read_resource(RASTER_FILE, layer="whatever")
+        assert isinstance(ds, Dataset)
+
+
+class TestNameHelpers:
+    """Pure, name-based helpers (`_is_archive`, `_strip_compression`)."""
+
+    @pytest.mark.parametrize(
+        "name, expected",
+        [
+            ("a.zip", True),
+            ("a.tar", True),
+            ("a.tgz", True),
+            ("a.tar.gz", True),
+            ("a.gz", False),
+            ("a.tif", False),
+        ],
+    )
+    def test_is_archive(self, name: str, expected: bool):
+        assert _is_archive(Path(name)) is expected
+
+    @pytest.mark.parametrize(
+        "name, inner",
+        [
+            ("kontur.gpkg.gz", "kontur.gpkg"),
+            ("rivers.shp.zip", "rivers.shp"),
+            ("noah.tif.tar.gz", "noah.tif"),
+            ("download.zip", "download"),
+            ("plain.tif", "plain.tif"),
+        ],
+    )
+    def test_strip_compression(self, name: str, inner: str):
+        assert _strip_compression(name) == inner
+
+
+class TestArchivePeeking:
+    """`_archive_members_for_kind` / `_sniff_from_archive` best-effort branches."""
+
+    def test_members_for_kind_missing_archive_returns_empty(self, tmp_path: Path):
+        assert _archive_members_for_kind(tmp_path / "nope.zip", "raster") == []
+
+    def test_sniff_unlistable_archive_returns_none(self, tmp_path: Path):
+        assert _sniff_from_archive(tmp_path / "nope.zip") is None
+
+    def test_sniff_non_archive_returns_none(self):
+        assert _sniff_from_archive(Path("plain.tif")) is None
+
+    def test_sniff_tabular_member(self, tmp_path: Path):
+        zp = tmp_path / "tab.zip"
+        with zipfile.ZipFile(zp, "w") as zf:
+            zf.writestr("data.csv", "a,b\n1,2\n")
+        assert _sniff_from_archive(zp) == "tabular"
+
+    def test_sniff_unknown_members_returns_none(self, tmp_path: Path):
+        zp = tmp_path / "misc.zip"
+        with zipfile.ZipFile(zp, "w") as zf:
+            zf.writestr("readme.xyz", "hello")
+        assert _sniff_from_archive(zp) is None
+
+
+class TestSelectVectorMember:
+    """Member / layer resolution for multi-member vector archives."""
+
+    def test_select_by_index(self):
+        member, passthrough = _select_vector_member(
+            ["a.shp", "b.shp"], 1, Path("x.zip")
+        )
+        assert member == "b.shp"
+        assert passthrough is None
+
+    def test_select_by_name_stem(self):
+        member, passthrough = _select_vector_member(
+            ["a.shp", "b.shp"], "a", Path("x.zip")
+        )
+        assert member == "a.shp"
+        assert passthrough is None
+
+    def test_none_with_multiple_members_warns(self):
+        with pytest.warns(UserWarning, match="2 vector members"):
+            member, passthrough = _select_vector_member(
+                ["a.shp", "b.shp"], None, Path("x.zip")
+            )
+        assert member == "a.shp"
+        assert passthrough is None
+
+    def test_unmatched_layer_forwarded_as_internal_layer(self):
+        # a single-file container (GPKG) with an internal layer name: the layer
+        # is not a member stem, so it is forwarded to the reader untouched.
+        member, passthrough = _select_vector_member(
+            ["city.gpkg"], "roads", Path("x.zip")
+        )
+        assert member == "city.gpkg"
+        assert passthrough == "roads"
+
+
+class TestHelperRobustness:
+    """Defensive branches that must never raise or mis-dispatch."""
+
+    def test_warn_if_multilayer_unreadable_is_silent(self, tmp_path: Path):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            _warn_if_multilayer(tmp_path / "missing.gpkg")
+
+    def test_kind_raster_on_archive_without_raster_member_raises(self, tmp_path: Path):
+        zp = tmp_path / "blob.zip"
+        with zipfile.ZipFile(zp, "w") as zf:
+            zf.writestr("blob.bin", "\x00\x01\x02")
+        with pytest.raises(Exception):
+            read_resource(zp, kind="raster")
+
+    def test_kind_vector_on_archive_without_vector_member_raises(self, tmp_path: Path):
+        zp = tmp_path / "blob.zip"
+        with zipfile.ZipFile(zp, "w") as zf:
+            zf.writestr("blob.bin", "\x00\x01\x02")
+        with pytest.raises(Exception):
+            read_resource(zp, kind="vector")
+
+
+class TestReadTabularBranches:
+    """`_read_tabular` per-suffix dispatch and engine-missing handling."""
+
+    def test_unsupported_suffix_raises(self, tmp_path: Path):
+        f = tmp_path / "weird.dat"
+        f.write_text("junk")
+        with pytest.raises(ValueError, match="unsupported tabular suffix"):
+            _read_tabular(f)
+
+    def test_parquet_round_trip(self, tmp_path: Path):
+        pytest.importorskip("pyarrow")
+        pq = tmp_path / "t.parquet"
+        pd.DataFrame({"a": [1, 2]}).to_parquet(pq)
+        df = _read_tabular(pq)
+        assert list(df["a"]) == [1, 2]
+
+    def test_xlsx_engine_missing_reraises_with_hint(self, tmp_path: Path, monkeypatch):
+        # pandas imports the Excel engine lazily; simulate it being absent and
+        # assert the wrapper re-raises with install guidance.
+        def _raise(*args, **kwargs):
+            raise ImportError("Missing optional dependency 'openpyxl'")
+
+        monkeypatch.setattr(pd, "read_excel", _raise)
+        f = tmp_path / "survey.xlsx"
+        f.write_bytes(b"stub")
+        with pytest.raises(ImportError, match="Excel engine"):
+            _read_tabular(f)
+
+    def test_parquet_engine_missing_reraises_with_hint(self, tmp_path: Path, monkeypatch):
+        def _raise(*args, **kwargs):
+            raise ImportError("Missing optional dependency 'pyarrow'")
+
+        monkeypatch.setattr(pd, "read_parquet", _raise)
+        f = tmp_path / "t.parquet"
+        f.write_bytes(b"stub")
+        with pytest.raises(ImportError, match="parquet engine"):
+            _read_tabular(f)


### PR DESCRIPTION
## Summary

Implements `PY-D` (issue #447): a single, decompress-aware entry point that takes a local
path (optionally plus a format hint), sniffs the format, transparently handles `.gz` / `.zip`
/ `.tar` containers, and returns the appropriate pyramids type.

- `read_resource(path, fmt=None, *, kind=None, layer=None)` — sniff → dispatch:
  - raster (`.tif/.tiff/.cog/.nc/.nc4/.vrt`) → `Dataset`
  - vector (`.gpkg/.shp/.geojson/.gdb/.kml/...`) → `FeatureCollection`
  - tabular (`.csv/.tsv/.xlsx/.xls/.parquet`) → `pandas.DataFrame`
- `sniff_kind(path, fmt=None)` — pure, name-based family classifier (peels one `.gz` layer,
  maps the suffix, falls back to the `fmt` / CKAN label).
- Both are exported at the top level: `pyramids.read_resource`, `pyramids.sniff_kind`.

## Design notes

- **Thin shim, no new I/O stack.** Dispatch reuses the existing `Dataset.read_file` /
  `FeatureCollection.read_file` readers plus a `pandas` branch; decompression is delegated to
  the existing `_io` GDAL-VSI layer (`/vsigzip/`, `/vsizip/`, `/vsitar/`) — no new
  decompression code.
- **Multi-layer policy.** Multi-layer containers (a `.gpkg`/`.gdb` with several layers, or a
  `.zip` of Shapefiles) default to the first/default layer and **warn** — never silently drop
  data — with `layer=<name|index>` to select.
- **Ambiguous containers.** A bare `.zip`/`.tar` (whose name does not imply its contents) is
  disambiguated from the `fmt` label, or by peeking at the archive members.
- **No new dependencies.** CSV/TSV use `pandas` (already core). `.xlsx`/`.parquet` call
  `pd.read_excel`/`pd.read_parquet` and re-raise a clear "install openpyxl/pyarrow" error if
  the engine is absent.

## Test plan

`tests/test_resource.py` — 37 tests, all passing:

- suffix + `fmt` classification (incl. `.gz`-layer peeling and the `fmt` tiebreaker on a bare
  `.zip`);
- plain reads for raster / vector / CSV / TSV;
- compressed round-trips: gzipped raster, gzipped vector, gzipped CSV, zipped raster (sniffed
  from members and via `fmt`);
- `kind` override and error surface (unknown format, bad kind);
- multi-layer GPKG: warns and reads first, `layer=` selects without warning, single-layer does
  not warn.

Closes #447