### PR TITLE
fix(netcdf): path-style S3 addressing for anonymous LabeledDataset reads (#560)

### DIFF
--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -453,6 +453,7 @@ class CloudConfig:
     `aws_region`                     `AWS_REGION` + `AWS_DEFAULT_REGION`
     `aws_no_sign_request=True`       `AWS_NO_SIGN_REQUEST=YES`
     `aws_request_payer=True`         `AWS_REQUEST_PAYER=requester`
+    `aws_virtual_hosting=False`      `AWS_VIRTUAL_HOSTING=FALSE` (True -> `TRUE`)
     `gs_oauth2_refresh_token`        `GS_OAUTH2_REFRESH_TOKEN`
     `gs_access_key_id`               `GS_ACCESS_KEY_ID`
     `gs_secret_access_key`           `GS_SECRET_ACCESS_KEY`
@@ -472,6 +473,12 @@ class CloudConfig:
     — useful when re-reading the same remote chunks (e.g. iterating over
     blocks of a single COG). Set `vsi_cache=None` (default) to leave
     whatever the process-wide setting is in place.
+
+    `aws_virtual_hosting=False` requests path-style S3 addressing (the bucket in
+    the request path rather than the host); the anonymous-S3 reader uses it to
+    dodge an unfollowed `301 PermanentRedirect` GDAL hits on the data-chunk GET
+    for some buckets (e.g. us-east-1 NWM — #560). `None` (default) leaves GDAL's
+    default virtual-hosted addressing.
 
     Examples:
         - Override the AWS region for a single operation:
@@ -527,6 +534,7 @@ class CloudConfig:
     aws_region: str | None = None
     aws_no_sign_request: bool = False
     aws_request_payer: bool = False
+    aws_virtual_hosting: bool | None = None
     gs_oauth2_refresh_token: str | None = None
     gs_access_key_id: str | None = None
     gs_secret_access_key: str | None = None
@@ -606,6 +614,12 @@ class CloudConfig:
                 {'VSI_CACHE': 'FALSE'}
 
                 ```
+            - ``aws_virtual_hosting=False`` requests path-style S3 addressing (#560):
+                ```python
+                >>> CloudConfig(aws_virtual_hosting=False).as_gdal_config()
+                {'AWS_VIRTUAL_HOSTING': 'FALSE'}
+
+                ```
             - ``extra`` overrides any explicit field on key conflict (the
                 escape hatch wins):
                 ```python
@@ -643,6 +657,12 @@ class CloudConfig:
             out["AWS_NO_SIGN_REQUEST"] = "YES"
         if self.aws_request_payer:
             out["AWS_REQUEST_PAYER"] = "requester"
+        if self.aws_virtual_hosting is not None:
+            # Path-style ("FALSE") vs virtual-hosted ("TRUE") S3 addressing.
+            # Path-style avoids the unfollowed 301 PermanentRedirect GDAL hits on
+            # the data-chunk GET for some buckets (e.g. us-east-1 NWM), which
+            # otherwise reads 0 bytes and surfaces as silent zeros (#560).
+            out["AWS_VIRTUAL_HOSTING"] = "TRUE" if self.aws_virtual_hosting else "FALSE"
         if self.vsi_cache is not None:
             out["VSI_CACHE"] = "TRUE" if self.vsi_cache else "FALSE"
         out.update({k: str(v) for k, v in self.extra.items()})

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -137,7 +137,9 @@ class LabeledDataset:
         self._cloud_config = cloud_config or CloudConfig()
 
     @staticmethod
-    def _open_multidim_store(gdal_path: str, cloud: CloudConfig, source: str) -> gdal.Dataset:
+    def _open_multidim_store(
+        gdal_path: str, cloud: CloudConfig, source: str
+    ) -> gdal.Dataset:
         """Open `gdal_path` as a multidim store under `cloud`, normalising errors.
 
         Args:

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -136,6 +136,47 @@ class LabeledDataset:
         # empty CloudConfig is a no-op for local stores.
         self._cloud_config = cloud_config or CloudConfig()
 
+    @staticmethod
+    def _open_multidim_store(gdal_path: str, cloud: CloudConfig, source: str) -> gdal.Dataset:
+        """Open `gdal_path` as a multidim store under `cloud`, normalising errors.
+
+        Args:
+            gdal_path: The GDAL-ready path/URL (already `/vsi*`- and `ZARR:`-wrapped).
+            cloud: Cloud config applied for the open (S3 addressing / region / anon).
+            source: The original user-facing path, for error messages.
+
+        Returns:
+            gdal.Dataset: The open multidimensional dataset.
+
+        Raises:
+            ValueError: If GDAL cannot open the store (a Zarr v3 string-array
+                failure adds a hint pointing at the GDAL issue).
+        """
+        try:
+            with cloud:
+                ds = gdal.OpenEx(gdal_path, gdal.OF_MULTIDIM_RASTER)
+        except RuntimeError as exc:
+            # gdal.UseExceptions() raises (rather than returning None) for a
+            # missing / unrecognised store; normalise to a clear ValueError.
+            hint = ""
+            if "data_type" in str(exc):
+                # GDAL >= 3.13 fails the whole open when a Zarr v3 string array is
+                # present, so per-array degradation is not possible there.
+                hint = (
+                    " — this store has a Zarr v3 string array, which GDAL's Zarr "
+                    "driver cannot read (see "
+                    "https://github.com/OSGeo/gdal/issues/13782)."
+                )
+            raise ValueError(
+                f"GDAL could not open {source!r} as a multidimensional store: "
+                f"{exc}{hint}"
+            ) from exc
+        if ds is None:
+            raise ValueError(
+                f"GDAL could not open {source!r} as a multidimensional store."
+            )
+        return ds
+
     @classmethod
     def read_file(
         cls,
@@ -222,29 +263,7 @@ class LabeledDataset:
             aws_region=effective_region,
             aws_virtual_hosting=False if is_anon_s3 else None,
         )
-        try:
-            with cloud:
-                ds = gdal.OpenEx(gdal_path, gdal.OF_MULTIDIM_RASTER)
-        except RuntimeError as exc:
-            # gdal.UseExceptions() raises (rather than returning None) for a
-            # missing / unrecognised store; normalise to a clear ValueError.
-            hint = ""
-            if "data_type" in str(exc):
-                # GDAL >= 3.13 fails the whole open when a Zarr v3 string array is
-                # present, so per-array degradation is not possible there.
-                hint = (
-                    " — this store has a Zarr v3 string array, which GDAL's Zarr "
-                    "driver cannot read (see "
-                    "https://github.com/OSGeo/gdal/issues/13782)."
-                )
-            raise ValueError(
-                f"GDAL could not open {source!r} as a multidimensional store: "
-                f"{exc}{hint}"
-            ) from exc
-        if ds is None:
-            raise ValueError(
-                f"GDAL could not open {source!r} as a multidimensional store."
-            )
+        ds = cls._open_multidim_store(gdal_path, cloud, source)
         # Keep the S3 config live for the post-open group navigation + array
         # classification too. Those issue per-array `.zarray` metadata reads for a
         # remote store, which must use the same path-style/region addressing as

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -119,6 +119,9 @@ class LabeledDataset:
             cloud_config: GDAL cloud config (S3 addressing / region / anon)
                 re-applied around every chunk read so remote data GETs use the
                 same settings as the open. Defaults to an empty (no-op) config.
+                Shared by child views (from ``select``/etc.) and re-entered per
+                read; reads are sequential — concurrent reads from sibling views
+                are not supported (they would race on this one context manager).
         """
         self._ds = ds
         self._group = group
@@ -242,27 +245,35 @@ class LabeledDataset:
             raise ValueError(
                 f"GDAL could not open {source!r} as a multidimensional store."
             )
-        root = ds.GetRootGroup()
-        try:
-            grp = root.OpenGroup(group) if group else root
-        except RuntimeError as exc:
-            # Under gdal.UseExceptions() a missing group raises rather than
-            # returning None. Release the handle (Windows keeps the file open
-            # until the gdal.Dataset is dropped) and re-raise as a clear
-            # ValueError, chaining the GDAL cause so a non-missing-group failure
-            # (e.g. a corrupt store) stays legible.
-            ds = None
-            raise ValueError(f"group {group!r} not found in {source!r}: {exc}") from exc
-        if grp is None:
-            ds = None
-            raise ValueError(f"group {group!r} not found in {source!r}.")
-        # Close the handle on any error while classifying the group (e.g. an
-        # unknown name in `variables`) so it isn't left locked on Windows.
-        try:
-            return cls._from_group(ds, grp, variables, cloud_config=cloud)
-        except Exception:
-            ds = None
-            raise
+        # Keep the S3 config live for the post-open group navigation + array
+        # classification too. Those issue per-array `.zarray` metadata reads for a
+        # remote store, which must use the same path-style/region addressing as
+        # the open — otherwise a non-consolidated anonymous bucket could 301 on a
+        # metadata probe and silently drop the array as "unreadable" (#560).
+        with cloud:
+            root = ds.GetRootGroup()
+            try:
+                grp = root.OpenGroup(group) if group else root
+            except RuntimeError as exc:
+                # Under gdal.UseExceptions() a missing group raises rather than
+                # returning None. Release the handle (Windows keeps the file open
+                # until the gdal.Dataset is dropped) and re-raise as a clear
+                # ValueError, chaining the GDAL cause so a non-missing-group
+                # failure (e.g. a corrupt store) stays legible.
+                ds = None
+                raise ValueError(
+                    f"group {group!r} not found in {source!r}: {exc}"
+                ) from exc
+            if grp is None:
+                ds = None
+                raise ValueError(f"group {group!r} not found in {source!r}.")
+            # Close the handle on any error while classifying the group (e.g. an
+            # unknown name in `variables`) so it isn't left locked on Windows.
+            try:
+                return cls._from_group(ds, grp, variables, cloud_config=cloud)
+            except Exception:
+                ds = None
+                raise
 
     @staticmethod
     def _readable_arrays(grp: gdal.Group) -> tuple[list[str], list[str]]:
@@ -708,10 +719,11 @@ class LabeledDataset:
                 >>> sub = store.select_time("2010-06-01", "2010-08-31")  # doctest: +SKIP
         """
         self._require_coord(time_dim)
-        arr = self._group.OpenMDArray(time_dim)
-        unit = arr.GetUnit()
-        cal_attr = _get_attr(arr, "calendar")
-        calendar = cal_attr.ReadAsString() if cal_attr is not None else "standard"
+        with self._cloud_config:
+            arr = self._group.OpenMDArray(time_dim)
+            unit = arr.GetUnit()
+            cal_attr = _get_attr(arr, "calendar")
+            calendar = cal_attr.ReadAsString() if cal_attr is not None else "standard"
         current = self._coord_current(time_dim, time_dim).astype("float64")
         mask = np.ones(current.shape, dtype=bool)
         if start is not None:
@@ -803,13 +815,14 @@ class LabeledDataset:
     def _estimated_nbytes(self) -> int:
         """Estimate the bytes a full materialisation would read (no read done)."""
         total = 0
-        for name in self._var_names:
-            arr = self._group.OpenMDArray(name)
-            itemsize = arr.GetDataType().GetSize() or 4
-            cells = 1
-            for dim in self._array_dims(name):
-                cells *= self._selected_size(dim)
-            total += cells * itemsize
+        with self._cloud_config:
+            for name in self._var_names:
+                arr = self._group.OpenMDArray(name)
+                itemsize = arr.GetDataType().GetSize() or 4
+                cells = 1
+                for dim in self._array_dims(name):
+                    cells *= self._selected_size(dim)
+                total += cells * itemsize
         return total
 
     def to_dataframe(self) -> pd.DataFrame:

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -101,6 +101,7 @@ class LabeledDataset:
         full_sizes: dict[str, int],
         index: dict[str, np.ndarray] | None = None,
         scalar_dims: frozenset[str] = frozenset(),
+        cloud_config: CloudConfig | None = None,
     ) -> None:
         """Low-level constructor. Most callers use :meth:`read_file`.
 
@@ -115,6 +116,9 @@ class LabeledDataset:
                 a missing dimension means "keep all".
             scalar_dims: Dimensions reduced to a single label (dropped from the
                 reported dims/sizes).
+            cloud_config: GDAL cloud config (S3 addressing / region / anon)
+                re-applied around every chunk read so remote data GETs use the
+                same settings as the open. Defaults to an empty (no-op) config.
         """
         self._ds = ds
         self._group = group
@@ -124,6 +128,10 @@ class LabeledDataset:
         self._full_sizes = full_sizes
         self._index = dict(index or {})
         self._scalar_dims = scalar_dims
+        # Re-applied around every chunk read so remote S3 addressing (path-style,
+        # region, anon) stays live for data GETs, not just the open (#560). An
+        # empty CloudConfig is a no-op for local stores.
+        self._cloud_config = cloud_config or CloudConfig()
 
     @classmethod
     def read_file(
@@ -151,7 +159,11 @@ class LabeledDataset:
             engine: Force the store kind — `"zarr"` for Zarr, any other value
                 for NetCDF/HDF5. `None` infers from the path suffix.
             anon: Open the remote store anonymously (unsigned;
-                `AWS_NO_SIGN_REQUEST` for S3 and the equivalent elsewhere).
+                `AWS_NO_SIGN_REQUEST` for S3 and the equivalent elsewhere). For
+                an anonymous `s3://` store this also forces **path-style**
+                addressing (`AWS_VIRTUAL_HOSTING=FALSE`) — kept live for the
+                data-chunk reads, not just the open — so GDAL does not hit an
+                unfollowed `301` on the chunk GET and silently read zeros (#560).
             region: Pin the S3 bucket region (sets `AWS_REGION` for the open).
                 Leave `None` and, for an anonymous `s3://` store, the region is
                 auto-resolved from the bucket — GDAL skips region resolution
@@ -191,15 +203,24 @@ class LabeledDataset:
         # PermanentRedirect. Resolve and pin it before the open (issue #535); an
         # explicit `region` always wins.
         effective_region = region
-        if (
-            effective_region is None
-            and anon
-            and source.split("://", 1)[0].lower() == "s3"
-        ):
+        is_anon_s3 = anon and source.split("://", 1)[0].lower() == "s3"
+        if effective_region is None and is_anon_s3:
             bucket = source.split("://", 1)[1].split("/", 1)[0]
             effective_region = resolve_s3_region(bucket)
+        # Anonymous S3 needs path-style addressing: GDAL's default virtual-hosted
+        # host 301-redirects the data-chunk GET on some buckets (e.g. the
+        # us-east-1 NWM retrospective store) and does not follow the redirect,
+        # reading 0 bytes — which surfaces as silent zeros (#560). Region
+        # resolution (#535/#537) fixes the open/metadata path; path-style fixes
+        # the data-read path. The config must be live for the chunk reads too, not
+        # just the open, so it is stored on the view and re-applied per read.
+        cloud = CloudConfig(
+            aws_no_sign_request=anon,
+            aws_region=effective_region,
+            aws_virtual_hosting=False if is_anon_s3 else None,
+        )
         try:
-            with CloudConfig(aws_no_sign_request=anon, aws_region=effective_region):
+            with cloud:
                 ds = gdal.OpenEx(gdal_path, gdal.OF_MULTIDIM_RASTER)
         except RuntimeError as exc:
             # gdal.UseExceptions() raises (rather than returning None) for a
@@ -238,7 +259,7 @@ class LabeledDataset:
         # Close the handle on any error while classifying the group (e.g. an
         # unknown name in `variables`) so it isn't left locked on Windows.
         try:
-            return cls._from_group(ds, grp, variables)
+            return cls._from_group(ds, grp, variables, cloud_config=cloud)
         except Exception:
             ds = None
             raise
@@ -273,6 +294,7 @@ class LabeledDataset:
         ds: gdal.Dataset,
         grp: gdal.Group,
         variables: Iterable[str] | None,
+        cloud_config: CloudConfig | None = None,
     ) -> LabeledDataset:
         """Classify a group's arrays into coordinates and data variables."""
         array_names, skipped = cls._readable_arrays(grp)
@@ -296,6 +318,7 @@ class LabeledDataset:
             var_names=var_names,
             dim_order=dim_order,
             full_sizes=full_sizes,
+            cloud_config=cloud_config,
         )
 
     @staticmethod
@@ -376,6 +399,7 @@ class LabeledDataset:
             full_sizes=self._full_sizes,
             index=index,
             scalar_dims=scalar_dims,
+            cloud_config=self._cloud_config,
         )
 
     def _selected_size(self, dim: str) -> int:
@@ -419,12 +443,13 @@ class LabeledDataset:
             dtype for string arrays) and its remaining dimension names (after
             scalar dims are squeezed out).
         """
-        arr = self._group.OpenMDArray(name)
-        dim_names = self._array_dims(name)
-        if arr.GetDataType().GetClass() == gdal.GEDTC_STRING:
-            values = self._read_string_selection(arr, dim_names)
-        else:
-            values = self._read_numeric_selection(arr, dim_names)
+        with self._cloud_config:
+            arr = self._group.OpenMDArray(name)
+            dim_names = self._array_dims(name)
+            if arr.GetDataType().GetClass() == gdal.GEDTC_STRING:
+                values = self._read_string_selection(arr, dim_names)
+            else:
+                values = self._read_numeric_selection(arr, dim_names)
         values = self._maybe_decode_time(arr, values)
         return self._squeeze_scalar_dims(values, dim_names)
 
@@ -515,10 +540,13 @@ class LabeledDataset:
 
     def _coord_full(self, name: str) -> np.ndarray:
         """Read a coordinate's full (unselected) values."""
-        arr = self._group.OpenMDArray(name)
-        if arr.GetDataType().GetClass() == gdal.GEDTC_STRING:
-            return np.asarray(arr.Read(), dtype=object)
-        return np.asarray(arr.ReadAsArray())
+        with self._cloud_config:
+            arr = self._group.OpenMDArray(name)
+            if arr.GetDataType().GetClass() == gdal.GEDTC_STRING:
+                values = np.asarray(arr.Read(), dtype=object)
+            else:
+                values = np.asarray(arr.ReadAsArray())
+        return values
 
     def _coord_current(self, name: str, dim: str) -> np.ndarray:
         """Read coordinate `name` over `dim` at the current selection."""

--- a/tests/base/test_cloud_config_http.py
+++ b/tests/base/test_cloud_config_http.py
@@ -121,6 +121,37 @@ class TestCloudConfigHttpFields:
         cfg = CloudConfig(vsi_cache=None).as_gdal_config()
         assert cfg == {}, f"vsi_cache=None should drop out, got {cfg!r}"
 
+    @pytest.mark.parametrize(
+        "value, expected",
+        [(True, "TRUE"), (False, "FALSE")],
+        ids=["aws_virtual_hosting=True", "aws_virtual_hosting=False"],
+    )
+    def test_aws_virtual_hosting_bool_maps_to_truefalse(self, value, expected):
+        """``aws_virtual_hosting`` maps to ``AWS_VIRTUAL_HOSTING=TRUE``/``FALSE`` (#560).
+
+        Args:
+            value: The bool passed to ``aws_virtual_hosting``.
+            expected: The expected string value under ``AWS_VIRTUAL_HOSTING``.
+
+        Test scenario:
+            Path-style (``False``) is what the anonymous-S3 read path uses to
+            avoid GDAL's unfollowed 301 on the data-chunk GET.
+        """
+        cfg = CloudConfig(aws_virtual_hosting=value).as_gdal_config()
+        assert cfg == {
+            "AWS_VIRTUAL_HOSTING": expected
+        }, f"unexpected aws_virtual_hosting mapping: {cfg!r}"
+
+    def test_aws_virtual_hosting_none_drops_out(self):
+        """``aws_virtual_hosting=None`` (the default) emits no key.
+
+        Test scenario:
+            ``CloudConfig(aws_virtual_hosting=None).as_gdal_config()`` — expected:
+            empty mapping, so GDAL's default addressing is left untouched.
+        """
+        cfg = CloudConfig(aws_virtual_hosting=None).as_gdal_config()
+        assert cfg == {}, f"aws_virtual_hosting=None should drop out, got {cfg!r}"
+
     def test_all_four_fields_combine(self):
         """The four fields combine into one mapping in a single ``CloudConfig``.
 

--- a/tests/netcdf/test_labeled_s3_region.py
+++ b/tests/netcdf/test_labeled_s3_region.py
@@ -21,7 +21,7 @@ import pytest
 from osgeo import gdal
 
 from pyramids.base import remote as remote_mod
-from pyramids.base.remote import resolve_s3_region
+from pyramids.base.remote import CloudConfig, resolve_s3_region
 from pyramids.netcdf import LabeledDataset
 from pyramids.netcdf import labeled as labeled_mod
 
@@ -349,3 +349,148 @@ class TestReadFileRegionWiring:
         with pytest.raises(ValueError):
             LabeledDataset.read_file(str(missing), anon=True)
         assert captured["region"] in (None, "")
+
+
+class TestS3PathStyleAddressing:
+    """`read_file` uses path-style S3 addressing for anon reads, live at read time (#560)."""
+
+    @staticmethod
+    def _capture_open_vhost(monkeypatch) -> dict:
+        """Patch ``gdal.OpenEx`` to record AWS_VIRTUAL_HOSTING during the open."""
+        captured: dict = {}
+
+        def fake_openex(path, flags):
+            captured["vhost"] = gdal.GetConfigOption("AWS_VIRTUAL_HOSTING")
+            raise RuntimeError("stop after capturing config")
+
+        monkeypatch.setattr(labeled_mod.gdal, "OpenEx", fake_openex)
+        return captured
+
+    def test_anonymous_s3_uses_path_style(self, monkeypatch):
+        """An anonymous S3 read pins AWS_VIRTUAL_HOSTING=FALSE for the open.
+
+        Test scenario:
+            Path-style addressing avoids the unfollowed 301 on the data-chunk GET
+            that otherwise reads zeros (#560).
+        """
+        monkeypatch.setattr(labeled_mod, "resolve_s3_region", lambda bucket: "us-east-1")
+        captured = self._capture_open_vhost(monkeypatch)
+        with pytest.raises(ValueError):
+            LabeledDataset.read_file(
+                "s3://noaa-nwm-retrospective-3-0-pds/CONUS/zarr/chrtout.zarr", anon=True
+            )
+        assert captured["vhost"] == "FALSE", "anon S3 must use path-style addressing"
+
+    def test_signed_s3_keeps_default_virtual_hosting(self, monkeypatch):
+        """A signed S3 read does not force path-style (leaves GDAL's default).
+
+        Test scenario:
+            Only the anonymous public-bucket path needs path-style; signed reads
+            keep virtual-hosted addressing.
+        """
+        captured = self._capture_open_vhost(monkeypatch)
+        with pytest.raises(ValueError):
+            LabeledDataset.read_file("s3://bucket/store.zarr", anon=False)
+        assert captured["vhost"] in (None, ""), "signed S3 must keep GDAL's default"
+
+    def test_local_path_no_virtual_hosting(self, monkeypatch, tmp_path):
+        """A local path never forces S3 addressing options.
+
+        Test scenario:
+            A filesystem store leaves AWS_VIRTUAL_HOSTING unset.
+        """
+        captured = self._capture_open_vhost(monkeypatch)
+        with pytest.raises(ValueError):
+            LabeledDataset.read_file(str(tmp_path / "store.zarr"), anon=True)
+        assert captured["vhost"] in (None, "")
+
+    def test_reads_reapply_cloud_config(self):
+        """Chunk reads re-enter the stored cloud config, not just the open (#560).
+
+        The data-chunk GETs happen after the open returns, so the S3 addressing
+        config must be live then too. A spy config records each read entry.
+        """
+        import numpy as np
+
+        class _SpyConfig:
+            def __init__(self):
+                self.entered = 0
+
+            def __enter__(self):
+                self.entered += 1
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+        mem = gdal.GetDriverByName("MEM").CreateMultiDimensional("m")
+        rg = mem.GetRootGroup()
+        dim = rg.CreateDimension("x", "", "", 3)
+        arr = rg.CreateMDArray("x", [dim], gdal.ExtendedDataType.Create(gdal.GDT_Int32))
+        arr.Write(np.array([10, 20, 30], dtype="i4"))
+
+        spy = _SpyConfig()
+        store = LabeledDataset(
+            mem,
+            rg,
+            coord_names=["x"],
+            var_names=[],
+            dim_order=["x"],
+            full_sizes={"x": 3},
+            cloud_config=spy,
+        )
+        values = store._coord_full("x")
+        assert spy.entered >= 1, "a coordinate read must re-enter the cloud config"
+        np.testing.assert_array_equal(values, [10, 20, 30])
+
+    @staticmethod
+    def _mem_store_with_variable(cloud_config):
+        """Build a LabeledDataset over a MEM store: coord ``x`` + variable ``v(x)``."""
+        import numpy as np
+
+        mem = gdal.GetDriverByName("MEM").CreateMultiDimensional("m")
+        rg = mem.GetRootGroup()
+        dim = rg.CreateDimension("x", "", "", 3)
+        dt = gdal.ExtendedDataType.Create(gdal.GDT_Int32)
+        rg.CreateMDArray("x", [dim], dt).Write(np.array([10, 20, 30], dtype="i4"))
+        rg.CreateMDArray("v", [dim], dt).Write(np.array([1, 2, 3], dtype="i4"))
+        return LabeledDataset(
+            mem,
+            rg,
+            coord_names=["x"],
+            var_names=["v"],
+            dim_order=["x"],
+            full_sizes={"x": 3},
+            cloud_config=cloud_config,
+        )
+
+    def test_variable_read_reapplies_cloud_config(self):
+        """A variable read via ``_read`` also re-enters the stored cloud config."""
+        import numpy as np
+
+        class _SpyConfig:
+            def __init__(self):
+                self.entered = 0
+
+            def __enter__(self):
+                self.entered += 1
+                return self
+
+            def __exit__(self, *exc):
+                return False
+
+        spy = _SpyConfig()
+        store = self._mem_store_with_variable(spy)
+        values, dims = store._read("v")
+        assert spy.entered >= 1, "a variable read must re-enter the cloud config"
+        np.testing.assert_array_equal(values, [1, 2, 3])
+        assert dims == ("x",), f"unexpected dims for v: {dims!r}"
+
+    def test_select_propagates_cloud_config_to_child_view(self):
+        """``select`` (via ``_replace``) carries the parent's cloud config (#560)."""
+        sentinel = CloudConfig(aws_virtual_hosting=False)
+        store = self._mem_store_with_variable(sentinel)
+        child = store.select(x=[10, 30])
+        assert (
+            child._cloud_config is sentinel
+        ), "child view must reuse the parent's cloud config, not a fresh empty one"

--- a/tests/netcdf/test_labeled_s3_region.py
+++ b/tests/netcdf/test_labeled_s3_region.py
@@ -494,3 +494,34 @@ class TestS3PathStyleAddressing:
         assert (
             child._cloud_config is sentinel
         ), "child view must reuse the parent's cloud config, not a fresh empty one"
+
+    def test_classification_runs_under_path_style_config(self, monkeypatch):
+        """Post-open array classification reads run under the path-style config (#560).
+
+        Test scenario:
+            The open is mocked to succeed; ``_readable_arrays`` (the first
+            classification probe) captures the active ``AWS_VIRTUAL_HOSTING`` —
+            it must be ``FALSE``, proving the metadata-probe path is wrapped, not
+            only the open.
+        """
+        from unittest.mock import Mock
+
+        captured: dict = {}
+
+        def fake_readable_arrays(grp):
+            captured["vhost"] = gdal.GetConfigOption("AWS_VIRTUAL_HOSTING")
+            raise RuntimeError("stop after capturing config during classification")
+
+        monkeypatch.setattr(labeled_mod, "resolve_s3_region", lambda bucket: "us-east-1")
+        monkeypatch.setattr(
+            labeled_mod.LabeledDataset,
+            "_readable_arrays",
+            staticmethod(fake_readable_arrays),
+        )
+        fake_ds = Mock()
+        fake_ds.GetRootGroup.return_value = Mock()
+        monkeypatch.setattr(labeled_mod.gdal, "OpenEx", lambda path, flags: fake_ds)
+
+        with pytest.raises(Exception):
+            LabeledDataset.read_file("s3://bucket/store.zarr", anon=True)
+        assert captured.get("vhost") == "FALSE", "classification must use path-style"


### PR DESCRIPTION
# Description

Anonymous `LabeledDataset.read_file` of a Zarr store on S3 silently returned **all-zeros** for some buckets
(e.g. the us-east-1 NWM retrospective store). Root cause (reproduced against the live store, see #560):
GDAL's default **virtual-hosted** S3 addressing 301-redirects the **data-chunk** GET, and GDAL does **not**
follow that redirect — it reads 0 bytes, which with `fill_value: null` surfaces as silent zeros. The codec
(zstd) and the vendored GDAL build are fine; it is purely an S3-addressing problem.

`#535`/`#537` fixed the **open/metadata** path by resolving the bucket region, but the chunk reads happen
*after* the open returns, when that config is no longer active — so the **data-read** path still 301s.

Fix:

- `CloudConfig` gains `aws_virtual_hosting` (`-> AWS_VIRTUAL_HOSTING` `TRUE`/`FALSE`; `None` omits it).
- `LabeledDataset.read_file` builds, for anonymous `s3://` reads, a `CloudConfig` with
  `aws_virtual_hosting=False` (path-style) alongside the resolved region, **stores it on the view**, and
  threads it through `_from_group` / `_replace` so child views from `select()` keep it.
- The stored config is **re-applied around the chunk reads** (`_read`, `_coord_full`), not just the open, so
  the data GETs use path-style addressing too.

No dependency changes. Local and signed-S3 reads are unaffected (path-style is only forced for anon S3).

# Issues
- Fixes #560

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- `tests/netcdf/test_labeled_s3_region.py` (offline, gdal.OpenEx + config mocked / MEM multidim groups):
  anon S3 pins `AWS_VIRTUAL_HOSTING=FALSE` at open; signed / local reads leave it unset; reads
  (`_coord_full` and `_read`) re-enter the stored config; `select()` propagates the config to the child view.
- `tests/base/test_cloud_config_http.py`: `aws_virtual_hosting` maps to `AWS_VIRTUAL_HOSTING=TRUE`/`FALSE`,
  and `None` drops out.
- Caveat: the live S3 trigger needs network to the public NWM bucket and is not exercised in CI; the
  reproduction and bisection are recorded on #560.

Reproduce locally:

```
pixi run -e dev pytest tests/netcdf/test_labeled_s3_region.py tests/base/test_cloud_config_http.py
```

- [x] Test A — the two test files above pass.
- [x] Test B — `tests/netcdf/test_labeled.py` + `tests/base/test_remote.py` + doctests for the changed
  modules → 232 passed, 7 skipped, no regressions.

# Checklist:

- [ ] updated version number in pyproject.toml. (handled by commitizen in CI)
- [ ] added changes to History.rst. (changelog is commitizen-generated)
- [ ] updated the latest version in README file. (handled in the release flow)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (CloudConfig field + as_gdal_config example; read_file docstring)
