### PR TITLE
fix(plot): add xc/yc to the curvilinear coordinate fallback names

### DIFF
--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -1329,9 +1329,14 @@ class NetCDFPlot:
                     x_arr = self._squeeze_leading_axes(xv, data_shape)
                     y_arr = self._squeeze_leading_axes(yv, data_shape)
                     if require_2d and (x_arr.ndim != 2 or y_arr.ndim != 2):
-                        # A generic name pair (e.g. xc/yc) resolving to 1-D arrays
-                        # is a projected rectilinear grid, not curvilinear; skip it
-                        # so the plot falls back to the geotransform extent.
+                        # A generic name pair (e.g. xc/yc) is trusted only when
+                        # BOTH arrays are genuinely 2-D. A 1-D pair (or a 1-D/2-D
+                        # mix) means projected/rectilinear axes, not curvilinear
+                        # coords, so skip it and fall back to the geotransform
+                        # extent. The gate is ndim-only: 2-D xc/yc in projected
+                        # metres cannot be told apart from 2-D lon/lat here — use
+                        # the CF `coordinates` attribute or explicit `coords=` for
+                        # those.
                         continue
                     if self._coord_shapes_match(x_arr, y_arr, data_shape):
                         warnings.warn(

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -132,10 +132,10 @@ class NetCDFPlot:
     on a pinned subset rather than the original instance).
     """
 
-    # Conventional curvilinear coordinate-variable name pairs, each ordered
-    # ``(lon_name, lat_name)`` — the first name maps to the x axis, the second to
-    # the y axis with no range disambiguation, so the order is load-bearing. The
-    # third field, ``require_2d``, restricts a *generic* pair (one also common as
+    # Conventional curvilinear coordinate-variable name triples, each
+    # ``(lon_name, lat_name, require_2d)``. The first name maps to the x axis,
+    # the second to the y axis with no range disambiguation, so the order is
+    # load-bearing. ``require_2d`` restricts a *generic* pair (one also common as
     # 1-D projected axis variables, e.g. ``xc``/``yc``) to genuinely 2-D
     # curvilinear coordinates, so a projected rectilinear grid is not
     # mis-detected as curvilinear.
@@ -1199,7 +1199,7 @@ class NetCDFPlot:
 
         Examples:
             - A NetCDF without curvilinear coords (no CF
-              ``coordinates`` attribute, no WRF/ROMS/NEMO names) returns
+              ``coordinates`` attribute, no WRF/ROMS/NEMO/RASM names) returns
               ``None`` so the caller can fall back to the
               geotransform-derived extent:
 

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -132,11 +132,18 @@ class NetCDFPlot:
     on a pinned subset rather than the original instance).
     """
 
+    # Conventional curvilinear coordinate-variable name pairs, each ordered
+    # ``(lon_name, lat_name)`` — the first name maps to the x axis, the second to
+    # the y axis with no range disambiguation, so the order is load-bearing. The
+    # third field, ``require_2d``, restricts a *generic* pair (one also common as
+    # 1-D projected axis variables, e.g. ``xc``/``yc``) to genuinely 2-D
+    # curvilinear coordinates, so a projected rectilinear grid is not
+    # mis-detected as curvilinear.
     _CURVILINEAR_NAME_PAIRS = (
-        ("XLONG", "XLAT"),
-        ("lon_rho", "lat_rho"),
-        ("nav_lon", "nav_lat"),
-        ("xc", "yc"),
+        ("XLONG", "XLAT", False),
+        ("lon_rho", "lat_rho", False),
+        ("nav_lon", "nav_lat", False),
+        ("xc", "yc", True),
     )
 
     def __init__(self, nc: NetCDF) -> None:
@@ -1311,7 +1318,7 @@ class NetCDFPlot:
                     result = (x_arr, y_arr)
 
         if result is None and data_shape is not None:
-            for x_name, y_name in self._CURVILINEAR_NAME_PAIRS:
+            for x_name, y_name, require_2d in self._CURVILINEAR_NAME_PAIRS:
                 if x_name in parent.variable_names and y_name in parent.variable_names:
                     xv = parent._read_variable(x_name)
                     yv = parent._read_variable(y_name)
@@ -1319,6 +1326,11 @@ class NetCDFPlot:
                         continue
                     x_arr = self._squeeze_leading_axes(xv, data_shape)
                     y_arr = self._squeeze_leading_axes(yv, data_shape)
+                    if require_2d and (x_arr.ndim != 2 or y_arr.ndim != 2):
+                        # A generic name pair (e.g. xc/yc) resolving to 1-D arrays
+                        # is a projected rectilinear grid, not curvilinear; skip it
+                        # so the plot falls back to the geotransform extent.
+                        continue
                     if self._coord_shapes_match(x_arr, y_arr, data_shape):
                         warnings.warn(
                             "Resolving curvilinear coordinates by hardcoded "

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -136,6 +136,7 @@ class NetCDFPlot:
         ("XLONG", "XLAT"),
         ("lon_rho", "lat_rho"),
         ("nav_lon", "nav_lat"),
+        ("xc", "yc"),
     )
 
     def __init__(self, nc: NetCDF) -> None:

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -460,7 +460,7 @@ class NetCDFPlot:
         # Curvilinear coord resolution. Priority (highest first):
         # 1. Explicit user `coords=`.
         # 2. CF `coordinates` attribute + well-known conventions
-        #    (XLAT/XLONG, lat_rho/lon_rho, nav_lat/nav_lon).
+        #    (XLAT/XLONG, lat_rho/lon_rho, nav_lat/nav_lon, yc/xc).
         # When nothing resolves the engine falls back to `extent=bbox`.
         resolved_coords = self._resolve_curvilinear_coords(pinned, coords=coords)
         if resolved_coords is not None:
@@ -1168,7 +1168,9 @@ class NetCDFPlot:
            the auxiliary coord variables for the data variable.
         4. Well-known curvilinear naming conventions for files that
            omit the CF attribute: WRF (``XLAT`` / ``XLONG``), ROMS
-           (``lat_rho`` / ``lon_rho``), NEMO (``nav_lat`` / ``nav_lon``).
+           (``lat_rho`` / ``lon_rho``), NEMO (``nav_lat`` / ``nav_lon``),
+           and RASM (``yc`` / ``xc``, matched only when the coords are
+           genuinely 2-D).
 
         For each candidate pair the helper reads the named variables
         via the parent container's :meth:`NetCDF._read_variable` (or uses
@@ -1335,10 +1337,10 @@ class NetCDFPlot:
                         warnings.warn(
                             "Resolving curvilinear coordinates by hardcoded "
                             f"model-specific names ({x_name!r}, {y_name!r}) is "
-                            "deprecated and will be removed: WRF/ROMS/NEMO name "
-                            "heuristics are domain knowledge, not a generic GIS "
-                            "convention. Set the CF `coordinates` attribute, or pass "
-                            "`coords=` explicitly.",
+                            "deprecated and will be removed: model-specific name "
+                            "heuristics (WRF, ROMS, NEMO, RASM) are domain "
+                            "knowledge, not a generic GIS convention. Set the CF "
+                            "`coordinates` attribute, or pass `coords=` explicitly.",
                             DeprecationWarning,
                             stacklevel=3,
                         )

--- a/tests/netcdf/plot/_plot_helpers.py
+++ b/tests/netcdf/plot/_plot_helpers.py
@@ -137,9 +137,9 @@ def _attach_curvilinear_coords(
     x_name: str = "XLONG",
     y_name: str = "XLAT",
     cf_attr: str | None = None,
-    coord_ndim: int = 2,
+    coord_ndim: int | tuple[int, int] = 2,
 ):
-    """Splice synthetic 2-D curvilinear coord arrays onto the container.
+    """Splice synthetic curvilinear coord arrays (2-D by default, 1-D on request) onto the container.
 
     Helper used by :class:`TestCurvilinearCoords` to simulate a WRF-style
     NetCDF without authoring a real GDAL MDIM file. Patches are scoped
@@ -158,16 +158,20 @@ def _attach_curvilinear_coords(
             the CF detection path fires.
         coord_ndim: ``2`` (default) installs 2-D meshgrid curvilinear
             coords; ``1`` installs 1-D axis vectors (``cols``-long x,
-            ``rows``-long y) to simulate a projected rectilinear grid.
+            ``rows``-long y) to simulate a projected rectilinear grid. A
+            ``(x_ndim, y_ndim)`` tuple installs a per-axis mix, e.g.
+            ``(2, 1)`` for a 2-D x with a 1-D y.
 
     Returns:
-        tuple: ``(x_arr, y_arr)`` — the synthetic coord arrays that were
-        installed (2-D by default, 1-D when ``coord_ndim == 1``).
+        tuple: ``(x_coord, y_coord)`` — the synthetic coord arrays that
+        were installed (2-D by default, 1-D / mixed per ``coord_ndim``).
     """
     x_arr = np.linspace(-110.0, -100.0, cols, dtype=np.float32)
     y_arr = np.linspace(35.0, 45.0, rows, dtype=np.float32)
     x_2d, y_2d = np.meshgrid(x_arr, y_arr)
-    x_installed, y_installed = (x_arr, y_arr) if coord_ndim == 1 else (x_2d, y_2d)
+    x_ndim, y_ndim = (coord_ndim, coord_ndim) if isinstance(coord_ndim, int) else coord_ndim
+    x_installed = x_arr if x_ndim == 1 else x_2d
+    y_installed = y_arr if y_ndim == 1 else y_2d
     extra_vars = {x_name: x_installed, y_name: y_installed}
     base_names = list(nc.variable_names)
     spliced_names = base_names + [x_name, y_name]
@@ -216,7 +220,7 @@ def _make_curvilinear_nc(
     y_name: str = "XLAT",
     cf_attr: str | None = None,
     n_times: int | None = None,
-    coord_ndim: int = 2,
+    coord_ndim: int | tuple[int, int] = 2,
 ):
     """Build a NetCDF whose container advertises curvilinear coords.
 
@@ -232,7 +236,8 @@ def _make_curvilinear_nc(
         n_times: When set, build a 3-D (time, lat, lon) variable;
             otherwise build a 2-D (lat, lon) variable.
         coord_ndim: ``2`` (default) attaches 2-D curvilinear coords;
-            ``1`` attaches 1-D projected axis vectors instead.
+            ``1`` attaches 1-D projected axis vectors; a
+            ``(x_ndim, y_ndim)`` tuple attaches a per-axis mix.
 
     Returns:
         tuple: ``(nc, x_arr, y_arr, data_var_name)`` — the container,

--- a/tests/netcdf/plot/_plot_helpers.py
+++ b/tests/netcdf/plot/_plot_helpers.py
@@ -137,6 +137,7 @@ def _attach_curvilinear_coords(
     x_name: str = "XLONG",
     y_name: str = "XLAT",
     cf_attr: str | None = None,
+    coord_ndim: int = 2,
 ):
     """Splice synthetic 2-D curvilinear coord arrays onto the container.
 
@@ -155,15 +156,19 @@ def _attach_curvilinear_coords(
         cf_attr: When not None, the value is written as a CF
             ``coordinates`` attribute on the data variable's subset so
             the CF detection path fires.
+        coord_ndim: ``2`` (default) installs 2-D meshgrid curvilinear
+            coords; ``1`` installs 1-D axis vectors (``cols``-long x,
+            ``rows``-long y) to simulate a projected rectilinear grid.
 
     Returns:
-        tuple: ``(x_arr, y_arr)`` — the synthetic 2-D coord arrays
-        that were installed.
+        tuple: ``(x_arr, y_arr)`` — the synthetic coord arrays that were
+        installed (2-D by default, 1-D when ``coord_ndim == 1``).
     """
     x_arr = np.linspace(-110.0, -100.0, cols, dtype=np.float32)
     y_arr = np.linspace(35.0, 45.0, rows, dtype=np.float32)
     x_2d, y_2d = np.meshgrid(x_arr, y_arr)
-    extra_vars = {x_name: x_2d, y_name: y_2d}
+    x_installed, y_installed = (x_arr, y_arr) if coord_ndim == 1 else (x_2d, y_2d)
+    extra_vars = {x_name: x_installed, y_name: y_installed}
     base_names = list(nc.variable_names)
     spliced_names = base_names + [x_name, y_name]
     original_read = type(nc)._read_variable
@@ -200,7 +205,7 @@ def _attach_curvilinear_coords(
         {"variable_names": property(lambda _self: spliced_names)},
     )
     nc.__class__ = subcls
-    return x_2d, y_2d
+    return x_installed, y_installed
 
 
 def _make_curvilinear_nc(
@@ -211,6 +216,7 @@ def _make_curvilinear_nc(
     y_name: str = "XLAT",
     cf_attr: str | None = None,
     n_times: int | None = None,
+    coord_ndim: int = 2,
 ):
     """Build a NetCDF whose container advertises curvilinear coords.
 
@@ -225,6 +231,8 @@ def _make_curvilinear_nc(
             the CF detection path fires.
         n_times: When set, build a 3-D (time, lat, lon) variable;
             otherwise build a 2-D (lat, lon) variable.
+        coord_ndim: ``2`` (default) attaches 2-D curvilinear coords;
+            ``1`` attaches 1-D projected axis vectors instead.
 
     Returns:
         tuple: ``(nc, x_arr, y_arr, data_var_name)`` — the container,
@@ -257,5 +265,6 @@ def _make_curvilinear_nc(
         x_name=x_name,
         y_name=y_name,
         cf_attr=cf_attr,
+        coord_ndim=coord_ndim,
     )
     return nc, x_2d, y_2d, data_var

--- a/tests/netcdf/plot/test_plot_coords.py
+++ b/tests/netcdf/plot/test_plot_coords.py
@@ -315,6 +315,26 @@ class TestCurvilinearCoords:
         assert cleo.coords is None
         assert cleo.extent is not None
 
+    def test_mixed_ndim_xc_yc_not_auto_detected(self):
+        """A 2-D `xc` with a 1-D `yc` is rejected as ambiguous (#633).
+
+        Test scenario:
+            The 2-D-only gate requires BOTH coord arrays to be 2-D. A
+            degenerate file with a 2-D `xc` and a 1-D `yc` is neither a
+            clean curvilinear grid nor a clean rectilinear one, so it is
+            skipped and the plot falls back to the geotransform extent.
+        """
+        nc, _, _, _ = _make_curvilinear_nc(
+            rows=5,
+            cols=6,
+            x_name="xc",
+            y_name="yc",
+            coord_ndim=(2, 1),
+        )
+        cleo = nc.plot(variable="CANWAT")
+        assert cleo.coords is None
+        assert cleo.extent is not None
+
     def test_kind_contour_forwards(self):
         """`kind="contour"` is forwarded and renders."""
         nc, _, _, _ = _make_curvilinear_nc(rows=5, cols=6)

--- a/tests/netcdf/plot/test_plot_coords.py
+++ b/tests/netcdf/plot/test_plot_coords.py
@@ -272,6 +272,25 @@ class TestCurvilinearCoords:
         assert cleo.coords is not None
         assert cleo.coords[0].shape == (5, 6)
 
+    def test_xc_yc_naming_convention_auto_detected(self):
+        """RASM-style `xc`/`yc` are auto-detected via the well-known fallback (#633).
+
+        Test scenario:
+            The container advertises `xc`/`yc` coordinate variables with no
+            CF `coordinates` attribute, so detection can only succeed through
+            the hardcoded name-pair fallback. Auto-detection must still pick
+            them up and forward the 2-D coords to cleopatra.
+        """
+        nc, _, _, _ = _make_curvilinear_nc(
+            rows=5,
+            cols=6,
+            x_name="xc",
+            y_name="yc",
+        )
+        cleo = nc.plot(variable="CANWAT")
+        assert cleo.coords is not None
+        assert cleo.coords[0].shape == (5, 6)
+
     def test_kind_contour_forwards(self):
         """`kind="contour"` is forwarded and renders."""
         nc, _, _, _ = _make_curvilinear_nc(rows=5, cols=6)

--- a/tests/netcdf/plot/test_plot_coords.py
+++ b/tests/netcdf/plot/test_plot_coords.py
@@ -281,7 +281,7 @@ class TestCurvilinearCoords:
             the hardcoded name-pair fallback. Auto-detection must still pick
             them up and forward the 2-D coords to cleopatra.
         """
-        nc, _, _, _ = _make_curvilinear_nc(
+        nc, x_2d, y_2d, _ = _make_curvilinear_nc(
             rows=5,
             cols=6,
             x_name="xc",
@@ -289,7 +289,31 @@ class TestCurvilinearCoords:
         )
         cleo = nc.plot(variable="CANWAT")
         assert cleo.coords is not None
-        assert cleo.coords[0].shape == (5, 6)
+        # Ordering is load-bearing: x must be xc (lon), y must be yc (lat).
+        # The two arrays live in disjoint ranges, so a swap would fail here.
+        np.testing.assert_allclose(cleo.coords[0], x_2d)
+        np.testing.assert_allclose(cleo.coords[1], y_2d)
+
+    def test_1d_xc_yc_not_auto_detected(self):
+        """1-D `xc`/`yc` (projected axes) are not treated as curvilinear (#633).
+
+        Test scenario:
+            `xc`/`yc` is also a common name for 1-D projected axis
+            variables (metres). Those must not flip the render to
+            pcolormesh: with 1-D `xc`/`yc` and no CF `coordinates`
+            attribute the 2-D-only gate skips them, auto-detection
+            returns nothing, and the plot keeps the geotransform extent.
+        """
+        nc, _, _, _ = _make_curvilinear_nc(
+            rows=5,
+            cols=6,
+            x_name="xc",
+            y_name="yc",
+            coord_ndim=1,
+        )
+        cleo = nc.plot(variable="CANWAT")
+        assert cleo.coords is None
+        assert cleo.extent is not None
 
     def test_kind_contour_forwards(self):
         """`kind="contour"` is forwarded and renders."""


### PR DESCRIPTION
# Description

Adds the RASM-style `xc` (longitude) / `yc` (latitude) pair to the curvilinear coordinate-name fallback
(`NetCDFPlot._CURVILINEAR_NAME_PAIRS`), so a curvilinear NetCDF that exposes `xc`/`yc` **without** a CF
`coordinates` attribute is auto-detected by `NetCDF.plot(variable=...)` — no explicit `coords=` needed —
alongside the existing WRF (`XLONG`/`XLAT`), ROMS (`lon_rho`/`lat_rho`), and NEMO (`nav_lon`/`nav_lat`) pairs.

This is the last remaining Definition-of-Done item on #633. The other two halves were already resolved on
`main`:

- **CF `coordinates` auto-detection** (`_cf_coordinates_pair` → parent-container resolution) — PR #316. The
  shipped RASM sample declares `coordinates: "yc xc"`, so it already resolves through this preferred path; the
  fallback added here covers files that expose `xc`/`yc` but omit the CF attribute.
- **0–360° antimeridian seam smear** — the `_unwrap_geographic_longitude` upstream unwrap in
  `_plot_helpers.py` — issue #669 / PR #670.

Note: resolving curvilinear coordinates via these hardcoded model names emits a `DeprecationWarning` (the CF
`coordinates` attribute is the preferred path); `xc`/`yc` simply joins the existing legacy pairs as a safety net.

# Issues

- Closes #633

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Added `TestCurvilinearCoords::test_xc_yc_naming_convention_auto_detected` — builds a container advertising
  `xc`/`yc` coordinate variables with no CF `coordinates` attribute (so only the name-pair fallback can succeed),
  calls `nc.plot(variable="CANWAT")`, and asserts the 2-D coords reach cleopatra (`cleo.coords is not None`,
  shape `(5, 6)`).
- Ran the curvilinear coordinate tests: `test_xc_yc_naming_convention_auto_detected`,
  `test_roms_naming_convention_auto_detected`, and `test_wrapping_curvilinear_grid_has_no_antimeridian_smear`
  — 3 passed (dev env, `MPLBACKEND=Agg`).

- [x] Test A — new xc/yc auto-detection regression test passes
- [x] Test B — existing ROMS + wrapping-seam curvilinear tests still pass

# Checklist:

- [ ] updated version number in pyproject.toml. — handled automatically by commitizen in CI, not bumped manually
- [ ] added changes to History.rst. — changelog is commitizen-generated in CI
- [ ] updated the latest version in README file. — handled by the release workflow
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated. — no user-facing docs change; the fallback list is internal
