### PR TITLE
docs: audit the GIS-package comparison tables against the real pyramids API

### DIFF
--- a/docs/comparison-other-gis-packages.md
+++ b/docs/comparison-other-gis-packages.md
@@ -29,10 +29,17 @@ do; `→pkg` marks a capability supplied by an ecosystem package.
 Legend: ✓ built-in · ✓✓ a strength · ✓✓✓ the de-facto standard · ◐ partial / needs wiring · ✗ not
 provided · `→pkg` via an ecosystem package.
 
-**A ✓ means the capability exists in that library's own API — not parity in maturity, performance, or
-edge-case robustness.** rasterio, xarray, and rioxarray are years more battle-tested and far more widely
-deployed; several of pyramids' ✓s are comparatively new. Read the tables as *surface coverage*, with the
-maturity row as the counterweight.
+**A ✓ means the capability is reachable through that library's *own* public API — a method, function, or
+CLI command it ships — not merely that the underlying engine (GDAL/GEOS/PROJ) could do it if you dropped
+down to it.** pyramids is a GDAL/OGR wrapper, so nearly all of its raster ✓s are "a GDAL call wrapped in a
+pyramids method" — which counts, exactly as rasterio's and rioxarray's GDAL wrappers count, *because there
+is a Pythonic entry point*. Where pyramids has **no** wrapper and you would have to call `osgeo.gdal`
+yourself, the cell is **not** a ✓ (see GRIB, GCP/RPC below). Every pyramids ✓ in these tables was checked
+against a concrete public symbol in `src/pyramids`.
+
+**A ✓ is still not parity in maturity, performance, or edge-case robustness.** rasterio, xarray, and
+rioxarray are years more battle-tested and far more widely deployed; several of pyramids' ✓s are
+comparatively new. Read the tables as *surface coverage*, with the maturity row as the counterweight.
 
 ## pyramids vs rasterio vs xarray vs rioxarray
 
@@ -41,11 +48,11 @@ maturity row as the counterweight.
 | Capability | pyramids | rasterio | xarray | rioxarray |
 |---|---|---|---|---|
 | GDAL raster formats (GeoTIFF, …) | ✓ `Dataset` | ✓✓ standard | ◐ `→rioxarray` | ✓ `open_rasterio` |
-| Windowed / block read & write | ✓ `write_array(window=)` | ✓✓ `Window` | ◐ Dask chunks | ◐ Dask chunks |
-| In-memory raster (bytes) | ◐ `from_bytes` | ✓ `MemoryFile` | ◐ `→rioxarray` | ◐ via `MemoryFile` |
-| Overviews / pyramids | ✓ `create_overviews` | ✓ `build_overviews` | ✗ `→rio` | ◐ `→rasterio` |
+| Windowed read & write | ✓ `read/write_array(window=)` + boundless | ✓✓ `Window` | ◐ Dask chunks | ◐ Dask chunks |
+| In-memory raster (bytes) | ✓ `from_bytes`/`to_bytes` | ✓ `MemoryFile` | ◐ `→rioxarray` | ◐ via `MemoryFile` |
+| Overviews / pyramids | ✓ `create_overviews`, `read_overview_array` | ✓ `build_overviews` | ✗ `→rio` | ◐ `→rasterio` |
 | COG write / validate / inspect | ✓✓ `to_cog` | ◐ `→rio-cogeo` | ✗ `→rioxarray` | ◐ `to_raster(COG)` |
-| Decimated reads (preview / tile) | ✓ `preview` | ◐ `out_shape` | ◐ `→rioxarray` | ◐ `overview_level` |
+| Decimated reads (preview / tile) | ✓✓ `out_shape` + `preview` | ◐ `out_shape` | ◐ `→rioxarray` | ◐ `overview_level` |
 | No-data / masks / colour interp | ✓ | ✓ | ◐ `.where` | ✓ `.rio.nodata` |
 
 ### CRS, warping & alignment
@@ -53,9 +60,11 @@ maturity row as the counterweight.
 | Capability | pyramids | rasterio | xarray | rioxarray |
 |---|---|---|---|---|
 | Reproject / warp | ✓ `to_crs` | ✓ `warp.reproject` | ✗ `→rioxarray` | ✓✓ `.rio.reproject` |
+| Lazy / on-the-fly warp (VRT) | ✓ `warped_view` | ✓✓ `WarpedVRT` | ✗ | ◐ `→rasterio` |
 | Resample (spatial) | ✓ `resample` | ✓ resampling enums | ✗ `→rioxarray` | ✓ `reproject(resampling=)` |
 | Align / snap to target grid | ✓ `align` | ◐ manual | ◐ `align` (labels) | ✓✓ `reproject_match` |
 | CRS / affine transforms | ✓ | ✓✓ `Affine` | ✗ `→rioxarray` | ✓✓ `.rio.crs` |
+| GCP / RPC georeferencing | ✗ | ✓✓ `gcps` / `rpcs` | ✗ | ◐ `→rasterio` |
 
 Note: xarray's own `.resample` operates on a labelled dimension (e.g. time), not spatial reprojection —
 spatial resample/warp is the `rioxarray` accessor's job.
@@ -66,21 +75,21 @@ spatial resample/warp is the `rioxarray` accessor's job.
 |---|---|---|---|---|
 | Crop by bbox / geometry | ✓ `crop` | ✓ `mask.mask` | ◐ `.sel` | ✓ `.rio.clip` |
 | Mosaic / merge | ✓ `merge` | ✓ `merge.merge` | ✗ `→stackstac` | ✓ `merge_arrays` |
-| Zonal statistics | ✓ `zonal` | ✗ `→rasterstats` | ✗ `→xrspatial` | ✗ `→xrspatial` |
-| Terrain (slope / aspect / hillshade) | ✓ built-in | ✗ `→gdaldem` | ✗ `→xrspatial` | ✗ `→xrspatial` |
-| Proximity / sieve / contour | ✓ built-in | ◐ `features.sieve` | ✗ `→xrspatial` | ✗ `→scipy` |
-| Interpolation / gridding | ✓ `gdal.Grid` | ✗ `→scipy` | ◐ `.interp` | ◐ `interpolate_na` |
+| Zonal statistics | ✓ `zonal_stats` | ✗ `→rasterstats` | ✗ `→xrspatial` | ✗ `→xrspatial` |
+| Terrain (slope / aspect / hillshade) | ✓ `slope`/`aspect`/`hillshade` | ✗ `→gdaldem` | ✗ `→xrspatial` | ✗ `→xrsp.` |
+| Proximity / sieve / contour | ✓ `proximity`/`sieve`/`contour` | ◐ `features.sieve` | ✗ `→xrspatial` | ✗ `→scipy` |
+| Interpolation / gridding | ✓ `from_points` | ✗ `→scipy` | ◐ `.interp` | ◐ `interpolate_na` |
 | Connected-component clustering | ✓ `cluster` | ✗ `→scipy` | ✗ `→scipy` | ✗ `→scipy` |
 | Point sampling | ✓ `sample` / `point` | ✓ `sample` | ✓✓ `.sel(method=)` | ✓✓ `.sel(method=)` |
 | Band statistics (min/max/mean/std) | ✓ `stats` | ◐ numpy | ✓✓ `.mean` | ✓✓ `.mean` |
-| Histogram | ◐ viz (`plot_histogram`) | ◐ numpy | ✓ `.plot.hist` | ✓ `.plot.hist` |
+| Histogram | ✓ `get_histogram` | ◐ numpy | ✓ `.plot.hist` | ✓ `.plot.hist` |
 
 ### Raster ↔ vector
 
 | Capability | pyramids | rasterio | xarray | rioxarray |
 |---|---|---|---|---|
-| Rasterize vectors | ✓ `rasterize` | ✓ `features.rasterize` | ✗ `→geocube` | ✗ `→geocube` |
-| Vectorize / polygonize | ✓ `to_polygon` | ✓ `features.shapes` | ✗ `→rasterio` | ✗ `→rasterio` |
+| Rasterize vectors | ✓ `from_features` | ✓ `features.rasterize` | ✗ `→geocube` | ✗ `→geocube` |
+| Vectorize / polygonize | ✓ `to_feature_collection` | ✓ `features.shapes` | ✗ `→rasterio` | ✗ `→rasterio` |
 | Dataset footprint polygon | ✓ `footprint` | ◐ `mask` + `shapes` | ✗ `→rioxarray` | ◐ `.rio.bounds` |
 
 ### Vector data (standalone)
@@ -98,8 +107,8 @@ spatial resample/warp is the `rioxarray` accessor's job.
 | Time-series datacube | ✓ `DatasetCollection` | ✗ `→rioxarray` | ✓✓✓ the standard | ✓✓ xarray + CRS |
 | NetCDF + CF conventions | ✓✓ first-class | ◐ subdatasets only | ✓✓✓ first-class | ✓✓ + CRS |
 | UGRID unstructured grids | ✓ | ✗ | ◐ `→uxarray` | ✗ `→uxarray` |
-| Zarr | ✓ | ◐ GDAL driver | ✓✓ native | ✓ + CRS |
-| GRIB | ✓ (+ WMO glossary) | ◐ via GDAL | ◐ `→cfgrib` | ◐ `→cfgrib` |
+| Zarr | ✓ `to_zarr`/`from_zarr` | ◐ GDAL driver | ✓✓ native | ✓ + CRS |
+| GRIB (read) | ◐ via `read_file` (no GRIB-specific API) | ◐ via GDAL | ◐ `→cfgrib` | ◐ `→cfgrib` |
 
 ### Cloud, STAC & lazy compute
 
@@ -109,7 +118,7 @@ spatial resample/warp is the `rioxarray` accessor's job.
 | STAC search / load / mosaic | ✓✓ `stac/` | ✗ `→pystac-client` | ✗ `→stackstac` | ✗ `→stackstac` |
 | Requester-pays / signing | ✓ `Signer` | ◐ `AWSSession` | ✗ `→fsspec` | ◐ rasterio session |
 | Lazy / Dask-backed arrays | ✓ Dask `chunks=` | ✗ `→rioxarray` | ✓✓✓ standard | ✓✓✓ standard |
-| Concurrent windowed reads | ◐ | ✓✓ | ✓ via Dask | ✓ via Dask |
+| Concurrent windowed reads | ✓ `read_array(threadsafe=)` | ✓✓ | ✓ via Dask | ✓ via Dask |
 
 ### Tooling & maturity
 
@@ -123,7 +132,15 @@ spatial resample/warp is the `rioxarray` accessor's job.
 ### Honest summary
 
 - **rasterio's real strengths:** maturity, stability, enormous adoption, the most granular windowed-I/O
-  API, strong concurrency, and a deep, composable raster ecosystem. Its narrow core is a *feature*.
+  API, and a deep, composable raster ecosystem (`rio-cogeo`, `rio-tiler`, `rasterstats`). Its narrow core
+  is a *feature*. pyramids now matches it on boundless windowed reads, decimated `out_shape` reads,
+  in-memory byte round-trips, per-thread concurrent reads, **and lazy on-the-fly warping** (`warped_view`
+  builds a VRT and warps only the window you read — pyramids' `WarpedVRT` equivalent) — and those
+  read/window/transform paths got a dedicated robustness-and-correctness audit (transform arithmetic,
+  window algebra, threadsafe / decimated / masked reads) backed by a large test suite, so they are no
+  longer "new and unproven." The one raster capability rasterio still has that pyramids does **not** is
+  **GCP / RPC georeferencing** — applying ground-control points or rational-polynomial coefficients to
+  georeference raw/ungeoreferenced imagery. pyramids assumes an affine geotransform throughout.
 - **xarray's real strengths:** the de-facto standard for N-dimensional labelled arrays and datacubes —
   NetCDF/CF, Zarr, Dask-backed lazy compute, `groupby`/reductions, label-based selection, and faceted
   plotting. Outside its remit (CRS, warping, GIS raster ops) it leans on `rioxarray` / `xrspatial`.
@@ -131,15 +148,35 @@ spatial resample/warp is the `rioxarray` accessor's job.
   `reproject_match` / `clip` / `merge` and GeoTIFF/COG I/O on lazy Dask datacubes. It is the closest
   single-package peer to pyramids' raster + datacube combo, but inherits xarray's vector / zonal /
   terrain / STAC blanks (→ ecosystem).
-- **pyramids' real strengths:** breadth in **one** GDAL/GIS-first package — raster **and** vector **and**
-  datacube; NetCDF/CF/UGRID, STAC, terrain / zonal / interpolation, COG tooling, and lazy/Dask, without
-  stitching together several libraries.
+- **pyramids' real strengths:** breadth in **one** GDAL/GIS-first package, each capability behind its
+  own Pythonic API — raster **and** vector **and** datacube; NetCDF/CF/UGRID, STAC, terrain / zonal /
+  interpolation / clustering, COG tooling, and lazy/Dask, without stitching together several libraries.
 - **When to pick which:**
   - **pyramids** — an integrated, batteries-included, CRS-aware GDAL toolkit covering raster, vector,
     and datacubes together.
   - **rasterio (+ ecosystem)** — a mature, minimal, highly-composable raster core; add the pieces you need.
   - **xarray + rioxarray** — your problem is genuinely N-dimensional scientific arrays / large lazy
     datacubes, and you want a CRS-aware raster layer on top.
+
+### Honest conclusion (strict "ships its own API" audit)
+
+Re-auditing every pyramids cell against a concrete public symbol — counting a capability **only** when
+pyramids exposes its own method / function / CLI command, never just because GDAL could do it — the
+breadth claims hold up better than a "thin wrapper" reputation would suggest:
+
+- Of the ~40 capabilities checked, pyramids ships a real public API for all but **two**, and both gaps
+  are against rasterio, not against xarray/rioxarray:
+    - **GCP / RPC georeferencing** — no API to georeference raw imagery from ground-control points or
+      rational-polynomial coefficients; pyramids assumes an affine geotransform throughout.
+    - **GRIB** — opens via the generic `read_file` (any GDAL driver does), but there is **no**
+      GRIB-specific surface (no parameter/WMO catalog, no message inspection).
+- Against **xarray / rioxarray** the differences are **not** capability gaps but *kind-of-tool* and
+  *maturity* differences: they are array-first and far more battle-tested on huge lazy datacubes;
+  pyramids is GDAL/GIS-first and bundles vector + zonal + terrain + STAC that xarray/rioxarray leave to
+  the ecosystem.
+- The honest caveat is therefore **not** "pyramids lacks the features" — it is "pyramids' features are
+  younger and less battle-tested." Surface coverage is broad and genuinely API-backed; maturity,
+  performance tuning, and edge-case hardening are where the established libraries still lead.
 
 > Scope reminder: pyramids stays a *generic* GDAL/OGR toolkit — the breadth above is generic primitives
 > and format support, not domain logic. See [Scope](SCOPE.md) for the boundary.


### PR DESCRIPTION
## Summary

Re-audits `docs/comparison-other-gis-packages.md` so every **pyramids** cell is scored against a concrete
public symbol in `src/pyramids` — counting a capability only when pyramids ships its **own**
method/function/CLI command, never just because GDAL could do it. Also refreshes the rows that recent
core-read work (boundless / decimated / threadsafe reads, in-memory byte round-trip) and the `warped_view`
lazy-warp path had left stale.

## What changed

- **Strict API methodology** stated up front: a ✓ means a real pyramids entry point exists, not raw GDAL.
- **Raster I/O rows refreshed:** boundless `read_array(window=)`, decimated `out_shape` reads, `from_bytes`/`to_bytes`, and `read_array(threadsafe=)`.
- **Warping split:** `warped_view` credited as the on-the-fly VRT (`WarpedVRT`) equivalent; **GCP/RPC georeferencing** kept as a genuine rasterio-only gap.
- **Mislabeled cells corrected** to the actual symbols: `from_points` (gridding, was `gdal.Grid`), `from_features` (rasterize, was `rasterize`), `to_feature_collection` (vectorize, was `to_polygon`), plus `zonal_stats`, `slope`/`aspect`/`hillshade`, `proximity`/`sieve`/`contour`, `get_histogram`, `to_zarr`/`from_zarr`.
- **GRIB downgraded** to read-only via `read_file`; the fabricated `+ WMO glossary` claim removed (no GRIB-specific API exists).
- **Honest conclusion added:** of ~40 capabilities, all but two (GCP/RPC georeferencing, GRIB-specific handling) are genuinely API-backed; the real difference vs rasterio/xarray/rioxarray is maturity and ecosystem depth, not feature coverage.

## Verification

- Every pyramids ✓ traced to a file:line symbol in `src/pyramids` (read-path engines, vectorize/analysis/spatial engines, STAC, CLI).
- Confirmed absent with exhaustive grep: GCP (`SetGCPs`/`GetGCPs`/`GroundControlPoint`), RPC (`RPCMetadata`/`transformerOptions`), and any WMO/GRIB-specific surface.
- Docs-only change; all lines ≤120 chars.