### PR TITLE
fix(netcdf): tolerate non-spatial aux variables in NetCDF.crop / to_crs (#513)

### DIFF
--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1739,21 +1739,60 @@ class NetCDF(Dataset):
             or self._named_spatial_axes(var_dims) is not None
         )
 
+    def _spatial_variable_names(self) -> list[str]:
+        """Names of the container's gridded variables (have a recognised (y, x) pair).
+
+        Used by every spatial fan-out (``crop`` / ``to_crs`` / ``resample`` /
+        ``reduce``) so they act only on griddable variables; the remaining
+        non-spatial auxiliary variables are carried through by
+        :meth:`_carry_aux_variables`.
+        """
+        rg = self._raster.GetRootGroup() if self._raster is not None else None
+        if rg is None:
+            return []
+        return [n for n in self.variable_names if self._variable_is_spatial(rg, n)]
+
+    def _carry_aux_variables(
+        self, result: "NetCDF", aux_vars: list[str], operation: str
+    ) -> None:
+        """Copy non-spatial auxiliary variables into ``result`` unchanged.
+
+        They can't be cropped/reprojected/reduced through the raster path but must
+        survive the op, so each is copied verbatim (dims / values / attrs) via
+        :meth:`add_variable`. Best-effort: a copy failure for one variable warns
+        rather than failing the whole operation.
+
+        Args:
+            result: The container built from the spatial variables.
+            aux_vars: Names of the non-spatial variables to carry through.
+            operation: Operation name, for the warning message.
+        """
+        for var_name in aux_vars:
+            try:
+                result.add_variable(self, var_name)
+            except (RuntimeError, ValueError) as exc:
+                warnings.warn(
+                    f"{operation}() could not carry non-spatial variable "
+                    f"{var_name!r} into the result: {exc}",
+                    stacklevel=3,
+                )
+
     def _apply_to_all_variables(self, operation, op_kwargs):
         """Apply a spatial operation to every gridded variable in the container.
 
+        Only variables carrying both spatial axes are cropped / reprojected.
         Non-spatial auxiliary variables (e.g. ERA5's ``expver`` / ``number``,
-        which have no ``y`` / ``x`` axes) are skipped with a warning rather than
-        crashing the fan-out — only variables carrying both spatial axes can be
-        cropped / reprojected.
+        which have no ``y`` / ``x`` axes) can't go through the raster op, so they
+        are **carried through unchanged** into the result rather than crashing the
+        fan-out.
 
         Args:
             operation: Name of the Dataset method to call (e.g. "crop").
             op_kwargs: Keyword arguments to pass to the method.
 
         Returns:
-            NetCDF: New container with the operation applied to all gridded
-            variables.
+            NetCDF: New container with the operation applied to every gridded
+            variable and the non-spatial auxiliary variables carried through.
 
         Raises:
             ValueError: If the container has no data variables, or none of them
@@ -1764,12 +1803,7 @@ class NetCDF(Dataset):
                 "Cannot apply operation to an empty container (no data variables)."
             )
 
-        rg = self._raster.GetRootGroup() if self._raster is not None else None
-        spatial_vars = [
-            name
-            for name in self.variable_names
-            if rg is not None and self._variable_is_spatial(rg, name)
-        ]
+        spatial_vars = self._spatial_variable_names()
         aux_vars = [n for n in self.variable_names if n not in spatial_vars]
         if not spatial_vars:
             raise ValueError(
@@ -1850,20 +1884,7 @@ class NetCDF(Dataset):
                 ds._band_dim_sizes = var._band_dim_sizes
                 result.set_variable(var_name, ds)
 
-        # Carry non-spatial auxiliary variables (e.g. ERA5 expver / number) through
-        # unchanged — they can't be cropped/reprojected, but must survive the op so
-        # the result is the same cube minus the spatial subsetting. add_variable
-        # copies the MDArray (dims/values/attrs) verbatim into the result group.
-        for var_name in aux_vars:
-            try:
-                result.add_variable(self, var_name)
-            except Exception as exc:  # best-effort: never fail the whole op on an aux
-                warnings.warn(
-                    f"{operation}() could not carry non-spatial variable "
-                    f"{var_name!r} into the result: {exc}",
-                    stacklevel=3,
-                )
-
+        self._carry_aux_variables(result, aux_vars, operation)
         return result
 
     def reduce(
@@ -1940,9 +1961,15 @@ class NetCDF(Dataset):
 
         group_positions = self._resolve_group_positions(dim, groupby)
 
+        # Reduce only the gridded variables; non-spatial auxiliaries (no y/x axes)
+        # can't go through the raster reduce path, so they are carried through
+        # unchanged below — the same split crop / to_crs use (#513).
+        spatial_vars = self._spatial_variable_names()
+        aux_vars = [n for n in self.variable_names if n not in spatial_vars]
+
         result = None
         found = False
-        for var_name in self.variable_names:
+        for var_name in spatial_vars:
             var = self.get_variable(var_name)
             arr = self._materialize_variable_array(var)
             band_names = list(var._band_dim_names)
@@ -1981,6 +2008,7 @@ class NetCDF(Dataset):
                 f"Dimension {dim!r} is not a non-spatial dimension of any "
                 f"variable in this container."
             )
+        self._carry_aux_variables(result, aux_vars, "reduce")
         return result
 
     @staticmethod

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1713,26 +1713,17 @@ class NetCDF(Dataset):
             result = self._preserve_netcdf_metadata(result)
         return result
 
-    def _container_spatial_dims(self, rg: Any) -> tuple[str, str] | None:
-        """Names of the container's ``(y, x)`` dimensions, or ``None`` if undetected.
+    def _variable_is_spatial(self, rg: Any, var_name: str) -> bool:
+        """True when ``var_name`` is a gridded variable (can be cropped / reprojected).
 
-        Detects the spatial axes over the root group's full dimension list using
-        the same CF-attribute / well-known-name machinery as :meth:`subset`.
-        """
-        all_dims = [d.GetName() for d in rg.GetDimensions()]
-        if len(all_dims) < 2:
-            return None
-        y_axis, x_axis = self._detect_spatial_axes(rg, all_dims, None, None)
-        return all_dims[y_axis], all_dims[x_axis]
-
-    def _variable_has_axes(
-        self, rg: Any, var_name: str, y_name: str, x_name: str
-    ) -> bool:
-        """True when ``var_name`` is gridded — its dims include both ``y`` and ``x``.
-
-        Checks the MDArray's dimensions directly (without ``get_variable``, which
-        can't build a classic raster for a non-spatial 1-D variable), so a
-        non-spatial auxiliary variable is identified before any spatial op runs.
+        A variable is spatial when it has at least two dimensions and a recognised
+        ``(y, x)`` pair among **its own** dimensions — detected via the CF-attribute
+        / well-known-name machinery (:meth:`_cf_spatial_axes` /
+        :meth:`_named_spatial_axes`), per variable, so a variable on a secondary
+        grid is judged on its own axes rather than one container-wide pair. The
+        check reads the MDArray's dimensions directly (not via ``get_variable``,
+        which can't build a classic raster for a non-spatial variable), so an
+        auxiliary variable is identified before any spatial op runs.
         """
         try:
             md = rg.OpenMDArray(var_name)
@@ -1740,8 +1731,13 @@ class NetCDF(Dataset):
             return False
         if md is None:
             return False
-        var_dims = {d.GetName() for d in md.GetDimensions()}
-        return y_name in var_dims and x_name in var_dims
+        var_dims = [d.GetName() for d in md.GetDimensions()]
+        if len(var_dims) < 2:
+            return False
+        return (
+            self._cf_spatial_axes(rg, var_dims) is not None
+            or self._named_spatial_axes(var_dims) is not None
+        )
 
     def _apply_to_all_variables(self, operation, op_kwargs):
         """Apply a spatial operation to every gridded variable in the container.
@@ -1769,23 +1765,16 @@ class NetCDF(Dataset):
             )
 
         rg = self._raster.GetRootGroup() if self._raster is not None else None
-        spatial = self._container_spatial_dims(rg) if rg is not None else None
         spatial_vars = [
             name
             for name in self.variable_names
-            if spatial is not None and self._variable_has_axes(rg, name, *spatial)
+            if rg is not None and self._variable_is_spatial(rg, name)
         ]
-        skipped = [n for n in self.variable_names if n not in spatial_vars]
+        aux_vars = [n for n in self.variable_names if n not in spatial_vars]
         if not spatial_vars:
             raise ValueError(
                 f"{operation}() needs at least one spatial (y, x) variable; none of "
                 f"{self.variable_names} have both spatial axes."
-            )
-        if skipped:
-            warnings.warn(
-                f"{operation}() skipped non-spatial variable(s) {skipped} (no y/x "
-                "axes); they are not carried into the result.",
-                stacklevel=3,
             )
 
         result = None
@@ -1860,6 +1849,20 @@ class NetCDF(Dataset):
                 ds._band_dim_values_map = dict(var._band_dim_values_map)
                 ds._band_dim_sizes = var._band_dim_sizes
                 result.set_variable(var_name, ds)
+
+        # Carry non-spatial auxiliary variables (e.g. ERA5 expver / number) through
+        # unchanged — they can't be cropped/reprojected, but must survive the op so
+        # the result is the same cube minus the spatial subsetting. add_variable
+        # copies the MDArray (dims/values/attrs) verbatim into the result group.
+        for var_name in aux_vars:
+            try:
+                result.add_variable(self, var_name)
+            except Exception as exc:  # best-effort: never fail the whole op on an aux
+                warnings.warn(
+                    f"{operation}() could not carry non-spatial variable "
+                    f"{var_name!r} into the result: {exc}",
+                    stacklevel=3,
+                )
 
         return result
 

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1724,6 +1724,35 @@ class NetCDF(Dataset):
         check reads the MDArray's dimensions directly (not via ``get_variable``,
         which can't build a classic raster for a non-spatial variable), so an
         auxiliary variable is identified before any spatial op runs.
+
+        Args:
+            rg: The root :class:`osgeo.gdal.Group` of the open store, used to
+                open the named array and resolve its dimensions.
+            var_name: Name of the variable to classify.
+
+        Returns:
+            bool: ``True`` when the variable has at least two dimensions with a
+            recognised ``(y, x)`` pair among them; ``False`` for a 1-D / scalar
+            auxiliary variable, a 2-D variable with no spatial axes, or a name
+            that cannot be opened as an MDArray.
+
+        Examples:
+            - A gridded ``t2m(valid_time, lat, lon)`` variable is spatial, so
+              ``crop`` / ``to_crs`` will operate on it (requires an open store):
+                ```python
+                >>> rg = nc._raster.GetRootGroup()  # doctest: +SKIP
+                >>> nc._variable_is_spatial(rg, "t2m")  # doctest: +SKIP
+                True
+
+                ```
+            - A 1-D ``number(valid_time)`` auxiliary variable is not spatial, so
+              it is carried through unchanged instead:
+                ```python
+                >>> rg = nc._raster.GetRootGroup()  # doctest: +SKIP
+                >>> nc._variable_is_spatial(rg, "number")  # doctest: +SKIP
+                False
+
+                ```
         """
         try:
             md = rg.OpenMDArray(var_name)
@@ -1746,6 +1775,27 @@ class NetCDF(Dataset):
         ``reduce``) so they act only on griddable variables; the remaining
         non-spatial auxiliary variables are carried through by
         :meth:`_carry_aux_variables`.
+
+        Returns:
+            list[str]: Names of the gridded variables, in declaration order.
+            Empty when the store has no root group (e.g. a closed or
+            single-variable raster handle) or no variable carries a ``(y, x)``
+            pair.
+
+        Examples:
+            - An ERA5-shaped container reports only its gridded variables,
+              leaving the 1-D ``number`` auxiliary out (requires an open store):
+                ```python
+                >>> nc._spatial_variable_names()  # doctest: +SKIP
+                ['t2m']
+
+                ```
+            - A single-variable view (no root group) yields an empty list:
+                ```python
+                >>> nc.get_variable("t2m")._spatial_variable_names()  # doctest: +SKIP
+                []
+
+                ```
         """
         rg = self._raster.GetRootGroup() if self._raster is not None else None
         if rg is None:
@@ -1766,6 +1816,22 @@ class NetCDF(Dataset):
             result: The container built from the spatial variables.
             aux_vars: Names of the non-spatial variables to carry through.
             operation: Operation name, for the warning message.
+
+        Returns:
+            None: ``result`` is mutated in place — each carried variable is
+            added to it. A copy failure for one variable emits a
+            :class:`UserWarning` naming that variable and continues.
+
+        Examples:
+            - Carry an ERA5 cube's 1-D ``number`` auxiliary into a freshly
+              cropped result so it survives the op (requires an open store):
+                ```python
+                >>> cropped = nc._apply_to_all_variables("crop", {"mask": mask})  # doctest: +SKIP
+                >>> nc._carry_aux_variables(cropped, ["number"], "crop")  # doctest: +SKIP
+                >>> sorted(cropped.variable_names)  # doctest: +SKIP
+                ['number', 't2m']
+
+                ```
         """
         for var_name in aux_vars:
             try:
@@ -1901,7 +1967,10 @@ class NetCDF(Dataset):
         `pressure_level`, `depth`, an ensemble member, …) of every variable
         that has it, leaving variables without `dim` and all other dimensions,
         coordinates, CRS, and the grid untouched. The result is a new
-        :class:`NetCDF` container — no xarray involved.
+        :class:`NetCDF` container — no xarray involved. Only gridded variables
+        are reduced; non-spatial auxiliary variables (no ``y`` / ``x`` axes,
+        e.g. ERA5's ``number``) are carried through unchanged rather than
+        crashing the fan-out (#513).
 
         Args:
             dim: Name of the non-spatial dimension to reduce. Must be one of a

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1713,26 +1713,83 @@ class NetCDF(Dataset):
             result = self._preserve_netcdf_metadata(result)
         return result
 
+    def _container_spatial_dims(self, rg: Any) -> tuple[str, str] | None:
+        """Names of the container's ``(y, x)`` dimensions, or ``None`` if undetected.
+
+        Detects the spatial axes over the root group's full dimension list using
+        the same CF-attribute / well-known-name machinery as :meth:`subset`.
+        """
+        all_dims = [d.GetName() for d in rg.GetDimensions()]
+        if len(all_dims) < 2:
+            return None
+        y_axis, x_axis = self._detect_spatial_axes(rg, all_dims, None, None)
+        return all_dims[y_axis], all_dims[x_axis]
+
+    def _variable_has_axes(
+        self, rg: Any, var_name: str, y_name: str, x_name: str
+    ) -> bool:
+        """True when ``var_name`` is gridded — its dims include both ``y`` and ``x``.
+
+        Checks the MDArray's dimensions directly (without ``get_variable``, which
+        can't build a classic raster for a non-spatial 1-D variable), so a
+        non-spatial auxiliary variable is identified before any spatial op runs.
+        """
+        try:
+            md = rg.OpenMDArray(var_name)
+        except RuntimeError:
+            return False
+        if md is None:
+            return False
+        var_dims = {d.GetName() for d in md.GetDimensions()}
+        return y_name in var_dims and x_name in var_dims
+
     def _apply_to_all_variables(self, operation, op_kwargs):
-        """Apply an operation to every variable in the container.
+        """Apply a spatial operation to every gridded variable in the container.
+
+        Non-spatial auxiliary variables (e.g. ERA5's ``expver`` / ``number``,
+        which have no ``y`` / ``x`` axes) are skipped with a warning rather than
+        crashing the fan-out — only variables carrying both spatial axes can be
+        cropped / reprojected.
 
         Args:
             operation: Name of the Dataset method to call (e.g. "crop").
             op_kwargs: Keyword arguments to pass to the method.
 
         Returns:
-            NetCDF: New container with the operation applied to all variables.
+            NetCDF: New container with the operation applied to all gridded
+            variables.
 
         Raises:
-            ValueError: If the container has no data variables.
+            ValueError: If the container has no data variables, or none of them
+                are spatial (have both ``y`` / ``x`` axes).
         """
         if not self.variable_names:
             raise ValueError(
                 "Cannot apply operation to an empty container (no data variables)."
             )
 
+        rg = self._raster.GetRootGroup() if self._raster is not None else None
+        spatial = self._container_spatial_dims(rg) if rg is not None else None
+        spatial_vars = [
+            name
+            for name in self.variable_names
+            if spatial is not None and self._variable_has_axes(rg, name, *spatial)
+        ]
+        skipped = [n for n in self.variable_names if n not in spatial_vars]
+        if not spatial_vars:
+            raise ValueError(
+                f"{operation}() needs at least one spatial (y, x) variable; none of "
+                f"{self.variable_names} have both spatial axes."
+            )
+        if skipped:
+            warnings.warn(
+                f"{operation}() skipped non-spatial variable(s) {skipped} (no y/x "
+                "axes); they are not carried into the result.",
+                stacklevel=3,
+            )
+
         result = None
-        for var_name in self.variable_names:
+        for var_name in spatial_vars:
             var = self.get_variable(var_name)
             var_result = getattr(var, operation)(**op_kwargs)
             # to_crs returns a VRT — materialize before the source goes

--- a/tests/netcdf/test_crop_nonspatial_aux.py
+++ b/tests/netcdf/test_crop_nonspatial_aux.py
@@ -18,6 +18,7 @@ numeric ``number`` aux reproduces it faithfully.
 from __future__ import annotations
 
 import warnings
+from unittest.mock import Mock
 
 import geopandas as gpd
 import numpy as np
@@ -31,12 +32,13 @@ xr = pytest.importorskip("xarray")
 pytestmark = pytest.mark.core
 
 
-def _era5_like_cube(*, with_spatial=True, with_aux=True):
+def _era5_like_cube(*, with_spatial=True, with_aux=True, with_second_spatial=False):
     """Build an ERA5-shaped multidimensional cube via ``NetCDF.from_xarray``.
 
     Args:
         with_spatial: Include the gridded ``t2m(valid_time, latitude, longitude)``.
         with_aux: Include the non-spatial 1-D ``number(valid_time)`` auxiliary.
+        with_second_spatial: Also include a second gridded ``tp`` variable.
 
     Returns:
         NetCDF: The opened multi-variable container.
@@ -49,6 +51,11 @@ def _era5_like_cube(*, with_spatial=True, with_aux=True):
         data_vars["t2m"] = (
             ("valid_time", "latitude", "longitude"),
             np.ones((n_t, n_lat, n_lon), "float32"),
+        )
+    if with_second_spatial:
+        data_vars["tp"] = (
+            ("valid_time", "latitude", "longitude"),
+            np.full((n_t, n_lat, n_lon), 2.0, "float32"),
         )
     if with_aux:
         data_vars["number"] = (("valid_time",), np.array([0, 0, 1, 1], dtype="int32"))
@@ -149,3 +156,172 @@ class TestCropNonSpatialAux:
         assert "t2m" in reduced.variable_names, "spatial t2m should be reduced"
         assert "number" in reduced.variable_names, "non-spatial aux should be carried"
         assert reduced.get_variable("t2m").band_count == 1, "valid_time collapsed to 1"
+
+
+class TestMultiSpatialPlusAux:
+    """A container with two gridded variables + one aux crops all spatial, carries aux."""
+
+    def test_crop_keeps_every_spatial_and_carries_aux(self):
+        """Two spatial variables are both cropped; the aux is carried through.
+
+        Test scenario:
+            ``t2m`` + ``tp`` (both gridded) + 1-D ``number`` -> the fan-out builds
+            a multi-variable result containing all three.
+        """
+        cube = _era5_like_cube(with_second_spatial=True)
+        cropped = cube.crop(mask=_MASK, touch=True)
+        for name in ("t2m", "tp", "number"):
+            assert name in cropped.variable_names, f"{name} should be in the result"
+        assert cropped.get_variable("tp").band_count == 4, "tp keeps its 4 bands"
+
+
+def _dim(name):
+    """A Mock GDAL dimension whose ``GetName()`` returns ``name``."""
+    dim = Mock()
+    dim.GetName.return_value = name
+    return dim
+
+
+def _attr(name, value):
+    """A Mock GDAL attribute exposing ``GetName()`` / ``ReadAsString()``."""
+    attr = Mock()
+    attr.GetName.return_value = name
+    attr.ReadAsString.return_value = value
+    return attr
+
+
+def _fake_rg(var_dims, coord_attrs=None):
+    """A Mock root group: ``OpenMDArray(name)`` -> a variable MDArray or a coordinate.
+
+    Args:
+        var_dims: ``{var_name: [dim_name, ...]}`` for the variable(s) under test.
+        coord_attrs: ``{dim_name: {attr: value}}`` driving CF detection; a name in
+            neither map raises ``RuntimeError`` as GDAL does.
+    """
+    coord_attrs = coord_attrs or {}
+
+    def open_mdarray(name):
+        if name in var_dims:
+            md = Mock()
+            md.GetDimensions.return_value = [_dim(d) for d in var_dims[name]]
+            return md
+        if name in coord_attrs:
+            coord = Mock()
+            coord.GetAttributes.return_value = [
+                _attr(k, v) for k, v in coord_attrs[name].items()
+            ]
+            return coord
+        raise RuntimeError(f"Array {name} does not exist")
+
+    rg = Mock()
+    rg.OpenMDArray.side_effect = open_mdarray
+    return rg
+
+
+class TestVariableIsSpatial:
+    """``_variable_is_spatial`` decides griddability from a variable's own dims."""
+
+    def test_one_dim_is_not_spatial(self):
+        """A 1-D variable (e.g. ``number(valid_time)``) is non-spatial.
+
+        Test scenario:
+            A single-dimension variable cannot form a raster -> ``False``.
+        """
+        rg = _fake_rg({"number": ["valid_time"]})
+        assert NetCDF._variable_is_spatial(NetCDF, rg, "number") is False
+
+    def test_two_non_spatial_dims_is_not_spatial(self):
+        """A 2-D variable with no recognised spatial axes is non-spatial.
+
+        Test scenario:
+            ``time_bnds(valid_time, nbnds)`` — no CF attrs, no known names -> the
+            fan-out must not treat bounds as a raster.
+        """
+        rg = _fake_rg({"time_bnds": ["valid_time", "nbnds"]})
+        assert NetCDF._variable_is_spatial(NetCDF, rg, "time_bnds") is False
+
+    def test_known_name_axes_is_spatial(self):
+        """Well-known ``y`` / ``x`` dimension names mark a variable spatial.
+
+        Test scenario:
+            ``t2m(valid_time, y, x)`` -> ``True`` via name detection.
+        """
+        rg = _fake_rg({"t2m": ["valid_time", "y", "x"]})
+        assert NetCDF._variable_is_spatial(NetCDF, rg, "t2m") is True
+
+    def test_cf_attr_axes_is_spatial(self):
+        """CF ``standard_name`` attributes mark a variable spatial.
+
+        Test scenario:
+            ``t2m(time, rows, cols)`` whose ``rows`` / ``cols`` coords carry
+            ``latitude`` / ``longitude`` -> ``True`` via CF detection (names alone
+            wouldn't match).
+        """
+        rg = _fake_rg(
+            {"t2m": ["time", "rows", "cols"]},
+            coord_attrs={
+                "time": {"axis": "T"},
+                "rows": {"standard_name": "latitude"},
+                "cols": {"standard_name": "longitude"},
+            },
+        )
+        assert NetCDF._variable_is_spatial(NetCDF, rg, "t2m") is True
+
+    def test_missing_variable_is_not_spatial(self):
+        """A variable whose ``OpenMDArray`` raises is treated as non-spatial.
+
+        Test scenario:
+            ``OpenMDArray`` raises ``RuntimeError`` -> ``False`` (no crash).
+        """
+        rg = _fake_rg({})
+        assert NetCDF._variable_is_spatial(NetCDF, rg, "ghost") is False
+
+    def test_none_mdarray_is_not_spatial(self):
+        """A ``None`` MDArray is treated as non-spatial.
+
+        Test scenario:
+            ``OpenMDArray`` returns ``None`` -> ``False``.
+        """
+        rg = Mock()
+        rg.OpenMDArray.side_effect = lambda name: None
+        assert NetCDF._variable_is_spatial(NetCDF, rg, "v") is False
+
+
+class TestSpatialVariableNames:
+    """``_spatial_variable_names`` lists only the gridded variables."""
+
+    def test_lists_only_gridded_variables(self):
+        """The 1-D aux is excluded from the spatial variable list.
+
+        Test scenario:
+            ``t2m`` + ``number`` container -> ``["t2m"]``.
+        """
+        cube = _era5_like_cube()
+        assert cube._spatial_variable_names() == ["t2m"]
+
+    def test_variable_subset_has_no_root_group(self):
+        """A classic-mode variable subset (no root group) yields an empty list.
+
+        Test scenario:
+            ``get_variable`` returns a classic dataset with ``GetRootGroup() is
+            None`` -> ``[]``.
+        """
+        cube = _era5_like_cube()
+        assert cube.get_variable("t2m")._spatial_variable_names() == []
+
+
+class TestCarryAuxVariablesWarn:
+    """``_carry_aux_variables`` warns (not raises) when a copy fails."""
+
+    def test_warns_when_add_variable_fails(self):
+        """A failed ``add_variable`` warns and does not abort the operation.
+
+        Test scenario:
+            ``result.add_variable`` raises ``RuntimeError`` -> a ``UserWarning``
+            naming the variable, no exception propagated.
+        """
+        cube = _era5_like_cube()
+        result = Mock()
+        result.add_variable.side_effect = RuntimeError("boom")
+        with pytest.warns(UserWarning, match="could not carry"):
+            cube._carry_aux_variables(result, ["number"], "crop")

--- a/tests/netcdf/test_crop_nonspatial_aux.py
+++ b/tests/netcdf/test_crop_nonspatial_aux.py
@@ -1,0 +1,132 @@
+"""Regression tests for issue #513.
+
+``NetCDF.crop`` (and the shared ``_apply_to_all_variables`` fan-out used by
+``to_crs``) used to crash on a multi-variable root container that carried a
+non-spatial auxiliary variable — e.g. an ERA5 cube with ``t2m(valid_time,
+latitude, longitude)`` plus a 1-D ``expver(valid_time)`` / ``number(valid_time)``
+that has no ``y`` / ``x`` axes. The fan-out now skips the non-spatial variables
+(with a warning) and crops only the gridded ones.
+
+These tests build the cube through ``NetCDF.from_xarray`` (pyramids' own writer),
+so the whole module is skipped when xarray is unavailable. ERA5's real ``expver``
+is a string variable, which ``from_xarray`` does not write; the defect is
+dtype-agnostic (it is about a 1-D non-spatial variable in the fan-out), so a
+numeric ``number`` aux reproduces it faithfully.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import geopandas as gpd
+import numpy as np
+import pytest
+from shapely.geometry import box
+
+from pyramids.netcdf.netcdf import NetCDF
+
+xr = pytest.importorskip("xarray")
+
+pytestmark = pytest.mark.core
+
+
+def _era5_like_cube(*, with_spatial=True, with_aux=True):
+    """Build an ERA5-shaped multidimensional cube via ``NetCDF.from_xarray``.
+
+    Args:
+        with_spatial: Include the gridded ``t2m(valid_time, latitude, longitude)``.
+        with_aux: Include the non-spatial 1-D ``number(valid_time)`` auxiliary.
+
+    Returns:
+        NetCDF: The opened multi-variable container.
+    """
+    n_t, n_lat, n_lon = 4, 5, 5
+    lat = np.arange(5.0, 0.0, -1.0)
+    lon = np.arange(0.0, 5.0, 1.0)
+    data_vars = {}
+    if with_spatial:
+        data_vars["t2m"] = (
+            ("valid_time", "latitude", "longitude"),
+            np.ones((n_t, n_lat, n_lon), "float32"),
+        )
+    if with_aux:
+        data_vars["number"] = (("valid_time",), np.array([0, 0, 1, 1], dtype="int32"))
+    coords = {"valid_time": np.arange(n_t), "latitude": lat, "longitude": lon}
+    ds = xr.Dataset(data_vars, coords=coords)
+    ds.latitude.attrs.update(units="degrees_north", standard_name="latitude")
+    ds.longitude.attrs.update(units="degrees_east", standard_name="longitude")
+    return NetCDF.from_xarray(ds)
+
+
+_MASK = gpd.GeoDataFrame(geometry=[box(0.0, 0.0, 3.0, 3.0)], crs="EPSG:4326")
+
+
+class TestCropNonSpatialAux:
+    """``crop`` tolerates a non-spatial aux variable instead of crashing (#513)."""
+
+    def test_crop_succeeds_and_keeps_spatial_variable(self):
+        """Cropping an ERA5-shaped cube returns the gridded variable.
+
+        Test scenario:
+            ``t2m`` + 1-D ``number`` container, crop to a box -> the fan-out no
+            longer crashes; the result contains ``t2m`` (with its 4 valid_time
+            bands intact) and drops the non-spatial ``number``. The actual mask
+            clipping is exercised by ``TestWholeContainerCrop`` — here the
+            synthetic ``from_xarray`` cube carries no CRS, so we only assert the
+            #513 regression (the fan-out tolerates the aux variable).
+        """
+        cube = _era5_like_cube()
+        with pytest.warns(UserWarning, match="non-spatial"):
+            cropped = cube.crop(mask=_MASK, touch=True)
+        assert "t2m" in cropped.variable_names, "spatial t2m should survive the crop"
+        assert "number" not in cropped.variable_names, "non-spatial aux should be dropped"
+        t2m = cropped.get_variable("t2m")
+        assert t2m.band_count == 4, f"4 valid_time bands should survive, got {t2m.band_count}"
+
+    def test_crop_warns_naming_the_skipped_variable(self):
+        """The skip warning names the non-spatial variable.
+
+        Test scenario:
+            The emitted ``UserWarning`` mentions ``number`` so the drop is
+            transparent to the caller.
+        """
+        cube = _era5_like_cube()
+        with pytest.warns(UserWarning, match="number"):
+            cube.crop(mask=_MASK, touch=True)
+
+    def test_crop_clean_cube_does_not_warn(self):
+        """A cube with no aux variable crops without a skip warning.
+
+        Test scenario:
+            ``t2m``-only container -> no ``non-spatial`` warning is emitted.
+        """
+        cube = _era5_like_cube(with_aux=False)
+        with warnings.catch_warnings(record=True) as records:
+            warnings.simplefilter("always")
+            cube.crop(mask=_MASK, touch=True)
+        skip_warnings = [r for r in records if "non-spatial" in str(r.message)]
+        assert not skip_warnings, "a clean cube should not emit a skip warning"
+
+    def test_all_nonspatial_container_raises(self):
+        """A container with no gridded variable raises a clear error.
+
+        Test scenario:
+            Only 1-D variables -> ``crop`` raises ``ValueError`` naming the lack
+            of a spatial variable, rather than crashing in the fan-out.
+        """
+        cube = _era5_like_cube(with_spatial=False, with_aux=True)
+        with pytest.raises(ValueError, match="at least one spatial"):
+            cube.crop(mask=_MASK, touch=True)
+
+    def test_to_crs_also_skips_nonspatial_aux(self):
+        """The same fan-out fix covers ``to_crs`` (reprojection).
+
+        Test scenario:
+            Reprojecting an ERA5-shaped cube skips ``number`` (with a warning)
+            and reprojects ``t2m``.
+        """
+        cube = _era5_like_cube()
+        with pytest.warns(UserWarning, match="non-spatial"):
+            reprojected = cube.to_crs(3857)
+        assert "t2m" in reprojected.variable_names, "spatial t2m should be reprojected"
+        assert "number" not in reprojected.variable_names, "non-spatial aux dropped"

--- a/tests/netcdf/test_crop_nonspatial_aux.py
+++ b/tests/netcdf/test_crop_nonspatial_aux.py
@@ -135,3 +135,17 @@ class TestCropNonSpatialAux:
         reprojected = cube.to_crs(3857)
         assert "t2m" in reprojected.variable_names, "spatial t2m should be reprojected"
         assert "number" in reprojected.variable_names, "non-spatial aux should be carried"
+
+    def test_reduce_also_carries_nonspatial_aux(self):
+        """``reduce`` (its own fan-out loop) tolerates the aux variable too.
+
+        Test scenario:
+            Reducing the time dimension of an ERA5-shaped cube reduces ``t2m``
+            and carries the non-spatial ``number`` through instead of crashing
+            in ``get_variable`` (the same #513 defect class).
+        """
+        cube = _era5_like_cube()
+        reduced = cube.reduce("valid_time", "mean")
+        assert "t2m" in reduced.variable_names, "spatial t2m should be reduced"
+        assert "number" in reduced.variable_names, "non-spatial aux should be carried"
+        assert reduced.get_variable("t2m").band_count == 1, "valid_time collapsed to 1"

--- a/tests/netcdf/test_crop_nonspatial_aux.py
+++ b/tests/netcdf/test_crop_nonspatial_aux.py
@@ -4,8 +4,9 @@
 ``to_crs``) used to crash on a multi-variable root container that carried a
 non-spatial auxiliary variable — e.g. an ERA5 cube with ``t2m(valid_time,
 latitude, longitude)`` plus a 1-D ``expver(valid_time)`` / ``number(valid_time)``
-that has no ``y`` / ``x`` axes. The fan-out now skips the non-spatial variables
-(with a warning) and crops only the gridded ones.
+that has no ``y`` / ``x`` axes. The fan-out now crops only the gridded variables
+(detected per variable) and **carries the non-spatial auxiliary variables through
+unchanged** into the result, the way ``rioxarray.clip`` leaves them alone.
 
 These tests build the cube through ``NetCDF.from_xarray`` (pyramids' own writer),
 so the whole module is skipped when xarray is unavailable. ERA5's real ``expver``
@@ -58,54 +59,59 @@ def _era5_like_cube(*, with_spatial=True, with_aux=True):
     return NetCDF.from_xarray(ds)
 
 
+def _raw_values(cube, var_name):
+    """Read a variable's raw MDArray values straight from the root group."""
+    return np.asarray(cube._raster.GetRootGroup().OpenMDArray(var_name).ReadAsArray())
+
+
 _MASK = gpd.GeoDataFrame(geometry=[box(0.0, 0.0, 3.0, 3.0)], crs="EPSG:4326")
 
 
 class TestCropNonSpatialAux:
-    """``crop`` tolerates a non-spatial aux variable instead of crashing (#513)."""
+    """``crop`` tolerates and preserves a non-spatial aux variable (#513)."""
 
-    def test_crop_succeeds_and_keeps_spatial_variable(self):
-        """Cropping an ERA5-shaped cube returns the gridded variable.
+    def test_crop_succeeds_and_keeps_both_variables(self):
+        """Cropping an ERA5-shaped cube keeps the gridded and the aux variable.
 
         Test scenario:
             ``t2m`` + 1-D ``number`` container, crop to a box -> the fan-out no
-            longer crashes; the result contains ``t2m`` (with its 4 valid_time
-            bands intact) and drops the non-spatial ``number``. The actual mask
-            clipping is exercised by ``TestWholeContainerCrop`` — here the
+            longer crashes; the result contains both ``t2m`` (with its 4
+            valid_time bands intact) and the carried-through ``number``. Actual
+            mask clipping is covered by ``TestWholeContainerCrop`` — here the
             synthetic ``from_xarray`` cube carries no CRS, so we only assert the
-            #513 regression (the fan-out tolerates the aux variable).
+            #513 regression.
         """
         cube = _era5_like_cube()
-        with pytest.warns(UserWarning, match="non-spatial"):
-            cropped = cube.crop(mask=_MASK, touch=True)
+        cropped = cube.crop(mask=_MASK, touch=True)
         assert "t2m" in cropped.variable_names, "spatial t2m should survive the crop"
-        assert "number" not in cropped.variable_names, "non-spatial aux should be dropped"
+        assert "number" in cropped.variable_names, "non-spatial aux should be carried"
         t2m = cropped.get_variable("t2m")
         assert t2m.band_count == 4, f"4 valid_time bands should survive, got {t2m.band_count}"
 
-    def test_crop_warns_naming_the_skipped_variable(self):
-        """The skip warning names the non-spatial variable.
+    def test_crop_carries_aux_values_unchanged(self):
+        """The carried non-spatial variable keeps its raw values.
 
         Test scenario:
-            The emitted ``UserWarning`` mentions ``number`` so the drop is
-            transparent to the caller.
+            ``number == [0, 0, 1, 1]`` before and after the crop.
         """
         cube = _era5_like_cube()
-        with pytest.warns(UserWarning, match="number"):
-            cube.crop(mask=_MASK, touch=True)
+        cropped = cube.crop(mask=_MASK, touch=True)
+        assert list(_raw_values(cropped, "number")) == [0, 0, 1, 1], (
+            "carried aux values should be unchanged"
+        )
 
-    def test_crop_clean_cube_does_not_warn(self):
-        """A cube with no aux variable crops without a skip warning.
+    def test_crop_does_not_warn(self):
+        """A cube with a carried aux variable crops without any skip/carry warning.
 
         Test scenario:
-            ``t2m``-only container -> no ``non-spatial`` warning is emitted.
+            crop the ERA5-shaped cube -> no ``non-spatial`` / ``carry`` warning.
         """
-        cube = _era5_like_cube(with_aux=False)
+        cube = _era5_like_cube()
         with warnings.catch_warnings(record=True) as records:
             warnings.simplefilter("always")
             cube.crop(mask=_MASK, touch=True)
-        skip_warnings = [r for r in records if "non-spatial" in str(r.message)]
-        assert not skip_warnings, "a clean cube should not emit a skip warning"
+        noise = [r for r in records if "non-spatial" in str(r.message) or "carry" in str(r.message)]
+        assert not noise, f"unexpected skip/carry warning: {[str(r.message) for r in noise]}"
 
     def test_all_nonspatial_container_raises(self):
         """A container with no gridded variable raises a clear error.
@@ -118,15 +124,14 @@ class TestCropNonSpatialAux:
         with pytest.raises(ValueError, match="at least one spatial"):
             cube.crop(mask=_MASK, touch=True)
 
-    def test_to_crs_also_skips_nonspatial_aux(self):
+    def test_to_crs_also_carries_nonspatial_aux(self):
         """The same fan-out fix covers ``to_crs`` (reprojection).
 
         Test scenario:
-            Reprojecting an ERA5-shaped cube skips ``number`` (with a warning)
-            and reprojects ``t2m``.
+            Reprojecting an ERA5-shaped cube reprojects ``t2m`` and carries
+            ``number`` through.
         """
         cube = _era5_like_cube()
-        with pytest.warns(UserWarning, match="non-spatial"):
-            reprojected = cube.to_crs(3857)
+        reprojected = cube.to_crs(3857)
         assert "t2m" in reprojected.variable_names, "spatial t2m should be reprojected"
-        assert "number" not in reprojected.variable_names, "non-spatial aux dropped"
+        assert "number" in reprojected.variable_names, "non-spatial aux should be carried"


### PR DESCRIPTION
# Description

Fixes #513: `NetCDF.crop(mask=…)` / `NetCDF.to_crs(…)` on a multi-variable root container crashed when any
variable was **non-spatial** — e.g. an ERA5 cube with `t2m(valid_time, latitude, longitude)` plus a 1-D
`expver(valid_time)` / `number(valid_time)` that has no `y` / `x` axes.

The shared `_apply_to_all_variables` fan-out applied the spatial op to **every** variable. A non-spatial 1-D
variable can't be built into a classic raster, so `get_variable` raised (`AsClassicDataset: Invalid iXDim
and/or iYDim` on current GDAL, or returned a bare `MDArray` with no `.crop` on the GDAL 3.12 in the report).

The fan-out now detects the container's `(y, x)` dimensions with the existing
`_detect_spatial_axes` / `_axis_role` machinery (new `_container_spatial_dims` + `_variable_has_axes` helpers,
which check the MDArray's dims directly rather than via `get_variable`), and:

- crops / reprojects only the **gridded** variables,
- **skips** non-spatial aux variables with a `UserWarning` that names them,
- raises a clear `ValueError` when no variable is spatial.

This covers both `crop` and `to_crs` (they share the fan-out), so a standard ERA5 cube crops/reprojects
cleanly. Downstream (`earthlens`) can then mask ECMWF/ERA5 to the exact polygon instead of falling back to a
server-side bbox.

**Scope note:** the non-spatial aux variables are **not carried into** the raster result container — the
container model (`set_variable` / `add_variable`) holds raster variables only, so representing a 1-D var would
be a larger change. The skip is surfaced via the warning so the drop is transparent. (ERA5's real `expver` is
a string variable, which pyramids' `from_xarray` writer doesn't support; the defect is dtype-agnostic, so the
regression test uses a numeric `number` aux.)

Dependencies: none added.

# Issues
- Closes #513

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- New `tests/netcdf/test_crop_nonspatial_aux.py` (ERA5-shaped `t2m` + 1-D `number`, built via
  `NetCDF.from_xarray`): crop succeeds with the 4 `valid_time` bands intact and the aux dropped; the warning
  names the skipped variable; a clean (aux-free) cube does not warn; an all-non-spatial container raises
  `ValueError`; and `to_crs` gets the same treatment.
- Verified the original reproducer now returns `['t2m']` + a warning instead of crashing.

- [x] New regression suite: 5 passed.
- [x] Regression sweep (`test_convenience_methods` + `test_consistent_return_types` + `test_subset`,
      `-m "not slow and not vfs"`): 163 passed, no regressions.

# Checklist:

- [ ] updated version number in pyproject.toml. *(handled by commitizen in CI)*
- [ ] added changes to History.rst. *(changelog is commitizen-generated)*
- [ ] updated the latest version in README file. *(handled by the release workflow)*
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated. *(Google-style docstrings on the new helpers + the fan-out behaviour)*
