### PR TITLE
feat(feature): vector tessellation & aggregation ops (voronoi, quadtree)

### DIFF
--- a/docs/reference/feature/index.md
+++ b/docs/reference/feature/index.md
@@ -29,6 +29,8 @@ classDiagram
         +column
         +with_coordinates()
         +with_centroid()
+        +voronoi(values, clip)
+        +quadtree(column, agg, nmax, nmin, clip)
         +concat(other)
         +plot(column, basemap, **kwargs)
         +create_polygon(coords)
@@ -93,6 +95,8 @@ classDiagram
 | Wrap an existing `GeoDataFrame` | `FeatureCollection(gdf)` or `FeatureCollection.from_features(gdf)` |
 | Inspect layers / schema without reading | `FeatureCollection.list_layers`, `.schema` |
 | Attach per-vertex or centroid columns | `.with_coordinates()`, `.with_centroid()` |
+| Tessellate points into Voronoi/Thiessen cells | `.voronoi(values=…, clip=…)` |
+| Bin points into adaptive quad-tree cells with a per-cell aggregate | `.quadtree(column=…, agg=…, nmax=…)` |
 | Concatenate two FCs safely (CRS-checked) | `.concat(other)` |
 | Build raw geometries | `pyramids.feature.geometry.create_polygon` / `create_points` |
 | Reproject coordinate arrays | `pyramids.base.crs.reproject_coordinates` |

--- a/pixi.lock
+++ b/pixi.lock
@@ -5,6 +5,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -569,6 +571,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -2372,6 +2376,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -3532,6 +3538,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -5059,6 +5067,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -6330,6 +6340,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -8083,6 +8095,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -9612,6 +9626,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -11132,6 +11148,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -12654,6 +12672,8 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -14184,6 +14204,8 @@ environments:
   wheel-build:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
@@ -37343,7 +37365,7 @@ packages:
 - pypi: ./
   name: pyramids-gis
   version: 0.34.0
-  sha256: bb984475fc88f4a777ec770c6275a293d5f1cc304685039541cce7e29af335f3
+  sha256: 2324f9cdbe077617b71758f3a17bfeb45123eb132cface1013392627343e276c
   requires_dist:
   - cftime>=1.6.4
   - geopandas>=1.0.0
@@ -37352,7 +37374,7 @@ packages:
   - pandas>=2.0.0
   - pyproj>=3.7.0
   - pyyaml>=6.0.0
-  - shapely>=2.0.0
+  - shapely>=2.1.0
   - scipy>=1.10.0
   - cleopatra[tiles]>=0.18.0 ; extra == 'viz'
   - dask>=2024.1.0 ; extra == 'lazy'
@@ -37369,7 +37391,6 @@ packages:
   - pystac-client>=0.8.0 ; extra == 'stac'
   - stac-asset>=0.4.7 ; extra == 'stac'
   requires_python: '>=3.11,<4'
-  editable: true
 - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
   sha256: d016e04b0e12063fbee4a2d5fbb9b39a8d191b5a0042f0b8459188aedeabb0ca
   md5: e2fd202833c4a981ce8a65974fe4abd1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "pandas >=2.0.0",
     "pyproj >=3.7.0",
     "PyYAML >=6.0.0",
-    "Shapely >=2.0.0",
+    "Shapely >=2.1.0",
     "scipy >=1.10.0",
 ]
 

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -30,7 +30,7 @@ import os
 import warnings
 from numbers import Number
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable
+from typing import TYPE_CHECKING, Any, Callable, Iterable
 
 if TYPE_CHECKING:
     from pyramids.feature._lazy_collection import LazyFeatureCollection
@@ -43,11 +43,17 @@ from osgeo import gdal, ogr
 from shapely.geometry import Point, box
 
 from pyramids import _io as _pyramids_io
-from pyramids.base._errors import CRSError, FeatureError, GeometryWarning
+from pyramids.base._errors import (
+    CRSError,
+    FeatureError,
+    GeometryWarning,
+    InvalidGeometryError,
+)
 from pyramids.base._utils import Catalog, import_pyarrow, require_cleopatra
 from pyramids.base.remote import is_remote
 from pyramids.basemap.basemap import add_basemap
 from pyramids.feature import geometry as _geom
+from pyramids.feature import tessellation as _tess
 
 CATALOG = Catalog(raster_driver=False)
 
@@ -2429,3 +2435,170 @@ class FeatureCollection(GeoDataFrame):
         ]
         fc["center_point"] = cleaned
         return fc
+
+    def _require_point_geometry(self, op: str) -> None:
+        """Raise :class:`InvalidGeometryError` unless every geometry is a single ``Point``.
+
+        Args:
+            op: Name of the calling operation, used in the error message.
+
+        Raises:
+            InvalidGeometryError: If the collection holds any non-``Point`` geometry (or is empty).
+        """
+        geom_types = sorted(set(self.geom_type.dropna().unique()))
+        if geom_types != ["Point"]:
+            raise InvalidGeometryError(
+                f"{op}: requires all-Point geometries, got {geom_types or 'an empty collection'}"
+            )
+
+    def voronoi(
+        self,
+        *,
+        values: str | None = None,
+        clip: FeatureCollection | None = None,
+    ) -> FeatureCollection:
+        """Voronoi (Thiessen) tessellation of a point ``FeatureCollection``.
+
+        Returns one polygon per distinct input point, ordered so cell *i* corresponds to the *i*-th distinct
+        point (``shapely.voronoi_polygons(ordered=True)``). Coincident (duplicate) points, and points that
+        produce an empty cell after clipping, are skipped. With ``clip`` each cell is intersected with the
+        boundary; with ``values`` the named column is copied onto each cell so the result can be rendered as a
+        choropleth.
+
+        Args:
+            values: Name of a column copied onto each cell (cell *i* ← point *i*), or ``None`` to carry no
+                attribute.
+            clip: A boundary ``FeatureCollection`` each cell is intersected with (reprojected to this
+                collection's CRS), or ``None`` to keep shapely's default bounded cells.
+
+        Returns:
+            FeatureCollection: One polygon per surviving cell, in this collection's CRS, carrying ``values``
+            when given.
+
+        Raises:
+            InvalidGeometryError: If the geometries are not all ``Point``, or there are fewer than two distinct
+                points with finite coordinates.
+
+        Examples:
+            - Tessellate four points and count the cells:
+                ```python
+                >>> import geopandas as gpd
+                >>> from shapely.geometry import Point
+                >>> from pyramids.feature import FeatureCollection
+                >>> fc = FeatureCollection(
+                ...     gpd.GeoDataFrame(
+                ...         {"v": [10, 20, 30, 40]},
+                ...         geometry=[Point(0, 0), Point(2, 0), Point(0, 2), Point(2, 2)],
+                ...         crs="EPSG:32618",
+                ...     )
+                ... )
+                >>> cells = fc.voronoi(values="v")
+                >>> len(cells)
+                4
+                >>> sorted(cells["v"].tolist())
+                [10, 20, 30, 40]
+
+                ```
+        """
+        self._require_point_geometry("voronoi")
+        xs, ys, keep = _tess.point_xy(self.geometry)
+        ux, uy, unique = _tess.dedupe_xy(xs, ys)
+        if ux.size < 2:
+            raise InvalidGeometryError(
+                f"voronoi: need at least 2 distinct points with finite coordinates to tessellate, got {ux.size}"
+            )
+        carried = self[values].to_numpy()[keep][unique] if values is not None else None
+        boundary = _tess.resolve_clip(clip, self.crs)
+        geometries: list = []
+        attributes: list = []
+        for i, cell in enumerate(_tess.voronoi_cells(ux, uy)):
+            bounded = cell if boundary is None else cell.intersection(boundary)
+            for part in _tess.polygon_parts(bounded):
+                geometries.append(part)
+                if carried is not None:
+                    attributes.append(carried[i])
+        data = {values: attributes} if values is not None else {}
+        result = FeatureCollection(gpd.GeoDataFrame(data, geometry=geometries, crs=self.crs))
+        return result
+
+    def quadtree(
+        self,
+        *,
+        column: str | None = None,
+        agg: str | Callable = "mean",
+        nmax: int = 100,
+        nmin: int = 0,
+        clip: FeatureCollection | None = None,
+    ) -> FeatureCollection:
+        """Adaptive quad-tree binning of a point ``FeatureCollection`` into rectangular cells.
+
+        Recursively splits the points' bounding box into quadrants until each cell holds ``<= nmax`` points,
+        then attaches a per-cell aggregate of ``column`` (or the point count when ``column`` is ``None``) to
+        each cell polygon.
+
+        Args:
+            column: Numeric column aggregated per cell, or ``None`` to attach the point count (density).
+            agg: Per-cell reducer — one of ``"mean"`` / ``"sum"`` / ``"median"`` / ``"min"`` / ``"max"`` /
+                ``"std"`` / ``"count"`` or a callable taking a 1-D array. Ignored when ``column`` is ``None``.
+            nmax: Maximum points in a cell before it is split (smaller → finer grid).
+            nmin: Cells with fewer than this many points are dropped.
+            clip: A boundary ``FeatureCollection`` each cell is intersected with (reprojected to this
+                collection's CRS), or ``None`` to keep the full rectangular cells.
+
+        Returns:
+            FeatureCollection: One polygon per kept cell, in this collection's CRS, with the aggregate in a
+            column named ``column`` (or ``"count"`` when ``column`` is ``None``).
+
+        Raises:
+            InvalidGeometryError: If the geometries are not all ``Point``, or there is no point with finite
+                coordinates.
+            ValueError: If ``agg`` is neither a known reducer name nor a callable.
+
+        Examples:
+            - Bin four points to one point per cell and read the counts:
+                ```python
+                >>> import geopandas as gpd
+                >>> from shapely.geometry import Point
+                >>> from pyramids.feature import FeatureCollection
+                >>> fc = FeatureCollection(
+                ...     gpd.GeoDataFrame(
+                ...         {"v": [10, 20, 30, 40]},
+                ...         geometry=[Point(0, 0), Point(2, 0), Point(0, 2), Point(2, 2)],
+                ...         crs="EPSG:32618",
+                ...     )
+                ... )
+                >>> cells = fc.quadtree(nmax=1)
+                >>> int(cells["count"].sum())
+                4
+
+                ```
+        """
+        self._require_point_geometry("quadtree")
+        xs, ys, keep = _tess.point_xy(self.geometry)
+        if xs.size < 1:
+            raise InvalidGeometryError("quadtree: need at least 1 point with finite coordinates, got 0")
+        if column is None:
+
+            def agg_fn(idx: np.ndarray) -> float:
+                return float(len(idx))
+
+        else:
+            reducer = _tess.resolve_reducer(agg)
+            column_values = self[column].to_numpy(dtype=float)[keep]
+
+            def agg_fn(idx: np.ndarray) -> float:
+                return float(reducer(column_values[idx]))
+
+        boundary = _tess.resolve_clip(clip, self.crs)
+        cells = _tess.quadtree_cells(xs, ys, agg_fn, nmax, nmin)
+        geometries: list = []
+        values_out: list = []
+        for xmin, ymin, xmax, ymax, value in cells:
+            rectangle = box(xmin, ymin, xmax, ymax)
+            bounded = rectangle if boundary is None else rectangle.intersection(boundary)
+            for part in _tess.polygon_parts(bounded):
+                geometries.append(part)
+                values_out.append(value)
+        name = column if column is not None else "count"
+        result = FeatureCollection(gpd.GeoDataFrame({name: values_out}, geometry=geometries, crs=self.crs))
+        return result

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -2590,6 +2590,8 @@ class FeatureCollection(GeoDataFrame):
         """
         self._require_point_geometry("quadtree")
         self._require_column("quadtree", column)
+        if nmax < 1:
+            raise ValueError(f"quadtree: nmax must be >= 1, got {nmax}")
         xs, ys, keep = _tess.point_xy(self.geometry)
         if xs.size < 1:
             raise InvalidGeometryError("quadtree: need at least 1 point with finite coordinates, got 0")

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -2451,6 +2451,19 @@ class FeatureCollection(GeoDataFrame):
                 f"{op}: requires all-Point geometries, got {geom_types or 'an empty collection'}"
             )
 
+    def _require_column(self, op: str, column: str | None) -> None:
+        """Raise :class:`ValueError` if ``column`` is given but absent from the collection.
+
+        Args:
+            op: Name of the calling operation, used in the error message.
+            column: Column name to check, or ``None`` to skip the check.
+
+        Raises:
+            ValueError: If ``column`` is not ``None`` and not one of this collection's columns.
+        """
+        if column is not None and column not in self.columns:
+            raise ValueError(f"{op}: column {column!r} not found; available columns are {list(self.columns)}")
+
     def voronoi(
         self,
         *,
@@ -2501,6 +2514,7 @@ class FeatureCollection(GeoDataFrame):
                 ```
         """
         self._require_point_geometry("voronoi")
+        self._require_column("voronoi", values)
         xs, ys, keep = _tess.point_xy(self.geometry)
         ux, uy, unique = _tess.dedupe_xy(xs, ys)
         if ux.size < 2:
@@ -2540,6 +2554,7 @@ class FeatureCollection(GeoDataFrame):
             column: Numeric column aggregated per cell, or ``None`` to attach the point count (density).
             agg: Per-cell reducer — one of ``"mean"`` / ``"sum"`` / ``"median"`` / ``"min"`` / ``"max"`` /
                 ``"std"`` / ``"count"`` or a callable taking a 1-D array. Ignored when ``column`` is ``None``.
+                NaN values in ``column`` propagate to a NaN cell value when every point in a cell is NaN.
             nmax: Maximum points in a cell before it is split (smaller → finer grid).
             nmin: Cells with fewer than this many points are dropped.
             clip: A boundary ``FeatureCollection`` each cell is intersected with (reprojected to this
@@ -2574,20 +2589,15 @@ class FeatureCollection(GeoDataFrame):
                 ```
         """
         self._require_point_geometry("quadtree")
+        self._require_column("quadtree", column)
         xs, ys, keep = _tess.point_xy(self.geometry)
         if xs.size < 1:
             raise InvalidGeometryError("quadtree: need at least 1 point with finite coordinates, got 0")
-        if column is None:
+        reducer = len if column is None else _tess.resolve_reducer(agg)
+        column_values = None if column is None else self[column].to_numpy(dtype=float)[keep]
 
-            def agg_fn(idx: np.ndarray) -> float:
-                return float(len(idx))
-
-        else:
-            reducer = _tess.resolve_reducer(agg)
-            column_values = self[column].to_numpy(dtype=float)[keep]
-
-            def agg_fn(idx: np.ndarray) -> float:
-                return float(reducer(column_values[idx]))
+        def agg_fn(idx: np.ndarray) -> float:
+            return float(len(idx)) if column_values is None else float(reducer(column_values[idx]))
 
         boundary = _tess.resolve_clip(clip, self.crs)
         cells = _tess.quadtree_cells(xs, ys, agg_fn, nmax, nmin)

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -2491,6 +2491,7 @@ class FeatureCollection(GeoDataFrame):
         Raises:
             InvalidGeometryError: If the geometries are not all ``Point``, or there are fewer than two distinct
                 points with finite coordinates.
+            ValueError: If ``values`` names a column that is not in the collection.
 
         Examples:
             - Tessellate four points and count the cells:
@@ -2567,7 +2568,8 @@ class FeatureCollection(GeoDataFrame):
         Raises:
             InvalidGeometryError: If the geometries are not all ``Point``, or there is no point with finite
                 coordinates.
-            ValueError: If ``agg`` is neither a known reducer name nor a callable.
+            ValueError: If ``column`` names a column that is not in the collection, if ``nmax`` is less than 1,
+                or if ``agg`` is neither a known reducer name nor a callable.
 
         Examples:
             - Bin four points to one point per cell and read the counts:

--- a/src/pyramids/feature/tessellation.py
+++ b/src/pyramids/feature/tessellation.py
@@ -77,14 +77,16 @@ def point_xy(geometry: Any) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
 def polygon_parts(geometry: Any) -> list:
     """Return the non-empty ``Polygon`` parts of a shapely geometry.
 
-    Explodes ``Multi*`` / ``GeometryCollection`` inputs and skips empty or non-polygonal parts, so the result
-    only ever contains usable ``Polygon`` geometries.
+    Recursively explodes ``Multi*`` / ``GeometryCollection`` inputs (including a ``MultiPolygon`` nested inside a
+    ``GeometryCollection``, which a clip intersection can produce) and skips empty or non-polygonal parts, so
+    the result only ever contains usable ``Polygon`` geometries.
 
     Args:
         geometry: Any shapely geometry, or ``None``.
 
     Returns:
-        list: The ``Polygon`` parts; ``[]`` for ``None``, an empty geometry, or non-polygonal input.
+        list: The ``Polygon`` parts in input order; ``[]`` for ``None``, an empty geometry, or non-polygonal
+        input.
 
     Examples:
         - A single polygon is returned as a one-element list:
@@ -107,8 +109,15 @@ def polygon_parts(geometry: Any) -> list:
     """
     parts: list = []
     if geometry is not None and not geometry.is_empty:
-        candidates = list(geometry.geoms) if hasattr(geometry, "geoms") else [geometry]
-        parts = [g for g in candidates if g.geom_type == "Polygon" and not g.is_empty]
+        stack = [geometry]
+        while stack:
+            geom = stack.pop()
+            if geom.is_empty:
+                continue
+            if geom.geom_type == "Polygon":
+                parts.append(geom)
+            elif hasattr(geom, "geoms"):
+                stack.extend(reversed(list(geom.geoms)))
     return parts
 
 

--- a/src/pyramids/feature/tessellation.py
+++ b/src/pyramids/feature/tessellation.py
@@ -263,6 +263,54 @@ def resolve_reducer(agg: Any) -> Callable[..., Any]:
     return reducer
 
 
+def _emit_cell(
+    out: list,
+    bounds: tuple[float, float, float, float],
+    idx: np.ndarray,
+    agg_fn: Callable[[np.ndarray], float],
+    nmin: int,
+) -> None:
+    """Append a ``(xmin, ymin, xmax, ymax, value)`` leaf cell to ``out`` when it holds ``>= nmin`` points.
+
+    Args:
+        out: The accumulator list the cell is appended to.
+        bounds: The cell's ``(xmin, ymin, xmax, ymax)`` extent.
+        idx: Index array of the points in the cell.
+        agg_fn: Callable mapping ``idx`` to the cell's scalar value.
+        nmin: Minimum points required to keep the cell.
+    """
+    if len(idx) >= nmin:
+        out.append((*bounds, float(agg_fn(idx))))
+
+
+def _split_quads(
+    bounds: tuple[float, float, float, float],
+    xs: np.ndarray,
+    ys: np.ndarray,
+    idx: np.ndarray,
+) -> list[tuple[float, float, float, float, np.ndarray]]:
+    """Split a cell into its four quadrants, partitioning ``idx`` by the cell midpoint.
+
+    Args:
+        bounds: The parent cell's ``(xmin, ymin, xmax, ymax)`` extent.
+        xs: All point x-coordinates.
+        ys: All point y-coordinates, aligned with ``xs``.
+        idx: Index array of the points in the parent cell.
+
+    Returns:
+        list[tuple]: Four ``(xmin, ymin, xmax, ymax, idx)`` quadrants (some may hold an empty ``idx``).
+    """
+    xmin, ymin, xmax, ymax = bounds
+    xmid, ymid = 0.5 * (xmin + xmax), 0.5 * (ymin + ymax)
+    cx, cy = xs[idx], ys[idx]
+    return [
+        (xmin, ymin, xmid, ymid, idx[(cx <= xmid) & (cy <= ymid)]),
+        (xmid, ymin, xmax, ymid, idx[(cx > xmid) & (cy <= ymid)]),
+        (xmin, ymid, xmid, ymax, idx[(cx <= xmid) & (cy > ymid)]),
+        (xmid, ymid, xmax, ymax, idx[(cx > xmid) & (cy > ymid)]),
+    ]
+
+
 def quadtree_cells(
     xs: np.ndarray,
     ys: np.ndarray,
@@ -328,22 +376,14 @@ def quadtree_cells(
         n = len(idx)
         if n == 0:
             continue
+        bounds = (xmin, ymin, xmax, ymax)
         if n <= nmax or depth >= max_depth:
-            if n >= nmin:
-                out.append((xmin, ymin, xmax, ymax, float(agg_fn(idx))))
+            _emit_cell(out, bounds, idx, agg_fn, nmin)
             continue
-        xmid, ymid = 0.5 * (xmin + xmax), 0.5 * (ymin + ymax)
-        cx, cy = xs[idx], ys[idx]
-        quads = [
-            (xmin, ymin, xmid, ymid, idx[(cx <= xmid) & (cy <= ymid)]),
-            (xmid, ymin, xmax, ymid, idx[(cx > xmid) & (cy <= ymid)]),
-            (xmin, ymid, xmid, ymax, idx[(cx <= xmid) & (cy > ymid)]),
-            (xmid, ymid, xmax, ymax, idx[(cx > xmid) & (cy > ymid)]),
-        ]
+        quads = _split_quads(bounds, xs, ys, idx)
         nonempty = [q for q in quads if len(q[4]) > 0]
         if len(nonempty) == 1 and len(nonempty[0][4]) == n:  # no progress (coincident points)
-            if n >= nmin:
-                out.append((xmin, ymin, xmax, ymax, float(agg_fn(idx))))
+            _emit_cell(out, bounds, idx, agg_fn, nmin)
             continue
         for qx0, qy0, qx1, qy1, qidx in quads:
             stack.append((qx0, qy0, qx1, qy1, qidx, depth + 1))

--- a/src/pyramids/feature/tessellation.py
+++ b/src/pyramids/feature/tessellation.py
@@ -106,6 +106,15 @@ def polygon_parts(geometry: Any) -> list:
             []
 
             ```
+        - A ``MultiPolygon`` nested inside a ``GeometryCollection`` is flattened to its polygons:
+            ```python
+            >>> from shapely.geometry import GeometryCollection, MultiPolygon, Point, box
+            >>> from pyramids.feature.tessellation import polygon_parts
+            >>> nested = GeometryCollection([Point(5, 5), MultiPolygon([box(0, 0, 1, 1), box(2, 2, 3, 3)])])
+            >>> [p.geom_type for p in polygon_parts(nested)]
+            ['Polygon', 'Polygon']
+
+            ```
     """
     parts: list = []
     if geometry is not None and not geometry.is_empty:

--- a/src/pyramids/feature/tessellation.py
+++ b/src/pyramids/feature/tessellation.py
@@ -1,0 +1,350 @@
+"""Vector tessellation and spatial-binning primitives for :class:`FeatureCollection`.
+
+Pure-geometry helpers backing :meth:`FeatureCollection.voronoi` and
+:meth:`FeatureCollection.quadtree`: Voronoi/Thiessen tessellation and adaptive quad-tree binning of point
+geometries. They operate on coordinate arrays and shapely geometries so the ``FeatureCollection`` facade can
+wrap the result back into a typed collection without this module importing ``FeatureCollection`` (which would
+create an import cycle).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import numpy as np
+from shapely import voronoi_polygons
+from shapely.geometry import MultiPoint
+
+NAN_REDUCERS: dict[str, Callable[..., Any]] = {
+    "mean": np.nanmean,
+    "sum": np.nansum,
+    "median": np.nanmedian,
+    "min": np.nanmin,
+    "max": np.nanmax,
+    "std": np.nanstd,
+}
+"""NaN-aware per-cell reducers, keyed by the name accepted on ``quadtree(agg=...)``."""
+
+QUADTREE_AGG: dict[str, Callable[..., Any]] = {**NAN_REDUCERS, "count": len}
+"""Reducers usable as ``quadtree(agg=...)`` — the NaN-aware reducers plus ``"count"``."""
+
+
+def point_xy(geometry: Any) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return the finite ``(xs, ys, keep)`` of a point ``GeoSeries``.
+
+    Points whose coordinates are non-finite are dropped, and ``keep`` holds the positional indices of the
+    surviving points so a caller can align an attribute column to the kept points by position.
+
+    Args:
+        geometry: A geopandas point ``GeoSeries``.
+
+    Returns:
+        tuple: ``(xs, ys, keep)`` numpy arrays — the finite x and y coordinates and the positional indices of
+        the kept points in the input order.
+
+    Examples:
+        - Extract coordinates from two finite points:
+            ```python
+            >>> import geopandas as gpd
+            >>> from shapely.geometry import Point
+            >>> from pyramids.feature.tessellation import point_xy
+            >>> xs, ys, keep = point_xy(gpd.GeoSeries([Point(0, 0), Point(2, 3)]))
+            >>> xs.tolist()
+            [0.0, 2.0]
+            >>> keep.tolist()
+            [0, 1]
+
+            ```
+        - A non-finite point is dropped and ``keep`` records the surviving position:
+            ```python
+            >>> import geopandas as gpd
+            >>> from shapely.geometry import Point
+            >>> from pyramids.feature.tessellation import point_xy
+            >>> xs, ys, keep = point_xy(gpd.GeoSeries([Point(float("inf"), 0), Point(2, 3)]))
+            >>> xs.tolist()
+            [2.0]
+            >>> keep.tolist()
+            [1]
+
+            ```
+    """
+    xs = np.asarray(geometry.x, dtype=float)
+    ys = np.asarray(geometry.y, dtype=float)
+    keep = np.flatnonzero(np.isfinite(xs) & np.isfinite(ys))
+    return xs[keep], ys[keep], keep
+
+
+def polygon_parts(geometry: Any) -> list:
+    """Return the non-empty ``Polygon`` parts of a shapely geometry.
+
+    Explodes ``Multi*`` / ``GeometryCollection`` inputs and skips empty or non-polygonal parts, so the result
+    only ever contains usable ``Polygon`` geometries.
+
+    Args:
+        geometry: Any shapely geometry, or ``None``.
+
+    Returns:
+        list: The ``Polygon`` parts; ``[]`` for ``None``, an empty geometry, or non-polygonal input.
+
+    Examples:
+        - A single polygon is returned as a one-element list:
+            ```python
+            >>> from shapely.geometry import Point
+            >>> from pyramids.feature.tessellation import polygon_parts
+            >>> parts = polygon_parts(Point(0, 0).buffer(1.0).envelope)
+            >>> [p.geom_type for p in parts]
+            ['Polygon']
+
+            ```
+        - Non-polygonal input yields an empty list:
+            ```python
+            >>> from shapely.geometry import Point
+            >>> from pyramids.feature.tessellation import polygon_parts
+            >>> polygon_parts(Point(0, 0))
+            []
+
+            ```
+    """
+    parts: list = []
+    if geometry is not None and not geometry.is_empty:
+        candidates = list(geometry.geoms) if hasattr(geometry, "geoms") else [geometry]
+        parts = [g for g in candidates if g.geom_type == "Polygon" and not g.is_empty]
+    return parts
+
+
+def dedupe_xy(xs: np.ndarray, ys: np.ndarray) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Drop coincident points, keeping the first occurrence of each in input order.
+
+    ``shapely.voronoi_polygons(..., ordered=True)`` raises ``GEOSException`` when two input points share a
+    cell, so exact duplicates must be removed before tessellation. The returned index lets a caller align an
+    attribute column to the kept points.
+
+    Args:
+        xs: Point x-coordinates.
+        ys: Point y-coordinates, aligned with ``xs``.
+
+    Returns:
+        tuple: ``(ux, uy, keep)`` numpy arrays — the unique x and y coordinates and the positional indices of
+        the kept points in input order.
+
+    Examples:
+        - The second of two coincident points is dropped:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.feature.tessellation import dedupe_xy
+            >>> ux, uy, keep = dedupe_xy(np.array([0.0, 0.0, 2.0]), np.array([0.0, 0.0, 3.0]))
+            >>> ux.tolist()
+            [0.0, 2.0]
+            >>> keep.tolist()
+            [0, 2]
+
+            ```
+    """
+    coords = np.column_stack([xs, ys])
+    _, first = np.unique(coords, axis=0, return_index=True)
+    keep = np.sort(first)
+    return xs[keep], ys[keep], keep
+
+
+def voronoi_cells(xs: np.ndarray, ys: np.ndarray) -> list:
+    """Tessellate points into ordered Voronoi cells.
+
+    Uses ``shapely.voronoi_polygons(..., ordered=True)`` so cell *i* corresponds to input point *i*. The inputs
+    must already be free of coincident points (see :func:`dedupe_xy`), since ``ordered=True`` raises on points
+    that share a cell.
+
+    Args:
+        xs: Point x-coordinates, with no coincident pairs.
+        ys: Point y-coordinates, aligned with ``xs``.
+
+    Returns:
+        list: One shapely geometry per input point, in input order.
+
+    Examples:
+        - Tessellate the four corners of a square into four cells:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.feature.tessellation import voronoi_cells
+            >>> cells = voronoi_cells(np.array([0.0, 2.0, 0.0, 2.0]), np.array([0.0, 0.0, 2.0, 2.0]))
+            >>> len(cells)
+            4
+            >>> all(cell.geom_type == "Polygon" for cell in cells)
+            True
+
+            ```
+    """
+    points = MultiPoint(np.column_stack([xs, ys]))
+    collection = voronoi_polygons(points, ordered=True)
+    return list(collection.geoms)
+
+
+def resolve_clip(clip: Any, target_crs: Any) -> Any:
+    """Resolve a clip boundary to a single geometry in ``target_crs``, or ``None``.
+
+    Accepts a ``FeatureCollection`` / geopandas ``GeoDataFrame`` / ``GeoSeries`` (reprojected to ``target_crs``
+    and unioned) or a shapely geometry (assumed already in ``target_crs``). ``None`` means no clip.
+
+    Args:
+        clip: A ``FeatureCollection`` / ``GeoDataFrame`` / ``GeoSeries`` (reprojected + unioned), a shapely
+            geometry already in ``target_crs``, or ``None``.
+        target_crs: The CRS the boundary is reprojected into before unioning.
+
+    Returns:
+        A single shapely geometry in ``target_crs``, or ``None`` when ``clip`` is ``None``.
+
+    Examples:
+        - Union a one-feature boundary into a single polygon:
+            ```python
+            >>> import geopandas as gpd
+            >>> from shapely.geometry import Point
+            >>> from pyramids.feature.tessellation import resolve_clip
+            >>> boundary = gpd.GeoDataFrame(geometry=[Point(0, 0).buffer(1.0)], crs="EPSG:4326")
+            >>> resolve_clip(boundary, "EPSG:4326").geom_type
+            'Polygon'
+
+            ```
+        - A ``None`` clip resolves to ``None``:
+            ```python
+            >>> from pyramids.feature.tessellation import resolve_clip
+            >>> resolve_clip(None, "EPSG:4326") is None
+            True
+
+            ```
+    """
+    boundary = None
+    if clip is not None:
+        if hasattr(clip, "to_crs"):
+            reprojected = clip.to_crs(target_crs)
+            geometry = reprojected.geometry if hasattr(reprojected, "geometry") else reprojected
+            boundary = geometry.union_all()
+        else:
+            boundary = clip
+    return boundary
+
+
+def resolve_reducer(agg: Any) -> Callable[..., Any]:
+    """Resolve a ``quadtree`` aggregation name (or callable) to a reducer.
+
+    Args:
+        agg: One of the names in :data:`QUADTREE_AGG`, or a callable taking a 1-D array.
+
+    Returns:
+        Callable: The reducer that maps a 1-D array of cell values to a scalar.
+
+    Raises:
+        ValueError: If ``agg`` is neither a known name nor a callable.
+
+    Examples:
+        - Resolve a named reducer and apply it:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.feature.tessellation import resolve_reducer
+            >>> reducer = resolve_reducer("sum")
+            >>> float(reducer(np.array([1.0, 2.0, 3.0])))
+            6.0
+
+            ```
+        - An unknown name raises ``ValueError``:
+            ```python
+            >>> from pyramids.feature.tessellation import resolve_reducer
+            >>> resolve_reducer("bogus")  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+                ...
+            ValueError: unknown agg 'bogus'; choose one of [...] or a callable
+
+            ```
+    """
+    if callable(agg):
+        reducer = agg
+    elif agg in QUADTREE_AGG:
+        reducer = QUADTREE_AGG[agg]
+    else:
+        raise ValueError(f"unknown agg {agg!r}; choose one of {sorted(QUADTREE_AGG)} or a callable")
+    return reducer
+
+
+def quadtree_cells(
+    xs: np.ndarray,
+    ys: np.ndarray,
+    agg_fn: Callable[[np.ndarray], float],
+    nmax: int,
+    nmin: int,
+    max_depth: int = 20,
+) -> list[tuple[float, float, float, float, float]]:
+    """Recursively split the points' bounding box into quadrants until each cell holds ``<= nmax`` points.
+
+    A cell with fewer than ``nmin`` points is dropped; splitting stops at ``max_depth`` and when a split makes
+    no progress (all points fall in one child), so coincident points cannot recurse forever.
+
+    Args:
+        xs: Finite point x-coordinates.
+        ys: Finite point y-coordinates, aligned with ``xs``.
+        agg_fn: Callable mapping an index array of the points in a cell to that cell's scalar value.
+        nmax: Maximum points in a cell before it is split (smaller → finer grid).
+        nmin: Cells with fewer than this many points are dropped.
+        max_depth: Hard recursion-depth cap guarding against coincident points. Default 20.
+
+    Returns:
+        list[tuple]: ``(xmin, ymin, xmax, ymax, value)`` for each kept cell.
+
+    Examples:
+        - Bin four corner points to one point per cell and read the per-cell counts:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.feature.tessellation import quadtree_cells
+            >>> xs = np.array([0.0, 2.0, 0.0, 2.0])
+            >>> ys = np.array([0.0, 0.0, 2.0, 2.0])
+            >>> cells = quadtree_cells(xs, ys, lambda idx: float(len(idx)), nmax=1, nmin=0)
+            >>> len(cells)
+            4
+            >>> sorted(round(cell[4]) for cell in cells)
+            [1, 1, 1, 1]
+
+            ```
+        - A loose ``nmax`` keeps every point in a single cell:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.feature.tessellation import quadtree_cells
+            >>> xs = np.array([0.0, 2.0, 0.0, 2.0])
+            >>> ys = np.array([0.0, 0.0, 2.0, 2.0])
+            >>> cells = quadtree_cells(xs, ys, lambda idx: float(len(idx)), nmax=100, nmin=0)
+            >>> len(cells)
+            1
+            >>> round(cells[0][4])
+            4
+
+            ```
+    """
+    x0, x1 = float(np.min(xs)), float(np.max(xs))
+    y0, y1 = float(np.min(ys)), float(np.max(ys))
+    if x1 <= x0:
+        x1 = x0 + 1.0
+    if y1 <= y0:
+        y1 = y0 + 1.0
+    out: list[tuple[float, float, float, float, float]] = []
+    stack = [(x0, y0, x1, y1, np.arange(len(xs)), 0)]
+    while stack:
+        xmin, ymin, xmax, ymax, idx, depth = stack.pop()
+        n = len(idx)
+        if n == 0:
+            continue
+        if n <= nmax or depth >= max_depth:
+            if n >= nmin:
+                out.append((xmin, ymin, xmax, ymax, float(agg_fn(idx))))
+            continue
+        xmid, ymid = 0.5 * (xmin + xmax), 0.5 * (ymin + ymax)
+        cx, cy = xs[idx], ys[idx]
+        quads = [
+            (xmin, ymin, xmid, ymid, idx[(cx <= xmid) & (cy <= ymid)]),
+            (xmid, ymin, xmax, ymid, idx[(cx > xmid) & (cy <= ymid)]),
+            (xmin, ymid, xmid, ymax, idx[(cx <= xmid) & (cy > ymid)]),
+            (xmid, ymid, xmax, ymax, idx[(cx > xmid) & (cy > ymid)]),
+        ]
+        nonempty = [q for q in quads if len(q[4]) > 0]
+        if len(nonempty) == 1 and len(nonempty[0][4]) == n:  # no progress (coincident points)
+            if n >= nmin:
+                out.append((xmin, ymin, xmax, ymax, float(agg_fn(idx))))
+            continue
+        for qx0, qy0, qx1, qy1, qidx in quads:
+            stack.append((qx0, qy0, qx1, qy1, qidx, depth + 1))
+    return out

--- a/tests/feature/test_tessellation.py
+++ b/tests/feature/test_tessellation.py
@@ -9,6 +9,7 @@ from shapely.geometry import (
     MultiPolygon,
     Point,
     Polygon,
+    box,
 )
 
 from pyramids.base._errors import InvalidGeometryError
@@ -123,6 +124,20 @@ class TestVoronoi:
     def test_missing_values_column_raises(self, point_fc: FeatureCollection) -> None:
         with pytest.raises(ValueError, match="not found"):
             point_fc.voronoi(values="nope")
+
+    def test_clip_splitting_cell_duplicates_value(self) -> None:
+        corners = FeatureCollection(
+            gpd.GeoDataFrame(
+                {"v": [100, 200, 300, 400]},
+                geometry=[Point(0, 0), Point(10, 0), Point(0, 10), Point(10, 10)],
+                crs="EPSG:32618",
+            )
+        )
+        two_boxes = MultiPolygon([box(1, 1, 2, 2), box(3, 3, 4, 4)])
+        clip = FeatureCollection(gpd.GeoDataFrame(geometry=[two_boxes], crs="EPSG:32618"))
+        cells = corners.voronoi(values="v", clip=clip)
+        assert len(cells) == 2, "the two clip boxes both fall in one Voronoi cell, splitting it in two"
+        assert cells["v"].tolist() == [100, 100], "both split parts carry the source point's value"
 
 
 class TestQuadtree:

--- a/tests/feature/test_tessellation.py
+++ b/tests/feature/test_tessellation.py
@@ -211,8 +211,8 @@ class TestTessellationHelpers:
     def test_point_xy_drops_non_finite(self) -> None:
         series = gpd.GeoSeries([Point(float("inf"), 0), Point(2, 3), Point(4, 5)])
         xs, ys, keep = tess.point_xy(series)
-        assert xs.tolist() == [2.0, 4.0]
-        assert ys.tolist() == [3.0, 5.0]
+        assert xs.tolist() == pytest.approx([2.0, 4.0])
+        assert ys.tolist() == pytest.approx([3.0, 5.0])
         assert keep.tolist() == [1, 2]
 
     def test_polygon_parts_explodes_multipolygon(self) -> None:

--- a/tests/feature/test_tessellation.py
+++ b/tests/feature/test_tessellation.py
@@ -206,6 +206,11 @@ class TestQuadtree:
         with pytest.raises(ValueError, match="not found"):
             point_fc.quadtree(column="nope")
 
+    @pytest.mark.parametrize("nmax", [0, -1])
+    def test_nmax_below_one_raises(self, point_fc: FeatureCollection, nmax: int) -> None:
+        with pytest.raises(ValueError, match="nmax must be >= 1"):
+            point_fc.quadtree(nmax=nmax)
+
 
 class TestTessellationHelpers:
     def test_point_xy_drops_non_finite(self) -> None:

--- a/tests/feature/test_tessellation.py
+++ b/tests/feature/test_tessellation.py
@@ -1,0 +1,243 @@
+"""Tests for FeatureCollection tessellation/binning ops (voronoi, quadtree)."""
+
+import geopandas as gpd
+import numpy as np
+import pytest
+from shapely.geometry import (
+    GeometryCollection,
+    MultiPoint,
+    MultiPolygon,
+    Point,
+    Polygon,
+)
+
+from pyramids.base._errors import InvalidGeometryError
+from pyramids.feature import FeatureCollection
+from pyramids.feature import tessellation as tess
+
+
+@pytest.fixture()
+def point_fc() -> FeatureCollection:
+    """Nine points on a 3x3 grid in a projected CRS, with a value column ``v``."""
+    coords = [(x, y) for y in (0.0, 2.0, 4.0) for x in (0.0, 2.0, 4.0)]
+    return FeatureCollection(
+        gpd.GeoDataFrame(
+            {"v": list(range(1, 10))},
+            geometry=[Point(x, y) for x, y in coords],
+            crs="EPSG:32618",
+        )
+    )
+
+
+@pytest.fixture()
+def boundary_fc() -> FeatureCollection:
+    """A square boundary covering the lower-left quadrant of the point grid."""
+    square = Point(0.0, 0.0).buffer(2.5).envelope
+    return FeatureCollection(gpd.GeoDataFrame(geometry=[square], crs="EPSG:32618"))
+
+
+class TestVoronoi:
+    def test_one_cell_per_point(self, point_fc: FeatureCollection) -> None:
+        cells = point_fc.voronoi()
+        assert isinstance(cells, FeatureCollection)
+        assert len(cells) == len(point_fc)
+        assert cells.crs.to_epsg() == 32618
+        assert set(cells.geom_type.unique()) == {"Polygon"}
+
+    def test_values_carried_to_containing_cell(self, point_fc: FeatureCollection) -> None:
+        cells = point_fc.voronoi(values="v")
+        assert "v" in cells.columns
+        assert sorted(cells["v"].tolist()) == list(range(1, 10))
+        # each point falls inside the cell carrying its own value
+        for _, point_row in point_fc.iterrows():
+            match = cells[cells.contains(point_row.geometry)]
+            assert match["v"].tolist() == [point_row["v"]]
+
+    def test_clip_shrinks_cells(self, point_fc: FeatureCollection, boundary_fc: FeatureCollection) -> None:
+        full = point_fc.voronoi()
+        clipped = point_fc.voronoi(clip=boundary_fc)
+        assert clipped.area.sum() < full.area.sum()
+        boundary = boundary_fc.geometry.union_all()
+        assert clipped.geometry.apply(lambda g: g.within(boundary.buffer(1e-6))).all()
+
+    def test_reprojected_clip(self, point_fc: FeatureCollection, boundary_fc: FeatureCollection) -> None:
+        clip_wgs84 = FeatureCollection(boundary_fc.to_crs(4326))
+        clipped = point_fc.voronoi(clip=clip_wgs84)
+        assert clipped.crs.to_epsg() == 32618
+        assert clipped.area.sum() < point_fc.voronoi().area.sum()
+
+    def test_non_point_raises(self) -> None:
+        polys = FeatureCollection(
+            gpd.GeoDataFrame(geometry=[Point(0, 0).buffer(1.0)], crs="EPSG:32618")
+        )
+        with pytest.raises(InvalidGeometryError):
+            polys.voronoi()
+
+    def test_single_point_raises(self) -> None:
+        single = FeatureCollection(
+            gpd.GeoDataFrame({"v": [1]}, geometry=[Point(0, 0)], crs="EPSG:32618")
+        )
+        with pytest.raises(InvalidGeometryError):
+            single.voronoi()
+
+    def test_empty_raises(self) -> None:
+        empty = FeatureCollection(gpd.GeoDataFrame({"geometry": []}, crs="EPSG:32618"))
+        with pytest.raises(InvalidGeometryError):
+            empty.voronoi()
+
+    def test_multipoint_rejected(self) -> None:
+        mp = FeatureCollection(
+            gpd.GeoDataFrame(geometry=[MultiPoint([(0, 0), (1, 1)])], crs="EPSG:32618")
+        )
+        with pytest.raises(InvalidGeometryError):
+            mp.voronoi()
+
+    def test_duplicate_point_skipped(self) -> None:
+        fc = FeatureCollection(
+            gpd.GeoDataFrame(
+                {"v": [1, 2, 3, 4, 5]},
+                geometry=[Point(0, 0), Point(0, 0), Point(2, 0), Point(0, 2), Point(2, 2)],
+                crs="EPSG:32618",
+            )
+        )
+        cells = fc.voronoi(values="v")
+        assert len(cells) == 4, f"duplicate point should yield one empty cell, got {len(cells)} cells"
+
+    def test_collinear_points_do_not_crash(self) -> None:
+        fc = FeatureCollection(
+            gpd.GeoDataFrame(
+                geometry=[Point(0, 0), Point(1, 0), Point(2, 0)], crs="EPSG:32618"
+            )
+        )
+        cells = fc.voronoi()
+        assert len(cells) >= 1, "collinear points should still tessellate into at least one cell"
+        assert set(cells.geom_type.unique()) == {"Polygon"}
+
+    def test_clip_excluding_all_cells_is_empty(self, point_fc: FeatureCollection) -> None:
+        far = Point(1000.0, 1000.0).buffer(1.0).envelope
+        clip = FeatureCollection(gpd.GeoDataFrame(geometry=[far], crs="EPSG:32618"))
+        cells = point_fc.voronoi(clip=clip)
+        assert len(cells) == 0, f"a disjoint clip should exclude every cell, got {len(cells)}"
+        assert cells.crs.to_epsg() == 32618
+
+
+class TestQuadtree:
+    def test_count_density(self, point_fc: FeatureCollection) -> None:
+        cells = point_fc.quadtree(nmax=1)
+        assert isinstance(cells, FeatureCollection)
+        assert "count" in cells.columns
+        assert int(cells["count"].sum()) == len(point_fc)
+        assert cells.crs.to_epsg() == 32618
+
+    def test_nmax_controls_resolution(self, point_fc: FeatureCollection) -> None:
+        fine = point_fc.quadtree(nmax=1)
+        coarse = point_fc.quadtree(nmax=100)
+        assert len(fine) > len(coarse)
+        assert len(coarse) == 1
+
+    @pytest.mark.parametrize("agg", ["mean", "sum", "median", "min", "max", "std", "count"])
+    def test_named_reducers(self, point_fc: FeatureCollection, agg: str) -> None:
+        cells = point_fc.quadtree(column="v", agg=agg, nmax=100)
+        assert len(cells) == 1
+        expected = {
+            "mean": 5.0,
+            "sum": 45.0,
+            "median": 5.0,
+            "min": 1.0,
+            "max": 9.0,
+            "std": float(np.std(range(1, 10))),
+            "count": 9.0,
+        }[agg]
+        assert cells["v"].iloc[0] == pytest.approx(expected)
+
+    def test_callable_reducer(self, point_fc: FeatureCollection) -> None:
+        cells = point_fc.quadtree(column="v", agg=lambda a: float(a.size), nmax=100)
+        assert cells["v"].iloc[0] == pytest.approx(9.0)
+
+    def test_nmin_drops_sparse_cells(self, point_fc: FeatureCollection) -> None:
+        cells = point_fc.quadtree(nmax=1, nmin=2)
+        assert len(cells) == 0
+
+    def test_clip_intersection(self, point_fc: FeatureCollection, boundary_fc: FeatureCollection) -> None:
+        clipped = point_fc.quadtree(nmax=1, clip=boundary_fc)
+        boundary = boundary_fc.geometry.union_all()
+        assert clipped.geometry.apply(lambda g: g.within(boundary.buffer(1e-6))).all()
+
+    def test_unknown_agg_raises(self, point_fc: FeatureCollection) -> None:
+        with pytest.raises(ValueError):
+            point_fc.quadtree(column="v", agg="bogus")
+
+    def test_non_point_raises(self) -> None:
+        polys = FeatureCollection(
+            gpd.GeoDataFrame(geometry=[Point(0, 0).buffer(1.0)], crs="EPSG:32618")
+        )
+        with pytest.raises(InvalidGeometryError):
+            polys.quadtree()
+
+    def test_callable_agg_returning_nan(self, point_fc: FeatureCollection) -> None:
+        cells = point_fc.quadtree(column="v", agg=lambda a: float("nan"), nmax=100)
+        assert len(cells) == 1
+        assert np.isnan(cells["v"].iloc[0]), "a NaN-returning reducer should propagate NaN to the cell"
+
+    def test_clip_excluding_all_cells_is_empty(self, point_fc: FeatureCollection) -> None:
+        far = Point(1000.0, 1000.0).buffer(1.0).envelope
+        clip = FeatureCollection(gpd.GeoDataFrame(geometry=[far], crs="EPSG:32618"))
+        cells = point_fc.quadtree(nmax=1, clip=clip)
+        assert len(cells) == 0, f"a disjoint clip should exclude every cell, got {len(cells)}"
+
+    def test_single_point_bins_to_one_cell(self) -> None:
+        single = FeatureCollection(
+            gpd.GeoDataFrame({"v": [7]}, geometry=[Point(5, 5)], crs="EPSG:32618")
+        )
+        cells = single.quadtree()
+        assert len(cells) == 1
+        assert int(cells["count"].iloc[0]) == 1
+
+    def test_empty_raises(self) -> None:
+        empty = FeatureCollection(gpd.GeoDataFrame({"geometry": []}, crs="EPSG:32618"))
+        with pytest.raises(InvalidGeometryError):
+            empty.quadtree()
+
+
+class TestTessellationHelpers:
+    def test_point_xy_drops_non_finite(self) -> None:
+        series = gpd.GeoSeries([Point(float("inf"), 0), Point(2, 3), Point(4, 5)])
+        xs, ys, keep = tess.point_xy(series)
+        assert xs.tolist() == [2.0, 4.0]
+        assert ys.tolist() == [3.0, 5.0]
+        assert keep.tolist() == [1, 2]
+
+    def test_polygon_parts_explodes_multipolygon(self) -> None:
+        mp = MultiPolygon(
+            [Point(0, 0).buffer(1.0).envelope, Point(10, 10).buffer(1.0).envelope]
+        )
+        parts = tess.polygon_parts(mp)
+        assert len(parts) == 2
+        assert all(p.geom_type == "Polygon" for p in parts)
+
+    def test_polygon_parts_filters_non_polygon_from_collection(self) -> None:
+        collection = GeometryCollection([Point(0, 0), Point(0, 0).buffer(1.0).envelope])
+        parts = tess.polygon_parts(collection)
+        assert [p.geom_type for p in parts] == ["Polygon"]
+
+    def test_polygon_parts_none_and_empty(self) -> None:
+        assert tess.polygon_parts(None) == []
+        assert tess.polygon_parts(Polygon()) == []
+
+    def test_resolve_clip_passthrough_shapely(self) -> None:
+        geom = Point(0, 0).buffer(1.0)
+        assert tess.resolve_clip(geom, "EPSG:4326") is geom
+
+    def test_resolve_clip_none(self) -> None:
+        assert tess.resolve_clip(None, "EPSG:4326") is None
+
+    def test_resolve_reducer_callable_passthrough(self) -> None:
+        fn = np.nanmax
+        assert tess.resolve_reducer(fn) is fn
+
+    def test_quadtree_cells_degenerate_extent(self) -> None:
+        xs = np.array([5.0, 5.0])
+        ys = np.array([5.0, 5.0])
+        cells = tess.quadtree_cells(xs, ys, lambda idx: float(len(idx)), nmax=1, nmin=0)
+        assert len(cells) == 1, "coincident points must not recurse forever"
+        assert cells[0][4] == pytest.approx(2.0)

--- a/tests/feature/test_tessellation.py
+++ b/tests/feature/test_tessellation.py
@@ -248,6 +248,22 @@ class TestTessellationHelpers:
         parts = tess.polygon_parts(collection)
         assert [p.geom_type for p in parts] == ["Polygon"]
 
+    def test_polygon_parts_flattens_nested_multipolygon(self) -> None:
+        nested = GeometryCollection(
+            [Point(5, 5), MultiPolygon([box(0, 0, 1, 1), box(2, 2, 3, 3)])]
+        )
+        parts = tess.polygon_parts(nested)
+        assert [p.geom_type for p in parts] == ["Polygon", "Polygon"]
+        assert sorted(p.area for p in parts) == pytest.approx([1.0, 1.0])
+
+    def test_dedupe_xy_keeps_first_occurrence(self) -> None:
+        xs = np.array([0.0, 2.0, 0.0, 2.0, 4.0])
+        ys = np.array([0.0, 0.0, 0.0, 0.0, 1.0])
+        ux, uy, keep = tess.dedupe_xy(xs, ys)
+        assert keep.tolist() == [0, 1, 4]
+        assert ux.tolist() == pytest.approx([0.0, 2.0, 4.0])
+        assert uy.tolist() == pytest.approx([0.0, 0.0, 1.0])
+
     def test_polygon_parts_none_and_empty(self) -> None:
         assert tess.polygon_parts(None) == []
         assert tess.polygon_parts(Polygon()) == []

--- a/tests/feature/test_tessellation.py
+++ b/tests/feature/test_tessellation.py
@@ -120,6 +120,10 @@ class TestVoronoi:
         assert len(cells) == 0, f"a disjoint clip should exclude every cell, got {len(cells)}"
         assert cells.crs.to_epsg() == 32618
 
+    def test_missing_values_column_raises(self, point_fc: FeatureCollection) -> None:
+        with pytest.raises(ValueError, match="not found"):
+            point_fc.voronoi(values="nope")
+
 
 class TestQuadtree:
     def test_count_density(self, point_fc: FeatureCollection) -> None:
@@ -197,6 +201,10 @@ class TestQuadtree:
         empty = FeatureCollection(gpd.GeoDataFrame({"geometry": []}, crs="EPSG:32618"))
         with pytest.raises(InvalidGeometryError):
             empty.quadtree()
+
+    def test_missing_column_raises(self, point_fc: FeatureCollection) -> None:
+        with pytest.raises(ValueError, match="not found"):
+            point_fc.quadtree(column="nope")
 
 
 class TestTessellationHelpers:


### PR DESCRIPTION
# Description

Add two general-purpose vector primitives to `FeatureCollection`, backed by a new
`pyramids.feature.tessellation` module:

- **`voronoi(values=None, clip=None)`** — Voronoi/Thiessen tessellation. Returns one polygon per distinct
  input point, ordered so cell *i* corresponds to the *i*-th distinct point
  (`shapely.voronoi_polygons(ordered=True)`). Coincident points are de-duplicated before tessellation
  (shapely's ordered tessellation raises on shared cells); the optional `values` column is carried onto each
  cell, and `clip` intersects each cell with a boundary.
- **`quadtree(column=None, agg="mean", nmax=100, nmin=0, clip=None)`** — adaptive quad-tree binning. Recursively
  splits the points' bounding box until each cell holds `<= nmax` points, then attaches a per-cell aggregate of
  `column` (or the point count when `column is None`). Supports the named reducers
  `mean/sum/median/min/max/std/count` or a callable, `nmin` cell filtering, and `clip`.

Both return a `FeatureCollection` of polygons in the input CRS, so they compose with the rest of the vector
API. Non-point inputs raise `InvalidGeometryError`.

These are scope-aligned generic GIS primitives (`docs/SCOPE.md` §4: the `feature/` module is the
fiona/geopandas niche, fully in scope) that downstream consumers previously had to fork with raw `shapely`.

**Dependency:** bumps the floor to `Shapely >=2.1.0` for the `voronoi_polygons(ordered=True)` keyword.

# Issues
- Fixes #521

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

`tests/feature/test_tessellation.py` adds 37 tests plus 7 module doctests:

- [x] voronoi: one cell per distinct point, value carry-through to the containing cell, clip intersection
      (incl. reprojected and all-excluding clips), duplicate/collinear points, MultiPoint/non-point/empty/
      single-point rejection.
- [x] quadtree: count density, `nmax` resolution control, every named reducer + a callable (incl. NaN),
      `nmin` filtering, clip intersection, single-point binning, empty rejection.
- [x] helper-level tests for `point_xy`, `polygon_parts`, `resolve_clip`, `resolve_reducer`, `dedupe_xy`,
      `quadtree_cells` (degenerate extent / coincident points).

Run: `pixi run -e dev pytest tests/feature/test_tessellation.py`. Regression sweep over the feature suite
(193 tests) passes.

# Checklist:

- [ ] updated version number in pyproject.toml. (handled by commitizen/CI)
- [ ] added changes to History.rst. (changelog is commitizen-generated)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.
