### PR TITLE
refactor(feature): rename from_ogc_api_features to from_ogc_features

### DIFF
--- a/src/pyramids/base/_errors.py
+++ b/src/pyramids/base/_errors.py
@@ -179,7 +179,7 @@ class WFSError(_PyramidsError):
 class OGCAPIError(_PyramidsError):
     """A failure talking to an **OGC API – Features** service.
 
-    Raised by :meth:`pyramids.feature.FeatureCollection.from_ogc_api_features`
+    Raised by :meth:`pyramids.feature.FeatureCollection.from_ogc_features`
     (implementation in :mod:`pyramids.feature._oapif`) when the service landing
     page / ``/collections`` document cannot be reached, returns a non-JSON or
     error body, or the items request fails. OGC API – Features is the modern

--- a/src/pyramids/feature/_oapif.py
+++ b/src/pyramids/feature/_oapif.py
@@ -1,6 +1,6 @@
 """OGC API – Features → :class:`~pyramids.feature.FeatureCollection`.
 
-Implementation behind :meth:`pyramids.feature.FeatureCollection.from_ogc_api_features`.
+Implementation behind :meth:`pyramids.feature.FeatureCollection.from_ogc_features`.
 It fetches a collection subset from an OGC API – Features service and returns a
 :class:`~pyramids.feature.FeatureCollection`.
 
@@ -19,7 +19,7 @@ This is the OGC-API-era sibling of :mod:`pyramids.feature._wfs` (the WFS reader)
 the two share the same generic-OGC-primitive shape and scope boundary (see
 ``docs/SCOPE.md``): provider specifics — catalogs, agency auth endpoints,
 non-PROJ CRS — live in the downstream consumer (``earthlens``), which calls
-``from_ogc_api_features`` and passes ``auth`` as needed.
+``from_ogc_features`` and passes ``auth`` as needed.
 """
 
 from __future__ import annotations
@@ -164,7 +164,7 @@ def _oapif_connection(endpoint: str) -> str:
     return f"OAPIF:{endpoint}"
 
 
-def from_ogc_api_features(
+def from_ogc_features(
     featurecollection_cls: type["FeatureCollection"],
     endpoint: str,
     *,
@@ -179,7 +179,7 @@ def from_ogc_api_features(
     """Fetch an OGC API – Features collection subset and return a :class:`FeatureCollection`.
 
     This is the private implementation; the public API is the
-    :meth:`pyramids.feature.FeatureCollection.from_ogc_api_features` classmethod,
+    :meth:`pyramids.feature.FeatureCollection.from_ogc_features` classmethod,
     which forwards here. See that method for the full parameter documentation.
 
     Raises:

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -57,7 +57,7 @@ from pyramids.basemap.basemap import add_basemap
 from pyramids.feature import _h3
 from pyramids.feature import geometry as _geom
 from pyramids.feature import tessellation as _tess
-from pyramids.feature._oapif import from_ogc_api_features as _from_ogc_api_features
+from pyramids.feature._oapif import from_ogc_features as _from_ogc_features
 from pyramids.feature._wfs import from_wfs as _from_wfs
 
 CATALOG = Catalog(raster_driver=False)
@@ -1729,7 +1729,7 @@ class FeatureCollection(GeoDataFrame):
         )
 
     @classmethod
-    def from_ogc_api_features(
+    def from_ogc_features(
         cls,
         endpoint: str,
         *,
@@ -1797,7 +1797,7 @@ class FeatureCollection(GeoDataFrame):
 
             ```python
             >>> from pyramids.feature import FeatureCollection
-            >>> fc = FeatureCollection.from_ogc_api_features(  # doctest: +SKIP
+            >>> fc = FeatureCollection.from_ogc_features(  # doctest: +SKIP
             ...     "https://demo.pygeoapi.io/master",
             ...     collection="lakes",
             ...     bbox=(-104, 35, -94, 41),
@@ -1811,7 +1811,7 @@ class FeatureCollection(GeoDataFrame):
             - :meth:`from_featureserver`: read an Esri ArcGIS FeatureServer layer.
             - :meth:`read_file`: read a vector file or URL.
         """
-        return _from_ogc_api_features(
+        return _from_ogc_features(
             cls,
             endpoint,
             collection=collection,

--- a/tests/feature/test_oapif.py
+++ b/tests/feature/test_oapif.py
@@ -2,7 +2,7 @@
 
 Network-free. The OGR ``OAPIF`` driver's ``next``-link paging is proven against a
 protocol-faithful local mock in ``TestOapifDriverPaging``. Elsewhere the OGR read
-is monkeypatched so ``from_ogc_api_features``'s own logic — collection validation,
+is monkeypatched so ``from_ogc_features``'s own logic — collection validation,
 the read filters, FeatureCollection wrapping, ``output_crs`` reproject and error
 normalisation — is covered without a live service, plus the pure helpers and the
 ``/collections`` fetch/parse/cache.
@@ -308,7 +308,7 @@ class TestFromOgcApiFeatures:
         """A successful read is wrapped into a FeatureCollection."""
         self._patch_collections(monkeypatch)
         monkeypatch.setattr(_oapif.gpd, "read_file", lambda *a, **k: _sample_gdf())
-        fc = FeatureCollection.from_ogc_api_features("https://h/api", collection="lakes")
+        fc = FeatureCollection.from_ogc_features("https://h/api", collection="lakes")
         assert isinstance(fc, FeatureCollection)
         assert len(fc) == 2 and fc.crs.to_epsg() == 4326
 
@@ -323,7 +323,7 @@ class TestFromOgcApiFeatures:
             return _sample_gdf()
 
         monkeypatch.setattr(_oapif.gpd, "read_file", fake_read)
-        FeatureCollection.from_ogc_api_features(
+        FeatureCollection.from_ogc_features(
             "https://h/api", collection="lakes", bbox=(1.0, 2.0, 3.0, 4.0),
             where="scalerank <= 2", max_features=5,
         )
@@ -336,7 +336,7 @@ class TestFromOgcApiFeatures:
     def test_output_crs_reprojects(self, monkeypatch):
         self._patch_collections(monkeypatch)
         monkeypatch.setattr(_oapif.gpd, "read_file", lambda *a, **k: _sample_gdf())
-        fc = FeatureCollection.from_ogc_api_features(
+        fc = FeatureCollection.from_ogc_features(
             "https://h/api", collection="lakes", output_crs="EPSG:3857"
         )
         assert fc.crs.to_epsg() == 3857
@@ -347,14 +347,14 @@ class TestFromOgcApiFeatures:
         crsless = gpd.GeoDataFrame({"name": ["a"]}, geometry=[Point(5.0, 52.0)])
         monkeypatch.setattr(_oapif.gpd, "read_file", lambda *a, **k: crsless)
         with pytest.raises(OGCAPIError, match="without a CRS"):
-            FeatureCollection.from_ogc_api_features(
+            FeatureCollection.from_ogc_features(
                 "https://h/api", collection="lakes", output_crs="EPSG:3857"
             )
 
     def test_unknown_collection_raises_valueerror(self, monkeypatch):
         self._patch_collections(monkeypatch, ids=("lakes",))
         with pytest.raises(ValueError, match="not advertised"):
-            FeatureCollection.from_ogc_api_features("https://h/api", collection="missing")
+            FeatureCollection.from_ogc_features("https://h/api", collection="missing")
 
     def test_read_failure_raises_ogcapierror(self, monkeypatch):
         self._patch_collections(monkeypatch)
@@ -364,7 +364,7 @@ class TestFromOgcApiFeatures:
 
         monkeypatch.setattr(_oapif.gpd, "read_file", boom)
         with pytest.raises(OGCAPIError, match="items request failed"):
-            FeatureCollection.from_ogc_api_features("https://h/api", collection="lakes")
+            FeatureCollection.from_ogc_features("https://h/api", collection="lakes")
 
     def test_auth_and_timeout_active_during_read(self, monkeypatch):
         """The items read runs inside a GDAL config context carrying auth + timeout."""
@@ -377,7 +377,7 @@ class TestFromOgcApiFeatures:
             return _sample_gdf()
 
         monkeypatch.setattr(_oapif.gpd, "read_file", fake_read)
-        FeatureCollection.from_ogc_api_features(
+        FeatureCollection.from_ogc_features(
             "https://h/api", collection="lakes", auth=("u", "p"), timeout=42.0
         )
         assert seen["userpwd"] == "u:p"
@@ -516,11 +516,11 @@ class _OapifHandler(http.server.BaseHTTPRequestHandler):
 class TestOapifDriverPaging:
     """Drive the real OAPIF driver against a local two-page mock service.
 
-    ``from_ogc_api_features`` reads through GDAL's OGR ``OAPIF`` driver (via
+    ``from_ogc_features`` reads through GDAL's OGR ``OAPIF`` driver (via
     ``gpd.read_file``); this test exercises that same driver directly with
     ``gdal.OpenEx`` so the ``rel="next"`` paging is proven offline. (The bundled
     pyogrio reader cannot reach a localhost mock reliably in CI, so the
-    ``from_ogc_api_features`` wrapper itself is covered end-to-end only by the
+    ``from_ogc_features`` wrapper itself is covered end-to-end only by the
     gated live test below.)
     """
 
@@ -560,6 +560,6 @@ class TestLiveOapif:
         """Exercise the real OGR OAPIF driver against a caller-supplied public endpoint."""
         endpoint = os.environ["PYRAMIDS_OAPIF_ENDPOINT"]
         collection = os.environ["PYRAMIDS_OAPIF_COLLECTION"]
-        fc = FeatureCollection.from_ogc_api_features(endpoint, collection=collection, max_features=5)
+        fc = FeatureCollection.from_ogc_features(endpoint, collection=collection, max_features=5)
         assert isinstance(fc, FeatureCollection)
         assert len(fc) <= 5


### PR DESCRIPTION
# Description

Drop the redundant `api` from the OGC API – Features reader's public method name (and its internal helper),
for a shorter, consistent OGC reader family: `from_ogc_features` now, and `from_ogc_coverages` for the planned
raster reader (#661).

`FeatureCollection.from_ogc_api_features` → **`FeatureCollection.from_ogc_features`**.

This method merged after the 0.38.0 release (PR #656) and is **unreleased**, so renaming it now is a pre-release
name change, not a breaking change to any shipped API.

# Issues

- Refs #661 — keeps the naming consistent with the upcoming `Dataset.from_ogc_coverages`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

(Pure rename of an unreleased public method; no behaviour change.)

# How Has This Been Tested?

- [x] `pytest tests/feature/test_oapif.py` — 36 passed, 1 skipped
- [x] Smoke import: `FeatureCollection.from_ogc_features` exists, old name removed

# Checklist:

- [ ] updated version number in pyproject.toml. — N/A: commitizen/CI handles versioning.
- [ ] added changes to History.rst. — N/A: commitizen-generated.
- [ ] updated the latest version in README file. — N/A: release workflow.
- [x] I have added tests that prove my fix is effective or that my feature works. — existing OAPIF suite updated to the new name.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. — docstrings/`OGCAPIError` reference updated to the new method name.