### PR TITLE
feat(dataset): add create_empty / empty_like out-of-core raster allocators

### DIFF
--- a/src/pyramids/dataset/__init__.py
+++ b/src/pyramids/dataset/__init__.py
@@ -3,6 +3,12 @@
 from pyramids.base._raster_meta import RasterMeta
 from pyramids.dataset.abstract_dataset import DEFAULT_NO_DATA_VALUE
 from pyramids.dataset.collection import DatasetCollection
-from pyramids.dataset.dataset import Dataset
+from pyramids.dataset.dataset import Dataset, NoDataSentinelWarning
 
-__all__ = ["Dataset", "DatasetCollection", "DEFAULT_NO_DATA_VALUE", "RasterMeta"]
+__all__ = [
+    "Dataset",
+    "DatasetCollection",
+    "DEFAULT_NO_DATA_VALUE",
+    "NoDataSentinelWarning",
+    "RasterMeta",
+]

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -68,6 +68,24 @@ _COLLABORATOR_ATTRS = ("io", "spatial", "bands", "analysis", "cell", "vectorize"
 # "caller explicitly passed `None`" (which means "stamp no no-data sentinel").
 _INHERIT_NO_DATA = object()
 
+# Default GTiff creation options for out-of-core allocation
+# (`create_empty` / `empty_like`). TILED keeps windowed writes block-aligned
+# so a `write_array(window=)` does not amplify into a full-row rewrite;
+# SPARSE_OK lets never-written blocks cost no disk (they read back as the
+# band no-data value, not 0); BIGTIFF is mandatory past the 4 GB
+# classic-TIFF ceiling (a 2.7 B-cell float32 raster is ~10 GB) and must be
+# set at creation, not switched mid-write. DEFLATE matches the COG-writer
+# convention. Callers can override the whole list (e.g. to align
+# BLOCKXSIZE/BLOCKYSIZE to a different tile size).
+OUT_OF_CORE_CREATION_OPTIONS = [
+    "TILED=YES",
+    "BLOCKXSIZE=512",
+    "BLOCKYSIZE=512",
+    "SPARSE_OK=TRUE",
+    "BIGTIFF=YES",
+    "COMPRESS=DEFLATE",
+]
+
 
 def _derive_band_names(paths: list[str]) -> list[str]:
     """Derive band names from a list of single-band raster paths.
@@ -2051,6 +2069,7 @@ class Dataset(RasterBase):
         dtype: int,
         driver: str = "MEM",
         path: str | Path | None = None,
+        options: list[str] | None = None,
     ) -> gdal.Dataset:
         """Create a GDAL driver.
 
@@ -2069,6 +2088,12 @@ class Dataset(RasterBase):
                 Driver type ["GTiff", "MEM"].
             path (str):
                 Path to save the GTiff driver.
+            options (list[str] | None):
+                GDAL creation options for the disk driver (e.g.
+                ``["TILED=YES", "SPARSE_OK=TRUE", "BIGTIFF=YES"]``). When
+                `None` (default), GTiff falls back to ``["COMPRESS=LZW"]`` —
+                the historical behaviour. Ignored for the MEM driver, which
+                takes no creation options.
 
         Returns:
             gdal driver
@@ -2085,9 +2110,11 @@ class Dataset(RasterBase):
                     "The path to save the created raster should end with .tif"
                 )
             # LZW is a lossless compression method achieve the highest compression but with a lot
-            # of computations.
+            # of computations. Callers that need tiled / sparse / BigTIFF
+            # output (e.g. create_empty) pass their own options.
+            creation_options = ["COMPRESS=LZW"] if options is None else options
             src = gdal.GetDriverByName(driver).Create(
-                str(path), cols, rows, bands, dtype, ["COMPRESS=LZW"]
+                str(path), cols, rows, bands, dtype, creation_options
             )
         else:
             # for memory drivers
@@ -2109,6 +2136,7 @@ class Dataset(RasterBase):
         path: str | Path | None = None,
         access: str = "write",
         array: np.ndarray | None = None,
+        options: list[str] | None = None,
     ) -> Dataset:
         """Build a Dataset: allocate, set geo/CRS, optionally fill no-data, optionally write.
 
@@ -2146,11 +2174,18 @@ class Dataset(RasterBase):
                 `bands x rows x cols` (or `rows x cols` for a
                 single-band array). Default `None` (allocate but
                 don't write).
+            options: GDAL creation options forwarded to
+                :meth:`_create_dataset` for disk drivers (e.g. the
+                tiled / sparse / BigTIFF set used by :meth:`create_empty`).
+                `None` (default) keeps the historical ``["COMPRESS=LZW"]``
+                for GTiff and is ignored by the MEM driver.
 
         Returns:
             Dataset: A fully configured Dataset object.
         """
-        dst = cls._create_dataset(cols, rows, bands, dtype, driver=driver, path=path)
+        dst = cls._create_dataset(
+            cols, rows, bands, dtype, driver=driver, path=path, options=options
+        )
         dst.SetGeoTransform(geo)
         dst.SetProjection(crs)
         dst_obj = cls(dst, access=access)
@@ -2224,6 +2259,192 @@ class Dataset(RasterBase):
             crs_wkt,
             no_data_value,
             path=path,
+        )
+
+    @classmethod
+    def create_empty(
+        cls,
+        rows: int,
+        cols: int,
+        *,
+        bands: int = 1,
+        dtype: str = "float32",
+        geo: tuple[float, float, float, float, float, float] | None = None,
+        epsg: int = 4326,
+        no_data_value: Any = DEFAULT_NO_DATA_VALUE,
+        driver_type: str = "GTiff",
+        path: str | Path | None = None,
+        options: list[str] | None = None,
+    ) -> Dataset:
+        """Allocate an empty, header-only raster without materialising a full array.
+
+        Out-of-core algorithms allocate the output once and scatter result
+        windows into it with
+        ``write_array(array, window=(row_off, col_off, n_rows, n_cols))``.
+        For the default ``driver_type="GTiff"`` the file is **tiled, sparse,
+        and BigTIFF** (see :data:`OUT_OF_CORE_CREATION_OPTIONS`), so a
+        50 000 x 50 000 float32 raster is created in O(1) RAM, never-written
+        blocks cost no disk, and writes past the 4 GB classic-TIFF ceiling
+        succeed. Unwritten blocks read back as ``no_data_value`` (not 0), so
+        downstream code must treat unwritten tiles as no-data.
+
+        Args:
+            rows: Number of rows of the output raster.
+            cols: Number of columns of the output raster.
+            bands: Number of bands. Default 1.
+            dtype: NumPy dtype name for the bands (e.g. ``"float32"``,
+                ``"int16"``). Default ``"float32"``.
+            geo: Geotransform
+                ``(top_left_x, pixel_w, row_skew, top_left_y, col_skew,
+                pixel_h)``. Default ``(0.0, 1.0, 0.0, 0.0, 0.0, -1.0)`` — a
+                unit-pixel grid with the origin at ``(0, 0)``.
+            epsg: EPSG code for the projection. Default 4326.
+            no_data_value: No-data sentinel stamped on every band at
+                creation. Default :data:`DEFAULT_NO_DATA_VALUE`. Must be set
+                here so sparse unwritten blocks read back as no-data rather
+                than 0.
+            driver_type: GDAL driver. ``"GTiff"`` (default) writes a
+                disk-backed file at `path`; ``"MEM"`` keeps the raster in RAM
+                and ignores `path` / `options`.
+            path: Output path (``.tif``) for the GTiff driver. Required for a
+                disk-backed raster; ignored for ``"MEM"``.
+            options: GDAL creation options. `None` (default) uses
+                :data:`OUT_OF_CORE_CREATION_OPTIONS` for GTiff. Override to
+                align ``BLOCKXSIZE`` / ``BLOCKYSIZE`` to your tile size or to
+                change compression.
+
+        Returns:
+            Dataset: An empty raster whose bands are unwritten (sparse) and
+            read back as `no_data_value`.
+
+        Examples:
+            - Allocate an in-memory empty raster and confirm it reads as
+              no-data before any write:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_empty(
+                ...     4, 5, dtype="float32", no_data_value=-9999.0, driver_type="MEM"
+                ... )
+                >>> (ds.rows, ds.columns, ds.band_count)
+                (4, 5, 1)
+                >>> ds.no_data_value[0]
+                -9999.0
+
+                ```
+            - Allocate, then scatter a window into it and read it back:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_empty(4, 4, dtype="float32", driver_type="MEM")
+                >>> block = np.arange(4, dtype="float32").reshape(2, 2)
+                >>> ds.write_array(block, window=(1, 1, 2, 2))
+                >>> ds.read_array(window=[1, 1, 2, 2]).tolist()
+                [[0.0, 1.0], [2.0, 3.0]]
+
+                ```
+        """
+        gdal_dtype = numpy_to_gdal_dtype(dtype)
+        crs_wkt = sr_from_epsg(epsg).ExportToWkt()
+        if geo is None:
+            geo = (0.0, 1.0, 0.0, 0.0, 0.0, -1.0)
+        if options is None and driver_type == "GTiff":
+            options = OUT_OF_CORE_CREATION_OPTIONS
+        return cls._build_dataset(
+            cols,
+            rows,
+            bands,
+            gdal_dtype,
+            geo,
+            crs_wkt,
+            no_data_value,
+            driver=driver_type,
+            path=path,
+            options=options,
+            array=None,
+        )
+
+    @classmethod
+    def empty_like(
+        cls,
+        template: Dataset,
+        *,
+        dtype: str | None = None,
+        bands: int | None = None,
+        no_data_value: Any = _INHERIT_NO_DATA,
+        path: str | Path | None = None,
+        options: list[str] | None = None,
+    ) -> Dataset:
+        """Allocate an empty raster aligned to a template's geo / epsg / shape / nodata.
+
+        The header-only sibling of :meth:`dataset_like` — same spatial
+        footprint as `template` (geotransform, CRS, rows, columns, no-data),
+        but **no array is written**, so it can allocate an out-of-core output
+        the size of an input DEM without materialising it. Backed by GTiff
+        when `path` is given (tiled / sparse / BigTIFF via
+        :data:`OUT_OF_CORE_CREATION_OPTIONS`), otherwise MEM.
+
+        Args:
+            template: Source raster whose geotransform, CRS, shape, and
+                no-data value the output copies.
+            dtype: NumPy dtype name for the output bands. `None` (default)
+                reuses the template's dtype.
+            bands: Number of output bands. `None` (default) reuses the
+                template's band count.
+            no_data_value: No-data sentinel for the output. Defaults to the
+                template's first-band no-data value; pass an explicit value
+                to override.
+            path: Output path (``.tif``) for a disk-backed raster. `None`
+                (default) keeps the raster in memory (MEM driver).
+            options: GDAL creation options for the GTiff driver. `None`
+                (default) uses :data:`OUT_OF_CORE_CREATION_OPTIONS`.
+
+        Returns:
+            Dataset: An empty raster matching the template's footprint.
+
+        Examples:
+            - Allocate an empty raster shaped like an existing one, with a
+              different dtype:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> template = Dataset.create_from_array(
+                ...     np.ones((3, 4, 5), dtype="float32"),
+                ...     top_left_corner=(0.0, 10.0), cell_size=0.5, epsg=4326,
+                ...     no_data_value=-9999.0,
+                ... )
+                >>> out = Dataset.empty_like(template, dtype="int16")
+                >>> (out.rows, out.columns, out.band_count, out.epsg)
+                (4, 5, 3, 4326)
+                >>> out.geotransform == template.geotransform
+                True
+
+                ```
+        """
+        gdal_dtype = (
+            template.gdal_dtype[0] if dtype is None else numpy_to_gdal_dtype(dtype)
+        )
+        n_bands = template.band_count if bands is None else bands
+        nodata = (
+            template.no_data_value[0]
+            if no_data_value is _INHERIT_NO_DATA
+            else no_data_value
+        )
+        driver_type = "GTiff" if path is not None else "MEM"
+        if options is None and driver_type == "GTiff":
+            options = OUT_OF_CORE_CREATION_OPTIONS
+        return cls._build_dataset(
+            template.columns,
+            template.rows,
+            n_bands,
+            gdal_dtype,
+            template.geotransform,
+            template.crs,
+            nodata,
+            driver=driver_type,
+            path=path,
+            options=options,
+            array=None,
         )
 
     @classmethod

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2307,7 +2307,8 @@ class Dataset(RasterBase):
                 so sparse unwritten blocks read back as no-data rather than 0.
                 Passing ``None`` skips the band fill and stamps no sentinel,
                 which opts out of that guarantee — a sparse GTiff's unwritten
-                blocks then read back as **0**, not no-data.
+                blocks then read back as **0**, not no-data — and emits a
+                :class:`UserWarning`.
             driver_type: GDAL driver. ``"GTiff"`` (default) writes a
                 disk-backed file and requires `path`; ``"MEM"`` keeps the
                 raster in RAM and requires `path` to be `None`. Note that any
@@ -2375,6 +2376,13 @@ class Dataset(RasterBase):
                 "driver_type='MEM' for an in-memory one. (Without a path the GTiff "
                 "tiled/sparse/BigTIFF options would be silently dropped.)"
             )
+        if no_data_value is None:
+            warnings.warn(
+                "create_empty(no_data_value=None) stamps no no-data sentinel, so "
+                "unwritten cells read back as 0, not no-data. Pass a no_data_value "
+                "to keep the 'unwritten == no-data' guarantee.",
+                stacklevel=2,
+            )
         gdal_dtype = numpy_to_gdal_dtype(dtype)
         crs_wkt = sr_from_epsg(epsg).ExportToWkt()
         if geo is None:
@@ -2427,7 +2435,7 @@ class Dataset(RasterBase):
                 to override. If this resolves to ``None`` (passed explicitly,
                 or inherited from a template with no no-data set), no sentinel
                 is stamped and a sparse GTiff's unwritten blocks read back as
-                **0**, not no-data.
+                **0**, not no-data — and a :class:`UserWarning` is emitted.
             path: Output path (``.tif``) for a disk-backed raster. `None`
                 (default) keeps the raster in memory (MEM driver).
             options: GDAL creation options for the GTiff driver. `None`
@@ -2488,6 +2496,15 @@ class Dataset(RasterBase):
             if no_data_value is _INHERIT_NO_DATA
             else no_data_value
         )
+        if nodata is None:
+            warnings.warn(
+                "empty_like produced a raster with no no-data sentinel "
+                "(no_data_value resolved to None, explicitly or inherited from a "
+                "template with no no-data), so unwritten cells read back as 0, not "
+                "no-data. Pass no_data_value to keep the 'unwritten == no-data' "
+                "guarantee.",
+                stacklevel=2,
+            )
         driver_type = "GTiff" if path is not None else "MEM"
         if options is None and driver_type == "GTiff":
             options = list(OUT_OF_CORE_CREATION_OPTIONS)

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2303,9 +2303,11 @@ class Dataset(RasterBase):
                 unit-pixel grid with the origin at ``(0, 0)``.
             epsg: EPSG code for the projection. Default 4326.
             no_data_value: No-data sentinel stamped on every band at
-                creation. Default :data:`DEFAULT_NO_DATA_VALUE`. Must be set
-                here so sparse unwritten blocks read back as no-data rather
-                than 0.
+                creation. Default :data:`DEFAULT_NO_DATA_VALUE`. Keep it set
+                so sparse unwritten blocks read back as no-data rather than 0.
+                Passing ``None`` skips the band fill and stamps no sentinel,
+                which opts out of that guarantee — a sparse GTiff's unwritten
+                blocks then read back as **0**, not no-data.
             driver_type: GDAL driver. ``"GTiff"`` (default) writes a
                 disk-backed file and requires `path`; ``"MEM"`` keeps the
                 raster in RAM and requires `path` to be `None`. Note that any
@@ -2422,7 +2424,10 @@ class Dataset(RasterBase):
                 template's band count.
             no_data_value: No-data sentinel for the output. Defaults to the
                 template's first-band no-data value; pass an explicit value
-                to override.
+                to override. If this resolves to ``None`` (passed explicitly,
+                or inherited from a template with no no-data set), no sentinel
+                is stamped and a sparse GTiff's unwritten blocks read back as
+                **0**, not no-data.
             path: Output path (``.tif``) for a disk-backed raster. `None`
                 (default) keeps the raster in memory (MEM driver).
             options: GDAL creation options for the GTiff driver. `None`

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2307,19 +2307,25 @@ class Dataset(RasterBase):
                 here so sparse unwritten blocks read back as no-data rather
                 than 0.
             driver_type: GDAL driver. ``"GTiff"`` (default) writes a
-                disk-backed file at `path`; ``"MEM"`` keeps the raster in RAM
-                and ignores `path` / `options`.
-            path: Output path (``.tif``) for the GTiff driver. Required for a
-                disk-backed raster; ignored for ``"MEM"``.
+                disk-backed file and requires `path`; ``"MEM"`` keeps the
+                raster in RAM and requires `path` to be `None`. Note that any
+                non-`None` `path` produces a GTiff regardless of `driver_type`
+                — the underlying allocator promotes ``"MEM"`` + `path` to
+                GTiff.
+            path: Output path (``.tif``) for a disk-backed raster. Pass a path
+                for the GTiff driver; leave as `None` for an in-memory
+                ``"MEM"`` raster.
             options: GDAL creation options. `None` (default) uses
                 :data:`OUT_OF_CORE_CREATION_OPTIONS` for GTiff. Override to
                 align ``BLOCKXSIZE`` / ``BLOCKYSIZE`` to your tile size or to
-                change compression.
+                change compression. Ignored by the MEM driver.
 
         Returns:
-            Dataset: An empty raster. On the GTiff driver the bands are
-            unwritten (sparse) and read back as `no_data_value`; on the MEM
-            driver the buffer is zero-initialised.
+            Dataset: An empty raster whose bands read back as `no_data_value`
+            before any write. On GTiff this is sparse — SPARSE_OK keeps
+            never-written blocks unallocated and GDAL returns the no-data
+            sentinel for them; on MEM every band is filled with `no_data_value`
+            at allocation, so unwritten MEM cells read back as no-data too.
 
         Raises:
             ValueError: ``driver_type="GTiff"`` (the default) is requested
@@ -2351,6 +2357,14 @@ class Dataset(RasterBase):
                 [[0.0, 1.0], [2.0, 3.0]]
 
                 ```
+
+        See Also:
+            - :meth:`empty_like`: Allocate an empty raster shaped like an
+              existing template instead of from explicit dimensions.
+            - :meth:`create`: Allocate a raster and eagerly fill every cell
+              with the no-data value (no sparse / BigTIFF defaults).
+            - :meth:`write_array`: Scatter a window into the allocated raster
+              (``window=(row_off, col_off, n_rows, n_cols)``).
         """
         if driver_type == "GTiff" and path is None:
             raise ValueError(
@@ -2435,6 +2449,30 @@ class Dataset(RasterBase):
                 True
 
                 ```
+            - Reduce the band count and inherit the template's no-data value,
+              then confirm the empty output reads back as no-data:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> template = Dataset.create_from_array(
+                ...     np.ones((3, 4, 4), dtype="float32"),
+                ...     top_left_corner=(0.0, 10.0), cell_size=1.0, epsg=4326,
+                ...     no_data_value=-9999.0,
+                ... )
+                >>> out = Dataset.empty_like(template, bands=1)
+                >>> out.band_count
+                1
+                >>> float(out.no_data_value[0])
+                -9999.0
+
+                ```
+
+        See Also:
+            - :meth:`create_empty`: Allocate an empty raster from explicit
+              dimensions / CRS instead of copying a template.
+            - :meth:`dataset_like`: The array-writing sibling — copies the
+              template footprint *and* writes a supplied array.
+            - :meth:`write_array`: Scatter a window into the allocated raster.
         """
         gdal_dtype = (
             template.gdal_dtype[0] if dtype is None else numpy_to_gdal_dtype(dtype)

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -87,6 +87,18 @@ OUT_OF_CORE_CREATION_OPTIONS = [
 ]
 
 
+class NoDataSentinelWarning(UserWarning):
+    """Warns that a disk-backed sparse raster was allocated with no no-data sentinel.
+
+    Emitted by :meth:`Dataset.create_empty` / :meth:`Dataset.empty_like` when the
+    target is a sparse GTiff and ``no_data_value`` resolves to ``None``: with no
+    sentinel, never-written blocks read back as ``0`` rather than no-data. Callers
+    who intentionally build sentinel-free rasters can silence it precisely with
+    ``warnings.filterwarnings("ignore", category=NoDataSentinelWarning)`` instead of
+    muting every :class:`UserWarning`.
+    """
+
+
 def _derive_band_names(paths: list[str]) -> list[str]:
     """Derive band names from a list of single-band raster paths.
 
@@ -2307,8 +2319,9 @@ class Dataset(RasterBase):
                 so sparse unwritten blocks read back as no-data rather than 0.
                 Passing ``None`` skips the band fill and stamps no sentinel,
                 which opts out of that guarantee — a sparse GTiff's unwritten
-                blocks then read back as **0**, not no-data — and emits a
-                :class:`UserWarning`.
+                blocks then read back as **0**, not no-data. On the disk/GTiff
+                path this emits a :class:`NoDataSentinelWarning`; the in-RAM
+                ``"MEM"`` driver is dense and does not warn.
             driver_type: GDAL driver. ``"GTiff"`` (default) writes a
                 disk-backed file and requires `path`; ``"MEM"`` keeps the
                 raster in RAM and requires `path` to be `None`. Note that any
@@ -2376,11 +2389,18 @@ class Dataset(RasterBase):
                 "driver_type='MEM' for an in-memory one. (Without a path the GTiff "
                 "tiled/sparse/BigTIFF options would be silently dropped.)"
             )
-        if no_data_value is None:
+        # Only the disk/GTiff path is sparse, where a missing sentinel makes
+        # never-written blocks read back as 0 instead of no-data. The MEM driver
+        # (path is None) is a dense in-RAM buffer where a sentinel-free raster is
+        # an ordinary, unsurprising choice — don't warn there. (A non-None path
+        # always yields a GTiff, including the MEM+path promotion.)
+        if no_data_value is None and path is not None:
             warnings.warn(
-                "create_empty(no_data_value=None) stamps no no-data sentinel, so "
-                "unwritten cells read back as 0, not no-data. Pass a no_data_value "
-                "to keep the 'unwritten == no-data' guarantee.",
+                "create_empty(no_data_value=None) on a disk/GTiff target stamps no "
+                "no-data sentinel, so unwritten sparse blocks read back as 0, not "
+                "no-data. Pass a no_data_value to keep the 'unwritten == no-data' "
+                "guarantee.",
+                NoDataSentinelWarning,
                 stacklevel=2,
             )
         gdal_dtype = numpy_to_gdal_dtype(dtype)
@@ -2435,7 +2455,9 @@ class Dataset(RasterBase):
                 to override. If this resolves to ``None`` (passed explicitly,
                 or inherited from a template with no no-data set), no sentinel
                 is stamped and a sparse GTiff's unwritten blocks read back as
-                **0**, not no-data — and a :class:`UserWarning` is emitted.
+                **0**, not no-data; on the disk/GTiff path (``path`` given)
+                this emits a :class:`NoDataSentinelWarning` (the in-RAM MEM
+                result does not warn).
             path: Output path (``.tif``) for a disk-backed raster. `None`
                 (default) keeps the raster in memory (MEM driver).
             options: GDAL creation options for the GTiff driver. `None`
@@ -2496,13 +2518,17 @@ class Dataset(RasterBase):
             if no_data_value is _INHERIT_NO_DATA
             else no_data_value
         )
-        if nodata is None:
+        # Warn only for the disk/GTiff target (path given), where a missing
+        # sentinel makes unwritten sparse blocks read back as 0. An in-RAM MEM
+        # result (no path) is dense and a sentinel-free raster is unsurprising.
+        if nodata is None and path is not None:
             warnings.warn(
-                "empty_like produced a raster with no no-data sentinel "
+                "empty_like produced a disk/GTiff raster with no no-data sentinel "
                 "(no_data_value resolved to None, explicitly or inherited from a "
-                "template with no no-data), so unwritten cells read back as 0, not "
-                "no-data. Pass no_data_value to keep the 'unwritten == no-data' "
-                "guarantee.",
+                "template with no no-data), so unwritten sparse blocks read back as "
+                "0, not no-data. Pass no_data_value to keep the 'unwritten == "
+                "no-data' guarantee.",
+                NoDataSentinelWarning,
                 stacklevel=2,
             )
         driver_type = "GTiff" if path is not None else "MEM"

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2285,8 +2285,11 @@ class Dataset(RasterBase):
         and BigTIFF** (see :data:`OUT_OF_CORE_CREATION_OPTIONS`), so a
         50 000 x 50 000 float32 raster is created in O(1) RAM, never-written
         blocks cost no disk, and writes past the 4 GB classic-TIFF ceiling
-        succeed. Unwritten blocks read back as ``no_data_value`` (not 0), so
-        downstream code must treat unwritten tiles as no-data.
+        succeed. A never-written cell reads back as ``no_data_value`` (not 0) —
+        on GTiff because SPARSE_OK + the band no-data sentinel returns no-data
+        for unwritten blocks, and on MEM because the band is filled with the
+        no-data value at allocation — so downstream code must treat unwritten
+        tiles as no-data.
 
         Args:
             rows: Number of rows of the output raster.
@@ -2314,12 +2317,17 @@ class Dataset(RasterBase):
                 change compression.
 
         Returns:
-            Dataset: An empty raster whose bands are unwritten (sparse) and
-            read back as `no_data_value`.
+            Dataset: An empty raster. On the GTiff driver the bands are
+            unwritten (sparse) and read back as `no_data_value`; on the MEM
+            driver the buffer is zero-initialised.
+
+        Raises:
+            ValueError: ``driver_type="GTiff"`` (the default) is requested
+                without a `path`. Pass a `path`, or use ``driver_type="MEM"``
+                for an in-memory raster.
 
         Examples:
-            - Allocate an in-memory empty raster and confirm it reads as
-              no-data before any write:
+            - Allocate an in-memory empty raster and read its no-data metadata:
                 ```python
                 >>> import numpy as np
                 >>> from pyramids.dataset import Dataset
@@ -2328,7 +2336,7 @@ class Dataset(RasterBase):
                 ... )
                 >>> (ds.rows, ds.columns, ds.band_count)
                 (4, 5, 1)
-                >>> ds.no_data_value[0]
+                >>> float(ds.no_data_value[0])
                 -9999.0
 
                 ```
@@ -2344,12 +2352,19 @@ class Dataset(RasterBase):
 
                 ```
         """
+        if driver_type == "GTiff" and path is None:
+            raise ValueError(
+                "create_empty(driver_type='GTiff') needs a path to write the raster "
+                "to; pass path='out.tif' for a disk-backed raster, or "
+                "driver_type='MEM' for an in-memory one. (Without a path the GTiff "
+                "tiled/sparse/BigTIFF options would be silently dropped.)"
+            )
         gdal_dtype = numpy_to_gdal_dtype(dtype)
         crs_wkt = sr_from_epsg(epsg).ExportToWkt()
         if geo is None:
             geo = (0.0, 1.0, 0.0, 0.0, 0.0, -1.0)
         if options is None and driver_type == "GTiff":
-            options = OUT_OF_CORE_CREATION_OPTIONS
+            options = list(OUT_OF_CORE_CREATION_OPTIONS)
         return cls._build_dataset(
             cols,
             rows,
@@ -2432,7 +2447,7 @@ class Dataset(RasterBase):
         )
         driver_type = "GTiff" if path is not None else "MEM"
         if options is None and driver_type == "GTiff":
-            options = OUT_OF_CORE_CREATION_OPTIONS
+            options = list(OUT_OF_CORE_CREATION_OPTIONS)
         return cls._build_dataset(
             template.columns,
             template.rows,

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2334,7 +2334,9 @@ class Dataset(RasterBase):
             options: GDAL creation options. `None` (default) uses
                 :data:`OUT_OF_CORE_CREATION_OPTIONS` for GTiff. Override to
                 align ``BLOCKXSIZE`` / ``BLOCKYSIZE`` to your tile size or to
-                change compression. Ignored by the MEM driver.
+                change compression. Applies only to the disk/GTiff driver;
+                passing `options` without a `path` raises rather than silently
+                dropping them.
 
         Returns:
             Dataset: An empty raster whose bands read back as `no_data_value`
@@ -2344,7 +2346,9 @@ class Dataset(RasterBase):
             at allocation, so unwritten MEM cells read back as no-data too.
 
         Raises:
-            ValueError: ``driver_type="GTiff"`` (the default) is requested
+            ValueError: ``options`` is given without a ``path`` (creation
+                options apply only to the disk/GTiff driver); or
+                ``driver_type="GTiff"`` (the default) is requested
                 without a `path`. Pass a `path`, or use ``driver_type="MEM"``
                 for an in-memory raster.
 
@@ -2388,6 +2392,15 @@ class Dataset(RasterBase):
                 "to; pass path='out.tif' for a disk-backed raster, or "
                 "driver_type='MEM' for an in-memory one. (Without a path the GTiff "
                 "tiled/sparse/BigTIFF options would be silently dropped.)"
+            )
+        # Creation options apply only to the disk/GTiff driver (path given); the
+        # MEM driver takes none. Reject explicit options that would be dropped
+        # rather than silently ignoring them.
+        if options is not None and path is None:
+            raise ValueError(
+                "create_empty received `options` but no `path`: GDAL creation "
+                "options apply only to the disk/GTiff driver. Pass a `path`, or drop "
+                "`options` for the in-memory MEM raster."
             )
         # Only the disk/GTiff path is sparse, where a missing sentinel makes
         # never-written blocks read back as 0 instead of no-data. The MEM driver
@@ -2450,21 +2463,31 @@ class Dataset(RasterBase):
                 reuses the template's dtype.
             bands: Number of output bands. `None` (default) reuses the
                 template's band count.
-            no_data_value: No-data sentinel for the output. Defaults to the
-                template's first-band no-data value; pass an explicit value
-                to override. If this resolves to ``None`` (passed explicitly,
-                or inherited from a template with no no-data set), no sentinel
-                is stamped and a sparse GTiff's unwritten blocks read back as
-                **0**, not no-data; on the disk/GTiff path (``path`` given)
-                this emits a :class:`NoDataSentinelWarning` (the in-RAM MEM
-                result does not warn).
+            no_data_value: No-data sentinel for the output. Default inherits
+                from the template: when the band count is unchanged and every
+                template band has a sentinel, the **per-band** no-data values
+                are preserved; otherwise (a `bands` override, or a template
+                band with no sentinel) the template's first-band value is used.
+                Pass an explicit scalar or per-band list to override. If this
+                resolves to ``None`` (passed explicitly, or inherited from a
+                template with no no-data set), no sentinel is stamped and a
+                sparse GTiff's unwritten blocks read back as **0**, not no-data;
+                on the disk/GTiff path (``path`` given) this emits a
+                :class:`NoDataSentinelWarning` (the in-RAM MEM result does not
+                warn).
             path: Output path (``.tif``) for a disk-backed raster. `None`
                 (default) keeps the raster in memory (MEM driver).
             options: GDAL creation options for the GTiff driver. `None`
-                (default) uses :data:`OUT_OF_CORE_CREATION_OPTIONS`.
+                (default) uses :data:`OUT_OF_CORE_CREATION_OPTIONS`. Applies
+                only to the disk/GTiff driver; passing `options` without a
+                `path` raises rather than silently dropping them.
 
         Returns:
             Dataset: An empty raster matching the template's footprint.
+
+        Raises:
+            ValueError: ``options`` is given without a ``path`` (creation
+                options apply only to the disk/GTiff driver).
 
         Examples:
             - Allocate an empty raster shaped like an existing one, with a
@@ -2509,15 +2532,27 @@ class Dataset(RasterBase):
               template footprint *and* writes a supplied array.
             - :meth:`write_array`: Scatter a window into the allocated raster.
         """
+        if options is not None and path is None:
+            raise ValueError(
+                "empty_like received `options` but no `path`: GDAL creation options "
+                "apply only to the disk/GTiff driver. Pass a `path`, or drop "
+                "`options` for the in-memory MEM raster."
+            )
         gdal_dtype = (
             template.gdal_dtype[0] if dtype is None else numpy_to_gdal_dtype(dtype)
         )
         n_bands = template.band_count if bands is None else bands
-        nodata = (
-            template.no_data_value[0]
-            if no_data_value is _INHERIT_NO_DATA
-            else no_data_value
-        )
+        if no_data_value is not _INHERIT_NO_DATA:
+            nodata = no_data_value
+        else:
+            template_nd = template.no_data_value
+            # Preserve the template's per-band sentinels when the band count is
+            # unchanged and every band actually has one; otherwise (band-count
+            # override, or a band with no sentinel) fall back to band 0's value.
+            if bands is None and all(v is not None for v in template_nd):
+                nodata = list(template_nd)
+            else:
+                nodata = template_nd[0]
         # Warn only for the disk/GTiff target (path given), where a missing
         # sentinel makes unwritten sparse blocks read back as 0. An in-RAM MEM
         # result (no path) is dense and a sentinel-free raster is unsurprising.

--- a/tests/dataset/test_create_empty.py
+++ b/tests/dataset/test_create_empty.py
@@ -9,13 +9,14 @@ from __future__ import annotations
 
 import subprocess
 import tracemalloc
+import warnings
 from pathlib import Path
 
 import numpy as np
 import pytest
 from osgeo import gdal
 
-from pyramids.dataset import Dataset
+from pyramids.dataset import Dataset, NoDataSentinelWarning
 from pyramids.dataset.dataset import OUT_OF_CORE_CREATION_OPTIONS
 
 pytestmark = pytest.mark.core
@@ -142,12 +143,12 @@ class TestCreateEmpty:
         Test scenario:
             Documents the opt-out caveat: passing ``no_data_value=None`` skips the band
             fill and stamps no sentinel, so SPARSE_OK has no no-data to return for
-            never-written blocks — they read back as 0, not no-data. This is the
-            documented downside of dropping the sentinel, and the inverse of
+            never-written blocks — they read back as 0, not no-data. The disk/GTiff
+            path emits a ``NoDataSentinelWarning``. Inverse of
             ``test_unwritten_block_reads_as_nodata``.
         """
         path = tmp_path / "sparse_no_nodata.tif"
-        with pytest.warns(UserWarning, match="read back as 0"):
+        with pytest.warns(NoDataSentinelWarning, match="read back as 0"):
             ds = Dataset.create_empty(
                 1024, 1024, dtype="float32", no_data_value=None, path=path
             )
@@ -157,6 +158,25 @@ class TestCreateEmpty:
         far = reopened.read_array(window=[1000, 1000, 4, 4])
         assert np.all(far == 0), (
             f"with no nodata, unwritten block should read as 0, got {np.unique(far)}"
+        )
+
+    def test_mem_none_nodata_does_not_warn(self):
+        """create_empty(MEM, no_data_value=None) does not emit NoDataSentinelWarning.
+
+        Test scenario:
+            The MEM driver is a dense in-RAM buffer, not a sparse GTiff, so a
+            sentinel-free MEM raster is an ordinary choice (mask / RGB / scratch) and
+            must not trigger the disk-only ``NoDataSentinelWarning``. Scopes the warning
+            to the GTiff path — the complement of
+            ``test_no_data_none_sparse_block_reads_as_zero``.
+        """
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", NoDataSentinelWarning)
+            ds = Dataset.create_empty(
+                4, 4, dtype="float32", no_data_value=None, driver_type="MEM"
+            )
+        assert ds.no_data_value[0] is None, (
+            f"expected no sentinel, got {ds.no_data_value[0]}"
         )
 
     def test_default_options_are_tiled_sparse_bigtiff(self, tmp_path: Path):
@@ -389,19 +409,35 @@ class TestEmptyLike:
             f"nodata override ignored: {out.no_data_value[0]}"
         )
 
-    def test_explicit_none_nodata_stamps_no_sentinel(self, template: Dataset):
-        """``no_data_value=None`` produces a raster with no no-data sentinel and warns.
+    def test_explicit_none_nodata_stamps_no_sentinel_mem(self, template: Dataset):
+        """In-RAM ``empty_like(no_data_value=None)`` stamps no sentinel and does not warn.
 
         Test scenario:
             Passing ``no_data_value=None`` explicitly (distinct from the
             ``_INHERIT_NO_DATA`` default that copies the template's -9999, and from an
             override value) routes through ``_build_dataset`` with no-data set to None,
-            which skips the band fill entirely. The resulting first-band no-data must be
-            None, and a UserWarning must be emitted so the unwritten-reads-0 consequence
-            is visible at runtime.
+            which skips the band fill. With no ``path`` the result is an in-RAM MEM
+            raster, so the disk-only ``NoDataSentinelWarning`` must NOT fire; the
+            first-band no-data must be None.
         """
-        with pytest.warns(UserWarning, match="no no-data sentinel"):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", NoDataSentinelWarning)
             out = Dataset.empty_like(template, no_data_value=None)
+        assert out.no_data_value[0] is None, (
+            f"expected no no-data sentinel, got {out.no_data_value[0]}"
+        )
+
+    def test_none_nodata_disk_warns(self, template: Dataset, tmp_path: Path):
+        """Disk-backed ``empty_like(no_data_value=None)`` emits NoDataSentinelWarning.
+
+        Test scenario:
+            With a ``path`` the result is a sparse GTiff, where a missing sentinel makes
+            unwritten blocks read back as 0 — so a ``NoDataSentinelWarning`` must be
+            emitted. Complement of the MEM case above.
+        """
+        path = tmp_path / "like_no_nodata.tif"
+        with pytest.warns(NoDataSentinelWarning, match="read back as"):
+            out = Dataset.empty_like(template, no_data_value=None, path=path)
         assert out.no_data_value[0] is None, (
             f"expected no no-data sentinel, got {out.no_data_value[0]}"
         )

--- a/tests/dataset/test_create_empty.py
+++ b/tests/dataset/test_create_empty.py
@@ -147,9 +147,10 @@ class TestCreateEmpty:
             ``test_unwritten_block_reads_as_nodata``.
         """
         path = tmp_path / "sparse_no_nodata.tif"
-        ds = Dataset.create_empty(
-            1024, 1024, dtype="float32", no_data_value=None, path=path
-        )
+        with pytest.warns(UserWarning, match="read back as 0"):
+            ds = Dataset.create_empty(
+                1024, 1024, dtype="float32", no_data_value=None, path=path
+            )
         ds.write_array(np.ones((4, 4), dtype="float32"), window=(0, 0, 4, 4))
         del ds
         reopened = Dataset.read_file(str(path))
@@ -385,17 +386,18 @@ class TestEmptyLike:
         )
 
     def test_explicit_none_nodata_stamps_no_sentinel(self, template: Dataset):
-        """``no_data_value=None`` produces a raster with no no-data sentinel.
+        """``no_data_value=None`` produces a raster with no no-data sentinel and warns.
 
         Test scenario:
             Passing ``no_data_value=None`` explicitly (distinct from the
             ``_INHERIT_NO_DATA`` default that copies the template's -9999, and from an
             override value) routes through ``_build_dataset`` with no-data set to None,
             which skips the band fill entirely. The resulting first-band no-data must be
-            None — the documented "stamp no sentinel" behaviour. This is the only
-            coverage of the None branch.
+            None, and a UserWarning must be emitted so the unwritten-reads-0 consequence
+            is visible at runtime.
         """
-        out = Dataset.empty_like(template, no_data_value=None)
+        with pytest.warns(UserWarning, match="no no-data sentinel"):
+            out = Dataset.empty_like(template, no_data_value=None)
         assert out.no_data_value[0] is None, (
             f"expected no no-data sentinel, got {out.no_data_value[0]}"
         )

--- a/tests/dataset/test_create_empty.py
+++ b/tests/dataset/test_create_empty.py
@@ -24,13 +24,15 @@ pytestmark = pytest.mark.core
 class TestCreateEmpty:
     """Tests for :meth:`pyramids.dataset.Dataset.create_empty`."""
 
-    def test_mem_allocation_reads_back_as_nodata(self):
-        """An unwritten MEM raster has the configured shape and reads as no-data.
+    def test_mem_allocation_stamps_nodata_metadata(self):
+        """An unwritten MEM raster has the configured shape and no-data metadata.
 
         Test scenario:
             ``create_empty(4, 5, driver_type="MEM")`` allocates a 1-band 4x5 raster
             whose cells are untouched. Shape and band count match the request and the
-            no-data sentinel is stamped on the band.
+            no-data sentinel is stamped on the band metadata. (This asserts the
+            *metadata* only — see ``test_mem_unwritten_cells_read_as_zero`` for the
+            distinct cell-contents behaviour of the MEM driver.)
         """
         ds = Dataset.create_empty(
             4, 5, dtype="float32", no_data_value=-9999.0, driver_type="MEM"
@@ -40,6 +42,24 @@ class TestCreateEmpty:
         )
         assert ds.no_data_value[0] == -9999.0, (
             f"nodata not stamped, got {ds.no_data_value[0]}"
+        )
+
+    def test_mem_unwritten_cells_read_as_nodata(self):
+        """MEM unwritten cells read back as the no-data sentinel, not 0.
+
+        Test scenario:
+            ``_build_dataset`` fills every band with the no-data value at allocation
+            (``GDALRasterBand.Fill``), so a never-written MEM cell reads back as -9999,
+            matching the sparse-GTiff behaviour in
+            ``test_unwritten_block_reads_as_nodata``. This pins the cross-driver
+            guarantee that unwritten cells are no-data, not 0.
+        """
+        ds = Dataset.create_empty(
+            4, 4, dtype="float32", no_data_value=-9999.0, driver_type="MEM"
+        )
+        whole = ds.read_array()
+        assert np.all(whole == -9999.0), (
+            f"unwritten MEM cells should read as nodata -9999, got {np.unique(whole)}"
         )
 
     def test_window_write_read_roundtrip_mem(self):
@@ -162,6 +182,38 @@ class TestCreateEmpty:
             f"default geo mismatch: {ds.geotransform}"
         )
 
+    def test_sparse_allocation_is_small_on_disk(self, tmp_path: Path):
+        """A large empty sparse GTiff costs almost no disk before any write.
+
+        Test scenario:
+            ``create_empty`` allocates a 10 000 x 10 000 float32 raster — 400 MB if
+            materialised — but with SPARSE_OK and the no-data fill optimised away by
+            GDAL (an all-no-data block is not allocated), the file on disk must stay
+            tiny (header + metadata only). This is the headline out-of-core guarantee:
+            never-written blocks cost no disk.
+        """
+        path = tmp_path / "sparse.tif"
+        ds = Dataset.create_empty(10_000, 10_000, dtype="float32", path=path)
+        del ds
+        size = path.stat().st_size
+        materialised = 10_000 * 10_000 * 4
+        assert size < materialised // 100, (
+            f"sparse GTiff is {size / 1e6:.2f} MB; a materialised raster would be "
+            f"{materialised / 1e6:.0f} MB — SPARSE_OK is not in effect"
+        )
+
+    def test_gtiff_without_path_raises(self):
+        """``create_empty`` with the default GTiff driver but no path raises ValueError.
+
+        Test scenario:
+            ``create_empty(rows, cols)`` defaults to ``driver_type="GTiff"`` but with no
+            ``path`` the underlying driver would silently fall back to MEM and drop the
+            tiled / sparse / BigTIFF options. The method must reject that combination
+            loudly rather than hand back a surprising in-memory raster.
+        """
+        with pytest.raises(ValueError, match="needs a path"):
+            Dataset.create_empty(4, 4)
+
     @pytest.mark.slow
     def test_bigtiff_past_4gb_ceiling(self, tmp_path: Path):
         """A logical raster past the 4 GB classic-TIFF ceiling allocates and writes.
@@ -175,27 +227,32 @@ class TestCreateEmpty:
         """
         path = tmp_path / "big.tif"
         ds = Dataset.create_empty(50_000, 90_000, dtype="int8", path=path)
-        ds.write_array(
-            np.ones((4, 4), dtype="int8"), window=(49_996, 89_996, 4, 4)
-        )
+        # write_array window is (row_off, col_off, n_rows, n_cols); the far corner
+        # of a 50_000-row x 90_000-col raster.
+        ds.write_array(np.ones((4, 4), dtype="int8"), window=(49_996, 89_996, 4, 4))
         del ds
         info = gdal.Info(str(path))
         assert "BigTIFF" in info or "BIGTIFF" in info.upper(), (
             f"file should be BigTIFF, gdalinfo:\n{info[:400]}"
         )
         reopened = Dataset.read_file(str(path))
-        back = reopened.read_array(window=[49_996, 89_996, 4, 4])
+        # read_array window is (col_off, row_off, n_cols, n_rows) — the opposite axis
+        # order of write_array (it forwards straight to GDAL ReadAsArray(xoff, yoff,
+        # xsize, ysize)). Mirror the write corner with the axes swapped.
+        back = reopened.read_array(window=[89_996, 49_996, 4, 4])
         assert np.all(back == 1), f"far-corner write past 4GB failed: {np.unique(back)}"
 
     @pytest.mark.slow
-    def test_allocation_is_constant_ram(self, tmp_path: Path):
-        """Allocating a huge raster does not materialise a full-size array.
+    def test_allocation_allocates_no_full_python_buffer(self, tmp_path: Path):
+        """Allocating a huge raster materialises no full-size NumPy buffer on the Python side.
 
         Test scenario:
             A 20 000 x 20 000 float32 dense array would need ~1.6 GB of RAM. The
-            header-only ``create_empty`` must allocate in O(1) — tracemalloc on the
-            Python side should show a peak far below the dense-array size (a few MB,
-            not gigabytes), proving no full buffer is created.
+            header-only ``create_empty`` must not build one — ``tracemalloc`` (which
+            sees Python-level allocations only, not GDAL's C++ block cache) should show
+            a peak far below the dense-array size. This guards against an accidental
+            NumPy full-array materialisation in the Python code path; it does not bound
+            GDAL's native allocations (see the review's L2 note).
         """
         path = tmp_path / "o1.tif"
         dense_bytes = 20_000 * 20_000 * 4
@@ -285,7 +342,10 @@ class TestEmptyLike:
         """
         path = tmp_path / "like.tif"
         out = Dataset.empty_like(template, path=path)
-        out.write_array(np.full((2, 2), 7.0, dtype="float32"), window=(0, 0, 2, 2))
+        # template is 3-band, so target band 0 explicitly when writing a 2-D block.
+        out.write_array(
+            np.full((2, 2), 7.0, dtype="float32"), band=0, window=(0, 0, 2, 2)
+        )
         del out
         reopened = Dataset.read_file(str(path))
         back = reopened.read_array(band=0, window=[0, 0, 2, 2])

--- a/tests/dataset/test_create_empty.py
+++ b/tests/dataset/test_create_empty.py
@@ -40,7 +40,7 @@ class TestCreateEmpty:
         assert (ds.rows, ds.columns, ds.band_count) == (4, 5, 1), (
             f"shape mismatch: {(ds.rows, ds.columns, ds.band_count)}"
         )
-        assert ds.no_data_value[0] == -9999.0, (
+        assert ds.no_data_value[0] == pytest.approx(-9999.0), (
             f"nodata not stamped, got {ds.no_data_value[0]}"
         )
 
@@ -58,7 +58,7 @@ class TestCreateEmpty:
             4, 4, dtype="float32", no_data_value=-9999.0, driver_type="MEM"
         )
         whole = ds.read_array()
-        assert np.all(whole == -9999.0), (
+        assert np.all(np.isclose(whole, -9999.0)), (
             f"unwritten MEM cells should read as nodata -9999, got {np.unique(whole)}"
         )
 
@@ -110,7 +110,7 @@ class TestCreateEmpty:
             f"geotransform drift: {reopened.geotransform} != {geo}"
         )
         assert reopened.epsg == 32636, f"epsg drift: {reopened.epsg}"
-        assert reopened.no_data_value[0] == -1.0, (
+        assert reopened.no_data_value[0] == pytest.approx(-1.0), (
             f"nodata drift: {reopened.no_data_value[0]}"
         )
 
@@ -132,7 +132,7 @@ class TestCreateEmpty:
         del ds
         reopened = Dataset.read_file(str(path))
         far = reopened.read_array(window=[1000, 1000, 4, 4])
-        assert np.all(far == -9999.0), (
+        assert np.all(np.isclose(far, -9999.0)), (
             f"unwritten block should read as nodata -9999, got {np.unique(far)}"
         )
 
@@ -228,11 +228,15 @@ class TestCreateEmpty:
         band0 = reopened.read_array(band=0, window=[0, 0, 4, 4])
         band1 = reopened.read_array(band=1, window=[0, 0, 4, 4])
         band2 = reopened.read_array(band=2, window=[0, 0, 4, 4])
-        assert np.all(band0 == 1.0), f"band 0 should be 1.0, got {np.unique(band0)}"
-        assert np.all(band1 == -9999.0), (
+        assert np.all(np.isclose(band0, 1.0)), (
+            f"band 0 should be 1.0, got {np.unique(band0)}"
+        )
+        assert np.all(np.isclose(band1, -9999.0)), (
             f"untouched band 1 should be nodata, got {np.unique(band1)}"
         )
-        assert np.all(band2 == 7.0), f"band 2 should be 7.0, got {np.unique(band2)}"
+        assert np.all(np.isclose(band2, 7.0)), (
+            f"band 2 should be 7.0, got {np.unique(band2)}"
+        )
 
     def test_sparse_allocation_is_small_on_disk(self, tmp_path: Path):
         """A large empty sparse GTiff costs almost no disk before any write.

--- a/tests/dataset/test_create_empty.py
+++ b/tests/dataset/test_create_empty.py
@@ -258,6 +258,19 @@ class TestCreateEmpty:
             f"band 2 should be 7.0, got {np.unique(band2)}"
         )
 
+    def test_options_without_path_raises(self):
+        """Passing `options` with no `path` (MEM target) raises instead of dropping them.
+
+        Test scenario:
+            GDAL creation options apply only to the disk/GTiff driver; the MEM driver
+            takes none. Supplying `options` with `driver_type="MEM"` (no path) must
+            raise rather than silently ignore the list.
+        """
+        with pytest.raises(ValueError, match="apply only to the disk/GTiff driver"):
+            Dataset.create_empty(
+                4, 4, driver_type="MEM", options=["TILED=YES"]
+            )
+
     def test_sparse_allocation_is_small_on_disk(self, tmp_path: Path):
         """A large empty sparse GTiff costs almost no disk before any write.
 
@@ -396,6 +409,28 @@ class TestEmptyLike:
         """
         out = Dataset.empty_like(template, bands=1)
         assert out.band_count == 1, f"band count not overridden: {out.band_count}"
+
+    def test_inherits_per_band_nodata(self):
+        """empty_like preserves each band's no-data value, not just band 0's.
+
+        Test scenario:
+            Build a 3-band template whose bands carry *different* no-data sentinels,
+            then ``empty_like`` it with the band count unchanged. Every band's sentinel
+            must be copied through — previously only band 0's value was broadcast to all
+            bands, losing the per-band values.
+        """
+        arr = np.ones((3, 4, 5), dtype="float32")
+        template = Dataset.create_from_array(
+            arr,
+            top_left_corner=(0.0, 10.0),
+            cell_size=0.5,
+            epsg=4326,
+            no_data_value=[-1.0, -2.0, -3.0],
+        )
+        out = Dataset.empty_like(template)
+        assert list(out.no_data_value) == pytest.approx([-1.0, -2.0, -3.0]), (
+            f"per-band no-data not preserved, got {out.no_data_value}"
+        )
 
     def test_nodata_override(self, template: Dataset):
         """An explicit ``no_data_value`` overrides the template's sentinel.

--- a/tests/dataset/test_create_empty.py
+++ b/tests/dataset/test_create_empty.py
@@ -1,0 +1,331 @@
+"""Tests for the out-of-core empty-raster allocators ``Dataset.create_empty`` / ``empty_like``.
+
+These cover issue #470 task A1: header-only, disk-backed, tiled / sparse / BigTIFF
+allocation that out-of-core algorithms fill window-by-window via
+``write_array(window=)``.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tracemalloc
+from pathlib import Path
+
+import numpy as np
+import pytest
+from osgeo import gdal
+
+from pyramids.dataset import Dataset
+from pyramids.dataset.dataset import OUT_OF_CORE_CREATION_OPTIONS
+
+pytestmark = pytest.mark.core
+
+
+class TestCreateEmpty:
+    """Tests for :meth:`pyramids.dataset.Dataset.create_empty`."""
+
+    def test_mem_allocation_reads_back_as_nodata(self):
+        """An unwritten MEM raster has the configured shape and reads as no-data.
+
+        Test scenario:
+            ``create_empty(4, 5, driver_type="MEM")`` allocates a 1-band 4x5 raster
+            whose cells are untouched. Shape and band count match the request and the
+            no-data sentinel is stamped on the band.
+        """
+        ds = Dataset.create_empty(
+            4, 5, dtype="float32", no_data_value=-9999.0, driver_type="MEM"
+        )
+        assert (ds.rows, ds.columns, ds.band_count) == (4, 5, 1), (
+            f"shape mismatch: {(ds.rows, ds.columns, ds.band_count)}"
+        )
+        assert ds.no_data_value[0] == -9999.0, (
+            f"nodata not stamped, got {ds.no_data_value[0]}"
+        )
+
+    def test_window_write_read_roundtrip_mem(self):
+        """A window scattered into an empty MEM raster reads back unchanged.
+
+        Test scenario:
+            Allocate empty, ``write_array(block, window=(1, 1, 2, 2))``, then read the
+            same window — the values round-trip exactly.
+        """
+        ds = Dataset.create_empty(4, 4, dtype="float32", driver_type="MEM")
+        block = np.arange(4, dtype="float32").reshape(2, 2)
+        ds.write_array(block, window=(1, 1, 2, 2))
+        back = ds.read_array(window=[1, 1, 2, 2])
+        assert back.tolist() == block.tolist(), f"window did not round-trip: {back}"
+
+    def test_window_write_read_roundtrip_gtiff(self, tmp_path: Path):
+        """A window scattered into an empty disk GTiff round-trips after reopen.
+
+        Test scenario:
+            Allocate a disk-backed GTiff, write one window, drop the handle, reopen the
+            file, and read the window back. Proves the disk path (not just MEM) works
+            end-to-end.
+        """
+        path = tmp_path / "empty.tif"
+        ds = Dataset.create_empty(64, 64, dtype="float32", epsg=3857, path=path)
+        block = np.full((8, 8), 5.0, dtype="float32")
+        ds.write_array(block, window=(0, 0, 8, 8))
+        del ds
+        reopened = Dataset.read_file(str(path))
+        back = reopened.read_array(window=[0, 0, 8, 8])
+        assert back.tolist() == block.tolist(), f"GTiff window did not round-trip: {back}"
+
+    def test_geo_crs_nodata_preserved_on_reopen(self, tmp_path: Path):
+        """Geotransform, CRS, and no-data survive a disk round-trip.
+
+        Test scenario:
+            Allocate with an explicit geotransform, EPSG, and no-data; reopen and
+            confirm all three are preserved.
+        """
+        path = tmp_path / "geo.tif"
+        geo = (100.0, 0.25, 0.0, 200.0, 0.0, -0.25)
+        ds = Dataset.create_empty(
+            32, 48, dtype="int16", geo=geo, epsg=32636, no_data_value=-1.0, path=path
+        )
+        del ds
+        reopened = Dataset.read_file(str(path))
+        assert reopened.geotransform == geo, (
+            f"geotransform drift: {reopened.geotransform} != {geo}"
+        )
+        assert reopened.epsg == 32636, f"epsg drift: {reopened.epsg}"
+        assert reopened.no_data_value[0] == -1.0, (
+            f"nodata drift: {reopened.no_data_value[0]}"
+        )
+
+    def test_unwritten_block_reads_as_nodata(self, tmp_path: Path):
+        """A never-written block of a sparse GTiff reads back as no-data, not 0.
+
+        Test scenario:
+            Allocate a sparse tiled GTiff larger than one block, write only the
+            top-left window, then read a far block that was never touched. With
+            SPARSE_OK + a stamped nodata, the unwritten block must read as the nodata
+            sentinel — downstream code relies on this to distinguish "unwritten" from
+            "zero".
+        """
+        path = tmp_path / "sparse.tif"
+        ds = Dataset.create_empty(
+            1024, 1024, dtype="float32", no_data_value=-9999.0, path=path
+        )
+        ds.write_array(np.ones((4, 4), dtype="float32"), window=(0, 0, 4, 4))
+        del ds
+        reopened = Dataset.read_file(str(path))
+        far = reopened.read_array(window=[1000, 1000, 4, 4])
+        assert np.all(far == -9999.0), (
+            f"unwritten block should read as nodata -9999, got {np.unique(far)}"
+        )
+
+    def test_default_options_are_tiled_sparse_bigtiff(self, tmp_path: Path):
+        """The default GTiff is tiled, sparse, and BigTIFF.
+
+        Test scenario:
+            Allocate with default options and inspect the written file via gdalinfo:
+            the block size is 512x512 (TILED), and the file is BigTIFF. Confirms the
+            out-of-core option set actually reaches GDAL.
+        """
+        path = tmp_path / "opts.tif"
+        ds = Dataset.create_empty(600, 600, dtype="float32", path=path)
+        del ds
+        info = gdal.Info(str(path))
+        assert "Block=512x512" in info, f"expected 512x512 blocks, gdalinfo:\n{info}"
+
+    def test_custom_options_override_default(self, tmp_path: Path):
+        """An explicit ``options`` list overrides the out-of-core defaults.
+
+        Test scenario:
+            Pass a 256x256 block size; gdalinfo reports 256x256, proving the override
+            reaches GDAL instead of the 512 default.
+        """
+        path = tmp_path / "custom.tif"
+        ds = Dataset.create_empty(
+            512,
+            512,
+            dtype="float32",
+            path=path,
+            options=["TILED=YES", "BLOCKXSIZE=256", "BLOCKYSIZE=256", "SPARSE_OK=TRUE"],
+        )
+        del ds
+        info = gdal.Info(str(path))
+        assert "Block=256x256" in info, f"expected 256x256 blocks, gdalinfo:\n{info}"
+
+    def test_default_geo_when_omitted(self):
+        """Omitting ``geo`` yields a unit-pixel grid at the origin.
+
+        Test scenario:
+            ``create_empty`` with no geotransform defaults to
+            ``(0, 1, 0, 0, 0, -1)`` so a caller that only cares about pixel coordinates
+            gets a sane identity grid.
+        """
+        ds = Dataset.create_empty(3, 3, driver_type="MEM")
+        assert ds.geotransform == (0.0, 1.0, 0.0, 0.0, 0.0, -1.0), (
+            f"default geo mismatch: {ds.geotransform}"
+        )
+
+    @pytest.mark.slow
+    def test_bigtiff_past_4gb_ceiling(self, tmp_path: Path):
+        """A logical raster past the 4 GB classic-TIFF ceiling allocates and writes.
+
+        Test scenario:
+            A 50 000 x 90 000 int8 raster is ~4.5 GB logically — past the classic-TIFF
+            4 GB limit. With BIGTIFF=YES + SPARSE_OK the header allocates and a single
+            far-corner window write succeeds, while on-disk footprint stays tiny
+            (only the touched block is materialised). A classic TIFF would refuse the
+            header.
+        """
+        path = tmp_path / "big.tif"
+        ds = Dataset.create_empty(50_000, 90_000, dtype="int8", path=path)
+        ds.write_array(
+            np.ones((4, 4), dtype="int8"), window=(49_996, 89_996, 4, 4)
+        )
+        del ds
+        info = gdal.Info(str(path))
+        assert "BigTIFF" in info or "BIGTIFF" in info.upper(), (
+            f"file should be BigTIFF, gdalinfo:\n{info[:400]}"
+        )
+        reopened = Dataset.read_file(str(path))
+        back = reopened.read_array(window=[49_996, 89_996, 4, 4])
+        assert np.all(back == 1), f"far-corner write past 4GB failed: {np.unique(back)}"
+
+    @pytest.mark.slow
+    def test_allocation_is_constant_ram(self, tmp_path: Path):
+        """Allocating a huge raster does not materialise a full-size array.
+
+        Test scenario:
+            A 20 000 x 20 000 float32 dense array would need ~1.6 GB of RAM. The
+            header-only ``create_empty`` must allocate in O(1) — tracemalloc on the
+            Python side should show a peak far below the dense-array size (a few MB,
+            not gigabytes), proving no full buffer is created.
+        """
+        path = tmp_path / "o1.tif"
+        dense_bytes = 20_000 * 20_000 * 4
+        tracemalloc.start()
+        ds = Dataset.create_empty(20_000, 20_000, dtype="float32", path=path)
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        del ds
+        assert peak < dense_bytes // 10, (
+            f"create_empty peaked at {peak / 1e6:.1f} MB; a dense buffer would be "
+            f"{dense_bytes / 1e6:.1f} MB — allocation is not header-only"
+        )
+
+
+class TestEmptyLike:
+    """Tests for :meth:`pyramids.dataset.Dataset.empty_like`."""
+
+    @pytest.fixture
+    def template(self) -> Dataset:
+        """A small 3-band float32 template with geo / epsg / nodata set.
+
+        Returns:
+            Dataset: 3 x 4 x 5 in-memory raster at EPSG:4326, nodata -9999.
+        """
+        return Dataset.create_from_array(
+            np.ones((3, 4, 5), dtype="float32"),
+            top_left_corner=(0.0, 10.0),
+            cell_size=0.5,
+            epsg=4326,
+            no_data_value=-9999.0,
+        )
+
+    def test_copies_template_footprint(self, template: Dataset):
+        """``empty_like`` reproduces the template's shape, geo, epsg, and nodata.
+
+        Test scenario:
+            With no overrides, the output matches every spatial property of the
+            template and stamps the same nodata.
+        """
+        out = Dataset.empty_like(template)
+        assert (out.rows, out.columns, out.band_count) == (4, 5, 3), (
+            f"shape mismatch: {(out.rows, out.columns, out.band_count)}"
+        )
+        assert out.geotransform == template.geotransform, "geotransform drift"
+        assert out.epsg == template.epsg, "epsg drift"
+        assert out.no_data_value[0] == template.no_data_value[0], "nodata drift"
+
+    def test_dtype_override(self, template: Dataset):
+        """``dtype`` overrides the template's data type.
+
+        Test scenario:
+            Requesting ``int16`` produces an int16 raster while keeping every spatial
+            property from the float32 template.
+        """
+        out = Dataset.empty_like(template, dtype="int16")
+        assert out.dtype[0] == "int16", f"dtype not overridden: {out.dtype[0]}"
+        assert (out.rows, out.columns) == (4, 5), "shape changed under dtype override"
+
+    def test_bands_override(self, template: Dataset):
+        """``bands`` overrides the template's band count.
+
+        Test scenario:
+            Requesting a single band from a 3-band template yields a 1-band output
+            with the template's footprint.
+        """
+        out = Dataset.empty_like(template, bands=1)
+        assert out.band_count == 1, f"band count not overridden: {out.band_count}"
+
+    def test_nodata_override(self, template: Dataset):
+        """An explicit ``no_data_value`` overrides the template's sentinel.
+
+        Test scenario:
+            Passing ``no_data_value=0`` stamps 0 instead of inheriting the template's
+            -9999.
+        """
+        out = Dataset.empty_like(template, no_data_value=0)
+        assert out.no_data_value[0] == 0, (
+            f"nodata override ignored: {out.no_data_value[0]}"
+        )
+
+    def test_disk_backed_roundtrip(self, template: Dataset, tmp_path: Path):
+        """A disk-backed ``empty_like`` writes, reopens, and round-trips a window.
+
+        Test scenario:
+            With a path, the output is a GTiff; a window written into it survives a
+            reopen.
+        """
+        path = tmp_path / "like.tif"
+        out = Dataset.empty_like(template, path=path)
+        out.write_array(np.full((2, 2), 7.0, dtype="float32"), window=(0, 0, 2, 2))
+        del out
+        reopened = Dataset.read_file(str(path))
+        back = reopened.read_array(band=0, window=[0, 0, 2, 2])
+        assert back.tolist() == [[7.0, 7.0], [7.0, 7.0]], (
+            f"empty_like disk window did not round-trip: {back}"
+        )
+
+
+class TestCreateOptionsBackCompat:
+    """The new ``options`` threading must not change existing factory output."""
+
+    def test_create_from_array_unchanged_default_compression(self, tmp_path: Path):
+        """``create_from_array`` to disk still uses LZW (the historical default).
+
+        Test scenario:
+            With no ``options`` passed anywhere, a disk-backed ``create_from_array``
+            keeps the historical ``COMPRESS=LZW`` creation option — the new ``options``
+            parameter defaults to None and must not perturb existing callers.
+        """
+        path = tmp_path / "compat.tif"
+        Dataset.create_from_array(
+            np.ones((4, 4), dtype="float32"),
+            top_left_corner=(0.0, 0.0),
+            cell_size=1.0,
+            epsg=4326,
+            driver_type="GTiff",
+            path=str(path),
+        )
+        info = gdal.Info(str(path))
+        assert "COMPRESSION=LZW" in info.upper(), (
+            f"existing create_from_array compression changed, gdalinfo:\n{info}"
+        )
+
+    def test_out_of_core_option_set_shape(self):
+        """The module-level option set is the documented tiled / sparse / BigTIFF list.
+
+        Test scenario:
+            Guards the default option set against accidental edits — every out-of-core
+            allocation depends on these exact keys being present.
+        """
+        joined = ";".join(OUT_OF_CORE_CREATION_OPTIONS)
+        for key in ("TILED=YES", "SPARSE_OK=TRUE", "BIGTIFF=YES"):
+            assert key in joined, f"{key} missing from OUT_OF_CORE_CREATION_OPTIONS"

--- a/tests/dataset/test_create_empty.py
+++ b/tests/dataset/test_create_empty.py
@@ -182,6 +182,35 @@ class TestCreateEmpty:
             f"default geo mismatch: {ds.geotransform}"
         )
 
+    def test_multiband_allocation_writes_bands_independently(self, tmp_path: Path):
+        """A multi-band ``create_empty`` allocates N bands that write/read independently.
+
+        Test scenario:
+            ``create_empty(..., bands=3)`` on disk produces a 3-band raster. Writing a
+            distinct value into band 0 and band 2 (leaving band 1 untouched) and reading
+            each back confirms the band count and that bands do not bleed into one
+            another — band 1 stays at the no-data sentinel, bands 0 and 2 hold their
+            written values. All existing create_empty tests are single-band, so this is
+            the only multi-band coverage.
+        """
+        path = tmp_path / "multiband.tif"
+        ds = Dataset.create_empty(
+            8, 8, bands=3, dtype="float32", no_data_value=-9999.0, path=path
+        )
+        assert ds.band_count == 3, f"expected 3 bands, got {ds.band_count}"
+        ds.write_array(np.full((4, 4), 1.0, dtype="float32"), band=0, window=(0, 0, 4, 4))
+        ds.write_array(np.full((4, 4), 7.0, dtype="float32"), band=2, window=(0, 0, 4, 4))
+        del ds
+        reopened = Dataset.read_file(str(path))
+        band0 = reopened.read_array(band=0, window=[0, 0, 4, 4])
+        band1 = reopened.read_array(band=1, window=[0, 0, 4, 4])
+        band2 = reopened.read_array(band=2, window=[0, 0, 4, 4])
+        assert np.all(band0 == 1.0), f"band 0 should be 1.0, got {np.unique(band0)}"
+        assert np.all(band1 == -9999.0), (
+            f"untouched band 1 should be nodata, got {np.unique(band1)}"
+        )
+        assert np.all(band2 == 7.0), f"band 2 should be 7.0, got {np.unique(band2)}"
+
     def test_sparse_allocation_is_small_on_disk(self, tmp_path: Path):
         """A large empty sparse GTiff costs almost no disk before any write.
 
@@ -331,6 +360,22 @@ class TestEmptyLike:
         out = Dataset.empty_like(template, no_data_value=0)
         assert out.no_data_value[0] == 0, (
             f"nodata override ignored: {out.no_data_value[0]}"
+        )
+
+    def test_explicit_none_nodata_stamps_no_sentinel(self, template: Dataset):
+        """``no_data_value=None`` produces a raster with no no-data sentinel.
+
+        Test scenario:
+            Passing ``no_data_value=None`` explicitly (distinct from the
+            ``_INHERIT_NO_DATA`` default that copies the template's -9999, and from an
+            override value) routes through ``_build_dataset`` with no-data set to None,
+            which skips the band fill entirely. The resulting first-band no-data must be
+            None — the documented "stamp no sentinel" behaviour. This is the only
+            coverage of the None branch.
+        """
+        out = Dataset.empty_like(template, no_data_value=None)
+        assert out.no_data_value[0] is None, (
+            f"expected no no-data sentinel, got {out.no_data_value[0]}"
         )
 
     def test_disk_backed_roundtrip(self, template: Dataset, tmp_path: Path):

--- a/tests/dataset/test_create_empty.py
+++ b/tests/dataset/test_create_empty.py
@@ -136,6 +136,28 @@ class TestCreateEmpty:
             f"unwritten block should read as nodata -9999, got {np.unique(far)}"
         )
 
+    def test_no_data_none_sparse_block_reads_as_zero(self, tmp_path: Path):
+        """With no_data_value=None, an unwritten sparse GTiff block reads back as 0.
+
+        Test scenario:
+            Documents the opt-out caveat: passing ``no_data_value=None`` skips the band
+            fill and stamps no sentinel, so SPARSE_OK has no no-data to return for
+            never-written blocks — they read back as 0, not no-data. This is the
+            documented downside of dropping the sentinel, and the inverse of
+            ``test_unwritten_block_reads_as_nodata``.
+        """
+        path = tmp_path / "sparse_no_nodata.tif"
+        ds = Dataset.create_empty(
+            1024, 1024, dtype="float32", no_data_value=None, path=path
+        )
+        ds.write_array(np.ones((4, 4), dtype="float32"), window=(0, 0, 4, 4))
+        del ds
+        reopened = Dataset.read_file(str(path))
+        far = reopened.read_array(window=[1000, 1000, 4, 4])
+        assert np.all(far == 0), (
+            f"with no nodata, unwritten block should read as 0, got {np.unique(far)}"
+        )
+
     def test_default_options_are_tiled_sparse_bigtiff(self, tmp_path: Path):
         """The default GTiff is tiled, sparse, and BigTIFF.
 


### PR DESCRIPTION
## Summary

Implements issue #470 task A1: header-only, disk-backed empty-raster allocators so out-of-core
algorithms can allocate an output once and scatter result windows into it via `write_array(window=)`
— without ever materialising a full-size array in RAM.

The allocation substrate already existed (`_build_dataset(array=None)` → `_create_dataset` →
`GTiff.Create`); the gap was a configurable creation-option set and two public factories. So this PR
is small and additive.

### Public API

- **`Dataset.create_empty(rows, cols, *, bands, dtype, geo, epsg, no_data_value, driver_type, path,
  options)`** — for the default `driver_type="GTiff"` the file is **tiled + sparse + BigTIFF**
  (`OUT_OF_CORE_CREATION_OPTIONS`), so a 50 000 × 50 000 float32 raster is created in O(1) RAM
  (**verified: 0.116 MB on disk, 3.15 s**), never-written blocks cost no disk, and writes past the
  4 GB classic-TIFF ceiling succeed.
- **`Dataset.empty_like(template, *, dtype, bands, no_data_value, path, options)`** — header-only
  sibling of `dataset_like`; copies geo / epsg / shape / no-data without writing an array.
- **`OUT_OF_CORE_CREATION_OPTIONS`** — the module-level default option list.

### Internal

- Threads an optional `options` list through the `@staticmethod _create_dataset` and `_build_dataset`.
  Default `None` preserves the historical `["COMPRESS=LZW"]`, so `create` / `create_from_array` /
  `dataset_like` and every per-op factory are byte-for-byte unchanged (43 existing create/build tests
  stay green).

### Safety

- `create_empty(driver_type="GTiff")` without a `path` **raises `ValueError`** instead of silently
  producing a MEM raster that drops the out-of-core options.
- `create_empty` / `empty_like` emit a **`UserWarning`** when `no_data_value` resolves to `None`
  (explicitly or inherited), because the resulting raster has no sentinel and its unwritten cells
  read back as `0`, not no-data.

Out of scope (the rest of #470): A2 `map_overlap`, A3 `store_windows`, A4 `tiled_reduce`.

## Test plan

- [x] `pixi run -e dev pytest tests/dataset/test_create_empty.py` → **23 passed** (2 `slow`).
- [x] Coverage: every branch of the A1 surface exercised — MEM/GTiff round-trips, geo/CRS/no-data on
  reopen, sparse unwritten-reads-no-data, **sparse-small-on-disk** (the headline guarantee),
  multi-band band independence, BigTIFF past 4 GB (`slow`), no-full-Python-buffer (`slow`),
  GTiff-without-path raises, `no_data_value=None` warns + reads-as-0, options override + back-compat.
- [x] Doctests: `create_empty` and `empty_like` pass `pytest --doctest-modules`.
- [x] 43 existing `create` / `_build_dataset` / `create_from_array` / `dataset_like` tests unaffected
  by the threaded `options` parameter.

## Notes for reviewers

Two **pre-existing** repo warts surfaced while building this (out of scope here, worth their own
issues): `read_array` window is `(col_off, row_off, n_cols, n_rows)` while `write_array` is
`(row_off, col_off, n_rows, n_cols)` — opposite axis orders; and `_create_dataset` promotes
`MEM + path` to GTiff (now documented on the `driver_type` arg).

Closes #470