### PR TITLE
feat(netcdf): read remote NetCDF over OPeNDAP/THREDDS via dods:// URLs

### DIFF
--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -317,48 +317,50 @@ def _to_vsi(path: str) -> str:
 
             ```
     """
-    new_path: str
     if path.startswith(_VSI_PREFIXES):
-        new_path = path
-    else:
-        parsed = urlparse(path)
-        scheme = parsed.scheme.lower()
-        if scheme == "dods":
-            # OPeNDAP / THREDDS: libnetcdf speaks DAP, so route the DAP URL to
-            # GDAL's netCDF driver rather than /vsicurl/ (which would byte-range a
-            # DAP endpoint and fail). dods://host/path -> NETCDF:"https://host/path"
-            # (query/fragment preserved). dods:// assumes https; an http-only DAP
-            # server is reached by passing the GDAL form directly, e.g.
-            # NetCDF.read_file('NETCDF:"http://host/path"'), which passes through here.
-            remainder = path[len(scheme) + 1 :].lstrip("/")  # after "dods:" / "dods://"
-            new_path = f'NETCDF:"https://{remainder}"'
-        elif scheme not in URL_SCHEMES or len(scheme) <= 1:
-            new_path = path
-        elif scheme in {"s3", "gs", "az", "abfs"}:
-            bucket = parsed.netloc
-            key = parsed.path.lstrip("/")
-            new_path = f"{URL_SCHEMES[scheme]}{bucket}/{key}"
-        elif scheme in {"http", "https"}:
-            new_path = f"/vsicurl/{path}"
-        elif scheme == "file":
-            local = parsed.path
-            # Windows file URIs: file:///C:/path -> /C:/path -> C:/path
-            if local.startswith("/") and len(local) > 2 and local[2] == ":":
-                local = local[1:]
-            new_path = local
-        else:  # pragma: no cover — all schemes above covered
-            new_path = path
-
-        new_path = _chain_archive_vsi(new_path)
-
-        if new_path != path:
-            # N2: downgraded from info to debug — a DatasetCollection
-            # of thousands of files fires this once per chunk read and
-            # floods the stream. Users can re-enable with
-            # `logging.getLogger("pyramids.base.remote").setLevel(
-            # logging.DEBUG)`.
-            logger.debug("cloud path rewritten: %r -> %r", path, new_path)
+        return path
+    parsed = urlparse(path)
+    scheme = parsed.scheme.lower()
+    new_path = _chain_archive_vsi(_scheme_to_vsi(parsed, scheme, path))
+    if new_path != path:
+        # N2: downgraded from info to debug — a DatasetCollection of thousands of
+        # files fires this once per chunk read and floods the stream. Re-enable with
+        # `logging.getLogger("pyramids.base.remote").setLevel(logging.DEBUG)`.
+        logger.debug("cloud path rewritten: %r -> %r", path, new_path)
     return new_path
+
+
+def _scheme_to_vsi(parsed: Any, scheme: str, path: str) -> str:
+    """Rewrite one URL scheme to its GDAL `/vsi*` (or `NETCDF:`) form.
+
+    Split out of :func:`_to_vsi` to keep that function within the
+    cognitive-complexity budget. `parsed` is the :func:`urllib.parse.urlparse`
+    result for `path`; `scheme` is its lower-cased scheme.
+    """
+    if scheme == "dods":
+        # OPeNDAP / THREDDS: libnetcdf speaks DAP, so route the DAP URL to GDAL's
+        # netCDF driver rather than /vsicurl/ (which would byte-range a DAP endpoint
+        # and fail). dods://host/path -> NETCDF:"https://host/path" (query/fragment
+        # preserved). dods:// assumes https; an http-only DAP server is reached by
+        # passing the GDAL form directly, e.g.
+        # NetCDF.read_file('NETCDF:"http://host/path"'), which passes through here.
+        remainder = path[len(scheme) + 1 :].lstrip("/")  # after "dods:" / "dods://"
+        return f'NETCDF:"https://{remainder}"'
+    if scheme not in URL_SCHEMES or len(scheme) <= 1:
+        return path
+    if scheme in {"s3", "gs", "az", "abfs"}:
+        bucket = parsed.netloc
+        key = parsed.path.lstrip("/")
+        return f"{URL_SCHEMES[scheme]}{bucket}/{key}"
+    if scheme in {"http", "https"}:
+        return f"/vsicurl/{path}"
+    if scheme == "file":
+        local = parsed.path
+        # Windows file URIs: file:///C:/path -> /C:/path -> C:/path
+        if local.startswith("/") and len(local) > 2 and local[2] == ":":
+            local = local[1:]
+        return local
+    return path  # pragma: no cover — all schemes above covered
 
 
 def _extract_archive_search_region(path: str) -> str | None:

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -29,7 +29,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, field
 from typing import Any, Mapping
-from urllib.parse import urlparse
+from urllib.parse import ParseResult, urlparse
 
 from osgeo import gdal
 
@@ -330,7 +330,7 @@ def _to_vsi(path: str) -> str:
     return new_path
 
 
-def _scheme_to_vsi(parsed: Any, scheme: str, path: str) -> str:
+def _scheme_to_vsi(parsed: ParseResult, scheme: str, path: str) -> str:
     """Rewrite one URL scheme to its GDAL `/vsi*` (or `NETCDF:`) form.
 
     Split out of :func:`_to_vsi` to keep that function within the

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -326,8 +326,12 @@ def _to_vsi(path: str) -> str:
         if scheme == "dods":
             # OPeNDAP / THREDDS: libnetcdf speaks DAP, so route the DAP URL to
             # GDAL's netCDF driver rather than /vsicurl/ (which would byte-range a
-            # DAP endpoint and fail). dods://host/path -> NETCDF:"https://host/path".
-            new_path = f'NETCDF:"https://{path.split("://", 1)[1]}"'
+            # DAP endpoint and fail). dods://host/path -> NETCDF:"https://host/path"
+            # (query/fragment preserved). dods:// assumes https; an http-only DAP
+            # server is reached by passing the GDAL form directly, e.g.
+            # NetCDF.read_file('NETCDF:"http://host/path"'), which passes through here.
+            remainder = path[len(scheme) + 1 :].lstrip("/")  # after "dods:" / "dods://"
+            new_path = f'NETCDF:"https://{remainder}"'
         elif scheme not in URL_SCHEMES or len(scheme) <= 1:
             new_path = path
         elif scheme in {"s3", "gs", "az", "abfs"}:

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -119,6 +119,8 @@ def is_remote(path: str) -> bool:
             True
             >>> is_remote("gs://bucket/key.tif")
             True
+            >>> is_remote("dods://test.opendap.org/data.nc")  # OPeNDAP / THREDDS
+            True
 
             ```
         - Already-rewritten VSI paths are also remote:
@@ -143,7 +145,7 @@ def is_remote(path: str) -> bool:
         result = True
     else:
         scheme = urlparse(path).scheme.lower()
-        result = scheme in URL_SCHEMES and len(scheme) > 1
+        result = (scheme in URL_SCHEMES or scheme == "dods") and len(scheme) > 1
     return result
 
 
@@ -299,6 +301,13 @@ def _to_vsi(path: str) -> str:
             '/vsicurl/https://example.com/scene.tif'
 
             ```
+        - OPeNDAP / THREDDS `dods://` URLs route to GDAL's netCDF driver
+          (libnetcdf speaks DAP) instead of `/vsicurl/`:
+            ```python
+            >>> _to_vsi("dods://test.opendap.org/data/coads.nc")
+            'NETCDF:"https://test.opendap.org/data/coads.nc"'
+
+            ```
         - Already-VSI and plain local paths pass through unchanged:
             ```python
             >>> _to_vsi("/vsis3/bucket/x.tif")
@@ -314,7 +323,12 @@ def _to_vsi(path: str) -> str:
     else:
         parsed = urlparse(path)
         scheme = parsed.scheme.lower()
-        if scheme not in URL_SCHEMES or len(scheme) <= 1:
+        if scheme == "dods":
+            # OPeNDAP / THREDDS: libnetcdf speaks DAP, so route the DAP URL to
+            # GDAL's netCDF driver rather than /vsicurl/ (which would byte-range a
+            # DAP endpoint and fail). dods://host/path -> NETCDF:"https://host/path".
+            new_path = f'NETCDF:"https://{path.split("://", 1)[1]}"'
+        elif scheme not in URL_SCHEMES or len(scheme) <= 1:
             new_path = path
         elif scheme in {"s3", "gs", "az", "abfs"}:
             bucket = parsed.netloc

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -78,6 +78,10 @@ URL_SCHEMES: dict[str, str] = {
 }
 """Map URL scheme to GDAL VSI prefix. Empty string means strip-and-use."""
 
+# OPeNDAP / THREDDS scheme. Not in URL_SCHEMES because it maps to a NETCDF:
+# connection string (GDAL's DAP-capable netCDF driver), not a /vsi* prefix.
+_DODS_SCHEME = "dods"
+
 
 _VSI_PREFIXES: tuple[str, ...] = (
     "/vsis3/",
@@ -145,7 +149,7 @@ def is_remote(path: str) -> bool:
         result = True
     else:
         scheme = urlparse(path).scheme.lower()
-        result = (scheme in URL_SCHEMES or scheme == "dods") and len(scheme) > 1
+        result = (scheme in URL_SCHEMES or scheme == _DODS_SCHEME) and len(scheme) > 1
     return result
 
 
@@ -337,7 +341,7 @@ def _scheme_to_vsi(parsed: ParseResult, scheme: str, path: str) -> str:
     cognitive-complexity budget. `parsed` is the :func:`urllib.parse.urlparse`
     result for `path`; `scheme` is its lower-cased scheme.
     """
-    if scheme == "dods":
+    if scheme == _DODS_SCHEME:
         # OPeNDAP / THREDDS: libnetcdf speaks DAP, so route the DAP URL to GDAL's
         # netCDF driver rather than /vsicurl/ (which would byte-range a DAP endpoint
         # and fail). dods://host/path -> NETCDF:"https://host/path" (query/fragment

--- a/tests/base/test_remote.py
+++ b/tests/base/test_remote.py
@@ -134,6 +134,10 @@ class TestToVsi:
     def test_dods_preserves_query(self):
         assert _to_vsi("dods://h/path?a=b") == 'NETCDF:"https://h/path?a=b"'
 
+    def test_dods_without_double_slash(self):
+        # urlparse still classifies "dods:host/path" as scheme dods; must not crash.
+        assert _to_vsi("dods:host/path") == 'NETCDF:"https://host/path"'
+
 
 class TestIsRemote:
     @pytest.mark.parametrize(

--- a/tests/base/test_remote.py
+++ b/tests/base/test_remote.py
@@ -9,6 +9,7 @@ import numpy as np  # noqa: E402
 import pytest
 from osgeo import gdal
 
+from pyramids import _io
 from pyramids.base.remote import (
     CloudConfig,
     _to_vsi,
@@ -137,6 +138,10 @@ class TestToVsi:
     def test_dods_without_double_slash(self):
         # urlparse still classifies "dods:host/path" as scheme dods; must not crash.
         assert _to_vsi("dods:host/path") == 'NETCDF:"https://host/path"'
+
+    def test_dods_routed_through_parse_path(self):
+        # The read path (read_file -> _parse_path -> _to_vsi) must yield the NETCDF: form.
+        assert _io._parse_path("dods://h/x.nc") == 'NETCDF:"https://h/x.nc"'
 
 
 class TestIsRemote:

--- a/tests/base/test_remote.py
+++ b/tests/base/test_remote.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from contextlib import nullcontext
 
 import numpy as np  # noqa: E402
@@ -14,6 +15,7 @@ from pyramids.base.remote import (
     is_remote,
     signer_cloud_config,
 )
+from pyramids.netcdf import NetCDF
 
 pytestmark = pytest.mark.core
 
@@ -123,6 +125,15 @@ class TestToVsi:
     def test_relative_path_unchanged(self):
         assert _to_vsi("data/x.tif") == "data/x.tif"
 
+    def test_dods_maps_to_netcdf_dap(self):
+        assert (
+            _to_vsi("dods://test.opendap.org/opendap/data/nc/coads.nc")
+            == 'NETCDF:"https://test.opendap.org/opendap/data/nc/coads.nc"'
+        )
+
+    def test_dods_preserves_query(self):
+        assert _to_vsi("dods://h/path?a=b") == 'NETCDF:"https://h/path?a=b"'
+
 
 class TestIsRemote:
     @pytest.mark.parametrize(
@@ -138,6 +149,7 @@ class TestIsRemote:
             "/vsicurl/https://foo/x.tif",
             "/vsimem/x.tif",
             "/vsizip/a.zip/b.tif",
+            "dods://test.opendap.org/opendap/data/nc/coads.nc",
         ],
     )
     def test_true_cases(self, path):
@@ -633,3 +645,26 @@ class TestToVsiArchiveChainingEdgeCases:
         assert (
             result == f"/vsicurl/{url}"
         ), f".tif/ is not an archive; must not chain; got: {result}"
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(
+    not os.environ.get("PYRAMIDS_OPENDAP_LIVE"),
+    reason="live OPeNDAP test; set PYRAMIDS_OPENDAP_LIVE=1 (optionally with "
+    "PYRAMIDS_OPENDAP_URL / PYRAMIDS_OPENDAP_VAR) to read a real DAP dataset",
+)
+class TestLiveOpenDAP:
+    """Read a real OPeNDAP/THREDDS dataset over dods:// via GDAL's netCDF DAP support."""
+
+    URL = os.environ.get(
+        "PYRAMIDS_OPENDAP_URL",
+        "dods://psl.noaa.gov/thredds/dodsC/Datasets/ncep.reanalysis/surface/air.sig995.2012.nc",
+    )
+    VAR = os.environ.get("PYRAMIDS_OPENDAP_VAR", "air")
+
+    def test_read_opendap_schema(self):
+        """A dods:// URL opens as a NetCDF and its variable schema is read without a full download."""
+        nc = NetCDF.read_file(self.URL)
+        assert self.VAR in list(nc.variables), f"{self.VAR!r} not in {list(nc.variables)[:8]}"
+        variable = nc.get_variable(self.VAR)
+        assert variable.shape[0] >= 1

--- a/tests/base/test_remote.py
+++ b/tests/base/test_remote.py
@@ -139,6 +139,10 @@ class TestToVsi:
         # urlparse still classifies "dods:host/path" as scheme dods; must not crash.
         assert _to_vsi("dods:host/path") == 'NETCDF:"https://host/path"'
 
+    def test_dods_uppercase_scheme(self):
+        # scheme match is case-insensitive; the slice uses the lower-cased length.
+        assert _to_vsi("DODS://test.opendap.org/data.nc") == 'NETCDF:"https://test.opendap.org/data.nc"'
+
     def test_dods_routed_through_parse_path(self):
         # The read path (read_file -> _parse_path -> _to_vsi) must yield the NETCDF: form.
         assert _io._parse_path("dods://h/x.nc") == 'NETCDF:"https://h/x.nc"'


### PR DESCRIPTION
# Description

Adds **OPeNDAP/THREDDS** remote NetCDF reads via `dods://` URLs — the next item in the remote-data-access family
after WCS (#632) and WFS (#635).

GDAL's netCDF driver speaks DAP (this build's libnetcdf is compiled with `--has-dap2`/`--has-dap4`, linked against
libcurl), but **only** when handed a `NETCDF:"<https-url>"` connection string. A plain `dods://` is unrecognised,
and a plain DAP `https://` goes through `/vsicurl/` byte-range and fails with HTTP 400. This PR wires `dods://` into
the existing URL-scheme rewriter so a DAP URL is routed to the netCDF driver transparently:

- `base.remote._to_vsi`: `dods://host/path` -> `NETCDF:"https://host/path"` (query + fragment preserved).
- `base.remote.is_remote` recognises the `dods` scheme.
- `read_file` / `NetCDF` therefore open `dods://` URLs through the existing `_io._parse_path` -> `_to_vsi` path
  with **no caller change**.

```python
from pyramids.netcdf import NetCDF
nc = NetCDF.read_file("dods://psl.noaa.gov/thredds/dodsC/Datasets/.../air.sig995.2012.nc")
air = nc.get_variable("air")   # schema read lazily; pull a slice, not the whole store
```

**No new dependency** (GDAL netCDF + DAP-enabled libnetcdf, already core). The value is lazy/partial reads, not a
full download.

# Issues

- Closes #640 — read remote NetCDF over OPeNDAP/THREDDS via dods:// URLs

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

`tests/base/test_remote.py`:

- [x] Offline, deterministic (no network): `dods://` -> `NETCDF:"https://..."` rewrite (incl. query preservation),
      and `is_remote("dods://...")` is `True`. Doctests on `_to_vsi` / `is_remote` updated.
- [x] **Gated live test** (`PYRAMIDS_OPENDAP_LIVE=1`, optional `PYRAMIDS_OPENDAP_URL` / `PYRAMIDS_OPENDAP_VAR`):
      opens a real NOAA PSL THREDDS dataset over `dods://` and reads its variable schema — passes in ~3s
      (metadata-only; confirms DAP works and reads are lazy, not a full download).

Run: `pixi run -e dev pytest tests/base/test_remote.py` (add `PYRAMIDS_OPENDAP_LIVE=1` for the live case).
**85 passed, 1 skipped.**

**CI note (DoD):** the feature depends on the `libgdal-netcdf` / libnetcdf build having DAP support. Verified
locally (`nc-config --has-dap2/dap4: yes`); the gated live test is the in-suite confirmation when enabled.

# Checklist:

- [ ] updated version number in pyproject.toml. *(commitizen in CI)*
- [ ] added changes to History.rst. *(changelog is commitizen-generated)*
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated. *(doctests + docstrings updated; a reference page is a follow-up)*
