### PR TITLE
fix(bootstrap): force GDAL_DRIVER_PATH to the bundled plugins (#465)

### DIFF
--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -27,9 +27,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
-permissions:
-  contents: read
-
 env:
   WHEEL_SIZE_BUDGET_MB: "120"
   # Toolchain pins for the GDAL-extraction scripts (ci/setup-gdal-*.sh,
@@ -43,6 +40,8 @@ jobs:
   build-sdist:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
@@ -70,6 +69,8 @@ jobs:
   build-linux-wheels:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: ${{ matrix.runs-on }}
+    permissions:
+      contents: read
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -106,6 +107,8 @@ jobs:
 
   build-macos-wheels:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -136,6 +139,8 @@ jobs:
   build-windows-wheels:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     runs-on: windows-2022
+    permissions:
+      contents: read
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -164,6 +169,8 @@ jobs:
 
   test-wheels:
     needs: [build-linux-wheels, build-macos-wheels, build-windows-wheels]
+    permissions:
+      contents: read
     timeout-minutes: 20
     strategy:
       fail-fast: false

--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -90,7 +90,7 @@ jobs:
           python-version: "3.12"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.4
+        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4
         env:
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
 
@@ -123,7 +123,7 @@ jobs:
           python-version: "3.12"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.4
+        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4
         env:
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
 
@@ -152,7 +152,7 @@ jobs:
           python-version: "3.12"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.4
+        uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084 # v3.4
         env:
           CIBW_ARCHS_WINDOWS: ${{ matrix.arch }}
 
@@ -259,7 +259,7 @@ jobs:
               --clobber
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           password: ${{ secrets.PYPI_PUBLISH }}
           packages-dir: dist/

--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -1,4 +1,4 @@
-name: Build Platform Wheels
+name: Bundle PyPI Wheels
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
 #       - "pyproject.toml"
 #       - "setup.py"
 #       - "ci/**"
-#       - ".github/workflows/build-wheels.yml"
+#       - ".github/workflows/bundle-pypi-wheels.yml"
   workflow_run:
     workflows: ["github-release"]
     types: [completed]

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -36,11 +36,11 @@ on:
         default: false
 
 jobs:
-  wheel-test:
-    uses: ./.github/workflows/wheel-test.yml
+  pure-wheel-test:
+    uses: ./.github/workflows/pure-wheel-test.yml
 
   release:
-    needs: wheel-test
+    needs: pure-wheel-test
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/pure-wheel-test.yml
+++ b/.github/workflows/pure-wheel-test.yml
@@ -1,4 +1,4 @@
-name: Wheel - Build & Test
+name: Pure Wheel - Build & Test
 
 # Validates the CONDA-FORGE install path: build a pure-Python wheel
 # from the sdist, install it on top of a conda env that provides GDAL

--- a/.github/workflows/pure-wheel-test.yml
+++ b/.github/workflows/pure-wheel-test.yml
@@ -4,14 +4,14 @@ name: Pure Wheel - Build & Test
 # from the sdist, install it on top of a conda env that provides GDAL
 # as a system package (the same shape as the conda-forge feedstock and
 # end users installing from conda). Complements
-# .github/workflows/build-wheels.yml's `test-wheels` job, which
+# .github/workflows/bundle-pypi-wheels.yml's `test-wheels` job, which
 # validates the OTHER install path — a platform wheel with native
 # libraries vendored in (`pip install pyramids-gis`, no conda).
 #
 # This workflow also runs a per-extra matrix (one job per
 # [project.optional-dependencies] entry) to verify that each extra's
 # headline dep is enough to make its marker-scoped tests pass; that
-# coverage is not duplicated in build-wheels.yml.
+# coverage is not duplicated in bundle-pypi-wheels.yml.
 
 permissions:
   contents: read

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,10 +1,10 @@
 name: pypi-release (emergency sdist-only fallback)
 
 # Emergency manual fallback that ships ONLY the sdist to PyPI. Use this
-# when build-wheels.yml is broken and conda-forge needs a new tarball
+# when bundle-pypi-wheels.yml is broken and conda-forge needs a new tarball
 # to pick up; do NOT use it for normal releases.
 #
-# The canonical release path is build-wheels.yml's `publish:` job,
+# The canonical release path is bundle-pypi-wheels.yml's `publish:` job,
 # which builds + tests + publishes sdist plus 20 platform wheels in
 # one workflow. That job fires automatically on `release: types:
 # [released]` (which github-release.yml's commitizen tag emits) and on

--- a/ci/verify-wheel.py
+++ b/ci/verify-wheel.py
@@ -16,6 +16,10 @@ checks mirror what an end user does on first import:
    store — the regression in issue #412, where the vendored libcurl
    pointed at the wheel-build prefix's `cacert.pem` (absent in the
    consuming env) and every TLS read failed to load trust anchors.
+5. A NetCDF round-trip + a foreign-`GDAL_DRIVER_PATH` override check
+   exercise the bundled netCDF driver — the regression in issue #465,
+   where an inherited conda `GDAL_DRIVER_PATH` shadowed the bundled,
+   version-locked plugins so every `.nc` read failed.
 
 Kept as a standalone file (rather than an inline `python -c "..."`
 heredoc in the workflow) so the script reads cleanly and adding a check
@@ -23,7 +27,10 @@ doesn't require fighting YAML + shell quoting.
 """
 
 import os
+import subprocess
 import sys
+import tempfile
+import textwrap
 from pathlib import Path
 
 import pyramids
@@ -119,6 +126,96 @@ def _check_tls_read() -> None:
     print("TLS /vsicurl read OK — bundled CA store loads trust anchors.")
 
 
+def _netcdf_roundtrip(nc_driver, workdir: str) -> None:
+    """Write a 1-band raster via the netCDF driver and read it back.
+
+    Self-contained (no xarray/netCDF4 needed): exercises the bundled
+    netCDF driver's write + read path. Raises on any failure. Handles
+    both the direct-raster and subdataset-container open results.
+    """
+    path = os.path.join(workdir, "verify.nc")
+    mem = gdal.GetDriverByName("MEM").Create("", 4, 3, 1, gdal.GDT_Float32)
+    mem.SetGeoTransform([0, 1, 0, 0, 0, -1])
+    if nc_driver.CreateCopy(path, mem) is None:
+        _fail("netCDF CreateCopy returned None — bundled driver cannot write (#465)")
+    ds = gdal.Open(path)
+    if ds is None:
+        _fail(f"gdal.Open({path}) returned None — netCDF read failed (#465)")
+    if ds.RasterCount == 0:
+        subs = ds.GetSubDatasets()
+        if subs:
+            ds = gdal.Open(subs[0][0])
+    if ds is None or ds.RasterCount == 0 or ds.GetRasterBand(1).ReadAsArray() is None:
+        _fail("netCDF read produced no readable raster band (#465)")
+
+
+def _check_netcdf_driver() -> None:
+    """Confirm the bundled netCDF driver loads, even under a foreign path.
+
+    Only meaningful for a bundled wheel that vendors the driver plugins.
+
+    1. Baseline (this process): the netCDF driver is registered and a
+       GDAL-written NetCDF file round-trips — guards the literal #465 /
+       #457 symptom ("not recognized as being in a supported file format").
+    2. Override (child process): pre-set GDAL_DRIVER_PATH to a foreign,
+       empty dir — exactly what an activated conda env exports for its own
+       GDAL — then import pyramids. The bootstrap must FORCE
+       GDAL_DRIVER_PATH back to the bundled, version-locked plugin dir so
+       the driver still loads. With the old `setdefault` behaviour the
+       foreign path would win and the driver would vanish. This is the
+       check that actually distinguishes the #465 fix from the bug.
+    """
+    plugins = Path(pyramids.__file__).parent / "_data" / "gdalplugins"
+    if not plugins.is_dir():
+        _fail(f"bundled wheel is missing {plugins} — driver plugins not vendored (#465)")
+
+    gdal.UseExceptions()
+    drv = gdal.GetDriverByName("netCDF")
+    if drv is None:
+        _fail("netCDF driver not registered in the bundled GDAL (#465)")
+    _netcdf_roundtrip(drv, tempfile.mkdtemp(prefix="nc-base-"))
+    print("netCDF baseline round-trip OK — bundled driver reads a NetCDF file.")
+
+    bogus = tempfile.mkdtemp(prefix="bogus-gdalplugins-")
+    env = dict(os.environ)
+    env["GDAL_DRIVER_PATH"] = bogus
+    child = textwrap.dedent(
+        """
+        import os, sys, tempfile
+        import pyramids
+        from osgeo import gdal
+        gdal.UseExceptions()
+        drv = gdal.GetDriverByName("netCDF")
+        if drv is None:
+            print("CHILD_FAIL driver=None path=%r" % os.environ.get("GDAL_DRIVER_PATH"))
+            sys.exit(3)
+        p = os.path.join(tempfile.mkdtemp(), "t.nc")
+        mem = gdal.GetDriverByName("MEM").Create("", 4, 3, 1, gdal.GDT_Float32)
+        mem.SetGeoTransform([0, 1, 0, 0, 0, -1])
+        drv.CreateCopy(p, mem)
+        ds = gdal.Open(p)
+        if ds is None or ds.GetRasterBand(1).ReadAsArray() is None:
+            print("CHILD_FAIL read p=%s" % p)
+            sys.exit(4)
+        print("CHILD_OK final_path=%s" % os.environ.get("GDAL_DRIVER_PATH"))
+        sys.stdout.flush()
+        os._exit(0)
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", child], env=env, capture_output=True, text=True, timeout=180
+    )
+    out = (result.stdout + result.stderr).strip()
+    tail = out.splitlines()[-1] if out else "(no output)"
+    print(f"netCDF override child rc={result.returncode}: {tail}")
+    if result.returncode != 0 or "CHILD_OK" not in result.stdout:
+        _fail(f"netCDF driver lost under a foreign GDAL_DRIVER_PATH — #465 fix not effective:\n{out}")
+    if bogus in result.stdout:
+        _fail(f"GDAL_DRIVER_PATH still points at the foreign dir {bogus!r} — #465 fix not effective")
+    print("netCDF override OK — bundled driver wins over a foreign GDAL_DRIVER_PATH (#465).")
+
+
+_check_netcdf_driver()
 _check_tls_read()
 
 print("All runtime checks passed.")

--- a/ci/verify-wheel.py
+++ b/ci/verify-wheel.py
@@ -206,9 +206,15 @@ def _check_netcdf_driver() -> None:
         [sys.executable, "-c", child], env=env, capture_output=True, text=True, timeout=180
     )
     out = (result.stdout + result.stderr).strip()
-    tail = out.splitlines()[-1] if out else "(no output)"
-    print(f"netCDF override child rc={result.returncode}: {tail}")
-    if result.returncode != 0 or "CHILD_OK" not in result.stdout:
+    print(f"netCDF override child rc={result.returncode}")
+    # The CHILD_OK marker — printed only after the driver loaded under the
+    # foreign GDAL_DRIVER_PATH AND a round-trip read succeeded — is the
+    # verdict, NOT the exit code. On Windows the bundled HDF5/netCDF libs can
+    # crash a worker thread during process teardown (nonzero exit, e.g.
+    # 0xC0000005) even though every check already passed, so a nonzero rc with
+    # CHILD_OK present is a teardown artifact, not a #465 regression. A crash
+    # *before* CHILD_OK leaves the marker absent and still fails here.
+    if "CHILD_OK" not in result.stdout:
         _fail(f"netCDF driver lost under a foreign GDAL_DRIVER_PATH — #465 fix not effective:\n{out}")
     if bogus in result.stdout:
         _fail(f"GDAL_DRIVER_PATH still points at the foreign dir {bogus!r} — #465 fix not effective")

--- a/src/pyramids/base/_bootstrap.py
+++ b/src/pyramids/base/_bootstrap.py
@@ -83,25 +83,44 @@ def activate_vendored_osgeo(pkg_dir: Path) -> bool:
     proj_data = data_dir / "proj_data"
     gdal_plugins = data_dir / "gdalplugins"
     ca_bundle = data_dir / "ssl" / "cacert.pem"
-    # setdefault is intentional: user-set GDAL_DATA / PROJ_DATA /
-    # PROJ_LIB / GDAL_DRIVER_PATH always win over the wheel's bundled
-    # data dirs. This lets advanced users override (e.g. point PROJ at
-    # a custom grid bundle) without having to unset our values first.
-    # Side effect: changing these env vars after import has no effect
-    # — the bootstrap reads them once at first `import pyramids`.
+    # setdefault for the DATA dirs is intentional: a user-set GDAL_DATA /
+    # PROJ_DATA / PROJ_LIB wins over the wheel's bundled data dirs. These
+    # are version-tolerant resource files, and overriding them is a
+    # legitimate advanced use case (e.g. pointing PROJ at a custom grid
+    # bundle). Side effect: changing these env vars after import has no
+    # effect — the bootstrap reads them once at first `import pyramids`.
     if gdal_data.is_dir():
         os.environ.setdefault("GDAL_DATA", str(gdal_data))
     if proj_data.is_dir():
         os.environ.setdefault("PROJ_DATA", str(proj_data))
         os.environ.setdefault("PROJ_LIB", str(proj_data))
     if gdal_plugins.is_dir():
-        # GDAL loads NetCDF / HDF4 / HDF5 drivers from this dir on
-        # Windows. The directory is populated by
-        # install-and-vendor-osgeo only on Windows builds —
-        # conda-forge's libgdal on Linux/macOS links those drivers in
-        # statically, so the dir is absent there and the is_dir()
-        # guard makes the bootstrap cross-platform.
-        os.environ.setdefault("GDAL_DRIVER_PATH", str(gdal_plugins))
+        # GDAL_DRIVER_PATH is handled DIFFERENTLY from the data dirs above:
+        # it points at compiled driver plugins (gdal_netCDF.so,
+        # gdal_HDF5.so, gdal_GRIB.so, ...) that are ABI-locked to the exact
+        # bundled libgdal build, so it is FORCED to the bundled dir rather
+        # than setdefault'd. conda-forge now ships these drivers as plugins
+        # on every platform (not statically linked), and we vendor them
+        # into `_data/gdalplugins/`.
+        #
+        # The failure this prevents (issue #465): when the wheel is
+        # imported inside an activated conda env, conda's activate.d already
+        # exports GDAL_DRIVER_PATH pointing at conda's own gdalplugins,
+        # built for a DIFFERENT libgdal version. With setdefault that
+        # inherited value would win, so the bundled libgdal would try to
+        # load conda's mismatched plugins; GDAL refuses to register them
+        # ("Function GDALRegister_netCDF of .../gdal_netCDF.so did not
+        # register a driver netCDF") and every NetCDF/HDF5 read then fails
+        # with "not recognized as being in a supported file format".
+        #
+        # A foreign GDAL_DRIVER_PATH is never safe for the bundled libgdal,
+        # so we override it. Power users who really want the bundled GDAL to
+        # load plugins from an external dir can set PYRAMIDS_KEEP_GDAL_ENV=1
+        # to restore the old "inherited GDAL_DRIVER_PATH wins" behaviour.
+        if os.environ.get("PYRAMIDS_KEEP_GDAL_ENV") == "1":
+            os.environ.setdefault("GDAL_DRIVER_PATH", str(gdal_plugins))
+        else:
+            os.environ["GDAL_DRIVER_PATH"] = str(gdal_plugins)
     if ca_bundle.is_file():
         # The bundled libcurl bakes its CA path to the wheel-build
         # prefix (`.pixi/envs/wheel-build/ssl/cacert.pem`), which is

--- a/tests/base/test_bootstrap.py
+++ b/tests/base/test_bootstrap.py
@@ -25,6 +25,15 @@ _CA_ENV_VARS = (
     "SSL_CERT_FILE",
 )
 
+# Env vars the driver-path / data-dir logic touches, plus the opt-out.
+_GDAL_ENV_VARS = (
+    "GDAL_DRIVER_PATH",
+    "GDAL_DATA",
+    "PROJ_DATA",
+    "PROJ_LIB",
+    "PYRAMIDS_KEEP_GDAL_ENV",
+)
+
 
 @pytest.fixture
 def vendored_pkg(tmp_path: Path):
@@ -34,7 +43,7 @@ def vendored_pkg(tmp_path: Path):
     present so individual tests can toggle it.
     """
 
-    def _build(with_ca: bool) -> Path:
+    def _build(with_ca: bool = False, with_plugins: bool = False) -> Path:
         osgeo = tmp_path / "_vendor" / "osgeo"
         osgeo.mkdir(parents=True)
         ext_suffix = sysconfig.get_config_var("EXT_SUFFIX") or ".so"
@@ -43,6 +52,10 @@ def vendored_pkg(tmp_path: Path):
             ssl_dir = tmp_path / "_data" / "ssl"
             ssl_dir.mkdir(parents=True)
             (ssl_dir / "cacert.pem").write_text("# fake bundle\n", encoding="utf-8")
+        if with_plugins:
+            plugins = tmp_path / "_data" / "gdalplugins"
+            plugins.mkdir(parents=True)
+            (plugins / "gdal_netCDF.so").touch()
         return tmp_path
 
     return _build
@@ -56,9 +69,10 @@ def _isolate_env_and_syspath():
     inserts the vendor dir into sys.path — both are process-global, so
     restore them to keep tests order-independent.
     """
-    saved_env = {k: os.environ.get(k) for k in _CA_ENV_VARS}
+    tracked = _CA_ENV_VARS + _GDAL_ENV_VARS
+    saved_env = {k: os.environ.get(k) for k in tracked}
     saved_path = list(sys.path)
-    for k in _CA_ENV_VARS:
+    for k in tracked:
         os.environ.pop(k, None)
     yield
     for k, v in saved_env.items():
@@ -113,3 +127,69 @@ class TestCaBundle:
         assert activate_vendored_osgeo(pkg) is True
         for var in _CA_ENV_VARS:
             assert var not in os.environ, f"{var} should be unset without a bundle"
+
+
+class TestDriverPath:
+    """GDAL_DRIVER_PATH override for the bundled, version-locked plugins (#465)."""
+
+    def test_sets_driver_path_when_unset(self, vendored_pkg):
+        """GDAL_DRIVER_PATH points at the bundled plugin dir when unset.
+
+        Test scenario:
+            A vendored package dir ships _data/gdalplugins; activation
+            with no inherited GDAL_DRIVER_PATH sets it to that dir.
+        """
+        pkg = vendored_pkg(with_plugins=True)
+        expected = str(pkg / "_data" / "gdalplugins")
+
+        assert activate_vendored_osgeo(pkg) is True
+        assert os.environ["GDAL_DRIVER_PATH"] == expected
+
+    def test_overrides_inherited_driver_path(self, vendored_pkg):
+        """A conda-style inherited GDAL_DRIVER_PATH is FORCED to the bundle.
+
+        Test scenario:
+            GDAL_DRIVER_PATH is pre-set to a foreign dir (as an activated
+            conda env exports it). Because the bundled plugins are
+            ABI-locked to the bundled libgdal, activation overrides it
+            rather than honoring the inherited value (#465).
+        """
+        pkg = vendored_pkg(with_plugins=True)
+        os.environ["GDAL_DRIVER_PATH"] = "/opt/conda/envs/x/lib/gdalplugins"
+
+        activate_vendored_osgeo(pkg)
+
+        assert os.environ["GDAL_DRIVER_PATH"] == str(pkg / "_data" / "gdalplugins")
+
+    def test_opt_out_keeps_inherited_driver_path(self, vendored_pkg):
+        """PYRAMIDS_KEEP_GDAL_ENV=1 restores the old setdefault behavior.
+
+        Test scenario:
+            With the opt-out set, a pre-set GDAL_DRIVER_PATH is preserved.
+        """
+        pkg = vendored_pkg(with_plugins=True)
+        os.environ["PYRAMIDS_KEEP_GDAL_ENV"] = "1"
+        os.environ["GDAL_DRIVER_PATH"] = "/opt/conda/envs/x/lib/gdalplugins"
+
+        activate_vendored_osgeo(pkg)
+
+        assert os.environ["GDAL_DRIVER_PATH"] == "/opt/conda/envs/x/lib/gdalplugins"
+
+    def test_data_dirs_still_respect_user_override(self, vendored_pkg):
+        """GDAL_DATA / PROJ_DATA keep setdefault semantics (not forced).
+
+        Test scenario:
+            A pre-set GDAL_DATA is left untouched even though the driver
+            path is forced — the data dirs are version-tolerant and the
+            override contract for them is intentional.
+        """
+        pkg = vendored_pkg(with_plugins=True)
+        (pkg / "_data" / "gdal_data").mkdir(parents=True)
+        (pkg / "_data" / "proj_data").mkdir(parents=True)
+        os.environ["GDAL_DATA"] = "/custom/gdal_data"
+
+        activate_vendored_osgeo(pkg)
+
+        assert os.environ["GDAL_DATA"] == "/custom/gdal_data"
+        assert os.environ["PROJ_DATA"] == str(pkg / "_data" / "proj_data")
+        assert os.environ["GDAL_DRIVER_PATH"] == str(pkg / "_data" / "gdalplugins")


### PR DESCRIPTION
# Description

The platform wheel's vendored GDAL could not read NetCDF inside a conda env — but **not** for the reason
#465's title suggests. The netCDF driver **is** vendored (the wheel ships `gdal_netCDF.so`, `gdal_HDF5.so`,
`libnetcdf`, `libhdf5`, `libhdf5_hl`, with correct RPATH and a matching libgdal hash). The real cause is a
driver-path shadowing bug in the bootstrap.

The bootstrap set `GDAL_DRIVER_PATH` with `os.environ.setdefault(...)`. When the wheel is imported inside an
activated conda env, conda's `activate.d` already exports `GDAL_DRIVER_PATH` pointing at conda's own
`gdalplugins`, built for a different libgdal version. `setdefault` then no-ops, so the bundled libgdal tries
to load conda's mismatched plugins; GDAL refuses to register them
(`Function GDALRegister_netCDF of .../gdal_netCDF.so did not register a driver netCDF`) and every NetCDF/HDF5
read fails with `not recognized as being in a supported file format`. This is the earthlens `wheel-test`
failure (6 NetCDF tests, CPython 3.11–3.14); its `main-package` job passes because there GDAL is conda's own
build with version-matched plugins.

Fix: the bundled driver plugins are ABI-locked to the exact bundled libgdal build, so an inherited
`GDAL_DRIVER_PATH` is never safe — force it to the bundled `_data/gdalplugins` dir (override, not
`setdefault`). The version-tolerant data dirs (`GDAL_DATA` / `PROJ_DATA` / `PROJ_LIB`) keep their
`setdefault` override contract, and `PYRAMIDS_KEEP_GDAL_ENV=1` restores the old behaviour for power users who
deliberately want an external driver dir. Also drops the stale comment claiming Linux/macOS link the drivers
statically.

This PR also renames the `wheel-test.yml` workflow to `pure-wheel-test.yml`. The old name collided with
`build-wheels.yml` — both build and test a wheel. `wheel-test.yml` specifically builds the pure-Python
(GDAL-less) wheel and tests it against an environment-provided GDAL, so "pure wheel" names it by what it
actually exercises and contrasts with the bundled platform wheels in `build-wheels.yml`. The
`github-release.yml` `workflow_call` path, job key, and `needs:` reference are updated to match.

No new dependencies.

# Issues
- Fixes #465

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- `tests/base/test_bootstrap.py::TestDriverPath` — 4 new unit tests (pass locally in `dev`): sets the path
  when unset; overrides an inherited conda-style path (the regression guard); opt-out preserves the inherited
  path; data dirs still honour user override.
- `ci/verify-wheel.py` — added a NetCDF round-trip plus an override check that pre-sets a foreign
  `GDAL_DRIVER_PATH` (simulating conda) in a child process and asserts the bundled driver still loads.
  Verified locally that this check FAILS on the old `setdefault` wheel (0.30.0) and passes with the fix, so
  it genuinely distinguishes the two.
- Wheel build dispatched on this branch so the full `test-wheels` matrix runs the new `verify-wheel.py`
  against freshly built wheels (Linux x86_64/aarch64, macOS, Windows × CPython 3.11–3.14).
- Workflow rename is name-only — `pure-wheel-test.yml` keeps the same jobs/steps; YAML validated and the
  `github-release.yml` `workflow_call` updated so the release path stays wired.

- [x] Bootstrap unit tests (`TestDriverPath`)
- [x] Wheel `verify-wheel.py` NetCDF + override check across the build matrix

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
