### PR TITLE
fix(netcdf): build kerchunk manifests natively to kill the zarr-v3 deadlock (#530)

### DIFF
--- a/docs/tutorials/lazy/kerchunk.md
+++ b/docs/tutorials/lazy/kerchunk.md
@@ -1,0 +1,171 @@
+# Kerchunk reference manifests
+
+## What kerchunk is, in one line
+
+**Kerchunk lets you read an existing archival file (NetCDF / HDF5 / GRIB / TIFF) *as if it were a cloud-native
+Zarr store* — without rewriting or converting the data.** It does this by producing a small JSON "reference
+manifest" that maps Zarr chunk keys to byte ranges inside the original file(s).
+
+pyramids emits these manifests from `NetCDF` and `DatasetCollection`; this page explains what they are, why
+they are useful, and how to generate them with the pyramids API.
+
+## The problem it solves
+
+Formats like NetCDF4 / HDF5 are excellent archival formats but awkward for cloud or lazy access:
+
+- To read one variable, a client traditionally has to open the whole file and walk HDF5's internal B-tree
+  layout.
+- Over object storage (S3 / GCS / Azure) or plain HTTP, that means many small range requests driven by HDF5
+  internals — slow and chatty.
+
+[Zarr](https://zarr.dev/), by contrast, is designed for the cloud: each chunk is addressable independently
+(`var/0.0.1`), metadata is plain JSON, and a client can fetch exactly the chunks it needs with simple `GET`
+range requests.
+
+Kerchunk bridges the two. It scans the HDF5 file **once**, records where every chunk physically lives
+(`[file_url, byte_offset, length]`), and writes that out as a Zarr-shaped JSON document. Any Zarr-aware
+consumer then opens the *manifest* and reads chunks straight out of the original file by byte range — **no
+data is copied and no conversion happens.**
+
+## What a manifest looks like
+
+A kerchunk v1 manifest is a JSON document. The interesting part is `refs`, mapping Zarr store keys to either
+metadata strings or `[url, offset, length]` byte-range pointers:
+
+```json
+{
+  "version": 1,
+  "refs": {
+    ".zgroup": "{\"zarr_format\":2}",
+    "values/.zarray": "{...shape, chunks, dtype, compressor...}",
+    "values/.zattrs": "{\"_ARRAY_DIMENSIONS\":[\"bands\",\"y\",\"x\"]}",
+    "values/0.0.0": ["data.nc", 14068, 2184]
+  }
+}
+```
+
+That last line says: *the chunk at grid position `0.0.0` of `values` lives in `data.nc`, at byte offset
+`14068`, and is `2184` bytes long.* Small chunks are inlined directly (base64) instead of referenced, so a
+fully self-contained manifest is possible for tiny arrays.
+
+## Generating a manifest with pyramids
+
+### Single file — `NetCDF.to_kerchunk`
+
+```python
+from pyramids.netcdf import NetCDF
+
+nc = NetCDF.read_file("noah_20240101.nc")
+manifest = nc.to_kerchunk("noah_20240101.kerchunk.json")
+
+# The manifest is also returned as a dict for inspection
+print(manifest["version"])                 # 1
+print(sorted(manifest["refs"])[:4])         # ['.zattrs', '.zgroup', 'values/.zarray', 'values/.zattrs']
+print(manifest["refs"]["values/0.0.0"])     # ['noah_20240101.nc', 14068, 2184]
+```
+
+Useful keyword arguments:
+
+- `inline_threshold` (default `500`): chunks smaller than this many bytes are embedded directly in the
+  manifest (base64) rather than referenced by offset. Raise it to make a more self-contained manifest; lower
+  it to keep the JSON tiny.
+- `vlen_encode` (default `"embed"`): how variable-length (VLEN) strings are handled.
+
+### Many files into one virtual cube — `NetCDF.combine_kerchunk`
+
+The headline use case: turn a directory of per-timestep NetCDFs into a **single** lazy, cloud-readable dataset
+described by one tiny sidecar JSON.
+
+```python
+from pathlib import Path
+from pyramids.netcdf import NetCDF
+
+sources = sorted(str(p) for p in Path("/data/noah").glob("noah_*.nc"))
+
+manifest = NetCDF.combine_kerchunk(
+    sources,
+    "noah_2024.kerchunk.json",
+    concat_dims=("time",),         # stack every variable that carries `time`
+    identical_dims=("lat", "lon"), # shared across files; taken from the first
+)
+```
+
+Every variable whose dimensions include the concat dimension is stacked along it (its shape grows to the sum
+across files); variables without it (e.g. the `lat` / `lon` coordinates) are carried through unchanged.
+
+### A collection — `DatasetCollection.to_kerchunk`
+
+If you already manage a folder of co-registered files as a `DatasetCollection`, it can emit the combined
+manifest directly:
+
+```python
+from pyramids.dataset import DatasetCollection
+
+collection = DatasetCollection.from_files(sorted(Path("/data/noah").glob("noah_*.nc")))
+manifest = collection.to_kerchunk("noah_2024.kerchunk.json", concat_dim="time")
+```
+
+## How the manifest is built (and why it is zarr-v3-safe)
+
+There are two distinct roles in the kerchunk workflow, and it helps to keep them separate:
+
+1. **Generating** the manifest — scanning the source files and recording chunk byte ranges. This is what
+   pyramids does.
+2. **Consuming** the manifest — opening it lazily and reading chunks. This is done by Zarr-aware clients.
+
+pyramids generates manifests **natively**: it walks the HDF5 container with `h5py` and writes the Zarr-v2
+metadata and chunk references directly, without ever instantiating a live Zarr group. This is deliberate —
+the older approach of driving kerchunk's HDF5 translator through Zarr's machinery could deadlock under
+Zarr v3 during *generation* (see issue #530). The native builder side-steps that entirely, so
+`to_kerchunk` / `combine_kerchunk` are safe to call anywhere, including inside long-lived processes and on CI.
+
+For files that use HDF5 features the native builder does not cover (for example VLEN/compound dtypes), it
+automatically falls back to the kerchunk translator and emits a warning.
+
+## Inspecting a manifest
+
+Because the functions return the manifest as a plain dict, you can inspect it with no extra dependencies:
+
+```python
+from pyramids.netcdf import NetCDF
+
+manifest = NetCDF.read_file("noah_20240101.nc").to_kerchunk("noah.json")
+refs = manifest["refs"]
+
+# Which variables are described?
+variables = sorted(key[: -len("/.zarray")] for key in refs if key.endswith("/.zarray"))
+print(variables)                                  # ['bands', 'values', 'x', 'y', ...]
+
+# Where does a given chunk live?
+print(refs["values/0.0.0"])                       # ['noah_20240101.nc', 14068, 2184]
+
+# Read a variable's Zarr metadata (it is a JSON string)
+import json
+print(json.loads(refs["values/.zarray"])["shape"])   # [3, 13, 14]
+print(json.loads(refs["values/.zattrs"]))             # {'_ARRAY_DIMENSIONS': ['bands', 'y', 'x'], ...}
+```
+
+## Consuming a manifest
+
+The manifest is a *Zarr reference store*, so it is opened by any Zarr-aware reader pointed at it through an
+fsspec "reference" filesystem. The canonical consumer in the scientific-Python stack is xarray
+(`xr.open_dataset(manifest, engine="kerchunk")`), but the manifest is just data — anything that speaks the
+Zarr v2 reference spec can read it. pyramids' role is to **produce** correct manifests; reading the underlying
+arrays directly (rather than through a manifest) is what `NetCDF.read_file` / `NetCDF.read_array` already do.
+
+## Why the name "kerchunk"?
+
+It is a coined name with no acronym — it evokes the *ker-chunk* of slotting data into chunks. The broader
+ecosystem has since standardized the idea as **"Zarr virtual datasets"** (the Zarr reference specification),
+with newer front-ends such as VirtualiZarr, but the manifest format pyramids emits is the original kerchunk
+v1 document.
+
+## Summary
+
+- Kerchunk is a **virtualization layer**: it makes legacy scientific files behave like cloud-native Zarr via a
+  **byte-range index**, with no data movement.
+- pyramids generates manifests with `NetCDF.to_kerchunk` (single file),
+  `NetCDF.combine_kerchunk` (many files → one cube), and `DatasetCollection.to_kerchunk`.
+- Generation is native and Zarr-v3-safe; the returned dict can be inspected directly.
+- A few-kilobyte JSON can stand in for a directory of multi-gigabyte NetCDFs, opened lazily by any Zarr-aware
+  consumer.

--- a/docs/tutorials/lazy/zarr.md
+++ b/docs/tutorials/lazy/zarr.md
@@ -1,0 +1,150 @@
+# What is Zarr (and why pyramids writes it)
+
+## Zarr in one line
+
+**Zarr is a storage format for large, chunked, compressed N-dimensional arrays — designed so each chunk is an
+independently addressable object and all metadata is plain JSON.** That makes it fast to read partially, cheap
+to write in parallel, and native to cloud object storage (S3 / GCS / Azure).
+
+pyramids reads and writes Zarr v3 stores for both single rasters (`Dataset`) and time-stacked cubes
+(`DatasetCollection`). This page explains the concept; for the full argument-by-argument contract see the
+[Zarr reference](../../reference/zarr.md).
+
+## The idea: arrays split into chunks
+
+A Zarr array is not one big file. It is:
+
+- a small JSON metadata document describing the array's shape, chunk shape, dtype, fill value, and codecs; plus
+- one object per **chunk** — a fixed-size block of the array (e.g. a `256 × 256` tile), each compressed
+  independently.
+
+```text
+my_array.zarr/
+├── zarr.json            # shape=(2,1024,1024), chunks=(1,256,256), dtype=float32, codec=blosc
+├── c/0/0/0              # chunk (band 0, rows 0–255,   cols 0–255)
+├── c/0/0/1              # chunk (band 0, rows 0–255,   cols 256–511)
+└── ...                  # one object per chunk
+```
+
+Because chunks are separate objects, a reader that wants one corner of a huge array fetches only the few chunks
+it overlaps — not the whole file. And a writer can produce many chunks **at once**, in parallel, with no
+central index to serialize through.
+
+## What it is used for
+
+- **Arrays bigger than RAM** — read and process a window or a few bands without loading everything.
+- **Parallel / distributed I/O** — every Dask chunk maps to one Zarr chunk, so writes fan out across cores or a
+  cluster. In pyramids, Zarr is the *only* raster output path that writes in true parallel.
+- **Cloud-native access** — a Zarr store on S3 is just a prefix of objects; clients do simple `GET`s for the
+  chunks they need, no special server.
+- **Incremental datasets** — append new timesteps to a cube, or overwrite a single time slice (a "region"
+  write), without rewriting the whole store.
+- **Fast previews** — multiscale pyramid levels let a viewer grab a decimated overview instead of full
+  resolution.
+
+## How Zarr relates to HDF5/NetCDF and to kerchunk
+
+- **vs HDF5 / NetCDF:** same goal (chunked N-D arrays) but HDF5 packs everything into one file with an internal
+  index, which is awkward over object storage. Zarr spreads chunks across many objects with JSON metadata —
+  built for the cloud.
+- **vs [kerchunk](kerchunk.md):** kerchunk does *not* move data — it writes a tiny manifest that makes an
+  existing NetCDF/HDF5 file **look like** a Zarr store by pointing at byte ranges inside it. `to_zarr` is the
+  opposite: it writes a **real, new** Zarr store with the data copied and re-chunked. Use kerchunk to virtualize
+  archives in place; use `to_zarr` when you want an independent, re-chunked, cloud-optimized copy.
+
+## pyramids examples
+
+> All Zarr I/O needs the `[lazy]` extra (`zarr>=3`, `dask`, `fsspec`).
+
+### Single raster — `Dataset.to_zarr` / `from_zarr`
+
+```python
+import numpy as np
+from pyramids.dataset import Dataset
+
+arr = np.arange(2 * 8 * 8, dtype=np.float32).reshape(2, 8, 8)
+ds = Dataset.create_from_array(arr, top_left_corner=(0.0, 8.0), cell_size=1.0, epsg=4326)
+ds.band_names = ["red", "nir"]
+
+# Write — parallel chunk writes, GeoZarr layout (CRS + GeoTransform preserved)
+ds.to_zarr("scene.zarr")
+
+# Read back — values, CRS, geotransform, nodata, and band names all round-trip
+rt = Dataset.from_zarr("scene.zarr")
+print(rt.epsg)          # 4326
+print(rt.band_names)    # ['red', 'nir']
+```
+
+The store follows the CF / **GeoZarr** convention, so it also opens georeferenced in other standards-aware
+readers (GDAL's Zarr driver, `xarray.open_zarr`, rioxarray) without pyramids in the loop.
+
+### Time-stacked cube — `DatasetCollection.to_zarr` / `from_zarr`
+
+```python
+from pathlib import Path
+from pyramids.dataset import DatasetCollection
+
+cube = DatasetCollection.from_files(sorted(Path("/data/series").glob("*.tif")))   # 4-D (T, B, R, C)
+cube.to_zarr("series.zarr")
+
+# Reopen lazily — data is read straight from the store via dask, not into memory
+reopened = DatasetCollection.from_zarr("series.zarr")
+print(reopened.time_length)
+```
+
+### Incremental writes — append a timestep / overwrite a slice
+
+```python
+# initial write
+cube_jan.to_zarr("series.zarr")
+
+# append later timesteps along the time axis (no full rewrite)
+cube_feb.to_zarr("series.zarr", mode="a", append_dim="time")
+
+# overwrite one existing time slice (e.g. fix a bad month) — an xarray-style region write
+cube_fixed.to_zarr("series.zarr", mode="a", region={"time": slice(1, 2)})
+```
+
+### Multiscale pyramid levels (fast previews)
+
+```python
+# write full resolution plus decimated overviews: data_2 / data_4 / data_8
+ds.to_zarr("scene.zarr", overview_factors=[2, 4, 8])
+
+# read a coarse level back — its cell size scales by the factor
+preview = Dataset.from_zarr("scene.zarr", level=4)
+print(preview.cell_size == ds.cell_size * 4)   # True
+```
+
+### Cloud store + codec control
+
+```python
+import zarr
+
+# write to S3 with explicit fsspec options and a zstd Blosc codec
+ds.to_zarr(
+    "s3://my-bucket/scene.zarr",
+    compressor=zarr.codecs.BloscCodec(cname="zstd"),
+    storage_options={"anon": False},
+)
+
+# read it back the same way
+remote = Dataset.from_zarr("s3://my-bucket/scene.zarr", storage_options={"anon": True})
+```
+
+## Summary
+
+- Zarr stores a large array as **many independently compressed chunk objects + JSON metadata**, which makes
+  partial reads, parallel writes, and cloud access natural.
+- pyramids writes/reads Zarr v3 in GeoZarr layout: `Dataset.to_zarr` / `from_zarr` for single rasters,
+  `DatasetCollection.to_zarr` / `from_zarr` for cubes, with append/region writes and multiscale overviews.
+- Reach for `to_zarr` when you want a real re-chunked cloud-optimized copy; reach for
+  [kerchunk](kerchunk.md) when you want to virtualize existing files without copying.
+
+## See also
+
+- [Zarr reference](../../reference/zarr.md) — full API, on-disk layout, foreign GeoZarr stores, STAC, legacy
+  stores.
+- [Kerchunk reference manifests](kerchunk.md) — virtualize NetCDF/HDF5 as Zarr without copying.
+- Example notebooks: *Zarr basics*, *Zarr cubes — append & region*, *Multiscale pyramids*, *Foreign GeoZarr
+  stores* (under Examples → Zarr).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,7 @@ nav:
           - Lazy NetCDF: tutorials/lazy/lazy-netcdf.md
           - Lazy collections (DatasetCollection): tutorials/lazy/lazy-collection.md
           - Lazy vector reads (FeatureCollection): tutorials/lazy/lazy-vector.md
+          - What is Zarr?: tutorials/lazy/zarr.md
           - Kerchunk reference manifests: tutorials/lazy/kerchunk.md
           - Using pyramids with Dask (notebook): examples/dask/overview.ipynb
           - Dask quickstart — Dataset: examples/dask/dataset.ipynb

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,7 @@ nav:
           - Lazy NetCDF: tutorials/lazy/lazy-netcdf.md
           - Lazy collections (DatasetCollection): tutorials/lazy/lazy-collection.md
           - Lazy vector reads (FeatureCollection): tutorials/lazy/lazy-vector.md
+          - Kerchunk reference manifests: tutorials/lazy/kerchunk.md
           - Using pyramids with Dask (notebook): examples/dask/overview.ipynb
           - Dask quickstart — Dataset: examples/dask/dataset.ipynb
           - Dask quickstart — DatasetCollection: examples/dask/collection.ipynb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,9 +50,7 @@ lazy = [
     "fsspec>=2024.1.0",
     "s3fs>=2024.1.0",
     "flox>=0.9.0",
-    # h5py powers pyramids' native kerchunk manifest builder (it walks HDF5 chunk
-    # metadata directly); kerchunk is the fallback for HDF5 features the native
-    # builder does not cover. Both serve the lazy NetCDF/HDF5 Zarr-reference path.
+    # kerchunk + h5py for the NetCDF/HDF5 lazy (Zarr-reference) path.
     "kerchunk>=0.2.10",
     "h5py>=3.8.0",
 ]
@@ -312,13 +310,12 @@ zarr = ">=3"
 fsspec = ">=2024.1.0"
 s3fs = ">=2024.1.0"
 flox = ">=0.9.0"
-# h5py + kerchunk for the NetCDF/HDF5 lazy Zarr-reference path. HDF5-linking
+# kerchunk (+ h5py) for the NetCDF/HDF5 lazy Zarr-reference path. HDF5-linking
 # libs must come from conda-forge to share the one HDF5 binary libgdal-netcdf
 # links against; PyPI h5py wheels bundle their own copy, which DLL-shadows on
 # Windows ("DLL load failed while importing defs") once two HDF5 backends load
-# in-process. pyramids' native kerchunk builder walks HDF5 chunk metadata with
-# h5py directly (kerchunk is now only the fallback for unsupported features); the
-# lazy NetCDF read path itself is pure GDAL MDArray, no netCDF4/h5netcdf.
+# in-process. Only kerchunk needs h5py here (to walk HDF5 chunk metadata) — the
+# lazy NetCDF path itself is pure GDAL MDArray, no netCDF4/h5netcdf.
 kerchunk = ">=0.2.10"
 # h5py 3.16 moved to hdf5 2.x, but libgdal-netcdf still links hdf5 1.14.x.
 # Pin h5py to the last 1.14-compatible release so the whole env shares

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,9 @@ lazy = [
     "fsspec>=2024.1.0",
     "s3fs>=2024.1.0",
     "flox>=0.9.0",
-    # kerchunk + h5py for the NetCDF/HDF5 lazy (Zarr-reference) path.
+    # h5py powers pyramids' native kerchunk manifest builder (it walks HDF5 chunk
+    # metadata directly); kerchunk is the fallback for HDF5 features the native
+    # builder does not cover. Both serve the lazy NetCDF/HDF5 Zarr-reference path.
     "kerchunk>=0.2.10",
     "h5py>=3.8.0",
 ]
@@ -310,12 +312,13 @@ zarr = ">=3"
 fsspec = ">=2024.1.0"
 s3fs = ">=2024.1.0"
 flox = ">=0.9.0"
-# kerchunk (+ h5py) for the NetCDF/HDF5 lazy Zarr-reference path. HDF5-linking
+# h5py + kerchunk for the NetCDF/HDF5 lazy Zarr-reference path. HDF5-linking
 # libs must come from conda-forge to share the one HDF5 binary libgdal-netcdf
 # links against; PyPI h5py wheels bundle their own copy, which DLL-shadows on
 # Windows ("DLL load failed while importing defs") once two HDF5 backends load
-# in-process. Only kerchunk needs h5py here (to walk HDF5 chunk metadata) — the
-# lazy NetCDF path itself is pure GDAL MDArray, no netCDF4/h5netcdf.
+# in-process. pyramids' native kerchunk builder walks HDF5 chunk metadata with
+# h5py directly (kerchunk is now only the fallback for unsupported features); the
+# lazy NetCDF read path itself is pure GDAL MDArray, no netCDF4/h5netcdf.
 kerchunk = ">=0.2.10"
 # h5py 3.16 moved to hdf5 2.x, but libgdal-netcdf still links hdf5 1.14.x.
 # Pin h5py to the last 1.14-compatible release so the whole env shares

--- a/src/pyramids/netcdf/_kerchunk.py
+++ b/src/pyramids/netcdf/_kerchunk.py
@@ -203,7 +203,10 @@ def to_kerchunk(
                 inline_threshold=inline_threshold,
                 vlen_encode=vlen_encode,
             )
-        except ValueError as exc:
+        except (ValueError, OSError) as exc:
+            # ValueError: unsupported HDF5 feature. OSError: h5py could not open the
+            # source — typically a remote URL (s3://, /vsicurl/...) the local-only
+            # native builder cannot read, but kerchunk's translator can via fsspec.
             warnings.warn(
                 f"native kerchunk builder could not handle {src_str!r} "
                 f"({exc}); falling back to the kerchunk translator.",
@@ -325,7 +328,10 @@ def combine_kerchunk(
                 for path in src_paths
             ]
             combined = combine_manifests(per_file, concat_dim=concat_dims[0])
-        except ValueError as exc:
+        except (ValueError, OSError) as exc:
+            # ValueError: >1 concat dim or unsupported feature. OSError: h5py could
+            # not open a source (e.g. a remote URL the local-only native builder
+            # cannot read) — kerchunk's translator handles those via fsspec.
             warnings.warn(
                 f"native kerchunk combine could not handle these inputs ({exc}); "
                 "falling back to the kerchunk translator.",

--- a/src/pyramids/netcdf/_kerchunk.py
+++ b/src/pyramids/netcdf/_kerchunk.py
@@ -22,6 +22,7 @@ Kerchunk is not a hard dependency — it lives in the
 from __future__ import annotations
 
 import json
+import os
 import warnings
 from contextlib import contextmanager
 from pathlib import Path
@@ -207,6 +208,11 @@ def to_kerchunk(
             # ValueError: unsupported HDF5 feature. OSError: h5py could not open the
             # source — typically a remote URL (s3://, /vsicurl/...) the local-only
             # native builder cannot read, but kerchunk's translator can via fsspec.
+            # A local file that exists but fails to open is corrupt/unreadable at the
+            # HDF5 level; surface that directly rather than masking it behind a
+            # kerchunk fallback that would also fail.
+            if isinstance(exc, OSError) and os.path.exists(src_str):
+                raise
             warnings.warn(
                 f"native kerchunk builder could not handle {src_str!r} "
                 f"({exc}); falling back to the kerchunk translator.",
@@ -331,7 +337,13 @@ def combine_kerchunk(
         except (ValueError, OSError) as exc:
             # ValueError: >1 concat dim or unsupported feature. OSError: h5py could
             # not open a source (e.g. a remote URL the local-only native builder
-            # cannot read) — kerchunk's translator handles those via fsspec.
+            # cannot read) — kerchunk's translator handles those via fsspec. If every
+            # input is a local file that exists, an OSError means a corrupt/unreadable
+            # file; surface it directly instead of a misleading fallback.
+            if isinstance(exc, OSError) and all(
+                os.path.exists(str(path)) for path in src_paths
+            ):
+                raise
             warnings.warn(
                 f"native kerchunk combine could not handle these inputs ({exc}); "
                 "falling back to the kerchunk translator.",

--- a/src/pyramids/netcdf/_kerchunk.py
+++ b/src/pyramids/netcdf/_kerchunk.py
@@ -22,11 +22,14 @@ Kerchunk is not a hard dependency — it lives in the
 from __future__ import annotations
 
 import json
+import warnings
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Iterator, Sequence
 
 import numpy as np
+
+from pyramids.netcdf._kerchunk_native import build_single_manifest, combine_manifests
 
 _KERCHUNK_IMPORT_ERROR = (
     "kerchunk is required for NetCDF → Zarr reference manifests. "
@@ -113,12 +116,34 @@ def _require_kerchunk_combine() -> Any:
     return MultiZarrToZarr
 
 
+def _kerchunk_translate_single(
+    src_str: str, *, inline_threshold: int, vlen_encode: str
+) -> dict[str, Any]:
+    """Generate a single-file manifest via kerchunk's HDF5 translator.
+
+    Fallback path for files the native builder cannot handle. Under zarr v3 this
+    can flakily deadlock (#530), so it is only used when the native builder
+    raises on an unsupported HDF5 feature.
+    """
+    SingleHdf5ToZarr = _require_kerchunk_single()
+    with _scalar_fill_value_shim():
+        refs = SingleHdf5ToZarr(
+            src_str,
+            src_str,
+            inline_threshold=inline_threshold,
+            error="warn",
+            vlen_encode=vlen_encode,
+        ).translate()
+    return refs
+
+
 def to_kerchunk(
     src_path: str | Path,
     output_path: str | Path,
     *,
     inline_threshold: int = 500,
     vlen_encode: str = "embed",
+    backend: str = "native",
 ) -> dict[str, Any]:
     """Emit a single-file kerchunk reference manifest.
 
@@ -127,19 +152,26 @@ def to_kerchunk(
         output_path: Path where the JSON manifest is written.
         inline_threshold: Chunks smaller than this many bytes are
             embedded directly in the manifest rather than referenced
-            by offset. Forwarded to
-            :class:`kerchunk.hdf.SingleHdf5ToZarr`.
+            by offset.
         vlen_encode: One of `"embed" | "null" | "leave" | "encode"`.
             Controls how VLEN (variable-length) strings are handled.
             Default `"embed"` inlines string values; other modes
             trade compatibility vs fidelity — see the kerchunk docs.
+        backend: `"native"` (default) builds the manifest directly with
+            h5py — no live zarr group, so it cannot hit the zarr-v3
+            `sync()` deadlock (#530). `"kerchunk"` forces the legacy
+            `kerchunk.hdf.SingleHdf5ToZarr` translator. The native
+            backend falls back to kerchunk for files using HDF5 features
+            it does not support (e.g. vlen/compound dtypes).
 
     Returns:
         The manifest dict that was written — useful for inspection
         or further programmatic use.
 
     Raises:
-        ImportError: When kerchunk is not installed.
+        ImportError: When the chosen backend's dependency is missing
+            (h5py for `"native"`, kerchunk for `"kerchunk"`).
+        ValueError: When `backend` is not `"native"` or `"kerchunk"`.
 
     Examples:
         - Emit a manifest for one NetCDF file (requires the
@@ -155,18 +187,63 @@ def to_kerchunk(
 
             ```
     """
-    SingleHdf5ToZarr = _require_kerchunk_single()
+    if backend not in ("native", "kerchunk"):
+        raise ValueError(
+            f"backend must be 'native' or 'kerchunk'; got {backend!r}"
+        )
     src_str = str(src_path)
-    with _scalar_fill_value_shim():
-        refs = SingleHdf5ToZarr(
-            src_str,
-            src_str,
-            inline_threshold=inline_threshold,
-            error="warn",
-            vlen_encode=vlen_encode,
-        ).translate()
+    if backend == "kerchunk":
+        refs = _kerchunk_translate_single(
+            src_str, inline_threshold=inline_threshold, vlen_encode=vlen_encode
+        )
+    else:
+        try:
+            refs = build_single_manifest(
+                src_str,
+                inline_threshold=inline_threshold,
+                vlen_encode=vlen_encode,
+            )
+        except ValueError as exc:
+            warnings.warn(
+                f"native kerchunk builder could not handle {src_str!r} "
+                f"({exc}); falling back to the kerchunk translator.",
+                stacklevel=2,
+            )
+            refs = _kerchunk_translate_single(
+                src_str, inline_threshold=inline_threshold, vlen_encode=vlen_encode
+            )
     Path(output_path).write_text(json.dumps(refs))
     return refs
+
+
+def _kerchunk_combine(
+    src_paths: Sequence[str | Path],
+    *,
+    concat_dims: Sequence[str],
+    identical_dims: Sequence[str],
+    inline_threshold: int,
+) -> dict[str, Any]:
+    """Combine via kerchunk's translator + ``MultiZarrToZarr`` (legacy path)."""
+    SingleHdf5ToZarr = _require_kerchunk_single()
+    MultiZarrToZarr = _require_kerchunk_combine()
+
+    per_file = []
+    with _scalar_fill_value_shim():
+        for path in src_paths:
+            src_str = str(path)
+            refs = SingleHdf5ToZarr(
+                src_str,
+                src_str,
+                inline_threshold=inline_threshold,
+                error="warn",
+            ).translate()
+            per_file.append(refs)
+
+    return MultiZarrToZarr(
+        per_file,
+        concat_dims=list(concat_dims),
+        identical_dims=list(identical_dims),
+    ).translate()
 
 
 def combine_kerchunk(
@@ -176,29 +253,39 @@ def combine_kerchunk(
     concat_dims: Sequence[str] = ("time",),
     identical_dims: Sequence[str] = ("lat", "lon"),
     inline_threshold: int = 500,
+    backend: str = "native",
 ) -> dict[str, Any]:
     """Emit a combined kerchunk manifest spanning many source files.
 
-    Each source is first scanned via
-    :class:`kerchunk.hdf.SingleHdf5ToZarr` (in memory, no per-file
-    sidecar JSON is written), then merged via
-    :class:`kerchunk.combine.MultiZarrToZarr`.
+    The default `"native"` backend scans each file with :func:`build_single_manifest`
+    (h5py, no live zarr group) and concatenates the per-file manifests along the
+    single `concat_dims` entry — every variable carrying that dimension is stacked,
+    the rest are carried from the first file. This avoids the zarr-v3 `sync()`
+    deadlock (#530). `"kerchunk"` forces the legacy
+    `SingleHdf5ToZarr` + `MultiZarrToZarr` path; the native backend also falls back
+    to it for inputs it cannot handle (e.g. multiple concat dims, unsupported HDF5
+    features).
 
     Args:
-        src_paths: Sequence of source NetCDF / HDF5 paths or URLs.
+        src_paths: Sequence of source NetCDF / HDF5 paths or URLs, in
+            concatenation order.
         output_path: Path where the combined JSON manifest is written.
-        concat_dims: Dimension name(s) along which to concatenate
-            per-file coordinates. Default `("time",)`.
-        identical_dims: Dimension name(s) expected to be identical
-            across every file (for example shared `lat`/`lon`
-            coordinates). Default `("lat", "lon")`.
+        concat_dims: Dimension name(s) along which to concatenate. The native
+            backend supports exactly one; more than one falls back to kerchunk.
+            Default `("time",)`.
+        identical_dims: Dimension name(s) expected to be identical across files
+            (e.g. shared `lat`/`lon`). Used by the kerchunk backend; the native
+            backend treats every non-concat variable as identical implicitly.
+            Default `("lat", "lon")`.
         inline_threshold: Same semantics as :func:`to_kerchunk`.
+        backend: `"native"` (default) or `"kerchunk"`.
 
     Returns:
         The combined manifest dict that was written.
 
     Raises:
-        ImportError: When kerchunk is not installed.
+        ImportError: When the chosen backend's dependency is missing.
+        ValueError: When `backend` is not `"native"` or `"kerchunk"`.
 
     Examples:
         - Combine a year's worth of daily NetCDFs into one manifest:
@@ -215,26 +302,41 @@ def combine_kerchunk(
 
             ```
     """
-    SingleHdf5ToZarr = _require_kerchunk_single()
-    MultiZarrToZarr = _require_kerchunk_combine()
-
-    per_file = []
-    with _scalar_fill_value_shim():
-        for path in src_paths:
-            src_str = str(path)
-            refs = SingleHdf5ToZarr(
-                src_str,
-                src_str,
+    if backend not in ("native", "kerchunk"):
+        raise ValueError(
+            f"backend must be 'native' or 'kerchunk'; got {backend!r}"
+        )
+    if backend == "kerchunk":
+        combined = _kerchunk_combine(
+            src_paths,
+            concat_dims=concat_dims,
+            identical_dims=identical_dims,
+            inline_threshold=inline_threshold,
+        )
+    else:
+        try:
+            if len(concat_dims) != 1:
+                raise ValueError(
+                    "native combine supports exactly one concat dimension; got "
+                    f"{tuple(concat_dims)}"
+                )
+            per_file = [
+                build_single_manifest(str(path), inline_threshold=inline_threshold)
+                for path in src_paths
+            ]
+            combined = combine_manifests(per_file, concat_dim=concat_dims[0])
+        except ValueError as exc:
+            warnings.warn(
+                f"native kerchunk combine could not handle these inputs ({exc}); "
+                "falling back to the kerchunk translator.",
+                stacklevel=2,
+            )
+            combined = _kerchunk_combine(
+                src_paths,
+                concat_dims=concat_dims,
+                identical_dims=identical_dims,
                 inline_threshold=inline_threshold,
-                error="warn",
-            ).translate()
-            per_file.append(refs)
-
-    combined = MultiZarrToZarr(
-        per_file,
-        concat_dims=list(concat_dims),
-        identical_dims=list(identical_dims),
-    ).translate()
+            )
     Path(output_path).write_text(json.dumps(combined))
     return combined
 

--- a/src/pyramids/netcdf/_kerchunk_native.py
+++ b/src/pyramids/netcdf/_kerchunk_native.py
@@ -57,7 +57,14 @@ _H5_FLETCHER32 = 3
 
 
 def _require_h5py() -> Any:
-    """Lazy-import :mod:`h5py`, raising a clear error when it is missing."""
+    """Lazy-import :mod:`h5py`, raising a clear error when it is missing.
+
+    Returns:
+        The imported ``h5py`` module.
+
+    Raises:
+        ImportError: When h5py is not installed (points at the ``[lazy]`` extra).
+    """
     try:
         import h5py
     except ImportError as exc:
@@ -66,7 +73,40 @@ def _require_h5py() -> Any:
 
 
 def _to_jsonable(value: Any) -> Any:
-    """Convert an HDF5 attribute value into a JSON-serialisable Python value."""
+    """Convert an HDF5 attribute value into a JSON-serialisable Python value.
+
+    Bytes / numpy bytes decode to ``str``; 1-element arrays squeeze to a scalar
+    (GDAL writes scalar CF attributes as size-1 arrays); larger arrays become
+    lists; numpy scalar types coerce to their Python equivalents.
+
+    Args:
+        value: An attribute value as returned by ``h5py`` (bytes, numpy array,
+            numpy scalar, or a plain Python value).
+
+    Returns:
+        A JSON-serialisable value (``str`` / ``int`` / ``float`` / ``bool`` /
+        ``list`` / the input unchanged).
+
+    Examples:
+        - Decode bytes and squeeze a size-1 array to a scalar:
+            ```python
+            >>> from pyramids.netcdf._kerchunk_native import _to_jsonable
+            >>> import numpy as np
+            >>> _to_jsonable(b"metres")
+            'metres'
+            >>> _to_jsonable(np.array([1.5], dtype="f8"))
+            1.5
+
+            ```
+        - Keep a real vector as a list:
+            ```python
+            >>> from pyramids.netcdf._kerchunk_native import _to_jsonable
+            >>> import numpy as np
+            >>> _to_jsonable(np.array([1, 2, 3], dtype="i4"))
+            [1, 2, 3]
+
+            ```
+    """
     if isinstance(value, bytes):
         result = value.decode("utf-8", "replace")
     elif isinstance(value, np.ndarray):
@@ -90,7 +130,15 @@ def _to_jsonable(value: Any) -> Any:
 
 
 def _clean_attrs(attrs: Any) -> dict[str, Any]:
-    """Return user-facing attributes, dropping HDF5/NetCDF bookkeeping keys."""
+    """Return user-facing attributes, dropping HDF5/NetCDF bookkeeping keys.
+
+    Args:
+        attrs: An ``h5py`` attribute mapping (group or dataset ``.attrs``).
+
+    Returns:
+        A JSON-serialisable dict with the keys in :data:`_DROP_ATTRS` removed and
+        every value passed through :func:`_to_jsonable`.
+    """
     cleaned: dict[str, Any] = {}
     for key, value in attrs.items():
         if key in _DROP_ATTRS:
@@ -100,7 +148,25 @@ def _clean_attrs(attrs: Any) -> dict[str, Any]:
 
 
 def _basename(path: str) -> str:
-    """Last path component of an HDF5 object path (``/g/x`` -> ``x``)."""
+    """Return the last path component of an HDF5 object path.
+
+    Args:
+        path: An HDF5 object path such as ``/group/x``.
+
+    Returns:
+        The final component (``x`` for ``/group/x``).
+
+    Examples:
+        - A nested path keeps only its leaf:
+            ```python
+            >>> from pyramids.netcdf._kerchunk_native import _basename
+            >>> _basename("/group/x")
+            'x'
+            >>> _basename("y")
+            'y'
+
+            ```
+    """
     return path.rstrip("/").rsplit("/", 1)[-1]
 
 
@@ -204,7 +270,31 @@ def _compressor_and_filters(dataset: Any) -> tuple[dict | None, list[dict] | Non
 
 
 def _chunk_grid_key(chunk_offset: tuple[int, ...], chunks: list[int]) -> str:
-    """Zarr chunk key (``"0.1.0"``) from element-space chunk offsets."""
+    """Build a zarr chunk key from element-space chunk offsets.
+
+    Args:
+        chunk_offset: The chunk's start coordinate per axis, in elements.
+        chunks: The chunk shape per axis (empty for a scalar array).
+
+    Returns:
+        The dot-joined grid index (``"0.1.0"``), or ``"0"`` for a scalar.
+
+    Examples:
+        - A 3-D chunk offset divided by the chunk shape gives the grid key:
+            ```python
+            >>> from pyramids.netcdf._kerchunk_native import _chunk_grid_key
+            >>> _chunk_grid_key((0, 5, 0), [1, 5, 6])
+            '0.1.0'
+
+            ```
+        - A scalar (no chunks) is always key ``"0"``:
+            ```python
+            >>> from pyramids.netcdf._kerchunk_native import _chunk_grid_key
+            >>> _chunk_grid_key((), [])
+            '0'
+
+            ```
+    """
     if not chunks:
         key = "0"
     else:
@@ -380,17 +470,75 @@ def build_single_manifest(
 
 
 def _manifest_refs(manifest: dict[str, Any]) -> dict[str, Any]:
-    """Return the flat refs mapping from a v0 (flat) or v1 (nested) manifest."""
+    """Return the flat refs mapping from a v0 (flat) or v1 (nested) manifest.
+
+    Args:
+        manifest: A kerchunk manifest — either v1 (``{"version", "refs"}``) or the
+            older flat v0 form (the refs mapping itself).
+
+    Returns:
+        The refs mapping (``manifest["refs"]`` for v1, else ``manifest``).
+
+    Examples:
+        - A v1 manifest yields its ``refs`` mapping:
+            ```python
+            >>> from pyramids.netcdf._kerchunk_native import _manifest_refs
+            >>> _manifest_refs({"version": 1, "refs": {".zgroup": "{}"}})
+            {'.zgroup': '{}'}
+
+            ```
+        - A flat v0 mapping is returned unchanged:
+            ```python
+            >>> from pyramids.netcdf._kerchunk_native import _manifest_refs
+            >>> _manifest_refs({".zgroup": "{}"})
+            {'.zgroup': '{}'}
+
+            ```
+    """
     return manifest["refs"] if "refs" in manifest else manifest
 
 
 def _variable_names(refs: dict[str, Any]) -> list[str]:
-    """Names of the array variables in a refs mapping (those with a ``.zarray``)."""
+    """List the array-variable names in a refs mapping.
+
+    Args:
+        refs: A kerchunk refs mapping (zarr store keys to metadata / chunk refs).
+
+    Returns:
+        The names of variables that carry a ``.zarray`` (the array variables).
+
+    Examples:
+        - Only keys with a ``.zarray`` count as variables:
+            ```python
+            >>> from pyramids.netcdf._kerchunk_native import _variable_names
+            >>> _variable_names({"t/.zarray": "{}", "t/.zattrs": "{}", ".zgroup": "{}"})
+            ['t']
+
+            ```
+    """
     return [key[: -len("/.zarray")] for key in refs if key.endswith("/.zarray")]
 
 
 def _shift_chunk_key(key: str, axis: int, offset: int) -> str:
-    """Shift a zarr chunk key's grid index on ``axis`` by ``offset`` chunks."""
+    """Shift a zarr chunk key's grid index on one axis by a number of chunks.
+
+    Args:
+        key: A dot-separated zarr chunk key (e.g. ``"0.1.0"``).
+        axis: The axis whose grid index is shifted.
+        offset: The number of chunks to add to that axis's index.
+
+    Returns:
+        The chunk key with ``offset`` added to the ``axis`` component.
+
+    Examples:
+        - Shift the first axis of a 3-D chunk key by two chunks:
+            ```python
+            >>> from pyramids.netcdf._kerchunk_native import _shift_chunk_key
+            >>> _shift_chunk_key("0.1.0", 0, 2)
+            '2.1.0'
+
+            ```
+    """
     parts = key.split(".")
     parts[axis] = str(int(parts[axis]) + offset)
     return ".".join(parts)
@@ -401,7 +549,25 @@ def _concat_variable(
     per_file_refs: list[dict[str, Any]],
     axis: int,
 ) -> dict[str, Any]:
-    """Stack one variable across files along ``axis``; return its merged refs."""
+    """Stack one variable across files along ``axis``; return its merged refs.
+
+    Each file's chunk keys are renumbered on ``axis`` by the cumulative chunk
+    count of the prior files, and the ``shape`` on ``axis`` is summed. Metadata
+    and ``.zattrs`` are taken from the first file.
+
+    Args:
+        name: The variable name (ref-key prefix, e.g. ``"time"``).
+        per_file_refs: Per-file refs mappings, in concatenation order.
+        axis: The concat axis index within the variable's dimensions.
+
+    Returns:
+        The merged refs for this variable (``.zarray`` / ``.zattrs`` + shifted
+        chunk keys).
+
+    Raises:
+        ValueError: When the concat-axis chunk size differs across files, or a
+            non-final file's length is not a multiple of that chunk size.
+    """
     base = json.loads(per_file_refs[0][f"{name}/.zarray"])
     chunk_size = base["chunks"][axis]
     total = 0

--- a/src/pyramids/netcdf/_kerchunk_native.py
+++ b/src/pyramids/netcdf/_kerchunk_native.py
@@ -167,6 +167,12 @@ def _compressor_and_filters(dataset: Any) -> tuple[dict | None, list[dict] | Non
     Supports deflate (-> zlib compressor) and shuffle (-> shuffle filter), and
     silently drops the fletcher32 checksum (zarr has no equivalent; the data
     remains readable). Any other filter id is unsupported.
+
+    zarr decodes the byte-compressor first, then reverses ``filters`` — so the
+    mapping is only correct when shuffle is applied *before* deflate in the HDF5
+    pipeline (which GDAL's netCDF driver always does). A shuffle that appears
+    after deflate would decode wrong, so that ordering is rejected rather than
+    silently mis-decoded.
     """
     dcpl = dataset.id.get_create_plist()
     compressor: dict | None = None
@@ -177,6 +183,12 @@ def _compressor_and_filters(dataset: Any) -> tuple[dict | None, list[dict] | Non
             level = cd_values[0] if cd_values else 4
             compressor = {"id": "zlib", "level": int(level)}
         elif filter_id == _H5_SHUFFLE:
+            if compressor is not None:
+                raise ValueError(
+                    f"Dataset {dataset.name!r} applies shuffle after deflate; the "
+                    "native builder only supports shuffle-before-deflate. Use the "
+                    "kerchunk backend for this file."
+                )
             elementsize = dataset.dtype.itemsize
             filters.append({"id": "shuffle", "elementsize": int(elementsize)})
         elif filter_id == _H5_FLETCHER32:

--- a/src/pyramids/netcdf/_kerchunk_native.py
+++ b/src/pyramids/netcdf/_kerchunk_native.py
@@ -428,9 +428,10 @@ def build_single_manifest(
         url = src_url
     elif src_local is not None:
         # Absolutise local paths so the manifest resolves regardless of the
-        # consumer's working directory (a relative path only resolves from the CWD
-        # the manifest was written in).
-        url = os.path.abspath(src_str)
+        # consumer's working directory, and use forward slashes (as_posix) so a
+        # Windows-written manifest carries a portable path rather than back-slashes
+        # that some fsspec/zarr consumers mishandle.
+        url = Path(src_str).resolve().as_posix()
     else:
         url = src_str
 

--- a/src/pyramids/netcdf/_kerchunk_native.py
+++ b/src/pyramids/netcdf/_kerchunk_native.py
@@ -203,14 +203,6 @@ def _compressor_and_filters(dataset: Any) -> tuple[dict | None, list[dict] | Non
     return compressor, (filters or None)
 
 
-def _read_raw_bytes(src_path: str, offset: int, size: int) -> bytes:
-    """Read ``size`` stored bytes at ``offset`` from a local source file."""
-    with open(src_path, "rb") as handle:
-        handle.seek(offset)
-        data = handle.read(size)
-    return data
-
-
 def _chunk_grid_key(chunk_offset: tuple[int, ...], chunks: list[int]) -> str:
     """Zarr chunk key (``"0.1.0"``) from element-space chunk offsets."""
     if not chunks:
@@ -228,18 +220,22 @@ def _emit_chunk_refs(
     dataset: Any,
     name: str,
     src_url: str,
-    src_local: str | None,
+    src_handle: Any,
     chunks: list[int],
     inline_threshold: int,
 ) -> None:
-    """Add this dataset's chunk references (byte-range or inlined) to ``refs``."""
-    h5py = _require_h5py()
+    """Add this dataset's chunk references (byte-range or inlined) to ``refs``.
+
+    ``src_handle`` is an open binary handle to the local source (or ``None`` for a
+    remote source, which is always referenced by byte range, never inlined).
+    """
 
     def add(key: str, offset: int, size: int) -> None:
         if size <= 0:
             return
-        if src_local is not None and size < inline_threshold:
-            blob = _read_raw_bytes(src_local, offset, size)
+        if src_handle is not None and size < inline_threshold:
+            src_handle.seek(offset)
+            blob = src_handle.read(size)
             refs[f"{name}/{key}"] = "base64:" + base64.b64encode(blob).decode("ascii")
         else:
             refs[f"{name}/{key}"] = [src_url, int(offset), int(size)]
@@ -266,7 +262,7 @@ def _emit_dataset(
     name: str,
     dataset: Any,
     src_url: str,
-    src_local: str | None,
+    src_handle: Any,
     inline_threshold: int,
     vlen_encode: str,
 ) -> None:
@@ -303,7 +299,7 @@ def _emit_dataset(
         dataset=dataset,
         name=name,
         src_url=src_url,
-        src_local=src_local,
+        src_handle=src_handle,
         chunks=chunks,
         inline_threshold=inline_threshold,
     )
@@ -349,29 +345,36 @@ def build_single_manifest(
         url = src_str
 
     refs: dict[str, Any] = {}
-    with h5py.File(src_str, "r") as h5file:
-        refs[".zgroup"] = json.dumps({"zarr_format": 2})
-        refs[".zattrs"] = json.dumps(_clean_attrs(h5file.attrs), allow_nan=False)
+    # One binary handle for the whole walk so inlined chunks don't reopen the file
+    # per chunk; None for a remote source (those are always referenced, not inlined).
+    src_handle = open(src_local, "rb") if src_local is not None else None
+    try:
+        with h5py.File(src_str, "r") as h5file:
+            refs[".zgroup"] = json.dumps({"zarr_format": 2})
+            refs[".zattrs"] = json.dumps(_clean_attrs(h5file.attrs), allow_nan=False)
 
-        def visit(name: str, obj: Any) -> None:
-            if isinstance(obj, h5py.Dataset):
-                _emit_dataset(
-                    refs,
-                    h5file=h5file,
-                    name=name,
-                    dataset=obj,
-                    src_url=url,
-                    src_local=src_local,
-                    inline_threshold=inline_threshold,
-                    vlen_encode=vlen_encode,
-                )
-            else:
-                refs[f"{name}/.zgroup"] = json.dumps({"zarr_format": 2})
-                refs[f"{name}/.zattrs"] = json.dumps(
-                    _clean_attrs(obj.attrs), allow_nan=False
-                )
+            def visit(name: str, obj: Any) -> None:
+                if isinstance(obj, h5py.Dataset):
+                    _emit_dataset(
+                        refs,
+                        h5file=h5file,
+                        name=name,
+                        dataset=obj,
+                        src_url=url,
+                        src_handle=src_handle,
+                        inline_threshold=inline_threshold,
+                        vlen_encode=vlen_encode,
+                    )
+                else:
+                    refs[f"{name}/.zgroup"] = json.dumps({"zarr_format": 2})
+                    refs[f"{name}/.zattrs"] = json.dumps(
+                        _clean_attrs(obj.attrs), allow_nan=False
+                    )
 
-        h5file.visititems(visit)
+            h5file.visititems(visit)
+    finally:
+        if src_handle is not None:
+            src_handle.close()
 
     return {"version": 1, "refs": refs}
 

--- a/src/pyramids/netcdf/_kerchunk_native.py
+++ b/src/pyramids/netcdf/_kerchunk_native.py
@@ -1,0 +1,493 @@
+"""zarr-v3-safe kerchunk manifest builder for NetCDF4 / HDF5.
+
+Builds a kerchunk v1 reference manifest by walking the HDF5 container with
+:mod:`h5py` and emitting zarr-v2 metadata + byte-range chunk references
+**directly** — without ever instantiating a live zarr group. This avoids the
+``kerchunk.hdf`` path that drives zarr's synchronous v2 API, which under zarr v3
+submits work to a process-global event loop and flakily deadlocks (#530).
+
+The output is the ordinary kerchunk reference document, so the consumer side
+(``xr.open_dataset(engine="kerchunk")``) is unchanged.
+
+Scope: the feature surface GDAL's netCDF driver writes — fixed-width numeric and
+fixed-length string dtypes, ``deflate``/``shuffle`` filters, dimension scales.
+Unsupported HDF5 features raise a clear :class:`ValueError`.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import math
+import os
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+_H5PY_IMPORT_ERROR = (
+    "h5py is required for native kerchunk reference manifests. "
+    "Install with the [lazy] extra:\n"
+    "  - PyPI:        pip install 'pyramids-gis[lazy]'\n"
+    "  - conda-forge: conda install -c conda-forge pyramids-lazy"
+)
+
+# HDF5 attribute keys that are container bookkeeping, not user metadata; they are
+# stripped from the emitted ``.zattrs`` (their information is carried elsewhere:
+# fill_value from _FillValue, dimension names from _ARRAY_DIMENSIONS).
+_DROP_ATTRS = frozenset(
+    {
+        "_Netcdf4Coordinates",
+        "_Netcdf4Dimid",
+        "_nc3_strict",
+        "CLASS",
+        "NAME",
+        "REFERENCE_LIST",
+        "DIMENSION_LIST",
+        "_FillValue",
+        "_NCProperties",
+    }
+)
+
+# HDF5 filter ids (see H5Zpublic.h).
+_H5_DEFLATE = 1
+_H5_SHUFFLE = 2
+_H5_FLETCHER32 = 3
+
+
+def _require_h5py() -> Any:
+    """Lazy-import :mod:`h5py`, raising a clear error when it is missing."""
+    try:
+        import h5py
+    except ImportError as exc:
+        raise ImportError(_H5PY_IMPORT_ERROR) from exc
+    return h5py
+
+
+def _to_jsonable(value: Any) -> Any:
+    """Convert an HDF5 attribute value into a JSON-serialisable Python value."""
+    if isinstance(value, bytes):
+        result = value.decode("utf-8", "replace")
+    elif isinstance(value, np.ndarray):
+        # GDAL writes scalar CF attributes as 1-element arrays; squeeze them to
+        # plain scalars (matching kerchunk / CF expectations), keep real vectors.
+        if value.size == 1:
+            result = _to_jsonable(value.reshape(-1)[0])
+        else:
+            result = [_to_jsonable(v) for v in value.tolist()]
+    elif isinstance(value, (np.bytes_,)):
+        result = bytes(value).decode("utf-8", "replace")
+    elif isinstance(value, np.floating):
+        result = float(value)
+    elif isinstance(value, np.integer):
+        result = int(value)
+    elif isinstance(value, np.bool_):
+        result = bool(value)
+    else:
+        result = value
+    return result
+
+
+def _clean_attrs(attrs: Any) -> dict[str, Any]:
+    """Return user-facing attributes, dropping HDF5/NetCDF bookkeeping keys."""
+    cleaned: dict[str, Any] = {}
+    for key, value in attrs.items():
+        if key in _DROP_ATTRS:
+            continue
+        cleaned[key] = _to_jsonable(value)
+    return cleaned
+
+
+def _basename(path: str) -> str:
+    """Last path component of an HDF5 object path (``/g/x`` -> ``x``)."""
+    return path.rstrip("/").rsplit("/", 1)[-1]
+
+
+def _array_dimensions(h5file: Any, dataset: Any) -> list[str]:
+    """Resolve a dataset's dimension names for the ``_ARRAY_DIMENSIONS`` attr.
+
+    A dimension-scale dataset is named for itself; a data variable carries a
+    ``DIMENSION_LIST`` of object references to its per-axis scales.
+    """
+    h5py = _require_h5py()
+    attrs = dataset.attrs
+    if attrs.get("CLASS") == b"DIMENSION_SCALE":
+        dims = [_basename(dataset.name)]
+    elif "DIMENSION_LIST" in attrs:
+        dims = []
+        for axis_refs in attrs["DIMENSION_LIST"]:
+            ref = axis_refs[0] if len(axis_refs) else None
+            if isinstance(ref, h5py.Reference) and ref:
+                dims.append(_basename(h5file[ref].name))
+            else:
+                dims.append(f"phony_dim_{len(dims)}")
+    elif dataset.ndim == 0:
+        dims = []
+    else:
+        dims = [f"phony_dim_{i}" for i in range(dataset.ndim)]
+    return dims
+
+
+def _encode_fill_value(dataset: Any) -> Any:
+    """Encode ``_FillValue`` for zarr v2 metadata, or ``None`` when absent.
+
+    Only an explicit ``_FillValue`` attribute counts — HDF5's implicit default
+    fill (which GDAL leaves on plain coordinate variables) is reported as
+    ``None`` so zarr does not treat real data as missing.
+    """
+    attrs = dataset.attrs
+    if "_FillValue" not in attrs:
+        return None
+    raw = attrs["_FillValue"]
+    value = np.asarray(raw)
+    if value.size == 1:
+        value = value.reshape(()).item() if value.ndim else value.item()
+    kind = dataset.dtype.kind
+    if kind in ("f", "c"):
+        as_float = float(value)
+        if math.isnan(as_float):
+            encoded: Any = "NaN"
+        elif math.isinf(as_float):
+            encoded = "Infinity" if as_float > 0 else "-Infinity"
+        else:
+            encoded = as_float
+    elif kind in ("i", "u"):
+        encoded = int(value)
+    elif kind in ("S", "V", "U"):
+        as_bytes = value if isinstance(value, bytes) else bytes(np.asarray(raw))
+        encoded = base64.b64encode(as_bytes).decode("ascii")
+    else:
+        encoded = _to_jsonable(value)
+    return encoded
+
+
+def _compressor_and_filters(dataset: Any) -> tuple[dict | None, list[dict] | None]:
+    """Map the HDF5 filter pipeline to a zarr v2 (compressor, filters) pair.
+
+    Supports deflate (-> zlib compressor) and shuffle (-> shuffle filter), and
+    silently drops the fletcher32 checksum (zarr has no equivalent; the data
+    remains readable). Any other filter id is unsupported.
+    """
+    dcpl = dataset.id.get_create_plist()
+    compressor: dict | None = None
+    filters: list[dict] = []
+    for index in range(dcpl.get_nfilters()):
+        filter_id, _flags, cd_values, _name = dcpl.get_filter(index)
+        if filter_id == _H5_DEFLATE:
+            level = cd_values[0] if cd_values else 4
+            compressor = {"id": "zlib", "level": int(level)}
+        elif filter_id == _H5_SHUFFLE:
+            elementsize = dataset.dtype.itemsize
+            filters.append({"id": "shuffle", "elementsize": int(elementsize)})
+        elif filter_id == _H5_FLETCHER32:
+            continue
+        else:
+            raise ValueError(
+                f"Dataset {dataset.name!r} uses unsupported HDF5 filter id "
+                f"{filter_id}; native kerchunk builder handles deflate/shuffle "
+                "only. Open an issue or use the kerchunk backend for this file."
+            )
+    return compressor, (filters or None)
+
+
+def _read_raw_bytes(src_path: str, offset: int, size: int) -> bytes:
+    """Read ``size`` stored bytes at ``offset`` from a local source file."""
+    with open(src_path, "rb") as handle:
+        handle.seek(offset)
+        data = handle.read(size)
+    return data
+
+
+def _chunk_grid_key(chunk_offset: tuple[int, ...], chunks: list[int]) -> str:
+    """Zarr chunk key (``"0.1.0"``) from element-space chunk offsets."""
+    if not chunks:
+        key = "0"
+    else:
+        key = ".".join(
+            str(offset // size) for offset, size in zip(chunk_offset, chunks)
+        )
+    return key
+
+
+def _emit_chunk_refs(
+    refs: dict[str, Any],
+    *,
+    dataset: Any,
+    name: str,
+    src_url: str,
+    src_local: str | None,
+    chunks: list[int],
+    inline_threshold: int,
+) -> None:
+    """Add this dataset's chunk references (byte-range or inlined) to ``refs``."""
+    h5py = _require_h5py()
+
+    def add(key: str, offset: int, size: int) -> None:
+        if size <= 0:
+            return
+        if src_local is not None and size < inline_threshold:
+            blob = _read_raw_bytes(src_local, offset, size)
+            refs[f"{name}/{key}"] = "base64:" + base64.b64encode(blob).decode("ascii")
+        else:
+            refs[f"{name}/{key}"] = [src_url, int(offset), int(size)]
+
+    if dataset.chunks is None:
+        offset = dataset.id.get_offset()
+        size = dataset.id.get_storage_size()
+        if offset is not None and size:
+            zero_key = "0" if not chunks else ".".join("0" for _ in chunks)
+            add(zero_key, offset, size)
+        return
+
+    num_chunks = dataset.id.get_num_chunks()
+    for index in range(num_chunks):
+        info = dataset.id.get_chunk_info(index)
+        key = _chunk_grid_key(tuple(info.chunk_offset), chunks)
+        add(key, info.byte_offset, info.size)
+
+
+def _emit_dataset(
+    refs: dict[str, Any],
+    *,
+    h5file: Any,
+    name: str,
+    dataset: Any,
+    src_url: str,
+    src_local: str | None,
+    inline_threshold: int,
+    vlen_encode: str,
+) -> None:
+    """Emit ``.zarray`` + ``.zattrs`` + chunk refs for one HDF5 dataset."""
+    shape = list(dataset.shape)
+    if dataset.chunks is not None:
+        chunks = list(dataset.chunks)
+    else:
+        chunks = list(shape)
+    if dataset.dtype.kind == "O":
+        raise ValueError(
+            f"Dataset {name!r} has an object/vlen dtype; native builder does not "
+            f"yet support vlen_encode={vlen_encode!r}. Use the kerchunk backend."
+        )
+    compressor, filters = _compressor_and_filters(dataset)
+    zarray = {
+        "shape": shape,
+        "chunks": chunks,
+        "dtype": dataset.dtype.str,
+        "fill_value": _encode_fill_value(dataset),
+        "order": "C",
+        "filters": filters,
+        "dimension_separator": ".",
+        "compressor": compressor,
+        "zarr_format": 2,
+    }
+    zattrs = _clean_attrs(dataset.attrs)
+    zattrs["_ARRAY_DIMENSIONS"] = _array_dimensions(h5file, dataset)
+
+    refs[f"{name}/.zarray"] = json.dumps(zarray, allow_nan=False)
+    refs[f"{name}/.zattrs"] = json.dumps(zattrs, allow_nan=False)
+    _emit_chunk_refs(
+        refs,
+        dataset=dataset,
+        name=name,
+        src_url=src_url,
+        src_local=src_local,
+        chunks=chunks,
+        inline_threshold=inline_threshold,
+    )
+
+
+def build_single_manifest(
+    src_path: str | Path,
+    *,
+    src_url: str | None = None,
+    inline_threshold: int = 500,
+    vlen_encode: str = "embed",
+) -> dict[str, Any]:
+    """Build a kerchunk v1 reference manifest for one NetCDF4 / HDF5 file.
+
+    Args:
+        src_path: Local path used to read chunk byte ranges and HDF5 metadata.
+        src_url: URL written into byte-range references. Defaults to
+            ``str(src_path)`` so the manifest points back at the source as
+            named (matching kerchunk's behaviour for local paths).
+        inline_threshold: Chunks smaller than this many bytes are embedded
+            directly (base64) rather than referenced by offset.
+        vlen_encode: VLEN string handling mode (reserved; object dtypes are
+            currently rejected with a clear error).
+
+    Returns:
+        The manifest dict ``{"version": 1, "refs": {...}}``.
+
+    Raises:
+        ImportError: When h5py is not installed.
+        ValueError: When the file uses an unsupported HDF5 feature.
+    """
+    h5py = _require_h5py()
+    src_str = str(src_path)
+    url = src_url if src_url is not None else src_str
+    src_local = src_str if os.path.exists(src_str) else None
+
+    refs: dict[str, Any] = {}
+    with h5py.File(src_str, "r") as h5file:
+        refs[".zgroup"] = json.dumps({"zarr_format": 2})
+        refs[".zattrs"] = json.dumps(_clean_attrs(h5file.attrs), allow_nan=False)
+
+        def visit(name: str, obj: Any) -> None:
+            if isinstance(obj, h5py.Dataset):
+                _emit_dataset(
+                    refs,
+                    h5file=h5file,
+                    name=name,
+                    dataset=obj,
+                    src_url=url,
+                    src_local=src_local,
+                    inline_threshold=inline_threshold,
+                    vlen_encode=vlen_encode,
+                )
+            else:
+                refs[f"{name}/.zgroup"] = json.dumps({"zarr_format": 2})
+                refs[f"{name}/.zattrs"] = json.dumps(
+                    _clean_attrs(obj.attrs), allow_nan=False
+                )
+
+        h5file.visititems(visit)
+
+    return {"version": 1, "refs": refs}
+
+
+def _manifest_refs(manifest: dict[str, Any]) -> dict[str, Any]:
+    """Return the flat refs mapping from a v0 (flat) or v1 (nested) manifest."""
+    return manifest["refs"] if "refs" in manifest else manifest
+
+
+def _variable_names(refs: dict[str, Any]) -> list[str]:
+    """Names of the array variables in a refs mapping (those with a ``.zarray``)."""
+    return [key[: -len("/.zarray")] for key in refs if key.endswith("/.zarray")]
+
+
+def _shift_chunk_key(key: str, axis: int, offset: int) -> str:
+    """Shift a zarr chunk key's grid index on ``axis`` by ``offset`` chunks."""
+    parts = key.split(".")
+    parts[axis] = str(int(parts[axis]) + offset)
+    return ".".join(parts)
+
+
+def _concat_variable(
+    name: str,
+    per_file_refs: list[dict[str, Any]],
+    axis: int,
+) -> dict[str, Any]:
+    """Stack one variable across files along ``axis``; return its merged refs."""
+    base = json.loads(per_file_refs[0][f"{name}/.zarray"])
+    chunk_size = base["chunks"][axis]
+    total = 0
+    prior_chunks = 0
+    merged: dict[str, Any] = {}
+    for index, refs in enumerate(per_file_refs):
+        zarray = json.loads(refs[f"{name}/.zarray"])
+        length = zarray["shape"][axis]
+        if zarray["chunks"][axis] != chunk_size:
+            raise ValueError(
+                f"variable {name!r} has inconsistent chunk size on the concat "
+                f"axis across files ({zarray['chunks'][axis]} vs {chunk_size}); "
+                "cannot concatenate into a uniform-chunk zarr array."
+            )
+        is_last = index == len(per_file_refs) - 1
+        if length % chunk_size and not is_last:
+            raise ValueError(
+                f"variable {name!r} length {length} on the concat axis is not a "
+                f"multiple of its chunk size {chunk_size} in a non-final file; "
+                "cannot concatenate without rechunking."
+            )
+        prefix = f"{name}/"
+        for key, value in refs.items():
+            if not key.startswith(prefix) or key.endswith(
+                (".zarray", ".zattrs", ".zgroup")
+            ):
+                continue
+            chunk_key = key[len(prefix) :]
+            merged[f"{prefix}{_shift_chunk_key(chunk_key, axis, prior_chunks)}"] = value
+        total += length
+        prior_chunks += -(-length // chunk_size)  # ceil division
+    base["shape"][axis] = total
+    merged[f"{name}/.zarray"] = json.dumps(base)
+    merged[f"{name}/.zattrs"] = per_file_refs[0][f"{name}/.zattrs"]
+    return merged
+
+
+def _identical_variable(
+    name: str, per_file_refs: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Carry a variable that is identical across files; assert metadata parity."""
+    base = json.loads(per_file_refs[0][f"{name}/.zarray"])
+    for refs in per_file_refs[1:]:
+        other = json.loads(refs[f"{name}/.zarray"])
+        if (other["shape"], other["dtype"], other["chunks"]) != (
+            base["shape"],
+            base["dtype"],
+            base["chunks"],
+        ):
+            raise ValueError(
+                f"variable {name!r} is not identical across files (shape/dtype/"
+                "chunks differ) but does not carry the concat dimension; it cannot "
+                "be merged. Pass it as a concat dimension or align the inputs."
+            )
+    prefix = f"{name}/"
+    return {key: value for key, value in per_file_refs[0].items() if key.startswith(prefix)}
+
+
+def combine_manifests(
+    per_file: list[dict[str, Any]],
+    *,
+    concat_dim: str,
+) -> dict[str, Any]:
+    """Concatenate per-file manifests along ``concat_dim`` into one manifest.
+
+    Every variable whose ``_ARRAY_DIMENSIONS`` contains ``concat_dim`` is stacked
+    along that axis (its concat-axis chunk indices are renumbered and its
+    ``shape`` summed); every other variable must be identical across files and is
+    carried from the first. No zarr group is created, so this cannot hit the
+    zarr-v3 ``sync()`` deadlock (#530).
+
+    Args:
+        per_file: Per-file manifests, in concatenation order, as returned by
+            :func:`build_single_manifest`.
+        concat_dim: Dimension name to concatenate along.
+
+    Returns:
+        The combined manifest dict ``{"version": 1, "refs": {...}}``.
+
+    Raises:
+        ValueError: When ``per_file`` is empty, files disagree on the variable
+            set, a concat variable has inconsistent chunking, or a non-concat
+            variable is not identical across files.
+    """
+    if not per_file:
+        raise ValueError("combine_manifests requires at least one manifest.")
+    refs_list = [_manifest_refs(m) for m in per_file]
+    if len(refs_list) == 1:
+        return {"version": 1, "refs": dict(refs_list[0])}
+
+    var_sets = [set(_variable_names(refs)) for refs in refs_list]
+    if any(names != var_sets[0] for names in var_sets[1:]):
+        raise ValueError(
+            "cannot combine manifests with differing variable sets: "
+            f"{[sorted(names) for names in var_sets]}"
+        )
+
+    combined: dict[str, Any] = {}
+    for key, value in refs_list[0].items():
+        if "/" not in key:  # group-level .zgroup / .zattrs
+            combined[key] = value
+
+    for name in _variable_names(refs_list[0]):
+        dims = json.loads(refs_list[0][f"{name}/.zattrs"]).get("_ARRAY_DIMENSIONS", [])
+        if concat_dim in dims:
+            combined.update(_concat_variable(name, refs_list, dims.index(concat_dim)))
+        else:
+            combined.update(_identical_variable(name, refs_list))
+
+    return {"version": 1, "refs": combined}
+
+
+__all__ = ["build_single_manifest", "combine_manifests"]

--- a/src/pyramids/netcdf/_kerchunk_native.py
+++ b/src/pyramids/netcdf/_kerchunk_native.py
@@ -55,6 +55,12 @@ _H5_DEFLATE = 1
 _H5_SHUFFLE = 2
 _H5_FLETCHER32 = 3
 
+# zarr-v2 store metadata key suffixes.
+_ZARR_ARRAY = ".zarray"
+_ZARR_ATTRS = ".zattrs"
+_ZARR_GROUP = ".zgroup"
+_META_SUFFIXES = (_ZARR_ARRAY, _ZARR_ATTRS, _ZARR_GROUP)
+
 
 def _require_h5py() -> Any:
     """Lazy-import :mod:`h5py`, raising a clear error when it is missing.
@@ -195,6 +201,26 @@ def _array_dimensions(h5file: Any, dataset: Any) -> list[str]:
     return dims
 
 
+def _encode_float_fill(value: Any) -> Any:
+    """Encode a float/complex fill value, mapping NaN/Inf to zarr's JSON strings.
+
+    Args:
+        value: A scalar float (or complex) fill value.
+
+    Returns:
+        The float itself, or ``"NaN"`` / ``"Infinity"`` / ``"-Infinity"`` for the
+        non-finite cases (zarr v2's JSON representation of those).
+    """
+    as_float = float(value)
+    if math.isnan(as_float):
+        encoded: Any = "NaN"
+    elif math.isinf(as_float):
+        encoded = "Infinity" if as_float > 0 else "-Infinity"
+    else:
+        encoded = as_float
+    return encoded
+
+
 def _encode_fill_value(dataset: Any) -> Any:
     """Encode ``_FillValue`` for zarr v2 metadata, or ``None`` when absent.
 
@@ -211,13 +237,7 @@ def _encode_fill_value(dataset: Any) -> Any:
         value = value.reshape(()).item() if value.ndim else value.item()
     kind = dataset.dtype.kind
     if kind in ("f", "c"):
-        as_float = float(value)
-        if math.isnan(as_float):
-            encoded: Any = "NaN"
-        elif math.isinf(as_float):
-            encoded = "Infinity" if as_float > 0 else "-Infinity"
-        else:
-            encoded = as_float
+        encoded = _encode_float_fill(value)
     elif kind in ("i", "u"):
         encoded = int(value)
     elif kind in ("S", "V", "U"):
@@ -382,8 +402,8 @@ def _emit_dataset(
     zattrs = _clean_attrs(dataset.attrs)
     zattrs["_ARRAY_DIMENSIONS"] = _array_dimensions(h5file, dataset)
 
-    refs[f"{name}/.zarray"] = json.dumps(zarray, allow_nan=False)
-    refs[f"{name}/.zattrs"] = json.dumps(zattrs, allow_nan=False)
+    refs[f"{name}/{_ZARR_ARRAY}"] = json.dumps(zarray, allow_nan=False)
+    refs[f"{name}/{_ZARR_ATTRS}"] = json.dumps(zattrs, allow_nan=False)
     _emit_chunk_refs(
         refs,
         dataset=dataset,
@@ -441,8 +461,8 @@ def build_single_manifest(
     src_handle = open(src_local, "rb") if src_local is not None else None
     try:
         with h5py.File(src_str, "r") as h5file:
-            refs[".zgroup"] = json.dumps({"zarr_format": 2})
-            refs[".zattrs"] = json.dumps(_clean_attrs(h5file.attrs), allow_nan=False)
+            refs[_ZARR_GROUP] = json.dumps({"zarr_format": 2})
+            refs[_ZARR_ATTRS] = json.dumps(_clean_attrs(h5file.attrs), allow_nan=False)
 
             def visit(name: str, obj: Any) -> None:
                 if isinstance(obj, h5py.Dataset):
@@ -457,8 +477,8 @@ def build_single_manifest(
                         vlen_encode=vlen_encode,
                     )
                 else:
-                    refs[f"{name}/.zgroup"] = json.dumps({"zarr_format": 2})
-                    refs[f"{name}/.zattrs"] = json.dumps(
+                    refs[f"{name}/{_ZARR_GROUP}"] = json.dumps({"zarr_format": 2})
+                    refs[f"{name}/{_ZARR_ATTRS}"] = json.dumps(
                         _clean_attrs(obj.attrs), allow_nan=False
                     )
 
@@ -517,7 +537,7 @@ def _variable_names(refs: dict[str, Any]) -> list[str]:
 
             ```
     """
-    return [key[: -len("/.zarray")] for key in refs if key.endswith("/.zarray")]
+    return [key[: -len("/" + _ZARR_ARRAY)] for key in refs if key.endswith("/" + _ZARR_ARRAY)]
 
 
 def _shift_chunk_key(key: str, axis: int, offset: int) -> str:
@@ -569,13 +589,13 @@ def _concat_variable(
         ValueError: When the concat-axis chunk size differs across files, or a
             non-final file's length is not a multiple of that chunk size.
     """
-    base = json.loads(per_file_refs[0][f"{name}/.zarray"])
+    base = json.loads(per_file_refs[0][f"{name}/{_ZARR_ARRAY}"])
     chunk_size = base["chunks"][axis]
     total = 0
     prior_chunks = 0
     merged: dict[str, Any] = {}
     for index, refs in enumerate(per_file_refs):
-        zarray = json.loads(refs[f"{name}/.zarray"])
+        zarray = json.loads(refs[f"{name}/{_ZARR_ARRAY}"])
         length = zarray["shape"][axis]
         if zarray["chunks"][axis] != chunk_size:
             raise ValueError(
@@ -593,7 +613,7 @@ def _concat_variable(
         prefix = f"{name}/"
         for key, value in refs.items():
             if not key.startswith(prefix) or key.endswith(
-                (".zarray", ".zattrs", ".zgroup")
+                _META_SUFFIXES
             ):
                 continue
             chunk_key = key[len(prefix) :]
@@ -601,8 +621,8 @@ def _concat_variable(
         total += length
         prior_chunks += -(-length // chunk_size)  # ceil division
     base["shape"][axis] = total
-    merged[f"{name}/.zarray"] = json.dumps(base)
-    merged[f"{name}/.zattrs"] = per_file_refs[0][f"{name}/.zattrs"]
+    merged[f"{name}/{_ZARR_ARRAY}"] = json.dumps(base)
+    merged[f"{name}/{_ZARR_ATTRS}"] = per_file_refs[0][f"{name}/{_ZARR_ATTRS}"]
     return merged
 
 
@@ -617,14 +637,14 @@ def _identical_variable(
     be merged silently.
     """
     prefix = f"{name}/"
-    base = json.loads(per_file_refs[0][f"{name}/.zarray"])
+    base = json.loads(per_file_refs[0][f"{name}/{_ZARR_ARRAY}"])
     base_chunks = {
         key: value
         for key, value in per_file_refs[0].items()
-        if key.startswith(prefix) and not key.endswith((".zarray", ".zattrs", ".zgroup"))
+        if key.startswith(prefix) and not key.endswith(_META_SUFFIXES)
     }
     for refs in per_file_refs[1:]:
-        other = json.loads(refs[f"{name}/.zarray"])
+        other = json.loads(refs[f"{name}/{_ZARR_ARRAY}"])
         if (other["shape"], other["dtype"], other["chunks"]) != (
             base["shape"],
             base["dtype"],
@@ -690,13 +710,17 @@ def combine_manifests(
     combined: dict[str, Any] = {}
     variables = set(_variable_names(refs_list[0]))
     for key, value in refs_list[0].items():
-        if "/" not in key:  # root .zgroup / .zattrs
+        is_root_meta = "/" not in key
+        is_subgroup_meta = (
+            key.endswith((_ZARR_GROUP, _ZARR_ATTRS))
+            and key.rsplit("/", 1)[0] not in variables
+        )
+        # carry root metadata and sub-group metadata (not owned by a variable)
+        if is_root_meta or is_subgroup_meta:
             combined[key] = value
-        elif key.endswith((".zgroup", ".zattrs")) and key.rsplit("/", 1)[0] not in variables:
-            combined[key] = value  # sub-group metadata (not owned by a variable)
 
     for name in _variable_names(refs_list[0]):
-        dims = json.loads(refs_list[0][f"{name}/.zattrs"]).get("_ARRAY_DIMENSIONS", [])
+        dims = json.loads(refs_list[0][f"{name}/{_ZARR_ATTRS}"]).get("_ARRAY_DIMENSIONS", [])
         if concat_dim in dims:
             combined.update(_concat_variable(name, refs_list, dims.index(concat_dim)))
         else:

--- a/src/pyramids/netcdf/_kerchunk_native.py
+++ b/src/pyramids/netcdf/_kerchunk_native.py
@@ -20,6 +20,7 @@ import base64
 import json
 import math
 import os
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -430,8 +431,20 @@ def _concat_variable(
 def _identical_variable(
     name: str, per_file_refs: list[dict[str, Any]]
 ) -> dict[str, Any]:
-    """Carry a variable that is identical across files; assert metadata parity."""
+    """Carry a variable that is identical across files; assert metadata parity.
+
+    Metadata (shape/dtype/chunks) must match exactly. For inlined chunks (small
+    coordinate arrays) the values are also compared, and a mismatch warns: the
+    first file's values are used, so genuinely misaligned inputs would otherwise
+    be merged silently.
+    """
+    prefix = f"{name}/"
     base = json.loads(per_file_refs[0][f"{name}/.zarray"])
+    base_chunks = {
+        key: value
+        for key, value in per_file_refs[0].items()
+        if key.startswith(prefix) and not key.endswith((".zarray", ".zattrs", ".zgroup"))
+    }
     for refs in per_file_refs[1:]:
         other = json.loads(refs[f"{name}/.zarray"])
         if (other["shape"], other["dtype"], other["chunks"]) != (
@@ -444,7 +457,16 @@ def _identical_variable(
                 "chunks differ) but does not carry the concat dimension; it cannot "
                 "be merged. Pass it as a concat dimension or align the inputs."
             )
-    prefix = f"{name}/"
+        for key, value in base_chunks.items():
+            inlined = isinstance(value, str) and value.startswith("base64:")
+            if inlined and refs.get(key) != value:
+                warnings.warn(
+                    f"non-concat variable {name!r} differs across files (chunk "
+                    f"{key[len(prefix):]}); using the first file's values — the "
+                    "inputs may not be co-registered.",
+                    stacklevel=3,
+                )
+                break
     return {key: value for key, value in per_file_refs[0].items() if key.startswith(prefix)}
 
 

--- a/src/pyramids/netcdf/_kerchunk_native.py
+++ b/src/pyramids/netcdf/_kerchunk_native.py
@@ -337,8 +337,16 @@ def build_single_manifest(
     """
     h5py = _require_h5py()
     src_str = str(src_path)
-    url = src_url if src_url is not None else src_str
     src_local = src_str if os.path.exists(src_str) else None
+    if src_url is not None:
+        url = src_url
+    elif src_local is not None:
+        # Absolutise local paths so the manifest resolves regardless of the
+        # consumer's working directory (a relative path only resolves from the CWD
+        # the manifest was written in).
+        url = os.path.abspath(src_str)
+    else:
+        url = src_str
 
     refs: dict[str, Any] = {}
     with h5py.File(src_str, "r") as h5file:

--- a/src/pyramids/netcdf/_kerchunk_native.py
+++ b/src/pyramids/netcdf/_kerchunk_native.py
@@ -521,9 +521,12 @@ def combine_manifests(
         )
 
     combined: dict[str, Any] = {}
+    variables = set(_variable_names(refs_list[0]))
     for key, value in refs_list[0].items():
-        if "/" not in key:  # group-level .zgroup / .zattrs
+        if "/" not in key:  # root .zgroup / .zattrs
             combined[key] = value
+        elif key.endswith((".zgroup", ".zattrs")) and key.rsplit("/", 1)[0] not in variables:
+            combined[key] = value  # sub-group metadata (not owned by a variable)
 
     for name in _variable_names(refs_list[0]):
         dims = json.loads(refs_list[0][f"{name}/.zattrs"]).get("_ARRAY_DIMENSIONS", [])

--- a/tests/dataset/collection/test_kerchunk.py
+++ b/tests/dataset/collection/test_kerchunk.py
@@ -94,7 +94,8 @@ class TestErrors:
         with pytest.raises(RuntimeError, match="file-backed"):
             collection.to_kerchunk(str(tmp_path / "nope.json"))
 
-    def test_import_error_without_kerchunk(self, tmp_path, monkeypatch):
+    def test_works_without_kerchunk(self, tmp_path, monkeypatch):
+        """The native combine path needs h5py, not kerchunk (#530)."""
         import builtins
 
         real_import = builtins.__import__
@@ -106,5 +107,7 @@ class TestErrors:
 
         monkeypatch.setattr(builtins, "__import__", fake_import)
         collection = DatasetCollection.from_files([NC_FIXTURE])
-        with pytest.raises(ImportError, match="pyramids-gis\\[lazy\\]"):
-            collection.to_kerchunk(tmp_path / "nope.json")
+        out = tmp_path / "refs.json"
+        result = collection.to_kerchunk(out)
+        assert out.exists()
+        assert "refs" in result or "version" in result

--- a/tests/netcdf/lazy/test_kerchunk.py
+++ b/tests/netcdf/lazy/test_kerchunk.py
@@ -60,21 +60,39 @@ class TestToKerchunkSingleFile:
         assert returned == written
 
     @requires_kerchunk
-    def test_native_falls_back_when_source_unopenable(self, tmp_path):
-        """An unopenable source (h5py OSError) falls back to the kerchunk backend.
+    def test_native_falls_back_when_source_nonlocal(self, tmp_path):
+        """A non-local / missing source falls back to the kerchunk backend.
 
         Guards #530 follow-up M1: the native builder is local-only, so a source it
-        cannot open must route to the kerchunk translator rather than crash.
+        cannot open (and that is not a local file) must route to the kerchunk
+        translator rather than crash. A non-existent path stands in for a remote
+        URL without needing the network.
         """
+        from pyramids.netcdf._kerchunk import to_kerchunk
+
+        missing = tmp_path / "does_not_exist.nc"  # os.path.exists -> False
+        # native build raises OSError -> fallback warning; the kerchunk translator
+        # then also fails (file not found), so the call raises -- the warning proves
+        # the fallback path was taken.
+        with pytest.warns(UserWarning, match="falling back to the kerchunk"):
+            with pytest.raises(Exception):
+                to_kerchunk(str(missing), tmp_path / "refs.json", backend="native")
+
+    def test_native_reraises_corrupt_local_file(self, tmp_path):
+        """A local file that exists but is not HDF5 surfaces OSError, no fallback.
+
+        Guards #530 follow-up N1: a corrupt/unreadable *local* file should not be
+        masked behind a misleading kerchunk fallback.
+        """
+        import warnings
+
         from pyramids.netcdf._kerchunk import to_kerchunk
 
         not_hdf5 = tmp_path / "plain.txt"
         not_hdf5.write_text("this is not an HDF5 file")
-        # native build raises OSError -> we expect the fallback warning; the
-        # kerchunk translator then also fails on the non-HDF5 file, so the call
-        # ultimately raises -- but the warning proves the fallback path was taken.
-        with pytest.warns(UserWarning, match="falling back to the kerchunk"):
-            with pytest.raises(Exception):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # a fallback warning would become an error
+            with pytest.raises(OSError):
                 to_kerchunk(str(not_hdf5), tmp_path / "refs.json", backend="native")
 
 

--- a/tests/netcdf/lazy/test_kerchunk.py
+++ b/tests/netcdf/lazy/test_kerchunk.py
@@ -59,6 +59,24 @@ class TestToKerchunkSingleFile:
         written = json.loads(out.read_text())
         assert returned == written
 
+    @requires_kerchunk
+    def test_native_falls_back_when_source_unopenable(self, tmp_path):
+        """An unopenable source (h5py OSError) falls back to the kerchunk backend.
+
+        Guards #530 follow-up M1: the native builder is local-only, so a source it
+        cannot open must route to the kerchunk translator rather than crash.
+        """
+        from pyramids.netcdf._kerchunk import to_kerchunk
+
+        not_hdf5 = tmp_path / "plain.txt"
+        not_hdf5.write_text("this is not an HDF5 file")
+        # native build raises OSError -> we expect the fallback warning; the
+        # kerchunk translator then also fails on the non-HDF5 file, so the call
+        # ultimately raises -- but the warning proves the fallback path was taken.
+        with pytest.warns(UserWarning, match="falling back to the kerchunk"):
+            with pytest.raises(Exception):
+                to_kerchunk(str(not_hdf5), tmp_path / "refs.json", backend="native")
+
 
 class TestCombineKerchunk:
     """Combine multiple file manifests into one."""

--- a/tests/netcdf/lazy/test_kerchunk.py
+++ b/tests/netcdf/lazy/test_kerchunk.py
@@ -78,9 +78,10 @@ class TestCombineKerchunk:
 
 
 class TestImportError:
-    """Missing kerchunk raises actionable ImportError."""
+    """Missing kerchunk raises actionable ImportError on the paths that need it."""
 
-    def test_to_kerchunk_raises_without_kerchunk(self, tmp_path, monkeypatch):
+    def test_native_to_kerchunk_works_without_kerchunk(self, tmp_path, monkeypatch):
+        """The default (native) single-file path needs h5py, not kerchunk (#530)."""
         import builtins
 
         real_import = builtins.__import__
@@ -92,11 +93,16 @@ class TestImportError:
 
         monkeypatch.setattr(builtins, "__import__", fake_import)
         nc = NetCDF.read_file(FIXTURE, open_as_multi_dimensional=False)
-        with pytest.raises(ImportError, match="pyramids-gis\\[lazy\\]"):
-            nc.to_kerchunk(tmp_path / "refs.json")
+        out = tmp_path / "refs.json"
+        result = nc.to_kerchunk(out)
+        assert out.exists()
+        assert "refs" in result and "values/.zarray" in result["refs"]
 
-    def test_combine_raises_without_kerchunk(self, tmp_path, monkeypatch):
+    def test_kerchunk_backend_raises_without_kerchunk(self, tmp_path, monkeypatch):
+        """Explicitly forcing the kerchunk backend still requires kerchunk."""
         import builtins
+
+        from pyramids.netcdf._kerchunk import to_kerchunk
 
         real_import = builtins.__import__
 
@@ -107,7 +113,23 @@ class TestImportError:
 
         monkeypatch.setattr(builtins, "__import__", fake_import)
         with pytest.raises(ImportError, match="pyramids-gis\\[lazy\\]"):
-            NetCDF.combine_kerchunk(
-                [FIXTURE],
-                tmp_path / "refs.json",
-            )
+            to_kerchunk(FIXTURE, tmp_path / "refs.json", backend="kerchunk")
+
+    def test_kerchunk_backend_combine_raises_without_kerchunk(
+        self, tmp_path, monkeypatch
+    ):
+        """Forcing the kerchunk backend on combine still requires kerchunk."""
+        import builtins
+
+        from pyramids.netcdf._kerchunk import combine_kerchunk
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name.startswith("kerchunk"):
+                raise ImportError("no kerchunk")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        with pytest.raises(ImportError, match="pyramids-gis\\[lazy\\]"):
+            combine_kerchunk([FIXTURE], tmp_path / "refs.json", backend="kerchunk")

--- a/tests/netcdf/lazy/test_kerchunk_native.py
+++ b/tests/netcdf/lazy/test_kerchunk_native.py
@@ -276,6 +276,24 @@ class TestCombine:
         finally:
             ds.close()
 
+    def test_misaligned_identical_dim_warns(self, tmp_path):
+        """A non-concat coord that differs across files warns (not silently merged)."""
+        from pyramids.netcdf._kerchunk_native import (
+            build_single_manifest,
+            combine_manifests,
+        )
+
+        a = str(tmp_path / "a.h5")
+        b = str(tmp_path / "b.h5")
+        _make_time_file(a, 0)
+        _make_time_file(b, 1)
+        # shift file b's lat so the inlined coordinate values diverge
+        with h5py.File(b, "r+") as f:
+            f["lat"][...] = np.arange(5, dtype="f4") + 0.5
+        per_file = [build_single_manifest(a), build_single_manifest(b)]
+        with pytest.warns(UserWarning, match="may not be co-registered"):
+            combine_manifests(per_file, concat_dim="time")
+
     def test_differing_variable_sets_rejected(self, tmp_path):
         """Files with different variables cannot be combined."""
         from pyramids.netcdf._kerchunk_native import (

--- a/tests/netcdf/lazy/test_kerchunk_native.py
+++ b/tests/netcdf/lazy/test_kerchunk_native.py
@@ -306,3 +306,17 @@ class TestUnsupportedFeatures:
                              dtype=h5py.string_dtype())
         with pytest.raises(ValueError, match="vlen|object"):
             build_single_manifest(src)
+
+    def test_unopenable_source_raises_oserror(self, tmp_path):
+        """A non-HDF5 / unreadable source raises OSError (not ValueError).
+
+        `to_kerchunk` relies on catching this to fall back to the kerchunk
+        translator for sources the local-only native builder cannot open
+        (e.g. remote URLs).
+        """
+        from pyramids.netcdf._kerchunk_native import build_single_manifest
+
+        not_hdf5 = tmp_path / "plain.txt"
+        not_hdf5.write_text("this is not an HDF5 file")
+        with pytest.raises(OSError):
+            build_single_manifest(str(not_hdf5))

--- a/tests/netcdf/lazy/test_kerchunk_native.py
+++ b/tests/netcdf/lazy/test_kerchunk_native.py
@@ -115,7 +115,13 @@ class TestParityWithKerchunk:
         for key in kref:
             if key.endswith((".zarray", ".zattrs", ".zgroup")):
                 continue
-            assert nref[key] == kref[key], f"chunk ref {key} must match kerchunk"
+            native, kerch = nref[key], kref[key]
+            if isinstance(kerch, list):
+                # byte-range ref [url, offset, size]: native absolutises the url, so
+                # compare offset + size (the bytes that matter), not the path string
+                assert native[1:] == kerch[1:], f"chunk {key} offset/size must match"
+            else:
+                assert native == kerch, f"inlined chunk {key} must match kerchunk"
 
     @requires_kerchunk
     def test_zarray_codec_chain_matches(self, tmp_path):
@@ -207,6 +213,23 @@ class TestMetadataSemantics:
         refs = build_single_manifest(FIXTURE)["refs"]
         crs = json.loads(refs["transverse_mercator/.zattrs"])
         assert crs["longitude_of_central_meridian"] == pytest.approx(-75.0)
+
+    def test_byte_range_url_is_absolute(self):
+        """Byte-range refs absolutise a local source so manifests are CWD-independent."""
+        import os
+
+        from pyramids.netcdf._kerchunk_native import build_single_manifest
+
+        refs = build_single_manifest(FIXTURE)["refs"]
+        url = refs["values/0.0.0"][0]   # values is a byte-range ref on this fixture
+        assert os.path.isabs(url), f"expected an absolute source path, got {url!r}"
+
+    def test_src_url_override_is_used_verbatim(self):
+        """An explicit src_url is written into refs unchanged (e.g. a cloud URL)."""
+        from pyramids.netcdf._kerchunk_native import build_single_manifest
+
+        refs = build_single_manifest(FIXTURE, src_url="s3://bucket/cube.nc")["refs"]
+        assert refs["values/0.0.0"][0] == "s3://bucket/cube.nc"
 
     def test_bookkeeping_attrs_stripped(self):
         """HDF5/NetCDF bookkeeping keys never leak into `.zattrs`."""

--- a/tests/netcdf/lazy/test_kerchunk_native.py
+++ b/tests/netcdf/lazy/test_kerchunk_native.py
@@ -1,0 +1,308 @@
+"""Tests for the zarr-v3-safe native kerchunk manifest builder (#530).
+
+The native builder (`pyramids.netcdf._kerchunk_native.build_single_manifest`)
+walks an HDF5/NetCDF4 file with h5py and emits a kerchunk v1 reference manifest
+without instantiating a live zarr group, avoiding the kerchunk->zarr-v3 `sync()`
+deadlock. These tests pin:
+
+* byte-parity of chunk references against the legacy kerchunk translator,
+* functional round-trip through `xr.open_dataset(engine="kerchunk")`,
+* the chunked + deflate + shuffle path,
+* dimension-name and fill-value semantics.
+
+The builder needs only h5py; parity tests additionally need kerchunk, and
+round-trip tests need xarray. Each is gated independently.
+"""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pytest
+
+from pyramids.base._errors import OptionalPackageDoesNotExist
+from pyramids.base._utils import import_kerchunk
+
+pytestmark = pytest.mark.netcdf_lazy
+
+h5py = pytest.importorskip("h5py")
+
+try:
+    import xarray as xr
+except ImportError:  # pragma: no cover
+    HAS_XARRAY = False
+else:
+    HAS_XARRAY = True
+try:
+    import_kerchunk("kerchunk not installed")
+except OptionalPackageDoesNotExist:  # pragma: no cover
+    HAS_KERCHUNK = False
+else:
+    HAS_KERCHUNK = True
+
+requires_xarray = pytest.mark.skipif(not HAS_XARRAY, reason="xarray not installed")
+requires_kerchunk = pytest.mark.skipif(
+    not HAS_KERCHUNK, reason="kerchunk not installed"
+)
+
+FIXTURE = "tests/data/netcdf/pyramids-netcdf-3d.nc"
+
+
+def _make_chunked_file(path: str) -> np.ndarray:
+    """Write a chunked + gzip + shuffle dataset; return the source array."""
+    rng = np.random.default_rng(0)
+    data = rng.random((4, 20, 25)).astype("f4")
+    with h5py.File(path, "w") as f:
+        d = f.create_dataset(
+            "temp",
+            data=data,
+            chunks=(1, 10, 13),
+            compression="gzip",
+            compression_opts=4,
+            shuffle=True,
+        )
+        d.attrs["_FillValue"] = np.array([-9999.0], dtype="f4")
+        d.attrs["units"] = "K"
+        f.attrs["Conventions"] = "CF-1.8"
+    return data
+
+
+def _make_time_file(path: str, index: int) -> np.ndarray:
+    """Write an HDF5 file with a (time, lat, lon) var and proper dim scales."""
+    data = (np.arange(2 * 5 * 6).reshape(2, 5, 6) + index * 1000).astype("f4")
+    times = np.array([index * 2, index * 2 + 1], dtype="f8")
+    with h5py.File(path, "w") as f:
+        f.create_dataset("time", data=times)
+        f.create_dataset("lat", data=np.arange(5, dtype="f4"))
+        f.create_dataset("lon", data=np.arange(6, dtype="f4"))
+        var = f.create_dataset("v", data=data, chunks=(1, 5, 6))
+        for name in ("time", "lat", "lon"):
+            f[name].make_scale(name)
+        var.dims[0].attach_scale(f["time"])
+        var.dims[1].attach_scale(f["lat"])
+        var.dims[2].attach_scale(f["lon"])
+    return data
+
+
+def _codec_chain(zarray: dict) -> list:
+    """Normalise (filters, compressor) into one ordered codec list.
+
+    kerchunk and the native builder both round-trip correctly but distribute
+    shuffle/zlib differently between `filters` and `compressor`; comparing the
+    concatenated chain makes the legitimate representational choice irrelevant.
+    """
+    chain = list(zarray.get("filters") or [])
+    if zarray.get("compressor"):
+        chain.append(zarray["compressor"])
+    return chain
+
+
+class TestParityWithKerchunk:
+    """Native manifest matches the kerchunk translator where it counts."""
+
+    @requires_kerchunk
+    def test_same_keys_and_chunk_refs_on_fixture(self, tmp_path):
+        """Native + kerchunk agree on every ref key and chunk byte-range/inline."""
+        from pyramids.netcdf._kerchunk import to_kerchunk
+        from pyramids.netcdf._kerchunk_native import build_single_manifest
+
+        kref = to_kerchunk(FIXTURE, tmp_path / "k.json", backend="kerchunk")["refs"]
+        nref = build_single_manifest(FIXTURE)["refs"]
+
+        assert set(nref) == set(kref), "ref key sets must match kerchunk"
+        for key in kref:
+            if key.endswith((".zarray", ".zattrs", ".zgroup")):
+                continue
+            assert nref[key] == kref[key], f"chunk ref {key} must match kerchunk"
+
+    @requires_kerchunk
+    def test_zarray_codec_chain_matches(self, tmp_path):
+        """Decoded codec chain matches kerchunk for the chunked compressed case."""
+        from pyramids.netcdf._kerchunk import to_kerchunk
+        from pyramids.netcdf._kerchunk_native import build_single_manifest
+
+        src = str(tmp_path / "chunked.nc")
+        _make_chunked_file(src)
+        kref = to_kerchunk(src, tmp_path / "k.json", backend="kerchunk")["refs"]
+        nref = build_single_manifest(src)["refs"]
+
+        k_arr = json.loads(kref["temp/.zarray"])
+        n_arr = json.loads(nref["temp/.zarray"])
+        assert _codec_chain(n_arr) == _codec_chain(k_arr), "codec chain must match"
+        assert n_arr["chunks"] == [1, 10, 13], "chunk shape preserved"
+
+
+class TestRoundTrip:
+    """Native manifest opens correctly through xarray's kerchunk engine."""
+
+    @requires_xarray
+    @requires_kerchunk
+    def test_fixture_values_match_direct_read(self, tmp_path):
+        """Non-fill data round-trips; fill cells decode to NaN."""
+        from pyramids.netcdf._kerchunk_native import build_single_manifest
+
+        manifest = tmp_path / "native.json"
+        manifest.write_text(json.dumps(build_single_manifest(FIXTURE)))
+        ds = xr.open_dataset(str(manifest), engine="kerchunk")
+        try:
+            got = np.asarray(ds["values"].values)
+            with h5py.File(FIXTURE, "r") as f:
+                truth = f["values"][...]
+                fill = np.asarray(f["values"].attrs["_FillValue"]).reshape(-1)[0]
+            mask = truth != fill
+            np.testing.assert_allclose(got[mask], truth[mask])
+            assert np.isnan(got[~mask]).all(), "fill cells must decode to NaN"
+            assert list(ds["values"].dims) == ["bands", "y", "x"]
+        finally:
+            ds.close()
+
+    @requires_xarray
+    @requires_kerchunk
+    def test_chunked_compressed_roundtrip(self, tmp_path):
+        """A chunked + gzip + shuffle dataset round-trips bit-for-bit."""
+        from pyramids.netcdf._kerchunk_native import build_single_manifest
+
+        src = str(tmp_path / "chunked.nc")
+        data = _make_chunked_file(src)
+        manifest = tmp_path / "native.json"
+        manifest.write_text(json.dumps(build_single_manifest(src)))
+        ds = xr.open_dataset(str(manifest), engine="kerchunk")
+        try:
+            np.testing.assert_array_equal(np.asarray(ds["temp"].values), data)
+        finally:
+            ds.close()
+
+
+class TestMetadataSemantics:
+    """Dimension names, fill values, and attribute hygiene."""
+
+    def test_array_dimensions_resolved(self):
+        """`_ARRAY_DIMENSIONS` come from the NetCDF dimension scales."""
+        from pyramids.netcdf._kerchunk_native import build_single_manifest
+
+        refs = build_single_manifest(FIXTURE)["refs"]
+        assert json.loads(refs["values/.zattrs"])["_ARRAY_DIMENSIONS"] == [
+            "bands",
+            "y",
+            "x",
+        ]
+        assert json.loads(refs["x/.zattrs"])["_ARRAY_DIMENSIONS"] == ["x"]
+
+    def test_fill_value_only_from_attribute(self):
+        """`_FillValue` attr -> fill_value; HDF5 default fill -> null."""
+        from pyramids.netcdf._kerchunk_native import build_single_manifest
+
+        refs = build_single_manifest(FIXTURE)["refs"]
+        values = json.loads(refs["values/.zarray"])
+        bands = json.loads(refs["bands/.zarray"])
+        assert values["fill_value"] == pytest.approx(-3.4028230607370965e38)
+        assert bands["fill_value"] is None, "no _FillValue attr -> null"
+
+    def test_scalar_attrs_squeezed(self):
+        """GDAL's 1-element CF attributes are emitted as scalars, not lists."""
+        from pyramids.netcdf._kerchunk_native import build_single_manifest
+
+        refs = build_single_manifest(FIXTURE)["refs"]
+        crs = json.loads(refs["transverse_mercator/.zattrs"])
+        assert crs["longitude_of_central_meridian"] == pytest.approx(-75.0)
+
+    def test_bookkeeping_attrs_stripped(self):
+        """HDF5/NetCDF bookkeeping keys never leak into `.zattrs`."""
+        from pyramids.netcdf._kerchunk_native import build_single_manifest
+
+        refs = build_single_manifest(FIXTURE)["refs"]
+        for key in ("values/.zattrs", "x/.zattrs", ".zattrs"):
+            attrs = json.loads(refs[key])
+            assert not (
+                {"CLASS", "NAME", "REFERENCE_LIST", "DIMENSION_LIST", "_FillValue"}
+                & set(attrs)
+            )
+
+
+class TestCombine:
+    """Native concat of per-file manifests along one dimension."""
+
+    def test_single_manifest_passthrough(self):
+        """Combining one manifest returns it unchanged (one file = no concat)."""
+        from pyramids.netcdf._kerchunk_native import (
+            build_single_manifest,
+            combine_manifests,
+        )
+
+        one = build_single_manifest(FIXTURE)
+        combined = combine_manifests([one], concat_dim="bands")
+        assert combined["refs"].keys() == one["refs"].keys()
+
+    def test_stacks_concat_variable_shape(self, tmp_path):
+        """Every var with the concat dim is stacked; its shape sums over files."""
+        from pyramids.netcdf._kerchunk_native import (
+            build_single_manifest,
+            combine_manifests,
+        )
+
+        paths = [str(tmp_path / f"f{i}.h5") for i in range(3)]
+        for index, path in enumerate(paths):
+            _make_time_file(path, index)
+        per_file = [build_single_manifest(p) for p in paths]
+        combined = combine_manifests(per_file, concat_dim="time")["refs"]
+
+        assert json.loads(combined["v/.zarray"])["shape"] == [6, 5, 6]
+        assert json.loads(combined["time/.zarray"])["shape"] == [6]
+        assert json.loads(combined["lat/.zarray"])["shape"] == [5], "lat not stacked"
+
+    @requires_xarray
+    @requires_kerchunk
+    def test_combined_data_equals_real_stack(self, tmp_path):
+        """Round-trip: the combined cube equals np.concatenate of the inputs."""
+        from pyramids.netcdf._kerchunk_native import (
+            build_single_manifest,
+            combine_manifests,
+        )
+
+        paths = [str(tmp_path / f"f{i}.h5") for i in range(3)]
+        datas = [_make_time_file(p, i) for i, p in enumerate(paths)]
+        per_file = [build_single_manifest(p) for p in paths]
+        manifest = tmp_path / "combined.json"
+        manifest.write_text(json.dumps(combine_manifests(per_file, concat_dim="time")))
+
+        ds = xr.open_dataset(str(manifest), engine="kerchunk")
+        try:
+            np.testing.assert_array_equal(
+                np.asarray(ds["v"].values), np.concatenate(datas, axis=0)
+            )
+            np.testing.assert_array_equal(ds["time"].values, np.arange(6))
+        finally:
+            ds.close()
+
+    def test_differing_variable_sets_rejected(self, tmp_path):
+        """Files with different variables cannot be combined."""
+        from pyramids.netcdf._kerchunk_native import (
+            build_single_manifest,
+            combine_manifests,
+        )
+
+        good = str(tmp_path / "good.h5")
+        _make_time_file(good, 0)
+        extra = str(tmp_path / "extra.h5")
+        _make_time_file(extra, 1)
+        with h5py.File(extra, "a") as f:
+            f.create_dataset("bonus", data=np.zeros(3, dtype="f4"))
+        per_file = [build_single_manifest(good), build_single_manifest(extra)]
+        with pytest.raises(ValueError, match="variable sets"):
+            combine_manifests(per_file, concat_dim="time")
+
+
+class TestUnsupportedFeatures:
+    """Out-of-scope HDF5 features fail with a clear, actionable error."""
+
+    def test_object_dtype_rejected(self, tmp_path):
+        """A vlen/object dtype raises ValueError (caller can fall back)."""
+        from pyramids.netcdf._kerchunk_native import build_single_manifest
+
+        src = str(tmp_path / "vlen.h5")
+        with h5py.File(src, "w") as f:
+            f.create_dataset("s", data=np.array(["a", "bb"], dtype=object),
+                             dtype=h5py.string_dtype())
+        with pytest.raises(ValueError, match="vlen|object"):
+            build_single_manifest(src)

--- a/tests/netcdf/lazy/test_kerchunk_native.py
+++ b/tests/netcdf/lazy/test_kerchunk_native.py
@@ -17,6 +17,7 @@ round-trip tests need xarray. Each is gated independently.
 from __future__ import annotations
 
 import json
+from unittest.mock import Mock
 
 import numpy as np
 import pytest
@@ -291,6 +292,31 @@ class TestCombine:
         per_file = [build_single_manifest(good), build_single_manifest(extra)]
         with pytest.raises(ValueError, match="variable sets"):
             combine_manifests(per_file, concat_dim="time")
+
+
+class TestFilterMapping:
+    """HDF5 filter pipeline → zarr (compressor, filters) mapping."""
+
+    def test_shuffle_after_deflate_rejected(self):
+        """An unsupported shuffle-after-deflate order raises (not silent wrong data).
+
+        h5py's high-level API only writes shuffle-before-deflate, so the reversed
+        order is exercised with a faked filter pipeline.
+        """
+        from pyramids.netcdf._kerchunk_native import _compressor_and_filters
+
+        dataset = Mock()
+        dataset.name = "/v"
+        dataset.dtype = np.dtype("f4")
+        dcpl = dataset.id.get_create_plist.return_value
+        dcpl.get_nfilters.return_value = 2
+        # index 0 = deflate (id 1), index 1 = shuffle (id 2) — the reversed order
+        dcpl.get_filter.side_effect = [
+            (1, 0, (4,), b"deflate"),
+            (2, 0, (), b"shuffle"),
+        ]
+        with pytest.raises(ValueError, match="shuffle after deflate"):
+            _compressor_and_filters(dataset)
 
 
 class TestUnsupportedFeatures:

--- a/tests/netcdf/lazy/test_kerchunk_native.py
+++ b/tests/netcdf/lazy/test_kerchunk_native.py
@@ -299,6 +299,25 @@ class TestCombine:
         finally:
             ds.close()
 
+    def test_subgroup_metadata_preserved(self, tmp_path):
+        """Combine keeps sub-group `.zgroup`/`.zattrs`, not just root + variables."""
+        from pyramids.netcdf._kerchunk_native import (
+            build_single_manifest,
+            combine_manifests,
+        )
+
+        paths = [str(tmp_path / f"f{i}.h5") for i in range(2)]
+        for index, path in enumerate(paths):
+            _make_time_file(path, index)
+            with h5py.File(path, "r+") as f:
+                grp = f.create_group("meta")
+                grp.attrs["source"] = "unit-test"
+        per_file = [build_single_manifest(p) for p in paths]
+        combined = combine_manifests(per_file, concat_dim="time")["refs"]
+
+        assert "meta/.zattrs" in combined, "sub-group attrs must survive combine"
+        assert json.loads(combined["meta/.zattrs"])["source"] == "unit-test"
+
     def test_misaligned_identical_dim_warns(self, tmp_path):
         """A non-concat coord that differs across files warns (not silently merged)."""
         from pyramids.netcdf._kerchunk_native import (

--- a/tests/netcdf/lazy/test_kerchunk_native.py
+++ b/tests/netcdf/lazy/test_kerchunk_native.py
@@ -214,8 +214,8 @@ class TestMetadataSemantics:
         crs = json.loads(refs["transverse_mercator/.zattrs"])
         assert crs["longitude_of_central_meridian"] == pytest.approx(-75.0)
 
-    def test_byte_range_url_is_absolute(self):
-        """Byte-range refs absolutise a local source so manifests are CWD-independent."""
+    def test_byte_range_url_is_absolute_and_posix(self):
+        """Byte-range refs use an absolute, forward-slash (portable) local path."""
         import os
 
         from pyramids.netcdf._kerchunk_native import build_single_manifest
@@ -223,6 +223,7 @@ class TestMetadataSemantics:
         refs = build_single_manifest(FIXTURE)["refs"]
         url = refs["values/0.0.0"][0]   # values is a byte-range ref on this fixture
         assert os.path.isabs(url), f"expected an absolute source path, got {url!r}"
+        assert "\\" not in url, f"path must use forward slashes, got {url!r}"
 
     def test_src_url_override_is_used_verbatim(self):
         """An explicit src_url is written into refs unchanged (e.g. a cloud URL)."""

--- a/tests/netcdf/lazy/test_kerchunk_native.py
+++ b/tests/netcdf/lazy/test_kerchunk_native.py
@@ -406,3 +406,163 @@ class TestUnsupportedFeatures:
         not_hdf5.write_text("this is not an HDF5 file")
         with pytest.raises(OSError):
             build_single_manifest(str(not_hdf5))
+
+
+def _mini_time_manifest(time_len: int, chunk: int) -> dict:
+    """A minimal v1 manifest with a single 1-D ``time`` variable."""
+    zarray = {
+        "shape": [time_len],
+        "chunks": [chunk],
+        "dtype": "<f8",
+        "fill_value": None,
+        "order": "C",
+        "filters": None,
+        "dimension_separator": ".",
+        "compressor": None,
+        "zarr_format": 2,
+    }
+    refs = {
+        ".zgroup": json.dumps({"zarr_format": 2}),
+        "time/.zarray": json.dumps(zarray),
+        "time/.zattrs": json.dumps({"_ARRAY_DIMENSIONS": ["time"]}),
+    }
+    for index in range(-(-time_len // chunk)):  # one inlined chunk per grid cell
+        refs[f"time/{index}"] = "base64:AAAAAAAAAAA="
+    return {"version": 1, "refs": refs}
+
+
+class TestToJsonable:
+    """`_to_jsonable` attribute coercion via emitted `.zattrs`."""
+
+    def test_vector_and_bool_and_bytes_attrs(self, tmp_path):
+        """Multi-element vectors stay lists; bytes decode; bools/ints coerce."""
+        from pyramids.netcdf._kerchunk_native import build_single_manifest
+
+        src = str(tmp_path / "attrs.h5")
+        with h5py.File(src, "w") as f:
+            d = f.create_dataset("v", data=np.zeros(3, dtype="f4"))
+            d.attrs["bounds"] = np.array([1.0, 2.0, 3.0], dtype="f8")  # vector -> list
+            d.attrs["flag"] = np.bool_(True)
+            d.attrs["count"] = np.int32(7)
+            d.attrs["label"] = b"hello"
+        attrs = json.loads(build_single_manifest(src)["refs"]["v/.zattrs"])
+        assert attrs["bounds"] == pytest.approx([1.0, 2.0, 3.0]), "vector kept as list"
+        assert attrs["flag"] is True, f"bool not coerced: {attrs['flag']!r}"
+        assert attrs["count"] == 7, f"int not coerced: {attrs['count']!r}"
+        assert attrs["label"] == "hello", f"bytes not decoded: {attrs['label']!r}"
+
+
+class TestEncodeFillValue:
+    """`_encode_fill_value` across dtypes and special values."""
+
+    def test_float_int_nan_inf_bytes_and_absent(self, tmp_path):
+        """_FillValue encodes per dtype; NaN/Inf become strings; absent -> None."""
+        from pyramids.netcdf._kerchunk_native import build_single_manifest
+
+        src = str(tmp_path / "fills.h5")
+        with h5py.File(src, "w") as f:
+            nan_v = f.create_dataset("nan_v", data=np.zeros(2, dtype="f4"))
+            nan_v.attrs["_FillValue"] = np.array([np.nan], dtype="f4")
+            inf_v = f.create_dataset("inf_v", data=np.zeros(2, dtype="f8"))
+            inf_v.attrs["_FillValue"] = np.array([-np.inf], dtype="f8")
+            int_v = f.create_dataset("int_v", data=np.zeros(2, dtype="i4"))
+            int_v.attrs["_FillValue"] = np.array([-1], dtype="i4")
+            str_v = f.create_dataset("str_v", data=np.zeros(2, dtype="S2"))
+            str_v.attrs["_FillValue"] = np.bytes_(b"ab")
+            f.create_dataset("plain_v", data=np.zeros(2, dtype="f4"))
+        refs = build_single_manifest(src)["refs"]
+        import base64 as _b64
+
+        assert json.loads(refs["nan_v/.zarray"])["fill_value"] == "NaN"
+        assert json.loads(refs["inf_v/.zarray"])["fill_value"] == "-Infinity"
+        assert json.loads(refs["int_v/.zarray"])["fill_value"] == -1
+        encoded = json.loads(refs["str_v/.zarray"])["fill_value"]
+        assert _b64.b64decode(encoded) == b"ab", f"S-fill base64 wrong: {encoded!r}"
+        assert json.loads(refs["plain_v/.zarray"])["fill_value"] is None
+
+
+class TestFilterMappingExtra:
+    """Filter-pipeline edge cases not reachable from the parity fixtures."""
+
+    def test_fletcher32_is_dropped(self, tmp_path):
+        """A fletcher32 checksum filter is silently dropped (data still readable)."""
+        from pyramids.netcdf._kerchunk_native import build_single_manifest
+
+        src = str(tmp_path / "fletcher.h5")
+        with h5py.File(src, "w") as f:
+            f.create_dataset("v", data=np.ones((2, 4), dtype="f4"),
+                             chunks=(1, 4), fletcher32=True)
+        zarray = json.loads(build_single_manifest(src)["refs"]["v/.zarray"])
+        assert zarray["filters"] is None, f"fletcher32 should be dropped: {zarray}"
+        assert zarray["compressor"] is None, "no compressor expected"
+
+    def test_unknown_filter_id_raises(self):
+        """An unrecognised HDF5 filter id raises a clear ValueError."""
+        from pyramids.netcdf._kerchunk_native import _compressor_and_filters
+
+        dataset = Mock()
+        dataset.name = "/v"
+        dataset.dtype = np.dtype("f4")
+        dcpl = dataset.id.get_create_plist.return_value
+        dcpl.get_nfilters.return_value = 1
+        dcpl.get_filter.side_effect = [(99999, 0, (), b"weird")]
+        with pytest.raises(ValueError, match="unsupported HDF5 filter id"):
+            _compressor_and_filters(dataset)
+
+
+class TestEmitChunkRefs:
+    """Direct `_emit_chunk_refs` behaviour for the non-inlining branch."""
+
+    def test_remote_handle_none_never_inlines(self):
+        """With src_handle=None (remote), small chunks are byte-range, not inlined."""
+        from pyramids.netcdf._kerchunk_native import _emit_chunk_refs
+
+        refs: dict = {}
+        with h5py.File(FIXTURE, "r") as f:
+            bands = f["bands"]  # tiny: would inline if a local handle were given
+            _emit_chunk_refs(
+                refs,
+                dataset=bands,
+                name="bands",
+                src_url="s3://bucket/cube.nc",
+                src_handle=None,
+                chunks=[3],
+                inline_threshold=500,
+            )
+        assert isinstance(refs["bands/0"], list), "remote chunk must be byte-range"
+        assert refs["bands/0"][0] == "s3://bucket/cube.nc"
+
+
+class TestCombineEdgeCases:
+    """`combine_manifests` validation and flat-manifest handling."""
+
+    def test_empty_input_raises(self):
+        """An empty manifest list raises ValueError."""
+        from pyramids.netcdf._kerchunk_native import combine_manifests
+
+        with pytest.raises(ValueError, match="at least one manifest"):
+            combine_manifests([], concat_dim="time")
+
+    def test_flat_v0_manifest_passthrough(self):
+        """A single flat (v0) manifest with no 'refs' key passes through."""
+        from pyramids.netcdf._kerchunk_native import combine_manifests
+
+        flat = {".zgroup": json.dumps({"zarr_format": 2})}
+        out = combine_manifests([flat], concat_dim="time")
+        assert out["refs"][".zgroup"] == flat[".zgroup"]
+
+    def test_inconsistent_concat_chunk_size_raises(self):
+        """Differing chunk size on the concat axis cannot form a uniform array."""
+        from pyramids.netcdf._kerchunk_native import combine_manifests
+
+        per_file = [_mini_time_manifest(2, 2), _mini_time_manifest(2, 1)]
+        with pytest.raises(ValueError, match="inconsistent chunk size"):
+            combine_manifests(per_file, concat_dim="time")
+
+    def test_non_final_partial_chunk_raises(self):
+        """A non-final file whose length is not a chunk multiple is rejected."""
+        from pyramids.netcdf._kerchunk_native import combine_manifests
+
+        per_file = [_mini_time_manifest(3, 2), _mini_time_manifest(2, 2)]
+        with pytest.raises(ValueError, match="multiple of its chunk size"):
+            combine_manifests(per_file, concat_dim="time")

--- a/tests/netcdf/lazy/test_netcdf_lazy_pipelines.py
+++ b/tests/netcdf/lazy/test_netcdf_lazy_pipelines.py
@@ -18,7 +18,6 @@ likely under future refactors:
 from __future__ import annotations
 
 import multiprocessing
-import os
 import pickle
 
 import numpy as np
@@ -53,14 +52,10 @@ requires_xarray = pytest.mark.skipif(not HAS_XARRAY, reason="xarray not installe
 requires_kerchunk = pytest.mark.skipif(
     not HAS_KERCHUNK, reason="kerchunk not installed"
 )
-# xarray's engine="kerchunk" (kerchunk -> fsspec async ReferenceFileSystem -> zarr v3)
-# flakily deadlocks on the CI runners while passing reliably locally; skip it on CI only
-# so the matrix stays green, and keep running it locally. Tracked in #530 (tied to the
-# zarr v2 -> v3 lazy-stack migration); the global pytest-timeout is the backstop.
-skip_kerchunk_xarray_on_ci = pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="kerchunk-via-xarray roundtrip flakily deadlocks on CI under zarr v3 (see #530)",
-)
+# #530: the deadlock was in manifest *generation* (kerchunk.hdf -> zarr-v3 sync()),
+# not the xarray read. NetCDF.to_kerchunk now builds the manifest natively with h5py
+# (no live zarr group), so generation can no longer deadlock and this runs on CI again.
+# The global pytest-timeout remains as a backstop.
 
 
 FIXTURE = "tests/data/netcdf/pyramids-netcdf-3d.nc"
@@ -100,7 +95,6 @@ class TestNetCDFLazyPipelines:
     @pytest.mark.xarray
     @requires_kerchunk
     @requires_xarray
-    @skip_kerchunk_xarray_on_ci
     def test_kerchunk_roundtrip_via_xarray(self, tmp_path):
         """to_kerchunk manifest opens with xarray engine="kerchunk".
 


### PR DESCRIPTION
# Description

`NetCDF.to_kerchunk` / `combine_kerchunk` drove kerchunk's HDF5 translator
(`SingleHdf5ToZarr.translate()`), which under **zarr v3** submits work to a
process-global event loop and flakily **deadlocks during manifest generation** —
not during the xarray read, as originally assumed. The CI faulthandler thread
dump shows the hang in `to_kerchunk` → `kerchunk.hdf` → `zarr … sync()`, never
reaching the consumer.

This replaces the generation path with a zarr-free native builder:

- `pyramids/netcdf/_kerchunk_native.py`
  - `build_single_manifest` — walks the HDF5 file with `h5py` and emits the
    kerchunk v1 reference document directly (zarr-v2 metadata + byte-range /
    inlined chunk refs). Resolves `_ARRAY_DIMENSIONS` from the NetCDF dimension
    scales, maps deflate/shuffle filters, squeezes GDAL's size-1 CF attributes
    and `_FillValue`.
  - `combine_manifests` — native concat along one dimension: every variable
    carrying the concat dim is stacked (chunk indices renumbered, shape summed),
    the rest are carried from the first file.
- `to_kerchunk` / `combine_kerchunk` route through the native builder by default
  with a `backend="native"|"kerchunk"` switch and an automatic kerchunk fallback
  (with a warning) for HDF5 features the native builder does not cover.
- The CI skip on `test_kerchunk_roundtrip_via_xarray` is removed (generation is
  now deadlock-free).
- Docs: added "What is Zarr?" and "Kerchunk reference manifests" tutorials.

Notes / context:

- Latest kerchunk (0.2.10) and zarr (3.2.1) are the broken pair — there is no
  version to bump to. Both zarr 3.1.6 (py311) and 3.2.1 (py312/py314) deadlocked,
  so pinning zarr does not help.
- **No new dependencies.** `h5py` was already declared in the `[lazy]` extra
  (transitively required by kerchunk); it is now used directly by the native
  builder. Comments updated to reflect that.

# Issues
- Fixes #530

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- New offline suite `tests/netcdf/lazy/test_kerchunk_native.py`: byte-parity of
  chunk references against the kerchunk translator (contiguous and
  chunked+deflate+shuffle), round-trip through `xr.open_dataset(engine="kerchunk")`,
  dimension-scale resolution, fill-value semantics, native combine (== a real
  `np.concatenate`), and the unsupported-feature error path.
- Re-enabled `test_kerchunk_roundtrip_via_xarray` on CI (the #530 reproducer).
- Updated the import-error contract tests (native path needs h5py, not kerchunk).

Reproduce locally (needs the `[lazy]` extra):

```
pixi run -e dev pytest tests/netcdf/lazy/test_kerchunk_native.py \
  tests/netcdf/lazy/test_kerchunk.py tests/dataset/collection/test_kerchunk.py
```

- [x] Test A — local: 31 kerchunk-related tests pass, including with `CI=true`.
- [x] Test B — CI: all 12 `main-package` jobs green (the matrix that previously
  deadlocked 7/12), plus `extras-package (netcdf_lazy)` on all three OS.

# Checklist:

- [ ] updated version number in pyproject.toml. (handled by commitizen in CI)
- [ ] added changes to History.rst. (changelog is commitizen-generated)
- [ ] updated the latest version in README file. (handled in the release flow)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.
