### PR TITLE
fix(collection): render DatasetCollection.plot() when rasters have no nodata

### DIFF
--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -2062,10 +2062,17 @@ class DatasetCollection:
         # (the user explicitly asked to render). Delegates the cleopatra
         # call to :func:`render_array` (D-2 — shared with `Analysis.plot`).
         data = np.stack([ds.read_array(band=band) for ds in self.datasets], axis=0)
+        # Sanitise an unset no-data value (``None``) to ``np.nan`` before
+        # building the exclusion list — mirrors ``Analysis.plot`` (the
+        # ``Dataset.plot`` engine). A raw ``None`` would reach cleopatra as
+        # ``[None]`` and crash in ``np.isclose(array, None)`` (``array - None``).
+        # ``np.nan`` masks nothing, so a collection of nodata-less rasters (e.g.
+        # Google Earth Engine exports) renders every cell instead of raising.
+        no_data_value = [np.nan if v is None else v for v in self.base.no_data_value]
         exclude_value = (
-            [self.base.no_data_value[band], exclude_value]
+            [no_data_value[band], exclude_value]
             if exclude_value is not None
-            else [self.base.no_data_value[band]]
+            else [no_data_value[band]]
         )
         return render_array(
             arr=data,

--- a/tests/dataset/test_plot.py
+++ b/tests/dataset/test_plot.py
@@ -491,9 +491,10 @@ class TestPlotDatasetCollection:
         The ``None`` -> ``np.nan`` sanitisation (mirroring ``Analysis.plot``) masks
         nothing and renders every cell instead of raising.
         """
+        rng = np.random.default_rng(0)
         files = []
         for i in range(3):
-            arr = np.random.rand(1, 12, 12).astype("float32")
+            arr = rng.random((1, 12, 12), dtype="float32")
             ds = Dataset.create_from_array(
                 arr=arr, geo=(0, 0.1, 0, 2, 0, -0.1), epsg=4326, no_data_value=None
             )

--- a/tests/dataset/test_plot.py
+++ b/tests/dataset/test_plot.py
@@ -479,6 +479,33 @@ class TestPlotDatasetCollection:
         cleo = cube.plot()
         assert isinstance(cleo, ArrayGlyph)
 
+    @pytest.mark.plot
+    def test_plot_no_nodata_value_does_not_crash(self, tmp_path):
+        """`DatasetCollection.plot()` must render rasters that carry no no-data value.
+
+        Regression for #480: rasters written without a no-data value (common for
+        external exports, e.g. Google Earth Engine ``getDownloadURL``) report
+        ``no_data_value == (None,)``. Previously the animate path forwarded
+        ``[None]`` to cleopatra, which crashed in ``np.isclose(array, None)`` with
+        ``TypeError: unsupported operand type(s) for -: 'float' and 'NoneType'``.
+        The ``None`` -> ``np.nan`` sanitisation (mirroring ``Analysis.plot``) masks
+        nothing and renders every cell instead of raising.
+        """
+        files = []
+        for i in range(3):
+            arr = np.random.rand(1, 12, 12).astype("float32")
+            ds = Dataset.create_from_array(
+                arr=arr, geo=(0, 0.1, 0, 2, 0, -0.1), epsg=4326, no_data_value=None
+            )
+            path = tmp_path / f"frame_{i}.tif"
+            ds.to_file(str(path))
+            files.append(str(path))
+
+        cube = DatasetCollection.from_files(files)
+        assert cube.base.no_data_value == (None,), "precondition: nodata is unset"
+        glyph = cube.plot(band=0)
+        assert isinstance(glyph, ArrayGlyph)
+
 
 class TestColorTable:
 


### PR DESCRIPTION
## Summary

Fixes #480 — `DatasetCollection.plot()` raised
`TypeError: unsupported operand type(s) for -: 'float' and 'NoneType'` whenever the
collection's rasters carried **no no-data value** (`no_data_value is None`). This is common for
GeoTIFFs written by external tools (e.g. Google Earth Engine `getDownloadURL` exports), so the
animation path was unusable for that very common case.

`Dataset.plot()` was **not** affected — its engine (`Analysis.plot`) already sanitises an unset
no-data value to `np.nan` before building the exclusion list. The collection path simply hadn't
been updated to match.

## Root cause

`DatasetCollection.plot()` built the exclusion list directly from the raw base no-data value:

```python
exclude_value = (
    [self.base.no_data_value[band], exclude_value] if exclude_value is not None
    else [self.base.no_data_value[band]]   # -> [None] when nodata is unset
)
```

`[None]` was forwarded to cleopatra, which does `np.isclose(array, exclude_value[0])` →
`np.isclose(array, None)` → `array - None` → `TypeError`.

## Fix

Mirror `Analysis.plot`: sanitise `None` → `np.nan` before building the exclusion list. `np.nan`
masks nothing, so a collection of nodata-less rasters renders every cell instead of raising.

```python
no_data_value = [np.nan if v is None else v for v in self.base.no_data_value]
```

Pyramids-side only — no dependency change; the fix stands alone and does not wait on a cleopatra
release.

## Test plan

- New regression test `TestPlotDatasetCollection::test_plot_no_nodata_value_does_not_crash`:
  builds a collection of three nodata-less rasters (`no_data_value=None`), confirms the
  precondition `base.no_data_value == (None,)`, and asserts `cube.plot(band=0)` returns an
  `ArrayGlyph` instead of raising.
- `pytest tests/dataset/test_plot.py::TestPlotDatasetCollection -m plot` → 2 passed (the new test
  plus the existing `test_geotiff`).
- Manually re-ran the issue's exact reproducer: previously `TypeError`, now returns an
  `ArrayGlyph`. A real-nodata collection still plots (regression guard).

Closes #480
