### PR TITLE
fix(ci): verify-alpine test paths broken by the test-suite reorg

### DIFF
--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -577,7 +577,7 @@ jobs:
         run: >-
           pytest -vvv -o "pythonpath=" --timeout=60 --timeout-method=thread
           -m "core and not vfs and not slow"
-          tests/base tests/netcdf tests/test_io.py tests/test_grib.py
+          tests/base tests/netcdf tests/io
           tests/dataset tests/feature
 
   release:


### PR DESCRIPTION
# Description

- `verify-alpine` fails at pytest collection on every push run on `main` (exit 4,
  `ERROR: file or directory not found: tests/test_io.py`; observed in run 28739106135) — no tests execute.
- Root cause: the #676 test reorg moved `tests/test_io.py` → `tests/io/` and `tests/test_grib.py` →
  `tests/dataset/io/test_grib.py`. PR #680's Alpine suite was developed on a branch whose merge-from-main
  had preserved the old files (delete/modify resolution), so its runs stayed green; the squash merge onto
  main's reorged tree left the workflow pointing at two paths that no longer exist.
- Fix: point the suite at `tests/io`; the grib tests are already covered by the existing `tests/dataset`
  argument. All other test/verify jobs run the whole `tests/` tree and are unaffected.

# Issues
- Fixes the red `verify-alpine` job on `main` (no tracked issue; regression from the #680 merge interacting
  with the #676 reorg)

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Verified against `origin/main`'s tree that `tests/test_io.py` and `tests/test_grib.py` are the only
  workflow-referenced paths that no longer exist, that `tests/io/` contains the relocated io tests, and that
  `tests/dataset/io/test_grib.py` is covered by the existing `tests/dataset` argument.
- YAML validated; the change is a single pytest-arguments line in the `verify-alpine` job.
- [x] The next `bundle-pypi-wheels` run on `main` (or a `workflow_dispatch` on this branch) exercises the job
  end to end.

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen-managed)
- [ ] added changes to History.rst. (changelog is commitizen-generated)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works. (CI job fix; the
      verify-alpine suite itself is the test)
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated. (not needed — workflow-internal path fix)
