### PR TITLE
feat(netcdf): surface time coord/length + subset interleaved-layer variables (#467)

### DIFF
--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4687,6 +4687,13 @@ class NetCDF(Dataset):
             (x_start, x_stop), (y_start, y_stop), time, dims,
         )
         arr = np.asarray(md_arr[tuple(slices)].ReadAsArray())
+        # The read must keep one axis per dimension (incl. size-1 pinned ones) for
+        # the y/x axis indices to stay valid; fail loudly if a future GDAL squeezes.
+        if arr.ndim != len(dim_names):
+            raise RuntimeError(
+                f"windowed read of {variable!r} returned {arr.ndim} axes, expected "
+                f"{len(dim_names)} (one per dimension); cannot locate the spatial axes."
+            )
         # Move the spatial axes to the trailing (y, x) positions — they may be
         # interleaved in storage (e.g. (time, y, soil_layers, x)) — then collapse
         # every remaining (non-spatial) axis onto the band axis, in dim order.
@@ -4840,36 +4847,73 @@ class NetCDF(Dataset):
         trailing dimensions (the common ``(…, y, x)`` layout).
 
         Raises:
-            ValueError: if only one of ``y_dim`` / ``x_dim`` is given, or a named
-                override is not a dimension of the variable.
+            ValueError: if only one of ``y_dim`` / ``x_dim`` is given, the two are
+                equal, or a named override is not a dimension of the variable.
         """
+        override = NetCDF._override_spatial_axes(dim_names, y_dim, x_dim)
+        if override is not None:
+            return override
+        return (
+            NetCDF._cf_spatial_axes(rg, dim_names)
+            or NetCDF._named_spatial_axes(dim_names)
+            or (len(dim_names) - 2, len(dim_names) - 1)
+        )
+
+    @staticmethod
+    def _override_spatial_axes(
+        dim_names: list[str], y_dim: str | None, x_dim: str | None
+    ) -> tuple[int, int] | None:
+        """Validate and apply an explicit ``y_dim`` / ``x_dim`` override.
+
+        Returns the ``(y_axis, x_axis)`` indices when both are given, or ``None``
+        when neither is (so detection proceeds). Raises on a partial or invalid
+        override.
+        """
+        if y_dim is None and x_dim is None:
+            return None
         if (y_dim is None) != (x_dim is None):
             raise ValueError("pass both y_dim and x_dim, or neither.")
-        if y_dim is not None:
-            for value, label in ((y_dim, "y_dim"), (x_dim, "x_dim")):
-                if value not in dim_names:
-                    raise ValueError(
-                        f"{label}={value!r} is not a dimension of this variable; "
-                        f"available: {dim_names}"
-                    )
-            return dim_names.index(y_dim), dim_names.index(x_dim)
+        if y_dim == x_dim:
+            raise ValueError(f"y_dim and x_dim must differ; both are {y_dim!r}.")
+        for value, label in ((y_dim, "y_dim"), (x_dim, "x_dim")):
+            if value not in dim_names:
+                raise ValueError(
+                    f"{label}={value!r} is not a dimension of this variable; "
+                    f"available: {dim_names}"
+                )
+        return dim_names.index(y_dim), dim_names.index(x_dim)
+
+    @staticmethod
+    def _cf_spatial_axes(
+        rg: Any, dim_names: list[str]
+    ) -> tuple[int, int] | None:
+        """``(y_axis, x_axis)`` from CF coordinate attributes, or ``None``.
+
+        Returns ``None`` when there is no root group or the coordinate variables
+        don't carry recognisable spatial attributes for both axes.
+        """
+        if rg is None:
+            return None
         y_idx = x_idx = None
-        if rg is not None:
-            for axis, name in enumerate(dim_names):
-                role = NetCDF._axis_role(rg, name)
-                if role == "Y" and y_idx is None:
-                    y_idx = axis
-                elif role == "X" and x_idx is None:
-                    x_idx = axis
-        if y_idx is None or x_idx is None:
-            lowered = [n.lower() for n in dim_names]
-            y_named = next((i for i, n in enumerate(lowered) if n in _Y_DIM_NAMES), None)
-            x_named = next((i for i, n in enumerate(lowered) if n in _X_DIM_NAMES), None)
-            if y_named is not None and x_named is not None:
-                y_idx, x_idx = y_named, x_named
-        if y_idx is None or x_idx is None:
-            return len(dim_names) - 2, len(dim_names) - 1
-        return y_idx, x_idx
+        for axis, name in enumerate(dim_names):
+            role = NetCDF._axis_role(rg, name)
+            if role == "Y" and y_idx is None:
+                y_idx = axis
+            elif role == "X" and x_idx is None:
+                x_idx = axis
+            if y_idx is not None and x_idx is not None:
+                return y_idx, x_idx
+        return None
+
+    @staticmethod
+    def _named_spatial_axes(dim_names: list[str]) -> tuple[int, int] | None:
+        """``(y_axis, x_axis)`` from well-known dimension names, or ``None``."""
+        lowered = [n.lower() for n in dim_names]
+        y_named = next((i for i, n in enumerate(lowered) if n in _Y_DIM_NAMES), None)
+        x_named = next((i for i, n in enumerate(lowered) if n in _X_DIM_NAMES), None)
+        if y_named is not None and x_named is not None:
+            return y_named, x_named
+        return None
 
     @staticmethod
     def _read_axis_coords(rg: Any, name: str, axis_label: str) -> np.ndarray:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4689,11 +4689,7 @@ class NetCDF(Dataset):
         arr = np.asarray(md_arr[tuple(slices)].ReadAsArray())
         # The read must keep one axis per dimension (incl. size-1 pinned ones) for
         # the y/x axis indices to stay valid; fail loudly if a future GDAL squeezes.
-        if arr.ndim != len(dim_names):
-            raise RuntimeError(
-                f"windowed read of {variable!r} returned {arr.ndim} axes, expected "
-                f"{len(dim_names)} (one per dimension); cannot locate the spatial axes."
-            )
+        self._assert_full_rank(arr, len(dim_names), variable)
         # Move the spatial axes to the trailing (y, x) positions — they may be
         # interleaved in storage (e.g. (time, y, soil_layers, x)) — then collapse
         # every remaining (non-spatial) axis onto the band axis, in dim order.
@@ -4798,6 +4794,45 @@ class NetCDF(Dataset):
         return arr, geo
 
     @staticmethod
+    def _assert_full_rank(arr: np.ndarray, n_dims: int, variable: str) -> None:
+        """Assert a windowed read kept one axis per dimension (incl. size-1 ones).
+
+        ``subset`` locates the spatial axes by their dimension index, so the array
+        returned by the windowed read must have exactly ``n_dims`` axes; a future
+        GDAL that squeezed singleton axes would invalidate those indices.
+
+        Args:
+            arr: The array returned by the windowed MDArray read.
+            n_dims: The variable's dimension count.
+            variable: Variable name, for the error message.
+
+        Raises:
+            RuntimeError: when ``arr.ndim != n_dims``.
+
+        Examples:
+            - A matching rank is accepted (returns ``None``)::
+
+                >>> import numpy as np
+                >>> from pyramids.netcdf import NetCDF
+                >>> NetCDF._assert_full_rank(np.zeros((1, 4, 5)), 3, "soil") is None
+                True
+
+            - A squeezed read is rejected::
+
+                >>> import numpy as np
+                >>> from pyramids.netcdf import NetCDF
+                >>> NetCDF._assert_full_rank(np.zeros((4, 5)), 3, "soil")
+                Traceback (most recent call last):
+                    ...
+                RuntimeError: windowed read of 'soil' returned 2 axes, expected 3; cannot locate the spatial axes.
+        """
+        if arr.ndim != n_dims:
+            raise RuntimeError(
+                f"windowed read of {variable!r} returned {arr.ndim} axes, expected "
+                f"{n_dims}; cannot locate the spatial axes."
+            )
+
+    @staticmethod
     def _axis_role(rg: Any, name: str) -> str | None:
         """CF spatial role of a coordinate variable: ``"Y"``, ``"X"``, or ``None``.
 
@@ -4838,11 +4873,11 @@ class NetCDF(Dataset):
         standard = attrs.get("standard_name", "")
         units = attrs.get("units", "")
         if standard in ("latitude", "projection_y_coordinate", "grid_latitude") or (
-            units in ("degrees_north", "degree_north", "degrees_n")
+            units in ("degrees_north", "degree_north", "degrees_n", "degree_n")
         ):
             return "Y"
         if standard in ("longitude", "projection_x_coordinate", "grid_longitude") or (
-            units in ("degrees_east", "degree_east", "degrees_e")
+            units in ("degrees_east", "degree_east", "degrees_e", "degree_e")
         ):
             return "X"
         return None

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -153,6 +153,17 @@ _REDUCERS: dict[str, tuple[Any, Any]] = {
 # ``grid_mapping_name="geostationary"`` grid-mapping).
 GEOSTATIONARY_PROJECTION = "Geostationary_Satellite"
 
+# Well-known dimension names for the spatial axes, used by
+# ``NetCDF._detect_spatial_axes`` as a fallback when the coordinate variables
+# carry no CF axis / standard_name / units attributes (e.g. NWM names them
+# plainly ``x`` / ``y``). Compared case-insensitively.
+_Y_DIM_NAMES = frozenset(
+    {"y", "lat", "latitude", "rlat", "south_north", "northing", "grid_latitude"}
+)
+_X_DIM_NAMES = frozenset(
+    {"x", "lon", "longitude", "rlon", "west_east", "easting", "grid_longitude"}
+)
+
 
 def _contiguous_range(
     coords: np.ndarray,
@@ -2755,6 +2766,63 @@ class NetCDF(Dataset):
                     time_stamp = list(map(func, time_vals.reshape(-1)))
         return time_stamp
 
+    @property
+    def dimension_sizes(self) -> dict[str, int]:
+        """Logical size of every dimension, in storage order, as ``{name: size}``.
+
+        Reads the true dimension lengths from the multidimensional root group
+        (e.g. ``{"time": 128568, "y": 3840, "x": 4608}``). Prefer this over
+        :attr:`shape` on a chunked cloud store: ``shape`` reflects the classic
+        single-raster view (band count + a chunk-sized window), so a remote Zarr
+        whose CF time axis GDAL can't parse reports ``(0, chunk_y, chunk_x)``
+        rather than the logical grid. Empty for a variable subset (no root group).
+
+        Returns:
+            dict[str, int]: Mapping of dimension name to its length; ``{}`` when
+            the cube is a variable subset rather than a root MDIM container.
+
+        Examples:
+            - True grid sizes of a NWM retrospective cube (needs the bucket)::
+
+                >>> nc.dimension_sizes  # doctest: +SKIP
+                {'soil_layers_stag': 4, 'time': 128568, 'vis_nir': 2, 'x': 4608, 'y': 3840}
+        """
+        rg = self._raster.GetRootGroup() if self._raster is not None else None
+        if rg is None:
+            return {}
+        return {dim.GetName(): int(dim.GetSize()) for dim in rg.GetDimensions()}
+
+    def get_time_values(self, var_name: str = "time") -> np.ndarray | None:
+        """Raw (undecoded) values of the time coordinate, or ``None`` if absent.
+
+        Use this when :meth:`get_time_variable` returns ``None`` because the
+        store's CF ``units`` are not parseable — some cloud Zarr stores do not
+        surface ``units`` through GDAL, so dates can't be decoded. The raw
+        offsets, together with the dimension's ``calendar`` / ``units`` attributes
+        (``meta_data.get_dimension(var_name).attrs``) and :attr:`dimension_sizes`,
+        let a caller map a date window to integer indices for :meth:`subset` and
+        detect out-of-range — instead of hard-coding an unverifiable schedule.
+
+        Args:
+            var_name: Name of the time coordinate / dimension. Defaults to
+                ``"time"``.
+
+        Returns:
+            numpy.ndarray or None: The raw coordinate values, or ``None`` when
+            the store has no such dimension.
+
+        Examples:
+            - Raw 3-hourly offsets of the NWM retrospective cube (needs the
+              bucket)::
+
+                >>> nc.get_time_values("time")[:3]  # doctest: +SKIP
+                array([0, 3, 6])
+        """
+        names = self.dimension_names
+        if names is None or var_name not in names:
+            return None
+        return self._read_variable(var_name)
+
     def _get_dimension_names(self) -> list[str] | None:
         """Return all dimension names, in storage order.
 
@@ -4475,6 +4543,8 @@ class NetCDF(Dataset):
         bbox: tuple[float, float, float, float] | list[float] | None = None,
         crs: int | str = 4326,
         densify: int = 25,
+        y_dim: str | None = None,
+        x_dim: str | None = None,
         **dims: int | tuple[int, int] | slice,
     ) -> Dataset:
         """Read a windowed ``(variable, time, bbox)`` slice of a gridded cube.
@@ -4511,10 +4581,19 @@ class NetCDF(Dataset):
             densify: Points per bbox edge used when reprojecting the box onto a
                 projected grid, so the envelope encloses the curved boundary
                 (conservative over-cover). Defaults to ``25``.
+            y_dim: Name of the ``y`` (row) dimension. Defaults to ``None`` —
+                auto-detected from CF axis / ``standard_name`` / ``units``
+                attributes, then well-known names (``y``/``lat``/…), then the
+                trailing two dims. Pass it (with ``x_dim``) to override when the
+                spatial axes can't be inferred.
+            x_dim: Name of the ``x`` (column) dimension. ``None`` auto-detects as
+                for ``y_dim``. Pass both ``y_dim`` and ``x_dim`` together.
             **dims: Index selector for any extra non-spatial dimension (e.g.
                 ``vis_nir=0``, ``soil_layers_stag=2``). Required for every such
-                dimension whose length is > 1. A key that is not a selectable
-                non-spatial dimension of the variable is an error.
+                dimension whose length is > 1, **including a layer dim
+                interleaved between ``y`` and ``x``** (e.g. NWM ``SOIL_M`` is
+                ``(time, y, soil_layers_stag, x)`` — pass ``soil_layers_stag=0``).
+                A key that is not a selectable non-spatial dimension is an error.
 
         Returns:
             Dataset: A georeferenced raster on the store's native CRS — one band
@@ -4569,8 +4648,11 @@ class NetCDF(Dataset):
             )
         dim_names = [d.GetName() for d in dim_objs]
         dim_sizes = [int(d.GetSize()) for d in dim_objs]
-        # GDAL exposes a gridded MDArray with the spatial axes last: (..., y, x).
-        y_axis, x_axis = len(dim_objs) - 2, len(dim_objs) - 1
+        # Locate the spatial axes by CF attributes / well-known names (falling
+        # back to the trailing two dims), so a variable whose layer dim is
+        # interleaved between y and x — e.g. NWM SOIL_M (time, y, soil_layers, x)
+        # — is windowed correctly rather than mistaking the layer dim for y.
+        y_axis, x_axis = self._detect_spatial_axes(rg, dim_names, y_dim, x_dim)
         x_coords = self._read_axis_coords(rg, dim_names[x_axis], "x")
         y_coords = self._read_axis_coords(rg, dim_names[y_axis], "y")
 
@@ -4605,7 +4687,10 @@ class NetCDF(Dataset):
             (x_start, x_stop), (y_start, y_stop), time, dims,
         )
         arr = np.asarray(md_arr[tuple(slices)].ReadAsArray())
-        # Collapse every selected non-spatial axis onto the band axis.
+        # Move the spatial axes to the trailing (y, x) positions — they may be
+        # interleaved in storage (e.g. (time, y, soil_layers, x)) — then collapse
+        # every remaining (non-spatial) axis onto the band axis, in dim order.
+        arr = np.moveaxis(arr, (y_axis, x_axis), (-2, -1))
         arr = arr.reshape(-1, arr.shape[-2], arr.shape[-1])
         arr, geo = self._north_up_geobox(
             arr, x_coords, y_coords, (x_start, x_stop), (y_start, y_stop)
@@ -4704,6 +4789,87 @@ class NetCDF(Dataset):
             float(y_vals[0] + d_y / 2.0), 0.0, -float(d_y),
         )
         return arr, geo
+
+    @staticmethod
+    def _axis_role(rg: Any, name: str) -> str | None:
+        """CF spatial role of a coordinate variable: ``"Y"``, ``"X"``, or ``None``.
+
+        Inspects the coordinate array's ``axis`` / ``standard_name`` / ``units``
+        attributes. Returns ``None`` when the dimension has no coordinate array
+        or no recognisable spatial attribute.
+        """
+        try:
+            coord = rg.OpenMDArray(name)
+        except RuntimeError:
+            coord = None
+        if coord is None:
+            return None
+        attrs: dict[str, str] = {}
+        for attr in coord.GetAttributes():
+            try:
+                attrs[attr.GetName().lower()] = attr.ReadAsString().lower()
+            except (RuntimeError, AttributeError):
+                continue
+        axis = attrs.get("axis")
+        if axis in ("y", "x"):
+            return axis.upper()
+        standard = attrs.get("standard_name", "")
+        units = attrs.get("units", "")
+        if standard in ("latitude", "projection_y_coordinate", "grid_latitude") or (
+            units in ("degrees_north", "degree_north", "degrees_n")
+        ):
+            return "Y"
+        if standard in ("longitude", "projection_x_coordinate", "grid_longitude") or (
+            units in ("degrees_east", "degree_east", "degrees_e")
+        ):
+            return "X"
+        return None
+
+    @staticmethod
+    def _detect_spatial_axes(
+        rg: Any,
+        dim_names: list[str],
+        y_dim: str | None,
+        x_dim: str | None,
+    ) -> tuple[int, int]:
+        """Resolve the ``(y_axis, x_axis)`` indices of a gridded variable.
+
+        Resolution order: an explicit ``y_dim`` / ``x_dim`` override → CF axis /
+        ``standard_name`` / ``units`` attributes on the coordinate variables →
+        well-known dimension names (``y``/``lat``/…, ``x``/``lon``/…) → the two
+        trailing dimensions (the common ``(…, y, x)`` layout).
+
+        Raises:
+            ValueError: if only one of ``y_dim`` / ``x_dim`` is given, or a named
+                override is not a dimension of the variable.
+        """
+        if (y_dim is None) != (x_dim is None):
+            raise ValueError("pass both y_dim and x_dim, or neither.")
+        if y_dim is not None:
+            for value, label in ((y_dim, "y_dim"), (x_dim, "x_dim")):
+                if value not in dim_names:
+                    raise ValueError(
+                        f"{label}={value!r} is not a dimension of this variable; "
+                        f"available: {dim_names}"
+                    )
+            return dim_names.index(y_dim), dim_names.index(x_dim)
+        y_idx = x_idx = None
+        if rg is not None:
+            for axis, name in enumerate(dim_names):
+                role = NetCDF._axis_role(rg, name)
+                if role == "Y" and y_idx is None:
+                    y_idx = axis
+                elif role == "X" and x_idx is None:
+                    x_idx = axis
+        if y_idx is None or x_idx is None:
+            lowered = [n.lower() for n in dim_names]
+            y_named = next((i for i, n in enumerate(lowered) if n in _Y_DIM_NAMES), None)
+            x_named = next((i for i, n in enumerate(lowered) if n in _X_DIM_NAMES), None)
+            if y_named is not None and x_named is not None:
+                y_idx, x_idx = y_named, x_named
+        if y_idx is None or x_idx is None:
+            return len(dim_names) - 2, len(dim_names) - 1
+        return y_idx, x_idx
 
     @staticmethod
     def _read_axis_coords(rg: Any, name: str, axis_label: str) -> np.ndarray:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4804,6 +4804,21 @@ class NetCDF(Dataset):
         Inspects the coordinate array's ``axis`` / ``standard_name`` / ``units``
         attributes. Returns ``None`` when the dimension has no coordinate array
         or no recognisable spatial attribute.
+
+        Args:
+            rg: The store's multidimensional root :class:`osgeo.gdal.Group`.
+            name: Dimension / coordinate name to inspect.
+
+        Returns:
+            str or None: ``"Y"`` for a latitude / northing axis, ``"X"`` for a
+            longitude / easting axis, or ``None`` when the role can't be
+            determined.
+
+        Examples:
+            - Inspect a latitude coordinate of an opened multidim store::
+
+                >>> nc._axis_role(nc._raster.GetRootGroup(), "lat")  # doctest: +SKIP
+                'Y'
         """
         try:
             coord = rg.OpenMDArray(name)
@@ -4846,9 +4861,33 @@ class NetCDF(Dataset):
         well-known dimension names (``y``/``lat``/…, ``x``/``lon``/…) → the two
         trailing dimensions (the common ``(…, y, x)`` layout).
 
+        Args:
+            rg: The multidimensional root group (``None`` skips CF-attribute
+                detection — used by the pure name/trailing fallbacks).
+            dim_names: The variable's dimension names, in storage order.
+            y_dim: Optional explicit name of the ``y`` dimension.
+            x_dim: Optional explicit name of the ``x`` dimension.
+
+        Returns:
+            tuple[int, int]: The ``(y_axis, x_axis)`` indices into ``dim_names``.
+
         Raises:
             ValueError: if only one of ``y_dim`` / ``x_dim`` is given, the two are
                 equal, or a named override is not a dimension of the variable.
+
+        Examples:
+            - A layer dim interleaved between ``y`` and ``x`` is still resolved
+              by name (``rg=None`` skips the CF-attribute step)::
+
+                >>> from pyramids.netcdf import NetCDF
+                >>> NetCDF._detect_spatial_axes(None, ["time", "y", "level", "x"], None, None)
+                (1, 3)
+
+            - An explicit override wins regardless of position::
+
+                >>> from pyramids.netcdf import NetCDF
+                >>> NetCDF._detect_spatial_axes(None, ["time", "y", "x"], "y", "x")
+                (1, 2)
         """
         override = NetCDF._override_spatial_axes(dim_names, y_dim, x_dim)
         if override is not None:
@@ -4865,9 +4904,32 @@ class NetCDF(Dataset):
     ) -> tuple[int, int] | None:
         """Validate and apply an explicit ``y_dim`` / ``x_dim`` override.
 
-        Returns the ``(y_axis, x_axis)`` indices when both are given, or ``None``
-        when neither is (so detection proceeds). Raises on a partial or invalid
-        override.
+        Args:
+            dim_names: The variable's dimension names, in storage order.
+            y_dim: Explicit ``y`` dimension name, or ``None``.
+            x_dim: Explicit ``x`` dimension name, or ``None``.
+
+        Returns:
+            tuple[int, int] or None: The ``(y_axis, x_axis)`` indices when both
+            names are given; ``None`` when neither is (so auto-detection
+            proceeds).
+
+        Raises:
+            ValueError: when exactly one name is given, the two are equal, or a
+                name is not a dimension of the variable.
+
+        Examples:
+            - Both names resolve to their indices::
+
+                >>> from pyramids.netcdf import NetCDF
+                >>> NetCDF._override_spatial_axes(["time", "y", "x"], "y", "x")
+                (1, 2)
+
+            - Neither name defers to auto-detection (returns ``None``)::
+
+                >>> from pyramids.netcdf import NetCDF
+                >>> NetCDF._override_spatial_axes(["y", "x"], None, None) is None
+                True
         """
         if y_dim is None and x_dim is None:
             return None
@@ -4891,6 +4953,21 @@ class NetCDF(Dataset):
 
         Returns ``None`` when there is no root group or the coordinate variables
         don't carry recognisable spatial attributes for both axes.
+
+        Args:
+            rg: The multidimensional root group, or ``None``.
+            dim_names: The variable's dimension names, in storage order.
+
+        Returns:
+            tuple[int, int] or None: The ``(y_axis, x_axis)`` indices when both
+            spatial axes are identified from coordinate attributes, else ``None``.
+
+        Examples:
+            - Without a root group there are no attributes to read::
+
+                >>> from pyramids.netcdf import NetCDF
+                >>> NetCDF._cf_spatial_axes(None, ["time", "y", "x"]) is None
+                True
         """
         if rg is None:
             return None
@@ -4907,7 +4984,31 @@ class NetCDF(Dataset):
 
     @staticmethod
     def _named_spatial_axes(dim_names: list[str]) -> tuple[int, int] | None:
-        """``(y_axis, x_axis)`` from well-known dimension names, or ``None``."""
+        """``(y_axis, x_axis)`` from well-known dimension names, or ``None``.
+
+        Matches each dimension name case-insensitively against
+        :data:`_Y_DIM_NAMES` / :data:`_X_DIM_NAMES`.
+
+        Args:
+            dim_names: The variable's dimension names, in storage order.
+
+        Returns:
+            tuple[int, int] or None: The ``(y_axis, x_axis)`` indices when both a
+            y-like and an x-like name are present, else ``None``.
+
+        Examples:
+            - Recognised names resolve even when interleaved::
+
+                >>> from pyramids.netcdf import NetCDF
+                >>> NetCDF._named_spatial_axes(["time", "y", "soil", "x"])
+                (1, 3)
+
+            - Unrecognised names return ``None``::
+
+                >>> from pyramids.netcdf import NetCDF
+                >>> NetCDF._named_spatial_axes(["time", "a", "b"]) is None
+                True
+        """
         lowered = [n.lower() for n in dim_names]
         y_named = next((i for i, n in enumerate(lowered) if n in _Y_DIM_NAMES), None)
         x_named = next((i for i, n in enumerate(lowered) if n in _X_DIM_NAMES), None)

--- a/tests/netcdf/test_subset.py
+++ b/tests/netcdf/test_subset.py
@@ -238,6 +238,132 @@ def _fake_group(arrays):
     return rg
 
 
+def _fake_group_with_attrs(coords):
+    """A Mock root group whose coords expose CF attributes via ``GetAttributes``.
+
+    ``coords`` maps a dimension name to either a ``{attr_name: value}`` dict (the
+    coordinate's string attributes) or ``None`` to make ``OpenMDArray`` raise as
+    GDAL does for a dimension with no coordinate variable.
+    """
+
+    def open_mdarray(name):
+        if name not in coords or coords[name] is None:
+            raise RuntimeError(f"Array {name} does not exist")
+        attr_objs = []
+        for attr_name, value in coords[name].items():
+            attr = Mock()
+            attr.GetName.return_value = attr_name
+            attr.ReadAsString.return_value = value
+            attr_objs.append(attr)
+        coord = Mock()
+        coord.GetAttributes.return_value = attr_objs
+        return coord
+
+    rg = Mock()
+    rg.OpenMDArray.side_effect = open_mdarray
+    return rg
+
+
+class TestAxisRole:
+    """``_axis_role`` maps a coordinate's CF attributes to ``"Y"``/``"X"``/None."""
+
+    @pytest.mark.parametrize(
+        "attrs, expected",
+        [
+            ({"axis": "Y"}, "Y"),
+            ({"axis": "X"}, "X"),
+            ({"axis": "T"}, None),
+            ({"standard_name": "latitude"}, "Y"),
+            ({"standard_name": "longitude"}, "X"),
+            ({"standard_name": "projection_y_coordinate"}, "Y"),
+            ({"standard_name": "projection_x_coordinate"}, "X"),
+            ({"standard_name": "grid_latitude"}, "Y"),
+            ({"standard_name": "grid_longitude"}, "X"),
+            ({"units": "degrees_north"}, "Y"),
+            ({"units": "degrees_east"}, "X"),
+            ({"units": "metre"}, None),
+            ({"long_name": "something"}, None),
+        ],
+    )
+    def test_attribute_roles(self, attrs, expected):
+        """Each recognised CF attribute maps to the right axis role (else None).
+
+        Args:
+            attrs: The coordinate variable's string attributes.
+            expected: The expected ``"Y"`` / ``"X"`` / ``None`` role.
+        """
+        rg = _fake_group_with_attrs({"c": attrs})
+        assert NetCDF._axis_role(rg, "c") == expected, f"attrs={attrs}"
+
+    def test_missing_coordinate_is_none(self):
+        """A dimension with no coordinate variable yields ``None`` (not an error).
+
+        Test scenario:
+            ``OpenMDArray`` raises ``RuntimeError`` -> role is ``None``.
+        """
+        rg = _fake_group_with_attrs({"c": None})
+        assert NetCDF._axis_role(rg, "c") is None, "missing coord should be None"
+
+    def test_unreadable_attribute_is_skipped(self):
+        """An attribute whose ``ReadAsString`` raises is skipped; others still read.
+
+        Test scenario:
+            A numeric ``valid_min`` (ReadAsString raises) alongside ``axis=Y`` ->
+            still detected as ``"Y"``.
+        """
+        bad = Mock()
+        bad.GetName.return_value = "valid_min"
+        bad.ReadAsString.side_effect = RuntimeError("not a string")
+        good = Mock()
+        good.GetName.return_value = "axis"
+        good.ReadAsString.return_value = "Y"
+        coord = Mock()
+        coord.GetAttributes.return_value = [bad, good]
+        rg = Mock()
+        rg.OpenMDArray.side_effect = lambda name: coord
+        assert NetCDF._axis_role(rg, "y") == "Y", "unreadable attr should be skipped"
+
+
+class TestCfSpatialAxes:
+    """``_cf_spatial_axes`` finds the spatial axes from coordinate attributes."""
+
+    def test_none_when_no_root_group(self):
+        """``rg is None`` -> ``None`` (detection falls through to names).
+
+        Test scenario:
+            No multidimensional root group available.
+        """
+        assert NetCDF._cf_spatial_axes(None, ["time", "y", "x"]) is None
+
+    def test_detects_interleaved_axes_by_attrs(self):
+        """CF attrs locate y/x even when a layer dim is interleaved between them.
+
+        Test scenario:
+            ``(time, y, level, x)`` with axis attrs on y/x -> ``(1, 3)``.
+        """
+        rg = _fake_group_with_attrs(
+            {
+                "time": {"axis": "T"},
+                "y": {"axis": "Y"},
+                "level": {"long_name": "soil layer"},
+                "x": {"axis": "X"},
+            }
+        )
+        out = NetCDF._cf_spatial_axes(rg, ["time", "y", "level", "x"])
+        assert out == (1, 3), f"expected (1, 3), got {out}"
+
+    def test_none_when_only_one_axis_has_attrs(self):
+        """Only one recognisable spatial axis -> ``None`` (incomplete).
+
+        Test scenario:
+            y carries an axis attr but x does not -> cannot resolve a pair.
+        """
+        rg = _fake_group_with_attrs(
+            {"time": None, "y": {"axis": "Y"}, "x": {"long_name": "col"}}
+        )
+        assert NetCDF._cf_spatial_axes(rg, ["time", "y", "x"]) is None
+
+
 class TestMdArrayNoData:
     """``_md_array_no_data`` prefers the driver value, then CF attrs, else None."""
 
@@ -483,6 +609,13 @@ class TestDimensionSizesAndTimeValues:
     def test_get_time_values_missing_dim_returns_none(self, tmp_path):
         nc = _synthetic_cube(tmp_path)
         assert nc.get_time_values("nope") is None
+
+    def test_dimension_sizes_empty_for_variable_subset(self, tmp_path):
+        # A variable subset is a classic-mode dataset with no root group, so
+        # dimension_sizes is empty (documented behaviour).
+        nc = _synthetic_cube(tmp_path)
+        var = nc.get_variable("temp")
+        assert var.dimension_sizes == {}
 
 
 class TestDetectSpatialAxes:

--- a/tests/netcdf/test_subset.py
+++ b/tests/netcdf/test_subset.py
@@ -280,7 +280,9 @@ class TestAxisRole:
             ({"standard_name": "grid_latitude"}, "Y"),
             ({"standard_name": "grid_longitude"}, "X"),
             ({"units": "degrees_north"}, "Y"),
+            ({"units": "degree_n"}, "Y"),
             ({"units": "degrees_east"}, "X"),
+            ({"units": "degree_e"}, "X"),
             ({"units": "metre"}, None),
             ({"long_name": "something"}, None),
         ],
@@ -322,6 +324,29 @@ class TestAxisRole:
         rg = Mock()
         rg.OpenMDArray.side_effect = lambda name: coord
         assert NetCDF._axis_role(rg, "y") == "Y", "unreadable attr should be skipped"
+
+
+class TestAssertFullRank:
+    """``_assert_full_rank`` guards that a windowed read kept one axis per dim."""
+
+    def test_matching_rank_is_accepted(self):
+        """An array with one axis per dimension passes (returns ``None``).
+
+        Test scenario:
+            A (1, 4, 5) read for a 3-D variable -> no error.
+        """
+        assert NetCDF._assert_full_rank(np.zeros((1, 4, 5)), 3, "soil") is None
+
+    def test_squeezed_read_raises(self):
+        """A read missing an axis raises a clear ``RuntimeError``.
+
+        Test scenario:
+            A (4, 5) read for a 3-D variable -> RuntimeError naming the variable
+            and the expected axis count.
+        """
+        with pytest.raises(RuntimeError, match="returned 2 axes, expected 3") as exc:
+            NetCDF._assert_full_rank(np.zeros((4, 5)), 3, "soil")
+        assert "soil" in str(exc.value), f"variable name missing: {exc.value}"
 
 
 class TestCfSpatialAxes:

--- a/tests/netcdf/test_subset.py
+++ b/tests/netcdf/test_subset.py
@@ -499,6 +499,10 @@ class TestDetectSpatialAxes:
         with pytest.raises(ValueError, match="not a dimension"):
             NetCDF._detect_spatial_axes(None, ["y", "x"], "lat", "lon")
 
+    def test_equal_override_raises(self):
+        with pytest.raises(ValueError, match="must differ"):
+            NetCDF._detect_spatial_axes(None, ["time", "y", "x"], "x", "x")
+
     def test_well_known_names_when_no_attrs(self):
         # rg=None -> CF-attr detection skipped; fall back to known names. y/x are
         # interleaved around a layer dim, so this is NOT the trailing-two case.
@@ -536,6 +540,21 @@ class TestSubsetInterleavedLayer:
         nc = _synthetic_cube(tmp_path, with_interleaved=True)
         ds = nc.subset("soil", time=0, level=0, y_dim="y", x_dim="x")
         assert (ds.rows, ds.columns) == (4, 5)
+
+    def test_interleaved_layer_range_is_multiband_in_c_order(self, tmp_path):
+        # L3: a ranged interleaved layer -> one band per layer, labelled and
+        # ordered to match the C-order band flatten after moveaxis.
+        nc = _synthetic_cube(tmp_path, with_interleaved=True)
+        ds = nc.subset("soil", time=0, level=(0, 2))
+        assert ds.band_count == 2
+        assert ds.band_names == ["level=0", "level=1"]
+        n_y, n_x, n_lev = 4, 5, 2
+        full = np.arange(3 * n_y * n_lev * n_x, dtype="float64").reshape(
+            3, n_y, n_lev, n_x
+        )
+        bands = np.asarray(ds.read_array())  # (2, rows, cols); row 0 = north (y=3)
+        assert list(bands[0][0]) == list(full[0, 3, 0, :])
+        assert list(bands[1][0]) == list(full[0, 3, 1, :])
 
 
 @pytest.mark.slow

--- a/tests/netcdf/test_subset.py
+++ b/tests/netcdf/test_subset.py
@@ -286,6 +286,7 @@ def _synthetic_cube(
     with_coords=True,
     with_extra=False,
     with_no_time=False,
+    with_interleaved=False,
     x_descending=False,
     step=1.0,
 ):
@@ -294,21 +295,27 @@ def _synthetic_cube(
     The ``y`` axis ascends (south->north) so the north-up normalisation in
     ``subset`` is exercised. ``temp`` holds ``np.arange`` values so band
     orientation can be verified exactly; with ``with_extra`` a 4-D ``flux`` adds
-    a non-spatial ``level`` axis for ``**dims`` coverage; with ``with_no_time`` a
-    3-D ``ens(member, y, x)`` adds a non-time leading axis. ``with_coords=False``
+    a non-spatial ``level`` axis (``time, level, y, x``) for ``**dims`` coverage;
+    with ``with_interleaved`` a 4-D ``soil`` puts the layer dim BETWEEN the
+    spatial axes (``time, y, level, x``); with ``with_no_time`` a 3-D
+    ``ens(member, y, x)`` adds a non-time leading axis. ``with_coords=False``
     drops the ``y`` / ``x`` coordinate variables (the missing-coordinate case).
     ``step`` scales the ``x`` / ``y`` cell spacing (to test cell-size handling).
     """
     xr = pytest.importorskip("xarray")
-    n_t, n_y, n_x = 3, 4, 5
+    n_t, n_y, n_x, n_lev = 3, 4, 5, 2
     temp = np.arange(n_t * n_y * n_x, dtype="float64").reshape(n_t, n_y, n_x)
     data_vars = {"temp": (("time", "y", "x"), temp)}
     if with_extra:
-        n_lev = 2
         flux = np.arange(n_t * n_lev * n_y * n_x, dtype="float64").reshape(
             n_t, n_lev, n_y, n_x
         )
         data_vars["flux"] = (("time", "level", "y", "x"), flux)
+    if with_interleaved:
+        soil = np.arange(n_t * n_y * n_lev * n_x, dtype="float64").reshape(
+            n_t, n_y, n_lev, n_x
+        )
+        data_vars["soil"] = (("time", "y", "level", "x"), soil)
     if with_no_time:
         n_member = 2
         ens = np.arange(n_member * n_y * n_x, dtype="float64").reshape(
@@ -324,8 +331,8 @@ def _synthetic_cube(
             "y": 10.0 + np.arange(n_y, dtype="float64") * step,  # ascending
             "x": x_vals,
         }
-        if with_extra:
-            coords["level"] = np.arange(2)
+        if with_extra or with_interleaved:
+            coords["level"] = np.arange(n_lev)
         if with_no_time:
             coords["member"] = np.arange(2)
     ds = xr.Dataset(data_vars, coords=coords)
@@ -459,6 +466,78 @@ class TestSubsetOffline:
         assert abs(ds.geotransform[5]) == pytest.approx(1000.0)
 
 
+class TestDimensionSizesAndTimeValues:
+    """G-1: surface true dimension sizes + raw time values (CF-unparseable case)."""
+
+    def test_dimension_sizes_reports_true_lengths(self, tmp_path):
+        nc = _synthetic_cube(tmp_path, with_extra=True)
+        assert nc.dimension_sizes == {"time": 3, "y": 4, "x": 5, "level": 2}
+
+    def test_get_time_values_returns_raw_coordinate(self, tmp_path):
+        # The synthetic store has no CF time units (like the NWM Zarr), so
+        # get_time_variable() is None but the raw coordinate is still readable.
+        nc = _synthetic_cube(tmp_path)
+        assert nc.get_time_variable() is None
+        assert list(nc.get_time_values("time")) == [0, 1, 2]
+
+    def test_get_time_values_missing_dim_returns_none(self, tmp_path):
+        nc = _synthetic_cube(tmp_path)
+        assert nc.get_time_values("nope") is None
+
+
+class TestDetectSpatialAxes:
+    """G-2: locate the spatial axes by override / CF attrs / name / trailing."""
+
+    def test_explicit_override(self):
+        assert NetCDF._detect_spatial_axes(None, ["time", "y", "lev", "x"], "y", "x") == (1, 3)
+
+    def test_only_one_override_raises(self):
+        with pytest.raises(ValueError, match="both y_dim and x_dim"):
+            NetCDF._detect_spatial_axes(None, ["y", "x"], "y", None)
+
+    def test_unknown_override_raises(self):
+        with pytest.raises(ValueError, match="not a dimension"):
+            NetCDF._detect_spatial_axes(None, ["y", "x"], "lat", "lon")
+
+    def test_well_known_names_when_no_attrs(self):
+        # rg=None -> CF-attr detection skipped; fall back to known names. y/x are
+        # interleaved around a layer dim, so this is NOT the trailing-two case.
+        assert NetCDF._detect_spatial_axes(None, ["time", "y", "soil", "x"], None, None) == (1, 3)
+
+    def test_trailing_two_fallback(self):
+        assert NetCDF._detect_spatial_axes(None, ["time", "a", "b"], None, None) == (1, 2)
+
+
+class TestSubsetInterleavedLayer:
+    """G-2: window a variable whose layer dim sits between y and x."""
+
+    def test_interleaved_layer_selected_by_name(self, tmp_path):
+        nc = _synthetic_cube(tmp_path, with_interleaved=True)
+        ds = nc.subset("soil", time=0, level=1)
+        assert (ds.rows, ds.columns) == (4, 5)
+        assert ds.band_count == 1
+
+    def test_interleaved_layer_correct_orientation_and_values(self, tmp_path):
+        # soil is (time, y, level, x); y ascends -> output row 0 is the
+        # northernmost (y index 3). Values are arange over (t, y, level, x).
+        nc = _synthetic_cube(tmp_path, with_interleaved=True)
+        ds = nc.subset("soil", time=0, level=0)
+        n_y, n_x, n_lev = 4, 5, 2
+        full = np.arange(3 * n_y * n_lev * n_x, dtype="float64").reshape(3, n_y, n_lev, n_x)
+        expected_row0 = full[0, 3, 0, :]  # time 0, y index 3 (north), level 0
+        assert list(np.asarray(ds.read_array())[0]) == list(expected_row0)
+
+    def test_interleaved_unselected_layer_raises(self, tmp_path):
+        nc = _synthetic_cube(tmp_path, with_interleaved=True)
+        with pytest.raises(ValueError, match="must be selected"):
+            nc.subset("soil", time=0)
+
+    def test_explicit_y_x_dim_override(self, tmp_path):
+        nc = _synthetic_cube(tmp_path, with_interleaved=True)
+        ds = nc.subset("soil", time=0, level=0, y_dim="y", x_dim="x")
+        assert (ds.rows, ds.columns) == (4, 5)
+
+
 @pytest.mark.slow
 @pytest.mark.vfs
 class TestSubsetLiveNWM:
@@ -497,3 +576,39 @@ class TestSubsetLiveNWM:
             pytest.skip(f"NWM store unreachable: {exc}")
 
         assert ds.band_count == 3
+
+    def test_dimension_sizes_and_time_values(self):
+        # G-1: true dim sizes + raw time coordinate are surfaced even though GDAL
+        # can't parse the CF time units (so get_time_variable() is None).
+        from pyramids.base.remote import CloudConfig
+
+        try:
+            with CloudConfig(aws_no_sign_request=True, aws_region="us-east-1"):
+                nc = NetCDF.read_file(NWM_LDASOUT)
+                sizes = nc.dimension_sizes
+                time_vals = nc.get_time_values("time")
+        except (RuntimeError, OSError) as exc:
+            pytest.skip(f"NWM store unreachable: {exc}")
+
+        assert sizes.get("time") == 128568
+        assert sizes.get("y") == 3840 and sizes.get("x") == 4608
+        assert time_vals is not None and time_vals.size == 128568
+
+    def test_subset_interleaved_layer_variable(self):
+        # G-2: SOIL_M is (time, y, soil_layers_stag, x) — layer between y and x.
+        from pyramids.base.remote import CloudConfig
+
+        try:
+            with CloudConfig(aws_no_sign_request=True, aws_region="us-east-1"):
+                nc = NetCDF.read_file(NWM_LDASOUT)
+                ds = nc.subset(
+                    "SOIL_M", time=0, soil_layers_stag=0,
+                    bbox=(-78.0, 38.0, -75.0, 40.0),
+                )
+        except (RuntimeError, OSError) as exc:
+            pytest.skip(f"NWM store unreachable: {exc}")
+
+        assert ds.rows > 0 and ds.columns > 0
+        assert ds.rows < 3840 and ds.columns < 4608
+        assert ds.band_count == 1
+        assert "Lambert_Conformal_Conic" in (ds.crs or "")


### PR DESCRIPTION
# Description

Closes the two gaps in #467 that block the **gridded retrospective** read of the NWM v3.0 retrospective Zarr,
building directly on `NetCDF.subset` (#462). No new GIS code is needed downstream — `earthlens.nwm` (PR #225)
extends its existing gridded path once these land.

**G-1 — surface the time coordinate / true sizes for a CF-unparseable cloud Zarr.** GDAL doesn't parse the
retrospective `ldasout.zarr` time `units`, so `get_time_variable()` / `time_stamp` are `None` and `shape`
reports the classic chunk view `(0, 512, 512)`. Added:

- `NetCDF.dimension_sizes` — true `{dim: size}` from the multidimensional root group (e.g.
  `{"time": 128568, "y": 3840, "x": 4608, ...}`).
- `NetCDF.get_time_values(var_name="time")` — the raw, undecoded time-coordinate values.

Together with the dimension's `calendar` / `units` attributes (`meta_data.get_dimension(name).attrs`), a
consumer can map a date window to integer indices for `subset` and detect out-of-range — verifiably, instead
of hard-coding a schedule. (Scope note: GDAL does not expose this store's CF `units`, so pyramids can't decode
raw offsets to absolute dates itself; it surfaces the raw values + true length so the caller can, with the
documented epoch.)

**G-2 — window a variable whose layer dim is interleaved between `y` and `x`.** `subset` assumed the spatial
axes were the trailing two dims, so `SOIL_M (time, y, soil_layers_stag, x)` and `ALBSND (…, vis_nir, x)` failed.
`subset` now detects the spatial axes by CF `axis` / `standard_name` / `units`, then well-known names
(`y`/`lat`/…, `x`/`lon`/…), then the trailing two dims — with an explicit `y_dim=` / `x_dim=` override — and
moves them to the trailing positions before banding. Interleaved-layer variables window at a chosen layer via
`**dims` (e.g. `soil_layers_stag=0`). The clean `(time, y, x)` path is unchanged.

Dependencies: none added.

# Issues
- Closes #467

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- Extended `tests/netcdf/test_subset.py`: +12 offline tests (dimension_sizes, get_time_values, spatial-axis
  detection incl. override/CF/name/trailing, interleaved-layer subset + orientation) and +2 opt-in live NWM
  tests.
- Test configuration: the worktree code was run through the project's `dev` pixi environment.

- [x] Offline: `pytest tests/netcdf/test_subset.py -m "not slow and not vfs"` → 68 passed.
- [x] Live (opt-in): `pytest tests/netcdf/test_subset.py -m "slow and vfs"` → 4 passed against
      `s3://noaa-nwm-retrospective-3-0-pds/.../ldasout.zarr` (incl. `dimension_sizes["time"]==128568` and a
      `SOIL_M` interleaved-layer windowed read).

# Checklist:

- [ ] updated version number in pyproject.toml. *(handled by commitizen in CI)*
- [ ] added changes to History.rst. *(changelog is commitizen-generated)*
- [ ] updated the latest version in README file. *(handled by the release workflow)*
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. *(Google-style docstrings on the new accessors and the subset y_dim/x_dim +
      interleaved behaviour)*
