### PR TITLE
build(pixi): pin Python 3.14 to the standard-GIL cp314 ABI

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -13847,7 +13847,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.6-hb5e19a0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3183152_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py314h31e7e59_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py314hd174a59_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h10d778d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
@@ -13908,13 +13908,13 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/minizip-4.2.1-he29b9bd_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/muparser-2.3.5-hb996559_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.5.0-py314h5af6b61_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.5.0-py314h7b24d9b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openjpeg-2.5.4-h52bb76a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.3-hc881268_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/pcre2-10.47-h13923f0_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/proj-9.8.1-he69a98e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.14.6-ha91e2d8_0_cp314t.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.14.6-h7c6738f_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/snappy-1.2.2-h01f5ddf_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/sqlite-3.53.3-h6775aab_0.conda
@@ -14033,7 +14033,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_9.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.6.17-h4c7d964_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py314h5f9b167_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py314h805a11e_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-2.1.0-nompi_ha9ae7cf_108.conda
@@ -14085,14 +14085,14 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/minizip-4.2.2-h0ffbb96_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/mkl-2026.0.0-hac47afa_908.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/muparser-2.3.5-he0c23c2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.5.0-py314hffb9209_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.5.0-py314h02f10f6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/onemkl-license-2026.0.0-h57928b3_908.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openjpeg-2.5.4-h0e57b4f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/openssl-3.6.3-hf411b9b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/pcre2-10.47-hd2b5f0e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/proj-9.8.1-hd30e2cd_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.14.6-h7c1dbca_0_cp314t.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/python-3.14.6-h4b44e0e_100_cp314.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/snappy-1.2.2-h7fa0ca8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/sqlite-3.53.3-hdb435a2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/swig-4.4.1-h9b0202b_0.conda
@@ -20229,48 +20229,6 @@ packages:
   - pkg:pypi/gdal?source=hash-mapping
   size: 2481420
   timestamp: 1780928456229
-- conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py314h31e7e59_1.conda
-  sha256: 6c8e523ab7a6dc77ad1c7c0d3bf96fd1aeabf3a97e607847c6755053480a2f2a
-  md5: ca775308e9defc22cb94dc3674f154e9
-  depends:
-  - python
-  - libgdal-core 3.13.1.*
-  - libcxx >=19
-  - __osx >=11.0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lerc >=4.1.0,<5.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - json-c >=0.18,<0.19.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libiconv >=1.18,<2.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - blosc >=1.21.6,<2.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libjxl >=0.11,<1.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - openssl >=3.5.6,<4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - numpy >=1.23,<3
-  - python_abi 3.14.* *_cp314t
-  license: MIT
-  license_family: MIT
-  size: 2518771
-  timestamp: 1780928456229
 - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py314hd174a59_1.conda
   sha256: 79a4eddf5bcf52d76155745c18d1df3391a749d6837d732b42488fc4c6f3fe10
   md5: 05ea035465fdd948b03be6441a6eaee6
@@ -20623,47 +20581,6 @@ packages:
   purls:
   - pkg:pypi/gdal?source=hash-mapping
   size: 2326183
-  timestamp: 1781522012443
-- conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py314h5f9b167_2.conda
-  sha256: eebd9a86221277e6158758ca73f4d3b29f63dde05143ffd376e3e62946dd17d7
-  md5: cdb99e8583a500c77660ad4747070736
-  depends:
-  - python
-  - libgdal-core 3.13.1.*
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - blosc >=1.21.6,<2.0a0
-  - lerc >=4.1.0,<5.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.20.0,<9.0a0
-  - libjpeg-turbo >=3.1.4.1,<4.0a0
-  - openssl >=3.5.7,<4.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - libarchive >=3.8.7,<3.9.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libiconv >=1.18,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libjxl >=0.11,<1.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - numpy >=1.23,<3
-  - python_abi 3.14.* *_cp314t
-  license: MIT
-  license_family: MIT
-  size: 2383069
   timestamp: 1781522012443
 - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py314h805a11e_2.conda
   sha256: 45ace15855f31c1a4db60ca1b2755da4b2be86f231a6ea77b9f29d86f77002cb
@@ -32539,23 +32456,6 @@ packages:
   - pkg:pypi/numpy?source=compressed-mapping
   size: 8201819
   timestamp: 1782112644198
-- conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.5.0-py314h5af6b61_0.conda
-  sha256: 4baa2a25dcf628a74939499257ec8e5c041cf39b8e36c72b964f6dabdc0e6725
-  md5: 43d6db7a0cc081a968fd3dcb74cf46b0
-  depends:
-  - python
-  - libcxx >=19
-  - __osx >=11.0
-  - libcblas >=3.9.0,<4.0a0
-  - liblapack >=3.9.0,<4.0a0
-  - python_abi 3.14.* *_cp314t
-  - libblas >=3.9.0,<4.0a0
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 8339295
-  timestamp: 1782112589341
 - conda: https://conda.anaconda.org/conda-forge/osx-64/numpy-2.5.0-py314h7b24d9b_0.conda
   sha256: 0fe6ee04bb5fd63ec7f0b85d612962b67da73d8817d71aa5d077371bde9e038f
   md5: 1728c5837f104059fa5a596189fc70e1
@@ -32731,24 +32631,6 @@ packages:
   - pkg:pypi/numpy?source=compressed-mapping
   size: 7436159
   timestamp: 1782112573833
-- conda: https://conda.anaconda.org/conda-forge/win-64/numpy-2.5.0-py314hffb9209_0.conda
-  sha256: 7e1607eb04ec13880a4b04b13c04268a1555b290cf0b5062222effde27de0287
-  md5: 9641d340afc0948bdf60bfbeab5b5dc0
-  depends:
-  - python
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - libblas >=3.9.0,<4.0a0
-  - libcblas >=3.9.0,<4.0a0
-  - python_abi 3.14.* *_cp314t
-  - liblapack >=3.9.0,<4.0a0
-  constrains:
-  - numpy-base <0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 7588792
-  timestamp: 1782112576400
 - conda: https://conda.anaconda.org/conda-forge/noarch/numpy_groupies-0.11.3-pyhd8ed1ab_0.conda
   sha256: 94c148b8d4687c839a37c4a68b1674fa548b065e833b9b4701865d548995239f
   md5: 5402c2b046432ceb2d192a82802e7854
@@ -36399,7 +36281,7 @@ packages:
 - pypi: ./
   name: pyramids-gis
   version: 0.39.0
-  sha256: 5327e32f2a784fc4bfb49a2b8908b5b5c0d302e295f182430769ce9a6ecfe09b
+  sha256: f04d40db167c946e1cfb6b9a2dae1e4c00dabddd313febf05a4fe3d7b3989909
   requires_dist:
   - cftime>=1.6.4
   - geopandas>=1.0.0
@@ -36847,31 +36729,6 @@ packages:
   size: 14368118
   timestamp: 1781256031540
   python_site_packages_path: lib/python3.14/site-packages
-- conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.14.6-ha91e2d8_0_cp314t.conda
-  sha256: becf51f5427fc0c1e68a64fa5467fe62116fff6ed098033c7844c7a9ce18e833
-  md5: 1bc59acd81f34797a157b4d05bbe8c5d
-  depends:
-  - __osx >=11.0
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libffi >=3.5.2,<3.6.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libmpdec >=4.0.0,<5.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - ncurses >=6.6,<7.0a0
-  - openssl >=3.5.7,<4.0a0
-  - python_abi 3.14.* *_cp314t
-  - readline >=8.3,<9.0a0
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - zstd >=1.5.7,<1.6.0a0
-  track_features:
-  - py_freethreading
-  license: Python-2.0
-  size: 16822275
-  timestamp: 1781257301733
-  python_site_packages_path: lib/python3.14t/site-packages
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.15-h0c9c016_1_cpython.conda
   build_number: 1
   sha256: a44be5222fe8d3c072ecd22491d37316724b70be6b8e8dabdc1a25e6d293fba8
@@ -37060,29 +36917,6 @@ packages:
   size: 18481352
   timestamp: 1781256034828
   python_site_packages_path: Lib/site-packages
-- conda: https://conda.anaconda.org/conda-forge/win-64/python-3.14.6-h7c1dbca_0_cp314t.conda
-  sha256: c53df5f2e8135cb3443279fd6b4de66ba81a20ee03188f7afc2affb711eb78cd
-  md5: e6cd651d30b56b0cce64b626c209dc30
-  depends:
-  - bzip2 >=1.0.8,<2.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libffi >=3.5.2,<3.6.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libmpdec >=4.0.0,<5.0a0
-  - libsqlite >=3.53.2,<4.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - openssl >=3.5.7,<4.0a0
-  - python_abi 3.14.* *_cp314t
-  - tk >=8.6.13,<8.7.0a0
-  - tzdata
-  - ucrt >=10.0.20348.0
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - zstd >=1.5.7,<1.6.0a0
-  license: Python-2.0
-  size: 17928931
-  timestamp: 1781256814063
-  python_site_packages_path: Lib/site-packages
 - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0.post0-pyhe01879c_2.conda
   sha256: d6a17ece93bbd5139e02d2bd7dbfa80bee1a4261dced63f65f679121686bf664
   md5: 5b8d21249ff20967101ffa321cab24e8
@@ -37201,16 +37035,6 @@ packages:
   purls: []
   size: 6989
   timestamp: 1752805904792
-- conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-8_cp314t.conda
-  build_number: 8
-  sha256: d9ed2538fba61265a330ee1b1afe99a4bb23ace706172b9464546c7e01259d63
-  md5: 3251796e09870c978e0f69fa05e38fb6
-  constrains:
-  - python 3.14.* *_cp314t
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 7020
-  timestamp: 1752805919426
 - pypi: https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl
   name: pywin32-ctypes
   version: 0.2.3

--- a/pixi.lock
+++ b/pixi.lock
@@ -36281,7 +36281,7 @@ packages:
 - pypi: ./
   name: pyramids-gis
   version: 0.39.0
-  sha256: f04d40db167c946e1cfb6b9a2dae1e4c00dabddd313febf05a4fe3d7b3989909
+  sha256: 12b27b10e9522166f67e78bafe4f28a88249c10f232a67243d668b61674da076
   requires_dist:
   - cftime>=1.6.4
   - geopandas>=1.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -372,10 +372,13 @@ libgdal-jp2openjpeg = ">=3.13,<3.14"
 # wheel-build feature (not the shared gdal feature). setup-gdal-micromamba.sh reads it.
 [tool.pixi.feature.wheel-build.dependencies]
 swig = ">=4.3,<5"
-# This no-default-feature env floats Python to the newest (3.14) with no ABI
-# constraint, so the solver was picking the free-threaded *_cp314t build on osx-64
-# and win-64 while the py314 test env used *_cp314 — a per-platform ABI mismatch in
-# the lock. Pin the same GIL ABI here so wheel-build and py314 agree everywhere.
+# This no-default-feature env used to float Python to the newest available with no ABI
+# constraint, so the solver picked the free-threaded *_cp314t build on osx-64 and win-64
+# while the py314 env used *_cp314 — a per-platform ABI mismatch in the lock. Pin it to
+# the same standard-GIL 3.14 build so wheel-build and py314 agree everywhere. This also
+# freezes the env at 3.14 (no longer floating): intended, since cibuildwheel provides its
+# own target interpreters and this env's Python only drives the build toolchain — bump
+# the version here when 3.15 support is added.
 python = { version = "3.14.*", build = "*_cp314" }
 
 # libstdcxx-ng provides the GCC-13 libstdc++.so.6 that conda-forge's GDAL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -302,7 +302,12 @@ python = "3.12.*"
 [tool.pixi.feature.py313.dependencies]
 python = "3.13.*"
 [tool.pixi.feature.py314.dependencies]
-python = "3.14.*"
+# Pin the standard-GIL ABI. conda-forge ships two Python 3.14 builds at the same
+# version — *_cp314 (GIL) and *_cp314t (free-threaded / no-GIL, PEP 703) — and a
+# bare "3.14.*" lets the solver pick either, inconsistently per platform. pyramids
+# has thread-sensitive code (per-thread GDAL handles, base/_locks.py), so the 3.14
+# leg must test one intended ABI. Free-threaded would be a separate opt-in leg.
+python = { version = "3.14.*", build = "*_cp314" }
 
 [tool.pixi.feature.dev.dependencies]
 scipy = ">=1.17.1,<2"
@@ -367,6 +372,11 @@ libgdal-jp2openjpeg = ">=3.13,<3.14"
 # wheel-build feature (not the shared gdal feature). setup-gdal-micromamba.sh reads it.
 [tool.pixi.feature.wheel-build.dependencies]
 swig = ">=4.3,<5"
+# This no-default-feature env floats Python to the newest (3.14) with no ABI
+# constraint, so the solver was picking the free-threaded *_cp314t build on osx-64
+# and win-64 while the py314 test env used *_cp314 — a per-platform ABI mismatch in
+# the lock. Pin the same GIL ABI here so wheel-build and py314 agree everywhere.
+python = { version = "3.14.*", build = "*_cp314" }
 
 # libstdcxx-ng provides the GCC-13 libstdc++.so.6 that conda-forge's GDAL
 # is built against (GLIBCXX_3.4.32). Linux-only — Apple Clang and MSVC

--- a/tests/test_python_abi_pin.py
+++ b/tests/test_python_abi_pin.py
@@ -14,11 +14,12 @@ Two complementary guards, because the ABI cannot be constrained the same way eve
   The feature list is derived from the manifest, so a newly added 3.14 feature is checked
   automatically.
 - :func:`test_lockfile_has_no_free_threaded_python` — the committed ``pixi.lock`` must carry no
-  ``cp314t`` build on any platform. This is the **universal** backstop: several envs (``default``,
-  ``dev``, ``docs``, ``lazy``, ``parquet``) float Python to the newest (3.14) with no ABI pin of
-  their own and cannot be ABI-constrained at solve time without freezing their version (a shared pin
-  would also break the ``py311`` / ``py312`` / ``py313`` envs). This whole-lock scan is therefore
-  what guarantees none of those envs drifts to the free-threaded interpreter on the next re-solve.
+  ``cp314t`` build on any platform. This is the **universal** backstop: the envs that share the
+  ``default`` / ``docs`` solve-groups float Python to the newest (3.14) with no ABI pin of their own
+  and cannot be ABI-constrained at solve time without freezing their version (a shared pin would also
+  break the ``py311`` / ``py312`` / ``py313`` envs). This whole-lock scan is therefore what
+  guarantees none of those envs drifts to the free-threaded interpreter on the next re-solve, and it
+  also backstops the per-feature guard against manifest forms it does not parse (see below).
 """
 
 import re
@@ -39,27 +40,40 @@ def _load_pixi() -> dict:
 
 
 def _python_spec(feature: dict):
-    """Return a feature's ``python`` dependency spec (bare string, table, or ``None``)."""
+    """Return a feature's top-level ``python`` dependency spec (bare string, table, or ``None``).
+
+    Only ``[...dependencies]`` is inspected, not per-platform
+    ``target.<platform>.dependencies`` tables. A 3.14 pin placed under a ``target`` table would be
+    missed by the per-feature check, but :func:`test_lockfile_has_no_free_threaded_python` scans the
+    whole lock and is the universal backstop for any form this helper does not parse.
+    """
     return feature.get("dependencies", {}).get("python")
 
 
+def _spec_tokens(python) -> list[str]:
+    """Tokens of a bare matchspec string, split on whitespace or ``=`` (``"3.14.* *_cp314"`` or
+    ``"3.14.*=*_cp314"``)."""
+    return [t for t in re.split(r"[ =]+", str(python).strip()) if t] if python else []
+
+
 def _spec_version(python) -> str:
-    """Version half of a pixi python spec — table ``{version=}`` or bare ``"3.14.* *_cp314"``."""
+    """Version half of a pixi python spec — table ``{version=}`` or a bare matchspec string."""
     if isinstance(python, dict):
         return str(python.get("version", ""))
-    return str(python).split()[0] if python else ""
+    tokens = _spec_tokens(python)
+    return tokens[0] if tokens else ""
 
 
 def _spec_build(python) -> str:
     """Build half of a pixi python spec (``""`` if the spec carries no build string)."""
     if isinstance(python, dict):
         return str(python.get("build", ""))
-    parts = str(python).split() if python else []
-    return parts[1] if len(parts) > 1 else ""
+    tokens = _spec_tokens(python)
+    return tokens[1] if len(tokens) > 1 else ""
 
 
 def _features_targeting_314() -> list[str]:
-    """Names of pixi features whose ``python`` spec explicitly targets 3.14."""
+    """Names of pixi features whose top-level ``python`` spec explicitly targets 3.14."""
     features = _load_pixi().get("feature", {})
     return sorted(
         name
@@ -81,11 +95,14 @@ def test_known_314_features_are_detected():
 def test_feature_targeting_314_pins_gil_abi(feature: str):
     """Each feature targeting Python 3.14 must pin the standard-GIL ``*_cp314`` build."""
     python = _python_spec(_load_pixi()["feature"][feature])
-    version, build = _spec_version(python), _spec_build(python)
-    assert version.startswith("3.14"), f"feature {feature!r} python {python!r} is not a 3.14 spec."
-    assert "cp314" in build and "cp314t" not in build, (
-        f"feature {feature!r} python spec {python!r} does not pin the standard-GIL 'cp314' ABI; a "
-        "bare '3.14.*' lets the solver pick the free-threaded 'cp314t' build."
+    # Reject the free-threaded ABI anywhere in the spec (so an =-delimited or oddly-formatted
+    # cp314t pin can't hide in the version half), and require the standard-GIL cp314 build pin.
+    assert "cp314t" not in str(python), (
+        f"feature {feature!r} python spec {python!r} allows the free-threaded 'cp314t' ABI."
+    )
+    assert "cp314" in _spec_build(python), (
+        f"feature {feature!r} python spec {python!r} does not pin the standard-GIL 'cp314' build; a "
+        "bare '3.14.*' lets the solver pick either ABI."
     )
 
 

--- a/tests/test_python_abi_pin.py
+++ b/tests/test_python_abi_pin.py
@@ -1,14 +1,24 @@
-"""Guard the Python 3.14 ABI pin against non-deterministic free-threaded drift.
+"""Guard the Python 3.14 ABI against non-deterministic free-threaded drift.
 
 conda-forge ships two Python 3.14 builds at the same version: ``*_cp314`` (standard, GIL) and
 ``*_cp314t`` (free-threaded / no-GIL, PEP 703). A bare ``python = "3.14.*"`` lets the conda solver
-pick either, and it did so inconsistently per platform — the ``py314`` test env resolved ``*_cp314``
-while the ``wheel-build`` env picked ``*_cp314t`` on ``osx-64`` / ``win-64`` — so the 3.14 legs were
-not comparing like for like. pyramids has thread-sensitive code (per-thread GDAL handle management,
-``base/_locks.py``, the engine ``weakref`` back-references), so the 3.14 leg must test one intended
-ABI (standard GIL). These tests enforce that the manifest pins ``*_cp314`` in every feature whose
-Python resolves to 3.14, and that the committed ``pixi.lock`` carries no free-threaded ``*_cp314t``
-build on any platform.
+pick either, and it did so inconsistently per platform — the ``wheel-build`` env picked ``*_cp314t``
+on ``osx-64`` / ``win-64`` while the ``py314`` env used ``*_cp314`` everywhere. pyramids has
+thread-sensitive code (per-thread GDAL handle management, ``base/_locks.py``), so the 3.14 legs must
+run one intended ABI (standard GIL).
+
+Two complementary guards, because the ABI cannot be constrained the same way everywhere:
+
+- :func:`test_feature_targeting_314_pins_gil_abi` — every pixi *feature* that explicitly targets
+  Python 3.14 (currently ``py314`` and ``wheel-build``) must pin the standard-GIL ``*_cp314`` build.
+  The feature list is derived from the manifest, so a newly added 3.14 feature is checked
+  automatically.
+- :func:`test_lockfile_has_no_free_threaded_python` — the committed ``pixi.lock`` must carry no
+  ``cp314t`` build on any platform. This is the **universal** backstop: several envs (``default``,
+  ``dev``, ``docs``, ``lazy``, ``parquet``) float Python to the newest (3.14) with no ABI pin of
+  their own and cannot be ABI-constrained at solve time without freezing their version (a shared pin
+  would also break the ``py311`` / ``py312`` / ``py313`` envs). This whole-lock scan is therefore
+  what guarantees none of those envs drifts to the free-threaded interpreter on the next re-solve.
 """
 
 import re
@@ -21,11 +31,6 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 PYPROJECT = REPO_ROOT / "pyproject.toml"
 PIXI_LOCK = REPO_ROOT / "pixi.lock"
 
-# Features whose Python resolves to 3.14 and must therefore pin the standard-GIL ABI. ``py314`` is
-# the 3.14 test matrix env; ``wheel-build`` is the ``no-default-feature`` cibuildwheel env that
-# floats Python to the newest available (3.14) with no ABI constraint of its own.
-PY314_FEATURES = ["py314", "wheel-build"]
-
 
 def _load_pixi() -> dict:
     """Return the ``[tool.pixi]`` table from ``pyproject.toml``."""
@@ -33,23 +38,65 @@ def _load_pixi() -> dict:
         return tomllib.load(fh)["tool"]["pixi"]
 
 
-@pytest.mark.parametrize("feature", PY314_FEATURES)
-def test_py314_feature_pins_standard_gil_abi(feature: str):
-    """Each 3.14 feature must pin python to the standard-GIL ``*_cp314`` build."""
-    python = _load_pixi()["feature"][feature]["dependencies"]["python"]
-    # pixi accepts a table ({version=, build=}) or a bare matchspec string ("3.14.* *_cp314").
-    build = python.get("build", "") if isinstance(python, dict) else python
-    assert "cp314t" not in build and "*_cp314" in build, (
-        f"feature {feature!r} python spec {python!r} does not pin the standard-GIL '*_cp314' "
-        "ABI; a bare '3.14.*' lets the solver pick the free-threaded '*_cp314t' build."
+def _python_spec(feature: dict):
+    """Return a feature's ``python`` dependency spec (bare string, table, or ``None``)."""
+    return feature.get("dependencies", {}).get("python")
+
+
+def _spec_version(python) -> str:
+    """Version half of a pixi python spec — table ``{version=}`` or bare ``"3.14.* *_cp314"``."""
+    if isinstance(python, dict):
+        return str(python.get("version", ""))
+    return str(python).split()[0] if python else ""
+
+
+def _spec_build(python) -> str:
+    """Build half of a pixi python spec (``""`` if the spec carries no build string)."""
+    if isinstance(python, dict):
+        return str(python.get("build", ""))
+    parts = str(python).split() if python else []
+    return parts[1] if len(parts) > 1 else ""
+
+
+def _features_targeting_314() -> list[str]:
+    """Names of pixi features whose ``python`` spec explicitly targets 3.14."""
+    features = _load_pixi().get("feature", {})
+    return sorted(
+        name
+        for name, feat in features.items()
+        if _spec_version(_python_spec(feat)).startswith("3.14")
+    )
+
+
+def test_known_314_features_are_detected():
+    """py314 and wheel-build must still be detected as 3.14-targeting features."""
+    found = set(_features_targeting_314())
+    assert {"py314", "wheel-build"} <= found, (
+        "expected 'py314' and 'wheel-build' among the features that target Python 3.14; found "
+        f"{sorted(found)}. If a pin was dropped, the ABI is no longer constrained for that feature."
+    )
+
+
+@pytest.mark.parametrize("feature", _features_targeting_314())
+def test_feature_targeting_314_pins_gil_abi(feature: str):
+    """Each feature targeting Python 3.14 must pin the standard-GIL ``*_cp314`` build."""
+    python = _python_spec(_load_pixi()["feature"][feature])
+    version, build = _spec_version(python), _spec_build(python)
+    assert version.startswith("3.14"), f"feature {feature!r} python {python!r} is not a 3.14 spec."
+    assert "cp314" in build and "cp314t" not in build, (
+        f"feature {feature!r} python spec {python!r} does not pin the standard-GIL 'cp314' ABI; a "
+        "bare '3.14.*' lets the solver pick the free-threaded 'cp314t' build."
     )
 
 
 def test_lockfile_has_no_free_threaded_python():
-    """The committed ``pixi.lock`` must carry no free-threaded ``cp314t`` Python 3.14 build."""
+    """The committed ``pixi.lock`` must carry no free-threaded ``cp314t`` build, in any env/platform."""
     lock = PIXI_LOCK.read_text(encoding="utf-8")
-    offenders = sorted(set(re.findall(r"python(?:_abi)?-3\.14[^\s/]*_cp314t", lock)))
+    # Any token containing ``cp314t`` is a free-threaded build — catches both the artifact filenames
+    # (``python-3.14.6-..._cp314t.conda``) and the space-delimited matchspec lines (``python_abi
+    # 3.14.* *_cp314t``). ``cp314t`` appears nowhere else in the lock.
+    offenders = sorted(set(re.findall(r"\S*cp314t\S*", lock)))
     assert not offenders, (
-        f"pixi.lock contains free-threaded (cp314t) Python 3.14 builds: {offenders}. Re-pin the "
-        "ABI in pyproject.toml and regenerate the lock with `pixi update`."
+        f"pixi.lock contains free-threaded (cp314t) Python builds: {offenders}. Re-pin the ABI in "
+        "pyproject.toml and regenerate the lock with `pixi update python python_abi`."
     )

--- a/tests/test_python_abi_pin.py
+++ b/tests/test_python_abi_pin.py
@@ -1,0 +1,55 @@
+"""Guard the Python 3.14 ABI pin against non-deterministic free-threaded drift.
+
+conda-forge ships two Python 3.14 builds at the same version: ``*_cp314`` (standard, GIL) and
+``*_cp314t`` (free-threaded / no-GIL, PEP 703). A bare ``python = "3.14.*"`` lets the conda solver
+pick either, and it did so inconsistently per platform — the ``py314`` test env resolved ``*_cp314``
+while the ``wheel-build`` env picked ``*_cp314t`` on ``osx-64`` / ``win-64`` — so the 3.14 legs were
+not comparing like for like. pyramids has thread-sensitive code (per-thread GDAL handle management,
+``base/_locks.py``, the engine ``weakref`` back-references), so the 3.14 leg must test one intended
+ABI (standard GIL). These tests enforce that the manifest pins ``*_cp314`` in every feature whose
+Python resolves to 3.14, and that the committed ``pixi.lock`` carries no free-threaded ``*_cp314t``
+build on any platform.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+PIXI_LOCK = REPO_ROOT / "pixi.lock"
+
+# Features whose Python resolves to 3.14 and must therefore pin the standard-GIL ABI. ``py314`` is
+# the 3.14 test matrix env; ``wheel-build`` is the ``no-default-feature`` cibuildwheel env that
+# floats Python to the newest available (3.14) with no ABI constraint of its own.
+PY314_FEATURES = ["py314", "wheel-build"]
+
+
+def _load_pixi() -> dict:
+    """Return the ``[tool.pixi]`` table from ``pyproject.toml``."""
+    with PYPROJECT.open("rb") as fh:
+        return tomllib.load(fh)["tool"]["pixi"]
+
+
+@pytest.mark.parametrize("feature", PY314_FEATURES)
+def test_py314_feature_pins_standard_gil_abi(feature: str):
+    """Each 3.14 feature must pin python to the standard-GIL ``*_cp314`` build."""
+    python = _load_pixi()["feature"][feature]["dependencies"]["python"]
+    # pixi accepts a table ({version=, build=}) or a bare matchspec string ("3.14.* *_cp314").
+    build = python.get("build", "") if isinstance(python, dict) else python
+    assert "cp314t" not in build and "*_cp314" in build, (
+        f"feature {feature!r} python spec {python!r} does not pin the standard-GIL '*_cp314' "
+        "ABI; a bare '3.14.*' lets the solver pick the free-threaded '*_cp314t' build."
+    )
+
+
+def test_lockfile_has_no_free_threaded_python():
+    """The committed ``pixi.lock`` must carry no free-threaded ``cp314t`` Python 3.14 build."""
+    lock = PIXI_LOCK.read_text(encoding="utf-8")
+    offenders = sorted(set(re.findall(r"python(?:_abi)?-3\.14[^\s/]*_cp314t", lock)))
+    assert not offenders, (
+        f"pixi.lock contains free-threaded (cp314t) Python 3.14 builds: {offenders}. Re-pin the "
+        "ABI in pyproject.toml and regenerate the lock with `pixi update`."
+    )

--- a/tests/test_python_abi_pin.py
+++ b/tests/test_python_abi_pin.py
@@ -109,10 +109,11 @@ def test_feature_targeting_314_pins_gil_abi(feature: str):
 def test_lockfile_has_no_free_threaded_python():
     """The committed ``pixi.lock`` must carry no free-threaded ``cp314t`` build, in any env/platform."""
     lock = PIXI_LOCK.read_text(encoding="utf-8")
-    # Any token containing ``cp314t`` is a free-threaded build — catches both the artifact filenames
-    # (``python-3.14.6-..._cp314t.conda``) and the space-delimited matchspec lines (``python_abi
-    # 3.14.* *_cp314t``). ``cp314t`` appears nowhere else in the lock.
-    offenders = sorted(set(re.findall(r"\S*cp314t\S*", lock)))
+    # Any whitespace-delimited token containing ``cp314t`` is a free-threaded build — catches both
+    # the artifact filenames (``python-3.14.6-..._cp314t.conda``) and the matchspec lines
+    # (``python_abi 3.14.* *_cp314t``). A plain token scan (not a regex) keeps this linear.
+    # ``cp314t`` appears nowhere else in the lock.
+    offenders = sorted({token for token in lock.split() if "cp314t" in token})
     assert not offenders, (
         f"pixi.lock contains free-threaded (cp314t) Python builds: {offenders}. Re-pin the ABI in "
         "pyproject.toml and regenerate the lock with `pixi update python python_abi`."


### PR DESCRIPTION
# Description

Pins the Python 3.14 ABI so `pixi.lock` is deterministic across platforms. conda-forge ships two Python 3.14 builds
at the same version — `*_cp314` (standard, GIL) and `*_cp314t` (free-threaded / no-GIL, PEP 703) — and the bare
`python = "3.14.*"` let the solver pick either. It did so **inconsistently per platform**: the `wheel-build` env
resolved `*_cp314t` on `osx-64` / `win-64` while the `py314` test env used `*_cp314` everywhere, so the 3.14 legs
were not comparing like for like. pyramids has thread-sensitive code (per-thread GDAL handle management,
`base/_locks.py`, engine `weakref` back-refs), so the 3.14 leg must test one intended ABI (standard GIL).

**Change:** pin both the `py314` and `wheel-build` features to `python = { version = "3.14.*", build = "*_cp314" }`
and regenerate `pixi.lock`. A GIL `cp314` build already exists for every platform (the `py314` env uses it), so the
pin resolves cleanly. Adds `tests/test_python_abi_pin.py` guarding both the manifest pin and the absence of any
`cp314t` build in the lock.

**Lock diff is only the ABI fix** — the two `wheel-build` platforms flip `cp314t -> cp314` (and their `gdal`/`numpy`
are rebuilt for the GIL ABI, same versions); no other package versions change and no platform is dropped.

## Wheel bundling — no change needed

The published platform wheels are unaffected. `[tool.cibuildwheel]` already builds GIL-only and explicitly
skips free-threaded 3.14:

```toml
build = ["cp311-*", "cp312-*", "cp313-*", "cp314-*"]
skip  = ["*pp*", "*musllinux*", "cp314t-*"]   # free-threaded 3.14 excluded
```

This PR only aligns the pixi `wheel-build` env (which feeds `libgdal` into the cibuildwheel container via
`ci/setup-gdal-from-pixi.sh`) to the same GIL `cp314` ABI cibuildwheel already targets — on `osx-64` / `win-64`
that env had resolved a free-threaded `cp314t` GDAL/numpy while the wheel itself was built for `cp314`. `libgdal`
is python-ABI-agnostic and cibuildwheel builds its own SWIG `osgeo` bindings against the GIL interpreter, so wheel
content is unchanged — this is purely a build-env / lock consistency fix. No edits to the cibuildwheel config, the
release workflow, or the vendoring scripts.

# Issues

- Closes #666 — pin the Python 3.14 ABI (cp314 vs cp314t) so the lock is deterministic across platforms.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

<!-- This is a build/lockfile reproducibility fix (no source-code behavior change). -->

# How Has This Been Tested?

- `grep -oE 'python(_abi)?-3\.14[^ /]*_cp314t' pixi.lock` → **no matches** (all 36 `python_abi-3.14` are `_cp314`).
- `pixi lock --check` → **"Lock-file was already up-to-date"** (workspace hash matches; CI's `pixi install --locked`
  gate will pass).
- `pixi update python python_abi --no-install` diff = only the two `wheel-build` python builds `cp314t -> cp314`
  plus their `gdal`/`numpy` ABI rebuilds (same versions) — no unrelated version moves.
- `tests/test_python_abi_pin.py` + `tests/test_gdal_pin.py` → **16 passed**.

- [x] Lock contains no `cp314t`; `py314` and `wheel-build` resolve to the same GIL ABI on every platform
- [x] `pixi lock --check` passes (lock consistent with the manifest)
- [x] New ABI guard test + existing GDAL-pin guard pass

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.

