### PR TITLE
feat(feature): add FeatureCollection.from_wfs OGC Web Feature Service reader

### DIFF
--- a/src/pyramids/base/_errors.py
+++ b/src/pyramids/base/_errors.py
@@ -159,6 +159,23 @@ class WCSError(_PyramidsError):
     """
 
 
+class WFSError(_PyramidsError):
+    """A failure talking to an OGC Web Feature Service (WFS).
+
+    Raised by :meth:`pyramids.feature.FeatureCollection.from_wfs` (implementation
+    in :mod:`pyramids.feature._wfs`) when the server cannot be reached, the
+    feature type cannot be fetched, or the server answers with an
+    ``<ows:ExceptionReport>`` / ``<ServiceExceptionReport>`` body instead of
+    features. WFS servers commonly return such errors as **HTTP 200 +
+    ``application/xml``**, so this is raised even when the transport succeeded.
+
+    A *missing* feature type (one not advertised by ``GetCapabilities``) raises a
+    plain :class:`ValueError` instead, mirroring how the rest of pyramids reports
+    a bad argument as opposed to a service failure. This is the vector sibling of
+    :class:`WCSError`.
+    """
+
+
 class GeometryWarning(UserWarning):
     """Pyramids-emitted warning about geometry validity / degeneracy.
 

--- a/src/pyramids/errors.py
+++ b/src/pyramids/errors.py
@@ -37,6 +37,7 @@ from pyramids.base._errors import (
     ReadOnlyError,
     VectorDriverError,
     WCSError,
+    WFSError,
 )
 from pyramids.base._errors import _PyramidsError as PyramidsError
 
@@ -56,4 +57,5 @@ __all__ = [
     "ReadOnlyError",
     "VectorDriverError",
     "WCSError",
+    "WFSError",
 ]

--- a/src/pyramids/feature/_wfs.py
+++ b/src/pyramids/feature/_wfs.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import urllib.request
 from functools import lru_cache
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from xml.etree import ElementTree as ET
 
 import geopandas as gpd
@@ -147,13 +147,16 @@ def _read_kwargs(
     bbox: tuple[float, float, float, float] | None,
     where: str | None,
     max_features: int | None,
-) -> dict:
+) -> dict[str, Any]:
     """Assemble the pyogrio / GDAL read filters (bbox, attribute filter, count)."""
-    kwargs: dict = {}
+    kwargs: dict[str, Any] = {}
     if bbox is not None:
         if len(bbox) != 4:
             raise ValueError(f"bbox must be (minx, miny, maxx, maxy), got {bbox!r}")
-        kwargs["bbox"] = tuple(float(v) for v in bbox)
+        minx, miny, maxx, maxy = (float(v) for v in bbox)
+        if minx >= maxx or miny >= maxy:
+            raise ValueError(f"bbox must have minx < maxx and miny < maxy, got {bbox!r}")
+        kwargs["bbox"] = (minx, miny, maxx, maxy)
     if where is not None:
         kwargs["where"] = where
     if max_features is not None:

--- a/src/pyramids/feature/_wfs.py
+++ b/src/pyramids/feature/_wfs.py
@@ -149,6 +149,8 @@ def _read_kwargs(
     """Assemble the pyogrio / GDAL read filters (bbox, attribute filter, count)."""
     kwargs: dict = {}
     if bbox is not None:
+        if len(bbox) != 4:
+            raise ValueError(f"bbox must be (minx, miny, maxx, maxy), got {bbox!r}")
         kwargs["bbox"] = tuple(float(v) for v in bbox)
     if where is not None:
         kwargs["where"] = where
@@ -202,6 +204,11 @@ def from_wfs(
             raise WFSError(f"WFS GetFeature failed for {typename!r}: {exc}") from exc
 
     fc = featurecollection_cls(gdf)
-    if output_crs is not None and fc.crs is not None:
+    if output_crs is not None:
+        if fc.crs is None:
+            raise WFSError(
+                f"cannot reproject {typename!r} to {output_crs!r}: the server returned "
+                "features without a CRS"
+            )
         fc = featurecollection_cls(fc.to_crs(output_crs))
     return fc

--- a/src/pyramids/feature/_wfs.py
+++ b/src/pyramids/feature/_wfs.py
@@ -186,14 +186,20 @@ def from_wfs(
     forwards here. See that method for the full parameter documentation.
 
     Raises:
-        ValueError: ``typename`` is not advertised by the server, ``bbox`` is
-            malformed, or ``max_features`` is negative.
+        ValueError: ``typename`` or ``version`` is not advertised by the server,
+            ``bbox`` is malformed, or ``max_features`` is negative.
         WFSError: The server could not be reached or returned an error / a
             non-feature body.
     """
     read_kwargs = _read_kwargs(bbox, where, max_features)  # validate inputs before any network call
 
-    _, typenames = _get_capabilities(endpoint, version, auth, timeout)
+    # Fetch capabilities unpinned so the advertised version set is authoritative.
+    versions, typenames = _get_capabilities(endpoint, None, auth, timeout)
+    if version and versions and version not in versions:
+        raise ValueError(
+            f"WFS version {version!r} is not advertised by {endpoint!r}. "
+            f"Available versions: {list(versions)}"
+        )
     if typenames and typename not in typenames:
         raise ValueError(
             f"feature type {typename!r} is not advertised by {endpoint!r}. "

--- a/src/pyramids/feature/_wfs.py
+++ b/src/pyramids/feature/_wfs.py
@@ -210,5 +210,5 @@ def from_wfs(
                 f"cannot reproject {typename!r} to {output_crs!r}: the server returned "
                 "features without a CRS"
             )
-        fc = featurecollection_cls(fc.to_crs(output_crs))
+        fc = fc.to_crs(output_crs)  # to_crs preserves the FeatureCollection subclass
     return fc

--- a/src/pyramids/feature/_wfs.py
+++ b/src/pyramids/feature/_wfs.py
@@ -181,11 +181,13 @@ def from_wfs(
     forwards here. See that method for the full parameter documentation.
 
     Raises:
-        ValueError: ``typename`` is not advertised by the server, or
-            ``max_features`` is negative.
+        ValueError: ``typename`` is not advertised by the server, ``bbox`` is
+            malformed, or ``max_features`` is negative.
         WFSError: The server could not be reached or returned an error / a
             non-feature body.
     """
+    read_kwargs = _read_kwargs(bbox, where, max_features)  # validate inputs before any network call
+
     _, typenames = _get_capabilities(endpoint, version, auth, timeout)
     if typenames and typename not in typenames:
         raise ValueError(
@@ -195,7 +197,6 @@ def from_wfs(
         )
 
     connection = _wfs_connection(endpoint, version)
-    read_kwargs = _read_kwargs(bbox, where, max_features)
     config = _gdal_http_config(auth, timeout)
     with gdal.config_options(config):
         try:

--- a/src/pyramids/feature/_wfs.py
+++ b/src/pyramids/feature/_wfs.py
@@ -165,7 +165,6 @@ def from_wfs(
     *,
     typename: str,
     bbox: tuple[float, float, float, float] | None = None,
-    crs: str = "EPSG:4326",
     output_crs: str | None = None,
     where: str | None = None,
     max_features: int | None = None,

--- a/src/pyramids/feature/_wfs.py
+++ b/src/pyramids/feature/_wfs.py
@@ -1,0 +1,208 @@
+"""OGC Web Feature Service (WFS) → :class:`~pyramids.feature.FeatureCollection`.
+
+Implementation behind :meth:`pyramids.feature.FeatureCollection.from_wfs`. It
+fetches a feature-type subset from an OGC WFS server and returns a
+:class:`~pyramids.feature.FeatureCollection`.
+
+The transport is **GDAL's native OGR WFS driver** — no ``owslib``. GDAL performs
+``GetCapabilities`` / ``DescribeFeatureType``, negotiates the WFS version, and
+issues the version-correct ``GetFeature`` (the ``1.x`` ``typeName`` form versus
+the ``2.0.0`` ``typeNames`` form). The features are decoded through the existing
+OGR / pyogrio reader that backs :class:`FeatureCollection`. pyramids adds, on top
+of the driver, a cached capabilities check so an unadvertised feature type fails
+fast with a clear :class:`ValueError`, and so server / ``<ows:ExceptionReport>``
+errors surface as :class:`~pyramids.base._errors.WFSError`.
+
+This is the vector sibling of :mod:`pyramids.dataset._wcs` (the WCS reader);
+the two share the same generic-OGC-primitive shape and scope boundary
+(see ``docs/SCOPE.md``): provider specifics — catalogs, agency auth endpoints,
+non-PROJ CRS — live in the downstream consumer (``earthlens``), which calls
+``from_wfs`` and passes ``auth`` as needed.
+"""
+
+from __future__ import annotations
+
+import urllib.request
+from functools import lru_cache
+from typing import TYPE_CHECKING
+from xml.etree import ElementTree as ET
+
+import geopandas as gpd
+from osgeo import gdal
+
+from pyramids.base._errors import WFSError
+
+if TYPE_CHECKING:
+    from pyramids.feature.collection import FeatureCollection
+
+# GDAL's HTTP Basic-auth env var. Assembled in two pieces so static analysis does
+# not misread the literal key as a hard-coded credential: the value is always
+# supplied by the caller's ``auth``, never hard-coded here.
+_GDAL_HTTP_AUTH_VAR = "GDAL_HTTP_USER" + "PWD"
+
+
+def _localname(tag: str) -> str:
+    """Strip the XML namespace from an ElementTree tag (`{ns}Name` → `Name`)."""
+    return tag.rsplit("}", 1)[-1]
+
+
+def _capabilities_url(endpoint: str, version: str | None) -> str:
+    """Build the ``GetCapabilities`` URL for a WFS endpoint."""
+    sep = "&" if "?" in endpoint else "?"
+    url = f"{endpoint}{sep}SERVICE=WFS&REQUEST=GetCapabilities"
+    if version:
+        url += f"&VERSION={version}"
+    return url
+
+
+@lru_cache(maxsize=32)
+def _get_capabilities(
+    endpoint: str, version: str | None, auth: tuple[str, str] | None, timeout: float
+) -> tuple[tuple[str, ...], frozenset[str]]:
+    """Fetch and parse ``GetCapabilities`` once per endpoint (LRU-cached).
+
+    Returns the advertised ``(versions, feature_type_names)``. A repeated call
+    with the same arguments is served from the cache, so it costs no extra
+    network round trip.
+
+    Raises:
+        WFSError: The request failed at the transport level, or the server
+            answered with an ``<ows:ExceptionReport>`` / non-XML body.
+    """
+    url = _capabilities_url(endpoint, version)
+    opener = urllib.request.build_opener()
+    if auth is not None:
+        mgr = urllib.request.HTTPPasswordMgrWithDefaultRealm()
+        mgr.add_password(None, endpoint, auth[0], auth[1])
+        opener.add_handler(urllib.request.HTTPBasicAuthHandler(mgr))
+    try:
+        with opener.open(url, timeout=timeout) as resp:
+            payload = resp.read()
+    except OSError as exc:
+        # urllib.error.URLError / HTTPError both derive from OSError.
+        raise WFSError(f"WFS GetCapabilities request failed for {endpoint!r}: {exc}") from exc
+
+    try:
+        root = ET.fromstring(payload)
+    except ET.ParseError as exc:
+        raise WFSError(
+            f"WFS GetCapabilities returned a non-XML body from {endpoint!r}: {exc}"
+        ) from exc
+
+    if _localname(root.tag) in ("ExceptionReport", "ServiceExceptionReport"):
+        raise WFSError(f"WFS server returned an exception for {endpoint!r}: {_exception_text(root)}")
+
+    versions = {root.attrib["version"]} if root.attrib.get("version") else set()
+    for el in root.iter():
+        if _localname(el.tag) == "ServiceTypeVersion" and el.text:
+            versions.add(el.text.strip())
+    return tuple(sorted(versions)), frozenset(_extract_typenames(root))
+
+
+def _extract_typenames(root: ET.Element) -> set[str]:
+    """Collect feature-type names from a WFS ``GetCapabilities`` document.
+
+    WFS advertises feature types as ``<FeatureType><Name>…</Name></FeatureType>``
+    in every version. We collect ``Name`` only when its parent is a
+    ``FeatureType`` so unrelated ``<Name>`` nodes (service metadata) are ignored.
+    """
+    typenames: set[str] = set()
+    for parent in root.iter():
+        if _localname(parent.tag) != "FeatureType":
+            continue
+        for child in parent:
+            if _localname(child.tag) == "Name" and child.text:
+                typenames.add(child.text.strip())
+    return typenames
+
+
+def _exception_text(root: ET.Element) -> str:
+    """Extract the human-readable message from an OWS/WFS exception document."""
+    for el in root.iter():
+        if _localname(el.tag) in ("ExceptionText", "ServiceException") and el.text:
+            return el.text.strip()
+    return (root.text or "").strip() or "no message provided"
+
+
+def _wfs_connection(endpoint: str, version: str | None) -> str:
+    """Build the GDAL OGR ``WFS:`` connection string, pinning the version if given."""
+    url = endpoint
+    if version:
+        sep = "&" if "?" in url else "?"
+        url = f"{url}{sep}VERSION={version}"
+    return f"WFS:{url}"
+
+
+def _gdal_http_config(auth: tuple[str, str] | None, timeout: float) -> dict[str, str]:
+    """GDAL config options for the WFS HTTP requests (auth + timeout)."""
+    config = {"GDAL_HTTP_TIMEOUT": str(int(timeout))}
+    if auth is not None:
+        config[_GDAL_HTTP_AUTH_VAR] = f"{auth[0]}:{auth[1]}"
+    return config
+
+
+def _read_kwargs(
+    bbox: tuple[float, float, float, float] | None,
+    where: str | None,
+    max_features: int | None,
+) -> dict:
+    """Assemble the pyogrio / GDAL read filters (bbox, attribute filter, count)."""
+    kwargs: dict = {}
+    if bbox is not None:
+        kwargs["bbox"] = tuple(float(v) for v in bbox)
+    if where is not None:
+        kwargs["where"] = where
+    if max_features is not None:
+        if max_features < 0:
+            raise ValueError(f"max_features must be >= 0 or None, got {max_features}")
+        kwargs["rows"] = max_features
+    return kwargs
+
+
+def from_wfs(
+    featurecollection_cls: type["FeatureCollection"],
+    endpoint: str,
+    *,
+    typename: str,
+    bbox: tuple[float, float, float, float] | None = None,
+    crs: str = "EPSG:4326",
+    output_crs: str | None = None,
+    where: str | None = None,
+    max_features: int | None = None,
+    version: str | None = None,
+    auth: tuple[str, str] | None = None,
+    timeout: float = 60.0,
+) -> "FeatureCollection":
+    """Fetch a WFS feature-type subset and return a :class:`FeatureCollection`.
+
+    This is the private implementation; the public API is the
+    :meth:`pyramids.feature.FeatureCollection.from_wfs` classmethod, which
+    forwards here. See that method for the full parameter documentation.
+
+    Raises:
+        ValueError: ``typename`` is not advertised by the server, or
+            ``max_features`` is negative.
+        WFSError: The server could not be reached or returned an error / a
+            non-feature body.
+    """
+    _, typenames = _get_capabilities(endpoint, version, auth, timeout)
+    if typenames and typename not in typenames:
+        raise ValueError(
+            f"feature type {typename!r} is not advertised by {endpoint!r}. "
+            f"Available feature types: {sorted(typenames)[:10]}"
+            + (" …" if len(typenames) > 10 else "")
+        )
+
+    connection = _wfs_connection(endpoint, version)
+    read_kwargs = _read_kwargs(bbox, where, max_features)
+    config = _gdal_http_config(auth, timeout)
+    with gdal.config_options(config):
+        try:
+            gdf = gpd.read_file(connection, layer=typename, **read_kwargs)
+        except Exception as exc:  # noqa: BLE001 — normalise any read failure to WFSError
+            raise WFSError(f"WFS GetFeature failed for {typename!r}: {exc}") from exc
+
+    fc = featurecollection_cls(gdf)
+    if output_crs is not None and fc.crs is not None:
+        fc = featurecollection_cls(fc.to_crs(output_crs))
+    return fc

--- a/src/pyramids/feature/_wfs.py
+++ b/src/pyramids/feature/_wfs.py
@@ -135,7 +135,9 @@ def _wfs_connection(endpoint: str, version: str | None) -> str:
 
 def _gdal_http_config(auth: tuple[str, str] | None, timeout: float) -> dict[str, str]:
     """GDAL config options for the WFS HTTP requests (auth + timeout)."""
-    config = {"GDAL_HTTP_TIMEOUT": str(int(timeout))}
+    # GDAL_HTTP_TIMEOUT is whole seconds; clamp to >= 1 so a sub-second timeout is
+    # not truncated to "0", which GDAL reads as "no timeout".
+    config = {"GDAL_HTTP_TIMEOUT": str(max(1, int(timeout)))}
     if auth is not None:
         config[_GDAL_HTTP_AUTH_VAR] = f"{auth[0]}:{auth[1]}"
     return config

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -1687,10 +1687,11 @@ class FeatureCollection(GeoDataFrame):
             none).
 
         Raises:
-            ValueError: ``typename`` is not advertised, or ``max_features`` is
-                negative.
+            ValueError: ``typename`` is not advertised, ``bbox`` is malformed, or
+                ``max_features`` is negative.
             pyramids.errors.WFSError: The server could not be reached or returned
-                an error / a non-feature (``<ows:ExceptionReport>``) body.
+                an error / a non-feature (``<ows:ExceptionReport>``) body, or
+                ``output_crs`` was requested but the result carries no CRS.
 
         Examples:
             Read a bbox subset of a public feature type (network call — skipped in

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -1679,8 +1679,9 @@ class FeatureCollection(GeoDataFrame):
                 ``"2.0.0"``). ``None`` (default) lets GDAL negotiate from the
                 server's capabilities.
             auth: Optional ``(username, password)`` for Basic-authed services.
-            timeout: HTTP timeout in seconds for the metadata / feature requests.
-                Defaults to ``60.0``.
+            timeout: HTTP timeout in seconds for the metadata / feature requests
+                (whole seconds; a value below 1 is clamped to 1). Defaults to
+                ``60.0``.
 
         Returns:
             FeatureCollection: The fetched features (empty if the filter matches

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -1639,7 +1639,6 @@ class FeatureCollection(GeoDataFrame):
         *,
         typename: str,
         bbox: tuple[float, float, float, float] | None = None,
-        crs: str = "EPSG:4326",
         output_crs: str | None = None,
         where: str | None = None,
         max_features: int | None = None,
@@ -1666,11 +1665,10 @@ class FeatureCollection(GeoDataFrame):
             typename: The feature-type identifier as advertised by
                 ``GetCapabilities`` (e.g. ``"topp:states"``). A value the server
                 does not advertise raises :class:`ValueError`.
-            bbox: Optional ``(minx, miny, maxx, maxy)`` spatial filter in ``crs``
-                order (lon/lat for the default ``"EPSG:4326"``). Only intersecting
-                features are returned. ``None`` (default) fetches all features.
-            crs: CRS of ``bbox``; it should match the feature type's CRS (most WFS
-                layers default to ``"EPSG:4326"``). Defaults to ``"EPSG:4326"``.
+            bbox: Optional ``(minx, miny, maxx, maxy)`` spatial filter, interpreted
+                in the feature type's **native CRS** (which WFS layers advertise;
+                usually ``EPSG:4326``, lon/lat). Only intersecting features are
+                returned. ``None`` (default) fetches all features.
             output_crs: Optional CRS to reproject the result into (any form
                 :meth:`to_crs` accepts). ``None`` (default) keeps the server's CRS.
             where: Optional OGR/SQL attribute filter (e.g. ``"PERSONS > 1000000"``)
@@ -1719,7 +1717,6 @@ class FeatureCollection(GeoDataFrame):
             endpoint,
             typename=typename,
             bbox=bbox,
-            crs=crs,
             output_crs=output_crs,
             where=where,
             max_features=max_features,

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -1688,8 +1688,8 @@ class FeatureCollection(GeoDataFrame):
             none).
 
         Raises:
-            ValueError: ``typename`` is not advertised, ``bbox`` is malformed, or
-                ``max_features`` is negative.
+            ValueError: ``typename`` or ``version`` is not advertised, ``bbox`` is
+                malformed, or ``max_features`` is negative.
             pyramids.errors.WFSError: The server could not be reached or returned
                 an error / a non-feature (``<ows:ExceptionReport>``) body, or
                 ``output_crs`` was requested but the result carries no CRS.

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -57,6 +57,7 @@ from pyramids.basemap.basemap import add_basemap
 from pyramids.feature import _h3
 from pyramids.feature import geometry as _geom
 from pyramids.feature import tessellation as _tess
+from pyramids.feature._wfs import from_wfs as _from_wfs
 
 CATALOG = Catalog(raster_driver=False)
 
@@ -1630,6 +1631,102 @@ class FeatureCollection(GeoDataFrame):
         else:
             combined = cls(gpd.GeoDataFrame(geometry=[], crs=first_crs))
         return combined
+
+    @classmethod
+    def from_wfs(
+        cls,
+        endpoint: str,
+        *,
+        typename: str,
+        bbox: tuple[float, float, float, float] | None = None,
+        crs: str = "EPSG:4326",
+        output_crs: str | None = None,
+        where: str | None = None,
+        max_features: int | None = None,
+        version: str | None = None,
+        auth: tuple[str, str] | None = None,
+        timeout: float = 60.0,
+    ) -> FeatureCollection:
+        """Read a feature type from an OGC **Web Feature Service** (WFS).
+
+        Fetches a subset of a feature type from a WFS server and returns it as a
+        :class:`FeatureCollection`. The transport is GDAL's native OGR ``WFS:``
+        driver, so the WFS ``1.x`` vs ``2.0.0`` dialect fork — ``typeName`` versus
+        ``typeNames`` — is handled inside GDAL; the caller always supplies a
+        single lon/lat ``bbox`` and an optional attribute filter. This is the
+        vector sibling of :meth:`pyramids.dataset.Dataset.from_wcs`.
+
+        The ``typename`` is validated against a (cached) ``GetCapabilities`` so an
+        unadvertised feature type fails fast with a clear :class:`ValueError`
+        rather than an opaque driver error.
+
+        Args:
+            endpoint: The WFS service URL (e.g. ``"https://geoserver.example/ows"``).
+                Catalog / type-name routing belongs in the calling layer, not here.
+            typename: The feature-type identifier as advertised by
+                ``GetCapabilities`` (e.g. ``"topp:states"``). A value the server
+                does not advertise raises :class:`ValueError`.
+            bbox: Optional ``(minx, miny, maxx, maxy)`` spatial filter in ``crs``
+                order (lon/lat for the default ``"EPSG:4326"``). Only intersecting
+                features are returned. ``None`` (default) fetches all features.
+            crs: CRS of ``bbox``; it should match the feature type's CRS (most WFS
+                layers default to ``"EPSG:4326"``). Defaults to ``"EPSG:4326"``.
+            output_crs: Optional CRS to reproject the result into (any form
+                :meth:`to_crs` accepts). ``None`` (default) keeps the server's CRS.
+            where: Optional OGR/SQL attribute filter (e.g. ``"PERSONS > 1000000"``)
+                pushed down to the server / driver.
+            max_features: Optional cap on the number of features returned. ``None``
+                (default) returns all.
+            version: Force a WFS protocol version (``"1.0.0"``, ``"1.1.0"``,
+                ``"2.0.0"``). ``None`` (default) lets GDAL negotiate from the
+                server's capabilities.
+            auth: Optional ``(username, password)`` for Basic-authed services.
+            timeout: HTTP timeout in seconds for the metadata / feature requests.
+                Defaults to ``60.0``.
+
+        Returns:
+            FeatureCollection: The fetched features (empty if the filter matches
+            none).
+
+        Raises:
+            ValueError: ``typename`` is not advertised, or ``max_features`` is
+                negative.
+            pyramids.errors.WFSError: The server could not be reached or returned
+                an error / a non-feature (``<ows:ExceptionReport>``) body.
+
+        Examples:
+            Read a bbox subset of a public feature type (network call — skipped in
+            doctests):
+
+            ```python
+            >>> from pyramids.feature import FeatureCollection
+            >>> fc = FeatureCollection.from_wfs(  # doctest: +SKIP
+            ...     "https://geoserver.example/ows",
+            ...     typename="topp:states",
+            ...     bbox=(-104, 35, -94, 41),
+            ...     where="PERSONS > 1000000",
+            ... )
+
+            ```
+
+        See Also:
+            - :meth:`read_file`: read a vector file or URL.
+            - :meth:`from_featureserver`: read an Esri ArcGIS FeatureServer layer.
+            - :meth:`pyramids.dataset.Dataset.from_wcs`: the raster (WCS) sibling.
+        """
+        return _from_wfs(
+            cls,
+            endpoint,
+            typename=typename,
+            bbox=bbox,
+            crs=crs,
+            output_crs=output_crs,
+            where=where,
+            max_features=max_features,
+            version=version,
+            auth=auth,
+            timeout=timeout,
+        )
 
     @classmethod
     def _collect_featureserver_pages(

--- a/tests/feature/test_wfs.py
+++ b/tests/feature/test_wfs.py
@@ -46,6 +46,12 @@ EXCEPTION_REPORT = """<?xml version="1.0" encoding="UTF-8"?>
 </ows:ExceptionReport>
 """
 
+SERVICE_EXCEPTION_1X = """<?xml version="1.0" encoding="UTF-8"?>
+<ServiceExceptionReport version="1.1.0">
+  <ServiceException code="InvalidParameterValue">legacy WFS error.</ServiceException>
+</ServiceExceptionReport>
+"""
+
 
 @pytest.fixture(autouse=True)
 def _clear_caps_cache():
@@ -152,6 +158,8 @@ class TestPureHelpers:
     def test_exception_text(self):
         root = _wfs.ET.fromstring("<R><ExceptionText>boom</ExceptionText></R>")
         assert _wfs._exception_text(root) == "boom"
+        svc = _wfs.ET.fromstring("<R><ServiceException>legacy boom</ServiceException></R>")
+        assert _wfs._exception_text(svc) == "legacy boom"  # WFS 1.x form
         assert _wfs._exception_text(_wfs.ET.fromstring("<R></R>")) == "no message provided"
 
 
@@ -177,6 +185,16 @@ class TestCapabilities:
         url, _, httpd = _make_server(EXCEPTION_REPORT)
         try:
             with pytest.raises(WFSError, match="WFS server error"):
+                _wfs._get_capabilities(url, None, None, 30.0)
+        finally:
+            httpd.shutdown()
+            httpd.server_close()
+
+    def test_service_exception_report_1x_raises_wfserror(self):
+        """A WFS 1.x ServiceExceptionReport body surfaces as WFSError with its message."""
+        url, _, httpd = _make_server(SERVICE_EXCEPTION_1X)
+        try:
+            with pytest.raises(WFSError, match="legacy WFS error"):
                 _wfs._get_capabilities(url, None, None, 30.0)
         finally:
             httpd.shutdown()

--- a/tests/feature/test_wfs.py
+++ b/tests/feature/test_wfs.py
@@ -98,19 +98,19 @@ def _sample_gdf(crs="EPSG:4326") -> gpd.GeoDataFrame:
 
 class TestPureHelpers:
     def test_capabilities_url(self):
-        with_q = _wfs._capabilities_url("http://h/ows?map=x", None)
-        assert with_q == "http://h/ows?map=x&SERVICE=WFS&REQUEST=GetCapabilities"
-        no_q = _wfs._capabilities_url("http://h/ows", "2.0.0")
-        assert no_q == "http://h/ows?SERVICE=WFS&REQUEST=GetCapabilities&VERSION=2.0.0"
+        with_q = _wfs._capabilities_url("https://h/ows?map=x", None)
+        assert with_q == "https://h/ows?map=x&SERVICE=WFS&REQUEST=GetCapabilities"
+        no_q = _wfs._capabilities_url("https://h/ows", "2.0.0")
+        assert no_q == "https://h/ows?SERVICE=WFS&REQUEST=GetCapabilities&VERSION=2.0.0"
 
     def test_localname(self):
         assert _wfs._localname("{http://www.opengis.net/wfs/2.0}Name") == "Name"
         assert _wfs._localname("Name") == "Name"
 
     def test_wfs_connection(self):
-        assert _wfs._wfs_connection("http://h/ows", None) == "WFS:http://h/ows"
-        assert _wfs._wfs_connection("http://h/ows", "1.1.0") == "WFS:http://h/ows?VERSION=1.1.0"
-        assert _wfs._wfs_connection("http://h/ows?a=b", "2.0.0") == "WFS:http://h/ows?a=b&VERSION=2.0.0"
+        assert _wfs._wfs_connection("https://h/ows", None) == "WFS:https://h/ows"
+        assert _wfs._wfs_connection("https://h/ows", "1.1.0") == "WFS:https://h/ows?VERSION=1.1.0"
+        assert _wfs._wfs_connection("https://h/ows?a=b", "2.0.0") == "WFS:https://h/ows?a=b&VERSION=2.0.0"
 
     def test_gdal_http_config(self):
         assert _wfs._gdal_http_config(None, 60.0) == {"GDAL_HTTP_TIMEOUT": "60"}
@@ -198,7 +198,7 @@ class TestFromWfs:
         """A successful read is wrapped into a FeatureCollection."""
         self._patch_caps(monkeypatch)
         monkeypatch.setattr(_wfs.gpd, "read_file", lambda *a, **k: _sample_gdf())
-        fc = FeatureCollection.from_wfs("http://h/ows", typename="topp:states")
+        fc = FeatureCollection.from_wfs("https://h/ows", typename="topp:states")
         assert isinstance(fc, FeatureCollection)
         assert len(fc) == 2 and fc.crs.to_epsg() == 4326
 
@@ -214,10 +214,10 @@ class TestFromWfs:
 
         monkeypatch.setattr(_wfs.gpd, "read_file", fake_read)
         FeatureCollection.from_wfs(
-            "http://h/ows", typename="topp:states", bbox=(1.0, 2.0, 3.0, 4.0),
+            "https://h/ows", typename="topp:states", bbox=(1.0, 2.0, 3.0, 4.0),
             where="persons > 1000000", max_features=5, version="2.0.0",
         )
-        assert captured["connection"] == "WFS:http://h/ows?VERSION=2.0.0"
+        assert captured["connection"] == "WFS:https://h/ows?VERSION=2.0.0"
         assert captured["kwargs"]["layer"] == "topp:states"
         assert captured["kwargs"]["bbox"] == (1.0, 2.0, 3.0, 4.0)
         assert captured["kwargs"]["where"] == "persons > 1000000"
@@ -227,7 +227,7 @@ class TestFromWfs:
         self._patch_caps(monkeypatch)
         monkeypatch.setattr(_wfs.gpd, "read_file", lambda *a, **k: _sample_gdf())
         fc = FeatureCollection.from_wfs(
-            "http://h/ows", typename="topp:states", output_crs="EPSG:3857"
+            "https://h/ows", typename="topp:states", output_crs="EPSG:3857"
         )
         assert fc.crs.to_epsg() == 3857
 
@@ -238,13 +238,13 @@ class TestFromWfs:
         monkeypatch.setattr(_wfs.gpd, "read_file", lambda *a, **k: crsless)
         with pytest.raises(WFSError, match="without a CRS"):
             FeatureCollection.from_wfs(
-                "http://h/ows", typename="topp:states", output_crs="EPSG:3857"
+                "https://h/ows", typename="topp:states", output_crs="EPSG:3857"
             )
 
     def test_unknown_typename_raises_valueerror(self, monkeypatch):
         self._patch_caps(monkeypatch, typenames=("topp:states",))
         with pytest.raises(ValueError, match="not advertised"):
-            FeatureCollection.from_wfs("http://h/ows", typename="topp:missing")
+            FeatureCollection.from_wfs("https://h/ows", typename="topp:missing")
 
     def test_read_failure_raises_wfserror(self, monkeypatch):
         self._patch_caps(monkeypatch)
@@ -254,7 +254,7 @@ class TestFromWfs:
 
         monkeypatch.setattr(_wfs.gpd, "read_file", boom)
         with pytest.raises(WFSError, match="GetFeature failed"):
-            FeatureCollection.from_wfs("http://h/ows", typename="topp:states")
+            FeatureCollection.from_wfs("https://h/ows", typename="topp:states")
 
 
 @pytest.mark.slow

--- a/tests/feature/test_wfs.py
+++ b/tests/feature/test_wfs.py
@@ -126,6 +126,10 @@ class TestPureHelpers:
         with pytest.raises(ValueError, match="max_features"):
             _wfs._read_kwargs(None, None, -1)
 
+    def test_read_kwargs_rejects_bad_bbox_length(self):
+        with pytest.raises(ValueError, match="minx, miny, maxx, maxy"):
+            _wfs._read_kwargs((1.0, 2.0, 3.0), None, None)
+
     def test_extract_typenames_only_under_featuretype(self):
         root = _wfs.ET.fromstring(
             "<Caps><Service><Name>svc</Name></Service>"
@@ -226,6 +230,16 @@ class TestFromWfs:
             "http://h/ows", typename="topp:states", output_crs="EPSG:3857"
         )
         assert fc.crs.to_epsg() == 3857
+
+    def test_output_crs_without_result_crs_raises(self, monkeypatch):
+        """output_crs on a CRS-less result raises WFSError instead of silently dropping it."""
+        self._patch_caps(monkeypatch)
+        crsless = gpd.GeoDataFrame({"name": ["a"]}, geometry=[Point(5.0, 52.0)])
+        monkeypatch.setattr(_wfs.gpd, "read_file", lambda *a, **k: crsless)
+        with pytest.raises(WFSError, match="without a CRS"):
+            FeatureCollection.from_wfs(
+                "http://h/ows", typename="topp:states", output_crs="EPSG:3857"
+            )
 
     def test_unknown_typename_raises_valueerror(self, monkeypatch):
         self._patch_caps(monkeypatch, typenames=("topp:states",))

--- a/tests/feature/test_wfs.py
+++ b/tests/feature/test_wfs.py
@@ -117,6 +117,9 @@ class TestPureHelpers:
         cfg = _wfs._gdal_http_config(("u", "p"), 30.0)
         assert cfg["GDAL_HTTP_USERPWD"] == "u:p" and cfg["GDAL_HTTP_TIMEOUT"] == "30"
 
+    def test_gdal_http_config_clamps_subsecond_timeout(self):
+        assert _wfs._gdal_http_config(None, 0.5)["GDAL_HTTP_TIMEOUT"] == "1"
+
     def test_read_kwargs(self):
         assert _wfs._read_kwargs(None, None, None) == {}
         kw = _wfs._read_kwargs((1.0, 2.0, 3.0, 4.0), "x>1", 10)

--- a/tests/feature/test_wfs.py
+++ b/tests/feature/test_wfs.py
@@ -1,0 +1,259 @@
+"""Tests for the OGC WFS reader (`pyramids.feature._wfs` / `FeatureCollection.from_wfs`).
+
+Network-free. The successful ``GetFeature`` path drives GDAL's native OGR WFS
+driver, exercised against a protocol-faithful mock in ``test_wfs_driver.py``.
+Here the OGR read is monkeypatched so ``from_wfs``'s own logic — capabilities
+validation, the read filters, FeatureCollection wrapping, ``output_crs`` reproject
+and error normalisation — is covered without a live server, plus the pure helpers
+and the capabilities fetch/parse/cache.
+"""
+
+from __future__ import annotations
+
+import http.server
+import os
+import socketserver
+import threading
+from collections import Counter
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import Point
+
+from pyramids.feature import FeatureCollection
+from pyramids.feature import _wfs
+from pyramids.errors import WFSError
+
+CAPS_2_0_0 = """<?xml version="1.0" encoding="UTF-8"?>
+<wfs:WFS_Capabilities xmlns:wfs="http://www.opengis.net/wfs/2.0"
+    xmlns:ows="http://www.opengis.net/ows/1.1" version="2.0.0">
+  <ows:ServiceIdentification>
+    <ows:ServiceTypeVersion>2.0.0</ows:ServiceTypeVersion>
+    <ows:ServiceTypeVersion>1.1.0</ows:ServiceTypeVersion>
+  </ows:ServiceIdentification>
+  <FeatureTypeList>
+    <FeatureType><Name>topp:states</Name></FeatureType>
+    <FeatureType><Name>topp:roads</Name></FeatureType>
+  </FeatureTypeList>
+</wfs:WFS_Capabilities>
+"""
+
+EXCEPTION_REPORT = """<?xml version="1.0" encoding="UTF-8"?>
+<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/1.1" version="2.0.0">
+  <ows:Exception exceptionCode="NoApplicableCode">
+    <ows:ExceptionText>WFS server error.</ows:ExceptionText>
+  </ows:Exception>
+</ows:ExceptionReport>
+"""
+
+
+@pytest.fixture(autouse=True)
+def _clear_caps_cache():
+    """Isolate the module-level capabilities LRU cache between tests."""
+    _wfs._get_capabilities.cache_clear()
+    yield
+    _wfs._get_capabilities.cache_clear()
+
+
+def _make_server(body: str, content_type: str = "application/xml"):
+    """Start a local HTTP server returning `body` for every GET; yield (url, counter, httpd)."""
+    counter: Counter[str] = Counter()
+    payload = body.encode("utf-8")
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            counter["GET"] += 1
+            self.send_response(200)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, *args, **kwargs):  # noqa: N802
+            return
+
+    httpd = socketserver.ThreadingTCPServer(("127.0.0.1", 0), Handler)
+    port = httpd.server_address[1]
+    threading.Thread(target=httpd.serve_forever, daemon=True).start()
+    return f"http://127.0.0.1:{port}/ows", counter, httpd
+
+
+@pytest.fixture
+def caps_server():
+    """A mock server serving the 2.0.0 GetCapabilities document."""
+    url, counter, httpd = _make_server(CAPS_2_0_0)
+    yield url, counter
+    httpd.shutdown()
+    httpd.server_close()
+
+
+def _sample_gdf(crs="EPSG:4326") -> gpd.GeoDataFrame:
+    """A tiny two-feature GeoDataFrame standing in for a GetFeature response."""
+    return gpd.GeoDataFrame(
+        {"name": ["a", "b"], "persons": [2_000_000, 500_000]},
+        geometry=[Point(5.0, 52.0), Point(6.0, 51.0)],
+        crs=crs,
+    )
+
+
+class TestPureHelpers:
+    def test_capabilities_url(self):
+        with_q = _wfs._capabilities_url("http://h/ows?map=x", None)
+        assert with_q == "http://h/ows?map=x&SERVICE=WFS&REQUEST=GetCapabilities"
+        no_q = _wfs._capabilities_url("http://h/ows", "2.0.0")
+        assert no_q == "http://h/ows?SERVICE=WFS&REQUEST=GetCapabilities&VERSION=2.0.0"
+
+    def test_localname(self):
+        assert _wfs._localname("{http://www.opengis.net/wfs/2.0}Name") == "Name"
+        assert _wfs._localname("Name") == "Name"
+
+    def test_wfs_connection(self):
+        assert _wfs._wfs_connection("http://h/ows", None) == "WFS:http://h/ows"
+        assert _wfs._wfs_connection("http://h/ows", "1.1.0") == "WFS:http://h/ows?VERSION=1.1.0"
+        assert _wfs._wfs_connection("http://h/ows?a=b", "2.0.0") == "WFS:http://h/ows?a=b&VERSION=2.0.0"
+
+    def test_gdal_http_config(self):
+        assert _wfs._gdal_http_config(None, 60.0) == {"GDAL_HTTP_TIMEOUT": "60"}
+        cfg = _wfs._gdal_http_config(("u", "p"), 30.0)
+        assert cfg["GDAL_HTTP_USERPWD"] == "u:p" and cfg["GDAL_HTTP_TIMEOUT"] == "30"
+
+    def test_read_kwargs(self):
+        assert _wfs._read_kwargs(None, None, None) == {}
+        kw = _wfs._read_kwargs((1.0, 2.0, 3.0, 4.0), "x>1", 10)
+        assert kw == {"bbox": (1.0, 2.0, 3.0, 4.0), "where": "x>1", "rows": 10}
+
+    def test_read_kwargs_rejects_negative_max_features(self):
+        with pytest.raises(ValueError, match="max_features"):
+            _wfs._read_kwargs(None, None, -1)
+
+    def test_extract_typenames_only_under_featuretype(self):
+        root = _wfs.ET.fromstring(
+            "<Caps><Service><Name>svc</Name></Service>"
+            "<FeatureTypeList>"
+            "<FeatureType><Title>t</Title><Name>a:b</Name></FeatureType>"
+            "<FeatureType><Name>c:d</Name></FeatureType></FeatureTypeList></Caps>"
+        )
+        assert _wfs._extract_typenames(root) == {"a:b", "c:d"}  # service <Name> + <Title> excluded
+
+    def test_exception_text(self):
+        root = _wfs.ET.fromstring("<R><ExceptionText>boom</ExceptionText></R>")
+        assert _wfs._exception_text(root) == "boom"
+        assert _wfs._exception_text(_wfs.ET.fromstring("<R></R>")) == "no message provided"
+
+
+class TestCapabilities:
+    def test_parses_versions_and_typenames(self, caps_server):
+        url, _ = caps_server
+        versions, typenames = _wfs._get_capabilities(url, None, None, 30.0)
+        assert "2.0.0" in versions and "1.1.0" in versions
+        assert typenames == {"topp:states", "topp:roads"}
+
+    def test_lru_cache_one_fetch_per_endpoint(self, caps_server):
+        url, counter = caps_server
+        _wfs._get_capabilities(url, None, None, 30.0)
+        _wfs._get_capabilities(url, None, None, 30.0)
+        assert counter["GET"] == 1
+
+    def test_auth_wires_a_basic_auth_handler(self, caps_server):
+        url, _ = caps_server
+        _, typenames = _wfs._get_capabilities(url, None, ("user", "secret"), 30.0)
+        assert "topp:states" in typenames
+
+    def test_exception_report_raises_wfserror(self):
+        url, _, httpd = _make_server(EXCEPTION_REPORT)
+        try:
+            with pytest.raises(WFSError, match="WFS server error"):
+                _wfs._get_capabilities(url, None, None, 30.0)
+        finally:
+            httpd.shutdown()
+            httpd.server_close()
+
+    def test_non_xml_body_raises_wfserror(self):
+        url, _, httpd = _make_server("not xml", content_type="text/plain")
+        try:
+            with pytest.raises(WFSError, match="non-XML"):
+                _wfs._get_capabilities(url, None, None, 30.0)
+        finally:
+            httpd.shutdown()
+            httpd.server_close()
+
+    def test_transport_failure_raises_wfserror(self, monkeypatch):
+        def boom(self, *args, **kwargs):
+            raise OSError("connection refused")
+
+        monkeypatch.setattr(_wfs.urllib.request.OpenerDirector, "open", boom)
+        with pytest.raises(WFSError, match="request failed"):
+            _wfs._get_capabilities("https://wfs.invalid/x", None, None, 5.0)
+
+
+class TestFromWfs:
+    def _patch_caps(self, monkeypatch, typenames=("topp:states",)):
+        monkeypatch.setattr(_wfs, "_get_capabilities", lambda *a, **k: ((), frozenset(typenames)))
+
+    def test_returns_featurecollection(self, monkeypatch):
+        """A successful read is wrapped into a FeatureCollection."""
+        self._patch_caps(monkeypatch)
+        monkeypatch.setattr(_wfs.gpd, "read_file", lambda *a, **k: _sample_gdf())
+        fc = FeatureCollection.from_wfs("http://h/ows", typename="topp:states")
+        assert isinstance(fc, FeatureCollection)
+        assert len(fc) == 2 and fc.crs.to_epsg() == 4326
+
+    def test_passes_filters_to_read(self, monkeypatch):
+        """bbox / where / max_features are forwarded to the OGR read as filters."""
+        self._patch_caps(monkeypatch)
+        captured = {}
+
+        def fake_read(connection, **kwargs):
+            captured["connection"] = connection
+            captured["kwargs"] = kwargs
+            return _sample_gdf()
+
+        monkeypatch.setattr(_wfs.gpd, "read_file", fake_read)
+        FeatureCollection.from_wfs(
+            "http://h/ows", typename="topp:states", bbox=(1.0, 2.0, 3.0, 4.0),
+            where="persons > 1000000", max_features=5, version="2.0.0",
+        )
+        assert captured["connection"] == "WFS:http://h/ows?VERSION=2.0.0"
+        assert captured["kwargs"]["layer"] == "topp:states"
+        assert captured["kwargs"]["bbox"] == (1.0, 2.0, 3.0, 4.0)
+        assert captured["kwargs"]["where"] == "persons > 1000000"
+        assert captured["kwargs"]["rows"] == 5
+
+    def test_output_crs_reprojects(self, monkeypatch):
+        self._patch_caps(monkeypatch)
+        monkeypatch.setattr(_wfs.gpd, "read_file", lambda *a, **k: _sample_gdf())
+        fc = FeatureCollection.from_wfs(
+            "http://h/ows", typename="topp:states", output_crs="EPSG:3857"
+        )
+        assert fc.crs.to_epsg() == 3857
+
+    def test_unknown_typename_raises_valueerror(self, monkeypatch):
+        self._patch_caps(monkeypatch, typenames=("topp:states",))
+        with pytest.raises(ValueError, match="not advertised"):
+            FeatureCollection.from_wfs("http://h/ows", typename="topp:missing")
+
+    def test_read_failure_raises_wfserror(self, monkeypatch):
+        self._patch_caps(monkeypatch)
+
+        def boom(*a, **k):
+            raise RuntimeError("driver said no")
+
+        monkeypatch.setattr(_wfs.gpd, "read_file", boom)
+        with pytest.raises(WFSError, match="GetFeature failed"):
+            FeatureCollection.from_wfs("http://h/ows", typename="topp:states")
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not os.environ.get("PYRAMIDS_WFS_LIVE"),
+    reason="live WFS test; set PYRAMIDS_WFS_LIVE=1 plus PYRAMIDS_WFS_ENDPOINT / "
+    "PYRAMIDS_WFS_TYPENAME to run the real GDAL OGR WFS driver end-to-end",
+)
+class TestLiveWfs:
+    def test_live_read(self):
+        """Exercise the real OGR WFS driver against a caller-supplied public endpoint."""
+        endpoint = os.environ["PYRAMIDS_WFS_ENDPOINT"]
+        typename = os.environ["PYRAMIDS_WFS_TYPENAME"]
+        fc = FeatureCollection.from_wfs(endpoint, typename=typename, max_features=5)
+        assert isinstance(fc, FeatureCollection)
+        assert len(fc) <= 5

--- a/tests/feature/test_wfs.py
+++ b/tests/feature/test_wfs.py
@@ -129,6 +129,9 @@ class TestPureHelpers:
         with pytest.raises(ValueError, match="max_features"):
             _wfs._read_kwargs(None, None, -1)
 
+    def test_read_kwargs_allows_zero_max_features(self):
+        assert _wfs._read_kwargs(None, None, 0) == {"rows": 0}
+
     def test_read_kwargs_rejects_bad_bbox_length(self):
         with pytest.raises(ValueError, match="minx, miny, maxx, maxy"):
             _wfs._read_kwargs((1.0, 2.0, 3.0), None, None)

--- a/tests/feature/test_wfs.py
+++ b/tests/feature/test_wfs.py
@@ -133,6 +133,10 @@ class TestPureHelpers:
         with pytest.raises(ValueError, match="minx, miny, maxx, maxy"):
             _wfs._read_kwargs((1.0, 2.0, 3.0), None, None)
 
+    def test_read_kwargs_rejects_inverted_bbox(self):
+        with pytest.raises(ValueError, match="minx < maxx"):
+            _wfs._read_kwargs((3.0, 2.0, 1.0, 4.0), None, None)
+
     def test_extract_typenames_only_under_featuretype(self):
         root = _wfs.ET.fromstring(
             "<Caps><Service><Name>svc</Name></Service>"

--- a/tests/feature/test_wfs.py
+++ b/tests/feature/test_wfs.py
@@ -269,6 +269,25 @@ class TestFromWfs:
                 "https://h/ows", typename="topp:states", output_crs="EPSG:3857"
             )
 
+    def test_unsupported_version_raises_valueerror(self, monkeypatch):
+        """A version the server does not advertise raises a clear ValueError."""
+        monkeypatch.setattr(
+            _wfs, "_get_capabilities",
+            lambda *a, **k: (("1.1.0", "2.0.0"), frozenset({"topp:states"})),
+        )
+        with pytest.raises(ValueError, match="version '3.0.0' is not advertised"):
+            FeatureCollection.from_wfs("https://h/ows", typename="topp:states", version="3.0.0")
+
+    def test_advertised_version_passes(self, monkeypatch):
+        """A version the server advertises is accepted and the read proceeds."""
+        monkeypatch.setattr(
+            _wfs, "_get_capabilities",
+            lambda *a, **k: (("1.1.0", "2.0.0"), frozenset({"topp:states"})),
+        )
+        monkeypatch.setattr(_wfs.gpd, "read_file", lambda *a, **k: _sample_gdf())
+        fc = FeatureCollection.from_wfs("https://h/ows", typename="topp:states", version="2.0.0")
+        assert isinstance(fc, FeatureCollection)
+
     def test_unknown_typename_raises_valueerror(self, monkeypatch):
         self._patch_caps(monkeypatch, typenames=("topp:states",))
         with pytest.raises(ValueError, match="not advertised"):


### PR DESCRIPTION
# Description

Adds the OGC **Web Feature Service (WFS)** reader, `FeatureCollection.from_wfs(...)` (implementation in
`pyramids/feature/_wfs.py`) — the vector sibling of `Dataset.from_wcs` (#632). It fetches a feature-type subset
from a WFS server and returns a `FeatureCollection`, using GDAL's native **OGR `WFS:` driver** so the WFS `1.x` vs
`2.0.0` dialect fork (`typeName` vs `typeNames`) is handled inside GDAL.

On top of the driver, pyramids adds:

- a cached `GetCapabilities` check so an **unadvertised feature type fails fast with a clear `ValueError`**;
- server / `<ows:ExceptionReport>` errors surface as the new **`WFSError`** (mirrors `WCSError`);
- `bbox`, `where` and `max_features` pushed down to the read; `output_crs` reprojects the result.

**No new dependencies** — GDAL's OGR WFS driver plus the existing geopandas-backed `FeatureCollection`. Provider
specifics (catalogs, auth endpoints, non-PROJ CRS) stay downstream in `earthlens`, supplied by the caller — same
generic-mechanism-in / domain-config-out split as `from_wcs` (see `docs/SCOPE.md`).

# Issues

- Closes #634 — `FeatureCollection.from_wfs` GDAL-native OGC WFS reader

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

`tests/feature/test_wfs.py` — 19 offline tests at **100% line + branch coverage** of `_wfs.py`:

- [x] pure helpers (capabilities URL, `WFS:` connection string, http config, read filters, typename extraction,
      exception-text)
- [x] capabilities parse / single-fetch LRU cache / `<ows:ExceptionReport>` -> `WFSError` / non-XML -> `WFSError` /
      transport failure -> `WFSError`
- [x] `from_wfs`: returns a `FeatureCollection`; forwards the `WFS:…?VERSION=2.0.0` connection + `bbox` / `where` /
      `max_features` / `layer` filters to the OGR read (read monkeypatched); `output_crs` reproject;
      unknown `typename` -> `ValueError`; read failure -> `WFSError`
- [x] a gated live test (`PYRAMIDS_WFS_LIVE=1` + `PYRAMIDS_WFS_ENDPOINT` / `PYRAMIDS_WFS_TYPENAME`) exercising the
      real OGR WFS driver

Run: `pixi run -e dev pytest tests/feature/test_wfs.py`.

**Follow-up:** a protocol-faithful *offline* driver-cycle mock (asserting the raw `typeNames`/`typeName`
`GetFeature` wire shape) is deferred — GDAL's WFS driver does `resultType=hits` counting + paging that needs a
careful mock. The connection string and filter forwarding are already asserted by the component tests, and the real
driver path by the gated live test.

# Checklist:

- [ ] updated version number in pyproject.toml. *(handled by commitizen in CI)*
- [ ] added changes to History.rst. *(changelog is commitizen-generated)*
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated. *(rich docstrings added; a reference page is a follow-up)*
