### PR TITLE
feat(base): add RasterLike structural protocol (ARC-18, additive)

### DIFF
--- a/src/pyramids/base/protocols.py
+++ b/src/pyramids/base/protocols.py
@@ -1,6 +1,6 @@
 """Structural-typing protocols shared across the pyramids package.
 
-This module exposes two cross-cutting structural types:
+This module exposes three cross-cutting structural types:
 
 * :class:`SpatialObject` — the surface shared by
   :class:`pyramids.dataset.Dataset` (raster) and

--- a/src/pyramids/base/protocols.py
+++ b/src/pyramids/base/protocols.py
@@ -7,6 +7,10 @@ This module exposes two cross-cutting structural types:
   :class:`pyramids.feature.FeatureCollection` (vector), so callers can
   write generic utilities that accept either without importing both
   concrete classes (and without creating import cycles).
+* :class:`RasterLike` — the raster-specific surface shared by
+  :class:`pyramids.dataset.Dataset` and its :class:`pyramids.netcdf.NetCDF`
+  subclass (extends :class:`SpatialObject`), for raster-only generic
+  utilities that should accept either without importing the concrete classes.
 * :class:`ArrayLike` — the structural type matching both
   :class:`numpy.ndarray` and :class:`dask.array.Array`, used to annotate
   array-returning methods that may be either eager or lazy.
@@ -101,6 +105,63 @@ class SpatialObject(Protocol):
 
     def plot(self, *args: Any, **kwargs: Any) -> Any:
         """Render a matplotlib view of this object (protocol stub; see concrete impls)."""
+        ...
+
+
+@runtime_checkable
+class RasterLike(SpatialObject, Protocol):
+    """Structural type for a pyramids raster (`Dataset` and its `NetCDF` subclass).
+
+    Extends :class:`SpatialObject` with the raster-specific read surface shared
+    by :class:`pyramids.dataset.Dataset` and :class:`pyramids.netcdf.NetCDF`:
+    the geotransform-derived geometry, grid shape, band / no-data metadata, the
+    underlying GDAL handle, and array reads. Use it to annotate generic
+    raster utilities that should accept either a `Dataset` or a `NetCDF`
+    (or any future raster type) **without importing the concrete classes** —
+    which also lets `base`-layer code, that sits below `dataset` in the import
+    graph, reference "a raster" without an import cycle.
+
+    This is purely a typing aid: it does **not** replace the concrete
+    :class:`pyramids.dataset.abstract_dataset.RasterBase` base class, and
+    `isinstance(x, RasterBase)` (a nominal check) is unaffected.
+
+    Attributes / properties (in addition to those on :class:`SpatialObject`):
+        cell_size:
+            Pixel size in CRS units (the geotransform's X spacing).
+        rows (int): Number of raster rows.
+        columns (int): Number of raster columns.
+        band_count (int): Number of raster bands.
+        no_data_value:
+            Per-band no-data sentinels (a sequence) or `None`.
+        geotransform:
+            The 6-tuple GDAL geotransform.
+        raster:
+            The underlying `osgeo.gdal.Dataset` handle.
+
+    Methods:
+        read_array(...):
+            Read band data into a numpy array (eager) or a dask array
+            (lazy `chunks=`), i.e. an :data:`ArrayLike`.
+
+    Because this is :func:`typing.runtime_checkable`, you can use it with
+    :func:`isinstance` (PEP 544 — attribute/method presence only, not
+    signatures or return types):
+
+    >>> from pyramids.base.protocols import RasterLike
+    >>> def cell_count(r: RasterLike) -> int:
+    ...     return r.rows * r.columns
+    """
+
+    cell_size: Any
+    rows: int
+    columns: int
+    band_count: int
+    no_data_value: Any
+    geotransform: Any
+    raster: Any
+
+    def read_array(self, *args: Any, **kwargs: Any) -> "ArrayLike":
+        """Read band data as a numpy or dask array (protocol stub; see concrete impls)."""
         ...
 
 

--- a/tests/base/test_raster_like_protocol.py
+++ b/tests/base/test_raster_like_protocol.py
@@ -1,0 +1,105 @@
+"""Tests for the :class:`pyramids.base.protocols.RasterLike` protocol.
+
+Both :class:`pyramids.dataset.Dataset` and its
+:class:`pyramids.netcdf.NetCDF` subclass implement the raster-specific
+`RasterLike` structural type, so callers can write generic raster code
+that accepts either without importing the concrete classes.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pyramids.base.protocols import RasterLike, SpatialObject
+from pyramids.dataset import Dataset
+from pyramids.netcdf.netcdf import NetCDF
+
+pytestmark = pytest.mark.core
+
+GEO = (0.0, 0.01, 0, 1.0, 0, -0.01)
+
+
+@pytest.fixture
+def ds() -> Dataset:
+    """A small in-memory single-band Dataset in EPSG:32636."""
+    src = Dataset.create(
+        cell_size=1000.0,
+        rows=10,
+        columns=10,
+        dtype="float32",
+        bands=1,
+        top_left_corner=(500000.0, 3410000.0),
+        epsg=32636,
+        no_data_value=-9999.0,
+    )
+    src.raster.GetRasterBand(1).WriteArray(np.ones((10, 10), dtype=np.float32))
+    return src
+
+
+@pytest.fixture
+def nc() -> NetCDF:
+    """A small in-memory NetCDF container built from a 2-D array."""
+    return NetCDF.create_from_array(
+        arr=np.ones((5, 8), dtype=np.float64), geo=GEO, variable_name="v"
+    )
+
+
+class TestRasterLikeProtocol:
+    """Dataset and NetCDF satisfy RasterLike; it refines SpatialObject."""
+
+    def test_dataset_is_raster_like(self, ds: Dataset):
+        """`isinstance(ds, RasterLike)` is True at runtime."""
+        assert isinstance(ds, RasterLike)
+
+    def test_netcdf_is_raster_like(self, nc: NetCDF):
+        """`isinstance(nc, RasterLike)` is True at runtime."""
+        assert isinstance(nc, RasterLike)
+
+    def test_raster_like_is_a_spatial_object(self, ds: Dataset):
+        """A RasterLike is also a SpatialObject (the protocol extends it)."""
+        assert isinstance(ds, SpatialObject)
+
+    def test_exposes_raster_surface(self, ds: Dataset):
+        """The raster-specific members are present and have sane values."""
+        assert ds.rows == 10 and ds.columns == 10
+        assert ds.band_count == 1
+        assert ds.cell_size == 1000.0
+        assert len(ds.geotransform) == 6
+        assert ds.raster is not None
+
+    def test_generic_consumer_accepts_both(self, ds: Dataset, nc: NetCDF):
+        """A function typed against RasterLike accepts both Dataset and NetCDF.
+
+        This is the value of the protocol — raster-generic utilities without
+        importing the concrete Dataset / NetCDF classes.
+        """
+
+        def cell_count(raster: RasterLike) -> int:
+            return raster.rows * raster.columns
+
+        assert cell_count(ds) == 100
+        # The NetCDF container's rows/columns reflect its underlying multidim
+        # handle (not a variable's dims); assert only that the RasterLike-typed
+        # function accepts and runs on it.
+        assert isinstance(cell_count(nc), int)
+
+
+class TestRasterLikeNegative:
+    """Objects missing the raster surface must NOT be RasterLike."""
+
+    def test_plain_string_is_not_raster_like(self):
+        """A string lacks every raster attribute."""
+        assert not isinstance("not a raster", RasterLike)
+
+    def test_dict_is_not_raster_like(self):
+        """A dict with a stray `epsg` key still lacks the raster surface."""
+        assert not isinstance({"epsg": 4326}, RasterLike)
+
+    def test_bare_gdal_dataset_is_not_raster_like(self, ds: Dataset):
+        """A raw `gdal.Dataset` handle has no `epsg`/`read_array`, so it is not RasterLike."""
+        assert not isinstance(ds.raster, RasterLike)
+
+    def test_ndarray_is_not_raster_like(self):
+        """A numpy array is not a raster object."""
+        assert not isinstance(np.zeros((4, 4)), RasterLike)

--- a/tests/base/test_raster_like_protocol.py
+++ b/tests/base/test_raster_like_protocol.py
@@ -8,11 +8,14 @@ that accepts either without importing the concrete classes.
 
 from __future__ import annotations
 
+import geopandas as gpd
 import numpy as np
 import pytest
+from shapely.geometry import box
 
 from pyramids.base.protocols import RasterLike, SpatialObject
 from pyramids.dataset import Dataset
+from pyramids.feature import FeatureCollection
 from pyramids.netcdf.netcdf import NetCDF
 
 pytestmark = pytest.mark.core
@@ -103,3 +106,15 @@ class TestRasterLikeNegative:
     def test_ndarray_is_not_raster_like(self):
         """A numpy array is not a raster object."""
         assert not isinstance(np.zeros((4, 4)), RasterLike)
+
+    def test_vector_spatial_object_is_not_raster_like(self):
+        """A FeatureCollection is a SpatialObject but lacks the raster surface, so not RasterLike.
+
+        This locks RasterLike to the raster-specific contract: refining
+        SpatialObject must not accidentally widen back to accepting vectors.
+        """
+        fc = FeatureCollection(
+            gpd.GeoDataFrame({"v": [1]}, geometry=[box(0, 0, 1, 1)], crs="EPSG:4326")
+        )
+        assert isinstance(fc, SpatialObject), "fixture must be a SpatialObject"
+        assert not isinstance(fc, RasterLike), "a vector SpatialObject must not be RasterLike"

--- a/tests/base/test_raster_like_protocol.py
+++ b/tests/base/test_raster_like_protocol.py
@@ -67,7 +67,7 @@ class TestRasterLikeProtocol:
         """The raster-specific members are present and have sane values."""
         assert ds.rows == 10 and ds.columns == 10
         assert ds.band_count == 1
-        assert ds.cell_size == 1000.0
+        assert ds.cell_size == pytest.approx(1000.0)
         assert len(ds.geotransform) == 6
         assert ds.raster is not None
 


### PR DESCRIPTION
# Description

Adds an additive, `runtime_checkable` `RasterLike` structural-typing protocol (ARC-18, the safe slice).

`RasterLike(SpatialObject, Protocol)` in `base/protocols.py` captures the raster-specific read surface shared by
`Dataset` and its `NetCDF` subclass (`cell_size`, `rows`, `columns`, `band_count`, `no_data_value`,
`geotransform`, the GDAL `raster` handle, `read_array`). It lets generic raster utilities — and `base`-layer code
that sits below `dataset` in the import graph — accept any raster structurally **without importing the concrete
`Dataset`/`NetCDF` classes** (and without an import cycle). Mirrors the existing `SpatialObject` pattern.

This is **purely additive typing**: it does not replace the concrete `RasterBase` ABC, and nominal
`isinstance(x, RasterBase)` checks are unaffected.

**Scope note (why this isn't the literal ARC-18):** the issue's "replace ABC inheritance with Protocols across the
abstract_dataset layer" was investigated and **declined**. `RasterBase` is a *stateful concrete base* — it sets
`self._raster`/`self._geotransform` in `__init__` and provides 52 concrete methods that `Dataset`/`NetCDF`
inherit — not a pure interface. Converting it to a Protocol would require splitting it into interface + impl and
rerouting ~18 `isinstance` sites: broad blast radius, real `isinstance`/subclass-check risk on a release-track
branch, and zero behavioural benefit. The full restructure stays out of scope (see the consolidated plan).

Note: this branch is stacked on the ARC-12 work (#642); it is based on that branch so the diff shows only the
RasterLike delta, and GitHub will retarget it to `main` once #642 merges.

Dependencies: none added.

# Issues
- Refs #618 (additive slice; full ABC→Protocol restructure declined — see description)

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

New suite `tests/base/test_raster_like_protocol.py` (10 tests). Run with:

```
pixi run -e dev pytest tests/base -m "not e2e and not plot"
```

- [x] `Dataset` and `NetCDF` satisfy `RasterLike` at runtime; it refines `SpatialObject`; a `RasterLike`-typed
      consumer accepts both.
- [x] Negatives do not satisfy it: string, dict, bare `gdal.Dataset`, ndarray, and a vector `FeatureCollection`
      (a `SpatialObject` lacking the raster surface) — locking the raster-specific contract.

Result: `tests/base` → 306+ passed locally; doctests on `base/protocols.py` green.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.
