### PR TITLE
fix(dataset): footprint on NetCDF views + non-zero bands; rename cluster2 to to_polygons

### DIFF
--- a/docs/overview/diagrams.md
+++ b/docs/overview/diagrams.md
@@ -514,7 +514,7 @@ classDiagram
     }
     class engines_Vectorize {
         +to_feature_collection · translate
-        +cluster · cluster2
+        +cluster · to_polygons
     }
     class engines_COG {
         +to_cog · is_cog · validate_cog

--- a/docs/reference/dataset/index.md
+++ b/docs/reference/dataset/index.md
@@ -229,7 +229,7 @@ classDiagram
         +fill()
         +normalize()
         +cluster()
-        +cluster2()
+        +to_polygons()
         +get_tile()
         +groupNeighbours()
     }

--- a/docs/reference/dataset/vectorize.md
+++ b/docs/reference/dataset/vectorize.md
@@ -6,7 +6,7 @@ Raster-to-vector conversion, clustering, and translate.
 flowchart LR
     VE(("Vectorize<br/>ds.vectorize"))
     VE --> TV["<b>raster → vector</b><br/>to_feature_collection · contour"]
-    VE --> CL["<b>cluster</b><br/>cluster · cluster2"]
+    VE --> CL["<b>cluster</b><br/>cluster · to_polygons"]
     VE --> TR["<b>translate</b><br/>translate"]
 ```
 

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -427,8 +427,13 @@ class Dataset(RasterBase):
         """Facade — delegates to :meth:`Vectorize.cluster <pyramids.dataset.engines.Vectorize.cluster>`."""
         return self.vectorize.cluster(*args, **kwargs)
 
+    def to_polygons(self, *args, **kwargs):
+        """Facade — delegates to :meth:`Vectorize.to_polygons <pyramids.dataset.engines.Vectorize.to_polygons>`."""
+        return self.vectorize.to_polygons(*args, **kwargs)
+
     def cluster2(self, *args, **kwargs):
-        """Facade — delegates to :meth:`Vectorize.cluster2 <pyramids.dataset.engines.Vectorize.cluster2>`."""
+        """Deprecated alias for :meth:`to_polygons` — delegates to
+        :meth:`Vectorize.cluster2 <pyramids.dataset.engines.Vectorize.cluster2>`."""
         return self.vectorize.cluster2(*args, **kwargs)
 
     def stats(self, *args, **kwargs):

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -1212,22 +1212,23 @@ class Analysis(_Engine["Dataset"]):
                     arr = arr.astype(np.float32)
                     arr[np.isclose(arr, val)] = no_data_val
 
-        # Build the coverage mask: valid cells -> 2, nodata cells -> 0, and register the
-        # mask's own nodata as 0. Polygonisation then collects only the covered cells
-        # regardless of the source nodata value — a positive fill (e.g. a NetCDF fill of
-        # 1e20) must not leak into the footprint.
-        if no_data_val is None:
+        # Build the coverage mask: covered cells -> 2, nodata cells -> 0. A NaN fill may
+        # be stored as None or as a float nan (GDAL's GetNoDataValue returns nan), and
+        # np.isclose(x, nan) is always False, so both are compared with np.isnan.
+        if no_data_val is None or (isinstance(no_data_val, float) and np.isnan(no_data_val)):
             valid = ~np.isnan(arr)
         else:
             valid = ~np.isclose(arr, no_data_val, rtol=0.00001)
         if not valid.any():
             self._ds.logger.warning("the raster is full of no_data_value")
             return None
-        arr = np.where(valid, 2.0, 0.0)
-        # The scratch mask must be a plain raster Dataset that exposes GetRasterBand
-        # for polygonisation. Dispatching through self._ds.create_from_array builds a
-        # NetCDF container (no conventional bands) for a NetCDF variable view, whose
-        # GetRasterBand returns None, so call the base Dataset classmethod explicitly.
+        # _band_to_polygon polygonises the mask using the band as its own Polygonize
+        # mask, which drops mask==0 cells, so only the covered (2) cells are collected
+        # for any source nodata value. float32 keeps the mask lightweight.
+        arr = np.where(valid, 2, 0).astype(np.float32)
+        # The scratch mask must be a plain raster Dataset that exposes GetRasterBand for
+        # polygonisation. self._ds.create_from_array would build a bandless NetCDF
+        # container for a variable view, so call the base Dataset classmethod explicitly.
         # Local import breaks the engines <-> Dataset import cycle.
         from pyramids.dataset.dataset import Dataset
 

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -1240,7 +1240,7 @@ class Analysis(_Engine["Dataset"]):
         )
         # The mask is always single-band (the one extracted band flagged as 2 / nodata),
         # so polygonise its first band regardless of the source band index.
-        gdf = new_dataset.cluster2(band=0)
+        gdf = new_dataset.to_polygons(band=0)
         names = self._ds.band_names
         col_name = names[band] if band < len(names) else f"Band_{band + 1}"
         gdf.rename(columns={"Band_1": col_name}, inplace=True)

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -1212,21 +1212,18 @@ class Analysis(_Engine["Dataset"]):
                     arr = arr.astype(np.float32)
                     arr[np.isclose(arr, val)] = no_data_val
 
-        # replace all the values with 2
+        # Build the coverage mask: valid cells -> 2, nodata cells -> 0, and register the
+        # mask's own nodata as 0. Polygonisation then collects only the covered cells
+        # regardless of the source nodata value — a positive fill (e.g. a NetCDF fill of
+        # 1e20) must not leak into the footprint.
         if no_data_val is None:
-            # check if the whole raster is full of no_data_value
-            if (np.isnan(arr)).all():
-                self._ds.logger.warning("the raster is full of no_data_value")
-                return None
-
-            arr[~np.isnan(arr)] = 2
+            valid = ~np.isnan(arr)
         else:
-            # check if the whole raster is full of no_data_value
-            if (np.isclose(arr, no_data_val, rtol=0.00001)).all():
-                self._ds.logger.warning("the raster is full of no_data_value")
-                return None
-
-            arr[~np.isclose(arr, no_data_val, rtol=0.00001)] = 2
+            valid = ~np.isclose(arr, no_data_val, rtol=0.00001)
+        if not valid.any():
+            self._ds.logger.warning("the raster is full of no_data_value")
+            return None
+        arr = np.where(valid, 2.0, 0.0)
         # The scratch mask must be a plain raster Dataset that exposes GetRasterBand
         # for polygonisation. Dispatching through self._ds.create_from_array builds a
         # NetCDF container (no conventional bands) for a NetCDF variable view, whose
@@ -1238,7 +1235,7 @@ class Analysis(_Engine["Dataset"]):
             arr,
             geo=self._ds.geotransform,
             epsg=self._ds.epsg,
-            no_data_value=self._ds.no_data_value,
+            no_data_value=0,
         )
         # The mask is always single-band (the one extracted band flagged as 2 / nodata),
         # so polygonise its first band regardless of the source band index.

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -1227,15 +1227,25 @@ class Analysis(_Engine["Dataset"]):
                 return None
 
             arr[~np.isclose(arr, no_data_val, rtol=0.00001)] = 2
-        new_dataset = self._ds.create_from_array(
+        # The scratch mask must be a plain raster Dataset that exposes GetRasterBand
+        # for polygonisation. Dispatching through self._ds.create_from_array builds a
+        # NetCDF container (no conventional bands) for a NetCDF variable view, whose
+        # GetRasterBand returns None, so call the base Dataset classmethod explicitly.
+        # Local import breaks the engines <-> Dataset import cycle.
+        from pyramids.dataset.dataset import Dataset
+
+        new_dataset = Dataset.create_from_array(
             arr,
             geo=self._ds.geotransform,
             epsg=self._ds.epsg,
             no_data_value=self._ds.no_data_value,
         )
-        # then convert the raster into polygon
-        gdf = new_dataset.cluster2(band=band)
-        gdf.rename(columns={"Band_1": self._ds.band_names[band]}, inplace=True)
+        # The mask is always single-band (the one extracted band flagged as 2 / nodata),
+        # so polygonise its first band regardless of the source band index.
+        gdf = new_dataset.cluster2(band=0)
+        names = self._ds.band_names
+        col_name = names[band] if band < len(names) else f"Band_{band + 1}"
+        gdf.rename(columns={"Band_1": col_name}, inplace=True)
 
         return gdf
 

--- a/src/pyramids/dataset/engines/vectorize.py
+++ b/src/pyramids/dataset/engines/vectorize.py
@@ -8,6 +8,7 @@ Owns the Vectorize family of operations on a Dataset. Accessed as
 from __future__ import annotations
 
 import collections
+import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -936,11 +937,11 @@ class Vectorize(_Engine["Dataset"]):
 
         return cluster, count, position, values
 
-    def cluster2(
+    def to_polygons(
         self,
         band: int | list[int] | None = None,
     ) -> GeoDataFrame:
-        """Cluster the connected equal cells into polygons.
+        """Polygonize a raster band — merge connected equal-valued cells into polygons.
 
         - Creates vector polygons for all connected regions of pixels in the raster sharing a common
             pixel value (group neighboring cells with the same value into one polygon).
@@ -982,7 +983,7 @@ class Vectorize(_Engine["Dataset"]):
 
             - Now, let's cluster the connected equal cells into polygons.
               ```python
-              >>> gdf = dataset.cluster2()
+              >>> gdf = dataset.to_polygons()
               >>> print(gdf)  # doctest: +SKIP
                   Band_1                                           geometry
               0        3  POLYGON ((0 0, 0 -0.05, 0.05 -0.05, 0.05 0, 0 0))
@@ -1019,3 +1020,17 @@ class Vectorize(_Engine["Dataset"]):
             gdf = gpd.GeoDataFrame(pd.concat(gdfs, ignore_index=True))
 
         return gdf
+
+    def cluster2(self, band: int | list[int] | None = None) -> GeoDataFrame:
+        """Deprecated alias for :meth:`to_polygons`.
+
+        .. deprecated::
+            ``cluster2`` was renamed to :meth:`to_polygons` for clarity. This alias forwards to
+            :meth:`to_polygons` and will be removed in a future release.
+        """
+        warnings.warn(
+            "cluster2 is deprecated and will be removed in a future release; use to_polygons instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.to_polygons(band=band)

--- a/tests/dataset/test_dataset_spatial.py
+++ b/tests/dataset/test_dataset_spatial.py
@@ -699,7 +699,7 @@ class TestCluster2:
         test_image: gdal.Dataset,
     ):
         dataset = Dataset(test_image)
-        gdf = dataset.cluster2()
+        gdf = dataset.to_polygons()
         assert isinstance(gdf, GeoDataFrame)
         assert len(gdf) == 4
         assert all(gdf.columns == ["GPP", "geometry"])
@@ -710,7 +710,7 @@ class TestCluster2:
         sentinel_raster: gdal.Dataset,
     ):
         dataset = Dataset(sentinel_raster)
-        gdf = dataset.cluster2()
+        gdf = dataset.to_polygons()
         assert isinstance(gdf, GeoDataFrame)
         assert len(gdf) == 1767
         assert all(

--- a/tests/dataset/test_engines.py
+++ b/tests/dataset/test_engines.py
@@ -278,7 +278,7 @@ FACADE_METHODS = [
     ("vectorize", "to_feature_collection"),
     ("vectorize", "translate"),
     ("vectorize", "cluster"),
-    ("vectorize", "cluster2"),
+    ("vectorize", "to_polygons"),
     ("analysis", "stats"),
     ("analysis", "count_domain_cells"),
     ("analysis", "apply"),

--- a/tests/dataset/test_unit_spatial.py
+++ b/tests/dataset/test_unit_spatial.py
@@ -1264,10 +1264,10 @@ class TestNormalizeRescale:
 
 
 class TestCluster2:
-    """Tests for cluster2/to_feature_collection band selection."""
+    """Tests for to_polygons/to_feature_collection band selection."""
 
-    def test_cluster2_band_as_list(self):
-        """cluster2 with band as a list should use the first element."""
+    def test_to_polygons_band_as_list(self):
+        """to_polygons with band as a list should use the first element."""
         arr = np.array([[1, 1, 2], [2, 3, 3], [3, 1, 2]], dtype=np.int32)
         ds = Dataset.create_from_array(
             arr,
@@ -1276,8 +1276,8 @@ class TestCluster2:
             epsg=4326,
             no_data_value=-9999,
         )
-        gdf = ds.cluster2(band=[0])
-        assert gdf is not None, "cluster2 with list band should return a GeoDataFrame"
+        gdf = ds.to_polygons(band=[0])
+        assert gdf is not None, "to_polygons with list band should return a GeoDataFrame"
         assert len(gdf) > 0, "Should have some polygons"
 
 
@@ -1565,10 +1565,10 @@ class TestCropWithRasterString:
 
 
 class TestCluster2BandList:
-    """Tests for cluster2 with band passed as a list."""
+    """Tests for to_polygons with band passed as a list."""
 
-    def test_cluster2_with_list_band(self):
-        """cluster2 with band=[0] should use the first element."""
+    def test_to_polygons_with_list_band(self):
+        """to_polygons with band=[0] should use the first element."""
         arr = np.array([[1, 2], [3, 4]], dtype=np.int32)
         ds = Dataset.create_from_array(
             arr,
@@ -1577,8 +1577,8 @@ class TestCluster2BandList:
             epsg=4326,
             no_data_value=-9999,
         )
-        gdf = ds.cluster2(band=[0])
-        assert gdf is not None, "cluster2 should return a GeoDataFrame"
+        gdf = ds.to_polygons(band=[0])
+        assert gdf is not None, "to_polygons should return a GeoDataFrame"
         assert len(gdf) > 0, "Should have some polygons"
 
 
@@ -1597,10 +1597,10 @@ class TestCropWithPolygonWarpError:
 
 
 class TestCluster2BandNone:
-    """Tests for cluster2 with band=None."""
+    """Tests for to_polygons with band=None."""
 
-    def test_cluster2_none_band(self):
-        """cluster2 with band=None should default to band 0."""
+    def test_to_polygons_none_band(self):
+        """to_polygons with band=None should default to band 0."""
         arr = np.array([[1, 1, 2], [2, 3, 3]], dtype=np.int32)
         ds = Dataset.create_from_array(
             arr,
@@ -1609,11 +1609,11 @@ class TestCluster2BandNone:
             epsg=4326,
             no_data_value=-9999,
         )
-        gdf = ds.cluster2(band=None)
-        assert gdf is not None, "cluster2 with None band should work"
+        gdf = ds.to_polygons(band=None)
+        assert gdf is not None, "to_polygons with None band should work"
 
-    def test_cluster2_int_band(self):
-        """cluster2 with band as integer."""
+    def test_to_polygons_int_band(self):
+        """to_polygons with band as integer."""
         arr = np.array([[1, 2], [3, 4]], dtype=np.int32)
         ds = Dataset.create_from_array(
             arr,
@@ -1622,11 +1622,11 @@ class TestCluster2BandNone:
             epsg=4326,
             no_data_value=-9999,
         )
-        gdf = ds.cluster2(band=0)
-        assert gdf is not None, "cluster2 with int band should work"
+        gdf = ds.to_polygons(band=0)
+        assert gdf is not None, "to_polygons with int band should work"
 
-    def test_cluster2_list_band(self):
-        """cluster2 with band as a list should use first element."""
+    def test_to_polygons_list_band(self):
+        """to_polygons with band as a list should use first element."""
         arr = np.array([[1, 2], [3, 4]], dtype=np.int32)
         ds = Dataset.create_from_array(
             arr,
@@ -1635,8 +1635,22 @@ class TestCluster2BandNone:
             epsg=4326,
             no_data_value=-9999,
         )
-        gdf = ds.cluster2(band=[0])
-        assert gdf is not None, "cluster2 with list band should work"
+        gdf = ds.to_polygons(band=[0])
+        assert gdf is not None, "to_polygons with list band should work"
+
+    def test_cluster2_deprecated_alias_warns_and_forwards(self):
+        """cluster2 is a deprecated alias that warns and returns the same result as to_polygons."""
+        arr = np.array([[1, 1, 2], [2, 3, 3]], dtype=np.int32)
+        ds = Dataset.create_from_array(
+            arr,
+            top_left_corner=(0.0, 0.0),
+            cell_size=0.05,
+            epsg=4326,
+            no_data_value=-9999,
+        )
+        with pytest.warns(DeprecationWarning, match="cluster2 is deprecated"):
+            legacy = ds.cluster2()
+        assert len(legacy) == len(ds.to_polygons()), "cluster2 should forward to to_polygons"
 
 
 class TestWrapLongitudeInplace:
@@ -1733,5 +1747,5 @@ class TestGroupNeighbours:
             epsg=4326,
             no_data_value=-9999,
         )
-        gdf = ds.cluster2(band=0)
+        gdf = ds.to_polygons(band=0)
         assert len(gdf) >= 4, "Should find at least 4 clusters"

--- a/tests/dataset/test_unit_vectorize.py
+++ b/tests/dataset/test_unit_vectorize.py
@@ -53,6 +53,22 @@ class TestFootprint:
         result = ds.footprint()
         assert result is None, "All-nodata footprint should return None"
 
+    def test_footprint_multiband_non_zero_band(self):
+        """footprint on band > 0 polygonises the single-band mask and names it after the source band."""
+        nd = -9999.0
+        band0 = np.full((3, 3), 5.0, dtype=np.float32)
+        band1 = np.array([[1.0, nd, 1.0], [1.0, 1.0, nd], [nd, 1.0, 1.0]], dtype=np.float32)
+        ds = Dataset.create_from_array(
+            np.stack([band0, band1]),
+            top_left_corner=(0.0, 0.0),
+            cell_size=0.05,
+            epsg=4326,
+            no_data_value=nd,
+        )
+        result = ds.footprint(band=1)
+        assert result is not None and len(result) > 0, "band-1 footprint should return polygons"
+        assert list(result.columns)[0] == ds.band_names[1], "column should carry the source band's name"
+
 
 class TestBandToPolygon:
     """Tests for _band_to_polygon method."""

--- a/tests/dataset/test_unit_vectorize.py
+++ b/tests/dataset/test_unit_vectorize.py
@@ -53,6 +53,20 @@ class TestFootprint:
         result = ds.footprint()
         assert result is None, "All-nodata footprint should return None"
 
+    def test_footprint_none_nodata_covers_non_nan(self):
+        """footprint with a None nodata treats every non-NaN cell as covered and drops NaN cells."""
+        arr = np.array([[1.0, np.nan, 3.0], [4.0, 5.0, np.nan]], dtype=np.float32)
+        ds = Dataset.create_from_array(
+            arr,
+            top_left_corner=(0.0, 0.0),
+            cell_size=1.0,
+            epsg=4326,
+            no_data_value=-9999.0,
+        )
+        ds._no_data_value = [None]
+        result = ds.footprint()
+        assert result is not None and len(result) > 0, "footprint should cover the non-NaN cells"
+
     @pytest.mark.filterwarnings("ignore:Geometry is in a geographic CRS")
     def test_footprint_multiband_non_zero_band_positive_nodata(self):
         """footprint on band > 0 with a positive nodata fill excludes the nodata cells."""

--- a/tests/dataset/test_unit_vectorize.py
+++ b/tests/dataset/test_unit_vectorize.py
@@ -53,21 +53,24 @@ class TestFootprint:
         result = ds.footprint()
         assert result is None, "All-nodata footprint should return None"
 
-    def test_footprint_multiband_non_zero_band(self):
-        """footprint on band > 0 polygonises the single-band mask and names it after the source band."""
-        nd = -9999.0
-        band0 = np.full((3, 3), 5.0, dtype=np.float32)
-        band1 = np.array([[1.0, nd, 1.0], [1.0, 1.0, nd], [nd, 1.0, 1.0]], dtype=np.float32)
+    @pytest.mark.filterwarnings("ignore:Geometry is in a geographic CRS")
+    def test_footprint_multiband_non_zero_band_positive_nodata(self):
+        """footprint on band > 0 with a positive nodata fill excludes the nodata cells."""
+        nd = 1e20
+        band0 = np.full((3, 3), 5.0, dtype=np.float64)
+        band1 = np.array([[1.0, nd, 1.0], [1.0, 1.0, nd], [nd, 1.0, 1.0]], dtype=np.float64)
         ds = Dataset.create_from_array(
             np.stack([band0, band1]),
             top_left_corner=(0.0, 0.0),
-            cell_size=0.05,
+            cell_size=1.0,
             epsg=4326,
             no_data_value=nd,
         )
         result = ds.footprint(band=1)
         assert result is not None and len(result) > 0, "band-1 footprint should return polygons"
         assert list(result.columns)[0] == ds.band_names[1], "column should carry the source band's name"
+        covered = round(result.geometry.area.sum())  # cell area is 1.0 (1x1 degree cells)
+        assert covered == 6, f"footprint should cover the 6 data cells only, got {covered}"
 
 
 class TestBandToPolygon:

--- a/tests/dataset/test_unit_vectorize.py
+++ b/tests/dataset/test_unit_vectorize.py
@@ -99,7 +99,7 @@ class TestFootprint:
         )
         result = ds.footprint(band=1)
         assert result is not None and len(result) > 0, "band-1 footprint should return polygons"
-        assert list(result.columns)[0] == ds.band_names[1], "column should carry the source band's name"
+        assert result.columns[0] == ds.band_names[1], "column should carry the source band's name"
         covered = round(result.geometry.area.sum())  # cell area is 1.0 (1x1 degree cells)
         assert covered == 6, f"footprint should cover the 6 data cells only, got {covered}"
 

--- a/tests/dataset/test_unit_vectorize.py
+++ b/tests/dataset/test_unit_vectorize.py
@@ -68,6 +68,23 @@ class TestFootprint:
         assert result is not None and len(result) > 0, "footprint should cover the non-NaN cells"
 
     @pytest.mark.filterwarnings("ignore:Geometry is in a geographic CRS")
+    def test_footprint_float_nan_nodata_excludes_fill(self):
+        """footprint with a float NaN nodata fill excludes the NaN cells, not the whole grid."""
+        nd = float("nan")
+        arr = np.array([[nd, nd, 5.0], [nd, 7.0, 9.0], [nd, nd, 11.0]], dtype=np.float64)
+        ds = Dataset.create_from_array(
+            arr,
+            top_left_corner=(0.0, 0.0),
+            cell_size=1.0,
+            epsg=4326,
+            no_data_value=nd,
+        )
+        result = ds.footprint(band=0)
+        assert result is not None and len(result) > 0, "footprint should return polygons"
+        covered = round(result.geometry.area.sum())  # cell area is 1.0 (1x1 degree cells)
+        assert covered == 4, f"footprint should cover the 4 data cells only, got {covered}"
+
+    @pytest.mark.filterwarnings("ignore:Geometry is in a geographic CRS")
     def test_footprint_multiband_non_zero_band_positive_nodata(self):
         """footprint on band > 0 with a positive nodata fill excludes the nodata cells."""
         nd = 1e20

--- a/tests/netcdf_samples/test_inherited_ops.py
+++ b/tests/netcdf_samples/test_inherited_ops.py
@@ -70,9 +70,8 @@ def test_inherited_noarg_method_runs(tos_view, method):
     getattr(tos_view, method)()
 
 
-@pytest.mark.xfail(reason="footprint's internal mask yields a None band on NetCDF views (#592)", strict=True)
 def test_inherited_footprint(tos_view):
-    """footprint should produce a coverage polygon for the variable view (currently fails, #592)."""
+    """footprint produces a coverage polygon for a NetCDF variable view (#592)."""
     assert tos_view.footprint() is not None
 
 

--- a/tests/netcdf_samples/test_inherited_ops.py
+++ b/tests/netcdf_samples/test_inherited_ops.py
@@ -6,6 +6,7 @@ property and every zero-argument inherited method against a real variable view t
 breakage (e.g. #588 resample, #592 color_table/footprint), plus a few argument-taking methods.
 """
 
+import numpy as np
 import pytest
 
 from pyramids.base._errors import ReadOnlyError
@@ -29,7 +30,7 @@ INHERITED_PROPERTIES_NULLABLE = [
 ]
 
 # Inherited zero-argument methods that should run on a variable view without raising.
-# (plot_histogram / plot_vector_field are exercised in the plot module; footprint is xfailed below.)
+# (plot_histogram / plot_vector_field are exercised in the plot module; footprint has its own test below.)
 INHERITED_NOARG_METHODS = [
     "aspect", "block_windows", "cluster2", "wrap_longitude", "count_domain_cells",
     "create_overviews", "extract", "focal_mean", "focal_std", "get_attribute_table",
@@ -70,9 +71,16 @@ def test_inherited_noarg_method_runs(tos_view, method):
     getattr(tos_view, method)()
 
 
+@pytest.mark.filterwarnings("ignore:Geometry is in a geographic CRS")
 def test_inherited_footprint(tos_view):
-    """footprint produces a coverage polygon for a NetCDF variable view (#592)."""
-    assert tos_view.footprint() is not None
+    """footprint covers only the data cells of a NetCDF variable view, not the nodata fill (#592)."""
+    arr = np.asarray(tos_view.read_array(band=0))
+    data_cells = int((~np.isclose(arr, tos_view.no_data_value[0], rtol=1e-5)).sum())
+    fp = tos_view.footprint(band=0)
+    assert fp is not None, "footprint should return a GeoDataFrame"
+    gt = tos_view.geotransform
+    covered = round(fp.geometry.area.sum() / abs(gt[1] * gt[5]))
+    assert covered == data_cells, f"footprint should cover {data_cells} data cells, got {covered}"
 
 
 def test_recreate_overviews_requires_write(tos_view):

--- a/tests/netcdf_samples/test_inherited_ops.py
+++ b/tests/netcdf_samples/test_inherited_ops.py
@@ -32,7 +32,7 @@ INHERITED_PROPERTIES_NULLABLE = [
 # Inherited zero-argument methods that should run on a variable view without raising.
 # (plot_histogram / plot_vector_field are exercised in the plot module; footprint has its own test below.)
 INHERITED_NOARG_METHODS = [
-    "aspect", "block_windows", "cluster2", "wrap_longitude", "count_domain_cells",
+    "aspect", "block_windows", "to_polygons", "wrap_longitude", "count_domain_cells",
     "create_overviews", "extract", "focal_mean", "focal_std", "get_attribute_table",
     "get_block_arrangement", "get_cell_coords", "get_cell_points", "get_cell_polygons",
     "get_histogram", "get_mask", "get_overview", "get_tile", "hillshade", "iter_blocks",

--- a/tests/test_e2e_workflows.py
+++ b/tests/test_e2e_workflows.py
@@ -775,7 +775,7 @@ class TestClusterE2E:
         """Create dataset -> cluster -> convert clusters to vector polygons.
 
         Test scenario:
-            Create a dataset, cluster it, then use cluster2 (GDAL
+            Create a dataset, cluster it, then use to_polygons (GDAL
             Polygonize) on the cluster array to produce vector polygons.
             Verify the polygons are valid and cover the clustered region.
         """
@@ -799,7 +799,7 @@ class TestClusterE2E:
             cell_size=1.0,
             epsg=4326,
         )
-        gdf = cluster_ds.cluster2()
+        gdf = cluster_ds.to_polygons()
 
         assert isinstance(
             gdf, gpd.GeoDataFrame


### PR DESCRIPTION
# Description

Fixes `Dataset.footprint()` on **NetCDF variable views** and on **`band > 0`** of multi-band rasters, hardens its
nodata handling, and renames the opaque `cluster2` method to `to_polygons`.

## `footprint` fixes

- **Bandless mask on NetCDF views:** `footprint` built its scratch mask via `self._ds.create_from_array`, which on
  a `Variable` view dispatches to `NetCDF.create_from_array` → a bandless NetCDF container, so `GetRasterBand(1)`
  was `None` and polygonisation raised `AttributeError`. It now builds the mask through the base
  `Dataset.create_from_array` (via a local import that breaks the engines↔Dataset cycle) and polygonises the mask's
  single band, which also fixes `footprint(band=1)`'s `Illegal band #` crash on plain multi-band rasters.
- **Nodata not excluded for non-`-9999` fills (found in review):** the mask left nodata cells at the source
  sentinel, so a positive fill (e.g. a NetCDF `_FillValue` of `1e20`) leaked the whole grid into the footprint —
  the `tos` view covered all 30600 cells instead of 21090. The mask is now valid→2 / nodata→0 with the mask's
  nodata registered as 0, so only covered cells are collected for any nodata value.
- **Float `NaN` fill (found in review):** GDAL returns a NaN nodata as a float `nan` (not `None`), which fell into
  the `isclose` branch (`isclose(x, nan)` is always `False`) and again returned the whole grid. NaN fills are now
  compared with `np.isnan`.

Tests assert **covered-cell counts** (NetCDF `tos` view == data cells; multi-band `band>0` with `1e20` nodata == 6
data cells), plus the None-nodata, float-NaN, and all-nodata paths. The previously `xfail` `test_inherited_footprint`
is now a real passing test.

## `cluster2` → `to_polygons` rename

`cluster2` is the `gdal.Polygonize` wrapper (connected equal-valued cells → polygons), but the name was opaque and
"polygonize" is already used here for a different thing (`contour(polygonize=True)`, and the docs' framing of
`to_feature_collection`). Renamed to **`to_polygons`** (matching the `to_*` converter convention), with `cluster2`
kept as a **deprecated alias** that emits `DeprecationWarning` and forwards — non-breaking. Facade, internal
`footprint` caller, tests, and the class/engine diagrams updated; a test asserts the alias warns and forwards.

# Issues

- Closes #592

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] `footprint()` on a NetCDF `tos` view covers exactly the data cells (21090, not 30600); `band=1` on a
      multi-band GeoTIFF returns polygons; `band=0` and single-band footprints unchanged (doctest byte-for-byte).
- [x] Positive-fill (`1e20`) and float-`NaN` nodata now exclude the fill; None-nodata and all-nodata paths covered.
- [x] `cluster2` deprecated alias warns (`DeprecationWarning`) and returns the same result as `to_polygons`.
- [x] Ran the dataset + netcdf_samples + vectorize/spatial/engines + e2e suites — all green
      (`2198 passed` dataset non-plot; `337 passed` rename-affected; `42 passed` e2e).

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen handles versions)
- [ ] added changes to History.rst. (changelog is commitizen-generated)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (engine/class diagrams reflect the rename)
