### PR TITLE
test(suite): delete verified-redundant overlapping scenarios (Theme D.4, Phase 4)

### DIFF
--- a/tests/dataset/cog/test_web_optimized.py
+++ b/tests/dataset/cog/test_web_optimized.py
@@ -85,21 +85,3 @@ class TestWebOptimizedCog:
             tmp_path / "web.tif", tiling_scheme="GoogleMapsCompatible"
         )
         assert Dataset.read_file(str(out)).validate_cog().is_valid, "invalid web COG"
-
-    def test_tiling_scheme_and_target_srs_warns(self, big_dataset, tmp_path):
-        """Passing both tiling_scheme and target_srs warns (scheme wins).
-
-        Args:
-            big_dataset: 600x600 EPSG:4326 fixture.
-            tmp_path: pytest temp directory.
-
-        Test scenario:
-            The two are mutually exclusive; tiling_scheme wins and a UserWarning
-            is emitted.
-        """
-        with pytest.warns(UserWarning, match="tiling_scheme"):
-            big_dataset.to_cog(
-                tmp_path / "w.tif",
-                tiling_scheme="GoogleMapsCompatible",
-                target_srs=4326,
-            )

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -2110,82 +2110,6 @@ class TestTiling:
         ]
 
 
-class TestIloc:
-    """extract band from a dataset."""
-
-    def test_iloc_out_of_bound_index(
-        self,
-        src: gdal.Dataset,
-        src_no_data_value: float,
-    ):
-        dataset = Dataset(src)
-        with pytest.raises(IndexError):
-            dataset._iloc(1)
-        with pytest.raises(IndexError):
-            dataset._iloc(-1)
-
-    def test_iloc(
-        self,
-        src: gdal.Dataset,
-        src_no_data_value: float,
-    ):
-        dataset = Dataset(src)
-        band = dataset._iloc(0)
-        assert isinstance(band, gdal.Band)
-
-
-class TestStats:
-    def test_all_bands(self, era5_image: gdal.Dataset, era5_image_stats: DataFrame):
-        dataset = Dataset(era5_image)
-        stats = dataset.stats()
-        assert isinstance(stats, DataFrame)
-        assert all(stats.columns == ["min", "max", "mean", "std"])
-        assert np.isclose(
-            stats.values, era5_image_stats.values, rtol=0.000001, atol=0.00001
-        ).all()
-
-    def test_specific_band(self, era5_image: gdal.Dataset, era5_image_stats: DataFrame):
-        dataset = Dataset(era5_image)
-        stats = dataset.stats(0)
-        assert isinstance(stats, DataFrame)
-        assert all(stats.columns == ["min", "max", "mean", "std"])
-        assert np.isclose(
-            stats.values,
-            era5_image_stats.iloc[0, :].values,
-            rtol=0.000001,
-            atol=0.00001,
-        ).all()
-
-    def test_all_bands_with_mask(
-        self,
-        era5_image: gdal.Dataset,
-        era5_image_stats: DataFrame,
-        era5_mask: GeoDataFrame,
-    ):
-        """
-        Test the stats function with a mask.
-        The mask covers only the second row of the array, the test checks if the mean of the second row is equal to the
-        mean calculated by the stats function.
-        """
-        dataset = Dataset(era5_image)
-        stats = dataset.stats(mask=era5_mask)
-        assert isinstance(stats, DataFrame)
-        assert all(stats.columns == ["min", "max", "mean", "std"])
-        arr = dataset.read_array()
-        mean = arr[:, 1, :].mean(axis=1)
-        std = arr[:, 1, :].std(axis=1)
-        min_val = arr[:, 1, :].min(axis=1)
-        max_val = arr[:, 1, :].max(axis=1)
-        assert np.isclose(stats["mean"].values, mean, rtol=0.000001, atol=0.00001).all()
-        assert np.isclose(stats["std"].values, std, rtol=0.000001, atol=0.00001).all()
-        assert np.isclose(
-            stats["min"].values, min_val, rtol=0.000001, atol=0.00001
-        ).all()
-        assert np.isclose(
-            stats["max"].values, max_val, rtol=0.000001, atol=0.00001
-        ).all()
-
-
 class TestDistributedRead:  # unittest.TestCase
     def test_get_block_arrangement_default(self, src: Dataset):
         dataset = Dataset(src)
@@ -2218,29 +2142,6 @@ class TestHistogram:
         hist, ranges = dataset.get_histogram(band=0)
         assert len(ranges) == 6
         assert hist == [75, 6, 0, 4, 2, 1]
-
-
-class TestWriteArray:
-    def test_single_band(self):
-        path = "tests/data/geotiff/empty-to-fill-single-band.tif"
-        dataset = Dataset.read_file(path, read_only=False).copy()
-        arr = np.array([[1, 2], [3, 4]])
-        xoff = 5  # col
-        yoff = 3  # row
-        dataset.write_array(arr, top_left_corner=[yoff, xoff])
-        retrieved_arr = dataset._raster.ReadAsArray(xoff, yoff, 2, 2)
-        np.testing.assert_array_equal(arr, retrieved_arr)
-
-    def test_multi_band(self):
-        # Multi Band
-        path = "tests/data/geotiff/empty-to-fill-multi-band.tif"
-        dataset = Dataset.read_file(path, read_only=False).copy()
-        arr = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
-        xoff = 5
-        yoff = 3
-        dataset.write_array(arr, top_left_corner=[yoff, xoff])
-        retrieved_arr = dataset._raster.ReadAsArray(xoff, yoff, 2, 2)
-        np.testing.assert_array_equal(arr, retrieved_arr)
 
 
 def test_nearest_neigbors():

--- a/tests/dataset/test_dataset_unit.py
+++ b/tests/dataset/test_dataset_unit.py
@@ -734,6 +734,27 @@ class TestWriteArray:
         assert result[2, 2] == pytest.approx(10.0), "Offset write failed at (2,2)"
         assert result[0, 0] == pytest.approx(0.0), "Cell outside patch should be unchanged"
 
+    def test_write_array_multi_band(self):
+        """write_array writes a multi-band patch at an offset across every band.
+
+        Ports the multi-band scenario from the legacy duplicate (which used the
+        on-disk ``empty-to-fill-multi-band.tif`` fixture). A (2, 2, 2) patch
+        written at row/col offset (3, 5) must round-trip exactly on both bands.
+        """
+        base = np.zeros((2, 8, 8), dtype=np.float64)
+        ds = Dataset.create_from_array(
+            base,
+            top_left_corner=(0.0, 0.0),
+            cell_size=0.05,
+            epsg=4326,
+        )
+        arr = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
+        xoff = 5
+        yoff = 3
+        ds.write_array(arr, top_left_corner=[yoff, xoff])
+        retrieved = ds._raster.ReadAsArray(xoff, yoff, 2, 2)
+        np.testing.assert_array_equal(arr, retrieved)
+
 
 class TestSetNoDataValueErrors:
     """Tests for _set_no_data_value error handling."""
@@ -1408,6 +1429,7 @@ class TestIloc:
         """Valid index should return a gdal.Band object."""
         band = single_band_dataset._iloc(0)
         assert band is not None, "Band should not be None"
+        assert isinstance(band, gdal.Band), "Band should be a gdal.Band"
 
     def test_iloc_on_closed_dataset(self, single_band_dataset):
         """Accessing a band on a closed dataset should raise RuntimeError.
@@ -1853,6 +1875,34 @@ class TestStats:
         """stats(band=0) should return stats for only that band."""
         df = multi_band_dataset.stats(band=0)
         assert len(df) == 1, "Should have 1 row for a single band"
+
+    def test_stats_all_bands_values(self, era5_image, era5_image_stats):
+        """stats() values match the reference era5 per-band statistics.
+
+        Ports the numeric-correctness scenario from the legacy duplicate so the
+        computed min/max/mean/std are checked against a known reference, not just
+        for the right column layout.
+        """
+        dataset = Dataset(era5_image)
+        stats = dataset.stats()
+        assert isinstance(stats, pd.DataFrame), "stats should return DataFrame"
+        assert list(stats.columns) == ["min", "max", "mean", "std"]
+        assert np.isclose(
+            stats.values, era5_image_stats.values, rtol=0.000001, atol=0.00001
+        ).all(), "stats() values diverge from the reference era5 statistics"
+
+    def test_stats_specific_band_values(self, era5_image, era5_image_stats):
+        """stats(0) values match the first band of the reference statistics."""
+        dataset = Dataset(era5_image)
+        stats = dataset.stats(0)
+        assert isinstance(stats, pd.DataFrame), "stats should return DataFrame"
+        assert list(stats.columns) == ["min", "max", "mean", "std"]
+        assert np.isclose(
+            stats.values,
+            era5_image_stats.iloc[0, :].values,
+            rtol=0.000001,
+            atol=0.00001,
+        ).all(), "stats(0) values diverge from the reference era5 statistics"
 
 
 class TestCreateDataset:
@@ -4004,6 +4054,35 @@ class TestStatsWithMask:
         gdf = gpd.GeoDataFrame(geometry=[poly], crs="EPSG:4326")
         df = single_band_dataset.stats(mask=gdf)
         assert isinstance(df, pd.DataFrame), "stats with mask should return DataFrame"
+
+    def test_stats_all_bands_with_mask_values(self, era5_image, era5_mask):
+        """Masked stats equal the statistics of the masked (second) row.
+
+        Ports the numeric mask scenario from the legacy duplicate. The era5 mask
+        covers only the second row of the array, so the masked mean/std/min/max
+        must equal those computed directly from ``arr[:, 1, :]``.
+        """
+        dataset = Dataset(era5_image)
+        stats = dataset.stats(mask=era5_mask)
+        assert isinstance(stats, pd.DataFrame), "stats with mask should return DataFrame"
+        assert list(stats.columns) == ["min", "max", "mean", "std"]
+        arr = dataset.read_array()
+        mean = arr[:, 1, :].mean(axis=1)
+        std = arr[:, 1, :].std(axis=1)
+        min_val = arr[:, 1, :].min(axis=1)
+        max_val = arr[:, 1, :].max(axis=1)
+        assert np.isclose(
+            stats["mean"].values, mean, rtol=0.000001, atol=0.00001
+        ).all(), "masked mean diverges from arr[:, 1, :]"
+        assert np.isclose(
+            stats["std"].values, std, rtol=0.000001, atol=0.00001
+        ).all(), "masked std diverges from arr[:, 1, :]"
+        assert np.isclose(
+            stats["min"].values, min_val, rtol=0.000001, atol=0.00001
+        ).all(), "masked min diverges from arr[:, 1, :]"
+        assert np.isclose(
+            stats["max"].values, max_val, rtol=0.000001, atol=0.00001
+        ).all(), "masked max diverges from arr[:, 1, :]"
 
 
 class TestGetStatsRuntimeError:

--- a/tests/feature/test_coverage_gaps.py
+++ b/tests/feature/test_coverage_gaps.py
@@ -11,7 +11,9 @@ Covers:
 * Direct unit tests for ``_get_line_coords`` and ``_get_poly_coords``
   (previously exercised only transitively via higher-level calls).
 * ``top_left_corner`` with negative coordinates and a single point.
-* ``iter_features`` / ``list_layers`` error paths on a missing file.
+* ``iter_features`` error path on a missing file (the ``list_layers``
+  missing-file case now lives in
+  ``tests/feature/test_schema_and_layers.py::TestListLayersMissingFile``).
 * ``schema`` on a pure-Polygon collection (existing tests only cover
   Point or mixed geom types).
 * ``reproject_coordinates`` edge cases: empty input lists,

--- a/tests/feature/test_coverage_gaps.py
+++ b/tests/feature/test_coverage_gaps.py
@@ -97,11 +97,6 @@ class TestMissingFileErrors:
         with pytest.raises((DataSourceError, FileNotFoundError)):
             list(FeatureCollection.iter_features(missing))
 
-    def test_list_layers_missing_file(self, tmp_path: Path):
-        missing = tmp_path / "nope.gpkg"
-        with pytest.raises((DataSourceError, FileNotFoundError)):
-            FeatureCollection.list_layers(missing)
-
 
 class TestSchemaPolygon:
     """Pure-Polygon schema reports 'Polygon'."""

--- a/tests/netcdf/test_plot.py
+++ b/tests/netcdf/test_plot.py
@@ -1542,18 +1542,6 @@ class TestNetCDFPlotFaceting:
                 facet=FacetSpec(col="time"),
             )
 
-    def test_row_without_col_raises(self):
-        """`row=` without `col=` is rejected with a clear error."""
-        nc = _make_4d_nc()
-        with pytest.raises(ValueError, match=r"requires `col=`"):
-            nc.plot(variable="temperature", facet=FacetSpec(row="time"))
-
-    def test_facet_dim_not_a_band_dim_raises(self):
-        """`col="bogus"` is not a band dim of the variable; raises."""
-        nc = make_plot_3d_nc()
-        with pytest.raises(ValueError, match=r"not a band dim"):
-            nc.plot(variable="t2m", facet=FacetSpec(col="bogus"))
-
     def test_invalid_col_wrap_raises(self):
         """`col_wrap=0` or non-int raises ValueError."""
         nc = make_plot_3d_nc(n_times=4)

--- a/tests/netcdf/test_sel.py
+++ b/tests/netcdf/test_sel.py
@@ -135,6 +135,12 @@ class TestSelSlice:
             12.0,
             18.0,
         ], f"Expected [6, 12, 18], got {result._band_dim_values}"
+        expected = np.stack([var.read_array(band=i) for i in (1, 2, 3)], axis=0)
+        assert_array_equal(
+            result.read_array(),
+            expected,
+            err_msg="slice(6, 18) data should equal stacked bands 1, 2, 3",
+        )
 
     def test_open_start(self):
         """slice(None, 12) should select from beginning up to 12.

--- a/tests/netcdf/test_sel.py
+++ b/tests/netcdf/test_sel.py
@@ -14,13 +14,18 @@ pytestmark = pytest.mark.core
 
 
 def _make_nc():
-    """Create a 3D NetCDF with known time coordinates [0, 6, 12, 18, 24]."""
+    """Create a 3D NetCDF with known time coordinates [0, 6, 12, 18, 24].
+
+    Carries a -9999.0 no-data sentinel so preservation tests can pin the
+    literal (the data values 0-59 never collide with it).
+    """
     arr = np.arange(60, dtype=np.float64).reshape(5, 3, 4)
     geo = (0.0, 1.0, 0, 3.0, 0, -1.0)
     nc = NetCDF.create_from_array(
         arr=arr,
         geo=geo,
         variable_name="temp",
+        no_data_value=-9999.0,
         extra_dim_name="time",
         extra_dim_values=[0, 6, 12, 18, 24],
     )
@@ -40,6 +45,8 @@ class TestSelSingleValue:
         var = nc.get_variable("temp")
         result = var.sel(time=6)
         assert result.shape == (1, 3, 4), f"Expected (1, 3, 4), got {result.shape}"
+        read = result.read_array()
+        assert read.shape == (3, 4), f"single-band read should squeeze to 2D, got {read.shape}"
 
     def test_data_matches_original_band(self):
         """Selected data should match the corresponding band in the original.
@@ -508,6 +515,7 @@ class TestSelPreservation:
         result = var.sel(time=[0, 6])
         orig_ndv = var.no_data_value[0]
         result_ndv = result.no_data_value[0]
+        assert orig_ndv == -9999.0, f"fixture nodata should be -9999.0, got {orig_ndv}"
         assert result_ndv == orig_ndv, f"No-data changed: {orig_ndv} → {result_ndv}"
 
 

--- a/tests/netcdf/test_windowed_reads.py
+++ b/tests/netcdf/test_windowed_reads.py
@@ -357,112 +357,6 @@ class TestReadVariableClassicMode:
         )
 
 
-class TestSelDataIntegrity:
-    """sel() data integrity — ARC-10 band-level reads produce correct data."""
-
-    def test_sel_single_matches_full_read_band(self):
-        """sel(time=12) data matches read_array(band=2).
-
-        Test scenario:
-            Band index 2 corresponds to time=12 in [0,6,12,18,24].
-            The sel() result data should exactly equal that band.
-        """
-        nc = _make_3d_nc()
-        var = nc.get_variable("temperature")
-        sel_result = var.sel(time=12)
-        expected = var.read_array(band=2)
-        assert_array_equal(
-            sel_result.read_array(),
-            expected,
-            err_msg="sel(time=12) data should match band index 2",
-        )
-
-    def test_sel_list_matches_stacked_bands(self):
-        """sel(time=[0, 18]) matches stacking bands 0 and 3.
-
-        Test scenario:
-            Selecting time steps 0 and 18 (band indices 0 and 3)
-            should produce the same array as np.stack([band0, band3]).
-        """
-        nc = _make_3d_nc()
-        var = nc.get_variable("temperature")
-        sel_result = var.sel(time=[0, 18])
-        band_0 = var.read_array(band=0)
-        band_3 = var.read_array(band=3)
-        expected = np.stack([band_0, band_3], axis=0)
-        assert_array_equal(
-            sel_result.read_array(),
-            expected,
-            err_msg="sel(time=[0,18]) should equal stack of bands 0,3",
-        )
-
-    def test_sel_slice_matches_sequential_bands(self):
-        """sel(time=slice(6, 18)) matches bands 1, 2, 3.
-
-        Test scenario:
-            Time coords [6,12,18] have band indices [1,2,3].
-        """
-        nc = _make_3d_nc()
-        var = nc.get_variable("temperature")
-        sel_result = var.sel(time=slice(6, 18))
-        bands = [var.read_array(band=i) for i in [1, 2, 3]]
-        expected = np.stack(bands, axis=0)
-        assert_array_equal(
-            sel_result.read_array(),
-            expected,
-            err_msg="sel(time=slice(6,18)) should match bands 1-3",
-        )
-
-    def test_sel_all_values_matches_full_read(self):
-        """sel(time=[0,6,12,18,24]) matches full read_array().
-
-        Test scenario:
-            Selecting all time steps should produce the exact same
-            array as read_array() on the full variable.
-        """
-        nc = _make_3d_nc()
-        var = nc.get_variable("temperature")
-        sel_result = var.sel(time=[0, 6, 12, 18, 24])
-        expected = var.read_array()
-        assert_array_equal(
-            sel_result.read_array(),
-            expected,
-            err_msg="Selecting all times should match full read",
-        )
-
-    def test_sel_first_band(self):
-        """sel(time=0) selects the first band correctly.
-
-        Test scenario:
-            Boundary: first band (index 0) should be returned as 2D.
-        """
-        nc = _make_3d_nc()
-        var = nc.get_variable("temperature")
-        result = var.sel(time=0)
-        expected = var.read_array(band=0)
-        assert_array_equal(
-            result.read_array(),
-            expected,
-            err_msg="sel(time=0) should match first band",
-        )
-
-    def test_sel_last_band(self):
-        """sel(time=24) selects the last band correctly.
-
-        Test scenario:
-            Boundary: last band (index 4) should be returned as 2D.
-        """
-        nc = _make_3d_nc()
-        var = nc.get_variable("temperature")
-        result = var.sel(time=24)
-        expected = var.read_array(band=4)
-        assert_array_equal(
-            result.read_array(),
-            expected,
-            err_msg="sel(time=24) should match last band",
-        )
-
-
 class TestSelChaining:
     """sel() chaining — sequential sel() calls produce correct results."""
 
@@ -525,50 +419,6 @@ class TestSelChaining:
         assert isinstance(
             second, NetCDF
         ), f"Expected NetCDF, got {type(second).__name__}"
-
-
-class TestSelShape:
-    """sel() output shape correctness."""
-
-    def test_single_value_shape_is_2d(self):
-        """Selecting a single time step returns a 2D array (squeezed).
-
-        Test scenario:
-            sel(time=6) on a (5, 6, 8) variable should produce a
-            (6, 8) array (the single band is squeezed).
-        """
-        nc = _make_3d_nc()
-        var = nc.get_variable("temperature")
-        result = var.sel(time=6)
-        arr = result.read_array()
-        assert arr.shape == (
-            6,
-            8,
-        ), f"Expected (6, 8) for single-band sel, got {arr.shape}"
-
-    def test_two_values_shape_is_3d(self):
-        """Selecting two time steps returns a 3D array.
-
-        Test scenario:
-            sel(time=[6, 18]) should produce shape (2, 6, 8).
-        """
-        nc = _make_3d_nc()
-        var = nc.get_variable("temperature")
-        result = var.sel(time=[6, 18])
-        arr = result.read_array()
-        assert arr.shape == (2, 6, 8), f"Expected (2, 6, 8), got {arr.shape}"
-
-    def test_all_values_shape_matches_original(self):
-        """Selecting all time steps returns the original shape.
-
-        Test scenario:
-            sel(time=[0,6,12,18,24]) should produce shape (5, 6, 8).
-        """
-        nc = _make_3d_nc()
-        var = nc.get_variable("temperature")
-        result = var.sel(time=[0, 6, 12, 18, 24])
-        arr = result.read_array()
-        assert arr.shape == (5, 6, 8), f"Expected (5, 6, 8), got {arr.shape}"
 
 
 class TestSelEdgeCases:
@@ -655,46 +505,6 @@ class TestSelReturnTypeAndMetadata:
             expected,
             rtol=1e-10,
             err_msg="Unpack should apply scale*value+offset",
-        )
-
-
-class TestSelSetVariableRoundTrip:
-    """sel() results can be written back via set_variable."""
-
-    def test_sel_result_stores_back(self):
-        """A sel() result can be stored in a container via set_variable.
-
-        Test scenario:
-            get_variable → sel → set_variable should produce a valid
-            container with the subsetted variable.
-        """
-        nc = _make_3d_nc()
-        var = nc.get_variable("temperature")
-        selected = var.sel(time=[0, 12])
-        nc.set_variable("temp_subset", selected)
-        assert (
-            "temp_subset" in nc.variable_names
-        ), "temp_subset should appear in variable_names"
-
-    def test_sel_round_trip_data_integrity(self):
-        """Data survives a sel -> set_variable -> get_variable round trip.
-
-        Test scenario:
-            The data stored via set_variable should match the original
-            sel() result when read back.
-        """
-        nc = _make_3d_nc()
-        var = nc.get_variable("temperature")
-        selected = var.sel(time=[6, 18])
-        sel_data = selected.read_array()
-        nc.set_variable("temp_sub", selected)
-        restored = nc.get_variable("temp_sub")
-        restored_data = restored.read_array()
-        assert_allclose(
-            restored_data,
-            sel_data,
-            rtol=1e-10,
-            err_msg="Data should survive sel -> set_variable round trip",
         )
 
 
@@ -823,59 +633,6 @@ class TestReadVariableWindowBoundary:
         assert (
             windowed.dtype == full.dtype
         ), f"Expected dtype {full.dtype}, got {windowed.dtype}"
-
-
-class TestSelNonContiguousBands:
-    """sel() with non-contiguous band indices."""
-
-    def test_sel_non_contiguous_indices(self):
-        """sel(time=[0, 12, 24]) selects bands 0, 2, 4 (skipping 1, 3).
-
-        Test scenario:
-            Non-contiguous selection should correctly pick each
-            requested band without including intermediate ones.
-        """
-        nc = _make_3d_nc()
-        var = nc.get_variable("temperature")
-        result = var.sel(time=[0, 12, 24])
-        band_0 = var.read_array(band=0)
-        band_2 = var.read_array(band=2)
-        band_4 = var.read_array(band=4)
-        expected = np.stack([band_0, band_2, band_4], axis=0)
-        assert_array_equal(
-            result.read_array(),
-            expected,
-            err_msg=("Non-contiguous sel should pick bands 0, 2, 4"),
-        )
-
-    def test_sel_non_contiguous_coords_correct(self):
-        """Non-contiguous sel carries the correct coordinate values.
-
-        Test scenario:
-            sel(time=[0, 12, 24]) -> _band_dim_values == [0, 12, 24].
-        """
-        nc = _make_3d_nc()
-        var = nc.get_variable("temperature")
-        result = var.sel(time=[0, 12, 24])
-        assert result._band_dim_values == [
-            0,
-            12,
-            24,
-        ], f"Expected [0, 12, 24], got {result._band_dim_values}"
-
-    def test_sel_preserves_nodata(self):
-        """sel() preserves the no_data_value on the result.
-
-        Test scenario:
-            The original variable has nodata=-9999.0 which must
-            survive selection.
-        """
-        nc = _make_3d_nc()
-        var = nc.get_variable("temperature")
-        result = var.sel(time=6)
-        ndv = result.no_data_value
-        ndv_scalar = ndv[0] if isinstance(ndv, (list, tuple)) else ndv
-        assert ndv_scalar == -9999.0, f"Expected nodata=-9999.0, got {ndv_scalar}"
 
 
 class TestSelOnDiskFile:

--- a/tests/netcdf_samples/test_errors_and_cleanup.py
+++ b/tests/netcdf_samples/test_errors_and_cleanup.py
@@ -18,16 +18,6 @@ def test_classic_mode_rename_raises(sample):
         nc.close()
 
 
-def test_get_variable_unknown_raises(sample):
-    """Requesting a missing variable raises ValueError naming the bad variable."""
-    nc = NetCDF.read_file(sample("cf__7v__1d3-2d3-3d1.nc"))
-    try:
-        with pytest.raises(ValueError, match="not a valid variable name"):
-            nc.get_variable("no_such_variable")
-    finally:
-        nc.close()
-
-
 def test_close_is_idempotent(sample):
     """Calling ``close`` twice releases the GDAL handle and is safe to repeat."""
     nc = NetCDF.read_file(sample("cf__7v__1d3-2d3-3d1.nc"))

--- a/tests/netcdf_samples/test_smoke_all_files.py
+++ b/tests/netcdf_samples/test_smoke_all_files.py
@@ -49,15 +49,6 @@ def test_every_root_variable_loads(sample_name, sample):
         nc.close()
 
 
-def test_global_attributes_readable(sample_name, sample):
-    """``global_attributes`` returns a dict (possibly empty) without raising on any shape."""
-    nc = NetCDF.read_file(sample(sample_name))
-    try:
-        assert isinstance(nc.global_attributes, dict)
-    finally:
-        nc.close()
-
-
 def test_close_releases_handle_and_reopens(sample_name, sample):
     """After ``close()`` the file handle is released, so the same path re-opens (Windows lock check)."""
     path = sample(sample_name)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -383,38 +383,3 @@ class TestHelperFunctions:
     def test_is_tar_non_tar(self):
         """_is_tar should return False for non-tar files."""
         assert _is_tar("file.tif") is False, "file.tif should not be tar"
-
-
-class TestParsePathRemote:
-    """URL-scheme rewriting in _parse_path (Task 5)."""
-
-    def test_s3_becomes_vsis3(self):
-        assert _parse_path("s3://bucket/key.tif") == "/vsis3/bucket/key.tif"
-
-    def test_gs_becomes_vsigs(self):
-        assert _parse_path("gs://bucket/key.tif") == "/vsigs/bucket/key.tif"
-
-    def test_az_becomes_vsiaz(self):
-        assert _parse_path("az://container/blob.tif") == "/vsiaz/container/blob.tif"
-
-    def test_https_becomes_vsicurl(self):
-        assert _parse_path("https://foo.com/x.tif") == "/vsicurl/https://foo.com/x.tif"
-
-    def test_http_becomes_vsicurl(self):
-        assert _parse_path("http://foo.com/x.tif") == "/vsicurl/http://foo.com/x.tif"
-
-    def test_already_vsi_passthrough(self):
-        assert _parse_path("/vsicurl/https://foo/x.tif") == "/vsicurl/https://foo/x.tif"
-
-    def test_vsis3_passthrough(self):
-        assert _parse_path("/vsis3/bucket/key.tif") == "/vsis3/bucket/key.tif"
-
-    def test_local_path_unchanged(self):
-        assert _parse_path("/home/user/x.tif") == "/home/user/x.tif"
-
-    def test_windows_local_unchanged(self):
-        assert _parse_path("C:/data/x.tif") == "C:/data/x.tif"
-
-    def test_presigned_url_query_preserved(self):
-        url = "https://foo.com/x.tif?sig=abc&exp=123"
-        assert _parse_path(url) == f"/vsicurl/{url}"


### PR DESCRIPTION
# Description

Phase 4a (Theme D.4 — delete overlapping/redundant scenarios) of the test-suite cleanup tracked in
`planning/testing/test-suite-audit-2026-06-27.md`. **Tests only — no `src/` changes, no behaviour change.** Each
deletion was made only after reading the keeper test and confirming it covers the deleted scenario at least as
strongly; the one case with unique coverage (D.4 #9) had that coverage ported first. 9 files, +79/-431.

- **#1** `netcdf/test_windowed_reads.py` — delete 4 redundant `Sel` classes (`TestSelDataIntegrity`, `TestSelShape`,
  `TestSelSetVariableRoundTrip`, `TestSelNonContiguousBands`) covered by `netcdf/test_sel.py`. **Kept**
  `TestSelReturnTypeAndMetadata` — its `scale/offset` and `unpack` assertions are not in `test_sel.py` (would be a
  coverage gap).
- **#2** `cog/test_web_optimized.py` — delete the `tiling_scheme+target_srs` warning test; `test_dataset_cog_api.py`
  asserts the same warning with a stricter `match="tiling_scheme wins"`.
- **#4** `feature/test_coverage_gaps.py` — delete the weaker `list_layers` missing-file test;
  `test_schema_and_layers.py` asserts `FileNotFoundError` with a message match and names the path.
- **#5/#6** `netcdf_samples/` — delete two single-file subset tests (`test_global_attributes_readable`, the
  single-file `test_get_variable_unknown_raises`); both are strict subsets of parametrized supersets in
  `test_global_attributes.py` / `test_variables_access.py`.
- **#8** `test_io.py` — delete `TestParsePathRemote`; every scheme + the `_parse_path -> _to_vsi` delegation is
  covered by `base/test_remote.py::TestToVsi` (a strict superset).
- **#10** `netcdf/test_plot.py` — delete two base faceting raise-only tests; the `…Edges` versions raise under the
  same condition AND assert the error message.
- **#9** `dataset/` — collapse `TestIloc`/`TestStats`/`TestWriteArray` from `test_dataset.py` into the richer
  `test_dataset_unit.py`. **Ported first**: the era5 numeric-stats correctness (all-bands / specific-band / masked),
  the multi-band `write_array` round-trip, and the `isinstance(band, gdal.Band)` iloc assertion.

Findings that were re-verified as NOT real duplicates are intentionally left in place: `is_cog`/`validate` (different
overview branch by raster size), suffix-vs-no-suffix `from_bytes`, the pin-dim facet pair, and the CF isolated-attr
singles.

# Issues

- Closes #667 — delete verified-redundant overlapping scenarios (Theme D.4, Phase 4).
- Refs #645 — parent test-suite-cleanup epic (E.1 file splits and the E.2-E.7 tail remain).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

> Test-only refactor — none of the above categories apply.

# How Has This Been Tested?

Run on the `dev` pixi env (GDAL 3.13) against the worktree (absolute paths so the edited files, not the main
checkout, are exercised).

- [x] All 9 edited files plus their keeper-superset counterparts (`test_sel.py`, `test_dataset_cog_api.py`,
      `test_schema_and_layers.py`, `test_global_attributes.py`, `test_variables_access.py`, `base/test_remote.py`):
      **1067 passed, 1 skipped, 1 deselected** (vfs).
- [x] Each deletion gated on reading the keeper and confirming coverage; D.4 #9's unique coverage ported and the 5
      ported/strengthened tests verified by node id.

# Checklist:

- [ ] updated version number in pyproject.toml. — N/A (commitizen/CI handles versions)
- [ ] added changes to History.rst. — N/A (generated)
- [ ] updated the latest version in README file. — N/A
- [x] I have added tests that prove my fix is effective or that my feature works. — net deletion; ported the unique
      coverage of the collapsed classes so nothing is lost.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated. — N/A (tests only)
