### PR TITLE
feat(collection): RGB true-colour animation in DatasetCollection.plot

### DIFF
--- a/docs/examples/dataset/rgb_animation.ipynb
+++ b/docs/examples/dataset/rgb_animation.ipynb
@@ -1,0 +1,226 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "id": "cell-01",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "import os\n",
+    "import tempfile\n",
+    "\n",
+    "import matplotlib\n",
+    "import numpy as np\n",
+    "from IPython.display import HTML\n",
+    "\n",
+    "from pyramids.dataset import Dataset, DatasetCollection\n",
+    "\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-02",
+   "metadata": {},
+   "source": [
+    "# RGB true-colour animation with `DatasetCollection`\n",
+    "\n",
+    "`DatasetCollection.plot` animates a temporal stack of co-registered rasters. By default it animates a **single\n",
+    "band** as a colormapped field. Passing `rgb_options` instead composites the requested bands of **every timestep**\n",
+    "into a true-colour frame, producing an RGB (or RGBA) time-lapse with one frame per timestep.\n",
+    "\n",
+    "This is the feature added for issue #538 and it needs **cleopatra >= 0.18.0**."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-03",
+   "metadata": {},
+   "source": [
+    "## Build a multi-band time series\n",
+    "\n",
+    "The bundled `rhine` example is single-band, so we synthesise a small 3-band (R, G, B) time series: five timesteps\n",
+    "of an `8`-bit image with a bright square that moves across the frame, written to a temporary folder."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-04",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rng = np.random.default_rng(0)\n",
+    "folder = tempfile.mkdtemp(prefix=\"rgb_cube_\")\n",
+    "n_times, size = 5, 48\n",
+    "\n",
+    "for t in range(n_times):\n",
+    "    # Low-level RGB noise plus a moving bright block so the animation is visible.\n",
+    "    arr = (rng.random((3, size, size)) * 60).astype(\"float32\")\n",
+    "    r0 = 4 + t * 8\n",
+    "    arr[:, r0:r0 + 8, r0:r0 + 8] = 230.0\n",
+    "    Dataset.create_from_array(\n",
+    "        arr=arr, geo=(0, 1, 0, size, 0, -1), epsg=4326\n",
+    "    ).to_file(os.path.join(folder, f\"frame_{t:02d}.tif\"))\n",
+    "\n",
+    "sorted(os.listdir(folder))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-05",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cube = DatasetCollection.from_files(\n",
+    "    [os.path.join(folder, f) for f in sorted(os.listdir(folder))]\n",
+    ")\n",
+    "print(\"timesteps:\", cube.time_length, \"| bands per dataset:\", cube.base.band_count)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-06",
+   "metadata": {},
+   "source": [
+    "## Single-band animation (the default)\n",
+    "\n",
+    "Without `rgb_options`, `plot` animates one band as a colormapped field — `glyph.arr` keeps the\n",
+    "`(time, rows, cols)` shape and the figure carries a colorbar."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-07",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "single = cube.plot(band=0)\n",
+    "print(\"arr shape:\", single.arr.shape, \"| has colorbar:\", single.cbar is not None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-08",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "HTML(single.anim.to_jshtml())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-09",
+   "metadata": {},
+   "source": [
+    "## RGB true-colour animation\n",
+    "\n",
+    "Pass `rgb_options={\"rgb\": [r, g, b], ...}` to composite a true-colour frame per timestep. The result's `arr` is\n",
+    "the `(time, rows, cols, 3)` display-ready stack, and `cbar` is `None` (true colour carries no colorbar). The\n",
+    "`percentile` stretch enhances contrast — every one of the five frames is preserved."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-10",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "rgb = cube.plot(rgb_options={\"rgb\": [0, 1, 2], \"percentile\": 2})\n",
+    "print(\"arr shape:\", rgb.arr.shape, \"| has colorbar:\", rgb.cbar is not None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-11",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "HTML(rgb.anim.to_jshtml())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-12",
+   "metadata": {},
+   "source": [
+    "### Normalisation options\n",
+    "\n",
+    "`rgb_options` groups the stretch controls that cleopatra's `prepare_array` understands:\n",
+    "\n",
+    "- `percentile` — contrast stretch by clipping to the given percentile (takes precedence).\n",
+    "- `surface_reflectance` — divide by a fixed scale (e.g. `10000` for Sentinel-2, `255` for 8-bit imagery).\n",
+    "- `cutoff` — per-band clip values.\n",
+    "\n",
+    "Use a four-index `rgb` (`[r, g, b, a]`) for an RGBA time-lapse — `arr` then ends in a `4` channel axis."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-13",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NBVAL_IGNORE_OUTPUT\n",
+    "sr = cube.plot(rgb_options={\"rgb\": [0, 1, 2], \"surface_reflectance\": 255})\n",
+    "print(\"surface-reflectance stretch -> arr shape:\", sr.arr.shape)\n",
+    "print(\"values normalised into [0, 1]:\", bool(sr.arr.min() >= 0 and sr.arr.max() <= 1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-14",
+   "metadata": {},
+   "source": [
+    "## Validation and guards\n",
+    "\n",
+    "The RGB path validates its inputs up front, so a malformed request fails with a clear message instead of silently\n",
+    "dropping frames (the #538 bug) or surfacing a cryptic cleopatra error:\n",
+    "\n",
+    "- the `rgb` list must hold exactly 3 (RGB) or 4 (RGBA) indices,\n",
+    "- every index must be non-negative,\n",
+    "- the datasets must carry at least `max(rgb) + 1` bands,\n",
+    "- `exclude_value` is ignored for true-colour frames (passing it warns)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "id": "cell-15",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for label, call in {\n",
+    "    \"wrong arity\": lambda: cube.plot(rgb_options={\"rgb\": [0, 1]}),\n",
+    "    \"negative index\": lambda: cube.plot(rgb_options={\"rgb\": [-1, 0, 1]}),\n",
+    "    \"needs 4 bands\": lambda: cube.plot(rgb_options={\"rgb\": [0, 1, 2, 3]}),\n",
+    "}.items():\n",
+    "    try:\n",
+    "        call()\n",
+    "    except ValueError as exc:\n",
+    "        print(f\"{label}: {exc}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "name": "python3",
+   "language": "python",
+   "display_name": "Python 3 (ipykernel)"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -156,6 +156,7 @@ nav:
           - Convert longitude: examples/dataset/convert-longitude.ipynb
           - DatasetCollection (guide): tutorials/dataset_collection.md
           - Dataset collection: examples/dataset/dataset_collection.ipynb
+          - RGB animation (DatasetCollection): examples/dataset/rgb_animation.ipynb
           - STAC solar-day grouping: examples/dataset/stac-solar-day.ipynb
           - South America: examples/dataset/south-america.ipynb
           - Cloud Optimized GeoTIFFs: tutorials/cog.md

--- a/pixi.lock
+++ b/pixi.lock
@@ -109,7 +109,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/5f/9ff93450ba96b09c7c2b3f81c94de31c89f92292f1380261bd7195bea4ea/contourpy-1.3.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl
@@ -225,7 +225,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-h80f16a2_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.2-hdc9db2a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/71/f93e1e9471d189f79d0ce2497007731c1e6bf9ef6d1d61b911430c3db4e5/contourpy-1.3.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl
@@ -335,7 +335,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.2-hbb4bfdb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/72/8b/4546f3ab60f78c514ffb7d01a0bd743f90de36f0019d1be84d0a708a580a/contourpy-1.3.3-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl
@@ -445,7 +445,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/e1/3542a9cb596cadd76fcef413f19c79216e002623158befe6daa03dbfa88c/contourpy-1.3.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl
@@ -551,7 +551,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl
@@ -798,7 +798,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -1164,7 +1164,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -1524,7 +1524,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -1881,7 +1881,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -2234,7 +2234,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
@@ -3714,7 +3714,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -4024,7 +4024,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -4329,7 +4329,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -4631,7 +4631,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -4930,7 +4930,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
@@ -5239,7 +5239,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/5f/9ff93450ba96b09c7c2b3f81c94de31c89f92292f1380261bd7195bea4ea/contourpy-1.3.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
@@ -5496,7 +5496,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/71/f93e1e9471d189f79d0ce2497007731c1e6bf9ef6d1d61b911430c3db4e5/contourpy-1.3.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
@@ -5748,7 +5748,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/72/8b/4546f3ab60f78c514ffb7d01a0bd743f90de36f0019d1be84d0a708a580a/contourpy-1.3.3-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
@@ -6000,7 +6000,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/e1/3542a9cb596cadd76fcef413f19c79216e002623158befe6daa03dbfa88c/contourpy-1.3.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
@@ -6249,7 +6249,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
@@ -6561,7 +6561,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -6917,7 +6917,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -7267,7 +7267,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -7614,7 +7614,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -7957,7 +7957,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
@@ -8267,7 +8267,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -8578,7 +8578,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -8883,7 +8883,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -9185,7 +9185,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -9484,7 +9484,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/4b/9bd370b004b5c9d8045c6c33cf65bae018b27aca550a3f657cdc99acdbd8/contourpy-1.3.3-cp311-cp311-win_amd64.whl
@@ -9797,7 +9797,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -10106,7 +10106,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -10409,7 +10409,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -10709,7 +10709,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -11006,7 +11006,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/19/e8/6026ed58a64563186a9ee3f29f41261fd1828f527dd93d33b60feca63352/contourpy-1.3.3-cp312-cp312-win_amd64.whl
@@ -11319,7 +11319,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -11628,7 +11628,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -11932,7 +11932,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -12233,7 +12233,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -12531,7 +12531,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/0b/0098c214843213759692cc638fce7de5c289200a830e5035d1791d7a2338/contourpy-1.3.3-cp313-cp313-win_amd64.whl
@@ -12845,7 +12845,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -13156,7 +13156,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -13462,7 +13462,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -13765,7 +13765,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
@@ -14065,7 +14065,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/35/c7995b1e66159193dd31ed5628d59acbaf4611811645eedf0fb2d5a91946/commitizen-4.16.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
@@ -18027,10 +18027,10 @@ packages:
   - pkg:pypi/charset-normalizer?source=hash-mapping
   size: 58872
   timestamp: 1775127203018
-- pypi: https://files.pythonhosted.org/packages/a9/1d/4b8420bdb6d6149959f5bb3b88aaea809f53a8c38b124f8409f72691cc01/cleopatra-0.17.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/02/f9/d94548a2184535bfaed83da453d119a76e2eeda8c3fe23940e6cf0c0116f/cleopatra-0.18.0-py3-none-any.whl
   name: cleopatra
-  version: 0.17.0
-  sha256: 8254832967f7ca59f43492fb665f2278f9b6f019cb2e33bfb751ddd981ee61ce
+  version: 0.18.0
+  sha256: cfc99432957d857a88bc4055a289bc0bb825feaf0179e78c95be3665ce954051
   requires_dist:
   - ffmpeg-python
   - hpc-utils>=0.1.4
@@ -37365,7 +37365,7 @@ packages:
 - pypi: ./
   name: pyramids-gis
   version: 0.33.0
-  sha256: b27414acdeab6c537bd79aec7b5a78446ca7c355fb66fb1ea0344bee0e69516d
+  sha256: aed0bbc4ded8db72ddf52e60967e45e6f19bf278504cf4fce9627ebdcfe9b9c7
   requires_dist:
   - cftime>=1.6.4
   - geopandas>=1.0.0
@@ -37376,7 +37376,7 @@ packages:
   - pyyaml>=6.0.0
   - shapely>=2.0.0
   - scipy>=1.10.0
-  - cleopatra[tiles]>=0.17.0 ; extra == 'viz'
+  - cleopatra[tiles]>=0.18.0 ; extra == 'viz'
   - dask>=2024.1.0 ; extra == 'lazy'
   - distributed>=2024.1.0 ; extra == 'lazy'
   - zarr>=3 ; extra == 'lazy'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-viz = ["cleopatra[tiles]>=0.17.0"]
+viz = ["cleopatra[tiles]>=0.18.0"]
 lazy = [
     "dask>=2024.1.0",
     "distributed>=2024.1.0",

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -208,6 +208,45 @@ def render_array(
 
             ```
 
+        - RGB animation path. The stack is 4-D
+          ``(time, bands, rows, cols)`` and ``rgb`` selects the colour
+          channels; the helper composites each timestep into a
+          display-ready true-colour frame before cleopatra renders it:
+
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.dataset._plot_helpers import render_array
+            >>> stack = np.random.rand(4, 3, 8, 8).astype(np.float32)
+            >>> cleo = render_array(  # doctest: +SKIP
+            ...     arr=stack,
+            ...     rgb=[0, 1, 2],
+            ...     percentile=2,
+            ...     mode="animate",
+            ...     animation_axis_values=[0, 1, 2, 3],
+            ... )
+
+            ```
+
+        - Passing ``rgb`` with a single-band 3-D stack is rejected
+          before any compositing, so the time axis is never silently
+          read as the colour channels (guards the #538 frame loss):
+
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.dataset._plot_helpers import render_array
+            >>> bad = np.random.rand(4, 8, 8).astype(np.float32)
+            >>> render_array(  # doctest: +IGNORE_EXCEPTION_DETAIL
+            ...     arr=bad,
+            ...     rgb=[0, 1, 2],
+            ...     mode="animate",
+            ...     animation_axis_values=[0, 1, 2, 3],
+            ... )
+            Traceback (most recent call last):
+                ...
+            ValueError: RGB animate requires a 4-D (time, bands, rows, cols)...
+
+            ```
+
         - Facet path used by :meth:`pyramids.netcdf.NetCDF.plot`. The
           caller pre-builds the stack with ``_build_facet_stack`` and
           passes the matching ``facet_kwargs`` dict (containing

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -328,7 +328,9 @@ def render_array(
             ],
             axis=0,
         )
-        rgb = None
+        # The stretch parameters have been consumed by ``prepare_array`` above;
+        # null them so the constructor call below cannot re-read inert values.
+        rgb = surface_reflectance = cutoff = percentile = None
     # Fail fast on an invalid ``color_scale`` with a pyramids-side message
     # that lists the valid options, instead of deferring to a less-targeted
     # cleopatra error deep in the render call. ``ColorScale`` lookup is

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -108,7 +108,12 @@ def render_array(
             * ``"plot"`` — 2-D ``(rows, cols)``; or 3-D
               ``(bands, rows, cols)`` when ``rgb`` is set so cleopatra
               can pick the colour channels.
-            * ``"animate"`` — 3-D ``(time, rows, cols)``.
+            * ``"animate"`` — 3-D ``(time, rows, cols)`` for a
+              single-band colormapped time-lapse; or 4-D
+              ``(time, bands, rows, cols)`` when ``rgb`` is set, which
+              this helper composites into display-ready true-colour
+              frames before handing cleopatra a
+              ``(time, rows, cols, 3|4)`` stack.
             * ``"facet"`` — 3-D ``(N, rows, cols)`` or 4-D
               ``(Ncol, Nrow, rows, cols)``.
         extent: Optional ``[xmin, ymin, xmax, ymax]`` extent. Mutually
@@ -118,7 +123,10 @@ def render_array(
             set the renderer routes via pcolormesh.
         exclude_value: Per-band no-data values to mask before rendering.
         rgb: Three- or four-element list of band indices for RGB
-            compositing. Sentinel-only; only meaningful for ``"plot"``.
+            compositing. Sentinel-only; meaningful for ``"plot"`` (a
+            single true-colour still) and ``"animate"`` (a true-colour
+            time-lapse, which requires a 4-D ``(time, bands, rows,
+            cols)`` ``arr``).
         surface_reflectance: Sentinel surface-reflectance scale factor.
         cutoff: Sentinel per-band clip values.
         percentile: Sentinel percentile-stretch value.
@@ -250,6 +258,38 @@ def render_array(
         raise ValueError("`facet_kwargs` is required when mode='facet'.")
     if basemap and basemap_epsg is None:
         raise ValueError("Dataset must have a CRS (epsg) to use basemap.")
+
+    # RGB animate: cleopatra's ``ArrayGlyph.animate`` renders a 4-D
+    # ``(time, rows, cols, 3|4)`` stack as true colour only when each frame is
+    # already display-ready (floats in ``[0, 1]`` / ``uint8``). We own that
+    # compositing here — the single backend abstraction — so the constructor
+    # receives a finished stack and must NOT re-run its own ``rgb`` preparation
+    # (which would re-collapse the first axis). We composite each timestep's
+    # ``(bands, rows, cols)`` slice with the same ``prepare_array`` cleopatra
+    # uses for the single-frame ``plot`` RGB path, then drop ``rgb`` so the
+    # 4-D stack flows straight through.
+    if mode == "animate" and rgb is not None:
+        if arr is None or arr.ndim != 4:
+            raise ValueError(
+                "RGB animate requires a 4-D (time, bands, rows, cols) array; "
+                f"got {None if arr is None else arr.ndim}-D. Pass rgb only with "
+                "a multi-band temporal stack."
+            )
+        compositor = ArrayGlyph(np.zeros((1, 1)))
+        arr = np.stack(
+            [
+                compositor.prepare_array(
+                    arr[frame],
+                    rgb=rgb,
+                    surface_reflectance=surface_reflectance,
+                    cutoff=cutoff,
+                    percentile=percentile,
+                )
+                for frame in range(arr.shape[0])
+            ],
+            axis=0,
+        )
+        rgb = None
     # Fail fast on an invalid ``color_scale`` with a pyramids-side message
     # that lists the valid options, instead of deferring to a less-targeted
     # cleopatra error deep in the render call. ``ColorScale`` lookup is

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -2065,7 +2065,8 @@ class DatasetCollection:
             exclude_value (Any):
                 Value to exclude from the plot. Default is None.
                 Ignored when ``rgb`` is set (true-colour frames are not
-                masked).
+                masked); passing it together with ``rgb`` emits a
+                :class:`UserWarning`.
             rgb (list[int], optional):
                 Band indices ``[red, green, blue]`` (or four, with
                 alpha) to composite into a true-colour time-lapse. When
@@ -2132,6 +2133,18 @@ class DatasetCollection:
                 ``(time, rows, cols)`` stack and it carries a colorbar; for
                 an RGB time-lapse its ``arr`` is the composited
                 ``(time, rows, cols, 3)`` stack and ``cbar`` is ``None``.
+
+        Raises:
+            ValueError: When ``rgb`` does not list exactly 3 (RGB) or 4
+                (RGBA) band indices, when any index is negative, or when the
+                collection's datasets carry fewer than ``max(rgb) + 1`` bands.
+                Also raised (via ``_merge_rgb_options``) for an unknown key
+                in ``rgb_options``.
+
+        Warns:
+            UserWarning: When ``exclude_value`` is passed together with
+                ``rgb`` — true-colour frames are not masked, so the value is
+                ignored.
 
         Examples:
             - Animate a single band across the collection's timesteps. The

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -2200,6 +2200,18 @@ class DatasetCollection:
                     f"rgb must list 3 band indices (RGB) or 4 (RGBA), got "
                     f"{rgb!r} with {len(rgb)} entries."
                 )
+            if min(rgb) < 0:
+                raise ValueError(
+                    f"rgb band indices must be non-negative, got {rgb!r}."
+                )
+            if exclude_value is not None:
+                warnings.warn(
+                    "exclude_value is ignored for RGB animations; true-colour "
+                    "frames are not masked. Drop exclude_value, or render a "
+                    "single band to mask by no-data.",
+                    UserWarning,
+                    stacklevel=2,
+                )
             needed = max(rgb) + 1
             if self.base.band_count < needed:
                 raise ValueError(

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -2128,6 +2128,51 @@ class DatasetCollection:
 
         Returns:
             ArrayGlyph: A plotting/animation handle (from cleopatra.ArrayGlyph).
+                For the single-band default its ``arr`` is the
+                ``(time, rows, cols)`` stack and it carries a colorbar; for
+                an RGB time-lapse its ``arr`` is the composited
+                ``(time, rows, cols, 3)`` stack and ``cbar`` is ``None``.
+
+        Examples:
+            - Animate a single band across the collection's timesteps. The
+              call is tagged ``+SKIP`` because it renders through cleopatra /
+              matplotlib (the optional ``[viz]`` extra):
+
+                ```python
+                >>> from pyramids.dataset import DatasetCollection
+                >>> cube = DatasetCollection.read_multiple_files(  # doctest: +SKIP
+                ...     "tests/data/geotiff/rhine"
+                ... )
+                >>> glyph = cube.plot(band=0)  # doctest: +SKIP
+                >>> glyph.arr.ndim  # doctest: +SKIP
+                3
+
+                ```
+            - Composite a true-colour time-lapse from three bands via the
+              grouped ``rgb_options`` form. Every timestep becomes one RGB
+              frame, so the rendered stack is ``(time, rows, cols, 3)`` with
+              no colorbar:
+
+                ```python
+                >>> from pyramids.dataset import DatasetCollection
+                >>> cube = DatasetCollection.read_multiple_files(  # doctest: +SKIP
+                ...     "tests/data/geotiff/sentinel"
+                ... )
+                >>> glyph = cube.plot(  # doctest: +SKIP
+                ...     rgb_options={"rgb": [0, 1, 2], "percentile": 2}
+                ... )
+                >>> glyph.cbar is None  # doctest: +SKIP
+                True
+
+                ```
+
+        See Also:
+            - :meth:`pyramids.dataset.Dataset.plot`: The single-frame
+              renderer (still or RGB still) for one ``Dataset``; shares the
+              ``rgb`` / ``rgb_options`` contract via ``_merge_rgb_options``.
+            - :func:`pyramids.dataset._plot_helpers.render_array`: The shared
+              cleopatra dispatch that composites the true-colour frames for
+              the animate path.
         """
         # Resolve the grouped ``rgb_options`` against the deprecated loose
         # kwargs exactly as ``Dataset.plot`` does, so both facades share one

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -2024,32 +2024,79 @@ class DatasetCollection:
         return self.datasets[i]
 
     def plot(
-        self, band: int = 0, exclude_value: Any | None = None, **kwargs: Any
+        self,
+        band: int = 0,
+        exclude_value: Any | None = None,
+        rgb: list[int] | None = None,
+        surface_reflectance: int | None = None,
+        cutoff: list | None = None,
+        percentile: int | None = None,
+        rgb_options: dict | None = None,
+        **kwargs: Any,
     ) -> ArrayGlyph:
         r"""Render the collection as an animated stack of band slices.
 
             - read the values stored in a given band across every
               ``Dataset`` in the collection and hand the resulting
               ``(time, rows, cols)`` array to cleopatra's animation
-              path.
+              path; or, when ``rgb`` is set, composite the requested
+              bands per timestep into a true-colour
+              ``(time, rows, cols, 3)`` stack for an RGB time-lapse.
 
         Implementation note: this method is a thin caller around the
         shared :func:`pyramids.dataset._plot_helpers.render_array`
-        helper. It stacks one band per ``Dataset`` into a 3-D array
-        and forwards to ``render_array(..., mode="animate",
-        animation_axis_values=...)``. The duplicated ``ArrayGlyph``
-        construction that used to live here is gone — the helper owns
-        the cleopatra dispatch and the same code path serves the
-        single-frame ``Dataset.plot`` and the multi-panel
-        ``NetCDF.plot`` facets. See
+        helper. For the single-band default it stacks one band per
+        ``Dataset`` into a 3-D ``(time, rows, cols)`` array; when
+        ``rgb`` is given it stacks the full multi-band array per
+        ``Dataset`` into a 4-D ``(time, bands, rows, cols)`` array and
+        the helper composites the true-colour frames. Both forward to
+        ``render_array(..., mode="animate", animation_axis_values=...)``.
+        The duplicated ``ArrayGlyph`` construction that used to live
+        here is gone — the helper owns the cleopatra dispatch and the
+        same code path serves the single-frame ``Dataset.plot`` and the
+        multi-panel ``NetCDF.plot`` facets. See
         :mod:`pyramids.dataset._plot_helpers` for the three-mode
         contract.
 
         Args:
             band (int):
                 The band you want to get its data. Default is 0.
+                Ignored when ``rgb`` is set (RGB reads every band).
             exclude_value (Any):
                 Value to exclude from the plot. Default is None.
+                Ignored when ``rgb`` is set (true-colour frames are not
+                masked).
+            rgb (list[int], optional):
+                Band indices ``[red, green, blue]`` (or four, with
+                alpha) to composite into a true-colour time-lapse. When
+                set, every timestep is rendered as an RGB frame instead
+                of a single colormapped band, and the result is a
+                ``(time, rows, cols, 3)`` animation with no colorbar.
+                Each ``Dataset`` in the collection must carry at least
+                ``max(rgb) + 1`` bands. Default ``None`` (single-band
+                colormapped animation). **Deprecated**; pass via
+                ``rgb_options={"rgb": [...]}`` instead.
+            surface_reflectance (int, optional):
+                Surface-reflectance scale for normalising RGB bands
+                (e.g. ``10000`` for Sentinel-2, ``255`` for 8-bit).
+                Only used when ``rgb`` is set. Default ``None``.
+                **Deprecated**; pass via
+                ``rgb_options={"surface_reflectance": ...}``.
+            cutoff (list, optional):
+                Per-band clip values for the RGB stretch. Only used when
+                ``rgb`` is set. Default ``None``. **Deprecated**; pass
+                via ``rgb_options={"cutoff": ...}``.
+            percentile (int, optional):
+                Percentile stretch for the RGB bands (takes precedence
+                over ``surface_reflectance``). Only used when ``rgb`` is
+                set. Default ``None``. **Deprecated**; pass via
+                ``rgb_options={"percentile": ...}``.
+            rgb_options (dict, optional):
+                Recommended grouped form of the RGB parameters above.
+                Accepted keys: ``"rgb"``, ``"surface_reflectance"``,
+                ``"cutoff"``, ``"percentile"``. Mirrors
+                :meth:`Dataset.plot`. On collision with a loose kwarg the
+                ``rgb_options`` value wins. Default ``None``.
             **kwargs:
                 | Parameter                  | Type                  | Description |
                 |----------------------------|-----------------------|-------------|
@@ -2082,11 +2129,46 @@ class DatasetCollection:
         Returns:
             ArrayGlyph: A plotting/animation handle (from cleopatra.ArrayGlyph).
         """
+        # Resolve the grouped ``rgb_options`` against the deprecated loose
+        # kwargs exactly as ``Dataset.plot`` does, so both facades share one
+        # RGB-parameter contract (and one deprecation message).
+        rgb, surface_reflectance, cutoff, percentile = Dataset._merge_rgb_options(
+            rgb_options=rgb_options,
+            rgb=rgb,
+            surface_reflectance=surface_reflectance,
+            cutoff=cutoff,
+            percentile=percentile,
+        )
         # Materialise the cube on demand for plotting. The render helper
         # expects a single (time, rows, cols) numpy array; reading each
         # Dataset's band into one stacked array is fine for a plot call
         # (the user explicitly asked to render). Delegates the cleopatra
         # call to :func:`render_array` (D-2 — shared with `Analysis.plot`).
+        if rgb is not None:
+            # RGB time-lapse: read the FULL multi-band array per timestep and
+            # stack to (time, bands, rows, cols); render_array composites the
+            # true-colour frames. Guard the band layout here so a misshapen
+            # ``rgb`` raises a clear error instead of cleopatra silently
+            # collapsing the time axis into the colour channels (issue #538).
+            needed = max(rgb) + 1
+            if self.base.band_count < needed:
+                raise ValueError(
+                    f"rgb={rgb} needs at least {needed} bands, but the "
+                    f"collection's datasets have {self.base.band_count}."
+                )
+            data = np.stack(
+                [ds.read_array(band=None) for ds in self.datasets], axis=0
+            )
+            return render_array(
+                arr=data,
+                rgb=rgb,
+                surface_reflectance=surface_reflectance,
+                cutoff=cutoff,
+                percentile=percentile,
+                mode="animate",
+                animation_axis_values=list(range(self.time_length)),
+                **kwargs,
+            )
         data = np.stack([ds.read_array(band=band) for ds in self.datasets], axis=0)
         # Sanitise an unset no-data value (``None``) to ``np.nan`` before
         # building the exclusion list — mirrors ``Analysis.plot`` (the

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -2195,6 +2195,11 @@ class DatasetCollection:
             # true-colour frames. Guard the band layout here so a misshapen
             # ``rgb`` raises a clear error instead of cleopatra silently
             # collapsing the time axis into the colour channels (issue #538).
+            if len(rgb) not in (3, 4):
+                raise ValueError(
+                    f"rgb must list 3 band indices (RGB) or 4 (RGBA), got "
+                    f"{rgb!r} with {len(rgb)} entries."
+                )
             needed = max(rgb) + 1
             if self.base.band_count < needed:
                 raise ValueError(

--- a/tests/dataset/test_plot.py
+++ b/tests/dataset/test_plot.py
@@ -625,6 +625,25 @@ class TestPlotDatasetCollection:
             cube.plot(rgb_options={"rgb": bad_rgb})
 
     @pytest.mark.plot
+    def test_rgb_negative_index_raises(self, tmp_path):
+        """A negative `rgb` index is rejected before band-count resolution.
+
+        `max(rgb)` would otherwise underestimate the bands needed and let a
+        wrap-around index through to a cryptic failure deep in cleopatra.
+        """
+        cube = self._rgb_cube(tmp_path, n_times=2, n_bands=4)
+        with pytest.raises(ValueError, match=r"must be non-negative"):
+            cube.plot(rgb_options={"rgb": [-1, 0, 1]})
+
+    @pytest.mark.plot
+    def test_rgb_with_exclude_value_warns(self, tmp_path):
+        """Passing `exclude_value` alongside `rgb` warns that it is ignored."""
+        cube = self._rgb_cube(tmp_path, n_times=2)
+        with pytest.warns(UserWarning, match="exclude_value is ignored"):
+            glyph = cube.plot(exclude_value=0, rgb_options={"rgb": [0, 1, 2]})
+        assert glyph.arr.shape == (2, 8, 8, 3), "RGB stack still rendered"
+
+    @pytest.mark.plot
     def test_rgb_options_wins_over_loose_kwarg(self, tmp_path):
         """On collision, `rgb_options` wins over the loose kwarg and still warns."""
         cube = self._rgb_cube(tmp_path, n_times=2, n_bands=4)

--- a/tests/dataset/test_plot.py
+++ b/tests/dataset/test_plot.py
@@ -576,6 +576,36 @@ class TestPlotDatasetCollection:
         assert isinstance(glyph, ArrayGlyph)
         assert glyph.arr.ndim == 3, "single-band animate stays (time, rows, cols)"
 
+    @pytest.mark.plot
+    def test_rgb_surface_reflectance_normalisation(self, tmp_path):
+        """`rgb_options` may normalise via surface_reflectance instead of percentile.
+
+        Exercises the non-percentile branch of cleopatra's ``prepare_array`` through
+        the collection RGB path: the result is still a display-ready
+        ``(time, rows, cols, 3)`` stack in ``[0, 1]``.
+        """
+        cube = self._rgb_cube(tmp_path, n_times=3)
+        glyph = cube.plot(rgb_options={"rgb": [0, 1, 2], "surface_reflectance": 255})
+        assert glyph.arr.shape == (3, 8, 8, 3), "RGB stack keeps every frame"
+        assert float(glyph.arr.min()) >= 0.0 and float(glyph.arr.max()) <= 1.0, (
+            "surface-reflectance frames must be normalised into [0, 1]"
+        )
+
+    @pytest.mark.plot
+    def test_rgb_options_unknown_key_raises(self, tmp_path):
+        """An unknown `rgb_options` key raises (delegated to `_merge_rgb_options`)."""
+        cube = self._rgb_cube(tmp_path, n_times=2)
+        with pytest.raises(ValueError, match=r"Unknown keys in `rgb_options`"):
+            cube.plot(rgb_options={"bogus": 1})
+
+    @pytest.mark.plot
+    def test_rgb_options_wins_over_loose_kwarg(self, tmp_path):
+        """On collision, `rgb_options` wins over the loose kwarg and still warns."""
+        cube = self._rgb_cube(tmp_path, n_times=2, n_bands=4)
+        with pytest.warns(DeprecationWarning, match="rgb_options` wins"):
+            glyph = cube.plot(rgb=[1, 2, 3], rgb_options={"rgb": [0, 1, 2]})
+        assert glyph.arr.shape == (2, 8, 8, 3), "grouped rgb composited every frame"
+
 
 class TestColorTable:
 
@@ -1517,6 +1547,17 @@ class TestPlotPhase3CrossCutting:
                 rgb=[0, 1, 2],
                 mode="animate",
                 animation_axis_values=[0, 1, 2, 3],
+            )
+
+    @pytest.mark.plot
+    def test_render_array_rgb_animate_none_arr_raises(self):
+        """RGB animate with `arr=None` hits the same 4-D guard and reports None-D."""
+        with pytest.raises(ValueError, match=r"got None-D"):
+            render_array(
+                arr=None,
+                rgb=[0, 1, 2],
+                mode="animate",
+                animation_axis_values=[0],
             )
 
     @pytest.mark.plot

--- a/tests/dataset/test_plot.py
+++ b/tests/dataset/test_plot.py
@@ -519,6 +519,63 @@ class TestPlotDatasetCollection:
         glyph = cube.plot(band=0)
         assert isinstance(glyph, ArrayGlyph)
 
+    @staticmethod
+    def _rgb_cube(tmp_path, n_times=4, n_bands=3, dim=8):
+        """Build a co-registered multi-band DatasetCollection for RGB tests."""
+        rng = np.random.default_rng(0)
+        files = []
+        for t in range(n_times):
+            arr = (rng.random((n_bands, dim, dim), dtype="float32") * 255).astype(
+                "float32"
+            )
+            ds = Dataset.create_from_array(
+                arr=arr, geo=(0, 1, 0, 0, 0, -1), epsg=4326
+            )
+            path = tmp_path / f"rgb_{t}.tif"
+            ds.to_file(str(path))
+            files.append(str(path))
+        return DatasetCollection.from_files(files)
+
+    @pytest.mark.plot
+    def test_rgb_animate_keeps_every_frame(self, tmp_path):
+        """`plot(rgb=...)` returns a true-colour animation, one frame per timestep.
+
+        Regression for #538: passing ``rgb`` used to flow through ``**kwargs`` into
+        ``render_array``'s ``rgb`` parameter with a single-band ``(time, rows, cols)``
+        stack, so cleopatra read the time axis as the RGB channels — collapsing the
+        frames into a single ``(rows, cols, 3)`` still. The dedicated ``rgb`` path now
+        stacks every band per timestep and composites a ``(time, rows, cols, 3)`` stack,
+        so all four frames survive.
+        """
+        cube = self._rgb_cube(tmp_path, n_times=4)
+        glyph = cube.plot(rgb_options={"rgb": [0, 1, 2], "percentile": 2})
+        assert isinstance(glyph, ArrayGlyph)
+        assert glyph.arr.shape == (4, 8, 8, 3), "must keep all 4 true-colour frames"
+        assert glyph.cbar is None, "true-colour frames carry no colorbar"
+
+    @pytest.mark.plot
+    def test_rgb_insufficient_bands_raises(self, tmp_path):
+        """A misshapen `rgb=` raises instead of silently dropping frames (#538)."""
+        cube = self._rgb_cube(tmp_path, n_times=3, n_bands=2)
+        with pytest.raises(ValueError, match="needs at least 3 bands"):
+            cube.plot(rgb_options={"rgb": [0, 1, 2]})
+
+    @pytest.mark.plot
+    def test_rgb_loose_kwarg_is_deprecated(self, tmp_path):
+        """The loose top-level `rgb=` still works but warns, mirroring Dataset.plot."""
+        cube = self._rgb_cube(tmp_path, n_times=3)
+        with pytest.warns(DeprecationWarning, match="rgb_options"):
+            glyph = cube.plot(rgb=[0, 1, 2], percentile=2)
+        assert glyph.arr.shape == (3, 8, 8, 3)
+
+    @pytest.mark.plot
+    def test_single_band_path_unchanged(self, tmp_path):
+        """Without `rgb`, plot() still yields a colormapped single-band animation."""
+        cube = self._rgb_cube(tmp_path, n_times=3)
+        glyph = cube.plot(band=0)
+        assert isinstance(glyph, ArrayGlyph)
+        assert glyph.arr.ndim == 3, "single-band animate stays (time, rows, cols)"
+
 
 class TestColorTable:
 
@@ -1445,6 +1502,22 @@ class TestPlotPhase3CrossCutting:
         arr = np.zeros((3, 4, 4), dtype="float32")
         with pytest.raises(ValueError, match=r"facet_kwargs"):
             render_array(arr=arr, mode="facet")
+
+    @pytest.mark.plot
+    def test_render_array_rgb_animate_requires_4d(self):
+        """RGB animate with a single-band 3-D stack raises rather than collapsing.
+
+        Guards the #538 silent-frame-loss: a 3-D ``(time, rows, cols)`` array plus
+        ``rgb`` would otherwise reach cleopatra as a single composited still.
+        """
+        arr = np.zeros((4, 8, 8), dtype="float32")
+        with pytest.raises(ValueError, match=r"RGB animate requires a 4-D"):
+            render_array(
+                arr=arr,
+                rgb=[0, 1, 2],
+                mode="animate",
+                animation_axis_values=[0, 1, 2, 3],
+            )
 
     @pytest.mark.plot
     def test_render_array_basemap_requires_epsg(self):

--- a/tests/dataset/test_plot.py
+++ b/tests/dataset/test_plot.py
@@ -599,6 +599,32 @@ class TestPlotDatasetCollection:
             cube.plot(rgb_options={"bogus": 1})
 
     @pytest.mark.plot
+    def test_rgba_four_channel_animation(self, tmp_path):
+        """A four-index `rgb` composites an RGBA `(time, rows, cols, 4)` time-lapse.
+
+        The alpha channel path is documented ("or four, with alpha"); this guards it
+        against silent regressions in the per-frame compositing.
+        """
+        cube = self._rgb_cube(tmp_path, n_times=3, n_bands=4)
+        glyph = cube.plot(rgb_options={"rgb": [0, 1, 2, 3], "percentile": 2})
+        assert glyph.arr.shape == (3, 8, 8, 4), "RGBA stack keeps four channels"
+        assert glyph.cbar is None, "true-colour frames carry no colorbar"
+
+    @pytest.mark.plot
+    @pytest.mark.parametrize("bad_rgb", [[0, 1], [0], []])
+    def test_rgb_wrong_arity_raises(self, tmp_path, bad_rgb):
+        """An `rgb` list that is not 3 or 4 indices raises a clear arity error.
+
+        Args:
+            bad_rgb: A malformed channel list (too few / empty) that must be rejected
+                before reaching cleopatra (which would give a cryptic message, or
+                ``max([])`` would raise on the empty list).
+        """
+        cube = self._rgb_cube(tmp_path, n_times=2, n_bands=4)
+        with pytest.raises(ValueError, match=r"rgb must list 3 band indices"):
+            cube.plot(rgb_options={"rgb": bad_rgb})
+
+    @pytest.mark.plot
     def test_rgb_options_wins_over_loose_kwarg(self, tmp_path):
         """On collision, `rgb_options` wins over the loose kwarg and still warns."""
         cube = self._rgb_cube(tmp_path, n_times=2, n_bands=4)


### PR DESCRIPTION
# Description

`DatasetCollection.plot` stacked a single band per timestep into a `(time, rows, cols)` array, so it could only
produce a single-band colormapped animation — never a true-colour RGB time-lapse. Worse, passing `rgb=` through
`**kwargs` silently flowed into `render_array`'s `rgb` parameter alongside that 3-D stack, so cleopatra read the
**time axis as the RGB channels** — collapsing every frame into one `(rows, cols, 3)` still, with no error.

This wires a real RGB-animation path through the shared `render_array` helper and guards the silent frame loss.

- Add `rgb` / `surface_reflectance` / `cutoff` / `percentile` plus the grouped `rgb_options={...}` form to
  `DatasetCollection.plot`, reusing `Dataset._merge_rgb_options` so both facades share one RGB contract and one
  deprecation path. When `rgb` is set, the full multi-band array is stacked per timestep into
  `(time, bands, rows, cols)` and the band count is guarded with a clear `ValueError`.
- Teach `render_array`'s animate path to composite a 4-D `(time, bands, rows, cols)` stack into display-ready
  true-colour frames via cleopatra's `prepare_array`, handing `animate` a `(time, rows, cols, 3)` stack
  (cleopatra renders these as true colour, no colorbar). A 3-D stack plus `rgb` now raises instead of silently
  dropping frames.
- Bump the cleopatra floor to `>=0.18.0`, where `ArrayGlyph.animate` gained 4-D RGB support
  (serapeum-org/cleopatra#168 / cleopatra#169).

Depends on cleopatra **0.18.0**.

# Issues
- Fixes #538

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Added tests in `tests/dataset/test_plot.py` and ran the plot + collection suites locally (cleopatra 0.18.0):

- [x] `test_rgb_animate_keeps_every_frame` — `plot(rgb_options={"rgb":[0,1,2],"percentile":2})` returns a
  `(time, rows, cols, 3)` animation with one frame per timestep (none dropped) and no colorbar.
- [x] `test_rgb_insufficient_bands_raises` — a misshapen `rgb` raises `ValueError` instead of a single still.
- [x] `test_rgb_loose_kwarg_is_deprecated` — the loose `rgb=` still works but warns, mirroring `Dataset.plot`.
- [x] `test_single_band_path_unchanged` — `plot()` / `plot(band=k)` behaviour is unchanged.
- [x] `test_render_array_rgb_animate_requires_4d` — the `render_array` guard rejects a 3-D stack + `rgb`.

Suites: `pytest tests/dataset/test_plot.py -m plot` → 104 passed; `pytest tests/dataset/collection/` → 102 passed.

# Checklist:

- [ ] updated version number in pyproject.toml. (handled by commitizen on release)
- [ ] added changes to History.rst. (changelog is commitizen-generated)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (method + helper docstrings updated)