### PR TITLE
test(netcdf): probe #530 — drop CI skip on kerchunk-via-xarray roundtrip

### DIFF
--- a/tests/netcdf/lazy/test_netcdf_lazy_pipelines.py
+++ b/tests/netcdf/lazy/test_netcdf_lazy_pipelines.py
@@ -100,7 +100,6 @@ class TestNetCDFLazyPipelines:
     @pytest.mark.xarray
     @requires_kerchunk
     @requires_xarray
-    @skip_kerchunk_xarray_on_ci
     def test_kerchunk_roundtrip_via_xarray(self, tmp_path):
         """to_kerchunk manifest opens with xarray engine="kerchunk".
 


### PR DESCRIPTION
Draft probe for #530, not for merge.

Re-enables `test_kerchunk_roundtrip_via_xarray` on CI (removes the
`skipif(CI == "true")` guard) to check whether the kerchunk -> fsspec
async ReferenceFileSystem -> zarr v3 deadlock still reproduces in the
`extras-package (netcdf_lazy)` matrix.

- If the `netcdf_lazy` jobs go green across the OS matrix, the deadlock
  is resolved and #530's skip can be removed for real.
- If any job hangs (caught by the 300s pytest-timeout), the issue stands
  and this branch is discarded.

Refs #530