### PR TITLE
test: confine optional-dep tests to extras markers + add marker-hygiene guard (Phase 1)

### DIFF
--- a/.github/workflows/pure-wheel-test.yml
+++ b/.github/workflows/pure-wheel-test.yml
@@ -126,8 +126,10 @@ jobs:
         # tests/conftest.py's ``pytest_collection_modifyitems`` auto-applies the
         # corresponding ``requires_<extra>`` skip to those — so ``-m core`` here
         # selects only the bare-install tests and never collects an extras test.
+        # ``not vfs`` deselects the live-network (S3/HTTP) tests, which are marked
+        # ``vfs`` and must not run in CI.
         run: |
-          pytest -vvv -sv -m core tests/
+          pytest -vvv -sv -m "core and not vfs" tests/
 
   # Per-extra wheel test: one job per optional extra. Each matrix cell
   # gets a freshly-provisioned conda env, installs the wheel with just

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,8 +44,12 @@ jobs:
           activate-environment: ${{ matrix.environment }}
           cache: true
 
-      - name: Run main tests (not plot, not xarray)
-        run: pixi run -e ${{ matrix.environment }} main --cov-append --cov-fail-under=0
+      - name: Run main tests (not plot, not xarray, not vfs)
+        # Run pytest directly (not the `main` task) so we can append `not vfs` to the
+        # selector — the live-network vfs tests must not run in CI. Editing the pixi
+        # `main` task in pyproject.toml would invalidate pixi.lock and fail the
+        # lock-freshness check, so the deselection lives here instead.
+        run: pixi run -e ${{ matrix.environment }} pytest -vvv --cov=src/pyramids -sv -m 'not plot and not xarray and not vfs' --cov-report=xml --cov-append --cov-fail-under=0
 
       - name: Run plot tests
         run: pixi run -e ${{ matrix.environment }} plot --cov-fail-under=0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,7 +249,7 @@ platforms = ["win-64", "linux-64", "linux-aarch64", "osx-arm64", "osx-64"]
 pyramids-gis = { path = ".", editable = true }
 
 [tool.pixi.tasks]
-main = { cmd = "pytest -vvv --cov=src/pyramids -sv -m 'not plot and not xarray' --cov-report=xml", description = "Run the main test suite" }
+main = { cmd = "pytest -vvv --cov=src/pyramids -sv -m 'not plot and not xarray and not vfs' --cov-report=xml", description = "Run the main test suite" }
 plot = { cmd = "pytest -vvv --cov=src/pyramids --cov-append -sv -m 'plot' --cov-report=xml", description = "Run plot test suite" }
 xarray-tests = { cmd = "pytest -vvv --cov=src/pyramids --cov-append -sv -m 'xarray' --cov-report=xml", description = "Run xarray interop tests" }
 test-all = { cmd = "pytest -vvv --cov=src/pyramids -sv --cov-report=xml --cov-report=term-missing", description = "Run all testsuite" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,7 +249,7 @@ platforms = ["win-64", "linux-64", "linux-aarch64", "osx-arm64", "osx-64"]
 pyramids-gis = { path = ".", editable = true }
 
 [tool.pixi.tasks]
-main = { cmd = "pytest -vvv --cov=src/pyramids -sv -m 'not plot and not xarray and not vfs' --cov-report=xml", description = "Run the main test suite" }
+main = { cmd = "pytest -vvv --cov=src/pyramids -sv -m 'not plot and not xarray' --cov-report=xml", description = "Run the main test suite" }
 plot = { cmd = "pytest -vvv --cov=src/pyramids --cov-append -sv -m 'plot' --cov-report=xml", description = "Run plot test suite" }
 xarray-tests = { cmd = "pytest -vvv --cov=src/pyramids --cov-append -sv -m 'xarray' --cov-report=xml", description = "Run xarray interop tests" }
 test-all = { cmd = "pytest -vvv --cov=src/pyramids -sv --cov-report=xml --cov-report=term-missing", description = "Run all testsuite" }

--- a/tests/_marks.py
+++ b/tests/_marks.py
@@ -18,6 +18,7 @@ mapping below spells both out explicitly.
 from __future__ import annotations
 
 import importlib.util
+import os
 
 import pytest
 
@@ -92,6 +93,14 @@ requires_parquet_lazy = pytest.mark.skipif(
 requires_stac = pytest.mark.skipif(
     not _HAS_STAC, reason="pyramids-gis[stac] not installed"
 )
+# `vfs` is not an optional-dependency extra — it gates live virtual-filesystem /
+# network tests (e.g. reading a COG over https from a public S3 bucket). They need
+# network access and can be flaky, so they are off by default and only run when
+# explicitly opted in via `PYRAMIDS_RUN_VFS=1`.
+requires_vfs = pytest.mark.skipif(
+    not os.environ.get("PYRAMIDS_RUN_VFS"),
+    reason="live VFS/network test; set PYRAMIDS_RUN_VFS=1 to run",
+)
 
 
 # Legacy aliases for existing callsites that import the older names.
@@ -117,4 +126,5 @@ EXTRA_MARKERS: dict[str, pytest.MarkDecorator] = {
     "parquet": requires_parquet,
     "parquet_lazy": requires_parquet_lazy,
     "stac": requires_stac,
+    "vfs": requires_vfs,
 }

--- a/tests/_marks.py
+++ b/tests/_marks.py
@@ -18,7 +18,6 @@ mapping below spells both out explicitly.
 from __future__ import annotations
 
 import importlib.util
-import os
 
 import pytest
 
@@ -93,14 +92,6 @@ requires_parquet_lazy = pytest.mark.skipif(
 requires_stac = pytest.mark.skipif(
     not _HAS_STAC, reason="pyramids-gis[stac] not installed"
 )
-# `vfs` is not an optional-dependency extra — it gates live virtual-filesystem /
-# network tests (e.g. reading a COG over https from a public S3 bucket). They need
-# network access and can be flaky, so they are off by default and only run when
-# explicitly opted in via `PYRAMIDS_RUN_VFS=1`.
-requires_vfs = pytest.mark.skipif(
-    not os.environ.get("PYRAMIDS_RUN_VFS"),
-    reason="live VFS/network test; set PYRAMIDS_RUN_VFS=1 to run",
-)
 
 
 # Legacy aliases for existing callsites that import the older names.
@@ -126,5 +117,4 @@ EXTRA_MARKERS: dict[str, pytest.MarkDecorator] = {
     "parquet": requires_parquet,
     "parquet_lazy": requires_parquet_lazy,
     "stac": requires_stac,
-    "vfs": requires_vfs,
 }

--- a/tests/dataset/collection/test_meta.py
+++ b/tests/dataset/collection/test_meta.py
@@ -20,7 +20,7 @@ import pytest
 from pyramids.base._raster_meta import RasterMeta
 from pyramids.dataset import Dataset, DatasetCollection
 
-pytestmark = pytest.mark.lazy
+pytestmark = pytest.mark.core
 
 
 @pytest.fixture

--- a/tests/dataset/ops/test_focal.py
+++ b/tests/dataset/ops/test_focal.py
@@ -5,19 +5,9 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from pyramids.base._errors import OptionalPackageDoesNotExist
-from pyramids.base._utils import import_dask
 from pyramids.dataset import Dataset
 
 pytestmark = pytest.mark.core
-
-try:
-    import_dask("dask not installed")
-except OptionalPackageDoesNotExist:  # pragma: no cover
-    HAS_DASK = False
-else:
-    HAS_DASK = True
-requires_dask = pytest.mark.skipif(not HAS_DASK, reason="dask not installed")
 
 
 @pytest.fixture
@@ -59,7 +49,7 @@ class TestFocalMean:
         out = constant_raster.focal_mean(radius=1)
         assert out.shape == (5, 5)
 
-    @requires_dask
+    @pytest.mark.lazy
     def test_lazy_matches_eager(self, constant_raster):
         eager = constant_raster.focal_mean(radius=1)
         lazy = constant_raster.focal_mean(radius=1, chunks="auto").compute()
@@ -92,7 +82,7 @@ class TestSlope:
         inside = out[1:-1, 1:-1]
         assert float(inside.mean()) > 0.0
 
-    @requires_dask
+    @pytest.mark.lazy
     def test_lazy_slope_equals_eager_interior(self, ramp_raster):
         """Interior cells agree; edge cells can differ due to boundary.
 
@@ -118,7 +108,7 @@ class TestHillshade:
         assert float(out.min()) >= 0.0
         assert float(out.max()) <= 255.0
 
-    @requires_dask
+    @pytest.mark.lazy
     def test_lazy_matches_eager_interior(self, ramp_raster):
         """Same boundary caveat as slope — compare interior cells."""
         eager = ramp_raster.hillshade()

--- a/tests/dataset/ops/test_geobox_zarr.py
+++ b/tests/dataset/ops/test_geobox_zarr.py
@@ -10,8 +10,6 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
-from pyramids.base._errors import OptionalPackageDoesNotExist
-from pyramids.base._utils import import_zarr
 from pyramids.dataset.ops._geobox_zarr import (
     GRID_MAPPING_VAR,
     detect_data_var,
@@ -23,13 +21,9 @@ from pyramids.dataset.ops._geobox_zarr import (
 pytestmark = pytest.mark.core
 
 try:
-    import_zarr("zarr not installed")
     import zarr
-except OptionalPackageDoesNotExist:  # pragma: no cover
-    HAS_ZARR = False
-else:
-    HAS_ZARR = True
-requires_zarr = pytest.mark.skipif(not HAS_ZARR, reason="zarr not installed")
+except ImportError:  # pragma: no cover - zarr-using tests are @pytest.mark.lazy gated
+    zarr = None
 
 _WKT_4326 = (
     'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]],'
@@ -72,7 +66,7 @@ class TestPixelCentreCoords:
         np.testing.assert_allclose(y, [3.5], err_msg=f"y={y}")
 
 
-@requires_zarr
+@pytest.mark.lazy
 class TestWriteGeobox:
     """Tests for write_geobox."""
 
@@ -175,7 +169,7 @@ class TestWriteGeobox:
         assert int(sr[()]) == 0, f"value {int(sr[()])}"
 
 
-@requires_zarr
+@pytest.mark.lazy
 class TestReadGeobox:
     """Tests for read_geobox."""
 
@@ -279,7 +273,7 @@ class TestReadGeobox:
             read_geobox(group)
 
 
-@requires_zarr
+@pytest.mark.lazy
 class TestFinalizeZarrMetadata:
     """Tests for finalize_zarr_metadata (shared Dataset/collection finalizer)."""
 
@@ -314,7 +308,7 @@ class TestFinalizeZarrMetadata:
         assert reopened["data"].attrs["grid_mapping"] == GRID_MAPPING_VAR
 
 
-@requires_zarr
+@pytest.mark.lazy
 class TestForeignGeoZarr:
     """read_geobox / detect_data_var handle non-pyramids GeoZarr stores (FR-8)."""
 

--- a/tests/dataset/ops/test_reprojector.py
+++ b/tests/dataset/ops/test_reprojector.py
@@ -23,14 +23,8 @@ pytestmark = pytest.mark.core
 
 try:
     from dask.delayed import Delayed
-
-    HAS_DASK = True
-except ImportError:  # pragma: no cover
+except ImportError:  # pragma: no cover - Delayed-using tests are @pytest.mark.lazy gated
     Delayed = None
-    HAS_DASK = False
-
-
-requires_dask = pytest.mark.skipif(not HAS_DASK, reason="dask not installed")
 
 
 @pytest.fixture
@@ -113,13 +107,13 @@ class TestReprojectorPickle:
 class TestReprojectorLazy:
     """``compute=False`` returns :class:`dask.delayed.Delayed`."""
 
-    @requires_dask
+    @pytest.mark.lazy
     def test_returns_delayed(self, wgs84_dataset):
         op = Reprojector(target_epsg=3857)
         result = op(wgs84_dataset, compute=False)
         assert isinstance(result, Delayed)
 
-    @requires_dask
+    @pytest.mark.lazy
     def test_delayed_compute_equals_eager(self, wgs84_dataset):
         op = Reprojector(target_epsg=3857)
         eager = op(wgs84_dataset)
@@ -145,13 +139,13 @@ class TestAlignerEager:
 class TestAlignerLazy:
     """``Aligner(..., compute=False)`` returns :class:`Delayed`."""
 
-    @requires_dask
+    @pytest.mark.lazy
     def test_returns_delayed(self, wgs84_dataset, wgs84_dataset_fine):
         aligner = Aligner(wgs84_dataset)
         result = aligner(wgs84_dataset_fine, compute=False)
         assert isinstance(result, Delayed)
 
-    @requires_dask
+    @pytest.mark.lazy
     def test_delayed_compute_matches_eager(self, wgs84_dataset, wgs84_dataset_fine):
         aligner = Aligner(wgs84_dataset)
         eager = aligner(wgs84_dataset_fine)

--- a/tests/dataset/ops/test_zarr.py
+++ b/tests/dataset/ops/test_zarr.py
@@ -13,20 +13,14 @@ import numpy as np
 import pytest
 
 from pyramids.base._errors import OptionalPackageDoesNotExist
-from pyramids.base._utils import import_dask, import_zarr
 from pyramids.dataset import Dataset
 
 pytestmark = pytest.mark.core
 
 try:
-    import_dask("dask not installed")
-    import_zarr("zarr not installed")
     import zarr
-except OptionalPackageDoesNotExist:  # pragma: no cover
-    HAS_ZARR = False
-else:
-    HAS_ZARR = True
-requires_zarr = pytest.mark.skipif(not HAS_ZARR, reason="dask + zarr not installed")
+except ImportError:  # pragma: no cover - zarr-using tests are @pytest.mark.lazy gated
+    zarr = None
 
 
 @pytest.fixture
@@ -51,7 +45,7 @@ def small_dataset(tmp_path):
 class TestRoundtripEager:
     """Eager Dataset → Zarr → Dataset round-trip preserves values + geobox."""
 
-    @requires_zarr
+    @pytest.mark.lazy
     def test_values_roundtrip(self, small_dataset, tmp_path):
         store = str(tmp_path / "roundtrip.zarr")
         small_dataset.to_zarr(store)
@@ -63,21 +57,21 @@ class TestRoundtripEager:
             roundtrip = np.atleast_3d(roundtrip)
         np.testing.assert_array_equal(original.squeeze(), roundtrip.squeeze())
 
-    @requires_zarr
+    @pytest.mark.lazy
     def test_epsg_roundtrip(self, small_dataset, tmp_path):
         store = str(tmp_path / "epsg.zarr")
         small_dataset.to_zarr(store)
         reloaded = Dataset.from_zarr(store)
         assert reloaded.epsg == small_dataset.epsg
 
-    @requires_zarr
+    @pytest.mark.lazy
     def test_geotransform_roundtrip(self, small_dataset, tmp_path):
         store = str(tmp_path / "gt.zarr")
         small_dataset.to_zarr(store)
         reloaded = Dataset.from_zarr(store)
         assert reloaded.geotransform == small_dataset.geotransform
 
-    @requires_zarr
+    @pytest.mark.lazy
     def test_per_band_nodata_roundtrip(self, tmp_path):
         """Per-band no-data values survive the round-trip (Z-4).
 
@@ -103,7 +97,7 @@ class TestRoundtripEager:
             6.0,
         ), f"per-band no-data not recovered: {reloaded.no_data_value}"
 
-    @requires_zarr
+    @pytest.mark.lazy
     def test_absent_nodata_roundtrip(self, tmp_path):
         """A dataset with no no-data stays no-data after round-trip (Z-4).
 
@@ -127,7 +121,7 @@ class TestRoundtripEager:
             None,
         ), f"absent no-data not preserved: {reloaded.no_data_value}"
 
-    @requires_zarr
+    @pytest.mark.lazy
     def test_projected_crs_roundtrip(self, tmp_path):
         """A projected CRS survives the round-trip via the stored WKT (Z-3).
 
@@ -147,7 +141,7 @@ class TestRoundtripEager:
         reloaded = Dataset.from_zarr(str(tmp_path / "utm.zarr"))
         assert reloaded.epsg == 32636, f"projected CRS not recovered: {reloaded.epsg}"
 
-    @requires_zarr
+    @pytest.mark.lazy
     def test_band_names_roundtrip(self, tmp_path):
         """Custom band names survive a Zarr round-trip (Z-5).
 
@@ -171,7 +165,7 @@ class TestRoundtripEager:
             "beta",
         ], f"band names not restored: {reloaded.band_names}"
 
-    @requires_zarr
+    @pytest.mark.lazy
     def test_multiband_band_read_finite_after_from_zarr(self, tmp_path):
         """A multi-band from_zarr store round-trips its pixels (end-to-end #570 guard).
 
@@ -215,7 +209,7 @@ class TestRoundtripEager:
 class TestComputeFalseDefers:
     """``compute=False`` returns :class:`dask.delayed.Delayed`."""
 
-    @requires_zarr
+    @pytest.mark.lazy
     def test_returns_delayed(self, small_dataset, tmp_path):
         from dask.delayed import Delayed
 
@@ -223,7 +217,7 @@ class TestComputeFalseDefers:
         result = small_dataset.to_zarr(store, compute=False)
         assert isinstance(result, Delayed)
 
-    @requires_zarr
+    @pytest.mark.lazy
     def test_delayed_compute_writes_data(self, small_dataset, tmp_path):
         store = str(tmp_path / "compute.zarr")
         delayed = small_dataset.to_zarr(store, compute=False)
@@ -234,7 +228,7 @@ class TestComputeFalseDefers:
             np.atleast_3d(small_dataset.read_array()).squeeze(),
         )
 
-    @requires_zarr
+    @pytest.mark.lazy
     def test_delayed_compute_finalizes_metadata(self, small_dataset, tmp_path):
         """Computing the deferred write also writes geobox attrs (Z-9).
 
@@ -257,14 +251,14 @@ class TestComputeFalseDefers:
 class TestChunksParameter:
     """``chunks=`` controls the underlying dask-array chunking."""
 
-    @requires_zarr
+    @pytest.mark.lazy
     def test_custom_chunks_respected(self, small_dataset, tmp_path):
         store = str(tmp_path / "chunked.zarr")
         small_dataset.to_zarr(store, chunks=(1, 3, 3))
         root = zarr.open_group(store, mode="r")
         assert root["data"].chunks == (1, 3, 3)
 
-    @requires_zarr
+    @pytest.mark.lazy
     def test_chunked_read_matches_eager(self, small_dataset, tmp_path):
         """from_zarr(chunks=...) parallel-reads identical values (FR-2).
 
@@ -324,7 +318,7 @@ class TestImportErrorPath:
 class TestGeoZarrLayout:
     """The written store follows the GeoZarr / CF convention (FR-1)."""
 
-    @requires_zarr
+    @pytest.mark.lazy
     def test_store_has_geozarr_arrays(self, small_dataset, tmp_path):
         """A written store carries spatial_ref + x/y coords + grid_mapping (FR-1).
 
@@ -354,7 +348,7 @@ class TestGeoZarrLayout:
         assert group["x"].shape == (small_dataset.columns,), "x length mismatch"
         assert group["y"].shape == (small_dataset.rows,), "y length mismatch"
 
-    @requires_zarr
+    @pytest.mark.lazy
     def test_legacy_store_read_warns_and_recovers(self, tmp_path):
         """Reading a legacy flat-attr store warns but still recovers the geobox.
 
@@ -394,7 +388,7 @@ class TestGeoZarrLayout:
 class TestCompressor:
     """``compressor=`` controls the zarr codec on the data array (FR-4)."""
 
-    @requires_zarr
+    @pytest.mark.lazy
     def test_custom_codec_applied(self, small_dataset, tmp_path):
         """A passed zarr-v3 codec is used for the data array (FR-4).
 
@@ -416,7 +410,7 @@ class TestCompressor:
             np.atleast_3d(small_dataset.read_array()).squeeze(),
         )
 
-    @requires_zarr
+    @pytest.mark.lazy
     def test_uncompressed(self, small_dataset, tmp_path):
         """``compressor=None`` writes an uncompressed data array (FR-4).
 
@@ -444,7 +438,7 @@ class TestMultiscalePyramid:
         ds.to_file(src)
         return Dataset.read_file(src)
 
-    @requires_zarr
+    @pytest.mark.lazy
     def test_writes_levels_and_multiscales_attr(self, big_dataset, tmp_path):
         """to_zarr(overview_factors=...) writes decimated levels + multiscales (FR-7).
 
@@ -471,7 +465,7 @@ class TestMultiscalePyramid:
         assert scales == [1.0, 2.0, 4.0], f"scales {scales}"
         assert ms[0]["axes"][0]["name"] == "band" and ms[0]["axes"][2]["name"] == "x"
 
-    @requires_zarr
+    @pytest.mark.lazy
     def test_read_level_scales_geobox(self, big_dataset, tmp_path):
         """from_zarr(level=f) reads the decimated level with cell size scaled (FR-7).
 
@@ -492,7 +486,7 @@ class TestMultiscalePyramid:
         assert lvl2.epsg == 4326, f"level-2 epsg {lvl2.epsg}"
         assert Dataset.from_zarr(store).rows == 16, "level-1 should be full res"
 
-    @requires_zarr
+    @pytest.mark.lazy
     def test_missing_level_raises(self, big_dataset, tmp_path):
         """Requesting an unwritten level raises a clear KeyError (FR-7).
 
@@ -505,7 +499,7 @@ class TestMultiscalePyramid:
         with pytest.raises(KeyError, match="data_8|overview level 8"):
             Dataset.from_zarr(store, level=8)
 
-    @requires_zarr
+    @pytest.mark.lazy
     def test_overviews_require_compute(self, big_dataset, tmp_path):
         """overview_factors with compute=False raises (FR-7).
 
@@ -517,7 +511,7 @@ class TestMultiscalePyramid:
         with pytest.raises(ValueError, match="compute=True"):
             big_dataset.to_zarr(store, overview_factors=[2], compute=False)
 
-    @requires_zarr
+    @pytest.mark.lazy
     def test_level_read_preserves_nodata_and_band_names(self, tmp_path):
         """Level reads carry nodata + band names from the base (M2).
 
@@ -568,7 +562,7 @@ class TestResolveStore:
         assert isinstance(result, str), f"expected str, got {type(result).__name__}"
         assert result.endswith("s.zarr"), f"unexpected return: {result}"
 
-    @requires_zarr
+    @pytest.mark.lazy
     def test_url_with_storage_options_uses_fsspec_store(self, monkeypatch):
         """A URL + storage_options routes through `FsspecStore.from_url` (M1).
 

--- a/tests/dataset/test_stac.py
+++ b/tests/dataset/test_stac.py
@@ -18,10 +18,8 @@ from osgeo import gdal
 
 from pyramids.base._errors import (
     AlignmentError,
-    OptionalPackageDoesNotExist,
     StacAssetError,
 )
-from pyramids.base._utils import import_dask
 from pyramids.dataset import Dataset, DatasetCollection
 from pyramids.dataset._stac import (
     _horizontal_bounds,
@@ -94,11 +92,8 @@ class TestFromStac:
             left == right
         ), f"files mismatch (normalised): got {left}, expected {right}"
 
+    @pytest.mark.lazy
     def test_lazy_data_computes(self, stac_items):
-        try:
-            import_dask("dask not installed")
-        except OptionalPackageDoesNotExist:
-            pytest.skip("dask not installed")
         collection = DatasetCollection.from_stac(stac_items, asset="data")
         arr = collection.data.compute()
         assert arr.shape[0] == 3

--- a/tests/feature/test_feature_gaps.py
+++ b/tests/feature/test_feature_gaps.py
@@ -21,6 +21,8 @@ from pyramids.feature import FeatureCollection
 from pyramids.feature import _h3
 from pyramids.feature import tessellation as tess
 
+pytestmark = pytest.mark.core
+
 
 def _h3_vectors():
     """Load the committed H3 ground-truth fixtures (generated from the h3 library)."""

--- a/tests/feature/test_geoparquet.py
+++ b/tests/feature/test_geoparquet.py
@@ -16,7 +16,6 @@ skips cleanly otherwise.
 
 from __future__ import annotations
 
-import importlib.util
 from pathlib import Path
 
 import geopandas as gpd
@@ -25,10 +24,7 @@ from shapely.geometry import Point, Polygon
 
 from pyramids.feature import FeatureCollection
 
-pytestmark = pytest.mark.skipif(
-    importlib.util.find_spec("pyarrow") is None,
-    reason="pyarrow not installed (install with `pip install pyramids-gis[parquet]`)",
-)
+pytestmark = pytest.mark.parquet
 
 
 @pytest.fixture

--- a/tests/netcdf/test_mdim.py
+++ b/tests/netcdf/test_mdim.py
@@ -20,6 +20,8 @@ from pyramids.netcdf._mdim import (
     scalar_no_data,
 )
 
+pytestmark = pytest.mark.core
+
 
 @pytest.fixture(scope="function")
 def mdim_dataset():

--- a/tests/netcdf/test_plot.py
+++ b/tests/netcdf/test_plot.py
@@ -2505,6 +2505,7 @@ class TestNetCDFPlotAnimate:
 class TestNetCDFPlotLazy:
     """Tests for the PR-5 ``chunks=`` lazy static-plot path."""
 
+    @pytest.mark.lazy
     def test_chunks_dict_routes_through_dask(self, tmp_path):
         """``chunks={"x": 5, "y": 5}`` switches the read path to dask.
 
@@ -2516,7 +2517,6 @@ class TestNetCDFPlotLazy:
             requested band. The result is the same cleopatra
             ``ArrayGlyph`` shape as the eager path.
         """
-        pytest.importorskip("dask", reason="dask not installed")
         nc_mem = _make_3d_nc(n_times=2, rows=4, cols=4)
         out = tmp_path / "tiny.nc"
         nc_mem.to_file(out)
@@ -2586,6 +2586,7 @@ class TestNetCDFPlotLazy:
             "chunks=" in m for m in msgs
         ), f"Expected chunks= hint in logs, got: {msgs}"
 
+    @pytest.mark.lazy
     def test_lazy_hint_not_logged_when_chunks_supplied(self, caplog):
         """No hint is logged when the caller already passed ``chunks=``.
 
@@ -2594,7 +2595,6 @@ class TestNetCDFPlotLazy:
             ``chunks={"cols": 1}`` set. The hint is gated on
             ``chunks is None`` so the log message must be absent.
         """
-        pytest.importorskip("dask", reason="dask not installed")
         nc = _make_3d_nc()
         var = nc.get_variable("t2m")
         large_shape = (50, 4000, 4000)
@@ -2614,6 +2614,7 @@ class TestNetCDFPlotLazy:
             "chunks=" in m for m in msgs
         ), f"Hint must not fire when chunks= is supplied; got: {msgs}"
 
+    @pytest.mark.lazy
     def test_chunks_with_unpinned_band_dims_renders_2d_slice(self, tmp_path):
         """`chunks=` on a multi-band-dim variable renders a 2-D slice, not the whole cube (L3).
 
@@ -2628,7 +2629,6 @@ class TestNetCDFPlotLazy:
             render). Plotted with no selectors, the rendered slice has
             the same shape as the eager band-0 read.
         """
-        pytest.importorskip("dask", reason="dask not installed")
         nc_mem = _make_4d_nc()
         out = tmp_path / "cube4d.nc"
         nc_mem.to_file(out)

--- a/tests/netcdf_samples/test_curvilinear_crop.py
+++ b/tests/netcdf_samples/test_curvilinear_crop.py
@@ -93,7 +93,7 @@ def test_rasm_curvilinear_crop(sample):
         nc.close()
 
 
-@pytest.mark.netcdf_lazy
+@pytest.mark.lazy
 def test_roms_curvilinear_crop_lazy_matches_eager(sample):
     """``chunks=`` reads the cropped window through the lazy/dask path and matches the eager crop."""
     nc = NetCDF.read_file(sample(ROMS))
@@ -192,7 +192,7 @@ def test_crop_touch_parameter_accepted(sample):
         nc.close()
 
 
-@pytest.mark.netcdf_lazy
+@pytest.mark.lazy
 def test_rasm_crop_lazy_matches_eager(sample):
     """rasm curvilinear crop: the ``chunks=`` (lazy) path matches the eager crop."""
     nc = NetCDF.read_file(sample(RASM))

--- a/tests/netcdf_samples/test_kerchunk.py
+++ b/tests/netcdf_samples/test_kerchunk.py
@@ -6,7 +6,7 @@ import pytest
 
 from pyramids.netcdf import NetCDF
 
-pytestmark = pytest.mark.core
+pytestmark = pytest.mark.netcdf_lazy
 pytest.importorskip("kerchunk")
 pytest.importorskip("fsspec")
 

--- a/tests/netcdf_samples/test_lazy_reads.py
+++ b/tests/netcdf_samples/test_lazy_reads.py
@@ -5,7 +5,7 @@ import pytest
 
 from pyramids.netcdf import NetCDF
 
-pytestmark = pytest.mark.core
+pytestmark = pytest.mark.lazy
 da = pytest.importorskip("dask.array")
 
 RHUM = "coards__5v__1d4-4d1.nc"

--- a/tests/netcdf_samples/test_mfdataset.py
+++ b/tests/netcdf_samples/test_mfdataset.py
@@ -6,7 +6,7 @@ import pytest
 
 from pyramids.netcdf import NetCDF
 
-pytestmark = pytest.mark.core
+pytestmark = pytest.mark.lazy
 pytest.importorskip("dask")
 
 AIR = "coards__4v__1d3-3d1.nc"

--- a/tests/netcdf_samples/test_zarr.py
+++ b/tests/netcdf_samples/test_zarr.py
@@ -4,7 +4,7 @@ import pytest
 
 from pyramids.netcdf import NetCDF
 
-pytestmark = pytest.mark.core
+pytestmark = pytest.mark.lazy
 pytest.importorskip("zarr")
 
 TOS = "cf__7v__1d3-2d3-3d1.nc"

--- a/tests/stac/test_geoparquet.py
+++ b/tests/stac/test_geoparquet.py
@@ -9,17 +9,6 @@ from pyramids.stac._geoparquet import from_geoparquet, to_geoparquet
 
 pytestmark = pytest.mark.core
 
-try:
-    import pyarrow  # noqa: F401
-
-    HAS_PYARROW = True
-except ImportError:
-    HAS_PYARROW = False
-
-requires_pyarrow = pytest.mark.skipif(
-    not HAS_PYARROW, reason="pyarrow ([parquet] extra) not installed"
-)
-
 
 def _item(item_id, lon, lat):
     """A minimal STAC item dict with a Point geometry."""
@@ -56,7 +45,7 @@ class TestToGeoparquetGuards:
             to_geoparquet([123], "x.parquet")
 
 
-@requires_pyarrow
+@pytest.mark.parquet
 class TestRoundTrip:
     """Round-trip items through GeoParquet (needs pyarrow)."""
 

--- a/tests/stac/test_loader.py
+++ b/tests/stac/test_loader.py
@@ -462,18 +462,7 @@ class TestLoadAsset:
             load_asset({"href": "s3://b/data.bin"})
 
 
-try:
-    from pyramids.base._utils import import_dask as _imp_dask
-    from pyramids.base._utils import import_zarr as _imp_zarr
-
-    _imp_dask("x")
-    _imp_zarr("x")
-    _HAS_ZARR = True
-except Exception:  # pragma: no cover
-    _HAS_ZARR = False
-
-
-@pytest.mark.skipif(not _HAS_ZARR, reason="zarr + dask not installed")
+@pytest.mark.lazy
 class TestLoadZarrAsset:
     """STAC Zarr assets load via pyramids' GeoZarr reader (FR-9)."""
 

--- a/tests/test_marker_hygiene.py
+++ b/tests/test_marker_hygiene.py
@@ -87,6 +87,28 @@ def _importorskip_dep(call: ast.Call) -> str | None:
     return None
 
 
+def _bare_import_deps(node: ast.stmt) -> list[str]:
+    """Optional-dep top-level modules imported by a top-level ``import`` / ``from`` node."""
+    if isinstance(node, ast.Import):
+        tops = [alias.name.split(".")[0] for alias in node.names]
+    elif isinstance(node, ast.ImportFrom):
+        tops = [(node.module or "").split(".")[0]]
+    else:
+        return []
+    return [top for top in tops if top in _OPTIONAL_DEPS]
+
+
+def _node_importorskip_dep(node: ast.stmt) -> str | None:
+    """Optional dep ``importorskip``ed by a top-level expr/assignment node, else ``None``."""
+    # `pytest.importorskip(...)` appears either bare (`Expr`) or assigned (`da = ...`); both
+    # expose the call as `node.value`, so they collapse into one branch.
+    if isinstance(node, (ast.Expr, ast.Assign)) and isinstance(node.value, ast.Call):
+        dep = _importorskip_dep(node.value)
+        if dep in _OPTIONAL_DEPS:
+            return dep
+    return None
+
+
 def _module_offenders(tree: ast.Module) -> tuple[list[str], list[str]]:
     """Optional deps pulled at MODULE scope (top-level only; guarded/inner are skipped).
 
@@ -97,26 +119,10 @@ def _module_offenders(tree: ast.Module) -> tuple[list[str], list[str]]:
     bare_imports: list[str] = []
     importorskips: list[str] = []
     for node in tree.body:
-        if isinstance(node, ast.Import):
-            bare_imports += [
-                alias.name.split(".")[0]
-                for alias in node.names
-                if alias.name.split(".")[0] in _OPTIONAL_DEPS
-            ]
-        elif isinstance(node, ast.ImportFrom):
-            top = (node.module or "").split(".")[0]
-            if top in _OPTIONAL_DEPS:
-                bare_imports.append(top)
-        else:
-            call = None
-            if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
-                call = node.value
-            elif isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
-                call = node.value
-            if call is not None:
-                dep = _importorskip_dep(call)
-                if dep in _OPTIONAL_DEPS:
-                    importorskips.append(dep)
+        bare_imports += _bare_import_deps(node)
+        dep = _node_importorskip_dep(node)
+        if dep is not None:
+            importorskips.append(dep)
     return bare_imports, importorskips
 
 

--- a/tests/test_marker_hygiene.py
+++ b/tests/test_marker_hygiene.py
@@ -1,0 +1,168 @@
+"""Guard meta-test: no `core`/unmarked module pulls an optional dep at module scope.
+
+Prevents the #638 / #645 class of bug — a test module that ``import``s or
+``pytest.importorskip``s an optional dependency at *module* scope while still being
+selected by the extras-free ``-m core`` pure-wheel job. Such a module either aborts
+collection (an unguarded ``import``) or silently skips (a module-level
+``importorskip``), so its coverage is lost in the bare-wheel build and reads as green.
+
+Rule: if a test module pulls an optional dependency at MODULE scope, it MUST carry a
+matching extras marker (``lazy`` / ``xarray`` / ``netcdf_lazy`` / ``parquet`` /
+``parquet_lazy`` / ``plot`` / ``stac`` / ``vfs``) so it is routed off the core
+selection. Collection-safe forms are intentionally NOT flagged:
+
+* a guarded import — ``try: import zarr`` / ``except ImportError: zarr = None`` — the
+  module still imports without the dep, so per-test ``@pytest.mark.<extra>`` is enough;
+* a function-body ``pytest.importorskip(...)`` inside an individual test.
+
+This is a static AST check; it runs in the ``core`` suite and needs no optional deps.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from tests._marks import EXTRA_MARKERS
+
+pytestmark = pytest.mark.core
+
+_TESTS_ROOT = Path(__file__).parent
+_EXTRAS = set(EXTRA_MARKERS)
+
+# Top-level module names of the optional dependencies pyramids gates behind extras.
+_OPTIONAL_DEPS = {
+    "dask",
+    "dask_geopandas",
+    "distributed",
+    "flox",
+    "zarr",
+    "xarray",
+    "kerchunk",
+    "h5py",
+    "h5netcdf",
+    "netCDF4",
+    # NB: cftime is intentionally absent — it is a hard `[project]` dependency
+    # (production `pyramids.netcdf.utils` imports it unguarded), always present.
+    "fsspec",
+    "s3fs",
+    "pyarrow",
+    "cleopatra",
+    "pystac",
+    "pystac_client",
+    "stac_asset",
+}
+
+
+def _marker_names(value: ast.expr) -> set[str]:
+    """Marker names from a ``pytestmark = ...`` RHS (single mark or list/tuple of marks)."""
+    nodes = value.elts if isinstance(value, (ast.List, ast.Tuple)) else [value]
+    names: set[str] = set()
+    for node in nodes:
+        # ``pytest.mark.<name>`` -> Attribute(attr=<name>, value=Attribute(attr="mark"))
+        if (
+            isinstance(node, ast.Attribute)
+            and isinstance(node.value, ast.Attribute)
+            and node.value.attr == "mark"
+        ):
+            names.add(node.attr)
+    return names
+
+
+def _importorskip_dep(call: ast.Call) -> str | None:
+    """Top-level module of a ``pytest.importorskip("x.y")`` / ``importorskip("x")`` call."""
+    func = call.func
+    is_importorskip = (isinstance(func, ast.Attribute) and func.attr == "importorskip") or (
+        isinstance(func, ast.Name) and func.id == "importorskip"
+    )
+    if (
+        is_importorskip
+        and call.args
+        and isinstance(call.args[0], ast.Constant)
+        and isinstance(call.args[0].value, str)
+    ):
+        return call.args[0].value.split(".")[0]
+    return None
+
+
+def _module_offenders(tree: ast.Module) -> tuple[list[str], list[str]]:
+    """Optional deps pulled at MODULE scope (top-level only; guarded/inner are skipped).
+
+    Returns ``(bare_imports, importorskips)``: bare ``import``/``from`` statements abort
+    collection regardless of marker, while ``importorskip`` is collection-safe but needs
+    the matching extras marker to avoid a silent skip in the core suite.
+    """
+    bare_imports: list[str] = []
+    importorskips: list[str] = []
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            bare_imports += [
+                alias.name.split(".")[0]
+                for alias in node.names
+                if alias.name.split(".")[0] in _OPTIONAL_DEPS
+            ]
+        elif isinstance(node, ast.ImportFrom):
+            top = (node.module or "").split(".")[0]
+            if top in _OPTIONAL_DEPS:
+                bare_imports.append(top)
+        else:
+            call = None
+            if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+                call = node.value
+            elif isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
+                call = node.value
+            if call is not None:
+                dep = _importorskip_dep(call)
+                if dep in _OPTIONAL_DEPS:
+                    importorskips.append(dep)
+    return bare_imports, importorskips
+
+
+def _module_markers(tree: ast.Module) -> set[str]:
+    """Marker names declared via a module-level ``pytestmark = ...`` assignment."""
+    markers: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id == "pytestmark"
+            for target in node.targets
+        ):
+            markers |= _marker_names(node.value)
+    return markers
+
+
+_TEST_FILES = sorted(
+    p for p in _TESTS_ROOT.rglob("test_*.py") if p.name != Path(__file__).name
+)
+
+
+@pytest.mark.parametrize(
+    "path", _TEST_FILES, ids=lambda p: str(p.relative_to(_TESTS_ROOT)).replace("\\", "/")
+)
+def test_module_optional_dep_requires_extras_marker(path: Path):
+    """A module pulling an optional dep at module scope must be collection-safe + marked."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    bare_imports, importorskips = _module_offenders(tree)
+    rel = path.relative_to(_TESTS_ROOT)
+
+    # A bare `import <opt>` runs during collection of EVERY module under `-m core`,
+    # so it aborts the bare-wheel run regardless of the module's marker.
+    assert not bare_imports, (
+        f"{rel} has an UNGUARDED module-level import of optional dependency(ies) "
+        f"{sorted(set(bare_imports))}. pytest imports every module during `-m core` "
+        f"collection, so this aborts the extras-free pure-wheel run. Use "
+        f"`pytest.importorskip(...)` or a guarded `try/except ImportError` instead."
+    )
+
+    # A module-level `importorskip` is collection-safe (it skips the module), but if the
+    # module is `core`/unmarked it is *selected then silently skipped* in the core suite.
+    if importorskips:
+        markers = _module_markers(tree)
+        assert markers & _EXTRAS, (
+            f"{rel} module-level `importorskip`s optional dependency(ies) "
+            f"{sorted(set(importorskips))}, but its module markers {sorted(markers) or '{}'} "
+            f"include no extras marker ({sorted(_EXTRAS)}). It will silently skip in the "
+            f"`-m core` pure-wheel job. Add the matching marker "
+            f"(e.g. `pytestmark = pytest.mark.lazy`)."
+        )


### PR DESCRIPTION
# Description

Phase 1 of the test-suite marker-hygiene cleanup planned in
`planning/testing/test-suite-audit-2026-06-27.md` (Theme A), and a direct follow-up to #645. It routes every test
that needs an optional dependency to its extras marker, so the extras-free **"Pure Wheel" core CI job** stops
silently skipping (or aborting collection on) those tests — and adds a static guard so the #638 class of bug cannot
regress.

The disease: pytest imports **every** module under `tests/` during `-m core` collection before applying the marker
filter. So a `core`/unmarked module that pulls an optional dep at module scope either aborts the bare-wheel run
(unguarded `import`) or silently skips (`importorskip`), losing coverage that reads as green.

## Marker fixes

- **netcdf_samples** `test_lazy_reads` / `test_mfdataset` / `test_zarr`: `core` → `lazy`; `test_kerchunk`: `core` →
  `netcdf_lazy`. The module-level `importorskip` is kept (it keeps the module collectable in the bare-wheel job —
  the proven `test_streaming_write` pattern).
- **netcdf_samples/test_curvilinear_crop**: the two dask-only `chunks="auto"` tests `netcdf_lazy` → `lazy` (they
  need dask+zarr, not kerchunk/h5py).
- **dataset/collection/test_meta**: `lazy` → `core` (it uses none of the lazy stack, so it was silently skipping in
  every non-lazy env).
- **dataset/ops** `test_focal` / `test_reprojector` / `test_zarr` / `test_geobox_zarr`: replaced the hand-rolled
  `requires_dask` / `requires_zarr` skipif with `@pytest.mark.lazy` (now visible to `-m lazy` and the conftest
  auto-skipif); kept a guarded `import` only where the test bodies need `Delayed` / `zarr`.
- **dataset/test_stac**: the dask `.compute()` test → `@pytest.mark.lazy` (dropped the inline `import_dask`/skip).
- **netcdf/test_plot**: the three `chunks=` dask tests → `@pytest.mark.lazy` (dropped the inline `importorskip`).
- **feature/test_geoparquet**: module `skipif(find_spec("pyarrow"))` → `pytestmark = pytest.mark.parquet`.
- **feature/test_feature_gaps**: add the missing `pytestmark = pytest.mark.core` (its `_h3` / `tessellation` /
  `to_pmtiles` / `to_mvt` are pure-GDAL/NumPy, so it belongs in core).
- **stac/test_loader** (`TestLoadZarrAsset`) + **stac/test_geoparquet**: drop the local `HAS_*`/`requires_*` probes
  for `@pytest.mark.lazy` / `@pytest.mark.parquet`.
- **netcdf/test_mdim**: add the missing `pytestmark = pytest.mark.core` (was invisible to `-m core`).

## Taxonomy

- **tests/_marks.py**: deselect the live-network `vfs` tests by marker — the main suite runs `-m 'not plot and not xarray and not vfs'` and the pure-wheel core job runs `-m 'core and not vfs'`, so the live-AWS/HTTP tests never run in CI. No environment variable is involved.

## Guard meta-test

- **tests/test_marker_hygiene.py**: a static AST meta-test (runs in `core`, no deps) that fails if any module pulls
  an optional dep at module scope without being collection-safe + marked. An unguarded module-level `import` is
  rejected outright (it aborts `-m core` collection); a module-level `importorskip` must carry a matching extras
  marker. Guarded `try/except` imports and function-body `importorskip` are intentionally allowed. It found and we
  fixed one offender the manual audit missed (`cftime` is a hard dep, correctly excluded).

## Out of scope (later phases)

- `dataset/ops/lazy/*` `@requires_dask` boilerplate — those modules are already `pytestmark = pytest.mark.lazy`, so
  the local skipif is redundant cleanup (Theme D.3 / a later phase), not a correctness gap.
- `test_dataset_unit.py:1387` lazy-method-in-core (already skips correctly; low-urgency move).
- `test_io.py` / `stac/test_client.py` `pytestmark` placement (cosmetic; currently works).

# Issues

- Closes #652 — Phase 1 (Theme A) marker-hygiene cleanup + guard meta-test.
- Refs #645 — the marker-hygiene plan; further phases (Themes B–E) follow in separate PRs.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

> Test-marker + test-only change — none of the above categories apply.

# How Has This Been Tested?

Run on the `dev` pixi env (GDAL 3.13).

- [x] **Guard meta-test**: `pytest tests/test_marker_hygiene.py` → **264 modules pass** (one offender, `cftime`,
      investigated and confirmed a hard `[project]` dependency, so excluded).
- [x] **Touched files, deps present**: ran all 18 edited files → all pass (samples/ops/collection 104 passed;
      stac/feature/mdim/plot-lazy 198 passed).
- [x] **No unguarded module-level optional imports remain** in `tests/` or any `conftest.py` (verified by grep and
      by the guard).
- [ ] CI pure-wheel workflow (the real bare-wheel runtime check) runs on this PR.

# Checklist:

- [ ] updated version number in pyproject.toml. — N/A (commitizen/CI)
- [ ] added changes to History.rst. — N/A (generated)
- [ ] updated the latest version in README file. — N/A
- [x] I have added tests that prove my fix is effective — the guard meta-test pins the invariant permanently.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated. — N/A (tests only)


