### PR TITLE
fix(netcdf): carry string aux variables through container spatial ops

### DIFF
--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4312,18 +4312,27 @@ class NetCDF(Dataset):
     def _add_md_array_to_group(dst_group, var_name, src_mdarray):
         """Copy an MDArray from one group to another, preserving data and metadata."""
         src_dims = src_mdarray.GetDimensions()
-        arr = src_mdarray.ReadAsArray()
-        dtype = gdal.ExtendedDataType.Create(numpy_to_gdal_dtype(arr))
-        new_md_array = dst_group.CreateMDArray(var_name, src_dims, dtype)
-        new_md_array.Write(arr)
-        ndv = src_mdarray.GetNoDataValue()
-        if ndv is not None:
-            try:
-                new_md_array.SetNoDataValueDouble(ndv)
-            except Exception:
-                pass
-
-        new_md_array.SetSpatialRef(src_mdarray.GetSpatialRef())
+        if src_mdarray.GetDataType().GetClass() == gdal.GEDTC_STRING:
+            # String MDArrays can't go through ReadAsArray (numpy) in the GDAL
+            # SWIG bindings, but the Python list Read()/Write() path works. Use it
+            # so non-spatial string aux vars (e.g. ERA5's 'expver') are carried
+            # through container spatial ops instead of being dropped (#565).
+            new_md_array = dst_group.CreateMDArray(
+                var_name, src_dims, gdal.ExtendedDataType.CreateString()
+            )
+            new_md_array.Write(src_mdarray.Read())
+        else:
+            arr = src_mdarray.ReadAsArray()
+            dtype = gdal.ExtendedDataType.Create(numpy_to_gdal_dtype(arr))
+            new_md_array = dst_group.CreateMDArray(var_name, src_dims, dtype)
+            new_md_array.Write(arr)
+            ndv = src_mdarray.GetNoDataValue()
+            if ndv is not None:
+                try:
+                    new_md_array.SetNoDataValueDouble(ndv)
+                except Exception:
+                    pass
+            new_md_array.SetSpatialRef(src_mdarray.GetSpatialRef())
 
     @staticmethod
     def _get_or_create_dimension(

--- a/tests/netcdf/test_crop_string_aux.py
+++ b/tests/netcdf/test_crop_string_aux.py
@@ -1,0 +1,86 @@
+"""Regression tests for #565 — string non-spatial aux vars survive spatial ops.
+
+ERA5's ``expver`` (dtype ``<U4``, dim ``valid_time``) was dropped with a
+``UserWarning`` by ``crop`` / ``to_crs`` / ``reduce`` because the GDAL SWIG
+bindings cannot ``ReadAsArray`` a string MDArray. The carry path now copies
+string variables via the Python-list ``Read()`` / ``Write()`` path, so they are
+carried through container spatial ops unchanged.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import geopandas as gpd
+import numpy as np
+import shapely
+from osgeo import gdal
+
+from pyramids.netcdf import NetCDF
+
+ERA5 = "tests/data/netcdf/era5_cds_beta_t2m_jan2022.nc"
+_MASK = gpd.GeoDataFrame(
+    geometry=[shapely.geometry.box(-75.0, 4.2, -74.0, 4.8)], crs="EPSG:4326"
+)
+
+
+def _read_expver(nc: NetCDF) -> list:
+    return nc._raster.GetRootGroup().OpenMDArray("expver").Read()
+
+
+class TestCropStringAux:
+    """A string aux var is carried through ``crop`` (no warn-and-drop)."""
+
+    def test_crop_carries_string_aux_without_warning(self):
+        """crop keeps ``expver`` with its values intact and emits no drop warning."""
+        cube = NetCDF.read_file(ERA5)
+        source_expver = _read_expver(cube)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            masked = cube.crop(mask=_MASK, touch=True)
+        try:
+            assert "expver" in masked.variable_names, "string aux var must survive crop"
+            assert _read_expver(masked) == source_expver, "carried values must match"
+            dropped = [str(w.message) for w in caught if "could not carry" in str(w.message)]
+            assert not dropped, f"expected no drop warning, got: {dropped}"
+        finally:
+            cube.close()
+            masked.close()
+
+
+class TestAddMdArrayString:
+    """`_add_md_array_to_group` copies a string MDArray via the Read/Write path."""
+
+    def test_string_md_array_is_copied(self):
+        """A string MDArray round-trips through `_add_md_array_to_group`."""
+        values = ["0001", "0001", "0005"]
+        src = gdal.GetDriverByName("MEM").CreateMultiDimensional("src")
+        src_rg = src.GetRootGroup()
+        dim = src_rg.CreateDimension("t", "", "", len(values))
+        src_md = src_rg.CreateMDArray("expver", [dim], gdal.ExtendedDataType.CreateString())
+        src_md.Write(values)
+
+        dst = gdal.GetDriverByName("MEM").CreateMultiDimensional("dst")
+        dst_rg = dst.GetRootGroup()
+        NetCDF._add_md_array_to_group(dst_rg, "expver", src_md)
+
+        copied = dst_rg.OpenMDArray("expver")
+        assert copied.GetDataType().GetClass() == gdal.GEDTC_STRING, "dtype preserved"
+        assert copied.Read() == values, "string values preserved"
+
+    def test_numeric_md_array_still_copied(self):
+        """The numeric path is unchanged: values and NoData carry over."""
+        arr = np.array([0, 0, 1, 1], dtype="i4")
+        src = gdal.GetDriverByName("MEM").CreateMultiDimensional("src")
+        src_rg = src.GetRootGroup()
+        dim = src_rg.CreateDimension("t", "", "", arr.size)
+        src_md = src_rg.CreateMDArray(
+            "number", [dim], gdal.ExtendedDataType.Create(gdal.GDT_Int32)
+        )
+        src_md.Write(arr)
+
+        dst = gdal.GetDriverByName("MEM").CreateMultiDimensional("dst")
+        dst_rg = dst.GetRootGroup()
+        NetCDF._add_md_array_to_group(dst_rg, "number", src_md)
+
+        np.testing.assert_array_equal(dst_rg.OpenMDArray("number").ReadAsArray(), arr)


### PR DESCRIPTION
# Description

A non-spatial **string** aux variable (e.g. ERA5's `expver`, dtype `<U4`, dim `valid_time`) was dropped from
the result by `NetCDF.crop` / `to_crs` / `reduce`, with a `UserWarning`:

```
crop() could not carry 1 non-spatial variable(s) ('expver') into the result:
'expver': String buffer data type not supported in SWIG bindings
```

`_add_md_array_to_group` copied variables via `ReadAsArray` (numpy), which the GDAL SWIG bindings reject for
string MDArrays. #514 carried the **numeric** aux case; string aux vars still fell through to warn-and-drop.

GDAL can read and write string MDArrays via the Python-list `Read()` / `Write()` path — only the numpy
`ReadAsArray` is unsupported. The fix detects a string datatype in `_add_md_array_to_group` and copies through
that path, so string aux variables are carried through container spatial ops **unchanged** instead of dropped.
Every real CDS ERA5 NetCDF ships `expver`, so any ERA5 polygon crop now preserves it.

No dependency changes.

# Issues
- Fixes #565

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- New `tests/netcdf/test_crop_string_aux.py`:
  - integration — cropping the real `era5_cds_beta_t2m_jan2022.nc` keeps `expver` with its values intact and
    emits no drop warning;
  - unit — `_add_md_array_to_group` copies a string MDArray (dtype + values preserved) and still copies the
    numeric case (values + NoData).
- Verified the round-trip: a cropped cube's `expver` survives `to_file` and reads back with the right values.

Reproduce locally:

```
pixi run -e dev pytest tests/netcdf/test_crop_string_aux.py
```

- [x] Test A — `tests/netcdf/test_crop_string_aux.py` (3 tests) pass.
- [x] Test B — full `tests/netcdf` suite (`-m "not slow and not vfs and not plot"`) → 1269 passed, 2 skipped,
  no regressions.

# Checklist:

- [ ] updated version number in pyproject.toml. (handled by commitizen in CI)
- [ ] added changes to History.rst. (changelog is commitizen-generated)
- [ ] updated the latest version in README file. (handled in the release flow)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated. (internal carry-path fix; no user-facing API change)
