### PR TITLE
feat(basemap): add relief() low-res global relief raster for offline backdrops

### DIFF
--- a/src/pyramids/basemap/__init__.py
+++ b/src/pyramids/basemap/__init__.py
@@ -13,21 +13,27 @@ The tile functions require the cleopatra ``[tiles]`` extra (which pins
 - conda-forge: ``conda install -c conda-forge pyramids-viz``
 
 :func:`~pyramids.basemap.natural_earth` returns Natural Earth *vector* features as a
-:class:`~pyramids.feature.FeatureCollection` and needs no extra (it downloads with the
-standard library and reads through GDAL).
+:class:`~pyramids.feature.FeatureCollection`, and :func:`~pyramids.basemap.relief`
+returns a low-res global relief *raster* as a :class:`~pyramids.dataset.Dataset` for
+offline ``stock_img``-style backdrops. Neither needs the ``[viz]`` extra (both download
+with the standard library and read through GDAL).
 """
 
 from pyramids.basemap.basemap import add_basemap, get_provider
 from pyramids.basemap.features import (
     available_layers,
+    available_relief_resolutions,
     available_resolutions,
     natural_earth,
+    relief,
 )
 
 __all__ = [
     "add_basemap",
     "available_layers",
+    "available_relief_resolutions",
     "available_resolutions",
     "get_provider",
     "natural_earth",
+    "relief",
 ]

--- a/src/pyramids/basemap/features.py
+++ b/src/pyramids/basemap/features.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pyramids._io import archive_dir_vsi, archive_members
+from pyramids.base._errors import FileFormatNotSupportedError
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from pyramids.dataset import Dataset
@@ -320,10 +321,14 @@ def relief(resolution: str = "low") -> Dataset:
         _download(_relief_url(resolution), cached)
     try:
         result = Dataset.read_file(str(cached))
-    except Exception as exc:
-        # A cached file that won't open is corrupt — e.g. a truncated download or an
-        # HTML error page served with HTTP 200. Drop it so the next call re-fetches,
-        # instead of failing forever on a poisoned cache.
+    except (RuntimeError, ValueError, OSError, FileFormatNotSupportedError) as exc:
+        # These are the failures that mean the cached bytes are not a readable raster
+        # — a truncated download or an HTML error page served with HTTP 200. GDAL
+        # surfaces an unopenable file as RuntimeError; read_file wraps some cases as
+        # FileFormatNotSupportedError / FileNotFoundError. Drop the file so the next
+        # call re-fetches, instead of failing forever on a poisoned cache. Anything
+        # else (e.g. a TypeError from a programming bug) is not a corrupt-cache signal
+        # and is left to propagate unchanged.
         cached.unlink(missing_ok=True)
         raise OSError(
             f"cached relief raster {cached} could not be read ({exc}); removed it — "

--- a/src/pyramids/basemap/features.py
+++ b/src/pyramids/basemap/features.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING
 from pyramids._io import archive_dir_vsi, archive_members
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
+    from pyramids.dataset import Dataset
     from pyramids.feature import FeatureCollection
 
 # layer name -> (Natural Earth category, dataset suffix). The dataset stem is
@@ -94,15 +95,19 @@ def _download_url(layer: str, resolution: str) -> str:
     return f"{_BASE_URL}/{resolution}/{category}/{stem}.zip"
 
 
-def _cache_dir() -> Path:
-    """Return the directory used to cache downloaded Natural Earth archives.
+def _cache_dir(subdir: str = "naturalearth") -> Path:
+    """Return the directory used to cache downloaded basemap data.
 
     Honors the ``PYRAMIDS_CACHE_DIR`` environment variable; otherwise defaults to
-    ``~/.pyramids/naturalearth``. The directory is created if missing.
+    ``~/.pyramids/{subdir}``. The directory is created if missing.
+
+    Args:
+        subdir: Cache sub-directory under the pyramids cache root. Defaults to
+            ``"naturalearth"`` (the vector layers); :func:`relief` uses ``"relief"``.
     """
     override = os.environ.get("PYRAMIDS_CACHE_DIR")
     root = Path(override) if override else Path.home() / ".pyramids"
-    cache = root / "naturalearth"
+    cache = root / subdir
     cache.mkdir(parents=True, exist_ok=True)
     return cache
 
@@ -118,7 +123,7 @@ def _download(url: str, destination: Path) -> None:
     if not url.lower().startswith(("http://", "https://")):
         raise ValueError(f"refusing to download from non-HTTP(S) URL: {url!r}")
     request = urllib.request.Request(url, headers={"User-Agent": "pyramids-gis"})
-    fd, tmp_name = tempfile.mkstemp(suffix=".zip", dir=str(destination.parent))
+    fd, tmp_name = tempfile.mkstemp(suffix=".tmp", dir=str(destination.parent))
     os.close(fd)
     tmp_path = Path(tmp_name)
     try:
@@ -131,8 +136,8 @@ def _download(url: str, destination: Path) -> None:
         # Don't leave a partial/empty temp archive behind on a failed download.
         tmp_path.unlink(missing_ok=True)
         raise OSError(
-            f"failed to download Natural Earth data from {url!r}: {exc}. Check the "
-            "network connection, or download the archive manually into the cache "
+            f"failed to download basemap data from {url!r}: {exc}. Check the "
+            "network connection, or download the file manually into the cache "
             f"directory ({destination.parent})."
         ) from exc
 
@@ -212,4 +217,103 @@ def natural_earth(
     preferred = f"{_dataset_stem(layer, resolution)}.shp"
     member = preferred if preferred in shp_members else shp_members[0]
     result = FeatureCollection.read_file(f"{archive}/{member}")
+    return result
+
+
+# Pre-baked, downsampled cross-blended hypsometric tint (3-band RGB, EPSG:4326),
+# derived from the public-domain Natural Earth ``HYP_50M_SR_W`` raster and hosted on
+# the pyramids release assets. The native Natural Earth raster is ~97 MB; these are
+# small downsamples (sub-MB / low-MB) meant only as a stock_img-style backdrop.
+# Keyed by ``resolution`` -> release-asset filename.
+_RELIEF_PRODUCTS: dict[str, str] = {
+    "low": "ne_hypso_rgb_720x360.tif",  # ~0.5 degree (720 x 360)
+    "medium": "ne_hypso_rgb_1440x720.tif",  # ~0.25 degree (1440 x 720)
+}
+
+_RELIEF_BASE_URL = (
+    "https://github.com/serapeum-org/pyramids/releases/download/basemap-data-v1"
+)
+
+
+def available_relief_resolutions() -> list[str]:
+    """List the resolutions :func:`relief` accepts, coarsest first.
+
+    Returns:
+        The supported ``resolution`` values for :func:`relief`.
+
+    Examples:
+        - The relief backdrop ships in two downsampled sizes:
+            ```python
+            >>> from pyramids.basemap.features import available_relief_resolutions
+            >>> available_relief_resolutions()
+            ['low', 'medium']
+
+            ```
+    """
+    return ["low", "medium"]
+
+
+def _relief_url(resolution: str) -> str:
+    """Build the release-asset download URL for a relief ``resolution``."""
+    return f"{_RELIEF_BASE_URL}/{_RELIEF_PRODUCTS[resolution]}"
+
+
+def relief(resolution: str = "low") -> Dataset:
+    """Return a low-res global cross-blended hypsometric relief raster.
+
+    A small RGB hypsometric-tint-with-shaded-relief image (3-band, EPSG:4326) — the
+    offline analogue of cartopy's ``GeoAxes.stock_img()``. The image is downsampled
+    from public-domain Natural Earth data, downloaded from the pyramids release assets
+    on first use and cached locally (see :func:`_cache_dir`), so it works offline
+    afterward — mirroring :func:`natural_earth`.
+
+    Unlike the XYZ tile basemaps (Web-Mercator only), this returns a reprojectable
+    EPSG:4326 raster, so it can back maps in other projections. Drawing/placement
+    (z-order, extent, globe transforms) is left to the visualization layer.
+
+    Args:
+        resolution: One of :func:`available_relief_resolutions` — ``"low"`` (~0.5
+            degree, the default) or ``"medium"`` (~0.25 degree).
+
+    Returns:
+        A :class:`~pyramids.dataset.Dataset` (3-band RGB, EPSG:4326), ready to draw or
+        to reproject with :meth:`~pyramids.dataset.Dataset.to_crs`.
+
+    Raises:
+        ValueError: ``resolution`` is not supported.
+        OSError: The raster is not cached and the download failed.
+
+    Examples:
+        - Unknown resolutions are rejected with the list of valid values:
+            ```python
+            >>> from pyramids.basemap.features import relief
+            >>> try:
+            ...     relief("high")
+            ... except ValueError as exc:
+            ...     print("unknown relief resolution" in str(exc))
+            True
+
+            ```
+        - Fetch the backdrop (downloads on first use, then reads from cache):
+            ```python
+            >>> from pyramids.basemap.features import relief
+            >>> ds = relief("low")  # doctest: +SKIP
+            >>> ds.band_count, ds.epsg  # doctest: +SKIP
+            (3, 4326)
+
+            ```
+    """
+    if resolution not in _RELIEF_PRODUCTS:
+        raise ValueError(
+            f"unknown relief resolution {resolution!r}; choose from "
+            f"{available_relief_resolutions()}."
+        )
+
+    # Local import breaks the import cycle pyramids.dataset -> pyramids.basemap.
+    from pyramids.dataset import Dataset
+
+    cached = _cache_dir("relief") / _RELIEF_PRODUCTS[resolution]
+    if not cached.exists():
+        _download(_relief_url(resolution), cached)
+    result = Dataset.read_file(str(cached))
     return result

--- a/src/pyramids/basemap/features.py
+++ b/src/pyramids/basemap/features.py
@@ -250,7 +250,9 @@ def available_relief_resolutions() -> list[str]:
 
             ```
     """
-    return ["low", "medium"]
+    # Derive from the product table so the two can't drift (insertion order is
+    # already coarsest-first: low, medium).
+    return list(_RELIEF_PRODUCTS)
 
 
 def _relief_url(resolution: str) -> str:
@@ -281,7 +283,8 @@ def relief(resolution: str = "low") -> Dataset:
 
     Raises:
         ValueError: ``resolution`` is not supported.
-        OSError: The raster is not cached and the download failed.
+        OSError: The raster is not cached and the download failed, or a cached file
+            could not be read (it is removed so the next call re-fetches).
 
     Examples:
         - Unknown resolutions are rejected with the list of valid values:
@@ -315,5 +318,15 @@ def relief(resolution: str = "low") -> Dataset:
     cached = _cache_dir("relief") / _RELIEF_PRODUCTS[resolution]
     if not cached.exists():
         _download(_relief_url(resolution), cached)
-    result = Dataset.read_file(str(cached))
+    try:
+        result = Dataset.read_file(str(cached))
+    except Exception as exc:
+        # A cached file that won't open is corrupt — e.g. a truncated download or an
+        # HTML error page served with HTTP 200. Drop it so the next call re-fetches,
+        # instead of failing forever on a poisoned cache.
+        cached.unlink(missing_ok=True)
+        raise OSError(
+            f"cached relief raster {cached} could not be read ({exc}); removed it — "
+            "retry to re-download."
+        ) from exc
     return result

--- a/tests/basemap/test_features.py
+++ b/tests/basemap/test_features.py
@@ -702,6 +702,32 @@ class TestRelief:
         assert "retry" in str(exc.value), f"Hint missing: {exc.value}"
         assert not bad.exists(), "corrupt cached file should be removed"
 
+    def test_non_corruption_error_propagates_and_keeps_cache(
+        self, relief_cache_dir, monkeypatch
+    ):
+        """A non-corruption read error is re-raised as itself and the cache is kept.
+
+        Args:
+            relief_cache_dir: Redirected relief cache directory fixture.
+            monkeypatch: pytest monkeypatch fixture.
+
+        Test scenario:
+            The self-heal path only treats genuine "unreadable bytes" failures as a
+            poisoned cache. A programming error surfacing from ``read_file`` (here a
+            ``TypeError``) must propagate unchanged — not be relabeled as a corrupt
+            cache — and the cached file must be left in place rather than deleted.
+        """
+        cached = relief_cache_dir / features._RELIEF_PRODUCTS["low"]
+        _make_relief_tif(cached)
+
+        def boom(*args, **kwargs):
+            raise TypeError("not a corruption signal")
+
+        monkeypatch.setattr(Dataset, "read_file", staticmethod(boom))
+        with pytest.raises(TypeError, match="not a corruption signal"):
+            features.relief("low")
+        assert cached.exists(), "a non-corruption error must not purge the cache"
+
     @pytest.mark.slow
     def test_real_download_low(self, relief_cache_dir):
         """End-to-end fetch of the low-res relief raster from the release assets.

--- a/tests/basemap/test_features.py
+++ b/tests/basemap/test_features.py
@@ -632,6 +632,60 @@ class TestRelief:
         assert isinstance(reprojected, Dataset), f"Got {type(reprojected)}"
         assert reprojected.epsg == 3857, f"Expected EPSG:3857, got {reprojected.epsg}"
 
+    def test_medium_cache_hit_returns_dataset(self, relief_cache_dir, monkeypatch):
+        """relief('medium') reads the medium product from its cached file, no download.
+
+        Args:
+            relief_cache_dir: Redirected relief cache directory fixture.
+            monkeypatch: pytest monkeypatch fixture.
+
+        Test scenario:
+            With a synthetic raster cached under the ``medium`` product filename, relief
+            routes to it (distinct from ``low``), returns a 3-band EPSG:4326 Dataset of
+            the placed size, and never downloads.
+        """
+        _make_relief_tif(
+            relief_cache_dir / features._RELIEF_PRODUCTS["medium"], rows=72, cols=144
+        )
+
+        def fail_download(url, destination):
+            raise AssertionError("download must not run on a cache hit")
+
+        monkeypatch.setattr(features, "_download", fail_download)
+        result = features.relief("medium")
+        assert isinstance(result, Dataset), f"Got {type(result)}"
+        assert result.band_count == 3, f"Expected 3 bands, got {result.band_count}"
+        assert result.epsg == 4326, f"Expected EPSG:4326, got {result.epsg}"
+        assert (result.columns, result.rows) == (
+            144,
+            72,
+        ), f"Expected the medium file (144x72), got {result.columns}x{result.rows}"
+
+    def test_corrupt_cache_is_removed_and_raises(self, relief_cache_dir, monkeypatch):
+        """An unreadable cached raster is removed and surfaces a clear OSError.
+
+        Args:
+            relief_cache_dir: Redirected relief cache directory fixture.
+            monkeypatch: pytest monkeypatch fixture.
+
+        Test scenario:
+            A poisoned cache file (e.g. a truncated download or an HTML error page
+            served with HTTP 200) cannot be read; relief raises OSError and deletes the
+            bad file so the next call re-fetches instead of failing forever.
+        """
+        bad = relief_cache_dir / features._RELIEF_PRODUCTS["low"]
+        bad.parent.mkdir(parents=True, exist_ok=True)
+        bad.write_bytes(b"<html>not a GeoTIFF</html>")
+
+        def fail_download(url, destination):
+            raise AssertionError("download must not run on a cache hit")
+
+        monkeypatch.setattr(features, "_download", fail_download)
+        with pytest.raises(OSError, match="could not be read") as exc:
+            features.relief("low")
+        assert "retry" in str(exc.value), f"Hint missing: {exc.value}"
+        assert not bad.exists(), "corrupt cached file should be removed"
+
     @pytest.mark.slow
     def test_real_download_low(self, relief_cache_dir):
         """End-to-end fetch of the low-res relief raster from the release assets.

--- a/tests/basemap/test_features.py
+++ b/tests/basemap/test_features.py
@@ -631,3 +631,24 @@ class TestRelief:
         reprojected = features.relief("low").to_crs(to_epsg=3857)
         assert isinstance(reprojected, Dataset), f"Got {type(reprojected)}"
         assert reprojected.epsg == 3857, f"Expected EPSG:3857, got {reprojected.epsg}"
+
+    @pytest.mark.slow
+    def test_real_download_low(self, relief_cache_dir):
+        """End-to-end fetch of the low-res relief raster from the release assets.
+
+        Test scenario:
+            Network-dependent; skipped offline. Downloads the real
+            ``ne_hypso_rgb_720x360.tif`` from the ``basemap-data-v1`` release and
+            asserts a 3-band EPSG:4326 Dataset of the expected size is returned.
+        """
+        try:
+            result = features.relief("low")
+        except OSError as exc:
+            pytest.skip(f"relief release asset unreachable: {exc}")
+        assert isinstance(result, Dataset), f"Got {type(result)}"
+        assert result.band_count == 3, f"Expected 3 bands, got {result.band_count}"
+        assert result.epsg == 4326, f"Expected EPSG:4326, got {result.epsg}"
+        assert (result.columns, result.rows) == (
+            720,
+            360,
+        ), f"Expected 720x360, got {result.columns}x{result.rows}"

--- a/tests/basemap/test_features.py
+++ b/tests/basemap/test_features.py
@@ -12,10 +12,12 @@ import zipfile
 from pathlib import Path
 
 import geopandas as gpd
+import numpy as np
 import pytest
 from shapely.geometry import LineString
 
 from pyramids.basemap import features
+from pyramids.dataset import Dataset
 from pyramids.feature import FeatureCollection
 
 pytestmark = pytest.mark.core
@@ -312,7 +314,7 @@ class TestDownload:
             raise urllib.error.URLError("no route to host")
 
         monkeypatch.setattr(urllib.request, "urlopen", boom)
-        with pytest.raises(OSError, match="failed to download Natural Earth") as exc:
+        with pytest.raises(OSError, match="failed to download basemap data") as exc:
             features._download("https://example.com/x.zip", tmp_path / "x.zip")
         assert "x.zip" in str(exc.value), f"URL missing from message: {exc.value}"
         assert exc.value.__cause__ is not None, "original error should be chained"
@@ -465,3 +467,167 @@ class TestNaturalEarth:
             pytest.skip(f"Natural Earth CDN unreachable: {exc}")
         assert isinstance(result, FeatureCollection), f"Got {type(result)}"
         assert len(result) > 0, "real coastline layer should have features"
+
+
+@pytest.fixture(scope="function")
+def relief_cache_dir(tmp_path, monkeypatch):
+    """Redirect the relief cache to a temp directory via PYRAMIDS_CACHE_DIR.
+
+    Args:
+        tmp_path: pytest temp directory.
+        monkeypatch: pytest monkeypatch fixture.
+
+    Returns:
+        Path: the ``relief`` cache directory features.py will use.
+    """
+    monkeypatch.setenv("PYRAMIDS_CACHE_DIR", str(tmp_path))
+    return tmp_path / "relief"
+
+
+def _make_relief_tif(path: Path, rows: int = 18, cols: int = 36) -> None:
+    """Write a tiny 3-band RGB EPSG:4326 global GeoTIFF (synthetic relief) to ``path``.
+
+    Args:
+        path: Destination file (its parent is created if missing).
+        rows: Raster height; with ``cols`` it spans the globe at ``180/rows`` degrees.
+        cols: Raster width.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True)
+    rng = np.random.default_rng(0)
+    arr = rng.integers(0, 255, size=(3, rows, cols), dtype="uint8")
+    Dataset.create_from_array(
+        arr,
+        top_left_corner=(-180.0, 90.0),
+        cell_size=180.0 / rows,
+        epsg=4326,
+        driver_type="GTiff",
+        path=str(path),
+    )
+
+
+class TestAvailableReliefResolutions:
+    """Tests for :func:`pyramids.basemap.features.available_relief_resolutions`."""
+
+    def test_returns_low_then_medium(self):
+        """available_relief_resolutions returns ``["low", "medium"]`` (coarsest first).
+
+        Test scenario:
+            The ordering is documented; assert the exact sequence.
+        """
+        assert features.available_relief_resolutions() == ["low", "medium"]
+
+
+class TestReliefUrl:
+    """Tests for :func:`pyramids.basemap.features._relief_url`."""
+
+    @pytest.mark.parametrize("resolution", ["low", "medium"])
+    def test_url_points_at_release_asset(self, resolution):
+        """_relief_url builds the release-asset URL for each resolution.
+
+        Args:
+            resolution: Relief resolution key.
+
+        Test scenario:
+            The URL is ``{_RELIEF_BASE_URL}/{product-filename}`` and ends in ``.tif``.
+        """
+        url = features._relief_url(resolution)
+        product = features._RELIEF_PRODUCTS[resolution]
+        assert url == f"{features._RELIEF_BASE_URL}/{product}", url
+        assert url.endswith(".tif"), url
+
+
+class TestRelief:
+    """Tests for :func:`pyramids.basemap.features.relief`."""
+
+    def test_unknown_resolution_raises(self):
+        """relief rejects an unknown resolution with the valid-options list.
+
+        Test scenario:
+            Passing a non-existent resolution raises ValueError naming the supported
+            ``low``/``medium`` values.
+        """
+        with pytest.raises(ValueError, match="unknown relief resolution") as exc:
+            features.relief("high")
+        assert "low" in str(exc.value), f"Options missing: {exc.value}"
+
+    def test_cache_dir_uses_relief_subdir(self, tmp_path, monkeypatch):
+        """_cache_dir('relief') resolves under the cache root, separate from vectors.
+
+        Args:
+            tmp_path: pytest temp directory.
+            monkeypatch: pytest monkeypatch fixture.
+
+        Test scenario:
+            With PYRAMIDS_CACHE_DIR set, the relief cache is ``<root>/relief`` and the
+            Natural Earth cache stays ``<root>/naturalearth`` — they don't collide.
+        """
+        monkeypatch.setenv("PYRAMIDS_CACHE_DIR", str(tmp_path))
+        assert features._cache_dir("relief") == tmp_path / "relief"
+        assert features._cache_dir() == tmp_path / "naturalearth"
+
+    def test_cache_hit_returns_rgb_dataset(self, relief_cache_dir, monkeypatch):
+        """relief reads a cached raster as a 3-band EPSG:4326 Dataset, no download.
+
+        Args:
+            relief_cache_dir: Redirected relief cache directory fixture.
+            monkeypatch: pytest monkeypatch fixture.
+
+        Test scenario:
+            With a synthetic relief GeoTIFF already in the cache, relief returns a
+            3-band (RGB), EPSG:4326 Dataset and never downloads.
+        """
+        _make_relief_tif(relief_cache_dir / features._RELIEF_PRODUCTS["low"])
+
+        def fail_download(url, destination):
+            raise AssertionError("download must not run on a cache hit")
+
+        monkeypatch.setattr(features, "_download", fail_download)
+        result = features.relief("low")
+        assert isinstance(result, Dataset), f"Got {type(result)}"
+        assert result.band_count == 3, f"Expected 3 bands, got {result.band_count}"
+        assert result.epsg == 4326, f"Expected EPSG:4326, got {result.epsg}"
+
+    def test_downloads_when_absent(self, relief_cache_dir, monkeypatch):
+        """relief downloads the raster once when it is not already cached.
+
+        Args:
+            relief_cache_dir: Redirected relief cache directory fixture.
+            monkeypatch: pytest monkeypatch fixture.
+
+        Test scenario:
+            With no cached file, _download is invoked exactly once (writing a synthetic
+            raster) and relief returns the resulting Dataset.
+        """
+        calls = []
+
+        def fake_download(url, destination):
+            calls.append(url)
+            _make_relief_tif(Path(destination))
+
+        monkeypatch.setattr(features, "_download", fake_download)
+        result = features.relief("low")
+        assert len(calls) == 1, f"Expected one download, got {len(calls)}"
+        assert calls[0] == features._relief_url("low"), f"Wrong URL: {calls[0]}"
+        assert isinstance(result, Dataset), f"Got {type(result)}"
+
+    def test_reprojectable_via_to_crs(self, relief_cache_dir, monkeypatch):
+        """The relief Dataset reprojects via to_crs (EPSG:3857 here).
+
+        Args:
+            relief_cache_dir: Redirected relief cache directory fixture.
+            monkeypatch: pytest monkeypatch fixture.
+
+        Test scenario:
+            relief returns an EPSG:4326 raster that ``to_crs`` can reproject to another
+            CRS without error. (``to_crs`` takes an EPSG code; orthographic/globe
+            rendering is handled downstream by the visualization layer.)
+        """
+        _make_relief_tif(relief_cache_dir / features._RELIEF_PRODUCTS["low"])
+
+        def fail_download(url, destination):
+            raise AssertionError("download must not run on a cache hit")
+
+        monkeypatch.setattr(features, "_download", fail_download)
+        reprojected = features.relief("low").to_crs(to_epsg=3857)
+        assert isinstance(reprojected, Dataset), f"Got {type(reprojected)}"
+        assert reprojected.epsg == 3857, f"Expected EPSG:3857, got {reprojected.epsg}"

--- a/tests/basemap/test_features.py
+++ b/tests/basemap/test_features.py
@@ -516,6 +516,22 @@ class TestAvailableReliefResolutions:
         """
         assert features.available_relief_resolutions() == ["low", "medium"]
 
+    def test_derived_from_products_table(self):
+        """The resolution list is derived from ``_RELIEF_PRODUCTS`` (no drift).
+
+        Test scenario:
+            ``available_relief_resolutions`` reflects the product table's keys rather
+            than a separately hardcoded list, so adding a product stays in sync. Also
+            confirm each call returns a fresh list (callers cannot mutate module state).
+        """
+        result = features.available_relief_resolutions()
+        assert result == list(
+            features._RELIEF_PRODUCTS
+        ), f"resolutions must mirror _RELIEF_PRODUCTS keys; got {result}"
+        assert (
+            result is not features.available_relief_resolutions()
+        ), "each call must return a fresh list"
+
 
 class TestReliefUrl:
     """Tests for :func:`pyramids.basemap.features._relief_url`."""


### PR DESCRIPTION
## Summary

Implements `pyramids.basemap.relief()` from #458 — the offline raster analogue of cartopy's
`GeoAxes.stock_img()`. It returns a small, downsampled **cross-blended hypsometric tint** (3-band RGB,
EPSG:4326) derived from **public-domain Natural Earth** data, downloaded from the pyramids release assets on
first use and cached locally — mirroring `natural_earth()`. Unlike the Web-Mercator-only XYZ tiles, it
returns a reprojectable `Dataset`, so it can back non-Mercator maps; drawing/placement stays in the
visualization layer.

## Changes

- **`relief(resolution="low"|"medium")`** + `available_relief_resolutions()`, exported from
  `pyramids.basemap`. Returns a `Dataset` (RGB, EPSG:4326), cached under `~/.pyramids/relief/`.
- **Refactor (shared with `natural_earth`)**:
  - `_cache_dir(subdir="naturalearth")` is now parameterized, so relief caches alongside the vector layers
    under the same `PYRAMIDS_CACHE_DIR` root.
  - `_download` generalized (tmp suffix + message) to serve both the vector zips and the relief GeoTIFF.
- **Tests** mirror the `natural_earth` pattern — mocked download, a synthetic cached raster, a `to_crs`
  reprojection, and a `@pytest.mark.slow` real-download test against the published release asset. All
  `core`-marked. `test_features.py`: 48 passed (47 + the slow real-download).

## Data assets — published

The two downsampled GeoTIFFs are baked from the public-domain Natural Earth `HYP_50M_SR_W` source and
attached to the **`basemap-data-v1`** release, which is what `relief()` fetches:

- `ne_hypso_rgb_720x360.tif` — 720×360 (~0.5°), 3-band RGB, EPSG:4326, ~266 KB → `relief("low")`
- `ne_hypso_rgb_1440x720.tif` — 1440×720 (~0.25°), 3-band RGB, EPSG:4326, ~983 KB → `relief("medium")`

Release: https://github.com/serapeum-org/pyramids/releases/tag/basemap-data-v1 (marked not-latest; it is a
data release, not a software/version release). Verified end-to-end: with a fresh cache, `relief("low")`
downloads the asset, caches it, and returns a 3-band EPSG:4326 720×360 `Dataset`. Natural Earth is public
domain, so redistributing a downsampled derivative is permitted.

Bake recipe (one-time, for reproducibility):

```bash
curl -LO https://naciscdn.org/naturalearth/50m/raster/HYP_50M_SR_W.zip && unzip HYP_50M_SR_W.zip
gdal_translate -outsize 720 360  -r average -co COMPRESS=DEFLATE -co PREDICTOR=2 \
  HYP_50M_SR_W/HYP_50M_SR_W.tif ne_hypso_rgb_720x360.tif
gdal_translate -outsize 1440 720 -r average -co COMPRESS=DEFLATE -co PREDICTOR=2 \
  HYP_50M_SR_W/HYP_50M_SR_W.tif ne_hypso_rgb_1440x720.tif
```

## Design decisions (from the #458 discussion)

- **RGB backdrop, not an elevation grid.** `relief()` returns the RGB hypsometric tint that a `stock_img`
  backdrop needs (you draw it, you don't colormap it). The issue's "negative = ocean depth" describes a
  *different* product (ETOPO-like single-band bathymetry, different source + licensing); that should be a
  separate function if ever wanted.
- **Download-and-cache, not bundled.** The native Natural Earth raster is ~97 MB; these are sub-MB/low-MB
  downsamples hosted on the release assets and fetched once, consistent with `natural_earth` (nothing is
  vendored into the wheel).
- **Reprojection**: `Dataset.to_crs` takes an EPSG code, so the test verifies reprojection to EPSG:3857.
  Orthographic/globe rendering is a downstream (visualization-layer) concern, per the issue's non-goals.

Closes #458
