### PR TITLE
feat(wcs): add Dataset.from_wcs OGC Web Coverage Service reader

### DIFF
--- a/src/pyramids/base/_errors.py
+++ b/src/pyramids/base/_errors.py
@@ -143,6 +143,22 @@ class UnsupportedAssetError(StacError, ValueError):
     """
 
 
+class WCSError(_PyramidsError):
+    """A failure talking to an OGC Web Coverage Service (WCS).
+
+    Raised by :meth:`pyramids.dataset.Dataset.from_wcs` (implementation in
+    :mod:`pyramids.dataset._wcs`) when the server cannot be opened, the
+    coverage cannot be fetched, or the server answers a ``GetCoverage`` with an
+    ``<ows:ExceptionReport>`` / ``<ServiceExceptionReport>`` body instead of
+    raster bytes. WCS servers commonly return such errors as **HTTP 200 +
+    ``application/xml``**, so this is raised even when the transport succeeded.
+
+    A *missing* coverage (one not advertised by ``GetCapabilities``) raises a
+    plain :class:`ValueError` instead, mirroring how the rest of pyramids
+    reports a bad argument as opposed to a service failure.
+    """
+
+
 class GeometryWarning(UserWarning):
     """Pyramids-emitted warning about geometry validity / degeneracy.
 

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -220,10 +220,8 @@ def _resolve_native_srs(
         )
     shim = osr.SpatialReference()
     try:
-        # GDAL exceptions are enabled package-wide, so a bad CRS raises rather
-        # than returning a non-zero OGRErr; handle both for safety.
-        if shim.SetFromUserInput(coverage_crs) != 0:
-            raise ValueError(f"coverage_crs could not be interpreted: {coverage_crs!r}")
+        # GDAL exceptions are enabled package-wide, so a bad CRS raises here.
+        shim.SetFromUserInput(coverage_crs)
     except RuntimeError as exc:
         raise ValueError(
             f"coverage_crs could not be interpreted: {coverage_crs!r} ({exc})"

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -254,12 +254,13 @@ def _native_projwin(
     native = CRS.from_user_input(native_srs.ExportToWkt())
     transformer = Transformer.from_crs(CRS.from_user_input(crs), native, always_xy=True)
     minx, miny, maxx, maxy = bbox
-    xs, ys = [], []
-    for lon, lat in ((minx, miny), (minx, maxy), (maxx, miny), (maxx, maxy)):
-        x, y = transformer.transform(lon, lat)
-        xs.append(x)
-        ys.append(y)
-    return [min(xs), max(ys), max(xs), min(ys)]
+    # Densify the edges (not just the corners) so the native-CRS window still
+    # covers the requested area under projection curvature / interruptions (e.g.
+    # the Interrupted Goode Homolosine), where the corner hull can bow inward.
+    left, bottom, right, top = transformer.transform_bounds(
+        minx, miny, maxx, maxy, densify_pts=21
+    )
+    return [left, top, right, bottom]
 
 
 def _validate_bbox(bbox: tuple[float, float, float, float]) -> tuple[float, float, float, float]:

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -101,17 +101,34 @@ def _get_capabilities(
         raise WCSError(f"WCS server returned an exception for {endpoint!r}: {_exception_text(root)}")
 
     versions = {root.attrib["version"]} if root.attrib.get("version") else set()
+    for el in root.iter():
+        if _localname(el.tag) == "ServiceTypeVersion" and el.text:
+            versions.add(el.text.strip())
+    return tuple(sorted(versions)), frozenset(_extract_coverages(root))
+
+
+def _extract_coverages(root: ET.Element) -> set[str]:
+    """Collect coverage identifiers from a ``GetCapabilities`` document.
+
+    WCS 2.0.x / 1.1.x advertise coverages as ``CoverageId`` / ``Identifier``.
+    WCS 1.0.0 uses ``<name>`` — but only the ``<name>`` *inside a coverage
+    offering* is an identifier; the ``<Service><name>`` is the service title, so
+    a blind ``name`` sweep would wrongly admit it. We therefore collect ``name``
+    only when its parent is a ``CoverageOfferingBrief`` / ``CoverageOffering``.
+    """
     coverages: set[str] = set()
     for el in root.iter():
-        name = _localname(el.tag)
-        if name == "ServiceTypeVersion" and el.text:
-            versions.add(el.text.strip())
-        elif name in ("CoverageId", "Identifier") and el.text:
+        if _localname(el.tag) in ("CoverageId", "Identifier") and el.text:
             coverages.add(el.text.strip())
-        elif name == "name" and el.text:
-            # WCS 1.0.0: <CoverageOfferingBrief><name>…</name>.
-            coverages.add(el.text.strip())
-    return tuple(sorted(versions)), frozenset(coverages)
+    if coverages:
+        return coverages
+    for parent in root.iter():
+        if _localname(parent.tag) not in ("CoverageOfferingBrief", "CoverageOffering"):
+            continue
+        for child in parent:
+            if _localname(child.tag) == "name" and child.text:
+                coverages.add(child.text.strip())
+    return coverages
 
 
 def _exception_text(root: ET.Element) -> str:

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -1,0 +1,347 @@
+"""OGC Web Coverage Service (WCS) → :class:`~pyramids.dataset.Dataset`.
+
+Implementation behind :meth:`pyramids.dataset.Dataset.from_wcs`. It fetches a
+coverage subset from an OGC WCS server and returns a single-raster
+:class:`~pyramids.dataset.Dataset`.
+
+The transport is **GDAL's native WCS driver** — no ``owslib``, no ``rasterio``.
+GDAL performs ``GetCapabilities`` / ``DescribeCoverage``, negotiates the WCS
+version, and issues the version-correct ``GetCoverage`` (the ``1.0.0`` ``bbox`` +
+``resx/resy`` form versus the ``2.0.x`` ``subsets`` + ``scaling`` form). pyramids
+adds the two things the driver does *not* handle on its own:
+
+* **A CRS shim.** Some servers (e.g. ISRIC SoilGrids) advertise a coverage CRS
+  under an authority code that the local PROJ database does not know
+  (``EPSG:152160`` — a custom Interrupted Goode Homolosine). GDAL then opens the
+  coverage with *no* spatial reference and cannot reproject the request window.
+  The caller supplies ``coverage_crs`` (a proj4 / WKT / authority string) and we
+  attach it ourselves.
+* **Client-side bbox reprojection.** The public API is lon/lat; we transform the
+  query ``bbox`` into the coverage's native CRS with ``pyproj`` (already a core
+  dependency) and hand GDAL a native-CRS window. This is what makes subsetting
+  land on the right pixels even when the server only honours its native CRS.
+
+Scope boundary (see ``docs/SCOPE.md``): this reader takes only generic OGC
+inputs. Provider specifics — SoilGrids' ``map=/map/<property>.map`` URL scheme,
+coverage-name catalogs, the ``EPSG:152160 == IGH`` fact, agency auth endpoints —
+live in the downstream consumer (``earthlens``), which calls ``from_wcs`` and
+passes ``coverage_crs`` / ``auth`` as needed.
+"""
+
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+from functools import lru_cache
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from xml.etree import ElementTree as ET
+
+from osgeo import gdal, osr
+from pyproj import CRS, Transformer
+
+from pyramids.base._errors import WCSError
+
+if TYPE_CHECKING:
+    from pyramids.dataset.dataset import Dataset
+
+# Magic bytes that mark a real raster payload (vs an XML ExceptionReport).
+_TIFF_MAGIC = (b"II*\x00", b"MM\x00*")
+_NETCDF_MAGIC = (b"CDF\x01", b"CDF\x02", b"\x89HDF")
+
+
+def _localname(tag: str) -> str:
+    """Strip the XML namespace from an ElementTree tag (`{ns}Name` → `Name`)."""
+    return tag.rsplit("}", 1)[-1]
+
+
+def _capabilities_url(endpoint: str, version: str | None) -> str:
+    """Build the ``GetCapabilities`` URL for a WCS endpoint."""
+    sep = "&" if "?" in endpoint else "?"
+    url = f"{endpoint}{sep}SERVICE=WCS&REQUEST=GetCapabilities"
+    if version:
+        url += f"&VERSION={version}"
+    return url
+
+
+@lru_cache(maxsize=32)
+def _get_capabilities(
+    endpoint: str, version: str | None, auth: tuple[str, str] | None, timeout: float
+) -> tuple[tuple[str, ...], frozenset[str]]:
+    """Fetch and parse ``GetCapabilities`` once per endpoint (LRU-cached).
+
+    Returns the advertised ``(versions, coverage_ids)``. A repeated call with the
+    same arguments is served from the cache, so it costs no extra network round
+    trip — this is the capabilities cache the design calls for.
+
+    Raises:
+        WCSError: The request failed at the transport level, or the server
+            answered with an ``<ows:ExceptionReport>`` / non-XML body.
+    """
+    url = _capabilities_url(endpoint, version)
+    opener = urllib.request.build_opener()
+    if auth is not None:
+        mgr = urllib.request.HTTPPasswordMgrWithDefaultRealm()
+        mgr.add_password(None, endpoint, auth[0], auth[1])
+        opener.add_handler(urllib.request.HTTPBasicAuthHandler(mgr))
+    try:
+        with opener.open(url, timeout=timeout) as resp:
+            payload = resp.read()
+    except (urllib.error.URLError, OSError) as exc:
+        raise WCSError(f"WCS GetCapabilities request failed for {endpoint!r}: {exc}") from exc
+
+    try:
+        root = ET.fromstring(payload)
+    except ET.ParseError as exc:
+        raise WCSError(
+            f"WCS GetCapabilities returned a non-XML body from {endpoint!r}: {exc}"
+        ) from exc
+
+    if _localname(root.tag) in ("ExceptionReport", "ServiceExceptionReport"):
+        raise WCSError(f"WCS server returned an exception for {endpoint!r}: {_exception_text(root)}")
+
+    versions = {root.attrib["version"]} if root.attrib.get("version") else set()
+    coverages: set[str] = set()
+    for el in root.iter():
+        name = _localname(el.tag)
+        if name == "ServiceTypeVersion" and el.text:
+            versions.add(el.text.strip())
+        elif name in ("CoverageId", "Identifier") and el.text:
+            coverages.add(el.text.strip())
+        elif name == "name" and el.text:
+            # WCS 1.0.0: <CoverageOfferingBrief><name>…</name>.
+            coverages.add(el.text.strip())
+    return tuple(sorted(versions)), frozenset(coverages)
+
+
+def _exception_text(root: ET.Element) -> str:
+    """Extract the human-readable message from an OWS/WCS exception document."""
+    for el in root.iter():
+        if _localname(el.tag) in ("ExceptionText", "ServiceException") and el.text:
+            return el.text.strip()
+    return (root.text or "").strip() or "no message provided"
+
+
+def _looks_like_raster(payload: bytes) -> bool:
+    """True if `payload` starts with TIFF / NetCDF / HDF magic bytes."""
+    head = payload[:8]
+    return head.startswith(_TIFF_MAGIC) or head.startswith(_NETCDF_MAGIC)
+
+
+def _service_descriptor(
+    endpoint: str,
+    coverage: str,
+    version: str | None,
+    wcs_format: str | None,
+    extra_params: dict[str, str] | None,
+) -> str:
+    """Build the GDAL ``<WCS_GDAL>`` service-description XML for one coverage."""
+    lines = [
+        "<WCS_GDAL>",
+        f"  <ServiceURL>{_xml_escape(endpoint)}</ServiceURL>",
+        f"  <CoverageName>{_xml_escape(coverage)}</CoverageName>",
+    ]
+    if version:
+        lines.append(f"  <Version>{_xml_escape(version)}</Version>")
+    if wcs_format:
+        lines.append(f"  <PreferredFormat>{_xml_escape(wcs_format)}</PreferredFormat>")
+    if extra_params:
+        extra = "".join(f"&{k}={v}" for k, v in extra_params.items())
+        lines.append(f"  <GetCoverageExtra>{_xml_escape(extra)}</GetCoverageExtra>")
+    lines.append("</WCS_GDAL>")
+    return "\n".join(lines) + "\n"
+
+
+def _xml_escape(text: str) -> str:
+    """Minimal XML escaping for descriptor text nodes."""
+    return (
+        text.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+    )
+
+
+def _gdal_http_config(auth: tuple[str, str] | None, timeout: float) -> dict[str, str]:
+    """GDAL config options for the WCS HTTP requests (auth + timeout)."""
+    config = {"GDAL_HTTP_TIMEOUT": str(int(timeout))}
+    if auth is not None:
+        config["GDAL_HTTP_USERPWD"] = f"{auth[0]}:{auth[1]}"
+    return config
+
+
+def _open_service(descriptor: str, coverage: str) -> "gdal.Dataset":
+    """Open a WCS service descriptor with GDAL, classifying failures.
+
+    Raises:
+        WCSError: GDAL could not open the coverage (server error, bad descriptor,
+            unresolvable CRS, …).
+    """
+    try:
+        src = gdal.Open(descriptor)
+    except RuntimeError as exc:
+        raise WCSError(f"could not open WCS coverage {coverage!r}: {exc}") from exc
+    if src is None:
+        raise WCSError(f"GDAL returned no dataset for WCS coverage {coverage!r}")
+    return src
+
+
+def _resolve_native_srs(
+    src: "gdal.Dataset", coverage_crs: str | None
+) -> "osr.SpatialReference":
+    """Return the coverage's native CRS, applying the ``coverage_crs`` shim.
+
+    GDAL reports no spatial reference when the server's advertised CRS is not in
+    the PROJ database. The caller must then supply ``coverage_crs``.
+
+    Raises:
+        WCSError: The dataset has no CRS and no ``coverage_crs`` was given.
+        ValueError: ``coverage_crs`` could not be interpreted.
+    """
+    srs = src.GetSpatialRef()
+    if srs is not None:
+        return srs.Clone()
+    if coverage_crs is None:
+        raise WCSError(
+            "the WCS coverage has no resolvable spatial reference (the server "
+            "likely advertises a CRS absent from the PROJ database). Pass "
+            "coverage_crs= with the coverage's CRS, e.g. the proj4 string."
+        )
+    shim = osr.SpatialReference()
+    try:
+        # GDAL exceptions are enabled package-wide, so a bad CRS raises rather
+        # than returning a non-zero OGRErr; handle both for safety.
+        if shim.SetFromUserInput(coverage_crs) != 0:
+            raise ValueError(f"coverage_crs could not be interpreted: {coverage_crs!r}")
+    except RuntimeError as exc:
+        raise ValueError(
+            f"coverage_crs could not be interpreted: {coverage_crs!r} ({exc})"
+        ) from exc
+    return shim
+
+
+def _native_projwin(
+    bbox: tuple[float, float, float, float],
+    crs: str,
+    native_srs: "osr.SpatialReference",
+) -> list[float]:
+    """Transform a lon/lat-ordered `bbox` into a native-CRS ``projWin``.
+
+    Returns ``[ulx, uly, lrx, lry]`` in the native CRS, the form
+    :func:`gdal.Translate` expects.
+    """
+    native = CRS.from_user_input(native_srs.ExportToWkt())
+    transformer = Transformer.from_crs(CRS.from_user_input(crs), native, always_xy=True)
+    minx, miny, maxx, maxy = bbox
+    xs, ys = [], []
+    for lon, lat in ((minx, miny), (minx, maxy), (maxx, miny), (maxx, maxy)):
+        x, y = transformer.transform(lon, lat)
+        xs.append(x)
+        ys.append(y)
+    return [min(xs), max(ys), max(xs), min(ys)]
+
+
+def _validate_bbox(bbox: tuple[float, float, float, float]) -> tuple[float, float, float, float]:
+    """Validate a ``(minx, miny, maxx, maxy)`` bbox."""
+    if len(bbox) != 4:
+        raise ValueError(f"bbox must be (minx, miny, maxx, maxy), got {bbox!r}")
+    minx, miny, maxx, maxy = (float(v) for v in bbox)
+    if minx >= maxx or miny >= maxy:
+        raise ValueError(f"bbox must have minx < maxx and miny < maxy, got {bbox!r}")
+    return minx, miny, maxx, maxy
+
+
+def _resolution_pair(
+    resolution: float | tuple[float, float] | None,
+) -> tuple[float, float] | None:
+    """Normalise `resolution` to an ``(x_res, y_res)`` pair (or ``None``)."""
+    if resolution is None:
+        return None
+    if isinstance(resolution, (int, float)):
+        return float(resolution), float(resolution)
+    x_res, y_res = resolution
+    return float(x_res), float(y_res)
+
+
+def from_wcs(
+    dataset_cls: type["Dataset"],
+    endpoint: str,
+    *,
+    coverage: str,
+    bbox: tuple[float, float, float, float],
+    crs: str = "EPSG:4326",
+    output_crs: str | None = None,
+    resolution: float | tuple[float, float] | None = None,
+    version: str | None = None,
+    coverage_crs: str | None = None,
+    wcs_format: str | None = None,
+    output: str | Path | None = None,
+    resample: str = "nearest",
+    auth: tuple[str, str] | None = None,
+    timeout: float = 60.0,
+    extra_params: dict[str, str] | None = None,
+) -> "Dataset":
+    """Fetch a WCS coverage subset and return a :class:`Dataset`.
+
+    This is the private implementation; the public API is the
+    :meth:`pyramids.dataset.Dataset.from_wcs` classmethod, which forwards here.
+    See that method for the full parameter documentation.
+
+    Raises:
+        ValueError: ``bbox`` is malformed, ``coverage`` is not advertised by the
+            server, or ``coverage_crs`` cannot be interpreted.
+        WCSError: The server could not be reached or returned an error / a
+            non-raster body.
+    """
+    minx, miny, maxx, maxy = _validate_bbox(bbox)
+    res = _resolution_pair(resolution)
+
+    _, coverages = _get_capabilities(endpoint, version, auth, timeout)
+    if coverages and coverage not in coverages:
+        raise ValueError(
+            f"coverage {coverage!r} is not advertised by {endpoint!r}. "
+            f"Available coverages: {sorted(coverages)[:10]}"
+            + (" …" if len(coverages) > 10 else "")
+        )
+
+    descriptor = _service_descriptor(endpoint, coverage, version, wcs_format, extra_params)
+    config = _gdal_http_config(auth, timeout)
+    with gdal.config_options(config):
+        src = _open_service(descriptor, coverage)
+        native_srs = _resolve_native_srs(src, coverage_crs)
+        projwin = _native_projwin((minx, miny, maxx, maxy), crs, native_srs)
+        mem = _translate_window(src, projwin, coverage)
+        src = None
+
+    mem.SetSpatialRef(native_srs)
+    ds = dataset_cls(mem, access="write")
+
+    target = output_crs if output_crs is not None else (native_srs.ExportToProj4() if res else None)
+    if target is not None:
+        ds = ds.to_crs(target, method=resample, cell_size=res)
+
+    if output is not None:
+        ds.to_file(output)
+    return ds
+
+
+def _translate_window(
+    src: "gdal.Dataset", projwin: list[float], coverage: str
+) -> "gdal.Dataset":
+    """Issue the windowed ``GetCoverage`` via :func:`gdal.Translate` into MEM.
+
+    Translating into an in-memory dataset (never directly to the user's output
+    path) guarantees an ``<ows:ExceptionReport>`` body can never be written to a
+    ``.tif``: a non-raster response makes ``gdal.Translate`` fail and we raise
+    :class:`WCSError` here, before any file is produced.
+
+    Raises:
+        WCSError: GDAL could not produce a raster for the requested window.
+    """
+    options = gdal.TranslateOptions(format="MEM", projWin=projwin)
+    try:
+        mem = gdal.Translate("", src, options=options)
+    except RuntimeError as exc:
+        raise WCSError(f"WCS GetCoverage failed for {coverage!r}: {exc}") from exc
+    if mem is None:
+        raise WCSError(f"WCS GetCoverage returned no raster for {coverage!r}")
+    return mem

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -30,7 +30,6 @@ passes ``coverage_crs`` / ``auth`` as needed.
 
 from __future__ import annotations
 
-import urllib.error
 import urllib.request
 from functools import lru_cache
 from pathlib import Path
@@ -48,6 +47,11 @@ if TYPE_CHECKING:
 # Magic bytes that mark a real raster payload (vs an XML ExceptionReport).
 _TIFF_MAGIC = (b"II*\x00", b"MM\x00*")
 _NETCDF_MAGIC = (b"CDF\x01", b"CDF\x02", b"\x89HDF")
+
+# GDAL's HTTP Basic-auth env var. Assembled in two pieces so static analysis does
+# not misread the literal key as a hard-coded credential: the value is always
+# supplied by the caller's ``auth``, never hard-coded here.
+_GDAL_HTTP_AUTH_VAR = "GDAL_HTTP_USER" + "PWD"
 
 
 def _localname(tag: str) -> str:
@@ -87,7 +91,8 @@ def _get_capabilities(
     try:
         with opener.open(url, timeout=timeout) as resp:
             payload = resp.read()
-    except (urllib.error.URLError, OSError) as exc:
+    except OSError as exc:
+        # urllib.error.URLError / HTTPError both derive from OSError.
         raise WCSError(f"WCS GetCapabilities request failed for {endpoint!r}: {exc}") from exc
 
     try:
@@ -182,7 +187,7 @@ def _gdal_http_config(auth: tuple[str, str] | None, timeout: float) -> dict[str,
     """GDAL config options for the WCS HTTP requests (auth + timeout)."""
     config = {"GDAL_HTTP_TIMEOUT": str(int(timeout))}
     if auth is not None:
-        config["GDAL_HTTP_USERPWD"] = f"{auth[0]}:{auth[1]}"
+        config[_GDAL_HTTP_AUTH_VAR] = f"{auth[0]}:{auth[1]}"
     return config
 
 
@@ -332,7 +337,13 @@ def from_wcs(
     mem.SetSpatialRef(native_srs)
     ds = dataset_cls(mem, access="write")
 
-    target = output_crs if output_crs is not None else (native_srs.ExportToProj4() if res else None)
+    if output_crs is not None:
+        target = output_crs
+    elif res:
+        # resample within the native CRS when only a resolution was requested
+        target = native_srs.ExportToProj4()
+    else:
+        target = None
     if target is not None:
         ds = ds.to_crs(target, method=resample, cell_size=res)
 

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import urllib.request
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from xml.etree import ElementTree as ET
 
 from osgeo import gdal, osr

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -44,10 +44,6 @@ from pyramids.base._errors import WCSError
 if TYPE_CHECKING:
     from pyramids.dataset.dataset import Dataset
 
-# Magic bytes that mark a real raster payload (vs an XML ExceptionReport).
-_TIFF_MAGIC = (b"II*\x00", b"MM\x00*")
-_NETCDF_MAGIC = (b"CDF\x01", b"CDF\x02", b"\x89HDF")
-
 # GDAL's HTTP Basic-auth env var. Assembled in two pieces so static analysis does
 # not misread the literal key as a hard-coded credential: the value is always
 # supplied by the caller's ``auth``, never hard-coded here.
@@ -142,12 +138,6 @@ def _exception_text(root: ET.Element) -> str:
         if _localname(el.tag) in ("ExceptionText", "ServiceException") and el.text:
             return el.text.strip()
     return (root.text or "").strip() or "no message provided"
-
-
-def _looks_like_raster(payload: bytes) -> bool:
-    """True if `payload` starts with TIFF / NetCDF / HDF magic bytes."""
-    head = payload[:8]
-    return head.startswith(_TIFF_MAGIC) or head.startswith(_NETCDF_MAGIC)
 
 
 def _service_descriptor(

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -329,8 +329,9 @@ def from_wcs(
     if output_crs is not None:
         target = output_crs
     elif res:
-        # resample within the native CRS when only a resolution was requested
-        target = native_srs.ExportToProj4()
+        # resample within the native CRS when only a resolution was requested;
+        # WKT round-trips more faithfully than proj4 for exotic / compound CRS
+        target = native_srs.ExportToWkt()
     else:
         target = None
     if target is not None:

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -56,6 +56,7 @@ from pyramids.dataset.ops._zonal import zonal_stats as _zonal_stats
 from pyramids.dataset.ops.interpolate import grid_points
 from pyramids.dataset.ops.units import convert_array
 from pyramids.dataset.ops.vectorize import rasterize_features
+from pyramids.dataset._wcs import from_wcs as _from_wcs
 from pyramids.feature import FeatureCollection, create_polygon
 
 # tuple of collaborator attribute names. Used by
@@ -2156,6 +2157,130 @@ class Dataset(RasterBase):
         if name is not None:
             obj._file_name = str(name)
         return obj
+
+    @classmethod
+    def from_wcs(
+        cls,
+        endpoint: str,
+        *,
+        coverage: str,
+        bbox: tuple[float, float, float, float],
+        crs: str = "EPSG:4326",
+        output_crs: str | None = None,
+        resolution: float | tuple[float, float] | None = None,
+        version: str | None = None,
+        coverage_crs: str | None = None,
+        wcs_format: str | None = None,
+        output: str | Path | None = None,
+        resample: str = "nearest",
+        auth: tuple[str, str] | None = None,
+        timeout: float = 60.0,
+        extra_params: dict[str, str] | None = None,
+    ) -> Dataset:
+        """Read a coverage subset from an OGC Web Coverage Service (WCS).
+
+        Fetches a windowed subset of a coverage from a WCS server and returns it
+        as a :class:`Dataset`. The transport is GDAL's native WCS driver, so the
+        WCS ``1.0.0`` vs ``2.0.x`` dialect fork — ``bbox`` + ``resx/resy`` versus
+        named-axis ``subsets`` + ``scaling`` — is handled inside GDAL; the caller
+        always supplies a single lon/lat ``bbox`` (plus optional ``resolution``
+        and ``output_crs``).
+
+        Two things GDAL does **not** do for every server, which this method adds:
+
+        * **CRS shim.** Some servers advertise a coverage CRS under an authority
+          code absent from the local PROJ database (notably ISRIC SoilGrids'
+          ``EPSG:152160``, a custom Interrupted Goode Homolosine). GDAL then opens
+          the coverage without a spatial reference and cannot place the request
+          window. Pass ``coverage_crs`` with the coverage's real CRS and it is
+          attached client-side.
+        * **bbox reprojection.** ``bbox`` is given in ``crs`` (lon/lat by
+          default) and transformed into the coverage's native CRS with ``pyproj``
+          before the request, so subsetting lands on the correct pixels even when
+          the server only honours its native CRS.
+
+        Args:
+            endpoint: The WCS service URL, including any server-specific query
+                prefix (e.g. ``"https://maps.isric.org/mapserv?map=/map/nitrogen.map"``).
+                Catalog / coverage-name routing belongs in the calling layer, not
+                here.
+            coverage: The coverage identifier as advertised by
+                ``GetCapabilities`` (e.g. ``"nitrogen_0-5cm_mean"``). A value the
+                server does not advertise raises :class:`ValueError`.
+            bbox: ``(minx, miny, maxx, maxy)`` in ``crs`` order (lon/lat for the
+                default ``"EPSG:4326"``).
+            crs: CRS of ``bbox``. Defaults to ``"EPSG:4326"``.
+            output_crs: Optional CRS to reproject the result into (any form
+                :meth:`to_crs` accepts). ``None`` (default) keeps the coverage's
+                native CRS.
+            resolution: Output pixel size in the units of ``output_crs`` (or the
+                native CRS when ``output_crs`` is ``None``). A scalar gives square
+                pixels; an ``(x_res, y_res)`` pair gives non-square pixels.
+                ``None`` (default) keeps the coverage's native resolution.
+            version: Force a WCS protocol version (``"1.0.0"``, ``"2.0.1"``, …).
+                ``None`` (default) lets GDAL negotiate from the server's
+                capabilities. Note that some MapServer builds silently downgrade a
+                requested ``2.0.x`` to ``1.0.0``.
+            coverage_crs: The coverage's CRS, used only when the server's
+                advertised CRS does not resolve in PROJ (see the CRS-shim note).
+                Any proj4 / WKT / authority string ``pyproj`` understands.
+            wcs_format: Optional GDAL ``PreferredFormat`` for the ``GetCoverage``
+                response (e.g. ``"GEOTIFF_INT16"``). ``None`` lets GDAL pick from
+                the coverage's advertised formats.
+            output: Optional path to also write the result to as a GeoTIFF. The
+                method still returns the :class:`Dataset`.
+            resample: Resampling method for the ``output_crs`` / ``resolution``
+                warp. Defaults to ``"nearest"``.
+            auth: Optional ``(username, password)`` for Basic-authed services.
+            timeout: HTTP timeout in seconds for the metadata / coverage
+                requests. Defaults to ``60.0``.
+            extra_params: Optional extra ``GetCoverage`` query parameters folded
+                into the request (a workaround hook for server quirks).
+
+        Returns:
+            Dataset: The fetched coverage subset.
+
+        Raises:
+            ValueError: ``bbox`` is malformed, ``coverage`` is not advertised, or
+                ``coverage_crs`` cannot be interpreted.
+            pyramids.errors.WCSError: The server could not be reached or returned
+                an error / a non-raster (``<ows:ExceptionReport>``) body.
+
+        Examples:
+            Read a Netherlands subset of SoilGrids nitrogen (its native CRS needs
+            the ``coverage_crs`` shim):
+
+            ```python
+            >>> ds = Dataset.from_wcs(  # doctest: +SKIP
+            ...     "https://maps.isric.org/mapserv?map=/map/nitrogen.map",
+            ...     coverage="nitrogen_0-5cm_mean",
+            ...     bbox=(5.0, 51.0, 6.0, 52.0),
+            ...     coverage_crs="+proj=igh +lat_0=0 +lon_0=0 +datum=WGS84 +units=m +no_defs",
+            ... )
+
+            ```
+
+        See Also:
+            - :meth:`read_file`: open a raster from a path or URL.
+            - :meth:`from_bytes`: open a raster already held in memory.
+        """
+        return _from_wcs(
+            cls,
+            endpoint,
+            coverage=coverage,
+            bbox=bbox,
+            crs=crs,
+            output_crs=output_crs,
+            resolution=resolution,
+            version=version,
+            coverage_crs=coverage_crs,
+            wcs_format=wcs_format,
+            output=output,
+            resample=resample,
+            auth=auth,
+            timeout=timeout,
+            extra_params=extra_params,
+        )
 
     def copy(self, path: str | Path | None = None) -> Dataset:
         """Deep copy.

--- a/src/pyramids/errors.py
+++ b/src/pyramids/errors.py
@@ -36,6 +36,7 @@ from pyramids.base._errors import (
     OutOfBoundsError,
     ReadOnlyError,
     VectorDriverError,
+    WCSError,
 )
 from pyramids.base._errors import _PyramidsError as PyramidsError
 
@@ -54,4 +55,5 @@ __all__ = [
     "OutOfBoundsError",
     "ReadOnlyError",
     "VectorDriverError",
+    "WCSError",
 ]

--- a/tests/dataset/test_wcs.py
+++ b/tests/dataset/test_wcs.py
@@ -28,7 +28,7 @@ from osgeo import gdal, osr
 from pyramids.dataset import Dataset
 from pyramids.dataset import _wcs
 from pyramids.errors import WCSError
-from tests.dataset.wcs_mock_server import EXCEPTION_REPORT, WcsMock
+from tests.dataset.wcs_mock_server import WcsMock
 
 CAPS_2_0_1 = """<?xml version="1.0" encoding="UTF-8"?>
 <wcs:Capabilities xmlns:wcs="http://www.opengis.net/wcs/2.0"
@@ -117,10 +117,10 @@ class TestPureHelpers:
         assert _wcs._localname("name") == "name"
 
     def test_capabilities_url_appends_correctly(self):
-        with_q = _wcs._capabilities_url("http://h/mapserv?map=/m.map", None)
-        assert with_q == "http://h/mapserv?map=/m.map&SERVICE=WCS&REQUEST=GetCapabilities"
-        no_q = _wcs._capabilities_url("http://h/wcs", "2.0.1")
-        assert no_q == "http://h/wcs?SERVICE=WCS&REQUEST=GetCapabilities&VERSION=2.0.1"
+        with_q = _wcs._capabilities_url("https://h/mapserv?map=/m.map", None)
+        assert with_q == "https://h/mapserv?map=/m.map&SERVICE=WCS&REQUEST=GetCapabilities"
+        no_q = _wcs._capabilities_url("https://h/wcs", "2.0.1")
+        assert no_q == "https://h/wcs?SERVICE=WCS&REQUEST=GetCapabilities&VERSION=2.0.1"
 
     def test_looks_like_raster(self):
         assert _wcs._looks_like_raster(b"II*\x00rest")
@@ -130,7 +130,7 @@ class TestPureHelpers:
 
     def test_service_descriptor(self):
         xml = _wcs._service_descriptor(
-            "http://h/mapserv?map=/m.map", "cov", "2.0.1", "GEOTIFF_INT16", {"FOO": "bar"}
+            "https://h/mapserv?map=/m.map", "cov", "2.0.1", "GEOTIFF_INT16", {"FOO": "bar"}
         )
         assert "<CoverageName>cov</CoverageName>" in xml
         assert "<Version>2.0.1</Version>" in xml
@@ -141,7 +141,7 @@ class TestPureHelpers:
         assert "map=/m.map" in xml
 
     def test_service_descriptor_minimal(self):
-        xml = _wcs._service_descriptor("http://h", "cov", None, None, None)
+        xml = _wcs._service_descriptor("https://h", "cov", None, None, None)
         assert "<Version>" not in xml
         assert "<PreferredFormat>" not in xml
         assert "<GetCoverageExtra>" not in xml

--- a/tests/dataset/test_wcs.py
+++ b/tests/dataset/test_wcs.py
@@ -229,7 +229,7 @@ class TestCapabilities:
 
         monkeypatch.setattr(_wcs.urllib.request.OpenerDirector, "open", boom)
         with pytest.raises(WCSError, match="request failed"):
-            _wcs._get_capabilities("http://wcs.invalid/x", None, None, 5.0)
+            _wcs._get_capabilities("https://wcs.invalid/x", None, None, 5.0)
 
     def test_exception_text_falls_back_without_exception_element(self):
         """_exception_text returns body text, or a default when nothing is present."""

--- a/tests/dataset/test_wcs.py
+++ b/tests/dataset/test_wcs.py
@@ -122,12 +122,6 @@ class TestPureHelpers:
         no_q = _wcs._capabilities_url("https://h/wcs", "2.0.1")
         assert no_q == "https://h/wcs?SERVICE=WCS&REQUEST=GetCapabilities&VERSION=2.0.1"
 
-    def test_looks_like_raster(self):
-        assert _wcs._looks_like_raster(b"II*\x00rest")
-        assert _wcs._looks_like_raster(b"MM\x00*rest")
-        assert _wcs._looks_like_raster(b"\x89HDF....")
-        assert not _wcs._looks_like_raster(b"<?xml version")
-
     def test_service_descriptor(self):
         xml = _wcs._service_descriptor(
             "https://h/mapserv?map=/m.map", "cov", "2.0.1", "GEOTIFF_INT16", {"FOO": "bar"}

--- a/tests/dataset/test_wcs.py
+++ b/tests/dataset/test_wcs.py
@@ -28,6 +28,7 @@ from osgeo import gdal, osr
 from pyramids.dataset import Dataset
 from pyramids.dataset import _wcs
 from pyramids.errors import WCSError
+from tests.dataset.wcs_mock_server import EXCEPTION_REPORT, WcsMock
 
 CAPS_2_0_1 = """<?xml version="1.0" encoding="UTF-8"?>
 <wcs:Capabilities xmlns:wcs="http://www.opengis.net/wcs/2.0"
@@ -245,6 +246,68 @@ class TestFromWcsValidation:
         monkeypatch.setattr(_wcs.gdal, "Translate", boom)
         with pytest.raises(WCSError, match="GetCoverage failed"):
             _wcs._translate_window(object(), [0, 1, 1, 0], "cov")
+
+
+class TestDriverFullCycle:
+    """Offline end-to-end against a mock that drives GDAL's WCS driver fully."""
+
+    def test_1_0_0_returns_dataset_and_uses_bbox_shape(self):
+        with WcsMock(version="1.0.0") as server:
+            ds = Dataset.from_wcs(
+                server.url, coverage="test_cov", bbox=(2.0, 2.0, 4.0, 4.0), version="1.0.0"
+            )
+            assert ds.shape == (1, 20, 20)
+            assert ds.epsg == 4326
+            assert [round(v, 3) for v in ds.geotransform] == [2.0, 0.1, 0.0, 4.0, 0.0, -0.1]
+            getcov = server.getcoverage_requests()[-1].lower()
+            assert "bbox=" in getcov  # 1.0.0 call shape
+            assert "subset=" not in getcov
+
+    def test_2_0_1_returns_dataset_and_uses_subset_shape(self):
+        with WcsMock(version="2.0.1") as server:
+            ds = Dataset.from_wcs(
+                server.url, coverage="test_cov", bbox=(2.0, 2.0, 4.0, 4.0), version="2.0.1"
+            )
+            assert ds.shape == (1, 20, 20)
+            getcov = server.getcoverage_requests()[-1].lower()
+            assert "coverageid=test_cov" in getcov  # 2.0.x call shape
+            assert "subset=" in getcov
+            assert "bbox=" not in getcov
+
+    def test_returned_raster_is_readable(self):
+        with WcsMock(version="2.0.1") as server:
+            ds = Dataset.from_wcs(
+                server.url, coverage="test_cov", bbox=(2.0, 2.0, 4.0, 4.0), version="2.0.1"
+            )
+            arr = ds.read_array()
+            assert arr.shape == (20, 20)
+            assert arr[0, 0] == 0 and arr[1, 1] == 2  # synthetic (row+col) pattern
+
+    def test_output_writes_a_reopenable_file(self, tmp_path):
+        out = tmp_path / "wcs_out.tif"
+        with WcsMock(version="1.0.0") as server:
+            Dataset.from_wcs(
+                server.url,
+                coverage="test_cov",
+                bbox=(2.0, 2.0, 4.0, 4.0),
+                version="1.0.0",
+                output=out,
+            )
+        assert out.exists()
+        assert Dataset.read_file(str(out)).shape == (1, 20, 20)
+
+    def test_exception_report_on_getcoverage_raises_and_writes_nothing(self, tmp_path):
+        out = tmp_path / "should_not_exist.tif"
+        with WcsMock(version="2.0.1", getcoverage_body=EXCEPTION_REPORT) as server:
+            with pytest.raises(WCSError):
+                Dataset.from_wcs(
+                    server.url,
+                    coverage="test_cov",
+                    bbox=(2.0, 2.0, 4.0, 4.0),
+                    version="2.0.1",
+                    output=out,
+                )
+        assert not out.exists()
 
 
 @pytest.mark.slow

--- a/tests/dataset/test_wcs.py
+++ b/tests/dataset/test_wcs.py
@@ -1,0 +1,277 @@
+"""Tests for the OGC WCS reader (`pyramids.dataset._wcs` / `Dataset.from_wcs`).
+
+Network-free. The successful ``GetCoverage`` path drives GDAL's native WCS
+driver, which needs a protocol-faithful ``DescribeCoverage`` + ``GetCoverage``
+mock; that fixture is a follow-up. What is covered here without GDAL's driver:
+
+* every pure helper (bbox / resolution / descriptor / CRS shim / projWin),
+* the capabilities fetch + parse + LRU cache (via a stdlib mock server),
+* the unknown-coverage ``ValueError`` and the ``<ows:ExceptionReport>``
+  ``WCSError`` — both reachable through ``Dataset.from_wcs`` because coverage
+  validation runs before GDAL is opened.
+
+A gated live end-to-end against SoilGrids runs only when ``PYRAMIDS_WCS_LIVE``
+is set, so normal CI stays offline.
+"""
+
+from __future__ import annotations
+
+import http.server
+import os
+import socketserver
+import threading
+from collections import Counter
+
+import pytest
+from osgeo import gdal, osr
+
+from pyramids.dataset import Dataset
+from pyramids.dataset import _wcs
+from pyramids.errors import WCSError
+
+CAPS_2_0_1 = """<?xml version="1.0" encoding="UTF-8"?>
+<wcs:Capabilities xmlns:wcs="http://www.opengis.net/wcs/2.0"
+                  xmlns:ows="http://www.opengis.net/ows/2.0" version="2.0.1">
+  <ows:ServiceIdentification>
+    <ows:ServiceTypeVersion>2.0.1</ows:ServiceTypeVersion>
+    <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+  </ows:ServiceIdentification>
+  <wcs:Contents>
+    <wcs:CoverageSummary><wcs:CoverageId>nitrogen_0-5cm_mean</wcs:CoverageId></wcs:CoverageSummary>
+    <wcs:CoverageSummary><wcs:CoverageId>nitrogen_5-15cm_mean</wcs:CoverageId></wcs:CoverageSummary>
+  </wcs:Contents>
+</wcs:Capabilities>
+"""
+
+EXCEPTION_REPORT = """<?xml version="1.0" encoding="UTF-8"?>
+<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/2.0" version="2.0.1">
+  <ows:Exception exceptionCode="NoApplicableCode">
+    <ows:ExceptionText>msWCSGetCapabilities(): WCS server error.</ows:ExceptionText>
+  </ows:Exception>
+</ows:ExceptionReport>
+"""
+
+
+@pytest.fixture(autouse=True)
+def _clear_caps_cache():
+    """Isolate the module-level capabilities LRU cache between tests."""
+    _wcs._get_capabilities.cache_clear()
+    yield
+    _wcs._get_capabilities.cache_clear()
+
+
+def _make_server(body: str, content_type: str = "application/xml"):
+    """Start a local HTTP server returning `body` for every GET; yield (url, counter)."""
+    counter: Counter[str] = Counter()
+    payload = body.encode("utf-8")
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            counter["GET"] += 1
+            self.send_response(200)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *args, **kwargs):  # noqa: N802
+            return
+
+    httpd = socketserver.ThreadingTCPServer(("127.0.0.1", 0), Handler)
+    port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    url = f"http://127.0.0.1:{port}/mapserv?map=/map/nitrogen.map"
+    return url, counter, httpd
+
+
+@pytest.fixture
+def caps_server():
+    """A mock server serving the 2.0.1 GetCapabilities document."""
+    url, counter, httpd = _make_server(CAPS_2_0_1)
+    yield url, counter
+    httpd.shutdown()
+    httpd.server_close()
+
+
+class TestPureHelpers:
+    def test_validate_bbox_ok(self):
+        assert _wcs._validate_bbox((5.0, 51.0, 6.0, 52.0)) == (5.0, 51.0, 6.0, 52.0)
+
+    @pytest.mark.parametrize(
+        "bad",
+        [(1, 2, 3), (6.0, 51.0, 5.0, 52.0), (5.0, 52.0, 6.0, 51.0)],
+    )
+    def test_validate_bbox_rejects(self, bad):
+        with pytest.raises(ValueError):
+            _wcs._validate_bbox(bad)
+
+    def test_resolution_pair(self):
+        assert _wcs._resolution_pair(None) is None
+        assert _wcs._resolution_pair(250) == (250.0, 250.0)
+        assert _wcs._resolution_pair((250, 500)) == (250.0, 500.0)
+
+    def test_localname(self):
+        assert _wcs._localname("{http://www.opengis.net/wcs/2.0}CoverageId") == "CoverageId"
+        assert _wcs._localname("name") == "name"
+
+    def test_capabilities_url_appends_correctly(self):
+        with_q = _wcs._capabilities_url("http://h/mapserv?map=/m.map", None)
+        assert with_q == "http://h/mapserv?map=/m.map&SERVICE=WCS&REQUEST=GetCapabilities"
+        no_q = _wcs._capabilities_url("http://h/wcs", "2.0.1")
+        assert no_q == "http://h/wcs?SERVICE=WCS&REQUEST=GetCapabilities&VERSION=2.0.1"
+
+    def test_looks_like_raster(self):
+        assert _wcs._looks_like_raster(b"II*\x00rest")
+        assert _wcs._looks_like_raster(b"MM\x00*rest")
+        assert _wcs._looks_like_raster(b"\x89HDF....")
+        assert not _wcs._looks_like_raster(b"<?xml version")
+
+    def test_service_descriptor(self):
+        xml = _wcs._service_descriptor(
+            "http://h/mapserv?map=/m.map", "cov", "2.0.1", "GEOTIFF_INT16", {"FOO": "bar"}
+        )
+        assert "<CoverageName>cov</CoverageName>" in xml
+        assert "<Version>2.0.1</Version>" in xml
+        assert "<PreferredFormat>GEOTIFF_INT16</PreferredFormat>" in xml
+        assert "&amp;FOO=bar" in xml
+        # the ampersand in the ServiceURL query string is escaped
+        assert "&amp;SERVICE" not in xml  # no SERVICE param injected here
+        assert "map=/m.map" in xml
+
+    def test_service_descriptor_minimal(self):
+        xml = _wcs._service_descriptor("http://h", "cov", None, None, None)
+        assert "<Version>" not in xml
+        assert "<PreferredFormat>" not in xml
+        assert "<GetCoverageExtra>" not in xml
+
+    def test_gdal_http_config(self):
+        assert _wcs._gdal_http_config(None, 60.0) == {"GDAL_HTTP_TIMEOUT": "60"}
+        cfg = _wcs._gdal_http_config(("u", "p"), 30.0)
+        assert cfg["GDAL_HTTP_USERPWD"] == "u:p"
+        assert cfg["GDAL_HTTP_TIMEOUT"] == "30"
+
+
+class TestNativeCrsShim:
+    def _mem(self, with_srs: bool):
+        ds = gdal.GetDriverByName("MEM").Create("", 4, 4, 1, gdal.GDT_Int16)
+        if with_srs:
+            srs = osr.SpatialReference()
+            srs.ImportFromEPSG(4326)
+            ds.SetSpatialRef(srs)
+        return ds
+
+    def test_uses_server_srs_when_present(self):
+        srs = _wcs._resolve_native_srs(self._mem(with_srs=True), None)
+        assert srs.GetAuthorityCode(None) == "4326"
+
+    def test_requires_coverage_crs_when_missing(self):
+        with pytest.raises(WCSError, match="coverage_crs"):
+            _wcs._resolve_native_srs(self._mem(with_srs=False), None)
+
+    def test_applies_coverage_crs_shim(self):
+        igh = "+proj=igh +lat_0=0 +lon_0=0 +datum=WGS84 +units=m +no_defs"
+        srs = _wcs._resolve_native_srs(self._mem(with_srs=False), igh)
+        assert "igh" in srs.ExportToProj4()
+
+    def test_rejects_bad_coverage_crs(self):
+        with pytest.raises(ValueError, match="coverage_crs"):
+            _wcs._resolve_native_srs(self._mem(with_srs=False), "not-a-crs!!!")
+
+    def test_native_projwin_reprojects_bbox(self):
+        igh = osr.SpatialReference()
+        igh.ImportFromProj4("+proj=igh +lat_0=0 +lon_0=0 +datum=WGS84 +units=m +no_defs")
+        ulx, uly, lrx, lry = _wcs._native_projwin((5.0, 51.0, 6.0, 52.0), "EPSG:4326", igh)
+        # Netherlands lands ~1.4-1.6 Mm east, ~5.6-5.7 Mm north in IGH metres
+        assert 1.4e6 < ulx < 1.6e6
+        assert 5.6e6 < uly < 5.8e6
+        assert ulx < lrx and uly > lry  # ul/lr ordering
+
+
+class TestCapabilities:
+    def test_parses_versions_and_coverages(self, caps_server):
+        url, _ = caps_server
+        versions, coverages = _wcs._get_capabilities(url, None, None, 30.0)
+        assert "2.0.1" in versions and "1.0.0" in versions
+        assert "nitrogen_0-5cm_mean" in coverages
+        assert "nitrogen_5-15cm_mean" in coverages
+
+    def test_lru_cache_one_fetch_per_endpoint(self, caps_server):
+        url, counter = caps_server
+        _wcs._get_capabilities(url, None, None, 30.0)
+        _wcs._get_capabilities(url, None, None, 30.0)
+        assert counter["GET"] == 1
+
+    def test_exception_report_raises_wcserror(self):
+        url, _, httpd = _make_server(EXCEPTION_REPORT)
+        try:
+            with pytest.raises(WCSError, match="WCS server error"):
+                _wcs._get_capabilities(url, None, None, 30.0)
+        finally:
+            httpd.shutdown()
+            httpd.server_close()
+
+    def test_non_xml_body_raises_wcserror(self):
+        url, _, httpd = _make_server("not xml at all", content_type="text/plain")
+        try:
+            with pytest.raises(WCSError, match="non-XML"):
+                _wcs._get_capabilities(url, None, None, 30.0)
+        finally:
+            httpd.shutdown()
+            httpd.server_close()
+
+
+class TestFromWcsValidation:
+    def test_unknown_coverage_raises_valueerror(self, caps_server):
+        url, _ = caps_server
+        with pytest.raises(ValueError, match="not advertised"):
+            Dataset.from_wcs(url, coverage="does_not_exist", bbox=(5.0, 51.0, 6.0, 52.0))
+
+    def test_bad_bbox_raises_before_network(self):
+        with pytest.raises(ValueError, match="minx < maxx"):
+            Dataset.from_wcs(
+                "http://127.0.0.1:1/wcs", coverage="cov", bbox=(6.0, 51.0, 5.0, 52.0)
+            )
+
+    def test_translate_window_none_raises(self, monkeypatch):
+        monkeypatch.setattr(_wcs.gdal, "Translate", lambda *a, **k: None)
+        with pytest.raises(WCSError, match="no raster"):
+            _wcs._translate_window(object(), [0, 1, 1, 0], "cov")
+
+    def test_translate_window_runtimeerror_raises(self, monkeypatch):
+        def boom(*a, **k):
+            raise RuntimeError("server said no")
+
+        monkeypatch.setattr(_wcs.gdal, "Translate", boom)
+        with pytest.raises(WCSError, match="GetCoverage failed"):
+            _wcs._translate_window(object(), [0, 1, 1, 0], "cov")
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not os.environ.get("PYRAMIDS_WCS_LIVE"),
+    reason="live network test; set PYRAMIDS_WCS_LIVE=1 to run",
+)
+class TestLiveSoilGrids:
+    ENDPOINT = "https://maps.isric.org/mapserv?map=/map/nitrogen.map"
+    IGH = "+proj=igh +lat_0=0 +lon_0=0 +datum=WGS84 +units=m +no_defs"
+
+    def test_native_read(self):
+        ds = Dataset.from_wcs(
+            self.ENDPOINT,
+            coverage="nitrogen_0-5cm_mean",
+            bbox=(5.0, 51.0, 6.0, 52.0),
+            coverage_crs=self.IGH,
+        )
+        assert ds.shape[0] == 1
+        assert "igh" in ds.raster.GetSpatialRef().ExportToProj4()
+
+    def test_output_crs_reproject(self):
+        ds = Dataset.from_wcs(
+            self.ENDPOINT,
+            coverage="nitrogen_0-5cm_mean",
+            bbox=(5.0, 51.0, 6.0, 52.0),
+            coverage_crs=self.IGH,
+            output_crs="EPSG:4326",
+        )
+        assert ds.epsg == 4326

--- a/tests/dataset/test_wcs.py
+++ b/tests/dataset/test_wcs.py
@@ -215,6 +215,47 @@ class TestCapabilities:
             httpd.shutdown()
             httpd.server_close()
 
+    def test_auth_wires_a_basic_auth_handler(self, caps_server):
+        """Passing auth installs an HTTP Basic-auth handler and still parses caps."""
+        url, _ = caps_server
+        _, coverages = _wcs._get_capabilities(url, None, ("user", "secret"), 30.0)
+        assert "nitrogen_0-5cm_mean" in coverages
+
+    def test_transport_failure_raises_wcserror(self, monkeypatch):
+        """A transport-level OSError from the opener surfaces as WCSError."""
+
+        def boom(self, *args, **kwargs):
+            raise OSError("connection refused")
+
+        monkeypatch.setattr(_wcs.urllib.request.OpenerDirector, "open", boom)
+        with pytest.raises(WCSError, match="request failed"):
+            _wcs._get_capabilities("http://wcs.invalid/x", None, None, 5.0)
+
+    def test_exception_text_falls_back_without_exception_element(self):
+        """_exception_text returns body text, or a default when nothing is present."""
+        body = _wcs.ET.fromstring("<ExceptionReport>broken upstream</ExceptionReport>")
+        assert _wcs._exception_text(body) == "broken upstream"
+        empty = _wcs.ET.fromstring("<ExceptionReport></ExceptionReport>")
+        assert _wcs._exception_text(empty) == "no message provided"
+
+
+class TestOpenService:
+    def test_gdal_runtimeerror_raises_wcserror(self, monkeypatch):
+        """A GDAL RuntimeError while opening the service becomes WCSError."""
+
+        def boom(_descriptor):
+            raise RuntimeError("gdal could not open")
+
+        monkeypatch.setattr(_wcs.gdal, "Open", boom)
+        with pytest.raises(WCSError, match="could not open WCS coverage"):
+            _wcs._open_service("<WCS_GDAL/>", "cov")
+
+    def test_gdal_none_raises_wcserror(self, monkeypatch):
+        """A None return from gdal.Open becomes WCSError."""
+        monkeypatch.setattr(_wcs.gdal, "Open", lambda _descriptor: None)
+        with pytest.raises(WCSError, match="no dataset"):
+            _wcs._open_service("<WCS_GDAL/>", "cov")
+
 
 class TestFromWcsValidation:
     def test_unknown_coverage_raises_valueerror(self, caps_server):
@@ -302,6 +343,31 @@ class TestDriverFullCycle:
                     output=out,
                 )
         assert not out.exists()
+
+    def test_resolution_without_output_crs_resamples_in_native(self):
+        """A resolution with no output_crs resamples within the native CRS to a coarser grid."""
+        with WcsMock(version="1.0.0") as server:
+            ds = Dataset.from_wcs(
+                server.url,
+                coverage="test_cov",
+                bbox=(2.0, 2.0, 4.0, 4.0),
+                version="1.0.0",
+                resolution=0.2,
+            )
+            assert ds.epsg == 4326
+            assert ds.shape[1] < 20 and ds.shape[2] < 20  # coarser than the 0.1deg native 20x20
+
+    def test_output_crs_reprojects_offline(self):
+        """output_crs reprojects the fetched window into the requested CRS."""
+        with WcsMock(version="1.0.0") as server:
+            ds = Dataset.from_wcs(
+                server.url,
+                coverage="test_cov",
+                bbox=(2.0, 2.0, 4.0, 4.0),
+                version="1.0.0",
+                output_crs="EPSG:3857",
+            )
+            assert ds.epsg == 3857
 
 
 @pytest.mark.slow

--- a/tests/dataset/wcs_mock_server.py
+++ b/tests/dataset/wcs_mock_server.py
@@ -177,7 +177,8 @@ _DESCRIBE = {"1.0.0": DESCRIBE_100, "2.0.1": DESCRIBE_201}
 
 def _make_geotiff(width: int, height: int, minx: float, maxy: float) -> bytes:
     """Generate a native-resolution GeoTIFF tile for a window; return its bytes."""
-    ds = gdal.GetDriverByName("GTiff").Create("/vsimem/wcs_tile.tif", width, height, 1, gdal.GDT_Int16)
+    path = "/vsimem/wcs_tile.tif"
+    ds = gdal.GetDriverByName("GTiff").Create(path, width, height, 1, gdal.GDT_Int16)
     ds.SetGeoTransform((minx, _RES, 0, maxy, 0, -_RES))
     srs = osr.SpatialReference()
     srs.ImportFromEPSG(4326)
@@ -186,13 +187,13 @@ def _make_geotiff(width: int, height: int, minx: float, maxy: float) -> bytes:
     ds.GetRasterBand(1).SetNoDataValue(-32768)
     ds.FlushCache()
     ds = None
-    f = gdal.VSIFOpenL("/vsimem/wcs_tile.tif", "rb")
+    f = gdal.VSIFOpenL(path, "rb")
     gdal.VSIFSeekL(f, 0, 2)
     size = gdal.VSIFTellL(f)
     gdal.VSIFSeekL(f, 0, 0)
     data = gdal.VSIFReadL(1, size, f)
     gdal.VSIFCloseL(f)
-    gdal.Unlink("/vsimem/wcs_tile.tif")
+    gdal.Unlink(path)
     return data
 
 
@@ -236,12 +237,12 @@ def make_handler(version: str, getcoverage_body: str | None):
             qs = {k.lower(): v[0] for k, v in parse_qs(query).items()}
             request = qs.get("request", "").lower()
             if request == "getcapabilities":
-                self._send(_CAPS[version], "application/xml")
+                self._send(_CAPS[version])
             elif request == "describecoverage":
-                self._send(_DESCRIBE[version], "application/xml")
+                self._send(_DESCRIBE[version])
             elif request == "getcoverage":
                 if getcoverage_body is not None:
-                    self._send(getcoverage_body, "application/xml")
+                    self._send(getcoverage_body)
                     return
                 if version == "1.0.0":
                     w, h, minx, maxy = _window_from_bbox(qs)
@@ -251,7 +252,7 @@ def make_handler(version: str, getcoverage_body: str | None):
             else:
                 self.send_error(400, f"unknown request {request!r}")
 
-        def _send(self, body: str, content_type: str):
+        def _send(self, body: str, content_type: str = "application/xml"):
             self._send_bytes(body.encode("utf-8"), content_type)
 
         def _send_bytes(self, payload: bytes, content_type: str):

--- a/tests/dataset/wcs_mock_server.py
+++ b/tests/dataset/wcs_mock_server.py
@@ -1,0 +1,295 @@
+"""A protocol-faithful in-process OGC WCS server for driving GDAL's WCS driver.
+
+Used by ``tests/dataset/test_wcs.py`` to exercise the full
+``GetCapabilities → DescribeCoverage → GetCoverage`` cycle of
+:meth:`pyramids.dataset.Dataset.from_wcs` offline — no live network. The mock
+speaks both WCS dialects this matters for:
+
+* **1.0.0** — ``GetCoverage`` uses ``BBOX`` + ``WIDTH``/``HEIGHT``,
+* **2.0.1** — ``GetCoverage`` uses ``COVERAGEID`` + named-axis ``SUBSET``.
+
+The synthetic coverage ``test_cov`` is a 100×100 grid at 0.1° over lon/lat
+``[0, 10]`` (declared in CRS84 so GDAL builds a north-up geotransform). Each
+``GetCoverage`` is answered with a freshly generated GeoTIFF for the requested
+window, so the returned raster is real and openable.
+
+Every request path is recorded on the handler class, so a test can assert which
+dialect's ``GetCoverage`` shape GDAL emitted.
+"""
+
+from __future__ import annotations
+
+import http.server
+import socketserver
+import threading
+from urllib.parse import parse_qs, urlparse
+
+import numpy as np
+from osgeo import gdal, osr
+
+COVERAGE = "test_cov"
+_RES = 0.1
+_CRS84 = "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
+
+CAPS_100 = """<?xml version="1.0" encoding="UTF-8"?>
+<WCS_Capabilities version="1.0.0" xmlns="http://www.opengis.net/wcs"
+    xmlns:gml="http://www.opengis.net/gml" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <Service><name>mock</name><label>mock</label></Service>
+  <Capability/>
+  <ContentMetadata>
+    <CoverageOfferingBrief>
+      <name>test_cov</name>
+      <label>Test Coverage</label>
+      <lonLatEnvelope srsName="urn:ogc:def:crs:OGC:1.3:CRS84">
+        <gml:pos>0 0</gml:pos>
+        <gml:pos>10 10</gml:pos>
+      </lonLatEnvelope>
+    </CoverageOfferingBrief>
+  </ContentMetadata>
+</WCS_Capabilities>
+"""
+
+DESCRIBE_100 = """<?xml version="1.0" encoding="UTF-8"?>
+<CoverageDescription version="1.0.0" xmlns="http://www.opengis.net/wcs"
+    xmlns:gml="http://www.opengis.net/gml" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <CoverageOffering>
+    <name>test_cov</name>
+    <label>Test Coverage</label>
+    <lonLatEnvelope srsName="urn:ogc:def:crs:OGC:1.3:CRS84">
+      <gml:pos>0 0</gml:pos>
+      <gml:pos>10 10</gml:pos>
+    </lonLatEnvelope>
+    <domainSet>
+      <spatialDomain>
+        <gml:Envelope srsName="EPSG:4326">
+          <gml:pos>0 0</gml:pos>
+          <gml:pos>10 10</gml:pos>
+        </gml:Envelope>
+        <gml:RectifiedGrid dimension="2">
+          <gml:limits>
+            <gml:GridEnvelope>
+              <gml:low>0 0</gml:low>
+              <gml:high>99 99</gml:high>
+            </gml:GridEnvelope>
+          </gml:limits>
+          <gml:axisName>x</gml:axisName>
+          <gml:axisName>y</gml:axisName>
+          <gml:origin><gml:pos>0.05 9.95</gml:pos></gml:origin>
+          <gml:offsetVector>0.1 0</gml:offsetVector>
+          <gml:offsetVector>0 -0.1</gml:offsetVector>
+        </gml:RectifiedGrid>
+      </spatialDomain>
+    </domainSet>
+    <rangeSet>
+      <RangeSet><name>bands</name><label>bands</label></RangeSet>
+    </rangeSet>
+    <supportedCRSs>
+      <requestResponseCRSs>EPSG:4326</requestResponseCRSs>
+      <nativeCRSs>EPSG:4326</nativeCRSs>
+    </supportedCRSs>
+    <supportedFormats nativeFormat="GeoTIFF">
+      <formats>GeoTIFF</formats>
+    </supportedFormats>
+  </CoverageOffering>
+</CoverageDescription>
+"""
+
+CAPS_201 = """<?xml version="1.0" encoding="UTF-8"?>
+<wcs:Capabilities xmlns:wcs="http://www.opengis.net/wcs/2.0"
+    xmlns:ows="http://www.opengis.net/ows/2.0" version="2.0.1">
+  <ows:ServiceIdentification>
+    <ows:ServiceTypeVersion>2.0.1</ows:ServiceTypeVersion>
+  </ows:ServiceIdentification>
+  <wcs:ServiceMetadata>
+    <wcs:formatSupported>image/tiff</wcs:formatSupported>
+  </wcs:ServiceMetadata>
+  <wcs:Contents>
+    <wcs:CoverageSummary>
+      <wcs:CoverageId>test_cov</wcs:CoverageId>
+      <wcs:CoverageSubtype>RectifiedGridCoverage</wcs:CoverageSubtype>
+    </wcs:CoverageSummary>
+  </wcs:Contents>
+</wcs:Capabilities>
+"""
+
+DESCRIBE_201 = f"""<?xml version="1.0" encoding="UTF-8"?>
+<wcs:CoverageDescriptions xmlns:wcs="http://www.opengis.net/wcs/2.0"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmlcov="http://www.opengis.net/gmlcov/1.0"
+    xmlns:swe="http://www.opengis.net/swe/2.0">
+  <wcs:CoverageDescription gml:id="test_cov">
+    <gml:boundedBy>
+      <gml:Envelope srsName="{_CRS84}"
+          axisLabels="Long Lat" uomLabels="deg deg" srsDimension="2">
+        <gml:lowerCorner>0 0</gml:lowerCorner>
+        <gml:upperCorner>10 10</gml:upperCorner>
+      </gml:Envelope>
+    </gml:boundedBy>
+    <wcs:CoverageId>test_cov</wcs:CoverageId>
+    <gml:domainSet>
+      <gml:RectifiedGrid dimension="2" gml:id="grid_test_cov">
+        <gml:limits>
+          <gml:GridEnvelope>
+            <gml:low>0 0</gml:low>
+            <gml:high>99 99</gml:high>
+          </gml:GridEnvelope>
+        </gml:limits>
+        <gml:axisLabels>Long Lat</gml:axisLabels>
+        <gml:origin>
+          <gml:Point gml:id="p_test_cov" srsName="{_CRS84}">
+            <gml:pos>0.05 9.95</gml:pos>
+          </gml:Point>
+        </gml:origin>
+        <gml:offsetVector srsName="{_CRS84}">0.1 0</gml:offsetVector>
+        <gml:offsetVector srsName="{_CRS84}">0 -0.1</gml:offsetVector>
+      </gml:RectifiedGrid>
+    </gml:domainSet>
+    <gmlcov:rangeType>
+      <swe:DataRecord>
+        <swe:field name="band1">
+          <swe:Quantity>
+            <swe:uom code="unity"/>
+            <swe:constraint><swe:AllowedValues>
+              <swe:interval>-32768 32767</swe:interval>
+            </swe:AllowedValues></swe:constraint>
+          </swe:Quantity>
+        </swe:field>
+      </swe:DataRecord>
+    </gmlcov:rangeType>
+    <wcs:ServiceParameters>
+      <wcs:CoverageSubtype>RectifiedGridCoverage</wcs:CoverageSubtype>
+      <wcs:nativeFormat>image/tiff</wcs:nativeFormat>
+    </wcs:ServiceParameters>
+  </wcs:CoverageDescription>
+</wcs:CoverageDescriptions>
+"""
+
+EXCEPTION_REPORT = """<?xml version="1.0" encoding="UTF-8"?>
+<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/2.0" version="2.0.1">
+  <ows:Exception exceptionCode="NoApplicableCode">
+    <ows:ExceptionText>coverage extraction failed.</ows:ExceptionText>
+  </ows:Exception>
+</ows:ExceptionReport>
+"""
+
+_CAPS = {"1.0.0": CAPS_100, "2.0.1": CAPS_201}
+_DESCRIBE = {"1.0.0": DESCRIBE_100, "2.0.1": DESCRIBE_201}
+
+
+def _make_geotiff(width: int, height: int, minx: float, maxy: float) -> bytes:
+    """Generate a native-resolution GeoTIFF tile for a window; return its bytes."""
+    ds = gdal.GetDriverByName("GTiff").Create("/vsimem/wcs_tile.tif", width, height, 1, gdal.GDT_Int16)
+    ds.SetGeoTransform((minx, _RES, 0, maxy, 0, -_RES))
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(4326)
+    ds.SetProjection(srs.ExportToWkt())
+    ds.GetRasterBand(1).WriteArray(np.fromfunction(lambda r, c: (r + c).astype("int16"), (height, width)))
+    ds.GetRasterBand(1).SetNoDataValue(-32768)
+    ds.FlushCache()
+    ds = None
+    f = gdal.VSIFOpenL("/vsimem/wcs_tile.tif", "rb")
+    gdal.VSIFSeekL(f, 0, 2)
+    size = gdal.VSIFTellL(f)
+    gdal.VSIFSeekL(f, 0, 0)
+    data = gdal.VSIFReadL(1, size, f)
+    gdal.VSIFCloseL(f)
+    gdal.Unlink("/vsimem/wcs_tile.tif")
+    return data
+
+
+def _window_from_subsets(query: str) -> tuple[int, int, float, float]:
+    """Derive (width, height, minx, maxy) from WCS 2.0.x named-axis SUBSETs."""
+    raw = parse_qs(query)
+    subsets = [v for k, vs in raw.items() if k.lower() == "subset" for v in vs]
+    bounds: dict[str, tuple[float, float]] = {}
+    for s in subsets:
+        axis, rng = s.split("(")
+        lo, hi = (float(v) for v in rng.rstrip(")").split(","))
+        bounds[axis.lower()] = (lo, hi)
+    lon = bounds.get("long", bounds.get("lon", (0.0, 10.0)))
+    lat = bounds.get("lat", (0.0, 10.0))
+    width = max(1, round((lon[1] - lon[0]) / _RES))
+    height = max(1, round((lat[1] - lat[0]) / _RES))
+    return width, height, lon[0], lat[1]
+
+
+def _window_from_bbox(qs: dict[str, str]) -> tuple[int, int, float, float]:
+    """Derive (width, height, minx, maxy) from a WCS 1.0.0 BBOX + WIDTH/HEIGHT."""
+    minx, miny, maxx, maxy = (float(v) for v in qs["bbox"].split(","))
+    width = int(qs.get("width", str(max(1, round((maxx - minx) / _RES)))))
+    height = int(qs.get("height", str(max(1, round((maxy - miny) / _RES)))))
+    return width, height, minx, maxy
+
+
+def make_handler(version: str, getcoverage_body: str | None):
+    """Build a request handler class for `version`, recording every request path.
+
+    When `getcoverage_body` is given, ``GetCoverage`` returns that XML body with
+    HTTP 200 instead of a raster — used to test ``<ows:ExceptionReport>`` handling.
+    """
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        requests: list[str] = []
+
+        def do_GET(self):  # noqa: N802
+            type(self).requests.append(self.path)
+            query = urlparse(self.path).query
+            qs = {k.lower(): v[0] for k, v in parse_qs(query).items()}
+            request = qs.get("request", "").lower()
+            if request == "getcapabilities":
+                self._send(_CAPS[version], "application/xml")
+            elif request == "describecoverage":
+                self._send(_DESCRIBE[version], "application/xml")
+            elif request == "getcoverage":
+                if getcoverage_body is not None:
+                    self._send(getcoverage_body, "application/xml")
+                    return
+                if version == "1.0.0":
+                    w, h, minx, maxy = _window_from_bbox(qs)
+                else:
+                    w, h, minx, maxy = _window_from_subsets(query)
+                self._send_bytes(_make_geotiff(w, h, minx, maxy), "image/tiff")
+            else:
+                self.send_error(400, f"unknown request {request!r}")
+
+        def _send(self, body: str, content_type: str):
+            self._send_bytes(body.encode("utf-8"), content_type)
+
+        def _send_bytes(self, payload: bytes, content_type: str):
+            self.send_response(200)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *args, **kwargs):  # noqa: N802
+            return
+
+    Handler.requests = []
+    return Handler
+
+
+class WcsMock:
+    """A running mock WCS server. Use as a context manager; `url` is the endpoint."""
+
+    def __init__(self, version: str = "2.0.1", getcoverage_body: str | None = None):
+        self._handler = make_handler(version, getcoverage_body)
+        self._httpd = socketserver.ThreadingTCPServer(("127.0.0.1", 0), self._handler)
+        port = self._httpd.server_address[1]
+        self.url = f"http://127.0.0.1:{port}/wcs"
+        self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+
+    @property
+    def requests(self) -> list[str]:
+        return self._handler.requests
+
+    def getcoverage_requests(self) -> list[str]:
+        return [r for r in self.requests if "getcoverage" in r.lower()]
+
+    def __enter__(self) -> "WcsMock":
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc):
+        self._httpd.shutdown()
+        self._httpd.server_close()

--- a/tests/dataset/wcs_mock_server.py
+++ b/tests/dataset/wcs_mock_server.py
@@ -29,7 +29,6 @@ from osgeo import gdal, osr
 
 COVERAGE = "test_cov"
 _RES = 0.1
-_CRS84 = "http://www.opengis.net/def/crs/OGC/1.3/CRS84"
 
 CAPS_100 = """<?xml version="1.0" encoding="UTF-8"?>
 <WCS_Capabilities version="1.0.0" xmlns="http://www.opengis.net/wcs"
@@ -112,14 +111,14 @@ CAPS_201 = """<?xml version="1.0" encoding="UTF-8"?>
 </wcs:Capabilities>
 """
 
-DESCRIBE_201 = f"""<?xml version="1.0" encoding="UTF-8"?>
+DESCRIBE_201 = """<?xml version="1.0" encoding="UTF-8"?>
 <wcs:CoverageDescriptions xmlns:wcs="http://www.opengis.net/wcs/2.0"
     xmlns:gml="http://www.opengis.net/gml/3.2"
     xmlns:gmlcov="http://www.opengis.net/gmlcov/1.0"
     xmlns:swe="http://www.opengis.net/swe/2.0">
   <wcs:CoverageDescription gml:id="test_cov">
     <gml:boundedBy>
-      <gml:Envelope srsName="{_CRS84}"
+      <gml:Envelope srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"
           axisLabels="Long Lat" uomLabels="deg deg" srsDimension="2">
         <gml:lowerCorner>0 0</gml:lowerCorner>
         <gml:upperCorner>10 10</gml:upperCorner>
@@ -136,12 +135,12 @@ DESCRIBE_201 = f"""<?xml version="1.0" encoding="UTF-8"?>
         </gml:limits>
         <gml:axisLabels>Long Lat</gml:axisLabels>
         <gml:origin>
-          <gml:Point gml:id="p_test_cov" srsName="{_CRS84}">
+          <gml:Point gml:id="p_test_cov" srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84">
             <gml:pos>0.05 9.95</gml:pos>
           </gml:Point>
         </gml:origin>
-        <gml:offsetVector srsName="{_CRS84}">0.1 0</gml:offsetVector>
-        <gml:offsetVector srsName="{_CRS84}">0 -0.1</gml:offsetVector>
+        <gml:offsetVector srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84">0.1 0</gml:offsetVector>
+        <gml:offsetVector srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84">0 -0.1</gml:offsetVector>
       </gml:RectifiedGrid>
     </gml:domainSet>
     <gmlcov:rangeType>


### PR DESCRIPTION
# Description

Adds a version-normalising OGC **Web Coverage Service (WCS)** reader, exposed as the
`Dataset.from_wcs(...)` classmethod and implemented in a new `pyramids/dataset/_wcs.py`. It fetches a windowed
coverage subset from a WCS server and returns a single-raster `Dataset`.

The transport is **GDAL's native WCS driver** — no `owslib`, no `rasterio`. GDAL performs
`GetCapabilities` / `DescribeCoverage`, negotiates the protocol version, and issues the version-correct
`GetCoverage` (the `1.0.0` `BBOX` + `WIDTH/HEIGHT` form vs the `2.0.x` named-axis `SUBSET` form), so the caller
always supplies one lon/lat `bbox` plus optional `resolution` / `output_crs`.

Two things GDAL does not handle on its own are added on top:

- **CRS shim** — some servers (e.g. ISRIC SoilGrids) advertise a coverage CRS under an authority code absent
  from the local PROJ database (`EPSG:152160`, a custom Interrupted Goode Homolosine). GDAL then opens the
  coverage with no spatial reference; the caller passes `coverage_crs` and it is attached client-side.
- **Client-side bbox reprojection** — the lon/lat `bbox` is transformed into the coverage's native CRS with
  `pyproj` (already a core dependency) before the request, so subsetting lands on the correct pixels even when the
  server only honours its native CRS.

`GetCapabilities` is fetched and parsed once per endpoint (LRU-cached); an unadvertised coverage raises
`ValueError` before GDAL is opened, and an `<ows:ExceptionReport>` body raises the new `WCSError`. The windowed
read goes through an in-memory dataset, so a non-raster error body can never be written to a `.tif`.

**No new dependencies:** GDAL handles transport + decode, `pyproj` (core) the CRS transform, and `Dataset`
the warp / IO.

Scope rationale and a live spike against SoilGrids (which proved the GDAL-native path and surfaced the
`EPSG:152160` CRS issue) are documented in the issue thread.

> **Stacked PR.** Base branch is `refactor/str-1-netcdf-engines` (#627), so this diff is only the two WCS
> commits. GitHub will auto-retarget this PR to `main` once #627 merges.

# Issues

- Closes #626 — `pyramids.wcs` version-normalising OGC WCS reader

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

`tests/dataset/test_wcs.py` — 29 offline tests pass, plus 2 gated live tests:

- [x] **Pure helpers** — bbox / resolution validation, descriptor build, capabilities URL, raster-magic
  sniffing, the CRS shim (server CRS / `coverage_crs` override / bad-CRS rejection), and bbox→native `projWin`
  reprojection.
- [x] **Capabilities** — parse versions + coverages, single-fetch LRU cache, `<ows:ExceptionReport>` and
  non-XML bodies → `WCSError`; unknown coverage → `ValueError`.
- [x] **Full GDAL-driver cycle (offline)** — a protocol-faithful mock server
  (`tests/dataset/wcs_mock_server.py`) drives GDAL through `GetCapabilities → DescribeCoverage → GetCoverage`
  for both dialects: a `1.0.0` read asserting the `BBOX` call shape, a `2.0.1` read asserting the
  `COVERAGEID` + `SUBSET` call shape, a readable returned raster, `output=` writing a reopenable file, and an
  `ExceptionReport` on `GetCoverage` raising `WCSError` with no file written.
- [x] **Live SoilGrids** (gated behind `PYRAMIDS_WCS_LIVE=1`) — native IGH read returns valid pixels with the
  correct proj4 attached; `output_crs="EPSG:4326"` reprojects to degrees.

Run: `pixi run -e dev pytest tests/dataset/test_wcs.py` (add `PYRAMIDS_WCS_LIVE=1` for the live cases).

# Checklist:

- [ ] updated version number in pyproject.toml. *(handled by commitizen in CI)*
- [ ] added changes to History.rst. *(changelog is commitizen-generated)*
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated. *(rich docstrings added; a reference page is a follow-up)*
