### PR TITLE
fix(netcdf): resolve S3 bucket region for anonymous LabeledDataset reads

### DIFF
--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -152,10 +152,26 @@ _S3_REGION_CACHE: dict[str, str | None] = {}
 
 
 class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
-    """Suppress redirect-following so an S3 301 surfaces as a readable HTTPError."""
+    """A ``urllib`` redirect handler that never follows redirects.
+
+    Used by :func:`resolve_s3_region` so an S3 ``PermanentRedirect`` (HTTP 301)
+    is raised as an :class:`urllib.error.HTTPError` we can read the
+    ``x-amz-bucket-region`` header off, instead of being silently followed (or
+    looping) by the default handler.
+    """
 
     def redirect_request(self, *args: Any, **kwargs: Any) -> None:
-        """Return ``None`` so urllib raises ``HTTPError`` on a 3xx instead of following it."""
+        """Refuse to build a redirected request.
+
+        Args:
+            *args: The positional arguments urllib passes (``req``, ``fp``,
+                ``code``, ``msg``, ``headers``, ``newurl``); all ignored.
+            **kwargs: Ignored.
+
+        Returns:
+            None: signals urllib to raise :class:`urllib.error.HTTPError` for the
+            3xx response rather than following its ``Location`` header.
+        """
         return None
 
 

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -206,22 +206,25 @@ def resolve_s3_region(bucket: str, *, timeout: float = 10.0) -> str | None:
             ```
     """
     if bucket not in _S3_REGION_CACHE:
-        # Path-style global endpoint (`s3.amazonaws.com/<bucket>`) rather than the
-        # virtual-hosted host (`<bucket>.s3.amazonaws.com`): the latter's TLS cert
-        # (`*.s3.amazonaws.com`) does not match a dot-containing bucket name, which
-        # would fail the handshake for exactly those buckets. The global endpoint
-        # still returns `x-amz-bucket-region` on its redirect.
-        request = urllib.request.Request(
-            f"https://s3.amazonaws.com/{bucket}", method="HEAD"
-        )
-        opener = urllib.request.build_opener(_NoRedirectHandler)
         try:
+            # Path-style global endpoint (`s3.amazonaws.com/<bucket>`) rather than
+            # the virtual-hosted host (`<bucket>.s3.amazonaws.com`): the latter's
+            # TLS cert (`*.s3.amazonaws.com`) does not match a dot-containing bucket
+            # name, which would fail the handshake for exactly those buckets. The
+            # global endpoint still returns `x-amz-bucket-region` on its redirect.
+            # Construction stays inside the try so this helper never raises — the
+            # caller relies on a `None` return for every failure mode.
+            request = urllib.request.Request(
+                f"https://s3.amazonaws.com/{bucket}", method="HEAD"
+            )
+            opener = urllib.request.build_opener(_NoRedirectHandler)
             with opener.open(request, timeout=timeout) as response:
                 region = response.headers.get("x-amz-bucket-region")
         except urllib.error.HTTPError as exc:
             region = exc.headers.get("x-amz-bucket-region") if exc.headers else None
-        except OSError:
-            # urllib.error.URLError and ssl.SSLError both derive from OSError.
+        except (OSError, ValueError):
+            # urllib.error.URLError and ssl.SSLError derive from OSError; ValueError
+            # guards a malformed bucket string reaching Request().
             region = None
         _S3_REGION_CACHE[bucket] = region
     return _S3_REGION_CACHE[bucket]

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -215,7 +215,8 @@ def resolve_s3_region(bucket: str, *, timeout: float = 10.0) -> str | None:
                 region = response.headers.get("x-amz-bucket-region")
         except urllib.error.HTTPError as exc:
             region = exc.headers.get("x-amz-bucket-region") if exc.headers else None
-        except (urllib.error.URLError, OSError):
+        except OSError:
+            # urllib.error.URLError and ssl.SSLError both derive from OSError.
             region = None
         _S3_REGION_CACHE[bucket] = region
     return _S3_REGION_CACHE[bucket]

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -212,6 +212,12 @@ def resolve_s3_region(bucket: str, *, timeout: float = 5.0) -> str | None:
             'eu-central-1'
 
             ```
+
+    See Also:
+        - :class:`CloudConfig`: pass the resolved region as ``aws_region`` to pin
+          ``AWS_REGION`` for a GDAL open.
+        - :meth:`pyramids.netcdf.LabeledDataset.read_file`: the primary caller,
+          which auto-resolves the region for anonymous ``s3://`` stores.
     """
     if bucket not in _S3_REGION_CACHE:
         try:

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -206,8 +206,13 @@ def resolve_s3_region(bucket: str, *, timeout: float = 10.0) -> str | None:
             ```
     """
     if bucket not in _S3_REGION_CACHE:
+        # Path-style global endpoint (`s3.amazonaws.com/<bucket>`) rather than the
+        # virtual-hosted host (`<bucket>.s3.amazonaws.com`): the latter's TLS cert
+        # (`*.s3.amazonaws.com`) does not match a dot-containing bucket name, which
+        # would fail the handshake for exactly those buckets. The global endpoint
+        # still returns `x-amz-bucket-region` on its redirect.
         request = urllib.request.Request(
-            f"https://{bucket}.s3.amazonaws.com", method="HEAD"
+            f"https://s3.amazonaws.com/{bucket}", method="HEAD"
         )
         opener = urllib.request.build_opener(_NoRedirectHandler)
         try:

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -220,26 +220,30 @@ def resolve_s3_region(bucket: str, *, timeout: float = 5.0) -> str | None:
           which auto-resolves the region for anonymous ``s3://`` stores.
     """
     if bucket not in _S3_REGION_CACHE:
+        region = None
+        # Path-style global endpoint (`s3.amazonaws.com/<bucket>`) rather than the
+        # virtual-hosted host (`<bucket>.s3.amazonaws.com`): the latter's TLS cert
+        # (`*.s3.amazonaws.com`) does not match a dot-containing bucket name, which
+        # would fail the handshake for exactly those buckets. The global endpoint
+        # still returns `x-amz-bucket-region` on its redirect.
         try:
-            # Path-style global endpoint (`s3.amazonaws.com/<bucket>`) rather than
-            # the virtual-hosted host (`<bucket>.s3.amazonaws.com`): the latter's
-            # TLS cert (`*.s3.amazonaws.com`) does not match a dot-containing bucket
-            # name, which would fail the handshake for exactly those buckets. The
-            # global endpoint still returns `x-amz-bucket-region` on its redirect.
-            # Construction stays inside the try so this helper never raises — the
-            # caller relies on a `None` return for every failure mode.
             request = urllib.request.Request(
                 f"https://s3.amazonaws.com/{bucket}", method="HEAD"
             )
+        except ValueError:
+            # A malformed bucket string can make Request() reject the URL; treat it
+            # as "region unknown" so this helper never raises for the caller.
+            request = None
+        if request is not None:
             opener = urllib.request.build_opener(_NoRedirectHandler)
-            with opener.open(request, timeout=timeout) as response:
-                region = response.headers.get("x-amz-bucket-region")
-        except urllib.error.HTTPError as exc:
-            region = exc.headers.get("x-amz-bucket-region") if exc.headers else None
-        except (OSError, ValueError):
-            # urllib.error.URLError and ssl.SSLError derive from OSError; ValueError
-            # guards a malformed bucket string reaching Request().
-            region = None
+            try:
+                with opener.open(request, timeout=timeout) as response:
+                    region = response.headers.get("x-amz-bucket-region")
+            except urllib.error.HTTPError as exc:
+                region = exc.headers.get("x-amz-bucket-region") if exc.headers else None
+            except OSError:
+                # urllib.error.URLError and ssl.SSLError both derive from OSError.
+                region = None
         _S3_REGION_CACHE[bucket] = region
     return _S3_REGION_CACHE[bucket]
 

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -18,6 +18,7 @@ Two concerns live in this module:
 
 from __future__ import annotations
 
+import http.client
 import logging
 import os
 import re
@@ -241,8 +242,11 @@ def resolve_s3_region(bucket: str, *, timeout: float = 5.0) -> str | None:
                     region = response.headers.get("x-amz-bucket-region")
             except urllib.error.HTTPError as exc:
                 region = exc.headers.get("x-amz-bucket-region") if exc.headers else None
-            except OSError:
-                # urllib.error.URLError and ssl.SSLError both derive from OSError.
+            except (OSError, http.client.HTTPException):
+                # urllib.error.URLError and ssl.SSLError derive from OSError;
+                # http.client raises HTTPException (e.g. BadStatusLine) for a
+                # malformed response, which is not an OSError. Catch both so the
+                # probe honours its never-raises contract for the caller.
                 region = None
         _S3_REGION_CACHE[bucket] = region
     return _S3_REGION_CACHE[bucket]

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -21,6 +21,8 @@ from __future__ import annotations
 import logging
 import os
 import re
+import urllib.error
+import urllib.request
 import warnings
 from collections.abc import Iterator
 from contextlib import contextmanager, nullcontext
@@ -142,6 +144,65 @@ def is_remote(path: str) -> bool:
         scheme = urlparse(path).scheme.lower()
         result = scheme in URL_SCHEMES and len(scheme) > 1
     return result
+
+
+# Per-process cache of resolved S3 bucket regions (None caches a failed probe so
+# a single offline/blocked attempt is not retried on every open of the bucket).
+_S3_REGION_CACHE: dict[str, str | None] = {}
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Suppress redirect-following so an S3 301 surfaces as a readable HTTPError."""
+
+    def redirect_request(self, *args: Any, **kwargs: Any) -> None:
+        """Return ``None`` so urllib raises ``HTTPError`` on a 3xx instead of following it."""
+        return None
+
+
+def resolve_s3_region(bucket: str, *, timeout: float = 10.0) -> str | None:
+    """Resolve an S3 bucket's home region via a single anonymous HEAD probe.
+
+    GDAL's ``/vsis3`` skips region auto-resolution under ``AWS_NO_SIGN_REQUEST``
+    (anonymous reads), so a bucket outside ``us-east-1`` answers an open with an
+    unfollowed ``PermanentRedirect`` (HTTP 301). S3 returns the bucket's region
+    in the ``x-amz-bucket-region`` response header on **any** request to the
+    bucket — including the 301 / 403 returned without credentials — so one
+    anonymous HEAD recovers it. The caller can then pin it as ``AWS_REGION``
+    before the open and avoid the redirect (see issue #535). Results are cached
+    per bucket for the life of the process; a failed probe caches ``None`` so it
+    is not retried on every open.
+
+    Args:
+        bucket: The S3 bucket name (no scheme, no key).
+        timeout: Per-request timeout in seconds.
+
+    Returns:
+        The region string (e.g. ``"eu-central-1"``), or ``None`` when the probe
+        could not determine it (offline, blocked, or no region header present).
+
+    Examples:
+        - Resolve a public bucket's region (needs network — skipped in doctests):
+            ```python
+            >>> from pyramids.base.remote import resolve_s3_region  # doctest: +SKIP
+            >>> resolve_s3_region("noaa-nwm-retrospective-3-0-pds")  # doctest: +SKIP
+            'eu-central-1'
+
+            ```
+    """
+    if bucket not in _S3_REGION_CACHE:
+        request = urllib.request.Request(
+            f"https://{bucket}.s3.amazonaws.com", method="HEAD"
+        )
+        opener = urllib.request.build_opener(_NoRedirectHandler)
+        try:
+            with opener.open(request, timeout=timeout) as response:
+                region = response.headers.get("x-amz-bucket-region")
+        except urllib.error.HTTPError as exc:
+            region = exc.headers.get("x-amz-bucket-region") if exc.headers else None
+        except (urllib.error.URLError, OSError):
+            region = None
+        _S3_REGION_CACHE[bucket] = region
+    return _S3_REGION_CACHE[bucket]
 
 
 def _to_vsi(path: str) -> str:

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -148,6 +148,11 @@ def is_remote(path: str) -> bool:
 
 # Per-process cache of resolved S3 bucket regions (None caches a failed probe so
 # a single offline/blocked attempt is not retried on every open of the bucket).
+# Intentionally lock-free: two threads racing the first probe of the same bucket
+# may both issue a HEAD, but the writes are idempotent (same region) and dict
+# insertion is atomic under the GIL, so the only cost is one redundant request.
+# A lock here would have to wrap the network call and would needlessly serialise
+# probes of *different* buckets.
 _S3_REGION_CACHE: dict[str, str | None] = {}
 
 

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -180,7 +180,7 @@ class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
         return None
 
 
-def resolve_s3_region(bucket: str, *, timeout: float = 10.0) -> str | None:
+def resolve_s3_region(bucket: str, *, timeout: float = 5.0) -> str | None:
     """Resolve an S3 bucket's home region via a single anonymous HEAD probe.
 
     GDAL's ``/vsis3`` skips region auto-resolution under ``AWS_NO_SIGN_REQUEST``
@@ -195,7 +195,10 @@ def resolve_s3_region(bucket: str, *, timeout: float = 10.0) -> str | None:
 
     Args:
         bucket: The S3 bucket name (no scheme, no key).
-        timeout: Per-request timeout in seconds.
+        timeout: Per-request timeout in seconds. Bounds the worst-case latency
+            this adds to the *first* anonymous open of a bucket (the result is
+            cached thereafter); keep it small so a slow/unreachable endpoint
+            does not stall the open.
 
     Returns:
         The region string (e.g. ``"eu-central-1"``), or ``None`` when the probe

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -28,7 +28,7 @@ import pandas as pd
 from osgeo import gdal
 
 from pyramids.base._utils import import_pyarrow
-from pyramids.base.remote import CloudConfig, _to_vsi
+from pyramids.base.remote import CloudConfig, _to_vsi, resolve_s3_region
 
 # Soft guard: realising a store this large into a DataFrame loads it all into
 # memory. Above this many bytes the write methods warn the caller to slice first
@@ -134,6 +134,7 @@ class LabeledDataset:
         group: str | None = None,
         engine: str | None = None,
         anon: bool = False,
+        region: str | None = None,
     ) -> LabeledDataset:
         """Open a label-indexed NetCDF or Zarr store lazily via GDAL multidim.
 
@@ -151,6 +152,12 @@ class LabeledDataset:
                 for NetCDF/HDF5. `None` infers from the path suffix.
             anon: Open the remote store anonymously (unsigned;
                 `AWS_NO_SIGN_REQUEST` for S3 and the equivalent elsewhere).
+            region: Pin the S3 bucket region (sets `AWS_REGION` for the open).
+                Leave `None` and, for an anonymous S3 store, the region is
+                auto-resolved from the bucket — GDAL skips region resolution
+                under `AWS_NO_SIGN_REQUEST`, so a bucket outside `us-east-1`
+                would otherwise fail with an unfollowed `PermanentRedirect`
+                (see issue #535). An explicit value always wins.
 
         Returns:
             LabeledDataset: The opened store.
@@ -177,8 +184,20 @@ class LabeledDataset:
                 if not gdal_path.startswith("ZARR:")
                 else gdal_path
             )
+        # GDAL does not auto-resolve the bucket region under AWS_NO_SIGN_REQUEST,
+        # so an anonymous read of a bucket outside us-east-1 hits an unfollowed
+        # PermanentRedirect. Resolve and pin it before the open (issue #535); an
+        # explicit `region` always wins.
+        effective_region = region
+        if (
+            effective_region is None
+            and anon
+            and source.split("://", 1)[0].lower() == "s3"
+        ):
+            bucket = source.split("://", 1)[1].split("/", 1)[0]
+            effective_region = resolve_s3_region(bucket)
         try:
-            with CloudConfig(aws_no_sign_request=anon):
+            with CloudConfig(aws_no_sign_request=anon, aws_region=effective_region):
                 ds = gdal.OpenEx(gdal_path, gdal.OF_MULTIDIM_RASTER)
         except RuntimeError as exc:
             # gdal.UseExceptions() raises (rather than returning None) for a

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -153,11 +153,13 @@ class LabeledDataset:
             anon: Open the remote store anonymously (unsigned;
                 `AWS_NO_SIGN_REQUEST` for S3 and the equivalent elsewhere).
             region: Pin the S3 bucket region (sets `AWS_REGION` for the open).
-                Leave `None` and, for an anonymous S3 store, the region is
+                Leave `None` and, for an anonymous `s3://` store, the region is
                 auto-resolved from the bucket — GDAL skips region resolution
                 under `AWS_NO_SIGN_REQUEST`, so a bucket outside `us-east-1`
                 would otherwise fail with an unfollowed `PermanentRedirect`
-                (see issue #535). An explicit value always wins.
+                (see issue #535). An explicit value always wins. Auto-resolution
+                applies only to `s3://`-scheme URLs; pass `region` explicitly for
+                an already-rewritten `/vsis3/...` path.
 
         Returns:
             LabeledDataset: The opened store.

--- a/tests/netcdf/test_labeled_s3_region.py
+++ b/tests/netcdf/test_labeled_s3_region.py
@@ -106,6 +106,49 @@ class TestResolveS3Region:
         )
         assert resolve_s3_region("b") is None
 
+    def test_returns_none_when_region_header_absent(self, monkeypatch):
+        """A 200 response without the region header resolves to ``None``.
+
+        Test scenario:
+            The bucket answers but omits ``x-amz-bucket-region`` (e.g. a
+            non-S3 endpoint); the probe yields ``None`` rather than crashing.
+        """
+        opener = _FakeOpener(response=_FakeResponse({}))
+        monkeypatch.setattr(
+            remote_mod.urllib.request, "build_opener", lambda *a, **k: opener
+        )
+        assert resolve_s3_region("b") is None
+
+    def test_http_error_without_headers_returns_none(self, monkeypatch):
+        """An ``HTTPError`` carrying no headers resolves to ``None``.
+
+        Test scenario:
+            The error has ``headers is None``; the ``exc.headers else None``
+            guard returns ``None`` instead of raising ``AttributeError``.
+        """
+        err = urllib.error.HTTPError(
+            url="https://b.s3.amazonaws.com", code=403, msg="Forbidden", hdrs=None, fp=None
+        )
+        opener = _FakeOpener(error=err)
+        monkeypatch.setattr(
+            remote_mod.urllib.request, "build_opener", lambda *a, **k: opener
+        )
+        assert resolve_s3_region("b") is None
+
+    def test_no_redirect_handler_suppresses_redirect(self):
+        """``_NoRedirectHandler.redirect_request`` returns ``None`` (no follow).
+
+        Test scenario:
+            Returning ``None`` makes urllib raise ``HTTPError`` for a 3xx
+            instead of following the ``Location``, so the region header on the
+            error is readable.
+        """
+        handler = remote_mod._NoRedirectHandler()
+        result = handler.redirect_request(
+            "request", "fp", 301, "Moved", {}, "https://elsewhere"
+        )
+        assert result is None, f"redirect must not be followed, got {result!r}"
+
     def test_result_is_cached(self, monkeypatch):
         """The probe runs once per bucket; the cached value is reused.
 
@@ -167,6 +210,19 @@ class TestReadFileRegionWiring:
             )
         assert captured["region"] == "eu-central-1"
         assert captured["nosign"] == "YES"
+
+    def test_anonymous_s3_unresolved_region_falls_back(self, monkeypatch):
+        """When the region cannot be resolved, the open proceeds with none pinned.
+
+        Test scenario:
+            ``resolve_s3_region`` returns ``None`` (offline); ``AWS_REGION`` is
+            left unset so GDAL's own behaviour is preserved (no regression).
+        """
+        monkeypatch.setattr(labeled_mod, "resolve_s3_region", lambda bucket: None)
+        captured = self._capture_open(monkeypatch)
+        with pytest.raises(ValueError):
+            LabeledDataset.read_file("s3://bucket/store.zarr", anon=True)
+        assert captured["region"] in (None, ""), f"region should be unset, got {captured['region']!r}"
 
     def test_explicit_region_overrides_and_skips_probe(self, monkeypatch):
         """An explicit ``region`` is used verbatim and the probe is not called.

--- a/tests/netcdf/test_labeled_s3_region.py
+++ b/tests/netcdf/test_labeled_s3_region.py
@@ -11,6 +11,7 @@ These tests are fully offline — the HTTP probe and the GDAL open are mocked.
 from __future__ import annotations
 
 import email.message
+import http.client
 import io
 import urllib.error
 import urllib.request
@@ -105,6 +106,21 @@ class TestResolveS3Region:
             The opener raises ``URLError`` (offline / blocked).
         """
         opener = _FakeOpener(error=urllib.error.URLError("offline"))
+        monkeypatch.setattr(
+            remote_mod.urllib.request, "build_opener", lambda *a, **k: opener
+        )
+        assert resolve_s3_region("b") is None
+
+    def test_http_exception_returns_none(self, monkeypatch):
+        """A malformed-response ``HTTPException`` resolves to ``None`` (never raises).
+
+        Test scenario:
+            ``opener.open`` raises ``http.client.BadStatusLine`` (not an
+            ``OSError``); the helper must still honour its never-raises contract
+            so the caller falls back to GDAL's behaviour instead of leaking the
+            error past ``read_file``'s clean error path.
+        """
+        opener = _FakeOpener(error=http.client.BadStatusLine("garbage"))
         monkeypatch.setattr(
             remote_mod.urllib.request, "build_opener", lambda *a, **k: opener
         )

--- a/tests/netcdf/test_labeled_s3_region.py
+++ b/tests/netcdf/test_labeled_s3_region.py
@@ -191,6 +191,10 @@ class TestResolveS3Region:
                 response = urllib.response.addinfourl(
                     io.BytesIO(b""), headers, req.full_url, code=301
                 )
+                # urllib's HTTPErrorProcessor reads response.msg when turning a
+                # non-2xx response into an HTTPError; addinfourl has no .msg, so
+                # set it here (a future urllib change here would surface as an
+                # AttributeError in this test).
                 response.msg = "Moved Permanently"
                 return response
 

--- a/tests/netcdf/test_labeled_s3_region.py
+++ b/tests/netcdf/test_labeled_s3_region.py
@@ -110,6 +110,21 @@ class TestResolveS3Region:
         )
         assert resolve_s3_region("b") is None
 
+    def test_request_construction_error_returns_none(self, monkeypatch):
+        """A ``ValueError`` building the request resolves to ``None`` (never raises).
+
+        Test scenario:
+            A malformed bucket string makes ``Request(...)`` raise ``ValueError``;
+            the guard inside the helper swallows it so the caller's never-raises
+            contract holds and the open falls back to GDAL's behaviour.
+        """
+
+        def _raise(*args, **kwargs):
+            raise ValueError("unknown url type")
+
+        monkeypatch.setattr(remote_mod.urllib.request, "Request", _raise)
+        assert resolve_s3_region("bad bucket") is None
+
     def test_returns_none_when_region_header_absent(self, monkeypatch):
         """A 200 response without the region header resolves to ``None``.
 

--- a/tests/netcdf/test_labeled_s3_region.py
+++ b/tests/netcdf/test_labeled_s3_region.py
@@ -11,6 +11,7 @@ These tests are fully offline — the HTTP probe and the GDAL open are mocked.
 from __future__ import annotations
 
 import urllib.error
+import urllib.request
 
 import pytest
 from osgeo import gdal
@@ -135,19 +136,21 @@ class TestResolveS3Region:
         )
         assert resolve_s3_region("b") is None
 
-    def test_no_redirect_handler_suppresses_redirect(self):
-        """``_NoRedirectHandler.redirect_request`` returns ``None`` (no follow).
+    def test_no_redirect_handler_is_a_noop_redirect_handler(self):
+        """``_NoRedirectHandler`` is a redirect handler whose redirect is a no-op.
 
         Test scenario:
-            Returning ``None`` makes urllib raise ``HTTPError`` for a 3xx
-            instead of following the ``Location``, so the region header on the
-            error is readable.
+            It subclasses urllib's redirect handler, and invoking
+            ``redirect_request`` does not raise (it suppresses the redirect so
+            urllib raises ``HTTPError`` on a 3xx instead of following it). The
+            end-to-end header read through this handler is covered by
+            ``test_real_301_flow_reads_region_header``.
         """
         handler = remote_mod._NoRedirectHandler()
-        result = handler.redirect_request(
-            "request", "fp", 301, "Moved", {}, "https://elsewhere"
-        )
-        assert result is None, f"redirect must not be followed, got {result!r}"
+        assert isinstance(
+            handler, urllib.request.HTTPRedirectHandler
+        ), "must subclass urllib's redirect handler"
+        handler.redirect_request("request", "fp", 301, "Moved", {}, "https://elsewhere")
 
     def test_result_is_cached(self, monkeypatch):
         """The probe runs once per bucket; the cached value is reused.

--- a/tests/netcdf/test_labeled_s3_region.py
+++ b/tests/netcdf/test_labeled_s3_region.py
@@ -10,8 +10,11 @@ These tests are fully offline — the HTTP probe and the GDAL open are mocked.
 
 from __future__ import annotations
 
+import email.message
+import io
 import urllib.error
 import urllib.request
+import urllib.response
 
 import pytest
 from osgeo import gdal
@@ -151,6 +154,40 @@ class TestResolveS3Region:
             handler, urllib.request.HTTPRedirectHandler
         ), "must subclass urllib's redirect handler"
         handler.redirect_request("request", "fp", 301, "Moved", {}, "https://elsewhere")
+
+    def test_real_301_flow_reads_region_header(self, monkeypatch):
+        """A real 301 driven through ``_NoRedirectHandler`` yields the region.
+
+        Test scenario:
+            A fake HTTPS transport returns a 301 carrying ``x-amz-bucket-region``.
+            The real ``build_opener(_NoRedirectHandler)`` chain must suppress the
+            redirect, raise ``HTTPError``, and let ``resolve_s3_region`` read the
+            header off it — exercising the handler end-to-end, not just a mocked
+            ``HTTPError``.
+        """
+        headers = email.message.Message()
+        headers["x-amz-bucket-region"] = "eu-central-1"
+
+        class _Fake301HTTPSHandler(urllib.request.HTTPSHandler):
+            """Fake transport that answers every request with a 301 + region header."""
+
+            def https_open(self, req):
+                """Return a 301 response carrying the region header."""
+                response = urllib.response.addinfourl(
+                    io.BytesIO(b""), headers, req.full_url, code=301
+                )
+                response.msg = "Moved Permanently"
+                return response
+
+        real_build_opener = urllib.request.build_opener
+
+        def build_with_fake_transport(*handlers):
+            return real_build_opener(*handlers, _Fake301HTTPSHandler())
+
+        monkeypatch.setattr(
+            remote_mod.urllib.request, "build_opener", build_with_fake_transport
+        )
+        assert resolve_s3_region("regional-bucket") == "eu-central-1"
 
     def test_result_is_cached(self, monkeypatch):
         """The probe runs once per bucket; the cached value is reused.

--- a/tests/netcdf/test_labeled_s3_region.py
+++ b/tests/netcdf/test_labeled_s3_region.py
@@ -1,0 +1,220 @@
+"""Tests for anonymous S3 bucket-region resolution on LabeledDataset reads (issue #535).
+
+GDAL's ``/vsis3`` skips region auto-resolution under ``AWS_NO_SIGN_REQUEST``, so an
+anonymous read of a bucket outside ``us-east-1`` fails with an unfollowed
+``PermanentRedirect``. ``resolve_s3_region`` recovers the region from the
+``x-amz-bucket-region`` header and ``LabeledDataset.read_file`` pins it before the open.
+
+These tests are fully offline — the HTTP probe and the GDAL open are mocked.
+"""
+
+from __future__ import annotations
+
+import urllib.error
+
+import pytest
+from osgeo import gdal
+
+from pyramids.base import remote as remote_mod
+from pyramids.base.remote import resolve_s3_region
+from pyramids.netcdf import LabeledDataset
+from pyramids.netcdf import labeled as labeled_mod
+
+pytestmark = pytest.mark.core
+
+
+@pytest.fixture(autouse=True)
+def _clear_region_cache():
+    """Clear the per-process region cache around each test so probes are observable."""
+    remote_mod._S3_REGION_CACHE.clear()
+    yield
+    remote_mod._S3_REGION_CACHE.clear()
+
+
+class _FakeResponse:
+    """Minimal context-manager response exposing a ``headers`` mapping."""
+
+    def __init__(self, headers: dict):
+        self.headers = headers
+
+    def __enter__(self) -> "_FakeResponse":
+        return self
+
+    def __exit__(self, *exc) -> bool:
+        return False
+
+
+class _FakeOpener:
+    """Stand-in for ``urllib.request.build_opener`` result with a scripted ``open``."""
+
+    def __init__(self, *, response=None, error=None):
+        self._response = response
+        self._error = error
+
+    def open(self, request, timeout=None):
+        """Return the scripted response or raise the scripted error."""
+        if self._error is not None:
+            raise self._error
+        return self._response
+
+
+class TestResolveS3Region:
+    """Tests for the anonymous bucket-region HEAD probe."""
+
+    def test_reads_region_header_on_success(self, monkeypatch):
+        """A 200 response's ``x-amz-bucket-region`` header is returned.
+
+        Test scenario:
+            The opener yields a response carrying the region header.
+        """
+        opener = _FakeOpener(
+            response=_FakeResponse({"x-amz-bucket-region": "eu-central-1"})
+        )
+        monkeypatch.setattr(
+            remote_mod.urllib.request, "build_opener", lambda *a, **k: opener
+        )
+        assert resolve_s3_region("some-bucket") == "eu-central-1"
+
+    def test_reads_region_header_from_http_error(self, monkeypatch):
+        """The region is recovered from a 301/403 ``HTTPError``'s headers.
+
+        Test scenario:
+            S3 returns the region header even on the PermanentRedirect (301).
+        """
+        err = urllib.error.HTTPError(
+            url="https://b.s3.amazonaws.com",
+            code=301,
+            msg="Moved Permanently",
+            hdrs={"x-amz-bucket-region": "ap-southeast-2"},
+            fp=None,
+        )
+        opener = _FakeOpener(error=err)
+        monkeypatch.setattr(
+            remote_mod.urllib.request, "build_opener", lambda *a, **k: opener
+        )
+        assert resolve_s3_region("b") == "ap-southeast-2"
+
+    def test_offline_returns_none(self, monkeypatch):
+        """A network failure resolves to ``None`` (caller falls back to GDAL).
+
+        Test scenario:
+            The opener raises ``URLError`` (offline / blocked).
+        """
+        opener = _FakeOpener(error=urllib.error.URLError("offline"))
+        monkeypatch.setattr(
+            remote_mod.urllib.request, "build_opener", lambda *a, **k: opener
+        )
+        assert resolve_s3_region("b") is None
+
+    def test_result_is_cached(self, monkeypatch):
+        """The probe runs once per bucket; the cached value is reused.
+
+        Test scenario:
+            A second call does not re-open; flipping the opener has no effect.
+        """
+        calls = {"n": 0}
+
+        def build(*a, **k):
+            calls["n"] += 1
+            return _FakeOpener(
+                response=_FakeResponse({"x-amz-bucket-region": "us-west-2"})
+            )
+
+        monkeypatch.setattr(remote_mod.urllib.request, "build_opener", build)
+        first = resolve_s3_region("cached-bucket")
+        second = resolve_s3_region("cached-bucket")
+        assert (first, second) == ("us-west-2", "us-west-2")
+        assert calls["n"] == 1
+
+
+class TestReadFileRegionWiring:
+    """Tests that ``read_file`` pins the right ``AWS_REGION`` for the GDAL open."""
+
+    @staticmethod
+    def _capture_open(monkeypatch) -> dict:
+        """Patch ``gdal.OpenEx`` to record the active config then short-circuit.
+
+        Args:
+            monkeypatch: pytest fixture.
+
+        Returns:
+            A dict populated with ``region`` / ``nosign`` read inside the open.
+        """
+        captured: dict = {}
+
+        def fake_openex(path, flags):
+            captured["region"] = gdal.GetConfigOption("AWS_REGION")
+            captured["nosign"] = gdal.GetConfigOption("AWS_NO_SIGN_REQUEST")
+            raise RuntimeError("stop after capturing config")
+
+        monkeypatch.setattr(labeled_mod.gdal, "OpenEx", fake_openex)
+        return captured
+
+    def test_anonymous_s3_auto_resolves_region(self, monkeypatch):
+        """An anonymous S3 read pins the auto-resolved region for the open.
+
+        Test scenario:
+            ``resolve_s3_region`` yields eu-central-1; the open sees AWS_REGION set.
+        """
+        monkeypatch.setattr(
+            labeled_mod, "resolve_s3_region", lambda bucket: "eu-central-1"
+        )
+        captured = self._capture_open(monkeypatch)
+        with pytest.raises(ValueError):
+            LabeledDataset.read_file(
+                "s3://noaa-nwm-retrospective-3-0-pds/CONUS/zarr/chrtout.zarr",
+                anon=True,
+            )
+        assert captured["region"] == "eu-central-1"
+        assert captured["nosign"] == "YES"
+
+    def test_explicit_region_overrides_and_skips_probe(self, monkeypatch):
+        """An explicit ``region`` is used verbatim and the probe is not called.
+
+        Test scenario:
+            ``resolve_s3_region`` would raise if called; the open sees us-west-2.
+        """
+
+        def _boom(bucket):
+            raise AssertionError("resolve_s3_region must not be called")
+
+        monkeypatch.setattr(labeled_mod, "resolve_s3_region", _boom)
+        captured = self._capture_open(monkeypatch)
+        with pytest.raises(ValueError):
+            LabeledDataset.read_file(
+                "s3://bucket/store.zarr", anon=True, region="us-west-2"
+            )
+        assert captured["region"] == "us-west-2"
+
+    def test_non_anonymous_s3_does_not_probe(self, monkeypatch):
+        """A signed S3 read leaves region resolution to GDAL (no probe).
+
+        Test scenario:
+            ``resolve_s3_region`` would raise if called; no AWS_REGION is pinned.
+        """
+
+        def _boom(bucket):
+            raise AssertionError("resolve_s3_region must not be called for signed reads")
+
+        monkeypatch.setattr(labeled_mod, "resolve_s3_region", _boom)
+        captured = self._capture_open(monkeypatch)
+        with pytest.raises(ValueError):
+            LabeledDataset.read_file("s3://bucket/store.zarr", anon=False)
+        assert captured["region"] in (None, "")
+
+    def test_local_path_does_not_probe(self, monkeypatch, tmp_path):
+        """A local path never triggers a region probe.
+
+        Test scenario:
+            ``resolve_s3_region`` would raise if called for a filesystem path.
+        """
+
+        def _boom(bucket):
+            raise AssertionError("resolve_s3_region must not be called for local paths")
+
+        monkeypatch.setattr(labeled_mod, "resolve_s3_region", _boom)
+        captured = self._capture_open(monkeypatch)
+        missing = tmp_path / "store.zarr"
+        with pytest.raises(ValueError):
+            LabeledDataset.read_file(str(missing), anon=True)
+        assert captured["region"] in (None, "")


### PR DESCRIPTION
# Description

Fixes an anonymous S3 region-resolution failure in `LabeledDataset.read_file`. GDAL's `/vsis3`
skips bucket-region auto-resolution under `AWS_NO_SIGN_REQUEST`, so an anonymous read of a Zarr/NetCDF
store in a bucket outside `us-east-1` (e.g. `eu-central-1`) hit an unfollowed S3 `PermanentRedirect`
and surfaced as a `Malformed AWS XML response` `ValueError`.

The change adds `remote.resolve_s3_region(bucket)` — a cached, anonymous `HEAD` probe against the
path-style global endpoint that reads the `x-amz-bucket-region` header S3 returns even on the 301/403
(a `_NoRedirectHandler` keeps the 301 a readable `HTTPError` rather than following it). `read_file`
gains a keyword-only `region`; for an anonymous `s3://` store with no explicit region it auto-resolves
the bucket region and pins `AWS_REGION` for the open via `CloudConfig`. Signed reads and local/non-S3
paths are untouched (no probe). The probe never raises (any failure → `None` → GDAL's prior behaviour).

Motivation/context: found while adapting the earthlens NWM backend to the `LabeledDataset` GDAL rewrite
(#520); the NWM retrospective store is a Zarr v2 dataset in `eu-central-1`.

Dependencies: none — standard-library `urllib` / `http.client` only.

# Issues
- Fixes #535

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

New offline suite `tests/netcdf/test_labeled_s3_region.py` (15 tests, `pytest.mark.core`) — the HTTP
probe and the GDAL open are mocked, so it runs with no network:

- `resolve_s3_region`: reads the region header on a 200 and on a 301/403 `HTTPError`; returns `None`
  when the header is absent, when the `HTTPError` has no headers, on `OSError`/`URLError`, on
  `http.client.HTTPException`, and on a `ValueError` from `Request()`; caches per bucket; and a real
  301 driven through `_NoRedirectHandler` end-to-end yields the region.
- `read_file` wiring: anonymous S3 pins the auto-resolved region; an unresolved region falls back with
  no `AWS_REGION`; an explicit `region=` overrides and skips the probe; signed reads and local paths
  never probe.

Commands:

- [x] `pixi run -e dev pytest tests/netcdf/test_labeled_s3_region.py` → 15 passed
- [x] `pixi run -e dev python -m pytest --doctest-modules src/pyramids/base/remote.py` → 9 passed, 1 skipped

The real-network read against the NWM store remains an opt-in e2e test in the earthlens backend.

# Checklist:

- [ ] updated version number in pyproject.toml. <!-- handled by commitizen via the release workflow -->
- [ ] added changes to History.rst. <!-- change-log is commitizen-generated -->
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.
