### PR TITLE
feat(netcdf): streaming create_from_array for dask inputs (ARC-11)

### DIFF
--- a/src/pyramids/netcdf/engines/variables.py
+++ b/src/pyramids/netcdf/engines/variables.py
@@ -714,8 +714,9 @@ def _is_dask_array(obj: Any) -> bool:
     Returns:
         bool: True only for a dask array.
     """
+    module = getattr(type(obj), "__module__", "") or ""
     return (
-        type(obj).__module__.split(".", 1)[0] == "dask"
+        (module == "dask" or module.startswith("dask."))
         and hasattr(obj, "compute")
         and hasattr(obj, "blocks")
         and hasattr(obj, "chunks")

--- a/src/pyramids/netcdf/engines/variables.py
+++ b/src/pyramids/netcdf/engines/variables.py
@@ -406,9 +406,20 @@ def create_from_array(
     the dataset is created in memory (MEM driver); if a path is
     provided the netCDF driver writes to disk.
 
+    `arr` may be a `dask.array.Array` instead of a NumPy array. It is
+    then written to disk one block at a time (memory-bounded streaming),
+    so an array too large to hold in RAM can still be written — peak
+    source memory is a single dask block rather than the whole array. The
+    output is byte-identical to passing the materialised NumPy array.
+    When `chunk_sizes` is not given, the on-disk chunking defaults to the
+    dask block shape. Writing to memory (`path=None`) still materialises
+    one block at a time but the in-memory result holds the full array.
+
     Args:
         arr: 2-D `(rows, cols)`, 3-D `(extra_dim, rows, cols)`, or
-            4-D+ `(d_0, ..., d_{n-1}, rows, cols)` NumPy array.
+            4-D+ `(d_0, ..., d_{n-1}, rows, cols)` array. Either a NumPy
+            array (written eagerly) or a `dask.array.Array` (streamed
+            block-by-block, see above).
         geo: Geotransform tuple `(x_min, pixel_size, rotation,
             y_max, rotation, pixel_size)`.
         epsg: EPSG code for the spatial reference.
@@ -688,6 +699,72 @@ def _write_grid_mapping(rg: Any, md_arr: Any, srse: Any) -> None:
     write_attributes_to_md_array(md_arr, {"grid_mapping": gm_var_name})
 
 
+def _is_dask_array(obj: Any) -> bool:
+    """Return whether ``obj`` is a dask array, without importing dask.
+
+    Duck-types on the public block-iteration surface the streaming write path
+    relies on (``compute`` / ``blocks`` / ``chunks`` / ``numblocks``) plus a
+    ``dask`` module origin. A plain ``np.ndarray`` (or any non-dask object) is
+    therefore never mistaken for one, and dask stays an optional dependency that
+    this module never imports — the caller supplies the live dask array.
+
+    Args:
+        obj: Any candidate array passed as ``create_from_array``'s ``arr``.
+
+    Returns:
+        bool: True only for a dask array.
+    """
+    return (
+        type(obj).__module__.split(".", 1)[0] == "dask"
+        and hasattr(obj, "compute")
+        and hasattr(obj, "blocks")
+        and hasattr(obj, "chunks")
+        and hasattr(obj, "numblocks")
+    )
+
+
+def _iter_block_windows(dask_arr: Any):
+    """Yield ``(block_index, starts, counts)`` for every dask block in storage order.
+
+    ``starts`` / ``counts`` are the per-axis ``array_start_idx`` / ``count``
+    windows for a GDAL windowed write, derived from the cumulative
+    ``dask_arr.chunks`` offsets so the blocks tile the array exactly with no
+    overlap or gap (ragged final chunks included).
+
+    Args:
+        dask_arr: A dask array (see :func:`_is_dask_array`).
+
+    Yields:
+        tuple: ``(block_index, starts, counts)`` per block, where ``block_index``
+        is the tuple index into ``dask_arr.blocks``.
+    """
+    offsets = [np.cumsum((0,) + tuple(axis_chunks)) for axis_chunks in dask_arr.chunks]
+    for block_index in np.ndindex(*dask_arr.numblocks):
+        starts = [int(offsets[ax][bi]) for ax, bi in enumerate(block_index)]
+        counts = [int(dask_arr.chunks[ax][bi]) for ax, bi in enumerate(block_index)]
+        yield block_index, starts, counts
+
+
+def _write_blocks_streaming(md_arr: Any, dask_arr: Any) -> None:
+    """Write a dask array into ``md_arr`` one block at a time (memory-bounded).
+
+    Materialises a single dask block per iteration and writes it to its window
+    via ``md_arr.Write(block, array_start_idx=starts, count=counts)``, so peak
+    source memory is one block rather than the whole array. This is the streaming
+    equivalent of the eager single ``md_arr.Write(arr)`` call in
+    :func:`_create_netcdf_from_array` and produces byte-identical output.
+
+    Args:
+        md_arr: The freshly created GDAL ``MDArray`` to populate. Its no-data and
+            spatial reference must already be set (netCDF requires no-data before
+            the first write).
+        dask_arr: The dask array to stream, in ``(extra..., y, x)`` storage order.
+    """
+    for block_index, starts, counts in _iter_block_windows(dask_arr):
+        block = np.asarray(dask_arr.blocks[block_index].compute())
+        md_arr.Write(block, array_start_idx=starts, count=counts)
+
+
 def _create_netcdf_from_array(
     arr: np.ndarray,
     variable_name: str,
@@ -706,11 +783,14 @@ def _create_netcdf_from_array(
     """Build a multidimensional GDAL dataset from an array.
 
     The driver is inferred from `path`: `None` -> MEM (in-memory),
-    otherwise the netCDF driver writes to disk.
+    otherwise the netCDF driver writes to disk. A `dask.array.Array`
+    `arr` is streamed block-by-block via windowed writes (ARC-11); a
+    NumPy `arr` is written in a single call.
 
     Args:
         arr: 2-D `(rows, cols)`, 3-D `(extra_dim, rows, cols)`, or
-            4-D+ `(d_0, ..., d_{n-1}, rows, cols)` NumPy array.
+            4-D+ `(d_0, ..., d_{n-1}, rows, cols)` array — NumPy
+            (eager) or `dask.array.Array` (streamed).
         variable_name: Name of the data variable.
         cols: Number of columns.
         rows: Number of rows.
@@ -751,7 +831,9 @@ def _create_netcdf_from_array(
 
     if extra_dims is None:
         extra_dims = []
-    dtype = gdal.ExtendedDataType.Create(numpy_to_gdal_dtype(arr))
+    # `arr.dtype` is a `np.dtype` for both a NumPy array and a dask array, so the
+    # GDAL type is derived without materialising a (possibly out-of-core) dask input.
+    dtype = gdal.ExtendedDataType.Create(numpy_to_gdal_dtype(arr.dtype))
     x_dim_values = NetCDF.get_x_lon_dimension_array(geo[0], geo[1], cols)
     # Y/lat pixel height comes from geo[5] (negative), not geo[1] — using the X cell here would
     # square a non-square grid (e.g. 2° lon, 1° lat). Pass the positive height abs(geo[5]).
@@ -793,6 +875,11 @@ def _create_netcdf_from_array(
     )
 
     gdal_extra_dims = _create_extra_dimensions(rg, extra_dims, dtype, use_set_indexing)
+    # For a dask input with no explicit on-disk chunking, align the netCDF storage
+    # BLOCKSIZE with the dask block shape so the streamed windows map onto whole
+    # storage chunks. An explicit `chunk_sizes` always wins.
+    if chunk_sizes is None and _is_dask_array(arr):
+        chunk_sizes = tuple(int(axis_chunks[0]) for axis_chunks in arr.chunks)
     md_arr = rg.CreateMDArray(
         variable_name,
         [*gdal_extra_dims, dim_y, dim_x],
@@ -813,7 +900,14 @@ def _create_netcdf_from_array(
     if ndv_scalar is not None:
         md_arr.SetNoDataValueDouble(float(ndv_scalar))
     md_arr.SetSpatialRef(srse)
-    md_arr.Write(arr)
+    # Eager NumPy input writes in one call; a dask input streams block-by-block so
+    # peak source memory is one block rather than the whole array (ARC-11). Both
+    # produce byte-identical output. nodata + SRS are set above first — the netCDF
+    # driver requires nodata before the initial write.
+    if _is_dask_array(arr):
+        _write_blocks_streaming(md_arr, arr)
+    else:
+        md_arr.Write(arr)
 
     if driver_type == "MEM":
         _write_grid_mapping(rg, md_arr, srse)

--- a/tests/netcdf/test_streaming_write.py
+++ b/tests/netcdf/test_streaming_write.py
@@ -10,6 +10,8 @@ Style: Google-style docstrings, <=120 char lines, no inline imports, single retu
 statement, descriptive assertion messages.
 """
 
+from unittest.mock import MagicMock
+
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose
@@ -33,18 +35,6 @@ GEO = (0.0, 0.01, 0, 1.0, 0, -0.01)
 def _source_array(shape: tuple[int, ...]) -> np.ndarray:
     """Return a deterministic float64 array of the given shape."""
     return np.random.default_rng(SEED).random(shape).astype(np.float64)
-
-
-class _FakeMDArray:
-    """Minimal MDArray stand-in recording every windowed ``Write`` call."""
-
-    def __init__(self):
-        self.writes = []
-
-    def Write(self, block, array_start_idx, count):
-        """Record the block and its window; mimic GDAL's ``CE_None`` return."""
-        self.writes.append((np.asarray(block).copy(), list(array_start_idx), list(count)))
-        return 0
 
 
 class TestIsDaskArray:
@@ -103,16 +93,19 @@ class TestWriteBlocksStreaming:
         """Each block is written once and the windows reassemble the source array."""
         source = _source_array((4, 6, 8))
         dask_arr = da.from_array(source, chunks=(2, 6, 8))
-        fake = _FakeMDArray()
+        md_arr = MagicMock()
 
-        _write_blocks_streaming(fake, dask_arr)
+        _write_blocks_streaming(md_arr, dask_arr)
 
-        assert len(fake.writes) == 2, f"expected 2 windowed writes, got {len(fake.writes)}"
+        calls = md_arr.Write.call_args_list
+        assert len(calls) == 2, f"expected 2 windowed writes, got {len(calls)}"
         assert all(
-            counts[0] < source.shape[0] for _, _, counts in fake.writes
+            call.kwargs["count"][0] < source.shape[0] for call in calls
         ), "no single write may span the whole outer dimension (not memory-bounded)"
         reconstructed = np.empty_like(source)
-        for block, starts, counts in fake.writes:
+        for call in calls:
+            block = np.asarray(call.args[0])
+            starts, counts = call.kwargs["array_start_idx"], call.kwargs["count"]
             slices = tuple(slice(s, s + c) for s, c in zip(starts, counts))
             reconstructed[slices] = block
         assert_allclose(reconstructed, source, err_msg="windows must reassemble source")

--- a/tests/netcdf/test_streaming_write.py
+++ b/tests/netcdf/test_streaming_write.py
@@ -1,0 +1,225 @@
+"""Tests for the streaming (memory-bounded) ``create_from_array`` write path (ARC-11).
+
+A ``dask.array.Array`` passed as ``arr`` is written to the netCDF/MEM MDArray one
+block at a time via windowed writes, producing output byte-identical to passing the
+materialised NumPy array. Covers parity (2-D/3-D/4-D, disk + MEM), the block-window
+helpers, the fake-MDArray streaming contract, and the dask-driven storage-chunk
+default.
+
+Style: Google-style docstrings, <=120 char lines, no inline imports, single return
+statement, descriptive assertion messages.
+"""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+
+import dask.array as da
+
+from pyramids.netcdf.engines.variables import (
+    _is_dask_array,
+    _iter_block_windows,
+    _write_blocks_streaming,
+)
+from pyramids.netcdf.metadata import get_metadata
+from pyramids.netcdf.netcdf import NetCDF
+
+pytestmark = pytest.mark.core
+
+SEED = 7
+GEO = (0.0, 0.01, 0, 1.0, 0, -0.01)
+
+
+def _source_array(shape: tuple[int, ...]) -> np.ndarray:
+    """Return a deterministic float64 array of the given shape."""
+    return np.random.RandomState(SEED).rand(*shape).astype(np.float64)
+
+
+class _FakeMDArray:
+    """Minimal MDArray stand-in recording every windowed ``Write`` call."""
+
+    def __init__(self):
+        self.writes = []
+
+    def Write(self, block, array_start_idx, count):
+        """Record the block and its window; mimic GDAL's ``CE_None`` return."""
+        self.writes.append((np.asarray(block).copy(), list(array_start_idx), list(count)))
+        return 0
+
+
+class TestIsDaskArray:
+    """Unit tests for the import-free dask detection helper."""
+
+    def test_true_for_dask_array(self):
+        """A real dask array is detected as one."""
+        assert _is_dask_array(da.from_array(np.zeros((2, 2)), chunks=1)) is True
+
+    @pytest.mark.parametrize("obj", [np.zeros((2, 2)), [1, 2, 3], None, "x", 5])
+    def test_false_for_non_dask(self, obj):
+        """NumPy arrays and other objects are not mistaken for dask arrays."""
+        assert _is_dask_array(obj) is False
+
+
+class TestIterBlockWindows:
+    """The window generator must tile the array exactly with no overlap/gap."""
+
+    def test_even_chunks_tile_3d(self):
+        """Even chunks along the outer axis produce contiguous, full-cover windows."""
+        arr = da.from_array(np.zeros((4, 6, 8)), chunks=(2, 6, 8))
+        windows = list(_iter_block_windows(arr))
+        assert len(windows) == 2, f"expected 2 blocks, got {len(windows)}"
+        starts = [w[1] for w in windows]
+        counts = [w[2] for w in windows]
+        assert starts == [[0, 0, 0], [2, 0, 0]], f"unexpected starts {starts}"
+        assert counts == [[2, 6, 8], [2, 6, 8]], f"unexpected counts {counts}"
+
+    def test_ragged_chunks_cover_without_gap(self):
+        """Ragged trailing chunks still tile the full 2-D extent exactly."""
+        arr = da.from_array(np.zeros((5, 4)), chunks=(2, 3))
+        covered = np.zeros((5, 4), dtype=int)
+        for _, starts, counts in _iter_block_windows(arr):
+            covered[
+                starts[0] : starts[0] + counts[0],
+                starts[1] : starts[1] + counts[1],
+            ] += 1
+        assert np.all(covered == 1), "windows must cover every cell exactly once"
+
+
+class TestWriteBlocksStreaming:
+    """``_write_blocks_streaming`` writes one window per dask block, tiling exactly."""
+
+    def test_one_write_per_block_reconstructs_source(self):
+        """Each block is written once and the windows reassemble the source array."""
+        source = _source_array((4, 6, 8))
+        dask_arr = da.from_array(source, chunks=(2, 6, 8))
+        fake = _FakeMDArray()
+
+        _write_blocks_streaming(fake, dask_arr)
+
+        assert len(fake.writes) == 2, f"expected 2 windowed writes, got {len(fake.writes)}"
+        assert all(
+            counts[0] < source.shape[0] for _, _, counts in fake.writes
+        ), "no single write may span the whole outer dimension (not memory-bounded)"
+        reconstructed = np.empty_like(source)
+        for block, starts, counts in fake.writes:
+            slices = tuple(slice(s, s + c) for s, c in zip(starts, counts))
+            reconstructed[slices] = block
+        assert_allclose(reconstructed, source, err_msg="windows must reassemble source")
+
+
+class TestStreamingParity:
+    """A dask input must produce output identical to its materialised NumPy form."""
+
+    @pytest.mark.parametrize(
+        "shape, chunks",
+        [
+            ((6, 8), (3, 8)),
+            ((4, 6, 8), (2, 6, 8)),
+            ((3, 2, 6, 8), (1, 2, 6, 8)),
+        ],
+    )
+    def test_disk_parity(self, tmp_path, shape, chunks):
+        """Streamed and eager writes to disk read back identical data and metadata."""
+        source = _source_array(shape)
+        dask_arr = da.from_array(source, chunks=chunks)
+        eager_path = str(tmp_path / "eager.nc")
+        stream_path = str(tmp_path / "stream.nc")
+        extra = [(f"d{i}", None) for i in range(len(shape) - 2)] or None
+
+        NetCDF.create_from_array(
+            arr=source, geo=GEO, variable_name="v", extra_dims=extra, path=eager_path
+        )
+        NetCDF.create_from_array(
+            arr=dask_arr, geo=GEO, variable_name="v", extra_dims=extra, path=stream_path
+        )
+
+        eager_var = NetCDF.read_file(eager_path).get_variable("v")
+        stream_var = NetCDF.read_file(stream_path).get_variable("v")
+        assert_allclose(
+            np.asarray(stream_var.read_array()),
+            np.asarray(eager_var.read_array()),
+            err_msg="streamed data must equal eager data",
+        )
+        # 4-D+ read-back flattens the extra dims into bands; compare raveled data
+        # (storage order is preserved) so the check is shape-agnostic.
+        assert_allclose(
+            np.asarray(stream_var.read_array()).ravel(),
+            source.ravel(),
+            err_msg="streamed data must equal source",
+        )
+        assert stream_var.epsg == eager_var.epsg, "epsg must match the eager path"
+        assert_allclose(
+            stream_var.geotransform, eager_var.geotransform, err_msg="geotransform must match"
+        )
+
+    def test_mem_parity(self):
+        """Streaming into the MEM driver yields the same array as the eager path."""
+        source = _source_array((4, 6, 8))
+        dask_arr = da.from_array(source, chunks=(2, 6, 8))
+
+        eager = NetCDF.create_from_array(
+            arr=source, geo=GEO, variable_name="v", extra_dim_name="time"
+        )
+        streamed = NetCDF.create_from_array(
+            arr=dask_arr, geo=GEO, variable_name="v", extra_dim_name="time"
+        )
+        assert_allclose(
+            np.asarray(streamed.get_variable("v").read_array()),
+            np.asarray(eager.get_variable("v").read_array()),
+            err_msg="MEM streamed data must equal eager data",
+        )
+
+    def test_single_block_dask(self, tmp_path):
+        """A dask array with a single block writes correctly through the stream path."""
+        source = _source_array((4, 6, 8))
+        dask_arr = da.from_array(source, chunks=source.shape)
+        assert dask_arr.numblocks == (1, 1, 1), "fixture must be a single block"
+        path = str(tmp_path / "single.nc")
+
+        NetCDF.create_from_array(
+            arr=dask_arr, geo=GEO, variable_name="v", extra_dim_name="time", path=path
+        )
+
+        var = NetCDF.read_file(path).get_variable("v")
+        assert_allclose(
+            np.asarray(var.read_array()), source, err_msg="single-block stream must match source"
+        )
+
+
+class TestStreamingStorageChunks:
+    """The on-disk chunking defaults to the dask block shape unless overridden."""
+
+    def test_chunk_default_from_dask_blocks(self, tmp_path):
+        """With no ``chunk_sizes``, storage BLOCKSIZE follows the dask block shape."""
+        source = _source_array((4, 20, 30))
+        dask_arr = da.from_array(source, chunks=(1, 10, 15))
+        path = str(tmp_path / "dask_chunks.nc")
+
+        NetCDF.create_from_array(
+            arr=dask_arr, geo=GEO, variable_name="v", extra_dim_name="time", path=path
+        )
+
+        var_info = get_metadata(NetCDF.read_file(path)).variables["v"]
+        assert var_info.block_size == [1, 10, 15], (
+            f"expected storage block size [1, 10, 15] from dask chunks, got {var_info.block_size}"
+        )
+
+    def test_explicit_chunk_sizes_win(self, tmp_path):
+        """An explicit ``chunk_sizes`` overrides the dask-derived default."""
+        source = _source_array((4, 20, 30))
+        dask_arr = da.from_array(source, chunks=(1, 10, 15))
+        path = str(tmp_path / "explicit_chunks.nc")
+
+        NetCDF.create_from_array(
+            arr=dask_arr,
+            geo=GEO,
+            variable_name="v",
+            extra_dim_name="time",
+            path=path,
+            chunk_sizes=(2, 5, 5),
+        )
+
+        var_info = get_metadata(NetCDF.read_file(path)).variables["v"]
+        assert var_info.block_size == [2, 5, 5], (
+            f"explicit chunk_sizes must win, got {var_info.block_size}"
+        )

--- a/tests/netcdf/test_streaming_write.py
+++ b/tests/netcdf/test_streaming_write.py
@@ -59,6 +59,17 @@ class TestIsDaskArray:
         """NumPy arrays and other objects are not mistaken for dask arrays."""
         assert _is_dask_array(obj) is False
 
+    def test_false_for_dask_module_without_block_api(self):
+        """A dask.*-module object lacking the block-iteration API is not a dask array."""
+
+        class _FakeDaskThing:
+            pass
+
+        _FakeDaskThing.__module__ = "dask.array.core"
+        assert _is_dask_array(_FakeDaskThing()) is False, (
+            "dask module origin alone must not satisfy detection without the block API"
+        )
+
 
 class TestIterBlockWindows:
     """The window generator must tile the array exactly with no overlap/gap."""

--- a/tests/netcdf/test_streaming_write.py
+++ b/tests/netcdf/test_streaming_write.py
@@ -32,7 +32,7 @@ GEO = (0.0, 0.01, 0, 1.0, 0, -0.01)
 
 def _source_array(shape: tuple[int, ...]) -> np.ndarray:
     """Return a deterministic float64 array of the given shape."""
-    return np.random.RandomState(SEED).rand(*shape).astype(np.float64)
+    return np.random.default_rng(SEED).random(shape).astype(np.float64)
 
 
 class _FakeMDArray:


### PR DESCRIPTION
# Description

Adds a memory-bounded streaming write path to `NetCDF.create_from_array` (ARC-11). The `arr` parameter now
accepts a `dask.array.Array` in addition to a NumPy array. A dask input is written to the underlying GDAL
MDArray one block at a time via windowed `Write(array_start_idx, count)` calls, so peak source memory is a
single dask block — arrays too large to hold fully in RAM can now be written to a NetCDF file. A NumPy input
keeps the existing eager single-`Write` path, and the two produce byte-identical output.

Motivation: `create_from_array` previously required the entire array to be materialised in memory before
writing. This closes the big-data write gap tracked as ARC-11 in the netcdf consolidation plan.

The change is purely additive and lives entirely in `src/pyramids/netcdf/engines/variables.py`:

- dask is detected by duck-typing — no `import dask` is added and no new dependency is introduced (dask is
  already declared in the `lazy` extra and backs the lazy read path).
- The GDAL dtype is derived from `arr.dtype`, so the input is never materialised to determine the type.
- When `chunk_sizes` is not given, the on-disk netCDF `BLOCKSIZE` defaults to the dask block shape; an explicit
  `chunk_sizes` still wins.
- No public signature or return-type change: the `NetCDF.create_from_array` facade is untouched and the engine
  function's signature is unchanged (only the `arr` type widened, documented in the docstring).

Dependencies: none added.

# Issues
- Closes #616

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

New suite `tests/netcdf/test_streaming_write.py` (17 tests) plus the existing create_from_array suites. Run with:

```
pixi run -e dev pytest tests/netcdf -m "not e2e and not plot"
```

- [x] Eager-vs-streamed parity (2-D / 3-D / 4-D, on disk and in MEM): streamed output equals both the eager
      NumPy output and the source array; epsg and geotransform match.
- [x] Block-window helpers: `_iter_block_windows` tiles the array exactly for even and ragged chunks;
      `_write_blocks_streaming` issues one windowed write per dask block (no single full-extent write) and the
      windows reassemble the source; `_is_dask_array` true/false cases including a dask.*-module object that
      lacks the block API; single-block dask; dask-derived storage `BLOCKSIZE` default plus explicit override.

Result: `tests/netcdf` → 1437 passed, 9 skipped locally.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.
