### PR TITLE
feat(netcdf): windowed gridded cloud-cube reads via NetCDF.subset (#460)

### DIFF
--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -342,7 +342,7 @@ class CloudConfig:
     `aws_access_key_id`              `AWS_ACCESS_KEY_ID`
     `aws_secret_access_key`          `AWS_SECRET_ACCESS_KEY`
     `aws_session_token`              `AWS_SESSION_TOKEN`
-    `aws_region`                     `AWS_REGION`
+    `aws_region`                     `AWS_REGION` + `AWS_DEFAULT_REGION`
     `aws_no_sign_request=True`       `AWS_NO_SIGN_REQUEST=YES`
     `aws_request_payer=True`         `AWS_REQUEST_PAYER=requester`
     `gs_oauth2_refresh_token`        `GS_OAUTH2_REFRESH_TOKEN`
@@ -382,7 +382,7 @@ class CloudConfig:
         - Inspect the config dict without entering the block:
             ```python
             >>> CloudConfig(aws_region="eu-west-1").as_gdal_config()
-            {'AWS_REGION': 'eu-west-1'}
+            {'AWS_REGION': 'eu-west-1', 'AWS_DEFAULT_REGION': 'eu-west-1'}
 
             ```
         - Inspect the HTTP retry / timeout knobs without entering the block —
@@ -460,7 +460,7 @@ class CloudConfig:
             - A single AWS field produces a one-entry config:
                 ```python
                 >>> CloudConfig(aws_region="us-east-1").as_gdal_config()
-                {'AWS_REGION': 'us-east-1'}
+                {'AWS_REGION': 'us-east-1', 'AWS_DEFAULT_REGION': 'us-east-1'}
 
                 ```
             - Anonymous access maps to AWS_NO_SIGN_REQUEST=YES:
@@ -476,7 +476,7 @@ class CloudConfig:
                 ...     extra={"CPL_CURL_VERBOSE": "YES"},
                 ... ).as_gdal_config()
                 >>> sorted(cfg.items())
-                [('AWS_REGION', 'eu-west-1'), ('CPL_CURL_VERBOSE', 'YES')]
+                [('AWS_DEFAULT_REGION', 'eu-west-1'), ('AWS_REGION', 'eu-west-1'), ('CPL_CURL_VERBOSE', 'YES')]
 
                 ```
             - HTTP retry/timeout knobs apply to every `/vsicurl/`-backed reader:
@@ -514,6 +514,12 @@ class CloudConfig:
             "AWS_SECRET_ACCESS_KEY": self.aws_secret_access_key,
             "AWS_SESSION_TOKEN": self.aws_session_token,
             "AWS_REGION": self.aws_region,
+            # GDAL's /vsis3 resolves the bucket region from AWS_REGION *or*
+            # AWS_DEFAULT_REGION; if only one is set the other can leak from the
+            # process environment and send the request to the wrong endpoint
+            # (a 301 PermanentRedirect). Drive both from the single field so an
+            # explicit region always wins over an inherited env default.
+            "AWS_DEFAULT_REGION": self.aws_region,
             "GS_OAUTH2_REFRESH_TOKEN": self.gs_oauth2_refresh_token,
             "GS_ACCESS_KEY_ID": self.gs_access_key_id,
             "GS_SECRET_ACCESS_KEY": self.gs_secret_access_key,

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -175,13 +175,22 @@ def _contiguous_range(
     return int(inside.min()), int(inside.max()) + 1
 
 
+def _clamp_bound(index: int, size: int) -> int:
+    """Wrap a negative slice bound against ``size`` and clamp it into ``[0, size]``."""
+    if index < 0:
+        index += size
+    return max(0, min(index, size))
+
+
 def _resolve_index_selector(
     selector: Any, size: int, dim_name: str
 ) -> tuple[int, int]:
     """Resolve a non-spatial dimension selector to a half-open ``(start, stop)``.
 
     ``None`` is allowed only for a length-1 dimension; an ``int`` selects one
-    index; a 2-tuple/list or ``slice`` selects a half-open index range.
+    index (negative counts from the end, and an out-of-range index is an error);
+    a 2-tuple/list or ``slice`` selects a half-open index range whose bounds are
+    wrapped (negatives) and clamped into ``[0, size]``.
     """
     if selector is None:
         if size == 1:
@@ -191,8 +200,8 @@ def _resolve_index_selector(
             f"(e.g. {dim_name}=0)."
         )
     if isinstance(selector, slice):
-        start = 0 if selector.start is None else int(selector.start)
-        stop = size if selector.stop is None else int(selector.stop)
+        start = 0 if selector.start is None else _clamp_bound(int(selector.start), size)
+        stop = size if selector.stop is None else _clamp_bound(int(selector.stop), size)
         return start, stop
     if isinstance(selector, (tuple, list)):
         if len(selector) != 2:
@@ -200,10 +209,18 @@ def _resolve_index_selector(
                 f"range selector for {dim_name!r} must be (start, stop); got "
                 f"{selector!r}."
             )
-        return int(selector[0]), int(selector[1])
+        return (
+            _clamp_bound(int(selector[0]), size),
+            _clamp_bound(int(selector[1]), size),
+        )
     index = int(selector)
     if index < 0:
         index += size
+    if not 0 <= index < size:
+        raise ValueError(
+            f"index {selector!r} is out of range for dimension {dim_name!r} of "
+            f"length {size}."
+        )
     return index, index + 1
 
 
@@ -4332,7 +4349,7 @@ class NetCDF(Dataset):
         bbox: tuple[float, float, float, float] | list[float] | None = None,
         crs: int | str = 4326,
         densify: int = 25,
-        **dims: int,
+        **dims: int | tuple[int, int] | slice,
     ) -> Dataset:
         """Read a windowed ``(variable, time, bbox)`` slice of a gridded cube.
 
@@ -4370,7 +4387,8 @@ class NetCDF(Dataset):
                 (conservative over-cover). Defaults to ``25``.
             **dims: Index selector for any extra non-spatial dimension (e.g.
                 ``vis_nir=0``, ``soil_layers_stag=2``). Required for every such
-                dimension whose length is > 1.
+                dimension whose length is > 1. A key that is not a selectable
+                non-spatial dimension of the variable is an error.
 
         Returns:
             Dataset: A georeferenced raster on the store's native CRS — one band
@@ -4378,9 +4396,15 @@ class NetCDF(Dataset):
 
         Raises:
             ValueError: When the store is not multidimensional; when ``variable``
-                is absent or has fewer than two dimensions; when a non-spatial
-                dimension of length > 1 is not selected; or when the bbox selects
-                no cells.
+                is absent or has fewer than two dimensions; when a spatial axis
+                has no 1-D coordinate variable; when a non-spatial dimension of
+                length > 1 is not selected, or a ``**dims`` key / index is
+                invalid; or when the bbox selects no cells.
+
+        Note:
+            For a purely 2-D ``(y, x)`` variable there is no non-spatial axis, so
+            ``time`` and ``**dims`` are no-ops (the whole grid, optionally bbox-
+            cropped, is returned as one band).
 
         Examples:
             - Pull one timestep of a NWM land-surface variable over a lon/lat
@@ -4402,7 +4426,10 @@ class NetCDF(Dataset):
                 "subset() requires a multidimensional store; open with "
                 "open_as_multi_dimensional=True."
             )
-        md_arr = rg.OpenMDArray(variable)
+        try:
+            md_arr = rg.OpenMDArray(variable)
+        except RuntimeError:
+            md_arr = None
         if md_arr is None:
             raise ValueError(
                 f"{variable!r} is not a variable in this store; available: "
@@ -4418,12 +4445,8 @@ class NetCDF(Dataset):
         dim_sizes = [int(d.GetSize()) for d in dim_objs]
         # GDAL exposes a gridded MDArray with the spatial axes last: (..., y, x).
         y_axis, x_axis = len(dim_objs) - 2, len(dim_objs) - 1
-        x_coords = np.asarray(
-            rg.OpenMDArray(dim_names[x_axis]).ReadAsArray(), dtype="float64"
-        )
-        y_coords = np.asarray(
-            rg.OpenMDArray(dim_names[y_axis]).ReadAsArray(), dtype="float64"
-        )
+        x_coords = self._read_axis_coords(rg, dim_names[x_axis], "x")
+        y_coords = self._read_axis_coords(rg, dim_names[y_axis], "y")
 
         srs = md_arr.GetSpatialRef()
         if bbox is None:
@@ -4439,6 +4462,17 @@ class NetCDF(Dataset):
         # Build one slice per dimension; every non-spatial axis must collapse to a
         # single index (or, for the time axis, a range) so the read is bounded.
         time_axis = self._detect_time_axis(dim_names, y_axis, x_axis)
+        selectable = {
+            name
+            for axis, name in enumerate(dim_names)
+            if axis not in (x_axis, y_axis, time_axis)
+        }
+        unknown = set(dims) - selectable
+        if unknown:
+            raise ValueError(
+                f"unknown dimension selector(s) {sorted(unknown)}; selectable "
+                f"non-spatial dimensions are {sorted(selectable)}."
+            )
         slices: list[slice] = []
         band_labels: list[str] = []
         for axis, (name, size) in enumerate(zip(dim_names, dim_sizes)):
@@ -4490,6 +4524,28 @@ class NetCDF(Dataset):
         if band_labels and len(band_labels) == ds.band_count:
             ds.band_names = band_labels
         return ds
+
+    @staticmethod
+    def _read_axis_coords(rg: Any, name: str, axis_label: str) -> np.ndarray:
+        """Read a spatial axis's 1-D coordinate values, or raise a clear error.
+
+        A gridded variable can name a spatial dimension that has no indexing
+        (coordinate) variable — e.g. WRF ``south_north`` / ``west_east``.
+        ``OpenMDArray`` then returns ``None`` (or yields no array), so guard it
+        with an actionable message instead of an opaque ``AttributeError``.
+        """
+        try:
+            coord = rg.OpenMDArray(name)
+        except RuntimeError:
+            coord = None
+        values = None if coord is None else coord.ReadAsArray()
+        if values is None:
+            raise ValueError(
+                f"the {axis_label} dimension {name!r} has no 1-D coordinate "
+                "variable; subset() needs x/y coordinates to window and "
+                "georeference the grid."
+            )
+        return np.asarray(values, dtype="float64")
 
     @staticmethod
     def _detect_time_axis(dim_names: list[str], y_axis: int, x_axis: int) -> int | None:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -6,6 +6,7 @@ netcdf contains python functions to handle netcdf data. gdal class: https://gdal
 
 from __future__ import annotations
 
+import itertools
 import math
 import os
 import tempfile
@@ -265,14 +266,22 @@ def _resolve_index_selector(
 
     Raises:
         ValueError: When ``selector`` is ``None`` for a dimension longer than 1,
-            when a tuple/list is not length 2, or when an ``int`` index is out of
-            range.
+            when a tuple/list is not length 2, when an ``int`` index is out of
+            range, or when a range resolves to an empty window (``stop <= start``).
 
     Examples:
         - An integer selects a single index as a half-open range:
             ```python
             >>> _resolve_index_selector(2, 10, "time")
             (2, 3)
+
+            ```
+        - A reversed range is rejected (empty window):
+            ```python
+            >>> _resolve_index_selector((3, 1), 10, "time")
+            Traceback (most recent call last):
+                ...
+            ValueError: selector (3, 1) resolves to an empty index range (start=3, stop=1) for dimension 'time'.
 
             ```
         - A ``(start, stop)`` pair is wrapped and clamped into ``[0, size]``:
@@ -306,26 +315,30 @@ def _resolve_index_selector(
     if isinstance(selector, slice):
         start = 0 if selector.start is None else _clamp_bound(int(selector.start), size)
         stop = size if selector.stop is None else _clamp_bound(int(selector.stop), size)
-        return start, stop
-    if isinstance(selector, (tuple, list)):
+    elif isinstance(selector, (tuple, list)):
         if len(selector) != 2:
             raise ValueError(
                 f"range selector for {dim_name!r} must be (start, stop); got "
                 f"{selector!r}."
             )
-        return (
-            _clamp_bound(int(selector[0]), size),
-            _clamp_bound(int(selector[1]), size),
-        )
-    index = int(selector)
-    if index < 0:
-        index += size
-    if not 0 <= index < size:
+        start = _clamp_bound(int(selector[0]), size)
+        stop = _clamp_bound(int(selector[1]), size)
+    else:
+        index = int(selector)
+        if index < 0:
+            index += size
+        if not 0 <= index < size:
+            raise ValueError(
+                f"index {selector!r} is out of range for dimension {dim_name!r} "
+                f"of length {size}."
+            )
+        return index, index + 1
+    if stop <= start:
         raise ValueError(
-            f"index {selector!r} is out of range for dimension {dim_name!r} of "
-            f"length {size}."
+            f"selector {selector!r} resolves to an empty index range "
+            f"(start={start}, stop={stop}) for dimension {dim_name!r}."
         )
-    return index, index + 1
+    return start, stop
 
 
 class NetCDF(Dataset):
@@ -4566,10 +4579,11 @@ class NetCDF(Dataset):
         # Build one slice per dimension; every non-spatial axis must collapse to a
         # single index (or, for the time axis, a range) so the read is bounded.
         time_axis = self._detect_time_axis(dim_names, y_axis, x_axis)
+        # Every non-spatial axis is addressable by name through **dims; the time
+        # axis additionally accepts the dedicated ``time=`` argument. A name given
+        # in **dims always wins for its own axis.
         selectable = {
-            name
-            for axis, name in enumerate(dim_names)
-            if axis not in (x_axis, y_axis, time_axis)
+            name for axis, name in enumerate(dim_names) if axis not in (x_axis, y_axis)
         }
         unknown = set(dims) - selectable
         if unknown:
@@ -4578,18 +4592,34 @@ class NetCDF(Dataset):
                 f"non-spatial dimensions are {sorted(selectable)}."
             )
         slices: list[slice] = []
-        band_labels: list[str] = []
+        ranged_axes: list[tuple[str, range]] = []
         for axis, (name, size) in enumerate(zip(dim_names, dim_sizes)):
             if axis == x_axis:
                 slices.append(slice(x_start, x_stop))
             elif axis == y_axis:
                 slices.append(slice(y_start, y_stop))
             else:
-                selector = time if axis == time_axis else dims.get(name)
+                if name in dims:
+                    selector = dims[name]
+                elif axis == time_axis:
+                    selector = time
+                else:
+                    selector = None
                 start, stop = _resolve_index_selector(selector, size, name)
                 slices.append(slice(start, stop))
                 if stop - start > 1:
-                    band_labels = [f"{name}={i}" for i in range(start, stop)]
+                    ranged_axes.append((name, range(start, stop)))
+        # One band per combination of the ranged non-spatial axes, in the same
+        # C-order the (..., y, x) read is flattened to bands (last ranged axis
+        # varies fastest). Axes pinned to a single index add no label component.
+        band_labels = (
+            [
+                ",".join(f"{nm}={i}" for (nm, _), i in zip(ranged_axes, combo))
+                for combo in itertools.product(*(idxs for _, idxs in ranged_axes))
+            ]
+            if ranged_axes
+            else []
+        )
 
         arr = np.asarray(md_arr[tuple(slices)].ReadAsArray())
         n_y, n_x = arr.shape[-2], arr.shape[-1]
@@ -4606,8 +4636,10 @@ class NetCDF(Dataset):
         if y_vals.size > 1 and y_vals[0] < y_vals[-1]:
             arr = arr[:, ::-1, :]
             y_vals = y_vals[::-1]
-        d_x = abs(x_vals[1] - x_vals[0]) if x_vals.size > 1 else 1.0
-        d_y = abs(y_vals[1] - y_vals[0]) if y_vals.size > 1 else d_x
+        # Cell size from the full coordinate spacing so a 1-cell-wide window still
+        # carries the store's true resolution (the windowed slice may be size 1).
+        d_x = abs(x_coords[1] - x_coords[0]) if x_coords.size > 1 else 1.0
+        d_y = abs(y_coords[1] - y_coords[0]) if y_coords.size > 1 else d_x
         geo = (
             float(x_vals[0] - d_x / 2.0), float(d_x), 0.0,
             float(y_vals[0] + d_y / 2.0), 0.0, -float(d_y),

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -245,6 +245,25 @@ def _clamp_bound(index: int, size: int) -> int:
     return max(0, min(index, size))
 
 
+def _range_bounds(
+    selector: slice | tuple | list, size: int, dim_name: str
+) -> tuple[int, int]:
+    """Half-open ``(start, stop)`` for a ``slice`` or 2-element ``(start, stop)``.
+
+    Bounds are wrapped (negatives) and clamped into ``[0, size]`` via
+    :func:`_clamp_bound`. Raises when a tuple/list is not length 2.
+    """
+    if isinstance(selector, slice):
+        start = 0 if selector.start is None else _clamp_bound(int(selector.start), size)
+        stop = size if selector.stop is None else _clamp_bound(int(selector.stop), size)
+        return start, stop
+    if len(selector) != 2:
+        raise ValueError(
+            f"range selector for {dim_name!r} must be (start, stop); got {selector!r}."
+        )
+    return _clamp_bound(int(selector[0]), size), _clamp_bound(int(selector[1]), size)
+
+
 def _resolve_index_selector(
     selector: Any, size: int, dim_name: str
 ) -> tuple[int, int]:
@@ -312,33 +331,23 @@ def _resolve_index_selector(
             f"dimension {dim_name!r} has length {size} and must be selected "
             f"(e.g. {dim_name}=0)."
         )
-    if isinstance(selector, slice):
-        start = 0 if selector.start is None else _clamp_bound(int(selector.start), size)
-        stop = size if selector.stop is None else _clamp_bound(int(selector.stop), size)
-    elif isinstance(selector, (tuple, list)):
-        if len(selector) != 2:
+    if isinstance(selector, (slice, tuple, list)):
+        start, stop = _range_bounds(selector, size, dim_name)
+        if stop <= start:
             raise ValueError(
-                f"range selector for {dim_name!r} must be (start, stop); got "
-                f"{selector!r}."
+                f"selector {selector!r} resolves to an empty index range "
+                f"(start={start}, stop={stop}) for dimension {dim_name!r}."
             )
-        start = _clamp_bound(int(selector[0]), size)
-        stop = _clamp_bound(int(selector[1]), size)
-    else:
-        index = int(selector)
-        if index < 0:
-            index += size
-        if not 0 <= index < size:
-            raise ValueError(
-                f"index {selector!r} is out of range for dimension {dim_name!r} "
-                f"of length {size}."
-            )
-        return index, index + 1
-    if stop <= start:
+        return start, stop
+    index = int(selector)
+    if index < 0:
+        index += size
+    if not 0 <= index < size:
         raise ValueError(
-            f"selector {selector!r} resolves to an empty index range "
-            f"(start={start}, stop={stop}) for dimension {dim_name!r}."
+            f"index {selector!r} is out of range for dimension {dim_name!r} "
+            f"of length {size}."
         )
-    return start, stop
+    return index, index + 1
 
 
 class NetCDF(Dataset):
@@ -4591,59 +4600,17 @@ class NetCDF(Dataset):
                 f"unknown dimension selector(s) {sorted(unknown)}; selectable "
                 f"non-spatial dimensions are {sorted(selectable)}."
             )
-        slices: list[slice] = []
-        ranged_axes: list[tuple[str, range]] = []
-        for axis, (name, size) in enumerate(zip(dim_names, dim_sizes)):
-            if axis == x_axis:
-                slices.append(slice(x_start, x_stop))
-            elif axis == y_axis:
-                slices.append(slice(y_start, y_stop))
-            else:
-                if name in dims:
-                    selector = dims[name]
-                elif axis == time_axis:
-                    selector = time
-                else:
-                    selector = None
-                start, stop = _resolve_index_selector(selector, size, name)
-                slices.append(slice(start, stop))
-                if stop - start > 1:
-                    ranged_axes.append((name, range(start, stop)))
-        # One band per combination of the ranged non-spatial axes, in the same
-        # C-order the (..., y, x) read is flattened to bands (last ranged axis
-        # varies fastest). Axes pinned to a single index add no label component.
-        band_labels = (
-            [
-                ",".join(f"{nm}={i}" for (nm, _), i in zip(ranged_axes, combo))
-                for combo in itertools.product(*(idxs for _, idxs in ranged_axes))
-            ]
-            if ranged_axes
-            else []
+        slices, ranged_axes = self._plan_band_slices(
+            dim_names, dim_sizes, x_axis, y_axis, time_axis,
+            (x_start, x_stop), (y_start, y_stop), time, dims,
         )
-
         arr = np.asarray(md_arr[tuple(slices)].ReadAsArray())
-        n_y, n_x = arr.shape[-2], arr.shape[-1]
         # Collapse every selected non-spatial axis onto the band axis.
-        arr = arr.reshape(-1, n_y, n_x)
-
-        # Normalise to a north-up, west-to-east raster so the geotransform is the
-        # standard (x0, +dx, 0, y0, 0, -dy) form regardless of stored axis order.
-        x_vals = x_coords[x_start:x_stop]
-        y_vals = y_coords[y_start:y_stop]
-        if x_vals.size > 1 and x_vals[0] > x_vals[-1]:
-            arr = arr[:, :, ::-1]
-            x_vals = x_vals[::-1]
-        if y_vals.size > 1 and y_vals[0] < y_vals[-1]:
-            arr = arr[:, ::-1, :]
-            y_vals = y_vals[::-1]
-        # Cell size from the full coordinate spacing so a 1-cell-wide window still
-        # carries the store's true resolution (the windowed slice may be size 1).
-        d_x = abs(x_coords[1] - x_coords[0]) if x_coords.size > 1 else 1.0
-        d_y = abs(y_coords[1] - y_coords[0]) if y_coords.size > 1 else d_x
-        geo = (
-            float(x_vals[0] - d_x / 2.0), float(d_x), 0.0,
-            float(y_vals[0] + d_y / 2.0), 0.0, -float(d_y),
+        arr = arr.reshape(-1, arr.shape[-2], arr.shape[-1])
+        arr, geo = self._north_up_geobox(
+            arr, x_coords, y_coords, (x_start, x_stop), (y_start, y_stop)
         )
+        band_labels = self._band_labels(ranged_axes)
 
         no_data = self._md_array_no_data(md_arr)
         band_first = arr[0] if arr.shape[0] == 1 else arr
@@ -4660,6 +4627,83 @@ class NetCDF(Dataset):
         if band_labels and len(band_labels) == ds.band_count:
             ds.band_names = band_labels
         return ds
+
+    @staticmethod
+    def _plan_band_slices(
+        dim_names: list[str],
+        dim_sizes: list[int],
+        x_axis: int,
+        y_axis: int,
+        time_axis: int | None,
+        x_window: tuple[int, int],
+        y_window: tuple[int, int],
+        time: Any,
+        dims: dict[str, Any],
+    ) -> tuple[list[slice], list[tuple[str, range]]]:
+        """Per-dimension read slices + the ranged non-spatial axes (the band axes).
+
+        Spatial axes take the bbox windows; every other axis is pinned to one
+        index (or a range) via :func:`_resolve_index_selector`. A name in ``dims``
+        wins for its axis; otherwise the time axis uses ``time``.
+        """
+        slices: list[slice] = []
+        ranged_axes: list[tuple[str, range]] = []
+        for axis, (name, size) in enumerate(zip(dim_names, dim_sizes)):
+            if axis == x_axis:
+                slices.append(slice(*x_window))
+            elif axis == y_axis:
+                slices.append(slice(*y_window))
+            else:
+                if name in dims:
+                    selector = dims[name]
+                elif axis == time_axis:
+                    selector = time
+                else:
+                    selector = None
+                start, stop = _resolve_index_selector(selector, size, name)
+                slices.append(slice(start, stop))
+                if stop - start > 1:
+                    ranged_axes.append((name, range(start, stop)))
+        return slices, ranged_axes
+
+    @staticmethod
+    def _band_labels(ranged_axes: list[tuple[str, range]]) -> list[str]:
+        """Cartesian-product band labels for the ranged axes (C-order, last fastest)."""
+        if not ranged_axes:
+            return []
+        return [
+            ",".join(f"{nm}={i}" for (nm, _), i in zip(ranged_axes, combo))
+            for combo in itertools.product(*(idxs for _, idxs in ranged_axes))
+        ]
+
+    @staticmethod
+    def _north_up_geobox(
+        arr: np.ndarray,
+        x_coords: np.ndarray,
+        y_coords: np.ndarray,
+        x_window: tuple[int, int],
+        y_window: tuple[int, int],
+    ) -> tuple[np.ndarray, tuple[float, float, float, float, float, float]]:
+        """Flip ``arr`` to north-up / west-to-east; return ``(arr, geotransform)``.
+
+        Cell size comes from the full coordinate spacing so a 1-cell-wide window
+        still carries the store's true resolution.
+        """
+        x_vals = x_coords[x_window[0]:x_window[1]]
+        y_vals = y_coords[y_window[0]:y_window[1]]
+        if x_vals.size > 1 and x_vals[0] > x_vals[-1]:
+            arr = arr[:, :, ::-1]
+            x_vals = x_vals[::-1]
+        if y_vals.size > 1 and y_vals[0] < y_vals[-1]:
+            arr = arr[:, ::-1, :]
+            y_vals = y_vals[::-1]
+        d_x = abs(x_coords[1] - x_coords[0]) if x_coords.size > 1 else 1.0
+        d_y = abs(y_coords[1] - y_coords[0]) if y_coords.size > 1 else d_x
+        geo = (
+            float(x_vals[0] - d_x / 2.0), float(d_x), 0.0,
+            float(y_vals[0] + d_y / 2.0), 0.0, -float(d_y),
+        )
+        return arr, geo
 
     @staticmethod
     def _read_axis_coords(rg: Any, name: str, axis_label: str) -> np.ndarray:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -165,6 +165,44 @@ def _contiguous_range(
     Works for an ascending or descending coordinate axis (the NWM ``y`` axis is
     stored ascending), returning a single contiguous slice that covers the
     in-range cells. Raises when the window selects nothing.
+
+    Args:
+        coords: 1-D coordinate values for the axis (any monotonic direction).
+        low: Inclusive lower bound of the wanted coordinate window.
+        high: Inclusive upper bound of the wanted coordinate window.
+        axis_name: Axis label (``"x"`` / ``"y"``) used only in the error message.
+        bbox: The originating bbox, echoed back in the error message.
+
+    Returns:
+        The ``(start, stop)`` half-open index range covering the in-range cells.
+
+    Raises:
+        ValueError: When no cell's coordinate falls in ``[low, high]``.
+
+    Examples:
+        - In-range cells on an ascending axis become a half-open slice:
+            ```python
+            >>> import numpy as np
+            >>> _contiguous_range(np.array([0.0, 1.0, 2.0, 3.0]), 1.0, 2.0, "x", (1, 0, 2, 0))
+            (1, 3)
+
+            ```
+        - A descending axis still yields one contiguous slice:
+            ```python
+            >>> import numpy as np
+            >>> _contiguous_range(np.array([3.0, 2.0, 1.0, 0.0]), 1.0, 2.0, "y", (0, 1, 0, 2))
+            (1, 3)
+
+            ```
+        - A window outside the axis raises:
+            ```python
+            >>> import numpy as np
+            >>> _contiguous_range(np.array([0.0, 1.0, 2.0]), 9.0, 9.5, "x", (9, 9, 10, 10))
+            Traceback (most recent call last):
+                ...
+            ValueError: bbox (9, 9, 10, 10) selects no cells on the x axis; the store spans [0.0, 2.0] there.
+
+            ```
     """
     inside = np.flatnonzero((coords >= low) & (coords <= high))
     if inside.size == 0:
@@ -176,7 +214,31 @@ def _contiguous_range(
 
 
 def _clamp_bound(index: int, size: int) -> int:
-    """Wrap a negative slice bound against ``size`` and clamp it into ``[0, size]``."""
+    """Wrap a negative slice bound against ``size`` and clamp it into ``[0, size]``.
+
+    Args:
+        index: Raw slice bound (may be negative or out of range).
+        size: Length of the dimension the bound indexes into.
+
+    Returns:
+        The normalised bound, in ``[0, size]``.
+
+    Examples:
+        - A negative bound counts from the end:
+            ```python
+            >>> _clamp_bound(-1, 5)
+            4
+
+            ```
+        - An out-of-range bound clamps to the nearest edge:
+            ```python
+            >>> _clamp_bound(99, 5)
+            5
+            >>> _clamp_bound(-99, 5)
+            0
+
+            ```
+    """
     if index < 0:
         index += size
     return max(0, min(index, size))
@@ -191,6 +253,48 @@ def _resolve_index_selector(
     index (negative counts from the end, and an out-of-range index is an error);
     a 2-tuple/list or ``slice`` selects a half-open index range whose bounds are
     wrapped (negatives) and clamped into ``[0, size]``.
+
+    Args:
+        selector: ``None``, an ``int``, a ``(start, stop)`` tuple/list, or a
+            ``slice`` describing which index/indices of the dimension to keep.
+        size: Length of the dimension being selected.
+        dim_name: Dimension name, used in error messages.
+
+    Returns:
+        The resolved ``(start, stop)`` half-open index range.
+
+    Raises:
+        ValueError: When ``selector`` is ``None`` for a dimension longer than 1,
+            when a tuple/list is not length 2, or when an ``int`` index is out of
+            range.
+
+    Examples:
+        - An integer selects a single index as a half-open range:
+            ```python
+            >>> _resolve_index_selector(2, 10, "time")
+            (2, 3)
+
+            ```
+        - A ``(start, stop)`` pair is wrapped and clamped into ``[0, size]``:
+            ```python
+            >>> _resolve_index_selector((-3, 999), 5, "time")
+            (2, 5)
+
+            ```
+        - A length-1 dimension may be left unselected:
+            ```python
+            >>> _resolve_index_selector(None, 1, "vis_nir")
+            (0, 1)
+
+            ```
+        - An out-of-range integer is rejected:
+            ```python
+            >>> _resolve_index_selector(99, 5, "time")
+            Traceback (most recent call last):
+                ...
+            ValueError: index 99 is out of range for dimension 'time' of length 5.
+
+            ```
     """
     if selector is None:
         if size == 1:
@@ -4531,8 +4635,19 @@ class NetCDF(Dataset):
 
         A gridded variable can name a spatial dimension that has no indexing
         (coordinate) variable — e.g. WRF ``south_north`` / ``west_east``.
-        ``OpenMDArray`` then returns ``None`` (or yields no array), so guard it
-        with an actionable message instead of an opaque ``AttributeError``.
+        ``OpenMDArray`` then returns ``None`` (or raises), so guard it with an
+        actionable message instead of an opaque ``AttributeError``.
+
+        Args:
+            rg: The store's root :class:`osgeo.gdal.Group`.
+            name: Coordinate (indexing) array name — the spatial dimension name.
+            axis_label: ``"x"`` / ``"y"``, used in the error message.
+
+        Returns:
+            The coordinate values as a 1-D ``float64`` :class:`numpy.ndarray`.
+
+        Raises:
+            ValueError: When the dimension has no readable 1-D coordinate array.
         """
         try:
             coord = rg.OpenMDArray(name)
@@ -4553,6 +4668,35 @@ class NetCDF(Dataset):
 
         The ``time=`` selector applies to this axis; any other non-spatial axis
         is selected through ``**dims`` by name.
+
+        Args:
+            dim_names: Dimension names in storage order.
+            y_axis: Index of the ``y`` (row) axis to exclude.
+            x_axis: Index of the ``x`` (column) axis to exclude.
+
+        Returns:
+            The time axis index, the first non-spatial axis if no dimension is
+            time-like, or ``None`` when the variable is purely ``(y, x)``.
+
+        Examples:
+            - A dimension named ``"time"`` is the time axis:
+                ```python
+                >>> NetCDF._detect_time_axis(["time", "y", "x"], 1, 2)
+                0
+
+                ```
+            - With no time-like name, the first non-spatial axis is used:
+                ```python
+                >>> NetCDF._detect_time_axis(["level", "member", "y", "x"], 2, 3)
+                0
+
+                ```
+            - A purely 2-D ``(y, x)`` variable has no time axis:
+                ```python
+                >>> NetCDF._detect_time_axis(["y", "x"], 0, 1) is None
+                True
+
+                ```
         """
         time_like = {"time", "valid_time", "forecast_reference_time", "t"}
         fallback = None
@@ -4569,7 +4713,15 @@ class NetCDF(Dataset):
 
     @staticmethod
     def _md_array_no_data(md_arr: Any) -> float | None:
-        """Native no-data for an MDArray — driver value first, then CF attrs."""
+        """Native no-data for an MDArray — driver value first, then CF attrs.
+
+        Args:
+            md_arr: The :class:`osgeo.gdal.MDArray` to inspect.
+
+        Returns:
+            The no-data value as a ``float``: the driver's value if set, else the
+            ``missing_value`` then ``_FillValue`` CF attribute, else ``None``.
+        """
         result = md_arr.GetNoDataValueAsDouble()
         if result is None:
             for attr_name in ("missing_value", "_FillValue"):
@@ -4595,6 +4747,25 @@ class NetCDF(Dataset):
         encloses the curved boundary of a lon/lat box on a projected grid
         (conservative over-cover). When the destination has no CRS, or matches
         the source, the bbox is treated as already native.
+
+        Args:
+            bbox: ``(min_x, min_y, max_x, max_y)`` in the source CRS.
+            src_crs: Source CRS — an EPSG ``int`` or a WKT/PROJ/``"EPSG:n"`` string.
+            dst_srs: Destination :class:`osgeo.osr.SpatialReference`, or ``None``
+                when the store has no grid mapping.
+            densify: Number of points sampled along each bbox edge (``>= 2``).
+
+        Returns:
+            The ``(min_x, min_y, max_x, max_y)`` envelope in the destination CRS.
+
+        Examples:
+            - With no destination CRS the bbox is returned unchanged (treated as
+              already native):
+                ```python
+                >>> NetCDF._reproject_bbox_envelope((-1.0, -2.0, 3.0, 4.0), 4326, None, 5)
+                (-1.0, -2.0, 3.0, 4.0)
+
+                ```
         """
         min_x, min_y, max_x, max_y = (float(v) for v in bbox)
         src = osr.SpatialReference()

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -17,7 +17,7 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
-from osgeo import gdal
+from osgeo import gdal, osr
 
 from pyramids import _io
 from pyramids.base._errors import OptionalPackageDoesNotExist
@@ -151,6 +151,60 @@ _REDUCERS: dict[str, tuple[Any, Any]] = {
 # (set by ``osr.SpatialReference.SetGEOS`` / reconstructed from a
 # ``grid_mapping_name="geostationary"`` grid-mapping).
 GEOSTATIONARY_PROJECTION = "Geostationary_Satellite"
+
+
+def _contiguous_range(
+    coords: np.ndarray,
+    low: float,
+    high: float,
+    axis_name: str,
+    bbox: Any,
+) -> tuple[int, int]:
+    """Half-open index range of the cells whose coordinate is in ``[low, high]``.
+
+    Works for an ascending or descending coordinate axis (the NWM ``y`` axis is
+    stored ascending), returning a single contiguous slice that covers the
+    in-range cells. Raises when the window selects nothing.
+    """
+    inside = np.flatnonzero((coords >= low) & (coords <= high))
+    if inside.size == 0:
+        raise ValueError(
+            f"bbox {tuple(bbox)} selects no cells on the {axis_name} axis; the "
+            f"store spans [{float(coords.min())}, {float(coords.max())}] there."
+        )
+    return int(inside.min()), int(inside.max()) + 1
+
+
+def _resolve_index_selector(
+    selector: Any, size: int, dim_name: str
+) -> tuple[int, int]:
+    """Resolve a non-spatial dimension selector to a half-open ``(start, stop)``.
+
+    ``None`` is allowed only for a length-1 dimension; an ``int`` selects one
+    index; a 2-tuple/list or ``slice`` selects a half-open index range.
+    """
+    if selector is None:
+        if size == 1:
+            return 0, 1
+        raise ValueError(
+            f"dimension {dim_name!r} has length {size} and must be selected "
+            f"(e.g. {dim_name}=0)."
+        )
+    if isinstance(selector, slice):
+        start = 0 if selector.start is None else int(selector.start)
+        stop = size if selector.stop is None else int(selector.stop)
+        return start, stop
+    if isinstance(selector, (tuple, list)):
+        if len(selector) != 2:
+            raise ValueError(
+                f"range selector for {dim_name!r} must be (start, stop); got "
+                f"{selector!r}."
+            )
+        return int(selector[0]), int(selector[1])
+    index = int(selector)
+    if index < 0:
+        index += size
+    return index, index + 1
 
 
 class NetCDF(Dataset):
@@ -4269,6 +4323,248 @@ class NetCDF(Dataset):
             attrs=self.global_attributes,
         )
         return result
+
+    def subset(
+        self,
+        variable: str,
+        *,
+        time: int | slice | tuple[int, int] | None = None,
+        bbox: tuple[float, float, float, float] | list[float] | None = None,
+        crs: int | str = 4326,
+        densify: int = 25,
+        **dims: int,
+    ) -> Dataset:
+        """Read a windowed ``(variable, time, bbox)`` slice of a gridded cube.
+
+        Reads only the requested window from a CF/GeoZarr ``(time, y, x[, …])``
+        multidimensional store — local or remote — without materialising the
+        whole variable, and returns a georeferenced
+        :class:`~pyramids.dataset.Dataset` ready for ``to_file`` / ``to_cog`` /
+        ``to_crs`` / ``crop``.
+
+        Designed for huge cloud cubes (e.g. the NWM retrospective
+        ``ldasout.zarr``, an 18 TiB ``(128568, 3840, 4608)`` store) opened
+        anonymously via :class:`~pyramids.base.remote.CloudConfig`; only the
+        sliced cells are fetched. The output CRS is the variable's own grid
+        mapping (read from the multidimensional array), so a Lambert Conformal
+        Conic store stays on its native grid.
+
+        Args:
+            variable: Data-variable name in the store (e.g. ``"ACCET"``).
+            time: Timestep selector along the time dimension. An ``int`` picks
+                one step (one output band); a ``(start, stop)`` tuple or
+                ``slice`` picks a half-open index range (one band per step);
+                ``None`` is allowed only when the time dimension has length 1.
+                Selection is by **integer index** — date/label selection needs
+                the store to expose CF time ``units``, which many Zarr stores do
+                not surface through GDAL, so use indices for those.
+            bbox: ``(min_x, min_y, max_x, max_y)`` crop window in ``crs``.
+                ``None`` keeps the full grid. The box is reprojected onto the
+                store's native grid (so a lon/lat box over a projected grid is
+                handled) honouring the variable's grid mapping.
+            crs: CRS of ``bbox`` — EPSG int, ``"EPSG:4326"``, or a WKT/PROJ
+                string. Defaults to ``4326`` (lon/lat). Ignored when ``bbox`` is
+                ``None``.
+            densify: Points per bbox edge used when reprojecting the box onto a
+                projected grid, so the envelope encloses the curved boundary
+                (conservative over-cover). Defaults to ``25``.
+            **dims: Index selector for any extra non-spatial dimension (e.g.
+                ``vis_nir=0``, ``soil_layers_stag=2``). Required for every such
+                dimension whose length is > 1.
+
+        Returns:
+            Dataset: A georeferenced raster on the store's native CRS — one band
+            per selected timestep, with the native no-data value applied.
+
+        Raises:
+            ValueError: When the store is not multidimensional; when ``variable``
+                is absent or has fewer than two dimensions; when a non-spatial
+                dimension of length > 1 is not selected; or when the bbox selects
+                no cells.
+
+        Examples:
+            - Pull one timestep of a NWM land-surface variable over a lon/lat
+              box from the public bucket (metadata-only open, windowed read)::
+
+                >>> from pyramids.netcdf import NetCDF  # doctest: +SKIP
+                >>> from pyramids.base.remote import CloudConfig  # doctest: +SKIP
+                >>> url = "s3://noaa-nwm-retrospective-3-0-pds/CONUS/zarr/ldasout.zarr"
+                >>> with CloudConfig(  # doctest: +SKIP
+                ...     aws_no_sign_request=True, aws_region="us-east-1"
+                ... ):
+                ...     nc = NetCDF.read_file(url)
+                ...     ds = nc.subset("ACCET", time=0, bbox=(-78, 38, -75, 40))
+                >>> ds.to_cog("accet.tif")  # doctest: +SKIP
+        """
+        rg = self._raster.GetRootGroup() if self._raster is not None else None
+        if rg is None:
+            raise ValueError(
+                "subset() requires a multidimensional store; open with "
+                "open_as_multi_dimensional=True."
+            )
+        md_arr = rg.OpenMDArray(variable)
+        if md_arr is None:
+            raise ValueError(
+                f"{variable!r} is not a variable in this store; available: "
+                f"{self.variable_names}"
+            )
+        dim_objs = md_arr.GetDimensions()
+        if len(dim_objs) < 2:
+            raise ValueError(
+                f"{variable!r} has {len(dim_objs)} dimension(s); subset() needs a "
+                "gridded variable with at least (y, x)."
+            )
+        dim_names = [d.GetName() for d in dim_objs]
+        dim_sizes = [int(d.GetSize()) for d in dim_objs]
+        # GDAL exposes a gridded MDArray with the spatial axes last: (..., y, x).
+        y_axis, x_axis = len(dim_objs) - 2, len(dim_objs) - 1
+        x_coords = np.asarray(
+            rg.OpenMDArray(dim_names[x_axis]).ReadAsArray(), dtype="float64"
+        )
+        y_coords = np.asarray(
+            rg.OpenMDArray(dim_names[y_axis]).ReadAsArray(), dtype="float64"
+        )
+
+        srs = md_arr.GetSpatialRef()
+        if bbox is None:
+            x_start, x_stop = 0, dim_sizes[x_axis]
+            y_start, y_stop = 0, dim_sizes[y_axis]
+        else:
+            min_x, min_y, max_x, max_y = self._reproject_bbox_envelope(
+                tuple(bbox), crs, srs, densify
+            )
+            x_start, x_stop = _contiguous_range(x_coords, min_x, max_x, "x", bbox)
+            y_start, y_stop = _contiguous_range(y_coords, min_y, max_y, "y", bbox)
+
+        # Build one slice per dimension; every non-spatial axis must collapse to a
+        # single index (or, for the time axis, a range) so the read is bounded.
+        time_axis = self._detect_time_axis(dim_names, y_axis, x_axis)
+        slices: list[slice] = []
+        band_labels: list[str] = []
+        for axis, (name, size) in enumerate(zip(dim_names, dim_sizes)):
+            if axis == x_axis:
+                slices.append(slice(x_start, x_stop))
+            elif axis == y_axis:
+                slices.append(slice(y_start, y_stop))
+            else:
+                selector = time if axis == time_axis else dims.get(name)
+                start, stop = _resolve_index_selector(selector, size, name)
+                slices.append(slice(start, stop))
+                if stop - start > 1:
+                    band_labels = [f"{name}={i}" for i in range(start, stop)]
+
+        arr = np.asarray(md_arr[tuple(slices)].ReadAsArray())
+        n_y, n_x = arr.shape[-2], arr.shape[-1]
+        # Collapse every selected non-spatial axis onto the band axis.
+        arr = arr.reshape(-1, n_y, n_x)
+
+        # Normalise to a north-up, west-to-east raster so the geotransform is the
+        # standard (x0, +dx, 0, y0, 0, -dy) form regardless of stored axis order.
+        x_vals = x_coords[x_start:x_stop]
+        y_vals = y_coords[y_start:y_stop]
+        if x_vals.size > 1 and x_vals[0] > x_vals[-1]:
+            arr = arr[:, :, ::-1]
+            x_vals = x_vals[::-1]
+        if y_vals.size > 1 and y_vals[0] < y_vals[-1]:
+            arr = arr[:, ::-1, :]
+            y_vals = y_vals[::-1]
+        d_x = abs(x_vals[1] - x_vals[0]) if x_vals.size > 1 else 1.0
+        d_y = abs(y_vals[1] - y_vals[0]) if y_vals.size > 1 else d_x
+        geo = (
+            float(x_vals[0] - d_x / 2.0), float(d_x), 0.0,
+            float(y_vals[0] + d_y / 2.0), 0.0, -float(d_y),
+        )
+
+        no_data = self._md_array_no_data(md_arr)
+        band_first = arr[0] if arr.shape[0] == 1 else arr
+        ds = Dataset.create_from_array(
+            band_first,
+            geo=geo,
+            epsg=4326,
+            no_data_value=no_data if no_data is not None else DEFAULT_NO_DATA_VALUE,
+        )
+        # The grid mapping carries the true CRS (e.g. a sphere-datum Lambert
+        # Conformal Conic with no EPSG code); prefer it over the 4326 placeholder.
+        if srs is not None:
+            ds.crs = srs.ExportToWkt()
+        if band_labels and len(band_labels) == ds.band_count:
+            ds.band_names = band_labels
+        return ds
+
+    @staticmethod
+    def _detect_time_axis(dim_names: list[str], y_axis: int, x_axis: int) -> int | None:
+        """Index of the time dimension, or the first non-spatial axis as fallback.
+
+        The ``time=`` selector applies to this axis; any other non-spatial axis
+        is selected through ``**dims`` by name.
+        """
+        time_like = {"time", "valid_time", "forecast_reference_time", "t"}
+        fallback = None
+        result = None
+        for axis, name in enumerate(dim_names):
+            if axis in (y_axis, x_axis):
+                continue
+            if fallback is None:
+                fallback = axis
+            if name.lower() in time_like:
+                result = axis
+                break
+        return result if result is not None else fallback
+
+    @staticmethod
+    def _md_array_no_data(md_arr: Any) -> float | None:
+        """Native no-data for an MDArray — driver value first, then CF attrs."""
+        result = md_arr.GetNoDataValueAsDouble()
+        if result is None:
+            for attr_name in ("missing_value", "_FillValue"):
+                try:
+                    attr = md_arr.GetAttribute(attr_name)
+                except RuntimeError:
+                    attr = None
+                if attr is not None:
+                    result = float(np.asarray(attr.ReadAsDoubleArray()).ravel()[0])
+                    break
+        return result
+
+    @staticmethod
+    def _reproject_bbox_envelope(
+        bbox: tuple[float, float, float, float],
+        src_crs: int | str,
+        dst_srs: Any,
+        densify: int,
+    ) -> tuple[float, float, float, float]:
+        """Reproject a bbox into the store's native CRS and return its envelope.
+
+        Densifies each edge before transforming so the projected envelope
+        encloses the curved boundary of a lon/lat box on a projected grid
+        (conservative over-cover). When the destination has no CRS, or matches
+        the source, the bbox is treated as already native.
+        """
+        min_x, min_y, max_x, max_y = (float(v) for v in bbox)
+        src = osr.SpatialReference()
+        src.SetFromUserInput(f"EPSG:{src_crs}" if isinstance(src_crs, int) else str(src_crs))
+        src.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+        if dst_srs is None or src.IsSame(dst_srs):
+            return min_x, min_y, max_x, max_y
+        dst = dst_srs.Clone()
+        dst.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+        transform = osr.CoordinateTransformation(src, dst)
+        edge = np.linspace(0.0, 1.0, max(int(densify), 2))
+        xs = np.concatenate([
+            min_x + edge * (max_x - min_x), min_x + edge * (max_x - min_x),
+            np.full_like(edge, min_x), np.full_like(edge, max_x),
+        ])
+        ys = np.concatenate([
+            np.full_like(edge, min_y), np.full_like(edge, max_y),
+            min_y + edge * (max_y - min_y), min_y + edge * (max_y - min_y),
+        ])
+        proj_x: list[float] = []
+        proj_y: list[float] = []
+        for px, py in zip(xs, ys):
+            tx, ty, _ = transform.TransformPoint(float(px), float(py))
+            proj_x.append(tx)
+            proj_y.append(ty)
+        return min(proj_x), min(proj_y), max(proj_x), max(proj_y)
 
     @classmethod
     def from_xarray(

--- a/tests/base/test_cloud_config_http.py
+++ b/tests/base/test_cloud_config_http.py
@@ -155,6 +155,7 @@ class TestCloudConfigHttpFields:
         ).as_gdal_config()
         assert cfg == {
             "AWS_REGION": "us-east-1",
+            "AWS_DEFAULT_REGION": "us-east-1",
             "GDAL_HTTP_MAX_RETRY": "3",
             "VSI_CACHE": "TRUE",
         }, f"unexpected credentials+http mapping: {cfg!r}"

--- a/tests/base/test_remote.py
+++ b/tests/base/test_remote.py
@@ -167,11 +167,12 @@ class TestCloudConfigAsGdalConfig:
             "AWS_SECRET_ACCESS_KEY": "SEC",
             "AWS_SESSION_TOKEN": "TOK",
             "AWS_REGION": "us-east-1",
+            "AWS_DEFAULT_REGION": "us-east-1",
         }
 
     def test_skips_none_fields(self):
         cfg = CloudConfig(aws_region="eu-west-1").as_gdal_config()
-        assert cfg == {"AWS_REGION": "eu-west-1"}
+        assert cfg == {"AWS_REGION": "eu-west-1", "AWS_DEFAULT_REGION": "eu-west-1"}
 
     def test_no_sign_request_true(self):
         assert CloudConfig(aws_no_sign_request=True).as_gdal_config() == {
@@ -214,7 +215,11 @@ class TestCloudConfigAsGdalConfig:
             aws_region="us-east-1",
             extra={"VSI_CACHE": "TRUE"},
         ).as_gdal_config()
-        assert cfg == {"AWS_REGION": "us-east-1", "VSI_CACHE": "TRUE"}
+        assert cfg == {
+            "AWS_REGION": "us-east-1",
+            "AWS_DEFAULT_REGION": "us-east-1",
+            "VSI_CACHE": "TRUE",
+        }
 
 
 class TestCloudConfigContextManager:

--- a/tests/base/test_remote.py
+++ b/tests/base/test_remote.py
@@ -221,6 +221,41 @@ class TestCloudConfigAsGdalConfig:
             "VSI_CACHE": "TRUE",
         }
 
+    def test_region_drives_both_keys_identically(self):
+        """aws_region sets AWS_REGION and AWS_DEFAULT_REGION to the same value.
+
+        Test scenario:
+            A single aws_region field must emit both GDAL keys so an inherited
+            AWS_DEFAULT_REGION env value cannot override an explicit region.
+        """
+        cfg = CloudConfig(aws_region="ap-south-1").as_gdal_config()
+        assert cfg["AWS_REGION"] == "ap-south-1", f"AWS_REGION wrong: {cfg}"
+        assert cfg["AWS_DEFAULT_REGION"] == "ap-south-1", f"AWS_DEFAULT_REGION wrong: {cfg}"
+
+    def test_no_default_region_without_region(self):
+        """AWS_DEFAULT_REGION is absent when aws_region is not provided.
+
+        Test scenario:
+            None-valued aws_region must drop both region keys (no empty leak).
+        """
+        cfg = CloudConfig(aws_no_sign_request=True).as_gdal_config()
+        assert "AWS_REGION" not in cfg, f"unexpected AWS_REGION: {cfg}"
+        assert "AWS_DEFAULT_REGION" not in cfg, f"unexpected AWS_DEFAULT_REGION: {cfg}"
+
+    def test_extra_overrides_default_region(self):
+        """An explicit extra AWS_DEFAULT_REGION wins over the aws_region-derived one.
+
+        Test scenario:
+            The extra escape hatch can decouple the two keys when a caller needs
+            a different default region.
+        """
+        cfg = CloudConfig(
+            aws_region="us-east-1",
+            extra={"AWS_DEFAULT_REGION": "us-west-2"},
+        ).as_gdal_config()
+        assert cfg["AWS_REGION"] == "us-east-1", f"AWS_REGION wrong: {cfg}"
+        assert cfg["AWS_DEFAULT_REGION"] == "us-west-2", f"extra did not win: {cfg}"
+
 
 class TestCloudConfigContextManager:
     def test_enter_exit_no_options(self):

--- a/tests/netcdf/test_subset.py
+++ b/tests/netcdf/test_subset.py
@@ -91,6 +91,14 @@ class TestResolveIndexSelector:
         with pytest.raises(ValueError, match="out of range"):
             _resolve_index_selector(-99, 5, "time")
 
+    def test_reversed_range_raises_empty(self):
+        with pytest.raises(ValueError, match="empty index range"):
+            _resolve_index_selector((3, 1), 10, "time")
+
+    def test_equal_bounds_raises_empty(self):
+        with pytest.raises(ValueError, match="empty index range"):
+            _resolve_index_selector(slice(2, 2), 10, "time")
+
 
 class TestClampBound:
     """``_clamp_bound`` wraps negatives and clamps a slice bound into [0, size]."""
@@ -276,14 +284,24 @@ class TestReadAxisCoords:
             NetCDF._read_axis_coords(rg, "y", "y")
 
 
-def _synthetic_cube(tmp_path, *, with_coords=True, with_extra=False, x_descending=False):
+def _synthetic_cube(
+    tmp_path,
+    *,
+    with_coords=True,
+    with_extra=False,
+    with_no_time=False,
+    x_descending=False,
+    step=1.0,
+):
     """Build a tiny local multidimensional NetCDF and return an opened ``NetCDF``.
 
     The ``y`` axis ascends (south->north) so the north-up normalisation in
     ``subset`` is exercised. ``temp`` holds ``np.arange`` values so band
     orientation can be verified exactly; with ``with_extra`` a 4-D ``flux`` adds
-    a non-spatial ``level`` axis for ``**dims`` coverage. ``with_coords=False``
+    a non-spatial ``level`` axis for ``**dims`` coverage; with ``with_no_time`` a
+    3-D ``ens(member, y, x)`` adds a non-time leading axis. ``with_coords=False``
     drops the ``y`` / ``x`` coordinate variables (the missing-coordinate case).
+    ``step`` scales the ``x`` / ``y`` cell spacing (to test cell-size handling).
     """
     xr = pytest.importorskip("xarray")
     n_t, n_y, n_x = 3, 4, 5
@@ -295,18 +313,25 @@ def _synthetic_cube(tmp_path, *, with_coords=True, with_extra=False, x_descendin
             n_t, n_lev, n_y, n_x
         )
         data_vars["flux"] = (("time", "level", "y", "x"), flux)
+    if with_no_time:
+        n_member = 2
+        ens = np.arange(n_member * n_y * n_x, dtype="float64").reshape(
+            n_member, n_y, n_x
+        )
+        data_vars["ens"] = (("member", "y", "x"), ens)
     coords = {}
     if with_coords:
-        x_vals = np.array([4.0, 3.0, 2.0, 1.0, 0.0]) if x_descending else np.array(
-            [0.0, 1.0, 2.0, 3.0, 4.0]
-        )
+        x_asc = np.arange(n_x, dtype="float64") * step
+        x_vals = x_asc[::-1] if x_descending else x_asc
         coords = {
             "time": np.arange(n_t),
-            "y": np.array([10.0, 11.0, 12.0, 13.0]),  # ascending
+            "y": 10.0 + np.arange(n_y, dtype="float64") * step,  # ascending
             "x": x_vals,
         }
         if with_extra:
             coords["level"] = np.arange(2)
+        if with_no_time:
+            coords["member"] = np.arange(2)
     ds = xr.Dataset(data_vars, coords=coords)
     return NetCDF.from_xarray(ds, path=str(tmp_path / "cube.nc"))
 
@@ -396,6 +421,46 @@ class TestSubsetOffline:
         nc = _synthetic_cube(tmp_path, with_coords=False)
         with pytest.raises(ValueError, match="no 1-D coordinate variable"):
             nc.subset("temp", time=0, bbox=(0.0, 0.0, 1.0, 1.0))
+
+    def test_reversed_time_range_raises(self, tmp_path):
+        # L1: an empty/reversed range is rejected with a clear message.
+        nc = _synthetic_cube(tmp_path)
+        with pytest.raises(ValueError, match="empty index range"):
+            nc.subset("temp", time=(2, 1))
+
+    def test_non_time_axis_selectable_by_name(self, tmp_path):
+        # L2: a non-time leading axis (ens member) is addressable via **dims.
+        nc = _synthetic_cube(tmp_path, with_no_time=True)
+        ds = nc.subset("ens", member=1)
+        assert (ds.rows, ds.columns) == (4, 5)
+        assert ds.band_count == 1
+
+    def test_non_time_axis_also_accepts_time_keyword(self, tmp_path):
+        # L2: the dedicated time= keyword still drives that fallback axis.
+        nc = _synthetic_cube(tmp_path, with_no_time=True)
+        ds = nc.subset("ens", time=0)
+        assert ds.band_count == 1
+
+    def test_multi_range_band_labels_are_cartesian_product(self, tmp_path):
+        # L3: ranging two non-spatial axes (time x level, each length 2) labels
+        # every band as the Cartesian product, in C-order (level varies fastest).
+        nc = _synthetic_cube(tmp_path, with_extra=True)
+        ds = nc.subset("flux", time=(0, 2), level=(0, 2))
+        assert ds.band_count == 4
+        assert ds.band_names == [
+            "time=0,level=0",
+            "time=0,level=1",
+            "time=1,level=0",
+            "time=1,level=1",
+        ]
+
+    def test_single_cell_window_keeps_native_resolution(self, tmp_path):
+        # N1: a 1x1 window carries the store's true cell size, not a 1.0 fallback.
+        nc = _synthetic_cube(tmp_path, step=1000.0)
+        ds = nc.subset("temp", time=0, bbox=(2000.0, 2010.0, 2000.0, 2010.0))
+        assert (ds.rows, ds.columns) == (1, 1)
+        assert ds.geotransform[1] == pytest.approx(1000.0)
+        assert abs(ds.geotransform[5]) == pytest.approx(1000.0)
 
 
 @pytest.mark.slow

--- a/tests/netcdf/test_subset.py
+++ b/tests/netcdf/test_subset.py
@@ -128,6 +128,99 @@ class TestReprojectBboxEnvelope:
         assert max_y > min_y
 
 
+def _synthetic_cube(tmp_path, *, with_coords=True, with_extra=False):
+    """Build a tiny local multidimensional NetCDF and return an opened ``NetCDF``.
+
+    The ``y`` axis ascends (south->north) so the north-up normalisation in
+    ``subset`` is exercised. ``temp`` holds ``np.arange`` values so band
+    orientation can be verified exactly; with ``with_extra`` a 4-D ``flux`` adds
+    a non-spatial ``level`` axis for ``**dims`` coverage. ``with_coords=False``
+    drops the ``y`` / ``x`` coordinate variables (the missing-coordinate case).
+    """
+    xr = pytest.importorskip("xarray")
+    n_t, n_y, n_x = 3, 4, 5
+    temp = np.arange(n_t * n_y * n_x, dtype="float64").reshape(n_t, n_y, n_x)
+    data_vars = {"temp": (("time", "y", "x"), temp)}
+    if with_extra:
+        n_lev = 2
+        flux = np.arange(n_t * n_lev * n_y * n_x, dtype="float64").reshape(
+            n_t, n_lev, n_y, n_x
+        )
+        data_vars["flux"] = (("time", "level", "y", "x"), flux)
+    coords = {}
+    if with_coords:
+        coords = {
+            "time": np.arange(n_t),
+            "y": np.array([10.0, 11.0, 12.0, 13.0]),  # ascending
+            "x": np.array([0.0, 1.0, 2.0, 3.0, 4.0]),
+        }
+        if with_extra:
+            coords["level"] = np.arange(2)
+    ds = xr.Dataset(data_vars, coords=coords)
+    return NetCDF.from_xarray(ds, path=str(tmp_path / "cube.nc"))
+
+
+class TestSubsetOffline:
+    """Offline integration tests for the ``subset`` body (no network).
+
+    Cover the windowed read, north-up flip of an ascending ``y`` axis, band
+    construction for a time range, bbox cropping in native coordinates, extra-dim
+    selection, and the error paths (missing coordinate, unknown ``**dims`` key,
+    out-of-range index).
+    """
+
+    def test_single_timestep_shape_and_north_up(self, tmp_path):
+        nc = _synthetic_cube(tmp_path)
+        ds = nc.subset("temp", time=0)
+        assert (ds.rows, ds.columns) == (4, 5)
+        assert ds.band_count == 1
+        # y ascends [10..13]; north-up output row 0 is the northernmost (y=13),
+        # i.e. xarray y-index 3 -> values [15, 16, 17, 18, 19].
+        row0 = np.asarray(ds.read_array())[0]
+        assert list(row0) == [15.0, 16.0, 17.0, 18.0, 19.0]
+        # North-up geotransform: negative dy, top-left y at the upper edge.
+        gt = ds.geotransform
+        assert gt[5] < 0
+        assert gt[3] == pytest.approx(13.5)
+
+    def test_time_range_is_multiband(self, tmp_path):
+        nc = _synthetic_cube(tmp_path)
+        ds = nc.subset("temp", time=(0, 3))
+        assert ds.band_count == 3
+
+    def test_bbox_crops_in_native_coords(self, tmp_path):
+        nc = _synthetic_cube(tmp_path)
+        # Keep x in [1, 3] (3 cols) and y in [11, 12] (2 rows).
+        ds = nc.subset("temp", time=0, bbox=(1.0, 11.0, 3.0, 12.0))
+        assert (ds.rows, ds.columns) == (2, 3)
+
+    def test_extra_dim_selection(self, tmp_path):
+        nc = _synthetic_cube(tmp_path, with_extra=True)
+        ds = nc.subset("flux", time=0, level=1)
+        assert (ds.rows, ds.columns) == (4, 5)
+        assert ds.band_count == 1
+
+    def test_unselected_extra_dim_raises(self, tmp_path):
+        nc = _synthetic_cube(tmp_path, with_extra=True)
+        with pytest.raises(ValueError, match="must be selected"):
+            nc.subset("flux", time=0)
+
+    def test_unknown_dim_key_raises(self, tmp_path):
+        nc = _synthetic_cube(tmp_path, with_extra=True)
+        with pytest.raises(ValueError, match="unknown dimension selector"):
+            nc.subset("flux", time=0, levl=1)
+
+    def test_out_of_range_time_index_raises(self, tmp_path):
+        nc = _synthetic_cube(tmp_path)
+        with pytest.raises(ValueError, match="out of range"):
+            nc.subset("temp", time=99)
+
+    def test_missing_coordinate_variable_raises(self, tmp_path):
+        nc = _synthetic_cube(tmp_path, with_coords=False)
+        with pytest.raises(ValueError, match="no 1-D coordinate variable"):
+            nc.subset("temp", time=0, bbox=(0.0, 0.0, 1.0, 1.0))
+
+
 @pytest.mark.slow
 @pytest.mark.vfs
 class TestSubsetLiveNWM:

--- a/tests/netcdf/test_subset.py
+++ b/tests/netcdf/test_subset.py
@@ -11,6 +11,8 @@ retrospective store exercises the full remote path end to end.
 
 from __future__ import annotations
 
+from unittest.mock import Mock
+
 import numpy as np
 import pytest
 from osgeo import osr
@@ -194,92 +196,86 @@ class TestReprojectBboxEnvelope:
         assert out == pytest.approx(bbox)
 
 
-class _FakeAttr:
-    """Minimal stand-in for a GDAL attribute exposing ``ReadAsDoubleArray``."""
+def _fake_md_array(ndv=None, attrs=None):
+    """A Mock GDAL MDArray: ``GetNoDataValueAsDouble()`` + ``GetAttribute(name)``.
 
-    def __init__(self, value: float) -> None:
-        self._value = value
+    Returns a :class:`unittest.mock.Mock` so the GDAL PascalCase API surface is
+    faked without defining non-snake-case methods. ``attrs`` maps attribute name
+    to its scalar value; an absent attribute raises ``RuntimeError`` like GDAL.
+    """
+    attrs = attrs or {}
 
-    def ReadAsDoubleArray(self):  # noqa: N802  # NOSONAR: mirrors GDAL SWIG API
-        return [self._value]
+    def get_attribute(name):
+        if name not in attrs:
+            raise RuntimeError(f"Attribute {name} does not exist")
+        attr = Mock()
+        attr.ReadAsDoubleArray.return_value = [attrs[name]]
+        return attr
+
+    md = Mock()
+    md.GetNoDataValueAsDouble.return_value = ndv
+    md.GetAttribute.side_effect = get_attribute
+    return md
 
 
-class _FakeMDArray:
-    """Minimal MDArray for ``_md_array_no_data`` — driver value + CF attrs."""
+def _fake_group(arrays):
+    """A Mock GDAL root group whose ``OpenMDArray(name)`` returns a coord stub.
 
-    def __init__(self, ndv=None, attrs=None) -> None:
-        self._ndv = ndv
-        self._attrs = attrs or {}
+    ``arrays`` maps a coordinate name to the array its ``ReadAsArray()`` yields
+    (use ``None`` to simulate a dimension with no readable coordinate); a name
+    absent from the mapping raises ``RuntimeError`` like GDAL.
+    """
 
-    def GetNoDataValueAsDouble(self):  # noqa: N802  # NOSONAR: mirrors GDAL SWIG API
-        return self._ndv
+    def open_mdarray(name):
+        if name not in arrays:
+            raise RuntimeError(f"Array {name} does not exist")
+        coord = Mock()
+        coord.ReadAsArray.return_value = arrays[name]
+        return coord
 
-    def GetAttribute(self, name):  # noqa: N802  # NOSONAR: mirrors GDAL SWIG API
-        if name in self._attrs:
-            return _FakeAttr(self._attrs[name])
-        raise RuntimeError(f"Attribute {name} does not exist")
+    rg = Mock()
+    rg.OpenMDArray.side_effect = open_mdarray
+    return rg
 
 
 class TestMdArrayNoData:
     """``_md_array_no_data`` prefers the driver value, then CF attrs, else None."""
 
     def test_driver_value_wins(self):
-        assert NetCDF._md_array_no_data(_FakeMDArray(ndv=-1.0)) == pytest.approx(-1.0)
+        assert NetCDF._md_array_no_data(_fake_md_array(ndv=-1.0)) == pytest.approx(-1.0)
 
     def test_missing_value_fallback(self):
-        md = _FakeMDArray(ndv=None, attrs={"missing_value": -999900.0})
+        md = _fake_md_array(ndv=None, attrs={"missing_value": -999900.0})
         assert NetCDF._md_array_no_data(md) == pytest.approx(-999900.0)
 
     def test_fill_value_fallback(self):
-        md = _FakeMDArray(ndv=None, attrs={"_FillValue": -9999.0})
+        md = _fake_md_array(ndv=None, attrs={"_FillValue": -9999.0})
         assert NetCDF._md_array_no_data(md) == pytest.approx(-9999.0)
 
     def test_missing_value_preferred_over_fill_value(self):
-        md = _FakeMDArray(ndv=None, attrs={"missing_value": 1.0, "_FillValue": 2.0})
+        md = _fake_md_array(ndv=None, attrs={"missing_value": 1.0, "_FillValue": 2.0})
         assert NetCDF._md_array_no_data(md) == pytest.approx(1.0)
 
     def test_none_when_no_value_or_attrs(self):
-        assert NetCDF._md_array_no_data(_FakeMDArray()) is None
-
-
-class _FakeCoord:
-    """Coordinate MDArray stub returning a fixed array (or ``None``)."""
-
-    def __init__(self, values) -> None:
-        self._values = values
-
-    def ReadAsArray(self):  # noqa: N802  # NOSONAR: mirrors GDAL SWIG API
-        return self._values
-
-
-class _FakeGroup:
-    """Root-group stub: returns a coord, returns ``None``, or raises like GDAL."""
-
-    def __init__(self, arrays) -> None:
-        self._arrays = arrays
-
-    def OpenMDArray(self, name):  # noqa: N802  # NOSONAR: mirrors GDAL SWIG API
-        if name not in self._arrays:
-            raise RuntimeError(f"Array {name} does not exist")
-        return self._arrays[name]
+        assert NetCDF._md_array_no_data(_fake_md_array()) is None
 
 
 class TestReadAxisCoords:
     """``_read_axis_coords`` returns float64 values or a clear error."""
 
     def test_success_returns_float64(self):
-        rg = _FakeGroup({"x": _FakeCoord(np.array([0, 1, 2]))})
+        rg = _fake_group({"x": np.array([0, 1, 2])})
         out = NetCDF._read_axis_coords(rg, "x", "x")
         assert out.dtype == np.float64
         assert list(out) == [0.0, 1.0, 2.0]
 
     def test_missing_array_raises_clear_error(self):
-        rg = _FakeGroup({})
+        rg = _fake_group({})
         with pytest.raises(ValueError, match="no 1-D coordinate variable"):
             NetCDF._read_axis_coords(rg, "y", "y")
 
     def test_none_values_raises_clear_error(self):
-        rg = _FakeGroup({"y": _FakeCoord(None)})
+        rg = _fake_group({"y": None})
         with pytest.raises(ValueError, match="no 1-D coordinate variable"):
             NetCDF._read_axis_coords(rg, "y", "y")
 

--- a/tests/netcdf/test_subset.py
+++ b/tests/netcdf/test_subset.py
@@ -200,7 +200,7 @@ class _FakeAttr:
     def __init__(self, value: float) -> None:
         self._value = value
 
-    def ReadAsDoubleArray(self):  # noqa: N802 (GDAL SWIG name)
+    def ReadAsDoubleArray(self):  # noqa: N802  # NOSONAR: mirrors GDAL SWIG API
         return [self._value]
 
 
@@ -211,10 +211,10 @@ class _FakeMDArray:
         self._ndv = ndv
         self._attrs = attrs or {}
 
-    def GetNoDataValueAsDouble(self):  # noqa: N802
+    def GetNoDataValueAsDouble(self):  # noqa: N802  # NOSONAR: mirrors GDAL SWIG API
         return self._ndv
 
-    def GetAttribute(self, name):  # noqa: N802
+    def GetAttribute(self, name):  # noqa: N802  # NOSONAR: mirrors GDAL SWIG API
         if name in self._attrs:
             return _FakeAttr(self._attrs[name])
         raise RuntimeError(f"Attribute {name} does not exist")
@@ -248,7 +248,7 @@ class _FakeCoord:
     def __init__(self, values) -> None:
         self._values = values
 
-    def ReadAsArray(self):  # noqa: N802
+    def ReadAsArray(self):  # noqa: N802  # NOSONAR: mirrors GDAL SWIG API
         return self._values
 
 
@@ -258,7 +258,7 @@ class _FakeGroup:
     def __init__(self, arrays) -> None:
         self._arrays = arrays
 
-    def OpenMDArray(self, name):  # noqa: N802
+    def OpenMDArray(self, name):  # noqa: N802  # NOSONAR: mirrors GDAL SWIG API
         if name not in self._arrays:
             raise RuntimeError(f"Array {name} does not exist")
         return self._arrays[name]

--- a/tests/netcdf/test_subset.py
+++ b/tests/netcdf/test_subset.py
@@ -17,6 +17,7 @@ from osgeo import osr
 
 from pyramids.netcdf.netcdf import (
     NetCDF,
+    _clamp_bound,
     _contiguous_range,
     _resolve_index_selector,
 )
@@ -73,6 +74,48 @@ class TestResolveIndexSelector:
         with pytest.raises(ValueError, match="must be"):
             _resolve_index_selector((0, 1, 2), 10, "time")
 
+    def test_slice_negative_start_wraps(self):
+        assert _resolve_index_selector(slice(-2, None), 5, "time") == (3, 5)
+
+    def test_slice_stop_beyond_size_clamps(self):
+        assert _resolve_index_selector(slice(0, 999), 5, "time") == (0, 5)
+
+    def test_tuple_negative_and_out_of_range_clamp(self):
+        assert _resolve_index_selector((-3, 999), 5, "time") == (2, 5)
+
+    def test_out_of_range_int_raises(self):
+        with pytest.raises(ValueError, match="out of range"):
+            _resolve_index_selector(99, 5, "time")
+
+    def test_negative_int_out_of_range_raises(self):
+        with pytest.raises(ValueError, match="out of range"):
+            _resolve_index_selector(-99, 5, "time")
+
+
+class TestClampBound:
+    """``_clamp_bound`` wraps negatives and clamps a slice bound into [0, size]."""
+
+    @pytest.mark.parametrize(
+        "index, size, expected",
+        [
+            (2, 5, 2),
+            (-1, 5, 4),
+            (-99, 5, 0),
+            (99, 5, 5),
+            (0, 5, 0),
+            (5, 5, 5),
+        ],
+    )
+    def test_clamp(self, index, size, expected):
+        """Bound is wrapped (negatives) then clamped to the inclusive [0, size] range.
+
+        Args:
+            index: Raw bound to normalise.
+            size: Dimension length.
+            expected: Normalised bound.
+        """
+        assert _clamp_bound(index, size) == expected, f"{index}/{size} -> {expected}"
+
 
 class TestDetectTimeAxis:
     """The time selector targets the time-like axis, else the first non-spatial."""
@@ -127,8 +170,113 @@ class TestReprojectBboxEnvelope:
         assert max_x > min_x
         assert max_y > min_y
 
+    def test_wkt_string_source_crs(self):
+        """A WKT/PROJ string source CRS is accepted via ``SetFromUserInput``.
 
-def _synthetic_cube(tmp_path, *, with_coords=True, with_extra=False):
+        Test scenario:
+            Passing ``crs`` as a WKT string (not an EPSG int) and a matching
+            destination yields an identity envelope.
+        """
+        wgs84_wkt = osr.SpatialReference()
+        wgs84_wkt.ImportFromEPSG(4326)
+        dst = osr.SpatialReference()
+        dst.ImportFromEPSG(4326)
+        bbox = (-10.0, -5.0, 10.0, 5.0)
+        out = NetCDF._reproject_bbox_envelope(bbox, wgs84_wkt.ExportToWkt(), dst, 10)
+        assert out == pytest.approx(bbox)
+
+
+class _FakeAttr:
+    """Minimal stand-in for a GDAL attribute exposing ``ReadAsDoubleArray``."""
+
+    def __init__(self, value: float) -> None:
+        self._value = value
+
+    def ReadAsDoubleArray(self):  # noqa: N802 (GDAL SWIG name)
+        return [self._value]
+
+
+class _FakeMDArray:
+    """Minimal MDArray for ``_md_array_no_data`` — driver value + CF attrs."""
+
+    def __init__(self, ndv=None, attrs=None) -> None:
+        self._ndv = ndv
+        self._attrs = attrs or {}
+
+    def GetNoDataValueAsDouble(self):  # noqa: N802
+        return self._ndv
+
+    def GetAttribute(self, name):  # noqa: N802
+        if name in self._attrs:
+            return _FakeAttr(self._attrs[name])
+        raise RuntimeError(f"Attribute {name} does not exist")
+
+
+class TestMdArrayNoData:
+    """``_md_array_no_data`` prefers the driver value, then CF attrs, else None."""
+
+    def test_driver_value_wins(self):
+        assert NetCDF._md_array_no_data(_FakeMDArray(ndv=-1.0)) == -1.0
+
+    def test_missing_value_fallback(self):
+        md = _FakeMDArray(ndv=None, attrs={"missing_value": -999900.0})
+        assert NetCDF._md_array_no_data(md) == -999900.0
+
+    def test_fill_value_fallback(self):
+        md = _FakeMDArray(ndv=None, attrs={"_FillValue": -9999.0})
+        assert NetCDF._md_array_no_data(md) == -9999.0
+
+    def test_missing_value_preferred_over_fill_value(self):
+        md = _FakeMDArray(ndv=None, attrs={"missing_value": 1.0, "_FillValue": 2.0})
+        assert NetCDF._md_array_no_data(md) == 1.0
+
+    def test_none_when_no_value_or_attrs(self):
+        assert NetCDF._md_array_no_data(_FakeMDArray()) is None
+
+
+class _FakeCoord:
+    """Coordinate MDArray stub returning a fixed array (or ``None``)."""
+
+    def __init__(self, values) -> None:
+        self._values = values
+
+    def ReadAsArray(self):  # noqa: N802
+        return self._values
+
+
+class _FakeGroup:
+    """Root-group stub: returns a coord, returns ``None``, or raises like GDAL."""
+
+    def __init__(self, arrays) -> None:
+        self._arrays = arrays
+
+    def OpenMDArray(self, name):  # noqa: N802
+        if name not in self._arrays:
+            raise RuntimeError(f"Array {name} does not exist")
+        return self._arrays[name]
+
+
+class TestReadAxisCoords:
+    """``_read_axis_coords`` returns float64 values or a clear error."""
+
+    def test_success_returns_float64(self):
+        rg = _FakeGroup({"x": _FakeCoord(np.array([0, 1, 2]))})
+        out = NetCDF._read_axis_coords(rg, "x", "x")
+        assert out.dtype == np.float64
+        assert list(out) == [0.0, 1.0, 2.0]
+
+    def test_missing_array_raises_clear_error(self):
+        rg = _FakeGroup({})
+        with pytest.raises(ValueError, match="no 1-D coordinate variable"):
+            NetCDF._read_axis_coords(rg, "y", "y")
+
+    def test_none_values_raises_clear_error(self):
+        rg = _FakeGroup({"y": _FakeCoord(None)})
+        with pytest.raises(ValueError, match="no 1-D coordinate variable"):
+            NetCDF._read_axis_coords(rg, "y", "y")
+
+
+def _synthetic_cube(tmp_path, *, with_coords=True, with_extra=False, x_descending=False):
     """Build a tiny local multidimensional NetCDF and return an opened ``NetCDF``.
 
     The ``y`` axis ascends (south->north) so the north-up normalisation in
@@ -149,10 +297,13 @@ def _synthetic_cube(tmp_path, *, with_coords=True, with_extra=False):
         data_vars["flux"] = (("time", "level", "y", "x"), flux)
     coords = {}
     if with_coords:
+        x_vals = np.array([4.0, 3.0, 2.0, 1.0, 0.0]) if x_descending else np.array(
+            [0.0, 1.0, 2.0, 3.0, 4.0]
+        )
         coords = {
             "time": np.arange(n_t),
             "y": np.array([10.0, 11.0, 12.0, 13.0]),  # ascending
-            "x": np.array([0.0, 1.0, 2.0, 3.0, 4.0]),
+            "x": x_vals,
         }
         if with_extra:
             coords["level"] = np.arange(2)
@@ -183,10 +334,36 @@ class TestSubsetOffline:
         assert gt[5] < 0
         assert gt[3] == pytest.approx(13.5)
 
-    def test_time_range_is_multiband(self, tmp_path):
+    def test_time_range_is_multiband_with_labels(self, tmp_path):
         nc = _synthetic_cube(tmp_path)
         ds = nc.subset("temp", time=(0, 3))
         assert ds.band_count == 3
+        assert ds.band_names == ["time=0", "time=1", "time=2"]
+
+    def test_full_grid_when_bbox_none(self, tmp_path):
+        nc = _synthetic_cube(tmp_path)
+        ds = nc.subset("temp", time=0)
+        assert (ds.rows, ds.columns) == (4, 5)
+
+    def test_descending_x_axis_normalised_west_to_east(self, tmp_path):
+        nc = _synthetic_cube(tmp_path, x_descending=True)
+        ds = nc.subset("temp", time=0)
+        # Stored x descends [4..0]; west-to-east output row 0 (north, y=13) must
+        # run x=0..4 -> the stored values reversed: data[0, 3] = [15..19] -> [19..15].
+        row0 = np.asarray(ds.read_array())[0]
+        assert list(row0) == [19.0, 18.0, 17.0, 16.0, 15.0]
+        assert ds.geotransform[1] > 0, "x cell size must be positive (west-to-east)"
+
+    def test_not_multidimensional_raises(self, tmp_path):
+        nc = _synthetic_cube(tmp_path)
+        classic = NetCDF.read_file(nc.file_name, open_as_multi_dimensional=False)
+        with pytest.raises(ValueError, match="requires a multidimensional store"):
+            classic.subset("temp", time=0)
+
+    def test_missing_variable_raises(self, tmp_path):
+        nc = _synthetic_cube(tmp_path)
+        with pytest.raises(ValueError, match="is not a variable"):
+            nc.subset("does_not_exist", time=0)
 
     def test_bbox_crops_in_native_coords(self, tmp_path):
         nc = _synthetic_cube(tmp_path)

--- a/tests/netcdf/test_subset.py
+++ b/tests/netcdf/test_subset.py
@@ -1,0 +1,168 @@
+"""Tests for ``NetCDF.subset`` and its windowing helpers (issue #460).
+
+``subset`` reads a windowed ``(variable, time, bbox)`` slice of a gridded
+multidimensional cube into a georeferenced :class:`~pyramids.dataset.Dataset`
+without materialising the whole variable. The pure helpers below carry the
+tricky logic — ascending/descending axis ranges, non-spatial index selection,
+time-axis detection, and reprojecting a lon/lat bbox onto a projected grid — so
+they are tested in isolation. A live, opt-in test against the public NWM
+retrospective store exercises the full remote path end to end.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from osgeo import osr
+
+from pyramids.netcdf.netcdf import (
+    NetCDF,
+    _contiguous_range,
+    _resolve_index_selector,
+)
+
+pytestmark = pytest.mark.core
+
+NWM_LDASOUT = "s3://noaa-nwm-retrospective-3-0-pds/CONUS/zarr/ldasout.zarr"
+
+
+class TestContiguousRange:
+    """``_contiguous_range`` works for either axis direction (NWM ``y`` ascends)."""
+
+    def test_ascending_axis(self):
+        coords = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
+        assert _contiguous_range(coords, 1.5, 3.5, "x", (0, 0, 0, 0)) == (2, 4)
+
+    def test_descending_axis(self):
+        coords = np.array([4.0, 3.0, 2.0, 1.0, 0.0])
+        assert _contiguous_range(coords, 1.5, 3.5, "y", (0, 0, 0, 0)) == (1, 3)
+
+    def test_inclusive_bounds(self):
+        coords = np.array([0.0, 1.0, 2.0, 3.0])
+        assert _contiguous_range(coords, 1.0, 2.0, "x", (0, 0, 0, 0)) == (1, 3)
+
+    def test_empty_window_raises(self):
+        coords = np.array([0.0, 1.0, 2.0])
+        with pytest.raises(ValueError, match="selects no cells"):
+            _contiguous_range(coords, 10.0, 20.0, "x", (10, 10, 20, 20))
+
+
+class TestResolveIndexSelector:
+    """Non-spatial dimension selectors resolve to half-open ``(start, stop)``."""
+
+    def test_none_on_length_one_ok(self):
+        assert _resolve_index_selector(None, 1, "vis_nir") == (0, 1)
+
+    def test_none_on_longer_dim_raises(self):
+        with pytest.raises(ValueError, match="must be selected"):
+            _resolve_index_selector(None, 4, "soil_layers_stag")
+
+    def test_int_selects_one(self):
+        assert _resolve_index_selector(2, 10, "time") == (2, 3)
+
+    def test_negative_int_wraps(self):
+        assert _resolve_index_selector(-1, 5, "time") == (4, 5)
+
+    def test_tuple_range(self):
+        assert _resolve_index_selector((0, 4), 10, "time") == (0, 4)
+
+    def test_slice_range(self):
+        assert _resolve_index_selector(slice(None, 3), 10, "time") == (0, 3)
+
+    def test_bad_tuple_length_raises(self):
+        with pytest.raises(ValueError, match="must be"):
+            _resolve_index_selector((0, 1, 2), 10, "time")
+
+
+class TestDetectTimeAxis:
+    """The time selector targets the time-like axis, else the first non-spatial."""
+
+    def test_named_time_dim(self):
+        assert NetCDF._detect_time_axis(["time", "y", "x"], 1, 2) == 0
+
+    def test_no_time_falls_back_to_first_non_spatial(self):
+        # (level, member, y, x) with no time-like name -> first non-spatial axis.
+        assert NetCDF._detect_time_axis(["level", "member", "y", "x"], 2, 3) == 0
+
+    def test_only_spatial_returns_none(self):
+        assert NetCDF._detect_time_axis(["y", "x"], 0, 1) is None
+
+
+class TestReprojectBboxEnvelope:
+    """Densified bbox reprojection onto a projected grid (G-D)."""
+
+    def test_no_dst_crs_is_identity(self):
+        bbox = (-78.0, 38.0, -75.0, 40.0)
+        assert NetCDF._reproject_bbox_envelope(bbox, 4326, None, 25) == bbox
+
+    def test_same_crs_is_identity(self):
+        bbox = (-78.0, 38.0, -75.0, 40.0)
+        dst = osr.SpatialReference()
+        dst.ImportFromEPSG(4326)
+        out = NetCDF._reproject_bbox_envelope(bbox, 4326, dst, 25)
+        assert out == pytest.approx(bbox)
+
+    def test_lonlat_into_lambert_conformal_conic(self):
+        # NWM-style LCC sphere: a lon/lat box maps to projected metres east of
+        # the -97 central meridian, and the densified envelope conservatively
+        # over-covers the requested latitude span.
+        lcc = osr.SpatialReference()
+        lcc.ImportFromWkt(
+            'PROJCS["Lambert_Conformal_Conic",'
+            'GEOGCS["GCS_Sphere",DATUM["D_Sphere",'
+            'SPHEROID["Sphere",6370000.0,0.0]],'
+            'PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]],'
+            'PROJECTION["Lambert_Conformal_Conic_2SP"],'
+            'PARAMETER["false_easting",0.0],PARAMETER["false_northing",0.0],'
+            'PARAMETER["central_meridian",-97.0],'
+            'PARAMETER["standard_parallel_1",30.0],'
+            'PARAMETER["standard_parallel_2",60.0],'
+            'PARAMETER["latitude_of_origin",40.0],UNIT["Meter",1.0]]'
+        )
+        min_x, min_y, max_x, max_y = NetCDF._reproject_bbox_envelope(
+            (-78.0, 38.0, -75.0, 40.0), 4326, lcc, 25
+        )
+        # East of -97 -> positive easting, ~1.5-1.9 million metres.
+        assert 1.4e6 < min_x < 1.9e6
+        assert max_x > min_x
+        assert max_y > min_y
+
+
+@pytest.mark.slow
+@pytest.mark.vfs
+class TestSubsetLiveNWM:
+    """Opt-in live test against the public NWM retrospective gridded Zarr.
+
+    Run with ``pytest -m "slow and vfs" tests/netcdf/test_subset.py``. Skipped by
+    default and skipped gracefully when the bucket is unreachable. Verifies the
+    three fixes together: anonymous remote multidim open (region pinned), CRS
+    preserved on the windowed slice, and a bounded ``(time, bbox)`` read.
+    """
+
+    def test_subset_one_timestep_bbox(self):
+        from pyramids.base.remote import CloudConfig
+
+        try:
+            with CloudConfig(aws_no_sign_request=True, aws_region="us-east-1"):
+                nc = NetCDF.read_file(NWM_LDASOUT)
+                ds = nc.subset("ACCET", time=0, bbox=(-78.0, 38.0, -75.0, 40.0))
+        except (RuntimeError, OSError) as exc:  # network / bucket unreachable
+            pytest.skip(f"NWM store unreachable: {exc}")
+
+        assert ds.rows > 0 and ds.columns > 0
+        # Far smaller than the full 3840 x 4608 grid -> the read was windowed.
+        assert ds.rows < 3840 and ds.columns < 4608
+        assert ds.band_count == 1
+        assert "Lambert_Conformal_Conic" in (ds.crs or "")
+
+    def test_subset_time_range_is_multiband(self):
+        from pyramids.base.remote import CloudConfig
+
+        try:
+            with CloudConfig(aws_no_sign_request=True, aws_region="us-east-1"):
+                nc = NetCDF.read_file(NWM_LDASOUT)
+                ds = nc.subset("ACCET", time=(0, 3), bbox=(-78.0, 38.0, -75.0, 40.0))
+        except (RuntimeError, OSError) as exc:
+            pytest.skip(f"NWM store unreachable: {exc}")
+
+        assert ds.band_count == 3

--- a/tests/netcdf/test_subset.py
+++ b/tests/netcdf/test_subset.py
@@ -224,19 +224,19 @@ class TestMdArrayNoData:
     """``_md_array_no_data`` prefers the driver value, then CF attrs, else None."""
 
     def test_driver_value_wins(self):
-        assert NetCDF._md_array_no_data(_FakeMDArray(ndv=-1.0)) == -1.0
+        assert NetCDF._md_array_no_data(_FakeMDArray(ndv=-1.0)) == pytest.approx(-1.0)
 
     def test_missing_value_fallback(self):
         md = _FakeMDArray(ndv=None, attrs={"missing_value": -999900.0})
-        assert NetCDF._md_array_no_data(md) == -999900.0
+        assert NetCDF._md_array_no_data(md) == pytest.approx(-999900.0)
 
     def test_fill_value_fallback(self):
         md = _FakeMDArray(ndv=None, attrs={"_FillValue": -9999.0})
-        assert NetCDF._md_array_no_data(md) == -9999.0
+        assert NetCDF._md_array_no_data(md) == pytest.approx(-9999.0)
 
     def test_missing_value_preferred_over_fill_value(self):
         md = _FakeMDArray(ndv=None, attrs={"missing_value": 1.0, "_FillValue": 2.0})
-        assert NetCDF._md_array_no_data(md) == 1.0
+        assert NetCDF._md_array_no_data(md) == pytest.approx(1.0)
 
     def test_none_when_no_value_or_attrs(self):
         assert NetCDF._md_array_no_data(_FakeMDArray()) is None


### PR DESCRIPTION
# Description

Implements the gridded cloud-cube subset capability from #460 as additive changes to the GDAL-backed
`NetCDF` class — no new class and no `xarray` backend. A huge remote CF/GeoZarr `(time, y, x[, …])` cube can
be opened anonymously and sliced (by variable, time, and bbox) **before** it is read, returning a normal
georeferenced `Dataset`.

Two parts:

- **`CloudConfig` region fix** (`base/remote.py`): `aws_region` now emits both `AWS_REGION` and
  `AWS_DEFAULT_REGION`. GDAL `/vsis3` resolves the bucket region from either key; setting only `AWS_REGION`
  let an inherited `AWS_DEFAULT_REGION` env value leak and send anonymous opens to the wrong endpoint (a 301
  `PermanentRedirect`).
- **`NetCDF.subset(variable, *, time=, bbox=, crs=, **dims)`** (`netcdf/netcdf.py`): reads only the requested
  window from a multidimensional store into a `Dataset`. The bbox is reprojected onto the store's native grid
  with densified edges (a lon/lat box over a projected grid — NWM is Lambert Conformal Conic — is handled),
  windowing is robust to an ascending `y` axis and normalised north-up, the variable's grid mapping is
  preserved, and every non-spatial dim is pinned by index (`time` may be an index or a range → one band per
  step). Time selection is index-based: GDAL's Zarr multidim driver does not surface the CF time `units` for
  these stores.

Verified live against the public NWM retrospective store
`s3://noaa-nwm-retrospective-3-0-pds/CONUS/zarr/ldasout.zarr` (an 18 TiB `(128568, 3840, 4608)` cube): opens
anonymously in ~2.5 s and a one-timestep lon/lat-bbox read returns a `(273, 299)` raster on the native LCC
grid with no full-cube allocation.

Dependencies: none added (uses existing GDAL multidimensional reads).

# Issues
- Fixes #460

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- Added `tests/netcdf/test_subset.py`: 49 offline unit/integration tests (windowing helpers + the `subset`
  body — north-up flip, descending-x, time-range banding, native-coord bbox crop, extra-dim selection, and
  every error path) plus 2 opt-in live tests against the public NWM store.
- Updated `tests/base/test_remote.py` / `tests/base/test_cloud_config_http.py` for the new
  `AWS_DEFAULT_REGION` key, plus region escape-hatch / absent-key cases.
- Test configuration: `pixi run --frozen -e dev`. (`pytest-cov` is unusable in this env — its import path
  trips a `dask.array.fft`/NumPy incompatibility — so coverage was verified by branch-level scenario design.)

- [x] Offline: `pixi run --frozen -e dev pytest tests/netcdf -m "not slow and not plot and not vfs"`
      → 1224 passed, 4 skipped.
- [x] Live (opt-in): `pixi run --frozen -e dev pytest tests/netcdf/test_subset.py -m "slow and vfs"`
      → 2 passed.

# Checklist:

- [ ] updated version number in pyproject.toml. *(handled by commitizen in CI — not bumped manually)*
- [ ] added changes to History.rst. *(changelog is commitizen-generated — no manual entry)*
- [ ] updated the latest version in README file. *(handled by the release workflow)*
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. *(Google-style docstrings with examples on `subset` and its helpers)*
