### PR TITLE
feat(grib): add grib_to_cog — convert a GRIB message to a COG

### DIFF
--- a/src/pyramids/grib.py
+++ b/src/pyramids/grib.py
@@ -189,24 +189,35 @@ def grib_band_metadata(dataset: Dataset) -> list[dict[str, Any]]:
 
 
 def _select_grib_band(
-    metadata: list[dict[str, Any]], variable: str | None, band_count: int
+    metadata: list[dict[str, Any]], variable: str | int | None
 ) -> int:
-    """Resolve the 0-based band index for `variable`, matched on the GRIB element.
+    """Resolve the 0-based band index for `variable`.
 
     Args:
         metadata: Per-band metadata from :func:`grib_band_metadata`.
-        variable: GRIB element name to select (case-insensitive, e.g. `"TMP"`),
-            or `None` to use the sole band of a single-message file.
-        band_count: Number of bands (messages) in the dataset.
+        variable: How to pick the message. An `int` is a 1-based band number
+            (the unambiguous escape hatch for files that repeat an element
+            across levels/horizons). A non-empty `str` matches the GRIB element
+            (case-insensitive, e.g. `"TMP"`); when several messages share the
+            element the first is used and a warning is emitted. `None` selects
+            the sole band of a single-message file.
 
     Returns:
         The 0-based band index to keep.
 
     Raises:
-        ValueError: `variable` is `None` but the file holds more than one message,
-            or no message carries the requested element.
+        ValueError: `variable` is `None` but the file holds more than one
+            message; an `int` band number is out of range; `variable` is an
+            empty string; or no message carries the requested element.
     """
-    if variable is None:
+    band_count = len(metadata)
+    if isinstance(variable, int):
+        if not 1 <= variable <= band_count:
+            raise ValueError(
+                f"band number {variable} out of range 1..{band_count}."
+            )
+        selected = variable - 1
+    elif variable is None:
         if band_count > 1:
             elements = [m.get("element") for m in metadata]
             raise ValueError(
@@ -215,10 +226,12 @@ def _select_grib_band(
             )
         selected = 0
     else:
-        wanted = variable.upper()
-        matches = [
-            m for m in metadata if (m.get("element") or "").upper() == wanted
-        ]
+        wanted = variable.strip().upper()
+        if not wanted:
+            raise ValueError(
+                "variable must be a non-empty element name or band number."
+            )
+        matches = [m for m in metadata if (m.get("element") or "").upper() == wanted]
         if not matches:
             elements = sorted({m.get("element") for m in metadata if m.get("element")})
             raise ValueError(
@@ -239,8 +252,8 @@ def grib_to_cog(
     grib_path: str | Path,
     *,
     output: str | Path,
-    variable: str | None = None,
-    target_crs: int | None = None,
+    variable: str | int | None = None,
+    target_crs: int | str | None = None,
     cog_profile: str = "deflate",
     vsi: str | None = None,
 ) -> Path:
@@ -257,11 +270,14 @@ def grib_to_cog(
             `s3://` / `gs://` / `https://` URI — resolved like
             :func:`open_grib`).
         output: Destination COG path. Its parent directory must already exist.
-        variable: GRIB element name of the message to convert (case-insensitive,
-            e.g. `"TMP"`). `None` is allowed only when the file holds a single
-            message; when several messages share the element, the first is used
-            and a warning is emitted.
-        target_crs: Optional EPSG code to reproject to before the COG is written;
+        variable: Which GRIB message to convert. A `str` matches the GRIB element
+            (case-insensitive, e.g. `"TMP"`); when several messages share the
+            element the first is used and a warning is emitted. Pass an `int`
+            1-based band number to select a message unambiguously (e.g. one
+            element repeated across pressure levels). `None` is allowed only when
+            the file holds a single message.
+        target_crs: Optional CRS to reproject to before the COG is written — an
+            EPSG `int` or a WKT `str` (forwarded to `to_cog(target_srs=...)`).
             `None` keeps the GRIB's native CRS.
         cog_profile: Named COG compression preset forwarded to
             :meth:`~pyramids.dataset.Dataset.to_cog` (`profile=`), e.g.
@@ -274,8 +290,10 @@ def grib_to_cog(
 
     Raises:
         DriverNotExistError: The GDAL build lacks the GRIB driver.
-        ValueError: `variable` is `None` on a multi-message file, or no message
-            carries the requested element.
+        FileNotFoundError: `grib_path` does not exist (raised by :func:`open_grib`).
+        ValueError: `variable` cannot be resolved (`None` on a multi-message file,
+            an out-of-range band number, an empty string, or an unknown element),
+            or `cog_profile` is not a recognised COG profile (raised by `to_cog`).
 
     Examples:
         - Convert the 2-metre temperature message to a COG (requires libgdal-grib):
@@ -290,13 +308,12 @@ def grib_to_cog(
 
             ```
     """
-    dataset = open_grib(grib_path, vsi=vsi)
-    band_index = _select_grib_band(
-        grib_band_metadata(dataset), variable, dataset.band_count
-    )
-    return dataset.to_cog(
-        output,
-        indexes=[band_index],
-        profile=cog_profile,
-        target_srs=target_crs,
-    )
+    with open_grib(grib_path, vsi=vsi) as dataset:
+        band_index = _select_grib_band(grib_band_metadata(dataset), variable)
+        result = dataset.to_cog(
+            output,
+            indexes=[band_index],
+            profile=cog_profile,
+            target_srs=target_crs,
+        )
+    return result

--- a/src/pyramids/grib.py
+++ b/src/pyramids/grib.py
@@ -206,12 +206,15 @@ def _select_grib_band(
         The 0-based band index to keep.
 
     Raises:
-        ValueError: `variable` is `None` but the file holds more than one
+        ValueError: `variable` is not a `str`, `int`, or `None` (a `bool` is
+            rejected too); `variable` is `None` but the file holds more than one
             message; an `int` band number is out of range; `variable` is an
             empty string; or no message carries the requested element.
     """
     band_count = len(metadata)
-    if isinstance(variable, bool):
+    # `variable`, `band` and the user's band number are all 1-based; the returned
+    # index (and `to_cog(indexes=)`) is 0-based, hence the `- 1` conversions below.
+    if isinstance(variable, bool) or not isinstance(variable, (str, int, type(None))):
         raise ValueError(
             f"variable must be a band number, element name, or None; got {variable!r}."
         )

--- a/src/pyramids/grib.py
+++ b/src/pyramids/grib.py
@@ -211,6 +211,10 @@ def _select_grib_band(
             empty string; or no message carries the requested element.
     """
     band_count = len(metadata)
+    if isinstance(variable, bool):
+        raise ValueError(
+            f"variable must be a band number, element name, or None; got {variable!r}."
+        )
     if isinstance(variable, int):
         if not 1 <= variable <= band_count:
             raise ValueError(
@@ -231,7 +235,9 @@ def _select_grib_band(
             raise ValueError(
                 "variable must be a non-empty element name or band number."
             )
-        matches = [m for m in metadata if (m.get("element") or "").upper() == wanted]
+        matches = [
+            m for m in metadata if (m.get("element") or "").strip().upper() == wanted
+        ]
         if not matches:
             elements = sorted({m.get("element") for m in metadata if m.get("element")})
             raise ValueError(

--- a/src/pyramids/grib.py
+++ b/src/pyramids/grib.py
@@ -233,28 +233,44 @@ def _select_grib_band(
             )
         selected = 0
     else:
-        wanted = variable.strip().upper()
-        if not wanted:
-            raise ValueError(
-                "variable must be a non-empty element name or band number."
-            )
-        matches = [
-            m for m in metadata if (m.get("element") or "").strip().upper() == wanted
-        ]
-        if not matches:
-            elements = sorted({m.get("element") for m in metadata if m.get("element")})
-            raise ValueError(
-                f"No GRIB message with element {variable!r}; "
-                f"available elements: {elements}."
-            )
-        if len(matches) > 1:
-            warnings.warn(
-                f"{len(matches)} GRIB messages match element {variable!r}; "
-                f"using the first (band {matches[0]['band']}).",
-                stacklevel=3,
-            )
-        selected = matches[0]["band"] - 1
+        selected = _match_grib_element(metadata, variable)
     return selected
+
+
+def _match_grib_element(metadata: list[dict[str, Any]], variable: str) -> int:
+    """Resolve the 0-based band index of the first message matching a GRIB element.
+
+    Args:
+        metadata: Per-band metadata from :func:`grib_band_metadata`.
+        variable: A non-empty GRIB element name (case-insensitive).
+
+    Returns:
+        The 0-based index of the first matching message.
+
+    Raises:
+        ValueError: `variable` is blank, or no message carries the element.
+    """
+    wanted = variable.strip().upper()
+    if not wanted:
+        raise ValueError(
+            "variable must be a non-empty element name or band number."
+        )
+    matches = [
+        m for m in metadata if (m.get("element") or "").strip().upper() == wanted
+    ]
+    if not matches:
+        elements = sorted({m.get("element") for m in metadata if m.get("element")})
+        raise ValueError(
+            f"No GRIB message with element {variable!r}; "
+            f"available elements: {elements}."
+        )
+    if len(matches) > 1:
+        warnings.warn(
+            f"{len(matches)} GRIB messages match element {variable!r}; "
+            f"using the first (band {matches[0]['band']}).",
+            stacklevel=4,
+        )
+    return matches[0]["band"] - 1
 
 
 def grib_to_cog(

--- a/src/pyramids/grib.py
+++ b/src/pyramids/grib.py
@@ -15,6 +15,7 @@ through the same path as :meth:`pyramids.dataset.Dataset.read_file`.
 
 from __future__ import annotations
 
+import warnings
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -185,3 +186,117 @@ def grib_band_metadata(dataset: Dataset) -> list[dict[str, Any]]:
         )
         metadata.append(entry)
     return metadata
+
+
+def _select_grib_band(
+    metadata: list[dict[str, Any]], variable: str | None, band_count: int
+) -> int:
+    """Resolve the 0-based band index for `variable`, matched on the GRIB element.
+
+    Args:
+        metadata: Per-band metadata from :func:`grib_band_metadata`.
+        variable: GRIB element name to select (case-insensitive, e.g. `"TMP"`),
+            or `None` to use the sole band of a single-message file.
+        band_count: Number of bands (messages) in the dataset.
+
+    Returns:
+        The 0-based band index to keep.
+
+    Raises:
+        ValueError: `variable` is `None` but the file holds more than one message,
+            or no message carries the requested element.
+    """
+    if variable is None:
+        if band_count > 1:
+            elements = [m.get("element") for m in metadata]
+            raise ValueError(
+                f"GRIB file has {band_count} messages; "
+                f"pass variable= to pick one of {elements}."
+            )
+        selected = 0
+    else:
+        wanted = variable.upper()
+        matches = [
+            m for m in metadata if (m.get("element") or "").upper() == wanted
+        ]
+        if not matches:
+            elements = sorted({m.get("element") for m in metadata if m.get("element")})
+            raise ValueError(
+                f"No GRIB message with element {variable!r}; "
+                f"available elements: {elements}."
+            )
+        if len(matches) > 1:
+            warnings.warn(
+                f"{len(matches)} GRIB messages match element {variable!r}; "
+                f"using the first (band {matches[0]['band']}).",
+                stacklevel=3,
+            )
+        selected = matches[0]["band"] - 1
+    return selected
+
+
+def grib_to_cog(
+    grib_path: str | Path,
+    *,
+    output: str | Path,
+    variable: str | None = None,
+    target_crs: int | None = None,
+    cog_profile: str = "deflate",
+    vsi: str | None = None,
+) -> Path:
+    """Convert a single GRIB message to a Cloud-Optimized GeoTIFF in one call.
+
+    Chains :func:`open_grib` → select the `variable` band → write with
+    :meth:`~pyramids.dataset.Dataset.to_cog`. Everything is in-repo (GDAL's GRIB
+    driver + pyramids' COG writer) — no `rasterio` / `rio-cogeo` / `cfgrib`. The
+    written COG carries the GRIB band's CRS and its `GRIB_*` band metadata, and
+    passes the COG validator (:func:`pyramids.dataset.cog.cog_info` `.is_cog`).
+
+    Args:
+        grib_path: Path or URI to a GRIB1/GRIB2 file (local, `/vsi*`, or a cloud
+            `s3://` / `gs://` / `https://` URI — resolved like
+            :func:`open_grib`).
+        output: Destination COG path. Its parent directory must already exist.
+        variable: GRIB element name of the message to convert (case-insensitive,
+            e.g. `"TMP"`). `None` is allowed only when the file holds a single
+            message; when several messages share the element, the first is used
+            and a warning is emitted.
+        target_crs: Optional EPSG code to reproject to before the COG is written;
+            `None` keeps the GRIB's native CRS.
+        cog_profile: Named COG compression preset forwarded to
+            :meth:`~pyramids.dataset.Dataset.to_cog` (`profile=`), e.g.
+            `"deflate"`, `"zstd"`, `"lzw"`.
+        vsi: Optional explicit archive kind forwarded to :func:`open_grib` (e.g.
+            for a GRIB inside a `.zip`).
+
+    Returns:
+        The `output` path as a :class:`~pathlib.Path`.
+
+    Raises:
+        DriverNotExistError: The GDAL build lacks the GRIB driver.
+        ValueError: `variable` is `None` on a multi-message file, or no message
+            carries the requested element.
+
+    Examples:
+        - Convert the 2-metre temperature message to a COG (requires libgdal-grib):
+            ```python
+            >>> from pyramids.grib import grib_to_cog  # doctest: +SKIP
+            >>> from pyramids.dataset.cog import cog_info  # doctest: +SKIP
+            >>> out = grib_to_cog(  # doctest: +SKIP
+            ...     "tmp2m.grib2", variable="TMP", output="tmp2m_cog.tif"
+            ... )
+            >>> cog_info(out).is_cog  # doctest: +SKIP
+            True
+
+            ```
+    """
+    dataset = open_grib(grib_path, vsi=vsi)
+    band_index = _select_grib_band(
+        grib_band_metadata(dataset), variable, dataset.band_count
+    )
+    return dataset.to_cog(
+        output,
+        indexes=[band_index],
+        profile=cog_profile,
+        target_srs=target_crs,
+    )

--- a/tests/dataset/io/test_grib.py
+++ b/tests/dataset/io/test_grib.py
@@ -338,6 +338,12 @@ class TestSelectGribBand:
         with pytest.raises(ValueError, match="band number, element name, or None"):
             _select_grib_band(meta, True)
 
+    def test_non_str_int_variable_raises(self):
+        """A float variable raises a clear ValueError, not a cryptic AttributeError."""
+        meta = [{"band": 1, "element": "TMP"}]
+        with pytest.raises(ValueError, match="band number, element name, or None"):
+            _select_grib_band(meta, 1.5)
+
     def test_matches_element_with_surrounding_whitespace(self):
         """A stored element with stray whitespace still matches (both stripped)."""
         meta = [{"band": 1, "element": " TMP "}]
@@ -367,8 +373,10 @@ class TestGribToCog:
         """
         with open_grib(grib_1band_path) as src:
             element = grib_band_metadata(src)[0]["element"]
+        # `element or None` keeps the test valid on GDAL builds that emit an empty
+        # or missing GRIB element (which would otherwise trip the empty-string guard).
         out = grib_to_cog(
-            grib_1band_path, output=tmp_path / "var_cog.tif", variable=element
+            grib_1band_path, output=tmp_path / "var_cog.tif", variable=element or None
         )
         with Dataset.read_file(str(out)) as ds:
             arr = ds.read_array()
@@ -409,6 +417,41 @@ class TestGribToCog:
             arr = ds.read_array()
         assert cog_info(out).is_cog, "output should be a COG"
         assert np.allclose(arr, 101325.0), "band 2 values (101325) should reach COG"
+
+    def test_preserves_grib_band_metadata(self, grib_1band_path, tmp_path):
+        """The output COG carries the source GRIB_* band metadata.
+
+        Args:
+            grib_1band_path: Fixture path to a 1-band GRIB2.
+            tmp_path: pytest temp directory.
+        """
+        out = grib_to_cog(grib_1band_path, output=tmp_path / "meta_cog.tif")
+        with Dataset.read_file(str(out)) as ds:
+            md = ds.raster.GetRasterBand(1).GetMetadata()
+        assert any(k.startswith("GRIB_") for k in md), "GRIB_* metadata should survive"
+
+    def test_shared_element_warns_and_takes_first(self, grib_path, tmp_path, mocker):
+        """A str element shared by several messages warns and selects the first band.
+
+        Args:
+            grib_path: Fixture path to a 2-band GRIB2 (band1=280.0, band2=101325.0).
+            tmp_path: pytest temp directory.
+            mocker: pytest-mock fixture (inject a duplicated element deterministically).
+        """
+        mocker.patch(
+            "pyramids.grib.grib_band_metadata",
+            return_value=[
+                {"band": 1, "element": "TMP"},
+                {"band": 2, "element": "TMP"},
+            ],
+        )
+        with pytest.warns(UserWarning, match="using the first"):
+            out = grib_to_cog(
+                grib_path, output=tmp_path / "warn_cog.tif", variable="TMP"
+            )
+        with Dataset.read_file(str(out)) as ds:
+            arr = ds.read_array()
+        assert np.allclose(arr, 280.0), "first matching band (280) should win"
 
     def test_preserves_native_crs(self, grib_1band_path, tmp_path):
         """Without target_crs the COG keeps the GRIB's native EPSG:4326.

--- a/tests/dataset/io/test_grib.py
+++ b/tests/dataset/io/test_grib.py
@@ -497,3 +497,45 @@ class TestGribToCog:
         """
         with pytest.raises(ValueError, match="No GRIB message with element"):
             grib_to_cog(grib_path, output=tmp_path / "y.tif", variable="NOPE")
+
+    def test_missing_grib_raises(self, tmp_path):
+        """A missing GRIB path raises FileNotFoundError (propagated from open_grib)."""
+        with pytest.raises(FileNotFoundError):
+            grib_to_cog(tmp_path / "nope.grib2", output=tmp_path / "x.tif")
+
+    def test_invalid_cog_profile_raises(self, grib_1band_path, tmp_path):
+        """An unrecognised cog_profile raises ValueError (propagated from to_cog).
+
+        Args:
+            grib_1band_path: Fixture path to a 1-band GRIB2.
+            tmp_path: pytest temp directory.
+        """
+        with pytest.raises(ValueError, match="COG profile"):
+            grib_to_cog(
+                grib_1band_path, output=tmp_path / "bad.tif", cog_profile="bogus"
+            )
+
+    def test_non_default_cog_profile_writes_cog(self, grib_1band_path, tmp_path):
+        """A non-default cog_profile (lzw) still produces a valid COG.
+
+        Args:
+            grib_1band_path: Fixture path to a 1-band GRIB2.
+            tmp_path: pytest temp directory.
+        """
+        out = grib_to_cog(
+            grib_1band_path, output=tmp_path / "lzw.tif", cog_profile="lzw"
+        )
+        assert cog_info(out).is_cog, "lzw profile should still be a valid COG"
+
+    def test_string_target_crs_reprojects(self, grib_1band_path, tmp_path):
+        """A string target_crs reprojects, matching to_cog's int|str contract.
+
+        Args:
+            grib_1band_path: Fixture path to a 1-band GRIB2.
+            tmp_path: pytest temp directory.
+        """
+        out = grib_to_cog(
+            grib_1band_path, output=tmp_path / "str_crs.tif", target_crs="EPSG:3857"
+        )
+        with Dataset.read_file(str(out)) as ds:
+            assert ds.epsg == 3857, "string target_crs should reproject to 3857"

--- a/tests/dataset/io/test_grib.py
+++ b/tests/dataset/io/test_grib.py
@@ -10,11 +10,14 @@ from osgeo import gdal, osr
 
 from pyramids.base._errors import DriverNotExistError
 from pyramids.dataset import Dataset
+from pyramids.dataset.cog import cog_info
 from pyramids.grib import (
     _parse_grib_seconds,
     _parse_leading_int,
     _require_grib_driver,
+    _select_grib_band,
     grib_band_metadata,
+    grib_to_cog,
     open_grib,
 )
 
@@ -39,6 +42,30 @@ def grib_path(tmp_path):
     mem.GetRasterBand(1).WriteArray(np.full((6, 8), 280.0, "float32"))
     mem.GetRasterBand(2).WriteArray(np.full((6, 8), 101325.0, "float32"))
     path = tmp_path / "sample.grib2"
+    dst = gdal.GetDriverByName("GRIB").CreateCopy(str(path), mem)
+    dst.FlushCache()
+    dst = None
+    mem = None
+    return path
+
+
+@pytest.fixture
+def grib_1band_path(tmp_path):
+    """Write a single-message 8x6 GRIB2 on EPSG:4326 and return its path.
+
+    Args:
+        tmp_path: pytest temp directory.
+
+    Returns:
+        pathlib.Path: Path to a 1-band GRIB2.
+    """
+    mem = gdal.GetDriverByName("MEM").Create("", 8, 6, 1, gdal.GDT_Float32)
+    mem.SetGeoTransform((0.0, 1.0, 0.0, 6.0, 0.0, -1.0))
+    sr = osr.SpatialReference()
+    sr.ImportFromEPSG(4326)
+    mem.SetProjection(sr.ExportToWkt())
+    mem.GetRasterBand(1).WriteArray(np.full((6, 8), 280.0, "float32"))
+    path = tmp_path / "single.grib2"
     dst = gdal.GetDriverByName("GRIB").CreateCopy(str(path), mem)
     dst.FlushCache()
     dst = None
@@ -250,3 +277,111 @@ class TestGribBandMetadata:
         assert isinstance(
             entry["forecast_seconds"], int
         ), "forecast_seconds should be int"
+
+
+class TestSelectGribBand:
+    """Tests for _select_grib_band (0-based band resolution from GRIB element)."""
+
+    def test_none_variable_single_band(self):
+        """variable=None on a single-message file selects band 0."""
+        meta = [{"band": 1, "element": "TMP"}]
+        assert _select_grib_band(meta, None, 1) == 0, "single-band None should be 0"
+
+    def test_none_variable_multiband_raises(self):
+        """variable=None on a multi-message file raises with the element list."""
+        meta = [{"band": 1, "element": "TMP"}, {"band": 2, "element": "PRES"}]
+        with pytest.raises(ValueError, match="pass variable="):
+            _select_grib_band(meta, None, 2)
+
+    def test_matches_element_returns_zero_based(self):
+        """A matching element returns its 0-based index (band 2 -> 1)."""
+        meta = [{"band": 1, "element": "TMP"}, {"band": 2, "element": "PRES"}]
+        assert _select_grib_band(meta, "PRES", 2) == 1, "PRES is band 2 -> index 1"
+
+    def test_match_is_case_insensitive(self):
+        """Element matching ignores case."""
+        meta = [{"band": 1, "element": "TMP"}]
+        assert _select_grib_band(meta, "tmp", 1) == 0, "lowercase should match TMP"
+
+    def test_multiple_matches_warns_and_uses_first(self):
+        """Several messages sharing the element warn and select the first."""
+        meta = [{"band": 1, "element": "TMP"}, {"band": 2, "element": "TMP"}]
+        with pytest.warns(UserWarning, match="using the first"):
+            assert _select_grib_band(meta, "TMP", 2) == 0
+
+    def test_unknown_element_raises(self):
+        """An absent element raises with the available-elements list."""
+        meta = [{"band": 1, "element": "TMP"}]
+        with pytest.raises(ValueError, match="available elements"):
+            _select_grib_band(meta, "NOPE", 1)
+
+
+class TestGribToCog:
+    """Tests for grib_to_cog (open_grib -> band select -> to_cog)."""
+
+    def test_single_band_writes_valid_cog(self, grib_1band_path, tmp_path):
+        """A single-message GRIB with variable=None writes a valid COG.
+
+        Args:
+            grib_1band_path: Fixture path to a 1-band GRIB2.
+            tmp_path: pytest temp directory.
+        """
+        out = grib_to_cog(grib_1band_path, output=tmp_path / "single_cog.tif")
+        assert out.exists(), "grib_to_cog should write the output file"
+        assert cog_info(out).is_cog, "output should pass the COG validator"
+
+    def test_selects_variable_band(self, grib_1band_path, tmp_path):
+        """Passing the band's GRIB element selects it and writes a valid COG.
+
+        Args:
+            grib_1band_path: Fixture path to a 1-band GRIB2.
+            tmp_path: pytest temp directory.
+        """
+        element = grib_band_metadata(open_grib(grib_1band_path))[0]["element"]
+        out = grib_to_cog(
+            grib_1band_path, output=tmp_path / "var_cog.tif", variable=element
+        )
+        assert cog_info(out).is_cog, "output should pass the COG validator"
+
+    def test_preserves_native_crs(self, grib_1band_path, tmp_path):
+        """Without target_crs the COG keeps the GRIB's native EPSG:4326.
+
+        Args:
+            grib_1band_path: Fixture path to a 1-band GRIB2.
+            tmp_path: pytest temp directory.
+        """
+        out = grib_to_cog(grib_1band_path, output=tmp_path / "native_cog.tif")
+        assert Dataset.read_file(str(out)).epsg == 4326, "native CRS should survive"
+
+    def test_target_crs_reprojects(self, grib_1band_path, tmp_path):
+        """target_crs reprojects the COG to the requested EPSG.
+
+        Args:
+            grib_1band_path: Fixture path to a 1-band GRIB2.
+            tmp_path: pytest temp directory.
+        """
+        out = grib_to_cog(
+            grib_1band_path, output=tmp_path / "reproj_cog.tif", target_crs=3857
+        )
+        assert Dataset.read_file(str(out)).epsg == 3857, "should reproject to 3857"
+        assert cog_info(out).is_cog, "reprojected output should still be a COG"
+
+    def test_multiband_requires_variable(self, grib_path, tmp_path):
+        """A multi-message GRIB without variable= raises.
+
+        Args:
+            grib_path: Fixture path to a 2-band GRIB2.
+            tmp_path: pytest temp directory.
+        """
+        with pytest.raises(ValueError, match="pass variable="):
+            grib_to_cog(grib_path, output=tmp_path / "x.tif")
+
+    def test_unknown_variable_raises(self, grib_path, tmp_path):
+        """Requesting an element no message carries raises.
+
+        Args:
+            grib_path: Fixture path to a 2-band GRIB2.
+            tmp_path: pytest temp directory.
+        """
+        with pytest.raises(ValueError, match="No GRIB message with element"):
+            grib_to_cog(grib_path, output=tmp_path / "y.tif", variable="NOPE")

--- a/tests/dataset/io/test_grib.py
+++ b/tests/dataset/io/test_grib.py
@@ -285,35 +285,52 @@ class TestSelectGribBand:
     def test_none_variable_single_band(self):
         """variable=None on a single-message file selects band 0."""
         meta = [{"band": 1, "element": "TMP"}]
-        assert _select_grib_band(meta, None, 1) == 0, "single-band None should be 0"
+        assert _select_grib_band(meta, None) == 0, "single-band None should be 0"
 
     def test_none_variable_multiband_raises(self):
         """variable=None on a multi-message file raises with the element list."""
         meta = [{"band": 1, "element": "TMP"}, {"band": 2, "element": "PRES"}]
         with pytest.raises(ValueError, match="pass variable="):
-            _select_grib_band(meta, None, 2)
+            _select_grib_band(meta, None)
 
     def test_matches_element_returns_zero_based(self):
         """A matching element returns its 0-based index (band 2 -> 1)."""
         meta = [{"band": 1, "element": "TMP"}, {"band": 2, "element": "PRES"}]
-        assert _select_grib_band(meta, "PRES", 2) == 1, "PRES is band 2 -> index 1"
+        assert _select_grib_band(meta, "PRES") == 1, "PRES is band 2 -> index 1"
 
     def test_match_is_case_insensitive(self):
         """Element matching ignores case."""
         meta = [{"band": 1, "element": "TMP"}]
-        assert _select_grib_band(meta, "tmp", 1) == 0, "lowercase should match TMP"
+        assert _select_grib_band(meta, "tmp") == 0, "lowercase should match TMP"
 
     def test_multiple_matches_warns_and_uses_first(self):
         """Several messages sharing the element warn and select the first."""
         meta = [{"band": 1, "element": "TMP"}, {"band": 2, "element": "TMP"}]
         with pytest.warns(UserWarning, match="using the first"):
-            assert _select_grib_band(meta, "TMP", 2) == 0
+            assert _select_grib_band(meta, "TMP") == 0
 
     def test_unknown_element_raises(self):
         """An absent element raises with the available-elements list."""
         meta = [{"band": 1, "element": "TMP"}]
         with pytest.raises(ValueError, match="available elements"):
-            _select_grib_band(meta, "NOPE", 1)
+            _select_grib_band(meta, "NOPE")
+
+    def test_int_selects_band_number(self):
+        """An int selects that 1-based band directly (band 2 -> index 1)."""
+        meta = [{"band": 1, "element": "TMP"}, {"band": 2, "element": "TMP"}]
+        assert _select_grib_band(meta, 2) == 1, "band number 2 -> index 1"
+
+    def test_int_out_of_range_raises(self):
+        """An out-of-range band number raises."""
+        meta = [{"band": 1, "element": "TMP"}]
+        with pytest.raises(ValueError, match="out of range"):
+            _select_grib_band(meta, 5)
+
+    def test_empty_string_raises(self):
+        """An empty-string variable raises instead of matching None-element bands."""
+        meta = [{"band": 1, "element": None}]
+        with pytest.raises(ValueError, match="non-empty"):
+            _select_grib_band(meta, "")
 
 
 class TestGribToCog:
@@ -330,18 +347,31 @@ class TestGribToCog:
         assert out.exists(), "grib_to_cog should write the output file"
         assert cog_info(out).is_cog, "output should pass the COG validator"
 
-    def test_selects_variable_band(self, grib_1band_path, tmp_path):
-        """Passing the band's GRIB element selects it and writes a valid COG.
+    def test_selects_variable_band_preserves_data(self, grib_1band_path, tmp_path):
+        """Selecting the sole message by its GRIB element preserves its data in the COG.
 
         Args:
-            grib_1band_path: Fixture path to a 1-band GRIB2.
+            grib_1band_path: Fixture path to a 1-band GRIB2 (values 280.0).
             tmp_path: pytest temp directory.
         """
         element = grib_band_metadata(open_grib(grib_1band_path))[0]["element"]
         out = grib_to_cog(
             grib_1band_path, output=tmp_path / "var_cog.tif", variable=element
         )
-        assert cog_info(out).is_cog, "output should pass the COG validator"
+        arr = Dataset.read_file(str(out)).read_array()
+        assert np.allclose(arr, 280.0), "selected band values should reach the COG"
+
+    def test_int_band_selection_writes_that_bands_data(self, grib_path, tmp_path):
+        """An int band number selects that specific message; its data reaches the COG.
+
+        Args:
+            grib_path: Fixture path to a 2-band GRIB2 (band1=280.0, band2=101325.0).
+            tmp_path: pytest temp directory.
+        """
+        out = grib_to_cog(grib_path, output=tmp_path / "band2_cog.tif", variable=2)
+        arr = Dataset.read_file(str(out)).read_array()
+        assert cog_info(out).is_cog, "output should be a COG"
+        assert np.allclose(arr, 101325.0), "band 2 values (101325) should reach COG"
 
     def test_preserves_native_crs(self, grib_1band_path, tmp_path):
         """Without target_crs the COG keeps the GRIB's native EPSG:4326.

--- a/tests/dataset/io/test_grib.py
+++ b/tests/dataset/io/test_grib.py
@@ -332,6 +332,17 @@ class TestSelectGribBand:
         with pytest.raises(ValueError, match="non-empty"):
             _select_grib_band(meta, "")
 
+    def test_bool_variable_raises(self):
+        """A bool is rejected rather than treated as a band number (True == 1)."""
+        meta = [{"band": 1, "element": "TMP"}]
+        with pytest.raises(ValueError, match="band number, element name, or None"):
+            _select_grib_band(meta, True)
+
+    def test_matches_element_with_surrounding_whitespace(self):
+        """A stored element with stray whitespace still matches (both stripped)."""
+        meta = [{"band": 1, "element": " TMP "}]
+        assert _select_grib_band(meta, "tmp") == 0, "padded element should still match"
+
 
 class TestGribToCog:
     """Tests for grib_to_cog (open_grib -> band select -> to_cog)."""
@@ -354,12 +365,37 @@ class TestGribToCog:
             grib_1band_path: Fixture path to a 1-band GRIB2 (values 280.0).
             tmp_path: pytest temp directory.
         """
-        element = grib_band_metadata(open_grib(grib_1band_path))[0]["element"]
+        with open_grib(grib_1band_path) as src:
+            element = grib_band_metadata(src)[0]["element"]
         out = grib_to_cog(
             grib_1band_path, output=tmp_path / "var_cog.tif", variable=element
         )
-        arr = Dataset.read_file(str(out)).read_array()
+        with Dataset.read_file(str(out)) as ds:
+            arr = ds.read_array()
         assert np.allclose(arr, 280.0), "selected band values should reach the COG"
+
+    def test_selects_element_by_string_writes_that_bands_data(
+        self, grib_path, tmp_path, mocker
+    ):
+        """A distinct element string selects the right band's data on a multi-band file.
+
+        Args:
+            grib_path: Fixture path to a 2-band GRIB2 (band1=280.0, band2=101325.0).
+            tmp_path: pytest temp directory.
+            mocker: pytest-mock fixture (GDAL writes 'unknown' for synthetic
+                elements, so distinct names are injected).
+        """
+        mocker.patch(
+            "pyramids.grib.grib_band_metadata",
+            return_value=[
+                {"band": 1, "element": "AAA"},
+                {"band": 2, "element": "BBB"},
+            ],
+        )
+        out = grib_to_cog(grib_path, output=tmp_path / "bbb_cog.tif", variable="BBB")
+        with Dataset.read_file(str(out)) as ds:
+            arr = ds.read_array()
+        assert np.allclose(arr, 101325.0), "element BBB (band 2) data reaches COG"
 
     def test_int_band_selection_writes_that_bands_data(self, grib_path, tmp_path):
         """An int band number selects that specific message; its data reaches the COG.
@@ -369,7 +405,8 @@ class TestGribToCog:
             tmp_path: pytest temp directory.
         """
         out = grib_to_cog(grib_path, output=tmp_path / "band2_cog.tif", variable=2)
-        arr = Dataset.read_file(str(out)).read_array()
+        with Dataset.read_file(str(out)) as ds:
+            arr = ds.read_array()
         assert cog_info(out).is_cog, "output should be a COG"
         assert np.allclose(arr, 101325.0), "band 2 values (101325) should reach COG"
 
@@ -381,7 +418,8 @@ class TestGribToCog:
             tmp_path: pytest temp directory.
         """
         out = grib_to_cog(grib_1band_path, output=tmp_path / "native_cog.tif")
-        assert Dataset.read_file(str(out)).epsg == 4326, "native CRS should survive"
+        with Dataset.read_file(str(out)) as ds:
+            assert ds.epsg == 4326, "native CRS should survive"
 
     def test_target_crs_reprojects(self, grib_1band_path, tmp_path):
         """target_crs reprojects the COG to the requested EPSG.
@@ -393,7 +431,8 @@ class TestGribToCog:
         out = grib_to_cog(
             grib_1band_path, output=tmp_path / "reproj_cog.tif", target_crs=3857
         )
-        assert Dataset.read_file(str(out)).epsg == 3857, "should reproject to 3857"
+        with Dataset.read_file(str(out)) as ds:
+            assert ds.epsg == 3857, "should reproject to 3857"
         assert cog_info(out).is_cog, "reprojected output should still be a COG"
 
     def test_multiband_requires_variable(self, grib_path, tmp_path):


### PR DESCRIPTION
# Description

Adds a one-call **`grib_to_cog(...)`** in `pyramids.grib` that converts a GRIB message to a Cloud-Optimized
GeoTIFF. Both halves already shipped — `open_grib` reads GRIB1/GRIB2 → `Dataset` (GDAL's native GRIB driver) and
`dataset/cog/` writes + validates COGs — this is the missing convenience that chains them, so callers no longer
hand-wire `open_grib(...)` → band select → `to_cog(...)`.

```python
def grib_to_cog(grib_path, *, output, variable=None, target_crs=None,
                cog_profile="deflate", vsi=None) -> Path
```

- **`variable`** picks the message by GRIB **element** (case-insensitive, e.g. `"TMP"`), resolved via
  `grib_band_metadata`. Required when the file holds several messages; on ties the first match is used with a
  `UserWarning`; `None` is allowed only for a single-message file.
- **`target_crs`** reprojects during the COG write (forwarded to `to_cog(target_srs=...)`).
- **`cog_profile`** maps to `to_cog`'s named `profile` (`"deflate"`, `"zstd"`, `"lzw"`, …).

Entirely in-repo — **no `rasterio` / `rio-cogeo` / `cfgrib`**. The output passes the COG validator
(`cog_info().is_cog`) and keeps the GRIB band's CRS and `GRIB_*` metadata.

Two corrections vs the issue's proposed API: it referenced a non-existent `Dataset.reproject` (this uses
`to_crs`/`to_cog(target_srs=)`), and `variable` selection semantics for repeated elements are now pinned down
(first match + warning).

# Issues

- Closes #687

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] `_select_grib_band` unit tests: single-band `None`, multiband-`None` raises, element match (0-based),
      case-insensitive, multiple-match warns + first, unknown-element raises.
- [x] `grib_to_cog` integration tests (synthetic GRIB2 fixtures): single-band writes a valid COG
      (`cog_info().is_cog`), select-by-element, native CRS preserved, `target_crs=3857` reprojects and stays a
      COG, multiband-without-`variable` raises, unknown `variable` raises.
- [x] `pytest tests/dataset/io/test_grib.py` — 33 passed.

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen handles versions)
- [ ] added changes to History.rst. (changelog is commitizen-generated)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated. (grib module has no mkdocstrings page today; kept consistent with open_grib)