### PR TITLE
docs: Dask quickstart notebooks + fix broken UGRID dask notebook

### DIFF
--- a/docs/examples/dask/collection.ipynb
+++ b/docs/examples/dask/collection.ipynb
@@ -1,0 +1,314 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "fd4f34af",
+   "metadata": {},
+   "source": [
+    "# Dask quickstart — `DatasetCollection`\n",
+    "\n",
+    "A time-series of co-registered rasters as one lazy 4-D `(T, B, R, C)` cube. Workers reopen\n",
+    "each file on demand — a `gdal.Dataset` handle never crosses the pickle boundary. For the\n",
+    "full surface (`groupby` via flox, metadata snapshots, kerchunk) see `lazy-collection-complete`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45917dcb",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "1f6f548f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:48.710900Z",
+     "iopub.status.busy": "2026-06-07T19:11:48.710294Z",
+     "iopub.status.idle": "2026-06-07T19:11:50.571177Z",
+     "shell.execute_reply": "2026-06-07T19:11:50.569352Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ['MPLBACKEND'] = 'Agg'  # never trigger an interactive backend\n",
+    "\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import dask.array as da\n",
+    "\n",
+    "\n",
+    "def _find_data():\n",
+    "    for base in [Path.cwd(), *Path.cwd().parents]:\n",
+    "        cand = base / 'tests' / 'data'\n",
+    "        if cand.is_dir():\n",
+    "            return cand.resolve()\n",
+    "    raise FileNotFoundError('Could not locate tests/data from ' + str(Path.cwd()))\n",
+    "\n",
+    "\n",
+    "DATA = _find_data()\n",
+    "DATA.is_dir()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5170fb00",
+   "metadata": {},
+   "source": [
+    "## Build a cube from a folder of rasters"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e6e3dd1b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:50.575564Z",
+     "iopub.status.busy": "2026-06-07T19:11:50.574846Z",
+     "iopub.status.idle": "2026-06-07T19:11:51.485397Z",
+     "shell.execute_reply": "2026-06-07T19:11:51.483825Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-07 21:11:50 | \u001b[32mINFO\u001b[0m | pyramids.base.config | Logging is configured.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(6, 24, 29)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pyramids.dataset import DatasetCollection\n",
+    "\n",
+    "files = sorted((DATA / 'crop_aligned_folder').glob('[0-5].tif'))\n",
+    "cube = DatasetCollection.from_files(files)\n",
+    "cube.time_length, cube.rows, cube.columns"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e2edfd92",
+   "metadata": {},
+   "source": [
+    "## The lazy 4-D cube — `collection.data`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "dec2e130",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:51.488893Z",
+     "iopub.status.busy": "2026-06-07T19:11:51.488129Z",
+     "iopub.status.idle": "2026-06-07T19:11:51.500252Z",
+     "shell.execute_reply": "2026-06-07T19:11:51.498671Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((6, 1, 24, 29), ((1, 1, 1, 1, 1, 1), (1,), (24,), (29,)))"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# One chunk per timestep by default: the delayed graph reads a whole file at a time.\n",
+    "cube.data.shape, cube.data.chunks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "154d25cd",
+   "metadata": {},
+   "source": [
+    "## Time-axis reductions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "67f0c9bf",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:51.503821Z",
+     "iopub.status.busy": "2026-06-07T19:11:51.503286Z",
+     "iopub.status.idle": "2026-06-07T19:11:51.978850Z",
+     "shell.execute_reply": "2026-06-07T19:11:51.976957Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'mean': 0.6656417846679688,\n",
+       " 'min': 0.0,\n",
+       " 'max': 5.150000095367432,\n",
+       " 'std': 1.144860863685608}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stats = {\n",
+    "    'mean': float(cube.mean(skipna=True).mean()),\n",
+    "    'min': float(cube.min().min()),\n",
+    "    'max': float(cube.max().max()),\n",
+    "    'std': float(cube.std().mean()),\n",
+    "}\n",
+    "stats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c518f524",
+   "metadata": {},
+   "source": [
+    "## Grouped reductions — `groupby(labels)`\n",
+    "\n",
+    "Pass one label per timestep; each group reduces to its own array. With the `[lazy]` extra\n",
+    "installed this routes through flox as a single tree-reduction over the cube."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "5c39f3f9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:51.982832Z",
+     "iopub.status.busy": "2026-06-07T19:11:51.982316Z",
+     "iopub.status.idle": "2026-06-07T19:11:52.050686Z",
+     "shell.execute_reply": "2026-06-07T19:11:52.048895Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "([np.str_('A'), np.str_('B')], (1, 24, 29))"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "labels = np.array(['A', 'A', 'A', 'B', 'B', 'B'][: cube.time_length])\n",
+    "group_means = cube.groupby(labels).mean()\n",
+    "sorted(group_means), group_means['A'].shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f0196e40",
+   "metadata": {},
+   "source": [
+    "## Parallel cube write — `to_zarr`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "034491dd",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:52.054043Z",
+     "iopub.status.busy": "2026-06-07T19:11:52.053464Z",
+     "iopub.status.idle": "2026-06-07T19:11:52.627883Z",
+     "shell.execute_reply": "2026-06-07T19:11:52.625905Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['data', 'spatial_ref', 'x', 'y', 'zarr.json']"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import tempfile\n",
+    "\n",
+    "store = Path(tempfile.mkdtemp(prefix='pyramids-cube-')) / 'cube.zarr'\n",
+    "cube.to_zarr(str(store), mode='w')\n",
+    "sorted(p.name for p in store.iterdir())[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c187fce5",
+   "metadata": {},
+   "source": [
+    "## Where to next\n",
+    "\n",
+    "- [Overview](overview.ipynb) — all classes at a glance.\n",
+    "- `lazy-collection-complete` — the exhaustive cookbook.\n",
+    "- The *Lazy collections* tutorial (`lazy-collection`) — construction paths and the cost model."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/dask/collection.ipynb
+++ b/docs/examples/dask/collection.ipynb
@@ -5,10 +5,10 @@
    "id": "fd4f34af",
    "metadata": {},
    "source": [
-    "# Dask quickstart — `DatasetCollection`\n",
+    "# Dask quickstart \u2014 `DatasetCollection`\n",
     "\n",
     "A time-series of co-registered rasters as one lazy 4-D `(T, B, R, C)` cube. Workers reopen\n",
-    "each file on demand — a `gdal.Dataset` handle never crosses the pickle boundary. For the\n",
+    "each file on demand \u2014 a `gdal.Dataset` handle never crosses the pickle boundary. For the\n",
     "full surface (`groupby` via flox, metadata snapshots, kerchunk) see `lazy-collection-complete`."
    ]
   },
@@ -119,7 +119,7 @@
    "id": "e2edfd92",
    "metadata": {},
    "source": [
-    "## The lazy 4-D cube — `collection.data`"
+    "## The lazy 4-D cube \u2014 `collection.data`"
    ]
   },
   {
@@ -201,7 +201,7 @@
    "id": "c518f524",
    "metadata": {},
    "source": [
-    "## Grouped reductions — `groupby(labels)`\n",
+    "## Grouped reductions \u2014 `groupby(labels)`\n",
     "\n",
     "Pass one label per timestep; each group reduces to its own array. With the `[lazy]` extra\n",
     "installed this routes through flox as a single tree-reduction over the cube."
@@ -242,7 +242,7 @@
    "id": "f0196e40",
    "metadata": {},
    "source": [
-    "## Parallel cube write — `to_zarr`"
+    "## Parallel cube write \u2014 `to_zarr`"
    ]
   },
   {
@@ -284,9 +284,16 @@
    "source": [
     "## Where to next\n",
     "\n",
-    "- [Overview](overview.ipynb) — all classes at a glance.\n",
-    "- `lazy-collection-complete` — the exhaustive cookbook.\n",
-    "- The *Lazy collections* tutorial (`lazy-collection`) — construction paths and the cost model."
+    "Three tiers for `DatasetCollection` + Dask:\n",
+    "\n",
+    "- **Complete cookbook (offline)** \u2014\n",
+    "  [Lazy `DatasetCollection`](../dataset/lazy-collection-complete.ipynb): flox `groupby`,\n",
+    "  picklable metadata snapshots, cube-to-Zarr.\n",
+    "- **Cloud (live data)** \u2014 the temporal-stack section of\n",
+    "  [Dask on Sentinel-2 COGs (AWS)](../dataset/dask-lazy-datasets.ipynb).\n",
+    "- **Narrative guide** \u2014\n",
+    "  the [Lazy collections tutorial](../../tutorials/lazy/lazy-collection.md).\n",
+    "- **All classes at a glance** \u2014 [the overview](overview.ipynb)."
    ]
   }
  ],

--- a/docs/examples/dask/dataset.ipynb
+++ b/docs/examples/dask/dataset.ipynb
@@ -5,7 +5,7 @@
    "id": "6b72103d",
    "metadata": {},
    "source": [
-    "# Dask quickstart — `Dataset`\n",
+    "# Dask quickstart \u2014 `Dataset`\n",
     "\n",
     "A single raster, read lazily. `read_array(chunks=...)` returns a `dask.array` instead of\n",
     "a NumPy array; you compose a graph and materialise it once with `.compute()`. For the full\n",
@@ -140,7 +140,7 @@
    ],
    "source": [
     "eager = ds.read_array()              # numpy.ndarray\n",
-    "lazy = ds.read_array(chunks=(32, 32))  # dask.array.Array — no I/O yet\n",
+    "lazy = ds.read_array(chunks=(32, 32))  # dask.array.Array \u2014 no I/O yet\n",
     "(type(eager).__name__, is_lazy(eager)), (type(lazy).__name__, is_lazy(lazy))"
    ]
   },
@@ -223,7 +223,7 @@
    "id": "7d6cfd97",
    "metadata": {},
    "source": [
-    "## Parallel writes — `to_zarr` / `from_zarr`\n",
+    "## Parallel writes \u2014 `to_zarr` / `from_zarr`\n",
     "\n",
     "Zarr is the only lazy-parallel write path for rasters: each chunk becomes an independent\n",
     "file, so workers write concurrently. Re-open with `chunks=` to stay lazy."
@@ -309,9 +309,16 @@
    "source": [
     "## Where to next\n",
     "\n",
-    "- [Overview](overview.ipynb) — all classes at a glance.\n",
-    "- `lazy-dataset-complete` — the exhaustive cookbook (DEM derivatives, zonal stats).\n",
-    "- The *Lazy rasters* tutorial (`lazy-raster`) — narrative guide and chunk-sizing tips."
+    "This quickstart is the first rung of a three-tier ladder for `Dataset` + Dask:\n",
+    "\n",
+    "- **Complete cookbook (offline)** \u2014\n",
+    "  [Lazy `Dataset`](../dataset/lazy-dataset-complete.ipynb): DEM derivatives,\n",
+    "  `focal_apply`, zonal stats \u2014 the full surface.\n",
+    "- **Cloud (live data)** \u2014\n",
+    "  [Dask on Sentinel-2 COGs (AWS)](../dataset/dask-lazy-datasets.ipynb): the same API\n",
+    "  against remote object storage.\n",
+    "- **Narrative guide** \u2014 the [Lazy rasters tutorial](../../tutorials/lazy/lazy-raster.md).\n",
+    "- **All classes at a glance** \u2014 [the overview](overview.ipynb)."
    ]
   }
  ],

--- a/docs/examples/dask/dataset.ipynb
+++ b/docs/examples/dask/dataset.ipynb
@@ -1,0 +1,339 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "6b72103d",
+   "metadata": {},
+   "source": [
+    "# Dask quickstart — `Dataset`\n",
+    "\n",
+    "A single raster, read lazily. `read_array(chunks=...)` returns a `dask.array` instead of\n",
+    "a NumPy array; you compose a graph and materialise it once with `.compute()`. For the full\n",
+    "surface (neighbourhood ops, DEM derivatives, zonal stats) see `lazy-dataset-complete`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0828ce19",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ab62eb9f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:42.162445Z",
+     "iopub.status.busy": "2026-06-07T19:11:42.162034Z",
+     "iopub.status.idle": "2026-06-07T19:11:43.784081Z",
+     "shell.execute_reply": "2026-06-07T19:11:43.782677Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ['MPLBACKEND'] = 'Agg'  # never trigger an interactive backend\n",
+    "\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import dask.array as da\n",
+    "\n",
+    "\n",
+    "def _find_data():\n",
+    "    for base in [Path.cwd(), *Path.cwd().parents]:\n",
+    "        cand = base / 'tests' / 'data'\n",
+    "        if cand.is_dir():\n",
+    "            return cand.resolve()\n",
+    "    raise FileNotFoundError('Could not locate tests/data from ' + str(Path.cwd()))\n",
+    "\n",
+    "\n",
+    "DATA = _find_data()\n",
+    "DATA.is_dir()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82f20c06",
+   "metadata": {},
+   "source": [
+    "## Eager vs lazy reads"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d81eda45",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:43.786989Z",
+     "iopub.status.busy": "2026-06-07T19:11:43.786374Z",
+     "iopub.status.idle": "2026-06-07T19:11:44.695128Z",
+     "shell.execute_reply": "2026-06-07T19:11:44.693710Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-07 21:11:43 | \u001b[32mINFO\u001b[0m | pyramids.base.config | Logging is configured.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "((1, 13, 14), 4000.0, 32618)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pyramids.dataset import Dataset\n",
+    "from pyramids.base.protocols import is_lazy, as_numpy\n",
+    "\n",
+    "ds = Dataset.read_file(str(DATA / 'acc4000.tif'))\n",
+    "ds.shape, ds.cell_size, ds.epsg"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b22ccab9",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:44.698158Z",
+     "iopub.status.busy": "2026-06-07T19:11:44.697550Z",
+     "iopub.status.idle": "2026-06-07T19:11:45.130651Z",
+     "shell.execute_reply": "2026-06-07T19:11:45.128998Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(('ndarray', False), ('Array', True))"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "eager = ds.read_array()              # numpy.ndarray\n",
+    "lazy = ds.read_array(chunks=(32, 32))  # dask.array.Array — no I/O yet\n",
+    "(type(eager).__name__, is_lazy(eager)), (type(lazy).__name__, is_lazy(lazy))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b82ec59e",
+   "metadata": {},
+   "source": [
+    "## Build a graph, then compute once"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "4aa87d75",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:45.133671Z",
+     "iopub.status.busy": "2026-06-07T19:11:45.133242Z",
+     "iopub.status.idle": "2026-06-07T19:11:45.160644Z",
+     "shell.execute_reply": "2026-06-07T19:11:45.159157Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'min': 0.0, 'max': 88.0, 'mean': 7.966291904449463}"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Mask the nodata sentinel in the graph before reducing.\n",
+    "nodata = ds.no_data_value[0]\n",
+    "masked = da.where(lazy == nodata, np.nan, lazy)\n",
+    "stats = {\n",
+    "    'min': float(da.nanmin(masked).compute()),\n",
+    "    'max': float(da.nanmax(masked).compute()),\n",
+    "    'mean': float(da.nanmean(masked).compute()),\n",
+    "}\n",
+    "stats"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "9ac42ac2",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:45.164500Z",
+     "iopub.status.busy": "2026-06-07T19:11:45.163818Z",
+     "iopub.status.idle": "2026-06-07T19:11:45.174526Z",
+     "shell.execute_reply": "2026-06-07T19:11:45.172638Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('ndarray', (13, 14))"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# as_numpy is a no-op on numpy and forces a compute on dask.\n",
+    "materialised = as_numpy(lazy)\n",
+    "type(materialised).__name__, materialised.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d6cfd97",
+   "metadata": {},
+   "source": [
+    "## Parallel writes — `to_zarr` / `from_zarr`\n",
+    "\n",
+    "Zarr is the only lazy-parallel write path for rasters: each chunk becomes an independent\n",
+    "file, so workers write concurrently. Re-open with `chunks=` to stay lazy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "7e38060f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:45.178333Z",
+     "iopub.status.busy": "2026-06-07T19:11:45.177716Z",
+     "iopub.status.idle": "2026-06-07T19:11:45.699269Z",
+     "shell.execute_reply": "2026-06-07T19:11:45.698023Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(32618, (1, 13, 14), 4000.0)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import tempfile\n",
+    "\n",
+    "store = Path(tempfile.mkdtemp(prefix='pyramids-ds-')) / 'acc4000.zarr'\n",
+    "ds.to_zarr(str(store), chunks=(1, 32, 32), mode='w')\n",
+    "reloaded = Dataset.from_zarr(str(store), chunks=(1, 32, 32))\n",
+    "reloaded.epsg, reloaded.shape, reloaded.cell_size"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6062f969",
+   "metadata": {},
+   "source": [
+    "## Neighbourhood ops are lazy too\n",
+    "\n",
+    "`focal_*`, `slope`, `aspect`, and `hillshade` accept `chunks=` and run via\n",
+    "`dask.array.map_overlap`, so halos are handled across chunk borders for you."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "7cbabe24",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:45.702638Z",
+     "iopub.status.busy": "2026-06-07T19:11:45.701788Z",
+     "iopub.status.idle": "2026-06-07T19:11:45.718861Z",
+     "shell.execute_reply": "2026-06-07T19:11:45.716885Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('Array', ((13,), (14,)))"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "focal = ds.focal_mean(radius=1, chunks=(32, 32))\n",
+    "type(focal).__name__, focal.chunks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dd0cd091",
+   "metadata": {},
+   "source": [
+    "## Where to next\n",
+    "\n",
+    "- [Overview](overview.ipynb) — all classes at a glance.\n",
+    "- `lazy-dataset-complete` — the exhaustive cookbook (DEM derivatives, zonal stats).\n",
+    "- The *Lazy rasters* tutorial (`lazy-raster`) — narrative guide and chunk-sizing tips."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/dask/feature.ipynb
+++ b/docs/examples/dask/feature.ipynb
@@ -1,0 +1,312 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "badc7c54",
+   "metadata": {},
+   "source": [
+    "# Dask quickstart — `FeatureCollection`\n",
+    "\n",
+    "A vector table read lazily as partitions. `backend='dask'` returns a\n",
+    "`LazyFeatureCollection` (a partitioned dask-geopandas frame); partition-aware ops stay\n",
+    "lazy and you materialise with `.compute()`. Needs the `[parquet-lazy]` extra. For the full\n",
+    "surface see `lazy-feature-complete`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f08d2f5f",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "478caad0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:56.537887Z",
+     "iopub.status.busy": "2026-06-07T19:11:56.537355Z",
+     "iopub.status.idle": "2026-06-07T19:11:58.760410Z",
+     "shell.execute_reply": "2026-06-07T19:11:58.758647Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ['MPLBACKEND'] = 'Agg'  # never trigger an interactive backend\n",
+    "\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import dask.array as da\n",
+    "\n",
+    "\n",
+    "def _find_data():\n",
+    "    for base in [Path.cwd(), *Path.cwd().parents]:\n",
+    "        cand = base / 'tests' / 'data'\n",
+    "        if cand.is_dir():\n",
+    "            return cand.resolve()\n",
+    "    raise FileNotFoundError('Could not locate tests/data from ' + str(Path.cwd()))\n",
+    "\n",
+    "\n",
+    "DATA = _find_data()\n",
+    "DATA.is_dir()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "56af39c9",
+   "metadata": {},
+   "source": [
+    "## Backend detection and a lazy read"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "61f0bdc3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:58.764677Z",
+     "iopub.status.busy": "2026-06-07T19:11:58.763782Z",
+     "iopub.status.idle": "2026-06-07T19:11:59.442884Z",
+     "shell.execute_reply": "2026-06-07T19:11:59.441633Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-07 21:11:58 | \u001b[32mINFO\u001b[0m | pyramids.base.config | Logging is configured.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pyramids.feature import FeatureCollection, has_lazy_backend, is_lazy_fc\n",
+    "\n",
+    "has_lazy_backend()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "70cd972b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:59.445537Z",
+     "iopub.status.busy": "2026-06-07T19:11:59.444957Z",
+     "iopub.status.idle": "2026-06-07T19:11:59.512995Z",
+     "shell.execute_reply": "2026-06-07T19:11:59.511844Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True, 'LazyFeatureCollection', 2)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lfc = FeatureCollection.read_file(\n",
+    "    str(DATA / 'coello-gauges.geojson'), backend='dask', npartitions=2\n",
+    ")\n",
+    "is_lazy_fc(lfc), type(lfc).__name__, lfc.npartitions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d1c1f930",
+   "metadata": {},
+   "source": [
+    "## Partition-aware ops\n",
+    "\n",
+    "`to_crs` / `clip` stay lazy and keep returning a `LazyFeatureCollection`. The bounds are a\n",
+    "lazy reduction — `compute_total_bounds()` returns the 4-float array directly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "174c681a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:59.516891Z",
+     "iopub.status.busy": "2026-06-07T19:11:59.516204Z",
+     "iopub.status.idle": "2026-06-07T19:11:59.986557Z",
+     "shell.execute_reply": "2026-06-07T19:11:59.985179Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('LazyFeatureCollection',\n",
+       " 4326,\n",
+       " array([-75.5060754 ,   4.32493719, -75.11452282,   4.55188404]))"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "projected = lfc.to_crs(4326)\n",
+    "type(projected).__name__, projected.epsg, projected.compute_total_bounds()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35e0b2bc",
+   "metadata": {},
+   "source": [
+    "## Spatial join — partition-pruned\n",
+    "\n",
+    "`spatial_shuffle` is a one-time cost that populates `spatial_partitions`; a subsequent\n",
+    "`sjoin` then prunes partition pairs that cannot intersect."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "384a6611",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:59.989918Z",
+     "iopub.status.busy": "2026-06-07T19:11:59.989285Z",
+     "iopub.status.idle": "2026-06-07T19:12:00.765242Z",
+     "shell.execute_reply": "2026-06-07T19:12:00.763610Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('LazyFeatureCollection', 2)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "polys = FeatureCollection.read_file(\n",
+    "    str(DATA / 'coello_polygons.geojson'), backend='dask', npartitions=2\n",
+    ").to_crs(4326)\n",
+    "gauges = projected.spatial_shuffle(by='hilbert')\n",
+    "polys = polys.spatial_shuffle(by='hilbert')\n",
+    "joined = gauges.sjoin(polys, how='inner', predicate='intersects')\n",
+    "type(joined).__name__, joined.npartitions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19f48195",
+   "metadata": {},
+   "source": [
+    "## Materialise and write\n",
+    "\n",
+    "`compute()` returns an eager `FeatureCollection`. `to_parquet` is the only lazy-native\n",
+    "write for vectors (it writes a partitioned directory)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "cbbb8d66",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:12:00.768000Z",
+     "iopub.status.busy": "2026-06-07T19:12:00.767553Z",
+     "iopub.status.idle": "2026-06-07T19:12:00.950296Z",
+     "shell.execute_reply": "2026-06-07T19:12:00.949091Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(2, 6)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import tempfile\n",
+    "\n",
+    "out = Path(tempfile.mkdtemp(prefix='pyramids-fc-')) / 'gauges.parquet'\n",
+    "lfc.to_parquet(str(out))\n",
+    "reopened = FeatureCollection.read_parquet(str(out), backend='dask')\n",
+    "reopened.npartitions, len(reopened.compute())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cfdffc7f",
+   "metadata": {},
+   "source": [
+    "## Where to next\n",
+    "\n",
+    "- [Overview](overview.ipynb) — all classes at a glance.\n",
+    "- `lazy-feature-complete` — the exhaustive cookbook (`persist`, scheduler config).\n",
+    "- The *Lazy vector reads* tutorial (`lazy-vector`) — the decision tree and method matrix."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/dask/feature.ipynb
+++ b/docs/examples/dask/feature.ipynb
@@ -5,7 +5,7 @@
    "id": "badc7c54",
    "metadata": {},
    "source": [
-    "# Dask quickstart — `FeatureCollection`\n",
+    "# Dask quickstart \u2014 `FeatureCollection`\n",
     "\n",
     "A vector table read lazily as partitions. `backend='dask'` returns a\n",
     "`LazyFeatureCollection` (a partitioned dask-geopandas frame); partition-aware ops stay\n",
@@ -152,7 +152,7 @@
     "## Partition-aware ops\n",
     "\n",
     "`to_crs` / `clip` stay lazy and keep returning a `LazyFeatureCollection`. The bounds are a\n",
-    "lazy reduction — `compute_total_bounds()` returns the 4-float array directly."
+    "lazy reduction \u2014 `compute_total_bounds()` returns the 4-float array directly."
    ]
   },
   {
@@ -191,7 +191,7 @@
    "id": "35e0b2bc",
    "metadata": {},
    "source": [
-    "## Spatial join — partition-pruned\n",
+    "## Spatial join \u2014 partition-pruned\n",
     "\n",
     "`spatial_shuffle` is a one-time cost that populates `spatial_partitions`; a subsequent\n",
     "`sjoin` then prunes partition pairs that cannot intersect."
@@ -282,9 +282,17 @@
    "source": [
     "## Where to next\n",
     "\n",
-    "- [Overview](overview.ipynb) — all classes at a glance.\n",
-    "- `lazy-feature-complete` — the exhaustive cookbook (`persist`, scheduler config).\n",
-    "- The *Lazy vector reads* tutorial (`lazy-vector`) — the decision tree and method matrix."
+    "Three tiers for `FeatureCollection` + Dask:\n",
+    "\n",
+    "- **Complete cookbook (offline)** \u2014\n",
+    "  [Lazy `FeatureCollection`](../feature/lazy-feature-complete.ipynb): `persist`,\n",
+    "  scheduler config, the full method matrix.\n",
+    "- **Cloud (live data)** \u2014\n",
+    "  [Dask on Overture Maps (AWS)](../feature/dask-lazy-features.ipynb): GeoParquet with\n",
+    "  Arrow pushdown filters.\n",
+    "- **Narrative guide** \u2014\n",
+    "  the [Lazy vector reads tutorial](../../tutorials/lazy/lazy-vector.md).\n",
+    "- **All classes at a glance** \u2014 [the overview](overview.ipynb)."
    ]
   }
  ],

--- a/docs/examples/dask/netcdf.ipynb
+++ b/docs/examples/dask/netcdf.ipynb
@@ -5,7 +5,7 @@
    "id": "c7df3393",
    "metadata": {},
    "source": [
-    "# Dask quickstart — `NetCDF`\n",
+    "# Dask quickstart \u2014 `NetCDF`\n",
     "\n",
     "Read one variable lazily, across time and across files. `read_array(variable, chunks=...)`\n",
     "returns a `dask.array`; `open_mfdataset` stacks many files into one. Kerchunk manifests\n",
@@ -140,7 +140,7 @@
    ],
    "source": [
     "eager = nc.read_array('values')                 # numpy\n",
-    "lazy = nc.read_array('values', chunks=(1, -1, -1))  # dask — one chunk per leading step\n",
+    "lazy = nc.read_array('values', chunks=(1, -1, -1))  # dask \u2014 one chunk per leading step\n",
     "(type(eager).__name__, eager.shape), (type(lazy).__name__, lazy.chunks)"
    ]
   },
@@ -195,7 +195,7 @@
    "id": "759998b2",
    "metadata": {},
    "source": [
-    "## Multi-file stacks — `open_mfdataset`\n",
+    "## Multi-file stacks \u2014 `open_mfdataset`\n",
     "\n",
     "One variable at a time; returns a `(n_files, *var_shape)` dask array. Here we reuse one\n",
     "file three times to stand in for a real multi-file cube."
@@ -247,7 +247,7 @@
     "## Kerchunk manifests (optional)\n",
     "\n",
     "`to_kerchunk` writes a JSON byte-range index so the file can be opened zero-copy by\n",
-    "downstream tools. It needs the `[netcdf-lazy]` extra — guard the call so the notebook\n",
+    "downstream tools. It needs the `[netcdf-lazy]` extra \u2014 guard the call so the notebook\n",
     "still runs without it."
    ]
   },
@@ -294,9 +294,16 @@
    "source": [
     "## Where to next\n",
     "\n",
-    "- [Overview](overview.ipynb) — all classes at a glance.\n",
-    "- `lazy-netcdf-complete` — the exhaustive cookbook (`unpack`, combined kerchunk, xarray).\n",
-    "- The *Lazy NetCDF* tutorial (`lazy-netcdf`) — chunk heuristics and the kerchunk workflow."
+    "Three tiers for `NetCDF` + Dask:\n",
+    "\n",
+    "- **Complete cookbook (offline)** \u2014\n",
+    "  [Lazy `NetCDF`](../netcdf/lazy-netcdf-complete.ipynb): `unpack`, combined kerchunk\n",
+    "  manifests, handing arrays to xarray.\n",
+    "- **Cloud (live data)** \u2014\n",
+    "  [Dask on ERA5 (AWS)](../netcdf/dask-lazy-netcdf.ipynb): kerchunk over a decade of\n",
+    "  reanalysis.\n",
+    "- **Narrative guide** \u2014 the [Lazy NetCDF tutorial](../../tutorials/lazy/lazy-netcdf.md).\n",
+    "- **All classes at a glance** \u2014 [the overview](overview.ipynb)."
    ]
   }
  ],

--- a/docs/examples/dask/netcdf.ipynb
+++ b/docs/examples/dask/netcdf.ipynb
@@ -1,0 +1,324 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c7df3393",
+   "metadata": {},
+   "source": [
+    "# Dask quickstart — `NetCDF`\n",
+    "\n",
+    "Read one variable lazily, across time and across files. `read_array(variable, chunks=...)`\n",
+    "returns a `dask.array`; `open_mfdataset` stacks many files into one. Kerchunk manifests\n",
+    "(zero-copy byte-range indexes) need the `[netcdf-lazy]` extra. For the full surface see\n",
+    "`lazy-netcdf-complete`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f437aae9",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "a9a9e30e",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:12:06.498642Z",
+     "iopub.status.busy": "2026-06-07T19:12:06.498142Z",
+     "iopub.status.idle": "2026-06-07T19:12:08.364373Z",
+     "shell.execute_reply": "2026-06-07T19:12:08.362685Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ['MPLBACKEND'] = 'Agg'  # never trigger an interactive backend\n",
+    "\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import dask.array as da\n",
+    "\n",
+    "\n",
+    "def _find_data():\n",
+    "    for base in [Path.cwd(), *Path.cwd().parents]:\n",
+    "        cand = base / 'tests' / 'data'\n",
+    "        if cand.is_dir():\n",
+    "            return cand.resolve()\n",
+    "    raise FileNotFoundError('Could not locate tests/data from ' + str(Path.cwd()))\n",
+    "\n",
+    "\n",
+    "DATA = _find_data()\n",
+    "DATA.is_dir()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "325f3e87",
+   "metadata": {},
+   "source": [
+    "## Eager vs lazy variable reads"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "f29f1eda",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:12:08.367960Z",
+     "iopub.status.busy": "2026-06-07T19:12:08.367075Z",
+     "iopub.status.idle": "2026-06-07T19:12:09.253416Z",
+     "shell.execute_reply": "2026-06-07T19:12:09.251968Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-07 21:12:08 | \u001b[32mINFO\u001b[0m | pyramids.base.config | Logging is configured.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "['values']"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pyramids.netcdf import NetCDF\n",
+    "\n",
+    "nc = NetCDF.read_file(str(DATA / 'netcdf' / 'pyramids-netcdf-3d.nc'))\n",
+    "nc.variable_names"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "cf9078ba",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:12:09.256698Z",
+     "iopub.status.busy": "2026-06-07T19:12:09.255874Z",
+     "iopub.status.idle": "2026-06-07T19:12:09.722036Z",
+     "shell.execute_reply": "2026-06-07T19:12:09.720840Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(('ndarray', (3, 13, 14)), ('Array', ((1, 1, 1), (13,), (14,))))"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "eager = nc.read_array('values')                 # numpy\n",
+    "lazy = nc.read_array('values', chunks=(1, -1, -1))  # dask — one chunk per leading step\n",
+    "(type(eager).__name__, eager.shape), (type(lazy).__name__, lazy.chunks)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df3d26a6",
+   "metadata": {},
+   "source": [
+    "## Reduce over the leading axis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "24225b12",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:12:09.725682Z",
+     "iopub.status.busy": "2026-06-07T19:12:09.725092Z",
+     "iopub.status.idle": "2026-06-07T19:12:09.744377Z",
+     "shell.execute_reply": "2026-06-07T19:12:09.742772Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\gdrive\\algorithms\\gis\\pyramids\\.claude\\worktrees\\dask-notebooks\\.pixi\\envs\\dev\\Lib\\site-packages\\numpy\\_core\\_methods.py:49: RuntimeWarning: overflow encountered in reduce\n",
+      "  return umr_sum(a, axis, dtype, out, keepdims, initial, where)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(13, 14)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# No I/O until compute().\n",
+    "per_cell_mean = lazy.mean(axis=0)\n",
+    "per_cell_mean.compute().shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "759998b2",
+   "metadata": {},
+   "source": [
+    "## Multi-file stacks — `open_mfdataset`\n",
+    "\n",
+    "One variable at a time; returns a `(n_files, *var_shape)` dask array. Here we reuse one\n",
+    "file three times to stand in for a real multi-file cube."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "56b04c62",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:12:09.747287Z",
+     "iopub.status.busy": "2026-06-07T19:12:09.746878Z",
+     "iopub.status.idle": "2026-06-07T19:12:09.782088Z",
+     "shell.execute_reply": "2026-06-07T19:12:09.780788Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\gdrive\\algorithms\\gis\\pyramids\\.claude\\worktrees\\dask-notebooks\\.pixi\\envs\\dev\\Lib\\site-packages\\numpy\\_core\\_methods.py:49: RuntimeWarning: overflow encountered in reduce\n",
+      "  return umr_sum(a, axis, dtype, out, keepdims, initial, where)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "((3, 3, 13, 14), (3, 13, 14))"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "paths = [str(DATA / 'netcdf' / 'pyramids-netcdf-3d.nc')] * 3\n",
+    "stack = NetCDF.open_mfdataset(paths, variable='values')\n",
+    "stack.shape, stack.mean(axis=0).compute().shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0cfa4d2f",
+   "metadata": {},
+   "source": [
+    "## Kerchunk manifests (optional)\n",
+    "\n",
+    "`to_kerchunk` writes a JSON byte-range index so the file can be opened zero-copy by\n",
+    "downstream tools. It needs the `[netcdf-lazy]` extra — guard the call so the notebook\n",
+    "still runs without it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "a2e722ec",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:12:09.785223Z",
+     "iopub.status.busy": "2026-06-07T19:12:09.784632Z",
+     "iopub.status.idle": "2026-06-07T19:12:10.235948Z",
+     "shell.execute_reply": "2026-06-07T19:12:10.234558Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('wrote manifest:', True)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import tempfile\n",
+    "\n",
+    "manifest = Path(tempfile.mkdtemp(prefix='pyramids-nc-')) / 'single.json'\n",
+    "try:\n",
+    "    refs = nc.to_kerchunk(str(manifest))\n",
+    "    outcome = 'wrote manifest:', manifest.exists()\n",
+    "except ImportError as exc:\n",
+    "    outcome = 'netcdf-lazy extra missing:', str(exc)\n",
+    "outcome"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ec490c60",
+   "metadata": {},
+   "source": [
+    "## Where to next\n",
+    "\n",
+    "- [Overview](overview.ipynb) — all classes at a glance.\n",
+    "- `lazy-netcdf-complete` — the exhaustive cookbook (`unpack`, combined kerchunk, xarray).\n",
+    "- The *Lazy NetCDF* tutorial (`lazy-netcdf`) — chunk heuristics and the kerchunk workflow."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/dask/overview.ipynb
+++ b/docs/examples/dask/overview.ipynb
@@ -22,7 +22,7 @@
     "Install the extras: `pip install 'pyramids-gis[lazy]'` (rasters, NetCDF, collections) and\n",
     "`pip install 'pyramids-gis[parquet-lazy]'` (vectors).\n",
     "\n",
-    "This page is a tour. Each class has a focused quickstart and an exhaustive cookbook —\n",
+    "This page is a tour. Each class has a focused quickstart and an exhaustive cookbook \u2014\n",
     "see the links at the bottom."
    ]
   },
@@ -86,10 +86,10 @@
    "id": "0502412d",
    "metadata": {},
    "source": [
-    "## `Dataset` — lazy raster reads\n",
+    "## `Dataset` \u2014 lazy raster reads\n",
     "\n",
     "`read_array()` returns NumPy; `read_array(chunks=...)` returns a `dask.array`. Reductions\n",
-    "are nodata-aware only if you mask the sentinel yourself — `pyramids` hands you the raw band."
+    "are nodata-aware only if you mask the sentinel yourself \u2014 `pyramids` hands you the raw band."
    ]
   },
   {
@@ -157,7 +157,7 @@
     }
    ],
    "source": [
-    "# Mask the nodata sentinel inside the graph, then reduce — no I/O until compute().\n",
+    "# Mask the nodata sentinel inside the graph, then reduce \u2014 no I/O until compute().\n",
     "nodata = ds.no_data_value[0]\n",
     "masked = da.where(lazy == nodata, np.nan, lazy)\n",
     "float(da.nanmin(masked).compute()), float(da.nanmax(masked).compute())"
@@ -168,7 +168,7 @@
    "id": "2b115d94",
    "metadata": {},
    "source": [
-    "## `DatasetCollection` — lazy raster time-series\n",
+    "## `DatasetCollection` \u2014 lazy raster time-series\n",
     "\n",
     "`from_files` stacks co-registered rasters into a 4-D `(T, B, R, C)` Dask cube exposed as\n",
     "`.data`. Reductions run over the whole cube and each file opens at most once."
@@ -241,10 +241,10 @@
    "id": "70b3f1e4",
    "metadata": {},
    "source": [
-    "## `FeatureCollection` — lazy vector tables\n",
+    "## `FeatureCollection` \u2014 lazy vector tables\n",
     "\n",
     "`backend='dask'` returns a `LazyFeatureCollection` (a partitioned dask-geopandas frame).\n",
-    "The bounds reduction is lazy — `compute_total_bounds()` materialises only the 4-float\n",
+    "The bounds reduction is lazy \u2014 `compute_total_bounds()` materialises only the 4-float\n",
     "result, not the rows."
    ]
   },
@@ -316,7 +316,7 @@
    "id": "3de46c87",
    "metadata": {},
    "source": [
-    "## `NetCDF` — lazy variable reads\n",
+    "## `NetCDF` \u2014 lazy variable reads\n",
     "\n",
     "One variable at a time. `chunks=(1, -1, -1)` is one chunk per leading-axis step."
    ]
@@ -399,19 +399,31 @@
     "\n",
     "- **`UgridDataset`** (UGRID meshes) has no native `dask.array` path: the mesh topology and\n",
     "  data variables are eager NumPy. To go lazy, grid a variable to a `Dataset` with\n",
-    "  `to_dataset(variable, cell_size)` and use the raster path above — see the\n",
+    "  `to_dataset(variable, cell_size)` and use the raster path above \u2014 see the\n",
     "  [UGRID notebook](../netcdf/ugrid/dask-lazy-ugrid.ipynb).\n",
     "- **Exotic model grids** (HEALPix / octahedral / ORCA) interpolate in a single eager pass.\n",
     "- **COG** writes are serial through GDAL; COG *reads* inherit the `Dataset` lazy path\n",
-    "  (`read_array(chunks=...)`) — there is nothing COG-specific to learn.\n",
+    "  (`read_array(chunks=...)`) \u2014 there is nothing COG-specific to learn.\n",
     "\n",
     "## Where to next\n",
     "\n",
-    "- Quickstarts: [Dataset](dataset.ipynb) · [DatasetCollection](collection.ipynb) ·\n",
-    "  [FeatureCollection](feature.ipynb) · [NetCDF](netcdf.ipynb)\n",
-    "- Exhaustive cookbooks: `lazy-dataset-complete`, `lazy-collection-complete`,\n",
-    "  `lazy-feature-complete`, `lazy-netcdf-complete` (under each subsystem in the nav).\n",
-    "- Narrative guides: the *Lazy / Dask* tutorials (`lazy-compute`, `lazy-raster`, …)."
+    "Each class has three tiers \u2014 pick by depth (quickstart \u2192 complete cookbook \u2192 live cloud):\n",
+    "\n",
+    "- `Dataset`: [quickstart](dataset.ipynb) \u00b7\n",
+    "  [complete cookbook](../dataset/lazy-dataset-complete.ipynb) \u00b7\n",
+    "  [cloud \u2014 Sentinel-2](../dataset/dask-lazy-datasets.ipynb)\n",
+    "- `DatasetCollection`: [quickstart](collection.ipynb) \u00b7\n",
+    "  [complete cookbook](../dataset/lazy-collection-complete.ipynb) \u00b7\n",
+    "  cloud: the stack section of the Sentinel-2 notebook\n",
+    "- `FeatureCollection`: [quickstart](feature.ipynb) \u00b7\n",
+    "  [complete cookbook](../feature/lazy-feature-complete.ipynb) \u00b7\n",
+    "  [cloud \u2014 Overture](../feature/dask-lazy-features.ipynb)\n",
+    "- `NetCDF`: [quickstart](netcdf.ipynb) \u00b7\n",
+    "  [complete cookbook](../netcdf/lazy-netcdf-complete.ipynb) \u00b7\n",
+    "  [cloud \u2014 ERA5](../netcdf/dask-lazy-netcdf.ipynb)\n",
+    "\n",
+    "Narrative guides: the *Lazy / Dask* tutorials (`lazy-compute`, `lazy-raster`,\n",
+    "`lazy-netcdf`, `lazy-collection`, `lazy-vector`)."
    ]
   }
  ],

--- a/docs/examples/dask/overview.ipynb
+++ b/docs/examples/dask/overview.ipynb
@@ -1,0 +1,439 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "dde86701",
+   "metadata": {},
+   "source": [
+    "# Using `pyramids` with Dask\n",
+    "\n",
+    "`pyramids` reads stay **eager NumPy by default**. Every lazy entry point is opt-in:\n",
+    "you pass `chunks=` (rasters / NetCDF) or `backend='dask'` (vectors), and the call\n",
+    "returns a Dask object instead of a materialised array. Nothing touches disk until you\n",
+    "call `.compute()`.\n",
+    "\n",
+    "| You have...                                | Go lazy when...                         | Entry point |\n",
+    "|--------------------------------------------|-----------------------------------------|-------------|\n",
+    "| a single raster (`Dataset`)                | it is larger than RAM, or you tile work | `read_array(chunks=...)`, `to_zarr` |\n",
+    "| a raster time-series (`DatasetCollection`) | you reduce / group over many files      | `from_files(...).data` |\n",
+    "| a vector table (`FeatureCollection`)       | the table does not fit in memory        | `read_file(..., backend='dask')` |\n",
+    "| a NetCDF cube (`NetCDF`)                    | you read one variable across time/files | `read_array(chunks=...)`, `open_mfdataset` |\n",
+    "\n",
+    "Install the extras: `pip install 'pyramids-gis[lazy]'` (rasters, NetCDF, collections) and\n",
+    "`pip install 'pyramids-gis[parquet-lazy]'` (vectors).\n",
+    "\n",
+    "This page is a tour. Each class has a focused quickstart and an exhaustive cookbook —\n",
+    "see the links at the bottom."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26c07a4f",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "f1a8150a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:35.878233Z",
+     "iopub.status.busy": "2026-06-07T19:11:35.877699Z",
+     "iopub.status.idle": "2026-06-07T19:11:37.734027Z",
+     "shell.execute_reply": "2026-06-07T19:11:37.732929Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ['MPLBACKEND'] = 'Agg'  # never trigger an interactive backend\n",
+    "\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "import dask.array as da\n",
+    "\n",
+    "\n",
+    "def _find_data():\n",
+    "    for base in [Path.cwd(), *Path.cwd().parents]:\n",
+    "        cand = base / 'tests' / 'data'\n",
+    "        if cand.is_dir():\n",
+    "            return cand.resolve()\n",
+    "    raise FileNotFoundError('Could not locate tests/data from ' + str(Path.cwd()))\n",
+    "\n",
+    "\n",
+    "DATA = _find_data()\n",
+    "DATA.is_dir()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0502412d",
+   "metadata": {},
+   "source": [
+    "## `Dataset` — lazy raster reads\n",
+    "\n",
+    "`read_array()` returns NumPy; `read_array(chunks=...)` returns a `dask.array`. Reductions\n",
+    "are nodata-aware only if you mask the sentinel yourself — `pyramids` hands you the raw band."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "4e73d7fc",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:37.736566Z",
+     "iopub.status.busy": "2026-06-07T19:11:37.736018Z",
+     "iopub.status.idle": "2026-06-07T19:11:38.935060Z",
+     "shell.execute_reply": "2026-06-07T19:11:38.933930Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-07 21:11:37 | \u001b[32mINFO\u001b[0m | pyramids.base.config | Logging is configured.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(True, 'Array', (13, 14), ((13,), (14,)))"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pyramids.dataset import Dataset\n",
+    "from pyramids.base.protocols import is_lazy\n",
+    "\n",
+    "ds = Dataset.read_file(str(DATA / 'acc4000.tif'))\n",
+    "lazy = ds.read_array(chunks=(32, 32))\n",
+    "is_lazy(lazy), type(lazy).__name__, lazy.shape, lazy.chunks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "3cc7f520",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:38.937384Z",
+     "iopub.status.busy": "2026-06-07T19:11:38.937008Z",
+     "iopub.status.idle": "2026-06-07T19:11:38.957146Z",
+     "shell.execute_reply": "2026-06-07T19:11:38.955100Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(0.0, 88.0)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Mask the nodata sentinel inside the graph, then reduce — no I/O until compute().\n",
+    "nodata = ds.no_data_value[0]\n",
+    "masked = da.where(lazy == nodata, np.nan, lazy)\n",
+    "float(da.nanmin(masked).compute()), float(da.nanmax(masked).compute())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2b115d94",
+   "metadata": {},
+   "source": [
+    "## `DatasetCollection` — lazy raster time-series\n",
+    "\n",
+    "`from_files` stacks co-registered rasters into a 4-D `(T, B, R, C)` Dask cube exposed as\n",
+    "`.data`. Reductions run over the whole cube and each file opens at most once."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "e860c2d1",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:38.960833Z",
+     "iopub.status.busy": "2026-06-07T19:11:38.960323Z",
+     "iopub.status.idle": "2026-06-07T19:11:38.992893Z",
+     "shell.execute_reply": "2026-06-07T19:11:38.991437Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((6, 1, 24, 29), ((1, 1, 1, 1, 1, 1), (1,), (24,), (29,)))"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pyramids.dataset import DatasetCollection\n",
+    "\n",
+    "files = sorted((DATA / 'crop_aligned_folder').glob('[0-5].tif'))\n",
+    "cube = DatasetCollection.from_files(files)\n",
+    "cube.data.shape, cube.data.chunks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2015456a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:38.995971Z",
+     "iopub.status.busy": "2026-06-07T19:11:38.995453Z",
+     "iopub.status.idle": "2026-06-07T19:11:39.015770Z",
+     "shell.execute_reply": "2026-06-07T19:11:39.014418Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('ndarray', (1, 24, 29))"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Time-axis reduction -> a single (B, R, C) NumPy array.\n",
+    "time_mean = cube.mean(skipna=True)\n",
+    "type(time_mean).__name__, time_mean.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "70b3f1e4",
+   "metadata": {},
+   "source": [
+    "## `FeatureCollection` — lazy vector tables\n",
+    "\n",
+    "`backend='dask'` returns a `LazyFeatureCollection` (a partitioned dask-geopandas frame).\n",
+    "The bounds reduction is lazy — `compute_total_bounds()` materialises only the 4-float\n",
+    "result, not the rows."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "1b777bfa",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:39.018734Z",
+     "iopub.status.busy": "2026-06-07T19:11:39.018275Z",
+     "iopub.status.idle": "2026-06-07T19:11:39.064452Z",
+     "shell.execute_reply": "2026-06-07T19:11:39.062980Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True, 2)"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pyramids.feature import FeatureCollection, is_lazy_fc\n",
+    "\n",
+    "lfc = FeatureCollection.read_file(\n",
+    "    str(DATA / 'coello-gauges.geojson'), backend='dask', npartitions=2\n",
+    ")\n",
+    "is_lazy_fc(lfc), lfc.npartitions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "2c5f53b4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:39.067885Z",
+     "iopub.status.busy": "2026-06-07T19:11:39.067141Z",
+     "iopub.status.idle": "2026-06-07T19:11:39.112389Z",
+     "shell.execute_reply": "2026-06-07T19:11:39.110995Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([-75.5060754 ,   4.32493719, -75.11452282,   4.55188404])"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Lazy reproject; the bounds reduction is computed on demand.\n",
+    "projected = lfc.to_crs(4326)\n",
+    "projected.compute_total_bounds()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3de46c87",
+   "metadata": {},
+   "source": [
+    "## `NetCDF` — lazy variable reads\n",
+    "\n",
+    "One variable at a time. `chunks=(1, -1, -1)` is one chunk per leading-axis step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "2ac803ef",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:39.115807Z",
+     "iopub.status.busy": "2026-06-07T19:11:39.115338Z",
+     "iopub.status.idle": "2026-06-07T19:11:39.178932Z",
+     "shell.execute_reply": "2026-06-07T19:11:39.177476Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('Array', (3, 13, 14), ((1, 1, 1), (13,), (14,)))"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pyramids.netcdf import NetCDF\n",
+    "\n",
+    "nc = NetCDF.read_file(str(DATA / 'netcdf' / 'pyramids-netcdf-3d.nc'))\n",
+    "vlazy = nc.read_array('values', chunks=(1, -1, -1))\n",
+    "type(vlazy).__name__, vlazy.shape, vlazy.chunks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "ee619d0c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:11:39.181969Z",
+     "iopub.status.busy": "2026-06-07T19:11:39.181398Z",
+     "iopub.status.idle": "2026-06-07T19:11:39.198807Z",
+     "shell.execute_reply": "2026-06-07T19:11:39.197460Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\gdrive\\algorithms\\gis\\pyramids\\.claude\\worktrees\\dask-notebooks\\.pixi\\envs\\dev\\Lib\\site-packages\\numpy\\_core\\_methods.py:49: RuntimeWarning: overflow encountered in reduce\n",
+      "  return umr_sum(a, axis, dtype, out, keepdims, initial, where)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(13, 14)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Reduce over the leading axis without materialising the cube.\n",
+    "vlazy.mean(axis=0).compute().shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb32241b",
+   "metadata": {},
+   "source": [
+    "## What is *not* lazy\n",
+    "\n",
+    "- **`UgridDataset`** (UGRID meshes) has no native `dask.array` path: the mesh topology and\n",
+    "  data variables are eager NumPy. To go lazy, grid a variable to a `Dataset` with\n",
+    "  `to_dataset(variable, cell_size)` and use the raster path above — see the\n",
+    "  [UGRID notebook](../netcdf/ugrid/dask-lazy-ugrid.ipynb).\n",
+    "- **Exotic model grids** (HEALPix / octahedral / ORCA) interpolate in a single eager pass.\n",
+    "- **COG** writes are serial through GDAL; COG *reads* inherit the `Dataset` lazy path\n",
+    "  (`read_array(chunks=...)`) — there is nothing COG-specific to learn.\n",
+    "\n",
+    "## Where to next\n",
+    "\n",
+    "- Quickstarts: [Dataset](dataset.ipynb) · [DatasetCollection](collection.ipynb) ·\n",
+    "  [FeatureCollection](feature.ipynb) · [NetCDF](netcdf.ipynb)\n",
+    "- Exhaustive cookbooks: `lazy-dataset-complete`, `lazy-collection-complete`,\n",
+    "  `lazy-feature-complete`, `lazy-netcdf-complete` (under each subsystem in the nav).\n",
+    "- Narrative guides: the *Lazy / Dask* tutorials (`lazy-compute`, `lazy-raster`, …)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/netcdf/ugrid/dask-lazy-ugrid.ipynb
+++ b/docs/examples/netcdf/ugrid/dask-lazy-ugrid.ipynb
@@ -2,202 +2,257 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "71f6e403",
    "metadata": {},
    "source": [
-    "# Lazy UGRID reads for unstructured ocean / hydro meshes\n",
+    "# UGRID meshes and Dask\n",
     "\n",
-    "UGRID is the [CF-compliant convention](https://ugrid-conventions.github.io/ugrid-conventions/) for storing unstructured meshes in NetCDF — FVCOM, SCHISM, ADCIRC, SELFE, Delft3D FM all emit it. A regional ocean run at minute cadence easily generates **~40 GB / day** of face-centred state variables; a full hindcast of Gulf of Maine at NECOFS 3-km resolution is > 1 TB. Going lazy is the only way to interactively explore these.\n",
+    "**`UgridDataset` has no native `dask.array` path.** Unstructured meshes are not rasters: the\n",
+    "topology (nodes, faces, edges) and the data variables are loaded as eager NumPy arrays,\n",
+    "because almost every mesh operation needs the whole connectivity at once.\n",
     "\n",
-    "This notebook uses a real public UGRID dataset — the NECOFS Gulf of Maine forecast, hosted by UMass Dartmouth SMAST as OPeNDAP / NetCDF — to demonstrate the dask-backed read path on `UgridDataset`.\n",
-    "\n",
-    "## What you'll see\n",
-    "\n",
-    "1. Open a UGRID NetCDF lazily — `UgridDataset.read_file(path)` + `.read_array(variable, chunks=...)`.\n",
-    "2. Reduce across time (node-wise mean temperature over a month) without materialising the full mesh.\n",
-    "3. Interpolate the unstructured mesh to a regular grid with `mesh_to_grid` — useful for cross-checking against gridded models.\n",
-    "4. Write the interpolated cube as Zarr for downstream xarray consumers.\n",
-    "\n",
-    "## Requirements\n",
-    "\n",
-    "```bash\n",
-    "pip install 'pyramids-gis[netcdf-lazy]'\n",
-    "```\n",
-    "\n",
-    "Pulls `xarray`, `netCDF4`, `h5netcdf`, `dask[array]`, `zarr`, `fsspec` (`cftime` is a core pyramids dependency). UGRID uses GDAL's NetCDF MDIM driver, which is already a hard pyramids dep."
+    "The way you bring Dask to mesh data is to **bridge to a raster**: interpolate a variable onto\n",
+    "a regular grid with `to_dataset(variable, cell_size)`, which returns a standard `Dataset`,\n",
+    "and then use the raster lazy path (`read_array(chunks=...)`, `to_zarr`). This notebook runs\n",
+    "fully offline on a small test mesh."
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "2a608c10",
    "metadata": {},
    "source": [
-    "## Scheduler + cloud defaults"
+    "## Setup"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 1,
+   "id": "4b6dec06",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:12:13.464618Z",
+     "iopub.status.busy": "2026-06-07T19:12:13.464264Z",
+     "iopub.status.idle": "2026-06-07T19:12:15.214286Z",
+     "shell.execute_reply": "2026-06-07T19:12:15.212529Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import os\n",
     "\n",
-    "os.environ['MPLBACKEND'] = 'Agg'\n",
+    "os.environ['MPLBACKEND'] = 'Agg'  # never trigger an interactive backend\n",
     "\n",
-    "import dask\n",
+    "from pathlib import Path\n",
     "\n",
-    "dask.config.set(scheduler=\"processes\")\n",
-    "\n",
-    "from pyramids import configure\n",
-    "\n",
-    "# GDAL_HTTP_MULTIRANGE + VSI_CACHE are the ones that matter most\n",
-    "# for OPeNDAP / HTTP NetCDF reads.\n",
-    "configure(cloud_defaults=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 1. Open NECOFS as a UgridDataset\n",
-    "\n",
-    "NECOFS (Northeast Coastal Ocean Forecast System) publishes FVCOM output at http://www.smast.umassd.edu:8080/thredds/. The daily-forecast dataset `NECOFS_GOM3_FORECAST.nc` is a ~200 GB running archive; the variable we'll reduce — `temp` (face-centred water temperature on 53k triangles × 40 vertical layers × ~720 hourly time steps) — is ~3 GB per month-slice.\n",
-    "\n",
-    "Pyramids' `UgridDataset` parses the mesh topology (node coords, face connectivity, edge list) eagerly because it's small (~10 MB); the data variables stay lazy."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from pyramids.netcdf.ugrid import UgridDataset\n",
-    "\n",
-    "# FVCOM NECOFS GOM3 hindcast, via OPeNDAP. Fragment is deterministic;\n",
-    "# swap to a more-recent URL if SMAST rotates the forecast archive.\n",
-    "NECOFS = (\n",
-    "    \"http://www.smast.umassd.edu:8080/thredds/dodsC/\"\n",
-    "    \"FVCOM/NECOFS/Forecasts/NECOFS_GOM3_FORECAST.nc\"\n",
-    ")\n",
-    "\n",
-    "ugrid = UgridDataset.read_file(NECOFS)\n",
-    "ugrid.n_node, ugrid.n_face, ugrid.data_variable_names[:5]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## 2. Lazy read of a data variable\n",
-    "\n",
-    "`UgridDataset.read_variable(name, chunks=...)` returns a `dask.array.Array` shaped `(time, sigma, face)` for face-centred vars (or `(time, node)` for node-centred). The block shape inherited from NetCDF is typically one time step × one sigma level per chunk — perfect for time-reductions."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Temperature on the face centroids — lazy.\n",
-    "temp = ugrid.read_variable(\"temp\", chunks={\"time\": 24})\n",
-    "type(temp).__name__, temp.shape, temp.chunksize"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Month-long mean at the surface layer (sigma=0) — reduce across time.\n",
-    "# Only the chunks we touch get fetched over OPeNDAP.\n",
     "import numpy as np\n",
+    "import dask.array as da\n",
     "\n",
-    "surface = temp[:720, 0, :]  # first 30 days, surface sigma\n",
-    "monthly_mean = surface.mean(axis=0)  # still lazy\n",
     "\n",
-    "monthly_mean_np = monthly_mean.compute()\n",
-    "monthly_mean_np.shape, float(np.nanmean(monthly_mean_np))"
+    "def _find_data():\n",
+    "    for base in [Path.cwd(), *Path.cwd().parents]:\n",
+    "        cand = base / 'tests' / 'data'\n",
+    "        if cand.is_dir():\n",
+    "            return cand.resolve()\n",
+    "    raise FileNotFoundError('Could not locate tests/data from ' + str(Path.cwd()))\n",
+    "\n",
+    "\n",
+    "DATA = _find_data()\n",
+    "DATA.is_dir()"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "774fc641",
    "metadata": {},
    "source": [
-    "## 3. Interpolate mesh → regular grid\n",
-    "\n",
-    "Unstructured-to-regular resampling is the classical \"make it xarray-friendly\" step. `mesh_to_grid` does barycentric / nearest-neighbour interpolation over the mesh connectivity; the resampled cube is a plain 2-D numpy array you can hand to `cleopatra` / matplotlib / rioxarray."
+    "## Open a UGRID mesh (eager)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 2,
+   "id": "cf808173",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:12:15.218722Z",
+     "iopub.status.busy": "2026-06-07T19:12:15.217760Z",
+     "iopub.status.idle": "2026-06-07T19:12:16.220674Z",
+     "shell.execute_reply": "2026-06-07T19:12:16.219447Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-07 21:12:15 | \u001b[32mINFO\u001b[0m | pyramids.base.config | Logging is configured.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(8916, 8355, 17270, ['mesh2d_node_z', 'mesh2d_edge_type'])"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "from pyramids.netcdf.ugrid.interpolation import mesh_to_grid\n",
+    "from pyramids.netcdf.ugrid.dataset import UgridDataset\n",
     "\n",
-    "# Regular 0.05° grid covering the Gulf of Maine.\n",
-    "grid = mesh_to_grid(\n",
-    "    mesh=ugrid.mesh,\n",
-    "    values=monthly_mean_np,\n",
-    "    cell_size=0.05,\n",
-    "    bounds=(-71.0, 41.0, -66.5, 45.0),\n",
-    "    method=\"nearest\",\n",
-    ")\n",
-    "grid.shape, float(np.nanmin(grid)), float(np.nanmax(grid))"
+    "u = UgridDataset.read_file(str(DATA / 'netcdf' / 'ugrid' / 'ugrid.nc'))\n",
+    "u.n_node, u.n_face, u.n_edge, u.data_variable_names"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "c6dff11a",
    "metadata": {},
    "source": [
-    "## 4. Save the interpolated cube as Zarr\n",
+    "## Data variables are eager NumPy\n",
     "\n",
-    "For a multi-month workflow, you'd loop monthly_mean → grid, stack across time, and write the stack as Zarr. The partitioned write is parallel under the process scheduler configured above."
+    "`get_data(name)` returns a `MeshVariable`; its `.data` is a plain `ndarray`, not a Dask\n",
+    "array. There is no `chunks=` here — this is the part that is *not* lazy."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
+   "id": "4b464863",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:12:16.223989Z",
+     "iopub.status.busy": "2026-06-07T19:12:16.223035Z",
+     "iopub.status.idle": "2026-06-07T19:12:16.230924Z",
+     "shell.execute_reply": "2026-06-07T19:12:16.229438Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('node', (8916,), 'ndarray', False)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "var = u.get_data('mesh2d_node_z')\n",
+    "var.location, var.shape, type(var.data).__name__, var.has_time"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2bffbf9d",
    "metadata": {},
-   "outputs": [],
+   "source": [
+    "## Bridge to a raster, then go lazy\n",
+    "\n",
+    "`to_dataset` interpolates the mesh variable onto a regular grid (nearest by default) and\n",
+    "returns a `Dataset`. It lives in GDAL's in-memory driver, so to read it *lazily* — the lazy\n",
+    "path reopens files by path on the workers — persist it once, then reopen. From there\n",
+    "everything in the [Dataset quickstart](../../dask/dataset.ipynb) applies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b14e6686",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:12:16.233785Z",
+     "iopub.status.busy": "2026-06-07T19:12:16.233382Z",
+     "iopub.status.idle": "2026-06-07T19:12:18.801695Z",
+     "shell.execute_reply": "2026-06-07T19:12:18.799590Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((1, 20, 40), 4326, 1721.2824206218236)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import tempfile\n",
-    "from pathlib import Path\n",
     "\n",
     "from pyramids.dataset import Dataset\n",
     "\n",
-    "# Wrap as a Dataset so we get the CF-compliant Zarr writer.\n",
-    "ds = Dataset.create_from_array(\n",
-    "    grid[np.newaxis, :, :].astype(np.float32),  # add band dim\n",
-    "    top_left_corner=(-71.0, 45.0),\n",
-    "    cell_size=0.05,\n",
-    "    epsg=4326,\n",
-    ")\n",
+    "xmin, ymin, xmax, ymax = u.bounds\n",
+    "grid = u.to_dataset('mesh2d_node_z', cell_size=(xmax - xmin) / 40)\n",
     "\n",
-    "store = Path(tempfile.mkdtemp()) / \"necofs_monthly.zarr\"\n",
-    "ds.to_zarr(str(store))\n",
-    "list(store.iterdir())[:4]"
+    "tif = Path(tempfile.mkdtemp(prefix='pyramids-ugrid-')) / 'node_z.tif'\n",
+    "grid.to_file(str(tif))            # persist the interpolated raster\n",
+    "gridded = Dataset.read_file(str(tif))  # reopen file-backed\n",
+    "gridded.shape, gridded.epsg, gridded.cell_size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "5f36fc1d",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-07T19:12:18.805811Z",
+     "iopub.status.busy": "2026-06-07T19:12:18.805069Z",
+     "iopub.status.idle": "2026-06-07T19:12:19.691163Z",
+     "shell.execute_reply": "2026-06-07T19:12:19.689422Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('Array', ((10, 10), (20, 20)), ['data', 'spatial_ref', 'x', 'y'])"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Now the standard raster lazy path works: read lazily and write Zarr chunks in parallel.\n",
+    "lazy = gridded.read_array(chunks=(10, 20))\n",
+    "store = tif.with_suffix('.zarr')\n",
+    "gridded.to_zarr(str(store), chunks=(1, 10, 20), mode='w')\n",
+    "type(lazy).__name__, lazy.chunks, sorted(p.name for p in store.iterdir())[:4]"
    ]
   },
   {
    "cell_type": "markdown",
+   "id": "97f5a553",
    "metadata": {},
    "source": [
-    "## Notes on UGRID + dask\n",
+    "## Summary\n",
     "\n",
-    "- **Mesh topology is NOT lazy.** The connectivity table (faces → nodes) is always materialised eagerly — it's tiny (~10 MB for 53k-face NECOFS) and every face-space operation needs it.\n",
-    "- **Face-space reductions parallelise naturally.** Mean / std / quantile over time or sigma layers are chunk-local.\n",
-    "- **Spatial neighbourhood ops do NOT chunk cleanly** on unstructured meshes. Gradient / divergence / smoothing need the full topology and are best materialised first (`.compute()`) before running.\n",
-    "- **OPeNDAP is slower than S3.** If you're running a long reduction, copy the source NetCDF to a local SSD / EBS volume and read from there — GDAL / xarray will still use the same code path.\n",
-    "\n",
-    "## Further reading\n",
-    "\n",
-    "- [UGRID Conventions v1.0](https://ugrid-conventions.github.io/ugrid-conventions/) — the format spec\n",
-    "- [FVCOM NECOFS forecasts](http://www.smast.umassd.edu:8080/thredds/catalog.html) — the dataset used above\n",
-    "- [Xugrid](https://deltares.github.io/xugrid/) — a complementary xarray-native UGRID reader; pyramids' UgridDataset wraps a subset of similar operations"
+    "- Mesh topology and `MeshVariable.data` are **eager** — there is no `read_variable(chunks=...)`.\n",
+    "- To parallelise with Dask, **grid to a `Dataset`** via `to_dataset(...)`, persist it, and use\n",
+    "  the raster lazy path (`read_array(chunks=...)`, `to_zarr`, `from_zarr`).\n",
+    "- See also: [Dataset quickstart](../../dask/dataset.ipynb), the *Lazy rasters* tutorial, and\n",
+    "  the UGRID reference pages."
    ]
   }
  ],
@@ -208,10 +263,18 @@
    "name": "python3"
   },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "version": "3.12"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.5"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 4
+ "nbformat_minor": 5
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -167,6 +167,11 @@ nav:
           - Lazy NetCDF: tutorials/lazy/lazy-netcdf.md
           - Lazy collections (DatasetCollection): tutorials/lazy/lazy-collection.md
           - Lazy vector reads (FeatureCollection): tutorials/lazy/lazy-vector.md
+          - Using pyramids with Dask (notebook): examples/dask/overview.ipynb
+          - Dask quickstart — Dataset: examples/dask/dataset.ipynb
+          - Dask quickstart — DatasetCollection: examples/dask/collection.ipynb
+          - Dask quickstart — FeatureCollection: examples/dask/feature.ipynb
+          - Dask quickstart — NetCDF: examples/dask/netcdf.ipynb
       - Dataset:
           - Overview: tutorials/dataset.md
           - Raster basics: tutorials/raster-basics.md
@@ -208,7 +213,7 @@ nav:
           - UGRID:
               - Mesh exploration: examples/netcdf/ugrid/ugrid-mesh-exploration.ipynb
               - River channel: examples/netcdf/ugrid/ugrid-river-channel.ipynb
-              - Dask (FVCOM NECOFS via OPeNDAP): examples/netcdf/ugrid/dask-lazy-ugrid.ipynb
+              - Dask (mesh → raster bridge): examples/netcdf/ugrid/dask-lazy-ugrid.ipynb
   - How-to:
       - Dev Container: how-to/devcontainer.md
       - Docker & GHCR: how-to/docker.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -186,8 +186,8 @@ nav:
           - COG basics (offline): examples/cog/cog-basics.ipynb
           - COG with real data: examples/cog/cog-real-data.ipynb
           - Dask (Sentinel-2 COGs on AWS): examples/dataset/dask-lazy-datasets.ipynb
-          - Dask — Dataset (local data): examples/dataset/lazy-dataset-complete.ipynb
-          - Dask — DatasetCollection (local data): examples/dataset/lazy-collection-complete.ipynb
+          - Dask — Dataset (complete cookbook): examples/dataset/lazy-dataset-complete.ipynb
+          - Dask — DatasetCollection (complete cookbook): examples/dataset/lazy-collection-complete.ipynb
       - Zarr:
           - Zarr basics (offline): examples/zarr/zarr-basics.ipynb
           - Zarr cubes — append & region: examples/zarr/zarr-cube.ipynb
@@ -198,7 +198,7 @@ nav:
       - Feature:
           - FeatureCollection tutorial: tutorials/feature.md
           - Dask (Overture Maps on AWS): examples/feature/dask-lazy-features.ipynb
-          - Dask — LazyFeatureCollection (local data): examples/feature/lazy-feature-complete.ipynb
+          - Dask — LazyFeatureCollection (complete cookbook): examples/feature/lazy-feature-complete.ipynb
       - STAC:
           - STAC tutorial: tutorials/stac.md
           - STAC (offline, local data): examples/stac/stac-local.ipynb
@@ -209,7 +209,7 @@ nav:
       - NetCDF:
           - Plotting NetCDF data: tutorials/netcdf-plotting.md
           - Dask (ERA5 on AWS): examples/netcdf/dask-lazy-netcdf.ipynb
-          - Dask — NetCDF (local data): examples/netcdf/lazy-netcdf-complete.ipynb
+          - Dask — NetCDF (complete cookbook): examples/netcdf/lazy-netcdf-complete.ipynb
           - UGRID:
               - Mesh exploration: examples/netcdf/ugrid/ugrid-mesh-exploration.ipynb
               - River channel: examples/netcdf/ugrid/ugrid-river-channel.ipynb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,7 +247,7 @@ main = { cmd = "pytest -vvv --cov=src/pyramids -sv -m 'not plot and not xarray' 
 plot = { cmd = "pytest -vvv --cov=src/pyramids --cov-append -sv -m 'plot' --cov-report=xml", description = "Run plot test suite" }
 xarray-tests = { cmd = "pytest -vvv --cov=src/pyramids --cov-append -sv -m 'xarray' --cov-report=xml", description = "Run xarray interop tests" }
 test-all = { cmd = "pytest -vvv --cov=src/pyramids -sv --cov-report=xml --cov-report=term-missing", description = "Run all testsuite" }
-notebooks = { cmd = "pytest --nbval --nbval-lax --verbose docs/examples --ignore-glob='docs/examples/**/dask-lazy-*.ipynb' --ignore-glob='docs/examples/**/lazy-*-complete.ipynb' --ignore-glob='docs/examples/**/stac-cloud-*.ipynb' --ignore-glob='docs/examples/zarr/*.ipynb'", description = "check notebooks (skips dask cookbooks, stac-cloud-* and zarr/* — all need extras envs or real endpoints)" }
+notebooks = { cmd = "pytest --nbval --nbval-lax --verbose docs/examples --ignore-glob='docs/examples/**/dask-lazy-*.ipynb' --ignore-glob='docs/examples/dask/*.ipynb' --ignore-glob='docs/examples/**/lazy-*-complete.ipynb' --ignore-glob='docs/examples/**/stac-cloud-*.ipynb' --ignore-glob='docs/examples/zarr/*.ipynb'", description = "check notebooks (skips dask cookbooks/quickstarts, stac-cloud-* and zarr/* — all need extras envs or real endpoints)" }
 jupyter = { cmd = "jupyter lab --no-browser --IdentityProvider.token='' --ServerApp.password='' --port=8889", description = "check notebooks" }
 build-dist = { cmd = "python -m build", description = "Build sdist and wheel for PyPI" }
 publish-pypi = { cmd = "twine upload --non-interactive --repository pypi dist/*", depends-on = ["build-dist"], description = "Build and upload package to PyPI" }


### PR DESCRIPTION
## Summary

Adds offline-runnable Dask example notebooks and fixes the one broken dask notebook.

**New — `docs/examples/dask/`** (one consolidated overview + four per-class quickstarts):

- `overview.ipynb` — *Using pyramids with Dask*: when to go lazy, the extras, and a section
  per class (Dataset / DatasetCollection / FeatureCollection / NetCDF), plus an honest note on
  what is **not** lazy (UGRID, exotic grids, COG).
- `dataset.ipynb` — `read_array(chunks=...)`, nodata-aware reductions, `to_zarr`/`from_zarr`,
  lazy `focal_mean`.
- `collection.ipynb` — `from_files(...).data`, time-axis reductions, `groupby`, `to_zarr`.
- `feature.ipynb` — `backend='dask'`, lazy `to_crs`/`compute_total_bounds`, partition-pruned
  `sjoin`, `to_parquet`.
- `netcdf.ipynb` — lazy `read_array`, leading-axis reduction, `open_mfdataset`, kerchunk
  (guarded).

**Fixed — `docs/examples/netcdf/ugrid/dask-lazy-ugrid.ipynb`:** it documented
`UgridDataset.read_variable(name, chunks=...)` / `.read_array(variable, chunks=...)`, **neither
of which exists** — `UgridDataset` only has `read_file`, and mesh topology + `MeshVariable.data`
are eager NumPy. Rewritten to run fully offline on `tests/data/netcdf/ugrid/ugrid.nc` and to show
the real story: meshes have no native dask path, so bridge to a `Dataset` via
`to_dataset(variable, cell_size)`, persist it, and use the raster lazy path.

## Test plan

- **Every notebook was executed end-to-end offline** (nbclient, Agg backend, lazy extras present
  in the `dev` env): all cells run with **0 error outputs**; outputs are stored for the
  `mkdocs-jupyter` `execute: false` render.
- `nbformat.validate` passes on all six.
- Wired into the *Lazy / Dask* nav; all nav targets resolve on disk.
- Added `docs/examples/dask/*.ipynb` to the `notebooks` task ignore-glob (they need the lazy
  extras, matching the existing dask cookbooks); the UGRID notebook stays covered by the existing
  `dask-lazy-*` glob.

## Note

The four main classes already had thorough dask coverage (a local "complete" cookbook + a
real-world cloud notebook + a markdown tutorial each). These quickstarts are intentionally
concise, offline-runnable intros that complement — not replace — those. Cross-links point back to
the exhaustive cookbooks and tutorials.