### PR TITLE
feat(dataset): add Dataset.to_bytes for in-memory serialization

### DIFF
--- a/src/pyramids/_io.py
+++ b/src/pyramids/_io.py
@@ -180,7 +180,8 @@ def read_vsi_bytes(path: str) -> bytes:
         gdal.VSIFSeekL(handle, 0, 2)
         size = gdal.VSIFTellL(handle)
         gdal.VSIFSeekL(handle, 0, 0)
-        data = gdal.VSIFReadL(1, size, handle)
+        # VSIFReadL returns None (not b"") for a zero-byte read.
+        data = gdal.VSIFReadL(1, size, handle) if size else b""
     finally:
         gdal.VSIFCloseL(handle)
     return bytes(data)

--- a/src/pyramids/_io.py
+++ b/src/pyramids/_io.py
@@ -123,6 +123,69 @@ def silent_unlink(path: str) -> None:
         pass
 
 
+def read_vsi_bytes(path: str) -> bytes:
+    """Read the full contents of a GDAL VSI file as bytes.
+
+    The standard ``VSIFOpenL`` / seek-to-end / ``VSIFReadL`` dance used to pull
+    an in-memory (``/vsimem/``) or other VSI file back into Python — shared by
+    every ``to_*_bytes`` serializer so the read-back logic lives in one place.
+
+    Args:
+        path: The VSI path to read (e.g. a ``/vsimem/...`` path produced by
+            :func:`new_vsimem_path`).
+
+    Returns:
+        bytes: The complete file contents.
+
+    Raises:
+        FileNotFoundError: The path cannot be opened (it does not exist or was
+            already unlinked).
+
+    Examples:
+        - Write a buffer to ``/vsimem/`` and read it back:
+            ```python
+            >>> from osgeo import gdal
+            >>> from pyramids._io import new_vsimem_path, read_vsi_bytes, silent_unlink
+            >>> path = new_vsimem_path(".bin")
+            >>> _ = gdal.FileFromMemBuffer(path, b"payload")
+            >>> read_vsi_bytes(path)
+            b'payload'
+            >>> silent_unlink(path)
+
+            ```
+        - A missing path raises ``FileNotFoundError``:
+            ```python
+            >>> from pyramids._io import read_vsi_bytes
+            >>> try:
+            ...     read_vsi_bytes("/vsimem/never-written.bin")
+            ... except FileNotFoundError as exc:
+            ...     print("could not open" in str(exc))
+            True
+
+            ```
+
+    See Also:
+        new_vsimem_path: Mints unique ``/vsimem/`` paths to write into.
+        silent_unlink: Removes the path once the bytes are extracted.
+    """
+    try:
+        handle = gdal.VSIFOpenL(path, "rb")
+    except RuntimeError:
+        # Under gdal.UseExceptions() a missing path raises instead of
+        # returning None; normalise both shapes to FileNotFoundError.
+        handle = None
+    if handle is None:
+        raise FileNotFoundError(f"could not open VSI path {path!r} for reading.")
+    try:
+        gdal.VSIFSeekL(handle, 0, 2)
+        size = gdal.VSIFTellL(handle)
+        gdal.VSIFSeekL(handle, 0, 0)
+        data = gdal.VSIFReadL(1, size, handle)
+    finally:
+        gdal.VSIFCloseL(handle)
+    return bytes(data)
+
+
 def _is_zip(path: str):
     return path.endswith(".zip") or path.__contains__(".zip")
 

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -971,6 +971,10 @@ class Dataset(RasterBase):
         """Facade — delegates to :meth:`IO.to_file <pyramids.dataset.engines.IO.to_file>`."""
         return self.io.to_file(*args, **kwargs)
 
+    def to_bytes(self, *args, **kwargs):
+        """Facade — delegates to :meth:`IO.to_bytes <pyramids.dataset.engines.IO.to_bytes>`."""
+        return self.io.to_bytes(*args, **kwargs)
+
     def to_raster(self, *args, **kwargs):
         """Facade — delegates to :meth:`IO.to_raster <pyramids.dataset.engines.IO.to_raster>`."""
         return self.io.to_raster(*args, **kwargs)

--- a/src/pyramids/dataset/engines/cog.py
+++ b/src/pyramids/dataset/engines/cog.py
@@ -17,6 +17,7 @@ import numpy as np
 from osgeo import gdal
 from pyproj import Transformer
 
+from pyramids._io import read_vsi_bytes, silent_unlink
 from pyramids.base._errors import FailedToSaveError, OutOfBoundsError
 from pyramids.base._utils import (
     default_cog_overview_resampling,
@@ -35,7 +36,6 @@ from pyramids.dataset.cog import (
     validate_blocksize,
     validate_profile,
 )
-from pyramids._io import read_vsi_bytes
 from pyramids.dataset.cog.validate import _resolve_read_config, config_context
 from pyramids.dataset.engines._base import _Engine
 
@@ -547,7 +547,11 @@ class COG(_Engine):
                     f"could not reopen in-memory COG at {vsi_path}"
                 ) from exc
         finally:
-            gdal.Unlink(vsi_path)
+            # silent_unlink: when to_cog fails before creating the file, a
+            # plain gdal.Unlink raises under gdal.UseExceptions() and masks
+            # the original exception. Sweep the PAM sidecar too.
+            silent_unlink(vsi_path)
+            silent_unlink(f"{vsi_path}.aux.xml")
         return data
 
     def _translate_with_statistics_retry(

--- a/src/pyramids/dataset/engines/cog.py
+++ b/src/pyramids/dataset/engines/cog.py
@@ -35,6 +35,7 @@ from pyramids.dataset.cog import (
     validate_blocksize,
     validate_profile,
 )
+from pyramids._io import read_vsi_bytes
 from pyramids.dataset.cog.validate import _resolve_read_config, config_context
 from pyramids.dataset.engines._base import _Engine
 
@@ -539,21 +540,15 @@ class COG(_Engine):
         vsi_path = f"/vsimem/{uuid.uuid4().hex}.tif"
         try:
             self.to_cog(vsi_path, **kwargs)
-            handle = gdal.VSIFOpenL(vsi_path, "rb")
-            if handle is None:
+            try:
+                data = read_vsi_bytes(vsi_path)
+            except FileNotFoundError as exc:
                 raise FailedToSaveError(
                     f"could not reopen in-memory COG at {vsi_path}"
-                )
-            try:
-                gdal.VSIFSeekL(handle, 0, 2)  # SEEK_END
-                size = gdal.VSIFTellL(handle)
-                gdal.VSIFSeekL(handle, 0, 0)  # SEEK_SET
-                data = gdal.VSIFReadL(1, size, handle)
-            finally:
-                gdal.VSIFCloseL(handle)
+                ) from exc
         finally:
             gdal.Unlink(vsi_path)
-        return bytes(data)
+        return data
 
     def _translate_with_statistics_retry(
         self,

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -812,6 +812,9 @@ class IO(_Engine):
         Raises:
             ValueError: ``driver`` is unknown, does not support ``CreateCopy``,
                 or produced a multi-file output.
+            RuntimeError: The driver cannot represent the dataset faithfully
+                (strict copy — e.g. ``PNG`` asked to encode ``float32``); no
+                silent downcasting is performed.
             FailedToSaveError: GDAL could not encode the dataset.
 
         Examples:
@@ -879,7 +882,10 @@ class IO(_Engine):
         stem = vsi_path.rsplit("/", 1)[1].rsplit(".", 1)[0]
         options = [f"{key}={value}" for key, value in (creation_options or {}).items()]
         try:
-            out = drv.CreateCopy(vsi_path, self._ds._raster, 0, options)
+            # strict=1 (the GDAL default): a driver that cannot represent the
+            # dataset faithfully (e.g. PNG asked to encode float32) must fail
+            # loudly instead of silently downcasting the payload.
+            out = drv.CreateCopy(vsi_path, self._ds._raster, 1, options)
             if out is None:
                 raise FailedToSaveError(
                     f"GDAL driver {driver!r} failed to encode the dataset."

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -35,6 +35,8 @@ if TYPE_CHECKING:
 
 from pyramids.dataset.engines._base import _Engine
 
+_VSIMEM_PREFIX = "/vsimem/"
+
 
 def _validate_band_index(band: int | None, band_count: int) -> None:
     """Raise ``ValueError`` if `band` is outside the valid range.
@@ -752,7 +754,7 @@ class IO(_Engine):
             # raises for MEM / /vsimem/ datasets — catching it now
             # surfaces a clear error before the graph materialises.
             file_name = getattr(self._ds, "_file_name", "") or ""
-            if not file_name or file_name.startswith("/vsimem/"):
+            if not file_name or file_name.startswith(_VSIMEM_PREFIX):
                 raise pickle.PicklingError(
                     "to_file(compute=False) requires an on-disk Dataset "
                     "— call .to_file(path) first to anchor the MEM "
@@ -897,9 +899,9 @@ class IO(_Engine):
             out = None
             siblings = [
                 name
-                for name in (gdal.ReadDir("/vsimem/") or [])
+                for name in (gdal.ReadDir(_VSIMEM_PREFIX) or [])
                 if name.startswith(stem)
-                and f"/vsimem/{name}" != vsi_path
+                and f"{_VSIMEM_PREFIX}{name}" != vsi_path
                 and not name.endswith(".aux.xml")
             ]
             if siblings:
@@ -909,9 +911,9 @@ class IO(_Engine):
                 )
             payload = read_vsi_bytes(vsi_path)
         finally:
-            for name in gdal.ReadDir("/vsimem/") or []:
+            for name in gdal.ReadDir(_VSIMEM_PREFIX) or []:
                 if name.startswith(stem):
-                    silent_unlink(f"/vsimem/{name}")
+                    silent_unlink(f"{_VSIMEM_PREFIX}{name}")
         return payload
 
     def to_raster(

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -795,9 +795,12 @@ class IO(_Engine):
         for HTTP responses, object-store uploads, database blobs, and tests.
 
         Only **single-file** raster drivers are supported: a driver that emits
-        sidecar files next to the main one (world files, multi-part outputs)
-        raises ``ValueError``. GDAL's optional ``.aux.xml`` statistics sidecar
-        is ignored and cleaned up.
+        sidecar files next to the main one (world files, ``.prj`` files,
+        multi-part outputs) raises ``ValueError``. GDAL's optional
+        ``.aux.xml`` PAM sidecar is ignored and cleaned up — note that for
+        formats that cannot embed georeferencing themselves (e.g. ``PNG``,
+        ``JPEG``) GDAL stores the CRS / geotransform in that sidecar, so the
+        returned payload carries pixel values only.
 
         Args:
             driver: GDAL raster driver name (e.g. ``"GTiff"``, ``"PNG"``,
@@ -828,7 +831,7 @@ class IO(_Engine):
                 ... )
                 >>> payload = ds.to_bytes()
                 >>> restored = Dataset.from_bytes(payload)
-                >>> bool((restored.read_array() == 1.0).all())
+                >>> bool(np.allclose(restored.read_array(), 1.0))
                 True
 
                 ```

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -20,7 +20,8 @@ from osgeo import gdal
 from osgeo_utils import gdal2xyz
 from pandas import DataFrame
 
-from pyramids.base._errors import OutOfBoundsError, ReadOnlyError
+from pyramids._io import new_vsimem_path, read_vsi_bytes, silent_unlink
+from pyramids.base._errors import FailedToSaveError, OutOfBoundsError, ReadOnlyError
 from pyramids.base._file_manager import CachingFileManager, gdal_raster_open
 from pyramids.base._locks import DummyLock, default_lock
 from pyramids.base.protocols import ArrayLike
@@ -780,6 +781,129 @@ class IO(_Engine):
                 driver,
             )
         return result
+
+    def to_bytes(
+        self: Dataset,
+        driver: str = "GTiff",
+        creation_options: dict[str, Any] | None = None,
+    ) -> bytes:
+        """Serialize the dataset into an in-memory file and return its bytes.
+
+        Writes the raster to a GDAL ``/vsimem/`` path with the requested driver
+        (no temp file on disk), reads the bytes back, and unlinks the virtual
+        file. The write-side counterpart of :meth:`Dataset.from_bytes` — useful
+        for HTTP responses, object-store uploads, database blobs, and tests.
+
+        Only **single-file** raster drivers are supported: a driver that emits
+        sidecar files next to the main one (world files, multi-part outputs)
+        raises ``ValueError``. GDAL's optional ``.aux.xml`` statistics sidecar
+        is ignored and cleaned up.
+
+        Args:
+            driver: GDAL raster driver name (e.g. ``"GTiff"``, ``"PNG"``,
+                ``"JPEG"``). Defaults to ``"GTiff"``. The driver must support
+                ``CreateCopy``.
+            creation_options: Optional driver creation options as a mapping,
+                e.g. ``{"COMPRESS": "DEFLATE"}`` for GTiff.
+
+        Returns:
+            bytes: The complete file contents in the requested format.
+
+        Raises:
+            ValueError: ``driver`` is unknown, does not support ``CreateCopy``,
+                or produced a multi-file output.
+            FailedToSaveError: GDAL could not encode the dataset.
+
+        Examples:
+            - Round-trip a raster through GTiff bytes:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_from_array(
+                ...     np.ones((4, 4), dtype="float32"),
+                ...     top_left_corner=(0, 4), cell_size=1.0, epsg=4326,
+                ... )
+                >>> payload = ds.to_bytes()
+                >>> restored = Dataset.from_bytes(payload)
+                >>> bool((restored.read_array() == 1.0).all())
+                True
+
+                ```
+            - Compressed GTiff bytes are smaller than uncompressed for
+              repetitive data:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_from_array(
+                ...     np.zeros((64, 64), dtype="float32"),
+                ...     top_left_corner=(0, 64), cell_size=1.0, epsg=4326,
+                ... )
+                >>> small = ds.to_bytes(creation_options={"COMPRESS": "DEFLATE"})
+                >>> len(small) < len(ds.to_bytes())
+                True
+
+                ```
+            - An unknown driver is rejected:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_from_array(
+                ...     np.ones((2, 2)), top_left_corner=(0, 2), cell_size=1.0, epsg=4326,
+                ... )
+                >>> try:
+                ...     ds.to_bytes(driver="not-a-driver")
+                ... except ValueError as exc:
+                ...     print("unknown GDAL driver" in str(exc))
+                True
+
+                ```
+
+        See Also:
+            Dataset.from_bytes: Open a raster held in memory as bytes.
+            Dataset.to_cog_bytes: The COG-specific bytes serializer.
+        """
+        drv = gdal.GetDriverByName(driver)
+        if drv is None:
+            raise ValueError(f"unknown GDAL driver {driver!r}.")
+        if drv.GetMetadataItem(gdal.DCAP_CREATECOPY) != "YES":
+            raise ValueError(
+                f"driver {driver!r} does not support CreateCopy; choose a "
+                "copy-capable single-file raster driver (e.g. GTiff, PNG)."
+            )
+        extension = (
+            drv.GetMetadataItem(gdal.DMD_EXTENSION)
+            or (drv.GetMetadataItem(gdal.DMD_EXTENSIONS) or "").split(" ")[0]
+            or "bin"
+        )
+        vsi_path = new_vsimem_path(f".{extension}")
+        stem = vsi_path.rsplit("/", 1)[1].rsplit(".", 1)[0]
+        options = [f"{key}={value}" for key, value in (creation_options or {}).items()]
+        try:
+            out = drv.CreateCopy(vsi_path, self._ds._raster, 0, options)
+            if out is None:
+                raise FailedToSaveError(
+                    f"GDAL driver {driver!r} failed to encode the dataset."
+                )
+            out.FlushCache()
+            out = None
+            siblings = [
+                name
+                for name in (gdal.ReadDir("/vsimem/") or [])
+                if name.startswith(stem)
+                and f"/vsimem/{name}" != vsi_path
+                and not name.endswith(".aux.xml")
+            ]
+            if siblings:
+                raise ValueError(
+                    f"driver {driver!r} produced a multi-file output "
+                    f"({siblings}); to_bytes supports single-file drivers only."
+                )
+            payload = read_vsi_bytes(vsi_path)
+        finally:
+            for name in gdal.ReadDir("/vsimem/") or []:
+                if name.startswith(stem):
+                    silent_unlink(f"/vsimem/{name}")
+        return payload
 
     def to_raster(
         self: Dataset,

--- a/tests/dataset/test_to_bytes.py
+++ b/tests/dataset/test_to_bytes.py
@@ -15,6 +15,7 @@ from osgeo import gdal
 import pyramids.dataset.engines.io as io_engine
 from pyramids._io import new_vsimem_path, read_vsi_bytes
 from pyramids.dataset import Dataset
+from pyramids.dataset.engines.cog import COG
 
 pytestmark = pytest.mark.core
 
@@ -58,6 +59,20 @@ class TestReadVsiBytes:
         with pytest.raises(FileNotFoundError, match="could not open"):
             read_vsi_bytes("/vsimem/never-written-anywhere.bin")
 
+    def test_empty_file_reads_as_empty_bytes(self):
+        """A zero-byte VSI file reads back as b"" instead of crashing.
+
+        Test scenario:
+            gdal.VSIFReadL returns None (not b"") for a zero-byte read; the
+            helper must normalise that to empty bytes.
+        """
+        path = new_vsimem_path(".bin")
+        gdal.FileFromMemBuffer(path, b"")
+        try:
+            assert read_vsi_bytes(path) == b"", "empty file should read as b''"
+        finally:
+            gdal.Unlink(path)
+
 
 class TestToBytes:
     """Tests for Dataset.to_bytes."""
@@ -75,7 +90,9 @@ class TestToBytes:
             restored.read_array(), ramp_dataset.read_array(),
             err_msg="array must survive the bytes round-trip",
         )
-        assert restored.geotransform == ramp_dataset.geotransform, "geotransform changed"
+        assert restored.geotransform == pytest.approx(ramp_dataset.geotransform), (
+            "geotransform changed"
+        )
         assert restored.epsg == 4326, f"CRS lost: {restored.epsg}"
         assert restored.no_data_value[0] == pytest.approx(-9999.0), (
             f"nodata lost: {restored.no_data_value}"
@@ -147,6 +164,30 @@ class TestToBytes:
         """
         with pytest.raises(ValueError, match="unknown GDAL driver"):
             ramp_dataset.to_bytes(driver="definitely-not-a-driver")
+
+    def test_driver_without_createcopy_raises(self, ramp_dataset):
+        """A driver lacking the CreateCopy capability is rejected up-front.
+
+        Test scenario:
+            The MEM driver advertises no DCAP_CREATECOPY -> ValueError before
+            anything is written to /vsimem/.
+        """
+        with pytest.raises(ValueError, match="does not support CreateCopy"):
+            ramp_dataset.to_bytes(driver="MEM")
+
+    def test_multi_file_driver_raises_and_cleans_up(self, ramp_dataset):
+        """A driver that writes sidecar files is rejected, leaving no leaks.
+
+        Test scenario:
+            AAIGrid emits a .prj sidecar next to the .asc for a georeferenced
+            raster -> ValueError naming the sibling, and every /vsimem/ entry
+            (main file + sidecar) is swept by the cleanup.
+        """
+        before = sorted(gdal.ReadDir("/vsimem/") or [])
+        with pytest.raises(ValueError, match="multi-file output"):
+            ramp_dataset.to_bytes(driver="AAIGrid")
+        after = sorted(gdal.ReadDir("/vsimem/") or [])
+        assert before == after, f"vsimem leaked: {set(after) - set(before)}"
 
     def test_vsimem_is_clean_after_success(self, ramp_dataset):
         """No /vsimem/ entries leak after a successful serialization.
@@ -220,3 +261,18 @@ class TestToCogBytesStillWorks:
             restored.read_array(), ramp_dataset.read_array(),
             err_msg="COG bytes round-trip changed values",
         )
+
+    def test_to_cog_failure_is_not_masked_by_cleanup(self, ramp_dataset, monkeypatch):
+        """An early to_cog failure propagates instead of a cleanup error.
+
+        Test scenario:
+            to_cog raises before the /vsimem/ file exists; the finally-cleanup
+            must not replace the original exception with the RuntimeError that
+            gdal.Unlink raises on a missing path under gdal.UseExceptions().
+        """
+        def _boom(self, path, **kwargs):
+            raise ValueError("forced to_cog failure")
+
+        monkeypatch.setattr(COG, "to_cog", _boom)
+        with pytest.raises(ValueError, match="forced to_cog failure"):
+            ramp_dataset.to_cog_bytes()

--- a/tests/dataset/test_to_bytes.py
+++ b/tests/dataset/test_to_bytes.py
@@ -126,6 +126,19 @@ class TestToBytes:
             err_msg="PNG round-trip changed pixel values",
         )
 
+    def test_strict_copy_rejects_lossy_driver(self, ramp_dataset):
+        """A driver that cannot represent the dtype fails loudly (strict copy).
+
+        Test scenario:
+            PNG supports Byte/UInt16 only; serializing a float32 dataset must
+            raise (no silent downcast) and leave /vsimem/ clean.
+        """
+        before = sorted(gdal.ReadDir("/vsimem/") or [])
+        with pytest.raises(RuntimeError, match="PNG driver"):
+            ramp_dataset.to_bytes(driver="PNG")
+        after = sorted(gdal.ReadDir("/vsimem/") or [])
+        assert before == after, f"vsimem leaked: {set(after) - set(before)}"
+
     def test_unknown_driver_raises(self, ramp_dataset):
         """An unknown driver name raises ValueError naming the driver.
 

--- a/tests/dataset/test_to_bytes.py
+++ b/tests/dataset/test_to_bytes.py
@@ -1,0 +1,209 @@
+"""Tests for `Dataset.to_bytes` and the shared VSI byte read-back helper.
+
+Covers the driver-generic in-memory serializer (`IO.to_bytes` +
+`Dataset.to_bytes` facade), its round-trip with `Dataset.from_bytes`, driver
+validation, creation options, `/vsimem/` hygiene, and
+`pyramids._io.read_vsi_bytes` (also reused by `to_cog_bytes`).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from osgeo import gdal
+
+import pyramids.dataset.engines.io as io_engine
+from pyramids._io import new_vsimem_path, read_vsi_bytes
+from pyramids.dataset import Dataset
+
+pytestmark = pytest.mark.core
+
+
+@pytest.fixture(scope="function")
+def ramp_dataset() -> Dataset:
+    """A 4x4 float32 ramp on EPSG:4326 with nodata -9999.
+
+    Returns:
+        Dataset: In-memory single-band dataset, value == row*4 + col.
+    """
+    arr = np.arange(16, dtype="float32").reshape(4, 4)
+    return Dataset.create_from_array(
+        arr, top_left_corner=(0, 4), cell_size=1.0, epsg=4326, no_data_value=-9999.0
+    )
+
+
+class TestReadVsiBytes:
+    """Tests for the shared read_vsi_bytes helper."""
+
+    def test_reads_back_written_buffer(self):
+        """A buffer written to /vsimem/ is read back byte-identical.
+
+        Test scenario:
+            FileFromMemBuffer -> read_vsi_bytes round-trips the payload.
+        """
+        path = new_vsimem_path(".bin")
+        gdal.FileFromMemBuffer(path, b"payload-123")
+        try:
+            assert read_vsi_bytes(path) == b"payload-123", "VSI read-back mismatch"
+        finally:
+            gdal.Unlink(path)
+
+    def test_missing_path_raises_file_not_found(self):
+        """A path that was never written raises FileNotFoundError.
+
+        Test scenario:
+            Both the None-return and the UseExceptions RuntimeError shapes of
+            GDAL normalise to FileNotFoundError.
+        """
+        with pytest.raises(FileNotFoundError, match="could not open"):
+            read_vsi_bytes("/vsimem/never-written-anywhere.bin")
+
+
+class TestToBytes:
+    """Tests for Dataset.to_bytes."""
+
+    def test_gtiff_round_trip_preserves_everything(self, ramp_dataset):
+        """Default GTiff bytes reopen to an identical dataset.
+
+        Test scenario:
+            from_bytes(to_bytes(ds)) preserves the array, geotransform, CRS,
+            and nodata marker.
+        """
+        payload = ramp_dataset.to_bytes()
+        restored = Dataset.from_bytes(payload)
+        np.testing.assert_array_equal(
+            restored.read_array(), ramp_dataset.read_array(),
+            err_msg="array must survive the bytes round-trip",
+        )
+        assert restored.geotransform == ramp_dataset.geotransform, "geotransform changed"
+        assert restored.epsg == 4326, f"CRS lost: {restored.epsg}"
+        assert restored.no_data_value[0] == pytest.approx(-9999.0), (
+            f"nodata lost: {restored.no_data_value}"
+        )
+
+    def test_payload_is_a_tiff_file(self, ramp_dataset):
+        """The default payload carries TIFF magic bytes.
+
+        Test scenario:
+            Little-endian TIFF files start with b"II*\\x00".
+        """
+        payload = ramp_dataset.to_bytes()
+        assert payload[:4] == b"II*\x00", f"not a TIFF payload: {payload[:4]!r}"
+
+    def test_creation_options_compress(self, ramp_dataset):
+        """COMPRESS=DEFLATE produces a payload no larger than uncompressed.
+
+        Test scenario:
+            Creation options reach the driver; for a constant raster the
+            deflate payload is strictly smaller.
+        """
+        flat = Dataset.create_from_array(
+            np.zeros((64, 64), dtype="float32"),
+            top_left_corner=(0, 64), cell_size=1.0, epsg=4326,
+        )
+        compressed = flat.to_bytes(creation_options={"COMPRESS": "DEFLATE"})
+        raw = flat.to_bytes()
+        assert len(compressed) < len(raw), (
+            f"deflate ({len(compressed)}) should beat raw ({len(raw)}) on zeros"
+        )
+
+    def test_png_driver(self):
+        """A uint8 dataset serializes to a valid PNG payload.
+
+        Test scenario:
+            driver="PNG" emits the PNG magic; from_bytes reopens it and the
+            pixel values survive.
+        """
+        ds = Dataset.create_from_array(
+            np.full((8, 8), 7, dtype="uint8"),
+            top_left_corner=(0, 8), cell_size=1.0, epsg=4326, no_data_value=255,
+        )
+        payload = ds.to_bytes(driver="PNG")
+        assert payload[:4] == b"\x89PNG", f"not a PNG payload: {payload[:4]!r}"
+        restored = Dataset.from_bytes(payload, suffix=".png")
+        np.testing.assert_array_equal(
+            restored.read_array(), ds.read_array(),
+            err_msg="PNG round-trip changed pixel values",
+        )
+
+    def test_unknown_driver_raises(self, ramp_dataset):
+        """An unknown driver name raises ValueError naming the driver.
+
+        Test scenario:
+            GetDriverByName returns None -> clear error, nothing written.
+        """
+        with pytest.raises(ValueError, match="unknown GDAL driver"):
+            ramp_dataset.to_bytes(driver="definitely-not-a-driver")
+
+    def test_vsimem_is_clean_after_success(self, ramp_dataset):
+        """No /vsimem/ entries leak after a successful serialization.
+
+        Test scenario:
+            The /vsimem/ directory listing is unchanged by to_bytes.
+        """
+        before = sorted(gdal.ReadDir("/vsimem/") or [])
+        ramp_dataset.to_bytes()
+        after = sorted(gdal.ReadDir("/vsimem/") or [])
+        assert before == after, f"vsimem leaked: {set(after) - set(before)}"
+
+    def test_vsimem_is_clean_after_failure(self, ramp_dataset, monkeypatch):
+        """No /vsimem/ entries leak when the serialization fails mid-way.
+
+        Test scenario:
+            The read-back step is forced to fail after the driver wrote the
+            virtual file; the finally-cleanup must still unlink every entry.
+        """
+        def _boom(path):
+            raise FileNotFoundError("forced read-back failure")
+
+        monkeypatch.setattr(io_engine, "read_vsi_bytes", _boom)
+        before = sorted(gdal.ReadDir("/vsimem/") or [])
+        with pytest.raises(FileNotFoundError, match="forced read-back"):
+            ramp_dataset.to_bytes()
+        after = sorted(gdal.ReadDir("/vsimem/") or [])
+        assert before == after, f"vsimem leaked on failure: {set(after) - set(before)}"
+
+    def test_multi_band_round_trip(self):
+        """A 3-band raster survives the bytes round-trip.
+
+        Test scenario:
+            Band count and every band's values are preserved.
+        """
+        arr = np.random.default_rng(7).random((3, 5, 5)).astype("float32")
+        ds = Dataset.create_from_array(
+            arr, top_left_corner=(0, 5), cell_size=1.0, epsg=4326
+        )
+        restored = Dataset.from_bytes(ds.to_bytes())
+        assert restored.band_count == 3, f"band count lost: {restored.band_count}"
+        np.testing.assert_array_equal(
+            restored.read_array(), arr, err_msg="multi-band values changed"
+        )
+
+    def test_facade_delegates_to_engine(self, ramp_dataset):
+        """Dataset.to_bytes and IO.to_bytes return identical payloads.
+
+        Test scenario:
+            The facade is a pure delegation of the engine method.
+        """
+        assert ramp_dataset.to_bytes() == ramp_dataset.io.to_bytes(), (
+            "facade and engine outputs differ"
+        )
+
+
+class TestToCogBytesStillWorks:
+    """Regression: to_cog_bytes survives the shared read-back refactor."""
+
+    def test_cog_bytes_round_trip(self, ramp_dataset):
+        """to_cog_bytes still emits a reopenable TIFF after the refactor.
+
+        Test scenario:
+            The refactored read-back path produces a payload from_bytes can
+            open with the original values.
+        """
+        payload = ramp_dataset.to_cog_bytes()
+        assert payload[:4] in (b"II*\x00", b"MM\x00*"), "not a TIFF payload"
+        restored = Dataset.from_bytes(payload)
+        np.testing.assert_array_equal(
+            restored.read_array(), ramp_dataset.read_array(),
+            err_msg="COG bytes round-trip changed values",
+        )


### PR DESCRIPTION
## Summary

Implements #492: `from_bytes` had no general write-side counterpart — serializing a raster to bytes was
COG-only (`to_cog_bytes`). This PR adds the missing direction.

- `IO.to_bytes(driver="GTiff", creation_options=None)` + `Dataset.to_bytes` facade: writes the raster
  to a unique GDAL `/vsimem/` path via `CreateCopy`, reads the bytes back, and always cleans the
  virtual filesystem (success and failure paths).
- **Strict copy**: a driver that cannot represent the dataset faithfully (e.g. PNG asked to encode
  float32) raises instead of silently downcasting.
- **Single-file drivers only**: sidecar-producing outputs are rejected with a clear `ValueError`
  (GDAL's optional PAM `.aux.xml` is tolerated and cleaned).
- New shared `pyramids._io.read_vsi_bytes()` (UseExceptions-safe VSIF read-back, `FileNotFoundError`
  on a missing path); `to_cog_bytes` refactored onto it so the VSIF dance lives in one place.

## Test plan

- New `tests/dataset/test_to_bytes.py` (13 tests): GTiff round-trip preserving array, geotransform,
  CRS, nodata; multi-band; PNG (uint8) round-trip + magic bytes; compression creation options;
  unknown-driver and strict-copy rejection; `/vsimem/` hygiene on success and forced failure; facade
  delegation; `to_cog_bytes` regression.
- `pytest tests/dataset/ -m "not plot"` -> 1706 passed, 4 skipped.

Closes #492
