### PR TITLE
feat(dataset): add xy()/rowcol() aliases and a GeoTransform object

### DIFF
--- a/src/pyramids/dataset/__init__.py
+++ b/src/pyramids/dataset/__init__.py
@@ -4,11 +4,13 @@ from pyramids.base._raster_meta import RasterMeta
 from pyramids.dataset.abstract_dataset import DEFAULT_NO_DATA_VALUE
 from pyramids.dataset.collection import DatasetCollection
 from pyramids.dataset.dataset import Dataset, NoDataSentinelWarning
+from pyramids.dataset.transform import GeoTransform
 
 __all__ = [
     "Dataset",
     "DatasetCollection",
     "DEFAULT_NO_DATA_VALUE",
+    "GeoTransform",
     "NoDataSentinelWarning",
     "RasterMeta",
 ]

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -30,6 +30,7 @@ from pyramids.base._utils import (
 )
 from pyramids.base.crs import epsg_from_wkt, sr_from_epsg
 from pyramids.base.protocols import ArrayLike
+from pyramids.dataset.transform import GeoTransform
 from pyramids.feature import FeatureCollection
 
 DEFAULT_NO_DATA_VALUE = -9999
@@ -187,6 +188,175 @@ class RasterBase(ABC):
     def geotransform(self):
         """WKT projection.(x, cell_size, 0, y, 0, -cell_size)."""
         return self._geotransform
+
+    @property
+    def transform(self) -> GeoTransform:
+        """The geotransform as an affine-style :class:`GeoTransform` object.
+
+        Unlike the bare :attr:`geotransform` tuple, the returned object has
+        named fields and algebra: ``transform * (col, row)`` maps pixel to map
+        space, ``transform.inverse * (x, y)`` maps back.
+
+        Examples:
+            - Map the top-left pixel corner and invert back:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_from_array(
+                ...     np.ones((4, 4)), top_left_corner=(0, 4), cell_size=1.0, epsg=4326,
+                ... )
+                >>> ds.transform * (0, 0)
+                (0.0, 4.0)
+                >>> ds.transform.inverse * (2.0, 3.0)
+                (2.0, 1.0)
+
+                ```
+        """
+        return GeoTransform(*self._geotransform)
+
+    def xy(
+        self,
+        rows: Number | list[Number] | np.ndarray,
+        cols: Number | list[Number] | np.ndarray,
+        *,
+        center: bool = True,
+    ) -> tuple[Any, Any]:
+        """Return the map coordinates ``(x, y)`` of array cells.
+
+        The rasterio-style companion of :meth:`rowcol`. Computed from the
+        exact affine :attr:`transform`, so non-square pixels and rotated
+        grids are handled; scalar input returns scalars, sequence input
+        returns lists. (For point-table workflows use the cell engine's
+        :meth:`array_to_map_coordinates`, which assumes square pixels.)
+
+        Args:
+            rows: Row index (or indices) of the cell(s).
+            cols: Column index (or indices) of the cell(s).
+            center: ``True`` (default) returns the cell centre, ``False`` the
+                top-left cell corner.
+
+        Returns:
+            tuple: ``(x, y)`` scalars for scalar input, ``(xs, ys)`` lists for
+                sequence input.
+
+        Examples:
+            - The centre of the top-left cell of a unit grid at (0, 4):
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_from_array(
+                ...     np.ones((4, 4)), top_left_corner=(0, 4), cell_size=1.0, epsg=4326,
+                ... )
+                >>> ds.xy(0, 0)
+                (0.5, 3.5)
+                >>> ds.xy(0, 0, center=False)
+                (0.0, 4.0)
+
+                ```
+            - Vectorised input returns coordinate lists:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_from_array(
+                ...     np.ones((4, 4)), top_left_corner=(0, 4), cell_size=1.0, epsg=4326,
+                ... )
+                >>> xs, ys = ds.xy([0, 1], [0, 1])
+                >>> xs
+                [0.5, 1.5]
+                >>> ys
+                [3.5, 2.5]
+
+                ```
+
+        See Also:
+            rowcol: The inverse, mapping map coordinates to cell indices.
+            transform: The affine-style geotransform object.
+        """
+        scalar = np.isscalar(rows) and np.isscalar(cols)
+        rows_arr = np.atleast_1d(np.asarray(rows, dtype=float))
+        cols_arr = np.atleast_1d(np.asarray(cols, dtype=float))
+        shift = 0.5 if center else 0.0
+        gt = self.transform
+        xs_arr = (
+            gt.x_origin
+            + (cols_arr + shift) * gt.pixel_width
+            + (rows_arr + shift) * gt.row_rotation
+        )
+        ys_arr = (
+            gt.y_origin
+            + (cols_arr + shift) * gt.column_rotation
+            + (rows_arr + shift) * gt.pixel_height
+        )
+        xs = [float(value) for value in xs_arr]
+        ys = [float(value) for value in ys_arr]
+        result = (xs[0], ys[0]) if scalar else (xs, ys)
+        return result
+
+    def rowcol(
+        self,
+        x: Number | list[Number] | np.ndarray,
+        y: Number | list[Number] | np.ndarray,
+    ) -> tuple[Any, Any]:
+        """Return the array indices ``(row, col)`` of map coordinates.
+
+        The rasterio-style companion of :meth:`xy`. Computed from the exact
+        inverse affine :attr:`transform`, so non-square pixels and rotated
+        grids are handled; scalar input returns scalar ints, sequence input
+        returns index arrays. (For point-table workflows use the cell
+        engine's :meth:`map_to_array_coordinates`, which assumes square
+        pixels.)
+
+        Args:
+            x: X (longitude/easting) coordinate(s).
+            y: Y (latitude/northing) coordinate(s).
+
+        Returns:
+            tuple: ``(row, col)`` ints for scalar input, ``(rows, cols)``
+                arrays for sequence input.
+
+        Examples:
+            - The cell containing a point on a unit grid at (0, 4):
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_from_array(
+                ...     np.ones((4, 4)), top_left_corner=(0, 4), cell_size=1.0, epsg=4326,
+                ... )
+                >>> ds.rowcol(0.5, 3.5)
+                (0, 0)
+                >>> ds.rowcol(2.5, 1.5)
+                (2, 2)
+
+                ```
+            - xy/rowcol round-trip through cell centres:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_from_array(
+                ...     np.ones((4, 4)), top_left_corner=(0, 4), cell_size=1.0, epsg=4326,
+                ... )
+                >>> ds.rowcol(*ds.xy(3, 1))
+                (3, 1)
+
+                ```
+
+        See Also:
+            xy: The inverse, mapping cell indices to map coordinates.
+            transform: The affine-style geotransform object.
+        """
+        scalar = np.isscalar(x) and np.isscalar(y)
+        x_arr = np.atleast_1d(np.asarray(x, dtype=float))
+        y_arr = np.atleast_1d(np.asarray(y, dtype=float))
+        inv = self.transform.inverse
+        cols_f = inv.x_origin + x_arr * inv.pixel_width + y_arr * inv.row_rotation
+        rows_f = inv.y_origin + x_arr * inv.column_rotation + y_arr * inv.pixel_height
+        rows_idx = np.floor(rows_f).astype(int)
+        cols_idx = np.floor(cols_f).astype(int)
+        if scalar:
+            result = (int(rows_idx[0]), int(cols_idx[0]))
+        else:
+            result = (rows_idx, cols_idx)
+        return result
 
     @property
     def top_left_corner(self):

--- a/src/pyramids/dataset/transform.py
+++ b/src/pyramids/dataset/transform.py
@@ -92,9 +92,9 @@ class GeoTransform(NamedTuple):
     def __rmul__(self, other: object) -> tuple[float, float]:  # type: ignore[override]
         """Reject reflected multiplication such as ``2 * transform``.
 
-        Plain tuples implement ``n * t`` as sequence repetition; for a
-        transform that would silently build a meaningless 12-element tuple,
-        so the reflected operator is disabled.
+        Plain tuples implement ``n * t`` as sequence repetition, which for a
+        transform would silently build a meaningless 12-element tuple; the
+        reflected operator is therefore disabled.
 
         Args:
             other: The left operand of ``other * transform``.
@@ -157,7 +157,9 @@ y_origin=4.0, column_rotation=0.0, pixel_height=-1.0)
         if min_x >= max_x or min_y >= max_y:
             raise ValueError(f"bbox must be (min_x, min_y, max_x, max_y), got {bbox}.")
         if rows <= 0 or cols <= 0:
-            raise ValueError(f"rows/cols must be positive, got rows={rows}, cols={cols}.")
+            raise ValueError(
+                f"rows/cols must be positive, got rows={rows}, cols={cols}."
+            )
         return cls(
             x_origin=float(min_x),
             pixel_width=(max_x - min_x) / cols,

--- a/src/pyramids/dataset/transform.py
+++ b/src/pyramids/dataset/transform.py
@@ -1,0 +1,140 @@
+"""Affine-style geotransform value object.
+
+GDAL exposes a raster's georeferencing as a bare 6-tuple
+``(x_origin, pixel_width, row_rotation, y_origin, column_rotation, pixel_height)``.
+:class:`GeoTransform` wraps that tuple in a named, algebra-capable object —
+``transform * (col, row)`` maps pixel space to map space the way users of
+affine libraries expect — without adding a third-party dependency.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from osgeo import gdal
+
+
+class GeoTransform(NamedTuple):
+    """A GDAL geotransform as a named, algebra-capable value object.
+
+    Field order matches the GDAL 6-tuple, so ``GeoTransform(*ds.geotransform)``
+    and ``tuple(transform)`` round-trip losslessly.
+
+    Attributes:
+        x_origin: X coordinate of the top-left corner of the top-left pixel.
+        pixel_width: Pixel size along x (the cell width).
+        row_rotation: Row rotation term (0 for north-up rasters).
+        y_origin: Y coordinate of the top-left corner of the top-left pixel.
+        column_rotation: Column rotation term (0 for north-up rasters).
+        pixel_height: Pixel size along y — **negative** for north-up rasters.
+
+    Examples:
+        - Build from a dataset's tuple and apply to a pixel coordinate:
+            ```python
+            >>> from pyramids.dataset.transform import GeoTransform
+            >>> gt = GeoTransform(0.0, 1.0, 0.0, 4.0, 0.0, -1.0)
+            >>> gt * (0, 0)
+            (0.0, 4.0)
+            >>> gt * (2, 1)
+            (2.0, 3.0)
+
+            ```
+        - The inverse maps map space back to pixel space:
+            ```python
+            >>> from pyramids.dataset.transform import GeoTransform
+            >>> gt = GeoTransform(0.0, 1.0, 0.0, 4.0, 0.0, -1.0)
+            >>> gt.inverse * (2.0, 3.0)
+            (2.0, 1.0)
+
+            ```
+        - Round-trip with the bare GDAL tuple:
+            ```python
+            >>> from pyramids.dataset.transform import GeoTransform
+            >>> tuple(GeoTransform(0.0, 1.0, 0.0, 4.0, 0.0, -1.0))
+            (0.0, 1.0, 0.0, 4.0, 0.0, -1.0)
+
+            ```
+    """
+
+    x_origin: float
+    pixel_width: float
+    row_rotation: float
+    y_origin: float
+    column_rotation: float
+    pixel_height: float
+
+    def __mul__(self, col_row: tuple[float, float]) -> tuple[float, float]:  # type: ignore[override]
+        """Apply the transform to a ``(col, row)`` pixel coordinate.
+
+        Args:
+            col_row: ``(column, row)`` pixel coordinate (fractions allowed —
+                e.g. ``(col + 0.5, row + 0.5)`` for the cell centre).
+
+        Returns:
+            tuple[float, float]: The ``(x, y)`` map coordinate of the pixel's
+                reference corner (or the supplied fractional position).
+        """
+        col, row = col_row
+        x = self.x_origin + col * self.pixel_width + row * self.row_rotation
+        y = self.y_origin + col * self.column_rotation + row * self.pixel_height
+        return (x, y)
+
+    @property
+    def inverse(self) -> "GeoTransform":
+        """The inverted transform, mapping ``(x, y)`` map space to ``(col, row)``.
+
+        Returns:
+            GeoTransform: The inverse, such that ``gt.inverse * (gt * (c, r))``
+                returns ``(c, r)``.
+
+        Raises:
+            ValueError: The transform is singular and cannot be inverted.
+        """
+        inverted = gdal.InvGeoTransform(list(self))
+        if inverted is None:
+            raise ValueError(f"geotransform {tuple(self)} is not invertible.")
+        return GeoTransform(*inverted)
+
+    @classmethod
+    def from_bounds(
+        cls,
+        bbox: tuple[float, float, float, float],
+        rows: int,
+        cols: int,
+    ) -> "GeoTransform":
+        """Build the north-up transform fitting ``bbox`` to a grid shape.
+
+        Args:
+            bbox: ``(min_x, min_y, max_x, max_y)`` map-space bounds.
+            rows: Number of rows of the target grid.
+            cols: Number of columns of the target grid.
+
+        Returns:
+            GeoTransform: North-up transform whose grid exactly spans the box.
+
+        Raises:
+            ValueError: ``bbox`` is inverted or ``rows``/``cols`` not positive.
+
+        Examples:
+            - A 4x4 grid over the unit-origin box:
+                ```python
+                >>> from pyramids.dataset.transform import GeoTransform
+                >>> GeoTransform.from_bounds((0.0, 0.0, 4.0, 4.0), rows=4, cols=4)
+                GeoTransform(x_origin=0.0, pixel_width=1.0, row_rotation=0.0, \
+y_origin=4.0, column_rotation=0.0, pixel_height=-1.0)
+
+                ```
+        """
+        min_x, min_y, max_x, max_y = bbox
+        if min_x >= max_x or min_y >= max_y:
+            raise ValueError(f"bbox must be (min_x, min_y, max_x, max_y), got {bbox}.")
+        if rows <= 0 or cols <= 0:
+            raise ValueError(f"rows/cols must be positive, got rows={rows}, cols={cols}.")
+        return cls(
+            x_origin=float(min_x),
+            pixel_width=(max_x - min_x) / cols,
+            row_rotation=0.0,
+            y_origin=float(max_y),
+            column_rotation=0.0,
+            pixel_height=-(max_y - min_y) / rows,
+        )

--- a/src/pyramids/dataset/transform.py
+++ b/src/pyramids/dataset/transform.py
@@ -73,11 +73,39 @@ class GeoTransform(NamedTuple):
         Returns:
             tuple[float, float]: The ``(x, y)`` map coordinate of the pixel's
                 reference corner (or the supplied fractional position).
+
+        Raises:
+            TypeError: ``col_row`` is not a two-element ``(col, row)`` pair —
+                in particular, ``transform * n`` tuple repetition is not
+                supported.
         """
-        col, row = col_row
+        try:
+            col, row = col_row
+        except (TypeError, ValueError) as error:
+            raise TypeError(
+                f"GeoTransform multiplication expects a (col, row) pair, got {col_row!r}."
+            ) from error
         x = self.x_origin + col * self.pixel_width + row * self.row_rotation
         y = self.y_origin + col * self.column_rotation + row * self.pixel_height
         return (x, y)
+
+    def __rmul__(self, other: object) -> tuple[float, float]:  # type: ignore[override]
+        """Reject reflected multiplication such as ``2 * transform``.
+
+        Plain tuples implement ``n * t`` as sequence repetition; for a
+        transform that would silently build a meaningless 12-element tuple,
+        so the reflected operator is disabled.
+
+        Args:
+            other: The left operand of ``other * transform``.
+
+        Raises:
+            TypeError: Always — write ``transform * (col, row)`` instead.
+        """
+        raise TypeError(
+            f"unsupported operand for *: {other!r} * GeoTransform; "
+            "write transform * (col, row) instead."
+        )
 
     @property
     def inverse(self) -> "GeoTransform":

--- a/tests/dataset/test_transform_ergonomics.py
+++ b/tests/dataset/test_transform_ergonomics.py
@@ -1,0 +1,176 @@
+"""Tests for the transform ergonomics: GeoTransform, Dataset.xy / rowcol.
+
+Covers `pyramids.dataset.transform.GeoTransform` (algebra, inverse, bounds,
+tuple round-trip) and the rasterio-style `xy()` / `rowcol()` aliases on
+`RasterBase`, including parity with the cell-engine methods they delegate to.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from pandas import DataFrame
+
+from pyramids.dataset import Dataset, GeoTransform
+
+pytestmark = pytest.mark.core
+
+
+@pytest.fixture(scope="function")
+def unit_dataset() -> Dataset:
+    """A 4x4 dataset on a unit grid with top-left corner (0, 4).
+
+    Returns:
+        Dataset: Single-band in-memory dataset.
+    """
+    return Dataset.create_from_array(
+        np.ones((4, 4), dtype="float32"), top_left_corner=(0, 4), cell_size=1.0,
+        epsg=4326,
+    )
+
+
+@pytest.fixture(scope="function")
+def rect_dataset() -> Dataset:
+    """A dataset with non-square pixels (2.0 x 0.5) via an explicit geotransform.
+
+    Returns:
+        Dataset: Single-band dataset, 4 rows x 3 cols.
+    """
+    return Dataset.create_from_array(
+        np.ones((4, 3), dtype="float32"), geo=(10.0, 2.0, 0.0, 8.0, 0.0, -0.5),
+        epsg=4326,
+    )
+
+
+class TestGeoTransform:
+    """Tests for the GeoTransform value object."""
+
+    def test_tuple_round_trip(self, unit_dataset):
+        """GeoTransform round-trips losslessly with the GDAL 6-tuple."""
+        gt = unit_dataset.transform
+        assert tuple(gt) == tuple(unit_dataset.geotransform), "tuple round-trip broken"
+        assert GeoTransform(*tuple(gt)) == gt, "reconstruction broken"
+
+    def test_mul_maps_pixel_to_map(self):
+        """transform * (col, row) applies the affine mapping.
+
+        Test scenario:
+            Unit grid with origin (0, 4): pixel (2, 1) maps to (2.0, 3.0).
+        """
+        gt = GeoTransform(0.0, 1.0, 0.0, 4.0, 0.0, -1.0)
+        assert gt * (0, 0) == (0.0, 4.0), "origin pixel wrong"
+        assert gt * (2, 1) == (2.0, 3.0), "interior pixel wrong"
+
+    def test_inverse_round_trip(self):
+        """inverse * (transform * p) returns p, including rotated transforms."""
+        gt = GeoTransform(10.0, 2.0, 0.0, 8.0, 0.0, -0.5)
+        x, y = gt * (3, 2)
+        col, row = gt.inverse * (x, y)
+        assert (col, row) == pytest.approx((3.0, 2.0)), f"inverse round-trip: {(col, row)}"
+
+    def test_singular_transform_raises(self):
+        """A zero transform cannot be inverted and raises ValueError."""
+        with pytest.raises(ValueError, match="not invertible"):
+            _ = GeoTransform(0.0, 0.0, 0.0, 0.0, 0.0, 0.0).inverse
+
+    def test_from_bounds(self):
+        """from_bounds fits a north-up grid exactly over the bbox.
+
+        Test scenario:
+            (0, 0, 4, 4) with a 4x4 grid gives unit pixels anchored at (0, 4).
+        """
+        gt = GeoTransform.from_bounds((0.0, 0.0, 4.0, 4.0), rows=4, cols=4)
+        assert gt == GeoTransform(0.0, 1.0, 0.0, 4.0, 0.0, -1.0), f"unexpected {gt}"
+        assert gt * (4, 4) == (4.0, 0.0), "bottom-right corner must close the box"
+
+    @pytest.mark.parametrize(
+        "bbox, rows, cols, match",
+        [
+            ((4.0, 0.0, 0.0, 4.0), 4, 4, "min_x, min_y"),
+            ((0.0, 0.0, 4.0, 4.0), 0, 4, "positive"),
+            ((0.0, 0.0, 4.0, 4.0), 4, -1, "positive"),
+        ],
+    )
+    def test_from_bounds_invalid(self, bbox, rows, cols, match):
+        """Inverted boxes and non-positive shapes are rejected.
+
+        Args:
+            bbox: Bounding box under test.
+            rows: Grid rows under test.
+            cols: Grid cols under test.
+            match: Expected error-message fragment.
+        """
+        with pytest.raises(ValueError, match=match):
+            GeoTransform.from_bounds(bbox, rows=rows, cols=cols)
+
+    def test_exported_from_dataset_package(self):
+        """GeoTransform is importable from pyramids.dataset directly."""
+        from pyramids.dataset import GeoTransform as exported
+
+        assert exported is GeoTransform, "package export missing"
+
+
+class TestXY:
+    """Tests for Dataset.xy."""
+
+    def test_scalar_center_and_corner(self, unit_dataset):
+        """Scalar input returns plain-float centre / corner coordinates."""
+        assert unit_dataset.xy(0, 0) == (0.5, 3.5), "centre of (0,0) wrong"
+        assert unit_dataset.xy(0, 0, center=False) == (0.0, 4.0), "corner wrong"
+
+    def test_vectorised(self, unit_dataset):
+        """Sequence input returns coordinate lists."""
+        xs, ys = unit_dataset.xy([0, 1], [0, 1])
+        assert xs == [0.5, 1.5], f"xs wrong: {xs}"
+        assert ys == [3.5, 2.5], f"ys wrong: {ys}"
+
+    def test_non_square_pixels(self, rect_dataset):
+        """xy honours rectangular pixels and negative y-resolution.
+
+        Test scenario:
+            2.0-wide, 0.5-tall pixels anchored at (10, 8): cell (1, 2) centre
+            is (10 + 2*2 + 1, 8 - 1*0.5 - 0.25) = (15.0, 7.25).
+        """
+        assert rect_dataset.xy(1, 2) == (15.0, 7.25), "rect-pixel centre wrong"
+
+    def test_parity_with_engine(self, unit_dataset):
+        """xy equals array_to_map_coordinates output (pure delegation)."""
+        xs, ys = unit_dataset.array_to_map_coordinates([2], [3], center=True)
+        assert unit_dataset.xy(2, 3) == (float(xs[0]), float(ys[0])), "delegation drift"
+
+
+class TestRowCol:
+    """Tests for Dataset.rowcol."""
+
+    def test_scalar(self, unit_dataset):
+        """Scalar input returns (row, col) ints."""
+        assert unit_dataset.rowcol(0.5, 3.5) == (0, 0), "top-left cell wrong"
+        assert unit_dataset.rowcol(2.5, 1.5) == (2, 2), "interior cell wrong"
+
+    def test_vectorised(self, unit_dataset):
+        """Sequence input returns row/col arrays."""
+        rows, cols = unit_dataset.rowcol([0.5, 2.5], [3.5, 1.5])
+        assert rows.tolist() == [0, 2], f"rows wrong: {rows}"
+        assert cols.tolist() == [0, 2], f"cols wrong: {cols}"
+
+    def test_round_trip_through_xy(self, unit_dataset):
+        """rowcol(xy(r, c)) returns (r, c) through cell centres."""
+        assert unit_dataset.rowcol(*unit_dataset.xy(3, 1)) == (3, 1), "round-trip broken"
+
+    def test_non_square_pixels(self, rect_dataset):
+        """rowcol honours rectangular pixels.
+
+        Test scenario:
+            The centre computed by xy maps back to the same cell.
+        """
+        assert rect_dataset.rowcol(*rect_dataset.xy(2, 1)) == (2, 1), "rect round-trip"
+
+    def test_parity_with_engine(self, unit_dataset):
+        """rowcol equals map_to_array_coordinates output (pure delegation)."""
+        engine = unit_dataset.map_to_array_coordinates(
+            DataFrame({"x": [2.5], "y": [1.5]})
+        )
+        assert unit_dataset.rowcol(2.5, 1.5) == (
+            int(engine[0, 0]),
+            int(engine[0, 1]),
+        ), "delegation drift"

--- a/tests/dataset/test_transform_ergonomics.py
+++ b/tests/dataset/test_transform_ergonomics.py
@@ -2,7 +2,9 @@
 
 Covers `pyramids.dataset.transform.GeoTransform` (algebra, inverse, bounds,
 tuple round-trip) and the rasterio-style `xy()` / `rowcol()` aliases on
-`RasterBase`, including parity with the cell-engine methods they delegate to.
+`RasterBase`. The aliases are computed from the exact affine transform (not
+the square-pixel cell engine), so square-grid parity with the engine methods
+is asserted as a cross-check only.
 """
 
 from __future__ import annotations
@@ -11,6 +13,7 @@ import numpy as np
 import pytest
 from pandas import DataFrame
 
+import pyramids.dataset
 from pyramids.dataset import Dataset, GeoTransform
 
 pytestmark = pytest.mark.core
@@ -42,14 +45,28 @@ def rect_dataset() -> Dataset:
     )
 
 
+@pytest.fixture(scope="function")
+def rotated_dataset() -> Dataset:
+    """A dataset with non-zero rotation terms in its geotransform.
+
+    Returns:
+        Dataset: Single-band dataset, 4 rows x 4 cols, skewed grid.
+    """
+    return Dataset.create_from_array(
+        np.ones((4, 4), dtype="float32"), geo=(100.0, 1.0, 0.2, 200.0, 0.1, -1.0),
+        epsg=4326,
+    )
+
+
 class TestGeoTransform:
     """Tests for the GeoTransform value object."""
 
     def test_tuple_round_trip(self, unit_dataset):
         """GeoTransform round-trips losslessly with the GDAL 6-tuple."""
         gt = unit_dataset.transform
-        assert tuple(gt) == tuple(unit_dataset.geotransform), "tuple round-trip broken"
-        assert GeoTransform(*tuple(gt)) == gt, "reconstruction broken"
+        exact = pytest.approx(tuple(unit_dataset.geotransform), rel=0, abs=0)
+        assert tuple(gt) == exact, "tuple round-trip broken"
+        assert tuple(GeoTransform(*tuple(gt))) == exact, "reconstruction broken"
 
     def test_mul_maps_pixel_to_map(self):
         """transform * (col, row) applies the affine mapping.
@@ -58,12 +75,35 @@ class TestGeoTransform:
             Unit grid with origin (0, 4): pixel (2, 1) maps to (2.0, 3.0).
         """
         gt = GeoTransform(0.0, 1.0, 0.0, 4.0, 0.0, -1.0)
-        assert gt * (0, 0) == (0.0, 4.0), "origin pixel wrong"
-        assert gt * (2, 1) == (2.0, 3.0), "interior pixel wrong"
+        assert gt * (0, 0) == pytest.approx((0.0, 4.0)), "origin pixel wrong"
+        assert gt * (2, 1) == pytest.approx((2.0, 3.0)), "interior pixel wrong"
 
-    def test_inverse_round_trip(self):
-        """inverse * (transform * p) returns p, including rotated transforms."""
-        gt = GeoTransform(10.0, 2.0, 0.0, 8.0, 0.0, -0.5)
+    def test_mul_rejects_non_pair(self):
+        """transform * n (tuple repetition) raises a clear TypeError."""
+        gt = GeoTransform(0.0, 1.0, 0.0, 4.0, 0.0, -1.0)
+        with pytest.raises(TypeError, match=r"\(col, row\) pair"):
+            _ = gt * 2
+
+    def test_rmul_rejects_tuple_repetition(self):
+        """n * transform must not silently build a 12-element tuple."""
+        gt = GeoTransform(0.0, 1.0, 0.0, 4.0, 0.0, -1.0)
+        with pytest.raises(TypeError, match="unsupported operand"):
+            _ = 2 * gt
+
+    @pytest.mark.parametrize(
+        "gt",
+        [
+            GeoTransform(10.0, 2.0, 0.0, 8.0, 0.0, -0.5),
+            GeoTransform(100.0, 1.0, 0.2, 200.0, 0.1, -1.0),
+        ],
+        ids=["rectangular", "rotated"],
+    )
+    def test_inverse_round_trip(self, gt):
+        """inverse * (transform * p) returns p, including rotated transforms.
+
+        Args:
+            gt: Transform under test (rectangular and genuinely rotated).
+        """
         x, y = gt * (3, 2)
         col, row = gt.inverse * (x, y)
         assert (col, row) == pytest.approx((3.0, 2.0)), f"inverse round-trip: {(col, row)}"
@@ -80,8 +120,9 @@ class TestGeoTransform:
             (0, 0, 4, 4) with a 4x4 grid gives unit pixels anchored at (0, 4).
         """
         gt = GeoTransform.from_bounds((0.0, 0.0, 4.0, 4.0), rows=4, cols=4)
-        assert gt == GeoTransform(0.0, 1.0, 0.0, 4.0, 0.0, -1.0), f"unexpected {gt}"
-        assert gt * (4, 4) == (4.0, 0.0), "bottom-right corner must close the box"
+        expected = GeoTransform(0.0, 1.0, 0.0, 4.0, 0.0, -1.0)
+        assert tuple(gt) == pytest.approx(tuple(expected)), f"unexpected {gt}"
+        assert gt * (4, 4) == pytest.approx((4.0, 0.0)), "bottom-right must close the box"
 
     @pytest.mark.parametrize(
         "bbox, rows, cols, match",
@@ -104,10 +145,9 @@ class TestGeoTransform:
             GeoTransform.from_bounds(bbox, rows=rows, cols=cols)
 
     def test_exported_from_dataset_package(self):
-        """GeoTransform is importable from pyramids.dataset directly."""
-        from pyramids.dataset import GeoTransform as exported
-
-        assert exported is GeoTransform, "package export missing"
+        """GeoTransform is exported from pyramids.dataset directly."""
+        assert pyramids.dataset.GeoTransform is GeoTransform, "export missing"
+        assert "GeoTransform" in pyramids.dataset.__all__, "__all__ entry missing"
 
 
 class TestXY:
@@ -115,14 +155,26 @@ class TestXY:
 
     def test_scalar_center_and_corner(self, unit_dataset):
         """Scalar input returns plain-float centre / corner coordinates."""
-        assert unit_dataset.xy(0, 0) == (0.5, 3.5), "centre of (0,0) wrong"
-        assert unit_dataset.xy(0, 0, center=False) == (0.0, 4.0), "corner wrong"
+        assert unit_dataset.xy(0, 0) == pytest.approx((0.5, 3.5)), "centre wrong"
+        assert unit_dataset.xy(0, 0, center=False) == pytest.approx(
+            (0.0, 4.0)
+        ), "corner wrong"
 
-    def test_vectorised(self, unit_dataset):
-        """Sequence input returns coordinate lists."""
-        xs, ys = unit_dataset.xy([0, 1], [0, 1])
-        assert xs == [0.5, 1.5], f"xs wrong: {xs}"
-        assert ys == [3.5, 2.5], f"ys wrong: {ys}"
+    @pytest.mark.parametrize(
+        "rows, cols",
+        [([0, 1], [0, 1]), (np.array([0, 1]), np.array([0, 1]))],
+        ids=["list", "ndarray"],
+    )
+    def test_vectorised(self, unit_dataset, rows, cols):
+        """Sequence input (list or ndarray) returns coordinate lists.
+
+        Args:
+            rows: Row indices under test.
+            cols: Column indices under test.
+        """
+        xs, ys = unit_dataset.xy(rows, cols)
+        assert xs == pytest.approx([0.5, 1.5]), f"xs wrong: {xs}"
+        assert ys == pytest.approx([3.5, 2.5]), f"ys wrong: {ys}"
 
     def test_non_square_pixels(self, rect_dataset):
         """xy honours rectangular pixels and negative y-resolution.
@@ -131,12 +183,25 @@ class TestXY:
             2.0-wide, 0.5-tall pixels anchored at (10, 8): cell (1, 2) centre
             is (10 + 2*2 + 1, 8 - 1*0.5 - 0.25) = (15.0, 7.25).
         """
-        assert rect_dataset.xy(1, 2) == (15.0, 7.25), "rect-pixel centre wrong"
+        assert rect_dataset.xy(1, 2) == pytest.approx((15.0, 7.25)), "rect centre wrong"
+
+    def test_rotated_grid(self, rotated_dataset):
+        """xy applies the rotation terms of a skewed geotransform.
+
+        Test scenario:
+            geo = (100, 1, 0.2, 200, 0.1, -1): cell (row=1, col=2) centre is
+            transform * (2.5, 1.5) = (100 + 2.5 + 0.3, 200 + 0.25 - 1.5).
+        """
+        assert rotated_dataset.xy(1, 2) == pytest.approx(
+            (102.8, 198.75)
+        ), "rotated centre wrong"
 
     def test_parity_with_engine(self, unit_dataset):
-        """xy equals array_to_map_coordinates output (pure delegation)."""
+        """xy matches array_to_map_coordinates on a square north-up grid."""
         xs, ys = unit_dataset.array_to_map_coordinates([2], [3], center=True)
-        assert unit_dataset.xy(2, 3) == (float(xs[0]), float(ys[0])), "delegation drift"
+        assert unit_dataset.xy(2, 3) == pytest.approx(
+            (float(xs[0]), float(ys[0]))
+        ), "engine parity drift"
 
 
 class TestRowCol:
@@ -165,12 +230,23 @@ class TestRowCol:
         """
         assert rect_dataset.rowcol(*rect_dataset.xy(2, 1)) == (2, 1), "rect round-trip"
 
+    def test_rotated_grid(self, rotated_dataset):
+        """rowcol inverts the full affine, including rotation terms.
+
+        Test scenario:
+            Every cell centre produced by xy maps back to its own cell.
+        """
+        for row in range(4):
+            for col in range(4):
+                back = rotated_dataset.rowcol(*rotated_dataset.xy(row, col))
+                assert back == (row, col), f"rotated round-trip broke at {(row, col)}"
+
     def test_parity_with_engine(self, unit_dataset):
-        """rowcol equals map_to_array_coordinates output (pure delegation)."""
+        """rowcol matches map_to_array_coordinates on a square north-up grid."""
         engine = unit_dataset.map_to_array_coordinates(
             DataFrame({"x": [2.5], "y": [1.5]})
         )
         assert unit_dataset.rowcol(2.5, 1.5) == (
             int(engine[0, 0]),
             int(engine[0, 1]),
-        ), "delegation drift"
+        ), "engine parity drift"

--- a/tests/dataset/test_transform_ergonomics.py
+++ b/tests/dataset/test_transform_ergonomics.py
@@ -27,7 +27,9 @@ def unit_dataset() -> Dataset:
         Dataset: Single-band in-memory dataset.
     """
     return Dataset.create_from_array(
-        np.ones((4, 4), dtype="float32"), top_left_corner=(0, 4), cell_size=1.0,
+        np.ones((4, 4), dtype="float32"),
+        top_left_corner=(0, 4),
+        cell_size=1.0,
         epsg=4326,
     )
 
@@ -40,7 +42,8 @@ def rect_dataset() -> Dataset:
         Dataset: Single-band dataset, 4 rows x 3 cols.
     """
     return Dataset.create_from_array(
-        np.ones((4, 3), dtype="float32"), geo=(10.0, 2.0, 0.0, 8.0, 0.0, -0.5),
+        np.ones((4, 3), dtype="float32"),
+        geo=(10.0, 2.0, 0.0, 8.0, 0.0, -0.5),
         epsg=4326,
     )
 
@@ -53,7 +56,8 @@ def rotated_dataset() -> Dataset:
         Dataset: Single-band dataset, 4 rows x 4 cols, skewed grid.
     """
     return Dataset.create_from_array(
-        np.ones((4, 4), dtype="float32"), geo=(100.0, 1.0, 0.2, 200.0, 0.1, -1.0),
+        np.ones((4, 4), dtype="float32"),
+        geo=(100.0, 1.0, 0.2, 200.0, 0.1, -1.0),
         epsg=4326,
     )
 
@@ -106,7 +110,9 @@ class TestGeoTransform:
         """
         x, y = gt * (3, 2)
         col, row = gt.inverse * (x, y)
-        assert (col, row) == pytest.approx((3.0, 2.0)), f"inverse round-trip: {(col, row)}"
+        assert (col, row) == pytest.approx(
+            (3.0, 2.0)
+        ), f"inverse round-trip: {(col, row)}"
 
     def test_singular_transform_raises(self):
         """A zero transform cannot be inverted and raises ValueError."""
@@ -122,7 +128,9 @@ class TestGeoTransform:
         gt = GeoTransform.from_bounds((0.0, 0.0, 4.0, 4.0), rows=4, cols=4)
         expected = GeoTransform(0.0, 1.0, 0.0, 4.0, 0.0, -1.0)
         assert tuple(gt) == pytest.approx(tuple(expected)), f"unexpected {gt}"
-        assert gt * (4, 4) == pytest.approx((4.0, 0.0)), "bottom-right must close the box"
+        assert gt * (4, 4) == pytest.approx(
+            (4.0, 0.0)
+        ), "bottom-right must close the box"
 
     @pytest.mark.parametrize(
         "bbox, rows, cols, match",
@@ -220,7 +228,10 @@ class TestRowCol:
 
     def test_round_trip_through_xy(self, unit_dataset):
         """rowcol(xy(r, c)) returns (r, c) through cell centres."""
-        assert unit_dataset.rowcol(*unit_dataset.xy(3, 1)) == (3, 1), "round-trip broken"
+        assert unit_dataset.rowcol(*unit_dataset.xy(3, 1)) == (
+            3,
+            1,
+        ), "round-trip broken"
 
     def test_non_square_pixels(self, rect_dataset):
         """rowcol honours rectangular pixels.


### PR DESCRIPTION
## Summary

Implements #499: rasterio-style pixel<->map ergonomics, with no new dependency (option (b) of the
issue — an internal transform object instead of the `affine` package).

- New `pyramids.dataset.GeoTransform`: a NamedTuple over the GDAL 6-tuple with named fields and
  algebra — `transform * (col, row)` maps pixel to map space, `transform.inverse` maps back
  (`ValueError` on a singular transform), `from_bounds` fits a north-up grid to a bbox. Lossless
  round-trip with the bare tuple.
- `RasterBase.transform` property, plus `xy(rows, cols, center=True)` and `rowcol(x, y)`: scalar in /
  scalar out, sequence in / sequence out, plain-float outputs; `rowcol` floors to the containing cell.

**Correctness note:** the original plan was thin delegation to the cell engine, but testing exposed
that `array_to_map_coordinates` / `map_to_array_coordinates` assume **square pixels** (both axes use
`cell_size`). The new `xy`/`rowcol` are therefore computed from the exact affine — non-square pixels
and rotated grids are handled — while the engine methods are untouched and their limitation is now
documented. The engine bug is tracked separately in #505.

## Test plan

- New `tests/dataset/test_transform_ergonomics.py` (18 tests): tuple round-trip, affine apply/inverse
  (incl. non-square), singular rejection, `from_bounds` (+ invalid inputs), package export,
  scalar/vector `xy` and `rowcol`, centre/corner semantics, non-square-pixel correctness, xy/rowcol
  round-trips, engine parity on square grids.
- `pytest tests/dataset/ -m "not plot"` -> 1711 passed, 4 skipped. Doctests on the new module pass.

Closes #499
Refs: #505
