### PR TITLE
chore(packaging): upgrade bundled GDAL 3.12 -> 3.13

### DIFF
--- a/ci/gdal-pin.py
+++ b/ci/gdal-pin.py
@@ -14,7 +14,7 @@ wheels vendor instead of re-encoding them:
 
 Usage::
 
-    spec=$(python ci/gdal-pin.py)                    # default: gdal ->  >=3.12,<3.13
+    spec=$(python ci/gdal-pin.py)                    # default: gdal ->  >=3.13,<3.14
     python ci/gdal-pin.py gdal libgdal-netcdf swig   # one spec per line
 """
 

--- a/ci/install-and-vendor-osgeo.py
+++ b/ci/install-and-vendor-osgeo.py
@@ -396,8 +396,8 @@ def _patch_vendored_osgeo_init(init_path: Path) -> None:
     and `from __future__` imports so the patch stays valid if
     upstream osgeo ever adds a future-import (PEP 236 requires
     __future__ imports to precede any other statement). The current
-    conda-forge osgeo doesn't use __future__, but `gdal=3.12.*` is
-    intentionally loose and a 3.12.x bump could add one without our
+    conda-forge osgeo doesn't use __future__, but `gdal=3.13.*` is
+    intentionally loose and a 3.13.x bump could add one without our
     pin moving.
     """
     original = init_path.read_text(encoding="utf-8")

--- a/ci/setup-gdal-micromamba.sh
+++ b/ci/setup-gdal-micromamba.sh
@@ -89,7 +89,7 @@ rm -rf "${PIXI_ENV}"
 # those tables; calling it here keeps this cross-compile branch from re-encoding (or
 # drifting from) the pins. One subprocess emits all four specs, newline-separated,
 # mapped onto the bash vars via `read`. micromamba accepts a conda match-spec
-# concatenated as ``<name><spec>`` (e.g. ``gdal>=3.12,<3.13``).
+# concatenated as ``<name><spec>`` (e.g. ``gdal>=3.13,<3.14``).
 GDAL_PIN="$(cd "$(dirname "$0")" && pwd)/gdal-pin.py"
 if [[ ! -f "${GDAL_PIN}" ]]; then
     echo "ERROR: gdal-pin.py not found at ${GDAL_PIN}" >&2

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,7 +16,7 @@ installation required.
 pip install pyramids-gis
 ```
 
-That's it. The wheel includes GDAL 3.12, PROJ, GEOS, HDF4/5, NetCDF,
+That's it. The wheel includes GDAL 3.13, PROJ, GEOS, HDF4/5, NetCDF,
 JPEG2000 (OpenJPEG, for JP2-packed GRIB2), libtiff, and all other native
 dependencies. No `gdal-config`, no `apt install libgdal-dev`, no OSGeo4W
 installer needed.
@@ -102,7 +102,7 @@ Open Python and run:
 import pyramids
 from osgeo import gdal
 print(pyramids.__version__)
-print(gdal.__version__)          # should print 3.12.x
+print(gdal.__version__)          # should print 3.13.x
 ```
 
 ## Platform support matrix

--- a/pixi.lock
+++ b/pixi.lock
@@ -18,7 +18,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.5-py314hc02f841_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.12.4-np2py314hc748478_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py314h3ef7809_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
@@ -45,12 +45,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.12.4-h2c8e1a9_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.12.4-h079cb0d_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.12.4-hc5b9174_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.12.4-hb6e0364_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.12.4-h4a420b2_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.12.4-h6643b6a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.1-h2c8e1a9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.1-h2ee2084_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.1-hbb32ccb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-hb4822db_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.1-hcd6cc38_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-h9d05ff3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
@@ -93,7 +93,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pandas-3.0.3-py314hb4ffadd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-haa7fec5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.8.1-he0df7b0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py314hbcf5174_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py314hab130c5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-habeac84_100_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
@@ -136,7 +136,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cftime-1.6.5-py314hc2f71db_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freexl-2.0.0-h82fd2cb_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.12.4-np2py314h38af87e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py314h54611df_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.14.1-h57520ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h31becfc_0.conda
@@ -163,12 +163,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.12.4-h126928a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.12.4-hf76e5b2_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.12.4-h480612f_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.12.4-hf116bd3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.12.4-h9dffbd3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.12.4-hd8ba4ad_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.1-h126928a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.1-h0d35cac_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.1-ha861f77_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-hf18d640_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.1-h4f433c8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-h0711251_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
@@ -211,7 +211,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pandas-3.0.3-py314he6363bd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/proj-9.8.1-hd211770_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py314h9155b42_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py314h0dd3294_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.14.6-hc679e19_100_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
@@ -254,7 +254,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cftime-1.6.5-py314h26e5826_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3183152_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.12.4-np2py314h6dfb594_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py314hd174a59_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h10d778d_0.conda
@@ -279,12 +279,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-15.2.0-h08519bb_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.12.4-h2e1b34b_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.12.4-h30be141_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.12.4-hd911a30_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.12.4-hb154ecb_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.12.4-h37a0a2f_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.12.4-h6369dcf_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.1-h2e1b34b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.1-hf913fc2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.1-hf66efad_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-hdedcdb7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.1-hbc28da0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-hbe79d85_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwy-1.4.0-hca42a69_0.conda
@@ -323,7 +323,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pandas-3.0.3-py314h99bb933_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.8.1-he69a98e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py314h687fbad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py314h7dc4300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.14.6-h7c6738f_100_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
@@ -366,7 +366,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.5-py314h2115a04_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyhc90fa1f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.12.4-np2py314hf76ae87_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py314h497824c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-h93a5062_0.conda
@@ -391,12 +391,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.12.4-hcee3826_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.12.4-he22df77_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.12.4-h5969d26_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.12.4-h24392f9_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.12.4-he6d8849_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.12.4-h629b07f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.1-hcee3826_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.1-h99414e2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.1-h5795c7d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-hcd92a64_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.1-ha0e568a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h9c8e0d5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwy-1.4.0-ha332bbd_0.conda
@@ -435,7 +435,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pandas-3.0.3-py314he609de1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pcre2-10.47-h30297fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.8.1-ha88f16d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py314h3da1bed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py314h618c026_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.6-h156bc91_100_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
@@ -477,7 +477,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/click-8.4.1-pyh6dadd2b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.12.4-np2py314he09f147_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py314h805a11e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
@@ -495,12 +495,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.25-h51727cc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.12.4-h9ea07af_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.12.4-ha539a3c_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.12.4-hd3704d6_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.12.4-h293a8ca_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.12.4-h3b90d24_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.12.4-h227a990_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.1-h9ea07af_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.1-h6e73097_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.1-h9da078d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h7603ba1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.1-h70292f5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-h57ca259_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.13.0-default_h049141e_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwy-1.4.0-h172a326_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
@@ -538,7 +538,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/pandas-3.0.3-py314hf700ef7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.47-hd2b5f0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.8.1-hd30e2cd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py314h1c1cb05_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py314he172734_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.14.6-h4b44e0e_100_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-tzdata-2026.2-pyhd8ed1ab_0.conda
@@ -635,7 +635,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.12.4-np2py314hc748478_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py314h3ef7809_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
@@ -682,12 +682,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.12.4-h2c8e1a9_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.12.4-h079cb0d_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.12.4-hc5b9174_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.12.4-hb6e0364_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.12.4-h4a420b2_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.12.4-h6643b6a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.1-h2c8e1a9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.1-h2ee2084_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.1-hbb32ccb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-hb4822db_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.1-hcd6cc38_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-h9d05ff3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
@@ -754,7 +754,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py314h0f05182_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-24.0.0-py314hdafbbf9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-24.0.0-py314h969be7f_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py314hbcf5174_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py314hab130c5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pystac-1.14.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pystac-client-0.9.0-pyhd8ed1ab_0.conda
@@ -1003,7 +1003,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freexl-2.0.0-h82fd2cb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.12.4-np2py314h38af87e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py314h54611df_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.14.1-h57520ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gflags-2.2.2-h5ad3122_1005.conda
@@ -1050,12 +1050,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.12.4-h126928a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.12.4-hf76e5b2_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.12.4-h480612f_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.12.4-hf116bd3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.12.4-h9dffbd3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.12.4-hd8ba4ad_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.1-h126928a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.1-h0d35cac_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.1-ha861f77_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-hf18d640_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.1-h4f433c8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-h0711251_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
@@ -1122,7 +1122,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psutil-7.2.2-py314h2e8dab5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyarrow-24.0.0-py314ha42fa4b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyarrow-core-24.0.0-py314h70cbd86_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py314h9155b42_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py314h0dd3294_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pystac-1.14.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pystac-client-0.9.0-pyhd8ed1ab_0.conda
@@ -1371,7 +1371,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3183152_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.12.4-np2py314h6dfb594_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py314hd174a59_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hac325c4_1005.conda
@@ -1416,12 +1416,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-15.2.0-h08519bb_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.12.4-h2e1b34b_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.12.4-h30be141_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.12.4-hd911a30_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.12.4-hb154ecb_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.12.4-h37a0a2f_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.12.4-h6369dcf_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.1-h2e1b34b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.1-hf913fc2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.1-hf66efad_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-hdedcdb7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.1-hbc28da0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-hbe79d85_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-3.5.0-h8b848e0_1.conda
@@ -1484,7 +1484,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.2.2-py314hd330473_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-24.0.0-py314hee6578b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-24.0.0-py314hfb10f56_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py314h687fbad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py314h7dc4300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pystac-1.14.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pystac-client-0.9.0-pyhd8ed1ab_0.conda
@@ -1730,7 +1730,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.12.4-np2py314hf76ae87_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py314h497824c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
@@ -1775,12 +1775,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.12.4-hcee3826_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.12.4-he22df77_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.12.4-h5969d26_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.12.4-h24392f9_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.12.4-he6d8849_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.12.4-h629b07f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.1-hcee3826_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.1-h99414e2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.1-h5795c7d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-hcd92a64_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.1-ha0e568a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h9c8e0d5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-3.5.0-h688a705_1.conda
@@ -1843,7 +1843,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py314ha14b1ff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-24.0.0-py314he55896b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-24.0.0-py314h109bba2_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py314h3da1bed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py314h618c026_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pystac-1.14.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pystac-client-0.9.0-pyhd8ed1ab_0.conda
@@ -2089,7 +2089,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.12.4-np2py314he09f147_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py314h805a11e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/google-crc32c-1.8.0-py314h720154c_1.conda
@@ -2125,12 +2125,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.12.4-h9ea07af_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.12.4-ha539a3c_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.12.4-hd3704d6_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.12.4-h293a8ca_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.12.4-h3b90d24_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.12.4-h227a990_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.1-h9ea07af_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.1-h6e73097_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.1-h9da078d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h7603ba1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.1-h70292f5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-h57ca259_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-3.5.0-he22669a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-3.5.0-he04ea4c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.78.1-h9ff2b3e_0.conda
@@ -2192,7 +2192,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.2.2-py314hc5dbbe4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-24.0.0-py314h86ab7b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-24.0.0-py314h159fc0c_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py314h1c1cb05_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py314he172734_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pystac-1.14.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pystac-client-0.9.0-pyhd8ed1ab_0.conda
@@ -2450,7 +2450,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.12.4-np2py314hc748478_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py314h3ef7809_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
@@ -2497,12 +2497,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.12.4-h2c8e1a9_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.12.4-h079cb0d_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.12.4-hc5b9174_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.12.4-hb6e0364_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.12.4-h4a420b2_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.12.4-h6643b6a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.1-h2c8e1a9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.1-h2ee2084_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.1-hbb32ccb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-hb4822db_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.1-hcd6cc38_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-h9d05ff3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
@@ -2569,7 +2569,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py314h0f05182_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-24.0.0-py314hdafbbf9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-24.0.0-py314h969be7f_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py314hbcf5174_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py314hab130c5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pystac-1.14.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pystac-client-0.9.0-pyhd8ed1ab_0.conda
@@ -2808,7 +2808,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freexl-2.0.0-h82fd2cb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.12.4-np2py314h38af87e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py314h54611df_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.14.1-h57520ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gflags-2.2.2-h5ad3122_1005.conda
@@ -2855,12 +2855,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.12.4-h126928a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.12.4-hf76e5b2_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.12.4-h480612f_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.12.4-hf116bd3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.12.4-h9dffbd3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.12.4-hd8ba4ad_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.1-h126928a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.1-h0d35cac_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.1-ha861f77_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-hf18d640_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.1-h4f433c8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-h0711251_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
@@ -2927,7 +2927,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psutil-7.2.2-py314h2e8dab5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyarrow-24.0.0-py314ha42fa4b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyarrow-core-24.0.0-py314h70cbd86_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py314h9155b42_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py314h0dd3294_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pystac-1.14.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pystac-client-0.9.0-pyhd8ed1ab_0.conda
@@ -3166,7 +3166,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3183152_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.12.4-np2py314h6dfb594_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py314hd174a59_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hac325c4_1005.conda
@@ -3211,12 +3211,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-15.2.0-h08519bb_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.12.4-h2e1b34b_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.12.4-h30be141_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.12.4-hd911a30_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.12.4-hb154ecb_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.12.4-h37a0a2f_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.12.4-h6369dcf_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.1-h2e1b34b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.1-hf913fc2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.1-hf66efad_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-hdedcdb7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.1-hbc28da0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-hbe79d85_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-3.5.0-h8b848e0_1.conda
@@ -3279,7 +3279,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.2.2-py314hd330473_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-24.0.0-py314hee6578b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-24.0.0-py314hfb10f56_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py314h687fbad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py314h7dc4300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pystac-1.14.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pystac-client-0.9.0-pyhd8ed1ab_0.conda
@@ -3518,7 +3518,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.12.4-np2py314hf76ae87_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py314h497824c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
@@ -3563,12 +3563,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.12.4-hcee3826_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.12.4-he22df77_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.12.4-h5969d26_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.12.4-h24392f9_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.12.4-he6d8849_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.12.4-h629b07f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.1-hcee3826_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.1-h99414e2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.1-h5795c7d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-hcd92a64_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.1-ha0e568a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h9c8e0d5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-3.5.0-h688a705_1.conda
@@ -3631,7 +3631,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py314ha14b1ff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-24.0.0-py314he55896b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-24.0.0-py314h109bba2_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py314h3da1bed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py314h618c026_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pystac-1.14.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pystac-client-0.9.0-pyhd8ed1ab_0.conda
@@ -3870,7 +3870,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.12.4-np2py314he09f147_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py314h805a11e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/google-crc32c-1.8.0-py314h720154c_1.conda
@@ -3906,12 +3906,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.12.4-h9ea07af_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.12.4-ha539a3c_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.12.4-hd3704d6_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.12.4-h293a8ca_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.12.4-h3b90d24_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.12.4-h227a990_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.1-h9ea07af_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.1-h6e73097_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.1-h9da078d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h7603ba1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.1-h70292f5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-h57ca259_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-3.5.0-he22669a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-3.5.0-he04ea4c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.78.1-h9ff2b3e_0.conda
@@ -3973,7 +3973,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.2.2-py314hc5dbbe4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-24.0.0-py314h86ab7b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-24.0.0-py314h159fc0c_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py314h1c1cb05_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py314he172734_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pystac-1.14.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pystac-client-0.9.0-pyhd8ed1ab_0.conda
@@ -4204,7 +4204,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.12.4-np2py314hc748478_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py314h3ef7809_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
@@ -4242,12 +4242,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.12.4-h2c8e1a9_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.12.4-h079cb0d_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.12.4-hc5b9174_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.12.4-hb6e0364_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.12.4-h4a420b2_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.12.4-h6643b6a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.1-h2c8e1a9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.1-h2ee2084_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.1-hbb32ccb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-hb4822db_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.1-hcd6cc38_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-h9d05ff3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
@@ -4299,7 +4299,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.8.1-he0df7b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/propcache-0.5.2-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py314h0f05182_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py314hbcf5174_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py314hab130c5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-habeac84_100_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -4516,7 +4516,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freexl-2.0.0-h82fd2cb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.12.4-np2py314h38af87e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py314h54611df_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.14.1-h57520ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h31becfc_0.conda
@@ -4554,12 +4554,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.12.4-h126928a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.12.4-hf76e5b2_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.12.4-h480612f_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.12.4-hf116bd3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.12.4-h9dffbd3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.12.4-hd8ba4ad_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.1-h126928a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.1-h0d35cac_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.1-ha861f77_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-hf18d640_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.1-h4f433c8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-h0711251_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
@@ -4611,7 +4611,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/proj-9.8.1-hd211770_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/propcache-0.5.2-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psutil-7.2.2-py314h2e8dab5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py314h9155b42_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py314h0dd3294_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.14.6-hc679e19_100_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -4828,7 +4828,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3183152_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.12.4-np2py314h6dfb594_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py314hd174a59_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h10d778d_0.conda
@@ -4864,12 +4864,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-15.2.0-h08519bb_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.12.4-h2e1b34b_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.12.4-h30be141_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.12.4-hd911a30_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.12.4-hb154ecb_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.12.4-h37a0a2f_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.12.4-h6369dcf_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.1-h2e1b34b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.1-hf913fc2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.1-hf66efad_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-hdedcdb7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.1-hbc28da0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-hbe79d85_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwy-1.4.0-hca42a69_0.conda
@@ -4917,7 +4917,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.8.1-he69a98e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/propcache-0.5.2-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.2.2-py314hd330473_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py314h687fbad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py314h7dc4300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.14.6-h7c6738f_100_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -5132,7 +5132,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.12.4-np2py314hf76ae87_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py314h497824c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-h93a5062_0.conda
@@ -5168,12 +5168,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.12.4-hcee3826_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.12.4-he22df77_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.12.4-h5969d26_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.12.4-h24392f9_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.12.4-he6d8849_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.12.4-h629b07f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.1-hcee3826_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.1-h99414e2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.1-h5795c7d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-hcd92a64_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.1-ha0e568a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h9c8e0d5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwy-1.4.0-ha332bbd_0.conda
@@ -5221,7 +5221,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.8.1-ha88f16d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/propcache-0.5.2-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py314ha14b1ff_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py314h3da1bed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py314h618c026_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.6-h156bc91_100_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -5435,7 +5435,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.12.4-np2py314he09f147_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py314h805a11e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/google-crc32c-1.8.0-py314h720154c_1.conda
@@ -5464,12 +5464,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.25-h51727cc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.12.4-h9ea07af_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.12.4-ha539a3c_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.12.4-hd3704d6_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.12.4-h293a8ca_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.12.4-h3b90d24_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.12.4-h227a990_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.1-h9ea07af_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.1-h6e73097_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.1-h9da078d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h7603ba1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.1-h70292f5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-h57ca259_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.13.0-default_h049141e_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwy-1.4.0-h172a326_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
@@ -5516,7 +5516,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.8.1-hd30e2cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/propcache-0.5.2-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.2.2-py314hc5dbbe4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py314h1c1cb05_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py314he172734_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.14.6-h4b44e0e_100_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -5762,7 +5762,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.12.4-np2py314hc748478_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py314h3ef7809_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.2.2-h5888daf_1005.conda
@@ -5809,12 +5809,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.12.4-h2c8e1a9_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.12.4-h079cb0d_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.12.4-hc5b9174_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.12.4-hb6e0364_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.12.4-h4a420b2_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.12.4-h6643b6a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.1-h2c8e1a9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.1-h2ee2084_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.1-hbb32ccb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-hb4822db_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.1-hcd6cc38_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-h9d05ff3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
@@ -5881,7 +5881,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py314h0f05182_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-24.0.0-py314hdafbbf9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pyarrow-core-24.0.0-py314h969be7f_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py314hbcf5174_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py314hab130c5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-habeac84_100_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -6120,7 +6120,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freexl-2.0.0-h82fd2cb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.12.4-np2py314h38af87e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py314h54611df_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.14.1-h57520ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gflags-2.2.2-h5ad3122_1005.conda
@@ -6167,12 +6167,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.12.4-h126928a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.12.4-hf76e5b2_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.12.4-h480612f_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.12.4-hf116bd3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.12.4-h9dffbd3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.12.4-hd8ba4ad_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.1-h126928a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.1-h0d35cac_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.1-ha861f77_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-hf18d640_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.1-h4f433c8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-h0711251_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
@@ -6239,7 +6239,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psutil-7.2.2-py314h2e8dab5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyarrow-24.0.0-py314ha42fa4b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyarrow-core-24.0.0-py314h70cbd86_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py314h9155b42_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py314h0dd3294_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.14.6-hc679e19_100_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -6478,7 +6478,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3183152_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.12.4-np2py314h6dfb594_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py314hd174a59_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.2.2-hac325c4_1005.conda
@@ -6523,12 +6523,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-15.2.0-h08519bb_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.12.4-h2e1b34b_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.12.4-h30be141_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.12.4-hd911a30_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.12.4-hb154ecb_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.12.4-h37a0a2f_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.12.4-h6369dcf_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.1-h2e1b34b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.1-hf913fc2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.1-hf66efad_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-hdedcdb7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.1-hbc28da0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-hbe79d85_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-3.5.0-h8b848e0_1.conda
@@ -6591,7 +6591,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.2.2-py314hd330473_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-24.0.0-py314hee6578b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pyarrow-core-24.0.0-py314hfb10f56_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py314h687fbad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py314h7dc4300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.14.6-h7c6738f_100_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -6827,7 +6827,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.12.4-np2py314hf76ae87_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py314h497824c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.2.2-hf9b8971_1005.conda
@@ -6872,12 +6872,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.12.4-hcee3826_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.12.4-he22df77_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.12.4-h5969d26_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.12.4-h24392f9_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.12.4-he6d8849_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.12.4-h629b07f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.1-hcee3826_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.1-h99414e2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.1-h5795c7d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-hcd92a64_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.1-ha0e568a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h9c8e0d5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-3.5.0-h688a705_1.conda
@@ -6940,7 +6940,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py314ha14b1ff_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-24.0.0-py314he55896b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyarrow-core-24.0.0-py314h109bba2_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py314h3da1bed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py314h618c026_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.6-h156bc91_100_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -7176,7 +7176,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.12.4-np2py314he09f147_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py314h805a11e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/geopandas-base-1.1.3-pyha770c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/google-crc32c-1.8.0-py314h720154c_1.conda
@@ -7212,12 +7212,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.12.4-h9ea07af_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.12.4-ha539a3c_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.12.4-hd3704d6_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.12.4-h293a8ca_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.12.4-h3b90d24_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.12.4-h227a990_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.1-h9ea07af_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.1-h6e73097_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.1-h9da078d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h7603ba1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.1-h70292f5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-h57ca259_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-3.5.0-he22669a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-3.5.0-he04ea4c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.78.1-h9ff2b3e_0.conda
@@ -7279,7 +7279,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.2.2-py314hc5dbbe4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-24.0.0-py314h86ab7b2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pyarrow-core-24.0.0-py314h159fc0c_0_cpu.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py314h1c1cb05_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py314he172734_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.14.6-h4b44e0e_100_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -7505,7 +7505,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.8.0-py311h52bc045_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.12.4-np2py311hb06986c_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py311hea7fcad_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.8.0-py311h2702b87_1.conda
@@ -7542,12 +7542,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.12.4-h2c8e1a9_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.12.4-h079cb0d_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.12.4-hc5b9174_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.12.4-hb6e0364_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.12.4-h4a420b2_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.12.4-h6643b6a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.1-h2c8e1a9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.1-h2ee2084_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.1-hbb32ccb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-hb4822db_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.1-hcd6cc38_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-h9d05ff3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
@@ -7599,7 +7599,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.8.1-he0df7b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.5.2-py311h3778330_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py311haee01d2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py311h422ce6a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py311h31673df_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.15-h7508c33_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -7818,7 +7818,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freexl-2.0.0-h82fd2cb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/frozenlist-1.8.0-py311h91c1192_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.12.4-np2py311headb13d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py311h16f0df5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.14.1-h57520ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/google-crc32c-1.8.0-py311h90304e7_1.conda
@@ -7855,12 +7855,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.12.4-h126928a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.12.4-hf76e5b2_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.12.4-h480612f_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.12.4-hf116bd3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.12.4-h9dffbd3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.12.4-hd8ba4ad_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.1-h126928a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.1-h0d35cac_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.1-ha861f77_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-hf18d640_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.1-h4f433c8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-h0711251_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
@@ -7912,7 +7912,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/proj-9.8.1-hd211770_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/propcache-0.5.2-py311h164a683_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psutil-7.2.2-py311h51cfe5d_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py311h886ba34_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py311hc9acec3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.11.15-h53314ec_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -8131,7 +8131,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3183152_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozenlist-1.8.0-py311ha09d3ca_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.12.4-np2py311h79c8043_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py311h8e56c0d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h10d778d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/google-crc32c-1.8.0-py311h19ff24f_1.conda
@@ -8166,12 +8166,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-15.2.0-h08519bb_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.12.4-h2e1b34b_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.12.4-h30be141_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.12.4-hd911a30_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.12.4-hb154ecb_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.12.4-h37a0a2f_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.12.4-h6369dcf_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.1-h2e1b34b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.1-hf913fc2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.1-hf66efad_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-hdedcdb7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.1-hbc28da0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-hbe79d85_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwy-1.4.0-hca42a69_0.conda
@@ -8218,7 +8218,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.8.1-he69a98e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/propcache-0.5.2-py311ha8ae342_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.2.2-py311ha332486_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py311hca869a8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py311h7bd8e69_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.15-ha9537fe_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -8435,7 +8435,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.8.0-py311hf75086c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.12.4-np2py311h52353ff_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py311h3027aaa_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-h93a5062_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/google-crc32c-1.8.0-py311hf1b1034_1.conda
@@ -8470,12 +8470,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.12.4-hcee3826_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.12.4-he22df77_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.12.4-h5969d26_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.12.4-h24392f9_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.12.4-he6d8849_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.12.4-h629b07f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.1-hcee3826_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.1-h99414e2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.1-h5795c7d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-hcd92a64_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.1-ha0e568a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h9c8e0d5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwy-1.4.0-ha332bbd_0.conda
@@ -8522,7 +8522,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.8.1-ha88f16d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/propcache-0.5.2-py311hc290fe0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py311he363849_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py311h336326a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py311h1a47db8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.15-h0c9c016_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -8738,7 +8738,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.8.0-py311hdf60d3a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.12.4-np2py311h98848c2_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py311h63e6df4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/google-crc32c-1.8.0-py311h178015e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
@@ -8766,12 +8766,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.25-h51727cc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.12.4-h9ea07af_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.12.4-ha539a3c_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.12.4-hd3704d6_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.12.4-h293a8ca_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.12.4-h3b90d24_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.12.4-h227a990_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.1-h9ea07af_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.1-h6e73097_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.1-h9da078d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h7603ba1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.1-h70292f5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-h57ca259_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.13.0-default_h049141e_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwy-1.4.0-h172a326_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
@@ -8817,7 +8817,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.8.1-hd30e2cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/propcache-0.5.2-py311h3f79411_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.2.2-py311hf893f09_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py311h8db5f30_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py311h5596f38_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.11.15-h0159041_1_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -9046,7 +9046,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.8.0-py312h447239a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.12.4-np2py312h902b4a0_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py312h14f9b9d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.8.0-py312h03f33d3_1.conda
@@ -9083,12 +9083,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.12.4-h2c8e1a9_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.12.4-h079cb0d_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.12.4-hc5b9174_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.12.4-hb6e0364_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.12.4-h4a420b2_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.12.4-h6643b6a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.1-h2c8e1a9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.1-h2ee2084_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.1-hbb32ccb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-hb4822db_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.1-hcd6cc38_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-h9d05ff3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
@@ -9140,7 +9140,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.8.1-he0df7b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.5.2-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py312h5253ce2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py312h053e1f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py312hdb6ebaa_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.13-hd63d673_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -9357,7 +9357,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freexl-2.0.0-h82fd2cb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/frozenlist-1.8.0-py312hb10c72c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.12.4-np2py312h6db1376_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py312h5b4899f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.14.1-h57520ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/google-crc32c-1.8.0-py312h6dea175_1.conda
@@ -9394,12 +9394,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.12.4-h126928a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.12.4-hf76e5b2_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.12.4-h480612f_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.12.4-hf116bd3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.12.4-h9dffbd3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.12.4-hd8ba4ad_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.1-h126928a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.1-h0d35cac_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.1-ha861f77_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-hf18d640_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.1-h4f433c8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-h0711251_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
@@ -9451,7 +9451,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/proj-9.8.1-hd211770_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/propcache-0.5.2-py312ha4530ae_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psutil-7.2.2-py312hd41f8a7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py312h2d25c45_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py312h2024594_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.12.13-h91f4b29_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -9668,7 +9668,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3183152_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozenlist-1.8.0-py312h90c63f8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.12.4-np2py312hc2a5786_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py312ha7829c1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h10d778d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/google-crc32c-1.8.0-py312hb9001e9_1.conda
@@ -9703,12 +9703,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-15.2.0-h08519bb_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.12.4-h2e1b34b_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.12.4-h30be141_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.12.4-hd911a30_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.12.4-hb154ecb_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.12.4-h37a0a2f_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.12.4-h6369dcf_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.1-h2e1b34b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.1-hf913fc2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.1-hf66efad_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-hdedcdb7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.1-hbc28da0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-hbe79d85_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwy-1.4.0-hca42a69_0.conda
@@ -9755,7 +9755,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.8.1-he69a98e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/propcache-0.5.2-py312heb39f77_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.2.2-py312hf7082af_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py312h17ccd7d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py312h52cd9ce_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.13-ha9537fe_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -9970,7 +9970,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.8.0-py312ha0ce254_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.12.4-np2py312h98b042f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py312h26cf90d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-h93a5062_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/google-crc32c-1.8.0-py312h090f823_1.conda
@@ -10005,12 +10005,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.12.4-hcee3826_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.12.4-he22df77_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.12.4-h5969d26_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.12.4-h24392f9_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.12.4-he6d8849_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.12.4-h629b07f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.1-hcee3826_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.1-h99414e2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.1-h5795c7d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-hcd92a64_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.1-ha0e568a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h9c8e0d5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwy-1.4.0-ha332bbd_0.conda
@@ -10057,7 +10057,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.8.1-ha88f16d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/propcache-0.5.2-py312h04c11ed_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py312hb3ab3e3_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py312h07dd7c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py312hd1c4548_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.13-h8561d8f_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -10271,7 +10271,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.8.0-py312hfdf67e6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.12.4-np2py312hb192d7b_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py312hd7b58ea_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/google-crc32c-1.8.0-py312h3d708b0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
@@ -10299,12 +10299,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.25-h51727cc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.12.4-h9ea07af_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.12.4-ha539a3c_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.12.4-hd3704d6_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.12.4-h293a8ca_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.12.4-h3b90d24_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.12.4-h227a990_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.1-h9ea07af_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.1-h6e73097_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.1-h9da078d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h7603ba1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.1-h70292f5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-h57ca259_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.13.0-default_h049141e_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwy-1.4.0-h172a326_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
@@ -10350,7 +10350,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.8.1-hd30e2cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/propcache-0.5.2-py312h05f76fc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.2.2-py312he5662c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py312h3f2e00f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py312h0e78342_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.12.13-h0159041_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -10577,7 +10577,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.8.0-py313h6b9daa2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.12.4-np2py313hd2543e4_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py313h990c737_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.8.0-py313h74173ec_1.conda
@@ -10614,12 +10614,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.12.4-h2c8e1a9_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.12.4-h079cb0d_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.12.4-hc5b9174_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.12.4-hb6e0364_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.12.4-h4a420b2_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.12.4-h6643b6a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.1-h2c8e1a9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.1-h2ee2084_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.1-hbb32ccb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-hb4822db_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.1-hcd6cc38_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-h9d05ff3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
@@ -10671,7 +10671,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.8.1-he0df7b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/propcache-0.5.2-py313h3dea7bd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py313h54dd161_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py313hae45665_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py313hdaccff5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.14-h6add32d_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -10888,7 +10888,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freexl-2.0.0-h82fd2cb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/frozenlist-1.8.0-py313hf71145f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.12.4-np2py313hf47746b_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py313h0689f24_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.14.1-h57520ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/google-crc32c-1.8.0-py313hfb67750_1.conda
@@ -10925,12 +10925,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.12.4-h126928a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.12.4-hf76e5b2_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.12.4-h480612f_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.12.4-hf116bd3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.12.4-h9dffbd3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.12.4-hd8ba4ad_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.1-h126928a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.1-h0d35cac_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.1-ha861f77_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-hf18d640_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.1-h4f433c8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-h0711251_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
@@ -10982,7 +10982,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/proj-9.8.1-hd211770_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/propcache-0.5.2-py313hd3a54cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psutil-7.2.2-py313h62ef0ea_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py313hea1baa3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py313h0860647_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.13.14-h6185564_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -11199,7 +11199,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3183152_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozenlist-1.8.0-py313h1cd6d9b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.12.4-np2py313hbd352ad_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py313hbd7d14c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h10d778d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/google-crc32c-1.8.0-py313h49a2f01_1.conda
@@ -11234,12 +11234,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-15.2.0-h08519bb_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.12.4-h2e1b34b_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.12.4-h30be141_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.12.4-hd911a30_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.12.4-hb154ecb_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.12.4-h37a0a2f_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.12.4-h6369dcf_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.1-h2e1b34b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.1-hf913fc2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.1-hf66efad_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-hdedcdb7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.1-hbc28da0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-hbe79d85_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwy-1.4.0-hca42a69_0.conda
@@ -11287,7 +11287,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.8.1-he69a98e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/propcache-0.5.2-py313h035b7d0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.2.2-py313h16366db_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py313h8e1be7a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py313h94b7238_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.14-h3d5d122_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -11502,7 +11502,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.8.0-py313h750ce70_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.12.4-np2py313hf0fd461_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py313h4d367ad_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-h93a5062_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/google-crc32c-1.8.0-py313h11ab6f4_1.conda
@@ -11537,12 +11537,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.12.4-hcee3826_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.12.4-he22df77_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.12.4-h5969d26_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.12.4-h24392f9_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.12.4-he6d8849_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.12.4-h629b07f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.1-hcee3826_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.1-h99414e2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.1-h5795c7d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-hcd92a64_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.1-ha0e568a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h9c8e0d5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwy-1.4.0-ha332bbd_0.conda
@@ -11590,7 +11590,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.8.1-ha88f16d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/propcache-0.5.2-py313h65a2061_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py313h6688731_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py313he6d61f9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py313haffc69d_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.14-h448ec07_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -11804,7 +11804,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.8.0-py313h0c48a3b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.12.4-np2py313h08c7d88_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py313h887f262_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/google-crc32c-1.8.0-py313h5327936_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
@@ -11832,12 +11832,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.25-h51727cc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.12.4-h9ea07af_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.12.4-ha539a3c_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.12.4-hd3704d6_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.12.4-h293a8ca_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.12.4-h3b90d24_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.12.4-h227a990_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.1-h9ea07af_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.1-h6e73097_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.1-h9da078d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h7603ba1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.1-h70292f5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-h57ca259_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.13.0-default_h049141e_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwy-1.4.0-h172a326_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
@@ -11884,7 +11884,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.8.1-hd30e2cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/propcache-0.5.2-py313hd650c13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.2.2-py313h5fd188c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py313h8b19803_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py313he1476db_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.13.14-h09917c8_100_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -12112,7 +12112,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.12.4-np2py314hc748478_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py314h3ef7809_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.8.0-py314hd6bf2bd_1.conda
@@ -12149,12 +12149,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.12.4-h2c8e1a9_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.12.4-h079cb0d_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.12.4-hc5b9174_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.12.4-hb6e0364_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.12.4-h4a420b2_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.12.4-h6643b6a_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.1-h2c8e1a9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.1-h2ee2084_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.1-hbb32ccb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-hb4822db_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.1-hcd6cc38_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-h9d05ff3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
@@ -12206,7 +12206,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/proj-9.8.1-he0df7b0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/propcache-0.5.2-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/psutil-7.2.2-py314h0f05182_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py314hbcf5174_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py314hab130c5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-habeac84_100_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -12425,7 +12425,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freexl-2.0.0-h82fd2cb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.12.4-np2py314h38af87e_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py314h54611df_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.14.1-h57520ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/google-crc32c-1.8.0-py314h94bc565_1.conda
@@ -12462,12 +12462,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.12.4-h126928a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.12.4-hf76e5b2_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.12.4-h480612f_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.12.4-hf116bd3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.12.4-h9dffbd3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.12.4-hd8ba4ad_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.1-h126928a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.1-h0d35cac_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.1-ha861f77_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-hf18d640_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.1-h4f433c8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-h0711251_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
@@ -12519,7 +12519,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/proj-9.8.1-hd211770_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/propcache-0.5.2-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/psutil-7.2.2-py314h2e8dab5_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py314h9155b42_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py314h0dd3294_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.14.6-hc679e19_100_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -12738,7 +12738,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3183152_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.12.4-np2py314h6dfb594_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py314hd174a59_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h10d778d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/google-crc32c-1.8.0-py314h19b641f_1.conda
@@ -12773,12 +12773,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-15.2.0-h08519bb_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.12.4-h2e1b34b_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.12.4-h30be141_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.12.4-hd911a30_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.12.4-hb154ecb_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.12.4-h37a0a2f_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.12.4-h6369dcf_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.1-h2e1b34b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.1-hf913fc2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.1-hf66efad_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-hdedcdb7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.1-hbc28da0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-hbe79d85_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwy-1.4.0-hca42a69_0.conda
@@ -12826,7 +12826,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.8.1-he69a98e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/propcache-0.5.2-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/psutil-7.2.2-py314hd330473_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py314h687fbad_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py314h7dc4300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.14.6-h7c6738f_100_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -13043,7 +13043,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.12.4-np2py314hf76ae87_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py314h497824c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-h93a5062_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/google-crc32c-1.8.0-py314h8744745_1.conda
@@ -13078,12 +13078,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.12.4-hcee3826_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.12.4-he22df77_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.12.4-h5969d26_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.12.4-h24392f9_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.12.4-he6d8849_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.12.4-h629b07f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.1-hcee3826_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.1-h99414e2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.1-h5795c7d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-hcd92a64_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.1-ha0e568a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h9c8e0d5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwy-1.4.0-ha332bbd_0.conda
@@ -13131,7 +13131,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/proj-9.8.1-ha88f16d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/propcache-0.5.2-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/psutil-7.2.2-py314ha14b1ff_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py314h3da1bed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py314h618c026_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha55dd90_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.6-h156bc91_100_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -13347,7 +13347,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.8.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fsspec-2026.4.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.12.4-np2py314he09f147_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py314h805a11e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/google-crc32c-1.8.0-py314h720154c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
@@ -13375,12 +13375,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.25-h51727cc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.12.4-h9ea07af_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.12.4-ha539a3c_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.12.4-hd3704d6_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.12.4-h293a8ca_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.12.4-h3b90d24_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.12.4-h227a990_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.1-h9ea07af_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.1-h6e73097_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.1-h9da078d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h7603ba1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.1-h70292f5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-h57ca259_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.13.0-default_h049141e_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwy-1.4.0-h172a326_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
@@ -13427,7 +13427,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.8.1-hd30e2cd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/propcache-0.5.2-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/psutil-7.2.2-py314hc5dbbe4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py314h1c1cb05_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py314he172734_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyh09c184e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.14.6-h4b44e0e_100_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
@@ -13640,7 +13640,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.6-hb03c661_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.12.4-np2py314hc748478_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py314h3ef7809_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
@@ -13666,12 +13666,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.5.2-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-15.2.0-he0feb66_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-15.2.0-h69a702a_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.12.4-h2c8e1a9_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.12.4-h079cb0d_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.12.4-hc5b9174_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.12.4-h138e628_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.12.4-h4a420b2_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.12.4-h7b6522d_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.1-h2c8e1a9_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.1-h2ee2084_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.1-hbb32ccb_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-h9a8cd84_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.1-hcd6cc38_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-h1ba7c67_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-15.2.0-h68bc16d_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-15.2.0-he0feb66_19.conda
@@ -13741,7 +13741,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.6-he30d5cf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freexl-2.0.0-h82fd2cb_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.12.4-np2py314h0fbb9ba_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py314h54611df_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.14.1-h57520ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h31becfc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf4-4.2.15-hb6ba311_7.conda
@@ -13767,12 +13767,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.5.2-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-15.2.0-h8acb6b2_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-15.2.0-he9431aa_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.12.4-h126928a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.12.4-hf76e5b2_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.12.4-h480612f_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.12.4-hde0d3c6_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.12.4-h9dffbd3_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.12.4-h6671c66_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.1-h126928a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.1-h0d35cac_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.1-ha861f77_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-h2a01ee8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.1-h4f433c8_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-h2ae5ab3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-15.2.0-he9431aa_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-15.2.0-h1b7bec0_19.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-15.2.0-h8acb6b2_19.conda
@@ -13808,13 +13808,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/minizip-4.2.1-hd80d073_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/muparser-2.3.5-h5ad3122_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/ncurses-6.6-hf8d1292_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.4.6-py314h314fbd6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.4.6-py314he1698a1_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openjpeg-2.5.4-h5da879a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/openssl-3.6.3-h546c87b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pcre2-10.47-hf841c20_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/proj-9.8.1-hd211770_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.14.6-h1c24c05_0_cp314t.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.14.6-hc679e19_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/readline-8.3-hb682ff5_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/s2n-1.7.3-h8d42d4d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/snappy-1.2.2-he774c54_1.conda
@@ -13842,7 +13842,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.6-hb5e19a0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3183152_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.12.4-np2py314h6dfb594_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py314h31e7e59_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h10d778d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
@@ -13866,12 +13866,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.5.2-hd1f9c09_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-15.2.0-h08519bb_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.12.4-h2e1b34b_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.12.4-h30be141_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.12.4-hd911a30_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.12.4-h46ab8d8_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.12.4-h37a0a2f_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.12.4-hc604f8b_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.1-h2e1b34b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.1-hf913fc2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.1-hf66efad_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-hae3a7c9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.1-hbc28da0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-hc8f89f0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-15.2.0-h7e5c614_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-15.2.0-hd16e46c_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwy-1.4.0-hca42a69_0.conda
@@ -13903,13 +13903,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.2.1-he29b9bd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/muparser-2.3.5-hb996559_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.4.6-py314h7b24d9b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.4.6-py314h5af6b61_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.4-h52bb76a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.3-hc881268_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.8.1-he69a98e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.14.6-h7c6738f_100_cp314.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.14.6-ha91e2d8_0_cp314t.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.2-h01f5ddf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.53.2-h6775aab_0.conda
@@ -13936,7 +13936,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.6-hc919400_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.12.4-np2py314hf76ae87_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py314h497824c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-h93a5062_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
@@ -13960,12 +13960,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.5.2-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-15.2.0-hcbb3090_19.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.12.4-hcee3826_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.12.4-he22df77_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.12.4-h5969d26_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.12.4-hdc9be99_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.12.4-he6d8849_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.12.4-h163acdd_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.1-hcee3826_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.1-h99414e2_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.1-h5795c7d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-ha9c7d31_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.1-ha0e568a_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h5cd3543_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-15.2.0-h07b0088_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-15.2.0-hdae7583_19.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwy-1.4.0-ha332bbd_0.conda
@@ -14028,7 +14028,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.5.20-h4c7d964_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.12.4-np2py314he09f147_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py314h5f9b167_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-2.1.0-nompi_h693361b_107.conda
@@ -14045,12 +14045,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.25-h51727cc_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.5.2-h3d046cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.12.4-h9ea07af_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.12.4-ha539a3c_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.12.4-hd3704d6_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.12.4-hdf22f65_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.12.4-h3b90d24_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.12.4-h6f7152f_4.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.1-h9ea07af_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.1-h6e73097_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.1-h9da078d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h08b2fd1_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.1-h70292f5_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-hcec535a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.13.0-default_h049141e_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwy-1.4.0-h172a326_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_2.conda
@@ -14080,14 +14080,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/minizip-4.2.1-h0ffbb96_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2026.0.0-hac47afa_908.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/muparser-2.3.5-he0c23c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.4.6-py314h02f10f6_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.4.6-py314hffb9209_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/onemkl-license-2026.0.0-h57928b3_908.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.4-h0e57b4f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.3-hf411b9b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.47-hd2b5f0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.8.1-hd30e2cd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.14.6-h4b44e0e_100_cp314.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.14.6-h7c1dbca_0_cp314t.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.2-h7fa0ca8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.53.2-hdb435a2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/swig-4.4.1-h9b0202b_0.conda
@@ -19733,222 +19733,222 @@ packages:
   version: 1.0.0
   sha256: 929292d34f5872e70396626ef385ec22355a1fae8ad29e1a734c3e43f9fbc216
   requires_python: '>=2.6,!=3.0.*,!=3.1.*,!=3.2.*'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.12.4-np2py311hb06986c_4.conda
-  sha256: 5ab35a9f409f9252b726928c97c8d7cc3d5335f9cb470d52a8f783414e0d8501
-  md5: f1e4d0d7f981b5f4af4e584152c35dec
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py311hea7fcad_2.conda
+  sha256: fb6c493c54581ab8902fdafce0048e222f2d54af6a82a606ee43279abe3f6124
+  md5: 278a885b1f8de6f4d3889a13ac7ba5e9
   depends:
   - python
-  - libgdal-core 3.12.4.*
-  - libgcc >=14
+  - libgdal-core 3.13.1.*
   - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - proj >=9.8.1,<9.9.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.11,<1.0a0
-  - libdeflate >=1.25,<1.26.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
   - pcre2 >=10.47,<10.48.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - giflib >=5.2.2,<5.3.0a0
-  - libiconv >=1.18,<2.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
   - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
   - json-c >=0.18,<0.19.0a0
-  - blosc >=1.21.6,<2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libdeflate >=1.25,<1.26.0a0
   - libexpat >=2.8.1,<3.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
   - numpy >=1.23,<3
   - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
-  size: 2478218
-  timestamp: 1780863219289
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.12.4-np2py312h902b4a0_4.conda
-  sha256: a563170db97f4ea1482215f0836b17c972fea7a30b4fe1e8449ab49521a41c5e
-  md5: d6e2092704fe9a87ff38bc044d054e8b
+  size: 2556890
+  timestamp: 1781521928633
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py312h14f9b9d_2.conda
+  sha256: b5f6f890a51ee0e11b2d1c8d0bf800ef5b58350335dde6ac678d81ae73cc6898
+  md5: 6b5482645c76f40eba3864279cd46b8c
   depends:
   - python
-  - libgdal-core 3.12.4.*
-  - libgcc >=14
+  - libgdal-core 3.13.1.*
   - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - proj >=9.8.1,<9.9.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.11,<1.0a0
-  - libdeflate >=1.25,<1.26.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
   - pcre2 >=10.47,<10.48.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - giflib >=5.2.2,<5.3.0a0
-  - libiconv >=1.18,<2.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
   - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
   - json-c >=0.18,<0.19.0a0
-  - blosc >=1.21.6,<2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libdeflate >=1.25,<1.26.0a0
   - libexpat >=2.8.1,<3.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
   - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/gdal?source=hash-mapping
-  size: 2448941
-  timestamp: 1780863219289
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.12.4-np2py313hd2543e4_4.conda
-  sha256: c3a63630fdad672b45b56b2b5bf6daa116e27ed6d9d83ac8929245e4bd08b3a1
-  md5: 704be15326517f89848dceacb4e10a64
+  - pkg:pypi/gdal?source=compressed-mapping
+  size: 2524146
+  timestamp: 1781521928633
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py313h990c737_2.conda
+  sha256: e4de5b2e8d75f31f6e892e7c196caa8bf3c341f3c7216ddb89b72b84332cffef
+  md5: 87401587fd35d28db150223c25ad2fc6
   depends:
   - python
-  - libgdal-core 3.12.4.*
-  - libgcc >=14
+  - libgdal-core 3.13.1.*
   - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - proj >=9.8.1,<9.9.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.11,<1.0a0
-  - libdeflate >=1.25,<1.26.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
   - pcre2 >=10.47,<10.48.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - giflib >=5.2.2,<5.3.0a0
-  - libiconv >=1.18,<2.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
   - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
   - json-c >=0.18,<0.19.0a0
-  - blosc >=1.21.6,<2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libdeflate >=1.25,<1.26.0a0
   - libexpat >=2.8.1,<3.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
   - numpy >=1.23,<3
   - python_abi 3.13.* *_cp313
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
-  size: 2438640
-  timestamp: 1780863219289
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.12.4-np2py314hc748478_4.conda
-  sha256: 418d4115f65242c28852f9efdad5066ad4a6d3d3ba29913da0883df06e273a52
-  md5: 6976faee993ef4357e3bea6ead1edaee
+  size: 2514658
+  timestamp: 1781521928633
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py314h3ef7809_2.conda
+  sha256: eb22723bfe8eabc3af5c616fa0831323fb21f6f333798967328d9b7353059d5e
+  md5: 9f45412a150a0add1f962e838715554c
   depends:
   - python
-  - libgdal-core 3.12.4.*
-  - libgcc >=14
+  - libgdal-core 3.13.1.*
   - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - proj >=9.8.1,<9.9.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.11,<1.0a0
-  - libdeflate >=1.25,<1.26.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
   - pcre2 >=10.47,<10.48.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - giflib >=5.2.2,<5.3.0a0
-  - libiconv >=1.18,<2.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
   - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
   - json-c >=0.18,<0.19.0a0
-  - blosc >=1.21.6,<2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libdeflate >=1.25,<1.26.0a0
   - libexpat >=2.8.1,<3.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
   - python_abi 3.14.* *_cp314
   - numpy >=1.23,<3
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
-  size: 2450125
-  timestamp: 1780863219289
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.12.4-np2py311headb13d_4.conda
-  sha256: 4ddebccd832429cd708aeca7114bd608cd95a9bcae407cb23ad6a53b89551d17
-  md5: 26742372258ab6fa5e2f917677564bf5
+  size: 2525959
+  timestamp: 1781521928633
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py311h16f0df5_2.conda
+  sha256: bad24770c8c3db3cf3b6167e113ef3cd92c45759e6eb36f0a03e990ae0d60b27
+  md5: 313df7ba41ddde156daca45a53f307ec
   depends:
   - python
-  - libgdal-core 3.12.4.*
-  - libgcc >=14
+  - libgdal-core 3.13.1.*
   - libstdcxx >=14
-  - libexpat >=2.8.1,<3.0a0
-  - libsqlite >=3.53.2,<4.0a0
+  - libgcc >=14
+  - libkml >=1.3.0,<1.4.0a0
   - xerces-c >=3.3.0,<3.4.0a0
-  - libiconv >=1.18,<2.0a0
+  - libjxl >=0.11,<1.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
   - blosc >=1.21.6,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
   - libdeflate >=1.25,<1.26.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - json-c >=0.18,<0.19.0a0
+  - openssl >=3.5.7,<4.0a0
   - geos >=3.14.1,<3.14.2.0a0
-  - liblzma >=5.8.3,<6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libiconv >=1.18,<2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
   - giflib >=5.2.2,<5.3.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - proj >=9.8.1,<9.9.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - openssl >=3.5.6,<4.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - lerc >=4.1.0,<5.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
   - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - libjxl >=0.11,<1.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - pcre2 >=10.47,<10.48.0a0
+  - libexpat >=2.8.1,<3.0a0
   - python 3.11.* *_cpython
   - python_abi 3.11.* *_cp311
   - numpy >=1.23,<3
@@ -19956,44 +19956,44 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
-  size: 2405229
-  timestamp: 1780863218586
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.12.4-np2py312h6db1376_4.conda
-  sha256: fc81f1f3fbd9865434a1e3e2b5fd9870788f75e65175f7157a9df08e20dbdcf4
-  md5: 016a001c698ccdfe683109648f5bf3aa
+  size: 2485439
+  timestamp: 1781521933600
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py312h5b4899f_2.conda
+  sha256: afe05107abf6127a05a54855b1735874d30e1d6657c15a9e35a6b76a136a9a7e
+  md5: bacbce37c74737be1830692f32007409
   depends:
   - python
-  - libgdal-core 3.12.4.*
-  - libgcc >=14
+  - libgdal-core 3.13.1.*
   - libstdcxx >=14
-  - libexpat >=2.8.1,<3.0a0
-  - libsqlite >=3.53.2,<4.0a0
+  - libgcc >=14
+  - libkml >=1.3.0,<1.4.0a0
   - xerces-c >=3.3.0,<3.4.0a0
-  - libiconv >=1.18,<2.0a0
+  - libjxl >=0.11,<1.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
   - blosc >=1.21.6,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
   - libdeflate >=1.25,<1.26.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - json-c >=0.18,<0.19.0a0
+  - openssl >=3.5.7,<4.0a0
   - geos >=3.14.1,<3.14.2.0a0
-  - liblzma >=5.8.3,<6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libiconv >=1.18,<2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
   - giflib >=5.2.2,<5.3.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - proj >=9.8.1,<9.9.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - openssl >=3.5.6,<4.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - lerc >=4.1.0,<5.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
   - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - libjxl >=0.11,<1.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - pcre2 >=10.47,<10.48.0a0
+  - libexpat >=2.8.1,<3.0a0
   - python 3.12.* *_cpython
   - python_abi 3.12.* *_cp312
   - numpy >=1.23,<3
@@ -20001,44 +20001,44 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
-  size: 2379811
-  timestamp: 1780863218586
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.12.4-np2py313hf47746b_4.conda
-  sha256: dd450b5bc3a9050e26db2f3e5a9fa4bafe804acf58d9514d17d800fca5167172
-  md5: c5bfe3137c66c83fd6da722032a280e4
+  size: 2454442
+  timestamp: 1781521933600
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py313h0689f24_2.conda
+  sha256: 5f5966e3a0c6b64edd51523cf1be19629cf1b17307715cbea351c3d8c04a4cf6
+  md5: b52ca92f48e69cec4253e53287792267
   depends:
   - python
-  - libgdal-core 3.12.4.*
-  - libgcc >=14
+  - libgdal-core 3.13.1.*
   - libstdcxx >=14
-  - libexpat >=2.8.1,<3.0a0
-  - libsqlite >=3.53.2,<4.0a0
+  - libgcc >=14
+  - libkml >=1.3.0,<1.4.0a0
   - xerces-c >=3.3.0,<3.4.0a0
-  - libiconv >=1.18,<2.0a0
+  - libjxl >=0.11,<1.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
   - blosc >=1.21.6,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
   - libdeflate >=1.25,<1.26.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - json-c >=0.18,<0.19.0a0
+  - openssl >=3.5.7,<4.0a0
   - geos >=3.14.1,<3.14.2.0a0
-  - liblzma >=5.8.3,<6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libiconv >=1.18,<2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
   - giflib >=5.2.2,<5.3.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - proj >=9.8.1,<9.9.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - openssl >=3.5.6,<4.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - lerc >=4.1.0,<5.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
   - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - libjxl >=0.11,<1.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - pcre2 >=10.47,<10.48.0a0
+  - libexpat >=2.8.1,<3.0a0
   - python 3.13.* *_cp313
   - numpy >=1.23,<3
   - python_abi 3.13.* *_cp313
@@ -20046,486 +20046,485 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
-  size: 2368204
-  timestamp: 1780863218586
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.12.4-np2py314h0fbb9ba_4.conda
-  sha256: 3970d17ec6ec4e3c39869b9f19480b3f8c2436ce1ddde282fc8869b6addbcc0b
-  md5: 8e0ca6929164679508e192b8f9709aba
+  size: 2446177
+  timestamp: 1781521933600
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py314h54611df_2.conda
+  sha256: 400ba36f982e6c4068264ac1b507f25544d8260c0c46b21ceb9fa5ca545bf53c
+  md5: 4fedef3fe885400c62bf2af06754e5d9
   depends:
   - python
-  - libgdal-core 3.12.4.*
-  - libgcc >=14
+  - libgdal-core 3.13.1.*
   - libstdcxx >=14
-  - libexpat >=2.8.1,<3.0a0
-  - libsqlite >=3.53.2,<4.0a0
+  - libgcc >=14
+  - libkml >=1.3.0,<1.4.0a0
   - xerces-c >=3.3.0,<3.4.0a0
-  - libiconv >=1.18,<2.0a0
+  - libjxl >=0.11,<1.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
   - blosc >=1.21.6,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
   - libdeflate >=1.25,<1.26.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - json-c >=0.18,<0.19.0a0
+  - openssl >=3.5.7,<4.0a0
   - geos >=3.14.1,<3.14.2.0a0
-  - liblzma >=5.8.3,<6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libiconv >=1.18,<2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
   - giflib >=5.2.2,<5.3.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - proj >=9.8.1,<9.9.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - openssl >=3.5.6,<4.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - lerc >=4.1.0,<5.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
   - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - python 3.14.* *_cp314
+  - python_abi 3.14.* *_cp314
+  - numpy >=1.23,<3
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/gdal?source=hash-mapping
+  size: 2455969
+  timestamp: 1781521933600
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py311h8e56c0d_1.conda
+  sha256: d4b55d7623a4036dccd267dca9e843472e176c3604c0679e3383162102723d2b
+  md5: bdd2e8c4f9345e7ba6d363e10648863c
+  depends:
+  - python
+  - libgdal-core 3.13.1.*
+  - libcxx >=19
+  - __osx >=11.0
   - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - libjxl >=0.11,<1.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libpng >=1.6.58,<1.7.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - json-c >=0.18,<0.19.0a0
   - pcre2 >=10.47,<10.48.0a0
-  - python 3.14.* *_cp314t
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libjxl >=0.11,<1.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - numpy >=1.23,<3
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/gdal?source=hash-mapping
+  size: 2505164
+  timestamp: 1780928456229
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py312ha7829c1_1.conda
+  sha256: 0f552e0fe5eadb4b94eb2b30db8159f9dd9c8fcadcc1a18e3e12b77525a82b13
+  md5: 8bd09e42d9909e65601f93d9ede6b1e0
+  depends:
+  - python
+  - libgdal-core 3.13.1.*
+  - libcxx >=19
+  - __osx >=11.0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - json-c >=0.18,<0.19.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libjxl >=0.11,<1.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - numpy >=1.23,<3
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/gdal?source=hash-mapping
+  size: 2484314
+  timestamp: 1780928456229
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py313hbd7d14c_1.conda
+  sha256: 31c2b6b97e4a16d551bd53b27b705fe8037cad3cf04cc965254a2b8b9adbc4cd
+  md5: 8c67741e1a661fdd8da5b318b7a6a18f
+  depends:
+  - python
+  - libgdal-core 3.13.1.*
+  - libcxx >=19
+  - __osx >=11.0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - json-c >=0.18,<0.19.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libjxl >=0.11,<1.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - python_abi 3.13.* *_cp313
+  - numpy >=1.23,<3
+  license: MIT
+  license_family: MIT
+  purls:
+  - pkg:pypi/gdal?source=hash-mapping
+  size: 2481420
+  timestamp: 1780928456229
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py314h31e7e59_1.conda
+  sha256: 6c8e523ab7a6dc77ad1c7c0d3bf96fd1aeabf3a97e607847c6755053480a2f2a
+  md5: ca775308e9defc22cb94dc3674f154e9
+  depends:
+  - python
+  - libgdal-core 3.13.1.*
+  - libcxx >=19
+  - __osx >=11.0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - json-c >=0.18,<0.19.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libjxl >=0.11,<1.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - numpy >=1.23,<3
   - python_abi 3.14.* *_cp314t
-  - numpy >=1.23,<3
   license: MIT
   license_family: MIT
-  size: 2401594
-  timestamp: 1780863218586
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.12.4-np2py314h38af87e_4.conda
-  sha256: d447b909ddc5b399fe4f4cf310ae196e96b9027c52d1f03a25c825ded32528ed
-  md5: 61045c48a3aed85f1064e84f153d8f13
+  size: 2518771
+  timestamp: 1780928456229
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py314hd174a59_1.conda
+  sha256: 79a4eddf5bcf52d76155745c18d1df3391a749d6837d732b42488fc4c6f3fe10
+  md5: 05ea035465fdd948b03be6441a6eaee6
   depends:
   - python
-  - libgdal-core 3.12.4.*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libexpat >=2.8.1,<3.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libiconv >=1.18,<2.0a0
-  - blosc >=1.21.6,<2.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - openssl >=3.5.6,<4.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - lerc >=4.1.0,<5.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - libjxl >=0.11,<1.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - python 3.14.* *_cp314
-  - python_abi 3.14.* *_cp314
-  - numpy >=1.23,<3
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/gdal?source=hash-mapping
-  size: 2378305
-  timestamp: 1780863218586
-- conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.12.4-np2py311h79c8043_4.conda
-  sha256: 0d812fe012ec97b2e4b8216be869d8eb9c21f947a089671f4184340b2278e388
-  md5: 2cf8df43c02af2eca1a3897e8e6f652c
-  depends:
-  - python
-  - libgdal-core 3.12.4.*
-  - __osx >=11.0
+  - libgdal-core 3.13.1.*
   - libcxx >=19
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libiconv >=1.18,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libjxl >=0.11,<1.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - openssl >=3.5.6,<4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - lerc >=4.1.0,<5.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - blosc >=1.21.6,<2.0a0
-  - numpy >=1.23,<3
-  - python_abi 3.11.* *_cp311
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/gdal?source=hash-mapping
-  size: 2433631
-  timestamp: 1780863326444
-- conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.12.4-np2py312hc2a5786_4.conda
-  sha256: f655b828b34cf130d8da5223df9382a9b86ac8602208bb7724faee83784c5b23
-  md5: 0bfa1b1851723bb6e80b708be12cafaa
-  depends:
-  - python
-  - libgdal-core 3.12.4.*
   - __osx >=11.0
-  - libcxx >=19
-  - xerces-c >=3.3.0,<3.4.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - json-c >=0.18,<0.19.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
   - libcurl >=8.20.0,<9.0a0
   - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libiconv >=1.18,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libjxl >=0.11,<1.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - openssl >=3.5.6,<4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - lerc >=4.1.0,<5.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
   - blosc >=1.21.6,<2.0a0
-  - numpy >=1.23,<3
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/gdal?source=hash-mapping
-  size: 2414184
-  timestamp: 1780863326444
-- conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.12.4-np2py313hbd352ad_4.conda
-  sha256: d5999295eb8e3983c8439a01a8a888810a8cb9bf80ceca4d379742a05c0f3382
-  md5: 887383fd36ebb6a80ba3217501f32e02
-  depends:
-  - python
-  - libgdal-core 3.12.4.*
-  - __osx >=11.0
-  - libcxx >=19
+  - libdeflate >=1.25,<1.26.0a0
+  - libjxl >=0.11,<1.0a0
   - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libiconv >=1.18,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libjxl >=0.11,<1.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - openssl >=3.5.6,<4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - json-c >=0.18,<0.19.0a0
   - libexpat >=2.8.1,<3.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - lerc >=4.1.0,<5.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - blosc >=1.21.6,<2.0a0
-  - numpy >=1.23,<3
-  - python_abi 3.13.* *_cp313
-  license: MIT
-  license_family: MIT
-  purls:
-  - pkg:pypi/gdal?source=hash-mapping
-  size: 2413550
-  timestamp: 1780863326444
-- conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.12.4-np2py314h6dfb594_4.conda
-  sha256: c3955fb173fefc4e79f5d5a3c1e2d0f6982ce370b97ebb4b3be5df6d44b8aca5
-  md5: eb9a2a1cd74a6b1fa7b4c820f2611af1
-  depends:
-  - python
-  - libgdal-core 3.12.4.*
-  - __osx >=11.0
-  - libcxx >=19
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libiconv >=1.18,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libjxl >=0.11,<1.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - openssl >=3.5.6,<4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - lerc >=4.1.0,<5.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - blosc >=1.21.6,<2.0a0
   - numpy >=1.23,<3
   - python_abi 3.14.* *_cp314
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
-  size: 2424595
-  timestamp: 1780863326444
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.12.4-np2py311h52353ff_4.conda
-  sha256: bc12e474045337a72ddd7640980a1dbca8601b82c247bb610d828db793d8c887
-  md5: a5696414ca12c6a2d3778406843f9ccb
+  size: 2492056
+  timestamp: 1780928456229
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py311h3027aaa_2.conda
+  sha256: 691f0b1768ec3ba497d35d4da325ed5bcebc6d5a74ed17556c2f40bc2b2619ae
+  md5: 012c0d2d5d637ed2975575d447ea9dbb
   depends:
   - python
-  - libgdal-core 3.12.4.*
+  - libgdal-core 3.13.1.*
   - __osx >=11.0
   - libcxx >=19
+  - lz4-c >=1.10.0,<1.11.0a0
+  - openssl >=3.5.7,<4.0a0
   - libjxl >=0.11,<1.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - muparser >=2.3.5,<2.4.0a0
   - liblzma >=5.8.3,<6.0a0
+  - libiconv >=1.18,<2.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libsqlite >=3.53.2,<4.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - geos >=3.14.1,<3.14.2.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - giflib >=5.2.2,<5.3.0a0
   - libspatialite >=5.1.0,<5.2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
   - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - openssl >=3.5.6,<4.0a0
-  - blosc >=1.21.6,<2.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - pcre2 >=10.47,<10.48.0a0
   - lerc >=4.1.0,<5.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - python 3.11.* *_cpython
-  - python_abi 3.11.* *_cp311
   - numpy >=1.23,<3
+  - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
-  size: 2412476
-  timestamp: 1780863488887
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.12.4-np2py312h98b042f_4.conda
-  sha256: 98a0497a0823e1c2bba19d1a990699725be7f6b7796daacf49a0608767678c25
-  md5: 97d725154b28c66d8af8d35d388ffbc6
+  size: 2483443
+  timestamp: 1781522319718
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py312h26cf90d_2.conda
+  sha256: 609896320ad24ea9b3de5a368665d91583c8b3602428ce56b5787cdcbf2fc819
+  md5: 88e777b7193d82af4ac4a69ecac384b4
   depends:
   - python
-  - libgdal-core 3.12.4.*
+  - libgdal-core 3.13.1.*
   - __osx >=11.0
   - libcxx >=19
+  - lz4-c >=1.10.0,<1.11.0a0
+  - openssl >=3.5.7,<4.0a0
   - libjxl >=0.11,<1.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - muparser >=2.3.5,<2.4.0a0
   - liblzma >=5.8.3,<6.0a0
+  - libiconv >=1.18,<2.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libsqlite >=3.53.2,<4.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - geos >=3.14.1,<3.14.2.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - giflib >=5.2.2,<5.3.0a0
   - libspatialite >=5.1.0,<5.2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
   - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - openssl >=3.5.6,<4.0a0
-  - blosc >=1.21.6,<2.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - pcre2 >=10.47,<10.48.0a0
   - lerc >=4.1.0,<5.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - python 3.12.* *_cpython
+  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.23,<3
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
-  size: 2389519
-  timestamp: 1780863488887
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.12.4-np2py313hf0fd461_4.conda
-  sha256: b948a37c3b74dadfaf8b2b3bc009f6b9c94ece3f55080e5c27146625ade98099
-  md5: 1c5702d2eb34a5600f2d5845e61b6d4e
+  size: 2458846
+  timestamp: 1781522319718
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py313h4d367ad_2.conda
+  sha256: 403a13f907e990b261927e2a97f6d6c2fd65437e032c9d0a74626619c53da95e
+  md5: f244fde641c23cfd55ae27553b45fa99
   depends:
   - python
-  - libgdal-core 3.12.4.*
+  - libgdal-core 3.13.1.*
   - __osx >=11.0
   - libcxx >=19
+  - lz4-c >=1.10.0,<1.11.0a0
+  - openssl >=3.5.7,<4.0a0
   - libjxl >=0.11,<1.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - muparser >=2.3.5,<2.4.0a0
   - liblzma >=5.8.3,<6.0a0
+  - libiconv >=1.18,<2.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libsqlite >=3.53.2,<4.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - geos >=3.14.1,<3.14.2.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - giflib >=5.2.2,<5.3.0a0
   - libspatialite >=5.1.0,<5.2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
   - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - openssl >=3.5.6,<4.0a0
-  - blosc >=1.21.6,<2.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - pcre2 >=10.47,<10.48.0a0
   - lerc >=4.1.0,<5.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - python 3.13.* *_cp313
-  - numpy >=1.23,<3
   - python_abi 3.13.* *_cp313
+  - numpy >=1.23,<3
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
-  size: 2381775
-  timestamp: 1780863488887
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.12.4-np2py314hf76ae87_4.conda
-  sha256: e52e35d52900228809143b3f172a47b61b976c5bdefbcdbe1b7c1b568ed058bf
-  md5: 34739cc7396d9ffbd58d822fd0b76938
+  size: 2451690
+  timestamp: 1781522319718
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py314h497824c_2.conda
+  sha256: d1d6fe75679ebd6deaf5c363e2529008bc3003f235343bba65316cc044adf186
+  md5: c46ba0e9d31b7df7f11145bf88bc8e3b
   depends:
   - python
-  - libgdal-core 3.12.4.*
+  - libgdal-core 3.13.1.*
   - __osx >=11.0
   - libcxx >=19
+  - lz4-c >=1.10.0,<1.11.0a0
+  - openssl >=3.5.7,<4.0a0
   - libjxl >=0.11,<1.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - muparser >=2.3.5,<2.4.0a0
   - liblzma >=5.8.3,<6.0a0
+  - libiconv >=1.18,<2.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libsqlite >=3.53.2,<4.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - geos >=3.14.1,<3.14.2.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - giflib >=5.2.2,<5.3.0a0
   - libspatialite >=5.1.0,<5.2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
   - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - openssl >=3.5.6,<4.0a0
-  - blosc >=1.21.6,<2.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - pcre2 >=10.47,<10.48.0a0
   - lerc >=4.1.0,<5.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - python 3.14.* *_cp314
-  - numpy >=1.23,<3
   - python_abi 3.14.* *_cp314
+  - numpy >=1.23,<3
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
-  size: 2393084
-  timestamp: 1780863488887
-- conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.12.4-np2py311h98848c2_4.conda
-  sha256: 2dcadb9b761706f7c53f75555b9216001c09ffddb2f3fb3929976124759a0dcb
-  md5: 8d4cecdfa7737792a1e533d4adb20aaa
+  size: 2462878
+  timestamp: 1781522319718
+- conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py311h63e6df4_2.conda
+  sha256: 8c00aed9338834624867acc1d422d77888d6dcd00acd1810d194a8cdeda9bd6b
+  md5: a16ce701be0328e5ae532d330561aabb
   depends:
   - python
-  - libgdal-core 3.12.4.*
+  - libgdal-core 3.13.1.*
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
   - libspatialite >=5.1.0,<5.2.0a0
   - libzlib >=1.3.2,<2.0a0
   - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - blosc >=1.21.6,<2.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
   - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libiconv >=1.18,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
   - libjxl >=0.11,<1.0a0
   - libexpat >=2.8.1,<3.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
+  - pcre2 >=10.47,<10.48.0a0
   - liblzma >=5.8.3,<6.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - geos >=3.14.1,<3.14.2.0a0
   - python_abi 3.11.* *_cp311
   - numpy >=1.23,<3
@@ -20533,85 +20532,85 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
-  size: 2289256
-  timestamp: 1780863283604
-- conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.12.4-np2py312hb192d7b_4.conda
-  sha256: 555e51945058d3786190bfcb8b7793d405e4370870b949b40338b17f8b6c3267
-  md5: 8b961c90aa653e4f3cb13b4a21020e96
+  size: 2359071
+  timestamp: 1781522012443
+- conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py312hd7b58ea_2.conda
+  sha256: 972fc720677a9461e66a330e6e9246fdb45e5c4929a1634751deb1f77bbdf8b8
+  md5: 0054b6d08a40104dbeb29527a572252f
   depends:
   - python
-  - libgdal-core 3.12.4.*
+  - libgdal-core 3.13.1.*
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
   - libspatialite >=5.1.0,<5.2.0a0
   - libzlib >=1.3.2,<2.0a0
   - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - blosc >=1.21.6,<2.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
   - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libiconv >=1.18,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
   - libjxl >=0.11,<1.0a0
   - libexpat >=2.8.1,<3.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
+  - pcre2 >=10.47,<10.48.0a0
   - liblzma >=5.8.3,<6.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - geos >=3.14.1,<3.14.2.0a0
-  - numpy >=1.23,<3
   - python_abi 3.12.* *_cp312
+  - numpy >=1.23,<3
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
-  size: 2267010
-  timestamp: 1780863283604
-- conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.12.4-np2py313h08c7d88_4.conda
-  sha256: 183b8092b9884fadc4f530b3e62bdc719de267d3cc6cc934f654aefa1aa50cfa
-  md5: 835fc8a9e3ea392268ca33fa439bcc5a
+  size: 2334720
+  timestamp: 1781522012443
+- conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py313h887f262_2.conda
+  sha256: 0f9aed5edd223c573968e96ed2f78881ea863c10271580bbb48057ac33f5f7cd
+  md5: 314ceec4e10c058ac543878be2b8a5d8
   depends:
   - python
-  - libgdal-core 3.12.4.*
+  - libgdal-core 3.13.1.*
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
   - libspatialite >=5.1.0,<5.2.0a0
   - libzlib >=1.3.2,<2.0a0
   - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - blosc >=1.21.6,<2.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
   - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libiconv >=1.18,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
   - libjxl >=0.11,<1.0a0
   - libexpat >=2.8.1,<3.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
+  - pcre2 >=10.47,<10.48.0a0
   - liblzma >=5.8.3,<6.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - geos >=3.14.1,<3.14.2.0a0
   - python_abi 3.13.* *_cp313
   - numpy >=1.23,<3
@@ -20619,42 +20618,83 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
-  size: 2258986
-  timestamp: 1780863283604
-- conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.12.4-np2py314he09f147_4.conda
-  sha256: c56828cbb8c5a13555fca6c69138bee38f0750491b7c87269b31433bdcb5e0a6
-  md5: a567b7d74bb07ab8509b470aa461e001
+  size: 2326183
+  timestamp: 1781522012443
+- conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py314h5f9b167_2.conda
+  sha256: eebd9a86221277e6158758ca73f4d3b29f63dde05143ffd376e3e62946dd17d7
+  md5: cdb99e8583a500c77660ad4747070736
   depends:
   - python
-  - libgdal-core 3.12.4.*
+  - libgdal-core 3.13.1.*
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
   - libspatialite >=5.1.0,<5.2.0a0
   - libzlib >=1.3.2,<2.0a0
   - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - blosc >=1.21.6,<2.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
   - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libiconv >=1.18,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
   - libjxl >=0.11,<1.0a0
   - libexpat >=2.8.1,<3.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - numpy >=1.23,<3
+  - python_abi 3.14.* *_cp314t
+  license: MIT
+  license_family: MIT
+  size: 2383069
+  timestamp: 1781522012443
+- conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py314h805a11e_2.conda
+  sha256: 45ace15855f31c1a4db60ca1b2755da4b2be86f231a6ea77b9f29d86f77002cb
+  md5: c557d9539ee244357bdd144a9b63d13d
+  depends:
+  - python
+  - libgdal-core 3.13.1.*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - liblzma >=5.8.3,<6.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - zstd >=1.5.7,<1.6.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
   - libarchive >=3.8.7,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libdeflate >=1.25,<1.26.0a0
   - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libkml >=1.3.0,<1.4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libjxl >=0.11,<1.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - liblzma >=5.8.3,<6.0a0
   - geos >=3.14.1,<3.14.2.0a0
   - python_abi 3.14.* *_cp314
   - numpy >=1.23,<3
@@ -20662,8 +20702,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
-  size: 2265970
-  timestamp: 1780863283604
+  size: 2336619
+  timestamp: 1781522012443
 - pypi: https://files.pythonhosted.org/packages/3c/78/6a04792ace63a93e162f1305392d500ae8ddcb620e7eb88a22fd622b35bb/geopandas-1.1.3-py3-none-any.whl
   name: geopandas
   version: 1.1.3
@@ -24820,1681 +24860,1681 @@ packages:
   purls: []
   size: 27738
   timestamp: 1778268759211
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.12.4-h2c8e1a9_4.conda
-  sha256: bcfe7ee49d92a8c42e508c79db2b48d0e7f395c167288d51cb2e99cc9162c9ef
-  md5: 58a8af3dc1f82dd2f38bd295d80b70da
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.1-h2c8e1a9_2.conda
+  sha256: 173721581c18af41d7762db7a86ca29c373a08aa1f52aa436ee225ca1f566121
+  md5: c55622ce7c6d453642fd3ad737f42bd7
   depends:
-  - libgcc >=14
   - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - proj >=9.8.1,<9.9.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.11,<1.0a0
-  - libdeflate >=1.25,<1.26.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
   - pcre2 >=10.47,<10.48.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - giflib >=5.2.2,<5.3.0a0
-  - libiconv >=1.18,<2.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
   - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
   - json-c >=0.18,<0.19.0a0
-  - blosc >=1.21.6,<2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libdeflate >=1.25,<1.26.0a0
   - libexpat >=2.8.1,<3.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
   constrains:
-  - libgdal 3.12.4.*
+  - libgdal 3.13.1.*
   license: MIT
   license_family: MIT
   purls: []
-  size: 14037330
-  timestamp: 1780863219289
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.12.4-h126928a_4.conda
-  sha256: cb625ebcba349ffeb9dd22e8cbfdae9641a867387bce595958ca819bd8e743e3
-  md5: 8c0263c324ccfc1e97060dc491bad8d5
+  size: 15026665
+  timestamp: 1781521928633
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.1-h126928a_2.conda
+  sha256: 1794608fa259056aa88e09f9a3e53ff1f4f940e22e426d50a2b429d7dca98878
+  md5: bf05314be0707b9906b4f5720d2049d4
   depends:
-  - libgcc >=14
   - libstdcxx >=14
-  - libexpat >=2.8.1,<3.0a0
-  - libsqlite >=3.53.2,<4.0a0
+  - libgcc >=14
+  - libkml >=1.3.0,<1.4.0a0
   - xerces-c >=3.3.0,<3.4.0a0
-  - libiconv >=1.18,<2.0a0
+  - libjxl >=0.11,<1.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
   - blosc >=1.21.6,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
   - libdeflate >=1.25,<1.26.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - json-c >=0.18,<0.19.0a0
+  - openssl >=3.5.7,<4.0a0
   - geos >=3.14.1,<3.14.2.0a0
-  - liblzma >=5.8.3,<6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libiconv >=1.18,<2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
   - giflib >=5.2.2,<5.3.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - proj >=9.8.1,<9.9.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - openssl >=3.5.6,<4.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - lerc >=4.1.0,<5.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
   - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - libjxl >=0.11,<1.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - pcre2 >=10.47,<10.48.0a0
+  - libexpat >=2.8.1,<3.0a0
   constrains:
-  - libgdal 3.12.4.*
+  - libgdal 3.13.1.*
   license: MIT
   license_family: MIT
   purls: []
-  size: 13886872
-  timestamp: 1780863218586
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.12.4-h2e1b34b_4.conda
-  sha256: 04b85dd7c47ae1be38a131c2e451116e5bddbda1b88eec2a0e31c8cecd7ea0ab
-  md5: 623e258313b349fd708a37274e5fb0eb
+  size: 14890768
+  timestamp: 1781521933600
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.1-h2e1b34b_1.conda
+  sha256: c25dd2f65daa84bdcff748a1d9c6083072237f43f4cb427447d43252e27f15f5
+  md5: 15f36c45b1f2bacdb95594fe923f51a3
+  depends:
+  - libcxx >=19
+  - __osx >=11.0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - json-c >=0.18,<0.19.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libjxl >=0.11,<1.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  constrains:
+  - libgdal 3.13.1.*
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 12588887
+  timestamp: 1780928456229
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.1-hcee3826_2.conda
+  sha256: 6a92da33a6689cc99ab6d182f7b26b68b4f7ccbdfae09e096655668112b3bdaf
+  md5: 6697ff3aaeffab689f7344c8adffa9eb
   depends:
   - __osx >=11.0
   - libcxx >=19
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libiconv >=1.18,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - giflib >=5.2.2,<5.3.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - openssl >=3.5.7,<4.0a0
   - libjxl >=0.11,<1.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - openssl >=3.5.6,<4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
   - liblzma >=5.8.3,<6.0a0
-  - json-c >=0.18,<0.19.0a0
+  - libiconv >=1.18,<2.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
   - libexpat >=2.8.1,<3.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libsqlite >=3.53.2,<4.0a0
   - libxml2
   - libxml2-16 >=2.14.6
+  - libarchive >=3.8.7,<3.9.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - pcre2 >=10.47,<10.48.0a0
   - lerc >=4.1.0,<5.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - blosc >=1.21.6,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
   constrains:
-  - libgdal 3.12.4.*
+  - libgdal 3.13.1.*
   license: MIT
   license_family: MIT
   purls: []
-  size: 11877993
-  timestamp: 1780863326444
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.12.4-hcee3826_4.conda
-  sha256: d9aa8373c16e49a1c6a938fd054fdd66f15234e1f2c0546e11c3dadc4aae8048
-  md5: 49f2866f62f7bf48e567b4330f991f8d
-  depends:
-  - __osx >=11.0
-  - libcxx >=19
-  - libjxl >=0.11,<1.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - openssl >=3.5.6,<4.0a0
-  - blosc >=1.21.6,<2.0a0
-  - lerc >=4.1.0,<5.0a0
-  constrains:
-  - libgdal 3.12.4.*
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 10815061
-  timestamp: 1780863488887
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.12.4-h9ea07af_4.conda
-  sha256: 1f6414f1ee89d958954c77e2f9853a89a9bc44fc966f8a9ae807663817a9584e
-  md5: 744ed760f15fa3a59fa0081e86eb15fd
+  size: 11483682
+  timestamp: 1781522319718
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.1-h9ea07af_2.conda
+  sha256: 19a4fcdcebfff899accedae185118921f8d69a4a3acfe4b8bed027550c2d7d3d
+  md5: 4a304d2b32076283a41362e486b129fb
   depends:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
   - libspatialite >=5.1.0,<5.2.0a0
   - libzlib >=1.3.2,<2.0a0
   - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - blosc >=1.21.6,<2.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
   - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libiconv >=1.18,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
   - libjxl >=0.11,<1.0a0
   - libexpat >=2.8.1,<3.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
+  - pcre2 >=10.47,<10.48.0a0
   - liblzma >=5.8.3,<6.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - geos >=3.14.1,<3.14.2.0a0
   constrains:
-  - libgdal 3.12.4.*
+  - libgdal 3.13.1.*
   license: MIT
   license_family: MIT
   purls: []
-  size: 10737202
-  timestamp: 1780863283604
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.12.4-h079cb0d_4.conda
-  sha256: 55746e8d6c6d3beb6449f6dcb1f72fa88561eb097bf482abcfe96e8cc18fcd54
-  md5: 24d499c6abb04d0525fedc4640332f94
+  size: 11336492
+  timestamp: 1781522012443
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.1-h2ee2084_2.conda
+  sha256: 6cfb2ff19342ac796578927c2c0aae43923487d80a6a9f611abcb5bfd5921ef0
+  md5: cfe951731d30544e18d26142948c04ac
   depends:
-  - libgdal-core ==3.12.4 h2c8e1a9_4
-  - libgcc >=14
+  - libgdal-core ==3.13.1 h2c8e1a9_2
   - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - proj >=9.8.1,<9.9.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.11,<1.0a0
-  - libdeflate >=1.25,<1.26.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
   - pcre2 >=10.47,<10.48.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - giflib >=5.2.2,<5.3.0a0
-  - libiconv >=1.18,<2.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
   - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
   - json-c >=0.18,<0.19.0a0
-  - blosc >=1.21.6,<2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libdeflate >=1.25,<1.26.0a0
   - libexpat >=2.8.1,<3.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
   - libaec >=1.1.5,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 819752
-  timestamp: 1780863219289
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.12.4-hf76e5b2_4.conda
-  sha256: 2a219df1a9eac8271fbcb26589ea221715e798510f677ce5a85acbd453c64569
-  md5: 6efacc3220de264ae7349fb1f2f3d842
+  size: 826470
+  timestamp: 1781521928633
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.1-h0d35cac_2.conda
+  sha256: 5edc886a9ea7a47de6cf2172c6b8ac6a0af69ad50ac274bd43c1429dfdbaa358
+  md5: 6ccd260cd410f67f75c9040e9ff5deab
   depends:
-  - libgdal-core ==3.12.4 h126928a_4
-  - libgcc >=14
+  - libgdal-core ==3.13.1 h126928a_2
   - libstdcxx >=14
-  - libexpat >=2.8.1,<3.0a0
-  - libsqlite >=3.53.2,<4.0a0
+  - libgcc >=14
+  - libkml >=1.3.0,<1.4.0a0
   - xerces-c >=3.3.0,<3.4.0a0
-  - libiconv >=1.18,<2.0a0
+  - libjxl >=0.11,<1.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
   - blosc >=1.21.6,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
   - libdeflate >=1.25,<1.26.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - json-c >=0.18,<0.19.0a0
+  - openssl >=3.5.7,<4.0a0
   - geos >=3.14.1,<3.14.2.0a0
-  - liblzma >=5.8.3,<6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libiconv >=1.18,<2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
   - giflib >=5.2.2,<5.3.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - proj >=9.8.1,<9.9.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - openssl >=3.5.6,<4.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - lerc >=4.1.0,<5.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
   - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - libjxl >=0.11,<1.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - pcre2 >=10.47,<10.48.0a0
+  - libexpat >=2.8.1,<3.0a0
   - libaec >=1.1.5,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 828216
-  timestamp: 1780863218586
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.12.4-h30be141_4.conda
-  sha256: 2c7d3c73a327c1d5be967728d495f22251148d39b074a165b93e702afe34676f
-  md5: 36b702d4dcd9c46c2a61d555550a904c
+  size: 832247
+  timestamp: 1781521933600
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.1-hf913fc2_1.conda
+  sha256: ca66e444bce3c86ba9dee56d701c3da36ca40d211efb4b5638796ee7ff200eb3
+  md5: 3453e8e854d8245128efb1d5a325aa64
   depends:
-  - libgdal-core ==3.12.4 h2e1b34b_4
+  - libgdal-core ==3.13.1 h2e1b34b_1
+  - libcxx >=19
+  - __osx >=11.0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - json-c >=0.18,<0.19.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libjxl >=0.11,<1.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libaec >=1.1.5,<2.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 737387
+  timestamp: 1780928456229
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.1-h99414e2_2.conda
+  sha256: 4456ddaa277335e641a49bedef9062275aa211ae0f6475e972aa2c7c1fa59614
+  md5: 1481909e692714742683588a8cba31bb
+  depends:
+  - libgdal-core ==3.13.1 hcee3826_2
   - __osx >=11.0
   - libcxx >=19
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libiconv >=1.18,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - giflib >=5.2.2,<5.3.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - openssl >=3.5.7,<4.0a0
   - libjxl >=0.11,<1.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - openssl >=3.5.6,<4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
   - liblzma >=5.8.3,<6.0a0
-  - json-c >=0.18,<0.19.0a0
+  - libiconv >=1.18,<2.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
   - libexpat >=2.8.1,<3.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libsqlite >=3.53.2,<4.0a0
   - libxml2
   - libxml2-16 >=2.14.6
+  - libarchive >=3.8.7,<3.9.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - pcre2 >=10.47,<10.48.0a0
   - lerc >=4.1.0,<5.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - blosc >=1.21.6,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - libaec >=1.1.5,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 734312
-  timestamp: 1780863326444
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.12.4-he22df77_4.conda
-  sha256: c533a7c24fdf33a9f5d17457c4dd38417b7e34bb3316ca144cf5bb6049e9290b
-  md5: a4bda65a7359ef6e5a3b7eec3f9fbc15
+  size: 722662
+  timestamp: 1781522319718
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.1-h6e73097_2.conda
+  sha256: 512621fa9bbb41831bd4fa9eb2ae84b5bbf94ebe65c12eb4cddfafdeff3496eb
+  md5: a995aa0308a1e05a88741ffe55a6f162
   depends:
-  - libgdal-core ==3.12.4 hcee3826_4
-  - __osx >=11.0
-  - libcxx >=19
-  - libjxl >=0.11,<1.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - openssl >=3.5.6,<4.0a0
-  - blosc >=1.21.6,<2.0a0
-  - lerc >=4.1.0,<5.0a0
-  - libaec >=1.1.5,<2.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 720491
-  timestamp: 1780863488887
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.12.4-ha539a3c_4.conda
-  sha256: bc96f8c4b9f5237a7c2525c640d3819eccd5f8d683590a52a545af97dac2576f
-  md5: eb3d632a6310a247211f12644dadb247
-  depends:
-  - libgdal-core ==3.12.4 h9ea07af_4
+  - libgdal-core ==3.13.1 h9ea07af_2
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
   - libspatialite >=5.1.0,<5.2.0a0
   - libzlib >=1.3.2,<2.0a0
   - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - blosc >=1.21.6,<2.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
   - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libiconv >=1.18,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
   - libjxl >=0.11,<1.0a0
   - libexpat >=2.8.1,<3.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
+  - pcre2 >=10.47,<10.48.0a0
   - liblzma >=5.8.3,<6.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - geos >=3.14.1,<3.14.2.0a0
   - libaec >=1.1.5,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 746816
-  timestamp: 1780863283604
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.12.4-hc5b9174_4.conda
-  sha256: 7d7f5d1f6bfe84a9211dadc95bbb2601acb0bf18367d47147696f0d78f361f58
-  md5: 71d424b11d106f77e679d9d88280080c
+  size: 749137
+  timestamp: 1781522012443
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.1-hbb32ccb_2.conda
+  sha256: 27d083bf14e83f7526d058ec0ec9dde2cab4cf7e1609edbe5e7393818a8cceaa
+  md5: 6e933c14ff2d197a68d19f6dedcc506e
   depends:
-  - libgdal-core ==3.12.4 h2c8e1a9_4
-  - libgcc >=14
+  - libgdal-core ==3.13.1 h2c8e1a9_2
   - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - proj >=9.8.1,<9.9.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.11,<1.0a0
-  - libdeflate >=1.25,<1.26.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
   - pcre2 >=10.47,<10.48.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - giflib >=5.2.2,<5.3.0a0
-  - libiconv >=1.18,<2.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - json-c >=0.18,<0.19.0a0
-  - blosc >=1.21.6,<2.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - libaec >=1.1.5,<2.0a0
-  - hdf4 >=4.2.15,<4.2.16.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 604837
-  timestamp: 1780863219289
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.12.4-h480612f_4.conda
-  sha256: 338114c6e479f425b45fd3ac037210d9e29901d7324c1729b25b07f541986649
-  md5: 0d379bc3eb4ccda67624f3b85d8636fe
-  depends:
-  - libgdal-core ==3.12.4 h126928a_4
-  - libgcc >=14
-  - libstdcxx >=14
-  - libexpat >=2.8.1,<3.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libiconv >=1.18,<2.0a0
-  - blosc >=1.21.6,<2.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - openssl >=3.5.6,<4.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - lerc >=4.1.0,<5.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - libjxl >=0.11,<1.0a0
   - proj >=9.8.1,<9.9.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - libaec >=1.1.5,<2.0a0
-  - hdf4 >=4.2.15,<4.2.16.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 621021
-  timestamp: 1780863218586
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.12.4-hd911a30_4.conda
-  sha256: 3665212a326f255ee5caa1cb14cec2abeed958fe7f922aa183e186dad0a52178
-  md5: 0f77cd9a5a4e3bd552956f5ae00dbc5b
-  depends:
-  - libgdal-core ==3.12.4 h2e1b34b_4
-  - __osx >=11.0
-  - libcxx >=19
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libiconv >=1.18,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libjxl >=0.11,<1.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - openssl >=3.5.6,<4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - lerc >=4.1.0,<5.0a0
-  - libzlib >=1.3.2,<2.0a0
   - zstd >=1.5.7,<1.6.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - lerc >=4.1.0,<5.0a0
   - lz4-c >=1.10.0,<1.11.0a0
-  - blosc >=1.21.6,<2.0a0
   - hdf4 >=4.2.15,<4.2.16.0a0
   - libaec >=1.1.5,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 595288
-  timestamp: 1780863326444
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.12.4-h5969d26_4.conda
-  sha256: fc289fea0ff8e92dc89df9e783b260faec154d6858071f94ba69c427a22ccdd0
-  md5: f1bb0d3ea1b5e62de75dd2c32f80db23
+  size: 606804
+  timestamp: 1781521928633
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.1-ha861f77_2.conda
+  sha256: a86c37de6dd1514a9c34073c3535ef61634e2be67f461f4bc828341b3de76213
+  md5: 4eed0c2994b9ab92783da9096dabf80e
   depends:
-  - libgdal-core ==3.12.4 hcee3826_4
-  - __osx >=11.0
-  - libcxx >=19
+  - libgdal-core ==3.13.1 h126928a_2
+  - libstdcxx >=14
+  - libgcc >=14
+  - libkml >=1.3.0,<1.4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
   - libjxl >=0.11,<1.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - json-c >=0.18,<0.19.0a0
+  - openssl >=3.5.7,<4.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libiconv >=1.18,<2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
   - giflib >=5.2.2,<5.3.0a0
   - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - libwebp-base >=1.6.0,<2.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - openssl >=3.5.6,<4.0a0
-  - blosc >=1.21.6,<2.0a0
-  - lerc >=4.1.0,<5.0a0
-  - hdf4 >=4.2.15,<4.2.16.0a0
-  - libaec >=1.1.5,<2.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 587988
-  timestamp: 1780863488887
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.12.4-hd3704d6_4.conda
-  sha256: 1d0437e588eea96c57a125676bf71b4d4ed5c2ad545ed292a24bbae137b224c0
-  md5: 7b0b00755d22a78e69acf3d88d38fcd2
-  depends:
-  - libgdal-core ==3.12.4 h9ea07af_4
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - blosc >=1.21.6,<2.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - libjxl >=0.11,<1.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
   - liblzma >=5.8.3,<6.0a0
   - proj >=9.8.1,<9.9.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - lerc >=4.1.0,<5.0a0
   - zstd >=1.5.7,<1.6.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - geos >=3.14.1,<3.14.2.0a0
+  - libexpat >=2.8.1,<3.0a0
   - libaec >=1.1.5,<2.0a0
   - hdf4 >=4.2.15,<4.2.16.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 602298
-  timestamp: 1780863283604
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.12.4-h138e628_4.conda
-  sha256: 405c32344691aa12376fbce97440f482d671af4fd7e5931cb333fafa6e221a56
-  md5: 0e84d10e0f8afac95a0aad85d7bcdd5c
+  size: 623507
+  timestamp: 1781521933600
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.1-hf66efad_1.conda
+  sha256: aecef3820748ab5a52be1aa034138634d59f570ee133e795f67a33eca3d988aa
+  md5: f4b794cf1e8d0c6f4f0163bf18dc92cf
   depends:
-  - libgdal-core ==3.12.4 h2c8e1a9_4
-  - libgcc >=14
-  - libstdcxx >=14
-  - __glibc >=2.17,<3.0.a0
-  - proj >=9.8.1,<9.9.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
+  - libgdal-core ==3.13.1 h2e1b34b_1
+  - libcxx >=19
+  - __osx >=11.0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
   - libkml >=1.3.0,<1.4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - json-c >=0.18,<0.19.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libjxl >=0.11,<1.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
   - muparser >=2.3.5,<2.4.0a0
   - libarchive >=3.8.7,<3.9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.11,<1.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - pcre2 >=10.47,<10.48.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - giflib >=5.2.2,<5.3.0a0
-  - libiconv >=1.18,<2.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - json-c >=0.18,<0.19.0a0
-  - blosc >=1.21.6,<2.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - hdf5 >=2.1.0,<3.0a0
-  license: MIT
-  license_family: MIT
-  size: 724199
-  timestamp: 1780863219289
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.12.4-hb6e0364_4.conda
-  sha256: 0e729d53cbfdf0fc0c0673d601c1f006a6701c4bd007b33639b96a7a8c267aad
-  md5: 20bf8beb8fe44bf11f1db00e8b56baab
-  depends:
-  - libgdal-core ==3.12.4 h2c8e1a9_4
-  - libgcc >=14
-  - libstdcxx >=14
-  - __glibc >=2.17,<3.0.a0
-  - proj >=9.8.1,<9.9.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.11,<1.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - giflib >=5.2.2,<5.3.0a0
-  - libiconv >=1.18,<2.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - json-c >=0.18,<0.19.0a0
-  - blosc >=1.21.6,<2.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - libaec >=1.1.5,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 722495
-  timestamp: 1780863219289
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.12.4-hde0d3c6_4.conda
-  sha256: 0adfe63f0a83d27b4ecaf9dde2ddfe2af6c1b1e5277ea91f750a5c5b1c7bbcb9
-  md5: e43da4ff252b1ffbeb751f4c27cd6ee4
+  size: 596981
+  timestamp: 1780928456229
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.1-h5795c7d_2.conda
+  sha256: 823b774ef30a9e88adab20e8b20d83cbfc64001c591df149be9b4fae2fb8698a
+  md5: eaeb400c54fb5159e7cf8779b3ff6697
   depends:
-  - libgdal-core ==3.12.4 h126928a_4
-  - libgcc >=14
-  - libstdcxx >=14
-  - libexpat >=2.8.1,<3.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libiconv >=1.18,<2.0a0
-  - blosc >=1.21.6,<2.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - openssl >=3.5.6,<4.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - libgdal-core ==3.13.1 hcee3826_2
+  - __osx >=11.0
+  - libcxx >=19
   - lz4-c >=1.10.0,<1.11.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libiconv >=1.18,<2.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - lerc >=4.1.0,<5.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libcurl >=8.20.0,<9.0a0
   - zstd >=1.5.7,<1.6.0a0
   - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - libjxl >=0.11,<1.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - hdf5 >=2.1.0,<3.0a0
-  license: MIT
-  license_family: MIT
-  size: 722506
-  timestamp: 1780863218586
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.12.4-hf116bd3_4.conda
-  sha256: e0df9a97ccad25ca986a8abb7b7c55372fec76e62fb043b17eb571f123c8e2cd
-  md5: 9d5bda1a79d96b8f385ec5c65eade990
-  depends:
-  - libgdal-core ==3.12.4 h126928a_4
-  - libgcc >=14
-  - libstdcxx >=14
-  - libexpat >=2.8.1,<3.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libiconv >=1.18,<2.0a0
   - blosc >=1.21.6,<2.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - giflib >=5.2.2,<5.3.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libsqlite >=3.53.2,<4.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - openssl >=3.5.6,<4.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - lerc >=4.1.0,<5.0a0
   - libarchive >=3.8.7,<3.9.0a0
+  - giflib >=5.2.2,<5.3.0a0
   - libspatialite >=5.1.0,<5.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - libjxl >=0.11,<1.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libpng >=1.6.58,<1.7.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - geos >=3.14.1,<3.14.2.0a0
   - pcre2 >=10.47,<10.48.0a0
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - lerc >=4.1.0,<5.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libaec >=1.1.5,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 721403
-  timestamp: 1780863218586
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.12.4-h46ab8d8_4.conda
-  sha256: 060b3ed4ab3f384bdfb4c92e557320e23210be84ab2fff5a6d9217314647e848
-  md5: 2ac99c3107b9d83cb5af1fcb8c9dba38
+  size: 589141
+  timestamp: 1781522319718
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.1-h9da078d_2.conda
+  sha256: cbbdb139622f46bf85d39e102fa3e61ce3d89c2103265fd24eb6d441c9d297ba
+  md5: 20ca94059054f2a887d4c484ba2c8160
   depends:
-  - libgdal-core ==3.12.4 h2e1b34b_4
-  - __osx >=11.0
-  - libcxx >=19
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libiconv >=1.18,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libjxl >=0.11,<1.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - openssl >=3.5.6,<4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - lerc >=4.1.0,<5.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - blosc >=1.21.6,<2.0a0
-  - hdf5 >=2.1.0,<3.0a0
-  license: MIT
-  license_family: MIT
-  size: 678904
-  timestamp: 1780863326444
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.12.4-hb154ecb_4.conda
-  sha256: a6471a4c3cdf44848a7185a3b5cc53bdca4893b62630e84cb59c40b817ee8b82
-  md5: 6f59a7f12ccfd3b6dc3a4ec8dc929fc8
-  depends:
-  - libgdal-core ==3.12.4 h2e1b34b_4
-  - __osx >=11.0
-  - libcxx >=19
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libiconv >=1.18,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libjxl >=0.11,<1.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - openssl >=3.5.6,<4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - lerc >=4.1.0,<5.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - blosc >=1.21.6,<2.0a0
-  - hdf5 >=1.14.6,<1.14.7.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 675280
-  timestamp: 1780863326444
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.12.4-h24392f9_4.conda
-  sha256: 1eeee53227b993443341aecc3d0882ca0a8947cdd6cbe7fc56858bb0b611d0de
-  md5: d704f21b267b32d908ae699c4912bc0d
-  depends:
-  - libgdal-core ==3.12.4 hcee3826_4
-  - __osx >=11.0
-  - libcxx >=19
-  - libjxl >=0.11,<1.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - openssl >=3.5.6,<4.0a0
-  - blosc >=1.21.6,<2.0a0
-  - lerc >=4.1.0,<5.0a0
-  - hdf5 >=1.14.6,<1.14.7.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 663338
-  timestamp: 1780863488887
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.12.4-hdc9be99_4.conda
-  sha256: ae67f2b5ff7b5287cc98cbe2c8eb43110e084e66b1f54e01398f494f0f0f7c6f
-  md5: bfb0d4ab29edbdfac13ed0cffb1ffc84
-  depends:
-  - libgdal-core ==3.12.4 hcee3826_4
-  - __osx >=11.0
-  - libcxx >=19
-  - libjxl >=0.11,<1.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - openssl >=3.5.6,<4.0a0
-  - blosc >=1.21.6,<2.0a0
-  - lerc >=4.1.0,<5.0a0
-  - hdf5 >=2.1.0,<3.0a0
-  license: MIT
-  license_family: MIT
-  size: 666041
-  timestamp: 1780863488887
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.12.4-h293a8ca_4.conda
-  sha256: d2ce8cfb53ebf5d7c33d62e876c2c814623496931b83e20cb96ef591e96fe71d
-  md5: 25857b176d541107c1289f5f03219c78
-  depends:
-  - libgdal-core ==3.12.4 h9ea07af_4
+  - libgdal-core ==3.13.1 h9ea07af_2
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
   - libspatialite >=5.1.0,<5.2.0a0
   - libzlib >=1.3.2,<2.0a0
   - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - blosc >=1.21.6,<2.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
   - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libiconv >=1.18,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
   - libjxl >=0.11,<1.0a0
   - libexpat >=2.8.1,<3.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libaec >=1.1.5,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 603415
+  timestamp: 1781522012443
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-h9a8cd84_2.conda
+  sha256: d3a16f0d3bbc01b3e82dc1787ee6d91fc29194716429b9dd9e8345de12b04e91
+  md5: 49c0d88a768eb8520add7f33333df800
+  depends:
+  - libgdal-core ==3.13.1 h2c8e1a9_2
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.2,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - pcre2 >=10.47,<10.48.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - liblzma >=5.8.3,<6.0a0
   - proj >=9.8.1,<9.9.0a0
   - zstd >=1.5.7,<1.6.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
   - libarchive >=3.8.7,<3.9.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblzma >=5.8.3,<6.0a0
   - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - hdf5 >=2.1.0,<3.0a0
+  license: MIT
+  license_family: MIT
+  size: 785560
+  timestamp: 1781521928633
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-hb4822db_2.conda
+  sha256: 85c047c30a2584dd8b2d381c92354beb283be2bf4200d1836d188a3faf5807c7
+  md5: a9474bc7d09c915b651ebd335d299612
+  depends:
+  - libgdal-core ==3.13.1 h2c8e1a9_2
+  - libstdcxx >=14
+  - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
+  - libzlib >=1.3.2,<2.0a0
   - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - proj >=9.8.1,<9.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 782906
+  timestamp: 1781521928633
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-h2a01ee8_2.conda
+  sha256: d00206b89f333f493ac329bcb4453184b10aa78661fd97b621d6a618cc7d3411
+  md5: 4e55bf88300321e07791032fb15cf8a3
+  depends:
+  - libgdal-core ==3.13.1 h126928a_2
+  - libstdcxx >=14
+  - libgcc >=14
+  - libkml >=1.3.0,<1.4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libjxl >=0.11,<1.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - json-c >=0.18,<0.19.0a0
+  - openssl >=3.5.7,<4.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libiconv >=1.18,<2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - lerc >=4.1.0,<5.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - hdf5 >=2.1.0,<3.0a0
+  license: MIT
+  license_family: MIT
+  size: 782817
+  timestamp: 1781521933600
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-hf18d640_2.conda
+  sha256: cc2534f9e0a5b054befe3ae87cbe223dc43735d3ce10d7b16e18ccca7ec2f408
+  md5: aa9f048f66f8f71efb842ab76c6d9b43
+  depends:
+  - libgdal-core ==3.13.1 h126928a_2
+  - libstdcxx >=14
+  - libgcc >=14
+  - libkml >=1.3.0,<1.4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libjxl >=0.11,<1.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - json-c >=0.18,<0.19.0a0
+  - openssl >=3.5.7,<4.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libiconv >=1.18,<2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - lerc >=4.1.0,<5.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 781288
+  timestamp: 1781521933600
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-hae3a7c9_1.conda
+  sha256: 45ccedf76984d055845e53b55a44afbaa4ef873e0c419efa4e9f3c470728695b
+  md5: 0bb510102206dcd6cbab3389af2ad3d8
+  depends:
+  - libgdal-core ==3.13.1 h2e1b34b_1
+  - libcxx >=19
+  - __osx >=11.0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - json-c >=0.18,<0.19.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libjxl >=0.11,<1.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - hdf5 >=2.1.0,<3.0a0
+  license: MIT
+  license_family: MIT
+  size: 729368
+  timestamp: 1780928456229
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-hdedcdb7_1.conda
+  sha256: 97c34c456528bd8d3e2783f76b7f987cf0be2948af6e440b6175c30283603630
+  md5: 563f62841e142e84c5218bddae4ca417
+  depends:
+  - libgdal-core ==3.13.1 h2e1b34b_1
+  - libcxx >=19
+  - __osx >=11.0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - json-c >=0.18,<0.19.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libjxl >=0.11,<1.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 725562
+  timestamp: 1780928456229
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-ha9c7d31_2.conda
+  sha256: 6c32b27ead8b4ac733a9bdec5e40c0f98956986a9cae6b2a784e09814d6949a0
+  md5: 32afad185d48002ededb45ab67628cba
+  depends:
+  - libgdal-core ==3.13.1 hcee3826_2
+  - __osx >=11.0
+  - libcxx >=19
+  - lz4-c >=1.10.0,<1.11.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libiconv >=1.18,<2.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libarchive >=3.8.7,<3.9.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - lerc >=4.1.0,<5.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - hdf5 >=2.1.0,<3.0a0
+  license: MIT
+  license_family: MIT
+  size: 715667
+  timestamp: 1781522319718
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-hcd92a64_2.conda
+  sha256: f44d0a867f3514acd884b61594f5a59f953db63a37db8162939da9d607f71b32
+  md5: ce4180595e0b01ed0636bede89fc7c99
+  depends:
+  - libgdal-core ==3.13.1 hcee3826_2
+  - __osx >=11.0
+  - libcxx >=19
+  - lz4-c >=1.10.0,<1.11.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libiconv >=1.18,<2.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libarchive >=3.8.7,<3.9.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - lerc >=4.1.0,<5.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 712187
+  timestamp: 1781522319718
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h08b2fd1_2.conda
+  sha256: 339a4f14a504c2451a3ff7eff8210b1cf87c085278718e798bc4d4f88436d78e
+  md5: f79340d02aa0afcf0165187ea4a83223
+  depends:
+  - libgdal-core ==3.13.1 h9ea07af_2
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libiconv >=1.18,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libjxl >=0.11,<1.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - hdf5 >=2.1.0,<3.0a0
+  license: MIT
+  license_family: MIT
+  size: 731138
+  timestamp: 1781522012443
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h7603ba1_2.conda
+  sha256: a635cc103a4a4ad756040dc6bd66f4cb5747fe19a82247ea2c7a247895f7e441
+  md5: f4b6261de8bc5526fad163ae14e5b8bc
+  depends:
+  - libgdal-core ==3.13.1 h9ea07af_2
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libiconv >=1.18,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libjxl >=0.11,<1.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - liblzma >=5.8.3,<6.0a0
   - geos >=3.14.1,<3.14.2.0a0
   - hdf5 >=1.14.6,<1.14.7.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 686091
-  timestamp: 1780863283604
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.12.4-hdf22f65_4.conda
-  sha256: 0f5e437f7b2314f44aa2e37425cfad70f1b60a93be1b8ab7e7915b20dcb1908e
-  md5: 7e0139eb201f582627c23cfed64f6c4c
+  size: 729369
+  timestamp: 1781522012443
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.1-hcd6cc38_2.conda
+  sha256: f9aa1c038c14c957605194f6c510f97669b929b6f3c67a79039287cea3ff2e50
+  md5: 37ec98a4dca7684def0699e3793e6b1f
   depends:
-  - libgdal-core ==3.12.4 h9ea07af_4
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - blosc >=1.21.6,<2.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - libjxl >=0.11,<1.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - liblzma >=5.8.3,<6.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - hdf5 >=2.1.0,<3.0a0
-  license: MIT
-  license_family: MIT
-  size: 688602
-  timestamp: 1780863283604
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.12.4-h4a420b2_4.conda
-  sha256: 86a6e1b34f0f71baa5f31d4a5e75615d6ab31aaddbf0462d6f7d97f45fe78bd2
-  md5: f61d8fdb4bbb045c667c0928ceb58448
-  depends:
-  - libgdal-core ==3.12.4 h2c8e1a9_4
-  - libgcc >=14
+  - libgdal-core ==3.13.1 h2c8e1a9_2
   - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - proj >=9.8.1,<9.9.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.11,<1.0a0
-  - libdeflate >=1.25,<1.26.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
   - pcre2 >=10.47,<10.48.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - giflib >=5.2.2,<5.3.0a0
-  - libiconv >=1.18,<2.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
   - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
   - json-c >=0.18,<0.19.0a0
-  - blosc >=1.21.6,<2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libdeflate >=1.25,<1.26.0a0
   - libexpat >=2.8.1,<3.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
   - openjpeg >=2.5.4,<3.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 500927
-  timestamp: 1780863219289
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.12.4-h9dffbd3_4.conda
-  sha256: ef52ce3ec5eabbe2609b37bc93af47ae09e7e33b42783589f8833159aeb17c66
-  md5: 1a3b9759aca63b2089fe7b943b784f57
+  size: 501686
+  timestamp: 1781521928633
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.1-h4f433c8_2.conda
+  sha256: fd456cfc6199679158848616599085b7f6c9912d90bd9ad590844b0537eb1d7c
+  md5: 607500f68f93ca4660ce5cb8dd7b2ac2
   depends:
-  - libgdal-core ==3.12.4 h126928a_4
-  - libgcc >=14
+  - libgdal-core ==3.13.1 h126928a_2
   - libstdcxx >=14
-  - libexpat >=2.8.1,<3.0a0
-  - libsqlite >=3.53.2,<4.0a0
+  - libgcc >=14
+  - libkml >=1.3.0,<1.4.0a0
   - xerces-c >=3.3.0,<3.4.0a0
-  - libiconv >=1.18,<2.0a0
+  - libjxl >=0.11,<1.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
   - blosc >=1.21.6,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
   - libdeflate >=1.25,<1.26.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - json-c >=0.18,<0.19.0a0
+  - openssl >=3.5.7,<4.0a0
   - geos >=3.14.1,<3.14.2.0a0
-  - liblzma >=5.8.3,<6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libiconv >=1.18,<2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
   - giflib >=5.2.2,<5.3.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - proj >=9.8.1,<9.9.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - openssl >=3.5.6,<4.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - lerc >=4.1.0,<5.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
   - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - libjxl >=0.11,<1.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - pcre2 >=10.47,<10.48.0a0
+  - libexpat >=2.8.1,<3.0a0
   - openjpeg >=2.5.4,<3.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 504380
-  timestamp: 1780863218586
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.12.4-h37a0a2f_4.conda
-  sha256: 60b0c044788ba0e7ecbe3cd0da5a62d6bb9a0576921b46de3c603f009435672f
-  md5: 15ae84df02d53c9abf2a4b5bd561ec2e
+  size: 505486
+  timestamp: 1781521933600
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.1-hbc28da0_1.conda
+  sha256: 6de3c9d33ca996a897e699364166c0ee8f4ea5a46240407eeba7603e8a928476
+  md5: c8d1ffdde860c66bc3a0721bb5cdf242
   depends:
-  - libgdal-core ==3.12.4 h2e1b34b_4
+  - libgdal-core ==3.13.1 h2e1b34b_1
+  - libcxx >=19
+  - __osx >=11.0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - json-c >=0.18,<0.19.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libjxl >=0.11,<1.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - openjpeg >=2.5.4,<3.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 497279
+  timestamp: 1780928456229
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.1-ha0e568a_2.conda
+  sha256: 911d16c920d9c023f79c926f6ec13034f698da08eb241afe07c514838242ddf8
+  md5: 3c915c4e361ba63cf8a33818fd50158b
+  depends:
+  - libgdal-core ==3.13.1 hcee3826_2
   - __osx >=11.0
   - libcxx >=19
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libiconv >=1.18,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - giflib >=5.2.2,<5.3.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - openssl >=3.5.7,<4.0a0
   - libjxl >=0.11,<1.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - openssl >=3.5.6,<4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
   - liblzma >=5.8.3,<6.0a0
-  - json-c >=0.18,<0.19.0a0
+  - libiconv >=1.18,<2.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
   - libexpat >=2.8.1,<3.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libsqlite >=3.53.2,<4.0a0
   - libxml2
   - libxml2-16 >=2.14.6
+  - libarchive >=3.8.7,<3.9.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - pcre2 >=10.47,<10.48.0a0
   - lerc >=4.1.0,<5.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - blosc >=1.21.6,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - openjpeg >=2.5.4,<3.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 496609
-  timestamp: 1780863326444
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.12.4-he6d8849_4.conda
-  sha256: ee42cf6666d72470c311857d2bf4000db4b5bb9ab37e974e87ad66d481f848b1
-  md5: 6c77e8bf5622b80fd57c4f84cbfd16f9
+  size: 496652
+  timestamp: 1781522319718
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.1-h70292f5_2.conda
+  sha256: 680b72b65792810caac4325d34e03bd06da3c5d5d21d3919ecf93ce2ad18ca78
+  md5: 2e6e77e47416b83f747334d81d97f567
   depends:
-  - libgdal-core ==3.12.4 hcee3826_4
-  - __osx >=11.0
-  - libcxx >=19
-  - libjxl >=0.11,<1.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - openssl >=3.5.6,<4.0a0
-  - blosc >=1.21.6,<2.0a0
-  - lerc >=4.1.0,<5.0a0
-  - openjpeg >=2.5.4,<3.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 495984
-  timestamp: 1780863488887
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.12.4-h3b90d24_4.conda
-  sha256: ccaa8197dfe9cb1be151bd15032f47e5d0e47ea79e24e4c7b2b8af016197c200
-  md5: 022b327d7c8830b4bbcc7b15302988c3
-  depends:
-  - libgdal-core ==3.12.4 h9ea07af_4
+  - libgdal-core ==3.13.1 h9ea07af_2
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
   - libspatialite >=5.1.0,<5.2.0a0
   - libzlib >=1.3.2,<2.0a0
   - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - blosc >=1.21.6,<2.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
   - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libiconv >=1.18,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
   - libjxl >=0.11,<1.0a0
   - libexpat >=2.8.1,<3.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
+  - pcre2 >=10.47,<10.48.0a0
   - liblzma >=5.8.3,<6.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - geos >=3.14.1,<3.14.2.0a0
   - openjpeg >=2.5.4,<3.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 541994
-  timestamp: 1780863283604
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.12.4-h6643b6a_4.conda
-  sha256: 5e33be0c24952949ca560867f2eefc490b26bf3ac9d819ac105331ec0ddff292
-  md5: 8815c8632cee018939a962390a914e45
+  size: 544991
+  timestamp: 1781522012443
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-h1ba7c67_2.conda
+  sha256: 59fc352e2b009dc7d3d407e89fd148b1d399ed13644220bd3f32f66002085a01
+  md5: e6461dcc8484acf76fed2c7890f8fa30
   depends:
-  - libgdal-core ==3.12.4 h2c8e1a9_4
-  - libgdal-hdf5 3.12.4.*
-  - libgdal-hdf4 3.12.4.*
-  - libgcc >=14
+  - libgdal-core ==3.13.1 h2c8e1a9_2
+  - libgdal-hdf5 3.13.1.*
+  - libgdal-hdf4 3.13.1.*
   - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - proj >=9.8.1,<9.9.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.11,<1.0a0
-  - libdeflate >=1.25,<1.26.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
   - pcre2 >=10.47,<10.48.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - giflib >=5.2.2,<5.3.0a0
-  - libiconv >=1.18,<2.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
   - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
   - json-c >=0.18,<0.19.0a0
-  - blosc >=1.21.6,<2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libdeflate >=1.25,<1.26.0a0
   - libexpat >=2.8.1,<3.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - hdf4 >=4.2.15,<4.2.16.0a0
-  - hdf5 >=1.14.6,<1.14.7.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
   - libnetcdf >=4.10.0,<4.10.1.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=2.1.0,<3.0a0
   license: MIT
   license_family: MIT
-  purls: []
-  size: 802264
-  timestamp: 1780863219289
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.12.4-h7b6522d_4.conda
-  sha256: 5bda6c8ca2a5d7c0f3a4f14e9378dab68e90ef4fbcf34a1e84cc8ae6e7895b0f
-  md5: 5c7c11436d85fffd693cdce1eac3e23e
+  size: 804305
+  timestamp: 1781521928633
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-h9d05ff3_2.conda
+  sha256: dabb8cbc769abb1980c1691be55ccc6db9245fb3a0224fdad0c0f43b47ce6230
+  md5: 1f1a257411f0cb781df19dd7b5f5e08d
   depends:
-  - libgdal-core ==3.12.4 h2c8e1a9_4
-  - libgdal-hdf5 3.12.4.*
-  - libgdal-hdf4 3.12.4.*
-  - libgcc >=14
+  - libgdal-core ==3.13.1 h2c8e1a9_2
+  - libgdal-hdf5 3.13.1.*
+  - libgdal-hdf4 3.13.1.*
   - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - proj >=9.8.1,<9.9.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libkml >=1.3.0,<1.4.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.11,<1.0a0
-  - libdeflate >=1.25,<1.26.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
   - pcre2 >=10.47,<10.48.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - giflib >=5.2.2,<5.3.0a0
-  - libiconv >=1.18,<2.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
   - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
   - json-c >=0.18,<0.19.0a0
-  - blosc >=1.21.6,<2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libdeflate >=1.25,<1.26.0a0
   - libexpat >=2.8.1,<3.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - libnetcdf >=4.10.0,<4.10.1.0a0
-  - hdf5 >=2.1.0,<3.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
   - hdf4 >=4.2.15,<4.2.16.0a0
+  - libnetcdf >=4.10.0,<4.10.1.0a0
+  - hdf5 >=1.14.6,<1.14.7.0a0
   license: MIT
   license_family: MIT
-  size: 802750
-  timestamp: 1780863219289
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.12.4-h6671c66_4.conda
-  sha256: 729db992189c436cd2b632c9e1f246b55b7c5af4cb3fbbd71aefc8b0b6e0bf78
-  md5: 286afe1f3f3cbd71f5323e24dd80ef6e
+  purls: []
+  size: 804715
+  timestamp: 1781521928633
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-h0711251_2.conda
+  sha256: 933ba2abdffee32af5a333c269dbf5d14ba2c3bdc66694caeaf868d2b4655ac5
+  md5: e5abab001596882ea8dd2ca822ca592e
   depends:
-  - libgdal-core ==3.12.4 h126928a_4
-  - libgdal-hdf5 3.12.4.*
-  - libgdal-hdf4 3.12.4.*
-  - libgcc >=14
+  - libgdal-core ==3.13.1 h126928a_2
+  - libgdal-hdf5 3.13.1.*
+  - libgdal-hdf4 3.13.1.*
   - libstdcxx >=14
-  - libexpat >=2.8.1,<3.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libiconv >=1.18,<2.0a0
-  - blosc >=1.21.6,<2.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - openssl >=3.5.6,<4.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - lerc >=4.1.0,<5.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - libjxl >=0.11,<1.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - hdf4 >=4.2.15,<4.2.16.0a0
-  - hdf5 >=2.1.0,<3.0a0
-  - libnetcdf >=4.10.0,<4.10.1.0a0
-  license: MIT
-  license_family: MIT
-  size: 796244
-  timestamp: 1780863218586
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.12.4-hd8ba4ad_4.conda
-  sha256: 53ed45aba840ffdc6ecd93d739e5410a309ed8964729fed06199fbdf7fae6957
-  md5: 3351efed4f6273032de8439fe919805c
-  depends:
-  - libgdal-core ==3.12.4 h126928a_4
-  - libgdal-hdf5 3.12.4.*
-  - libgdal-hdf4 3.12.4.*
   - libgcc >=14
+  - libkml >=1.3.0,<1.4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libjxl >=0.11,<1.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - json-c >=0.18,<0.19.0a0
+  - openssl >=3.5.7,<4.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libiconv >=1.18,<2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - lerc >=4.1.0,<5.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - libnetcdf >=4.10.0,<4.10.1.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 798770
+  timestamp: 1781521933600
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-h2ae5ab3_2.conda
+  sha256: 1adb516d9733f2ba060eda5fe0de1c7906e2d1b071e24b00f30b1a89659d024c
+  md5: 5b749d01bc9724e80e593b6ead765c01
+  depends:
+  - libgdal-core ==3.13.1 h126928a_2
+  - libgdal-hdf5 3.13.1.*
+  - libgdal-hdf4 3.13.1.*
   - libstdcxx >=14
-  - libexpat >=2.8.1,<3.0a0
-  - libsqlite >=3.53.2,<4.0a0
+  - libgcc >=14
+  - libkml >=1.3.0,<1.4.0a0
   - xerces-c >=3.3.0,<3.4.0a0
-  - libiconv >=1.18,<2.0a0
+  - libjxl >=0.11,<1.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
   - blosc >=1.21.6,<2.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - openssl >=3.5.6,<4.0a0
-  - libzlib >=1.3.2,<2.0a0
   - lz4-c >=1.10.0,<1.11.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - lerc >=4.1.0,<5.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - libjxl >=0.11,<1.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - libnetcdf >=4.10.0,<4.10.1.0a0
-  - hdf4 >=4.2.15,<4.2.16.0a0
-  - hdf5 >=1.14.6,<1.14.7.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 795482
-  timestamp: 1780863218586
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.12.4-h6369dcf_4.conda
-  sha256: 1efae1ca7c80c530e291262ac5f73d02a6d25fa33fe4bee27fd16f88a0bc1f17
-  md5: 0f5bbeeff5cb983dbccf34a0b1845d82
-  depends:
-  - libgdal-core ==3.12.4 h2e1b34b_4
-  - libgdal-hdf5 3.12.4.*
-  - libgdal-hdf4 3.12.4.*
-  - __osx >=11.0
-  - libcxx >=19
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libiconv >=1.18,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.53.2,<4.0a0
   - libdeflate >=1.25,<1.26.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libjxl >=0.11,<1.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - openssl >=3.5.6,<4.0a0
   - libarchive >=3.8.7,<3.9.0a0
-  - liblzma >=5.8.3,<6.0a0
+  - libpng >=1.6.58,<1.7.0a0
   - json-c >=0.18,<0.19.0a0
-  - libexpat >=2.8.1,<3.0a0
+  - openssl >=3.5.7,<4.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libiconv >=1.18,<2.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - proj >=9.8.1,<9.9.0a0
   - libxml2
   - libxml2-16 >=2.14.6
   - lerc >=4.1.0,<5.0a0
-  - libzlib >=1.3.2,<2.0a0
   - zstd >=1.5.7,<1.6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - blosc >=1.21.6,<2.0a0
-  - hdf4 >=4.2.15,<4.2.16.0a0
-  - libnetcdf >=4.10.0,<4.10.1.0a0
-  - hdf5 >=1.14.6,<1.14.7.0a0
-  license: MIT
-  license_family: MIT
-  purls: []
-  size: 752795
-  timestamp: 1780863326444
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.12.4-hc604f8b_4.conda
-  sha256: 1d5c78fd5d2da013b410c9a75bb2d7ae864e542f73b887054103f18ddc6e234f
-  md5: f73520b7383f9ccb59946b304ec8a4a5
-  depends:
-  - libgdal-core ==3.12.4 h2e1b34b_4
-  - libgdal-hdf5 3.12.4.*
-  - libgdal-hdf4 3.12.4.*
-  - __osx >=11.0
-  - libcxx >=19
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libiconv >=1.18,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libjxl >=0.11,<1.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - openssl >=3.5.6,<4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - json-c >=0.18,<0.19.0a0
   - libexpat >=2.8.1,<3.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - lerc >=4.1.0,<5.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - blosc >=1.21.6,<2.0a0
   - hdf4 >=4.2.15,<4.2.16.0a0
   - hdf5 >=2.1.0,<3.0a0
   - libnetcdf >=4.10.0,<4.10.1.0a0
   license: MIT
   license_family: MIT
-  size: 753170
-  timestamp: 1780863326444
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.12.4-h163acdd_4.conda
-  sha256: eb644939510d94c55b2ce779b9d9133484b5662f2a06766ae2ffc82a845ea459
-  md5: 299cad15f78f9975354f3fe2908d3ccf
+  size: 798476
+  timestamp: 1781521933600
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-hbe79d85_1.conda
+  sha256: a9cd416c17fff68fd74fedb40a09dedc145264a61a7496e8a6b8943649bedd3a
+  md5: 2acd2ee0b668069de4ce26e4402b713b
   depends:
-  - libgdal-core ==3.12.4 hcee3826_4
-  - libgdal-hdf5 3.12.4.*
-  - libgdal-hdf4 3.12.4.*
-  - __osx >=11.0
+  - libgdal-core ==3.13.1 h2e1b34b_1
+  - libgdal-hdf5 3.13.1.*
+  - libgdal-hdf4 3.13.1.*
   - libcxx >=19
-  - libjxl >=0.11,<1.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
+  - __osx >=11.0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
   - libkml >=1.3.0,<1.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libarchive >=3.8.7,<3.9.0a0
   - libzlib >=1.3.2,<2.0a0
-  - muparser >=2.3.5,<2.4.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - json-c >=0.18,<0.19.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libjxl >=0.11,<1.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libexpat >=2.8.1,<3.0a0
   - liblzma >=5.8.3,<6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
   - libxml2
   - libxml2-16 >=2.14.6
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - openssl >=3.5.6,<4.0a0
-  - blosc >=1.21.6,<2.0a0
-  - lerc >=4.1.0,<5.0a0
-  - hdf5 >=2.1.0,<3.0a0
-  - libnetcdf >=4.10.0,<4.10.1.0a0
-  - hdf4 >=4.2.15,<4.2.16.0a0
-  license: MIT
-  license_family: MIT
-  size: 733135
-  timestamp: 1780863488887
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.12.4-h629b07f_4.conda
-  sha256: 2e19d426a284f23a27ac7ed3efc311c682c09c710c58e9ad5d73152c757e7c60
-  md5: afba099c7400a45f6cf49ec34b146c69
-  depends:
-  - libgdal-core ==3.12.4 hcee3826_4
-  - libgdal-hdf5 3.12.4.*
-  - libgdal-hdf4 3.12.4.*
-  - __osx >=11.0
-  - libcxx >=19
-  - libjxl >=0.11,<1.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - openssl >=3.5.6,<4.0a0
-  - blosc >=1.21.6,<2.0a0
-  - lerc >=4.1.0,<5.0a0
   - hdf4 >=4.2.15,<4.2.16.0a0
   - hdf5 >=1.14.6,<1.14.7.0a0
   - libnetcdf >=4.10.0,<4.10.1.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 732335
-  timestamp: 1780863488887
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.12.4-h227a990_4.conda
-  sha256: 630f5997f3702e3098967973497a4faefb1e5b11cc1630ded516485caf6d4103
-  md5: d824feca03c95ba5022d0d468983dcfe
+  size: 753809
+  timestamp: 1780928456229
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-hc8f89f0_1.conda
+  sha256: 861d496593bad5660053a83e118bf9d66cc36e1e13ae6f94f9881446aab2ac15
+  md5: 361ecf05ef91827048425df5c1a6ca4c
   depends:
-  - libgdal-core ==3.12.4 h9ea07af_4
-  - libgdal-hdf5 3.12.4.*
-  - libgdal-hdf4 3.12.4.*
+  - libgdal-core ==3.13.1 h2e1b34b_1
+  - libgdal-hdf5 3.13.1.*
+  - libgdal-hdf4 3.13.1.*
+  - libcxx >=19
+  - __osx >=11.0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - json-c >=0.18,<0.19.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libjxl >=0.11,<1.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.6,<4.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - libnetcdf >=4.10.0,<4.10.1.0a0
+  - hdf5 >=2.1.0,<3.0a0
+  license: MIT
+  license_family: MIT
+  size: 754456
+  timestamp: 1780928456229
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h5cd3543_2.conda
+  sha256: f0152bc77fa6d51d367bc07c0d6e3804c25de3175d520d3e052878412cfbbe4b
+  md5: b26353f88a649b5704bbda48e50441a4
+  depends:
+  - libgdal-core ==3.13.1 hcee3826_2
+  - libgdal-hdf5 3.13.1.*
+  - libgdal-hdf4 3.13.1.*
+  - __osx >=11.0
+  - libcxx >=19
+  - lz4-c >=1.10.0,<1.11.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libiconv >=1.18,<2.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libarchive >=3.8.7,<3.9.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - lerc >=4.1.0,<5.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=2.1.0,<3.0a0
+  - libnetcdf >=4.10.0,<4.10.1.0a0
+  license: MIT
+  license_family: MIT
+  size: 733060
+  timestamp: 1781522319718
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h9c8e0d5_2.conda
+  sha256: 1d93493c56d20e4643e586c0b31617b43897af347bb65de8cf7f2a1b4d4690d5
+  md5: e993af0a066906407e217e34a8978141
+  depends:
+  - libgdal-core ==3.13.1 hcee3826_2
+  - libgdal-hdf5 3.13.1.*
+  - libgdal-hdf4 3.13.1.*
+  - __osx >=11.0
+  - libcxx >=19
+  - lz4-c >=1.10.0,<1.11.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libjxl >=0.11,<1.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libiconv >=1.18,<2.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libcurl >=8.20.0,<9.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
+  - libarchive >=3.8.7,<3.9.0a0
+  - giflib >=5.2.2,<5.3.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - lerc >=4.1.0,<5.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - libnetcdf >=4.10.0,<4.10.1.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  license: MIT
+  license_family: MIT
+  purls: []
+  size: 733560
+  timestamp: 1781522319718
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-h57ca259_2.conda
+  sha256: 8efd7a5b3cca91156a0dd0159cfa410c17279498b3e7772928278661ad4f3fc6
+  md5: e37a22a17c02e5632ed1afef68a23d8b
+  depends:
+  - libgdal-core ==3.13.1 h9ea07af_2
+  - libgdal-hdf5 3.13.1.*
+  - libgdal-hdf4 3.13.1.*
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
   - libspatialite >=5.1.0,<5.2.0a0
   - libzlib >=1.3.2,<2.0a0
   - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - blosc >=1.21.6,<2.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
   - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libiconv >=1.18,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
   - libjxl >=0.11,<1.0a0
   - libexpat >=2.8.1,<3.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
+  - pcre2 >=10.47,<10.48.0a0
   - liblzma >=5.8.3,<6.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - geos >=3.14.1,<3.14.2.0a0
-  - hdf5 >=1.14.6,<1.14.7.0a0
-  - libnetcdf >=4.10.0,<4.10.1.0a0
   - hdf4 >=4.2.15,<4.2.16.0a0
+  - libnetcdf >=4.10.0,<4.10.1.0a0
+  - hdf5 >=1.14.6,<1.14.7.0a0
   license: MIT
   license_family: MIT
   purls: []
-  size: 736468
-  timestamp: 1780863283604
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.12.4-h6f7152f_4.conda
-  sha256: 94b2cf1cfbdc95400d020f7b7994cd491d2d25005c770a578147cca46d48af58
-  md5: 53d159e47e179d865399b91559dcd5af
+  size: 736685
+  timestamp: 1781522012443
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-hcec535a_2.conda
+  sha256: d1d3887cea8d1e26ebe83facc6619c044454553fd2395240c86f49ca7bf86a8b
+  md5: 5782ceb3ed5df6548c1fb514ae9c09dc
   depends:
-  - libgdal-core ==3.12.4 h9ea07af_4
-  - libgdal-hdf5 3.12.4.*
-  - libgdal-hdf4 3.12.4.*
+  - libgdal-core ==3.13.1 h9ea07af_2
+  - libgdal-hdf5 3.13.1.*
+  - libgdal-hdf4 3.13.1.*
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - blosc >=1.21.6,<2.0a0
+  - lerc >=4.1.0,<5.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libxml2
+  - libxml2-16 >=2.14.6
   - libspatialite >=5.1.0,<5.2.0a0
   - libzlib >=1.3.2,<2.0a0
   - libcurl >=8.20.0,<9.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - blosc >=1.21.6,<2.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - openssl >=3.5.6,<4.0a0
-  - lerc >=4.1.0,<5.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
   - libjpeg-turbo >=3.1.4.1,<4.0a0
+  - openssl >=3.5.7,<4.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libarchive >=3.8.7,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libiconv >=1.18,<2.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - muparser >=2.3.5,<2.4.0a0
   - libjxl >=0.11,<1.0a0
   - libexpat >=2.8.1,<3.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
+  - pcre2 >=10.47,<10.48.0a0
   - liblzma >=5.8.3,<6.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libiconv >=1.18,<2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - geos >=3.14.1,<3.14.2.0a0
   - hdf5 >=2.1.0,<3.0a0
   - libnetcdf >=4.10.0,<4.10.1.0a0
   - hdf4 >=4.2.15,<4.2.16.0a0
   license: MIT
   license_family: MIT
-  size: 737243
-  timestamp: 1780863283604
+  size: 736491
+  timestamp: 1781522012443
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-15.2.0-h69a702a_19.conda
   sha256: 561a42758ef25b9ce308c4e2cf56daee4f06138385a17e29a492cd928e00be6f
   md5: 42bf7eca1a951735fa06c0e3c0d5c8e6
@@ -32407,23 +32447,6 @@ packages:
   - pkg:pypi/numpy?source=hash-mapping
   size: 7930467
   timestamp: 1779169224369
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.4.6-py314h314fbd6_0.conda
-  sha256: 80bbd96ce7c023edbac9b4b2ae0f2d5b3f4da54801c53be91de1071c17dfde69
-  md5: 7701250801c35f6a782287df118a486f
-  depends:
-  - python
-  - libgcc >=14
-  - libstdcxx >=14
-  - python_abi 3.14.* *_cp314t
-  - libblas >=3.9.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 8084931
-  timestamp: 1779169208044
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/numpy-2.4.6-py314he1698a1_0.conda
   sha256: 04af718b911f8a3a0095481c7e283aa081a175fe626eccbc2c5644bcb2aba9a1
   md5: 8b173772deea177b45d2a133b509b3f7
@@ -32500,6 +32523,23 @@ packages:
   - pkg:pypi/numpy?source=hash-mapping
   size: 8068573
   timestamp: 1779169285266
+- conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.4.6-py314h5af6b61_0.conda
+  sha256: 22cb0b3b59184d6b1f9da460b602792de9d13426dd07112908a6dad48060b224
+  md5: 5da2fc2fdfe8312e324c089fc0437ac2
+  depends:
+  - python
+  - __osx >=11.0
+  - libcxx >=19
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  - liblapack >=3.9.0,<4.0a0
+  - python_abi 3.14.* *_cp314t
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 8224189
+  timestamp: 1779169282330
 - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.4.6-py314h7b24d9b_0.conda
   sha256: 8127ecc9ffbb291830cd6849a8e4f8d9027b130672d277c9444b1d36949f0a38
   md5: e04ed878a4f06bb20201dabf7a25f9ee
@@ -32675,6 +32715,24 @@ packages:
   - pkg:pypi/numpy?source=hash-mapping
   size: 7318163
   timestamp: 1779169232086
+- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.4.6-py314hffb9209_0.conda
+  sha256: 1a5b5e4bfecbc5de8cbf2ae04a2a31f45ceeac454be96eb931abc9a78a06b24c
+  md5: 42e4fcaa6afcb0d68a9b73c3eff251da
+  depends:
+  - python
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - python_abi 3.14.* *_cp314t
+  - liblapack >=3.9.0,<4.0a0
+  - libblas >=3.9.0,<4.0a0
+  - libcblas >=3.9.0,<4.0a0
+  constrains:
+  - numpy-base <0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 7482657
+  timestamp: 1779169231603
 - conda: https://conda.anaconda.org/conda-forge/noarch/numpy_groupies-0.11.3-pyhd8ed1ab_0.conda
   sha256: 94c148b8d4687c839a37c4a68b1674fa548b065e833b9b4701865d548995239f
   md5: 5402c2b046432ceb2d192a82802e7854
@@ -35834,13 +35892,13 @@ packages:
   - pyyaml
   - pygments>=2.19.1 ; extra == 'extra'
   requires_python: '>=3.9'
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py311h422ce6a_0.conda
-  sha256: 323ac9639c346c062e3ba7b18493889f40102934ce4dab44258efd4f40a14377
-  md5: 2a8f7bc7cbfd311cfcac9ea87fbf88a3
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py311h31673df_2.conda
+  sha256: f3e5074ee7b7c3141630a0baf55fb79b05108f5066b6bd5f57da3e2751443ea0
+  md5: 589c03c3534a904e84244ccc6cf74091
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libgdal-core >=3.12.0,<3.13.0a0
+  - libgdal-core >=3.13.0,<3.14.0a0
   - libstdcxx >=14
   - numpy
   - packaging
@@ -35850,15 +35908,15 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 670016
-  timestamp: 1764402474320
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py312h053e1f3_0.conda
-  sha256: 2b0a366d9066e3d9f495369b95cdb1b9d3dba2f59577e4560b7d1086e1fe3d70
-  md5: f8e7e5ddfbdca16b65335b0b6615eb4c
+  size: 670341
+  timestamp: 1780298831033
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py312hdb6ebaa_2.conda
+  sha256: 12266c6353464ef98c516b558fc2df30f22134d2aeedf051b8f921fda28da397
+  md5: c83ded5ba6195af2ea5772751e0d8835
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libgdal-core >=3.12.0,<3.13.0a0
+  - libgdal-core >=3.13.0,<3.14.0a0
   - libstdcxx >=14
   - numpy
   - packaging
@@ -35868,15 +35926,15 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 661347
-  timestamp: 1764402531050
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py313hae45665_0.conda
-  sha256: 36d91e089f7c6fa3466a07e9c2167a64b97837433c09b6f3ba632c978cce22a3
-  md5: fa543477ad16de26ce5f2fd5bcd249fa
+  size: 663256
+  timestamp: 1780298837139
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py313hdaccff5_2.conda
+  sha256: ae000a8cadb8efb2e337789051c16bd206dc197f41d82605e60d9c9883aac1b1
+  md5: 1594347674228f5d637298d69e4590c3
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libgdal-core >=3.12.0,<3.13.0a0
+  - libgdal-core >=3.13.0,<3.14.0a0
   - libstdcxx >=14
   - numpy
   - packaging
@@ -35886,15 +35944,15 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 665424
-  timestamp: 1764402539337
-- conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py314hbcf5174_0.conda
-  sha256: 53b72845bc9051b1b94c83ed06047788cdb07af529b9368393ac1a9eb720ac21
-  md5: b6696a3d5c567d3b2015bf77f454f247
+  size: 666128
+  timestamp: 1780298840167
+- conda: https://conda.anaconda.org/conda-forge/linux-64/pyogrio-0.12.1-py314hab130c5_2.conda
+  sha256: 5e827a8b19b35097db97bf5b0ee41b8a29783dc98cb2bb432c0e693b7970f426
+  md5: e8222bf5b643eaf6521e9f2146e9ceb1
   depends:
   - __glibc >=2.17,<3.0.a0
   - libgcc >=14
-  - libgdal-core >=3.12.0,<3.13.0a0
+  - libgdal-core >=3.13.0,<3.14.0a0
   - libstdcxx >=14
   - numpy
   - packaging
@@ -35904,14 +35962,14 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 667940
-  timestamp: 1764402531595
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py311h886ba34_0.conda
-  sha256: e844472b33913be14883e9c343d614648adcce372a3eec39c1b7fa49364ce1f1
-  md5: 4583c6075888e15917bbe26fc5f63026
+  size: 668663
+  timestamp: 1780298841280
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py311hc9acec3_2.conda
+  sha256: 506ee2a33c932cfc3fab10d96a893376ea4ace9aa699d1968cddbd2bc369f0c6
+  md5: 18113315d7ba36963a48d61060c4f789
   depends:
   - libgcc >=14
-  - libgdal-core >=3.12.0,<3.13.0a0
+  - libgdal-core >=3.13.0,<3.14.0a0
   - libstdcxx >=14
   - numpy
   - packaging
@@ -35922,14 +35980,14 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 654691
-  timestamp: 1764402661153
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py312h2d25c45_0.conda
-  sha256: c14e3ff95240c2268b2adcd23868e5b5b8e8300654952f037f7d505fe0482828
-  md5: 187841db58491548db9eff39179489fc
+  size: 657982
+  timestamp: 1780298884130
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py312h2024594_2.conda
+  sha256: 9af087dd4bf775532adcb4632e6d9fe1c34ab4720df44d0409aa43173dd6386f
+  md5: 846a6e6909b18d3c5e4379ad90125d91
   depends:
   - libgcc >=14
-  - libgdal-core >=3.12.0,<3.13.0a0
+  - libgdal-core >=3.13.0,<3.14.0a0
   - libstdcxx >=14
   - numpy
   - packaging
@@ -35940,14 +35998,14 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 642443
-  timestamp: 1764402510558
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py313hea1baa3_0.conda
-  sha256: 01535edcdacac04f8d84a7a47ede296cba1af1459e731cf8a0bce1905757f928
-  md5: 15c7707cdfa3a3ffafa118765b07b8a6
+  size: 643509
+  timestamp: 1780298889341
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py313h0860647_2.conda
+  sha256: a64b777f661f21aa7b1c09cd8fe66d4803cb35565a504f2aa20424d3da1b828a
+  md5: 7c00d98ad5e42d56006dc11b9afb751b
   depends:
   - libgcc >=14
-  - libgdal-core >=3.12.0,<3.13.0a0
+  - libgdal-core >=3.13.0,<3.14.0a0
   - libstdcxx >=14
   - numpy
   - packaging
@@ -35958,14 +36016,14 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 642078
-  timestamp: 1764402517003
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py314h9155b42_0.conda
-  sha256: d41d2e846128b5c8bd2203b67e61d0d64242d00fca6b8d2319b9d4723881786c
-  md5: 7d9d5351aede8ab10676447843775c07
+  size: 646086
+  timestamp: 1780298902250
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/pyogrio-0.12.1-py314h0dd3294_2.conda
+  sha256: 458c9ca3b20084f79e4de2b035160f23244960d7e441d47ccd9eab3737d29543
+  md5: fb0771bfb8682095bbfe3be931bd75f9
   depends:
   - libgcc >=14
-  - libgdal-core >=3.12.0,<3.13.0a0
+  - libgdal-core >=3.13.0,<3.14.0a0
   - libstdcxx >=14
   - numpy
   - packaging
@@ -35976,15 +36034,15 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 650538
-  timestamp: 1764402728473
-- conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py311hca869a8_0.conda
-  sha256: 3462ff707ba4cdccc5650fe8ea3ae45c54d5048035187427dc69f1862de05459
-  md5: 200d3ef7823008c12d5a00fa85219e22
+  size: 652253
+  timestamp: 1780298884273
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py311h7bd8e69_2.conda
+  sha256: 6bca79f9b7dc68162893f376159f537a3b21738846f6b2607ccb1cfdf92014b9
+  md5: 4831215c1d9641cc4fbf0cfaa7e006a4
   depends:
-  - __osx >=10.13
+  - __osx >=11.0
   - libcxx >=19
-  - libgdal-core >=3.12.0,<3.13.0a0
+  - libgdal-core >=3.13.0,<3.14.0a0
   - numpy
   - packaging
   - python >=3.11,<3.12.0a0
@@ -35993,15 +36051,15 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 610750
-  timestamp: 1764402954374
-- conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py312h17ccd7d_0.conda
-  sha256: d22ac3e5a554878d739bd06dd412c47adfd5552c2f002eea3fcb6bde2c68bcf9
-  md5: e6452e30b697d485a9929bd1eebcd7a2
+  size: 612821
+  timestamp: 1780299538347
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py312h52cd9ce_2.conda
+  sha256: f82faa74861433f709f9cb6b891824139fee45c9692ef7e274f0f55e15fcf614
+  md5: 91981faa4d4131d0ab4505c0b335a213
   depends:
-  - __osx >=10.13
+  - __osx >=11.0
   - libcxx >=19
-  - libgdal-core >=3.12.0,<3.13.0a0
+  - libgdal-core >=3.13.0,<3.14.0a0
   - numpy
   - packaging
   - python >=3.12,<3.13.0a0
@@ -36010,15 +36068,15 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 601808
-  timestamp: 1764402817339
-- conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py313h8e1be7a_0.conda
-  sha256: d6f0e668999d958000ca1621699ac877405e375eeb46a7bc4c98334feea68c85
-  md5: b58a673faf1399b9bdcdddef8ecea923
+  size: 602208
+  timestamp: 1780299360883
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py313h94b7238_2.conda
+  sha256: 8f44d092096c83ead813457f8494e1560f2ae233abd29692aaa99c3f3ac601f7
+  md5: fdf5806d6cd91453342c6f8ceb883426
   depends:
-  - __osx >=10.13
+  - __osx >=11.0
   - libcxx >=19
-  - libgdal-core >=3.12.0,<3.13.0a0
+  - libgdal-core >=3.13.0,<3.14.0a0
   - numpy
   - packaging
   - python >=3.13,<3.14.0a0
@@ -36027,15 +36085,15 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 607350
-  timestamp: 1764402734273
-- conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py314h687fbad_0.conda
-  sha256: 99d658c184c934b7b8a38e05e2f138e1deeb6adb8aed9d5ffb02176e78d1e438
-  md5: adbb3fccb1336078d0263369698285cc
+  size: 608308
+  timestamp: 1780299110300
+- conda: https://conda.anaconda.org/conda-forge/osx-64/pyogrio-0.12.1-py314h7dc4300_2.conda
+  sha256: 0aee1fc933c3b36dec150b759dbb13fca0105fbdd7ac2d1b4130b1ad0280ff52
+  md5: d8808c36e85c755b69b95c31883d26f4
   depends:
-  - __osx >=10.13
+  - __osx >=11.0
   - libcxx >=19
-  - libgdal-core >=3.12.0,<3.13.0a0
+  - libgdal-core >=3.13.0,<3.14.0a0
   - numpy
   - packaging
   - python >=3.14,<3.15.0a0
@@ -36044,15 +36102,15 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 610356
-  timestamp: 1764402783220
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py311h336326a_0.conda
-  sha256: 83ca164b273f77b5376d64db5a8fb56bbbbafe525d78cf26a17d04b2f5e6938c
-  md5: 5bd50e582540935f62fe87cc0ce6a220
+  size: 610630
+  timestamp: 1780299182490
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py311h1a47db8_2.conda
+  sha256: 98a7280dfa180611d0af2a01f9cc316209a1e32ad5189fa5ac5c150057a3104d
+  md5: 24e816a5f3c6bc25cb5099fffd0c3b2d
   depends:
   - __osx >=11.0
   - libcxx >=19
-  - libgdal-core >=3.12.0,<3.13.0a0
+  - libgdal-core >=3.13.0,<3.14.0a0
   - numpy
   - packaging
   - python >=3.11,<3.12.0a0
@@ -36062,15 +36120,15 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 601648
-  timestamp: 1764402784716
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py312h07dd7c3_0.conda
-  sha256: 4f2fa1d32919b07ad91efefbe5f35ab8ab0f48c9d03351c35321f73b1cab9fa9
-  md5: 41000dd333aabfc38a70ff8635cf1d6e
+  size: 604279
+  timestamp: 1780299185512
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py312hd1c4548_2.conda
+  sha256: d8ce8558ce62ff2367121a51c9e6876297d4a3fe99d126fcd94ab5b0464515b6
+  md5: 84520fdb33c74a46ac14ddb86534d4fb
   depends:
   - __osx >=11.0
   - libcxx >=19
-  - libgdal-core >=3.12.0,<3.13.0a0
+  - libgdal-core >=3.13.0,<3.14.0a0
   - numpy
   - packaging
   - python >=3.12,<3.13.0a0
@@ -36080,15 +36138,15 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 589304
-  timestamp: 1764402908352
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py313he6d61f9_0.conda
-  sha256: 10a0ccaf95e3217d9fa6439cd092eca5fee810d1fd55e052efe5a904fef8e994
-  md5: f82ee6aa14c6ed19ff28144ef74cf32a
+  size: 589630
+  timestamp: 1780299216833
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py313haffc69d_2.conda
+  sha256: f8604fb6272d2c2101590410596109b3d6d7f8d21d2d8e49cb5a11d881b751cb
+  md5: b13438c33c450d486fe21923307f5966
   depends:
   - __osx >=11.0
   - libcxx >=19
-  - libgdal-core >=3.12.0,<3.13.0a0
+  - libgdal-core >=3.13.0,<3.14.0a0
   - numpy
   - packaging
   - python >=3.13,<3.14.0a0
@@ -36098,15 +36156,15 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 595647
-  timestamp: 1764402845925
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py314h3da1bed_0.conda
-  sha256: dcaaab4d8b539f7c4ee740e0242ae09c48f68e75949476ca36d9c67e61aafc3b
-  md5: 9b33fa020bd4da86a2dddfd0f63a43ba
+  size: 595669
+  timestamp: 1780299162691
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/pyogrio-0.12.1-py314h618c026_2.conda
+  sha256: c75763e3bd94091b8321001556d3d2eac67df351ae2409ced4ebde27c30614c8
+  md5: 67de7bcafd2059acaf7b4c6b77152e3c
   depends:
   - __osx >=11.0
   - libcxx >=19
-  - libgdal-core >=3.12.0,<3.13.0a0
+  - libgdal-core >=3.13.0,<3.14.0a0
   - numpy
   - packaging
   - python >=3.14,<3.15.0a0
@@ -36116,13 +36174,13 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 599877
-  timestamp: 1764402722213
-- conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py311h8db5f30_0.conda
-  sha256: 790609dc81ffa65ce79438d0f016b7fe927d3d62fb374aea747949aa3e042bda
-  md5: 8c20bd5f0b834df9797031eb70333d6d
+  size: 600162
+  timestamp: 1780299267950
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py311h5596f38_2.conda
+  sha256: c266d25b8a5362b4c5396e3bb0277de1f1986e788e007732b0f502b8b6595ba4
+  md5: ad4aba214c9898a200716ca0cde22b93
   depends:
-  - libgdal-core >=3.12.0,<3.13.0a0
+  - libgdal-core >=3.13.0,<3.14.0a0
   - numpy
   - packaging
   - python >=3.11,<3.12.0a0
@@ -36134,13 +36192,13 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 890949
-  timestamp: 1764402774351
-- conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py312h3f2e00f_0.conda
-  sha256: ce75abd4eecdffac3160c3230119e9fc6f77875ca90deb04b84986832ec91b1f
-  md5: d63733f2a0893b5d42fc4e005d5dc265
+  size: 892560
+  timestamp: 1780298930349
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py312h0e78342_2.conda
+  sha256: 9b68bb884601f83d360206f12865a70bc06a67daae5f3898b731855afcb6f033
+  md5: 5bdfa9615736bb71a22f5f542d618a7b
   depends:
-  - libgdal-core >=3.12.0,<3.13.0a0
+  - libgdal-core >=3.13.0,<3.14.0a0
   - numpy
   - packaging
   - python >=3.12,<3.13.0a0
@@ -36152,13 +36210,13 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 880946
-  timestamp: 1764402680849
-- conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py313h8b19803_0.conda
-  sha256: 48fd958bdc15a280c4fbf764aea0767f8bb6ac61951567a39bed9d86290e51b9
-  md5: 6cfe8b00a3bd2a29e46c062063d3c575
+  size: 880366
+  timestamp: 1780298930493
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py313he1476db_2.conda
+  sha256: 914b0f974039aa082ac42271b10c67a4443931cfd78b0f94fff13c1a686b41c4
+  md5: 3d0acc4608c1112f6320c68c6d98d855
   depends:
-  - libgdal-core >=3.12.0,<3.13.0a0
+  - libgdal-core >=3.13.0,<3.14.0a0
   - numpy
   - packaging
   - python >=3.13,<3.14.0a0
@@ -36170,13 +36228,13 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 886220
-  timestamp: 1764402582887
-- conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py314h1c1cb05_0.conda
-  sha256: 3ed86ebf3d68f9ae52b5a74f9db919d367af33acf26d481fcdb00fff7079e350
-  md5: da6ef5e9a5931e73a7638b60fd82fc63
+  size: 881410
+  timestamp: 1780298930597
+- conda: https://conda.anaconda.org/conda-forge/win-64/pyogrio-0.12.1-py314he172734_2.conda
+  sha256: 5e70627d72d0c8c6e2f508bdb898d77d4f78ef559b34f13a28999231aa3ec14b
+  md5: e8d4a6a9b9e6ee870d040f1d27073ec8
   depends:
-  - libgdal-core >=3.12.0,<3.13.0a0
+  - libgdal-core >=3.13.0,<3.14.0a0
   - numpy
   - packaging
   - python >=3.14,<3.15.0a0
@@ -36188,8 +36246,8 @@ packages:
   license_family: MIT
   purls:
   - pkg:pypi/pyogrio?source=hash-mapping
-  size: 899343
-  timestamp: 1764402737921
+  size: 899813
+  timestamp: 1780298926057
 - pypi: https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl
   name: pyparsing
   version: 3.3.2
@@ -36325,7 +36383,7 @@ packages:
 - pypi: ./
   name: pyramids-gis
   version: 0.35.0
-  sha256: 7d5b69a82ff349565634a3fa6e33fac747bb053600eabf2c9cd9ebfc40adce1f
+  sha256: 61a2c049b404d66159f5807e0156b83c754da35d46fb4040259fd70561fb09b5
   requires_dist:
   - cftime>=1.6.4
   - geopandas>=1.0.0
@@ -36652,33 +36710,6 @@ packages:
   size: 35563239
   timestamp: 1781258961235
   python_site_packages_path: lib/python3.13/site-packages
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.14.6-h1c24c05_0_cp314t.conda
-  sha256: 7fc81ed776b89786c00b3bf9d67e5472e78b63f5c82e0bc66bd763f7d1df3d24
-  md5: 3ccb01876bc484acb5ea03d3c3949cea
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - ld_impl_linux-aarch64 >=2.36.1
-  - libexpat >=2.8.1,<3.0a0
-  - libffi >=3.5.2,<3.6.0a0
-  - libgcc >=14
-  - liblzma >=5.8.3,<6.0a0
-  - libmpdec >=4.0.0,<5.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - libuuid >=2.42.1,<3.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - ncurses >=6.6,<7.0a0
-  - openssl >=3.5.7,<4.0a0
-  - python_abi 3.14.* *_cp314t
-  - readline >=8.3,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - zstd >=1.5.7,<1.6.0a0
-  track_features:
-  - py_freethreading
-  license: Python-2.0
-  size: 46058573
-  timestamp: 1781254957859
-  python_site_packages_path: lib/python3.14t/site-packages
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/python-3.14.6-hc679e19_100_cp314.conda
   build_number: 100
   sha256: dd56fd95db3cb49a69fbe41df80afc8bd5214daa829bcd3930de80f0408ba5eb
@@ -36800,6 +36831,31 @@ packages:
   size: 14368118
   timestamp: 1781256031540
   python_site_packages_path: lib/python3.14/site-packages
+- conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.14.6-ha91e2d8_0_cp314t.conda
+  sha256: becf51f5427fc0c1e68a64fa5467fe62116fff6ed098033c7844c7a9ce18e833
+  md5: 1bc59acd81f34797a157b4d05bbe8c5d
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - ncurses >=6.6,<7.0a0
+  - openssl >=3.5.7,<4.0a0
+  - python_abi 3.14.* *_cp314t
+  - readline >=8.3,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - zstd >=1.5.7,<1.6.0a0
+  track_features:
+  - py_freethreading
+  license: Python-2.0
+  size: 16822275
+  timestamp: 1781257301733
+  python_site_packages_path: lib/python3.14t/site-packages
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.15-h0c9c016_1_cpython.conda
   build_number: 1
   sha256: a44be5222fe8d3c072ecd22491d37316724b70be6b8e8dabdc1a25e6d293fba8
@@ -36987,6 +37043,29 @@ packages:
   purls: []
   size: 18481352
   timestamp: 1781256034828
+  python_site_packages_path: Lib/site-packages
+- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.14.6-h7c1dbca_0_cp314t.conda
+  sha256: c53df5f2e8135cb3443279fd6b4de66ba81a20ee03188f7afc2affb711eb78cd
+  md5: e6cd651d30b56b0cce64b626c209dc30
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libffi >=3.5.2,<3.6.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - libmpdec >=4.0.0,<5.0a0
+  - libsqlite >=3.53.2,<4.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - openssl >=3.5.7,<4.0a0
+  - python_abi 3.14.* *_cp314t
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - ucrt >=10.0.20348.0
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - zstd >=1.5.7,<1.6.0a0
+  license: Python-2.0
+  size: 17928931
+  timestamp: 1781256814063
   python_site_packages_path: Lib/site-packages
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
   sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -351,11 +351,11 @@ xarray = ">=2023.1.0"
 # libgdal-jp2openjpeg ships the JP2OpenJPEG driver (pulls openjpeg) so the bundled GDAL
 # can read JPEG2000-packed GRIB2 (WMO template 5.40 — NCEP/ECCC/ECMWF); see issue #600.
 [tool.pixi.feature.gdal.dependencies]
-gdal = ">=3.12,<3.13"
-libgdal-netcdf = ">=3.12,<3.13"
-libgdal-hdf4 = ">=3.12,<3.13"
-libgdal-grib = ">=3.12,<3.13"
-libgdal-jp2openjpeg = ">=3.12,<3.13"
+gdal = ">=3.13,<3.14"
+libgdal-netcdf = ">=3.13,<3.14"
+libgdal-hdf4 = ">=3.13,<3.14"
+libgdal-grib = ">=3.13,<3.14"
+libgdal-jp2openjpeg = ">=3.13,<3.14"
 
 # swig builds the osgeo bindings against libgdal; build-only, so it stays in the
 # wheel-build feature (not the shared gdal feature). setup-gdal-micromamba.sh reads it.
@@ -413,7 +413,7 @@ manylinux-aarch64-image = "manylinux_2_28"
 environment-pass = ["PIXI_VERSION", "MICROMAMBA_VERSION"]
 before-all = ["bash ./ci/setup-gdal-from-pixi.sh"]
 # install-and-vendor-osgeo.py runs pip WITH build isolation so it picks
-# up setuptools>=77 (GDAL 3.12.3's build-system.requires) and a matching
+# up setuptools>=77 (GDAL's build-system.requires) and a matching
 # numpy. Without isolation, the manylinux container's pre-installed
 # setuptools 75.5.0 rejects GDAL's PEP 639 license string.
 before-build = ["python ./ci/install-and-vendor-osgeo.py"]

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -300,10 +300,12 @@ class LabeledDataset:
     def _readable_arrays(grp: gdal.Group) -> tuple[list[str], list[str]]:
         """Split a group's arrays into those GDAL can read and those it cannot.
 
-        GDAL's Zarr driver rejects Zarr v3 string-typed arrays — they list in
-        ``GetMDArrayNames()`` but raise ``RuntimeError`` on access
-        (https://github.com/OSGeo/gdal/issues/13782). Probe each array so an
-        otherwise-numeric store still opens; the unreadable ones are reported.
+        Historically GDAL's Zarr driver rejected Zarr v3 string-typed arrays —
+        they listed in ``GetMDArrayNames()`` but raised ``RuntimeError`` on
+        access (https://github.com/OSGeo/gdal/issues/13782, fixed in GDAL 3.13).
+        The probe stays as defence-in-depth: any array that still raises on
+        access (older GDAL, an unsupported dtype, a corrupt array) is skipped so
+        an otherwise-readable store still opens, and the skipped names reported.
 
         Returns:
             tuple[list[str], list[str]]: ``(readable, skipped)`` array names.

--- a/tests/netcdf/test_labeled.py
+++ b/tests/netcdf/test_labeled.py
@@ -94,20 +94,63 @@ class TestLabeledDatasetRead:
         store = LabeledDataset.read_file(zarr_store, engine="zarr")
         assert store.variables == ["streamflow"]
 
-    def test_zarr_v3_string_coord_degrades_gracefully(self, tmp_path: Path):
-        """A Zarr v3 string coord GDAL can't read is skipped with a warning.
+    def test_zarr_v3_string_coord_is_read(self, tmp_path: Path):
+        """A Zarr v3 string coord is read as a normal coordinate (GDAL >= 3.13).
 
         Test scenario:
-            GDAL's Zarr driver rejects Zarr v3 string arrays
-            (https://github.com/OSGeo/gdal/issues/13782). On GDAL versions where
-            the store still opens, the unreadable string coord (``gage_id``) is
-            dropped with a warning and the numeric data stays available.
+            GDAL's Zarr driver gained Zarr v3 string-array support in 3.13
+            (https://github.com/OSGeo/gdal/issues/13782, milestone 3.13.0). The
+            string coordinate (``gage_id``) now reads back as its string values
+            with no warning, alongside the numeric coordinates and data. (On
+            GDAL < 3.13 the array was unreadable and dropped with a warning —
+            that degradation path is covered version-independently by
+            ``test_unreadable_array_skipped_with_warning``.)
         """
         path = tmp_path / "v3.zarr"
         _streamflow_dataset().to_zarr(path, mode="w", zarr_format=3)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            store = LabeledDataset.read_file(path)
+        assert "gage_id" in store.coordinates, "v3 string coord must be read"
+        assert "feature_id" in store.coordinates
+        assert store.variables == ["streamflow"]
+        np.testing.assert_array_equal(
+            store["gage_id"].values, np.array(["01010000", "01010500", "01011000"])
+        )
+        np.testing.assert_array_equal(
+            store["streamflow"].values,
+            np.arange(N_TIME * N_FEAT, dtype="f4").reshape(N_TIME, N_FEAT),
+        )
+
+    def test_unreadable_array_skipped_with_warning(self, tmp_path: Path, monkeypatch):
+        """An array GDAL cannot read is dropped with a warning; numeric data stays.
+
+        Test scenario:
+            Exercises the degradation path (``_readable_arrays`` skips an array
+            that raises on probe; ``_from_group`` warns and keeps the rest) in a
+            GDAL-version-independent way: force ``gage_id`` to be reported
+            unreadable, then confirm it is dropped, the ``13782`` warning fires,
+            and the remaining coords + numeric data are intact. This keeps the
+            ``GDAL < 3.13`` fallback covered now that 3.13 reads such arrays
+            natively (see ``test_zarr_v3_string_coord_is_read``).
+        """
+        path = tmp_path / "v3.zarr"
+        _streamflow_dataset().to_zarr(path, mode="w", zarr_format=3)
+        real_readable_arrays = LabeledDataset._readable_arrays  # @staticmethod -> plain fn
+
+        def _force_skip_gage_id(grp):
+            readable, skipped = real_readable_arrays(grp)
+            if "gage_id" in readable:
+                readable.remove("gage_id")
+                skipped.append("gage_id")
+            return readable, skipped
+
+        monkeypatch.setattr(
+            LabeledDataset, "_readable_arrays", staticmethod(_force_skip_gage_id)
+        )
         with pytest.warns(UserWarning, match="13782"):
             store = LabeledDataset.read_file(path)
-        assert "gage_id" not in store.coordinates, "v3 string coord must be dropped"
+        assert "gage_id" not in store.coordinates, "unreadable coord must be dropped"
         assert "feature_id" in store.coordinates
         assert store.variables == ["streamflow"]
         np.testing.assert_array_equal(


### PR DESCRIPTION
# Description

Upgrade the bundled GDAL from **3.12.4 → 3.13.1** (conda-forge's current latest). Routine stay-current
maintenance — **no pyramids code requires a 3.13 feature** (the codebase is version-tolerant; a prior audit
found zero `>=3.13` gates), so this is a pin + relock, not a behavior change.

- `pyproject.toml`: bump all five shared gdal-feature pins `>=3.12,<3.13` → `>=3.13,<3.14`
  (`gdal`, `libgdal-netcdf`, `libgdal-hdf4`, `libgdal-grib`, `libgdal-jp2openjpeg`).
- `pixi.lock`: re-solved (`pixi lock`) → GDAL **3.13.1** across all platforms. `geos` was already 3.14.1
  (no transitive CRS-lib bump), and `libgdal-netcdf` 3.13.1 still links HDF5 1.14.x, so the `netcdf-lazy`
  `hdf5=1.14.*` / `h5py<3.16` pins stay valid.
- Docs + comment references updated 3.12 → 3.13.

**Watch-outs flagged for review:**

- The lock diff is large (~4.5k lines) — inherent to a stack-wide minor bump (gdal + 6 `libgdal-*` +
  `pyogrio` rebuilds across every env×platform). It also includes some `cp314`↔`cp314t` python-build
  flips from the re-solve; those land in build envs and don't flow into the shipped wheels (cibuildwheel
  builds cp314, not cp314t), but CI is the real check.
- GDAL/PROJ minor bumps can shift EPSG/CRS-name resolution — the suite has tests that pin the acceptance
  *policy* against the bundled GDAL/PROJ; if any need a tolerance tweak for 3.13, CI will surface it.

# Issues
- Closes #603

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] `pyproject.toml` parses; all five gdal pins resolve to `>=3.13,<3.14`; `pixi lock` solves cleanly
      with GDAL 3.13.1 across all platforms.
- [ ] CI `main-package` + `extras-package` matrices (Py 3.11–3.14 × Linux/macOS/Windows) — run the full
      suite against the 3.13 envs; catch any EPSG/CRS-name or behavior drift. (on push)
- [ ] CI `bundle-pypi-wheels.yml` — build + `test-wheels` + `verify-wheel.py` confirm the 3.13 wheels
      bundle and the netCDF + JP2OpenJPEG drivers still round-trip. (dispatched)

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen-managed)
- [ ] added changes to History.rst. (changelog is commitizen-generated)
- [ ] updated the latest version in README file.
- [ ] I have added tests that prove my fix is effective or that my feature works. (no new tests — the
      existing suite + wheel matrix validate the bump)
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (docs/installation.md: GDAL 3.12 → 3.13)

