### PR TITLE
test(plot): guard matplotlib import behind importorskip in test_plot_…

### DIFF
--- a/tests/feature/test_plot_cleopatra.py
+++ b/tests/feature/test_plot_cleopatra.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import geopandas as gpd
 import pytest
-from matplotlib.axes import Axes
 from shapely.geometry import Point, Polygon, box
 
 from pyramids.base._errors import GeometryWarning
@@ -18,12 +17,17 @@ from pyramids.feature import FeatureCollection
 
 pytestmark = pytest.mark.plot
 
+# Guard every optional-dependency import (cleopatra + its matplotlib backend)
+# behind importorskip so the module skips cleanly in a core-only install
+# (e.g. the wheel-test job), rather than erroring at collection.
 _pg = pytest.importorskip("cleopatra.polygon_glyph", reason="cleopatra not installed")
 _sg = pytest.importorskip("cleopatra.scatter_glyph", reason="cleopatra not installed")
 _cfg = pytest.importorskip("cleopatra.config", reason="cleopatra not installed")
+_mpl_axes = pytest.importorskip("matplotlib.axes", reason="matplotlib not installed")
 _cfg.Config.set_matplotlib_backend("agg")
 PolygonGlyph = _pg.PolygonGlyph
 ScatterGlyph = _sg.ScatterGlyph
+Axes = _mpl_axes.Axes
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
…cleopatra

The wheel-test job installs the core wheel (no [viz] extra), so a top-level `from matplotlib.axes import Axes` errored at collection with ModuleNotFoundError, aborting the whole core suite. Move it (and an explicit matplotlib.axes importorskip) below the cleopatra importorskip guards so the module skips cleanly in a matplotlib-free install, matching the other plot-test modules.

# Description

- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context.
- List any dependencies that are required for this change.


# Issues
- Fixes # (issue)

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Please describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
