### PR TITLE
release: 0.29.0

### DIFF
--- a/.github/workflows/wheel-test.yml
+++ b/.github/workflows/wheel-test.yml
@@ -143,7 +143,10 @@ jobs:
         python-version: ["3.13"]
         extra:
           - { name: viz,          pip_extra: "viz",          marker: "plot",         dir: "tests/" }
-          - { name: xarray,       pip_extra: "xarray",       marker: "xarray",       dir: "tests/" }
+          # xarray-marked tests include the LabeledDataset reader, which needs the lazy
+          # data stack (zarr / dask / s3fs) to open Zarr stores, chunk, and read remote
+          # URLs — so install [xarray,lazy], not [xarray] alone.
+          - { name: xarray,       pip_extra: "xarray,lazy",  marker: "xarray",       dir: "tests/" }
           - { name: lazy,         pip_extra: "lazy",         marker: "lazy",         dir: "tests/" }
           - { name: netcdf-lazy,  pip_extra: "netcdf-lazy",  marker: "netcdf_lazy",  dir: "tests/netcdf/lazy" }
           - { name: parquet,      pip_extra: "parquet",      marker: "parquet",      dir: "tests/feature" }

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -1,6 +1,12 @@
 ﻿# Change log
 
 
+## 0.29.0 (2026-06-01)
+
+### Feat
+
+- **netcdf**: add LabeledDataset reader for label-indexed NetCDF/Zarr stores (#455)
+
 ## 0.28.0 (2026-05-31)
 
 ### Feat

--- a/pixi.lock
+++ b/pixi.lock
@@ -40949,8 +40949,8 @@ packages:
   requires_python: '>=3.7'
 - pypi: ./
   name: pyramids-gis
-  version: 0.28.0
-  sha256: ca877eea59b6433d10a3697dfa6f6ef63f68e80ebfe28d150bd81dc7848a97f6
+  version: 0.29.0
+  sha256: 56b6daa9250ad1e0fb397ee6271965851d07a73ed1499805af9fbcc2085a2c16
   requires_dist:
   - cftime>=1.6.4
   - geopandas>=1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyramids-gis"
-version = "0.28.0"
+version = "0.29.0"
 description = "GIS utility package"
 readme = {file = "README.md", content-type = "text/markdown"}
 authors = [{ name = "Mostafa Farrag", email = "moah.farag@gmail.com" }]


### PR DESCRIPTION
## Summary

Fixes the `test-wheel-extras (ubuntu-latest, 3.13, xarray, …)` wheel job, which started failing after the
`LabeledDataset` reader landed (#455).

That matrix row installs the built wheel with **only** the `[xarray]` extra and runs all `-m xarray` tests.
The new `LabeledDataset` tests are `xarray`-marked but need the **lazy data stack** (`zarr` / `dask` / `s3fs`)
to open Zarr stores, back arrays with dask, and exercise the remote-open wiring — so they failed with:

```
ModuleNotFoundError: No module named 'zarr'
```

## Change

Install `[xarray,lazy]` (not `[xarray]`) for the `xarray` wheel-extras row, so the xarray-marked tests run
with their real dependencies. This mirrors the pixi-side fix already on `main`, where the `py311`–`py314`
test envs were given the `lazy` feature for the same reason. The `pyarrow`- and `h5netcdf`-dependent
`LabeledDataset` tests remain guarded by `importorskip`, so they skip cleanly in this row.

Only the one `xarray` row changes; every other wheel-extras row already installs the stack its marker needs.

## Test plan

- [ ] `test-wheel-extras (ubuntu-latest, 3.13, xarray, …)` is green.
- [ ] All other `test-wheel-extras` rows remain green (unchanged).
- [ ] `Wheel - Build & Test` workflow passes end to end.
