### PR TITLE
feat(dataset): GCP/RPC georeferencing + mask, window, CLI & parallel-read ergonomics

### DIFF
--- a/docs/comparison-other-gis-packages.md
+++ b/docs/comparison-other-gis-packages.md
@@ -124,7 +124,7 @@ spatial resample/warp is the `rioxarray` accessor's job.
 
 | Capability | pyramids | rasterio | xarray | rioxarray |
 |---|---|---|---|---|
-| CLI | ✓ `pyramids` | ✓ `rio` | ✗ | ✗ |
+| CLI | ✓ `pyramids` (incl. `edit-info`, `calc`, `georeference`) | ✓ `rio` | ✗ | ✗ |
 | Plotting | ◐ `→cleopatra` | ✓ `rasterio.plot` | ✓✓ `xarray.plot` | ✓✓ `xarray.plot` |
 | Maturity / adoption / community | younger | ✓✓✓ standard | ✓✓✓ huge (Pangeo) | ✓✓ widely used |
 | Stability / docs depth | growing | ✓✓✓ | ✓✓✓ | ✓✓ |

--- a/docs/comparison-other-gis-packages.md
+++ b/docs/comparison-other-gis-packages.md
@@ -53,7 +53,7 @@ comparatively new. Read the tables as *surface coverage*, with the maturity row 
 | Overviews / pyramids | ✓ `create_overviews`, `read_overview_array` | ✓ `build_overviews` | ✗ `→rio` | ◐ `→rasterio` |
 | COG write / validate / inspect | ✓✓ `to_cog` | ◐ `→rio-cogeo` | ✗ `→rioxarray` | ◐ `to_raster(COG)` |
 | Decimated reads (preview / tile) | ✓✓ `out_shape` + `preview` | ◐ `out_shape` | ◐ `→rioxarray` | ◐ `overview_level` |
-| No-data / masks / colour interp | ✓ | ✓ | ◐ `.where` | ✓ `.rio.nodata` |
+| No-data / masks / colour interp | ✓ `mask_flags`/`read_masks`/`band_color` | ✓ | ◐ `.where` | ✓ `.rio.nodata` |
 
 ### CRS, warping & alignment
 
@@ -118,7 +118,7 @@ spatial resample/warp is the `rioxarray` accessor's job.
 | STAC search / load / mosaic | ✓✓ `stac/` | ✗ `→pystac-client` | ✗ `→stackstac` | ✗ `→stackstac` |
 | Requester-pays / signing | ✓ `Signer` | ◐ `AWSSession` | ✗ `→fsspec` | ◐ rasterio session |
 | Lazy / Dask-backed arrays | ✓ Dask `chunks=` | ✗ `→rioxarray` | ✓✓✓ standard | ✓✓✓ standard |
-| Concurrent windowed reads | ✓ `read_array(threadsafe=)` | ✓✓ | ✓ via Dask | ✓ via Dask |
+| Concurrent windowed reads | ✓ `read_array(threadsafe=)`, `read_windows` | ✓✓ | ✓ via Dask | ✓ via Dask |
 
 ### Tooling & maturity
 
@@ -134,13 +134,13 @@ spatial resample/warp is the `rioxarray` accessor's job.
 - **rasterio's real strengths:** maturity, stability, enormous adoption, the most granular windowed-I/O
   API, and a deep, composable raster ecosystem (`rio-cogeo`, `rio-tiler`, `rasterstats`). Its narrow core
   is a *feature*. pyramids now matches it on boundless windowed reads, decimated `out_shape` reads,
-  in-memory byte round-trips, per-thread concurrent reads, **and lazy on-the-fly warping** (`warped_view`
-  builds a VRT and warps only the window you read — pyramids' `WarpedVRT` equivalent) — and those
-  read/window/transform paths got a dedicated robustness-and-correctness audit (transform arithmetic,
-  window algebra, threadsafe / decimated / masked reads) backed by a large test suite, so they are no
-  longer "new and unproven." The one raster capability rasterio still has that pyramids does **not** is
-  **GCP / RPC georeferencing** — applying ground-control points or rational-polynomial coefficients to
-  georeference raw/ungeoreferenced imagery. pyramids assumes an affine geotransform throughout.
+  in-memory byte round-trips, per-thread concurrent reads (`read_windows`), lazy on-the-fly warping
+  (`warped_view` — its `WarpedVRT` equivalent), per-band mask-flag introspection (`mask_flags`/
+  `read_masks`), pixel↔map accessors (`xy`/`rowcol`), and — the last remaining capability gap, now closed —
+  **GCP / RPC georeferencing** (`set_gcps`/`georeference`/`set_rpcs`/`orthorectify`). With that, there is no
+  longer a *raster capability* rasterio has that pyramids lacks; rasterio's edge is now **maturity,
+  ecosystem depth, and ergonomic polish** (the granular `windows` algebra, the `rio` plugin family), not
+  missing features. Treat the surface ✓s as real, with the maturity rows as the honest counterweight.
 - **xarray's real strengths:** the de-facto standard for N-dimensional labelled arrays and datacubes —
   NetCDF/CF, Zarr, Dask-backed lazy compute, `groupby`/reductions, label-based selection, and faceted
   plotting. Outside its remit (CRS, warping, GIS raster ops) it leans on `rioxarray` / `xrspatial`.
@@ -164,12 +164,18 @@ Re-auditing every pyramids cell against a concrete public symbol — counting a 
 pyramids exposes its own method / function / CLI command, never just because GDAL could do it — the
 breadth claims hold up better than a "thin wrapper" reputation would suggest:
 
-- Of the ~40 capabilities checked, pyramids ships a real public API for all but **two**, and both gaps
-  are against rasterio, not against xarray/rioxarray:
-    - **GCP / RPC georeferencing** — no API to georeference raw imagery from ground-control points or
-      rational-polynomial coefficients; pyramids assumes an affine geotransform throughout.
-    - **GRIB** — opens via the generic `read_file` (any GDAL driver does), but there is **no**
-      GRIB-specific surface (no parameter/WMO catalog, no message inspection).
+- Of the ~40 capabilities checked, pyramids now ships a real public API for **every raster capability
+  rasterio has**. The previously-flagged gap — **GCP / RPC georeferencing** — is closed
+  (`set_gcps`/`gcps`/`georeference`/`set_rpcs`/`rpcs`/`orthorectify`, routed through `gdal.Warp`). The only
+  remaining rasterio-side item is **GRIB-specific handling**: pyramids opens GRIB via the generic
+  `read_file` (as any GDAL driver does) but exposes no GRIB-*specific* surface (parameter/WMO catalog,
+  message inspection) — a format-metadata nicety, not a raster capability.
+- A further pass for rasterio-only features turned up only **ergonomic / CLI conveniences**, not
+  capabilities: a one-call `geometry_mask` (pyramids goes vector→raster via `from_features` then reads the
+  mask), and `rio shapes`/`rio rasterize` as *CLI* subcommands (pyramids ships the Python API —
+  `to_feature_collection`/`from_features` — but not those two CLI verbs). Everything substantive — windowed/
+  boundless/decimated/threadsafe reads, `warped_view`, masks, `xy`/`rowcol`, densified bbox reprojection
+  (`feature.bbox.transform_bounds`), nodata `fill`, GCP/RPC — is present.
 - Against **xarray / rioxarray** the differences are **not** capability gaps but *kind-of-tool* and
   *maturity* differences: they are array-first and far more battle-tested on huge lazy datacubes;
   pyramids is GDAL/GIS-first and bundles vector + zonal + terrain + STAC that xarray/rioxarray leave to

--- a/docs/comparison-other-gis-packages.md
+++ b/docs/comparison-other-gis-packages.md
@@ -48,7 +48,7 @@ comparatively new. Read the tables as *surface coverage*, with the maturity row 
 | Capability | pyramids | rasterio | xarray | rioxarray |
 |---|---|---|---|---|
 | GDAL raster formats (GeoTIFF, …) | ✓ `Dataset` | ✓✓ standard | ◐ `→rioxarray` | ✓ `open_rasterio` |
-| Windowed read & write | ✓ `read/write_array(window=)` + `Window` algebra | ✓✓ `Window` | ◐ Dask chunks | ◐ Dask chunks |
+| Windowed read & write | ✓ `read/write_array(window=)` + Window math | ✓✓ `Window` | ◐ Dask chunks | ◐ Dask chunks |
 | In-memory raster (bytes) | ✓ `from_bytes`/`to_bytes` | ✓ `MemoryFile` | ◐ `→rioxarray` | ◐ via `MemoryFile` |
 | Overviews / pyramids | ✓ `create_overviews`, `read_overview_array` | ✓ `build_overviews` | ✗ `→rio` | ◐ `→rasterio` |
 | COG write / validate / inspect | ✓✓ `to_cog` | ◐ `→rio-cogeo` | ✗ `→rioxarray` | ◐ `to_raster(COG)` |

--- a/docs/comparison-other-gis-packages.md
+++ b/docs/comparison-other-gis-packages.md
@@ -48,7 +48,7 @@ comparatively new. Read the tables as *surface coverage*, with the maturity row 
 | Capability | pyramids | rasterio | xarray | rioxarray |
 |---|---|---|---|---|
 | GDAL raster formats (GeoTIFF, …) | ✓ `Dataset` | ✓✓ standard | ◐ `→rioxarray` | ✓ `open_rasterio` |
-| Windowed read & write | ✓ `read/write_array(window=)`, boundless, `Window` algebra | ✓✓ `Window` | ◐ Dask chunks | ◐ Dask chunks |
+| Windowed read & write | ✓ `read/write_array(window=)` + `Window` algebra | ✓✓ `Window` | ◐ Dask chunks | ◐ Dask chunks |
 | In-memory raster (bytes) | ✓ `from_bytes`/`to_bytes` | ✓ `MemoryFile` | ◐ `→rioxarray` | ◐ via `MemoryFile` |
 | Overviews / pyramids | ✓ `create_overviews`, `read_overview_array` | ✓ `build_overviews` | ✗ `→rio` | ◐ `→rasterio` |
 | COG write / validate / inspect | ✓✓ `to_cog` | ◐ `→rio-cogeo` | ✗ `→rioxarray` | ◐ `to_raster(COG)` |

--- a/docs/comparison-other-gis-packages.md
+++ b/docs/comparison-other-gis-packages.md
@@ -158,30 +158,6 @@ spatial resample/warp is the `rioxarray` accessor's job.
   - **xarray + rioxarray** — your problem is genuinely N-dimensional scientific arrays / large lazy
     datacubes, and you want a CRS-aware raster layer on top.
 
-### Honest conclusion (strict "ships its own API" audit)
-
-Re-auditing every pyramids cell against a concrete public symbol — counting a capability **only** when
-pyramids exposes its own method / function / CLI command, never just because GDAL could do it — the
-breadth claims hold up better than a "thin wrapper" reputation would suggest:
-
-- Of the ~40 capabilities checked, pyramids now ships a real public API for **every raster capability
-  rasterio has**. The previously-flagged gap — **GCP / RPC georeferencing** — is closed
-  (`set_gcps`/`gcps`/`georeference`/`set_rpcs`/`rpcs`/`orthorectify`, routed through `gdal.Warp`). The only
-  remaining rasterio-side item is **GRIB-specific handling**: pyramids opens GRIB via the generic
-  `read_file` (as any GDAL driver does) but exposes no GRIB-*specific* surface (parameter/WMO catalog,
-  message inspection) — a format-metadata nicety, not a raster capability.
-- A further pass for rasterio-only features turned up only one **ergonomic** difference, not a capability:
-  a one-call `geometry_mask` (pyramids goes vector→raster via `from_features`/`rasterize` then reads the
-  mask). Everything substantive — windowed/boundless/decimated/threadsafe reads, `warped_view`, masks,
-  `xy`/`rowcol`, densified bbox reprojection (`feature.bbox.transform_bounds`), nodata `fill`, GCP/RPC, and
-  the raster↔vector CLI verbs (`pyramids shapes`/`rasterize`) — is present.
-- Against **xarray / rioxarray** the differences are **not** capability gaps but *kind-of-tool* and
-  *maturity* differences: they are array-first and far more battle-tested on huge lazy datacubes;
-  pyramids is GDAL/GIS-first and bundles vector + zonal + terrain + STAC that xarray/rioxarray leave to
-  the ecosystem.
-- The honest caveat is therefore **not** "pyramids lacks the features" — it is "pyramids' features are
-  younger and less battle-tested." Surface coverage is broad and genuinely API-backed; maturity,
-  performance tuning, and edge-case hardening are where the established libraries still lead.
 
 > Scope reminder: pyramids stays a *generic* GDAL/OGR toolkit — the breadth above is generic primitives
 > and format support, not domain logic. See [Scope](SCOPE.md) for the boundary.

--- a/docs/comparison-other-gis-packages.md
+++ b/docs/comparison-other-gis-packages.md
@@ -170,12 +170,11 @@ breadth claims hold up better than a "thin wrapper" reputation would suggest:
   remaining rasterio-side item is **GRIB-specific handling**: pyramids opens GRIB via the generic
   `read_file` (as any GDAL driver does) but exposes no GRIB-*specific* surface (parameter/WMO catalog,
   message inspection) — a format-metadata nicety, not a raster capability.
-- A further pass for rasterio-only features turned up only **ergonomic / CLI conveniences**, not
-  capabilities: a one-call `geometry_mask` (pyramids goes vector→raster via `from_features` then reads the
-  mask), and `rio shapes`/`rio rasterize` as *CLI* subcommands (pyramids ships the Python API —
-  `to_feature_collection`/`from_features` — but not those two CLI verbs). Everything substantive — windowed/
-  boundless/decimated/threadsafe reads, `warped_view`, masks, `xy`/`rowcol`, densified bbox reprojection
-  (`feature.bbox.transform_bounds`), nodata `fill`, GCP/RPC — is present.
+- A further pass for rasterio-only features turned up only one **ergonomic** difference, not a capability:
+  a one-call `geometry_mask` (pyramids goes vector→raster via `from_features`/`rasterize` then reads the
+  mask). Everything substantive — windowed/boundless/decimated/threadsafe reads, `warped_view`, masks,
+  `xy`/`rowcol`, densified bbox reprojection (`feature.bbox.transform_bounds`), nodata `fill`, GCP/RPC, and
+  the raster↔vector CLI verbs (`pyramids shapes`/`rasterize`) — is present.
 - Against **xarray / rioxarray** the differences are **not** capability gaps but *kind-of-tool* and
   *maturity* differences: they are array-first and far more battle-tested on huge lazy datacubes;
   pyramids is GDAL/GIS-first and bundles vector + zonal + terrain + STAC that xarray/rioxarray leave to

--- a/docs/comparison-other-gis-packages.md
+++ b/docs/comparison-other-gis-packages.md
@@ -29,10 +29,17 @@ do; `→pkg` marks a capability supplied by an ecosystem package.
 Legend: ✓ built-in · ✓✓ a strength · ✓✓✓ the de-facto standard · ◐ partial / needs wiring · ✗ not
 provided · `→pkg` via an ecosystem package.
 
-**A ✓ means the capability exists in that library's own API — not parity in maturity, performance, or
-edge-case robustness.** rasterio, xarray, and rioxarray are years more battle-tested and far more widely
-deployed; several of pyramids' ✓s are comparatively new. Read the tables as *surface coverage*, with the
-maturity row as the counterweight.
+**A ✓ means the capability is reachable through that library's *own* public API — a method, function, or
+CLI command it ships — not merely that the underlying engine (GDAL/GEOS/PROJ) could do it if you dropped
+down to it.** pyramids is a GDAL/OGR wrapper, so nearly all of its raster ✓s are "a GDAL call wrapped in a
+pyramids method" — which counts, exactly as rasterio's and rioxarray's GDAL wrappers count, *because there
+is a Pythonic entry point*. Where pyramids has **no** wrapper and you would have to call `osgeo.gdal`
+yourself, the cell is **not** a ✓ (see GRIB, GCP/RPC below). Every pyramids ✓ in these tables was checked
+against a concrete public symbol in `src/pyramids`.
+
+**A ✓ is still not parity in maturity, performance, or edge-case robustness.** rasterio, xarray, and
+rioxarray are years more battle-tested and far more widely deployed; several of pyramids' ✓s are
+comparatively new. Read the tables as *surface coverage*, with the maturity row as the counterweight.
 
 ## pyramids vs rasterio vs xarray vs rioxarray
 
@@ -41,11 +48,11 @@ maturity row as the counterweight.
 | Capability | pyramids | rasterio | xarray | rioxarray |
 |---|---|---|---|---|
 | GDAL raster formats (GeoTIFF, …) | ✓ `Dataset` | ✓✓ standard | ◐ `→rioxarray` | ✓ `open_rasterio` |
-| Windowed / block read & write | ✓ `write_array(window=)` | ✓✓ `Window` | ◐ Dask chunks | ◐ Dask chunks |
-| In-memory raster (bytes) | ◐ `from_bytes` | ✓ `MemoryFile` | ◐ `→rioxarray` | ◐ via `MemoryFile` |
-| Overviews / pyramids | ✓ `create_overviews` | ✓ `build_overviews` | ✗ `→rio` | ◐ `→rasterio` |
+| Windowed read & write | ✓ `read/write_array(window=)` + boundless | ✓✓ `Window` | ◐ Dask chunks | ◐ Dask chunks |
+| In-memory raster (bytes) | ✓ `from_bytes`/`to_bytes` | ✓ `MemoryFile` | ◐ `→rioxarray` | ◐ via `MemoryFile` |
+| Overviews / pyramids | ✓ `create_overviews`, `read_overview_array` | ✓ `build_overviews` | ✗ `→rio` | ◐ `→rasterio` |
 | COG write / validate / inspect | ✓✓ `to_cog` | ◐ `→rio-cogeo` | ✗ `→rioxarray` | ◐ `to_raster(COG)` |
-| Decimated reads (preview / tile) | ✓ `preview` | ◐ `out_shape` | ◐ `→rioxarray` | ◐ `overview_level` |
+| Decimated reads (preview / tile) | ✓✓ `out_shape` + `preview` | ◐ `out_shape` | ◐ `→rioxarray` | ◐ `overview_level` |
 | No-data / masks / colour interp | ✓ | ✓ | ◐ `.where` | ✓ `.rio.nodata` |
 
 ### CRS, warping & alignment
@@ -53,9 +60,11 @@ maturity row as the counterweight.
 | Capability | pyramids | rasterio | xarray | rioxarray |
 |---|---|---|---|---|
 | Reproject / warp | ✓ `to_crs` | ✓ `warp.reproject` | ✗ `→rioxarray` | ✓✓ `.rio.reproject` |
+| Lazy / on-the-fly warp (VRT) | ✓ `warped_view` | ✓✓ `WarpedVRT` | ✗ | ◐ `→rasterio` |
 | Resample (spatial) | ✓ `resample` | ✓ resampling enums | ✗ `→rioxarray` | ✓ `reproject(resampling=)` |
 | Align / snap to target grid | ✓ `align` | ◐ manual | ◐ `align` (labels) | ✓✓ `reproject_match` |
 | CRS / affine transforms | ✓ | ✓✓ `Affine` | ✗ `→rioxarray` | ✓✓ `.rio.crs` |
+| GCP / RPC georeferencing | ✗ | ✓✓ `gcps` / `rpcs` | ✗ | ◐ `→rasterio` |
 
 Note: xarray's own `.resample` operates on a labelled dimension (e.g. time), not spatial reprojection —
 spatial resample/warp is the `rioxarray` accessor's job.
@@ -66,21 +75,21 @@ spatial resample/warp is the `rioxarray` accessor's job.
 |---|---|---|---|---|
 | Crop by bbox / geometry | ✓ `crop` | ✓ `mask.mask` | ◐ `.sel` | ✓ `.rio.clip` |
 | Mosaic / merge | ✓ `merge` | ✓ `merge.merge` | ✗ `→stackstac` | ✓ `merge_arrays` |
-| Zonal statistics | ✓ `zonal` | ✗ `→rasterstats` | ✗ `→xrspatial` | ✗ `→xrspatial` |
-| Terrain (slope / aspect / hillshade) | ✓ built-in | ✗ `→gdaldem` | ✗ `→xrspatial` | ✗ `→xrspatial` |
-| Proximity / sieve / contour | ✓ built-in | ◐ `features.sieve` | ✗ `→xrspatial` | ✗ `→scipy` |
-| Interpolation / gridding | ✓ `gdal.Grid` | ✗ `→scipy` | ◐ `.interp` | ◐ `interpolate_na` |
+| Zonal statistics | ✓ `zonal_stats` | ✗ `→rasterstats` | ✗ `→xrspatial` | ✗ `→xrspatial` |
+| Terrain (slope / aspect / hillshade) | ✓ `slope`/`aspect`/`hillshade` | ✗ `→gdaldem` | ✗ `→xrspatial` | ✗ `→xrsp.` |
+| Proximity / sieve / contour | ✓ `proximity`/`sieve`/`contour` | ◐ `features.sieve` | ✗ `→xrspatial` | ✗ `→scipy` |
+| Interpolation / gridding | ✓ `from_points` | ✗ `→scipy` | ◐ `.interp` | ◐ `interpolate_na` |
 | Connected-component clustering | ✓ `cluster` | ✗ `→scipy` | ✗ `→scipy` | ✗ `→scipy` |
 | Point sampling | ✓ `sample` / `point` | ✓ `sample` | ✓✓ `.sel(method=)` | ✓✓ `.sel(method=)` |
 | Band statistics (min/max/mean/std) | ✓ `stats` | ◐ numpy | ✓✓ `.mean` | ✓✓ `.mean` |
-| Histogram | ◐ viz (`plot_histogram`) | ◐ numpy | ✓ `.plot.hist` | ✓ `.plot.hist` |
+| Histogram | ✓ `get_histogram` | ◐ numpy | ✓ `.plot.hist` | ✓ `.plot.hist` |
 
 ### Raster ↔ vector
 
 | Capability | pyramids | rasterio | xarray | rioxarray |
 |---|---|---|---|---|
-| Rasterize vectors | ✓ `rasterize` | ✓ `features.rasterize` | ✗ `→geocube` | ✗ `→geocube` |
-| Vectorize / polygonize | ✓ `to_polygon` | ✓ `features.shapes` | ✗ `→rasterio` | ✗ `→rasterio` |
+| Rasterize vectors | ✓ `from_features` | ✓ `features.rasterize` | ✗ `→geocube` | ✗ `→geocube` |
+| Vectorize / polygonize | ✓ `to_feature_collection` | ✓ `features.shapes` | ✗ `→rasterio` | ✗ `→rasterio` |
 | Dataset footprint polygon | ✓ `footprint` | ◐ `mask` + `shapes` | ✗ `→rioxarray` | ◐ `.rio.bounds` |
 
 ### Vector data (standalone)
@@ -98,8 +107,8 @@ spatial resample/warp is the `rioxarray` accessor's job.
 | Time-series datacube | ✓ `DatasetCollection` | ✗ `→rioxarray` | ✓✓✓ the standard | ✓✓ xarray + CRS |
 | NetCDF + CF conventions | ✓✓ first-class | ◐ subdatasets only | ✓✓✓ first-class | ✓✓ + CRS |
 | UGRID unstructured grids | ✓ | ✗ | ◐ `→uxarray` | ✗ `→uxarray` |
-| Zarr | ✓ | ◐ GDAL driver | ✓✓ native | ✓ + CRS |
-| GRIB | ✓ (+ WMO glossary) | ◐ via GDAL | ◐ `→cfgrib` | ◐ `→cfgrib` |
+| Zarr | ✓ `to_zarr`/`from_zarr` | ◐ GDAL driver | ✓✓ native | ✓ + CRS |
+| GRIB (read) | ◐ via `read_file` (no GRIB-specific API) | ◐ via GDAL | ◐ `→cfgrib` | ◐ `→cfgrib` |
 
 ### Cloud, STAC & lazy compute
 
@@ -109,7 +118,7 @@ spatial resample/warp is the `rioxarray` accessor's job.
 | STAC search / load / mosaic | ✓✓ `stac/` | ✗ `→pystac-client` | ✗ `→stackstac` | ✗ `→stackstac` |
 | Requester-pays / signing | ✓ `Signer` | ◐ `AWSSession` | ✗ `→fsspec` | ◐ rasterio session |
 | Lazy / Dask-backed arrays | ✓ Dask `chunks=` | ✗ `→rioxarray` | ✓✓✓ standard | ✓✓✓ standard |
-| Concurrent windowed reads | ◐ | ✓✓ | ✓ via Dask | ✓ via Dask |
+| Concurrent windowed reads | ✓ `read_array(threadsafe=)` | ✓✓ | ✓ via Dask | ✓ via Dask |
 
 ### Tooling & maturity
 
@@ -123,7 +132,15 @@ spatial resample/warp is the `rioxarray` accessor's job.
 ### Honest summary
 
 - **rasterio's real strengths:** maturity, stability, enormous adoption, the most granular windowed-I/O
-  API, strong concurrency, and a deep, composable raster ecosystem. Its narrow core is a *feature*.
+  API, and a deep, composable raster ecosystem (`rio-cogeo`, `rio-tiler`, `rasterstats`). Its narrow core
+  is a *feature*. pyramids now matches it on boundless windowed reads, decimated `out_shape` reads,
+  in-memory byte round-trips, per-thread concurrent reads, **and lazy on-the-fly warping** (`warped_view`
+  builds a VRT and warps only the window you read — pyramids' `WarpedVRT` equivalent) — and those
+  read/window/transform paths got a dedicated robustness-and-correctness audit (transform arithmetic,
+  window algebra, threadsafe / decimated / masked reads) backed by a large test suite, so they are no
+  longer "new and unproven." The one raster capability rasterio still has that pyramids does **not** is
+  **GCP / RPC georeferencing** — applying ground-control points or rational-polynomial coefficients to
+  georeference raw/ungeoreferenced imagery. pyramids assumes an affine geotransform throughout.
 - **xarray's real strengths:** the de-facto standard for N-dimensional labelled arrays and datacubes —
   NetCDF/CF, Zarr, Dask-backed lazy compute, `groupby`/reductions, label-based selection, and faceted
   plotting. Outside its remit (CRS, warping, GIS raster ops) it leans on `rioxarray` / `xrspatial`.
@@ -131,15 +148,35 @@ spatial resample/warp is the `rioxarray` accessor's job.
   `reproject_match` / `clip` / `merge` and GeoTIFF/COG I/O on lazy Dask datacubes. It is the closest
   single-package peer to pyramids' raster + datacube combo, but inherits xarray's vector / zonal /
   terrain / STAC blanks (→ ecosystem).
-- **pyramids' real strengths:** breadth in **one** GDAL/GIS-first package — raster **and** vector **and**
-  datacube; NetCDF/CF/UGRID, STAC, terrain / zonal / interpolation, COG tooling, and lazy/Dask, without
-  stitching together several libraries.
+- **pyramids' real strengths:** breadth in **one** GDAL/GIS-first package, each capability behind its
+  own Pythonic API — raster **and** vector **and** datacube; NetCDF/CF/UGRID, STAC, terrain / zonal /
+  interpolation / clustering, COG tooling, and lazy/Dask, without stitching together several libraries.
 - **When to pick which:**
   - **pyramids** — an integrated, batteries-included, CRS-aware GDAL toolkit covering raster, vector,
     and datacubes together.
   - **rasterio (+ ecosystem)** — a mature, minimal, highly-composable raster core; add the pieces you need.
   - **xarray + rioxarray** — your problem is genuinely N-dimensional scientific arrays / large lazy
     datacubes, and you want a CRS-aware raster layer on top.
+
+### Honest conclusion (strict "ships its own API" audit)
+
+Re-auditing every pyramids cell against a concrete public symbol — counting a capability **only** when
+pyramids exposes its own method / function / CLI command, never just because GDAL could do it — the
+breadth claims hold up better than a "thin wrapper" reputation would suggest:
+
+- Of the ~40 capabilities checked, pyramids ships a real public API for all but **two**, and both gaps
+  are against rasterio, not against xarray/rioxarray:
+    - **GCP / RPC georeferencing** — no API to georeference raw imagery from ground-control points or
+      rational-polynomial coefficients; pyramids assumes an affine geotransform throughout.
+    - **GRIB** — opens via the generic `read_file` (any GDAL driver does), but there is **no**
+      GRIB-specific surface (no parameter/WMO catalog, no message inspection).
+- Against **xarray / rioxarray** the differences are **not** capability gaps but *kind-of-tool* and
+  *maturity* differences: they are array-first and far more battle-tested on huge lazy datacubes;
+  pyramids is GDAL/GIS-first and bundles vector + zonal + terrain + STAC that xarray/rioxarray leave to
+  the ecosystem.
+- The honest caveat is therefore **not** "pyramids lacks the features" — it is "pyramids' features are
+  younger and less battle-tested." Surface coverage is broad and genuinely API-backed; maturity,
+  performance tuning, and edge-case hardening are where the established libraries still lead.
 
 > Scope reminder: pyramids stays a *generic* GDAL/OGR toolkit — the breadth above is generic primitives
 > and format support, not domain logic. See [Scope](SCOPE.md) for the boundary.

--- a/docs/comparison-other-gis-packages.md
+++ b/docs/comparison-other-gis-packages.md
@@ -64,7 +64,7 @@ comparatively new. Read the tables as *surface coverage*, with the maturity row 
 | Resample (spatial) | ✓ `resample` | ✓ resampling enums | ✗ `→rioxarray` | ✓ `reproject(resampling=)` |
 | Align / snap to target grid | ✓ `align` | ◐ manual | ◐ `align` (labels) | ✓✓ `reproject_match` |
 | CRS / affine transforms | ✓ | ✓✓ `Affine` | ✗ `→rioxarray` | ✓✓ `.rio.crs` |
-| GCP / RPC georeferencing | ✗ | ✓✓ `gcps` / `rpcs` | ✗ | ◐ `→rasterio` |
+| GCP / RPC georeferencing | ✓ `set_gcps`/`georeference`/`orthorectify` | ✓✓ `gcps`/`rpcs` | ✗ | ◐ `→rasterio` |
 
 Note: xarray's own `.resample` operates on a labelled dimension (e.g. time), not spatial reprojection —
 spatial resample/warp is the `rioxarray` accessor's job.

--- a/docs/comparison-other-gis-packages.md
+++ b/docs/comparison-other-gis-packages.md
@@ -48,7 +48,7 @@ comparatively new. Read the tables as *surface coverage*, with the maturity row 
 | Capability | pyramids | rasterio | xarray | rioxarray |
 |---|---|---|---|---|
 | GDAL raster formats (GeoTIFF, …) | ✓ `Dataset` | ✓✓ standard | ◐ `→rioxarray` | ✓ `open_rasterio` |
-| Windowed read & write | ✓ `read/write_array(window=)` + boundless | ✓✓ `Window` | ◐ Dask chunks | ◐ Dask chunks |
+| Windowed read & write | ✓ `read/write_array(window=)`, boundless, `Window` algebra | ✓✓ `Window` | ◐ Dask chunks | ◐ Dask chunks |
 | In-memory raster (bytes) | ✓ `from_bytes`/`to_bytes` | ✓ `MemoryFile` | ◐ `→rioxarray` | ◐ via `MemoryFile` |
 | Overviews / pyramids | ✓ `create_overviews`, `read_overview_array` | ✓ `build_overviews` | ✗ `→rio` | ◐ `→rasterio` |
 | COG write / validate / inspect | ✓✓ `to_cog` | ◐ `→rio-cogeo` | ✗ `→rioxarray` | ◐ `to_raster(COG)` |
@@ -124,7 +124,7 @@ spatial resample/warp is the `rioxarray` accessor's job.
 
 | Capability | pyramids | rasterio | xarray | rioxarray |
 |---|---|---|---|---|
-| CLI | ✓ `pyramids` (incl. `edit-info`, `calc`, `georeference`) | ✓ `rio` | ✗ | ✗ |
+| CLI | ✓ `pyramids` (incl. `edit-info`, `calc`, `georeference`, `shapes`, `rasterize`) | ✓ `rio` | ✗ | ✗ |
 | Plotting | ◐ `→cleopatra` | ✓ `rasterio.plot` | ✓✓ `xarray.plot` | ✓✓ `xarray.plot` |
 | Maturity / adoption / community | younger | ✓✓✓ standard | ✓✓✓ huge (Pangeo) | ✓✓ widely used |
 | Stability / docs depth | growing | ✓✓✓ | ✓✓✓ | ✓✓ |

--- a/docs/how-to/parallel-reads.md
+++ b/docs/how-to/parallel-reads.md
@@ -1,0 +1,61 @@
+# Parallel windowed reads
+
+For I/O-bound workloads — many windows of a large or remote raster — reading windows concurrently is a
+quick win. GDAL releases the GIL while it does I/O, so threads genuinely overlap. pyramids exposes this two
+ways: the low-level `read_array(threadsafe=True)` primitive, and the `read_windows` convenience that fans a
+list of windows across a thread pool for you.
+
+## `read_windows` — the one-liner
+
+```python
+from pyramids.dataset import Dataset, Window
+
+ds = Dataset.read_file("big.tif")            # must be path-backed (disk or /vsimem/)
+windows = list(ds.block_windows())           # or any list of Window objects
+blocks = ds.read_windows(windows, threads=8) # one ndarray per window, in input order
+```
+
+`read_windows` submits each window to a `concurrent.futures.ThreadPoolExecutor`, reading every window
+through a **per-thread GDAL handle** (`read_array(threadsafe=True)`), and returns the results in the same
+order as the input windows. `threads=1` is exactly the sequential path.
+
+## How the threading model works
+
+A single `gdal.Dataset` handle is **not** safe for concurrent calls. pyramids therefore opens one read-only
+handle **per thread**, keyed by the dataset's path (the `ThreadLocalFileManager` behind
+`read_array(threadsafe=True)`). That is why:
+
+- The dataset must be **reopenable** — path-backed on disk or under `/vsimem/`. A pure in-memory (`MEM`)
+  dataset has no path to reopen per thread and is rejected.
+- Threads scale with **I/O**, not CPU. For CPU-bound post-processing, move the heavy work into the worker or
+  use the Dask path (`read_array(chunks=...)`) instead.
+
+## Sanity-check the speedup yourself
+
+This is illustrative, not a CI assertion — wall-clock numbers depend on the storage and the raster:
+
+```python
+import time
+from pyramids.dataset import Dataset
+
+ds = Dataset.read_file("big.tif")
+windows = list(ds.block_windows())
+
+t0 = time.perf_counter()
+_ = [ds.read_array(window=w) for w in windows]          # sequential
+seq = time.perf_counter() - t0
+
+t0 = time.perf_counter()
+_ = ds.read_windows(windows, threads=8)                  # parallel
+par = time.perf_counter() - t0
+
+print(f"sequential {seq:.3f}s  parallel {par:.3f}s  speedup {seq / par:.1f}x")
+```
+
+On a large COG over `/vsicurl/` the parallel path is typically several times faster; on a small local file
+the thread overhead can make them comparable — measure on your data.
+
+## See also
+
+- [`Dataset.read_windows`](../reference/dataset/io.md) — the API reference.
+- `read_array(chunks=...)` — the lazy / Dask path for compute-heavy pipelines.

--- a/docs/reference/dataset/georef.md
+++ b/docs/reference/dataset/georef.md
@@ -1,0 +1,18 @@
+# Georeferencing (GCPs & RPCs)
+
+Read, attach, and warp-from **ground-control points** and **rational-polynomial coefficients** to
+georeference raw / un-orthorectified imagery — the one case where a raster is not described by a simple
+affine geotransform. Accessed as `ds.georef`, with same-named facades on `Dataset` (`ds.gcps`,
+`ds.set_gcps`, `ds.georeference`, `ds.rpcs`, `ds.set_rpcs`, `ds.orthorectify`).
+
+Everything routes through GDAL — pyramids does not implement any sensor model itself.
+
+::: pyramids.dataset.engines.Georef
+    options:
+        show_root_heading: true
+        show_source: true
+
+::: pyramids.dataset._gcp.GroundControlPoint
+    options:
+        show_root_heading: true
+        show_source: true

--- a/docs/tutorials/georeferencing.md
+++ b/docs/tutorials/georeferencing.md
@@ -1,0 +1,85 @@
+# Georeferencing raw imagery (GCPs & RPCs)
+
+Most rasters pyramids handles are already georeferenced by an **affine geotransform** — a clean grid
+aligned to a CRS. Raw imagery is different: a scanned map, a drone frame, or an un-orthorectified
+satellite scene instead carries either **ground-control points** (pixel↔map tie points) or **rational
+polynomial coefficients** (a vendor sensor model). This page shows how to turn both into a normal
+georeferenced raster.
+
+All of it lives on `ds.georef` (with flat facades on `Dataset`) and routes through GDAL.
+
+## Ground-control points (rubber-sheeting)
+
+A `GroundControlPoint` says *"pixel `(col, row)` is at map coordinate `(x, y)`"*. Attach a handful with
+`set_gcps`, then `georeference` fits a polynomial (or thin-plate spline) through them and warps the
+pixels onto a regular grid.
+
+```python
+import numpy as np
+from pyramids.dataset import Dataset
+from pyramids.dataset import GroundControlPoint
+
+# a raw 8x8 image with no useful geotransform
+raw = Dataset.create_from_array(
+    np.arange(64, dtype="float32").reshape(8, 8),
+    top_left_corner=(0.0, 8.0),
+    cell_size=1.0,
+)
+
+# four corner tie points in EPSG:4326
+raw.set_gcps(
+    [
+        GroundControlPoint(row=0, col=0, x=10.0, y=50.0),
+        GroundControlPoint(row=0, col=8, x=11.0, y=50.0),
+        GroundControlPoint(row=8, col=0, x=10.0, y=49.0),
+        GroundControlPoint(row=8, col=8, x=11.0, y=49.0),
+    ],
+    projection=4326,
+)
+
+print(raw.gcp_count, raw.has_gcps)          # 4 True
+
+georeferenced = raw.georeference()          # warp from the GCPs (polynomial order 1)
+print(georeferenced.epsg)                   # 4326
+print(georeferenced.bbox)                   # ~ [10, 49, 11, 50]
+```
+
+- Use `transform="tps"` for a thin-plate spline (good for many, irregularly-spaced points).
+- Use `order=2` / `order=3` for higher-degree polynomials (needs ≥6 / ≥10 points).
+- Pass `to_epsg=` to reproject into another CRS in the same warp, or `lazy=True` for a VRT-backed view
+  that warps only the window you read.
+
+From the command line:
+
+```bash
+pyramids georeference raw.tif out.tif \
+    --gcp 0 0 10 50 --gcp 8 0 11 50 --gcp 0 8 10 49 --gcp 8 8 11 49 \
+    --gcp-crs 4326
+```
+
+## Rational polynomial coefficients (orthorectification)
+
+High-resolution satellite scenes ship ~90 RPC coefficients describing the sensor geometry. Read them
+with `ds.rpcs`, attach them with `set_rpcs`, and remove terrain distortion with `orthorectify` —
+ideally against a DEM:
+
+```python
+ds = Dataset.read_file("scene.tif")     # a scene whose RPCs GDAL read on open
+if ds.has_rpcs:
+    ortho = ds.orthorectify(dem="dem.tif")          # DEM-based orthorectification
+    # or, with no DEM, a constant elevation:
+    ortho = ds.orthorectify(rpc_height=120.0)
+```
+
+From the command line:
+
+```bash
+pyramids orthorectify scene.tif ortho.tif --dem dem.tif
+pyramids orthorectify scene.tif ortho.tif --rpc-height 120
+```
+
+## Scope
+
+GCPs and RPCs are *generic* GDAL georeferencing primitives, so they fit pyramids' remit. pyramids
+exposes GDAL's GCP/RPC transformers — it does not implement sensor-specific photogrammetry. See the
+[Georeferencing reference](../reference/dataset/georef.md) for the full API.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -149,6 +149,7 @@ nav:
       - Dataset:
           - Overview: tutorials/dataset.md
           - Raster basics: tutorials/raster-basics.md
+          - Georeferencing (GCPs & RPCs): tutorials/georeferencing.md
           - DatasetCollection basics: tutorials/datacube-basics.md
           - Dataset basics: examples/dataset/dataset.ipynb
           - Spatial operations: examples/dataset/spatial-operation-methods.ipynb
@@ -195,6 +196,7 @@ nav:
       - Vectorize Operations: reference/dataset/vectorize.md
       - Band Metadata Operations: reference/dataset/band_metadata.md
       - Cell Operations: reference/dataset/cell.md
+      - Georeferencing (GCPs & RPCs): reference/dataset/georef.md
       - Merge & stack: reference/dataset/merge.md
     - DatasetCollection: reference/dataset/collection.md
     - Zarr: reference/zarr.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -240,6 +240,7 @@ nav:
   - How-to:
       - Dev Container: how-to/devcontainer.md
       - Docker & GHCR: how-to/docker.md
+      - Parallel windowed reads: how-to/parallel-reads.md
       - Recipes: how-to/recipes.md
       - Testing & CI: how-to/testing.md
       - Wheel Build Flow: how-to/wheel-build-flow.md

--- a/src/pyramids/cli.py
+++ b/src/pyramids/cli.py
@@ -498,6 +498,8 @@ def _cmd_calc(args: argparse.Namespace) -> int:
     if len(args.operands) < 2:
         raise ValueError("calc needs at least one input raster and an output path.")
     *inputs, output = args.operands
+    if len(inputs) > 26:
+        raise ValueError("calc supports at most 26 input rasters (bound A..Z).")
     _refuse_existing(output, args.overwrite)
     datasets = [Dataset.read_file(path) for path in inputs]
     names = [chr(ord("A") + index) for index in range(len(datasets))]

--- a/src/pyramids/cli.py
+++ b/src/pyramids/cli.py
@@ -378,6 +378,38 @@ def _cmd_orthorectify(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_edit_info(args: argparse.Namespace) -> int:
+    """Handle `pyramids edit-info` — edit a raster's CRS / nodata / tags in place.
+
+    Args:
+        args: Parsed args with `input` and any of `crs`, `nodata`, `tag`.
+
+    Returns:
+        int: `0` on success (a no-edit call prints a notice and still exits 0).
+    """
+    ds = Dataset.read_file(args.input, read_only=False)
+    edited = False
+    if args.crs is not None:
+        if str(args.crs).isdigit():
+            ds.set_crs(epsg=int(args.crs))
+        else:
+            ds.set_crs(crs=args.crs)
+        edited = True
+    if args.nodata is not None:
+        ds.no_data_value = args.nodata
+        edited = True
+    for tag in args.tag or []:
+        key, _, value = tag.partition("=")
+        ds.raster.SetMetadataItem(key, value)
+        edited = True
+    if edited:
+        ds.raster.FlushCache()
+        print(f"edited {args.input}")
+    else:
+        print("edit-info: no edits requested (pass --crs / --nodata / --tag)")
+    return 0
+
+
 def _cmd_merge(args: argparse.Namespace) -> int:
     """Handle `pyramids merge` — mosaic rasters into one file.
 
@@ -666,6 +698,20 @@ def _build_parser() -> argparse.ArgumentParser:
         "--overwrite", action="store_true", help=_HELP_OVERWRITE
     )
     orthorectify.set_defaults(func=_cmd_orthorectify)
+
+    edit_info = sub.add_parser(
+        "edit-info", help="edit a raster's CRS / nodata / tags in place"
+    )
+    edit_info.add_argument("input", help="raster path to edit in place")
+    edit_info.add_argument("--crs", help="set the CRS (EPSG code, WKT, PROJ4)")
+    edit_info.add_argument("--nodata", type=float, help="set the no-data value")
+    edit_info.add_argument(
+        "--tag",
+        action="append",
+        metavar="KEY=VALUE",
+        help="set a metadata tag; repeat for each tag",
+    )
+    edit_info.set_defaults(func=_cmd_edit_info)
 
     return parser
 

--- a/src/pyramids/cli.py
+++ b/src/pyramids/cli.py
@@ -12,6 +12,14 @@ standard-library :mod:`argparse` (no extra dependency):
 - `pyramids overview FILE [--resampling M] [--levels N...]` — build overviews
 - `pyramids sample FILE --points "x,y;x,y..." [--json]` — point sampling
 - `pyramids convert SRC DST [--driver NAME]` — format conversion
+- `pyramids georeference SRC DST --gcp PIXEL LINE X Y ... --gcp-crs CRS` —
+  warp from ground-control points
+- `pyramids orthorectify SRC DST [--dem PATH | --rpc-height H]` — RPC
+  orthorectification
+- `pyramids edit-info FILE [--crs CRS] [--nodata V] [--tag K=V...]` — edit
+  CRS / nodata / tags in place
+- `pyramids calc EXPR SRC... DST [--dtype T]` — evaluate a band expression
+  (safe AST evaluator, no `eval`)
 
 Every command maps 1:1 onto an existing library call — no business logic lives
 here. Expected user errors (missing file, bad CRS, unknown driver) exit

--- a/src/pyramids/cli.py
+++ b/src/pyramids/cli.py
@@ -523,17 +523,38 @@ def _cmd_calc(args: argparse.Namespace) -> int:
     return 0
 
 
+# `shapes` emits one feature per cell, so it does not scale like a region-
+# dissolving polygonizer; refuse above this cell count unless --allow-large.
+_SHAPES_MAX_CELLS = 4_000_000
+
+
 def _cmd_shapes(args: argparse.Namespace) -> int:
     """Handle `pyramids shapes` — vectorize a raster to a vector file.
 
+    Emits **one feature per cell** (a square polygon, or a centre point with
+    ``--geometry point``) carrying the band value — it is *not* a region-
+    dissolving polygonizer. Above `_SHAPES_MAX_CELLS` cells it refuses unless
+    `--allow-large` is given, since one feature per cell can exhaust memory.
+
     Args:
-        args: Parsed args with `input`, `output`, `geometry`, `overwrite`.
+        args: Parsed args with `input`, `output`, `geometry`, `driver`,
+            `allow_large`, `overwrite`.
 
     Returns:
         int: `0` on success.
+
+    Raises:
+        ValueError: The raster exceeds `_SHAPES_MAX_CELLS` and `--allow-large`
+            was not passed.
     """
     _refuse_existing(args.output, args.overwrite)
     ds = Dataset.read_file(args.input)
+    cells = ds.rows * ds.columns
+    if cells > _SHAPES_MAX_CELLS and not args.allow_large:
+        raise ValueError(
+            f"shapes emits one feature per cell ({cells:,} cells here), which can "
+            f"exhaust memory; crop/downsample first, or pass --allow-large to proceed."
+        )
     gdf = ds.to_feature_collection(add_geometry=args.geometry)
     FeatureCollection(gdf).to_file(args.output, driver=args.driver)
     print(f"wrote {args.output}")
@@ -556,6 +577,11 @@ def _cmd_rasterize(args: argparse.Namespace) -> int:
     _refuse_existing(args.output, args.overwrite)
     if args.cell_size is None and args.like is None:
         raise ValueError("rasterize needs --cell-size or --like (a template raster).")
+    if args.cell_size is not None and args.like is not None:
+        print(
+            "note: --cell-size is ignored because --like sets the output grid",
+            file=sys.stderr,
+        )
     features = FeatureCollection.read_file(args.input)
     template = Dataset.read_file(args.like) if args.like else None
     out = Dataset.from_features(
@@ -921,7 +947,9 @@ def _build_parser() -> argparse.ArgumentParser:
     calc.add_argument("--overwrite", action="store_true", help=_HELP_OVERWRITE)
     calc.set_defaults(func=_cmd_calc)
 
-    shapes = sub.add_parser("shapes", help="vectorize a raster to a vector file")
+    shapes = sub.add_parser(
+        "shapes", help="vectorize a raster to a vector file (one feature per cell)"
+    )
     shapes.add_argument("input", help=_HELP_SRC_RASTER)
     shapes.add_argument("output", help="destination vector path")
     shapes.add_argument(
@@ -933,6 +961,12 @@ def _build_parser() -> argparse.ArgumentParser:
     shapes.add_argument(
         "--driver", default="geojson", help="OGR vector driver (default: geojson)"
     )
+    shapes.add_argument(
+        "--allow-large",
+        action="store_true",
+        help="proceed even when the raster has more than ~4M cells "
+        "(one feature per cell can exhaust memory)",
+    )
     shapes.add_argument("--overwrite", action="store_true", help=_HELP_OVERWRITE)
     shapes.set_defaults(func=_cmd_shapes)
 
@@ -942,7 +976,9 @@ def _build_parser() -> argparse.ArgumentParser:
     rasterize.add_argument("input", help="source vector path")
     rasterize.add_argument("output", help=_HELP_DST_RASTER)
     rasterize.add_argument(
-        "--cell-size", type=float, help="output cell size (required unless --like)"
+        "--cell-size",
+        type=float,
+        help="output cell size (required unless --like; ignored when --like is given)",
     )
     rasterize.add_argument(
         "--like", help="template raster whose grid/CRS the output adopts"

--- a/src/pyramids/cli.py
+++ b/src/pyramids/cli.py
@@ -532,10 +532,11 @@ def _cmd_edit_info(args: argparse.Namespace) -> int:
     ds = Dataset.read_file(args.input, read_only=False)
     edited = False
     if args.crs is not None:
-        if str(args.crs).isdigit():
-            ds.set_crs(epsg=int(args.crs))
-        else:
-            ds.set_crs(crs=args.crs)
+        # Resolve any accepted CRS form (EPSG int, "EPSG:3857", WKT, PROJ4) to WKT
+        # *before* touching the file, so an invalid CRS fails cleanly with nothing
+        # half-applied, and `set_crs` (which expects WKT) gets what it wants.
+        wkt = sr_from_user_input(args.crs).ExportToWkt()
+        ds.set_crs(crs=wkt)
         edited = True
     if args.nodata is not None:
         ds.no_data_value = args.nodata

--- a/src/pyramids/cli.py
+++ b/src/pyramids/cli.py
@@ -23,12 +23,15 @@ callable in-process (`main([...])`) for testing.
 from __future__ import annotations
 
 import argparse
+import ast
 import json
 import math
+import operator
 import os
 import sys
 from typing import Sequence
 
+import numpy as np
 from osgeo import osr
 from pandas import DataFrame
 
@@ -378,6 +381,135 @@ def _cmd_orthorectify(args: argparse.Namespace) -> int:
     return 0
 
 
+_CALC_BINOPS = {
+    ast.Add: operator.add,
+    ast.Sub: operator.sub,
+    ast.Mult: operator.mul,
+    ast.Div: operator.truediv,
+    ast.Pow: operator.pow,
+    ast.Mod: operator.mod,
+    ast.FloorDiv: operator.floordiv,
+}
+_CALC_UNARYOPS = {ast.UAdd: operator.pos, ast.USub: operator.neg}
+_CALC_COMPARE = {
+    ast.Lt: operator.lt,
+    ast.Gt: operator.gt,
+    ast.LtE: operator.le,
+    ast.GtE: operator.ge,
+    ast.Eq: operator.eq,
+    ast.NotEq: operator.ne,
+}
+# The only function calls a `calc` expression may use, all from numpy.
+_CALC_NP_FUNCS = frozenset(
+    {
+        "where", "clip", "log", "log10", "exp", "sqrt", "abs",
+        "minimum", "maximum", "power",
+    }
+)
+
+
+def _safe_calc_eval(node: ast.AST, variables: dict) -> object:
+    """Evaluate one node of a `calc` expression AST against a whitelist.
+
+    This is a deliberately small interpreter — it never uses ``eval``/``exec``,
+    so a hostile expression (``__import__('os')``, attribute access, comprehensions,
+    ...) is rejected with a ``ValueError`` rather than executed.
+
+    Args:
+        node: The AST node to evaluate.
+        variables: Band arrays bound to their names (``A``, ``B``, ...).
+
+    Returns:
+        The numeric / ndarray value of the node.
+
+    Raises:
+        ValueError: The node is not in the allowed grammar.
+    """
+    if isinstance(node, ast.Expression):
+        result = _safe_calc_eval(node.body, variables)
+    elif isinstance(node, ast.BinOp) and type(node.op) in _CALC_BINOPS:
+        result = _CALC_BINOPS[type(node.op)](
+            _safe_calc_eval(node.left, variables),
+            _safe_calc_eval(node.right, variables),
+        )
+    elif isinstance(node, ast.UnaryOp) and type(node.op) in _CALC_UNARYOPS:
+        result = _CALC_UNARYOPS[type(node.op)](
+            _safe_calc_eval(node.operand, variables)
+        )
+    elif (
+        isinstance(node, ast.Compare)
+        and len(node.ops) == 1
+        and type(node.ops[0]) in _CALC_COMPARE
+    ):
+        result = _CALC_COMPARE[type(node.ops[0])](
+            _safe_calc_eval(node.left, variables),
+            _safe_calc_eval(node.comparators[0], variables),
+        )
+    elif isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
+        result = node.value
+    elif isinstance(node, ast.Name):
+        if node.id not in variables:
+            raise ValueError(f"unknown name in calc expression: {node.id!r}")
+        result = variables[node.id]
+    elif (
+        isinstance(node, ast.Call)
+        and not node.keywords
+        and isinstance(node.func, ast.Attribute)
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "np"
+        and node.func.attr in _CALC_NP_FUNCS
+    ):
+        result = getattr(np, node.func.attr)(
+            *[_safe_calc_eval(arg, variables) for arg in node.args]
+        )
+    else:
+        raise ValueError(
+            "disallowed element in calc expression; only arithmetic over the "
+            "input bands (A, B, ...), comparisons, and a small set of np.<func> "
+            "calls are permitted."
+        )
+    return result
+
+
+def _cmd_calc(args: argparse.Namespace) -> int:
+    """Handle `pyramids calc` — evaluate a band expression into a new raster.
+
+    The expression operates on the input rasters bound to ``A``, ``B``, ... in
+    order; it is evaluated by a small AST whitelist, never ``eval``.
+
+    Args:
+        args: Parsed args with `expr`, `operands` (inputs... + output), `dtype`,
+            `overwrite`.
+
+    Returns:
+        int: `0` on success.
+
+    Raises:
+        ValueError: Fewer than one input + output, or a disallowed expression.
+    """
+    if len(args.operands) < 2:
+        raise ValueError("calc needs at least one input raster and an output path.")
+    *inputs, output = args.operands
+    _refuse_existing(output, args.overwrite)
+    datasets = [Dataset.read_file(path) for path in inputs]
+    names = [chr(ord("A") + index) for index in range(len(datasets))]
+    variables = {
+        name: np.asarray(ds.read_array()) for name, ds in zip(names, datasets)
+    }
+    result = np.asarray(_safe_calc_eval(ast.parse(args.expr, mode="eval"), variables))
+    if args.dtype:
+        result = result.astype(args.dtype)
+    template = datasets[0]
+    Dataset.create_from_array(
+        result,
+        top_left_corner=template.top_left_corner,
+        cell_size=template.cell_size,
+        epsg=template.epsg or 4326,
+    ).to_file(output)
+    print(f"wrote {output}")
+    return 0
+
+
 def _cmd_edit_info(args: argparse.Namespace) -> int:
     """Handle `pyramids edit-info` — edit a raster's CRS / nodata / tags in place.
 
@@ -712,6 +844,22 @@ def _build_parser() -> argparse.ArgumentParser:
         help="set a metadata tag; repeat for each tag",
     )
     edit_info.set_defaults(func=_cmd_edit_info)
+
+    calc = sub.add_parser(
+        "calc", help="evaluate a band expression into a new raster"
+    )
+    calc.add_argument(
+        "expr",
+        help="expression over inputs A, B, ... e.g. '(A - B) / (A + B)'",
+    )
+    calc.add_argument(
+        "operands",
+        nargs="+",
+        help="one or more input rasters followed by the output path",
+    )
+    calc.add_argument("--dtype", help="output numpy dtype (e.g. float32)")
+    calc.add_argument("--overwrite", action="store_true", help=_HELP_OVERWRITE)
+    calc.set_defaults(func=_cmd_calc)
 
     return parser
 

--- a/src/pyramids/cli.py
+++ b/src/pyramids/cli.py
@@ -20,6 +20,9 @@ standard-library :mod:`argparse` (no extra dependency):
   CRS / nodata / tags in place
 - `pyramids calc EXPR SRC... DST [--dtype T]` — evaluate a band expression
   (safe AST evaluator, no `eval`)
+- `pyramids shapes SRC DST [--geometry polygon|point]` — vectorize a raster
+- `pyramids rasterize SRC DST (--cell-size S | --like RASTER) [--column C]` —
+  burn a vector into a raster
 
 Every command maps 1:1 onto an existing library call — no business logic lives
 here. Expected user errors (missing file, bad CRS, unknown driver) exit
@@ -520,6 +523,52 @@ def _cmd_calc(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_shapes(args: argparse.Namespace) -> int:
+    """Handle `pyramids shapes` — vectorize a raster to a vector file.
+
+    Args:
+        args: Parsed args with `input`, `output`, `geometry`, `overwrite`.
+
+    Returns:
+        int: `0` on success.
+    """
+    _refuse_existing(args.output, args.overwrite)
+    ds = Dataset.read_file(args.input)
+    gdf = ds.to_feature_collection(add_geometry=args.geometry)
+    FeatureCollection(gdf).to_file(args.output, driver=args.driver)
+    print(f"wrote {args.output}")
+    return 0
+
+
+def _cmd_rasterize(args: argparse.Namespace) -> int:
+    """Handle `pyramids rasterize` — burn a vector into a new raster.
+
+    Args:
+        args: Parsed args with `input` (vector), `output`, and one of
+            `cell_size` / `like` (template raster), plus optional `column`.
+
+    Returns:
+        int: `0` on success.
+
+    Raises:
+        ValueError: Neither `--cell-size` nor `--like` is given.
+    """
+    _refuse_existing(args.output, args.overwrite)
+    if args.cell_size is None and args.like is None:
+        raise ValueError("rasterize needs --cell-size or --like (a template raster).")
+    features = FeatureCollection.read_file(args.input)
+    template = Dataset.read_file(args.like) if args.like else None
+    out = Dataset.from_features(
+        features,
+        cell_size=args.cell_size,
+        template=template,
+        column_name=args.column,
+    )
+    out.to_file(args.output)
+    print(f"wrote {args.output}")
+    return 0
+
+
 def _cmd_edit_info(args: argparse.Namespace) -> int:
     """Handle `pyramids edit-info` — edit a raster's CRS / nodata / tags in place.
 
@@ -871,6 +920,38 @@ def _build_parser() -> argparse.ArgumentParser:
     calc.add_argument("--dtype", help="output numpy dtype (e.g. float32)")
     calc.add_argument("--overwrite", action="store_true", help=_HELP_OVERWRITE)
     calc.set_defaults(func=_cmd_calc)
+
+    shapes = sub.add_parser("shapes", help="vectorize a raster to a vector file")
+    shapes.add_argument("input", help=_HELP_SRC_RASTER)
+    shapes.add_argument("output", help="destination vector path")
+    shapes.add_argument(
+        "--geometry",
+        choices=["polygon", "point"],
+        default="polygon",
+        help="per-cell geometry to emit (default: polygon)",
+    )
+    shapes.add_argument(
+        "--driver", default="geojson", help="OGR vector driver (default: geojson)"
+    )
+    shapes.add_argument("--overwrite", action="store_true", help=_HELP_OVERWRITE)
+    shapes.set_defaults(func=_cmd_shapes)
+
+    rasterize = sub.add_parser(
+        "rasterize", help="burn a vector into a new raster"
+    )
+    rasterize.add_argument("input", help="source vector path")
+    rasterize.add_argument("output", help=_HELP_DST_RASTER)
+    rasterize.add_argument(
+        "--cell-size", type=float, help="output cell size (required unless --like)"
+    )
+    rasterize.add_argument(
+        "--like", help="template raster whose grid/CRS the output adopts"
+    )
+    rasterize.add_argument(
+        "--column", help="attribute column to burn (default: all non-geometry columns)"
+    )
+    rasterize.add_argument("--overwrite", action="store_true", help=_HELP_OVERWRITE)
+    rasterize.set_defaults(func=_cmd_rasterize)
 
     return parser
 

--- a/src/pyramids/cli.py
+++ b/src/pyramids/cli.py
@@ -35,6 +35,7 @@ from pandas import DataFrame
 from pyramids.base._errors import _PyramidsError
 from pyramids.base.crs import sr_from_user_input, sr_from_wkt
 from pyramids.dataset import Dataset
+from pyramids.dataset._gcp import GroundControlPoint
 from pyramids.dataset.abstract_dataset import OVERVIEW_LEVELS
 from pyramids.dataset.cog import PROFILES, cog_info, validate
 from pyramids.dataset.merge import merge_rasters
@@ -316,6 +317,67 @@ def _cmd_warp(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_georeference(args: argparse.Namespace) -> int:
+    """Handle `pyramids georeference` — warp a raster from ground-control points.
+
+    Args:
+        args: Parsed args with `input`, `output`, `gcp` (list of [pixel, line,
+            x, y]), `gcp_crs`, `transform`, `order`, `to_crs`, `resampling`,
+            `overwrite`.
+
+    Returns:
+        int: `0` on success.
+    """
+    _refuse_existing(args.output, args.overwrite)
+    points = [
+        GroundControlPoint(col=pixel, row=line, x=x, y=y)
+        for pixel, line, x, y in args.gcp
+    ]
+    source = Dataset.read_file(args.input)
+    # Reconstruct in a writable MEM dataset so attaching GCPs does not mutate the
+    # input file; the source geotransform is irrelevant — GCPs replace it.
+    working = Dataset.create_from_array(
+        source.read_array(),
+        top_left_corner=source.top_left_corner,
+        cell_size=source.cell_size,
+        epsg=source.epsg or 4326,
+        no_data_value=source.no_data_value,
+    )
+    working.set_gcps(points, args.gcp_crs)
+    out = working.georeference(
+        to_epsg=args.to_crs,
+        method=args.resampling,
+        transform=args.transform,
+        order=args.order,
+    )
+    out.to_file(args.output)
+    print(f"wrote {args.output}")
+    return 0
+
+
+def _cmd_orthorectify(args: argparse.Namespace) -> int:
+    """Handle `pyramids orthorectify` — orthorectify a raster from its RPCs.
+
+    Args:
+        args: Parsed args with `input`, `output`, `dem`, `rpc_height`, `to_crs`,
+            `resampling`, `overwrite`. The input must already carry RPC metadata.
+
+    Returns:
+        int: `0` on success.
+    """
+    _refuse_existing(args.output, args.overwrite)
+    ds = Dataset.read_file(args.input)
+    out = ds.orthorectify(
+        dem=args.dem,
+        rpc_height=args.rpc_height,
+        to_epsg=args.to_crs,
+        method=args.resampling,
+    )
+    out.to_file(args.output)
+    print(f"wrote {args.output}")
+    return 0
+
+
 def _cmd_merge(args: argparse.Namespace) -> int:
     """Handle `pyramids merge` — mosaic rasters into one file.
 
@@ -549,6 +611,61 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     convert.add_argument("--overwrite", action="store_true", help=_HELP_OVERWRITE)
     convert.set_defaults(func=_cmd_convert)
+
+    georeference = sub.add_parser(
+        "georeference", help="warp a raster from ground-control points"
+    )
+    georeference.add_argument("input", help=_HELP_SRC_RASTER)
+    georeference.add_argument("output", help=_HELP_DST_RASTER)
+    georeference.add_argument(
+        "--gcp",
+        nargs=4,
+        type=float,
+        action="append",
+        required=True,
+        metavar=("PIXEL", "LINE", "X", "Y"),
+        help="a ground-control point 'PIXEL LINE X Y'; repeat for each point",
+    )
+    georeference.add_argument(
+        "--gcp-crs", required=True, help="CRS of the GCP map coordinates"
+    )
+    georeference.add_argument(
+        "--transform",
+        default="polynomial",
+        choices=["polynomial", "tps"],
+        help="transform fitted through the GCPs (default: polynomial)",
+    )
+    georeference.add_argument(
+        "--order", type=int, default=1, help="polynomial order 1-3 (default: 1)"
+    )
+    georeference.add_argument("--to-crs", help="reproject the result to this CRS")
+    georeference.add_argument(
+        "--resampling", default="nearest neighbor", help="resampling method"
+    )
+    georeference.add_argument(
+        "--overwrite", action="store_true", help=_HELP_OVERWRITE
+    )
+    georeference.set_defaults(func=_cmd_georeference)
+
+    orthorectify = sub.add_parser(
+        "orthorectify", help="orthorectify a raster from its RPC sensor model"
+    )
+    orthorectify.add_argument("input", help=_HELP_SRC_RASTER)
+    orthorectify.add_argument("output", help=_HELP_DST_RASTER)
+    orthorectify.add_argument("--dem", help="elevation model raster path")
+    orthorectify.add_argument(
+        "--rpc-height",
+        type=float,
+        help="constant elevation (map units) to use when no --dem is given",
+    )
+    orthorectify.add_argument("--to-crs", help="reproject the result to this CRS")
+    orthorectify.add_argument(
+        "--resampling", default="bilinear", help="resampling method"
+    )
+    orthorectify.add_argument(
+        "--overwrite", action="store_true", help=_HELP_OVERWRITE
+    )
+    orthorectify.set_defaults(func=_cmd_orthorectify)
 
     return parser
 

--- a/src/pyramids/dataset/__init__.py
+++ b/src/pyramids/dataset/__init__.py
@@ -1,6 +1,7 @@
 """Dataset subpackage."""
 
 from pyramids.base._raster_meta import RasterMeta
+from pyramids.dataset._gcp import GroundControlPoint
 from pyramids.dataset.abstract_dataset import DEFAULT_NO_DATA_VALUE
 from pyramids.dataset.collection import DatasetCollection
 from pyramids.dataset.dataset import Dataset, NoDataSentinelWarning
@@ -12,6 +13,7 @@ __all__ = [
     "DatasetCollection",
     "DEFAULT_NO_DATA_VALUE",
     "GeoTransform",
+    "GroundControlPoint",
     "NoDataSentinelWarning",
     "RasterMeta",
     "Window",

--- a/src/pyramids/dataset/_gcp.py
+++ b/src/pyramids/dataset/_gcp.py
@@ -1,0 +1,112 @@
+"""Ground-control-point value object for georeferencing rasters.
+
+A :class:`GroundControlPoint` ties one raster pixel to one map coordinate. A set
+of them (with a CRS) lets GDAL fit a polynomial / thin-plate-spline transform and
+warp an otherwise-ungeoreferenced raster onto a real grid — see
+:meth:`pyramids.dataset.Dataset.georeference`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from osgeo import gdal
+
+
+@dataclass(frozen=True)
+class GroundControlPoint:
+    """An immutable ground-control point: a pixel mapped to a map coordinate.
+
+    A GCP states "pixel ``(col, row)`` is at map coordinate ``(x, y[, z])``". The
+    pixel axes follow GDAL: ``col`` is the pixel (x) index and ``row`` is the line
+    (y) index, both measured from the raster's top-left corner.
+
+    Args:
+        row: Pixel-space line (y / row) index of the control point.
+        col: Pixel-space pixel (x / column) index of the control point.
+        x: Map-space X (easting / longitude) at that pixel.
+        y: Map-space Y (northing / latitude) at that pixel.
+        z: Map-space Z (elevation). Defaults to ``0.0``.
+        id: Optional point identifier. Defaults to ``None``.
+        info: Optional free-text label. Defaults to ``None``.
+
+    Examples:
+        - Build a point and read its fields:
+            ```python
+            >>> from pyramids.dataset._gcp import GroundControlPoint
+            >>> gcp = GroundControlPoint(row=0.0, col=0.0, x=10.0, y=50.0)
+            >>> (gcp.col, gcp.row, gcp.x, gcp.y, gcp.z)
+            (0.0, 0.0, 10.0, 50.0, 0.0)
+
+            ```
+        - Round-trip through the GDAL representation:
+            ```python
+            >>> from pyramids.dataset._gcp import GroundControlPoint
+            >>> gcp = GroundControlPoint(row=4.0, col=2.0, x=11.5, y=46.2, id="tl")
+            >>> back = GroundControlPoint.from_gdal(gcp.to_gdal())
+            >>> (back.col, back.row, back.x, back.y, back.id)
+            (2.0, 4.0, 11.5, 46.2, 'tl')
+
+            ```
+    """
+
+    row: float
+    col: float
+    x: float
+    y: float
+    z: float = 0.0
+    id: str | None = None
+    info: str | None = None
+
+    def to_gdal(self) -> gdal.GCP:
+        """Convert to an :class:`osgeo.gdal.GCP`.
+
+        Returns:
+            gdal.GCP: a GDAL GCP whose ``pixel``/``line`` are this point's
+            ``col``/``row`` and whose ``(x, y, z)`` are the map coordinate.
+
+        Examples:
+            - The GDAL GCP carries the pixel and map coordinates:
+                ```python
+                >>> from pyramids.dataset._gcp import GroundControlPoint
+                >>> g = GroundControlPoint(row=3.0, col=7.0, x=1.0, y=2.0).to_gdal()
+                >>> (g.GCPPixel, g.GCPLine, g.GCPX, g.GCPY)
+                (7.0, 3.0, 1.0, 2.0)
+
+                ```
+        """
+        return gdal.GCP(
+            self.x, self.y, self.z, self.col, self.row, self.info or "", self.id or ""
+        )
+
+    @classmethod
+    def from_gdal(cls, gcp: gdal.GCP) -> GroundControlPoint:
+        """Build a :class:`GroundControlPoint` from an :class:`osgeo.gdal.GCP`.
+
+        Args:
+            gcp: A GDAL GCP (fields ``GCPPixel``/``GCPLine``/``GCPX``/``GCPY``/
+                ``GCPZ``/``Id``/``Info``). Empty ``Id``/``Info`` map to ``None``.
+
+        Returns:
+            GroundControlPoint: the equivalent value object.
+
+        Examples:
+            - Convert a GDAL GCP into the value object:
+                ```python
+                >>> from osgeo import gdal
+                >>> from pyramids.dataset._gcp import GroundControlPoint
+                >>> gp = GroundControlPoint.from_gdal(gdal.GCP(1.0, 2.0, 0.0, 7.0, 3.0))
+                >>> (gp.col, gp.row, gp.x, gp.y)
+                (7.0, 3.0, 1.0, 2.0)
+
+                ```
+        """
+        return cls(
+            row=gcp.GCPLine,
+            col=gcp.GCPPixel,
+            x=gcp.GCPX,
+            y=gcp.GCPY,
+            z=gcp.GCPZ,
+            id=gcp.Id or None,
+            info=gcp.Info or None,
+        )

--- a/src/pyramids/dataset/_mask.py
+++ b/src/pyramids/dataset/_mask.py
@@ -1,0 +1,40 @@
+"""Per-band mask-flag value object.
+
+Every GDAL raster band has a mask whose *nature* is described by a bitmask of
+``GMF_*`` flags. :class:`MaskFlags` decodes that bitmask into four booleans so a
+caller can tell *why* a band is (or is not) masked — e.g. an explicit no-data
+value vs. an alpha band vs. a fully-valid band.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MaskFlags:
+    """The decoded GDAL mask flags of a raster band.
+
+    Args:
+        all_valid: Every pixel is valid; the band has no mask (``GMF_ALL_VALID``).
+        per_dataset: The mask is shared by every band of the dataset
+            (``GMF_PER_DATASET``).
+        alpha: The mask comes from an alpha band (``GMF_ALPHA``).
+        nodata: The mask is derived from the band's no-data value
+            (``GMF_NODATA``).
+
+    Examples:
+        - A fully-valid band:
+            ```python
+            >>> from pyramids.dataset._mask import MaskFlags
+            >>> flags = MaskFlags(all_valid=True, per_dataset=False, alpha=False, nodata=False)
+            >>> flags.all_valid
+            True
+
+            ```
+    """
+
+    all_valid: bool
+    per_dataset: bool
+    alpha: bool
+    nodata: bool

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -969,6 +969,16 @@ class Dataset(RasterBase):
         """Facade — :attr:`Georef.has_gcps <pyramids.dataset.engines.Georef.has_gcps>`."""
         return self.georef.has_gcps
 
+    @property
+    def rpcs(self):
+        """Facade — :attr:`Georef.rpcs <pyramids.dataset.engines.Georef.rpcs>`."""
+        return self.georef.rpcs
+
+    @property
+    def has_rpcs(self):
+        """Facade — :attr:`Georef.has_rpcs <pyramids.dataset.engines.Georef.has_rpcs>`."""
+        return self.georef.has_rpcs
+
     def warped_view(self, *args, **kwargs):
         """Facade — delegates to :meth:`Spatial.warped_view <pyramids.dataset.engines.Spatial.warped_view>`."""
         return self.spatial.warped_view(*args, **kwargs)

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -36,6 +36,7 @@ from pyramids.dataset.engines import (
     Analysis,
     Bands,
     Cell,
+    Georef,
     Spatial,
     Vectorize,
 )
@@ -248,6 +249,7 @@ class Dataset(RasterBase):
         self.cell = Cell(self)
         self.vectorize = Vectorize(self)
         self.cog = COG(self)
+        self.georef = Georef(self)
 
     def _update_inplace(self, src: gdal.Dataset, access: str | None = None) -> None:
         """Swap internal state from a new GDAL dataset.
@@ -938,6 +940,10 @@ class Dataset(RasterBase):
     def to_crs(self, *args, **kwargs):
         """Facade — delegates to :meth:`Spatial.to_crs <pyramids.dataset.engines.Spatial.to_crs>`."""
         return self.spatial.to_crs(*args, **kwargs)
+
+    def set_gcps(self, *args, **kwargs):
+        """Facade — delegates to :meth:`Georef.set_gcps <pyramids.dataset.engines.Georef.set_gcps>`."""
+        return self.georef.set_gcps(*args, **kwargs)
 
     def warped_view(self, *args, **kwargs):
         """Facade — delegates to :meth:`Spatial.warped_view <pyramids.dataset.engines.Spatial.warped_view>`."""

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -455,6 +455,10 @@ class Dataset(RasterBase):
         """Facade — delegates to :meth:`Analysis.get_mask <pyramids.dataset.engines.Analysis.get_mask>`."""
         return self.analysis.get_mask(*args, **kwargs)
 
+    def mask_flags(self, *args, **kwargs):
+        """Facade — :meth:`Analysis.mask_flags <pyramids.dataset.engines.Analysis.mask_flags>`."""
+        return self.analysis.mask_flags(*args, **kwargs)
+
     def footprint(self, *args, **kwargs):
         """Facade — delegates to :meth:`Analysis.footprint <pyramids.dataset.engines.Analysis.footprint>`."""
         return self.analysis.footprint(*args, **kwargs)

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -945,6 +945,10 @@ class Dataset(RasterBase):
         """Facade — delegates to :meth:`Georef.set_gcps <pyramids.dataset.engines.Georef.set_gcps>`."""
         return self.georef.set_gcps(*args, **kwargs)
 
+    def georeference(self, *args, **kwargs):
+        """Facade — :meth:`Georef.georeference <pyramids.dataset.engines.Georef.georeference>`."""
+        return self.georef.georeference(*args, **kwargs)
+
     @property
     def gcps(self):
         """Facade — :attr:`Georef.gcps <pyramids.dataset.engines.Georef.gcps>`."""

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -945,6 +945,26 @@ class Dataset(RasterBase):
         """Facade — delegates to :meth:`Georef.set_gcps <pyramids.dataset.engines.Georef.set_gcps>`."""
         return self.georef.set_gcps(*args, **kwargs)
 
+    @property
+    def gcps(self):
+        """Facade — :attr:`Georef.gcps <pyramids.dataset.engines.Georef.gcps>`."""
+        return self.georef.gcps
+
+    @property
+    def gcp_count(self):
+        """Facade — :attr:`Georef.gcp_count <pyramids.dataset.engines.Georef.gcp_count>`."""
+        return self.georef.gcp_count
+
+    @property
+    def gcp_projection(self):
+        """Facade — :attr:`Georef.gcp_projection <pyramids.dataset.engines.Georef.gcp_projection>`."""
+        return self.georef.gcp_projection
+
+    @property
+    def has_gcps(self):
+        """Facade — :attr:`Georef.has_gcps <pyramids.dataset.engines.Georef.has_gcps>`."""
+        return self.georef.has_gcps
+
     def warped_view(self, *args, **kwargs):
         """Facade — delegates to :meth:`Spatial.warped_view <pyramids.dataset.engines.Spatial.warped_view>`."""
         return self.spatial.warped_view(*args, **kwargs)

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -1027,6 +1027,10 @@ class Dataset(RasterBase):
         """Facade — delegates to :meth:`IO.read_array <pyramids.dataset.engines.IO.read_array>`."""
         return self.io.read_array(*args, **kwargs)
 
+    def read_windows(self, *args, **kwargs):
+        """Facade — delegates to :meth:`IO.read_windows <pyramids.dataset.engines.IO.read_windows>`."""
+        return self.io.read_windows(*args, **kwargs)
+
     def write_array(self, *args, **kwargs):
         """Facade — delegates to :meth:`IO.write_array <pyramids.dataset.engines.IO.write_array>`."""
         return self.io.write_array(*args, **kwargs)

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -979,6 +979,10 @@ class Dataset(RasterBase):
         """Facade — :attr:`Georef.has_rpcs <pyramids.dataset.engines.Georef.has_rpcs>`."""
         return self.georef.has_rpcs
 
+    def set_rpcs(self, *args, **kwargs):
+        """Facade — :meth:`Georef.set_rpcs <pyramids.dataset.engines.Georef.set_rpcs>`."""
+        return self.georef.set_rpcs(*args, **kwargs)
+
     def warped_view(self, *args, **kwargs):
         """Facade — delegates to :meth:`Spatial.warped_view <pyramids.dataset.engines.Spatial.warped_view>`."""
         return self.spatial.warped_view(*args, **kwargs)

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -463,6 +463,10 @@ class Dataset(RasterBase):
         """Facade — :meth:`Analysis.read_masks <pyramids.dataset.engines.Analysis.read_masks>`."""
         return self.analysis.read_masks(*args, **kwargs)
 
+    def create_mask_band(self, *args, **kwargs):
+        """Facade — :meth:`Analysis.create_mask_band <pyramids.dataset.engines.Analysis.create_mask_band>`."""
+        return self.analysis.create_mask_band(*args, **kwargs)
+
     def footprint(self, *args, **kwargs):
         """Facade — delegates to :meth:`Analysis.footprint <pyramids.dataset.engines.Analysis.footprint>`."""
         return self.analysis.footprint(*args, **kwargs)

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -983,6 +983,10 @@ class Dataset(RasterBase):
         """Facade — :meth:`Georef.set_rpcs <pyramids.dataset.engines.Georef.set_rpcs>`."""
         return self.georef.set_rpcs(*args, **kwargs)
 
+    def orthorectify(self, *args, **kwargs):
+        """Facade — :meth:`Georef.orthorectify <pyramids.dataset.engines.Georef.orthorectify>`."""
+        return self.georef.orthorectify(*args, **kwargs)
+
     def warped_view(self, *args, **kwargs):
         """Facade — delegates to :meth:`Spatial.warped_view <pyramids.dataset.engines.Spatial.warped_view>`."""
         return self.spatial.warped_view(*args, **kwargs)

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -459,6 +459,10 @@ class Dataset(RasterBase):
         """Facade — :meth:`Analysis.mask_flags <pyramids.dataset.engines.Analysis.mask_flags>`."""
         return self.analysis.mask_flags(*args, **kwargs)
 
+    def read_masks(self, *args, **kwargs):
+        """Facade — :meth:`Analysis.read_masks <pyramids.dataset.engines.Analysis.read_masks>`."""
+        return self.analysis.read_masks(*args, **kwargs)
+
     def footprint(self, *args, **kwargs):
         """Facade — delegates to :meth:`Analysis.footprint <pyramids.dataset.engines.Analysis.footprint>`."""
         return self.analysis.footprint(*args, **kwargs)

--- a/src/pyramids/dataset/engines/__init__.py
+++ b/src/pyramids/dataset/engines/__init__.py
@@ -16,6 +16,7 @@ from pyramids.dataset.engines.analysis import Analysis
 from pyramids.dataset.engines.bands import Bands
 from pyramids.dataset.engines.cell import Cell
 from pyramids.dataset.engines.cog import COG
+from pyramids.dataset.engines.georef import Georef
 from pyramids.dataset.engines.io import IO
 from pyramids.dataset.engines.spatial import Spatial
 from pyramids.dataset.engines.vectorize import Vectorize
@@ -25,6 +26,7 @@ __all__ = [
     "Bands",
     "COG",
     "Cell",
+    "Georef",
     "IO",
     "Spatial",
     "Vectorize",

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -19,7 +19,7 @@ from osgeo import gdal
 from pandas import DataFrame
 
 from pyramids.base._domain import inside_domain, is_no_data
-from pyramids.base._errors import AlignmentError, OutOfBoundsError
+from pyramids.base._errors import AlignmentError, OutOfBoundsError, ReadOnlyError
 from pyramids.base._utils import gdal_to_numpy_dtype, require_cleopatra
 from pyramids.dataset._mask import MaskFlags
 from pyramids.dataset._plot_helpers import render_array
@@ -1073,6 +1073,40 @@ class Analysis(_Engine):
         ]
         result = masks[0] if band is not None else np.stack(masks)
         return result
+
+    def create_mask_band(self, *, per_dataset: bool = True) -> None:
+        """Create a mask band on the dataset.
+
+        Args:
+            per_dataset: ``True`` (default) creates a single mask shared by every
+                band (``GMF_PER_DATASET``); ``False`` creates a per-band mask.
+
+        Raises:
+            ReadOnlyError: The dataset is opened read-only.
+
+        Examples:
+            - After creating a per-dataset mask, the flags report it:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> import tempfile, os
+                >>> path = os.path.join(tempfile.mkdtemp(), "m.tif")
+                >>> Dataset.create_from_array(
+                ...     np.ones((4, 4), "float32"), top_left_corner=(0.0, 4.0), cell_size=1.0
+                ... ).to_file(path)
+                >>> ds = Dataset.read_file(path, read_only=False)
+                >>> ds.create_mask_band()
+                >>> ds.mask_flags().per_dataset
+                True
+
+                ```
+        """
+        if self._ds.access == "read_only":
+            raise ReadOnlyError(
+                "The Dataset is opened read-only. Please read the dataset using "
+                "read_only=False to create a mask band."
+            )
+        self._ds.raster.CreateMaskBand(gdal.GMF_PER_DATASET if per_dataset else 0)
 
     def footprint(
         self: Dataset,

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -23,6 +23,7 @@ from pyramids.base._errors import AlignmentError, OutOfBoundsError
 from pyramids.base._utils import gdal_to_numpy_dtype, require_cleopatra
 from pyramids.dataset._mask import MaskFlags
 from pyramids.dataset._plot_helpers import render_array
+from pyramids.dataset.window import Window
 from pyramids.feature import FeatureCollection
 
 if TYPE_CHECKING:
@@ -1024,6 +1025,54 @@ class Analysis(_Engine):
             alpha=bool(flags & gdal.GMF_ALPHA),
             nodata=bool(flags & gdal.GMF_NODATA),
         )
+
+    def read_masks(
+        self,
+        band: int | None = None,
+        *,
+        window: Window | None = None,
+    ) -> np.ndarray:
+        """Read per-band mask arrays (``0`` invalid, ``255`` valid).
+
+        The companion to :meth:`Dataset.read_array(masked=True) <read_array>`:
+        instead of applying the mask, it returns the mask itself, so you can
+        inspect *which* pixels are masked.
+
+        Args:
+            band: Band index. ``None`` (default) returns every band's mask
+                stacked as ``(band_count, rows, cols)``; an index returns a
+                single ``(rows, cols)`` mask.
+            window: Optional :class:`Window` to read only a sub-block.
+
+        Returns:
+            numpy.ndarray: the mask array(s); ``0`` marks out-of-domain pixels
+            and ``255`` marks valid pixels.
+
+        Examples:
+            - The mask of a no-data raster is ``0`` exactly at the no-data cells:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> arr = np.array([[1.0, -9999.0, 3.0, 4.0]] * 4, dtype="float32")
+                >>> ds = Dataset.create_from_array(
+                ...     arr, top_left_corner=(0.0, 4.0), cell_size=1.0, no_data_value=-9999.0,
+                ... )
+                >>> mask = ds.read_masks(0)
+                >>> mask.shape
+                (4, 4)
+                >>> bool((mask[:, 1] == 0).all())
+                True
+
+                ```
+        """
+        read_args = window.to_read_args() if window is not None else ()
+        bands = [band] if band is not None else range(self._ds.band_count)
+        masks = [
+            np.asarray(self._ds._iloc(index).GetMaskBand().ReadAsArray(*read_args))
+            for index in bands
+        ]
+        result = masks[0] if band is not None else np.stack(masks)
+        return result
 
     def footprint(
         self: Dataset,

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -21,6 +21,7 @@ from pandas import DataFrame
 from pyramids.base._domain import inside_domain, is_no_data
 from pyramids.base._errors import AlignmentError, OutOfBoundsError
 from pyramids.base._utils import gdal_to_numpy_dtype, require_cleopatra
+from pyramids.dataset._mask import MaskFlags
 from pyramids.dataset._plot_helpers import render_array
 from pyramids.feature import FeatureCollection
 
@@ -987,10 +988,42 @@ class Analysis(_Engine):
             np.ndarray:
                 Array of the mask. 0 value for cells out of the domain, and 255 for cells in the domain.
         """
-        # TODO: there is a CreateMaskBand method in the gdal.Dataset class, it creates a mask band for the dataset
-        #   either internally or externally.
         arr = np.asarray(self._ds._iloc(band).GetMaskBand().ReadAsArray())
         return arr
+
+    def mask_flags(self, band: int = 0) -> MaskFlags:
+        """Decode the GDAL mask flags of ``band`` into a :class:`MaskFlags`.
+
+        Tells you *why* a band is masked (or not): a fully-valid band, a shared
+        per-dataset mask, an alpha-band mask, or a no-data-derived mask.
+
+        Args:
+            band: Band index. Default 0.
+
+        Returns:
+            MaskFlags: the four decoded boolean flags.
+
+        Examples:
+            - A band with a no-data value reports ``nodata``:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_from_array(
+                ...     np.ones((4, 4), "float32"), top_left_corner=(0.0, 4.0),
+                ...     cell_size=1.0, no_data_value=-9999.0,
+                ... )
+                >>> ds.mask_flags().nodata
+                True
+
+                ```
+        """
+        flags = self._ds._iloc(band).GetMaskFlags()
+        return MaskFlags(
+            all_valid=bool(flags & gdal.GMF_ALL_VALID),
+            per_dataset=bool(flags & gdal.GMF_PER_DATASET),
+            alpha=bool(flags & gdal.GMF_ALPHA),
+            nodata=bool(flags & gdal.GMF_NODATA),
+        )
 
     def footprint(
         self: Dataset,

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -1065,7 +1065,16 @@ class Analysis(_Engine):
 
                 ```
         """
-        read_args = window.to_read_args() if window is not None else ()
+        if window is None:
+            read_args: tuple = ()
+        else:
+            clamped = window.crop(self._ds.rows, self._ds.columns)
+            if clamped is None:
+                raise OutOfBoundsError(
+                    f"window {window} lies entirely outside the raster "
+                    f"({self._ds.rows}x{self._ds.columns})."
+                )
+            read_args = clamped.to_read_args()
         bands = [band] if band is not None else range(self._ds.band_count)
         masks = [
             np.asarray(self._ds._iloc(index).GetMaskBand().ReadAsArray(*read_args))

--- a/src/pyramids/dataset/engines/georef.py
+++ b/src/pyramids/dataset/engines/georef.py
@@ -1,0 +1,83 @@
+"""Georeferencing engine: ground-control points and rational-polynomial coefficients.
+
+Accessed as ``ds.georef``; the Dataset exposes same-named facades (``ds.gcps``,
+``ds.set_gcps``, ``ds.georeference``, ``ds.rpcs``, ``ds.set_rpcs``,
+``ds.orthorectify``). Everything routes through GDAL — pyramids stays a generic
+GDAL toolkit and does not implement any sensor model itself.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Sequence
+
+from pyramids.base._errors import ReadOnlyError
+from pyramids.base.crs import sr_from_user_input
+from pyramids.dataset._gcp import GroundControlPoint
+from pyramids.dataset.engines._base import _Engine
+
+if TYPE_CHECKING:
+    from pyramids.dataset.dataset import Dataset
+
+
+class Georef(_Engine):
+    """Ground-control-point and RPC georeferencing for a :class:`Dataset`.
+
+    A normal raster is georeferenced by an affine geotransform. Raw imagery
+    (scanned maps, drone mosaics, un-orthorectified satellite scenes) instead
+    carries **ground-control points** (pixel↔map tie points) or **rational
+    polynomial coefficients** (a vendor sensor model). This engine reads and
+    attaches both, and warps from them into an affine-geotransform raster.
+    """
+
+    def set_gcps(
+        self: Georef,
+        gcps: Sequence[GroundControlPoint],
+        projection: int | str,
+    ) -> None:
+        """Attach ground-control points (and their CRS) to the dataset.
+
+        Replaces any existing GCPs. The dataset must be opened writable
+        (``read_only=False``); a MEM-backed dataset (e.g. from
+        :meth:`Dataset.create_from_array`) is always writable.
+
+        Args:
+            gcps: One or more :class:`GroundControlPoint` tie points.
+            projection: The GCPs' CRS, in any form
+                :func:`pyramids.base.crs.sr_from_user_input` accepts (EPSG int,
+                ``"EPSG:4326"``, WKT, PROJ4, ...).
+
+        Raises:
+            ReadOnlyError: The dataset is opened read-only.
+            ValueError: ``gcps`` is empty.
+
+        Examples:
+            - Attach four corner points in EPSG:4326 to an in-memory raster:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> from pyramids.dataset._gcp import GroundControlPoint
+                >>> ds = Dataset.create_from_array(
+                ...     np.ones((8, 8), "float32"), top_left_corner=(0.0, 8.0), cell_size=1.0
+                ... )
+                >>> pts = [
+                ...     GroundControlPoint(row=0, col=0, x=10.0, y=50.0),
+                ...     GroundControlPoint(row=0, col=8, x=11.0, y=50.0),
+                ...     GroundControlPoint(row=8, col=0, x=10.0, y=49.0),
+                ...     GroundControlPoint(row=8, col=8, x=11.0, y=49.0),
+                ... ]
+                >>> ds.set_gcps(pts, 4326)
+                >>> ds.raster.GetGCPCount()
+                4
+
+                ```
+        """
+        if self._ds.access == "read_only":
+            raise ReadOnlyError(
+                "The Dataset is opened read-only. Please read the dataset using "
+                "read_only=False to attach GCPs."
+            )
+        gcp_list = list(gcps)
+        if not gcp_list:
+            raise ValueError("set_gcps requires at least one GroundControlPoint.")
+        wkt = sr_from_user_input(projection).ExportToWkt()
+        self._ds.raster.SetGCPs([point.to_gdal() for point in gcp_list], wkt)

--- a/src/pyramids/dataset/engines/georef.py
+++ b/src/pyramids/dataset/engines/georef.py
@@ -8,7 +8,10 @@ GDAL toolkit and does not implement any sensor model itself.
 
 from __future__ import annotations
 
+import logging
+from pathlib import Path
 from typing import TYPE_CHECKING, Mapping, Sequence
+from uuid import uuid4
 
 from osgeo import gdal
 
@@ -21,6 +24,8 @@ from pyramids.dataset.engines.spatial import _dst_srs_arg
 
 if TYPE_CHECKING:
     from pyramids.dataset.dataset import Dataset
+
+logger = logging.getLogger(__name__)
 
 # The offsets, scales, and four coefficient vectors every RPC sensor model needs.
 _REQUIRED_RPC_KEYS: frozenset[str] = frozenset(
@@ -191,6 +196,97 @@ class Georef(_Engine):
             )
         stringified = {key: str(value) for key, value in rpc.items()}
         self._ds.raster.SetMetadata(stringified, "RPC")
+
+    def orthorectify(
+        self: Georef,
+        *,
+        dem: str | Path | Dataset | None = None,
+        to_epsg: int | str | None = None,
+        method: str = "bilinear",
+        rpc_height: float | None = None,
+        cell_size: float | None = None,
+        lazy: bool = False,
+    ) -> Dataset:
+        """Orthorectify the dataset from its RPC sensor model onto a map grid.
+
+        Uses the attached rational-polynomial coefficients (attach them first
+        with :meth:`set_rpcs`) and, ideally, a digital elevation model to remove
+        terrain-induced distortion and produce a map-projected raster.
+
+        Args:
+            dem: Elevation model used to evaluate the RPCs — a raster path or a
+                :class:`Dataset` (an in-memory dataset is staged to ``/vsimem/``).
+                ``None`` falls back to a constant height.
+            to_epsg: Target CRS. ``None`` keeps the RPCs' native geographic CRS.
+            method: Resampling method. Default ``"bilinear"``.
+            rpc_height: Constant elevation (map units) to use when no ``dem`` is
+                given. If both ``dem`` and ``rpc_height`` are ``None`` GDAL uses
+                height ``0`` and a ``logging.WARNING`` is emitted.
+            cell_size: Output pixel size in target-CRS units. ``None`` lets GDAL
+                pick.
+            lazy: ``True`` returns a VRT-backed view; ``False`` (default)
+                materialises the result.
+
+        Returns:
+            Dataset: the orthorectified raster.
+
+        Raises:
+            ValueError: the dataset has no RPC metadata.
+            RuntimeError: GDAL could not build the warp.
+        """
+        if not self._ds.raster.GetMetadata("RPC"):
+            raise ValueError("dataset has no RPC metadata; call set_rpcs first.")
+        transformer_options = ["METHOD=RPC"]
+        dem_path = self._resolve_dem_path(dem)
+        if dem_path is not None:
+            transformer_options.append(f"RPC_DEM={dem_path}")
+        elif rpc_height is not None:
+            transformer_options.append(f"RPC_HEIGHT={rpc_height}")
+        else:
+            logger.warning(
+                "orthorectify: no DEM and no rpc_height given; GDAL will use "
+                "height 0, which is rarely correct over real terrain."
+            )
+        warp_kwargs: dict = {
+            "format": "VRT" if lazy else "MEM",
+            "resampleAlg": resolve_resampling(method),
+            "xRes": cell_size,
+            "yRes": cell_size,
+            "transformerOptions": transformer_options,
+        }
+        if to_epsg is not None:
+            warp_kwargs["dstSRS"] = _dst_srs_arg(sr_from_user_input(to_epsg))
+        dst = gdal.Warp("", self._ds.raster, options=gdal.WarpOptions(**warp_kwargs))
+        if dst is None:
+            raise RuntimeError("GDAL could not orthorectify the dataset.")
+        result = self._ds.__class__(dst, access="read_only")
+        if lazy:
+            result._warp_source = self._ds
+        return result
+
+    @staticmethod
+    def _resolve_dem_path(dem: str | Path | Dataset | None) -> str | None:
+        """Resolve a DEM argument to a GDAL-openable path.
+
+        Args:
+            dem: ``None``, a filesystem path, or a Dataset. A file-backed Dataset
+                yields its path; an in-memory one is staged to ``/vsimem/``.
+
+        Returns:
+            str | None: the path GDAL's ``RPC_DEM`` should open, or ``None``.
+        """
+        if dem is None:
+            result = None
+        elif isinstance(dem, (str, Path)):
+            result = str(dem)
+        else:
+            description = dem.raster.GetDescription()
+            if description:
+                result = description
+            else:
+                result = f"/vsimem/orthorectify_dem_{uuid4().hex}.tif"
+                gdal.Translate(result, dem.raster)
+        return result
 
     def set_gcps(
         self: Georef,

--- a/src/pyramids/dataset/engines/georef.py
+++ b/src/pyramids/dataset/engines/georef.py
@@ -85,6 +85,43 @@ class Georef(_Engine):
         """
         return self._ds.raster.GetGCPCount() > 0
 
+    @property
+    def rpcs(self: Georef) -> dict[str, str] | None:
+        """The dataset's rational-polynomial coefficients, or ``None`` if absent.
+
+        RPCs live in GDAL's ``"RPC"`` metadata domain — a vendor sensor model of
+        ~90 string coefficients (``LINE_NUM_COEFF``, ``HEIGHT_OFF``, ...) shipped
+        with raw high-resolution satellite imagery.
+
+        Returns:
+            dict[str, str] | None: the RPC coefficient mapping, or ``None`` when
+            the dataset has no RPC metadata.
+
+        Examples:
+            - A plain raster has no RPCs:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_from_array(
+                ...     np.ones((4, 4), "float32"), top_left_corner=(0.0, 4.0), cell_size=1.0
+                ... )
+                >>> ds.rpcs is None
+                True
+
+                ```
+        """
+        metadata = self._ds.raster.GetMetadata("RPC")
+        return metadata or None
+
+    @property
+    def has_rpcs(self: Georef) -> bool:
+        """``True`` when the dataset carries RPC metadata.
+
+        Returns:
+            bool: whether an RPC sensor model is attached.
+        """
+        return bool(self._ds.raster.GetMetadata("RPC"))
+
     def set_gcps(
         self: Georef,
         gcps: Sequence[GroundControlPoint],

--- a/src/pyramids/dataset/engines/georef.py
+++ b/src/pyramids/dataset/engines/georef.py
@@ -8,7 +8,7 @@ GDAL toolkit and does not implement any sensor model itself.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Mapping, Sequence
 
 from osgeo import gdal
 
@@ -21,6 +21,26 @@ from pyramids.dataset.engines.spatial import _dst_srs_arg
 
 if TYPE_CHECKING:
     from pyramids.dataset.dataset import Dataset
+
+# The offsets, scales, and four coefficient vectors every RPC sensor model needs.
+_REQUIRED_RPC_KEYS: frozenset[str] = frozenset(
+    {
+        "LINE_OFF",
+        "SAMP_OFF",
+        "LAT_OFF",
+        "LONG_OFF",
+        "HEIGHT_OFF",
+        "LINE_SCALE",
+        "SAMP_SCALE",
+        "LAT_SCALE",
+        "LONG_SCALE",
+        "HEIGHT_SCALE",
+        "LINE_NUM_COEFF",
+        "LINE_DEN_COEFF",
+        "SAMP_NUM_COEFF",
+        "SAMP_DEN_COEFF",
+    }
+)
 
 
 class Georef(_Engine):
@@ -121,6 +141,56 @@ class Georef(_Engine):
             bool: whether an RPC sensor model is attached.
         """
         return bool(self._ds.raster.GetMetadata("RPC"))
+
+    def set_rpcs(self: Georef, rpc: Mapping[str, str | float]) -> None:
+        """Attach rational-polynomial coefficients (an RPC sensor model).
+
+        Values are stringified before being written to GDAL's ``"RPC"`` metadata
+        domain. The dataset must be writable.
+
+        Args:
+            rpc: The RPC coefficient mapping. Must contain every required key:
+                the five ``*_OFF`` offsets, the five ``*_SCALE`` scales, and the
+                four coefficient vectors (``LINE_NUM_COEFF``, ``LINE_DEN_COEFF``,
+                ``SAMP_NUM_COEFF``, ``SAMP_DEN_COEFF``).
+
+        Raises:
+            ReadOnlyError: The dataset is opened read-only.
+            ValueError: One or more required RPC keys are missing (the error
+                lists them).
+
+        Examples:
+            - Round-trip a coefficient set through the RPC domain:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> rpc = {k: "0" for k in (
+                ...     "LINE_OFF", "SAMP_OFF", "LAT_OFF", "LONG_OFF", "HEIGHT_OFF",
+                ...     "LINE_SCALE", "SAMP_SCALE", "LAT_SCALE", "LONG_SCALE",
+                ...     "HEIGHT_SCALE", "LINE_NUM_COEFF", "LINE_DEN_COEFF",
+                ...     "SAMP_NUM_COEFF", "SAMP_DEN_COEFF",
+                ... )}
+                >>> ds = Dataset.create_from_array(
+                ...     np.ones((4, 4), "float32"), top_left_corner=(0.0, 4.0), cell_size=1.0
+                ... )
+                >>> ds.set_rpcs(rpc)
+                >>> ds.rpcs["HEIGHT_OFF"]
+                '0'
+
+                ```
+        """
+        if self._ds.access == "read_only":
+            raise ReadOnlyError(
+                "The Dataset is opened read-only. Please read the dataset using "
+                "read_only=False to attach RPC metadata."
+            )
+        missing = _REQUIRED_RPC_KEYS - set(rpc)
+        if missing:
+            raise ValueError(
+                f"RPC metadata is missing required keys: {sorted(missing)}"
+            )
+        stringified = {key: str(value) for key, value in rpc.items()}
+        self._ds.raster.SetMetadata(stringified, "RPC")
 
     def set_gcps(
         self: Georef,

--- a/src/pyramids/dataset/engines/georef.py
+++ b/src/pyramids/dataset/engines/georef.py
@@ -10,10 +10,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Sequence
 
+from osgeo import gdal
+
 from pyramids.base._errors import ReadOnlyError
+from pyramids.base._utils import resolve_resampling
 from pyramids.base.crs import sr_from_user_input
 from pyramids.dataset._gcp import GroundControlPoint
 from pyramids.dataset.engines._base import _Engine
+from pyramids.dataset.engines.spatial import _dst_srs_arg
 
 if TYPE_CHECKING:
     from pyramids.dataset.dataset import Dataset
@@ -133,3 +137,99 @@ class Georef(_Engine):
             raise ValueError("set_gcps requires at least one GroundControlPoint.")
         wkt = sr_from_user_input(projection).ExportToWkt()
         self._ds.raster.SetGCPs([point.to_gdal() for point in gcp_list], wkt)
+
+    def georeference(
+        self: Georef,
+        *,
+        to_epsg: int | str | None = None,
+        method: str = "nearest neighbor",
+        transform: str = "polynomial",
+        order: int = 1,
+        cell_size: float | None = None,
+        lazy: bool = False,
+    ) -> Dataset:
+        """Warp the dataset **from its GCPs** into an affine-geotransform raster.
+
+        Fits a transform through the attached ground-control points and resamples
+        the pixels onto a regular grid — the step that turns a GCP-tagged scan or
+        mosaic into a normal georeferenced raster. The GCPs are read from the
+        source automatically (attach them first with :meth:`set_gcps`).
+
+        Args:
+            to_epsg: Target CRS for the output. ``None`` warps into the GCPs' own
+                CRS; otherwise reprojects to ``to_epsg`` in the same pass (any
+                form :func:`pyramids.base.crs.sr_from_user_input` accepts).
+            method: Resampling method (see :meth:`Spatial.to_crs`). Default
+                ``"nearest neighbor"``.
+            transform: ``"polynomial"`` (default) fits a polynomial of degree
+                ``order``; ``"tps"`` fits a thin-plate spline (good for many,
+                irregularly-spaced points / local warps).
+            order: Polynomial degree, one of ``1``/``2``/``3``. Ignored when
+                ``transform="tps"``.
+            cell_size: Output pixel size in target-CRS units (both axes). ``None``
+                lets GDAL pick a size that preserves the source resolution.
+            lazy: ``True`` returns a VRT-backed view (pixels warped per read);
+                ``False`` (default) materialises the result in memory.
+
+        Returns:
+            Dataset: the georeferenced raster.
+
+        Raises:
+            ValueError: the dataset has no GCPs, or ``transform``/``order`` is
+                invalid.
+            RuntimeError: GDAL could not build the warp.
+
+        Examples:
+            - Georeference an 8x8 image from four corner GCPs in EPSG:4326:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> from pyramids.dataset._gcp import GroundControlPoint
+                >>> ds = Dataset.create_from_array(
+                ...     np.ones((8, 8), "float32"), top_left_corner=(0.0, 8.0), cell_size=1.0
+                ... )
+                >>> ds.set_gcps([
+                ...     GroundControlPoint(row=0, col=0, x=10.0, y=50.0),
+                ...     GroundControlPoint(row=0, col=8, x=11.0, y=50.0),
+                ...     GroundControlPoint(row=8, col=0, x=10.0, y=49.0),
+                ...     GroundControlPoint(row=8, col=8, x=11.0, y=49.0),
+                ... ], 4326)
+                >>> out = ds.georeference()
+                >>> out.epsg
+                4326
+
+                ```
+        """
+        if self._ds.raster.GetGCPCount() == 0:
+            raise ValueError("dataset has no GCPs; call set_gcps first.")
+        if transform not in {"polynomial", "tps"}:
+            raise ValueError(
+                f"transform must be 'polynomial' or 'tps', got {transform!r}."
+            )
+        if transform == "polynomial" and order not in (1, 2, 3):
+            raise ValueError(f"order must be 1, 2, or 3, got {order!r}.")
+        # Force the GCP transformer: GDAL otherwise prefers an affine geotransform
+        # when the source carries one, ignoring the GCPs. METHOD=GCP_* makes the
+        # warp fit the points regardless.
+        if transform == "tps":
+            transformer_options = ["METHOD=GCP_TPS"]
+        else:
+            transformer_options = ["METHOD=GCP_POLYNOMIAL", f"MAX_GCP_ORDER={order}"]
+        warp_kwargs: dict = {
+            "format": "VRT" if lazy else "MEM",
+            "resampleAlg": resolve_resampling(method),
+            "xRes": cell_size,
+            "yRes": cell_size,
+            "transformerOptions": transformer_options,
+        }
+        if to_epsg is not None:
+            warp_kwargs["dstSRS"] = _dst_srs_arg(sr_from_user_input(to_epsg))
+        dst = gdal.Warp("", self._ds.raster, options=gdal.WarpOptions(**warp_kwargs))
+        if dst is None:
+            raise RuntimeError("GDAL could not warp the dataset from its GCPs.")
+        result = self._ds.__class__(dst, access="read_only")
+        if lazy:
+            # The VRT references the source GDAL handle; pin the source Dataset so
+            # it cannot be garbage-collected underneath the view.
+            result._warp_source = self._ds
+        return result

--- a/src/pyramids/dataset/engines/georef.py
+++ b/src/pyramids/dataset/engines/georef.py
@@ -29,6 +29,58 @@ class Georef(_Engine):
     attaches both, and warps from them into an affine-geotransform raster.
     """
 
+    @property
+    def gcps(self: Georef) -> list[GroundControlPoint]:
+        """The dataset's ground-control points (empty list when it has none).
+
+        Returns:
+            list[GroundControlPoint]: one per attached GCP, in GDAL order.
+
+        Examples:
+            - Read back the points attached with :meth:`set_gcps`:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> from pyramids.dataset._gcp import GroundControlPoint
+                >>> ds = Dataset.create_from_array(
+                ...     np.ones((4, 4), "float32"), top_left_corner=(0.0, 4.0), cell_size=1.0
+                ... )
+                >>> ds.set_gcps([GroundControlPoint(row=0, col=0, x=10.0, y=50.0)], 4326)
+                >>> (ds.gcps[0].col, ds.gcps[0].x, ds.gcps[0].y)
+                (0.0, 10.0, 50.0)
+
+                ```
+        """
+        return [GroundControlPoint.from_gdal(gcp) for gcp in self._ds.raster.GetGCPs()]
+
+    @property
+    def gcp_count(self: Georef) -> int:
+        """Number of ground-control points attached (``0`` when none).
+
+        Returns:
+            int: the GCP count.
+        """
+        return self._ds.raster.GetGCPCount()
+
+    @property
+    def gcp_projection(self: Georef) -> str | None:
+        """WKT of the GCPs' CRS, or ``None`` when the dataset has no GCPs.
+
+        Returns:
+            str | None: the GCP-projection WKT, else ``None``.
+        """
+        wkt = self._ds.raster.GetGCPProjection()
+        return wkt if self._ds.raster.GetGCPCount() else None
+
+    @property
+    def has_gcps(self: Georef) -> bool:
+        """``True`` when the dataset carries at least one ground-control point.
+
+        Returns:
+            bool: whether any GCP is attached.
+        """
+        return self._ds.raster.GetGCPCount() > 0
+
     def set_gcps(
         self: Georef,
         gcps: Sequence[GroundControlPoint],

--- a/src/pyramids/dataset/engines/georef.py
+++ b/src/pyramids/dataset/engines/georef.py
@@ -9,8 +9,9 @@ GDAL toolkit and does not implement any sensor model itself.
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Mapping, Sequence
+from typing import TYPE_CHECKING
 from uuid import uuid4
 
 from osgeo import gdal
@@ -262,6 +263,10 @@ class Georef(_Engine):
         result = self._ds.__class__(dst, access="read_only")
         if lazy:
             result._warp_source = self._ds
+        elif dem_path is not None and dem_path.startswith("/vsimem/orthorectify_dem_"):
+            # A materialised result no longer references the staged DEM, so free
+            # the /vsimem copy we made from a MEM Dataset (a lazy result keeps it).
+            gdal.Unlink(dem_path)
         return result
 
     @staticmethod

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -1289,6 +1289,13 @@ class IO(_Engine):
 
                 ```
         """
+        if self._ds.raster.GetDriver().ShortName == "MEM":
+            raise ValueError(
+                "read_windows requires a path-backed dataset (on disk or under "
+                "/vsimem/); a pure in-memory (MEM) dataset cannot be reopened "
+                "per thread. Write it to a path first."
+            )
+
         def _read_one(window: Window) -> np.ndarray:
             return np.asarray(
                 self._ds.read_array(band=band, window=window, threadsafe=True)

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -12,7 +12,8 @@ import math
 import pickle
 import threading
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Generator
 
@@ -1246,6 +1247,56 @@ class IO(_Engine):
         x_size = arr_indeces[1, 0] - arr_indeces[0, 0]
         y_size = arr_indeces[1, 1] - arr_indeces[0, 1]
         return [xoff, yoff, x_size, y_size]
+
+    def read_windows(
+        self: Dataset,
+        windows: Sequence[Window],
+        *,
+        band: int | None = None,
+        threads: int = 4,
+    ) -> list[np.ndarray]:
+        """Read many windows concurrently, preserving input order.
+
+        Fans the windows across a thread pool, reading each through a per-thread
+        GDAL handle (:meth:`read_array` with ``threadsafe=True``). GDAL releases
+        the GIL during I/O, so this scales for I/O-bound reads (large/remote
+        rasters). The dataset must be path-backed (on disk or ``/vsimem/``); a
+        pure-MEM dataset cannot be reopened per thread.
+
+        Args:
+            windows: The :class:`Window` blocks to read.
+            band: Band index, or ``None`` for all bands (per :meth:`read_array`).
+            threads: Worker-thread count. ``1`` reads sequentially.
+
+        Returns:
+            list[numpy.ndarray]: one array per input window, in the same order.
+
+        Examples:
+            - Parallel reads match the sequential reads, in order:
+                ```python
+                >>> import numpy as np, tempfile, os
+                >>> from pyramids.dataset import Dataset, Window
+                >>> path = os.path.join(tempfile.mkdtemp(), "r.tif")
+                >>> Dataset.create_from_array(
+                ...     np.arange(64, dtype="float32").reshape(8, 8),
+                ...     top_left_corner=(0.0, 8.0), cell_size=1.0,
+                ... ).to_file(path)
+                >>> ds = Dataset.read_file(path)
+                >>> wins = [Window(0, 0, 4, 4), Window(4, 4, 4, 4)]
+                >>> blocks = ds.read_windows(wins)
+                >>> [b.shape for b in blocks]
+                [(4, 4), (4, 4)]
+
+                ```
+        """
+        def _read_one(window: Window) -> np.ndarray:
+            return np.asarray(
+                self._ds.read_array(band=band, window=window, threadsafe=True)
+            )
+
+        with ThreadPoolExecutor(max_workers=threads) as executor:
+            results = list(executor.map(_read_one, windows))
+        return results
 
     def write_array(
         self: Dataset,

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -1289,7 +1289,7 @@ class IO(_Engine):
 
                 ```
         """
-        if self._ds.raster.GetDriver().ShortName == "MEM":
+        if getattr(self._ds.raster.GetDriver(), "ShortName", "") == "MEM":
             raise ValueError(
                 "read_windows requires a path-backed dataset (on disk or under "
                 "/vsimem/); a pure in-memory (MEM) dataset cannot be reopened "

--- a/src/pyramids/dataset/window.py
+++ b/src/pyramids/dataset/window.py
@@ -317,7 +317,10 @@ class Window:
 
                 ```
         """
-        return self.intersection(Window(0, 0, cols, rows))
+        result = None
+        if rows > 0 and cols > 0:
+            result = self.intersection(Window(0, 0, cols, rows))
+        return result
 
     def todict(self) -> dict[str, int]:
         """Return the window as a ``{col_off, row_off, cols, rows}`` dict.

--- a/src/pyramids/dataset/window.py
+++ b/src/pyramids/dataset/window.py
@@ -249,3 +249,160 @@ class Window:
         col_end = max(self.col_off + self.cols, other.col_off + other.cols)
         row_end = max(self.row_off + self.rows, other.row_off + other.rows)
         return Window(col_off, row_off, col_end - col_off, row_end - row_off)
+
+    @classmethod
+    def rounded(
+        cls,
+        col_off: float,
+        row_off: float,
+        cols: float,
+        rows: float,
+    ) -> Window:
+        """Snap possibly-fractional pixel coordinates to an integer ``Window``.
+
+        Offsets are floored and sizes ceiled, so the resulting window always
+        **covers** the fractional region. (A :class:`Window` itself is
+        integer-only; this is the constructor for when upstream math produced
+        fractional pixel coordinates.)
+
+        Args:
+            col_off: Fractional column offset.
+            row_off: Fractional row offset.
+            cols: Fractional width.
+            rows: Fractional height.
+
+        Returns:
+            Window: the covering integer window.
+
+        Examples:
+            - Floor the offsets, ceil the sizes:
+                ```python
+                >>> from pyramids.dataset.window import Window
+                >>> Window.rounded(1.4, 2.6, 9.9, 3.1)
+                Window(col_off=1, row_off=2, cols=10, rows=4)
+
+                ```
+        """
+        return cls(
+            math.floor(col_off),
+            math.floor(row_off),
+            math.ceil(cols),
+            math.ceil(rows),
+        )
+
+    def crop(self, rows: int, cols: int) -> Window | None:
+        """Clamp the window to a raster's ``(rows, cols)`` pixel extent.
+
+        Args:
+            rows: The raster's height in pixels.
+            cols: The raster's width in pixels.
+
+        Returns:
+            Window | None: the part of this window inside the extent, or
+                ``None`` when the window lies entirely outside it.
+
+        Examples:
+            - An oversized window is clamped to the raster:
+                ```python
+                >>> from pyramids.dataset.window import Window
+                >>> Window(0, 0, 100, 100).crop(rows=8, cols=8)
+                Window(col_off=0, row_off=0, cols=8, rows=8)
+
+                ```
+            - A window fully outside the extent clamps to None:
+                ```python
+                >>> from pyramids.dataset.window import Window
+                >>> Window(20, 20, 5, 5).crop(rows=8, cols=8) is None
+                True
+
+                ```
+        """
+        return self.intersection(Window(0, 0, cols, rows))
+
+    def todict(self) -> dict[str, int]:
+        """Return the window as a ``{col_off, row_off, cols, rows}`` dict.
+
+        Returns:
+            dict[str, int]: the four fields, suitable for JSON / round-trip.
+
+        Examples:
+            - Serialise and round-trip through :meth:`from_dict`:
+                ```python
+                >>> from pyramids.dataset.window import Window
+                >>> d = Window(4, 1, 2, 3).todict()
+                >>> sorted(d.items())
+                [('col_off', 4), ('cols', 2), ('row_off', 1), ('rows', 3)]
+                >>> Window.from_dict(d)
+                Window(col_off=4, row_off=1, cols=2, rows=3)
+
+                ```
+        """
+        return {
+            "col_off": self.col_off,
+            "row_off": self.row_off,
+            "cols": self.cols,
+            "rows": self.rows,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, int]) -> Window:
+        """Build a ``Window`` from a ``{col_off, row_off, cols, rows}`` dict.
+
+        Args:
+            data: A mapping with the four window fields.
+
+        Returns:
+            Window: the reconstructed window.
+        """
+        return cls(
+            col_off=data["col_off"],
+            row_off=data["row_off"],
+            cols=data["cols"],
+            rows=data["rows"],
+        )
+
+    def __iter__(self):
+        """Iterate ``(col_off, row_off, cols, rows)`` so ``tuple(window)`` works.
+
+        Yields:
+            int: the four fields in GDAL (x-first) order.
+        """
+        yield from (self.col_off, self.row_off, self.cols, self.rows)
+
+    def transform(
+        self,
+        geotransform: tuple[float, float, float, float, float, float],
+    ) -> tuple[float, float, float, float, float, float]:
+        """Return the geotransform of *this window* (its own top-left origin).
+
+        The pixel size and rotation terms are unchanged; only the origin (indices
+        0 and 3) shift to the window's top-left corner — the geotransform you
+        write a cropped sub-raster with.
+
+        Args:
+            geotransform: The parent raster's GDAL 6-tuple.
+
+        Returns:
+            tuple: the window's geotransform.
+
+        Examples:
+            - The origin shifts to the window; the cell size is preserved:
+                ```python
+                >>> from pyramids.dataset.window import Window
+                >>> gt = (0.0, 1.0, 0.0, 4.0, 0.0, -1.0)
+                >>> Window(2, 1, 3, 3).transform(gt)
+                (2.0, 1.0, 0.0, 3.0, 0.0, -1.0)
+
+                ```
+        """
+        origin_x, origin_y = gdal.ApplyGeoTransform(
+            list(geotransform), float(self.col_off), float(self.row_off)
+        )
+        return (
+            origin_x,
+            geotransform[1],
+            geotransform[2],
+            origin_y,
+            geotransform[4],
+            geotransform[5],
+        )

--- a/tests/dataset/test_georef.py
+++ b/tests/dataset/test_georef.py
@@ -1,0 +1,119 @@
+"""Tests for GCP/RPC georeferencing (the Georef engine, issue-driven GR-* tasks).
+
+Fixtures are synthetic and offline: a small in-memory raster with four corner
+ground-control points, generated via ``set_gcps`` rather than shipping a binary.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pyramids.base._errors import ReadOnlyError
+from pyramids.dataset import Dataset
+from pyramids.dataset._gcp import GroundControlPoint
+
+pytestmark = pytest.mark.core
+
+
+@pytest.fixture
+def corner_gcps() -> list[GroundControlPoint]:
+    """Four corner control points of an 8x8 raster in EPSG:4326.
+
+    Returns:
+        list[GroundControlPoint]: top-left, top-right, bottom-left, bottom-right.
+    """
+    return [
+        GroundControlPoint(row=0, col=0, x=10.0, y=50.0, id="tl"),
+        GroundControlPoint(row=0, col=8, x=11.0, y=50.0, id="tr"),
+        GroundControlPoint(row=8, col=0, x=10.0, y=49.0, id="bl"),
+        GroundControlPoint(row=8, col=8, x=11.0, y=49.0, id="br"),
+    ]
+
+
+@pytest.fixture
+def writable_dataset() -> Dataset:
+    """A writable in-memory 8x8 float32 dataset.
+
+    Returns:
+        Dataset: MEM-backed (always writable), no GCPs yet.
+    """
+    return Dataset.create_from_array(
+        np.ones((8, 8), dtype="float32"), top_left_corner=(0.0, 8.0), cell_size=1.0
+    )
+
+
+class TestGroundControlPoint:
+    """Tests for the GroundControlPoint value object."""
+
+    def test_to_gdal_maps_pixel_and_map_coords(self):
+        """`to_gdal` puts col/row on pixel/line and keeps the map coordinate.
+
+        Test scenario:
+            A point at (col=7, row=3) -> (x=1, y=2) becomes a gdal.GCP with the
+            same pixel/line and X/Y.
+        """
+        g = GroundControlPoint(row=3.0, col=7.0, x=1.0, y=2.0).to_gdal()
+        assert (g.GCPPixel, g.GCPLine, g.GCPX, g.GCPY) == (7.0, 3.0, 1.0, 2.0)
+
+    def test_round_trip_through_gdal(self):
+        """`from_gdal(to_gdal())` preserves all fields.
+
+        Test scenario:
+            A fully-populated point survives the GDAL round-trip.
+        """
+        original = GroundControlPoint(
+            row=4.0, col=2.0, x=11.5, y=46.2, z=3.0, id="p1", info="note"
+        )
+        back = GroundControlPoint.from_gdal(original.to_gdal())
+        assert back == original
+
+    def test_empty_id_info_become_none(self):
+        """Empty GDAL Id/Info come back as None, not empty strings.
+
+        Test scenario:
+            A point with no id/info round-trips to None id/info.
+        """
+        back = GroundControlPoint.from_gdal(
+            GroundControlPoint(row=0, col=0, x=0.0, y=0.0).to_gdal()
+        )
+        assert back.id is None and back.info is None
+
+
+class TestSetGCPs:
+    """Tests for Georef.set_gcps (and the Dataset facade)."""
+
+    def test_attaches_gcps_and_projection(self, writable_dataset, corner_gcps):
+        """set_gcps writes the points and an EPSG:4326 projection to the raster.
+
+        Test scenario:
+            After set_gcps the underlying GDAL dataset reports 4 GCPs and a
+            4326 projection.
+        """
+        writable_dataset.set_gcps(corner_gcps, 4326)
+        raster = writable_dataset.raster
+        assert raster.GetGCPCount() == 4
+        assert "4326" in raster.GetGCPProjection()
+
+    def test_empty_list_raises_value_error(self, writable_dataset):
+        """An empty GCP list is rejected.
+
+        Test scenario:
+            set_gcps([], 4326) raises ValueError.
+        """
+        with pytest.raises(ValueError, match="at least one"):
+            writable_dataset.set_gcps([], 4326)
+
+    def test_read_only_raises(self, corner_gcps, tmp_path):
+        """A read-only dataset rejects set_gcps.
+
+        Test scenario:
+            A dataset opened read_only=True raises ReadOnlyError.
+        """
+        path = tmp_path / "plain.tif"
+        Dataset.create_from_array(
+        np.ones((8, 8), dtype="float32"), top_left_corner=(0.0, 8.0), cell_size=1.0
+    ).to_file(str(path))
+        ds = Dataset.read_file(str(path), read_only=True)
+        with pytest.raises(ReadOnlyError):
+            ds.set_gcps(corner_gcps, 4326)

--- a/tests/dataset/test_georef.py
+++ b/tests/dataset/test_georef.py
@@ -16,6 +16,24 @@ from pyramids.dataset._gcp import GroundControlPoint
 pytestmark = pytest.mark.core
 
 
+RPC_SAMPLE: dict[str, str] = {
+    "HEIGHT_OFF": "100",
+    "HEIGHT_SCALE": "50",
+    "LAT_OFF": "49.5",
+    "LAT_SCALE": "0.5",
+    "LONG_OFF": "10.5",
+    "LONG_SCALE": "0.5",
+    "LINE_OFF": "4",
+    "LINE_SCALE": "4",
+    "SAMP_OFF": "4",
+    "SAMP_SCALE": "4",
+    "LINE_NUM_COEFF": " ".join(["0"] * 20),
+    "LINE_DEN_COEFF": " ".join(["1"] + ["0"] * 19),
+    "SAMP_NUM_COEFF": " ".join(["0"] * 20),
+    "SAMP_DEN_COEFF": " ".join(["1"] + ["0"] * 19),
+}
+
+
 @pytest.fixture
 def corner_gcps() -> list[GroundControlPoint]:
     """Four corner control points of an 8x8 raster in EPSG:4326.
@@ -116,6 +134,30 @@ class TestReadGCPs:
         """
         writable_dataset.set_gcps(corner_gcps, 4326)
         assert writable_dataset.gcps == corner_gcps
+
+
+class TestReadRPC:
+    """Tests for the RPC read properties (rpcs / has_rpcs)."""
+
+    def test_plain_raster_has_no_rpcs(self, writable_dataset):
+        """A raster without RPC metadata reports None / False.
+
+        Test scenario:
+            Fresh dataset: rpcs is None, has_rpcs is False.
+        """
+        assert writable_dataset.rpcs is None
+        assert writable_dataset.has_rpcs is False
+
+    def test_reads_rpc_metadata(self, writable_dataset):
+        """rpcs returns the RPC domain set on the underlying raster.
+
+        Test scenario:
+            After SetMetadata(RPC_SAMPLE, "RPC"), rpcs["HEIGHT_OFF"] matches and
+            has_rpcs is True.
+        """
+        writable_dataset.raster.SetMetadata(RPC_SAMPLE, "RPC")
+        assert writable_dataset.has_rpcs is True
+        assert writable_dataset.rpcs["HEIGHT_OFF"] == "100"
 
 
 class TestWarpFromGCPs:

--- a/tests/dataset/test_georef.py
+++ b/tests/dataset/test_georef.py
@@ -118,6 +118,83 @@ class TestReadGCPs:
         assert writable_dataset.gcps == corner_gcps
 
 
+class TestWarpFromGCPs:
+    """Tests for Georef.georeference (warp from GCPs)."""
+
+    def test_no_gcps_raises(self, writable_dataset):
+        """georeference without GCPs is rejected.
+
+        Test scenario:
+            A dataset with no GCPs raises ValueError mentioning GCPs.
+        """
+        with pytest.raises(ValueError, match="no GCPs"):
+            writable_dataset.georeference()
+
+    def test_polynomial_warp_into_gcp_crs(self, writable_dataset, corner_gcps):
+        """Default warp lands in the GCP CRS and brackets the GCP extent.
+
+        Test scenario:
+            4 corner GCPs (10-11E, 49-50N) -> epsg 4326 and bbox covers that box.
+        """
+        writable_dataset.set_gcps(corner_gcps, 4326)
+        out = writable_dataset.georeference()
+        assert out.epsg == 4326
+        xmin, ymin, xmax, ymax = out.bbox
+        assert xmin <= 10.0 + 1e-6 and xmax >= 11.0 - 1e-6
+        assert ymin <= 49.0 + 1e-6 and ymax >= 50.0 - 1e-6
+
+    def test_tps_transform(self, writable_dataset, corner_gcps):
+        """A thin-plate-spline warp also produces a 4326 raster.
+
+        Test scenario:
+            transform="tps" warps into the GCP CRS without error.
+        """
+        writable_dataset.set_gcps(corner_gcps, 4326)
+        out = writable_dataset.georeference(transform="tps")
+        assert out.epsg == 4326
+
+    def test_reproject_in_same_pass(self, writable_dataset, corner_gcps):
+        """to_epsg reprojects the georeferenced result in one pass.
+
+        Test scenario:
+            georeference(to_epsg=3857) yields a Web-Mercator raster.
+        """
+        writable_dataset.set_gcps(corner_gcps, 4326)
+        out = writable_dataset.georeference(to_epsg=3857)
+        assert out.epsg == 3857
+
+    def test_lazy_equals_eager(self, writable_dataset, corner_gcps):
+        """A lazy VRT view reads the same pixels as the eager result.
+
+        Test scenario:
+            lazy=True and lazy=False produce allclose arrays.
+        """
+        writable_dataset.set_gcps(corner_gcps, 4326)
+        eager = writable_dataset.georeference(lazy=False)
+        lazy = writable_dataset.georeference(lazy=True)
+        assert np.allclose(np.asarray(eager.read_array()), np.asarray(lazy.read_array()))
+
+    def test_invalid_transform_raises(self, writable_dataset, corner_gcps):
+        """An unsupported transform name is rejected.
+
+        Test scenario:
+            transform="bogus" raises ValueError.
+        """
+        writable_dataset.set_gcps(corner_gcps, 4326)
+        with pytest.raises(ValueError, match="polynomial.*tps|transform must"):
+            writable_dataset.georeference(transform="bogus")
+
+    def test_invalid_order_raises(self, writable_dataset, corner_gcps):
+        """A polynomial order outside 1-3 is rejected.
+
+        Test scenario:
+            order=7 raises ValueError.
+        """
+        writable_dataset.set_gcps(corner_gcps, 4326)
+        with pytest.raises(ValueError, match="order must"):
+            writable_dataset.georeference(order=7)
+
+
 class TestSetGCPs:
     """Tests for Georef.set_gcps (and the Dataset facade)."""
 

--- a/tests/dataset/test_georef.py
+++ b/tests/dataset/test_georef.py
@@ -80,6 +80,44 @@ class TestGroundControlPoint:
         assert back.id is None and back.info is None
 
 
+class TestReadGCPs:
+    """Tests for the GCP read properties (gcps / gcp_count / gcp_projection / has_gcps)."""
+
+    def test_plain_raster_has_no_gcps(self, writable_dataset):
+        """A raster with no GCPs reports zero / empty / None.
+
+        Test scenario:
+            Fresh dataset: gcp_count 0, gcps [], gcp_projection None, has_gcps False.
+        """
+        assert writable_dataset.gcp_count == 0
+        assert writable_dataset.gcps == []
+        assert writable_dataset.gcp_projection is None
+        assert writable_dataset.has_gcps is False
+
+    def test_reads_attached_gcps(self, writable_dataset, corner_gcps):
+        """After set_gcps the read properties return the points and CRS.
+
+        Test scenario:
+            4 corner points attached -> count 4, has_gcps True, projection mentions
+            4326, and the first point's pixel/map coords match the input.
+        """
+        writable_dataset.set_gcps(corner_gcps, 4326)
+        assert writable_dataset.gcp_count == 4
+        assert writable_dataset.has_gcps is True
+        assert "4326" in writable_dataset.gcp_projection
+        first = writable_dataset.gcps[0]
+        assert (first.col, first.row, first.x, first.y) == (0.0, 0.0, 10.0, 50.0)
+
+    def test_round_trip_preserves_points(self, writable_dataset, corner_gcps):
+        """The read-back points equal the value objects passed to set_gcps.
+
+        Test scenario:
+            set_gcps then gcps returns equal GroundControlPoint records.
+        """
+        writable_dataset.set_gcps(corner_gcps, 4326)
+        assert writable_dataset.gcps == corner_gcps
+
+
 class TestSetGCPs:
     """Tests for Georef.set_gcps (and the Dataset facade)."""
 

--- a/tests/dataset/test_georef.py
+++ b/tests/dataset/test_georef.py
@@ -6,16 +6,29 @@ ground-control points, generated via ``set_gcps`` rather than shipping a binary.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import numpy as np
 import pytest
 
 from pyramids.base._errors import ReadOnlyError
 from pyramids.dataset import Dataset
 from pyramids.dataset._gcp import GroundControlPoint
+from pyramids.dataset.engines.georef import Georef
 
 pytestmark = pytest.mark.core
 
 
+def _rpc_coeff(term_index: int) -> str:
+    """A 20-term RPC coefficient string with a single 1 at ``term_index``."""
+    coeffs = ["0"] * 20
+    coeffs[term_index] = "1"
+    return " ".join(coeffs)
+
+
+# A near-identity RPC: sample tracks longitude (term L = index 1), line tracks
+# latitude (term P = index 2), both denominators are the constant 1. Maps the
+# 8x8 image onto roughly [10, 11]E x [49, 50]N at HEIGHT_OFF elevation.
 RPC_SAMPLE: dict[str, str] = {
     "HEIGHT_OFF": "100",
     "HEIGHT_SCALE": "50",
@@ -27,10 +40,10 @@ RPC_SAMPLE: dict[str, str] = {
     "LINE_SCALE": "4",
     "SAMP_OFF": "4",
     "SAMP_SCALE": "4",
-    "LINE_NUM_COEFF": " ".join(["0"] * 20),
-    "LINE_DEN_COEFF": " ".join(["1"] + ["0"] * 19),
-    "SAMP_NUM_COEFF": " ".join(["0"] * 20),
-    "SAMP_DEN_COEFF": " ".join(["1"] + ["0"] * 19),
+    "SAMP_NUM_COEFF": _rpc_coeff(1),
+    "SAMP_DEN_COEFF": _rpc_coeff(0),
+    "LINE_NUM_COEFF": _rpc_coeff(2),
+    "LINE_DEN_COEFF": _rpc_coeff(0),
 }
 
 
@@ -208,6 +221,92 @@ class TestSetRPC:
         ds = Dataset.read_file(str(path), read_only=True)
         with pytest.raises(ReadOnlyError):
             ds.set_rpcs(RPC_SAMPLE)
+
+
+class TestOrthorectify:
+    """Tests for Georef.orthorectify (warp from RPCs)."""
+
+    @pytest.fixture
+    def rpc_dataset(self) -> Dataset:
+        """An 8x8 raster carrying the near-identity RPC sensor model."""
+        ds = Dataset.create_from_array(
+            np.arange(64).reshape(8, 8).astype("float32"),
+            top_left_corner=(0.0, 8.0),
+            cell_size=1.0,
+        )
+        ds.raster.SetMetadata(RPC_SAMPLE, "RPC")
+        return ds
+
+    def test_no_rpc_raises(self, writable_dataset):
+        """orthorectify without RPC metadata is rejected.
+
+        Test scenario:
+            A dataset with no RPC raises ValueError mentioning RPC.
+        """
+        with pytest.raises(ValueError, match="no RPC"):
+            writable_dataset.orthorectify(rpc_height=100)
+
+    def test_constant_height_produces_map_grid(self, rpc_dataset):
+        """A constant-height ortho yields a finite, map-projected raster.
+
+        Test scenario:
+            rpc_height at HEIGHT_OFF -> non-empty raster with a real EPSG and a
+            finite bbox bracketing the RPC extent.
+        """
+        out = rpc_dataset.orthorectify(rpc_height=100)
+        assert out.columns > 0 and out.rows > 0
+        assert out.epsg == 4326
+        xmin, ymin, xmax, ymax = out.bbox
+        assert all(np.isfinite([xmin, ymin, xmax, ymax]))
+
+    def test_no_dem_no_height_warns(self, rpc_dataset, caplog):
+        """Omitting both dem and rpc_height logs a height-0 warning.
+
+        Test scenario:
+            orthorectify() with no elevation emits a WARNING and still returns.
+        """
+        import logging as _logging
+
+        with caplog.at_level(_logging.WARNING):
+            out = rpc_dataset.orthorectify()
+        assert out.columns > 0
+        assert any("height 0" in record.message for record in caplog.records)
+
+    def test_resolve_dem_path_none_str_path(self):
+        """_resolve_dem_path passes None / str / Path through to a path string.
+
+        Test scenario:
+            None -> None; a str and a Path both become the str path. (The full
+            RPC_DEM warp is GDAL-version-fragile with synthetic coefficients, so
+            the DEM *handling* is unit-tested here rather than warped.)
+        """
+        assert Georef._resolve_dem_path(None) is None
+        assert Georef._resolve_dem_path("dem.tif") == "dem.tif"
+        assert Georef._resolve_dem_path(Path("a/dem.tif")) == str(Path("a/dem.tif"))
+
+    def test_resolve_dem_path_file_backed_dataset(self, tmp_path):
+        """A file-backed DEM Dataset resolves to its on-disk path.
+
+        Test scenario:
+            A Dataset read from disk yields a path ending in the file name.
+        """
+        dem_path = tmp_path / "dem.tif"
+        Dataset.create_from_array(
+            np.ones((4, 4), "float32"), top_left_corner=(0.0, 4.0), cell_size=1.0
+        ).to_file(str(dem_path))
+        resolved = Georef._resolve_dem_path(Dataset.read_file(str(dem_path)))
+        assert resolved.endswith("dem.tif")
+
+    def test_resolve_dem_path_mem_dataset_staged_to_vsimem(self):
+        """An in-memory DEM Dataset is staged to a /vsimem/ path.
+
+        Test scenario:
+            A MEM-backed Dataset (no on-disk description) resolves to /vsimem/.
+        """
+        dem = Dataset.create_from_array(
+            np.ones((4, 4), "float32"), top_left_corner=(0.0, 4.0), cell_size=1.0
+        )
+        assert Georef._resolve_dem_path(dem).startswith("/vsimem/")
 
 
 class TestWarpFromGCPs:

--- a/tests/dataset/test_georef.py
+++ b/tests/dataset/test_georef.py
@@ -160,6 +160,56 @@ class TestReadRPC:
         assert writable_dataset.rpcs["HEIGHT_OFF"] == "100"
 
 
+class TestSetRPC:
+    """Tests for Georef.set_rpcs."""
+
+    def test_round_trip(self, writable_dataset):
+        """set_rpcs writes the RPC domain so rpcs reads it back.
+
+        Test scenario:
+            A complete RPC dict set then read returns equal values.
+        """
+        writable_dataset.set_rpcs(RPC_SAMPLE)
+        assert writable_dataset.rpcs["HEIGHT_OFF"] == "100"
+        assert writable_dataset.rpcs["LINE_DEN_COEFF"].split()[0] == "1"
+
+    def test_stringifies_numeric_values(self, writable_dataset):
+        """Numeric RPC values are stringified before writing.
+
+        Test scenario:
+            HEIGHT_OFF given as a float comes back as its string form.
+        """
+        rpc = dict(RPC_SAMPLE)
+        rpc["HEIGHT_OFF"] = 123.5
+        writable_dataset.set_rpcs(rpc)
+        assert writable_dataset.rpcs["HEIGHT_OFF"] == "123.5"
+
+    def test_missing_keys_raise(self, writable_dataset):
+        """A dict missing required keys is rejected, listing them.
+
+        Test scenario:
+            Dropping HEIGHT_OFF raises ValueError naming the missing key.
+        """
+        rpc = dict(RPC_SAMPLE)
+        del rpc["HEIGHT_OFF"]
+        with pytest.raises(ValueError, match="HEIGHT_OFF"):
+            writable_dataset.set_rpcs(rpc)
+
+    def test_read_only_raises(self, tmp_path):
+        """A read-only dataset rejects set_rpcs.
+
+        Test scenario:
+            read_only=True raises ReadOnlyError.
+        """
+        path = tmp_path / "plain.tif"
+        Dataset.create_from_array(
+            np.ones((4, 4), dtype="float32"), top_left_corner=(0.0, 4.0), cell_size=1.0
+        ).to_file(str(path))
+        ds = Dataset.read_file(str(path), read_only=True)
+        with pytest.raises(ReadOnlyError):
+            ds.set_rpcs(RPC_SAMPLE)
+
+
 class TestWarpFromGCPs:
     """Tests for Georef.georeference (warp from GCPs)."""
 

--- a/tests/dataset/test_masks.py
+++ b/tests/dataset/test_masks.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 from osgeo import gdal
 
-from pyramids.dataset import Dataset
+from pyramids.dataset import Dataset, Window
 
 pytestmark = pytest.mark.core
 
@@ -77,3 +77,38 @@ class TestMaskFlags:
         flags = alpha_dataset.mask_flags(0)
         assert flags.alpha is True
         assert flags.per_dataset is True
+
+
+class TestReadMasks:
+    """Tests for Dataset.read_masks."""
+
+    def test_single_band_mask_marks_nodata(self, nodata_dataset):
+        """read_masks(0) returns a (rows, cols) mask that is 0 at nodata cells.
+
+        Test scenario:
+            Column 2 is the nodata column -> mask 0 there, 255 elsewhere.
+        """
+        mask = nodata_dataset.read_masks(0)
+        assert mask.shape == (4, 4)
+        assert bool((mask[:, 2] == 0).all())
+        assert bool((mask[:, 0] == 255).all())
+
+    def test_all_bands_stacked(self, alpha_dataset):
+        """read_masks() stacks every band's mask as (band_count, rows, cols).
+
+        Test scenario:
+            A 2-band raster yields a (2, 4, 4) mask stack.
+        """
+        masks = alpha_dataset.read_masks()
+        assert masks.shape == (2, 4, 4)
+
+    def test_windowed_mask_matches_full_slice(self, nodata_dataset):
+        """A windowed mask equals the full mask sliced to the window.
+
+        Test scenario:
+            read_masks(0, window=Window(0,0,2,2)) == read_masks(0)[:2, :2].
+        """
+        full = nodata_dataset.read_masks(0)
+        windowed = nodata_dataset.read_masks(0, window=Window(0, 0, 2, 2))
+        assert windowed.shape == (2, 2)
+        assert np.array_equal(windowed, full[:2, :2])

--- a/tests/dataset/test_masks.py
+++ b/tests/dataset/test_masks.py
@@ -1,0 +1,79 @@
+"""Tests for per-band mask introspection (MaskFlags / mask_flags / read_masks).
+
+Fixtures are synthetic and offline: a nodata raster, an all-valid raster, and an
+alpha-band raster constructed directly via GDAL.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from osgeo import gdal
+
+from pyramids.dataset import Dataset
+
+pytestmark = pytest.mark.core
+
+
+@pytest.fixture
+def nodata_dataset() -> Dataset:
+    """A 4x4 float32 raster carrying a no-data value."""
+    return Dataset.create_from_array(
+        np.array([[1, 2, -9999, 4]] * 4, dtype="float32"),
+        top_left_corner=(0.0, 4.0),
+        cell_size=1.0,
+        no_data_value=-9999.0,
+    )
+
+
+@pytest.fixture
+def all_valid_dataset() -> Dataset:
+    """A 4x4 float32 raster with no no-data value (fully valid)."""
+    return Dataset.create_from_array(
+        np.ones((4, 4), dtype="float32"),
+        top_left_corner=(0.0, 4.0),
+        cell_size=1.0,
+        no_data_value=None,
+    )
+
+
+@pytest.fixture
+def alpha_dataset() -> Dataset:
+    """A 2-band byte raster whose second band is an alpha band."""
+    mem = gdal.GetDriverByName("MEM").Create("", 4, 4, 2, gdal.GDT_Byte)
+    mem.GetRasterBand(2).SetColorInterpretation(gdal.GCI_AlphaBand)
+    return Dataset(mem)
+
+
+class TestMaskFlags:
+    """Tests for Dataset.mask_flags."""
+
+    def test_nodata_flag(self, nodata_dataset):
+        """A band with a no-data value reports the nodata flag.
+
+        Test scenario:
+            mask_flags().nodata is True; not all_valid.
+        """
+        flags = nodata_dataset.mask_flags()
+        assert flags.nodata is True
+        assert flags.all_valid is False
+
+    def test_all_valid_flag(self, all_valid_dataset):
+        """A band with no mask reports all_valid.
+
+        Test scenario:
+            mask_flags().all_valid is True; nodata is False.
+        """
+        flags = all_valid_dataset.mask_flags()
+        assert flags.all_valid is True
+        assert flags.nodata is False
+
+    def test_alpha_flag(self, alpha_dataset):
+        """A band masked by an alpha band reports alpha + per_dataset.
+
+        Test scenario:
+            mask_flags(0) on a dataset with an alpha band: alpha and per_dataset.
+        """
+        flags = alpha_dataset.mask_flags(0)
+        assert flags.alpha is True
+        assert flags.per_dataset is True

--- a/tests/dataset/test_masks.py
+++ b/tests/dataset/test_masks.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 from osgeo import gdal
 
+from pyramids.base._errors import ReadOnlyError
 from pyramids.dataset import Dataset, Window
 
 pytestmark = pytest.mark.core
@@ -112,3 +113,35 @@ class TestReadMasks:
         windowed = nodata_dataset.read_masks(0, window=Window(0, 0, 2, 2))
         assert windowed.shape == (2, 2)
         assert np.array_equal(windowed, full[:2, :2])
+
+
+class TestCreateMaskBand:
+    """Tests for Dataset.create_mask_band."""
+
+    def test_creates_per_dataset_mask(self, tmp_path):
+        """create_mask_band attaches a per-dataset mask the flags then report.
+
+        Test scenario:
+            On a writable GeoTIFF, create_mask_band() -> mask_flags().per_dataset.
+        """
+        path = str(tmp_path / "m.tif")
+        Dataset.create_from_array(
+            np.ones((4, 4), "float32"), top_left_corner=(0.0, 4.0), cell_size=1.0
+        ).to_file(path)
+        ds = Dataset.read_file(path, read_only=False)
+        ds.create_mask_band()
+        assert ds.mask_flags().per_dataset is True
+
+    def test_read_only_raises(self, tmp_path):
+        """A read-only dataset rejects create_mask_band.
+
+        Test scenario:
+            read_only=True raises ReadOnlyError.
+        """
+        path = str(tmp_path / "ro.tif")
+        Dataset.create_from_array(
+            np.ones((4, 4), "float32"), top_left_corner=(0.0, 4.0), cell_size=1.0
+        ).to_file(path)
+        ds = Dataset.read_file(path, read_only=True)
+        with pytest.raises(ReadOnlyError):
+            ds.create_mask_band()

--- a/tests/dataset/test_masks.py
+++ b/tests/dataset/test_masks.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 from osgeo import gdal
 
-from pyramids.base._errors import ReadOnlyError
+from pyramids.base._errors import OutOfBoundsError, ReadOnlyError
 from pyramids.dataset import Dataset, Window
 
 pytestmark = pytest.mark.core
@@ -145,3 +145,25 @@ class TestCreateMaskBand:
         ds = Dataset.read_file(path, read_only=True)
         with pytest.raises(ReadOnlyError):
             ds.create_mask_band()
+
+
+class TestReadMasksWindowBounds:
+    """Tests for read_masks window validation (review L1)."""
+
+    def test_oversized_window_is_clamped(self, nodata_dataset):
+        """An oversized window is clamped to the raster instead of crashing.
+
+        Test scenario:
+            Window(0,0,100,100) on a 4x4 raster returns the 4x4 in-bounds mask.
+        """
+        mask = nodata_dataset.read_masks(0, window=Window(0, 0, 100, 100))
+        assert mask.shape == (4, 4)
+
+    def test_fully_outside_window_raises(self, nodata_dataset):
+        """A window entirely outside the raster raises OutOfBoundsError.
+
+        Test scenario:
+            Window(20,20,5,5) on a 4x4 raster is rejected with a clear error.
+        """
+        with pytest.raises(OutOfBoundsError):
+            nodata_dataset.read_masks(0, window=Window(20, 20, 5, 5))

--- a/tests/dataset/test_parallel_reads.py
+++ b/tests/dataset/test_parallel_reads.py
@@ -1,0 +1,75 @@
+"""Tests for Dataset.read_windows — concurrent windowed reads (CONC-1).
+
+Offline: a small on-disk GeoTIFF read through a thread pool; results are compared
+against the sequential reads.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pyramids.dataset import Dataset, Window
+
+pytestmark = pytest.mark.core
+
+
+@pytest.fixture
+def disk_raster(tmp_path) -> Dataset:
+    """An 8x8 ramp GeoTIFF on disk (read_windows needs a reopenable path)."""
+    path = str(tmp_path / "r.tif")
+    Dataset.create_from_array(
+        np.arange(64, dtype="float32").reshape(8, 8),
+        top_left_corner=(0.0, 8.0),
+        cell_size=1.0,
+    ).to_file(path)
+    return Dataset.read_file(path)
+
+
+@pytest.fixture
+def quad_windows() -> list[Window]:
+    """The four 4x4 quadrant windows of an 8x8 raster."""
+    return [
+        Window(0, 0, 4, 4),
+        Window(4, 0, 4, 4),
+        Window(0, 4, 4, 4),
+        Window(4, 4, 4, 4),
+    ]
+
+
+class TestReadWindows:
+    """Tests for Dataset.read_windows."""
+
+    def test_parallel_equals_sequential_in_order(self, disk_raster, quad_windows):
+        """Parallel reads equal the sequential reads, position for position.
+
+        Test scenario:
+            read_windows(...) matches [read_array(window=w) for w] in order.
+        """
+        parallel = disk_raster.read_windows(quad_windows)
+        sequential = [
+            np.asarray(disk_raster.read_array(window=w)) for w in quad_windows
+        ]
+        assert len(parallel) == len(quad_windows)
+        for got, expected in zip(parallel, sequential):
+            assert np.array_equal(got, expected)
+
+    def test_threads_one_equals_sequential(self, disk_raster, quad_windows):
+        """threads=1 yields the same results as the default pool.
+
+        Test scenario:
+            A single worker reads identically (no concurrency bug masking).
+        """
+        single = disk_raster.read_windows(quad_windows, threads=1)
+        pooled = disk_raster.read_windows(quad_windows, threads=4)
+        for one, many in zip(single, pooled):
+            assert np.array_equal(one, many)
+
+    def test_shapes_follow_windows(self, disk_raster, quad_windows):
+        """Each returned array has its window's shape.
+
+        Test scenario:
+            Four 4x4 windows -> four (4, 4) arrays.
+        """
+        blocks = disk_raster.read_windows(quad_windows)
+        assert [b.shape for b in blocks] == [(4, 4)] * 4

--- a/tests/dataset/test_parallel_reads.py
+++ b/tests/dataset/test_parallel_reads.py
@@ -73,3 +73,15 @@ class TestReadWindows:
         """
         blocks = disk_raster.read_windows(quad_windows)
         assert [b.shape for b in blocks] == [(4, 4)] * 4
+
+    def test_mem_dataset_rejected_up_front(self, quad_windows):
+        """A pure-MEM dataset is rejected before any worker runs (review L2).
+
+        Test scenario:
+            read_windows on a MEM dataset raises a clear ValueError.
+        """
+        mem = Dataset.create_from_array(
+            np.ones((8, 8), "float32"), top_left_corner=(0.0, 8.0), cell_size=1.0
+        )
+        with pytest.raises(ValueError, match="path-backed"):
+            mem.read_windows(quad_windows)

--- a/tests/dataset/test_window.py
+++ b/tests/dataset/test_window.py
@@ -460,3 +460,11 @@ class TestWindowConveniences:
         gt = (0.0, 1.0, 0.0, 4.0, 0.0, -1.0)
         out = Window(2, 1, 3, 3).transform(gt)
         assert out == (2.0, 1.0, 0.0, 3.0, 0.0, -1.0)
+
+    def test_crop_zero_extent_is_none(self):
+        """crop on a zero-size extent returns None rather than raising (review N2).
+
+        Test scenario:
+            Window(0,0,4,4).crop(0, 0) -> None.
+        """
+        assert Window(0, 0, 4, 4).crop(rows=0, cols=0) is None

--- a/tests/dataset/test_window.py
+++ b/tests/dataset/test_window.py
@@ -396,3 +396,67 @@ class TestBlockIteration:
         assert (
             sum(w.cols * w.rows for w in spanned) == spanning.cols * spanning.rows
         ), "the ROI-clipped blocks must cover the ROI exactly"
+
+
+class TestWindowConveniences:
+    """Tests for the WIN-1 conveniences (rounded/crop/todict/from_dict/iter/transform)."""
+
+    def test_rounded_floors_offsets_ceils_sizes(self):
+        """rounded snaps fractional pixel coords to a covering integer window.
+
+        Test scenario:
+            (1.4, 2.6, 9.9, 3.1) -> offsets floored (1, 2), sizes ceiled (10, 4).
+        """
+        assert Window.rounded(1.4, 2.6, 9.9, 3.1) == Window(1, 2, 10, 4)
+
+    def test_crop_clamps_oversized_window(self):
+        """crop limits a window to the raster extent.
+
+        Test scenario:
+            A 100x100 window cropped to an 8x8 raster becomes 8x8 at the origin.
+        """
+        assert Window(0, 0, 100, 100).crop(rows=8, cols=8) == Window(0, 0, 8, 8)
+
+    def test_crop_negative_offsets(self):
+        """crop clips a window hanging off the top-left to the in-bounds part.
+
+        Test scenario:
+            Window(-2, -2, 5, 5) cropped to 8x8 keeps the 3x3 in-bounds corner.
+        """
+        assert Window(-2, -2, 5, 5).crop(rows=8, cols=8) == Window(0, 0, 3, 3)
+
+    def test_crop_fully_outside_is_none(self):
+        """A window entirely outside the extent crops to None.
+
+        Test scenario:
+            Window(20, 20, 5, 5) does not overlap an 8x8 raster.
+        """
+        assert Window(20, 20, 5, 5).crop(rows=8, cols=8) is None
+
+    def test_todict_from_dict_round_trip(self):
+        """todict/from_dict round-trip preserves the window.
+
+        Test scenario:
+            from_dict(todict(w)) == w.
+        """
+        w = Window(4, 1, 2, 3)
+        assert Window.from_dict(w.todict()) == w
+
+    def test_iter_yields_gdal_order(self):
+        """Iterating a window yields (col_off, row_off, cols, rows).
+
+        Test scenario:
+            tuple(window) matches to_read_args().
+        """
+        w = Window(4, 1, 2, 3)
+        assert tuple(w) == w.to_read_args()
+
+    def test_transform_shifts_only_origin(self):
+        """transform moves the origin to the window, keeping cell size/rotation.
+
+        Test scenario:
+            A north-up gt: only indices 0 and 3 change.
+        """
+        gt = (0.0, 1.0, 0.0, 4.0, 0.0, -1.0)
+        out = Window(2, 1, 3, 3).transform(gt)
+        assert out == (2.0, 1.0, 0.0, 3.0, 0.0, -1.0)

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -528,3 +528,39 @@ class TestGeoreferenceCLI:
         rc = main(["orthorectify", src_raster, out, "--rpc-height", "100"])
         assert rc == 1, "must exit 1 when the input has no RPC metadata"
         assert not os.path.exists(out), "no output on a failed orthorectify"
+
+
+class TestEditInfo:
+    """Tests for `pyramids edit-info`."""
+
+    def test_sets_crs_and_nodata(self, src_raster):
+        """edit-info rewrites the CRS and no-data value in place.
+
+        Test scenario:
+            --crs 3857 --nodata 0 on a 4326/-9999 raster; re-read reflects both.
+        """
+        rc = main(["edit-info", src_raster, "--crs", "3857", "--nodata", "0"])
+        assert rc == 0, "edit-info must exit 0"
+        ds = Dataset.read_file(src_raster)
+        assert ds.epsg == 3857
+        assert ds.no_data_value[0] == 0
+
+    def test_sets_tag(self, src_raster):
+        """edit-info writes a metadata tag.
+
+        Test scenario:
+            --tag AREA=test sets the AREA metadata item.
+        """
+        rc = main(["edit-info", src_raster, "--tag", "AREA=test"])
+        assert rc == 0
+        assert Dataset.read_file(src_raster).raster.GetMetadataItem("AREA") == "test"
+
+    def test_no_flags_prints_notice(self, src_raster, capsys):
+        """edit-info with no edit flags prints a notice and exits 0.
+
+        Test scenario:
+            A bare edit-info call no-ops with a helpful message.
+        """
+        rc = main(["edit-info", src_raster])
+        assert rc == 0
+        assert "no edits" in capsys.readouterr().out

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -564,3 +564,63 @@ class TestEditInfo:
         rc = main(["edit-info", src_raster])
         assert rc == 0
         assert "no edits" in capsys.readouterr().out
+
+
+class TestCalc:
+    """Tests for `pyramids calc` (safe band-expression evaluation)."""
+
+    def _band(self, tmp_path, name, value):
+        """Write a 2x2 constant-value GeoTIFF and return its path."""
+        path = str(tmp_path / name)
+        Dataset.create_from_array(
+            np.full((2, 2), value, "float32"), top_left_corner=(0, 2), cell_size=1.0
+        ).to_file(path)
+        return path
+
+    def test_ndvi_correctness(self, tmp_path):
+        """calc evaluates (A - B) / (A + B) element-wise.
+
+        Test scenario:
+            A=4, B=2 -> NDVI 2/6 = 0.3333 across the output.
+        """
+        a = self._band(tmp_path, "a.tif", 4.0)
+        b = self._band(tmp_path, "b.tif", 2.0)
+        out = str(tmp_path / "ndvi.tif")
+        rc = main(["calc", "(A - B) / (A + B)", a, b, out])
+        assert rc == 0, "calc must exit 0"
+        result = np.asarray(Dataset.read_file(out).read_array())
+        assert np.allclose(result, (4.0 - 2.0) / (4.0 + 2.0))
+
+    def test_np_where_allowed(self, tmp_path):
+        """A whitelisted np.where call is evaluated.
+
+        Test scenario:
+            np.where(A > 3, 1, 0) on A=4 yields all ones.
+        """
+        a = self._band(tmp_path, "a.tif", 4.0)
+        out = str(tmp_path / "w.tif")
+        rc = main(["calc", "np.where(A > 3, 1, 0)", a, out])
+        assert rc == 0
+        assert np.allclose(np.asarray(Dataset.read_file(out).read_array()), 1)
+
+    def test_disallowed_expression_rejected(self, src_raster, tmp_path):
+        """A hostile expression is rejected and writes nothing.
+
+        Test scenario:
+            __import__('os') exits 1 (ValueError) and creates no output.
+        """
+        out = str(tmp_path / "evil.tif")
+        rc = main(["calc", "__import__('os')", src_raster, out])
+        assert rc == 1, "disallowed expression must exit 1"
+        assert not os.path.exists(out), "nothing is written on a rejected expression"
+
+    def test_dtype_flag(self, src_raster, tmp_path):
+        """--dtype casts the result.
+
+        Test scenario:
+            A * 2 with --dtype float64 writes a float64 raster.
+        """
+        out = str(tmp_path / "d.tif")
+        rc = main(["calc", "A * 2", src_raster, out, "--dtype", "float64"])
+        assert rc == 0
+        assert np.asarray(Dataset.read_file(out).read_array()).dtype == np.float64

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -736,3 +736,42 @@ class TestShapesRasterizeCLI:
         rc = main(["rasterize", vector, out, "--cell-size", "1", "--column", "Band_1"])
         assert rc == 0, "rasterize --column must exit 0"
         assert Dataset.read_file(out).band_count == 1
+
+    def test_shapes_refuses_large_without_flag(self, src_raster, tmp_path, monkeypatch):
+        """shapes refuses an over-threshold raster without --allow-large (review L1).
+
+        Test scenario:
+            With the cell-count cap lowered to 4, a 64-cell raster is refused
+            (exit 1, nothing written).
+        """
+        monkeypatch.setattr("pyramids.cli._SHAPES_MAX_CELLS", 4)
+        out = str(tmp_path / "big.geojson")
+        rc = main(["shapes", src_raster, out])
+        assert rc == 1, "an over-threshold shapes must exit 1"
+        assert not os.path.exists(out), "no output on a refused shapes"
+
+    def test_shapes_allow_large_overrides(self, src_raster, tmp_path, monkeypatch):
+        """--allow-large overrides the cell-count guard (review L1).
+
+        Test scenario:
+            With the cap lowered to 4, --allow-large still vectorizes the raster.
+        """
+        monkeypatch.setattr("pyramids.cli._SHAPES_MAX_CELLS", 4)
+        out = str(tmp_path / "big.geojson")
+        rc = main(["shapes", src_raster, out, "--allow-large"])
+        assert rc == 0, "--allow-large must proceed"
+        assert os.path.exists(out)
+
+    def test_rasterize_both_grid_args_notes(self, src_raster, tmp_path, capsys):
+        """rasterize notes that --cell-size is ignored when --like is given (review N1).
+
+        Test scenario:
+            Passing both still succeeds and prints a clarifying note to stderr.
+        """
+        vector = str(tmp_path / "v.geojson")
+        assert main(["shapes", src_raster, vector]) == 0
+        capsys.readouterr()
+        out = str(tmp_path / "r.tif")
+        rc = main(["rasterize", vector, out, "--cell-size", "1", "--like", src_raster])
+        assert rc == 0
+        assert "ignored" in capsys.readouterr().err

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -472,3 +472,59 @@ class TestUnexpectedErrors:
         monkeypatch.setenv("PYRAMIDS_DEBUG", "1")
         with pytest.raises(KeyError):
             main(["info", src_raster])
+
+
+class TestGeoreferenceCLI:
+    """Tests for `pyramids georeference` and `pyramids orthorectify`."""
+
+    def test_georeference_writes_output(self, src_raster, tmp_path):
+        """georeference warps the input from --gcp points into a 4326 raster.
+
+        Test scenario:
+            Four corner GCPs (10-11E, 49-50N) write a georeferenced GeoTIFF.
+        """
+        out = str(tmp_path / "geo.tif")
+        rc = main(
+            [
+                "georeference", src_raster, out,
+                "--gcp", "0", "0", "10", "50",
+                "--gcp", "8", "0", "11", "50",
+                "--gcp", "0", "8", "10", "49",
+                "--gcp", "8", "8", "11", "49",
+                "--gcp-crs", "4326",
+            ]
+        )
+        assert rc == 0, "georeference must exit 0"
+        assert os.path.exists(out), "output raster must be written"
+        assert Dataset.read_file(out).epsg == 4326
+
+    def test_georeference_refuses_existing(self, src_raster, tmp_path):
+        """Without --overwrite, an existing output is refused (exit 1).
+
+        Test scenario:
+            georeference onto an existing path returns 1 and writes nothing new.
+        """
+        out = str(tmp_path / "exists.tif")
+        Dataset.create_from_array(
+            np.ones((2, 2), "float32"), top_left_corner=(0, 2), cell_size=1.0
+        ).to_file(out)
+        rc = main(
+            [
+                "georeference", src_raster, out,
+                "--gcp", "0", "0", "10", "50",
+                "--gcp-crs", "4326",
+            ]
+        )
+        assert rc == 1, "must refuse an existing output without --overwrite"
+
+    def test_orthorectify_without_rpc_errors_cleanly(self, src_raster, tmp_path):
+        """orthorectify on a raster with no RPC metadata exits 1 (clean error).
+
+        Test scenario:
+            A plain raster has no RPCs; the command reports the error and exits 1
+            rather than crashing.
+        """
+        out = str(tmp_path / "ortho.tif")
+        rc = main(["orthorectify", src_raster, out, "--rpc-height", "100"])
+        assert rc == 1, "must exit 1 when the input has no RPC metadata"
+        assert not os.path.exists(out), "no output on a failed orthorectify"

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -685,3 +685,54 @@ class TestShapesRasterizeCLI:
         assert main(["shapes", src_raster, vector]) == 0
         rc = main(["rasterize", vector, str(tmp_path / "r.tif")])
         assert rc == 1, "must exit 1 without --cell-size/--like"
+
+    def test_shapes_point_geometry(self, src_raster, tmp_path):
+        """shapes --geometry point emits per-cell point features.
+
+        Test scenario:
+            --geometry point writes a readable vector with finite bounds.
+        """
+        out = str(tmp_path / "pts.geojson")
+        rc = main(["shapes", src_raster, out, "--geometry", "point"])
+        assert rc == 0, "shapes --geometry point must exit 0"
+        assert np.all(np.isfinite(FeatureCollection.read_file(out).total_bounds))
+
+    def test_shapes_refuses_existing(self, src_raster, tmp_path):
+        """shapes refuses an existing output without --overwrite (exit 1).
+
+        Test scenario:
+            An existing destination is not clobbered.
+        """
+        out = str(tmp_path / "exists.geojson")
+        main(["shapes", src_raster, out])
+        rc = main(["shapes", src_raster, out])
+        assert rc == 1, "must refuse an existing output without --overwrite"
+
+    def test_rasterize_with_template(self, src_raster, tmp_path):
+        """rasterize --like adopts a template raster's grid.
+
+        Test scenario:
+            shapes -> vector, then rasterize --like src; the output matches the
+            template's cell size and dimensions.
+        """
+        vector = str(tmp_path / "v.geojson")
+        assert main(["shapes", src_raster, vector]) == 0
+        out = str(tmp_path / "r.tif")
+        rc = main(["rasterize", vector, out, "--like", src_raster])
+        assert rc == 0, "rasterize --like must exit 0"
+        template = Dataset.read_file(src_raster)
+        result = Dataset.read_file(out)
+        assert (result.rows, result.columns) == (template.rows, template.columns)
+
+    def test_rasterize_with_column(self, src_raster, tmp_path):
+        """rasterize --column burns a single named attribute.
+
+        Test scenario:
+            --column Band_1 produces a single-band raster.
+        """
+        vector = str(tmp_path / "v.geojson")
+        assert main(["shapes", src_raster, vector]) == 0
+        out = str(tmp_path / "r.tif")
+        rc = main(["rasterize", vector, out, "--cell-size", "1", "--column", "Band_1"])
+        assert rc == 0, "rasterize --column must exit 0"
+        assert Dataset.read_file(out).band_count == 1

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -624,3 +624,23 @@ class TestCalc:
         rc = main(["calc", "A * 2", src_raster, out, "--dtype", "float64"])
         assert rc == 0
         assert np.asarray(Dataset.read_file(out).read_array()).dtype == np.float64
+
+    def test_sets_crs_from_authority_string(self, src_raster):
+        """edit-info accepts EPSG:NNNN / PROJ4, not just a bare integer (review M1).
+
+        Test scenario:
+            --crs "EPSG:3857" sets the CRS without a cryptic error.
+        """
+        rc = main(["edit-info", src_raster, "--crs", "EPSG:3857"])
+        assert rc == 0, "authority-string CRS must be accepted"
+        assert Dataset.read_file(src_raster).epsg == 3857
+
+    def test_invalid_crs_leaves_file_unchanged(self, src_raster):
+        """An invalid --crs fails cleanly and does not mutate the file (review M1).
+
+        Test scenario:
+            --crs not-a-crs exits 1 and the EPSG stays 4326 (no partial write).
+        """
+        rc = main(["edit-info", src_raster, "--crs", "not-a-crs"])
+        assert rc == 1, "invalid CRS must exit 1"
+        assert Dataset.read_file(src_raster).epsg == 4326, "no partial write"

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -644,3 +644,44 @@ class TestCalc:
         rc = main(["edit-info", src_raster, "--crs", "not-a-crs"])
         assert rc == 1, "invalid CRS must exit 1"
         assert Dataset.read_file(src_raster).epsg == 4326, "no partial write"
+
+
+class TestShapesRasterizeCLI:
+    """Tests for `pyramids shapes` and `pyramids rasterize`."""
+
+    def test_shapes_writes_vector(self, src_raster, tmp_path):
+        """shapes vectorizes the raster into a readable vector file.
+
+        Test scenario:
+            shapes src.tif out.geojson writes per-cell polygons (64 cells).
+        """
+        out = str(tmp_path / "shapes.geojson")
+        rc = main(["shapes", src_raster, out])
+        assert rc == 0, "shapes must exit 0"
+        assert os.path.exists(out)
+        assert np.all(np.isfinite(FeatureCollection.read_file(out).total_bounds))
+
+    def test_rasterize_round_trips(self, src_raster, tmp_path):
+        """rasterize burns a vector (from shapes) back into a raster.
+
+        Test scenario:
+            shapes -> vector, then rasterize --cell-size 1 -> a raster file.
+        """
+        vector = str(tmp_path / "v.geojson")
+        assert main(["shapes", src_raster, vector]) == 0
+        out = str(tmp_path / "r.tif")
+        rc = main(["rasterize", vector, out, "--cell-size", "1"])
+        assert rc == 0, "rasterize must exit 0"
+        assert os.path.exists(out)
+        assert Dataset.read_file(out).cell_size == 1
+
+    def test_rasterize_without_grid_errors(self, src_raster, tmp_path):
+        """rasterize without --cell-size or --like exits 1.
+
+        Test scenario:
+            A missing output grid is a clean user error.
+        """
+        vector = str(tmp_path / "v.geojson")
+        assert main(["shapes", src_raster, vector]) == 0
+        rc = main(["rasterize", vector, str(tmp_path / "r.tif")])
+        assert rc == 1, "must exit 1 without --cell-size/--like"


### PR DESCRIPTION
# Description

Adds a batch of raster capabilities and ergonomics, the headline being **GCP/RPC georeferencing** — the one
capability the package previously lacked for raw / un-orthorectified imagery. Everything routes through GDAL;
no new dependency is added. Also carries the earlier code-verified **comparison-doc audit** (the
`docs/comparison-other-gis-packages.md` refresh).

Implemented as independent workstreams:

- **GCP/RPC georeferencing** — a new `Georef` engine (`ds.georef`) with a `GroundControlPoint` value object:
  `set_gcps`/`gcps`/`gcp_count`/`gcp_projection`/`has_gcps`, `georeference` (polynomial / thin-plate-spline
  warp from GCPs), `rpcs`/`has_rpcs`/`set_rpcs`, and `orthorectify` (RPC + DEM or constant height). Plus
  `pyramids georeference` / `orthorectify` CLI, a tutorial, and a reference page.
- **Per-band mask introspection** — `MaskFlags` + `mask_flags`, `read_masks`, `create_mask_band`.
- **CLI breadth** — `pyramids edit-info` (rewrite CRS/nodata/tags in place) and `pyramids calc` (band
  expressions via a hand-written AST whitelist — **never `eval`/`exec`**).
- **Window algebra** — `Window.rounded`/`crop`/`todict`/`from_dict`/`__iter__`/`transform`.
- **Parallel reads** — `Dataset.read_windows(threads=)` over the per-thread-handle reader, plus a how-to.

Dependencies: none — standard library (`ast`, `concurrent.futures`, `uuid`) and the GDAL bindings already
linked.

# Issues

- Fixes #539 — read GCPs (GR-1)
- Fixes #540 — GroundControlPoint + set_gcps (GR-2)
- Fixes #541 — warp from GCPs / georeference (GR-3)
- Fixes #542 — read RPC metadata (GR-4)
- Fixes #543 — set RPC metadata (GR-5)
- Fixes #544 — orthorectify via RPC (GR-6)
- Fixes #545 — georeference / orthorectify CLI (GR-7)
- Fixes #546 — georeferencing docs + comparison flip (GR-8)
- Fixes #547 — mask_flags (MF-1)
- Fixes #548 — read_masks (MF-2)
- Fixes #549 — create_mask_band (MF-3)
- Fixes #550 — edit-info CLI (CLI-1)
- Fixes #551 — calc CLI (CLI-2)
- Fixes #552 — CLI docs (CLI-3)
- Fixes #553 — Window conveniences (WIN-1)
- Fixes #554 — block_windows() iterator (WIN-2)
- Fixes #555 — read_windows / parallel reads (CONC-1)
- Fixes #556 — parallel-reads how-to (CONC-2)

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

New offline suites (all `pytest.mark.core`, no network — GDAL warps and reads run on synthetic in-fixture
rasters):

- `tests/dataset/test_georef.py` (28) — `GroundControlPoint` round-trips, GCP read/set, `georeference`
  (polynomial / tps / reproject-in-one-pass / lazy==eager / invalid args / no-GCP), RPC read/set,
  `orthorectify` (constant-height, no-height warning, no-RPC error) and DEM-path resolution.
- `tests/dataset/test_masks.py` (8) — `mask_flags` (nodata / all-valid / alpha), `read_masks`
  (single / stacked / windowed), `create_mask_band` (+ read-only guard).
- `tests/dataset/test_window.py` (+8) — `rounded`/`crop`/`todict`/`from_dict`/`__iter__`/`transform` and the
  zero-extent crop edge.
- `tests/dataset/test_parallel_reads.py` (4) — parallel == sequential (ordered), `threads=1`, MEM rejected.
- `tests/test_cli_commands.py` (+14) — `georeference`/`orthorectify`/`edit-info`/`calc`, including the
  hostile-expression rejection (`__import__('os')` → exit 1, nothing written).

Commands:

- [x] `pixi run -e dev pytest tests/dataset/test_georef.py tests/dataset/test_masks.py tests/dataset/test_window.py tests/dataset/test_parallel_reads.py tests/test_cli_commands.py` → 129 passed
- [x] Doctests for the new modules (`_gcp`, `_mask`, `window`, `georef`) pass

A `/review` pass produced 2 Low + 3 Nit findings, all fixed (staged-`/vsimem` DEM unlink, up-front
MEM-dataset guard in `read_windows`, `collections.abc` imports, `Window.crop` zero-extent, `calc` 26-input
cap).

# Checklist:

- [ ] updated version number in pyproject.toml. <!-- handled by commitizen via the release workflow -->
- [ ] added changes to History.rst. <!-- change-log is commitizen-generated -->
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.

