### PR TITLE
fix(dataset): array_to_map_coordinates honours non-square and rotated grids

### DIFF
--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -234,7 +234,7 @@ class RasterBase(ABC):
         exact affine :attr:`transform`, so non-square pixels and rotated
         grids are handled; scalar input returns scalars, sequence input
         returns lists. (For point-table workflows use the cell engine's
-        :meth:`array_to_map_coordinates`, which assumes square pixels.)
+        :meth:`array_to_map_coordinates`, which is also affine-exact.)
 
         Args:
             rows: Row index (or indices) of the cell(s).
@@ -312,8 +312,10 @@ class RasterBase(ABC):
         inverse affine :attr:`transform`, so non-square pixels and rotated
         grids are handled; scalar input returns scalar ints, sequence input
         returns index arrays. (For point-table workflows use the cell
-        engine's :meth:`map_to_array_coordinates`, which assumes square
-        pixels.)
+        engine's :meth:`map_to_array_coordinates`, which handles non-square
+        pixels via the per-axis coordinate arrays but matches the nearest
+        cell rather than inverting the affine, so it does not resolve
+        rotated grids.)
 
         Args:
             x: X (longitude/easting) coordinate(s).

--- a/src/pyramids/dataset/engines/cell.py
+++ b/src/pyramids/dataset/engines/cell.py
@@ -17,6 +17,7 @@ from hpc.indexing import get_indices2, locate_values
 from pandas import DataFrame
 
 from pyramids.dataset.engines._base import _Engine
+from pyramids.dataset.transform import GeoTransform
 from pyramids.feature import FeatureCollection, create_points, create_polygon
 
 
@@ -434,17 +435,24 @@ class Cell(_Engine):
               ([0.1, 0.2, 0.3], [-0.05, -0.15, -0.25])
 
               ```
+
+        Notes:
+            The conversion is affine-exact: it applies the full geotransform
+            (per-axis pixel sizes and the rotation terms), so it is correct on
+            non-square and rotated grids rather than assuming square pixels.
         """
-        top_left_x, top_left_y = self._ds.top_left_corner
-        cell_size = self._ds.cell_size
-        if center:
-            top_left_x += cell_size / 2
-            top_left_y -= cell_size / 2
-
-        x_coord_fn = lambda x: top_left_x + x * cell_size
-        y_coord_fn = lambda y: top_left_y - y * cell_size
-
-        x_coords = list(map(x_coord_fn, column_index))
-        y_coords = list(map(y_coord_fn, rows_index))
+        # Apply the full affine geotransform per point so the y axis uses the
+        # pixel height (geotransform[5]) and the rotation terms are honoured,
+        # instead of reusing the pixel width for both axes (issue #505). The
+        # ``center`` half-pixel shift becomes a +0.5 offset on (col, row),
+        # which the transform maps through the same affine.
+        transform = GeoTransform(*self._ds.geotransform)
+        offset = 0.5 if center else 0.0
+        x_coords: list[Number] = []
+        y_coords: list[Number] = []
+        for row, col in zip(rows_index, column_index):
+            x, y = transform * (col + offset, row + offset)
+            x_coords.append(x)
+            y_coords.append(y)
 
         return x_coords, y_coords

--- a/src/pyramids/dataset/engines/cell.py
+++ b/src/pyramids/dataset/engines/cell.py
@@ -422,7 +422,7 @@ class Cell(_Engine):
 
               ```python
               >>> import numpy as np
-              >>> import pandas as pd
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.randint(1, 3, size=(10, 10))
               >>> top_left_corner = (0, 0)
               >>> cell_size = 0.05
@@ -445,6 +445,12 @@ class Cell(_Engine):
             The conversion is affine-exact: it applies the full geotransform
             (per-axis pixel sizes and the rotation terms), so it is correct on
             non-square and rotated grids rather than assuming square pixels.
+
+        See Also:
+            - :meth:`map_to_array_coordinates`: The inverse direction
+              (map coordinates to the nearest array indices).
+            - :meth:`pyramids.dataset.abstract_dataset.RasterBase.xy`: The
+              scalar/array affine companion used by the rasterio-style API.
         """
         if len(rows_index) != len(column_index):
             raise ValueError(

--- a/src/pyramids/dataset/engines/cell.py
+++ b/src/pyramids/dataset/engines/cell.py
@@ -17,7 +17,6 @@ from hpc.indexing import get_indices2, locate_values
 from pandas import DataFrame
 
 from pyramids.dataset.engines._base import _Engine
-from pyramids.dataset.transform import GeoTransform
 from pyramids.feature import FeatureCollection, create_points, create_polygon
 
 
@@ -410,7 +409,13 @@ class Cell(_Engine):
 
         Returns:
             Tuple[List[Number], List[Number]]:
-                A tuple of two lists: the x coordinates and the y coordinates of the cells.
+                A tuple of two equal-length lists, the x coordinates and the y
+                coordinates of the cells. The elements are plain Python floats
+                regardless of whether the inputs were lists or NumPy arrays.
+
+        Raises:
+            ValueError: ``rows_index`` and ``column_index`` have different
+                lengths (the indices are paired element-wise).
 
         Examples:
             - Create `Dataset` consisting of 1 band, 10 rows, 10 columns, at the point lon/lat (0, 0):
@@ -441,18 +446,27 @@ class Cell(_Engine):
             (per-axis pixel sizes and the rotation terms), so it is correct on
             non-square and rotated grids rather than assuming square pixels.
         """
-        # Apply the full affine geotransform per point so the y axis uses the
-        # pixel height (geotransform[5]) and the rotation terms are honoured,
-        # instead of reusing the pixel width for both axes (issue #505). The
-        # ``center`` half-pixel shift becomes a +0.5 offset on (col, row),
-        # which the transform maps through the same affine.
-        transform = GeoTransform(*self._ds.geotransform)
+        if len(rows_index) != len(column_index):
+            raise ValueError(
+                "rows_index and column_index must have the same length, got "
+                f"{len(rows_index)} and {len(column_index)}."
+            )
+        # Apply the full affine geotransform (vectorised over the points) so the
+        # y axis uses the pixel height (geotransform[5]) and the rotation terms
+        # are honoured, instead of reusing the pixel width for both axes (issue
+        # #505). The ``center`` half-pixel shift is a +0.5 offset on (col, row).
+        (
+            x_origin,
+            pixel_width,
+            row_rotation,
+            y_origin,
+            column_rotation,
+            pixel_height,
+        ) = self._ds.geotransform
         offset = 0.5 if center else 0.0
-        x_coords: list[Number] = []
-        y_coords: list[Number] = []
-        for row, col in zip(rows_index, column_index):
-            x, y = transform * (col + offset, row + offset)
-            x_coords.append(x)
-            y_coords.append(y)
+        cols = np.asarray(column_index, dtype=float) + offset
+        rows = np.asarray(rows_index, dtype=float) + offset
+        x_coords = (x_origin + cols * pixel_width + rows * row_rotation).tolist()
+        y_coords = (y_origin + cols * column_rotation + rows * pixel_height).tolist()
 
         return x_coords, y_coords

--- a/src/pyramids/dataset/engines/cell.py
+++ b/src/pyramids/dataset/engines/cell.py
@@ -401,9 +401,11 @@ class Cell(_Engine):
 
         Args:
             rows_index (List[Number] | np.ndarray):
-                The row indices of the cells in the raster array.
+                The row indices of the cells in the raster array. Any finite
+                iterable of indices is accepted (list, tuple, ndarray, generator).
             column_index (List[Number] | np.ndarray):
-                The column indices of the cells in the raster array.
+                The column indices of the cells in the raster array. Any finite
+                iterable of indices is accepted (list, tuple, ndarray, generator).
             center (bool):
                 If True, the coordinates will be the center of the cell. Default is False.
 
@@ -452,10 +454,15 @@ class Cell(_Engine):
             - :meth:`pyramids.dataset.abstract_dataset.RasterBase.xy`: The
               scalar/array affine companion used by the rasterio-style API.
         """
-        if len(rows_index) != len(column_index):
+        # Materialise to 1-D float arrays first. Going through ``list`` accepts
+        # any finite iterable of indices (lists, tuples, ndarrays, generators)
+        # and gives one source of truth for the equal-length check.
+        cols = np.asarray(list(column_index), dtype=float)
+        rows = np.asarray(list(rows_index), dtype=float)
+        if cols.shape != rows.shape:
             raise ValueError(
                 "rows_index and column_index must have the same length, got "
-                f"{len(rows_index)} and {len(column_index)}."
+                f"{rows.size} and {cols.size}."
             )
         # Apply the full affine geotransform (vectorised over the points) so the
         # y axis uses the pixel height (geotransform[5]) and the rotation terms
@@ -470,8 +477,8 @@ class Cell(_Engine):
             pixel_height,
         ) = self._ds.geotransform
         offset = 0.5 if center else 0.0
-        cols = np.asarray(column_index, dtype=float) + offset
-        rows = np.asarray(rows_index, dtype=float) + offset
+        cols = cols + offset
+        rows = rows + offset
         x_coords = (x_origin + cols * pixel_width + rows * row_rotation).tolist()
         y_coords = (y_origin + cols * column_rotation + rows * pixel_height).tolist()
 

--- a/tests/dataset/test_dataset_unit.py
+++ b/tests/dataset/test_dataset_unit.py
@@ -2761,6 +2761,27 @@ class TestMapToArrayCoordinates:
         with pytest.raises(ValueError, match="x, and y"):
             single_band_dataset.map_to_array_coordinates(df)
 
+    def test_map_to_array_nonsquare_roundtrip(self):
+        """On a non-square grid the cell centres round-trip back to their indices.
+
+        ``map_to_array_coordinates`` matches against the per-axis coordinate
+        arrays (not the pixel width), so it already resolves the correct cell
+        on a non-square grid. This guards that it stays the inverse of the
+        fixed ``array_to_map_coordinates`` (issue #505).
+        """
+        ds = Dataset.create_from_array(
+            np.ones((4, 3), dtype="float32"),
+            geo=(10.0, 2.0, 0.0, 8.0, 0.0, -0.5),
+            epsg=4326,
+        )
+        rows, cols = [0, 1, 3], [0, 1, 2]
+        x, y = ds.array_to_map_coordinates(rows, cols, center=True)
+        df = pd.DataFrame({"x": x, "y": y})
+        indices = ds.map_to_array_coordinates(df)
+        assert indices.tolist() == [[0, 0], [1, 1], [3, 2]], (
+            f"cell centres must map back to their (row, col), got {indices.tolist()}"
+        )
+
 
 class TestArrayToMapCoordinates:
     """Tests for the array_to_map_coordinates method."""
@@ -2785,6 +2806,62 @@ class TestArrayToMapCoordinates:
             center=False,
         )
         assert abs(x[0] - 0.0) < 1e-6, "Corner x should be 0.0"
+
+    @staticmethod
+    def _nonsquare():
+        """Grid with 2.0-wide, 0.5-tall pixels anchored at (10, 8)."""
+        return Dataset.create_from_array(
+            np.ones((4, 3), dtype="float32"),
+            geo=(10.0, 2.0, 0.0, 8.0, 0.0, -0.5),
+            epsg=4326,
+        )
+
+    def test_array_to_map_nonsquare_center(self):
+        """The y axis uses the pixel height, not the width, on non-square grids.
+
+        Regression for #505: cell (row=1, col=2) centre is x=15.0, y=7.25
+        (8 - 1*0.5 - 0.25); the old code returned y=5.0 by reusing the 2.0
+        pixel width for the y axis.
+        """
+        x, y = self._nonsquare().array_to_map_coordinates([1], [2], center=True)
+        assert abs(x[0] - 15.0) < 1e-9, f"x should be 15.0, got {x[0]}"
+        assert abs(y[0] - 7.25) < 1e-9, f"y should be 7.25 (height-based), got {y[0]}"
+
+    def test_array_to_map_nonsquare_corner(self):
+        """Corner coordinates also use the per-axis pixel sizes."""
+        x, y = self._nonsquare().array_to_map_coordinates([1], [2], center=False)
+        assert abs(x[0] - 14.0) < 1e-9, f"corner x should be 14.0, got {x[0]}"
+        assert abs(y[0] - 7.5) < 1e-9, f"corner y should be 7.5, got {y[0]}"
+
+    def test_array_to_map_nonsquare_vector(self):
+        """Vector inputs are converted element-wise with the per-axis sizes."""
+        x, y = self._nonsquare().array_to_map_coordinates([0, 1, 3], [0, 1, 2])
+        assert x == [10.0, 12.0, 14.0], f"x corners wrong: {x}"
+        assert y == [8.0, 7.5, 6.5], f"y corners must step by 0.5, got {y}"
+
+    def test_array_to_map_rotated(self):
+        """The rotation terms are honoured (not dropped as before)."""
+        rot = Dataset.create_from_array(
+            np.ones((4, 4), dtype="float32"),
+            geo=(0.0, 1.0, 0.5, 0.0, 0.5, -1.0),
+            epsg=4326,
+        )
+        x, y = rot.array_to_map_coordinates([1], [2], center=False)
+        # x = 0 + 2*1 + 1*0.5 = 2.5 ; y = 0 + 2*0.5 + 1*(-1) = 0.0
+        assert abs(x[0] - 2.5) < 1e-9, f"rotated x should be 2.5, got {x[0]}"
+        assert abs(y[0] - 0.0) < 1e-9, f"rotated y should be 0.0, got {y[0]}"
+
+    def test_array_to_map_square_unchanged(self):
+        """Square north-up grids match the historical width-based formula."""
+        sq = Dataset.create_from_array(
+            np.ones((10, 10), dtype="float32"),
+            top_left_corner=(0.0, 0.0),
+            cell_size=0.05,
+            epsg=4326,
+        )
+        x, y = sq.array_to_map_coordinates([1, 3, 5], [2, 4, 6])
+        assert x == pytest.approx([0.1, 0.2, 0.3]), f"square x changed: {x}"
+        assert y == pytest.approx([-0.05, -0.15, -0.25]), f"square y changed: {y}"
 
 
 class TestOverlay:

--- a/tests/dataset/test_dataset_unit.py
+++ b/tests/dataset/test_dataset_unit.py
@@ -2853,6 +2853,11 @@ class TestArrayToMapCoordinates:
         assert abs(x[0] - 2.5) < 1e-9, f"rotated x should be 2.5, got {x[0]}"
         assert abs(y[0] - 0.0) < 1e-9, f"rotated y should be 0.0, got {y[0]}"
 
+    def test_array_to_map_length_mismatch_raises(self):
+        """Mismatched-length index inputs raise instead of pairing silently."""
+        with pytest.raises(ValueError, match="same length"):
+            self._nonsquare().array_to_map_coordinates([0, 1], [0])
+
     def test_array_to_map_square_unchanged(self):
         """Square north-up grids match the historical width-based formula."""
         sq = Dataset.create_from_array(

--- a/tests/dataset/test_dataset_unit.py
+++ b/tests/dataset/test_dataset_unit.py
@@ -2858,6 +2858,11 @@ class TestArrayToMapCoordinates:
         with pytest.raises(ValueError, match="same length"):
             self._nonsquare().array_to_map_coordinates([0, 1], [0])
 
+    def test_array_to_map_empty_input(self):
+        """Empty index inputs return a pair of empty lists, not an error."""
+        x, y = self._nonsquare().array_to_map_coordinates([], [])
+        assert x == [] and y == [], f"empty input must give ([], []), got ({x}, {y})"
+
     def test_array_to_map_accepts_generator(self):
         """Generator (non-Sized) index inputs are accepted, same as lists.
 

--- a/tests/dataset/test_dataset_unit.py
+++ b/tests/dataset/test_dataset_unit.py
@@ -2858,6 +2858,19 @@ class TestArrayToMapCoordinates:
         with pytest.raises(ValueError, match="same length"):
             self._nonsquare().array_to_map_coordinates([0, 1], [0])
 
+    def test_array_to_map_accepts_generator(self):
+        """Generator (non-Sized) index inputs are accepted, same as lists.
+
+        Guards N1: the equal-length check materialises the inputs, so any finite
+        iterable works, not only ``len()``-able sequences.
+        """
+        ds = self._nonsquare()
+        x_gen, y_gen = ds.array_to_map_coordinates(
+            (r for r in [0, 1, 3]), (c for c in [0, 1, 2]), center=True
+        )
+        x_list, y_list = ds.array_to_map_coordinates([0, 1, 3], [0, 1, 2], center=True)
+        assert x_gen == x_list and y_gen == y_list, "generator input must match list"
+
     def test_array_to_map_ndarray_input_returns_python_floats(self):
         """NumPy-array indices yield plain Python floats, same values as lists.
 

--- a/tests/dataset/test_dataset_unit.py
+++ b/tests/dataset/test_dataset_unit.py
@@ -2863,18 +2863,19 @@ class TestArrayToMapCoordinates:
         x, y = self._nonsquare().array_to_map_coordinates([], [])
         assert x == [] and y == [], f"empty input must give ([], []), got ({x}, {y})"
 
-    def test_array_to_map_accepts_generator(self):
-        """Generator (non-Sized) index inputs are accepted, same as lists.
+    def test_array_to_map_accepts_iterator(self):
+        """Non-Sized iterator index inputs are accepted, same as lists.
 
         Guards N1: the equal-length check materialises the inputs, so any finite
-        iterable works, not only ``len()``-able sequences.
+        iterable works (here single-pass ``list_iterator`` objects that have no
+        ``__len__``), not only ``len()``-able sequences.
         """
         ds = self._nonsquare()
-        x_gen, y_gen = ds.array_to_map_coordinates(
-            (r for r in [0, 1, 3]), (c for c in [0, 1, 2]), center=True
+        x_iter, y_iter = ds.array_to_map_coordinates(
+            iter([0, 1, 3]), iter([0, 1, 2]), center=True
         )
         x_list, y_list = ds.array_to_map_coordinates([0, 1, 3], [0, 1, 2], center=True)
-        assert x_gen == x_list and y_gen == y_list, "generator input must match list"
+        assert x_iter == x_list and y_iter == y_list, "iterator input must match list"
 
     def test_array_to_map_ndarray_input_returns_python_floats(self):
         """NumPy-array indices yield plain Python floats, same values as lists.

--- a/tests/dataset/test_dataset_unit.py
+++ b/tests/dataset/test_dataset_unit.py
@@ -2847,7 +2847,9 @@ class TestArrayToMapCoordinates:
             epsg=4326,
         )
         x, y = rot.array_to_map_coordinates([1], [2], center=False)
-        # x = 0 + 2*1 + 1*0.5 = 2.5 ; y = 0 + 2*0.5 + 1*(-1) = 0.0
+        # Column 2 and row 1 through the affine give x of 2.5 (two pixel
+        # widths plus one row-rotation half) and y of 0.0 (one column
+        # rotation minus one pixel height).
         assert abs(x[0] - 2.5) < 1e-9, f"rotated x should be 2.5, got {x[0]}"
         assert abs(y[0] - 0.0) < 1e-9, f"rotated y should be 0.0, got {y[0]}"
 

--- a/tests/dataset/test_dataset_unit.py
+++ b/tests/dataset/test_dataset_unit.py
@@ -2858,6 +2858,22 @@ class TestArrayToMapCoordinates:
         with pytest.raises(ValueError, match="same length"):
             self._nonsquare().array_to_map_coordinates([0, 1], [0])
 
+    def test_array_to_map_ndarray_input_returns_python_floats(self):
+        """NumPy-array indices yield plain Python floats, same values as lists.
+
+        Guards the N1 contract: the output element type is independent of whether
+        the inputs were lists or ndarrays.
+        """
+        ds = self._nonsquare()
+        x, y = ds.array_to_map_coordinates(
+            np.array([0, 1, 3]), np.array([0, 1, 2]), center=True
+        )
+        assert all(type(v) is float for v in x + y), (
+            f"elements must be plain Python floats, got {[type(v) for v in x + y]}"
+        )
+        x_list, y_list = ds.array_to_map_coordinates([0, 1, 3], [0, 1, 2], center=True)
+        assert x == x_list and y == y_list, "ndarray and list inputs must agree"
+
     def test_array_to_map_square_unchanged(self):
         """Square north-up grids match the historical width-based formula."""
         sq = Dataset.create_from_array(


### PR DESCRIPTION
# Description

`Cell.array_to_map_coordinates` reused a single cell size (`geotransform[1]`, the pixel **width**) for both axes
and the `center` half-pixel offset, ignoring the pixel height (`geotransform[5]`) and the rotation terms. On a
non-square grid the y coordinate was wrong, e.g.:

```python
ds = Dataset.create_from_array(
    np.ones((4, 3), "float32"), geo=(10.0, 2.0, 0.0, 8.0, 0.0, -0.5), epsg=4326
)
ds.array_to_map_coordinates([1], [2], center=True)
# was ([15.0], [5.0]); correct is ([15.0], [7.25])  (8 - 1*0.5 - 0.25)
```

The fix routes the conversion through the exact affine (`pyramids.dataset.transform.GeoTransform`, from #499), so
the y axis uses the pixel height and rotation is honoured. Square north-up grids are bit-for-bit unchanged.

Scope note: `map_to_array_coordinates` does **not** use `cell_size` — it matches against the per-axis coordinate
arrays (`self._ds.x` / `self._ds.y`), so it already resolves the correct cell on non-square grids (verified by a
round-trip test and the `extract`/`sample` paths). It uses nearest-cell matching rather than inverting the affine,
so rotated grids remain a known limitation for that method; the docstring notes are corrected accordingly.

# Issues
- Fixes #505

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

(The breaking-change box is ticked in the sense that callers who relied on the wrong y output on non-square grids
will now get the corrected value — square grids are unchanged.)

# How Has This Been Tested?

- [x] Non-square `array_to_map_coordinates`: centre + corner, scalar + vector.
- [x] Rotated grid: rotation terms honoured.
- [x] Square grid: output matches the historical width-based formula (regression).
- [x] `map_to_array_coordinates` non-square round-trip (cell centres map back to their indices).
- [x] `extract` / `sample` path re-verified on a non-square fixture.

Runs (worktree, PYTHONPATH-shadowed): `pytest tests/dataset/test_dataset_unit.py tests/dataset/test_engines.py
tests/dataset/test_transform_ergonomics.py -m "not plot"` -> 429 passed, 3 skipped; coordinate/extract subset of
`test_dataset.py` -> 17 passed; the 10 new/existing `Array/MapToArrayCoordinates` tests pass.

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen handles versions)
- [ ] added changes to History.rst. (changelog is commitizen-generated)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (docstring note + xy/rowcol notes corrected)