### PR TITLE
docs: add Tier-1 operation notebooks (reproject/crop/mosaic/zonal/extract/rasterize)

### DIFF
--- a/docs/examples/operations/crop-mask.ipynb
+++ b/docs/examples/operations/crop-mask.ipynb
@@ -1,0 +1,268 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "72d09c19",
+   "metadata": {},
+   "source": [
+    "# Crop & mask\n",
+    "\n",
+    "Restrict a raster to an area of interest:\n",
+    "\n",
+    "- **`crop(mask=vector)`** — clip to polygon geometry (everything outside becomes no-data).\n",
+    "- **`crop(bbox=..., epsg=...)`** — clip to a rectangular bounding box.\n",
+    "- **`get_mask()`** — the boolean valid-data mask (True where a cell holds real data)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "21c36cb3",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "2f58697c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:01:51.118253Z",
+     "iopub.status.busy": "2026-06-08T21:01:51.118049Z",
+     "iopub.status.idle": "2026-06-08T21:01:51.221507Z",
+     "shell.execute_reply": "2026-06-08T21:01:51.220614Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True, True)"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ['MPLBACKEND'] = 'Agg'  # never trigger an interactive backend\n",
+    "\n",
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "def _find_data():\n",
+    "    for base in [Path.cwd(), *Path.cwd().parents]:\n",
+    "        cand = base / 'tests' / 'data'\n",
+    "        if cand.is_dir():\n",
+    "            return cand.resolve()\n",
+    "    raise FileNotFoundError('Could not locate tests/data from ' + str(Path.cwd()))\n",
+    "\n",
+    "\n",
+    "DATA = _find_data()\n",
+    "WORK = Path(tempfile.mkdtemp(prefix='pyramids-ops-'))\n",
+    "DATA.is_dir(), WORK.is_dir()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "d8a6d9e3",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:01:51.223900Z",
+     "iopub.status.busy": "2026-06-08T21:01:51.223438Z",
+     "iopub.status.idle": "2026-06-08T21:01:52.940763Z",
+     "shell.execute_reply": "2026-06-08T21:01:52.939897Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-08 23:01:51 | \u001b[32mINFO\u001b[0m | pyramids.base.config | Logging is configured.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "((1, 13, 14), 32618, (4, 32618))"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pyramids.dataset import Dataset\n",
+    "from pyramids.feature import FeatureCollection\n",
+    "\n",
+    "ds = Dataset.read_file(str(DATA / 'acc4000.tif'))\n",
+    "polys = FeatureCollection.read_file(str(DATA / 'coello_polygons.geojson'))\n",
+    "ds.shape, ds.epsg, (len(polys), polys.epsg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44888bd7",
+   "metadata": {},
+   "source": [
+    "## Crop to polygons — `crop(mask=...)`\n",
+    "\n",
+    "The raster shrinks to the polygons' envelope; cells outside the polygons are set to no-data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "42934eac",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:01:52.943153Z",
+     "iopub.status.busy": "2026-06-08T21:01:52.942605Z",
+     "iopub.status.idle": "2026-06-08T21:01:52.964090Z",
+     "shell.execute_reply": "2026-06-08T21:01:52.963285Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((1, 5, 8), 32618)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "clipped = ds.crop(mask=polys)\n",
+    "clipped.shape, clipped.epsg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf982082",
+   "metadata": {},
+   "source": [
+    "## Crop to a bounding box — `crop(bbox=...)`\n",
+    "\n",
+    "Keep only the inner half of the raster's extent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "97a5cd4a",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:01:52.966195Z",
+     "iopub.status.busy": "2026-06-08T21:01:52.965858Z",
+     "iopub.status.idle": "2026-06-08T21:01:52.983323Z",
+     "shell.execute_reply": "2026-06-08T21:01:52.982505Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1, 7, 7)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "xmin, ymin, xmax, ymax = ds.bbox\n",
+    "dx, dy = (xmax - xmin) / 4, (ymax - ymin) / 4\n",
+    "inner = ds.crop(bbox=(xmin + dx, ymin + dy, xmax - dx, ymax - dy), epsg=ds.epsg)\n",
+    "inner.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "324c67b5",
+   "metadata": {},
+   "source": [
+    "## The valid-data mask — `get_mask`\n",
+    "\n",
+    "A GDAL-style mask: **nonzero (255)** where the cell holds data, **0** where it is no-data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "58a33b4b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:01:52.985670Z",
+     "iopub.status.busy": "2026-06-08T21:01:52.985321Z",
+     "iopub.status.idle": "2026-06-08T21:01:52.990566Z",
+     "shell.execute_reply": "2026-06-08T21:01:52.989464Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((13, 14), 89, 'valid of', 182)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mask = ds.get_mask()\n",
+    "valid = int((mask > 0).sum())\n",
+    "mask.shape, valid, 'valid of', mask.size"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "051f5cc1",
+   "metadata": {},
+   "source": [
+    "## Notes\n",
+    "\n",
+    "- `crop` accepts a `FeatureCollection` or a GeoDataFrame as the mask; pass `touch=False` to\n",
+    "  keep only cells whose centre falls inside the geometry.\n",
+    "- See also: [Reproject / resample / align](reproject-resample-align.ipynb),\n",
+    "  [Zonal statistics](zonal-statistics.ipynb)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/operations/extract-at-points.ipynb
+++ b/docs/examples/operations/extract-at-points.ipynb
@@ -1,0 +1,224 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "648cfb84",
+   "metadata": {},
+   "source": [
+    "# Extract raster values at points\n",
+    "\n",
+    "- **`sample(points)`** — read the raster value at each point location (e.g. gauge stations).\n",
+    "- **`extract()`** — pull every valid (non-no-data) cell value into a flat array, handy for\n",
+    "  histograms or training samples."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d653a841",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "79b27dcb",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:02:03.724238Z",
+     "iopub.status.busy": "2026-06-08T21:02:03.723871Z",
+     "iopub.status.idle": "2026-06-08T21:02:03.830789Z",
+     "shell.execute_reply": "2026-06-08T21:02:03.829443Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True, True)"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ['MPLBACKEND'] = 'Agg'  # never trigger an interactive backend\n",
+    "\n",
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "def _find_data():\n",
+    "    for base in [Path.cwd(), *Path.cwd().parents]:\n",
+    "        cand = base / 'tests' / 'data'\n",
+    "        if cand.is_dir():\n",
+    "            return cand.resolve()\n",
+    "    raise FileNotFoundError('Could not locate tests/data from ' + str(Path.cwd()))\n",
+    "\n",
+    "\n",
+    "DATA = _find_data()\n",
+    "WORK = Path(tempfile.mkdtemp(prefix='pyramids-ops-'))\n",
+    "DATA.is_dir(), WORK.is_dir()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "12a262b5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:02:03.833056Z",
+     "iopub.status.busy": "2026-06-08T21:02:03.832742Z",
+     "iopub.status.idle": "2026-06-08T21:02:05.550680Z",
+     "shell.execute_reply": "2026-06-08T21:02:05.549477Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-08 23:02:03 | \u001b[32mINFO\u001b[0m | pyramids.base.config | Logging is configured.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "((1, 13, 14), 32618, (6, 32618))"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pyramids.dataset import Dataset\n",
+    "from pyramids.feature import FeatureCollection\n",
+    "\n",
+    "ds = Dataset.read_file(str(DATA / 'acc4000.tif'))\n",
+    "gauges = FeatureCollection.read_file(str(DATA / 'coello-gauges.geojson'))\n",
+    "ds.shape, ds.epsg, (len(gauges), gauges.epsg)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f3cf9b53",
+   "metadata": {},
+   "source": [
+    "## Sample at point locations — `sample`\n",
+    "\n",
+    "Returns an array of shape `(bands, n_points)` — one value per band per point."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "7063df2b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:02:05.553326Z",
+     "iopub.status.busy": "2026-06-08T21:02:05.552733Z",
+     "iopub.status.idle": "2026-06-08T21:02:05.566870Z",
+     "shell.execute_reply": "2026-06-08T21:02:05.565947Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((1, 6), array([ 4.,  6.,  1.,  5., 49., 88.], dtype=float32))"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "pts = gauges if gauges.epsg == ds.epsg else FeatureCollection(gauges.to_crs(ds.epsg))\n",
+    "values = ds.sample(pts)\n",
+    "values.shape, np.asarray(values).ravel()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd6db864",
+   "metadata": {},
+   "source": [
+    "## All valid cell values — `extract`\n",
+    "\n",
+    "A 1-D array of the cells that are not no-data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "34b4d300",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:02:05.570042Z",
+     "iopub.status.busy": "2026-06-08T21:02:05.569467Z",
+     "iopub.status.idle": "2026-06-08T21:02:05.576077Z",
+     "shell.execute_reply": "2026-06-08T21:02:05.574828Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((89,), 0.0, 88.0)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "cells = ds.extract()\n",
+    "cells.shape, float(cells.min()), float(cells.max())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5ca7266",
+   "metadata": {},
+   "source": [
+    "## Notes\n",
+    "\n",
+    "- `sample` accepts a `FeatureCollection`, a GeoDataFrame, or a plain DataFrame of x/y.\n",
+    "- `bands=` on `sample` selects which band(s) to read.\n",
+    "- See also: [Zonal statistics](zonal-statistics.ipynb)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/operations/mosaic-merge.ipynb
+++ b/docs/examples/operations/mosaic-merge.ipynb
@@ -1,0 +1,228 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "dbbf526a",
+   "metadata": {},
+   "source": [
+    "# Mosaic & merge\n",
+    "\n",
+    "Combine several rasters into one:\n",
+    "\n",
+    "- **`merge_rasters(src, dst)`** — mosaic many (overlapping or adjacent) rasters into a single\n",
+    "  raster covering their union.\n",
+    "- **`stack_bands(files, path=...)`** — stack several single-band rasters into one multi-band\n",
+    "  raster (e.g. assembling per-band Sentinel files into one image)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4e182512",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "7c4e94ed",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:01:55.115332Z",
+     "iopub.status.busy": "2026-06-08T21:01:55.115063Z",
+     "iopub.status.idle": "2026-06-08T21:01:55.218775Z",
+     "shell.execute_reply": "2026-06-08T21:01:55.217803Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True, True)"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ['MPLBACKEND'] = 'Agg'  # never trigger an interactive backend\n",
+    "\n",
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "def _find_data():\n",
+    "    for base in [Path.cwd(), *Path.cwd().parents]:\n",
+    "        cand = base / 'tests' / 'data'\n",
+    "        if cand.is_dir():\n",
+    "            return cand.resolve()\n",
+    "    raise FileNotFoundError('Could not locate tests/data from ' + str(Path.cwd()))\n",
+    "\n",
+    "\n",
+    "DATA = _find_data()\n",
+    "WORK = Path(tempfile.mkdtemp(prefix='pyramids-ops-'))\n",
+    "DATA.is_dir(), WORK.is_dir()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "a0399327",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:01:55.221405Z",
+     "iopub.status.busy": "2026-06-08T21:01:55.221099Z",
+     "iopub.status.idle": "2026-06-08T21:01:56.874809Z",
+     "shell.execute_reply": "2026-06-08T21:01:56.873976Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-08 23:01:55 | \u001b[32mINFO\u001b[0m | pyramids.base.config | Logging is configured.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "[(1, 24, 29), (1, 24, 29), (1, 24, 29)]"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pyramids.dataset import Dataset\n",
+    "from pyramids.dataset.merge import merge_rasters, stack_bands\n",
+    "\n",
+    "tiles = [str(DATA / 'crop_aligned_folder' / f'{i}.tif') for i in range(3)]\n",
+    "[Dataset.read_file(t).shape for t in tiles]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee97bd87",
+   "metadata": {},
+   "source": [
+    "## Mosaic — `merge_rasters`\n",
+    "\n",
+    "Writes one raster covering the inputs' combined extent. `method` controls how overlaps resolve (`'last'`, `'first'`, …)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b88e5065",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:01:56.877917Z",
+     "iopub.status.busy": "2026-06-08T21:01:56.877394Z",
+     "iopub.status.idle": "2026-06-08T21:01:56.924403Z",
+     "shell.execute_reply": "2026-06-08T21:01:56.923332Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1, 24, 29)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mosaic = WORK / 'mosaic.tif'\n",
+    "merge_rasters(tiles, str(mosaic))\n",
+    "Dataset.read_file(str(mosaic)).shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d71f9121",
+   "metadata": {},
+   "source": [
+    "## Stack bands — `stack_bands`\n",
+    "\n",
+    "Combine single-band rasters into one multi-band raster (order = input order)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "fde2b599",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:01:56.926561Z",
+     "iopub.status.busy": "2026-06-08T21:01:56.926320Z",
+     "iopub.status.idle": "2026-06-08T21:01:56.995118Z",
+     "shell.execute_reply": "2026-06-08T21:01:56.994210Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(3, ['t0', 't1', 't2'])"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stacked = WORK / 'stacked.tif'\n",
+    "stack_bands(tiles, path=str(stacked), band_names=['t0', 't1', 't2'])\n",
+    "out = Dataset.read_file(str(stacked))\n",
+    "out.band_count, out.band_names"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7e44e92d",
+   "metadata": {},
+   "source": [
+    "## Notes\n",
+    "\n",
+    "- `merge_rasters` takes `no_data_value=` and `method=` to control fill and overlap handling.\n",
+    "- `stack_bands` can `align=True` to snap mismatched grids before stacking.\n",
+    "- See also: [Reproject / resample / align](reproject-resample-align.ipynb)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/operations/rasterize-vectorize.ipynb
+++ b/docs/examples/operations/rasterize-vectorize.ipynb
@@ -1,0 +1,269 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "b83e0479",
+   "metadata": {},
+   "source": [
+    "# Rasterize ↔ vectorize\n",
+    "\n",
+    "Cross the raster/vector divide both ways:\n",
+    "\n",
+    "- **Vectorize** a raster: `to_feature_collection()` (polygonize equal-valued regions) and\n",
+    "  `contour(interval=...)` (iso-value lines).\n",
+    "- **Rasterize** a vector: `Dataset.from_features(fc, ...)` burns an attribute column into a\n",
+    "  new raster grid."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00105330",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "9421a0e5",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:02:10.492738Z",
+     "iopub.status.busy": "2026-06-08T21:02:10.492326Z",
+     "iopub.status.idle": "2026-06-08T21:02:10.625169Z",
+     "shell.execute_reply": "2026-06-08T21:02:10.624090Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True, True)"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ['MPLBACKEND'] = 'Agg'  # never trigger an interactive backend\n",
+    "\n",
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "def _find_data():\n",
+    "    for base in [Path.cwd(), *Path.cwd().parents]:\n",
+    "        cand = base / 'tests' / 'data'\n",
+    "        if cand.is_dir():\n",
+    "            return cand.resolve()\n",
+    "    raise FileNotFoundError('Could not locate tests/data from ' + str(Path.cwd()))\n",
+    "\n",
+    "\n",
+    "DATA = _find_data()\n",
+    "WORK = Path(tempfile.mkdtemp(prefix='pyramids-ops-'))\n",
+    "DATA.is_dir(), WORK.is_dir()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "62abc7e6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:02:10.627840Z",
+     "iopub.status.busy": "2026-06-08T21:02:10.627378Z",
+     "iopub.status.idle": "2026-06-08T21:02:12.393938Z",
+     "shell.execute_reply": "2026-06-08T21:02:12.393186Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-08 23:02:10 | \u001b[32mINFO\u001b[0m | pyramids.base.config | Logging is configured.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "((1, 13, 14), 32618)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pyramids.dataset import Dataset\n",
+    "from pyramids.feature import FeatureCollection\n",
+    "\n",
+    "ds = Dataset.read_file(str(DATA / 'acc4000.tif'))\n",
+    "ds.shape, ds.epsg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77543ce6",
+   "metadata": {},
+   "source": [
+    "## Vectorize — polygonize\n",
+    "\n",
+    "`to_feature_collection(add_geometry='Polygon')` merges equal-valued cells into polygons."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "6d9786d0",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:02:12.396629Z",
+     "iopub.status.busy": "2026-06-08T21:02:12.396239Z",
+     "iopub.status.idle": "2026-06-08T21:02:12.416102Z",
+     "shell.execute_reply": "2026-06-08T21:02:12.415255Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('GeoDataFrame', 89, ['Band_1', 'geometry'])"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "polys = ds.to_feature_collection(add_geometry='Polygon')\n",
+    "type(polys).__name__, len(polys), list(polys.columns)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "786ab9c3",
+   "metadata": {},
+   "source": [
+    "## Vectorize — contour lines\n",
+    "\n",
+    "`contour(interval=...)` traces iso-value lines into a `FeatureCollection`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f7c9a861",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:02:12.418198Z",
+     "iopub.status.busy": "2026-06-08T21:02:12.417826Z",
+     "iopub.status.idle": "2026-06-08T21:02:12.450283Z",
+     "shell.execute_reply": "2026-06-08T21:02:12.449514Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('FeatureCollection', 19)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "lines = ds.contour(interval=10.0)\n",
+    "type(lines).__name__, len(lines)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6fbfa07f",
+   "metadata": {},
+   "source": [
+    "## Rasterize — burn a vector into a raster\n",
+    "\n",
+    "`Dataset.from_features` rasterises an attribute column onto a new grid. Give it a numeric\n",
+    "column to burn and a `cell_size` (or a `template` raster to inherit the grid)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "4af24fda",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:02:12.453203Z",
+     "iopub.status.busy": "2026-06-08T21:02:12.452450Z",
+     "iopub.status.idle": "2026-06-08T21:02:12.471646Z",
+     "shell.execute_reply": "2026-06-08T21:02:12.470667Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((1, 13, 13), 32618)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "zones = FeatureCollection.read_file(str(DATA / 'coello_polygons.geojson'))\n",
+    "zones['value'] = np.arange(1, len(zones) + 1, dtype='int32')  # numeric column to burn\n",
+    "burned = Dataset.from_features(zones, cell_size=ds.cell_size, column_name='value')\n",
+    "burned.shape, burned.epsg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b74832aa",
+   "metadata": {},
+   "source": [
+    "## Notes\n",
+    "\n",
+    "- `to_feature_collection()` without `add_geometry` returns a plain table of cell values;\n",
+    "  pass `add_geometry='Polygon'` (or `'Point'`) to attach geometry.\n",
+    "- `from_features(..., template=ds)` inherits an existing raster's grid instead of `cell_size`.\n",
+    "- `sieve()` removes speckle (small regions) before vectorizing — useful on classified rasters.\n",
+    "- See also: [Zonal statistics](zonal-statistics.ipynb), [Crop & mask](crop-mask.ipynb)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/operations/reproject-resample-align.ipynb
+++ b/docs/examples/operations/reproject-resample-align.ipynb
@@ -1,0 +1,265 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "837da92f",
+   "metadata": {},
+   "source": [
+    "# Reproject, resample & align\n",
+    "\n",
+    "Three ways to change a raster's grid:\n",
+    "\n",
+    "- **`to_crs(epsg)`** — reproject to another coordinate reference system.\n",
+    "- **`resample(cell_size)`** — change the pixel size (resolution) within the same CRS.\n",
+    "- **`align(reference)`** — snap rows/columns/cell-size/CRS to match another raster. This is\n",
+    "  the operation you use to make every layer line up with a DEM before modelling."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e119269a",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0cdb9769",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:01:46.811997Z",
+     "iopub.status.busy": "2026-06-08T21:01:46.811777Z",
+     "iopub.status.idle": "2026-06-08T21:01:46.920899Z",
+     "shell.execute_reply": "2026-06-08T21:01:46.919768Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True, True)"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ['MPLBACKEND'] = 'Agg'  # never trigger an interactive backend\n",
+    "\n",
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "def _find_data():\n",
+    "    for base in [Path.cwd(), *Path.cwd().parents]:\n",
+    "        cand = base / 'tests' / 'data'\n",
+    "        if cand.is_dir():\n",
+    "            return cand.resolve()\n",
+    "    raise FileNotFoundError('Could not locate tests/data from ' + str(Path.cwd()))\n",
+    "\n",
+    "\n",
+    "DATA = _find_data()\n",
+    "WORK = Path(tempfile.mkdtemp(prefix='pyramids-ops-'))\n",
+    "DATA.is_dir(), WORK.is_dir()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ba7fe8c7",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:01:46.922991Z",
+     "iopub.status.busy": "2026-06-08T21:01:46.922718Z",
+     "iopub.status.idle": "2026-06-08T21:01:48.587977Z",
+     "shell.execute_reply": "2026-06-08T21:01:48.586967Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-08 23:01:46 | \u001b[32mINFO\u001b[0m | pyramids.base.config | Logging is configured.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "((1, 13, 14), 32618, 4000.0)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pyramids.dataset import Dataset\n",
+    "\n",
+    "ds = Dataset.read_file(str(DATA / 'acc4000.tif'))\n",
+    "ds.shape, ds.epsg, ds.cell_size"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eff3fd58",
+   "metadata": {},
+   "source": [
+    "## Reproject — `to_crs`\n",
+    "\n",
+    "Reproject from UTM (EPSG:32618) to geographic lon/lat (EPSG:4326)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "15410cd4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:01:48.590426Z",
+     "iopub.status.busy": "2026-06-08T21:01:48.589857Z",
+     "iopub.status.idle": "2026-06-08T21:01:48.617993Z",
+     "shell.execute_reply": "2026-06-08T21:01:48.616985Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(4326, (1, 13, 14), 0.03611587177268461)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "wgs84 = ds.to_crs(4326)\n",
+    "wgs84.epsg, wgs84.shape, wgs84.cell_size"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe05362a",
+   "metadata": {},
+   "source": [
+    "## Resample — `resample`\n",
+    "\n",
+    "Double the cell size; the row/column count roughly halves."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "f953f88c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:01:48.620179Z",
+     "iopub.status.busy": "2026-06-08T21:01:48.619930Z",
+     "iopub.status.idle": "2026-06-08T21:01:48.629403Z",
+     "shell.execute_reply": "2026-06-08T21:01:48.628507Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(8000.0, (1, 6, 7))"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "coarser = ds.resample(cell_size=ds.cell_size * 2)\n",
+    "coarser.cell_size, coarser.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7ffd2e8e",
+   "metadata": {},
+   "source": [
+    "## Align to a reference — `align`\n",
+    "\n",
+    "`align` copies the reference raster's grid (rows, columns, cell size, CRS) onto the data, so\n",
+    "the two share an identical geotransform — the prerequisite for cell-by-cell raster algebra."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "4e936413",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:01:48.631275Z",
+     "iopub.status.busy": "2026-06-08T21:01:48.631046Z",
+     "iopub.status.idle": "2026-06-08T21:01:48.639913Z",
+     "shell.execute_reply": "2026-06-08T21:01:48.638662Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True, True)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "reference = ds.resample(cell_size=ds.cell_size * 2)  # stand-in reference grid\n",
+    "aligned = ds.align(reference)\n",
+    "aligned.shape == reference.shape, aligned.cell_size == reference.cell_size"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9fb33172",
+   "metadata": {},
+   "source": [
+    "## Notes\n",
+    "\n",
+    "- `to_crs` / `resample` take a `method=` (`\"nearest neighbor\"`, `\"bilinear\"`, `\"cubic\"`);\n",
+    "  use nearest for categorical data, bilinear/cubic for continuous.\n",
+    "- See also: [Crop & mask](crop-mask.ipynb), [Mosaic / merge](mosaic-merge.ipynb)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/operations/zonal-statistics.ipynb
+++ b/docs/examples/operations/zonal-statistics.ipynb
@@ -1,0 +1,259 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e7cbe945",
+   "metadata": {},
+   "source": [
+    "# Zonal statistics\n",
+    "\n",
+    "Summarise raster values **within each vector polygon** — the classic \"average elevation per\n",
+    "watershed\" operation. `ds.zonal_stats(polygons, stats=(...))` returns a table with one row\n",
+    "per polygon and one column per requested statistic."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a088ec1a",
+   "metadata": {},
+   "source": [
+    "## Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "711c8dba",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:01:59.392846Z",
+     "iopub.status.busy": "2026-06-08T21:01:59.392623Z",
+     "iopub.status.idle": "2026-06-08T21:01:59.508611Z",
+     "shell.execute_reply": "2026-06-08T21:01:59.507680Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True, True)"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "import os\n",
+    "\n",
+    "os.environ['MPLBACKEND'] = 'Agg'  # never trigger an interactive backend\n",
+    "\n",
+    "import tempfile\n",
+    "from pathlib import Path\n",
+    "\n",
+    "import numpy as np\n",
+    "\n",
+    "\n",
+    "def _find_data():\n",
+    "    for base in [Path.cwd(), *Path.cwd().parents]:\n",
+    "        cand = base / 'tests' / 'data'\n",
+    "        if cand.is_dir():\n",
+    "            return cand.resolve()\n",
+    "    raise FileNotFoundError('Could not locate tests/data from ' + str(Path.cwd()))\n",
+    "\n",
+    "\n",
+    "DATA = _find_data()\n",
+    "WORK = Path(tempfile.mkdtemp(prefix='pyramids-ops-'))\n",
+    "DATA.is_dir(), WORK.is_dir()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "c1e1a1ba",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:01:59.510676Z",
+     "iopub.status.busy": "2026-06-08T21:01:59.510401Z",
+     "iopub.status.idle": "2026-06-08T21:02:01.195471Z",
+     "shell.execute_reply": "2026-06-08T21:02:01.194465Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2026-06-08 23:01:59 | \u001b[32mINFO\u001b[0m | pyramids.base.config | Logging is configured.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "(4, 32618)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pyramids.dataset import Dataset\n",
+    "from pyramids.feature import FeatureCollection\n",
+    "\n",
+    "ds = Dataset.read_file(str(DATA / 'acc4000.tif'))\n",
+    "zones = FeatureCollection.read_file(str(DATA / 'coello_polygons.geojson'))\n",
+    "len(zones), zones.epsg"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5afed9e0",
+   "metadata": {},
+   "source": [
+    "## Compute per-zone statistics\n",
+    "\n",
+    "Each polygon is rasterised onto the raster grid, then the covered cells are reduced."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "619b6da4",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-08T21:02:01.197424Z",
+     "iopub.status.busy": "2026-06-08T21:02:01.197067Z",
+     "iopub.status.idle": "2026-06-08T21:02:01.214352Z",
+     "shell.execute_reply": "2026-06-08T21:02:01.213501Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\gdrive\\algorithms\\gis\\pyramids\\.claude\\worktrees\\operation-notebooks\\.pixi\\envs\\dev\\Lib\\site-packages\\osgeo\\ogr.py:7515: RuntimeWarning: DeprecationWarning: 'Memory' driver is deprecated since GDAL 3.11. Use 'MEM' onwards. Further messages of this type will be suppressed.\n",
+      "  return _ogr.GetDriverByName(*args)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>mean</th>\n",
+       "      <th>min</th>\n",
+       "      <th>max</th>\n",
+       "      <th>sum</th>\n",
+       "      <th>count</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>2.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2.307692</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>11.0</td>\n",
+       "      <td>30.0</td>\n",
+       "      <td>13.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>18.066667</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>63.0</td>\n",
+       "      <td>271.0</td>\n",
+       "      <td>15.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        mean  min   max    sum  count\n",
+       "0   0.000000  0.0   0.0    0.0    1.0\n",
+       "1   0.000000  0.0   0.0    0.0    2.0\n",
+       "2   2.307692  0.0  11.0   30.0   13.0\n",
+       "3  18.066667  0.0  63.0  271.0   15.0"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stats = ds.zonal_stats(zones, stats=('mean', 'min', 'max', 'sum', 'count'))\n",
+    "stats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3522e024",
+   "metadata": {},
+   "source": [
+    "## Notes\n",
+    "\n",
+    "- `band=` selects which band to summarise (default 0).\n",
+    "- The polygons may be in any CRS — they are reprojected to the raster's CRS internally.\n",
+    "- See also: [Crop & mask](crop-mask.ipynb), [Extract at points](extract-at-points.ipynb)."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -171,6 +171,13 @@ nav:
           - Dask quickstart — DatasetCollection: examples/dask/collection.ipynb
           - Dask quickstart — FeatureCollection: examples/dask/feature.ipynb
           - Dask quickstart — NetCDF: examples/dask/netcdf.ipynb
+      - Operations:
+          - Reproject, resample & align: examples/operations/reproject-resample-align.ipynb
+          - Crop & mask: examples/operations/crop-mask.ipynb
+          - Mosaic & merge: examples/operations/mosaic-merge.ipynb
+          - Zonal statistics: examples/operations/zonal-statistics.ipynb
+          - Extract at points: examples/operations/extract-at-points.ipynb
+          - Rasterize ↔ vectorize: examples/operations/rasterize-vectorize.ipynb
       - Dataset:
           - Overview: tutorials/dataset.md
           - Raster basics: tutorials/raster-basics.md


### PR DESCRIPTION
# Description

First batch of rasterio-style per-operation example notebooks (Tier 1 of the notebook documentation
plan). Docs only — no runtime changes, no new dependencies, no pyproject/lock changes.

New under `docs/examples/operations/`:

- **reproject-resample-align** — `to_crs`, `resample`, `align` (align-to-reference grid)
- **crop-mask** — `crop(mask=polygons)`, `crop(bbox=...)`, `get_mask`
- **mosaic-merge** — `merge_rasters`, `stack_bands`
- **zonal-statistics** — `Dataset.zonal_stats(polygons, stats=...)`
- **extract-at-points** — `sample(points)`, `extract()`
- **rasterize-vectorize** — `to_feature_collection` (polygonize), `contour`, `Dataset.from_features`
  (rasterize)

# Issues
- Fixes # (none — documentation addition)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- Every operation was first prototyped against `tests/data` (a throwaway probe run via
  `pixi run -e dev`) to confirm exact signatures and return shapes before authoring.
- All six notebooks executed end-to-end offline via nbclient (Agg backend) → **0 error cells**;
  outputs stored for the `mkdocs-jupyter` `execute: false` render; `nbformat.validate` passes.
- Nav targets resolve; no `pyproject.toml` / `pixi.lock` changes.

- [x] Prototyped each operation against tests/data
- [x] Executed all six notebooks offline (0 error cells)

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.

---

Follows the plan in `planning/docs/notebook-documentation-plan.md`. Tiers 2–3 (terrain, nodata/fill,
overviews, visualization gallery, windowed reads, raster algebra, vector geometry, color tables) can
follow as separate PRs.