### PR TITLE
fix(io): scope GeoTIFF creation options to the GeoTIFF driver (fixes to_file('.nc'))

### DIFF
--- a/src/pyramids/dataset/ops/io.py
+++ b/src/pyramids/dataset/ops/io.py
@@ -155,17 +155,25 @@ def _write_to_file_sync(
         xmin, ymin, _, _ = ds.bbox
         _io.to_ascii(arr, ds.cell_size, xmin, ymin, no_data_value, path)
     else:
-        options = ["COMPRESS=DEFLATE"]
-        if tile_length is not None:
-            options += [
-                "TILED=YES",
-                f"TILE_LENGTH={tile_length}",
-            ]
-            if ds._block_size is not None and ds._block_size != []:
+        # COMPRESS=DEFLATE and the TILED/BLOCK options are GeoTIFF creation
+        # options. Applying them to other drivers is at best ignored and at
+        # worst breaks the output — e.g. on the netCDF driver COMPRESS=DEFLATE
+        # forces the NC4C format, which some GDAL builds cannot read back,
+        # making ``to_file("out.nc")`` produce an unreadable file. Only emit
+        # them for GeoTIFF; user-supplied creation_options always pass through.
+        options: list[str] = []
+        if driver_name == "GTiff":
+            options.append("COMPRESS=DEFLATE")
+            if tile_length is not None:
                 options += [
-                    "BLOCKXSIZE={}".format(ds._block_size[0][0]),
-                    "BLOCKYSIZE={}".format(ds._block_size[0][1]),
+                    "TILED=YES",
+                    f"TILE_LENGTH={tile_length}",
                 ]
+                if ds._block_size is not None and ds._block_size != []:
+                    options += [
+                        "BLOCKXSIZE={}".format(ds._block_size[0][0]),
+                        "BLOCKYSIZE={}".format(ds._block_size[0][1]),
+                    ]
         if creation_options is not None:
             options += creation_options
 

--- a/tests/dataset/test_dataset_unit.py
+++ b/tests/dataset/test_dataset_unit.py
@@ -1519,6 +1519,40 @@ class TestToFile:
             err_msg="File data differs from original",
         )
 
+    def test_to_file_netcdf_roundtrip(self, tmp_path):
+        """to_file('.nc') must write a NetCDF that can be reopened.
+
+        Regression: the writer applied ``COMPRESS=DEFLATE`` to every driver,
+        which forces the netCDF driver into the NC4C format. Some GDAL builds
+        cannot read NC4C back, so ``to_file("out.nc")`` produced a file that
+        no reader (not even GDAL) could open. The fix scopes the GeoTIFF
+        creation options to the GeoTIFF driver only.
+        """
+        from pyramids.netcdf import NetCDF
+
+        arr = np.array(
+            [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]],
+            dtype=np.float32,
+        )
+        ds = Dataset.create_from_array(
+            arr,
+            top_left_corner=(0.0, 0.0),
+            cell_size=0.05,
+            epsg=4326,
+        )
+        path = tmp_path / "output.nc"
+        ds.to_file(path)
+        assert path.exists(), "File should exist after to_file"
+        # The whole point of the regression: the written file is readable again.
+        reopened = NetCDF.read_file(str(path))
+        assert reopened.variable_names, "NetCDF should expose at least one variable"
+        values = reopened.get_variable(reopened.variable_names[0]).read_array()
+        np.testing.assert_array_almost_equal(
+            np.asarray(values).squeeze(),
+            arr,
+            err_msg="NetCDF round-trip data differs from original",
+        )
+
     def test_to_file_wrong_type_raises(self, single_band_dataset):
         """to_file with a non-string path should raise TypeError."""
         with pytest.raises(TypeError, match="string"):


### PR DESCRIPTION
# Description

`Dataset.to_file()` applied `COMPRESS=DEFLATE` (plus the `TILED`/`BLOCKXSIZE`/`BLOCKYSIZE` options)
to **every** non-ASCII, non-COG driver. Those are GeoTIFF creation options. On the **netCDF** driver,
`COMPRESS=DEFLATE` forces the `NC4C` format, which some GDAL builds cannot read back — so
`Dataset.to_file("out.nc")` produced a file that **no reader (not even `gdal.Open`) could reopen**,
and user-supplied `creation_options` like `FORMAT=NC` were silently overridden.

The fix emits `COMPRESS=DEFLATE` and the tiling/block options **only for the GeoTIFF driver**; other
drivers receive just the caller's `creation_options`.

- GeoTIFF output is unchanged — still `COMPRESSION=DEFLATE`.
- `Dataset.to_file("out.nc")` now writes a readable NetCDF (round-trips via `NetCDF.read_file`).
- ASCII path unchanged.

Found while building the format-conversion notebooks (#483): the geotiff→netcdf examples had to
route around this via `DatasetCollection.to_netcdf`; this fixes the direct `to_file('.nc')` path.

# Issues
- Fixes # (none filed — discovered during docs work)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- New regression test `TestToFile::test_to_file_netcdf_roundtrip` — writes a Dataset to `.nc` and
  reopens it with `NetCDF.read_file`, asserting the values round-trip.
- Verified manually: `to_file('.nc')` reopens and data matches source; GeoTIFF still reports
  `COMPRESSION=DEFLATE`; ASCII round-trips.
- `pytest -k "to_file or block_size or creation_option"` → **11 passed** (no regressions).

- [x] Added a regression test that proves the fix
- [x] Existing to_file / creation-option / block-size tests pass locally

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.