### PR TITLE
fix: clear SonarCloud main quality gate (reliability, security, hotspots)

### DIFF
--- a/.github/workflows/github-pages-mkdocs.yml
+++ b/.github/workflows/github-pages-mkdocs.yml
@@ -1,8 +1,7 @@
 name: Deploy MkDocs
 
 permissions:
-  contents: write
-  pages: write
+  contents: read
 
 on:
   push:
@@ -22,6 +21,9 @@ jobs:
   deploy-pr:
       if: github.event_name == 'pull_request'
       runs-on: ubuntu-latest
+      permissions:
+        contents: write
+        pages: write
       steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -46,6 +48,9 @@ jobs:
   deploy-main:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
@@ -70,6 +75,9 @@ jobs:
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_repository.full_name == github.repository)
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -76,10 +76,12 @@ jobs:
         run: pixi lock
 
       - name: Commit and push updated lockfile
+        env:
+          RELEASE_BRANCH: ${{ inputs.release-branch }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pixi.lock
           git diff --cached --quiet && echo "No lockfile changes" && exit 0
           git commit -m "build: sync pixi.lock after version bump"
-          git push origin ${{ inputs.release-branch }}
+          git push origin "$RELEASE_BRANCH"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,6 @@ name: Tests - Suite
 
 permissions:
   contents: read
-  id-token: write
 
 on:
   push:
@@ -18,6 +17,10 @@ concurrency:
 jobs:
   main-package:
     runs-on: ${{ matrix.os }}
+    # id-token: write is scoped here (not workflow-level) for the Codecov OIDC upload.
+    permissions:
+      contents: read
+      id-token: write
     # Bound a hung test (e.g. a flaky kerchunk/fsspec read in the xarray step) so the
     # job fails in minutes instead of running to GitHub's 6-hour default. The full
     # matrix completes in well under this; faulthandler_timeout (pyproject) dumps the
@@ -57,6 +60,10 @@ jobs:
         run: pixi run -e ${{ matrix.environment }} notebooks
 
   extras-package:
+    # id-token: write is scoped here (not workflow-level) for the Codecov OIDC upload.
+    permissions:
+      contents: read
+      id-token: write
     # One job per [project.optional-dependencies] group that ships native
     # deps (conda-forge backed). Each job installs the matching
     # ``dev-<extra>`` pixi env and runs only the tests tagged with the

--- a/examples/convert_examples.py
+++ b/examples/convert_examples.py
@@ -44,7 +44,7 @@ Convert.polygonToRaster(gdf, src_raster_path, output_raster)
 
 ## case 3 there is no given path to save the output raster to disk to it will be returned as an output.
 src = Convert.polygonToRaster(gdf, src_raster_path)
-type(src)
+print(type(src))
 # %%
 """
 Dataset To DataFrame

--- a/src/pyramids/_io.py
+++ b/src/pyramids/_io.py
@@ -312,10 +312,7 @@ def _get_tar_path(path: str):
         str: Path for GDAL to read the tar file.
     """
     # get list of files inside the compressed file
-    if path.__contains__(".tar") and not path.endswith(".tar"):
-        vsi_path = f"/vsitar/{path}"
-    else:
-        vsi_path = f"/vsitar/{path}"
+    vsi_path = f"/vsitar/{path}"
     return vsi_path
 
 

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1031,9 +1031,7 @@ class Spatial(_Engine):
         # get information from the mask raster
         if isinstance(mask, (str, Path)):
             mask = self._ds.__class__.read_file(mask)
-        elif isinstance(mask, RasterBase):
-            mask = mask
-        else:
+        elif not isinstance(mask, RasterBase):
             raise TypeError(
                 "The second parameter has to be either path to the mask raster or a gdal.Dataset object"
             )

--- a/src/pyramids/netcdf/cf.py
+++ b/src/pyramids/netcdf/cf.py
@@ -9,6 +9,7 @@ UgridDataset class.
 from __future__ import annotations
 
 import logging
+import math
 import re
 from typing import Any
 
@@ -244,9 +245,9 @@ def _extract_proj_params(srs: osr.SpatialReference, proj_name: str) -> dict[str,
     p: dict[str, Any] = {}
     fe = srs.GetProjParm(osr.SRS_PP_FALSE_EASTING, 0.0)
     fn = srs.GetProjParm(osr.SRS_PP_FALSE_NORTHING, 0.0)
-    if fe != 0.0:
+    if not math.isclose(fe, 0.0):
         p["false_easting"] = fe
-    if fn != 0.0:
+    if not math.isclose(fn, 0.0):
         p["false_northing"] = fn
 
     if "Transverse_Mercator" in proj_name:
@@ -278,9 +279,9 @@ def _extract_proj_params(srs: osr.SpatialReference, proj_name: str) -> dict[str,
         )
         sf = srs.GetProjParm(osr.SRS_PP_SCALE_FACTOR, 0.0)
         sp = srs.GetProjParm(osr.SRS_PP_STANDARD_PARALLEL_1, 0.0)
-        if sf != 0.0:
+        if not math.isclose(sf, 0.0):
             p["scale_factor_at_projection_origin"] = sf
-        if sp != 0.0:
+        if not math.isclose(sp, 0.0):
             p["standard_parallel"] = sp
     elif "Polar_Stereographic" in proj_name:
         p["straight_vertical_longitude_from_pole"] = srs.GetProjParm(
@@ -291,9 +292,9 @@ def _extract_proj_params(srs: osr.SpatialReference, proj_name: str) -> dict[str,
         )
         sf = srs.GetProjParm(osr.SRS_PP_SCALE_FACTOR, 0.0)
         sp = srs.GetProjParm(osr.SRS_PP_STANDARD_PARALLEL_1, 0.0)
-        if sf != 0.0:
+        if not math.isclose(sf, 0.0):
             p["scale_factor_at_projection_origin"] = sf
-        if sp != 0.0:
+        if not math.isclose(sp, 0.0):
             p["standard_parallel"] = sp
     elif "Albers" in proj_name:
         p["latitude_of_projection_origin"] = srs.GetProjParm(

--- a/src/pyramids/netcdf/models.py
+++ b/src/pyramids/netcdf/models.py
@@ -436,17 +436,17 @@ class VariableInfo:
                 for dimension metadata.
         """
         try:
-            md_arr_name = md_arr.GetName()
+            resolved_name = md_arr.GetName()
         except Exception:
-            md_arr_name = md_arr_name
+            resolved_name = md_arr_name
 
         try:
             md_arr_full_name = md_arr.GetFullName()
         except Exception:
             md_arr_full_name = (
-                f"{group_full_name}/{md_arr_name}"
+                f"{group_full_name}/{resolved_name}"
                 if group_full_name != "/"
-                else f"/{md_arr_name}"
+                else f"/{resolved_name}"
             )
 
         # dtype
@@ -500,7 +500,7 @@ class VariableInfo:
         coord_vars = _get_coord_variable_names(md_arr)
 
         return cls(
-            name=md_arr_name,
+            name=resolved_name,
             full_name=md_arr_full_name,
             dtype=dt,
             shape=[int(x) for x in (shape or [])],

--- a/src/pyramids/netcdf/utils.py
+++ b/src/pyramids/netcdf/utils.py
@@ -370,12 +370,8 @@ def _normalize_origin_string(origin: str) -> str:
         hms.append("0")
     H, M, S = (hms[0].zfill(2), hms[1].zfill(2), hms[2].zfill(2))
 
-    # Support fractional seconds
-    if "." in S:
-        # Keep fractional seconds as-is; datetime.fromisoformat can handle it
-        return f"{y}-{m}-{d} {H}:{M}:{S}"
-    else:
-        return f"{y}-{m}-{d} {H}:{M}:{S}"
+    # Keep fractional seconds as-is; datetime.fromisoformat can handle them.
+    return f"{y}-{m}-{d} {H}:{M}:{S}"
 
 
 def _parse_units_origin(units: str) -> tuple[str, datetime]:

--- a/tests/base/test_array_like_protocol.py
+++ b/tests/base/test_array_like_protocol.py
@@ -123,14 +123,14 @@ class TestArrayLikeAlias:
         def sum_array(x: ArrayLike) -> float:
             return float(as_numpy(x).sum())
 
-        assert sum_array(np.arange(5)) == 10.0
+        assert sum_array(np.arange(5)) == pytest.approx(10.0)
 
     @requires_dask
     def test_function_accepts_dask(self):
         def sum_array(x: ArrayLike) -> float:
             return float(as_numpy(x).sum())
 
-        assert sum_array(dask_array.arange(5, chunks=2)) == 10.0
+        assert sum_array(dask_array.arange(5, chunks=2)) == pytest.approx(10.0)
 
 
 class TestAliasExport:

--- a/tests/base/test_raster_meta.py
+++ b/tests/base/test_raster_meta.py
@@ -68,7 +68,7 @@ class TestEpsg:
 
 class TestCellSize:
     def test_absolute_x_resolution(self, basic_meta):
-        assert basic_meta.cell_size == 1.0
+        assert basic_meta.cell_size == pytest.approx(1.0)
 
     def test_negative_x_sign_ignored(self):
         meta = RasterMeta(
@@ -79,7 +79,7 @@ class TestCellSize:
             transform=(0.0, -2.0, 0.0, 0.0, 0.0, -2.0),
             crs=CRS.from_epsg(4326),
         )
-        assert meta.cell_size == 2.0
+        assert meta.cell_size == pytest.approx(2.0)
 
 
 class TestGeotransform:
@@ -102,7 +102,7 @@ class TestFromDataset:
         assert meta.columns == 5
         assert meta.epsg == 4326
         assert meta.shape == (1, 4, 5)
-        assert meta.cell_size == 1.0
+        assert meta.cell_size == pytest.approx(1.0)
 
     def test_dtype_derived_from_gdal_band_when_numpy_dtype_empty(
         self,

--- a/tests/dataset/cog/test_facade.py
+++ b/tests/dataset/cog/test_facade.py
@@ -415,7 +415,7 @@ class TestNormalizeToDataset:
         """
         result = _normalize_to_dataset(mem_dataset, None, None, 5.0)
         assert (
-            result.no_data_value[0] == 5.0
+            result.no_data_value[0] == pytest.approx(5.0)
         ), f"nodata override not applied: {result.no_data_value}"
 
     def test_unsupported_type_raises(self):

--- a/tests/dataset/cog/test_partial_reads.py
+++ b/tests/dataset/cog/test_partial_reads.py
@@ -427,4 +427,4 @@ class TestReadTile:
         tile = straddle_3857.read_tile(1, 0, 0, tilesize=256, band=0)
         assert tile.shape == (256, 256), f"edge tile must keep tilesize: {tile.shape}"
         assert (tile == -1.0).any(), "edge tile should have NoData-padded margin"
-        assert (tile == pytest.approx(1.0)).any(), "edge tile should also contain real data"
+        assert np.isclose(tile, 1.0).any(), "edge tile should also contain real data"

--- a/tests/dataset/cog/test_partial_reads.py
+++ b/tests/dataset/cog/test_partial_reads.py
@@ -427,4 +427,4 @@ class TestReadTile:
         tile = straddle_3857.read_tile(1, 0, 0, tilesize=256, band=0)
         assert tile.shape == (256, 256), f"edge tile must keep tilesize: {tile.shape}"
         assert (tile == -1.0).any(), "edge tile should have NoData-padded margin"
-        assert (tile == 1.0).any(), "edge tile should also contain real data"
+        assert (tile == pytest.approx(1.0)).any(), "edge tile should also contain real data"

--- a/tests/dataset/ops/lazy/test_read.py
+++ b/tests/dataset/ops/lazy/test_read.py
@@ -430,8 +430,8 @@ class TestE2EFixtureTiff:
         ds = Dataset.read_file(str(tiled_tif_path))
         arr = ds.read_array()
         assert arr.dtype == np.float32
-        assert arr[0, 0, 0] == 0.0
-        assert arr[1, 0, 0] == 1000.0
+        assert arr[0, 0, 0] == pytest.approx(0.0)
+        assert arr[1, 0, 0] == pytest.approx(1000.0)
 
     @requires_dask
     def test_lazy_path_e2e(self, tiled_tif_path: Path):
@@ -439,5 +439,5 @@ class TestE2EFixtureTiff:
         arr = ds.read_array(chunks="auto")
         computed = arr.compute(scheduler="synchronous")
         assert computed.dtype == np.float32
-        assert computed[0, 0, 0] == 0.0
-        assert computed[1, 0, 0] == 1000.0
+        assert computed[0, 0, 0] == pytest.approx(0.0)
+        assert computed[1, 0, 0] == pytest.approx(1000.0)

--- a/tests/dataset/test_clustering_unit.py
+++ b/tests/dataset/test_clustering_unit.py
@@ -84,7 +84,7 @@ class TestGroupNeighbours:
         assert (
             len(position) == 9
         ), f"Expected 9 cells (8 neighbors + start), got {len(position)}"
-        assert all(v == 5.0 for v in values), f"All values should be 5.0, got {values}"
+        assert all(v == pytest.approx(5.0) for v in values), f"All values should be 5.0, got {values}"
         visited = {(r, c) for r, c in position}
         expected = {(r, c) for r in range(3) for c in range(3)}
         assert visited == expected, f"Expected all 9 cells, got {visited}"

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -896,8 +896,8 @@ class TestResample:
         assert dst.rows == resampled_multi_band_dims[0]
         assert dst.columns == resampled_multi_band_dims[1]
         assert (
-            dst.raster.GetGeoTransform()[1] == cell_size
-            and dst.raster.GetGeoTransform()[-1] == -1 * cell_size
+            dst.raster.GetGeoTransform()[1] == pytest.approx(cell_size)
+            and dst.raster.GetGeoTransform()[-1] == pytest.approx(-1 * cell_size)
         )
 
         # GDAL bilinear output drifts across minor versions (e.g. 3.12 -> 3.13

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -296,8 +296,8 @@ class TestProperties:
     def test_top_left_corner(self, src: gdal.Dataset):
         dataset = Dataset(src)
         xy = dataset.top_left_corner
-        assert xy[0] == 432968.1206170588
-        assert xy[1] == 520007.787999178
+        assert xy[0] == pytest.approx(432968.1206170588)
+        assert xy[1] == pytest.approx(520007.787999178)
 
     def test_lon_lat(self, src: gdal.Dataset, lon_coords: list, lat_coords: list):
         dataset = Dataset(src)
@@ -407,14 +407,14 @@ class TestProperties:
         src = src.copy()
         assert src.scale == [1.0]
         src.scale = [2.0]
-        assert src._iloc(0).GetScale() == 2.0
+        assert src._iloc(0).GetScale() == pytest.approx(2.0)
 
     def test_offset(self, src: gdal.Dataset):
         src = Dataset(src)
         src = src.copy()
         assert src.offset == [0]
         src.offset = [2.0]
-        assert src._iloc(0).GetOffset() == 2.0
+        assert src._iloc(0).GetOffset() == pytest.approx(2.0)
 
     def test_band_color(self, src: gdal.Dataset):
         src = Dataset(src)
@@ -885,10 +885,10 @@ class TestResample:
         resampled_multi_band_dims: tuple,
         sentinel_resample_arr: np.ndarray,
     ):
-        resample_raster_cell_size = 0.00015
+        cell_size = 0.00015
         src = Dataset(sentinel_raster)
         dst = src.resample(
-            resample_raster_cell_size,
+            cell_size,
             method=resample_raster_resample_technique,
         )
 
@@ -896,8 +896,8 @@ class TestResample:
         assert dst.rows == resampled_multi_band_dims[0]
         assert dst.columns == resampled_multi_band_dims[1]
         assert (
-            dst.raster.GetGeoTransform()[1] == resample_raster_cell_size
-            and dst.raster.GetGeoTransform()[-1] == -1 * resample_raster_cell_size
+            dst.raster.GetGeoTransform()[1] == cell_size
+            and dst.raster.GetGeoTransform()[-1] == -1 * cell_size
         )
 
         # GDAL bilinear output drifts across minor versions (e.g. 3.12 -> 3.13

--- a/tests/dataset/test_dataset_collection.py
+++ b/tests/dataset/test_dataset_collection.py
@@ -25,7 +25,7 @@ class TestCreateDatasetCollection:
             rasters_folder_path, with_order=False
         )
         assert isinstance(dataset.base, Dataset)
-        assert dataset.base.no_data_value[0] == 2147483648.0
+        assert dataset.base.no_data_value[0] == pytest.approx(2147483648.0)
         assert isinstance(dataset.files, list)
         assert dataset.time_length == rasters_folder_rasters_number
         assert dataset.base.rows == rasters_folder_dim[0]
@@ -43,7 +43,7 @@ class TestCreateDatasetCollection:
             file_name_data_fmt="%Y.%m.%d",
         )
         assert isinstance(dataset.base, Dataset)
-        assert dataset.base.no_data_value[0] == 2147483648.0
+        assert dataset.base.no_data_value[0] == pytest.approx(2147483648.0)
         assert isinstance(dataset.files, list)
         assert dataset.time_length == rasters_folder_rasters_number
         assert dataset.base.rows == rasters_folder_dim[0]
@@ -67,7 +67,7 @@ class TestCreateDatasetCollection:
             fmt=rasters_folder_date_fmt,
         )
         assert isinstance(dataset.base, Dataset)
-        assert dataset.base.no_data_value[0] == 2147483648.0
+        assert dataset.base.no_data_value[0] == pytest.approx(2147483648.0)
         assert isinstance(dataset.files, list)
         assert dataset.time_length == rasters_folder_between_dates_raster_number
         assert dataset.base.rows == rasters_folder_dim[0]
@@ -86,7 +86,7 @@ class TestCreateDatasetCollection:
             date=False,
         )
         assert isinstance(dataset.base, Dataset)
-        assert dataset.base.no_data_value[0] == 2147483648.0
+        assert dataset.base.no_data_value[0] == pytest.approx(2147483648.0)
         assert isinstance(dataset.files, list)
         assert dataset.time_length == 3
         assert dataset.base.rows == rasters_folder_dim[0]
@@ -124,7 +124,7 @@ class TestAscii:
             ascii_folder_path, with_order=False, extension=".asc"
         )
         assert isinstance(dataset.base, Dataset)
-        assert dataset.base.no_data_value[0] == 2147483648.0
+        assert dataset.base.no_data_value[0] == pytest.approx(2147483648.0)
         assert isinstance(dataset.files, list)
         assert dataset.time_length == rasters_folder_rasters_number
         assert dataset.base.rows == rasters_folder_dim[0]

--- a/tests/dataset/test_dataset_collection_unit.py
+++ b/tests/dataset/test_dataset_collection_unit.py
@@ -277,7 +277,7 @@ class TestApply:
         double_fn = np.frompyfunc(lambda x: x * 2, 1, 1)
         result = md.apply(double_fn)
         assert (
-            result.values[0, 1, 0] == 20.0
+            result.values[0, 1, 0] == pytest.approx(20.0)
         ), f"Expected 20.0 after doubling, got {result.values[0, 1, 0]}"
 
     def test_apply_non_callable_raises(self, cube_with_values: DatasetCollection):

--- a/tests/dataset/test_dataset_unit.py
+++ b/tests/dataset/test_dataset_unit.py
@@ -290,7 +290,7 @@ class TestScaleOffset:
         """Setting scale should update GDAL band scale."""
         single_band_dataset.scale = [0.5]
         assert (
-            single_band_dataset._iloc(0).GetScale() == 0.5
+            single_band_dataset._iloc(0).GetScale() == pytest.approx(0.5)
         ), "GDAL band scale not updated by setter"
 
     def test_offset_default(self, single_band_dataset):
@@ -301,7 +301,7 @@ class TestScaleOffset:
         """Setting offset should update GDAL band offset."""
         single_band_dataset.offset = [100.0]
         assert (
-            single_band_dataset._iloc(0).GetOffset() == 100.0
+            single_band_dataset._iloc(0).GetOffset() == pytest.approx(100.0)
         ), "GDAL band offset not updated by setter"
 
     def test_multi_band_scale_offset(self, multi_band_dataset):
@@ -714,8 +714,8 @@ class TestWriteArray:
         patch = np.array([[99.0, 99.0], [99.0, 99.0]], dtype=np.float32)
         ds.write_array(patch, top_left_corner=[0, 0])
         result = ds.read_array()
-        assert result[0, 0] == 99.0, "Top-left cell should be 99 after write"
-        assert result[0, 1] == 99.0, "Cell (0,1) should be 99 after write"
+        assert result[0, 0] == pytest.approx(99.0), "Top-left cell should be 99 after write"
+        assert result[0, 1] == pytest.approx(99.0), "Cell (0,1) should be 99 after write"
 
     def test_write_array_with_offset(self):
         """write_array with offset should write at the given position."""
@@ -730,9 +730,9 @@ class TestWriteArray:
         patch = np.array([[7.0, 8.0], [9.0, 10.0]], dtype=np.float32)
         ds.write_array(patch, top_left_corner=[1, 1])
         result = ds.read_array()
-        assert result[1, 1] == 7.0, "Offset write failed at (1,1)"
-        assert result[2, 2] == 10.0, "Offset write failed at (2,2)"
-        assert result[0, 0] == 0.0, "Cell outside patch should be unchanged"
+        assert result[1, 1] == pytest.approx(7.0), "Offset write failed at (1,1)"
+        assert result[2, 2] == pytest.approx(10.0), "Offset write failed at (2,2)"
+        assert result[0, 0] == pytest.approx(0.0), "Cell outside patch should be unchanged"
 
 
 class TestSetNoDataValueErrors:
@@ -1283,7 +1283,7 @@ class TestDatasetProperties:
     def test_cell_size_property(self, single_band_dataset):
         """cell_size should match the value passed during creation."""
         assert (
-            single_band_dataset.cell_size == 0.05
+            single_band_dataset.cell_size == pytest.approx(0.05)
         ), "cell_size property does not match"
 
     def test_driver_type_property(self, single_band_dataset):
@@ -1326,7 +1326,7 @@ class TestDatasetProperties:
         """geotransform should return a 6-element tuple."""
         gt = single_band_dataset.geotransform
         assert len(gt) == 6, f"Geotransform should have 6 elements, got {len(gt)}"
-        assert gt[1] == 0.05, "Cell size in geotransform is wrong"
+        assert gt[1] == pytest.approx(0.05), "Cell size in geotransform is wrong"
 
     def test_str_repr(self, single_band_dataset):
         """__str__ and __repr__ should return strings."""
@@ -1897,7 +1897,7 @@ class TestResample:
         """Resampling to a larger cell size should reduce rows/columns."""
         resampled = single_band_dataset.resample(cell_size=0.1)
         assert (
-            resampled.cell_size == 0.1
+            resampled.cell_size == pytest.approx(0.1)
         ), f"Cell size should be 0.1, got {resampled.cell_size}"
         # Original is 3x3 with 0.05 cell size -> 0.15 extent
         # With 0.1 cell size -> floor(0.15/0.1) = 2 (or 1, depending on rounding)
@@ -2140,7 +2140,7 @@ class TestWriteArrayErrors:
         ds.write_array(new_data, top_left_corner=[0, 0])
         result = ds.read_array()
         assert np.all(
-            result == 77.0
+            result == pytest.approx(77.0)
         ), "All cells should be 77 after writing with None top_left"
 
 
@@ -2709,7 +2709,7 @@ class TestNearestNeighbour:
         # Cell (1,2) is last col, so right check skipped.
         # Left (1,1) = 5.0 != nd -> filled
         result = Vectorize._nearest_neighbour(arr.copy(), nd, [1], [2])
-        assert result[1, 2] == 5.0, "Cell at last col should fill from left"
+        assert result[1, 2] == pytest.approx(5.0), "Cell at last col should fill from left"
 
     def test_nearest_neighbour_above_neighbor(self):
         """_nearest_neighbour fills from above at last col, col-1=0."""
@@ -2744,7 +2744,7 @@ class TestNearestNeighbour:
         )
         # Cell (1,2) at last col. Left (1,1)=5.0, cols[i]-1=1 > 0
         result = Vectorize._nearest_neighbour(arr2.copy(), nd, [1], [2])
-        assert result[1, 2] == 5.0, "Cell should be filled from left neighbor"
+        assert result[1, 2] == pytest.approx(5.0), "Cell should be filled from left neighbor"
 
 
 class TestMapToArrayCoordinates:
@@ -3970,7 +3970,7 @@ class TestToFeatureCollection:
         )
         df = ds.to_feature_collection()
         assert len(df) == 1, f"Expected 1 row, got {len(df)}"
-        assert df.iloc[0, 0] == 42.0, f"Expected value 42.0, got {df.iloc[0, 0]}"
+        assert df.iloc[0, 0] == pytest.approx(42.0), f"Expected value 42.0, got {df.iloc[0, 0]}"
 
     def test_to_feature_collection_column_names_match_band_names(
         self, multi_band_dataset
@@ -4765,7 +4765,7 @@ class TestInplaceConsistency:
         assert result is not None, "resample should return a Dataset"
         assert isinstance(result, Dataset), f"Expected Dataset, got {type(result)}"
         assert (
-            result.cell_size == 0.1
+            result.cell_size == pytest.approx(0.1)
         ), f"Cell size should be 0.1 after resample, got {result.cell_size}"
         assert (
             single_band_dataset.cell_size == original_cell_size
@@ -4794,7 +4794,7 @@ class TestInplaceConsistency:
         result = single_band_dataset.apply(lambda x: x * 2, inplace=True)
         assert result is single_band_dataset, "inplace apply should return self"
         arr = single_band_dataset.read_array()
-        assert arr[0, 0] == 2.0, f"Expected 2.0 after doubling, got {arr[0, 0]}"
+        assert arr[0, 0] == pytest.approx(2.0), f"Expected 2.0 after doubling, got {arr[0, 0]}"
 
     def test_apply_not_inplace_returns_new_dataset(self, single_band_dataset):
         """apply(inplace=False) should return a new Dataset without modifying the original."""

--- a/tests/dataset/test_engines.py
+++ b/tests/dataset/test_engines.py
@@ -524,8 +524,8 @@ class TestAnalysisNormalize:
             with min=0.0 and max=1.0 (linear scaling preserves rank).
         """
         out = Analysis.normalize(np.array([[2.0, 4.0], [6.0, 8.0]]))
-        assert float(out.min()) == 0.0, f"Expected min 0.0, got {out.min()}"
-        assert float(out.max()) == 1.0, f"Expected max 1.0, got {out.max()}"
+        assert float(out.min()) == pytest.approx(0.0), f"Expected min 0.0, got {out.min()}"
+        assert float(out.max()) == pytest.approx(1.0), f"Expected max 1.0, got {out.max()}"
         assert out.shape == (2, 2), f"Shape mismatch: {out.shape}"
 
     def test_normalize_signed_values(self):

--- a/tests/dataset/test_merge.py
+++ b/tests/dataset/test_merge.py
@@ -131,8 +131,8 @@ class TestMergeMethod:
         assert (
             arr[0, 2] == expected_overlap and arr[0, 3] == expected_overlap
         ), f"{method} overlap should be {expected_overlap}, got {arr[0, 2]} / {arr[0, 3]}"
-        assert arr[0, 0] == 10.0, f"A-only column changed: {arr[0, 0]}"
-        assert arr[0, 5] == 20.0, f"B-only column changed: {arr[0, 5]}"
+        assert arr[0, 0] == pytest.approx(10.0), f"A-only column changed: {arr[0, 0]}"
+        assert arr[0, 5] == pytest.approx(20.0), f"B-only column changed: {arr[0, 5]}"
 
     def test_default_method_is_last(self, overlapping_pair, tmp_path):
         """Omitting method defaults to last-wins (backward compatible).
@@ -144,7 +144,9 @@ class TestMergeMethod:
         out = tmp_path / "default.tif"
         merge_rasters([pa, pb], out, no_data_value=-9999.0)
         arr = Dataset.read_file(str(out)).read_array()
-        assert arr[0, 2] == 20.0, f"Default should be last-wins (20), got {arr[0, 2]}"
+        assert arr[0, 2] == pytest.approx(
+            20.0
+        ), f"Default should be last-wins (20), got {arr[0, 2]}"
 
     def test_reduce_fills_uncovered_with_nodata(self, tmp_path):
         """Reduction methods write nodata where no source covers a pixel.
@@ -161,8 +163,10 @@ class TestMergeMethod:
         out = tmp_path / "gappy.tif"
         merge_rasters([pa, pb], out, no_data_value=-1.0, method="sum")
         arr = Dataset.read_file(str(out)).read_array()
-        assert arr[0, 0] == 5.0, f"Top-left should be A=5, got {arr[0, 0]}"
-        assert arr[3, 3] == 7.0, f"Bottom-right should be B=7, got {arr[3, 3]}"
+        assert arr[0, 0] == pytest.approx(5.0), f"Top-left should be A=5, got {arr[0, 0]}"
+        assert arr[3, 3] == pytest.approx(
+            7.0
+        ), f"Bottom-right should be B=7, got {arr[3, 3]}"
         assert (
             arr[0, 3] == -1.0
         ), f"Uncovered top-right should be nodata -1, got {arr[0, 3]}"
@@ -184,8 +188,12 @@ class TestMergeMethod:
         out = tmp_path / "mmax.tif"
         merge_rasters([pa, pb], out, no_data_value=-9999.0, method="max")
         arr = Dataset.read_file(str(out)).read_array()
-        assert arr[0, 1, 1] == 4.0, f"Band 0 max should be 4, got {arr[0, 1, 1]}"
-        assert arr[1, 1, 1] == 8.0, f"Band 1 max should be 8, got {arr[1, 1, 1]}"
+        assert arr[0, 1, 1] == pytest.approx(
+            4.0
+        ), f"Band 0 max should be 4, got {arr[0, 1, 1]}"
+        assert arr[1, 1, 1] == pytest.approx(
+            8.0
+        ), f"Band 1 max should be 8, got {arr[1, 1, 1]}"
 
     def test_n_ignores_source_value_in_reduction(self, tmp_path):
         """The n knob makes a source pixel value count as no-data in reduction.
@@ -451,7 +459,9 @@ class TestMergeRastersDstCrs:
         result = Dataset.read_file(str(out))
         arr = result.read_array()
         assert result.epsg == 4326, f"Expected output EPSG 4326, got {result.epsg}"
-        assert arr[0, 2] == 20.0, f"Last-wins overlap should be 20, got {arr[0, 2]}"
+        assert arr[0, 2] == pytest.approx(
+            20.0
+        ), f"Last-wins overlap should be 20, got {arr[0, 2]}"
 
     def test_disagree_reprojects_onto_first_source_crs(self, disagree_pair, tmp_path):
         """Mismatched CRSs with ``dst_crs=None`` reproject onto the first source.
@@ -729,7 +739,9 @@ class TestMergeRastersSigner:
         out = tmp_path / "no_signer.tif"
         merge_rasters([pa, pb], out, no_data_value=-9999.0, signer=None)
         arr = Dataset.read_file(str(out)).read_array()
-        assert arr[0, 2] == 20.0, f"signer=None overlap should be 20, got {arr[0, 2]}"
+        assert arr[0, 2] == pytest.approx(
+            20.0
+        ), f"signer=None overlap should be 20, got {arr[0, 2]}"
 
     def test_signer_produces_correct_output(self, shared_crs_pair, tmp_path):
         """A signer does not change the merge result for local inputs.
@@ -747,7 +759,9 @@ class TestMergeRastersSigner:
             signer=_FakeSigner({"GDAL_HTTP_TIMEOUT": "30"}),
         )
         arr = Dataset.read_file(str(out)).read_array()
-        assert arr[0, 2] == 20.0, f"Signed merge overlap should be 20, got {arr[0, 2]}"
+        assert arr[0, 2] == pytest.approx(
+            20.0
+        ), f"Signed merge overlap should be 20, got {arr[0, 2]}"
 
     def test_signer_config_active_during_merge(
         self, shared_crs_pair, tmp_path, monkeypatch

--- a/tests/dataset/test_plot.py
+++ b/tests/dataset/test_plot.py
@@ -2100,8 +2100,8 @@ class TestMeshRenderHelper:
             )
         assert captured.get("location") == "node"
         assert captured.get("cmap") == "plasma"
-        assert captured.get("vmin") == 0.0
-        assert captured.get("vmax") == 10.0
+        assert captured.get("vmin") == pytest.approx(0.0)
+        assert captured.get("vmax") == pytest.approx(10.0)
         assert captured.get("title") == "t"
 
     def test_mesh_render_basemap_triggers_add_basemap_with_crs(self):

--- a/tests/dataset/test_sample.py
+++ b/tests/dataset/test_sample.py
@@ -135,7 +135,7 @@ class TestSample:
             False,
             True,
         ], f"Wrong mask: {result.mask.tolist()}"
-        assert result[0] == 12.0, f"Inside value lost: {result[0]}"
+        assert result[0] == pytest.approx(12.0), f"Inside value lost: {result[0]}"
 
     def test_masked_output_multiband(self, two_band, mixed_points):
         """masked=True broadcasts the mask across all bands.
@@ -163,7 +163,7 @@ class TestSample:
         )
         result = ds.sample(mixed_points, bands=0)
         assert result.dtype == np.float64, f"Expected float64, got {result.dtype}"
-        assert result[0] == 12.0, f"Inside value wrong: {result[0]}"
+        assert result[0] == pytest.approx(12.0), f"Inside value wrong: {result[0]}"
         assert np.isnan(result[1]), f"Outside point should be NaN, got {result[1]}"
 
     def test_dataframe_input(self, two_band):

--- a/tests/dataset/test_stac.py
+++ b/tests/dataset/test_stac.py
@@ -624,11 +624,11 @@ class TestFromStacMultiAsset:
         )
         arr = coll.datasets[0].read_array()
         assert arr.shape[0] == 3, f"expected 3 bands, got {arr.shape}"
-        assert float(arr[0, 0, 0]) == 1.0, f"band1 should be red=1, got {arr[0, 0, 0]}"
+        assert float(arr[0, 0, 0]) == pytest.approx(1.0), f"band1 should be red=1, got {arr[0, 0, 0]}"
         assert (
             float(arr[1, 0, 0]) == pytest.approx(2.0)
         ), f"band2 should be green=2, got {arr[1, 0, 0]}"
-        assert float(arr[2, 0, 0]) == 3.0, f"band3 should be blue=3, got {arr[2, 0, 0]}"
+        assert float(arr[2, 0, 0]) == pytest.approx(3.0), f"band3 should be blue=3, got {arr[2, 0, 0]}"
 
     def test_band_order_follows_asset_sequence(self, multi_asset_items):
         """Reordering the asset list reorders the output bands.
@@ -840,7 +840,7 @@ class TestFromStacSolarDay:
         assert (
             float(first[0, 0]) == pytest.approx(10.0)
         ), f"first day should be first-valid 10, got {first[0, 0]}"
-        assert float(last[0, 0]) == 12.0, f"second day should be 12, got {last[0, 0]}"
+        assert float(last[0, 0]) == pytest.approx(12.0), f"second day should be 12, got {last[0, 0]}"
 
     def test_invalid_groupby_raises(self, solar_day_items):
         """An unsupported groupby value raises ValueError.
@@ -914,7 +914,7 @@ class TestAntimeridian:
         Test scenario:
             [170, -170] -> centroid ~180 (not the wrong ~0 from a naive mean).
         """
-        assert _item_centroid_lon({"bbox": [170.0, 0.0, -170.0, 5.0]}) == 180.0
+        assert _item_centroid_lon({"bbox": [170.0, 0.0, -170.0, 5.0]}) == pytest.approx(180.0)
 
     def test_centroid_lon_normalised_past_dateline(self):
         """An asymmetric wrapping box normalises its centroid into [-180, 180].

--- a/tests/dataset/test_write_array_window.py
+++ b/tests/dataset/test_write_array_window.py
@@ -63,7 +63,9 @@ class TestWriteArrayWindow:
             [1.0, 1.0],
             [1.0, 1.0],
         ], f"Window not written: {arr}"
-        assert arr[0, 0] == 0.0 and arr[4, 4] == 0.0, "Cells outside the window changed"
+        assert arr[0, 0] == pytest.approx(0.0) and arr[4, 4] == pytest.approx(
+        0.0
+    ), "Cells outside the window changed"
 
     def test_top_left_corner_still_works(self, blank):
         """The legacy top_left_corner placement is unchanged.
@@ -85,7 +87,9 @@ class TestWriteArrayWindow:
             A full 5x5 array of ones overwrites the whole raster.
         """
         blank.write_array(np.ones((5, 5)))
-        assert blank.read_array().sum() == 25.0, "Default write did not fill the raster"
+        assert blank.read_array().sum() == pytest.approx(
+            25.0
+        ), "Default write did not fill the raster"
 
     def test_band_targeted_window(self, blank_multiband):
         """A band-targeted window write touches only that band.
@@ -97,8 +101,10 @@ class TestWriteArrayWindow:
             np.full((2, 2), 3.0), band=1, window=Window(0, 0, 2, 2)
         )
         arr = blank_multiband.read_array()
-        assert arr[1, 0, 0] == 3.0, f"Band 1 not patched: {arr[1, 0, 0]}"
-        assert arr[0, 0, 0] == 0.0, f"Band 0 should be untouched: {arr[0, 0, 0]}"
+        assert arr[1, 0, 0] == pytest.approx(3.0), f"Band 1 not patched: {arr[1, 0, 0]}"
+        assert arr[0, 0, 0] == pytest.approx(
+            0.0
+        ), f"Band 0 should be untouched: {arr[0, 0, 0]}"
 
     def test_band_targeted_top_left_corner(self, blank_multiband):
         """Band targeting also works with top_left_corner.
@@ -110,8 +116,10 @@ class TestWriteArrayWindow:
             np.full((2, 2), 5.0), band=0, top_left_corner=[3, 3]
         )
         arr = blank_multiband.read_array()
-        assert arr[0, 3, 3] == 5.0, f"Band 0 not patched: {arr[0, 3, 3]}"
-        assert arr[1, 3, 3] == 0.0, f"Band 1 should be untouched: {arr[1, 3, 3]}"
+        assert arr[0, 3, 3] == pytest.approx(5.0), f"Band 0 not patched: {arr[0, 3, 3]}"
+        assert arr[1, 3, 3] == pytest.approx(
+            0.0
+        ), f"Band 1 should be untouched: {arr[1, 3, 3]}"
 
     def test_multiband_array_write(self, blank_multiband):
         """A 3D array writes across bands when band is not given.

--- a/tests/feature/test_bbox.py
+++ b/tests/feature/test_bbox.py
@@ -216,7 +216,7 @@ class TestToShapely:
             A 4x3 bbox has area 12.
         """
         assert (
-            to_shapely((0.0, 0.0, 4.0, 3.0)).area == 12.0
+            to_shapely((0.0, 0.0, 4.0, 3.0)).area == pytest.approx(12.0)
         ), "Area should be width*height"
 
 
@@ -334,7 +334,7 @@ class TestSplitPolygonAntimeridian:
             The Fiji box spans 10 deg lon by 10 deg lat.
         """
         result = split_polygon_antimeridian(_crossing_ring())
-        assert round(result.area, 6) == 100.0, f"Area not preserved: {result.area}"
+        assert result.area == pytest.approx(100.0), f"Area not preserved: {result.area}"
 
     def test_non_crossing_unchanged(self):
         """A non-crossing polygon is returned unchanged.
@@ -372,7 +372,7 @@ class TestSplitPolygonAntimeridian:
         multi = MultiPolygon([_crossing_ring()])
         result = split_polygon_antimeridian(multi)
         assert result.is_valid, "Result should be valid"
-        assert round(result.area, 6) == 100.0, f"Area not preserved: {result.area}"
+        assert result.area == pytest.approx(100.0), f"Area not preserved: {result.area}"
 
     def test_invalid_type_raises(self):
         """A non-polygon geometry raises TypeError.

--- a/tests/feature/test_coverage_gaps.py
+++ b/tests/feature/test_coverage_gaps.py
@@ -63,7 +63,8 @@ class TestLowLevelCoordHelpers:
         poly = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
         xs = get_poly_coords(poly, "x")
         # First + last are the same (closed ring).
-        assert xs[0] == xs[-1] == 0.0
+        assert xs[0] == pytest.approx(0.0)
+        assert xs[-1] == pytest.approx(0.0)
         assert set(xs) == {0.0, 1.0}
 
 

--- a/tests/feature/test_feature.py
+++ b/tests/feature/test_feature.py
@@ -248,7 +248,7 @@ class TestToDataset:
             src = Dataset.from_features(vector, cell_size=200)
             assert src.cell_size == 200
             arr = src.read_array()
-            values = arr[arr[:, :] == 1.0]
+            values = arr[np.isclose(arr[:, :], 1.0)]
             assert values.shape[0] == 6400
 
         def test_multi_polygon(self, polygons_coello_gdf: GeoDataFrame):
@@ -340,7 +340,7 @@ class TestWithCoordinates:
     ):
         feature = FeatureCollection(geometry_collection_gdf)
         result = feature.with_coordinates()
-        assert result.loc[0, "x"] == 100.0
+        assert result.loc[0, "x"] == pytest.approx(100.0)
         assert result.loc[1, "x"] == [101.0, 102.0]
         assert result.loc[2, "x"] == [
             460717.3717217822,

--- a/tests/netcdf/test_cf_classify.py
+++ b/tests/netcdf/test_cf_classify.py
@@ -212,13 +212,13 @@ class TestApplyValidRangeMask:
         result = apply_valid_range_mask(arr, valid_min=2.5)
         assert np.isnan(result[0]), "1.0 should be masked"
         assert np.isnan(result[1]), "2.0 should be masked"
-        assert result[2] == 3.0, "3.0 should be preserved"
+        assert result[2] == pytest.approx(3.0), "3.0 should be preserved"
 
     def test_valid_max(self):
         """Values above valid_max are replaced with NaN."""
         arr = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
         result = apply_valid_range_mask(arr, valid_max=3.5)
-        assert result[2] == 3.0, "3.0 should be preserved"
+        assert result[2] == pytest.approx(3.0), "3.0 should be preserved"
         assert np.isnan(result[3]), "4.0 should be masked"
         assert np.isnan(result[4]), "5.0 should be masked"
 
@@ -227,8 +227,8 @@ class TestApplyValidRangeMask:
         arr = np.array([0.0, 1.0, 2.0, 3.0, 4.0])
         result = apply_valid_range_mask(arr, valid_range=[1.0, 3.0])
         assert np.isnan(result[0]), "0.0 should be masked"
-        assert result[1] == 1.0, "1.0 should be preserved"
-        assert result[3] == 3.0, "3.0 should be preserved"
+        assert result[1] == pytest.approx(1.0), "1.0 should be preserved"
+        assert result[3] == pytest.approx(3.0), "3.0 should be preserved"
         assert np.isnan(result[4]), "4.0 should be masked"
 
     def test_custom_fill_value(self):

--- a/tests/netcdf/test_cf_grid_mapping.py
+++ b/tests/netcdf/test_cf_grid_mapping.py
@@ -54,7 +54,7 @@ class TestSrsToGridMapping:
             abs(params["scale_factor_at_central_meridian"] - 0.9996) < 1e-6
         ), f"Expected scale ~0.9996, got {params.get('scale_factor_at_central_meridian')}"
         assert (
-            params.get("false_easting") == 500000.0
+            params.get("false_easting") == pytest.approx(500000.0)
         ), f"Expected FE=500000, got {params.get('false_easting')}"
 
     def test_crs_wkt_always_present(self):

--- a/tests/netcdf/test_consistent_return_types.py
+++ b/tests/netcdf/test_consistent_return_types.py
@@ -221,9 +221,11 @@ class TestPreserveNetcdfMetadata:
             epsg=4326,
         )
         wrapped = var_3d._preserve_netcdf_metadata(ds)
-        assert wrapped._scale == 0.01, f"Expected scale=0.01, got {wrapped._scale}"
-        assert (
-            wrapped._offset == 273.15
+        assert wrapped._scale == pytest.approx(
+            0.01
+        ), f"Expected scale=0.01, got {wrapped._scale}"
+        assert wrapped._offset == pytest.approx(
+            273.15
         ), f"Expected offset=273.15, got {wrapped._offset}"
 
     def test_copies_is_subset_flag(self, var_3d):
@@ -446,8 +448,12 @@ class TestToCrsReturnType:
         var_3d._scale = 0.1
         var_3d._offset = -50.0
         result = var_3d.to_crs(to_epsg=32637)
-        assert result._scale == 0.1, f"Expected scale=0.1, got {result._scale}"
-        assert result._offset == -50.0, f"Expected offset=-50.0, got {result._offset}"
+        assert result._scale == pytest.approx(
+            0.1
+        ), f"Expected scale=0.1, got {result._scale}"
+        assert result._offset == pytest.approx(
+            -50.0
+        ), f"Expected offset=-50.0, got {result._offset}"
 
     def test_variable_to_crs_changes_epsg(self, var_3d):
         """to_crs() actually changes the CRS of the result.
@@ -620,8 +626,12 @@ class TestSelReturnType:
         var_3d._scale = 0.5
         var_3d._offset = 100.0
         result = var_3d.sel(time=6)
-        assert result._scale == 0.5, f"Expected scale=0.5, got {result._scale}"
-        assert result._offset == 100.0, f"Expected offset=100.0, got {result._offset}"
+        assert result._scale == pytest.approx(
+            0.5
+        ), f"Expected scale=0.5, got {result._scale}"
+        assert result._offset == pytest.approx(
+            100.0
+        ), f"Expected offset=100.0, got {result._offset}"
 
     def test_sel_preserves_is_subset(self, var_3d):
         """sel() preserves _is_subset=True.
@@ -771,9 +781,11 @@ class TestChaining:
         var._scale = 0.5
         var._offset = 100.0
         reprojected = var.to_crs(to_epsg=32637, method="bilinear")
-        assert reprojected._scale == 0.5, f"Scale not preserved: {reprojected._scale}"
-        assert (
-            reprojected._offset == 100.0
+        assert reprojected._scale == pytest.approx(
+            0.5
+        ), f"Scale not preserved: {reprojected._scale}"
+        assert reprojected._offset == pytest.approx(
+            100.0
         ), f"Offset not preserved: {reprojected._offset}"
         raw = reprojected.read_array()
         unpacked = reprojected.read_array(unpack=True)
@@ -797,8 +809,12 @@ class TestChaining:
         var._scale = 0.01
         var._offset = 273.15
         resampled = var.resample(cell_size=2.0, method="cubic")
-        assert resampled._scale == 0.01, f"Scale not preserved: {resampled._scale}"
-        assert resampled._offset == 273.15, f"Offset not preserved: {resampled._offset}"
+        assert resampled._scale == pytest.approx(
+            0.01
+        ), f"Scale not preserved: {resampled._scale}"
+        assert resampled._offset == pytest.approx(
+            273.15
+        ), f"Offset not preserved: {resampled._offset}"
         raw = resampled.read_array()
         unpacked = resampled.read_array(unpack=True)
         expected = raw.astype(np.float64) * 0.01 + 273.15

--- a/tests/netcdf/test_create_from_array.py
+++ b/tests/netcdf/test_create_from_array.py
@@ -282,7 +282,7 @@ class TestCreateFromArrayGeoParams:
         var = nc.get_variable("v")
         gt = var.geotransform
         assert gt is not None, "Geotransform should not be None"
-        assert gt[1] == 0.5, f"Expected pixel size 0.5, got {gt[1]}"
+        assert gt[1] == pytest.approx(0.5), f"Expected pixel size 0.5, got {gt[1]}"
 
     def test_top_left_corner_and_cell_size(self):
         """``top_left_corner`` + ``cell_size`` should build ``geo`` internally.
@@ -302,7 +302,7 @@ class TestCreateFromArrayGeoParams:
         var = nc.get_variable("v")
         gt = var.geotransform
         assert gt is not None, "Geotransform should not be None"
-        assert gt[1] == 0.5, f"Expected pixel size 0.5, got {gt[1]}"
+        assert gt[1] == pytest.approx(0.5), f"Expected pixel size 0.5, got {gt[1]}"
 
     def test_no_geo_raises(self):
         """Omitting both ``geo`` and ``top_left_corner`` should raise.

--- a/tests/netcdf/test_global_attributes.py
+++ b/tests/netcdf/test_global_attributes.py
@@ -97,7 +97,7 @@ class TestSetGlobalAttribute:
         """
         nc = _make_nc()
         nc.set_global_attribute("version", 2.5)
-        assert nc.global_attributes["version"] == 2.5, f"Float not stored correctly"
+        assert nc.global_attributes["version"] == pytest.approx(2.5), f"Float not stored correctly"
 
     def test_int_value(self):
         """Setting an int attribute should store it correctly.

--- a/tests/netcdf/test_metadata_unit.py
+++ b/tests/netcdf/test_metadata_unit.py
@@ -1506,8 +1506,8 @@ class TestFromJson:
         md = _make_metadata(variables={"/full": full_arr})
         restored = from_json(to_json(md))
         r = restored.variables["/full"]
-        assert r.scale == 0.01, f"Expected scale=0.01, got {r.scale}"
-        assert r.offset == 0.5, f"Expected offset=0.5, got {r.offset}"
+        assert r.scale == pytest.approx(0.01), f"Expected scale=0.01, got {r.scale}"
+        assert r.offset == pytest.approx(0.5), f"Expected offset=0.5, got {r.offset}"
         assert r.nodata == -9999, f"Expected nodata=-9999, got {r.nodata}"
         assert (
             r.srs_wkt == 'GEOGCS["WGS 84"]'

--- a/tests/netcdf/test_netcdf_unit.py
+++ b/tests/netcdf/test_netcdf_unit.py
@@ -630,7 +630,7 @@ class TestCreateFromArrayAlternatives:
         )
         assert nc is not None, "NetCDF should be created"
         var = nc.get_variable("data")
-        assert var.cell_size == 0.5, f"Expected cell_size 0.5, got {var.cell_size}"
+        assert var.cell_size == pytest.approx(0.5), f"Expected cell_size 0.5, got {var.cell_size}"
 
     def test_create_from_array_no_geo_raises(self):
         """Verify create_from_array raises ValueError without geo information.
@@ -1604,11 +1604,7 @@ class TestSetVariableAttrException:
 
         def open_and_patch(name, *args, **kwargs):
             """Open the array and patch CreateAttribute to fail."""
-            arr = (
-                original_open(name, *args, **kwargs)
-                if not args
-                else original_open(name, *args, **kwargs)
-            )
+            arr = original_open(name, *args, **kwargs)
             return arr
 
         nc.set_variable(

--- a/tests/netcdf/test_plot.py
+++ b/tests/netcdf/test_plot.py
@@ -357,7 +357,7 @@ class TestNetCDFPlotColourForwarding:
         with patch.object(type(var.analysis), "plot", autospec=True) as mock_plot:
             mock_plot.return_value = "ok"
             nc.plot(variable="t2m", colour=ColourOpts(center=0.0))
-        assert mock_plot.call_args.kwargs.get("center") == 0.0
+        assert mock_plot.call_args.kwargs.get("center") == pytest.approx(0.0)
 
     def test_robust_default_not_forwarded(self):
         """`robust=False` (the default) is NOT forwarded to keep kwargs lean."""
@@ -877,8 +877,8 @@ class TestNetCDFPlotForwardingExtra:
             mock_plot.return_value = "ok"
             nc.plot(variable="t2m", colour=ColourOpts(vmin=0.0, vmax=1.0))
         kw = mock_plot.call_args.kwargs
-        assert kw.get("vmin") == 0.0, f"vmin not forwarded: {kw}"
-        assert kw.get("vmax") == 1.0, f"vmax not forwarded: {kw}"
+        assert kw.get("vmin") == pytest.approx(0.0), f"vmin not forwarded: {kw}"
+        assert kw.get("vmax") == pytest.approx(1.0), f"vmax not forwarded: {kw}"
 
     def test_basemap_without_epsg_raises(self):
         """``basemap=True`` on a CRS-less subset must surface the underlying ValueError.

--- a/tests/netcdf/test_reduce.py
+++ b/tests/netcdf/test_reduce.py
@@ -142,8 +142,8 @@ class TestReduceSkipna:
             extra_dim_values=[0, 1],
         )
         skip = nc.reduce("time", "mean", skipna=True).get_variable("v").read_array()
-        assert skip[0, 0] == 10.0, "all-but-nodata cell should keep the valid value"
-        assert skip[0, 1] == 20.0, "mean of 10 and 30 should be 20"
+        assert skip[0, 0] == pytest.approx(10.0), "all-but-nodata cell should keep the valid value"
+        assert skip[0, 1] == pytest.approx(20.0), "mean of 10 and 30 should be 20"
 
     def test_no_skipna_uses_raw_values(self):
         """Without skipna the raw values (including sentinels) are reduced.

--- a/tests/netcdf/test_utils.py
+++ b/tests/netcdf/test_utils.py
@@ -307,7 +307,7 @@ class TestGetArrayNodata:
         mdarr = MagicMock(spec=[])
         attrs = {"_FillValue": [1e20, 1e20]}
         result = _get_array_nodata(mdarr, attrs)
-        assert result == 1e20, "Should return first element of list _FillValue"
+        assert result == pytest.approx(1e20), "Should return first element of list _FillValue"
 
     def test_fill_value_empty_list_returns_none(self):
         """Empty list _FillValue returns None."""

--- a/tests/netcdf/test_windowed_reads.py
+++ b/tests/netcdf/test_windowed_reads.py
@@ -632,8 +632,8 @@ class TestSelReturnTypeAndMetadata:
         var._scale = 0.01
         var._offset = 273.15
         result = var.sel(time=12)
-        assert result._scale == 0.01, f"Expected scale=0.01, got {result._scale}"
-        assert result._offset == 273.15, f"Expected offset=273.15, got {result._offset}"
+        assert result._scale == pytest.approx(0.01), f"Expected scale=0.01, got {result._scale}"
+        assert result._offset == pytest.approx(273.15), f"Expected offset=273.15, got {result._offset}"
 
     def test_sel_result_supports_unpack(self):
         """read_array(unpack=True) works on a sel() result.

--- a/tests/netcdf/test_xarray_interop.py
+++ b/tests/netcdf/test_xarray_interop.py
@@ -548,7 +548,6 @@ class TestToXarrayErrors:
         """
         nc = _make_3d_nc()
         var = nc.get_variable("temperature")
-        var._raster = var._raster
         nc_fake = NetCDF.__new__(NetCDF)
         nc_fake.__dict__.update(var.__dict__)
         nc_fake._file_name = ""
@@ -589,8 +588,8 @@ class TestGlobalAttributes:
         nc = _make_3d_nc()
         nc.set_global_attribute("version", 2.0)
         ds = nc.to_xarray()
-        assert (
-            ds.attrs.get("version") == 2.0
+        assert ds.attrs.get("version") == pytest.approx(
+            2.0
         ), f"Expected 2.0, got {ds.attrs.get('version')}"
 
 

--- a/tests/stac/test_extensions.py
+++ b/tests/stac/test_extensions.py
@@ -73,7 +73,7 @@ class TestParseNumber:
         Test scenario:
             A missing field falls back to the default sentinel.
         """
-        assert parse_number(None, default=42.0) == 42.0
+        assert parse_number(None, default=42.0) == pytest.approx(42.0)
 
     def test_unparseable_returns_default(self):
         """An unparseable string yields the default.
@@ -81,7 +81,7 @@ class TestParseNumber:
         Test scenario:
             'n/a' cannot be parsed, so the default is returned.
         """
-        assert parse_number("n/a", default=0.0) == 0.0
+        assert parse_number("n/a", default=0.0) == pytest.approx(0.0)
 
     def test_bool_returns_default(self):
         """Booleans are not treated as numbers.

--- a/tests/test_e2e_workflows.py
+++ b/tests/test_e2e_workflows.py
@@ -150,7 +150,7 @@ class TestRasterizeRoundTrip:
         arr = raster.read_array()
 
         # Verify burned value
-        burned = arr[arr == 7.0]
+        burned = arr[np.isclose(arr, 7.0)]
         assert burned.size > 0, "At least some cells should contain the burned value 7"
         assert (
             raster.epsg == epsg
@@ -183,7 +183,7 @@ class TestRasterizeRoundTrip:
             cols,
         ), f"Rasterized shape should match reference ({rows},{cols}), got {arr.shape}"
         # Burned value should appear
-        burned = arr[arr == 42.0]
+        burned = arr[np.isclose(arr, 42.0)]
         assert burned.size > 0, "Burned value 42 should appear in the raster"
 
     def test_from_features_rejects_non_positive_cell_size(self):

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -67,7 +67,7 @@ class TestPyramidsErrorBase:
             traceability.
         """
         with caplog.at_level(logging.DEBUG):
-            _PyramidsError("base debug test")
+            _ = _PyramidsError("base debug test")
         assert (
             "_PyramidsError: base debug test" in caplog.text
         ), f"Expected '_PyramidsError: base debug test' in log, got: {caplog.text}"

--- a/tests/test_io_from_bytes.py
+++ b/tests/test_io_from_bytes.py
@@ -93,8 +93,7 @@ class TestSilentUnlink:
             ``None`` without raising (this is what makes it safe inside
             ``weakref.finalize``).
         """
-        result = silent_unlink("/vsimem/this-path-never-existed-xyz.tif")
-        assert result is None, "silent_unlink should swallow the error and return None"
+        silent_unlink("/vsimem/this-path-never-existed-xyz.tif")
 
 
 class TestBytesToGdal:

--- a/tests/ugrid/test_advanced.py
+++ b/tests/ugrid/test_advanced.py
@@ -72,7 +72,7 @@ class TestCrsHandling:
         )
         reprojected = ds.to_crs(4326)
         assert (
-            reprojected["temp"].data[0] == 25.0
+            reprojected["temp"].data[0] == pytest.approx(25.0)
         ), f"Data should be preserved, got {reprojected['temp'].data[0]}"
 
     def test_to_crs_preserves_topology(self):

--- a/tests/ugrid/test_integration.py
+++ b/tests/ugrid/test_integration.py
@@ -89,7 +89,7 @@ class TestFullLifecycle:
         gdf = ds.to_geodataframe("depth", location="face")
         assert len(gdf) == 1, f"Expected 1 row, got {len(gdf)}"
         assert (
-            gdf["depth"].iloc[0] == 5.5
+            gdf["depth"].iloc[0] == pytest.approx(5.5)
         ), f"Expected depth 5.5, got {gdf['depth'].iloc[0]}"
         assert (
             gdf.geometry.iloc[0].geom_type == "Polygon"

--- a/tests/ugrid/test_interpolation.py
+++ b/tests/ugrid/test_interpolation.py
@@ -83,10 +83,10 @@ class TestMeshToGridNearest:
         """
         mesh, data = grid_mesh
         _, geo = mesh_to_grid(mesh, data, "face", cell_size=0.5)
-        assert geo[0] == 0.0, f"Expected x_origin=0, got {geo[0]}"
-        assert geo[1] == 0.5, f"Expected cell_size=0.5, got {geo[1]}"
-        assert geo[3] == 2.0, f"Expected y_origin=2, got {geo[3]}"
-        assert geo[5] == -0.5, f"Expected -cell_size=-0.5, got {geo[5]}"
+        assert geo[0] == pytest.approx(0.0), f"Expected x_origin=0, got {geo[0]}"
+        assert geo[1] == pytest.approx(0.5), f"Expected cell_size=0.5, got {geo[1]}"
+        assert geo[3] == pytest.approx(2.0), f"Expected y_origin=2, got {geo[3]}"
+        assert geo[5] == pytest.approx(-0.5), f"Expected -cell_size=-0.5, got {geo[5]}"
 
     def test_values_mapped_correctly(self, grid_mesh):
         """Test that grid values correspond to nearest face values.
@@ -96,8 +96,8 @@ class TestMeshToGridNearest:
         """
         mesh, data = grid_mesh
         grid, _ = mesh_to_grid(mesh, data, "face", cell_size=1.0)
-        assert grid[1, 0] == 10.0, f"Expected 10.0 at face 0 region, got {grid[1, 0]}"
-        assert grid[1, 1] == 20.0, f"Expected 20.0 at face 1 region, got {grid[1, 1]}"
+        assert grid[1, 0] == pytest.approx(10.0), f"Expected 10.0 at face 0 region, got {grid[1, 0]}"
+        assert grid[1, 1] == pytest.approx(20.0), f"Expected 20.0 at face 1 region, got {grid[1, 1]}"
 
     def test_nodata_outside_mesh(self, grid_mesh):
         """Test nodata for cells far from mesh.

--- a/tests/ugrid/test_mesh2d.py
+++ b/tests/ugrid/test_mesh2d.py
@@ -76,10 +76,10 @@ class TestMesh2dProperties:
             Nodes span x=[0,2], y=[0,1].
         """
         xmin, ymin, xmax, ymax = triangle_mesh.bounds
-        assert xmin == 0.0, f"Expected xmin=0.0, got {xmin}"
-        assert ymin == 0.0, f"Expected ymin=0.0, got {ymin}"
-        assert xmax == 2.0, f"Expected xmax=2.0, got {xmax}"
-        assert ymax == 1.0, f"Expected ymax=1.0, got {ymax}"
+        assert xmin == pytest.approx(0.0), f"Expected xmin=0.0, got {xmin}"
+        assert ymin == pytest.approx(0.0), f"Expected ymin=0.0, got {ymin}"
+        assert xmax == pytest.approx(2.0), f"Expected xmax=2.0, got {xmax}"
+        assert ymax == pytest.approx(1.0), f"Expected ymax=1.0, got {ymax}"
 
     def test_bounds_mixed(self, mixed_mesh):
         """Test bounds for mixed mesh.
@@ -88,10 +88,10 @@ class TestMesh2dProperties:
             Nodes span x=[0,2], y=[0,1].
         """
         xmin, ymin, xmax, ymax = mixed_mesh.bounds
-        assert xmin == 0.0, f"Expected xmin=0.0, got {xmin}"
-        assert ymin == 0.0, f"Expected ymin=0.0, got {ymin}"
-        assert xmax == 2.0, f"Expected xmax=2.0, got {xmax}"
-        assert ymax == 1.0, f"Expected ymax=1.0, got {ymax}"
+        assert xmin == pytest.approx(0.0), f"Expected xmin=0.0, got {xmin}"
+        assert ymin == pytest.approx(0.0), f"Expected ymin=0.0, got {ymin}"
+        assert xmax == pytest.approx(2.0), f"Expected xmax=2.0, got {xmax}"
+        assert ymax == pytest.approx(1.0), f"Expected ymax=1.0, got {ymax}"
 
 
 class TestMesh2dFaceCentroids:
@@ -134,8 +134,8 @@ class TestMesh2dFaceCentroids:
             face_y=face_y,
         )
         cx, cy = mesh.face_centroids
-        assert cx[0] == 99.0, f"Expected provided face_x=99.0, got {cx[0]}"
-        assert cy[0] == 99.0, f"Expected provided face_y=99.0, got {cy[0]}"
+        assert cx[0] == pytest.approx(99.0), f"Expected provided face_x=99.0, got {cx[0]}"
+        assert cy[0] == pytest.approx(99.0), f"Expected provided face_y=99.0, got {cy[0]}"
 
     def test_centroids_cached(self, triangle_mesh):
         """Test that centroids are cached after first computation.

--- a/tests/ugrid/test_write.py
+++ b/tests/ugrid/test_write.py
@@ -230,7 +230,7 @@ class TestCreateFromArrays:
         assert (
             "temperature" in ds.data_variable_names
         ), "Should have temperature variable"
-        assert ds["temperature"].data[0] == 20.0, "Temperature should be 20.0"
+        assert ds["temperature"].data[0] == pytest.approx(20.0), "Temperature should be 20.0"
 
     def test_mixed_mesh(self):
         """Test creating a mixed mesh from arrays.


### PR DESCRIPTION
# Description

Clears the SonarCloud **main-branch quality gate**, which was failing on all three new-code conditions:
`new_reliability_rating` (C), `new_security_rating` (E), and `new_security_hotspots_reviewed` (0%).

The change is in three parts:

- **Reliability (119+ bugs → fixed):** resolve the flagged `python:S1244` float-equality bugs and a handful of others
  (`S1656`, `S1226`, `S3923`, `S3699`, `S3984`, `S2201`, `S4143`, `S1763`) across ~45 test files and 5 source files.
  - In tests: wrap genuine float comparisons in `pytest.approx(...)`.
  - In `src/`: use `math.isclose` for float checks (`netcdf/cf.py`), replace a parameter mutation with a local
    (`netcdf/models.py`), drop a self-assignment (`dataset/engines/spatial.py`), and collapse identical if/else
    branches (`_io.py`, `netcdf/utils.py`).
- **Security (vulnerabilities → fixed):**
  - `githubactions:S7630` — `github-release.yml` passed `inputs.release-branch` straight into a `run:` block
    (script-injection); now passed via an `env:` var and quoted.
  - `githubactions:S8233` ×3 — moved workflow-level write permissions to the specific jobs that need them
    (`tests.yml`: `id-token: write` on the two test jobs for the Codecov OIDC upload; `github-pages-mkdocs.yml`:
    `contents`/`pages: write` on the three deploy jobs).
- **Triaged in SonarCloud (no code change required):** 3 false-positive vulnerabilities (`S2083` osgeo-init patch
  path, `S6096` `/vsigzip/` virtual read path, `S8565` "lock file missing" — the repo uses a committed `pixi.lock`),
  4 false-positive bugs (intentional LRU duplicate-key test, the idiomatic empty-generator `yield`, two
  `-> None` contract assertions), and all 11 security hotspots reviewed as safe (HTTP-prefix matching / test URLs,
  fork-guarded workflows, and the deliberate root build image).

# Issues

- Closes #578 — resolve SonarCloud main quality-gate findings (reliability, security, hotspots).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Full local suite: `pixi run -e dev test-all` (all tests incl. plot + xarray) — green.
- `python -m py_compile` on every changed source/test file.
- YAML validity check on the three edited workflows.

- [x] Full local test suite
- [x] py_compile + YAML parse of all edited files

# Checklist:

- [ ] updated version number in pyproject.toml. <!-- handled by commitizen via the release workflow -->
- [ ] added changes to History.rst. <!-- change-log is commitizen-generated -->
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works. <!-- existing tests, hardened -->
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.


