### PR TITLE
feat(netcdf): zero-copy lazy get_group view (ARC-12)

### DIFF
--- a/src/pyramids/netcdf/engines/interop.py
+++ b/src/pyramids/netcdf/engines/interop.py
@@ -90,7 +90,7 @@ class Interop(_Engine):
                 "  - conda-forge: conda install -c conda-forge xarray"
             )
 
-        rg = ds._raster.GetRootGroup()
+        rg = ds._working_group()
         if rg is None:
             raise ValueError(
                 "to_xarray requires a multidimensional container. "

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -607,7 +607,7 @@ class Selection(_Engine):
         from pyramids.netcdf.netcdf import Variable, _contiguous_range
 
         nc = self._ds
-        rg = nc._raster.GetRootGroup() if nc._raster is not None else None
+        rg = nc._working_group()
         if rg is None:
             raise ValueError(
                 "subset() requires a multidimensional store; open with "
@@ -798,7 +798,7 @@ class Selection(_Engine):
         # can't go through the raster reduce path, so they are carried through
         # unchanged below — the same split crop / to_crs use (#513). Resolve the root
         # group once and reuse it for the spanning-aux probe further down.
-        rg = nc._raster.GetRootGroup() if nc._raster is not None else None
+        rg = nc._working_group()
         spatial_vars = nc._spatial_variable_names(rg)
         aux_vars = [n for n in names if n not in spatial_vars]
 

--- a/src/pyramids/netcdf/engines/variables.py
+++ b/src/pyramids/netcdf/engines/variables.py
@@ -95,7 +95,7 @@ class Variables(_Engine):
                 (not opened in multidimensional mode).
         """
         nc = self._ds
-        rg = nc._raster.GetRootGroup()
+        rg = nc._working_group()
         if rg is None:
             raise ValueError(
                 "set_variable requires a multidimensional container. "
@@ -186,7 +186,13 @@ class Variables(_Engine):
         from pyramids.netcdf.netcdf import NetCDF
 
         nc = self._ds
-        var_rg = dataset._raster.GetRootGroup()
+        # A NetCDF source may be a group view; read its working group so variables
+        # are copied from the active sub-group. A plain Dataset has no group view.
+        var_rg = (
+            dataset._working_group()
+            if hasattr(dataset, "_working_group")
+            else dataset._raster.GetRootGroup()
+        )
         names_to_copy: list[str]
         if variable_name is not None:
             names_to_copy = [variable_name]
@@ -249,7 +255,7 @@ class Variables(_Engine):
         if new_name in nc.variable_names:
             raise ValueError(f"Variable '{new_name}' already exists.")
 
-        if nc._raster.GetRootGroup() is None:
+        if nc._working_group() is None:
             raise ValueError("rename_variable requires a multidimensional container.")
 
         # CreateMDArray is rejected on a file-backed group (netCDF data mode);

--- a/src/pyramids/netcdf/metadata.py
+++ b/src/pyramids/netcdf/metadata.py
@@ -77,6 +77,7 @@ class MetadataBuilder:
         self,
         src: gdal.Dataset,
         open_options: dict[str, Any] | None = None,
+        start_group: "gdal.Group | None" = None,
     ) -> None:
         """Initialize MetadataBuilder.
 
@@ -85,9 +86,16 @@ class MetadataBuilder:
                 to a NetCDF file. Must not be `None`.
             open_options: Optional dictionary of GDAL
                 open-options recorded for provenance.
+            start_group: Optional GDAL group to traverse from
+                instead of the dataset's root group. Used by a
+                `NetCDF` group view (`get_group()`) so its metadata
+                is scoped to the sub-group rather than the whole
+                store (ARC-12). When `None`, the dataset's root
+                group is used (the historical behaviour).
         """
         self.gdal_dataset = src
         self.open_options = open_options or None
+        self.start_group = start_group
         # Cache for `_read_classic_metadata_for_topup`: lazy-filled on
         # first call so repeat builds (or repeat calls within a build)
         # don't re-open the file in classic mode. `None` means "not yet
@@ -124,9 +132,11 @@ class MetadataBuilder:
         """
         ds = self.gdal_dataset
 
-        # Driver name and root group
+        # Driver name and root group. A group view passes an explicit
+        # start_group so traversal is scoped to that sub-group (ARC-12);
+        # otherwise traverse from the dataset's root group as before.
         driver_name = _get_driver_name(ds)
-        root_group = _get_root_group(ds)
+        root_group = self.start_group if self.start_group is not None else _get_root_group(ds)
 
         groups_map: dict[str, GroupInfo] = {}
         variables_map: dict[str, VariableInfo] = {}
@@ -612,6 +622,7 @@ class GroupTraverser:
 def get_metadata(
     source,
     open_options: dict[str, Any] | None = None,
+    start_group: "gdal.Group | None" = None,
 ) -> NetCDFMetadata:
     """Read and normalize all NetCDF MDIM metadata.
 
@@ -627,6 +638,10 @@ def get_metadata(
         open_options: Optional dictionary of GDAL open-options.
             Stored in the resulting metadata for provenance but
             not used to open the file.
+        start_group: Optional GDAL group to traverse from instead
+            of the dataset's root group. A `NetCDF` group view
+            passes its working sub-group so the metadata is scoped
+            to that group (ARC-12). Ignored for string/path sources.
 
     Returns:
         NetCDFMetadata: Fully populated metadata dataclass.
@@ -658,10 +673,10 @@ def get_metadata(
         ds = None  # close the temporary handle
         return result
     elif hasattr(source, "_raster"):
-        builder = MetadataBuilder(source._raster, open_options)
+        builder = MetadataBuilder(source._raster, open_options, start_group)
         return builder.build()
     else:
-        builder = MetadataBuilder(source, open_options)
+        builder = MetadataBuilder(source, open_options, start_group)
         return builder.build()
 
 

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -520,6 +520,12 @@ class NetCDF(Dataset):
         # Origin-tracking attributes set by get_variable (RT-4)
         self._parent_nc: NetCDF | None = None
         self._source_var_name: str | None = None
+        # ARC-12: a group view shares the parent container's open dataset and
+        # records the "/"-joined path to its working sub-group here. None (the
+        # default) means this container is rooted at the dataset's root group;
+        # `_working_group()` resolves the active group from this field so a
+        # `get_group()` view reads variables/dims/attrs without copying data.
+        self._group_path: str | None = None
         self._gdal_md_arr_ref: Any = None
         self._gdal_rg_ref: Any = None
         # Keeps the source MDIM view alive when a geostationary variable is
@@ -1914,7 +1920,7 @@ class NetCDF(Dataset):
                 ```
         """
         if rg is None:
-            rg = self._raster.GetRootGroup() if self._raster is not None else None
+            rg = self._working_group()
         if rg is None:
             return []
         return [n for n in self.variable_names if self._variable_is_spatial(rg, n)]
@@ -2013,7 +2019,7 @@ class NetCDF(Dataset):
 
         # Resolve the root group once and thread it through the spatial-variable scan
         # and the aux-variable dimension probe below, instead of re-resolving per call.
-        rg = self._raster.GetRootGroup() if self._raster is not None else None
+        rg = self._working_group()
         spatial_vars = self._spatial_variable_names(rg)
         aux_vars = [n for n in names if n not in spatial_vars]
         if not spatial_vars:
@@ -2867,7 +2873,7 @@ class NetCDF(Dataset):
                 >>> nc.dimension_sizes  # doctest: +SKIP
                 {'soil_layers_stag': 4, 'time': 128568, 'vis_nir': 2, 'x': 4608, 'y': 3840}
         """
-        rg = self._raster.GetRootGroup() if self._raster is not None else None
+        rg = self._working_group()
         if rg is None:
             return {}
         return {dim.GetName(): int(dim.GetSize()) for dim in rg.GetDimensions()}
@@ -2918,7 +2924,7 @@ class NetCDF(Dataset):
             list[str] or None: Dim names. `None` only when the cube is
             neither MDIM-backed nor has cached `_md_array_dims`.
         """
-        rg = self._raster.GetRootGroup()
+        rg = self._working_group()
         if rg is not None:
             dims = rg.GetDimensions()
             return [dim.GetName() for dim in dims]
@@ -2947,7 +2953,7 @@ class NetCDF(Dataset):
     def _get_dimension(self, name: str) -> gdal.Dimension:
         dim_names = self.dimension_names
         if dim_names is not None and name in dim_names:
-            rg = self._raster.GetRootGroup()
+            rg = self._working_group()
             dims = rg.GetDimensions()
             dim = dims[dim_names.index(name)]
         else:
@@ -2994,7 +3000,7 @@ class NetCDF(Dataset):
                 variable is not found.
         """
         result = None
-        rg = self._raster.GetRootGroup()
+        rg = self._working_group()
         if rg is not None:
             try:
                 md_arr = rg.OpenMDArray(var)
@@ -3041,6 +3047,36 @@ class NetCDF(Dataset):
                 pass
         return result
 
+    def _working_group(self) -> Any:
+        """Return the GDAL group this container is rooted at.
+
+        For a normal container (`_group_path` is None) this is the dataset's
+        root group — identical to the historical `self._raster.GetRootGroup()`.
+        For a `get_group()` view it walks the `/`-joined `_group_path` from the
+        root and returns the nested sub-group, so the container reads that
+        group's variables, dimensions, and attributes in place without copying
+        any data (ARC-12).
+
+        Returns:
+            The active `osgeo.gdal.Group`, or `None` when the dataset is closed,
+            in classic (non-MDIM) mode, or the recorded group path no longer
+            resolves.
+        """
+        if self._raster is None:
+            return None
+        rg = self._raster.GetRootGroup()
+        if rg is None or not self._group_path:
+            return rg
+        group = rg
+        for part in self._group_path.split("/"):
+            try:
+                group = group.OpenGroup(part)
+            except RuntimeError:
+                group = None
+            if group is None:
+                return None
+        return group
+
     @property
     def group_names(self) -> list[str]:
         """Names of sub-groups in the root group.
@@ -3050,7 +3086,7 @@ class NetCDF(Dataset):
             Empty list if no sub-groups exist or the dataset is in
             classic mode.
         """
-        rg = self._raster.GetRootGroup()
+        rg = self._working_group()
         result = []
         if rg is not None:
             try:
@@ -3079,7 +3115,7 @@ class NetCDF(Dataset):
             ValueError: If the group doesn't exist or the dataset
                 has no root group.
         """
-        rg = self._raster.GetRootGroup()
+        rg = self._working_group()
         if rg is None:
             raise ValueError("get_group requires a multidimensional container.")
 
@@ -3183,7 +3219,7 @@ class NetCDF(Dataset):
         if self._cached_meta_data is not None and self._cached_meta_data.cf is not None:
             variable_names = list(self._cached_meta_data.cf.data_variable_names)
         else:
-            rg = self._raster.GetRootGroup()
+            rg = self._working_group()
             if rg is not None:
                 variable_names = self._mdim_data_variable_names(rg)
             else:
@@ -3343,7 +3379,7 @@ class NetCDF(Dataset):
         collected the view becomes a dangling pointer (segfault on
         Windows).
         """
-        rg = self._raster.GetRootGroup()
+        rg = self._working_group()
         md_arr = rg.OpenMDArray(variable_name)
         dims = md_arr.GetDimensions()
 
@@ -3437,7 +3473,7 @@ class NetCDF(Dataset):
             )
 
         prefix = self.driver_type.upper()
-        rg = self._raster.GetRootGroup()
+        rg = self._working_group()
         md_arr_ref = None
         rg_ref = None
 
@@ -3925,7 +3961,7 @@ class NetCDF(Dataset):
         Root-level variables and global attributes only; hierarchical groups are not handled here
         (those files copy fine through ``CreateCopy``), so this raises if the source has subgroups.
         """
-        src_rg = self._raster.GetRootGroup()
+        src_rg = self._working_group()
         if src_rg is None:
             raise RuntimeError("manual netCDF copy requires a multidimensional container")
         if src_rg.GetGroupNames():
@@ -4300,7 +4336,7 @@ class NetCDF(Dataset):
         Returns:
             dict[str, Any]: Key-value mapping of global attributes.
         """
-        rg = self._raster.GetRootGroup()
+        rg = self._working_group()
         if rg is not None:
             result = _read_attributes(rg)
         else:
@@ -4321,7 +4357,7 @@ class NetCDF(Dataset):
             ValueError: If the dataset has no root group
                 (not opened in MDIM mode).
         """
-        rg = self._raster.GetRootGroup()
+        rg = self._working_group()
         if rg is None:
             raise ValueError(
                 "set_global_attribute requires a multidimensional "
@@ -4360,7 +4396,7 @@ class NetCDF(Dataset):
         Raises:
             ValueError: If the dataset has no root group.
         """
-        rg = self._raster.GetRootGroup()
+        rg = self._working_group()
         if rg is None:
             raise ValueError(
                 "delete_global_attribute requires a multidimensional " "container."

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -128,18 +128,22 @@ def _reconstruct_netcdf(
     is_md_array: bool,
     is_subset: bool,
     source_var_name: str | None,
+    group_path: str | None = None,
 ) -> NetCDF:
     """Re-open a :class:`NetCDF` from its pickle recipe tuple.
 
-    Called by :meth:`NetCDF.__reduce__` on unpickle. Carries four
-    bits of extra state beyond the base :class:`RasterBase`
-    recipe so the reconstructed instance retains identity:
+    Called by :meth:`NetCDF.__reduce__` on unpickle. Carries extra
+    state beyond the base :class:`RasterBase` recipe so the
+    reconstructed instance retains identity:
 
     * `is_md_array` — was the file opened via
       :data:`gdal.OF_MULTIDIM_RASTER` (MDIM mode) or classic mode?
     * `is_subset` — is this instance a container or a single variable?
     * `source_var_name` — when `is_subset` is True, the variable
       path to re-traverse via :meth:`NetCDF.get_variable`.
+    * `group_path` — when set, the `/`-joined sub-group path to
+      re-traverse via :meth:`NetCDF.get_group` so a group view (ARC-12)
+      round-trips back to the same sub-group.
 
     Args:
         path: On-disk path or VSI URL to re-open.
@@ -151,9 +155,12 @@ def _reconstruct_netcdf(
             rebuilt container is then drilled into via
             :meth:`NetCDF.get_variable` before return.
         source_var_name: Variable path for the subset drill-down.
+        group_path: Sub-group path for a group view; when set, the
+            rebuilt container is drilled into via
+            :meth:`NetCDF.get_group`. Defaults to None.
 
     Returns:
-        NetCDF: Container or variable-subset instance.
+        NetCDF: Container, group view, or variable-subset instance.
     """
     read_only = access == "read_only"
     container = NetCDF.read_file(
@@ -161,7 +168,9 @@ def _reconstruct_netcdf(
         read_only=read_only,
         open_as_multi_dimensional=is_md_array,
     )
-    if is_subset and source_var_name is not None:
+    if group_path:
+        result = container.get_group(group_path)
+    elif is_subset and source_var_name is not None:
         result = container.get_variable(source_var_name)
     else:
         result = container
@@ -454,7 +463,7 @@ class NetCDF(Dataset):
                 in-memory NetCDF is not supported.
         """
         path = self._file_name
-        if (not path) and self._is_subset:
+        if (not path) and (self._is_subset or self._group_path):
             parent = getattr(self, "_parent_nc", None)
             if parent is not None:
                 path = parent._file_name
@@ -472,6 +481,7 @@ class NetCDF(Dataset):
                 bool(self._is_md_array),
                 bool(self._is_subset),
                 self._source_var_name,
+                self._group_path,
             ),
         )
 
@@ -631,6 +641,7 @@ class NetCDF(Dataset):
             "_is_subset": self._is_subset,
             "_parent_nc": self._parent_nc,
             "_source_var_name": self._source_var_name,
+            "_group_path": self._group_path,
             "_gdal_md_arr_ref": self._gdal_md_arr_ref,
             "_gdal_rg_ref": self._gdal_rg_ref,
             "_gdal_classic_src_ref": self._gdal_classic_src_ref,
@@ -2791,7 +2802,12 @@ class NetCDF(Dataset):
             open_options = {
                 "Open Mode": "SHARED" if self.is_subset else "MULTIDIM_RASTER"
             }
-            self._cached_meta_data = get_metadata(self._raster, open_options)
+            # Scope traversal to the working group so a get_group() view reports
+            # its sub-group's metadata, not the whole store (ARC-12). For a normal
+            # container the working group is the root group, so this is unchanged.
+            self._cached_meta_data = get_metadata(
+                self._raster, open_options, start_group=self._working_group()
+            )
         return self._cached_meta_data
 
     @meta_data.setter
@@ -2816,7 +2832,9 @@ class NetCDF(Dataset):
         Returns:
             NetCDFMetadata
         """
-        result = get_metadata(self._raster, open_options)
+        result = get_metadata(
+            self._raster, open_options, start_group=self._working_group()
+        )
         return result
 
     def get_time_variable(
@@ -3098,18 +3116,28 @@ class NetCDF(Dataset):
         return result
 
     def get_group(self, group_name: str) -> NetCDF:
-        """Open a sub-group as a NetCDF container.
+        """Open a sub-group as a NetCDF container, without copying its data.
 
-        The returned object wraps the sub-group's GDAL dataset and
-        exposes the sub-group's variables and dimensions via the
-        same API as the root container.
+        The returned :class:`Container` is a **zero-copy view** (ARC-12): it
+        shares this container's open GDAL dataset and records the path to the
+        sub-group, rather than materialising every array into a new in-memory
+        store. Variables, dimensions, and attributes are read from the
+        sub-group in place, and `read_array(chunks=)` on a variable extracted
+        from the view stays lazy — so opening a group of large variables no
+        longer reads them all into memory up front.
+
+        The view holds its own reference to the shared dataset and keeps this
+        parent container alive, so closing either side only drops a reference;
+        the underlying GDAL dataset is freed once both are released.
 
         Args:
             group_name: Name of the sub-group. Supports nested paths
-                separated by `/` (e.g. `"forecast/surface"`).
+                separated by `/` (e.g. `"forecast/surface"`). Applied
+                relative to this container's current group, so `get_group`
+                can be chained.
 
         Returns:
-            NetCDF: A container backed by the sub-group.
+            NetCDF: A `Container` view backed by the sub-group.
 
         Raises:
             ValueError: If the group doesn't exist or the dataset
@@ -3119,10 +3147,10 @@ class NetCDF(Dataset):
         if rg is None:
             raise ValueError("get_group requires a multidimensional container.")
 
-        # Navigate nested paths: "forecast/surface" → open each level
+        # Validate that the requested (possibly nested) path resolves from the
+        # current working group before building the view.
         group = rg
-        parts = group_name.split("/")
-        for part in parts:
+        for part in group_name.split("/"):
             try:
                 group = group.OpenGroup(part)
             except RuntimeError:
@@ -3133,63 +3161,17 @@ class NetCDF(Dataset):
                     f"Available groups: {self.group_names}"
                 )
 
-        # Create a multidimensional dataset from the sub-group.
-        # GDAL doesn't have a direct "group → dataset" conversion,
-        # so we build a MEM MDIM dataset and copy the group's
-        # arrays and dimensions into it.
-        dst = gdal.GetDriverByName("MEM").CreateMultiDimensional("group")
-        dst_rg = dst.GetRootGroup()
-
-        # Copy dimensions from the sub-group
-        dim_map = {}
-        for gdal_dim in group.GetDimensions() or []:
-            dim_name = gdal_dim.GetName()
-            new_dim = dst_rg.CreateDimension(
-                dim_name, gdal_dim.GetType(), None, gdal_dim.GetSize()
-            )
-            iv = gdal_dim.GetIndexingVariable()
-            if iv is not None:
-                coord_arr = dst_rg.CreateMDArray(
-                    dim_name,
-                    [new_dim],
-                    gdal.ExtendedDataType.Create(numpy_to_gdal_dtype(iv.ReadAsArray())),
-                )
-                coord_arr.Write(iv.ReadAsArray())
-                new_dim.SetIndexingVariable(coord_arr)
-            dim_map[dim_name] = new_dim
-
-        # Copy arrays from the sub-group
-        for arr_name in group.GetMDArrayNames() or []:
-            md_arr = group.OpenMDArray(arr_name)
-            if md_arr is None:
-                continue
-            arr_dims = md_arr.GetDimensions()
-            # Map source dims to destination dims (by name)
-            new_dims = []
-            for d in arr_dims:
-                d_name = d.GetName()
-                if d_name in dim_map:
-                    new_dims.append(dim_map[d_name])
-                else:
-                    # Dimension from parent group — create locally
-                    new_d = dst_rg.CreateDimension(
-                        d_name, d.GetType(), None, d.GetSize()
-                    )
-                    dim_map[d_name] = new_d
-                    new_dims.append(new_d)
-            arr_data = md_arr.ReadAsArray()
-            arr_dtype = gdal.ExtendedDataType.Create(numpy_to_gdal_dtype(arr_data))
-            new_arr = dst_rg.CreateMDArray(arr_name, new_dims, arr_dtype)
-            new_arr.Write(arr_data)
-            ndv = md_arr.GetNoDataValue()
-            if ndv is not None:
-                new_arr.SetNoDataValueDouble(ndv)
-            srs = md_arr.GetSpatialRef()
-            if srs is not None:
-                new_arr.SetSpatialRef(srs)
-
-        result = Container(dst)
-        return result
+        # Zero-copy view: share the parent's open dataset and record the path to
+        # the sub-group. `_working_group()` resolves it on demand, so no array
+        # data is copied. Compose paths so get_group() chains on an existing view.
+        view = Container(self._raster, access=self._access)
+        view._group_path = (
+            group_name if not self._group_path else f"{self._group_path}/{group_name}"
+        )
+        # Pin the parent so the shared dataset (and its SWIG wrappers) outlive the
+        # view even if the caller drops the parent reference.
+        view._parent_nc = self
+        return view
 
     def get_variable_names(self) -> list[str]:
         """Deprecated alias for the :attr:`variable_names` property (API-3).

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -3065,7 +3065,7 @@ class NetCDF(Dataset):
                 pass
         return result
 
-    def _working_group(self) -> Any:
+    def _working_group(self) -> "gdal.Group | None":
         """Return the GDAL group this container is rooted at.
 
         For a normal container (`_group_path` is None) this is the dataset's
@@ -3122,9 +3122,14 @@ class NetCDF(Dataset):
         shares this container's open GDAL dataset and records the path to the
         sub-group, rather than materialising every array into a new in-memory
         store. Variables, dimensions, and attributes are read from the
-        sub-group in place, and `read_array(chunks=)` on a variable extracted
-        from the view stays lazy — so opening a group of large variables no
-        longer reads them all into memory up front.
+        sub-group in place, and each variable's data is materialised only when
+        it is extracted via `get_variable` — so opening a group of large
+        variables no longer reads them all into memory up front.
+
+        (The lazy `read_array(chunks=)` dask path resolves a variable from the
+        store's root group, so it does not yet reach a sub-group variable — the
+        same pre-existing limitation as the group-qualified
+        `get_variable("group/var")` path; eager reads work as usual.)
 
         The view holds its own reference to the shared dataset and keeps this
         parent container alive, so closing either side only drops a reference;
@@ -3715,7 +3720,7 @@ class NetCDF(Dataset):
             cube._offset = None
 
     def _writable_root_group(self) -> tuple[gdal.Dataset, gdal.Group]:
-        """Return a ``(dataset, root_group)`` pair that is safe to mutate.
+        """Return a ``(dataset, working_group)`` pair that is safe to mutate.
 
         A file-backed netCDF root group is opened in "data mode", which rejects
         ``CreateMDArray`` / ``DeleteMDArray`` / ``CreateDimension``. So for a file-backed
@@ -3723,14 +3728,28 @@ class NetCDF(Dataset):
         an already in-memory container is returned as-is. The caller is responsible for
         swapping the returned dataset in via :meth:`_replace_raster`.
 
+        For a `get_group()` view (`_group_path` set) the returned group is the
+        **sub-group** inside the writable dataset, not its root — so
+        ``set_variable`` / ``add_variable`` / ``rename_variable`` mutate the group
+        the view reads from rather than the store root (ARC-12). `_group_path` is
+        preserved across :meth:`_replace_raster`, so reads stay consistent with the
+        write. For a normal container the working group is the root group, so the
+        behaviour is unchanged.
+
         Returns:
-            tuple: The writable :class:`osgeo.gdal.Dataset` and its root group.
+            tuple: The writable :class:`osgeo.gdal.Dataset` and its working group.
         """
         if self.driver_type == "memory":
             dst = self._raster
         else:
             dst = gdal.GetDriverByName("MEM").CreateCopy("", self._raster, 0)
-        return dst, dst.GetRootGroup()
+        group = dst.GetRootGroup()
+        if group is not None and self._group_path:
+            for part in self._group_path.split("/"):
+                group = group.OpenGroup(part)
+                if group is None:
+                    break
+        return dst, group
 
     @staticmethod
     def _derive_primary_band_view(

--- a/tests/netcdf/test_api1_type_split.py
+++ b/tests/netcdf/test_api1_type_split.py
@@ -210,10 +210,11 @@ class TestTypePreservation:
         out = tmp_path / "var_copy.nc"
         copied = variable.copy(str(out))
         _func, args = copied.__reduce__()
-        path, _access, _is_md, is_subset, source_var = args
+        path, _access, _is_md, is_subset, source_var, group_path = args
         assert Path(path).name == "var_copy.nc", f"recipe must target the copy, got {path!r}"
         assert is_subset is False, "a copy must not be pickled as a parent subset"
         assert source_var is None, "a copy must not carry a parent source-variable name"
+        assert group_path is None, "a copy must not be pickled as a group view"
 
     def test_epsg_setter_inplace_preserves_variable_type(self, variable):
         """An in-place op (the ``epsg`` setter) does not downgrade a Variable.

--- a/tests/netcdf/test_lazy_get_group.py
+++ b/tests/netcdf/test_lazy_get_group.py
@@ -1,0 +1,147 @@
+"""Tests for the zero-copy lazy get_group view (ARC-12).
+
+`get_group` returns a `Container` that shares the parent's open GDAL dataset and
+reads the sub-group in place, instead of MEM-copying every array. These tests
+cover zero-copy sharing, group-scoped `variable_names` / `meta_data`, correct
+reads (parity with the group-qualified `get_variable` path), nested chaining,
+`close()` reference-count safety, and the pickle round-trip carrying
+`_group_path`.
+
+Style: Google-style docstrings, <=120 char lines, no inline imports, single
+return statement, descriptive assertion messages.
+"""
+
+import pickle
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+from osgeo import gdal
+
+from pyramids.netcdf.netcdf import Container, NetCDF
+
+pytestmark = pytest.mark.core
+
+DISK_GROUPS = "tests/data/netcdf/none__35v__1d35__groups-nc4.nc"
+
+
+def _build_grouped_mem() -> Container:
+    """Return an in-memory container: root elevation + forecast (nested surface) + analysis."""
+    src = gdal.GetDriverByName("MEM").CreateMultiDimensional("test")
+    rg = src.GetRootGroup()
+    dtype = gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    dim_x = rg.CreateDimension("x", "HORIZONTAL_X", None, 8)
+    dim_y = rg.CreateDimension("y", "HORIZONTAL_Y", None, 5)
+    rg.CreateMDArray("elevation", [dim_y, dim_x], dtype).Write(np.full((5, 8), 100.0))
+
+    forecast = rg.CreateGroup("forecast")
+    forecast.CreateMDArray("temperature", [dim_y, dim_x], dtype).Write(np.full((5, 8), 300.0))
+    surface = forecast.CreateGroup("surface")
+    surface.CreateMDArray("t2m", [dim_y, dim_x], dtype).Write(np.full((5, 8), 288.0))
+
+    analysis = rg.CreateGroup("analysis")
+    analysis.CreateMDArray("wind_speed", [dim_y, dim_x], dtype).Write(np.full((5, 8), 5.5))
+    return Container(src)
+
+
+class TestZeroCopyView:
+    """The view shares the parent dataset rather than copying arrays."""
+
+    def test_get_group_shares_parent_dataset(self):
+        """The returned view's raster IS the parent's dataset (no MEM copy)."""
+        nc = _build_grouped_mem()
+        view = nc.get_group("forecast")
+        assert view._raster is nc._raster, "group view must share the parent's gdal.Dataset"
+        assert isinstance(view, Container), "group view must be a Container"
+        assert view._group_path == "forecast", "view must record its sub-group path"
+
+    def test_view_variable_names_are_group_scoped(self):
+        """The view reports the sub-group's variables, not the root's or siblings'."""
+        nc = _build_grouped_mem()
+        view = nc.get_group("forecast")
+        assert "temperature" in view.variable_names, "view must see its own variable"
+        assert "elevation" not in view.variable_names, "view must not see the root variable"
+        assert "wind_speed" not in view.variable_names, "view must not see a sibling group"
+
+    def test_view_metadata_is_group_scoped(self):
+        """`meta_data` traversal is scoped to the sub-group."""
+        nc = _build_grouped_mem()
+        view = nc.get_group("analysis")
+        # Metadata keys variables by full path (e.g. "analysis/wind_speed"); compare leaf names.
+        leaves = {name.split("/")[-1] for name in view.meta_data.variables}
+        assert "wind_speed" in leaves, "group metadata must include the group's variable"
+        assert "temperature" not in leaves, "group metadata must exclude other groups"
+        assert "elevation" not in leaves, "group metadata must exclude the root variable"
+
+
+class TestViewReads:
+    """Reading through the view matches the group-qualified get_variable path."""
+
+    def test_read_matches_group_qualified_path(self):
+        """`view.get_variable(name)` reads the same data as `nc.get_variable('grp/name')`."""
+        nc = _build_grouped_mem()
+        view = nc.get_group("forecast")
+        via_view = np.asarray(view.get_variable("temperature").read_array(band=0))
+        via_root = np.asarray(nc.get_variable("forecast/temperature").read_array(band=0))
+        assert_allclose(via_view, via_root, err_msg="view read must match the qualified path")
+        assert_allclose(
+            via_view, np.full((5, 8), 300.0), err_msg="view must read the stored values"
+        )
+
+
+class TestNestedChaining:
+    """get_group composes paths so it can be chained."""
+
+    def test_chained_equals_slashed_path(self):
+        """`get_group('a').get_group('b')` matches `get_group('a/b')`."""
+        nc = _build_grouped_mem()
+        chained = nc.get_group("forecast").get_group("surface")
+        slashed = nc.get_group("forecast/surface")
+        assert chained._group_path == "forecast/surface", "chained path must compose"
+        assert slashed._group_path == "forecast/surface", "slashed path must match"
+        assert "t2m" in chained.variable_names, "nested group's variable must be visible"
+        assert_allclose(
+            np.asarray(chained.get_variable("t2m").read_array(band=0)),
+            np.full((5, 8), 288.0),
+            err_msg="nested-group read must return the stored values",
+        )
+
+    def test_invalid_group_raises(self):
+        """An unknown group name raises ValueError."""
+        nc = _build_grouped_mem()
+        with pytest.raises(ValueError, match="not found"):
+            nc.get_group("nonexistent")
+
+
+class TestCloseRefcount:
+    """Sharing the dataset must not let one side close it out from under the other."""
+
+    def test_closing_view_leaves_parent_usable(self):
+        """Closing the view only drops its reference; the parent keeps working."""
+        nc = _build_grouped_mem()
+        view = nc.get_group("forecast")
+        view.close()
+        assert "forecast" in nc.group_names, "parent must survive the view's close()"
+        assert "elevation" in nc.variable_names, "parent reads must still work"
+
+    def test_view_survives_parent_close(self):
+        """The view holds its own dataset reference, so it outlives the parent's close()."""
+        nc = _build_grouped_mem()
+        view = nc.get_group("forecast")
+        nc.close()
+        assert "temperature" in view.variable_names, "view must still read after parent close()"
+
+
+class TestPickleRoundTrip:
+    """A group view round-trips back to the same sub-group (on-disk source)."""
+
+    def test_group_view_pickle_preserves_group(self):
+        """Unpickling a group view yields a view of the same group with the same variables."""
+        nc = NetCDF.read_file(DISK_GROUPS)
+        group_name = nc.group_names[0]
+        view = nc.get_group(group_name)
+        restored = pickle.loads(pickle.dumps(view))
+        assert restored._group_path == group_name, "pickle must preserve the group path"
+        assert sorted(restored.variable_names) == sorted(
+            view.variable_names
+        ), "restored view must expose the same group variables"

--- a/tests/netcdf/test_lazy_get_group.py
+++ b/tests/netcdf/test_lazy_get_group.py
@@ -25,6 +25,19 @@ pytestmark = pytest.mark.core
 DISK_GROUPS = "tests/data/netcdf/none__35v__1d35__groups-nc4.nc"
 
 
+GEO = (0.0, 1.0, 0, 5.0, 0, -1.0)
+
+
+def _write_grouped_disk(path) -> str:
+    """Write the in-memory grouped fixture to an on-disk netCDF and return the path."""
+    mem = _build_grouped_mem()
+    out = gdal.GetDriverByName("netCDF").CreateCopy(str(path), mem._raster)
+    out.FlushCache()
+    out = None
+    mem.close()
+    return str(path)
+
+
 def _build_grouped_mem() -> Container:
     """Return an in-memory container: root elevation + forecast (nested surface) + analysis."""
     src = gdal.GetDriverByName("MEM").CreateMultiDimensional("test")
@@ -130,6 +143,47 @@ class TestCloseRefcount:
         view = nc.get_group("forecast")
         nc.close()
         assert "temperature" in view.variable_names, "view must still read after parent close()"
+
+
+class TestNoEagerCopy:
+    """get_group must not read array data up front (the ARC-12 win)."""
+
+    def test_get_group_does_not_read_arrays(self, monkeypatch):
+        """Building the view performs no MDArray ReadAsArray (no eager materialisation)."""
+        nc = _build_grouped_mem()
+        calls = {"n": 0}
+        original = gdal.MDArray.ReadAsArray
+
+        def _counting_read(self, *args, **kwargs):
+            calls["n"] += 1
+            return original(self, *args, **kwargs)
+
+        monkeypatch.setattr(gdal.MDArray, "ReadAsArray", _counting_read)
+        view = nc.get_group("forecast")
+        assert view._raster is nc._raster, "view must share the dataset (no copy)"
+        assert calls["n"] == 0, "get_group must not read any array data eagerly"
+
+
+class TestFileBackedMutation:
+    """Mutating a file-backed group view targets the sub-group, not the store root."""
+
+    def test_set_variable_targets_subgroup(self, tmp_path):
+        """set_variable on a file-backed group view lands in the group the view reads."""
+        path = _write_grouped_disk(tmp_path / "grouped.nc")
+        nc = NetCDF.read_file(path)
+        view = nc.get_group("forecast")
+        source = NetCDF.create_from_array(
+            arr=np.full((5, 8), 7.0), geo=GEO, variable_name="precip"
+        ).get_variable("precip")
+
+        view.set_variable("precip", source)
+
+        assert "precip" in view.variable_names, "written variable must be visible in the group view"
+        assert_allclose(
+            np.asarray(view.get_variable("precip").read_array(band=0)),
+            np.full((5, 8), 7.0),
+            err_msg="the group view must read back the value it wrote",
+        )
 
 
 class TestPickleRoundTrip:


### PR DESCRIPTION
# Description

Makes `NetCDF.get_group` a zero-copy lazy view instead of eagerly MEM-copying every array in the sub-group
(ARC-12). Opening a group of large variables no longer reads them all into memory up front.

`get_group` now returns a `Container` that shares the parent's open GDAL dataset and records the sub-group path
in a new `_group_path` field. A new `NetCDF._working_group()` accessor resolves the active group on demand (the
root group for a normal container, the nested sub-group for a view), and the container's "working group"
`GetRootGroup()` call sites in `netcdf.py` and the engines route through it. Variables, dimensions, and
attributes are read from the sub-group in place; each variable's data is materialised only when extracted via
`get_variable`.

Supporting changes:

- Metadata traversal (`MetadataBuilder` / `get_metadata`) takes an optional `start_group`, so a view's
  `meta_data` is scoped to its sub-group rather than the whole store. For a normal container the working group is
  the root group, so behaviour is unchanged.
- The pickle recipe carries `_group_path` and `_update_inplace` preserves it, so a group view round-trips back to
  its sub-group.
- `_writable_root_group()` resolves `_group_path` in the writable dataset and returns the working group, so
  `set_variable` / `add_variable` / `rename_variable` on a group view mutate the sub-group the view reads (rather
  than the store root).

The view holds its own reference to the shared dataset and pins the parent, so closing either side only drops a
reference; the underlying GDAL dataset is freed once both are released. No public signature or return-type change.

Note: this branch is stacked on the ARC-11 streaming-`create_from_array` work (#637); it is based on that branch
so the diff shows only the ARC-12 delta, and GitHub will retarget it to `main` once #637 merges.

Dependencies: none added.

# Issues
- Closes #617

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

New suite `tests/netcdf/test_lazy_get_group.py` (11 tests) plus the existing group suites. Run with:

```
pixi run -e dev pytest tests/netcdf -m "not e2e and not plot"
```

- [x] Zero-copy: the view shares the parent's `gdal.Dataset` (no MEM copy), and `get_group` performs zero
      `MDArray.ReadAsArray` calls at construction.
- [x] Group-scoped `variable_names` and `meta_data` (the view reports the sub-group, not root or siblings).
- [x] Read parity with the group-qualified `get_variable("group/var")` path; nested `get_group` chaining.
- [x] `close()` reference-count safety: the view and the parent each survive the other's `close()`.
- [x] File-backed group-view `set_variable` lands in (and reads back from) the sub-group.
- [x] Pickle round-trip preserves `_group_path`.

Result: `tests/netcdf` → 1448 passed, 9 skipped locally.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.
