### PR TITLE
feat(dataset): add Dataset.to_terrain_rgb (terrain-RGB encoding + XYZ tiles)

### DIFF
--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -1063,6 +1063,11 @@ class Dataset(RasterBase):
         """Facade — delegates to :meth:`IO.to_xyz <pyramids.dataset.engines.IO.to_xyz>`."""
         return self.io.to_xyz(*args, **kwargs)
 
+    def to_terrain_rgb(self, *args, **kwargs):
+        """Facade — delegates to
+        :meth:`IO.to_terrain_rgb <pyramids.dataset.engines.IO.to_terrain_rgb>`."""
+        return self.io.to_terrain_rgb(*args, **kwargs)
+
     @property
     def overview_count(self):
         """Facade — delegates to :attr:`IO.overview_count <pyramids.dataset.engines.IO.overview_count>`."""

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -2287,7 +2287,8 @@ class IO(_Engine):
 
         Raises:
             ValueError: ``encoding`` is not ``"mapbox"``/``"terrarium"``,
-                ``resampling`` is unknown, or ``max_zoom < min_zoom``.
+                ``resampling`` is unknown, ``interval <= 0`` (mapbox),
+                ``min_zoom < 0``, or ``max_zoom < min_zoom``.
 
         Examples:
             - Encode a small DEM to a single terrain-RGB PNG (the write is
@@ -2315,6 +2316,12 @@ class IO(_Engine):
             raise ValueError(
                 f"encoding must be one of {_TERRAIN_RGB_ENCODINGS}, got {encoding!r}."
             )
+        if encoding == "mapbox" and interval <= 0:
+            raise ValueError(
+                f"interval must be positive for mapbox encoding, got {interval}."
+            )
+        if min_zoom < 0:
+            raise ValueError(f"min_zoom must be >= 0, got {min_zoom}.")
         # Validate the resampling name once (also reused by the per-tile warp).
         resample_alg = resolve_resampling(resampling)
         source = (
@@ -2492,6 +2499,10 @@ class IO(_Engine):
         if nodata is not None:
             warp_kwargs["dstNodata"] = nodata
         warped = gdal.Warp("", source.raster, **warp_kwargs)
+        if warped is None:
+            raise FailedToSaveError(
+                f"GDAL could not warp the terrain-RGB tile {zoom}/{x}/{y}."
+            )
         elevation = np.asarray(
             warped.GetRasterBand(band + 1).ReadAsArray(), dtype=float
         )

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -2322,6 +2322,7 @@ class IO(_Engine):
             )
         if min_zoom < 0:
             raise ValueError(f"min_zoom must be >= 0, got {min_zoom}.")
+        _validate_band_index(band, self._ds.band_count)
         # Validate the resampling name once (also reused by the per-tile warp).
         resample_alg = resolve_resampling(resampling)
         source = (

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -199,6 +199,42 @@ def _encode_terrain_rgb(
 
     Returns:
         np.ndarray: ``(3, rows, cols)`` ``uint8`` array of the R, G, B channels.
+
+    Examples:
+        - Mapbox-pack a single elevation and read back the byte triple:
+            ```python
+            >>> import numpy as np
+            >>> rgb = _encode_terrain_rgb(
+            ...     np.array([[0.0]]), encoding="mapbox",
+            ...     base_val=-10000.0, interval=0.1,
+            ... )
+            >>> rgb.shape
+            (3, 1, 1)
+            >>> tuple(int(v) for v in rgb[:, 0, 0])
+            (1, 134, 160)
+
+            ```
+        - Elevations above the encodable range clamp to white, not wrap:
+            ```python
+            >>> import numpy as np
+            >>> rgb = _encode_terrain_rgb(
+            ...     np.array([[1e12]]), encoding="mapbox",
+            ...     base_val=-10000.0, interval=0.1,
+            ... )
+            >>> tuple(int(v) for v in rgb[:, 0, 0])
+            (255, 255, 255)
+
+            ```
+        - Terrarium packs sea level as ``(128, 0, 0)``:
+            ```python
+            >>> import numpy as np
+            >>> rgb = _encode_terrain_rgb(
+            ...     np.array([[0.0]]), encoding="terrarium", base_val=0.0, interval=1.0
+            ... )
+            >>> tuple(int(v) for v in rgb[:, 0, 0])
+            (128, 0, 0)
+
+            ```
     """
     if encoding == "mapbox":
         packed = np.round((np.asarray(elevation, dtype=float) - base_val) / interval)
@@ -242,6 +278,32 @@ def _terrain_rgba_stack(
     Returns:
         np.ndarray: ``(3, rows, cols)`` RGB, or ``(4, rows, cols)`` RGBA when a
         no-data value is present.
+
+    Examples:
+        - Without a no-data value the stack is plain 3-band RGB:
+            ```python
+            >>> import numpy as np
+            >>> stack = _terrain_rgba_stack(
+            ...     np.array([[100.0]]), None,
+            ...     encoding="mapbox", base_val=-10000.0, interval=0.1,
+            ... )
+            >>> stack.shape[0]
+            3
+
+            ```
+        - A no-data cell adds a 4th alpha band that is 0 there, 255 elsewhere:
+            ```python
+            >>> import numpy as np
+            >>> stack = _terrain_rgba_stack(
+            ...     np.array([[100.0, -9999.0]]), -9999.0,
+            ...     encoding="mapbox", base_val=-10000.0, interval=0.1,
+            ... )
+            >>> stack.shape[0]
+            4
+            >>> int(stack[3, 0, 0]), int(stack[3, 0, 1])
+            (255, 0)
+
+            ```
     """
     rgb = _encode_terrain_rgb(
         elevation, encoding=encoding, base_val=base_val, interval=interval

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -34,8 +34,13 @@ from pyramids.base._file_manager import (
 )
 from pyramids.base._locks import DummyLock, default_lock
 from pyramids.base.protocols import ArrayLike
+from pyramids.base._utils import resolve_resampling
 from pyramids.dataset.abstract_dataset import OVERVIEW_LEVELS, RESAMPLING_METHODS
-from pyramids.dataset.engines.cog import _RESAMPLING_ALG
+from pyramids.dataset.engines.cog import (
+    _RESAMPLING_ALG,
+    _WEB_MERCATOR_HALF_EXTENT,
+    _xyz_bounds_3857,
+)
 from pyramids.dataset.ops import io as _io_module
 from pyramids.dataset.ops.io import _LAZY_IMPORT_ERROR
 from pyramids.dataset.window import Window
@@ -168,6 +173,84 @@ def _validate_fill_value(fill_value: float, dtype: np.dtype) -> None:
             f"dtype {dtype.name} (whole numbers in [{info.min}, "
             f"{info.max}])."
         )
+
+
+_TERRAIN_RGB_ENCODINGS = ("mapbox", "terrarium")
+"""Supported terrain-RGB elevation encodings (Mapbox Terrain-RGB / Mapzen Terrarium)."""
+
+
+def _encode_terrain_rgb(
+    elevation: np.ndarray,
+    *,
+    encoding: str,
+    base_val: float,
+    interval: float,
+) -> np.ndarray:
+    """Pack a float elevation grid (metres) into a ``(3, rows, cols)`` uint8 RGB stack.
+
+    Mirrors the Mapbox Terrain-RGB and Mapzen Terrarium specs. Out-of-range
+    elevations are clamped to the encodable range rather than wrapping.
+
+    Args:
+        elevation: 2-D float array of heights in metres.
+        encoding: ``"mapbox"`` or ``"terrarium"``.
+        base_val: Mapbox base elevation that maps to RGB ``(0, 0, 0)``.
+        interval: Mapbox metres-per-encoded-unit (ignored for terrarium).
+
+    Returns:
+        np.ndarray: ``(3, rows, cols)`` ``uint8`` array of the R, G, B channels.
+    """
+    if encoding == "mapbox":
+        packed = np.round((np.asarray(elevation, dtype=float) - base_val) / interval)
+        packed = np.clip(packed, 0, 2**24 - 1).astype(np.uint32)
+        red = ((packed >> 16) & 0xFF).astype(np.uint8)
+        green = ((packed >> 8) & 0xFF).astype(np.uint8)
+        blue = (packed & 0xFF).astype(np.uint8)
+    else:
+        # Terrarium: v = height + 32768, split into integer hi/lo bytes plus a
+        # 1/256-metre fractional byte. Clamp to the representable [-32768, 32768).
+        shifted = np.clip(
+            np.asarray(elevation, dtype=float) + 32768.0, 0.0, 65536.0 - 1.0 / 256.0
+        )
+        floor_shifted = np.floor(shifted)
+        red = np.floor(shifted / 256.0).astype(np.uint8)
+        green = (floor_shifted % 256.0).astype(np.uint8)
+        blue = np.floor((shifted - floor_shifted) * 256.0).astype(np.uint8)
+    return np.stack([red, green, blue], axis=0)
+
+
+def _terrain_rgba_stack(
+    elevation: np.ndarray,
+    nodata: float | None,
+    *,
+    encoding: str,
+    base_val: float,
+    interval: float,
+) -> np.ndarray:
+    """Build the terrain-RGB(A) byte stack, adding an alpha band only when needed.
+
+    No-data pixels become fully transparent (alpha 0); when the source declares
+    no no-data value a plain 3-band RGB stack is returned.
+
+    Args:
+        elevation: 2-D float array of heights in metres.
+        nodata: The source no-data marker, or ``None`` when unset.
+        encoding: ``"mapbox"`` or ``"terrarium"``.
+        base_val: Mapbox base elevation (see :func:`_encode_terrain_rgb`).
+        interval: Mapbox metres-per-encoded-unit.
+
+    Returns:
+        np.ndarray: ``(3, rows, cols)`` RGB, or ``(4, rows, cols)`` RGBA when a
+        no-data value is present.
+    """
+    rgb = _encode_terrain_rgb(
+        elevation, encoding=encoding, base_val=base_val, interval=interval
+    )
+    if nodata is None:
+        return rgb
+    invalid = is_no_data(np.asarray(elevation, dtype=float), nodata)
+    alpha = np.where(invalid, 0, 255).astype(np.uint8)
+    return np.concatenate([rgb, alpha[np.newaxis, :, :]], axis=0)
 
 
 class IO(_Engine):
@@ -2141,6 +2224,295 @@ class IO(_Engine):
         else:
             result = None
         return result
+
+    def to_terrain_rgb(
+        self: Dataset,
+        path: str | Path,
+        *,
+        encoding: str = "mapbox",
+        tiles: bool = True,
+        min_zoom: int = 0,
+        max_zoom: int | None = None,
+        tile_size: int = 256,
+        base_val: float = -10000.0,
+        interval: float = 0.1,
+        resampling: str = "bilinear",
+        band: int = 0,
+    ) -> Path:
+        """Encode an elevation band into terrain-RGB raster or XYZ tiles.
+
+        Packs a single-band DEM (heights in metres) into the R/G/B channels of
+        8-bit imagery so browser/GPU engines (MapLibre ``raster-dem``, deck.gl,
+        Cesium) can decode elevation and render 3-D terrain. The source is
+        reprojected to Web Mercator (EPSG:3857) when it is not already.
+
+        Two encodings are supported (the decoder formulae are exact inverses):
+
+        - ``"mapbox"`` (Mapbox Terrain-RGB) — with
+          ``v = round((height - base_val) / interval)``: ``R = (v >> 16) & 255``,
+          ``G = (v >> 8) & 255``, ``B = v & 255``. Decode:
+          ``height = base_val + (R*65536 + G*256 + B) * interval``.
+        - ``"terrarium"`` (Mapzen) — with ``v = height + 32768``:
+          ``R = floor(v / 256)``, ``G = floor(v) % 256``,
+          ``B = floor((v - floor(v)) * 256)``. Decode:
+          ``height = (R*256 + G + B/256) - 32768``.
+
+        No-data pixels are written fully transparent (RGBA alpha 0); a source
+        without a no-data value yields plain RGB. Elevations outside the
+        encodable range are clamped, not wrapped.
+
+        Args:
+            path: Destination. With ``tiles=False`` a single file (``.png`` ->
+                PNG, otherwise GeoTIFF); with ``tiles=True`` the root directory
+                of the ``{z}/{x}/{y}.png`` pyramid (created if missing).
+            encoding: ``"mapbox"`` (default) or ``"terrarium"``,
+                case-insensitive.
+            tiles: ``True`` (default) writes an XYZ PNG pyramid;
+                ``False`` writes one RGB(A) raster.
+            min_zoom: Lowest XYZ zoom to write. Default ``0``.
+            max_zoom: Highest XYZ zoom. ``None`` (default) derives it from the
+                source pixel size.
+            tile_size: Tile edge in pixels. Default ``256``.
+            base_val: Mapbox base elevation mapping to RGB ``(0, 0, 0)``.
+                Default ``-10000.0``. Ignored for terrarium.
+            interval: Mapbox metres-per-encoded-unit. Default ``0.1``. Ignored
+                for terrarium.
+            resampling: Resampling for reprojection / tile warping. Default
+                ``"bilinear"``.
+            band: Zero-based elevation band index. Default ``0``.
+
+        Returns:
+            Path: The written file (``tiles=False``) or the tile-root directory
+            (``tiles=True``).
+
+        Raises:
+            ValueError: ``encoding`` is not ``"mapbox"``/``"terrarium"``,
+                ``resampling`` is unknown, or ``max_zoom < min_zoom``.
+
+        Examples:
+            - Encode a small DEM to a single terrain-RGB PNG (the write is
+              tagged ``+SKIP`` — it touches GDAL/disk):
+
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> dem = Dataset.create_from_array(
+                ...     np.array([[0.0, 100.0], [2000.0, 8848.0]], dtype="float32"),
+                ...     top_left_corner=(0, 0), cell_size=0.01, epsg=4326,
+                ... )
+                >>> out = dem.to_terrain_rgb("dem.png", tiles=False)  # doctest: +SKIP
+                >>> out.name  # doctest: +SKIP
+                'dem.png'
+
+                ```
+
+        See Also:
+            - :meth:`to_xyz`: Export band values as a lon/lat point table.
+            - :meth:`to_cog`: Write a Cloud-Optimized GeoTIFF.
+        """
+        encoding = encoding.lower().strip()
+        if encoding not in _TERRAIN_RGB_ENCODINGS:
+            raise ValueError(
+                f"encoding must be one of {_TERRAIN_RGB_ENCODINGS}, got {encoding!r}."
+            )
+        # Validate the resampling name once (also reused by the per-tile warp).
+        resample_alg = resolve_resampling(resampling)
+        source = (
+            self._ds
+            if self._ds.epsg == 3857
+            else self._ds.to_crs(3857, method=resampling)
+        )
+        if tiles:
+            result = self._terrain_rgb_tiles(
+                source,
+                Path(path),
+                band=band,
+                encoding=encoding,
+                base_val=base_val,
+                interval=interval,
+                min_zoom=min_zoom,
+                max_zoom=max_zoom,
+                tile_size=tile_size,
+                resample_alg=resample_alg,
+            )
+        else:
+            result = self._terrain_rgb_single(
+                source,
+                Path(path),
+                band=band,
+                encoding=encoding,
+                base_val=base_val,
+                interval=interval,
+            )
+        return result
+
+    @staticmethod
+    def _terrain_byte_dataset(
+        stack: np.ndarray, geotransform: tuple, projection: str
+    ) -> "gdal.Dataset":
+        """Build an in-memory Byte GDAL dataset from a ``(bands, rows, cols)`` stack."""
+        n_bands, rows, cols = stack.shape
+        mem = gdal.GetDriverByName("MEM").Create("", cols, rows, n_bands, gdal.GDT_Byte)
+        mem.SetGeoTransform(geotransform)
+        if projection:
+            mem.SetProjection(projection)
+        for index in range(n_bands):
+            mem.GetRasterBand(index + 1).WriteArray(stack[index])
+        if n_bands == 4:
+            mem.GetRasterBand(4).SetColorInterpretation(gdal.GCI_AlphaBand)
+        return mem
+
+    def _terrain_rgb_single(
+        self: Dataset,
+        source: Dataset,
+        path: Path,
+        *,
+        band: int,
+        encoding: str,
+        base_val: float,
+        interval: float,
+    ) -> Path:
+        """Write one RGB(A) terrain raster (PNG by ``.png`` suffix, else GeoTIFF)."""
+        elevation = np.asarray(source.read_array(band=band), dtype=float)
+        stack = _terrain_rgba_stack(
+            elevation,
+            source.no_data_value[band],
+            encoding=encoding,
+            base_val=base_val,
+            interval=interval,
+        )
+        mem = self._terrain_byte_dataset(
+            stack, source.geotransform, source.raster.GetProjection()
+        )
+        driver = "PNG" if path.suffix.lower() == ".png" else "GTiff"
+        out = gdal.GetDriverByName(driver).CreateCopy(str(path), mem)
+        if out is None:
+            raise FailedToSaveError(
+                f"GDAL could not write the terrain-RGB raster to {path}."
+            )
+        out.FlushCache()
+        return path
+
+    def _terrain_rgb_tiles(
+        self: Dataset,
+        source: Dataset,
+        path: Path,
+        *,
+        band: int,
+        encoding: str,
+        base_val: float,
+        interval: float,
+        min_zoom: int,
+        max_zoom: int | None,
+        tile_size: int,
+        resample_alg: int,
+    ) -> Path:
+        """Write an XYZ ``{z}/{x}/{y}.png`` terrain-RGB pyramid; return the root."""
+        gt = source.geotransform
+        west, north = gt[0], gt[3]
+        east = west + source.columns * gt[1]
+        south = north + source.rows * gt[5]
+        if max_zoom is None:
+            max_zoom = self._native_terrain_zoom(abs(gt[1]), tile_size, min_zoom)
+        if max_zoom < min_zoom:
+            raise ValueError(
+                f"max_zoom ({max_zoom}) must be >= min_zoom ({min_zoom})."
+            )
+        nodata = source.no_data_value[band]
+        path.mkdir(parents=True, exist_ok=True)
+        for zoom in range(min_zoom, max_zoom + 1):
+            for x, y in self._terrain_tile_indices(zoom, west, south, east, north):
+                self._write_terrain_tile(
+                    source,
+                    path,
+                    zoom,
+                    x,
+                    y,
+                    band=band,
+                    tile_size=tile_size,
+                    encoding=encoding,
+                    base_val=base_val,
+                    interval=interval,
+                    resample_alg=resample_alg,
+                    nodata=nodata,
+                )
+        return path
+
+    @staticmethod
+    def _native_terrain_zoom(pixel_size: float, tile_size: int, min_zoom: int) -> int:
+        """XYZ zoom whose tile resolution matches the pixel size (>= ``min_zoom``)."""
+        world = 2 * _WEB_MERCATOR_HALF_EXTENT
+        zoom = round(math.log2(world / (tile_size * pixel_size)))
+        return max(min_zoom, int(zoom))
+
+    @staticmethod
+    def _terrain_tile_indices(
+        zoom: int, west: float, south: float, east: float, north: float
+    ) -> Generator[tuple[int, int], None, None]:
+        """Yield the ``(x, y)`` XYZ tile indices covering the 3857 bounds at `zoom`."""
+        n_tiles = 2**zoom
+        radius = _WEB_MERCATOR_HALF_EXTENT
+        span = (2 * radius) / n_tiles
+        # Pull the east/south edges in by a sliver so bounds that fall exactly on
+        # a tile boundary do not spill into an extra empty tile.
+        eps = span * 1e-9
+        x_min = max(0, int(math.floor((west + radius) / span)))
+        x_max = min(n_tiles - 1, int(math.floor((east - eps + radius) / span)))
+        y_min = max(0, int(math.floor((radius - north) / span)))
+        y_max = min(n_tiles - 1, int(math.floor((radius - south - eps) / span)))
+        for x in range(x_min, x_max + 1):
+            for y in range(y_min, y_max + 1):
+                yield x, y
+
+    def _write_terrain_tile(
+        self: Dataset,
+        source: Dataset,
+        root: Path,
+        zoom: int,
+        x: int,
+        y: int,
+        *,
+        band: int,
+        tile_size: int,
+        encoding: str,
+        base_val: float,
+        interval: float,
+        resample_alg: int,
+        nodata: float | None,
+    ) -> None:
+        """Warp one XYZ tile from `source`, encode it, write ``root/z/x/y.png``."""
+        west, south, east, north = _xyz_bounds_3857(zoom, x, y)
+        warp_kwargs: dict[str, Any] = {
+            "format": "MEM",
+            "outputBounds": (west, south, east, north),
+            "width": tile_size,
+            "height": tile_size,
+            "resampleAlg": resample_alg,
+        }
+        if nodata is not None:
+            warp_kwargs["dstNodata"] = nodata
+        warped = gdal.Warp("", source.raster, **warp_kwargs)
+        elevation = np.asarray(
+            warped.GetRasterBand(band + 1).ReadAsArray(), dtype=float
+        )
+        stack = _terrain_rgba_stack(
+            elevation,
+            nodata,
+            encoding=encoding,
+            base_val=base_val,
+            interval=interval,
+        )
+        mem = self._terrain_byte_dataset(
+            stack, warped.GetGeoTransform(), warped.GetProjection()
+        )
+        tile_dir = root / str(zoom) / str(x)
+        tile_dir.mkdir(parents=True, exist_ok=True)
+        out = gdal.GetDriverByName("PNG").CreateCopy(str(tile_dir / f"{y}.png"), mem)
+        if out is None:
+            raise FailedToSaveError(
+                f"GDAL could not write terrain-RGB tile {zoom}/{x}/{y}.png."
+            )
+        out.FlushCache()
 
     @property
     def overview_count(self: Dataset) -> list[int]:

--- a/tests/dataset/test_terrain_rgb.py
+++ b/tests/dataset/test_terrain_rgb.py
@@ -46,7 +46,9 @@ class TestToTerrainRgbRoundtrip:
         out = dem.to_terrain_rgb(tmp_path / "dem.png", tiles=False, encoding="mapbox")
         count, (r, g, b) = _read_bands(out)
         assert count == 3, f"no-nodata source must yield 3-band RGB, got {count}"
-        decoded = _decode_mapbox(r.astype("int64"), g.astype("int64"), b.astype("int64"))
+        decoded = _decode_mapbox(
+            r.astype("int64"), g.astype("int64"), b.astype("int64")
+        )
         source = np.array([[0.0, 100.0], [2000.0, 8848.0]])
         assert np.max(np.abs(decoded - source)) <= 0.1, (
             f"decode must be within 0.1 m, got {np.abs(decoded - source)}"
@@ -63,7 +65,9 @@ class TestToTerrainRgbRoundtrip:
 
     def test_encoding_is_case_insensitive(self, tmp_path):
         """``encoding`` is normalised, so upper-case names are accepted."""
-        out = _dem_3857().to_terrain_rgb(tmp_path / "u.png", tiles=False, encoding="MapBox")
+        out = _dem_3857().to_terrain_rgb(
+            tmp_path / "u.png", tiles=False, encoding="MapBox"
+        )
         assert out.exists(), "upper-case encoding name must be accepted"
 
 
@@ -88,9 +92,23 @@ class TestToTerrainRgbNoData:
 
     def test_no_nodata_yields_rgb(self, tmp_path):
         """A source without a nodata value yields a 3-band RGB raster."""
-        out = _dem_3857(no_data_value=None).to_terrain_rgb(tmp_path / "r.png", tiles=False)
+        out = _dem_3857(no_data_value=None).to_terrain_rgb(
+            tmp_path / "r.png", tiles=False
+        )
         count, _ = _read_bands(out)
         assert count == 3, f"expected 3-band RGB without nodata, got {count}"
+
+    def test_reproject_preserves_nodata_transparency(self, tmp_path):
+        """A 4326 source with nodata stays transparent after the warp to 3857."""
+        arr = np.array([[100.0, -9999.0], [2000.0, 3000.0]], dtype="float32")
+        dem = Dataset.create_from_array(
+            arr=arr, geo=(10.0, 0.01, 0.0, 47.0, 0.0, -0.01), epsg=4326,
+            no_data_value=-9999.0,
+        )
+        out = dem.to_terrain_rgb(tmp_path / "rn.png", tiles=False)
+        count, bands = _read_bands(out)
+        assert count == 4, f"reprojected nodata source must be RGBA, got {count}"
+        assert (bands[3] == 0).any(), "nodata cell must survive reprojection as alpha 0"
 
 
 class TestToTerrainRgbOutputs:
@@ -160,6 +178,18 @@ class TestToTerrainRgbErrors:
         with pytest.raises(ValueError, match="max_zoom"):
             _dem_3857(no_data_value=None).to_terrain_rgb(
                 tmp_path / "t", tiles=True, min_zoom=8, max_zoom=4
+            )
+
+    def test_non_positive_interval_raises(self, tmp_path):
+        """A non-positive mapbox ``interval`` raises instead of dividing by zero."""
+        with pytest.raises(ValueError, match="interval must be positive"):
+            _dem_3857().to_terrain_rgb(tmp_path / "x.png", tiles=False, interval=0.0)
+
+    def test_negative_min_zoom_raises(self, tmp_path):
+        """A negative ``min_zoom`` raises ValueError."""
+        with pytest.raises(ValueError, match="min_zoom must be >= 0"):
+            _dem_3857(no_data_value=None).to_terrain_rgb(
+                tmp_path / "t", tiles=True, min_zoom=-1
             )
 
 

--- a/tests/dataset/test_terrain_rgb.py
+++ b/tests/dataset/test_terrain_rgb.py
@@ -192,6 +192,11 @@ class TestToTerrainRgbErrors:
                 tmp_path / "t", tiles=True, min_zoom=-1
             )
 
+    def test_out_of_range_band_raises(self, tmp_path):
+        """A band index past the source band count raises a clear ValueError."""
+        with pytest.raises(ValueError, match="band index"):
+            _dem_3857().to_terrain_rgb(tmp_path / "x.png", tiles=False, band=5)
+
 
 class TestToTerrainRgbExposure:
     """Facade wiring."""

--- a/tests/dataset/test_terrain_rgb.py
+++ b/tests/dataset/test_terrain_rgb.py
@@ -18,13 +18,16 @@ from pyramids.dataset.engines.io import (
 
 pytestmark = pytest.mark.core
 
+# A north-up EPSG:3857 geotransform (30 m pixels) reused across the DEM fixtures.
+_GEO_3857 = (0.0, 30.0, 0.0, 6000000.0, 0.0, -30.0)
+
 
 def _dem_3857(no_data_value=None):
     """A small DEM already in EPSG:3857 (so no reprojection on encode)."""
     arr = np.array([[0.0, 100.0], [2000.0, 8848.0]], dtype="float32")
     return Dataset.create_from_array(
         arr=arr,
-        geo=(0.0, 30.0, 0.0, 6000000.0, 0.0, -30.0),
+        geo=_GEO_3857,
         epsg=3857,
         no_data_value=no_data_value,
     )
@@ -84,7 +87,7 @@ class TestToTerrainRgbNoData:
         arr = np.array([[0.0, -9999.0], [2000.0, 8848.0]], dtype="float32")
         dem = Dataset.create_from_array(
             arr=arr,
-            geo=(0.0, 30.0, 0.0, 6000000.0, 0.0, -30.0),
+            geo=_GEO_3857,
             epsg=3857,
             no_data_value=-9999.0,
         )
@@ -320,7 +323,7 @@ class TestToTerrainRgbClamping:
         """An elevation above the encodable range writes the max RGB, not garbage."""
         arr = np.array([[1e9, 0.0]], dtype="float64").astype("float32")
         dem = Dataset.create_from_array(
-            arr=arr, geo=(0.0, 30.0, 0.0, 6000000.0, 0.0, -30.0), epsg=3857,
+            arr=arr, geo=_GEO_3857, epsg=3857,
             no_data_value=None,
         )
         out = dem.to_terrain_rgb(tmp_path / "c.png", tiles=False)

--- a/tests/dataset/test_terrain_rgb.py
+++ b/tests/dataset/test_terrain_rgb.py
@@ -10,6 +10,11 @@ import pytest
 from osgeo import gdal
 
 from pyramids.dataset import Dataset
+from pyramids.dataset.engines.io import (
+    IO,
+    _encode_terrain_rgb,
+    _terrain_rgba_stack,
+)
 
 pytestmark = pytest.mark.core
 
@@ -205,4 +210,121 @@ class TestToTerrainRgbExposure:
         """``to_terrain_rgb`` is a callable method on the Dataset facade."""
         assert callable(getattr(Dataset, "to_terrain_rgb", None)), (
             "Dataset must expose to_terrain_rgb"
+        )
+
+
+class TestEncodeTerrainRgb:
+    """Unit tests for the pure ``_encode_terrain_rgb`` packer."""
+
+    def test_mapbox_known_value(self):
+        """0 m with the default base/interval packs to the spec's R, G, B bytes."""
+        rgb = _encode_terrain_rgb(
+            np.array([[0.0]]), encoding="mapbox", base_val=-10000.0, interval=0.1
+        )
+        # v = (0 - -10000)/0.1 = 100000 -> R=1, G=134, B=160
+        assert rgb.shape == (3, 1, 1), f"expected (3,1,1), got {rgb.shape}"
+        assert rgb.dtype == np.uint8, f"expected uint8, got {rgb.dtype}"
+        assert tuple(rgb[:, 0, 0]) == (1, 134, 160), f"wrong bytes: {rgb[:, 0, 0]}"
+
+    @pytest.mark.parametrize(
+        "elevation, expected",
+        [(1e12, (255, 255, 255)), (-1e9, (0, 0, 0))],
+    )
+    def test_mapbox_clamps_out_of_range(self, elevation, expected):
+        """Out-of-range elevations clamp to the encodable extremes, not wrap.
+
+        Args:
+            elevation: An elevation far outside the encodable window.
+            expected: The clamped ``(R, G, B)`` byte triple.
+        """
+        rgb = _encode_terrain_rgb(
+            np.array([[elevation]]), encoding="mapbox", base_val=-10000.0, interval=0.1
+        )
+        assert tuple(rgb[:, 0, 0]) == expected, f"clamp failed: {rgb[:, 0, 0]}"
+
+    def test_terrarium_known_value(self):
+        """0 m terrarium-encodes to (128, 0, 0) and decodes back to 0."""
+        rgb = _encode_terrain_rgb(
+            np.array([[0.0]]), encoding="terrarium", base_val=0.0, interval=1.0
+        )
+        r, g, b = (int(v) for v in rgb[:, 0, 0])
+        assert (r, g, b) == (128, 0, 0), f"terrarium 0 m wrong: {(r, g, b)}"
+        decoded = (r * 256 + g + b / 256.0) - 32768
+        assert decoded == 0.0, f"terrarium decode of 0 m must be 0, got {decoded}"
+
+    def test_terrarium_fractional_metre(self):
+        """The terrarium blue byte carries the sub-metre fraction (1/256 m)."""
+        rgb = _encode_terrain_rgb(
+            np.array([[0.5]]), encoding="terrarium", base_val=0.0, interval=1.0
+        )
+        b = int(rgb[2, 0, 0])
+        assert b == 128, f"0.5 m must encode B=128 (0.5*256), got {b}"
+
+
+class TestTerrainRgbaStack:
+    """Unit tests for the ``_terrain_rgba_stack`` band-count / alpha logic."""
+
+    def test_no_nodata_returns_three_bands(self):
+        """Without a nodata value the stack is plain 3-band RGB."""
+        stack = _terrain_rgba_stack(
+            np.array([[100.0]]), None, encoding="mapbox",
+            base_val=-10000.0, interval=0.1,
+        )
+        assert stack.shape[0] == 3, f"expected 3 bands, got {stack.shape[0]}"
+
+    def test_nodata_adds_transparent_alpha(self):
+        """A nodata cell yields a 4th alpha band that is 0 there and 255 elsewhere."""
+        elev = np.array([[100.0, -9999.0]])
+        stack = _terrain_rgba_stack(
+            elev, -9999.0, encoding="mapbox", base_val=-10000.0, interval=0.1
+        )
+        assert stack.shape[0] == 4, f"expected RGBA, got {stack.shape[0]} bands"
+        assert stack[3, 0, 0] == 255 and stack[3, 0, 1] == 0, (
+            f"alpha must be 255 valid / 0 nodata, got {stack[3, 0]}"
+        )
+
+
+class TestTerrainTileMath:
+    """Unit tests for the slippy-tile index and native-zoom helpers."""
+
+    def test_zoom_zero_is_single_tile(self):
+        """At zoom 0 the whole world is a single tile (0, 0)."""
+        r = 20037508.34
+        tiles = list(IO._terrain_tile_indices(0, -r, -r, r, r))
+        assert tiles == [(0, 0)], f"zoom 0 must be one tile (0,0), got {tiles}"
+
+    def test_indices_stay_in_range(self):
+        """Every emitted tile index is within ``[0, 2**zoom)``."""
+        tiles = list(IO._terrain_tile_indices(5, 0.0, 0.0, 1_000_000.0, 1_000_000.0))
+        assert tiles, "a covered region must yield at least one tile"
+        assert all(0 <= x < 32 and 0 <= y < 32 for x, y in tiles), (
+            f"indices out of [0, 32) at zoom 5: {tiles}"
+        )
+
+    def test_native_zoom_floored_at_min_zoom(self):
+        """A coarse pixel size would give a low zoom; ``min_zoom`` is the floor."""
+        # huge pixel size -> computed zoom is small/negative -> min_zoom wins
+        assert IO._native_terrain_zoom(1e7, 256, min_zoom=3) == 3, "min_zoom must floor"
+
+    def test_native_zoom_matches_resolution(self):
+        """A finer pixel size yields a higher zoom than a coarser one."""
+        fine = IO._native_terrain_zoom(30.0, 256, 0)
+        coarse = IO._native_terrain_zoom(1000.0, 256, 0)
+        assert fine > coarse, f"finer pixels need a higher zoom: {fine} <= {coarse}"
+
+
+class TestToTerrainRgbClamping:
+    """End-to-end clamping through the public method."""
+
+    def test_extreme_elevation_clamps_to_max(self, tmp_path):
+        """An elevation above the encodable range writes the max RGB, not garbage."""
+        arr = np.array([[1e9, 0.0]], dtype="float64").astype("float32")
+        dem = Dataset.create_from_array(
+            arr=arr, geo=(0.0, 30.0, 0.0, 6000000.0, 0.0, -30.0), epsg=3857,
+            no_data_value=None,
+        )
+        out = dem.to_terrain_rgb(tmp_path / "c.png", tiles=False)
+        _, (r, g, b) = _read_bands(out)
+        assert (r[0, 0], g[0, 0], b[0, 0]) == (255, 255, 255), (
+            f"clamped cell must be (255,255,255), got {(r[0,0], g[0,0], b[0,0])}"
         )

--- a/tests/dataset/test_terrain_rgb.py
+++ b/tests/dataset/test_terrain_rgb.py
@@ -253,7 +253,7 @@ class TestEncodeTerrainRgb:
         r, g, b = (int(v) for v in rgb[:, 0, 0])
         assert (r, g, b) == (128, 0, 0), f"terrarium 0 m wrong: {(r, g, b)}"
         decoded = (r * 256 + g + b / 256.0) - 32768
-        assert decoded == 0.0, f"terrarium decode of 0 m must be 0, got {decoded}"
+        assert abs(decoded) < 1e-9, f"terrarium decode of 0 m must be 0, got {decoded}"
 
     def test_terrarium_fractional_metre(self):
         """The terrarium blue byte carries the sub-metre fraction (1/256 m)."""

--- a/tests/dataset/test_terrain_rgb.py
+++ b/tests/dataset/test_terrain_rgb.py
@@ -1,0 +1,173 @@
+"""Tests for Dataset.to_terrain_rgb (terrain-RGB encoding + XYZ tiling)."""
+
+from __future__ import annotations
+
+import glob
+import os
+
+import numpy as np
+import pytest
+from osgeo import gdal
+
+from pyramids.dataset import Dataset
+
+pytestmark = pytest.mark.core
+
+
+def _dem_3857(no_data_value=None):
+    """A small DEM already in EPSG:3857 (so no reprojection on encode)."""
+    arr = np.array([[0.0, 100.0], [2000.0, 8848.0]], dtype="float32")
+    return Dataset.create_from_array(
+        arr=arr,
+        geo=(0.0, 30.0, 0.0, 6000000.0, 0.0, -30.0),
+        epsg=3857,
+        no_data_value=no_data_value,
+    )
+
+
+def _decode_mapbox(r, g, b, base_val=-10000.0, interval=0.1):
+    """Mapbox Terrain-RGB decoder (inverse of the encoder)."""
+    return base_val + (r * 65536 + g * 256 + b) * interval
+
+
+def _read_bands(path):
+    """Return the per-band int arrays of a raster on disk."""
+    ds = gdal.Open(str(path))
+    bands = [ds.GetRasterBand(i + 1).ReadAsArray() for i in range(ds.RasterCount)]
+    return ds.RasterCount, bands
+
+
+class TestToTerrainRgbRoundtrip:
+    """Decoding a written raster recovers the source elevation."""
+
+    def test_mapbox_roundtrip_within_interval(self, tmp_path):
+        """Mapbox decode recovers each height to within one ``interval``."""
+        dem = _dem_3857()
+        out = dem.to_terrain_rgb(tmp_path / "dem.png", tiles=False, encoding="mapbox")
+        count, (r, g, b) = _read_bands(out)
+        assert count == 3, f"no-nodata source must yield 3-band RGB, got {count}"
+        decoded = _decode_mapbox(r.astype("int64"), g.astype("int64"), b.astype("int64"))
+        source = np.array([[0.0, 100.0], [2000.0, 8848.0]])
+        assert np.max(np.abs(decoded - source)) <= 0.1, (
+            f"decode must be within 0.1 m, got {np.abs(decoded - source)}"
+        )
+
+    def test_terrarium_roundtrip_within_quantum(self, tmp_path):
+        """Terrarium decode recovers each height to within 1/256 m."""
+        dem = _dem_3857()
+        out = dem.to_terrain_rgb(tmp_path / "t.png", tiles=False, encoding="terrarium")
+        _, (r, g, b) = _read_bands(out)
+        decoded = (r.astype("int64") * 256 + g + b / 256.0) - 32768
+        source = np.array([[0.0, 100.0], [2000.0, 8848.0]])
+        assert np.max(np.abs(decoded - source)) <= 1 / 256, "terrarium within 1/256 m"
+
+    def test_encoding_is_case_insensitive(self, tmp_path):
+        """``encoding`` is normalised, so upper-case names are accepted."""
+        out = _dem_3857().to_terrain_rgb(tmp_path / "u.png", tiles=False, encoding="MapBox")
+        assert out.exists(), "upper-case encoding name must be accepted"
+
+
+class TestToTerrainRgbNoData:
+    """No-data handling: transparent alpha where the source is masked."""
+
+    def test_nodata_becomes_transparent(self, tmp_path):
+        """A nodata cell becomes alpha 0; valid cells alpha 255 (RGBA output)."""
+        arr = np.array([[0.0, -9999.0], [2000.0, 8848.0]], dtype="float32")
+        dem = Dataset.create_from_array(
+            arr=arr,
+            geo=(0.0, 30.0, 0.0, 6000000.0, 0.0, -30.0),
+            epsg=3857,
+            no_data_value=-9999.0,
+        )
+        out = dem.to_terrain_rgb(tmp_path / "n.png", tiles=False)
+        count, bands = _read_bands(out)
+        assert count == 4, f"nodata source must yield 4-band RGBA, got {count}"
+        alpha = bands[3]
+        assert alpha[0, 1] == 0, "nodata cell must be transparent"
+        assert alpha[0, 0] == 255, "valid cell must be opaque"
+
+    def test_no_nodata_yields_rgb(self, tmp_path):
+        """A source without a nodata value yields a 3-band RGB raster."""
+        out = _dem_3857(no_data_value=None).to_terrain_rgb(tmp_path / "r.png", tiles=False)
+        count, _ = _read_bands(out)
+        assert count == 3, f"expected 3-band RGB without nodata, got {count}"
+
+
+class TestToTerrainRgbOutputs:
+    """File-format and reprojection behaviour."""
+
+    def test_geotiff_when_not_png(self, tmp_path):
+        """A non-``.png`` suffix writes a GeoTIFF carrying the 3857 projection."""
+        out = _dem_3857().to_terrain_rgb(tmp_path / "dem.tif", tiles=False)
+        ds = gdal.Open(str(out))
+        assert ds.GetDriver().ShortName == "GTiff", "non-png suffix must write GeoTIFF"
+        assert "3857" in ds.GetProjection(), "output must be Web Mercator"
+
+    def test_reprojects_4326_source(self, tmp_path):
+        """A non-3857 source is reprojected, not rejected."""
+        arr = np.ones((4, 4), dtype="float32") * 500.0
+        dem = Dataset.create_from_array(
+            arr=arr, geo=(10.0, 0.01, 0.0, 47.0, 0.0, -0.01), epsg=4326,
+            no_data_value=None,
+        )
+        out = dem.to_terrain_rgb(tmp_path / "w.tif", tiles=False)
+        assert "3857" in gdal.Open(str(out)).GetProjection(), "must reproject to 3857"
+
+
+class TestToTerrainRgbTiles:
+    """XYZ ``{z}/{x}/{y}.png`` pyramid output."""
+
+    def test_writes_xyz_layout(self, tmp_path):
+        """``tiles=True`` writes valid 256x256 RGBA PNGs under ``{z}/{x}/{y}.png``."""
+        root = _dem_3857(no_data_value=None).to_terrain_rgb(
+            tmp_path / "tiles", tiles=True, min_zoom=4, max_zoom=6
+        )
+        pngs = glob.glob(os.path.join(str(root), "**", "*.png"), recursive=True)
+        assert pngs, "at least one tile must be written"
+        for png in pngs:
+            rel = os.path.relpath(png, str(root)).replace(os.sep, "/")
+            z, x, name = rel.split("/")
+            assert name.endswith(".png") and z.isdigit() and x.isdigit(), (
+                f"tile path must be z/x/y.png, got {rel}"
+            )
+            tile = gdal.Open(png)
+            assert (tile.RasterXSize, tile.RasterYSize) == (256, 256), "256x256 tiles"
+
+    def test_zoom_levels_span_min_to_max(self, tmp_path):
+        """Every requested zoom level produces a directory."""
+        root = _dem_3857(no_data_value=None).to_terrain_rgb(
+            tmp_path / "z", tiles=True, min_zoom=3, max_zoom=5
+        )
+        zooms = {int(d) for d in os.listdir(root) if d.isdigit()}
+        assert {3, 4, 5} <= zooms, f"zooms 3-5 must be written, got {zooms}"
+
+
+class TestToTerrainRgbErrors:
+    """Input validation."""
+
+    def test_invalid_encoding_raises(self, tmp_path):
+        """An unknown encoding name raises ValueError."""
+        with pytest.raises(ValueError, match="encoding must be one of"):
+            _dem_3857().to_terrain_rgb(tmp_path / "x.png", encoding="rainbow")
+
+    def test_invalid_resampling_raises(self, tmp_path):
+        """An unknown resampling name raises ValueError."""
+        with pytest.raises(ValueError, match="does not exist|resampling"):
+            _dem_3857().to_terrain_rgb(tmp_path / "x.png", resampling="bogus")
+
+    def test_max_zoom_below_min_zoom_raises(self, tmp_path):
+        """``max_zoom < min_zoom`` raises ValueError."""
+        with pytest.raises(ValueError, match="max_zoom"):
+            _dem_3857(no_data_value=None).to_terrain_rgb(
+                tmp_path / "t", tiles=True, min_zoom=8, max_zoom=4
+            )
+
+
+class TestToTerrainRgbExposure:
+    """Facade wiring."""
+
+    def test_exposed_on_dataset(self):
+        """``to_terrain_rgb`` is a callable method on the Dataset facade."""
+        assert callable(getattr(Dataset, "to_terrain_rgb", None)), (
+            "Dataset must expose to_terrain_rgb"
+        )


### PR DESCRIPTION
# Description

Implements **item 1** of the Digital-Earth parity roadmap (#576): encode a single-band **elevation** raster (DEM,
metres) into **terrain-RGB** so browser/GPU engines (MapLibre `raster-dem`, deck.gl, Cesium) can decode elevation
and render 3-D terrain.

- New IO-engine method `to_terrain_rgb` + a thin `Dataset` delegator, following the writer convention
  (`path` first, keyword-only options, returns `Path`).
- **Mapbox Terrain-RGB** and **Mapzen Terrarium** encodings (numpy bit-packing; out-of-range values clamped, not
  wrapped). The source is reprojected to **EPSG:3857** first via `to_crs`. No new dependency.
- **No-data → transparent** (RGBA alpha 0); a source without a no-data value yields plain RGB.
- `tiles=False` → one RGB(A) raster (PNG by suffix, else GeoTIFF). `tiles=True` → a `{z}/{x}/{y}.png` XYZ pyramid
  (per-tile `gdal.Warp` over `cog._xyz_bounds_3857` bounds), with `max_zoom` derived from the source resolution
  when unset.
- Up-front validation: `encoding`, `resampling`, `interval > 0` (mapbox), `min_zoom >= 0`, `max_zoom >= min_zoom`,
  and the `band` index.

Scope note: this is the encoder + a working slippy-tile writer. The `tiles=True` pyramid reuses the COG engine's
existing web-mercator tile-bounds math. Items 2–6 of #576 are separate (vector / dependency-gated) and out of
scope here.

# Issues
- Closes #593 — Dataset.to_terrain_rgb (terrain-RGB encoding + XYZ tiles)
- Refs #576 — parent roadmap (Digital-Earth mapLibre-parity audit), Item 1 / PY-IO.9

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

`tests/dataset/test_terrain_rgb.py` (17 tests):

- [x] Mapbox / terrarium decode round-trips (within `interval` / `1/256` m) on a 3857 source.
- [x] No-data → transparent RGBA; no-nodata → RGB; reproject (4326→3857) preserves no-data transparency.
- [x] GeoTIFF vs PNG output; output carries the 3857 projection; 4326 source is reprojected.
- [x] `tiles=True` writes a valid `{z}/{x}/{y}.png` layout of 256×256 tiles spanning the requested zooms.
- [x] Validation errors: bad encoding / resampling, `max_zoom < min_zoom`, non-positive `interval`, negative
      `min_zoom`, out-of-range `band`.

Local: `pytest tests/dataset/test_terrain_rgb.py` → 17 passed; broader
`pytest tests/dataset/test_dataset_unit.py tests/dataset/test_to_bytes.py tests/dataset/cog/ -m "not plot"`
→ no regressions.

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen handles versions)
- [ ] added changes to History.rst. (changelog is commitizen-generated)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (Google-style docstring + doctest with the encode/decode formulae)