### PR TITLE
fix(netcdf): release the GDAL handle on close() so the file unlocks immediately (#564)

### DIFF
--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -6,6 +6,7 @@ netcdf contains python functions to handle netcdf data. gdal class: https://gdal
 
 from __future__ import annotations
 
+import gc
 import itertools
 import math
 import os
@@ -495,6 +496,50 @@ class NetCDF(Dataset):
         self._variable_attrs: dict[str, Any] = {}
         self._scale: float | None = None
         self._offset: float | None = None
+
+    def close(self) -> None:
+        """Release every GDAL handle this container holds, then close the base.
+
+        A NetCDF container keeps more open GDAL references than the single
+        ``self._raster`` that :meth:`Dataset.close` drops:
+
+        * cached per-variable child objects (:attr:`_cached_variables`), each
+          with its own ``_raster`` and SWIG MDArray / root-group references;
+        * the ``_gdal_md_arr_ref`` / ``_gdal_rg_ref`` views that keep an
+          extracted variable's C++ backing alive;
+        * ``_gdal_classic_src_ref`` (the source kept alive behind a
+          geostationary VRT);
+        * the ``_parent_nc`` back-reference forming a refcount cycle with the
+          parent's variable cache.
+
+        This override closes the cached children and drops every extra reference
+        before deferring to :meth:`Dataset.close`. It then runs a single
+        :func:`gc.collect`: a spatial op (``crop`` / ``to_crs`` / ``reduce``)
+        extracts variables whose ``AsClassicDataset`` view, MDArray and root
+        group form a **reference cycle among the GDAL SWIG wrappers** that plain
+        refcounting cannot reclaim. Without the collect those wrappers keep the
+        source file open, so on Windows a later ``os.replace`` / ``os.remove``
+        fails with ``PermissionError`` until the caller forces a GC themselves
+        (#564). Doing it here makes ``close()`` honour its contract — the file is
+        unlocked immediately. Safe to call more than once.
+        """
+        cached = self._cached_variables
+        if cached is not None:
+            # Only the materialised children (bypass the lazy dict's loading
+            # ``values()`` so closing does not force every variable open).
+            for child in dict.values(cached):
+                if isinstance(child, Dataset):
+                    child.close()
+            self._cached_variables = None
+        self._gdal_md_arr_ref = None
+        self._gdal_rg_ref = None
+        self._gdal_classic_src_ref = None
+        self._parent_nc = None
+        self._cached_meta_data = None
+        super().close()
+        # Break the GDAL SWIG view/MDArray/root-group cycle left by variable
+        # extraction so the source file is released now, not on the next GC.
+        gc.collect()
 
     def _update_inplace(  # type: ignore[override]
         self, src: gdal.Dataset, access: str | None = None

--- a/tests/netcdf/test_close_handle_release.py
+++ b/tests/netcdf/test_close_handle_release.py
@@ -1,0 +1,81 @@
+"""Regression tests for #564 — ``NetCDF.close()`` releases the GDAL handle.
+
+A spatial op (``crop`` / ``to_crs`` / ``reduce``) extracts per-variable views
+whose GDAL SWIG wrappers (``AsClassicDataset`` view + MDArray + root group) form
+a reference cycle that plain refcounting cannot reclaim. Before the fix the
+source file stayed open after ``close()`` and a Windows ``os.replace`` /
+``os.remove`` raised ``PermissionError`` until the caller forced a
+``gc.collect()``. ``close()`` now breaks that cycle itself.
+
+These assert the file is unlocked immediately after ``close()`` — **no caller
+gc.collect()**. On POSIX, replacing an open file is allowed regardless, so the
+assertions pass there too; the meaningful coverage is on Windows.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import warnings
+
+import geopandas as gpd
+import shapely
+
+from pyramids.netcdf import NetCDF
+
+ERA5 = "tests/data/netcdf/era5_cds_beta_t2m_jan2022.nc"
+_MASK = gpd.GeoDataFrame(
+    geometry=[shapely.geometry.box(-75.0, 4.2, -74.0, 4.8)], crs="EPSG:4326"
+)
+
+
+class TestCloseHandleRelease:
+    """``close()`` unlocks the source file without a caller-side gc.collect()."""
+
+    def test_replace_after_crop_to_file_close(self, tmp_path):
+        """read -> crop -> write sibling -> close -> os.replace over the original.
+
+        The exact read-modify-atomic-replace idiom from #564.
+        """
+        target = tmp_path / "cube.nc"
+        shutil.copy(ERA5, target)
+        out = tmp_path / "cube.masked.nc"
+
+        cube = NetCDF.read_file(str(target))
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")  # #565: string aux var warn-and-drop
+            masked = cube.crop(mask=_MASK, touch=True)
+            masked.to_file(str(out))
+        cube.close()
+        masked.close()
+
+        os.replace(out, target)  # PermissionError on Windows before the fix
+        assert target.exists(), "atomic replace over the original must succeed"
+
+    def test_remove_after_crop_close(self, tmp_path):
+        """A cropped container's source can be deleted right after close()."""
+        target = tmp_path / "cube.nc"
+        shutil.copy(ERA5, target)
+
+        cube = NetCDF.read_file(str(target))
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            cube.crop(mask=_MASK, touch=True)
+        cube.close()
+
+        os.remove(target)  # locked on Windows before the fix
+        assert not target.exists(), "source file must be removable after close()"
+
+    def test_remove_after_reduce_close(self, tmp_path):
+        """The reduce fan-out also leaves no lingering source handle after close()."""
+        target = tmp_path / "cube.nc"
+        shutil.copy(ERA5, target)
+
+        cube = NetCDF.read_file(str(target))
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            cube.reduce("valid_time", "mean")
+        cube.close()
+
+        os.remove(target)
+        assert not target.exists(), "source file must be removable after reduce+close"


### PR DESCRIPTION
# Description

On Windows, `NetCDF.close()` did not release the underlying GDAL handle, so the source file stayed locked: a
subsequent `os.replace(...)` / `os.remove(...)` raised `PermissionError: [WinError 5]` until the caller forced
a `gc.collect()`. This broke the common read → transform → write-sibling-temp → atomically-replace idiom
(e.g. earthlens' ECMWF polygon masking).

Root cause: a spatial op (`crop` / `to_crs` / `reduce`) extracts per-variable views whose GDAL SWIG wrappers —
the `AsClassicDataset` view, its MDArray, and the root group — form a **reference cycle** that plain
refcounting cannot reclaim. The inherited `Dataset.close()` only nulls `self._raster`, leaving those wrappers
(and the open file) alive until the next cyclic GC.

Fix: override `NetCDF.close()` to

- close cached per-variable children (`_cached_variables`),
- drop the SWIG references (`_gdal_md_arr_ref`, `_gdal_rg_ref`, `_gdal_classic_src_ref`) and the `_parent_nc`
  back-reference, then
- defer to `Dataset.close()` and run a single `gc.collect()` to break the residual SWIG cycle.

`close()` now unlocks the source file immediately — no caller-side `gc.collect()` needed. No dependency
changes.

# Issues
- Fixes #564

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- New regression suite `tests/netcdf/test_close_handle_release.py`: the crop → to_file → close → `os.replace`
  idiom from the issue, plus crop → close → `os.remove` and reduce → close → `os.remove`, all asserting the
  source unlocks after `close()` with **no caller gc.collect()**.
- Verified the bug reproduces on the unpatched code and is gone with the fix (the exact issue reproduction
  script, on the real `era5_cds_beta_t2m_jan2022.nc` fixture). Confirmed the `gc.collect()` is load-bearing:
  the reference-drops alone leave the file locked.

Reproduce locally:

```
pixi run -e dev pytest tests/netcdf/test_close_handle_release.py
```

- [x] Test A — `tests/netcdf/test_close_handle_release.py` (3 tests) pass.
- [x] Test B — full `tests/netcdf` suite (`-m "not slow and not vfs and not plot"`) → 1266 passed, 2 skipped,
  no regressions.

# Checklist:

- [ ] updated version number in pyproject.toml. (handled by commitizen in CI)
- [ ] added changes to History.rst. (changelog is commitizen-generated)
- [ ] updated the latest version in README file. (handled in the release flow)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated. (internal handle-lifecycle fix; no user-facing API change)
