### PR TITLE
feat(cli): add info/bounds/clip/warp/merge/overview/sample/convert subcommands

### DIFF
--- a/src/pyramids/cli.py
+++ b/src/pyramids/cli.py
@@ -1,25 +1,40 @@
-"""Command-line interface for pyramids — currently the `cog` command group.
+"""Command-line interface for pyramids.
 
-Exposes the common Cloud Optimized GeoTIFF workflow from the shell, built on the
-pyramids `COG` engine and the standard-library :mod:`argparse` (no extra
-dependency):
+Thin, scriptable wrappers over the library's primitives, built on the
+standard-library :mod:`argparse` (no extra dependency):
 
-- `pyramids cog create IN OUT [--profile P] [--compress C] [--blocksize N]`
-- `pyramids cog validate FILE [--strict]`
-- `pyramids cog info FILE`
+- `pyramids cog create|validate|info ...` — the Cloud Optimized GeoTIFF group
+- `pyramids info FILE [--json]` — raster metadata at a glance
+- `pyramids bounds FILE [--crs CRS] [--json]` — bounding box
+- `pyramids clip SRC DST (--bbox MINX MINY MAXX MAXY | --vector PATH)` — crop
+- `pyramids warp SRC DST --crs CRS [--resampling M]` — reproject
+- `pyramids merge SRC... DST` — mosaic
+- `pyramids overview FILE [--resampling M] [--levels N...]` — build overviews
+- `pyramids sample FILE --points "x,y;x,y..." [--json]` — point sampling
+- `pyramids convert SRC DST [--driver NAME]` — format conversion
 
-The entry point is registered as the `pyramids` console script; the functions
-here are also callable in-process (`main([...])`) for testing.
+Every command maps 1:1 onto an existing library call — no business logic lives
+here. Expected user errors (missing file, bad CRS, unknown driver) exit
+non-zero with a one-line message instead of a traceback. The entry point is
+registered as the `pyramids` console script; the functions here are also
+callable in-process (`main([...])`) for testing.
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import sys
 from typing import Sequence
 
+from osgeo import osr
+from pandas import DataFrame
+
+from pyramids.base.crs import sr_from_user_input, sr_from_wkt
 from pyramids.dataset import Dataset
 from pyramids.dataset.cog import PROFILES, cog_info, validate
+from pyramids.dataset.merge import merge_rasters
+from pyramids.feature import FeatureCollection
 
 
 def _cmd_create(args: argparse.Namespace) -> int:
@@ -102,6 +117,191 @@ def _cmd_info(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_raster_info(args: argparse.Namespace) -> int:
+    """Handle `pyramids info` — print raster metadata.
+
+    Args:
+        args: Parsed arguments with `file` and `json`.
+
+    Returns:
+        int: `0` on success.
+    """
+    ds = Dataset.read_file(args.file)
+    payload = {
+        "path": args.file,
+        "driver": ds.raster.GetDriver().ShortName,
+        "epsg": ds.epsg,
+        "bands": ds.band_count,
+        "rows": ds.rows,
+        "columns": ds.columns,
+        "cell_size": ds.cell_size,
+        "dtype": list(ds.dtype),
+        "no_data_value": [
+            None if value is None else float(value) for value in ds.no_data_value
+        ],
+        "bounds": [float(value) for value in ds.bbox],
+    }
+    if args.json:
+        print(json.dumps(payload))
+    else:
+        for key, value in payload.items():
+            print(f"{key}: {value}")
+    return 0
+
+
+def _cmd_bounds(args: argparse.Namespace) -> int:
+    """Handle `pyramids bounds` — print the bounding box.
+
+    With `--crs` the four corners are reprojected and the min/max taken —
+    a corner-based approximation (no edge densification).
+
+    Args:
+        args: Parsed arguments with `file`, `crs`, and `json`.
+
+    Returns:
+        int: `0` on success.
+    """
+    ds = Dataset.read_file(args.file)
+    min_x, min_y, max_x, max_y = [float(value) for value in ds.bbox]
+    if args.crs:
+        src_sr = sr_from_wkt(ds.crs)
+        dst_sr = sr_from_user_input(args.crs)
+        src_sr.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+        dst_sr.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+        transformer = osr.CoordinateTransformation(src_sr, dst_sr)
+        corners = transformer.TransformPoints(
+            [(min_x, min_y), (min_x, max_y), (max_x, min_y), (max_x, max_y)]
+        )
+        xs = [corner[0] for corner in corners]
+        ys = [corner[1] for corner in corners]
+        min_x, min_y, max_x, max_y = min(xs), min(ys), max(xs), max(ys)
+    payload = {"bounds": [min_x, min_y, max_x, max_y]}
+    if args.json:
+        print(json.dumps(payload))
+    else:
+        print(f"{min_x} {min_y} {max_x} {max_y}")
+    return 0
+
+
+def _cmd_clip(args: argparse.Namespace) -> int:
+    """Handle `pyramids clip` — crop a raster by bbox or vector mask.
+
+    Args:
+        args: Parsed arguments with `input`, `output`, `bbox`, and `vector`.
+
+    Returns:
+        int: `0` on success.
+    """
+    ds = Dataset.read_file(args.input)
+    if args.vector:
+        mask = FeatureCollection.read_file(args.vector)
+    else:
+        mask = FeatureCollection.from_bbox(tuple(args.bbox), epsg=ds.epsg)
+    clipped = ds.crop(mask)
+    clipped.to_file(args.output)
+    print(f"wrote {args.output}")
+    return 0
+
+
+def _cmd_warp(args: argparse.Namespace) -> int:
+    """Handle `pyramids warp` — reproject a raster.
+
+    Args:
+        args: Parsed arguments with `input`, `output`, `crs`, `resampling`.
+
+    Returns:
+        int: `0` on success.
+    """
+    ds = Dataset.read_file(args.input)
+    warped = ds.to_crs(args.crs, method=args.resampling)
+    warped.to_file(args.output)
+    print(f"wrote {args.output}")
+    return 0
+
+
+def _cmd_merge(args: argparse.Namespace) -> int:
+    """Handle `pyramids merge` — mosaic rasters into one file.
+
+    Args:
+        args: Parsed arguments with `inputs` (>= 2 paths) and `output`.
+
+    Returns:
+        int: `0` on success.
+    """
+    merge_rasters(args.inputs, args.output)
+    print(f"wrote {args.output}")
+    return 0
+
+
+def _cmd_overview(args: argparse.Namespace) -> int:
+    """Handle `pyramids overview` — build image pyramids in place.
+
+    Args:
+        args: Parsed arguments with `file`, `resampling`, and `levels`.
+
+    Returns:
+        int: `0` on success.
+    """
+    ds = Dataset.read_file(args.file, read_only=False)
+    ds.create_overviews(
+        resampling_method=args.resampling, overview_levels=args.levels
+    )
+    counts = ds.overview_count
+    print(f"built {counts[0] if counts else 0} overview level(s) for {args.file}")
+    return 0
+
+
+def _cmd_sample(args: argparse.Namespace) -> int:
+    """Handle `pyramids sample` — read band values at points.
+
+    Args:
+        args: Parsed arguments with `file`, `points` (``"x,y;x,y..."``),
+            and `json`.
+
+    Returns:
+        int: `0` on success.
+    """
+    pairs = [chunk for chunk in args.points.split(";") if chunk.strip()]
+    if not pairs:
+        raise ValueError("--points must contain at least one 'x,y' pair.")
+    xs, ys = [], []
+    for chunk in pairs:
+        x_str, y_str = chunk.split(",")
+        xs.append(float(x_str))
+        ys.append(float(y_str))
+    ds = Dataset.read_file(args.file)
+    values = ds.sample(DataFrame({"x": xs, "y": ys}))
+    # ds.sample returns (bands, points); transpose to one row per point.
+    per_point = values.T.tolist()
+    if args.json:
+        print(json.dumps({"values": per_point}))
+    else:
+        for (x, y), point_values in zip(zip(xs, ys), per_point):
+            print(f"{x},{y}: {point_values}")
+    return 0
+
+
+def _cmd_convert(args: argparse.Namespace) -> int:
+    """Handle `pyramids convert` — re-save a raster in another format.
+
+    The driver is inferred from the output extension unless `--driver` is
+    given (a pyramids catalog driver name, e.g. ``geotiff``, ``ascii``).
+
+    Args:
+        args: Parsed arguments with `input`, `output`, and `driver`.
+
+    Returns:
+        int: `0` on success.
+    """
+    ds = Dataset.read_file(args.input)
+    if args.driver:
+        ds.to_file(args.output, driver=args.driver)
+    else:
+        ds.to_file(args.output)
+    print(f"wrote {args.output}")
+    return 0
+
+
 def _build_parser() -> argparse.ArgumentParser:
     """Build the top-level argument parser.
 
@@ -139,6 +339,70 @@ def _build_parser() -> argparse.ArgumentParser:
     info.add_argument("file", help="raster path to inspect")
     info.set_defaults(func=_cmd_info)
 
+    raster_info = sub.add_parser("info", help="print raster metadata")
+    raster_info.add_argument("file", help="raster path to inspect")
+    raster_info.add_argument("--json", action="store_true", help="emit JSON")
+    raster_info.set_defaults(func=_cmd_raster_info)
+
+    bounds = sub.add_parser("bounds", help="print the raster bounding box")
+    bounds.add_argument("file", help="raster path to inspect")
+    bounds.add_argument(
+        "--crs", help="reproject the corners to this CRS (corner-based approximation)"
+    )
+    bounds.add_argument("--json", action="store_true", help="emit JSON")
+    bounds.set_defaults(func=_cmd_bounds)
+
+    clip = sub.add_parser("clip", help="crop a raster by bbox or vector mask")
+    clip.add_argument("input", help="source raster path")
+    clip.add_argument("output", help="destination raster path")
+    clip_how = clip.add_mutually_exclusive_group(required=True)
+    clip_how.add_argument(
+        "--bbox", nargs=4, type=float, metavar=("MINX", "MINY", "MAXX", "MAXY"),
+        help="clip extent in the raster CRS",
+    )
+    clip_how.add_argument("--vector", help="vector file whose polygons clip the raster")
+    clip.set_defaults(func=_cmd_clip)
+
+    warp = sub.add_parser("warp", help="reproject a raster")
+    warp.add_argument("input", help="source raster path")
+    warp.add_argument("output", help="destination raster path")
+    warp.add_argument("--crs", required=True, help="target CRS (EPSG code, WKT, PROJ4)")
+    warp.add_argument(
+        "--resampling", default="nearest neighbor", help="resampling method"
+    )
+    warp.set_defaults(func=_cmd_warp)
+
+    merge = sub.add_parser("merge", help="mosaic rasters into one file")
+    merge.add_argument("inputs", nargs="+", help="source raster paths (two or more)")
+    merge.add_argument("output", help="destination raster path")
+    merge.set_defaults(func=_cmd_merge)
+
+    overview = sub.add_parser("overview", help="build image pyramids in place")
+    overview.add_argument("file", help="raster path to build overviews for")
+    overview.add_argument(
+        "--resampling", default="nearest", help="overview resampling method"
+    )
+    overview.add_argument(
+        "--levels", nargs="+", type=int, help="decimation levels (e.g. 2 4 8)"
+    )
+    overview.set_defaults(func=_cmd_overview)
+
+    sample = sub.add_parser("sample", help="read band values at points")
+    sample.add_argument("file", help="raster path to sample")
+    sample.add_argument(
+        "--points", required=True, help="semicolon-separated 'x,y' pairs"
+    )
+    sample.add_argument("--json", action="store_true", help="emit JSON")
+    sample.set_defaults(func=_cmd_sample)
+
+    convert = sub.add_parser("convert", help="re-save a raster in another format")
+    convert.add_argument("input", help="source raster path")
+    convert.add_argument("output", help="destination raster path")
+    convert.add_argument(
+        "--driver", help="pyramids catalog driver name (default: from extension)"
+    )
+    convert.set_defaults(func=_cmd_convert)
+
     return parser
 
 
@@ -162,7 +426,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     """
     parser = _build_parser()
     args = parser.parse_args(argv)
-    return args.func(args)
+    try:
+        result = args.func(args)
+    except (ValueError, TypeError, FileNotFoundError, OSError, RuntimeError) as exc:
+        # Expected user errors (missing file, bad CRS, unknown driver, ...)
+        # exit non-zero with a one-line message instead of a traceback.
+        print(f"error: {exc}", file=sys.stderr)
+        result = 1
+    return result
 
 
 if __name__ == "__main__":  # pragma: no cover

--- a/src/pyramids/cli.py
+++ b/src/pyramids/cli.py
@@ -57,6 +57,12 @@ def _json_safe(value: float | None) -> float | None:
     return result
 
 
+_HELP_SRC_RASTER = "source raster path"
+_HELP_DST_RASTER = "destination raster path"
+_HELP_INSPECT_RASTER = "raster path to inspect"
+_HELP_JSON = "emit JSON"
+
+
 def _cmd_create(args: argparse.Namespace) -> int:
     """Handle `pyramids cog create`.
 
@@ -356,7 +362,7 @@ def _build_parser() -> argparse.ArgumentParser:
     cog_sub = cog.add_subparsers(dest="command", required=True)
 
     create = cog_sub.add_parser("create", help="write a raster as a COG")
-    create.add_argument("input", help="source raster path")
+    create.add_argument("input", help=_HELP_SRC_RASTER)
     create.add_argument("output", help="destination COG path")
     create.add_argument(
         "--profile", choices=sorted(PROFILES), help="named compression profile"
@@ -374,25 +380,25 @@ def _build_parser() -> argparse.ArgumentParser:
     val.set_defaults(func=_cmd_validate)
 
     info = cog_sub.add_parser("info", help="print structured COG metadata")
-    info.add_argument("file", help="raster path to inspect")
+    info.add_argument("file", help=_HELP_INSPECT_RASTER)
     info.set_defaults(func=_cmd_info)
 
     raster_info = sub.add_parser("info", help="print raster metadata")
-    raster_info.add_argument("file", help="raster path to inspect")
-    raster_info.add_argument("--json", action="store_true", help="emit JSON")
+    raster_info.add_argument("file", help=_HELP_INSPECT_RASTER)
+    raster_info.add_argument("--json", action="store_true", help=_HELP_JSON)
     raster_info.set_defaults(func=_cmd_raster_info)
 
     bounds = sub.add_parser("bounds", help="print the raster bounding box")
-    bounds.add_argument("file", help="raster path to inspect")
+    bounds.add_argument("file", help=_HELP_INSPECT_RASTER)
     bounds.add_argument(
         "--crs", help="reproject the corners to this CRS (corner-based approximation)"
     )
-    bounds.add_argument("--json", action="store_true", help="emit JSON")
+    bounds.add_argument("--json", action="store_true", help=_HELP_JSON)
     bounds.set_defaults(func=_cmd_bounds)
 
     clip = sub.add_parser("clip", help="crop a raster by bbox or vector mask")
-    clip.add_argument("input", help="source raster path")
-    clip.add_argument("output", help="destination raster path")
+    clip.add_argument("input", help=_HELP_SRC_RASTER)
+    clip.add_argument("output", help=_HELP_DST_RASTER)
     clip_how = clip.add_mutually_exclusive_group(required=True)
     clip_how.add_argument(
         "--bbox",
@@ -405,8 +411,8 @@ def _build_parser() -> argparse.ArgumentParser:
     clip.set_defaults(func=_cmd_clip)
 
     warp = sub.add_parser("warp", help="reproject a raster")
-    warp.add_argument("input", help="source raster path")
-    warp.add_argument("output", help="destination raster path")
+    warp.add_argument("input", help=_HELP_SRC_RASTER)
+    warp.add_argument("output", help=_HELP_DST_RASTER)
     warp.add_argument("--crs", required=True, help="target CRS (EPSG code, WKT, PROJ4)")
     warp.add_argument(
         "--resampling", default="nearest neighbor", help="resampling method"
@@ -415,7 +421,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     merge = sub.add_parser("merge", help="mosaic rasters into one file")
     merge.add_argument("inputs", nargs="+", help="source raster paths (two or more)")
-    merge.add_argument("output", help="destination raster path")
+    merge.add_argument("output", help=_HELP_DST_RASTER)
     merge.set_defaults(func=_cmd_merge)
 
     overview = sub.add_parser("overview", help="build image pyramids in place")
@@ -433,12 +439,12 @@ def _build_parser() -> argparse.ArgumentParser:
     sample.add_argument(
         "--points", required=True, help="semicolon-separated 'x,y' pairs"
     )
-    sample.add_argument("--json", action="store_true", help="emit JSON")
+    sample.add_argument("--json", action="store_true", help=_HELP_JSON)
     sample.set_defaults(func=_cmd_sample)
 
     convert = sub.add_parser("convert", help="re-save a raster in another format")
-    convert.add_argument("input", help="source raster path")
-    convert.add_argument("output", help="destination raster path")
+    convert.add_argument("input", help=_HELP_SRC_RASTER)
+    convert.add_argument("output", help=_HELP_DST_RASTER)
     convert.add_argument(
         "--driver",
         help="catalog (geotiff) or GDAL (GTiff) driver name (default: from extension)",
@@ -473,7 +479,6 @@ def main(argv: Sequence[str] | None = None) -> int:
     except (
         ValueError,
         TypeError,
-        FileNotFoundError,
         OSError,
         RuntimeError,
         _PyramidsError,

--- a/src/pyramids/cli.py
+++ b/src/pyramids/cli.py
@@ -323,7 +323,8 @@ def _cmd_convert(args: argparse.Namespace) -> int:
     """Handle `pyramids convert` — re-save a raster in another format.
 
     The driver is inferred from the output extension unless `--driver` is
-    given (a pyramids catalog driver name, e.g. ``geotiff``, ``ascii``).
+    given — a pyramids catalog driver name (e.g. ``geotiff``, ``ascii``)
+    or a GDAL driver name (e.g. ``GTiff``, ``COG``).
 
     Args:
         args: Parsed arguments with `input`, `output`, and `driver`.
@@ -332,10 +333,7 @@ def _cmd_convert(args: argparse.Namespace) -> int:
         int: `0` on success.
     """
     ds = Dataset.read_file(args.input)
-    if args.driver:
-        ds.to_file(args.output, driver=args.driver)
-    else:
-        ds.to_file(args.output)
+    ds.to_file(args.output, driver=args.driver)
     print(f"wrote {args.output}")
     return 0
 
@@ -442,7 +440,8 @@ def _build_parser() -> argparse.ArgumentParser:
     convert.add_argument("input", help="source raster path")
     convert.add_argument("output", help="destination raster path")
     convert.add_argument(
-        "--driver", help="pyramids catalog driver name (default: from extension)"
+        "--driver",
+        help="catalog (geotiff) or GDAL (GTiff) driver name (default: from extension)",
     )
     convert.set_defaults(func=_cmd_convert)
 

--- a/src/pyramids/cli.py
+++ b/src/pyramids/cli.py
@@ -266,9 +266,11 @@ def _cmd_sample(args: argparse.Namespace) -> int:
         raise ValueError("--points must contain at least one 'x,y' pair.")
     xs, ys = [], []
     for chunk in pairs:
-        x_str, y_str = chunk.split(",")
-        xs.append(float(x_str))
-        ys.append(float(y_str))
+        parts = chunk.split(",")
+        if len(parts) != 2:
+            raise ValueError(f"bad point {chunk.strip()!r}; expected 'x,y'.")
+        xs.append(float(parts[0]))
+        ys.append(float(parts[1]))
     ds = Dataset.read_file(args.file)
     values = ds.sample(DataFrame({"x": xs, "y": ys}))
     # ds.sample returns (bands, points); transpose to one row per point.

--- a/src/pyramids/cli.py
+++ b/src/pyramids/cli.py
@@ -24,17 +24,37 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import sys
 from typing import Sequence
 
 from osgeo import osr
 from pandas import DataFrame
 
+from pyramids.base._errors import _PyramidsError
 from pyramids.base.crs import sr_from_user_input, sr_from_wkt
 from pyramids.dataset import Dataset
 from pyramids.dataset.cog import PROFILES, cog_info, validate
 from pyramids.dataset.merge import merge_rasters
 from pyramids.feature import FeatureCollection
+
+
+def _json_safe(value: float | None) -> float | None:
+    """Map non-finite floats to `None` so the JSON output stays parseable.
+
+    `json.dumps` serializes NaN/Infinity as bare `NaN` / `Infinity`,
+    which is not valid JSON and breaks strict consumers (e.g. `jq`).
+
+    Args:
+        value: A float (possibly NaN/infinite) or `None`.
+
+    Returns:
+        float | None: `value` unchanged, or `None` when it is not finite.
+    """
+    result: float | None = value
+    if isinstance(value, float) and not math.isfinite(value):
+        result = None
+    return result
 
 
 def _cmd_create(args: argparse.Namespace) -> int:
@@ -137,7 +157,8 @@ def _cmd_raster_info(args: argparse.Namespace) -> int:
         "cell_size": ds.cell_size,
         "dtype": list(ds.dtype),
         "no_data_value": [
-            None if value is None else float(value) for value in ds.no_data_value
+            None if value is None else _json_safe(float(value))
+            for value in ds.no_data_value
         ],
         "bounds": [float(value) for value in ds.bbox],
     }
@@ -162,7 +183,7 @@ def _cmd_bounds(args: argparse.Namespace) -> int:
         int: `0` on success.
     """
     ds = Dataset.read_file(args.file)
-    min_x, min_y, max_x, max_y = [float(value) for value in ds.bbox]
+    min_x, min_y, max_x, max_y = (float(value) for value in ds.bbox)
     if args.crs:
         src_sr = sr_from_wkt(ds.crs)
         dst_sr = sr_from_user_input(args.crs)
@@ -227,7 +248,12 @@ def _cmd_merge(args: argparse.Namespace) -> int:
 
     Returns:
         int: `0` on success.
+
+    Raises:
+        ValueError: Fewer than two input rasters are given.
     """
+    if len(args.inputs) < 2:
+        raise ValueError("merge needs at least two input rasters.")
     merge_rasters(args.inputs, args.output)
     print(f"wrote {args.output}")
     return 0
@@ -243,9 +269,7 @@ def _cmd_overview(args: argparse.Namespace) -> int:
         int: `0` on success.
     """
     ds = Dataset.read_file(args.file, read_only=False)
-    ds.create_overviews(
-        resampling_method=args.resampling, overview_levels=args.levels
-    )
+    ds.create_overviews(resampling_method=args.resampling, overview_levels=args.levels)
     counts = ds.overview_count
     print(f"built {counts[0] if counts else 0} overview level(s) for {args.file}")
     return 0
@@ -254,12 +278,18 @@ def _cmd_overview(args: argparse.Namespace) -> int:
 def _cmd_sample(args: argparse.Namespace) -> int:
     """Handle `pyramids sample` — read band values at points.
 
+    Points outside the raster extent sample as the band's no-data fill
+    (NaN when none is set) and are printed as `None` / JSON `null`.
+
     Args:
         args: Parsed arguments with `file`, `points` (``"x,y;x,y..."``),
             and `json`.
 
     Returns:
         int: `0` on success.
+
+    Raises:
+        ValueError: `points` is empty or a chunk is not a numeric `'x,y'` pair.
     """
     pairs = [chunk for chunk in args.points.split(";") if chunk.strip()]
     if not pairs:
@@ -269,12 +299,18 @@ def _cmd_sample(args: argparse.Namespace) -> int:
         parts = chunk.split(",")
         if len(parts) != 2:
             raise ValueError(f"bad point {chunk.strip()!r}; expected 'x,y'.")
-        xs.append(float(parts[0]))
-        ys.append(float(parts[1]))
+        try:
+            xs.append(float(parts[0]))
+            ys.append(float(parts[1]))
+        except ValueError:
+            raise ValueError(
+                f"bad point {chunk.strip()!r}; coordinates must be numeric."
+            ) from None
     ds = Dataset.read_file(args.file)
     values = ds.sample(DataFrame({"x": xs, "y": ys}))
     # ds.sample returns (bands, points); transpose to one row per point.
-    per_point = values.T.tolist()
+    # Out-of-bounds points come back as NaN — emit them as None/null.
+    per_point = [[_json_safe(value) for value in row] for row in values.T.tolist()]
     if args.json:
         print(json.dumps({"values": per_point}))
     else:
@@ -309,9 +345,13 @@ def _build_parser() -> argparse.ArgumentParser:
 
     Returns:
         argparse.ArgumentParser: The configured parser with the `cog`
-        command group and its `create` / `validate` / `info` subcommands.
+        command group (`create` / `validate` / `info`) and the
+        single-shot raster commands (`info`, `bounds`, `clip`, `warp`,
+        `merge`, `overview`, `sample`, `convert`).
     """
-    parser = argparse.ArgumentParser(prog="pyramids", description="pyramids GIS toolkit")
+    parser = argparse.ArgumentParser(
+        prog="pyramids", description="pyramids GIS toolkit"
+    )
     sub = parser.add_subparsers(dest="group", required=True)
 
     cog = sub.add_parser("cog", help="Cloud Optimized GeoTIFF commands")
@@ -332,9 +372,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     val = cog_sub.add_parser("validate", help="validate a COG")
     val.add_argument("file", help="raster path to validate")
-    val.add_argument(
-        "--strict", action="store_true", help="treat warnings as errors"
-    )
+    val.add_argument("--strict", action="store_true", help="treat warnings as errors")
     val.set_defaults(func=_cmd_validate)
 
     info = cog_sub.add_parser("info", help="print structured COG metadata")
@@ -359,7 +397,10 @@ def _build_parser() -> argparse.ArgumentParser:
     clip.add_argument("output", help="destination raster path")
     clip_how = clip.add_mutually_exclusive_group(required=True)
     clip_how.add_argument(
-        "--bbox", nargs=4, type=float, metavar=("MINX", "MINY", "MAXX", "MAXY"),
+        "--bbox",
+        nargs=4,
+        type=float,
+        metavar=("MINX", "MINY", "MAXX", "MAXY"),
         help="clip extent in the raster CRS",
     )
     clip_how.add_argument("--vector", help="vector file whose polygons clip the raster")
@@ -430,7 +471,14 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parser.parse_args(argv)
     try:
         result = args.func(args)
-    except (ValueError, TypeError, FileNotFoundError, OSError, RuntimeError) as exc:
+    except (
+        ValueError,
+        TypeError,
+        FileNotFoundError,
+        OSError,
+        RuntimeError,
+        _PyramidsError,
+    ) as exc:
         # Expected user errors (missing file, bad CRS, unknown driver, ...)
         # exit non-zero with a one-line message instead of a traceback.
         print(f"error: {exc}", file=sys.stderr)

--- a/src/pyramids/dataset/ops/io.py
+++ b/src/pyramids/dataset/ops/io.py
@@ -11,6 +11,7 @@ from osgeo import gdal
 
 from pyramids import _io
 from pyramids.base._errors import (
+    DriverNotExistError,
     FailedToSaveError,
 )
 from pyramids.base._file_manager import CachingFileManager
@@ -146,8 +147,19 @@ def _write_to_file_sync(
         )
 
     path = Path(path)
-    extension = path.suffix[1:]
-    driver = CATALOG.get_driver_name_by_extension(extension)
+    if driver is None:
+        extension = path.suffix[1:]
+        driver = CATALOG.get_driver_name_by_extension(extension)
+    elif not CATALOG.exists(driver):
+        # Accept GDAL driver names (e.g. "GTiff") as well as catalog keys
+        # (e.g. "geotiff") before declaring the driver unknown.
+        catalog_key = CATALOG.get_driver_name(driver)
+        if catalog_key is None:
+            raise DriverNotExistError(
+                f"The driver: {driver!r} is not in the driver catalog. Known "
+                f"driver names: {sorted(CATALOG.catalog)}"
+            )
+        driver = catalog_key
     driver_name = CATALOG.get_gdal_name(driver)
 
     if driver == "ascii":

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -1,0 +1,206 @@
+"""Smoke tests for the general-purpose CLI subcommands.
+
+Each command is a thin wrapper over a library primitive; these tests pin the
+wiring: exit codes, JSON output shapes, written artifacts, and the
+one-line-error contract for expected user mistakes. The COG group has its own
+suite in `tests/dataset/cog/test_cli.py`.
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from pyramids.cli import main
+from pyramids.dataset import Dataset
+
+pytestmark = pytest.mark.core
+
+
+@pytest.fixture(scope="function")
+def src_raster(tmp_path) -> str:
+    """An 8x8 float32 ramp GeoTIFF on EPSG:4326 with nodata -9999.
+
+    Returns:
+        str: Path to the written raster.
+    """
+    path = str(tmp_path / "src.tif")
+    Dataset.create_from_array(
+        np.arange(64, dtype="float32").reshape(8, 8),
+        top_left_corner=(0, 8), cell_size=1.0, epsg=4326, no_data_value=-9999.0,
+    ).to_file(path)
+    return path
+
+
+class TestInfoCommand:
+    """`pyramids info`."""
+
+    def test_json_payload(self, src_raster, capsys):
+        """--json emits parseable metadata with the key facts.
+
+        Test scenario:
+            epsg, shape, dtype, nodata, and bounds are all present and right.
+        """
+        assert main(["info", src_raster, "--json"]) == 0, "info must exit 0"
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["epsg"] == 4326, f"epsg wrong: {payload['epsg']}"
+        assert (payload["bands"], payload["rows"], payload["columns"]) == (1, 8, 8)
+        assert payload["dtype"] == ["float32"], f"dtype wrong: {payload['dtype']}"
+        assert payload["no_data_value"] == [-9999.0], "nodata wrong"
+        assert payload["bounds"] == [0.0, 0.0, 8.0, 8.0], "bounds wrong"
+
+    def test_plain_output_lists_keys(self, src_raster, capsys):
+        """The human-readable form prints key: value lines."""
+        assert main(["info", src_raster]) == 0
+        out = capsys.readouterr().out
+        assert "epsg: 4326" in out, f"missing epsg line in: {out}"
+
+    def test_missing_file_one_line_error(self, tmp_path, capsys):
+        """A missing path exits 1 with a one-line error (no traceback)."""
+        rc = main(["info", str(tmp_path / "nope.tif")])
+        err = capsys.readouterr().err
+        assert rc == 1, "missing file must exit 1"
+        assert err.startswith("error: "), f"unexpected stderr: {err}"
+        assert "Traceback" not in err, "tracebacks must not leak to users"
+
+
+class TestBoundsCommand:
+    """`pyramids bounds`."""
+
+    def test_native_bounds(self, src_raster, capsys):
+        """The native bbox is printed space-separated."""
+        assert main(["bounds", src_raster]) == 0
+        assert capsys.readouterr().out.split() == ["0.0", "0.0", "8.0", "8.0"]
+
+    def test_reprojected_bounds_json(self, src_raster, capsys):
+        """--crs reprojects the corners; --json wraps them.
+
+        Test scenario:
+            4326 -> 3857: longitude 8 deg is ~890 km east.
+        """
+        assert main(["bounds", src_raster, "--crs", "EPSG:3857", "--json"]) == 0
+        bounds = json.loads(capsys.readouterr().out)["bounds"]
+        assert bounds[0] == pytest.approx(0.0, abs=1e-6), "min_x wrong"
+        assert bounds[2] == pytest.approx(890_555.9, rel=1e-3), "max_x wrong"
+
+
+class TestClipCommand:
+    """`pyramids clip`."""
+
+    def test_bbox_clip_writes_subset(self, src_raster, tmp_path, capsys):
+        """--bbox crops to the requested extent."""
+        out_path = str(tmp_path / "clip.tif")
+        assert main(["clip", src_raster, out_path, "--bbox", "1", "1", "5", "5"]) == 0
+        clipped = Dataset.read_file(out_path)
+        assert (clipped.rows, clipped.columns) == (4, 4), "clip extent wrong"
+
+    def test_bbox_and_vector_mutually_exclusive(self, src_raster, tmp_path, capsys):
+        """Passing both --bbox and --vector is rejected by argparse."""
+        with pytest.raises(SystemExit):
+            main([
+                "clip", src_raster, str(tmp_path / "o.tif"),
+                "--bbox", "1", "1", "5", "5", "--vector", "mask.geojson",
+            ])
+
+
+class TestWarpCommand:
+    """`pyramids warp`."""
+
+    def test_warp_writes_target_crs(self, src_raster, tmp_path, capsys):
+        """--crs reprojects and writes the output."""
+        out_path = str(tmp_path / "warp.tif")
+        assert main(["warp", src_raster, out_path, "--crs", "3857"]) == 0
+        assert Dataset.read_file(out_path).epsg == 3857, "output CRS wrong"
+
+    def test_invalid_resampling_one_line_error(self, src_raster, tmp_path, capsys):
+        """An unknown resampling exits 1 with a clean message."""
+        rc = main([
+            "warp", src_raster, str(tmp_path / "w.tif"),
+            "--crs", "3857", "--resampling", "sinc",
+        ])
+        assert rc == 1, "bad resampling must exit 1"
+        assert "error: " in capsys.readouterr().err, "expected one-line error"
+
+
+class TestMergeCommand:
+    """`pyramids merge`."""
+
+    def test_merge_two_tiles(self, src_raster, tmp_path, capsys):
+        """Two overlapping tiles mosaic into one readable output."""
+        second = str(tmp_path / "b.tif")
+        Dataset.create_from_array(
+            np.ones((8, 8), dtype="float32"),
+            top_left_corner=(4, 8), cell_size=1.0, epsg=4326, no_data_value=-9999.0,
+        ).to_file(second)
+        out_path = str(tmp_path / "merged.tif")
+        assert main(["merge", src_raster, second, out_path]) == 0
+        merged = Dataset.read_file(out_path)
+        assert merged.columns > 8, "mosaic must span both tiles"
+
+
+class TestOverviewCommand:
+    """`pyramids overview`."""
+
+    def test_builds_requested_levels(self, src_raster, capsys):
+        """--levels builds that many overview levels in place."""
+        assert main(["overview", src_raster, "--levels", "2", "4"]) == 0
+        assert Dataset.read_file(src_raster).overview_count[0] == 2, (
+            "expected 2 overview levels"
+        )
+
+
+class TestSampleCommand:
+    """`pyramids sample`."""
+
+    def test_json_per_point_values(self, src_raster, capsys):
+        """--json emits one row of band values per point.
+
+        Test scenario:
+            (0.5, 7.5) is cell (0, 0) = 0; (3.5, 4.5) is cell (3, 3) = 27.
+        """
+        assert main([
+            "sample", src_raster, "--points", "0.5,7.5;3.5,4.5", "--json",
+        ]) == 0
+        values = json.loads(capsys.readouterr().out)["values"]
+        assert values == [[0.0], [27.0]], f"per-point values wrong: {values}"
+
+    def test_empty_points_rejected(self, src_raster, capsys):
+        """An empty --points exits 1 with a clean message."""
+        rc = main(["sample", src_raster, "--points", ";"])
+        assert rc == 1, "empty points must exit 1"
+        assert "at least one" in capsys.readouterr().err, "expected guidance"
+
+
+class TestConvertCommand:
+    """`pyramids convert`."""
+
+    def test_extension_inferred_conversion(self, src_raster, tmp_path, capsys):
+        """The output driver is inferred from the extension (.nc -> NetCDF)."""
+        out_path = str(tmp_path / "out.nc")
+        assert main(["convert", src_raster, out_path]) == 0
+        converted = Dataset.read_file(out_path)
+        np.testing.assert_array_equal(
+            converted.read_array(), Dataset.read_file(src_raster).read_array(),
+            err_msg="conversion must preserve values",
+        )
+
+
+class TestHelpSurface:
+    """--help wiring for every new command."""
+
+    @pytest.mark.parametrize(
+        "command",
+        ["info", "bounds", "clip", "warp", "merge", "overview", "sample", "convert"],
+    )
+    def test_help_exits_zero(self, command, capsys):
+        """Each subcommand exposes --help (argparse exits 0).
+
+        Args:
+            command: Subcommand under test.
+        """
+        with pytest.raises(SystemExit) as exc:
+            main([command, "--help"])
+        assert exc.value.code == 0, f"{command} --help must exit 0"
+        assert command in capsys.readouterr().out, "help text must name the command"

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -15,6 +15,7 @@ import pytest
 
 from pyramids.cli import main
 from pyramids.dataset import Dataset
+from pyramids.feature import FeatureCollection
 
 pytestmark = pytest.mark.core
 
@@ -88,6 +89,14 @@ class TestBoundsCommand:
         assert bounds[0] == pytest.approx(0.0, abs=1e-6), "min_x wrong"
         assert bounds[2] == pytest.approx(890_555.9, rel=1e-3), "max_x wrong"
 
+    def test_invalid_crs_one_line_error(self, src_raster, capsys):
+        """An uninterpretable --crs exits 1 with a clean message."""
+        rc = main(["bounds", src_raster, "--crs", "not-a-crs"])
+        err = capsys.readouterr().err
+        assert rc == 1, "bad CRS must exit 1"
+        assert err.startswith("error: "), f"unexpected stderr: {err}"
+        assert "Traceback" not in err, "tracebacks must not leak to users"
+
 
 class TestClipCommand:
     """`pyramids clip`."""
@@ -98,6 +107,20 @@ class TestClipCommand:
         assert main(["clip", src_raster, out_path, "--bbox", "1", "1", "5", "5"]) == 0
         clipped = Dataset.read_file(out_path)
         assert (clipped.rows, clipped.columns) == (4, 4), "clip extent wrong"
+
+    def test_vector_clip_writes_subset(self, src_raster, tmp_path, capsys):
+        """--vector crops to the mask polygon's extent.
+
+        Test scenario:
+            A rectangular GeoJSON mask covering (1, 1, 5, 5) yields the
+            same 4x4 subset as the equivalent --bbox clip.
+        """
+        mask_path = str(tmp_path / "mask.geojson")
+        FeatureCollection.from_bbox((1.0, 1.0, 5.0, 5.0), epsg=4326).to_file(mask_path)
+        out_path = str(tmp_path / "clip_vec.tif")
+        assert main(["clip", src_raster, out_path, "--vector", mask_path]) == 0
+        clipped = Dataset.read_file(out_path)
+        assert (clipped.rows, clipped.columns) == (4, 4), "vector clip extent wrong"
 
     def test_bbox_and_vector_mutually_exclusive(self, src_raster, tmp_path, capsys):
         """Passing both --bbox and --vector is rejected by argparse."""

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -172,6 +172,12 @@ class TestSampleCommand:
         assert rc == 1, "empty points must exit 1"
         assert "at least one" in capsys.readouterr().err, "expected guidance"
 
+    def test_malformed_point_rejected(self, src_raster, capsys):
+        """A point that is not 'x,y' exits 1 naming the bad chunk."""
+        rc = main(["sample", src_raster, "--points", "1,2,3"])
+        assert rc == 1, "malformed point must exit 1"
+        assert "expected 'x,y'" in capsys.readouterr().err, "expected format hint"
+
 
 class TestConvertCommand:
     """`pyramids convert`."""

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -29,7 +29,10 @@ def src_raster(tmp_path) -> str:
     path = str(tmp_path / "src.tif")
     Dataset.create_from_array(
         np.arange(64, dtype="float32").reshape(8, 8),
-        top_left_corner=(0, 8), cell_size=1.0, epsg=4326, no_data_value=-9999.0,
+        top_left_corner=(0, 8),
+        cell_size=1.0,
+        epsg=4326,
+        no_data_value=-9999.0,
     ).to_file(path)
     return path
 
@@ -48,8 +51,8 @@ class TestInfoCommand:
         assert payload["epsg"] == 4326, f"epsg wrong: {payload['epsg']}"
         assert (payload["bands"], payload["rows"], payload["columns"]) == (1, 8, 8)
         assert payload["dtype"] == ["float32"], f"dtype wrong: {payload['dtype']}"
-        assert payload["no_data_value"] == [-9999.0], "nodata wrong"
-        assert payload["bounds"] == [0.0, 0.0, 8.0, 8.0], "bounds wrong"
+        assert payload["no_data_value"] == pytest.approx([-9999.0]), "nodata wrong"
+        assert payload["bounds"] == pytest.approx([0.0, 0.0, 8.0, 8.0]), "bounds wrong"
 
     def test_plain_output_lists_keys(self, src_raster, capsys):
         """The human-readable form prints key: value lines."""
@@ -99,10 +102,20 @@ class TestClipCommand:
     def test_bbox_and_vector_mutually_exclusive(self, src_raster, tmp_path, capsys):
         """Passing both --bbox and --vector is rejected by argparse."""
         with pytest.raises(SystemExit):
-            main([
-                "clip", src_raster, str(tmp_path / "o.tif"),
-                "--bbox", "1", "1", "5", "5", "--vector", "mask.geojson",
-            ])
+            main(
+                [
+                    "clip",
+                    src_raster,
+                    str(tmp_path / "o.tif"),
+                    "--bbox",
+                    "1",
+                    "1",
+                    "5",
+                    "5",
+                    "--vector",
+                    "mask.geojson",
+                ]
+            )
 
 
 class TestWarpCommand:
@@ -116,10 +129,17 @@ class TestWarpCommand:
 
     def test_invalid_resampling_one_line_error(self, src_raster, tmp_path, capsys):
         """An unknown resampling exits 1 with a clean message."""
-        rc = main([
-            "warp", src_raster, str(tmp_path / "w.tif"),
-            "--crs", "3857", "--resampling", "sinc",
-        ])
+        rc = main(
+            [
+                "warp",
+                src_raster,
+                str(tmp_path / "w.tif"),
+                "--crs",
+                "3857",
+                "--resampling",
+                "sinc",
+            ]
+        )
         assert rc == 1, "bad resampling must exit 1"
         assert "error: " in capsys.readouterr().err, "expected one-line error"
 
@@ -132,12 +152,26 @@ class TestMergeCommand:
         second = str(tmp_path / "b.tif")
         Dataset.create_from_array(
             np.ones((8, 8), dtype="float32"),
-            top_left_corner=(4, 8), cell_size=1.0, epsg=4326, no_data_value=-9999.0,
+            top_left_corner=(4, 8),
+            cell_size=1.0,
+            epsg=4326,
+            no_data_value=-9999.0,
         ).to_file(second)
         out_path = str(tmp_path / "merged.tif")
         assert main(["merge", src_raster, second, out_path]) == 0
         merged = Dataset.read_file(out_path)
         assert merged.columns > 8, "mosaic must span both tiles"
+
+    def test_single_input_rejected(self, src_raster, tmp_path, capsys):
+        """One source raster exits 1 with a clean message.
+
+        Test scenario:
+            `merge a.tif out.tif` parses as one input + the output; the
+            command must reject it instead of silently copying the file.
+        """
+        rc = main(["merge", src_raster, str(tmp_path / "m.tif")])
+        assert rc == 1, "single-input merge must exit 1"
+        assert "at least two" in capsys.readouterr().err, "expected guidance"
 
 
 class TestOverviewCommand:
@@ -146,9 +180,9 @@ class TestOverviewCommand:
     def test_builds_requested_levels(self, src_raster, capsys):
         """--levels builds that many overview levels in place."""
         assert main(["overview", src_raster, "--levels", "2", "4"]) == 0
-        assert Dataset.read_file(src_raster).overview_count[0] == 2, (
-            "expected 2 overview levels"
-        )
+        assert (
+            Dataset.read_file(src_raster).overview_count[0] == 2
+        ), "expected 2 overview levels"
 
 
 class TestSampleCommand:
@@ -160,11 +194,21 @@ class TestSampleCommand:
         Test scenario:
             (0.5, 7.5) is cell (0, 0) = 0; (3.5, 4.5) is cell (3, 3) = 27.
         """
-        assert main([
-            "sample", src_raster, "--points", "0.5,7.5;3.5,4.5", "--json",
-        ]) == 0
+        assert (
+            main(
+                [
+                    "sample",
+                    src_raster,
+                    "--points",
+                    "0.5,7.5;3.5,4.5",
+                    "--json",
+                ]
+            )
+            == 0
+        )
         values = json.loads(capsys.readouterr().out)["values"]
-        assert values == [[0.0], [27.0]], f"per-point values wrong: {values}"
+        expected = [pytest.approx([0.0]), pytest.approx([27.0])]
+        assert values == expected, f"per-point values wrong: {values}"
 
     def test_empty_points_rejected(self, src_raster, capsys):
         """An empty --points exits 1 with a clean message."""
@@ -178,6 +222,34 @@ class TestSampleCommand:
         assert rc == 1, "malformed point must exit 1"
         assert "expected 'x,y'" in capsys.readouterr().err, "expected format hint"
 
+    def test_non_numeric_point_rejected(self, src_raster, capsys):
+        """A non-numeric coordinate exits 1 naming the bad chunk."""
+        rc = main(["sample", src_raster, "--points", "a,2"])
+        err = capsys.readouterr().err
+        assert rc == 1, "non-numeric point must exit 1"
+        assert "'a,2'" in err, f"error must name the bad chunk: {err}"
+        assert "numeric" in err, f"expected a numeric hint: {err}"
+
+    def test_out_of_bounds_point_is_json_null(self, tmp_path, capsys):
+        """An outside point emits JSON null, keeping the payload parseable.
+
+        Test scenario:
+            On a raster without nodata, (100, 100) is outside the 8x8
+            extent and samples as NaN, which `json.dumps` would emit as
+            bare `NaN` (invalid JSON) — the CLI must map it to null.
+        """
+        path = str(tmp_path / "no_nodata.tif")
+        Dataset.create_from_array(
+            np.arange(64, dtype="float32").reshape(8, 8),
+            top_left_corner=(0, 8),
+            cell_size=1.0,
+            epsg=4326,
+            no_data_value=None,
+        ).to_file(path)
+        assert main(["sample", path, "--points", "100,100", "--json"]) == 0
+        values = json.loads(capsys.readouterr().out)["values"]
+        assert values == [[None]], f"out-of-bounds must be null: {values}"
+
 
 class TestConvertCommand:
     """`pyramids convert`."""
@@ -188,9 +260,47 @@ class TestConvertCommand:
         assert main(["convert", src_raster, out_path]) == 0
         converted = Dataset.read_file(out_path)
         np.testing.assert_array_equal(
-            converted.read_array(), Dataset.read_file(src_raster).read_array(),
+            converted.read_array(),
+            Dataset.read_file(src_raster).read_array(),
             err_msg="conversion must preserve values",
         )
+
+    def test_explicit_driver_overrides_extension(self, src_raster, tmp_path, capsys):
+        """--driver wins over the output extension.
+
+        Test scenario:
+            `.nc` would infer NetCDF; `--driver geotiff` must produce a
+            GTiff file regardless.
+        """
+        out_path = str(tmp_path / "tiff_in_disguise.nc")
+        assert main(["convert", src_raster, out_path, "--driver", "geotiff"]) == 0
+        converted = Dataset.read_file(out_path)
+        driver = converted.raster.GetDriver().ShortName
+        assert driver == "GTiff", f"--driver geotiff ignored; wrote {driver}"
+
+    def test_unknown_driver_one_line_error(self, src_raster, tmp_path, capsys):
+        """An unknown --driver exits 1 with a clean message."""
+        rc = main(
+            [
+                "convert",
+                src_raster,
+                str(tmp_path / "o.tif"),
+                "--driver",
+                "bogus",
+            ]
+        )
+        err = capsys.readouterr().err
+        assert rc == 1, "unknown driver must exit 1"
+        assert err.startswith("error: "), f"unexpected stderr: {err}"
+        assert "Traceback" not in err, "tracebacks must not leak to users"
+
+    def test_unknown_extension_one_line_error(self, src_raster, tmp_path, capsys):
+        """An extension absent from the catalog exits 1 with a clean message."""
+        rc = main(["convert", src_raster, str(tmp_path / "o.unknown")])
+        err = capsys.readouterr().err
+        assert rc == 1, "unknown extension must exit 1"
+        assert err.startswith("error: "), f"unexpected stderr: {err}"
+        assert "Traceback" not in err, "tracebacks must not leak to users"
 
 
 class TestHelpSurface:


### PR DESCRIPTION
## Summary

Implements #500: the CLI exposed only the COG group. This PR adds eight general-purpose subcommands,
each a thin, scriptable wrapper over an existing library primitive — no business logic in the CLI
layer.

| Command | Maps to |
|---------|---------|
| `pyramids info FILE [--json]` | metadata (driver, epsg, shape, dtype, nodata, cell_size, bounds) |
| `pyramids bounds FILE [--crs] [--json]` | `Dataset.bbox` (+ corner-based reprojection) |
| `pyramids clip SRC DST (--bbox ... \| --vector ...)` | `crop` |
| `pyramids warp SRC DST --crs [--resampling]` | `to_crs` + `to_file` |
| `pyramids merge SRC... DST` | `merge_rasters` |
| `pyramids overview FILE [--resampling] [--levels]` | `create_overviews` |
| `pyramids sample FILE --points "x,y;..." [--json]` | `sample` (one row of band values per point) |
| `pyramids convert SRC DST [--driver]` | `to_file` (driver from extension) |

Expected user errors (missing file, bad CRS, unknown resampling, malformed points) exit non-zero with
a one-line `error: ...` message — no tracebacks; `info`/`bounds`/`sample` are scriptable via `--json`.

## Test plan

- New `tests/test_cli_commands.py` (19 tests): JSON payloads, written artifacts, clip extent,
  bbox/vector exclusivity, error one-liners (no traceback), per-point sample values against known
  cells, conversion value-preservation, and a `--help` sweep over all eight commands.
- Existing COG CLI suite unaffected (combined run 27 passed).

Closes #500
