### PR TITLE
feat(spatial,netcdf): support antimeridian-crossing (west>east) bbox in crop

### DIFF
--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -193,6 +193,52 @@ def _antimeridian_halves(
     return _split_lon_bbox(bbox, float(ds.bbox[2]), abs(ds.geotransform[1]))
 
 
+def _reaches_antimeridian_seam(ds: RasterBase) -> bool:
+    """Whether the grid's longitude extent reaches the 180 antimeridian seam.
+
+    A ``west > east`` bbox only makes sense as an antimeridian crossing on a grid
+    that actually covers the seam: a 0..360 grid reaching past 180, or a -180..180
+    grid whose extent touches +180 or -180 (within a cell). A regional grid that
+    reaches neither (e.g. Europe, lon -10..40) cannot be antimeridian-cropped, so a
+    ``west > east`` bbox there is a transposed/typo bbox rather than a crossing.
+
+    Args:
+        ds: The dataset whose affine ``bbox`` / ``geotransform`` set the extent.
+
+    Returns:
+        True when the extent reaches the seam; False for a regional grid that
+        does not.
+    """
+    lon_min, lon_max = float(ds.bbox[0]), float(ds.bbox[2])
+    cell_x = abs(ds.geotransform[1])
+    return (
+        lon_max > 180.0 + cell_x
+        or lon_max >= 180.0 - cell_x
+        or lon_min <= -180.0 + cell_x
+    )
+
+
+def _require_antimeridian_seam(ds: RasterBase) -> None:
+    """Raise unless the grid's longitude extent reaches the antimeridian seam.
+
+    Guards the ``west > east`` reinterpretation: on a grid that does not reach the
+    seam the bbox cannot be a genuine antimeridian crossing, so raise a clear error
+    instead of silently returning a truncated single-half crop.
+
+    Args:
+        ds: The dataset being cropped.
+
+    Raises:
+        ValueError: The grid does not reach the 180 seam.
+    """
+    if not _reaches_antimeridian_seam(ds):
+        raise ValueError(
+            "bbox has west > east (antimeridian) but the dataset's longitude "
+            "extent does not reach the 180 seam - the bbox may be transposed, or "
+            "the dataset does not cover the antimeridian region."
+        )
+
+
 def _crop_seam_halves(
     ds: RasterBase,
     bbox: tuple[float, float, float, float],
@@ -1647,13 +1693,16 @@ class Spatial(_Engine["Dataset"]):
                 seam, each half cropped, and the halves stitched into one
                 contiguous strip whose longitudes continue past the seam
                 (``170..190``). Works for ``-180..180`` and ``0..360`` grids.
-                Behaviour change: a *geographic* ``west > east`` bbox no longer
-                raises ``bbox must satisfy west < east``; it is read as the STAC
-                antimeridian convention and returns a wrapped strip, so a
-                transposed / typo'd bbox on a geographic dataset is no longer
-                rejected (the two inputs are indistinguishable). A *projected*
-                ``west > east`` bbox is still validated and raises, since the
-                antimeridian has no meaning off a geographic CRS.
+                Behaviour change: a *geographic* ``west > east`` bbox is read as
+                the STAC antimeridian convention (rather than raising
+                ``bbox must satisfy west < east``) — but only when the dataset's
+                longitude extent actually reaches the 180 seam. On a *regional*
+                grid that does not reach the seam (e.g. Europe, lon ``-10..40``) a
+                ``west > east`` bbox cannot be a genuine crossing, so it raises a
+                clear error instead of silently returning a truncated crop —
+                catching a transposed / typo'd bbox. A *projected* ``west > east``
+                bbox is still validated and raises, since the antimeridian has no
+                meaning off a geographic CRS.
             epsg (Any, keyword-only):
                 CRS for ``bbox`` — anything ``geopandas`` accepts for ``crs=``
                 (EPSG int, ``"EPSG:4326"``, WKT, ``pyproj.CRS``). Defaults to
@@ -1815,6 +1864,7 @@ class Spatial(_Engine["Dataset"]):
             ds_epsg = self._ds.epsg
             ds_geo = ds_epsg is not None and sr_from_user_input(ds_epsg).IsGeographic()
             if west > east and crs_geo and ds_geo:
+                _require_antimeridian_seam(self._ds)
                 return self._crop_antimeridian(tuple(bbox), crs, touch)
             mask = FeatureCollection.from_bbox(bbox, epsg=crs)
         if mask is None:

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -194,44 +194,51 @@ def _antimeridian_halves(
 
 
 def _reaches_antimeridian_seam(ds: RasterBase) -> bool:
-    """Whether the grid's longitude extent reaches the 180 antimeridian seam.
+    """Whether the grid can serve a *wrapping* antimeridian crop.
 
-    A ``west > east`` bbox only makes sense as an antimeridian crossing on a grid
-    that actually covers the seam: a 0..360 grid reaching past 180, or a -180..180
-    grid whose extent touches +180 or -180 (within a cell). A regional grid that
-    reaches neither (e.g. Europe, lon -10..40) cannot be antimeridian-cropped, so a
-    ``west > east`` bbox there is a transposed/typo bbox rather than a crossing.
+    A two-half (wrapping) crop needs the grid to actually reach the seam it wraps
+    across: a 0..360 grid must span (nearly) the full 0..360 (so the wrap at the
+    0/360 edge has data on both sides), and a -180..180 grid must touch +180 or
+    -180 (within a cell). A regional grid that reaches neither (e.g. Europe, lon
+    -10..40) — or a partial 0..360 grid that stops well short of 360 (e.g. lon
+    0..256) — cannot serve a wrap, so a ``west > east`` bbox producing one there is
+    a transposed/typo bbox rather than a genuine crossing.
 
     Args:
         ds: The dataset whose affine ``bbox`` / ``geotransform`` set the extent.
 
     Returns:
-        True when the extent reaches the seam; False for a regional grid that
-        does not.
+        True when the extent reaches the seam; False otherwise.
     """
     lon_min, lon_max = float(ds.bbox[0]), float(ds.bbox[2])
     cell_x = abs(ds.geotransform[1])
-    return (
-        lon_max > 180.0 + cell_x
-        or lon_max >= 180.0 - cell_x
-        or lon_min <= -180.0 + cell_x
-    )
+    if lon_max > 180.0 + cell_x:
+        # 0..360 frame: the wrap is at the 0/360 edge, so require a near-full span.
+        return lon_max >= 360.0 - cell_x and lon_min <= cell_x
+    # -180..180 frame: the extent must touch +180 or -180.
+    return lon_max >= 180.0 - cell_x or lon_min <= -180.0 + cell_x
 
 
-def _require_antimeridian_seam(ds: RasterBase) -> None:
-    """Raise unless the grid's longitude extent reaches the antimeridian seam.
+def _require_antimeridian_seam(
+    ds: RasterBase, bbox: tuple[float, float, float, float]
+) -> None:
+    """Raise when a *wrapping* antimeridian bbox targets a grid that can't serve it.
 
-    Guards the ``west > east`` reinterpretation: on a grid that does not reach the
-    seam the bbox cannot be a genuine antimeridian crossing, so raise a clear error
-    instead of silently returning a truncated single-half crop.
+    Guards the ``west > east`` reinterpretation. A contiguous (single-half) split —
+    e.g. ``170..190`` on a 0..360 grid — is just a normal crop and needs no check;
+    only a two-half **wrapping** split requires the grid to actually reach the seam.
+    Raising here turns a transposed/typo bbox into a clear error instead of a
+    truncated single-half crop or a downstream empty-crop failure.
 
     Args:
         ds: The dataset being cropped.
+        bbox: ``(west, south, east, north)`` with ``west > east``.
 
     Raises:
-        ValueError: The grid does not reach the 180 seam.
+        ValueError: A wrapping split targets a grid that does not reach the seam.
     """
-    if not _reaches_antimeridian_seam(ds):
+    wrapping = len(_antimeridian_halves(ds, bbox)) >= 2
+    if wrapping and not _reaches_antimeridian_seam(ds):
         raise ValueError(
             "bbox has west > east (antimeridian) but the dataset's longitude "
             "extent does not reach the 180 seam - the bbox may be transposed, or "
@@ -1588,8 +1595,15 @@ class Spatial(_Engine["Dataset"]):
         else:
             raise ValueError("Array must be 2D or 3D")
 
-        x_ind = np.where(~rows_to_remove)[0][0]
-        y_ind = np.where(~cols_to_remove)[0][0]
+        valid_rows = np.where(~rows_to_remove)[0]
+        valid_cols = np.where(~cols_to_remove)[0]
+        if valid_rows.size == 0 or valid_cols.size == 0:
+            raise ValueError(
+                "crop produced no valid pixels: the bbox / polygon does not "
+                "overlap any valid (non-no-data) data in the dataset."
+            )
+        x_ind = valid_rows[0]
+        y_ind = valid_cols[0]
         # Use the source's separate X/Y pixel sizes (gt[1], gt[5]) rather than a single cell_size, so
         # a non-square grid (e.g. 2° lon, 1° lat) keeps its true latitude spacing. Identical to the
         # old cell_size form on square grids (gt[1] == -gt[5] == cell_size).
@@ -1864,7 +1878,7 @@ class Spatial(_Engine["Dataset"]):
             ds_epsg = self._ds.epsg
             ds_geo = ds_epsg is not None and sr_from_user_input(ds_epsg).IsGeographic()
             if west > east and crs_geo and ds_geo:
-                _require_antimeridian_seam(self._ds)
+                _require_antimeridian_seam(self._ds, tuple(bbox))
                 return self._crop_antimeridian(tuple(bbox), crs, touch)
             mask = FeatureCollection.from_bbox(bbox, epsg=crs)
         if mask is None:

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -27,6 +27,7 @@ from pyramids.base.crs import (
 from pyramids.dataset.abstract_dataset import RasterBase
 from pyramids.feature import FeatureCollection
 from pyramids.feature import _ogr as _feature_ogr
+from pyramids.feature.bbox import split_antimeridian
 
 if TYPE_CHECKING:
     from pyramids.dataset.dataset import Dataset
@@ -1385,6 +1386,89 @@ class Spatial(_Engine["Dataset"]):
             new_src.crs = src.crs
         return new_src
 
+    def _crop_antimeridian(
+        self,
+        bbox: tuple[float, float, float, float],
+        crs: Any,
+        touch: bool,
+    ) -> Dataset:
+        """Crop with a geographic bbox whose ``west > east`` crosses the antimeridian.
+
+        Splits the bbox at the grid's longitude seam (``180`` on a ``-180..180``
+        grid, ``360`` on a ``0..360`` grid), crops each ``west < east`` half through
+        the normal path, and concatenates the halves along longitude into one
+        contiguous raster. A half that falls outside the dataset's longitude extent
+        is skipped, so a single-sided overlap returns just that half.
+
+        Args:
+            bbox: ``(west, south, east, north)`` with ``west > east``.
+            crs: The bbox CRS (defaults to the dataset's own upstream).
+            touch: Forwarded to the per-half crop.
+
+        Returns:
+            Dataset: The cropped strip spanning the seam.
+
+        Raises:
+            ValueError: The bbox does not overlap the dataset's longitude extent.
+        """
+        west, south, east, north = bbox
+        xmin, xmax = float(self._ds.bbox[0]), float(self._ds.bbox[2])
+        if xmax > 180.0:
+            # 0..360 grid: bring the STAC (-180..180) bbox into the grid's frame.
+            west = west + 360.0 if west < 0 else west
+            east = east + 360.0 if east < 0 else east
+            if west <= east:
+                halves = [(west, south, east, north)]
+            else:
+                halves = [(west, south, 360.0, north), (0.0, south, east, north)]
+        else:
+            halves = split_antimeridian(bbox)
+        parts = [
+            self.crop(bbox=half, epsg=crs, touch=touch)
+            for half in halves
+            if half[0] < xmax and half[2] > xmin
+        ]
+        if not parts:
+            raise ValueError(
+                f"antimeridian bbox {bbox!r} does not overlap the dataset extent"
+            )
+        result = (
+            parts[0] if len(parts) == 1 else self._merge_lon_halves(parts[0], parts[1])
+        )
+        return result
+
+    def _merge_lon_halves(self, west_part: Dataset, east_part: Dataset) -> Dataset:
+        """Concatenate two longitude-adjacent crops into one contiguous raster.
+
+        `west_part` (the pre-seam half) sits to the left and `east_part` (the
+        wrapped half past the seam) to its right; the merged raster keeps
+        `west_part`'s north-up geotransform, so the linear longitude mapping simply
+        continues past the seam (e.g. 170..180 then 180..190).
+
+        Args:
+            west_part: Crop of the pre-seam half.
+            east_part: Crop of the post-seam half.
+
+        Returns:
+            Dataset: The concatenated raster.
+        """
+        # Local import breaks the engines <-> Dataset cycle; the merged result must
+        # be a plain raster Dataset (self._ds.create_from_array would build a NetCDF
+        # container on a variable view).
+        from pyramids.dataset.dataset import Dataset
+
+        merged = np.concatenate(
+            [west_part.read_array(), east_part.read_array()], axis=-1
+        )
+        out = Dataset.create_from_array(
+            merged,
+            geo=west_part.geotransform,
+            epsg=west_part.epsg,
+            no_data_value=west_part.no_data_value,
+        )
+        out.band_names = self._ds.band_names
+        return out
+
     def crop(
         self,
         mask: GeoDataFrame | FeatureCollection | None = None,
@@ -1412,7 +1496,12 @@ class Spatial(_Engine["Dataset"]):
                 ``(west, south, east, north)`` quadruple in the CRS named by
                 ``epsg``. Internally wrapped in a one-row
                 :class:`FeatureCollection` and routed through the same polygon
-                path. Mutually exclusive with ``mask``.
+                path. Mutually exclusive with ``mask``. A *geographic* bbox with
+                ``west > east`` (the STAC convention for an antimeridian-crossing
+                area, e.g. ``(170, -10, -170, 10)``) is split at the 180°/360°
+                seam, each half cropped, and the halves stitched into one
+                contiguous strip whose longitudes continue past the seam
+                (``170..190``). Works for ``-180..180`` and ``0..360`` grids.
             epsg (Any, keyword-only):
                 CRS for ``bbox`` — anything ``geopandas`` accepts for ``crs=``
                 (EPSG int, ``"EPSG:4326"``, WKT, ``pyproj.CRS``). Defaults to
@@ -1526,6 +1615,25 @@ class Spatial(_Engine["Dataset"]):
 
               ```
 
+            - Crop across the antimeridian with a ``west > east`` geographic bbox
+              (STAC convention); the two sides are stitched into one contiguous
+              strip whose longitudes continue past the 180° seam:
+
+              ```python
+              >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
+              >>> grid = Dataset.create_from_array(
+              ...     np.arange(180 * 360, dtype="float32").reshape(180, 360),
+              ...     top_left_corner=(-180.0, 90.0), cell_size=1.0, epsg=4326,
+              ... )
+              >>> strip = grid.crop(bbox=(170.0, -10.0, -170.0, 10.0))
+              >>> strip.shape
+              (1, 20, 20)
+              >>> strip.bbox
+              [170.0, -10.0, 190.0, 10.0]
+
+              ```
+
             - Supplying both ``mask`` and ``bbox`` is rejected:
 
               ```python
@@ -1550,6 +1658,9 @@ class Spatial(_Engine["Dataset"]):
             if mask is not None:
                 raise ValueError("crop accepts either `mask` or `bbox`, not both")
             crs = epsg if epsg is not None else self._ds.epsg
+            west, _, east, _ = bbox
+            if west > east and sr_from_user_input(crs).IsGeographic():
+                return self._crop_antimeridian(tuple(bbox), crs, touch)
             mask = FeatureCollection.from_bbox(bbox, epsg=crs)
         if mask is None:
             raise TypeError(

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -95,12 +95,15 @@ def _resolve_resolution(
     return result
 
 
-def _check_lon_halves_concatenable(west_part: RasterBase, east_part: RasterBase) -> None:
-    """Validate two longitude-adjacent crop halves before concatenating them.
+def _check_lon_halves_concatenable(
+    west_part: RasterBase, east_part: RasterBase
+) -> None:
+    """Assert the invariant that two longitude-adjacent crop halves are stitchable.
 
-    Ensures the halves share row and band counts and meet exactly at the 180/360
-    seam (a cell boundary), so `np.concatenate` yields a geometrically correct
-    contiguous raster rather than a silently shifted or shape-mismatched one.
+    Both halves are cropped from the same source lattice, so equal row/band counts
+    and a shared cell boundary at the 180/360 seam are expected to hold — this is a
+    defensive guard that turns any future violation into a clear error instead of a
+    raw NumPy shape error or a silently shifted `np.concatenate` result.
 
     Args:
         west_part: Crop of the pre-seam half.
@@ -1461,18 +1464,22 @@ class Spatial(_Engine["Dataset"]):
                 halves = [(west, south, 360.0, north), (0.0, south, east, north)]
         else:
             halves = split_antimeridian(bbox)
-        parts = [
-            self.crop(bbox=half, epsg=crs, touch=touch)
-            for half in halves
-            if half[0] < xmax and half[2] > xmin
-        ]
-        if not parts:
-            raise ValueError(
-                f"antimeridian bbox {bbox!r} does not overlap the dataset extent"
-            )
-        result = (
-            parts[0] if len(parts) == 1 else self._merge_lon_halves(parts[0], parts[1])
-        )
+        parts: list[Dataset] = []
+        try:
+            for half in halves:
+                if half[0] < xmax and half[2] > xmin:
+                    parts.append(self.crop(bbox=half, epsg=crs, touch=touch))
+            if not parts:
+                raise ValueError(
+                    f"antimeridian bbox {bbox!r} does not overlap the dataset extent"
+                )
+            if len(parts) == 1:
+                result, parts = parts[0], []  # hand ownership to the caller
+            else:
+                result = self._merge_lon_halves(parts[0], parts[1])
+        finally:
+            for part in parts:
+                part.close()
         return result
 
     def _merge_lon_halves(self, west_part: Dataset, east_part: Dataset) -> Dataset:
@@ -1506,8 +1513,6 @@ class Spatial(_Engine["Dataset"]):
             no_data_value=west_part.no_data_value,
         )
         out.band_names = self._ds.band_names
-        west_part.close()
-        east_part.close()
         return out
 
     def crop(
@@ -1700,8 +1705,10 @@ class Spatial(_Engine["Dataset"]):
                 raise ValueError("crop accepts either `mask` or `bbox`, not both")
             crs = epsg if epsg is not None else self._ds.epsg
             west, _, east, _ = bbox
-            geographic = crs is not None and sr_from_user_input(crs).IsGeographic()
-            if west > east and geographic:
+            crs_geo = crs is not None and sr_from_user_input(crs).IsGeographic()
+            ds_epsg = self._ds.epsg
+            ds_geo = ds_epsg is not None and sr_from_user_input(ds_epsg).IsGeographic()
+            if west > east and crs_geo and ds_geo:
                 return self._crop_antimeridian(tuple(bbox), crs, touch)
             mask = FeatureCollection.from_bbox(bbox, epsg=crs)
         if mask is None:

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -165,6 +165,87 @@ def _antimeridian_halves(
     return halves
 
 
+def _crop_seam_halves(
+    ds: RasterBase,
+    bbox: tuple[float, float, float, float],
+    crop_half: Any,
+    merge_halves: Any,
+) -> Any:
+    """Crop the overlapping antimeridian halves of ``bbox`` and stitch them.
+
+    Shared by the raster (`Spatial`) and NetCDF (`Selection`) crop engines: each
+    half that overlaps the dataset's longitude extent is cropped through the normal
+    path via ``crop_half``; a single overlapping half is handed straight back, two
+    are stitched with ``merge_halves``. Non-adopted parts are always closed.
+
+    Args:
+        ds: The dataset whose ``bbox`` sets the longitude extent to test overlap
+            against.
+        bbox: The original ``(west, south, east, north)`` with ``west > east``.
+        crop_half: Callable cropping one ``west < east`` sub-bbox to a part.
+        merge_halves: Callable concatenating two parts into the final result.
+
+    Returns:
+        The single overlapping half or the stitched strip spanning the seam.
+
+    Raises:
+        ValueError: The bbox does not overlap the dataset's longitude extent.
+    """
+    xmin, xmax = float(ds.bbox[0]), float(ds.bbox[2])
+    halves = _antimeridian_halves(ds, bbox)
+    parts: list = []
+    try:
+        for half in halves:
+            if half[0] < xmax and half[2] > xmin:
+                parts.append(crop_half(half))
+        if not parts:
+            raise ValueError(
+                f"antimeridian bbox {bbox!r} does not overlap the dataset extent"
+            )
+        if len(parts) == 1:
+            result, parts = parts[0], []  # hand ownership to the caller
+        else:
+            result = merge_halves(parts[0], parts[1])
+    finally:
+        for part in parts:
+            part.close()
+    return result
+
+
+def _stitch_lon_halves(ds: RasterBase, west_part: Any, east_part: Any) -> "Dataset":
+    """Concatenate two longitude-adjacent crops into one contiguous raster Dataset.
+
+    `west_part` (pre-seam) sits to the left of `east_part` (wrapped past the seam);
+    the merged raster keeps `west_part`'s north-up geotransform, so the longitude
+    mapping continues past the seam (e.g. 170..180 then 180..190). Shared by both
+    crop engines; the NetCDF engine re-wraps the result to preserve variable
+    metadata.
+
+    Args:
+        ds: The dataset supplying the band names for the merged raster.
+        west_part: Crop of the pre-seam half.
+        east_part: Crop of the post-seam half.
+
+    Returns:
+        Dataset: The concatenated raster.
+    """
+    # Local import breaks the engines <-> Dataset cycle; the merged result must be a
+    # plain raster Dataset (create_from_array on a variable view would build a NetCDF
+    # container).
+    from pyramids.dataset.dataset import Dataset
+
+    _check_lon_halves_concatenable(west_part, east_part)
+    merged = np.concatenate([west_part.read_array(), east_part.read_array()], axis=-1)
+    out = Dataset.create_from_array(
+        merged,
+        geo=west_part.geotransform,
+        epsg=west_part.epsg,
+        no_data_value=west_part.no_data_value,
+    )
+    out.band_names = ds.band_names
+    return out
+
+
 class Spatial(_Engine["Dataset"]):
 
     def _get_crs(self) -> str:
@@ -1481,25 +1562,12 @@ class Spatial(_Engine["Dataset"]):
         Raises:
             ValueError: The bbox does not overlap the dataset's longitude extent.
         """
-        xmin, xmax = float(self._ds.bbox[0]), float(self._ds.bbox[2])
-        halves = _antimeridian_halves(self._ds, bbox)
-        parts: list[Dataset] = []
-        try:
-            for half in halves:
-                if half[0] < xmax and half[2] > xmin:
-                    parts.append(self.crop(bbox=half, epsg=crs, touch=touch))
-            if not parts:
-                raise ValueError(
-                    f"antimeridian bbox {bbox!r} does not overlap the dataset extent"
-                )
-            if len(parts) == 1:
-                result, parts = parts[0], []  # hand ownership to the caller
-            else:
-                result = self._merge_lon_halves(parts[0], parts[1])
-        finally:
-            for part in parts:
-                part.close()
-        return result
+        return _crop_seam_halves(
+            self._ds,
+            bbox,
+            lambda half: self.crop(bbox=half, epsg=crs, touch=touch),
+            self._merge_lon_halves,
+        )
 
     def _merge_lon_halves(self, west_part: Dataset, east_part: Dataset) -> Dataset:
         """Concatenate two longitude-adjacent crops into one contiguous raster.
@@ -1516,23 +1584,7 @@ class Spatial(_Engine["Dataset"]):
         Returns:
             Dataset: The concatenated raster.
         """
-        # Local import breaks the engines <-> Dataset cycle; the merged result must
-        # be a plain raster Dataset (self._ds.create_from_array would build a NetCDF
-        # container on a variable view).
-        from pyramids.dataset.dataset import Dataset
-
-        _check_lon_halves_concatenable(west_part, east_part)
-        merged = np.concatenate(
-            [west_part.read_array(), east_part.read_array()], axis=-1
-        )
-        out = Dataset.create_from_array(
-            merged,
-            geo=west_part.geotransform,
-            epsg=west_part.epsg,
-            no_data_value=west_part.no_data_value,
-        )
-        out.band_names = self._ds.band_names
-        return out
+        return _stitch_lon_halves(self._ds, west_part, east_part)
 
     def crop(
         self,

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -95,6 +95,41 @@ def _resolve_resolution(
     return result
 
 
+def _check_lon_halves_concatenable(west_part: RasterBase, east_part: RasterBase) -> None:
+    """Validate two longitude-adjacent crop halves before concatenating them.
+
+    Ensures the halves share row and band counts and meet exactly at the 180/360
+    seam (a cell boundary), so `np.concatenate` yields a geometrically correct
+    contiguous raster rather than a silently shifted or shape-mismatched one.
+
+    Args:
+        west_part: Crop of the pre-seam half.
+        east_part: Crop of the post-seam half (wrapped past the seam).
+
+    Raises:
+        ValueError: The halves have mismatched row/band counts, or the grid has no
+            cell boundary at the seam so the halves are not seam-aligned.
+    """
+    if (
+        west_part.rows != east_part.rows
+        or west_part.band_count != east_part.band_count
+    ):
+        raise ValueError(
+            "antimeridian halves are not concatenable "
+            f"(rows {west_part.rows}/{east_part.rows}, "
+            f"bands {west_part.band_count}/{east_part.band_count})"
+        )
+    w_gt = west_part.geotransform
+    seam_gap = abs(
+        (w_gt[0] + west_part.columns * w_gt[1]) - (east_part.geotransform[0] + 360.0)
+    )
+    if seam_gap > 0.5 * abs(w_gt[1]):
+        raise ValueError(
+            "antimeridian halves are not seam-aligned; the grid has no cell "
+            "boundary at the 180/360 seam, so the halves cannot be stitched"
+        )
+
+
 class Spatial(_Engine["Dataset"]):
 
     def _get_crs(self) -> str:
@@ -1413,8 +1448,11 @@ class Spatial(_Engine["Dataset"]):
         """
         west, south, east, north = bbox
         xmin, xmax = float(self._ds.bbox[0]), float(self._ds.bbox[2])
-        if xmax > 180.0:
-            # 0..360 grid: bring the STAC (-180..180) bbox into the grid's frame.
+        cell_x = abs(self._ds.geotransform[1])
+        if xmax > 180.0 + cell_x:
+            # 0..360 grid: longitudes genuinely reach past 180 (the +cell tolerance
+            # avoids misrouting a -180..180 grid whose xmax floats a hair over 180).
+            # Bring the STAC (-180..180) bbox into the grid's frame.
             west = west + 360.0 if west < 0 else west
             east = east + 360.0 if east < 0 else east
             if west <= east:
@@ -1457,6 +1495,7 @@ class Spatial(_Engine["Dataset"]):
         # container on a variable view).
         from pyramids.dataset.dataset import Dataset
 
+        _check_lon_halves_concatenable(west_part, east_part)
         merged = np.concatenate(
             [west_part.read_array(), east_part.read_array()], axis=-1
         )
@@ -1467,6 +1506,8 @@ class Spatial(_Engine["Dataset"]):
             no_data_value=west_part.no_data_value,
         )
         out.band_names = self._ds.band_names
+        west_part.close()
+        east_part.close()
         return out
 
     def crop(
@@ -1659,7 +1700,8 @@ class Spatial(_Engine["Dataset"]):
                 raise ValueError("crop accepts either `mask` or `bbox`, not both")
             crs = epsg if epsg is not None else self._ds.epsg
             west, _, east, _ = bbox
-            if west > east and sr_from_user_input(crs).IsGeographic():
+            geographic = crs is not None and sr_from_user_input(crs).IsGeographic()
+            if west > east and geographic:
                 return self._crop_antimeridian(tuple(bbox), crs, touch)
             mask = FeatureCollection.from_bbox(bbox, epsg=crs)
         if mask is None:

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -143,6 +143,11 @@ def _split_lon_bbox(
     shifted into its own frame, which usually removes the wrap (one half); a
     -180..180 grid is split at 180 via :func:`split_antimeridian`.
 
+    The frame is inferred from ``lon_max`` alone: a 0..360 grid must actually
+    reach past 180 to be detected as such. An eastern-hemisphere-only grid that
+    ends at or below 180 is treated as -180..180 — harmless, since an
+    antimeridian bbox barely overlaps it and the non-overlapping half is skipped.
+
     Args:
         bbox: ``(west, south, east, north)`` with ``west > east``.
         lon_max: The grid's maximum longitude (its own frame's east edge).
@@ -1642,6 +1647,13 @@ class Spatial(_Engine["Dataset"]):
                 seam, each half cropped, and the halves stitched into one
                 contiguous strip whose longitudes continue past the seam
                 (``170..190``). Works for ``-180..180`` and ``0..360`` grids.
+                Behaviour change: a *geographic* ``west > east`` bbox no longer
+                raises ``bbox must satisfy west < east``; it is read as the STAC
+                antimeridian convention and returns a wrapped strip, so a
+                transposed / typo'd bbox on a geographic dataset is no longer
+                rejected (the two inputs are indistinguishable). A *projected*
+                ``west > east`` bbox is still validated and raises, since the
+                antimeridian has no meaning off a geographic CRS.
             epsg (Any, keyword-only):
                 CRS for ``bbox`` — anything ``geopandas`` accepts for ``crs=``
                 (EPSG int, ``"EPSG:4326"``, WKT, ``pyproj.CRS``). Defaults to

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -133,6 +133,38 @@ def _check_lon_halves_concatenable(
         )
 
 
+def _antimeridian_halves(
+    ds: RasterBase, bbox: tuple[float, float, float, float]
+) -> list[tuple[float, float, float, float]]:
+    """Split a geographic ``west > east`` bbox into ``west < east`` halves.
+
+    A 0..360 grid (longitudes reaching past 180 by more than a cell) has the bbox
+    shifted into its own frame, which usually removes the wrap (one half); a
+    -180..180 grid is split at 180 via :func:`split_antimeridian`.
+
+    Args:
+        ds: The dataset whose longitude frame and cell size set the seam.
+        bbox: ``(west, south, east, north)`` with ``west > east``.
+
+    Returns:
+        One or two ``west < east`` sub-bboxes to crop and stitch, in west-to-east
+        order.
+    """
+    west, south, east, north = bbox
+    cell_x = abs(ds.geotransform[1])
+    if float(ds.bbox[2]) > 180.0 + cell_x:
+        # 0..360 grid: bring the STAC (-180..180) bbox into the grid's frame.
+        west = west + 360.0 if west < 0 else west
+        east = east + 360.0 if east < 0 else east
+        if west <= east:
+            halves = [(west, south, east, north)]
+        else:
+            halves = [(west, south, 360.0, north), (0.0, south, east, north)]
+    else:
+        halves = split_antimeridian(bbox)
+    return halves
+
+
 class Spatial(_Engine["Dataset"]):
 
     def _get_crs(self) -> str:
@@ -1449,21 +1481,8 @@ class Spatial(_Engine["Dataset"]):
         Raises:
             ValueError: The bbox does not overlap the dataset's longitude extent.
         """
-        west, south, east, north = bbox
         xmin, xmax = float(self._ds.bbox[0]), float(self._ds.bbox[2])
-        cell_x = abs(self._ds.geotransform[1])
-        if xmax > 180.0 + cell_x:
-            # 0..360 grid: longitudes genuinely reach past 180 (the +cell tolerance
-            # avoids misrouting a -180..180 grid whose xmax floats a hair over 180).
-            # Bring the STAC (-180..180) bbox into the grid's frame.
-            west = west + 360.0 if west < 0 else west
-            east = east + 360.0 if east < 0 else east
-            if west <= east:
-                halves = [(west, south, east, north)]
-            else:
-                halves = [(west, south, 360.0, north), (0.0, south, east, north)]
-        else:
-            halves = split_antimeridian(bbox)
+        halves = _antimeridian_halves(self._ds, bbox)
         parts: list[Dataset] = []
         try:
             for half in halves:

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -133,26 +133,29 @@ def _check_lon_halves_concatenable(
         )
 
 
-def _antimeridian_halves(
-    ds: RasterBase, bbox: tuple[float, float, float, float]
+def _split_lon_bbox(
+    bbox: tuple[float, float, float, float], lon_max: float, cell_x: float
 ) -> list[tuple[float, float, float, float]]:
     """Split a geographic ``west > east`` bbox into ``west < east`` halves.
 
-    A 0..360 grid (longitudes reaching past 180 by more than a cell) has the bbox
+    Pure numeric core shared by the rectilinear and curvilinear crop paths. A
+    0..360 grid (``lon_max`` reaching past 180 by more than a cell) has the bbox
     shifted into its own frame, which usually removes the wrap (one half); a
     -180..180 grid is split at 180 via :func:`split_antimeridian`.
 
     Args:
-        ds: The dataset whose longitude frame and cell size set the seam.
         bbox: ``(west, south, east, north)`` with ``west > east``.
+        lon_max: The grid's maximum longitude (its own frame's east edge).
+        cell_x: The grid's longitude cell size, used as a one-cell tolerance so a
+            -180..180 grid whose ``lon_max`` floats a hair over 180 is not
+            mistaken for a 0..360 grid.
 
     Returns:
         One or two ``west < east`` sub-bboxes to crop and stitch, in west-to-east
         order.
     """
     west, south, east, north = bbox
-    cell_x = abs(ds.geotransform[1])
-    if float(ds.bbox[2]) > 180.0 + cell_x:
+    if lon_max > 180.0 + cell_x:
         # 0..360 grid: bring the STAC (-180..180) bbox into the grid's frame.
         west = west + 360.0 if west < 0 else west
         east = east + 360.0 if east < 0 else east
@@ -163,6 +166,26 @@ def _antimeridian_halves(
     else:
         halves = split_antimeridian(bbox)
     return halves
+
+
+def _antimeridian_halves(
+    ds: RasterBase, bbox: tuple[float, float, float, float]
+) -> list[tuple[float, float, float, float]]:
+    """Split a ``west > east`` bbox using a rectilinear dataset's affine frame.
+
+    Reads the grid's east edge and cell size from the affine ``bbox`` /
+    ``geotransform`` and delegates to :func:`_split_lon_bbox`. Curvilinear grids
+    have no single affine frame and key the split off their 2-D longitude array
+    instead.
+
+    Args:
+        ds: The dataset whose longitude frame and cell size set the seam.
+        bbox: ``(west, south, east, north)`` with ``west > east``.
+
+    Returns:
+        One or two ``west < east`` sub-bboxes, in west-to-east order.
+    """
+    return _split_lon_bbox(bbox, float(ds.bbox[2]), abs(ds.geotransform[1]))
 
 
 def _crop_seam_halves(

--- a/src/pyramids/grib.py
+++ b/src/pyramids/grib.py
@@ -189,24 +189,35 @@ def grib_band_metadata(dataset: Dataset) -> list[dict[str, Any]]:
 
 
 def _select_grib_band(
-    metadata: list[dict[str, Any]], variable: str | None, band_count: int
+    metadata: list[dict[str, Any]], variable: str | int | None
 ) -> int:
-    """Resolve the 0-based band index for `variable`, matched on the GRIB element.
+    """Resolve the 0-based band index for `variable`.
 
     Args:
         metadata: Per-band metadata from :func:`grib_band_metadata`.
-        variable: GRIB element name to select (case-insensitive, e.g. `"TMP"`),
-            or `None` to use the sole band of a single-message file.
-        band_count: Number of bands (messages) in the dataset.
+        variable: How to pick the message. An `int` is a 1-based band number
+            (the unambiguous escape hatch for files that repeat an element
+            across levels/horizons). A non-empty `str` matches the GRIB element
+            (case-insensitive, e.g. `"TMP"`); when several messages share the
+            element the first is used and a warning is emitted. `None` selects
+            the sole band of a single-message file.
 
     Returns:
         The 0-based band index to keep.
 
     Raises:
-        ValueError: `variable` is `None` but the file holds more than one message,
-            or no message carries the requested element.
+        ValueError: `variable` is `None` but the file holds more than one
+            message; an `int` band number is out of range; `variable` is an
+            empty string; or no message carries the requested element.
     """
-    if variable is None:
+    band_count = len(metadata)
+    if isinstance(variable, int):
+        if not 1 <= variable <= band_count:
+            raise ValueError(
+                f"band number {variable} out of range 1..{band_count}."
+            )
+        selected = variable - 1
+    elif variable is None:
         if band_count > 1:
             elements = [m.get("element") for m in metadata]
             raise ValueError(
@@ -215,10 +226,12 @@ def _select_grib_band(
             )
         selected = 0
     else:
-        wanted = variable.upper()
-        matches = [
-            m for m in metadata if (m.get("element") or "").upper() == wanted
-        ]
+        wanted = variable.strip().upper()
+        if not wanted:
+            raise ValueError(
+                "variable must be a non-empty element name or band number."
+            )
+        matches = [m for m in metadata if (m.get("element") or "").upper() == wanted]
         if not matches:
             elements = sorted({m.get("element") for m in metadata if m.get("element")})
             raise ValueError(
@@ -239,8 +252,8 @@ def grib_to_cog(
     grib_path: str | Path,
     *,
     output: str | Path,
-    variable: str | None = None,
-    target_crs: int | None = None,
+    variable: str | int | None = None,
+    target_crs: int | str | None = None,
     cog_profile: str = "deflate",
     vsi: str | None = None,
 ) -> Path:
@@ -257,11 +270,14 @@ def grib_to_cog(
             `s3://` / `gs://` / `https://` URI — resolved like
             :func:`open_grib`).
         output: Destination COG path. Its parent directory must already exist.
-        variable: GRIB element name of the message to convert (case-insensitive,
-            e.g. `"TMP"`). `None` is allowed only when the file holds a single
-            message; when several messages share the element, the first is used
-            and a warning is emitted.
-        target_crs: Optional EPSG code to reproject to before the COG is written;
+        variable: Which GRIB message to convert. A `str` matches the GRIB element
+            (case-insensitive, e.g. `"TMP"`); when several messages share the
+            element the first is used and a warning is emitted. Pass an `int`
+            1-based band number to select a message unambiguously (e.g. one
+            element repeated across pressure levels). `None` is allowed only when
+            the file holds a single message.
+        target_crs: Optional CRS to reproject to before the COG is written — an
+            EPSG `int` or a WKT `str` (forwarded to `to_cog(target_srs=...)`).
             `None` keeps the GRIB's native CRS.
         cog_profile: Named COG compression preset forwarded to
             :meth:`~pyramids.dataset.Dataset.to_cog` (`profile=`), e.g.
@@ -274,8 +290,10 @@ def grib_to_cog(
 
     Raises:
         DriverNotExistError: The GDAL build lacks the GRIB driver.
-        ValueError: `variable` is `None` on a multi-message file, or no message
-            carries the requested element.
+        FileNotFoundError: `grib_path` does not exist (raised by :func:`open_grib`).
+        ValueError: `variable` cannot be resolved (`None` on a multi-message file,
+            an out-of-range band number, an empty string, or an unknown element),
+            or `cog_profile` is not a recognised COG profile (raised by `to_cog`).
 
     Examples:
         - Convert the 2-metre temperature message to a COG (requires libgdal-grib):
@@ -290,13 +308,12 @@ def grib_to_cog(
 
             ```
     """
-    dataset = open_grib(grib_path, vsi=vsi)
-    band_index = _select_grib_band(
-        grib_band_metadata(dataset), variable, dataset.band_count
-    )
-    return dataset.to_cog(
-        output,
-        indexes=[band_index],
-        profile=cog_profile,
-        target_srs=target_crs,
-    )
+    with open_grib(grib_path, vsi=vsi) as dataset:
+        band_index = _select_grib_band(grib_band_metadata(dataset), variable)
+        result = dataset.to_cog(
+            output,
+            indexes=[band_index],
+            profile=cog_profile,
+            target_srs=target_crs,
+        )
+    return result

--- a/src/pyramids/grib.py
+++ b/src/pyramids/grib.py
@@ -206,12 +206,15 @@ def _select_grib_band(
         The 0-based band index to keep.
 
     Raises:
-        ValueError: `variable` is `None` but the file holds more than one
+        ValueError: `variable` is not a `str`, `int`, or `None` (a `bool` is
+            rejected too); `variable` is `None` but the file holds more than one
             message; an `int` band number is out of range; `variable` is an
             empty string; or no message carries the requested element.
     """
     band_count = len(metadata)
-    if isinstance(variable, bool):
+    # `variable`, `band` and the user's band number are all 1-based; the returned
+    # index (and `to_cog(indexes=)`) is 0-based, hence the `- 1` conversions below.
+    if isinstance(variable, bool) or not isinstance(variable, (str, int, type(None))):
         raise ValueError(
             f"variable must be a band number, element name, or None; got {variable!r}."
         )

--- a/src/pyramids/grib.py
+++ b/src/pyramids/grib.py
@@ -211,6 +211,10 @@ def _select_grib_band(
             empty string; or no message carries the requested element.
     """
     band_count = len(metadata)
+    if isinstance(variable, bool):
+        raise ValueError(
+            f"variable must be a band number, element name, or None; got {variable!r}."
+        )
     if isinstance(variable, int):
         if not 1 <= variable <= band_count:
             raise ValueError(
@@ -231,7 +235,9 @@ def _select_grib_band(
             raise ValueError(
                 "variable must be a non-empty element name or band number."
             )
-        matches = [m for m in metadata if (m.get("element") or "").upper() == wanted]
+        matches = [
+            m for m in metadata if (m.get("element") or "").strip().upper() == wanted
+        ]
         if not matches:
             elements = sorted({m.get("element") for m in metadata if m.get("element")})
             raise ValueError(

--- a/src/pyramids/grib.py
+++ b/src/pyramids/grib.py
@@ -233,28 +233,44 @@ def _select_grib_band(
             )
         selected = 0
     else:
-        wanted = variable.strip().upper()
-        if not wanted:
-            raise ValueError(
-                "variable must be a non-empty element name or band number."
-            )
-        matches = [
-            m for m in metadata if (m.get("element") or "").strip().upper() == wanted
-        ]
-        if not matches:
-            elements = sorted({m.get("element") for m in metadata if m.get("element")})
-            raise ValueError(
-                f"No GRIB message with element {variable!r}; "
-                f"available elements: {elements}."
-            )
-        if len(matches) > 1:
-            warnings.warn(
-                f"{len(matches)} GRIB messages match element {variable!r}; "
-                f"using the first (band {matches[0]['band']}).",
-                stacklevel=3,
-            )
-        selected = matches[0]["band"] - 1
+        selected = _match_grib_element(metadata, variable)
     return selected
+
+
+def _match_grib_element(metadata: list[dict[str, Any]], variable: str) -> int:
+    """Resolve the 0-based band index of the first message matching a GRIB element.
+
+    Args:
+        metadata: Per-band metadata from :func:`grib_band_metadata`.
+        variable: A non-empty GRIB element name (case-insensitive).
+
+    Returns:
+        The 0-based index of the first matching message.
+
+    Raises:
+        ValueError: `variable` is blank, or no message carries the element.
+    """
+    wanted = variable.strip().upper()
+    if not wanted:
+        raise ValueError(
+            "variable must be a non-empty element name or band number."
+        )
+    matches = [
+        m for m in metadata if (m.get("element") or "").strip().upper() == wanted
+    ]
+    if not matches:
+        elements = sorted({m.get("element") for m in metadata if m.get("element")})
+        raise ValueError(
+            f"No GRIB message with element {variable!r}; "
+            f"available elements: {elements}."
+        )
+    if len(matches) > 1:
+        warnings.warn(
+            f"{len(matches)} GRIB messages match element {variable!r}; "
+            f"using the first (band {matches[0]['band']}).",
+            stacklevel=4,
+        )
+    return matches[0]["band"] - 1
 
 
 def grib_to_cog(

--- a/src/pyramids/grib.py
+++ b/src/pyramids/grib.py
@@ -15,6 +15,7 @@ through the same path as :meth:`pyramids.dataset.Dataset.read_file`.
 
 from __future__ import annotations
 
+import warnings
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -185,3 +186,117 @@ def grib_band_metadata(dataset: Dataset) -> list[dict[str, Any]]:
         )
         metadata.append(entry)
     return metadata
+
+
+def _select_grib_band(
+    metadata: list[dict[str, Any]], variable: str | None, band_count: int
+) -> int:
+    """Resolve the 0-based band index for `variable`, matched on the GRIB element.
+
+    Args:
+        metadata: Per-band metadata from :func:`grib_band_metadata`.
+        variable: GRIB element name to select (case-insensitive, e.g. `"TMP"`),
+            or `None` to use the sole band of a single-message file.
+        band_count: Number of bands (messages) in the dataset.
+
+    Returns:
+        The 0-based band index to keep.
+
+    Raises:
+        ValueError: `variable` is `None` but the file holds more than one message,
+            or no message carries the requested element.
+    """
+    if variable is None:
+        if band_count > 1:
+            elements = [m.get("element") for m in metadata]
+            raise ValueError(
+                f"GRIB file has {band_count} messages; "
+                f"pass variable= to pick one of {elements}."
+            )
+        selected = 0
+    else:
+        wanted = variable.upper()
+        matches = [
+            m for m in metadata if (m.get("element") or "").upper() == wanted
+        ]
+        if not matches:
+            elements = sorted({m.get("element") for m in metadata if m.get("element")})
+            raise ValueError(
+                f"No GRIB message with element {variable!r}; "
+                f"available elements: {elements}."
+            )
+        if len(matches) > 1:
+            warnings.warn(
+                f"{len(matches)} GRIB messages match element {variable!r}; "
+                f"using the first (band {matches[0]['band']}).",
+                stacklevel=3,
+            )
+        selected = matches[0]["band"] - 1
+    return selected
+
+
+def grib_to_cog(
+    grib_path: str | Path,
+    *,
+    output: str | Path,
+    variable: str | None = None,
+    target_crs: int | None = None,
+    cog_profile: str = "deflate",
+    vsi: str | None = None,
+) -> Path:
+    """Convert a single GRIB message to a Cloud-Optimized GeoTIFF in one call.
+
+    Chains :func:`open_grib` → select the `variable` band → write with
+    :meth:`~pyramids.dataset.Dataset.to_cog`. Everything is in-repo (GDAL's GRIB
+    driver + pyramids' COG writer) — no `rasterio` / `rio-cogeo` / `cfgrib`. The
+    written COG carries the GRIB band's CRS and its `GRIB_*` band metadata, and
+    passes the COG validator (:func:`pyramids.dataset.cog.cog_info` `.is_cog`).
+
+    Args:
+        grib_path: Path or URI to a GRIB1/GRIB2 file (local, `/vsi*`, or a cloud
+            `s3://` / `gs://` / `https://` URI — resolved like
+            :func:`open_grib`).
+        output: Destination COG path. Its parent directory must already exist.
+        variable: GRIB element name of the message to convert (case-insensitive,
+            e.g. `"TMP"`). `None` is allowed only when the file holds a single
+            message; when several messages share the element, the first is used
+            and a warning is emitted.
+        target_crs: Optional EPSG code to reproject to before the COG is written;
+            `None` keeps the GRIB's native CRS.
+        cog_profile: Named COG compression preset forwarded to
+            :meth:`~pyramids.dataset.Dataset.to_cog` (`profile=`), e.g.
+            `"deflate"`, `"zstd"`, `"lzw"`.
+        vsi: Optional explicit archive kind forwarded to :func:`open_grib` (e.g.
+            for a GRIB inside a `.zip`).
+
+    Returns:
+        The `output` path as a :class:`~pathlib.Path`.
+
+    Raises:
+        DriverNotExistError: The GDAL build lacks the GRIB driver.
+        ValueError: `variable` is `None` on a multi-message file, or no message
+            carries the requested element.
+
+    Examples:
+        - Convert the 2-metre temperature message to a COG (requires libgdal-grib):
+            ```python
+            >>> from pyramids.grib import grib_to_cog  # doctest: +SKIP
+            >>> from pyramids.dataset.cog import cog_info  # doctest: +SKIP
+            >>> out = grib_to_cog(  # doctest: +SKIP
+            ...     "tmp2m.grib2", variable="TMP", output="tmp2m_cog.tif"
+            ... )
+            >>> cog_info(out).is_cog  # doctest: +SKIP
+            True
+
+            ```
+    """
+    dataset = open_grib(grib_path, vsi=vsi)
+    band_index = _select_grib_band(
+        grib_band_metadata(dataset), variable, dataset.band_count
+    )
+    return dataset.to_cog(
+        output,
+        indexes=[band_index],
+        profile=cog_profile,
+        target_srs=target_crs,
+    )

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -21,14 +21,16 @@ import math
 import warnings
 from typing import TYPE_CHECKING, Any, cast
 
+import geopandas as gpd
 import numpy as np
-from shapely import contains_xy
+from shapely import box, contains_xy
 
 from pyramids.base.crs import sr_from_epsg, sr_from_user_input
 from pyramids.dataset import DEFAULT_NO_DATA_VALUE, Dataset
 from pyramids.dataset.engines._base import _Engine
 from pyramids.dataset.engines.spatial import (
     _crop_seam_halves,
+    _split_lon_bbox,
     _stitch_lon_halves,
 )
 from pyramids.feature import FeatureCollection
@@ -88,11 +90,14 @@ class Selection(_Engine["NetCDF"]):
                 :meth:`FeatureCollection.from_bbox` and routed through
                 the same polygon path. The FC is built **once** so a
                 root-container crop does not rebuild it for every
-                variable. Mutually exclusive with ``mask``. On a
-                variable subset, a *geographic* bbox with ``west > east``
-                (the STAC antimeridian convention, e.g.
-                ``(170, -10, -170, 10)``) is split at the 180°/360° seam
-                and stitched into one contiguous strip.
+                variable. Mutually exclusive with ``mask``. A *geographic*
+                bbox with ``west > east`` (the STAC antimeridian
+                convention, e.g. ``(170, -10, -170, 10)``) crosses the
+                180° meridian: on a rectilinear variable it is split at
+                the 180°/360° seam and stitched into one contiguous strip;
+                on a curvilinear variable the split halves become a
+                polygon mask over the 2-D coordinates; on a root container
+                it fans out to every variable.
             epsg (keyword-only): CRS for ``bbox`` — anything geopandas
                 accepts for ``crs=`` (EPSG int, ``"EPSG:4326"``, WKT,
                 :class:`pyproj.CRS`). Defaults to the dataset's own
@@ -205,11 +210,10 @@ class Selection(_Engine["NetCDF"]):
             chunks: Forwarded to the per-half crop.
 
         Returns:
-            The cropped variable strip when the bbox is a geographic ``west > east``
-            antimeridian request on a geographic dataset; otherwise ``None``.
-
-        Raises:
-            ValueError: The antimeridian bbox targets a root container.
+            The cropped result when the bbox is a geographic ``west > east``
+            antimeridian request on a geographic dataset — a stitched variable
+            strip, a masked curvilinear window, or a container with every variable
+            cropped — otherwise ``None``.
         """
         if bbox is None or mask is not None:
             return None
@@ -221,11 +225,43 @@ class Selection(_Engine["NetCDF"]):
         if not (west > east and crs_geo and ds_geo):
             return None
         if is_container:
-            raise ValueError(
-                "antimeridian crop (west > east) is not supported on a root "
-                "container; crop a single variable via get_variable(name)."
-            )
+            return self._crop_antimeridian_container(tuple(bbox), crs, touch, chunks)
         return self._crop_antimeridian(tuple(bbox), crs, touch, chunks)
+
+    def _crop_antimeridian_container(
+        self,
+        bbox: tuple[float, float, float, float],
+        crs: Any,
+        touch: bool,
+        chunks: Any,
+    ) -> "NetCDF":
+        """Fan an antimeridian bbox out across every variable of a root container.
+
+        The container has no single crop to run — each variable splits the bbox in
+        its own longitude frame and stitches (rectilinear) or masks (curvilinear)
+        itself, and :meth:`_apply_to_all_variables` reassembles the cropped
+        variables into a new container.
+
+        Args:
+            bbox: ``(west, south, east, north)`` with ``west > east``.
+            crs: The bbox CRS, forwarded to every per-variable crop.
+            touch: Forwarded to every per-variable crop.
+            chunks: Must be ``None`` — antimeridian crops are eager.
+
+        Returns:
+            NetCDF: A new container with every gridded variable cropped.
+
+        Raises:
+            ValueError: ``chunks`` was supplied.
+        """
+        if chunks is not None:
+            raise ValueError(
+                "chunks= is not supported for an antimeridian crop; it is eager "
+                "(the wrapped halves are read and concatenated)."
+            )
+        return self._ds._apply_to_all_variables(
+            "crop", {"bbox": bbox, "epsg": crs, "touch": touch}
+        )
 
     def _crop_antimeridian(
         self,
@@ -236,26 +272,32 @@ class Selection(_Engine["NetCDF"]):
     ) -> "NetCDF":
         """Crop a variable with a geographic ``west > east`` (antimeridian) bbox.
 
-        Splits the bbox at the grid's longitude seam (``180`` on a ``-180..180``
-        grid, ``360`` on a ``0..360`` grid — reusing :func:`split_antimeridian` for
-        the former), crops each ``west < east`` half through the normal path, and
-        concatenates the halves along longitude into one contiguous variable whose
-        coordinates continue past the seam. A half outside the variable's longitude
-        extent is skipped, so a single-sided overlap returns just that half.
+        A curvilinear variable (2-D lon/lat coords) is masked on its coordinate
+        arrays; a rectilinear one splits the bbox at the grid's longitude seam
+        (``180`` on a ``-180..180`` grid, ``360`` on a ``0..360`` grid), crops each
+        ``west < east`` half through the normal path, and concatenates the halves
+        along longitude into one contiguous variable whose coordinates continue past
+        the seam. A half outside the variable's longitude extent is skipped, so a
+        single-sided overlap returns just that half.
 
         Args:
             bbox: ``(west, south, east, north)`` with ``west > east``.
             crs: The bbox CRS.
-            touch: Forwarded to the per-half crop.
-            chunks: Must be ``None`` — the antimeridian merge is eager.
+            touch: Forwarded to the per-half crop / curvilinear mask.
+            chunks: Curvilinear-only lazy read; must be ``None`` on the rectilinear
+                path, whose merge is eager.
 
         Returns:
-            NetCDF: The cropped strip spanning the seam.
+            NetCDF: The cropped strip (rectilinear) or masked window (curvilinear)
+            spanning the seam.
 
         Raises:
-            ValueError: ``chunks`` was supplied, or the bbox does not overlap the
-                variable's longitude extent.
+            ValueError: ``chunks`` was supplied on the rectilinear path, or the bbox
+                does not overlap the variable's longitude extent.
         """
+        curv = _curvilinear_coords_2d(self._ds)
+        if curv is not None:
+            return self._crop_antimeridian_curvilinear(bbox, crs, curv, touch, chunks)
         if chunks is not None:
             raise ValueError(
                 "chunks= is not supported for an antimeridian crop; it is eager "
@@ -267,6 +309,43 @@ class Selection(_Engine["NetCDF"]):
             lambda half: self.crop(bbox=half, epsg=crs, touch=touch),
             self._merge_lon_halves,
         )
+
+    def _crop_antimeridian_curvilinear(
+        self,
+        bbox: tuple[float, float, float, float],
+        crs: Any,
+        coords2d: tuple[np.ndarray, np.ndarray],
+        touch: bool,
+        chunks: Any,
+    ) -> "NetCDF":
+        """Crop a curvilinear variable with a ``west > east`` bbox via a split mask.
+
+        Curvilinear grids have no affine seam to stitch across, but their crop
+        already masks on the 2-D ``(lon, lat)`` arrays — so the wrap is handled by
+        the *mask*, not a stitch. The bbox is split into ``west < east`` halves
+        (keyed off the 2-D longitude array's own max, so a 0..360 grid is detected
+        without an affine geotransform), turned into a polygon per half (a
+        ``MultiPolygon`` on a -180..180 grid, one box on a 0..360 grid), and passed
+        to the standard curvilinear point-in-polygon mask + window.
+
+        Args:
+            bbox: ``(west, south, east, north)`` with ``west > east``.
+            crs: The bbox CRS for the polygon mask.
+            coords2d: The variable's 2-D ``(lon, lat)`` coordinate arrays.
+            touch: Forwarded to the curvilinear mask (currently a no-op there).
+            chunks: Forwarded to the curvilinear windowed read (lazy when set).
+
+        Returns:
+            NetCDF: The masked + windowed curvilinear subset spanning the seam.
+        """
+        lon2d = np.asarray(coords2d[0], dtype=float)
+        halves = _split_lon_bbox(
+            bbox, float(np.nanmax(lon2d)), _lon_cell_size(lon2d)
+        )
+        mask = FeatureCollection(
+            gpd.GeoDataFrame(geometry=[box(*half) for half in halves], crs=crs)
+        )
+        return self._crop_curvilinear(mask, coords2d, touch=touch, chunks=chunks)
 
     def _merge_lon_halves(self, west_part: "NetCDF", east_part: "NetCDF") -> "NetCDF":
         """Concatenate two longitude-adjacent variable crops into one contiguous result.
@@ -348,16 +427,11 @@ class Selection(_Engine["NetCDF"]):
             ValueError: ``chunks`` was given for a rectilinear (affine) crop, which is eager.
         """
         nc = self._ds
-        curv = NetCDFPlot(nc)._resolve_curvilinear_coords(nc, coords=None)
-        is_curvilinear = (
-            curv is not None
-            and np.asarray(curv[0]).ndim == 2
-            and np.asarray(curv[1]).ndim == 2
-        )
-        if is_curvilinear:
+        curv = _curvilinear_coords_2d(nc)
+        if curv is not None:
             result = self._crop_curvilinear(
                 mask,
-                cast("tuple[np.typing.NDArray, np.typing.NDArray]", curv),
+                curv,
                 touch=touch,
                 chunks=chunks,
             )
@@ -985,6 +1059,38 @@ class Selection(_Engine["NetCDF"]):
             )
         nc._carry_aux_variables(cast("NetCDF", result), carry_aux, "reduce")
         return cast("NetCDF", result)
+
+
+def _curvilinear_coords_2d(
+    nc: NetCDF,
+) -> tuple[np.typing.NDArray, np.typing.NDArray] | None:
+    """Return the variable's 2-D ``(lon, lat)`` coords when it is curvilinear.
+
+    A curvilinear variable carries 2-D longitude/latitude arrays (no single affine
+    geotransform). Returns the coordinate pair when both are 2-D, else ``None`` for
+    a rectilinear grid. Shared by the plain and antimeridian crop paths.
+    """
+    curv = NetCDFPlot(nc)._resolve_curvilinear_coords(nc, coords=None)
+    if (
+        curv is not None
+        and np.asarray(curv[0]).ndim == 2
+        and np.asarray(curv[1]).ndim == 2
+    ):
+        return cast("tuple[np.typing.NDArray, np.typing.NDArray]", curv)
+    return None
+
+
+def _lon_cell_size(lon2d: np.typing.NDArray) -> float:
+    """Return the median centre-to-centre longitude spacing of a 2-D lon array.
+
+    Used as the one-cell seam tolerance for a curvilinear grid. The median is
+    robust to the ~360 jump a -180..180 grid shows at the dateline, so it recovers
+    the true cell size there; a single-column grid has no spacing and yields 0.0.
+    """
+    if lon2d.shape[-1] < 2:
+        return 0.0
+    med = float(np.nanmedian(np.abs(np.diff(lon2d, axis=-1))))
+    return med if math.isfinite(med) else 0.0
 
 
 def _reconcile_mask_to_crs(mask: FeatureCollection, epsg: int | None) -> Any:

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -298,14 +298,18 @@ class Selection(_Engine["NetCDF"]):
         """
         curv = _curvilinear_coords_2d(self._ds)
         if curv is not None:
-            return self._crop_antimeridian_curvilinear(bbox, crs, curv, touch, chunks)
-        _reject_antimeridian_chunks(chunks)
-        return _crop_seam_halves(
-            self._ds,
-            bbox,
-            lambda half: self.crop(bbox=half, epsg=crs, touch=touch),
-            self._merge_lon_halves,
-        )
+            result = self._crop_antimeridian_curvilinear(
+                bbox, crs, curv, touch, chunks
+            )
+        else:
+            _reject_antimeridian_chunks(chunks)
+            result = _crop_seam_halves(
+                self._ds,
+                bbox,
+                lambda half: self.crop(bbox=half, epsg=crs, touch=touch),
+                self._merge_lon_halves,
+            )
+        return result
 
     def _crop_antimeridian_curvilinear(
         self,
@@ -336,9 +340,9 @@ class Selection(_Engine["NetCDF"]):
             NetCDF: The masked + windowed curvilinear subset spanning the seam.
         """
         lon2d = np.asarray(coords2d[0], dtype=float)
-        halves = _split_lon_bbox(
-            bbox, float(np.nanmax(lon2d)), _lon_cell_size(lon2d)
-        )
+        finite = lon2d[np.isfinite(lon2d)]
+        lon_max = float(finite.max()) if finite.size else 0.0
+        halves = _split_lon_bbox(bbox, lon_max, _lon_cell_size(lon2d))
         mask = FeatureCollection(
             gpd.GeoDataFrame(geometry=[box(*half) for half in halves], crs=crs)
         )
@@ -1068,13 +1072,15 @@ def _curvilinear_coords_2d(
     a rectilinear grid. Shared by the plain and antimeridian crop paths.
     """
     curv = NetCDFPlot(nc)._resolve_curvilinear_coords(nc, coords=None)
-    if (
+    is_2d = (
         curv is not None
         and np.asarray(curv[0]).ndim == 2
         and np.asarray(curv[1]).ndim == 2
-    ):
-        return cast("tuple[np.typing.NDArray, np.typing.NDArray]", curv)
-    return None
+    )
+    result = None
+    if is_2d:
+        result = cast("tuple[np.typing.NDArray, np.typing.NDArray]", curv)
+    return result
 
 
 def _reject_antimeridian_chunks(chunks: Any) -> None:
@@ -1095,12 +1101,16 @@ def _lon_cell_size(lon2d: np.typing.NDArray) -> float:
 
     Used as the one-cell seam tolerance for a curvilinear grid. The median is
     robust to the ~360 jump a -180..180 grid shows at the dateline, so it recovers
-    the true cell size there; a single-column grid has no spacing and yields 0.0.
+    the true cell size there; a single-column grid (or all-NaN coordinates) has no
+    spacing to measure and yields 0.0. The all-finite guard avoids a NumPy
+    "All-NaN slice" RuntimeWarning on degenerate coordinate arrays.
     """
-    if lon2d.shape[-1] < 2:
-        return 0.0
-    med = float(np.nanmedian(np.abs(np.diff(lon2d, axis=-1))))
-    return med if math.isfinite(med) else 0.0
+    size = 0.0
+    if lon2d.shape[-1] >= 2:
+        diffs = np.abs(np.diff(lon2d, axis=-1))
+        if np.any(np.isfinite(diffs)):
+            size = float(np.nanmedian(diffs))
+    return size
 
 
 def _reconcile_mask_to_crs(mask: FeatureCollection, epsg: int | None) -> Any:

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -28,8 +28,8 @@ from pyramids.base.crs import sr_from_epsg, sr_from_user_input
 from pyramids.dataset import DEFAULT_NO_DATA_VALUE, Dataset
 from pyramids.dataset.engines._base import _Engine
 from pyramids.dataset.engines.spatial import (
-    _antimeridian_halves,
-    _check_lon_halves_concatenable,
+    _crop_seam_halves,
+    _stitch_lon_halves,
 )
 from pyramids.feature import FeatureCollection
 from pyramids.netcdf._mdim import open_mdarray
@@ -261,25 +261,12 @@ class Selection(_Engine["NetCDF"]):
                 "chunks= is not supported for an antimeridian crop; it is eager "
                 "(the wrapped halves are read and concatenated)."
             )
-        xmin, xmax = float(self._ds.bbox[0]), float(self._ds.bbox[2])
-        halves = _antimeridian_halves(self._ds, bbox)
-        parts: list = []
-        try:
-            for half in halves:
-                if half[0] < xmax and half[2] > xmin:
-                    parts.append(self.crop(bbox=half, epsg=crs, touch=touch))
-            if not parts:
-                raise ValueError(
-                    f"antimeridian bbox {bbox!r} does not overlap the dataset extent"
-                )
-            if len(parts) == 1:
-                result, parts = parts[0], []  # hand ownership to the caller
-            else:
-                result = self._merge_lon_halves(parts[0], parts[1])
-        finally:
-            for part in parts:
-                part.close()
-        return result
+        return _crop_seam_halves(
+            self._ds,
+            bbox,
+            lambda half: self.crop(bbox=half, epsg=crs, touch=touch),
+            self._merge_lon_halves,
+        )
 
     def _merge_lon_halves(self, west_part: "NetCDF", east_part: "NetCDF") -> "NetCDF":
         """Concatenate two longitude-adjacent variable crops into one contiguous result.
@@ -297,17 +284,7 @@ class Selection(_Engine["NetCDF"]):
         Returns:
             NetCDF: The concatenated variable.
         """
-        _check_lon_halves_concatenable(west_part, east_part)
-        merged = np.concatenate(
-            [west_part.read_array(), east_part.read_array()], axis=-1
-        )
-        raster = Dataset.create_from_array(
-            merged,
-            geo=west_part.geotransform,
-            epsg=west_part.epsg,
-            no_data_value=west_part.no_data_value,
-        )
-        raster.band_names = self._ds.band_names
+        raster = _stitch_lon_halves(self._ds, west_part, east_part)
         return self._ds._preserve_netcdf_metadata(raster)
 
     def _resolve_crop_mask(

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -27,9 +27,11 @@ from shapely import contains_xy
 from pyramids.base.crs import sr_from_epsg, sr_from_user_input
 from pyramids.dataset import DEFAULT_NO_DATA_VALUE, Dataset
 from pyramids.dataset.engines._base import _Engine
-from pyramids.dataset.engines.spatial import _check_lon_halves_concatenable
+from pyramids.dataset.engines.spatial import (
+    _antimeridian_halves,
+    _check_lon_halves_concatenable,
+)
 from pyramids.feature import FeatureCollection
-from pyramids.feature.bbox import split_antimeridian
 from pyramids.netcdf._mdim import open_mdarray
 from pyramids.netcdf._plot import NetCDFPlot
 
@@ -259,21 +261,8 @@ class Selection(_Engine["NetCDF"]):
                 "chunks= is not supported for an antimeridian crop; it is eager "
                 "(the wrapped halves are read and concatenated)."
             )
-        west, south, east, north = bbox
         xmin, xmax = float(self._ds.bbox[0]), float(self._ds.bbox[2])
-        cell_x = abs(self._ds.geotransform[1])
-        if xmax > 180.0 + cell_x:
-            # 0..360 grid: longitudes genuinely reach past 180 (the +cell tolerance
-            # avoids misrouting a -180..180 grid whose xmax floats a hair over 180).
-            # Bring the STAC (-180..180) bbox into the grid's frame.
-            west = west + 360.0 if west < 0 else west
-            east = east + 360.0 if east < 0 else east
-            if west <= east:
-                halves = [(west, south, east, north)]
-            else:
-                halves = [(west, south, 360.0, north), (0.0, south, east, north)]
-        else:
-            halves = split_antimeridian(bbox)
+        halves = _antimeridian_halves(self._ds, bbox)
         parts: list = []
         try:
             for half in halves:

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -162,18 +162,11 @@ class Selection(_Engine["NetCDF"]):
         """
         nc = self._ds
         is_container = nc._is_md_array and not nc._is_subset and nc.band_count == 0
-        if bbox is not None and mask is None:
-            crs = epsg if epsg is not None else nc.epsg
-            west, _, east, _ = bbox
-            crs_geo = crs is not None and sr_from_user_input(crs).IsGeographic()
-            ds_geo = nc.epsg is not None and sr_from_user_input(nc.epsg).IsGeographic()
-            if west > east and crs_geo and ds_geo:
-                if is_container:
-                    raise ValueError(
-                        "antimeridian crop (west > east) is not supported on a root "
-                        "container; crop a single variable via get_variable(name)."
-                    )
-                return self._crop_antimeridian(tuple(bbox), crs, touch, chunks)
+        antimeridian = self._try_antimeridian(
+            bbox, mask, epsg, is_container, touch, chunks
+        )
+        if antimeridian is not None:
+            return antimeridian
         mask = self._resolve_crop_mask(mask, bbox, epsg)
         if is_container:
             # A container crops every variable; `chunks` is a curvilinear-only, per-variable knob
@@ -189,6 +182,48 @@ class Selection(_Engine["NetCDF"]):
         else:
             result = self._crop_one(mask, touch=touch, chunks=chunks)
         return cast("NetCDF", result)
+
+    def _try_antimeridian(
+        self,
+        bbox: tuple[float, float, float, float] | list[float] | None,
+        mask: Any,
+        epsg: Any,
+        is_container: bool,
+        touch: bool,
+        chunks: Any,
+    ) -> "NetCDF | None":
+        """Return an antimeridian crop when a geographic west>east bbox warrants it.
+
+        Args:
+            bbox: The crop bbox, or ``None``.
+            mask: The crop mask, or ``None`` (antimeridian is bbox-only).
+            epsg: The bbox CRS override, or ``None`` (defaults to the dataset CRS).
+            is_container: Whether ``self`` is a root MDIM container.
+            touch: Forwarded to the per-half crop.
+            chunks: Forwarded to the per-half crop.
+
+        Returns:
+            The cropped variable strip when the bbox is a geographic ``west > east``
+            antimeridian request on a geographic dataset; otherwise ``None``.
+
+        Raises:
+            ValueError: The antimeridian bbox targets a root container.
+        """
+        if bbox is None or mask is not None:
+            return None
+        nc = self._ds
+        crs = epsg if epsg is not None else nc.epsg
+        west, _, east, _ = bbox
+        crs_geo = crs is not None and sr_from_user_input(crs).IsGeographic()
+        ds_geo = nc.epsg is not None and sr_from_user_input(nc.epsg).IsGeographic()
+        if not (west > east and crs_geo and ds_geo):
+            return None
+        if is_container:
+            raise ValueError(
+                "antimeridian crop (west > east) is not supported on a root "
+                "container; crop a single variable via get_variable(name)."
+            )
+        return self._crop_antimeridian(tuple(bbox), crs, touch, chunks)
 
     def _crop_antimeridian(
         self,

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -97,7 +97,12 @@ class Selection(_Engine["NetCDF"]):
                 the 180°/360° seam and stitched into one contiguous strip;
                 on a curvilinear variable the split halves become a
                 polygon mask over the 2-D coordinates; on a root container
-                it fans out to every variable.
+                it fans out to every variable. Behaviour change: a
+                *geographic* ``west > east`` bbox no longer raises
+                ``west < east``; it is read as the STAC antimeridian
+                convention, so a transposed / typo'd geographic bbox is no
+                longer rejected. A *projected* ``west > east`` bbox is
+                still validated and raises.
             epsg (keyword-only): CRS for ``bbox`` — anything geopandas
                 accepts for ``crs=`` (EPSG int, ``"EPSG:4326"``, WKT,
                 :class:`pyproj.CRS`). Defaults to the dataset's own

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -27,6 +27,7 @@ from shapely import contains_xy
 from pyramids.base.crs import sr_from_epsg, sr_from_user_input
 from pyramids.dataset import DEFAULT_NO_DATA_VALUE, Dataset
 from pyramids.dataset.engines._base import _Engine
+from pyramids.dataset.engines.spatial import _check_lon_halves_concatenable
 from pyramids.feature import FeatureCollection
 from pyramids.feature.bbox import split_antimeridian
 from pyramids.netcdf._mdim import open_mdarray
@@ -161,14 +162,19 @@ class Selection(_Engine["NetCDF"]):
         """
         nc = self._ds
         is_container = nc._is_md_array and not nc._is_subset and nc.band_count == 0
-        if bbox is not None and mask is None and not is_container:
+        if bbox is not None and mask is None:
             crs = epsg if epsg is not None else nc.epsg
             west, _, east, _ = bbox
             geographic = crs is not None and sr_from_user_input(crs).IsGeographic()
             if west > east and geographic:
+                if is_container:
+                    raise ValueError(
+                        "antimeridian crop (west > east) is not supported on a root "
+                        "container; crop a single variable via get_variable(name)."
+                    )
                 return self._crop_antimeridian(tuple(bbox), crs, touch, chunks)
         mask = self._resolve_crop_mask(mask, bbox, epsg)
-        if nc._is_md_array and not nc._is_subset and nc.band_count == 0:
+        if is_container:
             # A container crops every variable; `chunks` is a curvilinear-only, per-variable knob
             # (a container may mix curvilinear and rectilinear variables), so the per-variable fan-out
             # cannot honour it. Reject it explicitly rather than silently reading eagerly.
@@ -203,18 +209,27 @@ class Selection(_Engine["NetCDF"]):
             bbox: ``(west, south, east, north)`` with ``west > east``.
             crs: The bbox CRS.
             touch: Forwarded to the per-half crop.
-            chunks: Forwarded to the per-half crop.
+            chunks: Must be ``None`` — the antimeridian merge is eager.
 
         Returns:
             NetCDF: The cropped strip spanning the seam.
 
         Raises:
-            ValueError: The bbox does not overlap the variable's longitude extent.
+            ValueError: ``chunks`` was supplied, or the bbox does not overlap the
+                variable's longitude extent.
         """
+        if chunks is not None:
+            raise ValueError(
+                "chunks= is not supported for an antimeridian crop; it is eager "
+                "(the wrapped halves are read and concatenated)."
+            )
         west, south, east, north = bbox
         xmin, xmax = float(self._ds.bbox[0]), float(self._ds.bbox[2])
-        if xmax > 180.0:
-            # 0..360 grid: bring the STAC (-180..180) bbox into the grid's frame.
+        cell_x = abs(self._ds.geotransform[1])
+        if xmax > 180.0 + cell_x:
+            # 0..360 grid: longitudes genuinely reach past 180 (the +cell tolerance
+            # avoids misrouting a -180..180 grid whose xmax floats a hair over 180).
+            # Bring the STAC (-180..180) bbox into the grid's frame.
             west = west + 360.0 if west < 0 else west
             east = east + 360.0 if east < 0 else east
             if west <= east:
@@ -224,7 +239,7 @@ class Selection(_Engine["NetCDF"]):
         else:
             halves = split_antimeridian(bbox)
         parts = [
-            self.crop(bbox=half, epsg=crs, touch=touch, chunks=chunks)
+            self.crop(bbox=half, epsg=crs, touch=touch)
             for half in halves
             if half[0] < xmax and half[2] > xmin
         ]
@@ -253,6 +268,7 @@ class Selection(_Engine["NetCDF"]):
         Returns:
             NetCDF: The concatenated variable.
         """
+        _check_lon_halves_concatenable(west_part, east_part)
         merged = np.concatenate(
             [west_part.read_array(), east_part.read_array()], axis=-1
         )
@@ -262,7 +278,11 @@ class Selection(_Engine["NetCDF"]):
             epsg=west_part.epsg,
             no_data_value=west_part.no_data_value,
         )
-        return self._ds._preserve_netcdf_metadata(raster)
+        raster.band_names = self._ds.band_names
+        wrapped = self._ds._preserve_netcdf_metadata(raster)
+        west_part.close()
+        east_part.close()
+        return wrapped
 
     def _resolve_crop_mask(
         self,

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -220,18 +220,21 @@ class Selection(_Engine["NetCDF"]):
             strip, a masked curvilinear window, or a container with every variable
             cropped — otherwise ``None``.
         """
-        if bbox is None or mask is not None:
-            return None
-        nc = self._ds
-        crs = epsg if epsg is not None else nc.epsg
-        west, _, east, _ = bbox
-        crs_geo = crs is not None and sr_from_user_input(crs).IsGeographic()
-        ds_geo = nc.epsg is not None and sr_from_user_input(nc.epsg).IsGeographic()
-        if not (west > east and crs_geo and ds_geo):
-            return None
-        if is_container:
-            return self._crop_antimeridian_container(tuple(bbox), crs, touch, chunks)
-        return self._crop_antimeridian(tuple(bbox), crs, touch, chunks)
+        result: "NetCDF | None" = None
+        if bbox is not None and mask is None:
+            nc = self._ds
+            crs = epsg if epsg is not None else nc.epsg
+            west, _, east, _ = bbox
+            crs_geo = crs is not None and sr_from_user_input(crs).IsGeographic()
+            ds_geo = nc.epsg is not None and sr_from_user_input(nc.epsg).IsGeographic()
+            if west > east and crs_geo and ds_geo:
+                if is_container:
+                    result = self._crop_antimeridian_container(
+                        tuple(bbox), crs, touch, chunks
+                    )
+                else:
+                    result = self._crop_antimeridian(tuple(bbox), crs, touch, chunks)
+        return result
 
     def _crop_antimeridian_container(
         self,
@@ -246,6 +249,12 @@ class Selection(_Engine["NetCDF"]):
         its own longitude frame and stitches (rectilinear) or masks (curvilinear)
         itself, and :meth:`_apply_to_all_variables` reassembles the cropped
         variables into a new container.
+
+        Note: as with any container fan-out, a *curvilinear* variable is rebuilt
+        from its cropped result's affine (bbox) geotransform, so its 2-D lon/lat
+        coordinates are dropped and it comes back rectilinear-approximated. Crop a
+        curvilinear variable directly (``get_variable(name).crop(...)``) to keep
+        its 2-D coordinates.
 
         Args:
             bbox: ``(west, south, east, north)`` with ``west > east``.
@@ -1099,11 +1108,15 @@ def _reject_antimeridian_chunks(chunks: Any) -> None:
 def _lon_cell_size(lon2d: np.typing.NDArray) -> float:
     """Return the median centre-to-centre longitude spacing of a 2-D lon array.
 
-    Used as the one-cell seam tolerance for a curvilinear grid. The median is
-    robust to the ~360 jump a -180..180 grid shows at the dateline, so it recovers
-    the true cell size there; a single-column grid (or all-NaN coordinates) has no
-    spacing to measure and yields 0.0. The all-finite guard avoids a NumPy
-    "All-NaN slice" RuntimeWarning on degenerate coordinate arrays.
+    Used as the one-cell seam tolerance for a curvilinear grid. Each row of a
+    -180..180 grid has one ~360 jump at the dateline; the median rejects it only
+    when it is a strict minority, i.e. for ``nx >= 4`` columns (for ``nx <= 3`` the
+    median collapses toward the jump, inflating the estimate). This is harmless
+    here: the inflated tolerance only widens the ``lon_max > 180 + cell_x`` test in
+    :func:`_split_lon_bbox`, and a -180..180 grid has ``lon_max < 180``, so the
+    0..360 branch is never wrongly taken. A single-column grid (or all-NaN
+    coordinates) has no spacing to measure and yields 0.0; the all-finite guard
+    avoids a NumPy "All-NaN slice" RuntimeWarning on degenerate arrays.
     """
     size = 0.0
     if lon2d.shape[-1] >= 2:

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -165,8 +165,9 @@ class Selection(_Engine["NetCDF"]):
         if bbox is not None and mask is None:
             crs = epsg if epsg is not None else nc.epsg
             west, _, east, _ = bbox
-            geographic = crs is not None and sr_from_user_input(crs).IsGeographic()
-            if west > east and geographic:
+            crs_geo = crs is not None and sr_from_user_input(crs).IsGeographic()
+            ds_geo = nc.epsg is not None and sr_from_user_input(nc.epsg).IsGeographic()
+            if west > east and crs_geo and ds_geo:
                 if is_container:
                     raise ValueError(
                         "antimeridian crop (west > east) is not supported on a root "
@@ -238,18 +239,22 @@ class Selection(_Engine["NetCDF"]):
                 halves = [(west, south, 360.0, north), (0.0, south, east, north)]
         else:
             halves = split_antimeridian(bbox)
-        parts = [
-            self.crop(bbox=half, epsg=crs, touch=touch)
-            for half in halves
-            if half[0] < xmax and half[2] > xmin
-        ]
-        if not parts:
-            raise ValueError(
-                f"antimeridian bbox {bbox!r} does not overlap the dataset extent"
-            )
-        result = (
-            parts[0] if len(parts) == 1 else self._merge_lon_halves(parts[0], parts[1])
-        )
+        parts: list = []
+        try:
+            for half in halves:
+                if half[0] < xmax and half[2] > xmin:
+                    parts.append(self.crop(bbox=half, epsg=crs, touch=touch))
+            if not parts:
+                raise ValueError(
+                    f"antimeridian bbox {bbox!r} does not overlap the dataset extent"
+                )
+            if len(parts) == 1:
+                result, parts = parts[0], []  # hand ownership to the caller
+            else:
+                result = self._merge_lon_halves(parts[0], parts[1])
+        finally:
+            for part in parts:
+                part.close()
         return result
 
     def _merge_lon_halves(self, west_part: "NetCDF", east_part: "NetCDF") -> "NetCDF":
@@ -279,10 +284,7 @@ class Selection(_Engine["NetCDF"]):
             no_data_value=west_part.no_data_value,
         )
         raster.band_names = self._ds.band_names
-        wrapped = self._ds._preserve_netcdf_metadata(raster)
-        west_part.close()
-        east_part.close()
-        return wrapped
+        return self._ds._preserve_netcdf_metadata(raster)
 
     def _resolve_crop_mask(
         self,

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -254,11 +254,7 @@ class Selection(_Engine["NetCDF"]):
         Raises:
             ValueError: ``chunks`` was supplied.
         """
-        if chunks is not None:
-            raise ValueError(
-                "chunks= is not supported for an antimeridian crop; it is eager "
-                "(the wrapped halves are read and concatenated)."
-            )
+        _reject_antimeridian_chunks(chunks)
         return self._ds._apply_to_all_variables(
             "crop", {"bbox": bbox, "epsg": crs, "touch": touch}
         )
@@ -298,11 +294,7 @@ class Selection(_Engine["NetCDF"]):
         curv = _curvilinear_coords_2d(self._ds)
         if curv is not None:
             return self._crop_antimeridian_curvilinear(bbox, crs, curv, touch, chunks)
-        if chunks is not None:
-            raise ValueError(
-                "chunks= is not supported for an antimeridian crop; it is eager "
-                "(the wrapped halves are read and concatenated)."
-            )
+        _reject_antimeridian_chunks(chunks)
         return _crop_seam_halves(
             self._ds,
             bbox,
@@ -1078,6 +1070,19 @@ def _curvilinear_coords_2d(
     ):
         return cast("tuple[np.typing.NDArray, np.typing.NDArray]", curv)
     return None
+
+
+def _reject_antimeridian_chunks(chunks: Any) -> None:
+    """Reject ``chunks`` on an eager antimeridian path (rectilinear stitch / container).
+
+    Only the curvilinear antimeridian path (a windowed read) honours ``chunks``; the
+    rectilinear stitch and the container fan-out read the wrapped halves eagerly.
+    """
+    if chunks is not None:
+        raise ValueError(
+            "chunks= is not supported for an antimeridian crop; it is eager "
+            "(the wrapped halves are read and concatenated)."
+        )
 
 
 def _lon_cell_size(lon2d: np.typing.NDArray) -> float:

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -30,6 +30,7 @@ from pyramids.dataset import DEFAULT_NO_DATA_VALUE, Dataset
 from pyramids.dataset.engines._base import _Engine
 from pyramids.dataset.engines.spatial import (
     _crop_seam_halves,
+    _require_antimeridian_seam,
     _split_lon_bbox,
     _stitch_lon_halves,
 )
@@ -98,11 +99,13 @@ class Selection(_Engine["NetCDF"]):
                 on a curvilinear variable the split halves become a
                 polygon mask over the 2-D coordinates; on a root container
                 it fans out to every variable. Behaviour change: a
-                *geographic* ``west > east`` bbox no longer raises
-                ``west < east``; it is read as the STAC antimeridian
-                convention, so a transposed / typo'd geographic bbox is no
-                longer rejected. A *projected* ``west > east`` bbox is
-                still validated and raises.
+                *geographic* ``west > east`` bbox is read as the STAC
+                antimeridian convention (rather than raising
+                ``west < east``) — but only when the dataset's longitude
+                extent reaches the 180 seam. On a *regional* grid that
+                does not reach the seam it raises a clear error instead,
+                catching a transposed / typo'd bbox. A *projected*
+                ``west > east`` bbox is still validated and raises.
             epsg (keyword-only): CRS for ``bbox`` — anything geopandas
                 accepts for ``crs=`` (EPSG int, ``"EPSG:4326"``, WKT,
                 :class:`pyproj.CRS`). Defaults to the dataset's own
@@ -228,6 +231,7 @@ class Selection(_Engine["NetCDF"]):
             crs_geo = crs is not None and sr_from_user_input(crs).IsGeographic()
             ds_geo = nc.epsg is not None and sr_from_user_input(nc.epsg).IsGeographic()
             if west > east and crs_geo and ds_geo:
+                _require_antimeridian_seam(nc)
                 if is_container:
                     result = self._crop_antimeridian_container(
                         tuple(bbox), crs, touch, chunks

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -24,10 +24,11 @@ from typing import TYPE_CHECKING, Any, cast
 import numpy as np
 from shapely import contains_xy
 
-from pyramids.base.crs import sr_from_epsg
+from pyramids.base.crs import sr_from_epsg, sr_from_user_input
 from pyramids.dataset import DEFAULT_NO_DATA_VALUE, Dataset
 from pyramids.dataset.engines._base import _Engine
 from pyramids.feature import FeatureCollection
+from pyramids.feature.bbox import split_antimeridian
 from pyramids.netcdf._mdim import open_mdarray
 from pyramids.netcdf._plot import NetCDFPlot
 
@@ -84,7 +85,11 @@ class Selection(_Engine["NetCDF"]):
                 :meth:`FeatureCollection.from_bbox` and routed through
                 the same polygon path. The FC is built **once** so a
                 root-container crop does not rebuild it for every
-                variable. Mutually exclusive with ``mask``.
+                variable. Mutually exclusive with ``mask``. On a
+                variable subset, a *geographic* bbox with ``west > east``
+                (the STAC antimeridian convention, e.g.
+                ``(170, -10, -170, 10)``) is split at the 180°/360° seam
+                and stitched into one contiguous strip.
             epsg (keyword-only): CRS for ``bbox`` — anything geopandas
                 accepts for ``crs=`` (EPSG int, ``"EPSG:4326"``, WKT,
                 :class:`pyproj.CRS`). Defaults to the dataset's own
@@ -155,6 +160,13 @@ class Selection(_Engine["NetCDF"]):
               shared primitive that builds the one-row FC.
         """
         nc = self._ds
+        is_container = nc._is_md_array and not nc._is_subset and nc.band_count == 0
+        if bbox is not None and mask is None and not is_container:
+            crs = epsg if epsg is not None else nc.epsg
+            west, _, east, _ = bbox
+            geographic = crs is not None and sr_from_user_input(crs).IsGeographic()
+            if west > east and geographic:
+                return self._crop_antimeridian(tuple(bbox), crs, touch, chunks)
         mask = self._resolve_crop_mask(mask, bbox, epsg)
         if nc._is_md_array and not nc._is_subset and nc.band_count == 0:
             # A container crops every variable; `chunks` is a curvilinear-only, per-variable knob
@@ -170,6 +182,87 @@ class Selection(_Engine["NetCDF"]):
         else:
             result = self._crop_one(mask, touch=touch, chunks=chunks)
         return cast("NetCDF", result)
+
+    def _crop_antimeridian(
+        self,
+        bbox: tuple[float, float, float, float],
+        crs: Any,
+        touch: bool,
+        chunks: Any,
+    ) -> "NetCDF":
+        """Crop a variable with a geographic ``west > east`` (antimeridian) bbox.
+
+        Splits the bbox at the grid's longitude seam (``180`` on a ``-180..180``
+        grid, ``360`` on a ``0..360`` grid — reusing :func:`split_antimeridian` for
+        the former), crops each ``west < east`` half through the normal path, and
+        concatenates the halves along longitude into one contiguous variable whose
+        coordinates continue past the seam. A half outside the variable's longitude
+        extent is skipped, so a single-sided overlap returns just that half.
+
+        Args:
+            bbox: ``(west, south, east, north)`` with ``west > east``.
+            crs: The bbox CRS.
+            touch: Forwarded to the per-half crop.
+            chunks: Forwarded to the per-half crop.
+
+        Returns:
+            NetCDF: The cropped strip spanning the seam.
+
+        Raises:
+            ValueError: The bbox does not overlap the variable's longitude extent.
+        """
+        west, south, east, north = bbox
+        xmin, xmax = float(self._ds.bbox[0]), float(self._ds.bbox[2])
+        if xmax > 180.0:
+            # 0..360 grid: bring the STAC (-180..180) bbox into the grid's frame.
+            west = west + 360.0 if west < 0 else west
+            east = east + 360.0 if east < 0 else east
+            if west <= east:
+                halves = [(west, south, east, north)]
+            else:
+                halves = [(west, south, 360.0, north), (0.0, south, east, north)]
+        else:
+            halves = split_antimeridian(bbox)
+        parts = [
+            self.crop(bbox=half, epsg=crs, touch=touch, chunks=chunks)
+            for half in halves
+            if half[0] < xmax and half[2] > xmin
+        ]
+        if not parts:
+            raise ValueError(
+                f"antimeridian bbox {bbox!r} does not overlap the dataset extent"
+            )
+        result = (
+            parts[0] if len(parts) == 1 else self._merge_lon_halves(parts[0], parts[1])
+        )
+        return result
+
+    def _merge_lon_halves(self, west_part: "NetCDF", east_part: "NetCDF") -> "NetCDF":
+        """Concatenate two longitude-adjacent variable crops into one contiguous result.
+
+        `west_part` (the pre-seam half) sits to the left and `east_part` (the
+        wrapped half past the seam) to its right; the merged raster keeps
+        `west_part`'s north-up geotransform, so the longitude mapping continues
+        past the seam. The result is re-wrapped as :class:`NetCDF` so variable
+        metadata (band dims, ``sel``) survives.
+
+        Args:
+            west_part: Crop of the pre-seam half.
+            east_part: Crop of the post-seam half.
+
+        Returns:
+            NetCDF: The concatenated variable.
+        """
+        merged = np.concatenate(
+            [west_part.read_array(), east_part.read_array()], axis=-1
+        )
+        raster = Dataset.create_from_array(
+            merged,
+            geo=west_part.geotransform,
+            epsg=west_part.epsg,
+            no_data_value=west_part.no_data_value,
+        )
+        return self._ds._preserve_netcdf_metadata(raster)
 
     def _resolve_crop_mask(
         self,

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -231,7 +231,7 @@ class Selection(_Engine["NetCDF"]):
             crs_geo = crs is not None and sr_from_user_input(crs).IsGeographic()
             ds_geo = nc.epsg is not None and sr_from_user_input(nc.epsg).IsGeographic()
             if west > east and crs_geo and ds_geo:
-                _require_antimeridian_seam(nc)
+                _require_antimeridian_seam(nc, tuple(bbox))
                 if is_container:
                     result = self._crop_antimeridian_container(
                         tuple(bbox), crs, touch, chunks

--- a/tests/dataset/io/test_grib.py
+++ b/tests/dataset/io/test_grib.py
@@ -338,6 +338,12 @@ class TestSelectGribBand:
         with pytest.raises(ValueError, match="band number, element name, or None"):
             _select_grib_band(meta, True)
 
+    def test_non_str_int_variable_raises(self):
+        """A float variable raises a clear ValueError, not a cryptic AttributeError."""
+        meta = [{"band": 1, "element": "TMP"}]
+        with pytest.raises(ValueError, match="band number, element name, or None"):
+            _select_grib_band(meta, 1.5)
+
     def test_matches_element_with_surrounding_whitespace(self):
         """A stored element with stray whitespace still matches (both stripped)."""
         meta = [{"band": 1, "element": " TMP "}]
@@ -367,8 +373,10 @@ class TestGribToCog:
         """
         with open_grib(grib_1band_path) as src:
             element = grib_band_metadata(src)[0]["element"]
+        # `element or None` keeps the test valid on GDAL builds that emit an empty
+        # or missing GRIB element (which would otherwise trip the empty-string guard).
         out = grib_to_cog(
-            grib_1band_path, output=tmp_path / "var_cog.tif", variable=element
+            grib_1band_path, output=tmp_path / "var_cog.tif", variable=element or None
         )
         with Dataset.read_file(str(out)) as ds:
             arr = ds.read_array()
@@ -409,6 +417,41 @@ class TestGribToCog:
             arr = ds.read_array()
         assert cog_info(out).is_cog, "output should be a COG"
         assert np.allclose(arr, 101325.0), "band 2 values (101325) should reach COG"
+
+    def test_preserves_grib_band_metadata(self, grib_1band_path, tmp_path):
+        """The output COG carries the source GRIB_* band metadata.
+
+        Args:
+            grib_1band_path: Fixture path to a 1-band GRIB2.
+            tmp_path: pytest temp directory.
+        """
+        out = grib_to_cog(grib_1band_path, output=tmp_path / "meta_cog.tif")
+        with Dataset.read_file(str(out)) as ds:
+            md = ds.raster.GetRasterBand(1).GetMetadata()
+        assert any(k.startswith("GRIB_") for k in md), "GRIB_* metadata should survive"
+
+    def test_shared_element_warns_and_takes_first(self, grib_path, tmp_path, mocker):
+        """A str element shared by several messages warns and selects the first band.
+
+        Args:
+            grib_path: Fixture path to a 2-band GRIB2 (band1=280.0, band2=101325.0).
+            tmp_path: pytest temp directory.
+            mocker: pytest-mock fixture (inject a duplicated element deterministically).
+        """
+        mocker.patch(
+            "pyramids.grib.grib_band_metadata",
+            return_value=[
+                {"band": 1, "element": "TMP"},
+                {"band": 2, "element": "TMP"},
+            ],
+        )
+        with pytest.warns(UserWarning, match="using the first"):
+            out = grib_to_cog(
+                grib_path, output=tmp_path / "warn_cog.tif", variable="TMP"
+            )
+        with Dataset.read_file(str(out)) as ds:
+            arr = ds.read_array()
+        assert np.allclose(arr, 280.0), "first matching band (280) should win"
 
     def test_preserves_native_crs(self, grib_1band_path, tmp_path):
         """Without target_crs the COG keeps the GRIB's native EPSG:4326.

--- a/tests/dataset/io/test_grib.py
+++ b/tests/dataset/io/test_grib.py
@@ -497,3 +497,45 @@ class TestGribToCog:
         """
         with pytest.raises(ValueError, match="No GRIB message with element"):
             grib_to_cog(grib_path, output=tmp_path / "y.tif", variable="NOPE")
+
+    def test_missing_grib_raises(self, tmp_path):
+        """A missing GRIB path raises FileNotFoundError (propagated from open_grib)."""
+        with pytest.raises(FileNotFoundError):
+            grib_to_cog(tmp_path / "nope.grib2", output=tmp_path / "x.tif")
+
+    def test_invalid_cog_profile_raises(self, grib_1band_path, tmp_path):
+        """An unrecognised cog_profile raises ValueError (propagated from to_cog).
+
+        Args:
+            grib_1band_path: Fixture path to a 1-band GRIB2.
+            tmp_path: pytest temp directory.
+        """
+        with pytest.raises(ValueError, match="COG profile"):
+            grib_to_cog(
+                grib_1band_path, output=tmp_path / "bad.tif", cog_profile="bogus"
+            )
+
+    def test_non_default_cog_profile_writes_cog(self, grib_1band_path, tmp_path):
+        """A non-default cog_profile (lzw) still produces a valid COG.
+
+        Args:
+            grib_1band_path: Fixture path to a 1-band GRIB2.
+            tmp_path: pytest temp directory.
+        """
+        out = grib_to_cog(
+            grib_1band_path, output=tmp_path / "lzw.tif", cog_profile="lzw"
+        )
+        assert cog_info(out).is_cog, "lzw profile should still be a valid COG"
+
+    def test_string_target_crs_reprojects(self, grib_1band_path, tmp_path):
+        """A string target_crs reprojects, matching to_cog's int|str contract.
+
+        Args:
+            grib_1band_path: Fixture path to a 1-band GRIB2.
+            tmp_path: pytest temp directory.
+        """
+        out = grib_to_cog(
+            grib_1band_path, output=tmp_path / "str_crs.tif", target_crs="EPSG:3857"
+        )
+        with Dataset.read_file(str(out)) as ds:
+            assert ds.epsg == 3857, "string target_crs should reproject to 3857"

--- a/tests/dataset/io/test_grib.py
+++ b/tests/dataset/io/test_grib.py
@@ -10,11 +10,14 @@ from osgeo import gdal, osr
 
 from pyramids.base._errors import DriverNotExistError
 from pyramids.dataset import Dataset
+from pyramids.dataset.cog import cog_info
 from pyramids.grib import (
     _parse_grib_seconds,
     _parse_leading_int,
     _require_grib_driver,
+    _select_grib_band,
     grib_band_metadata,
+    grib_to_cog,
     open_grib,
 )
 
@@ -39,6 +42,30 @@ def grib_path(tmp_path):
     mem.GetRasterBand(1).WriteArray(np.full((6, 8), 280.0, "float32"))
     mem.GetRasterBand(2).WriteArray(np.full((6, 8), 101325.0, "float32"))
     path = tmp_path / "sample.grib2"
+    dst = gdal.GetDriverByName("GRIB").CreateCopy(str(path), mem)
+    dst.FlushCache()
+    dst = None
+    mem = None
+    return path
+
+
+@pytest.fixture
+def grib_1band_path(tmp_path):
+    """Write a single-message 8x6 GRIB2 on EPSG:4326 and return its path.
+
+    Args:
+        tmp_path: pytest temp directory.
+
+    Returns:
+        pathlib.Path: Path to a 1-band GRIB2.
+    """
+    mem = gdal.GetDriverByName("MEM").Create("", 8, 6, 1, gdal.GDT_Float32)
+    mem.SetGeoTransform((0.0, 1.0, 0.0, 6.0, 0.0, -1.0))
+    sr = osr.SpatialReference()
+    sr.ImportFromEPSG(4326)
+    mem.SetProjection(sr.ExportToWkt())
+    mem.GetRasterBand(1).WriteArray(np.full((6, 8), 280.0, "float32"))
+    path = tmp_path / "single.grib2"
     dst = gdal.GetDriverByName("GRIB").CreateCopy(str(path), mem)
     dst.FlushCache()
     dst = None
@@ -250,3 +277,111 @@ class TestGribBandMetadata:
         assert isinstance(
             entry["forecast_seconds"], int
         ), "forecast_seconds should be int"
+
+
+class TestSelectGribBand:
+    """Tests for _select_grib_band (0-based band resolution from GRIB element)."""
+
+    def test_none_variable_single_band(self):
+        """variable=None on a single-message file selects band 0."""
+        meta = [{"band": 1, "element": "TMP"}]
+        assert _select_grib_band(meta, None, 1) == 0, "single-band None should be 0"
+
+    def test_none_variable_multiband_raises(self):
+        """variable=None on a multi-message file raises with the element list."""
+        meta = [{"band": 1, "element": "TMP"}, {"band": 2, "element": "PRES"}]
+        with pytest.raises(ValueError, match="pass variable="):
+            _select_grib_band(meta, None, 2)
+
+    def test_matches_element_returns_zero_based(self):
+        """A matching element returns its 0-based index (band 2 -> 1)."""
+        meta = [{"band": 1, "element": "TMP"}, {"band": 2, "element": "PRES"}]
+        assert _select_grib_band(meta, "PRES", 2) == 1, "PRES is band 2 -> index 1"
+
+    def test_match_is_case_insensitive(self):
+        """Element matching ignores case."""
+        meta = [{"band": 1, "element": "TMP"}]
+        assert _select_grib_band(meta, "tmp", 1) == 0, "lowercase should match TMP"
+
+    def test_multiple_matches_warns_and_uses_first(self):
+        """Several messages sharing the element warn and select the first."""
+        meta = [{"band": 1, "element": "TMP"}, {"band": 2, "element": "TMP"}]
+        with pytest.warns(UserWarning, match="using the first"):
+            assert _select_grib_band(meta, "TMP", 2) == 0
+
+    def test_unknown_element_raises(self):
+        """An absent element raises with the available-elements list."""
+        meta = [{"band": 1, "element": "TMP"}]
+        with pytest.raises(ValueError, match="available elements"):
+            _select_grib_band(meta, "NOPE", 1)
+
+
+class TestGribToCog:
+    """Tests for grib_to_cog (open_grib -> band select -> to_cog)."""
+
+    def test_single_band_writes_valid_cog(self, grib_1band_path, tmp_path):
+        """A single-message GRIB with variable=None writes a valid COG.
+
+        Args:
+            grib_1band_path: Fixture path to a 1-band GRIB2.
+            tmp_path: pytest temp directory.
+        """
+        out = grib_to_cog(grib_1band_path, output=tmp_path / "single_cog.tif")
+        assert out.exists(), "grib_to_cog should write the output file"
+        assert cog_info(out).is_cog, "output should pass the COG validator"
+
+    def test_selects_variable_band(self, grib_1band_path, tmp_path):
+        """Passing the band's GRIB element selects it and writes a valid COG.
+
+        Args:
+            grib_1band_path: Fixture path to a 1-band GRIB2.
+            tmp_path: pytest temp directory.
+        """
+        element = grib_band_metadata(open_grib(grib_1band_path))[0]["element"]
+        out = grib_to_cog(
+            grib_1band_path, output=tmp_path / "var_cog.tif", variable=element
+        )
+        assert cog_info(out).is_cog, "output should pass the COG validator"
+
+    def test_preserves_native_crs(self, grib_1band_path, tmp_path):
+        """Without target_crs the COG keeps the GRIB's native EPSG:4326.
+
+        Args:
+            grib_1band_path: Fixture path to a 1-band GRIB2.
+            tmp_path: pytest temp directory.
+        """
+        out = grib_to_cog(grib_1band_path, output=tmp_path / "native_cog.tif")
+        assert Dataset.read_file(str(out)).epsg == 4326, "native CRS should survive"
+
+    def test_target_crs_reprojects(self, grib_1band_path, tmp_path):
+        """target_crs reprojects the COG to the requested EPSG.
+
+        Args:
+            grib_1band_path: Fixture path to a 1-band GRIB2.
+            tmp_path: pytest temp directory.
+        """
+        out = grib_to_cog(
+            grib_1band_path, output=tmp_path / "reproj_cog.tif", target_crs=3857
+        )
+        assert Dataset.read_file(str(out)).epsg == 3857, "should reproject to 3857"
+        assert cog_info(out).is_cog, "reprojected output should still be a COG"
+
+    def test_multiband_requires_variable(self, grib_path, tmp_path):
+        """A multi-message GRIB without variable= raises.
+
+        Args:
+            grib_path: Fixture path to a 2-band GRIB2.
+            tmp_path: pytest temp directory.
+        """
+        with pytest.raises(ValueError, match="pass variable="):
+            grib_to_cog(grib_path, output=tmp_path / "x.tif")
+
+    def test_unknown_variable_raises(self, grib_path, tmp_path):
+        """Requesting an element no message carries raises.
+
+        Args:
+            grib_path: Fixture path to a 2-band GRIB2.
+            tmp_path: pytest temp directory.
+        """
+        with pytest.raises(ValueError, match="No GRIB message with element"):
+            grib_to_cog(grib_path, output=tmp_path / "y.tif", variable="NOPE")

--- a/tests/dataset/io/test_grib.py
+++ b/tests/dataset/io/test_grib.py
@@ -285,35 +285,52 @@ class TestSelectGribBand:
     def test_none_variable_single_band(self):
         """variable=None on a single-message file selects band 0."""
         meta = [{"band": 1, "element": "TMP"}]
-        assert _select_grib_band(meta, None, 1) == 0, "single-band None should be 0"
+        assert _select_grib_band(meta, None) == 0, "single-band None should be 0"
 
     def test_none_variable_multiband_raises(self):
         """variable=None on a multi-message file raises with the element list."""
         meta = [{"band": 1, "element": "TMP"}, {"band": 2, "element": "PRES"}]
         with pytest.raises(ValueError, match="pass variable="):
-            _select_grib_band(meta, None, 2)
+            _select_grib_band(meta, None)
 
     def test_matches_element_returns_zero_based(self):
         """A matching element returns its 0-based index (band 2 -> 1)."""
         meta = [{"band": 1, "element": "TMP"}, {"band": 2, "element": "PRES"}]
-        assert _select_grib_band(meta, "PRES", 2) == 1, "PRES is band 2 -> index 1"
+        assert _select_grib_band(meta, "PRES") == 1, "PRES is band 2 -> index 1"
 
     def test_match_is_case_insensitive(self):
         """Element matching ignores case."""
         meta = [{"band": 1, "element": "TMP"}]
-        assert _select_grib_band(meta, "tmp", 1) == 0, "lowercase should match TMP"
+        assert _select_grib_band(meta, "tmp") == 0, "lowercase should match TMP"
 
     def test_multiple_matches_warns_and_uses_first(self):
         """Several messages sharing the element warn and select the first."""
         meta = [{"band": 1, "element": "TMP"}, {"band": 2, "element": "TMP"}]
         with pytest.warns(UserWarning, match="using the first"):
-            assert _select_grib_band(meta, "TMP", 2) == 0
+            assert _select_grib_band(meta, "TMP") == 0
 
     def test_unknown_element_raises(self):
         """An absent element raises with the available-elements list."""
         meta = [{"band": 1, "element": "TMP"}]
         with pytest.raises(ValueError, match="available elements"):
-            _select_grib_band(meta, "NOPE", 1)
+            _select_grib_band(meta, "NOPE")
+
+    def test_int_selects_band_number(self):
+        """An int selects that 1-based band directly (band 2 -> index 1)."""
+        meta = [{"band": 1, "element": "TMP"}, {"band": 2, "element": "TMP"}]
+        assert _select_grib_band(meta, 2) == 1, "band number 2 -> index 1"
+
+    def test_int_out_of_range_raises(self):
+        """An out-of-range band number raises."""
+        meta = [{"band": 1, "element": "TMP"}]
+        with pytest.raises(ValueError, match="out of range"):
+            _select_grib_band(meta, 5)
+
+    def test_empty_string_raises(self):
+        """An empty-string variable raises instead of matching None-element bands."""
+        meta = [{"band": 1, "element": None}]
+        with pytest.raises(ValueError, match="non-empty"):
+            _select_grib_band(meta, "")
 
 
 class TestGribToCog:
@@ -330,18 +347,31 @@ class TestGribToCog:
         assert out.exists(), "grib_to_cog should write the output file"
         assert cog_info(out).is_cog, "output should pass the COG validator"
 
-    def test_selects_variable_band(self, grib_1band_path, tmp_path):
-        """Passing the band's GRIB element selects it and writes a valid COG.
+    def test_selects_variable_band_preserves_data(self, grib_1band_path, tmp_path):
+        """Selecting the sole message by its GRIB element preserves its data in the COG.
 
         Args:
-            grib_1band_path: Fixture path to a 1-band GRIB2.
+            grib_1band_path: Fixture path to a 1-band GRIB2 (values 280.0).
             tmp_path: pytest temp directory.
         """
         element = grib_band_metadata(open_grib(grib_1band_path))[0]["element"]
         out = grib_to_cog(
             grib_1band_path, output=tmp_path / "var_cog.tif", variable=element
         )
-        assert cog_info(out).is_cog, "output should pass the COG validator"
+        arr = Dataset.read_file(str(out)).read_array()
+        assert np.allclose(arr, 280.0), "selected band values should reach the COG"
+
+    def test_int_band_selection_writes_that_bands_data(self, grib_path, tmp_path):
+        """An int band number selects that specific message; its data reaches the COG.
+
+        Args:
+            grib_path: Fixture path to a 2-band GRIB2 (band1=280.0, band2=101325.0).
+            tmp_path: pytest temp directory.
+        """
+        out = grib_to_cog(grib_path, output=tmp_path / "band2_cog.tif", variable=2)
+        arr = Dataset.read_file(str(out)).read_array()
+        assert cog_info(out).is_cog, "output should be a COG"
+        assert np.allclose(arr, 101325.0), "band 2 values (101325) should reach COG"
 
     def test_preserves_native_crs(self, grib_1band_path, tmp_path):
         """Without target_crs the COG keeps the GRIB's native EPSG:4326.

--- a/tests/dataset/io/test_grib.py
+++ b/tests/dataset/io/test_grib.py
@@ -332,6 +332,17 @@ class TestSelectGribBand:
         with pytest.raises(ValueError, match="non-empty"):
             _select_grib_band(meta, "")
 
+    def test_bool_variable_raises(self):
+        """A bool is rejected rather than treated as a band number (True == 1)."""
+        meta = [{"band": 1, "element": "TMP"}]
+        with pytest.raises(ValueError, match="band number, element name, or None"):
+            _select_grib_band(meta, True)
+
+    def test_matches_element_with_surrounding_whitespace(self):
+        """A stored element with stray whitespace still matches (both stripped)."""
+        meta = [{"band": 1, "element": " TMP "}]
+        assert _select_grib_band(meta, "tmp") == 0, "padded element should still match"
+
 
 class TestGribToCog:
     """Tests for grib_to_cog (open_grib -> band select -> to_cog)."""
@@ -354,12 +365,37 @@ class TestGribToCog:
             grib_1band_path: Fixture path to a 1-band GRIB2 (values 280.0).
             tmp_path: pytest temp directory.
         """
-        element = grib_band_metadata(open_grib(grib_1band_path))[0]["element"]
+        with open_grib(grib_1band_path) as src:
+            element = grib_band_metadata(src)[0]["element"]
         out = grib_to_cog(
             grib_1band_path, output=tmp_path / "var_cog.tif", variable=element
         )
-        arr = Dataset.read_file(str(out)).read_array()
+        with Dataset.read_file(str(out)) as ds:
+            arr = ds.read_array()
         assert np.allclose(arr, 280.0), "selected band values should reach the COG"
+
+    def test_selects_element_by_string_writes_that_bands_data(
+        self, grib_path, tmp_path, mocker
+    ):
+        """A distinct element string selects the right band's data on a multi-band file.
+
+        Args:
+            grib_path: Fixture path to a 2-band GRIB2 (band1=280.0, band2=101325.0).
+            tmp_path: pytest temp directory.
+            mocker: pytest-mock fixture (GDAL writes 'unknown' for synthetic
+                elements, so distinct names are injected).
+        """
+        mocker.patch(
+            "pyramids.grib.grib_band_metadata",
+            return_value=[
+                {"band": 1, "element": "AAA"},
+                {"band": 2, "element": "BBB"},
+            ],
+        )
+        out = grib_to_cog(grib_path, output=tmp_path / "bbb_cog.tif", variable="BBB")
+        with Dataset.read_file(str(out)) as ds:
+            arr = ds.read_array()
+        assert np.allclose(arr, 101325.0), "element BBB (band 2) data reaches COG"
 
     def test_int_band_selection_writes_that_bands_data(self, grib_path, tmp_path):
         """An int band number selects that specific message; its data reaches the COG.
@@ -369,7 +405,8 @@ class TestGribToCog:
             tmp_path: pytest temp directory.
         """
         out = grib_to_cog(grib_path, output=tmp_path / "band2_cog.tif", variable=2)
-        arr = Dataset.read_file(str(out)).read_array()
+        with Dataset.read_file(str(out)) as ds:
+            arr = ds.read_array()
         assert cog_info(out).is_cog, "output should be a COG"
         assert np.allclose(arr, 101325.0), "band 2 values (101325) should reach COG"
 
@@ -381,7 +418,8 @@ class TestGribToCog:
             tmp_path: pytest temp directory.
         """
         out = grib_to_cog(grib_1band_path, output=tmp_path / "native_cog.tif")
-        assert Dataset.read_file(str(out)).epsg == 4326, "native CRS should survive"
+        with Dataset.read_file(str(out)) as ds:
+            assert ds.epsg == 4326, "native CRS should survive"
 
     def test_target_crs_reprojects(self, grib_1band_path, tmp_path):
         """target_crs reprojects the COG to the requested EPSG.
@@ -393,7 +431,8 @@ class TestGribToCog:
         out = grib_to_cog(
             grib_1band_path, output=tmp_path / "reproj_cog.tif", target_crs=3857
         )
-        assert Dataset.read_file(str(out)).epsg == 3857, "should reproject to 3857"
+        with Dataset.read_file(str(out)) as ds:
+            assert ds.epsg == 3857, "should reproject to 3857"
         assert cog_info(out).is_cog, "reprojected output should still be a COG"
 
     def test_multiband_requires_variable(self, grib_path, tmp_path):

--- a/tests/dataset/spatial/test_bbox_crop_read_array.py
+++ b/tests/dataset/spatial/test_bbox_crop_read_array.py
@@ -255,7 +255,7 @@ class TestAntimeridianCrop:
         arr, ds = self._global()
         strip = ds.crop(bbox=(170.0, -10.0, -170.0, 10.0))
         assert strip.shape == (1, 20, 20), "20 lat x 20 lon strip"
-        assert strip.bbox == [170.0, -10.0, 190.0, 10.0], "extent continues past 180"
+        assert strip.bbox == pytest.approx([170.0, -10.0, 190.0, 10.0]), "past 180"
         expected = np.concatenate([arr[80:100, 350:360], arr[80:100, 0:10]], axis=-1)
         assert np.array_equal(strip.read_array(), expected), "seam values preserved"
 
@@ -298,7 +298,7 @@ class TestAntimeridianCrop:
         """A west < east bbox still crops normally (no antimeridian path)."""
         _, ds = self._global()
         out = ds.crop(bbox=(10.0, -10.0, 30.0, 10.0))
-        assert out.bbox == [10.0, -10.0, 30.0, 10.0], "normal crop unaffected"
+        assert out.bbox == pytest.approx([10.0, -10.0, 30.0, 10.0]), "unaffected"
 
     def test_projected_dataset_not_treated_as_antimeridian(self):
         """A geographic west>east bbox on a projected dataset is not an antimeridian crop."""

--- a/tests/dataset/spatial/test_bbox_crop_read_array.py
+++ b/tests/dataset/spatial/test_bbox_crop_read_array.py
@@ -11,7 +11,10 @@ import pytest
 from shapely.geometry import box
 
 from pyramids.dataset import Dataset, DatasetCollection
-from pyramids.dataset.engines.spatial import _split_lon_bbox
+from pyramids.dataset.engines.spatial import (
+    _reaches_antimeridian_seam,
+    _split_lon_bbox,
+)
 from pyramids.feature import FeatureCollection
 
 pytestmark = pytest.mark.core
@@ -329,14 +332,14 @@ class TestAntimeridianCrop:
         with pytest.raises(ValueError, match="west < east"):
             ds.crop(bbox=(170.0, -10.0, -170.0, 10.0), epsg=4326)
 
-    def test_no_overlap_raises(self):
-        """An antimeridian bbox disjoint from the grid's longitudes raises."""
+    def test_regional_grid_reversed_bbox_raises(self):
+        """A west>east bbox on a regional grid that never reaches the seam raises."""
         arr = np.arange(180 * 50, dtype="float32").reshape(180, 50)
         ds = Dataset.create_from_array(
-            arr, top_left_corner=(0.0, 90.0), cell_size=1.0, epsg=4326
-        )  # lon 0..50 only
-        with pytest.raises(ValueError, match="does not overlap"):
-            ds.crop(bbox=(170.0, -10.0, -170.0, 10.0))
+            arr, top_left_corner=(-10.0, 90.0), cell_size=1.0, epsg=4326
+        )  # lon -10..40 (Europe): reaches neither +180 nor -180
+        with pytest.raises(ValueError, match="transposed|does not reach the 180 seam"):
+            ds.crop(bbox=(40.0, -10.0, 10.0, 10.0))
 
     def test_single_side_overlap_returns_half(self):
         """When only one side of the seam overlaps, that half is returned as-is."""
@@ -347,6 +350,26 @@ class TestAntimeridianCrop:
         strip = ds.crop(bbox=(175.0, -10.0, -170.0, 10.0))
         assert strip.bbox[0] == pytest.approx(175.0), "west edge kept"
         assert strip.bbox[2] == pytest.approx(180.0), "only the west half (no wrap)"
+
+    @pytest.mark.parametrize(
+        "top_left_x, ncols, reaches",
+        [
+            (-180.0, 360, True),  # global -180..180 (touches -180 and 180)
+            (0.0, 360, True),  # global 0..360 (reaches past 180)
+            (170.0, 10, True),  # regional but ends exactly at the +180 seam
+            (-10.0, 50, False),  # Europe -10..40: reaches neither seam
+            (0.0, 90, False),  # eastern hemisphere 0..90: reaches neither
+        ],
+    )
+    def test_reaches_antimeridian_seam(self, top_left_x, ncols, reaches):
+        """The seam gate accepts grids reaching 180/-180 and rejects regional ones."""
+        ds = Dataset.create_from_array(
+            np.zeros((2, ncols), dtype="float32"),
+            top_left_corner=(top_left_x, 1.0),
+            cell_size=1.0,
+            epsg=4326,
+        )
+        assert _reaches_antimeridian_seam(ds) is reaches
 
     def test_split_lon_bbox_0_360_yields_single_half(self):
         """On a 0..360 grid the west>east bbox shifts into one west<east half."""

--- a/tests/dataset/spatial/test_bbox_crop_read_array.py
+++ b/tests/dataset/spatial/test_bbox_crop_read_array.py
@@ -241,6 +241,26 @@ class TestDatasetCropBbox:
         with pytest.raises(ValueError, match=r"west < east"):
             dataset.crop(bbox=(1, 0, 0, 1), epsg=3857)
 
+    def test_crop_entirely_nodata_raises_clear_error(self):
+        """A crop overlapping only no-data cells raises a clear error, not IndexError.
+
+        Args:
+            None.
+
+        Test scenario:
+            A grid with valid data only in its top-left quadrant, cropped over the
+            all-no-data bottom-right, must raise a "no valid pixels" ValueError from
+            the touch-cutline correction rather than crash with an IndexError.
+        """
+        arr = np.full((10, 10), -9999.0, dtype="float32")
+        arr[0:5, 0:5] = 1.0  # valid only in the top-left quadrant
+        ds = Dataset.create_from_array(
+            arr, top_left_corner=(0.0, 10.0), cell_size=1.0, epsg=4326,
+            no_data_value=-9999.0,
+        )
+        with pytest.raises(ValueError, match="no valid pixels"):
+            ds.crop(bbox=(6.0, 0.0, 9.0, 4.0))  # bottom-right: all no-data
+
 
 class TestAntimeridianCrop:
     """Tests for crop with a geographic ``west > east`` (antimeridian) bbox."""
@@ -355,14 +375,15 @@ class TestAntimeridianCrop:
         "top_left_x, ncols, reaches",
         [
             (-180.0, 360, True),  # global -180..180 (touches -180 and 180)
-            (0.0, 360, True),  # global 0..360 (reaches past 180)
+            (0.0, 360, True),  # global 0..360 (reaches past 180 to ~360)
             (170.0, 10, True),  # regional but ends exactly at the +180 seam
             (-10.0, 50, False),  # Europe -10..40: reaches neither seam
             (0.0, 90, False),  # eastern hemisphere 0..90: reaches neither
+            (0.0, 256, False),  # partial 0..360 (lon 0..256): stops short of 360
         ],
     )
     def test_reaches_antimeridian_seam(self, top_left_x, ncols, reaches):
-        """The seam gate accepts grids reaching 180/-180 and rejects regional ones."""
+        """The seam gate accepts grids reaching 180/-180 and rejects regional/partial ones."""
         ds = Dataset.create_from_array(
             np.zeros((2, ncols), dtype="float32"),
             top_left_corner=(top_left_x, 1.0),

--- a/tests/dataset/spatial/test_bbox_crop_read_array.py
+++ b/tests/dataset/spatial/test_bbox_crop_read_array.py
@@ -267,7 +267,7 @@ class TestAntimeridianCrop:
         assert np.array_equal(strip.read_array(), arr[80:100, 170:190]), "0..360 values"
 
     def test_multiband_keeps_all_bands(self):
-        """A multi-band grid keeps all bands across the seam."""
+        """A multi-band grid keeps all bands with correct stitched values."""
         arr, _ = self._global()
         ds = Dataset.create_from_array(
             np.stack([arr, arr + 1000.0]),
@@ -277,6 +277,22 @@ class TestAntimeridianCrop:
         )
         strip = ds.crop(bbox=(170.0, -10.0, -170.0, 10.0))
         assert strip.shape == (2, 20, 20), "both bands retained"
+        seam = np.concatenate([arr[80:100, 350:360], arr[80:100, 0:10]], axis=-1)
+        assert np.array_equal(strip.read_array(band=1), seam + 1000.0), "band 2"
+
+    def test_float_overshoot_grid_keeps_both_halves(self):
+        """A grid whose xmax floats past 180 is not misrouted to 0..360 (H1)."""
+        cell = 360.0 / 169  # 169 cols -> bbox[2] == 180.00000000000006 > 180
+        ds = Dataset.create_from_array(
+            np.arange(20 * 169, dtype="float32").reshape(20, 169),
+            top_left_corner=(-180.0, 20.0),
+            cell_size=cell,
+            epsg=4326,
+        )
+        assert ds.bbox[2] > 180.0, "fixture must actually overshoot to exercise H1"
+        strip = ds.crop(bbox=(170.0, -10.0, -170.0, 10.0))
+        # both halves kept -> the strip's east edge continues to ~190, not ~180
+        assert abs(strip.bbox[2] - 190.0) < cell, "wrapped half must not be dropped"
 
     def test_normal_bbox_unchanged(self):
         """A west < east bbox still crops normally (no antimeridian path)."""

--- a/tests/dataset/spatial/test_bbox_crop_read_array.py
+++ b/tests/dataset/spatial/test_bbox_crop_read_array.py
@@ -281,6 +281,22 @@ class TestAntimeridianCrop:
         seam = np.concatenate([arr[80:100, 350:360], arr[80:100, 0:10]], axis=-1)
         assert np.array_equal(strip.read_array(band=1), seam + 1000.0), "band 2"
 
+    def test_multiband_on_0_360_grid_keeps_all_bands(self):
+        """A multi-band 0..360 grid keeps every band with correct 170..190 values."""
+        arr, _ = self._global(top_left_x=0.0)
+        ds = Dataset.create_from_array(
+            np.stack([arr, arr + 1000.0]),
+            top_left_corner=(0.0, 90.0),
+            cell_size=1.0,
+            epsg=4326,
+        )
+        strip = ds.crop(bbox=(170.0, -10.0, -170.0, 10.0))
+        assert strip.shape == (2, 20, 20), "both bands retained"
+        assert np.array_equal(strip.read_array(band=0), arr[80:100, 170:190]), "band 1"
+        assert np.array_equal(
+            strip.read_array(band=1), arr[80:100, 170:190] + 1000.0
+        ), "band 2"
+
     def test_float_overshoot_grid_keeps_both_halves(self):
         """A grid whose xmax floats past 180 is not misrouted to 0..360 (H1)."""
         cell = 360.0 / 169  # 169 cols -> bbox[2] == 180.00000000000006 > 180
@@ -333,12 +349,14 @@ class TestAntimeridianCrop:
 
     def test_split_lon_bbox_0_360_yields_single_half(self):
         """On a 0..360 grid the west>east bbox shifts into one west<east half."""
-        halves = _split_lon_bbox((170.0, -10.0, -170.0, 10.0), lon_max=359.0, cell_x=1.0)
+        bbox = (170.0, -10.0, -170.0, 10.0)
+        halves = _split_lon_bbox(bbox, lon_max=359.0, cell_x=1.0)
         assert halves == [(170.0, -10.0, 190.0, 10.0)]
 
     def test_split_lon_bbox_180_yields_two_halves(self):
         """On a -180..180 grid the west>east bbox splits at the 180 seam."""
-        halves = _split_lon_bbox((170.0, -10.0, -170.0, 10.0), lon_max=180.0, cell_x=1.0)
+        bbox = (170.0, -10.0, -170.0, 10.0)
+        halves = _split_lon_bbox(bbox, lon_max=180.0, cell_x=1.0)
         assert halves == [
             (170.0, -10.0, 180.0, 10.0),
             (-180.0, -10.0, -170.0, 10.0),

--- a/tests/dataset/spatial/test_bbox_crop_read_array.py
+++ b/tests/dataset/spatial/test_bbox_crop_read_array.py
@@ -265,6 +265,7 @@ class TestAntimeridianCrop:
         arr, ds = self._global(top_left_x=0.0)
         strip = ds.crop(bbox=(170.0, -10.0, -170.0, 10.0))
         assert strip.shape == (1, 20, 20), "20x20 strip"
+        assert strip.bbox == pytest.approx([170.0, -10.0, 190.0, 10.0]), "170..190 extent"
         assert np.array_equal(strip.read_array(), arr[80:100, 170:190]), "0..360 values"
 
     def test_multiband_keeps_all_bands(self):

--- a/tests/dataset/spatial/test_bbox_crop_read_array.py
+++ b/tests/dataset/spatial/test_bbox_crop_read_array.py
@@ -11,6 +11,7 @@ import pytest
 from shapely.geometry import box
 
 from pyramids.dataset import Dataset, DatasetCollection
+from pyramids.dataset.engines.spatial import _split_lon_bbox
 from pyramids.feature import FeatureCollection
 
 pytestmark = pytest.mark.core
@@ -329,6 +330,19 @@ class TestAntimeridianCrop:
         strip = ds.crop(bbox=(175.0, -10.0, -170.0, 10.0))
         assert strip.bbox[0] == pytest.approx(175.0), "west edge kept"
         assert strip.bbox[2] == pytest.approx(180.0), "only the west half (no wrap)"
+
+    def test_split_lon_bbox_0_360_yields_single_half(self):
+        """On a 0..360 grid the west>east bbox shifts into one west<east half."""
+        halves = _split_lon_bbox((170.0, -10.0, -170.0, 10.0), lon_max=359.0, cell_x=1.0)
+        assert halves == [(170.0, -10.0, 190.0, 10.0)]
+
+    def test_split_lon_bbox_180_yields_two_halves(self):
+        """On a -180..180 grid the west>east bbox splits at the 180 seam."""
+        halves = _split_lon_bbox((170.0, -10.0, -170.0, 10.0), lon_max=180.0, cell_x=1.0)
+        assert halves == [
+            (170.0, -10.0, 180.0, 10.0),
+            (-180.0, -10.0, -170.0, 10.0),
+        ]
 
 
 class TestDatasetReadArrayBbox:

--- a/tests/dataset/spatial/test_bbox_crop_read_array.py
+++ b/tests/dataset/spatial/test_bbox_crop_read_array.py
@@ -230,11 +230,77 @@ class TestDatasetCropBbox:
             dataset: Raster fixture.
 
         Test scenario:
-            ``crop(bbox=(1, 0, 0, 1))`` (west >= east) — expected: ``ValueError``
-            from the underlying validator.
+            ``crop(bbox=(1, 0, 0, 1), epsg=3857)`` — ``west > east`` in a projected
+            CRS is not an antimeridian case, so the ``west < east`` validator still
+            raises (a geographic ``west > east`` is instead cropped across the seam).
         """
         with pytest.raises(ValueError, match=r"west < east"):
-            dataset.crop(bbox=(1, 0, 0, 1))
+            dataset.crop(bbox=(1, 0, 0, 1), epsg=3857)
+
+
+class TestAntimeridianCrop:
+    """Tests for crop with a geographic ``west > east`` (antimeridian) bbox."""
+
+    @staticmethod
+    def _global(top_left_x=-180.0):
+        """Return (source array, global 1-degree Dataset) with the given lon origin."""
+        arr = np.arange(180 * 360, dtype="float32").reshape(180, 360)
+        ds = Dataset.create_from_array(
+            arr, top_left_corner=(top_left_x, 90.0), cell_size=1.0, epsg=4326
+        )
+        return arr, ds
+
+    def test_strip_values_and_extent(self):
+        """A -180..180 grid crop across the dateline stitches a contiguous strip."""
+        arr, ds = self._global()
+        strip = ds.crop(bbox=(170.0, -10.0, -170.0, 10.0))
+        assert strip.shape == (1, 20, 20), "20 lat x 20 lon strip"
+        assert strip.bbox == [170.0, -10.0, 190.0, 10.0], "extent continues past 180"
+        expected = np.concatenate([arr[80:100, 350:360], arr[80:100, 0:10]], axis=-1)
+        assert np.array_equal(strip.read_array(), expected), "seam values preserved"
+
+    def test_on_0_360_grid(self):
+        """A 0..360 grid crops the same STAC bbox as a contiguous 170..190 strip."""
+        arr, ds = self._global(top_left_x=0.0)
+        strip = ds.crop(bbox=(170.0, -10.0, -170.0, 10.0))
+        assert strip.shape == (1, 20, 20), "20x20 strip"
+        assert np.array_equal(strip.read_array(), arr[80:100, 170:190]), "0..360 values"
+
+    def test_multiband_keeps_all_bands(self):
+        """A multi-band grid keeps all bands across the seam."""
+        arr, _ = self._global()
+        ds = Dataset.create_from_array(
+            np.stack([arr, arr + 1000.0]),
+            top_left_corner=(-180.0, 90.0),
+            cell_size=1.0,
+            epsg=4326,
+        )
+        strip = ds.crop(bbox=(170.0, -10.0, -170.0, 10.0))
+        assert strip.shape == (2, 20, 20), "both bands retained"
+
+    def test_normal_bbox_unchanged(self):
+        """A west < east bbox still crops normally (no antimeridian path)."""
+        _, ds = self._global()
+        out = ds.crop(bbox=(10.0, -10.0, 30.0, 10.0))
+        assert out.bbox == [10.0, -10.0, 30.0, 10.0], "normal crop unaffected"
+
+    def test_no_overlap_raises(self):
+        """An antimeridian bbox disjoint from the grid's longitudes raises."""
+        arr = np.arange(180 * 50, dtype="float32").reshape(180, 50)
+        ds = Dataset.create_from_array(
+            arr, top_left_corner=(0.0, 90.0), cell_size=1.0, epsg=4326
+        )  # lon 0..50 only
+        with pytest.raises(ValueError, match="does not overlap"):
+            ds.crop(bbox=(170.0, -10.0, -170.0, 10.0))
+
+    def test_single_side_overlap_returns_half(self):
+        """When only one side of the seam overlaps, that half is returned as-is."""
+        arr = np.arange(180 * 10, dtype="float32").reshape(180, 10)
+        ds = Dataset.create_from_array(
+            arr, top_left_corner=(170.0, 90.0), cell_size=1.0, epsg=4326
+        )  # lon 170..180 only (west side of the seam)
+        strip = ds.crop(bbox=(175.0, -10.0, -170.0, 10.0))
+        assert strip.bbox[0] == 175.0 and strip.bbox[2] == 180.0, "only the west half"
 
 
 class TestDatasetReadArrayBbox:

--- a/tests/dataset/spatial/test_bbox_crop_read_array.py
+++ b/tests/dataset/spatial/test_bbox_crop_read_array.py
@@ -327,7 +327,8 @@ class TestAntimeridianCrop:
             arr, top_left_corner=(170.0, 90.0), cell_size=1.0, epsg=4326
         )  # lon 170..180 only (west side of the seam)
         strip = ds.crop(bbox=(175.0, -10.0, -170.0, 10.0))
-        assert strip.bbox[0] == 175.0 and strip.bbox[2] == 180.0, "only the west half"
+        assert strip.bbox[0] == pytest.approx(175.0), "west edge kept"
+        assert strip.bbox[2] == pytest.approx(180.0), "only the west half (no wrap)"
 
 
 class TestDatasetReadArrayBbox:

--- a/tests/dataset/spatial/test_bbox_crop_read_array.py
+++ b/tests/dataset/spatial/test_bbox_crop_read_array.py
@@ -300,6 +300,17 @@ class TestAntimeridianCrop:
         out = ds.crop(bbox=(10.0, -10.0, 30.0, 10.0))
         assert out.bbox == [10.0, -10.0, 30.0, 10.0], "normal crop unaffected"
 
+    def test_projected_dataset_not_treated_as_antimeridian(self):
+        """A geographic west>east bbox on a projected dataset is not an antimeridian crop."""
+        ds = Dataset.create_from_array(
+            np.zeros((5, 5), dtype="float32"),
+            top_left_corner=(0.0, 1000.0),
+            cell_size=1000.0,
+            epsg=3857,
+        )
+        with pytest.raises(ValueError, match="west < east"):
+            ds.crop(bbox=(170.0, -10.0, -170.0, 10.0), epsg=4326)
+
     def test_no_overlap_raises(self):
         """An antimeridian bbox disjoint from the grid's longitudes raises."""
         arr = np.arange(180 * 50, dtype="float32").reshape(180, 50)

--- a/tests/netcdf/samples/test_curvilinear_crop.py
+++ b/tests/netcdf/samples/test_curvilinear_crop.py
@@ -119,6 +119,7 @@ def test_rasm_antimeridian_crop_windows_across_seam(sample):
     [
         (np.array([[10.0, 12.0, 14.0], [10.0, 12.0, 14.0]]), 2.0),  # even spacing
         (np.array([[172.0, 174.0, 176.0, 178.0, -180.0, -178.0]]), 2.0),  # seam outlier
+        (np.array([[170.0, 178.0, -178.0]]), 182.0),  # 3-col: median=mean of [8,356]
         (np.array([[10.0], [10.0]]), 0.0),  # single column -> no spacing
         (np.array([[np.nan, np.nan], [np.nan, np.nan]]), 0.0),  # all-NaN -> 0.0
     ],

--- a/tests/netcdf/samples/test_curvilinear_crop.py
+++ b/tests/netcdf/samples/test_curvilinear_crop.py
@@ -93,6 +93,49 @@ def test_rasm_curvilinear_crop(sample):
         nc.close()
 
 
+def test_rasm_antimeridian_crop_windows_across_seam(sample):
+    """A west>east bbox on the 0..360 rasm grid windows across 180 and stays curvilinear."""
+    nc = NetCDF.read_file(sample(RASM))
+    try:
+        tair = nc.get_variable("Tair")
+        full = np.asarray(tair.read_array())
+        strip = tair.crop(bbox=(170.0, 40.0, -170.0, 70.0))
+        arr = np.asarray(strip.read_array())
+        assert arr.shape[-1] < full.shape[-1], "antimeridian crop must window the grid"
+        assert hasattr(strip, "_curvilinear_coords"), "result must stay curvilinear"
+        lon = np.asarray(strip._curvilinear_coords[0])
+        # The bbox is brought into the grid's 0..360 frame as 170..190; the windowed
+        # longitudes must straddle the 180 seam.
+        assert (
+            float(np.nanmin(lon)) <= 180.0 <= float(np.nanmax(lon))
+        ), "windowed longitudes must span the 180 seam"
+    finally:
+        nc.close()
+
+
+def test_synthetic_curvilinear_antimeridian_masks_both_sides():
+    """A -180..180 curvilinear grid crossing the dateline masks both sides (MultiPolygon)."""
+    ny, nx = 8, 12
+    lon_row = ((np.arange(nx) + 172.0 + 180.0) % 360.0) - 180.0  # 172..179, -180..-169
+    lon2d = np.tile(lon_row, (ny, 1)).astype(float)
+    lat2d = np.tile(np.linspace(9.0, -9.0, ny).reshape(ny, 1), (1, nx)).astype(float)
+    data = np.arange(ny * nx, dtype="float32").reshape(1, ny, nx)
+    nc = NetCDF.create_from_array(
+        arr=data, geo=(172.0, 1.0, 0.0, 9.0, 0.0, -2.0), epsg=4326, variable_name="c"
+    )
+    try:
+        var = nc.get_variable("c")
+        var._curvilinear_coords = (lon2d, lat2d)
+        strip = var.crop(bbox=(175.0, -10.0, -177.0, 10.0))
+        assert hasattr(strip, "_curvilinear_coords"), "result must stay curvilinear"
+        slon = np.asarray(strip._curvilinear_coords[0])
+        present = set(np.round(slon[~np.isnan(slon)]).astype(int).tolist())
+        assert present & {176, 177, 178, 179}, f"west-of-seam cells missing: {present}"
+        assert present & {-180, -179, -178}, f"east-of-seam cells missing: {present}"
+    finally:
+        nc.close()
+
+
 @pytest.mark.lazy
 def test_roms_curvilinear_crop_lazy_matches_eager(sample):
     """``chunks=`` reads the cropped window through the lazy/dask path and matches the eager crop."""

--- a/tests/netcdf/samples/test_curvilinear_crop.py
+++ b/tests/netcdf/samples/test_curvilinear_crop.py
@@ -16,6 +16,7 @@ from shapely.geometry import MultiPolygon, Polygon
 from pyramids.feature import FeatureCollection
 from pyramids.netcdf import NetCDF
 from pyramids.netcdf._plot import NetCDFPlot
+from pyramids.netcdf.engines.selection import _lon_cell_size
 from tests.netcdf.samples.conftest import TOS as RECTILINEAR
 
 pytestmark = pytest.mark.core
@@ -111,6 +112,20 @@ def test_rasm_antimeridian_crop_windows_across_seam(sample):
         ), "windowed longitudes must span the 180 seam"
     finally:
         nc.close()
+
+
+@pytest.mark.parametrize(
+    "lon2d, expected",
+    [
+        (np.array([[10.0, 12.0, 14.0], [10.0, 12.0, 14.0]]), 2.0),  # even spacing
+        (np.array([[172.0, 174.0, 176.0, 178.0, -180.0, -178.0]]), 2.0),  # seam outlier
+        (np.array([[10.0], [10.0]]), 0.0),  # single column -> no spacing
+        (np.array([[np.nan, np.nan], [np.nan, np.nan]]), 0.0),  # all-NaN -> 0.0
+    ],
+)
+def test_lon_cell_size(lon2d, expected):
+    """`_lon_cell_size` returns the seam-robust median spacing, 0.0 when undefined."""
+    assert _lon_cell_size(lon2d) == pytest.approx(expected)
 
 
 def test_synthetic_curvilinear_antimeridian_masks_both_sides():

--- a/tests/netcdf/samples/test_selection.py
+++ b/tests/netcdf/samples/test_selection.py
@@ -97,3 +97,34 @@ class TestAntimeridianCrop:
         var = nc.get_variable("v")
         with pytest.raises(ValueError, match="does not overlap"):
             var.crop(bbox=(170.0, -10.0, -170.0, 10.0))
+
+    def test_container_fans_out_across_variables(self):
+        """A root-container antimeridian crop crops every variable into the seam strip."""
+        v_arr = np.arange(180 * 360, dtype="float32").reshape(180, 360)
+        w_arr = (v_arr * -1.0).astype("float32")
+        geo = (-180.0, 1.0, 0.0, 90.0, 0.0, -1.0)
+        nc = NetCDF.create_from_array(arr=v_arr, geo=geo, epsg=4326, variable_name="v")
+        nc.set_variable("w", Dataset.create_from_array(w_arr, geo=geo, epsg=4326))
+        cropped = nc.crop(bbox=(170.0, -10.0, -170.0, 10.0))
+        assert isinstance(cropped, NetCDF), "container crop stays a NetCDF container"
+        assert sorted(cropped.variable_names) == ["v", "w"], "every variable is kept"
+        for name, src in (("v", v_arr), ("w", w_arr)):
+            var = cropped.get_variable(name)
+            assert var.shape == (1, 20, 20), f"{name} strip shape"
+            assert var.bbox == pytest.approx([170.0, -10.0, 190.0, 10.0]), "past seam"
+            expected = np.concatenate(
+                [src[80:100, 350:360], src[80:100, 0:10]], axis=-1
+            )
+            assert np.array_equal(np.asarray(var.read_array()), expected), name
+
+    def test_chunks_rejected_on_container(self):
+        """``chunks`` is unsupported for an antimeridian container crop (eager merge)."""
+        arr = np.arange(180 * 360, dtype="float32").reshape(180, 360)
+        nc = NetCDF.create_from_array(
+            arr=arr,
+            geo=(-180.0, 1.0, 0.0, 90.0, 0.0, -1.0),
+            epsg=4326,
+            variable_name="v",
+        )
+        with pytest.raises(ValueError, match="chunks"):
+            nc.crop(bbox=(170.0, -10.0, -170.0, 10.0), chunks="auto")

--- a/tests/netcdf/samples/test_selection.py
+++ b/tests/netcdf/samples/test_selection.py
@@ -117,6 +117,34 @@ class TestAntimeridianCrop:
             )
             assert np.array_equal(np.asarray(var.read_array()), expected), name
 
+    def test_container_on_0_360_grid(self):
+        """A 0..360 root-container antimeridian crop windows every variable to 170..190."""
+        v_arr = np.arange(180 * 360, dtype="float32").reshape(180, 360)
+        w_arr = (v_arr + 1000.0).astype("float32")
+        geo = (0.0, 1.0, 0.0, 90.0, 0.0, -1.0)
+        nc = NetCDF.create_from_array(arr=v_arr, geo=geo, epsg=4326, variable_name="v")
+        nc.set_variable("w", Dataset.create_from_array(w_arr, geo=geo, epsg=4326))
+        cropped = nc.crop(bbox=(170.0, -10.0, -170.0, 10.0))
+        assert sorted(cropped.variable_names) == ["v", "w"], "every variable is kept"
+        for name, src in (("v", v_arr), ("w", w_arr)):
+            var = cropped.get_variable(name)
+            assert var.shape == (1, 20, 20), f"{name} strip shape"
+            got = np.asarray(var.read_array())
+            assert np.array_equal(got, src[80:100, 170:190]), f"{name} 0..360 values"
+
+    def test_single_side_overlap_returns_half(self):
+        """When only one side of the seam overlaps, that half is returned as-is."""
+        arr = np.arange(180 * 10, dtype="float32").reshape(180, 10)
+        nc = NetCDF.create_from_array(
+            arr=arr,
+            geo=(170.0, 1.0, 0.0, 90.0, 0.0, -1.0),
+            epsg=4326,
+            variable_name="v",
+        )  # lon 170..180 only (west side of the seam)
+        strip = nc.get_variable("v").crop(bbox=(175.0, -10.0, -170.0, 10.0))
+        assert strip.bbox[0] == pytest.approx(175.0), "west edge kept"
+        assert strip.bbox[2] == pytest.approx(180.0), "only the west half (no wrap)"
+
     def test_chunks_rejected_on_container(self):
         """``chunks`` is unsupported for an antimeridian container crop (eager merge)."""
         arr = np.arange(180 * 360, dtype="float32").reshape(180, 360)

--- a/tests/netcdf/samples/test_selection.py
+++ b/tests/netcdf/samples/test_selection.py
@@ -66,9 +66,7 @@ class TestAntimeridianCrop:
         strip = var.crop(bbox=(170.0, -10.0, -170.0, 10.0))
         assert isinstance(strip, NetCDF), "result stays a NetCDF variable"
         assert strip.shape == (1, 20, 20), "20 lat x 20 lon strip"
-        assert [float(x) for x in strip.bbox] == [170.0, -10.0, 190.0, 10.0], (
-            "extent continues past the 180 seam"
-        )
+        assert strip.bbox == pytest.approx([170.0, -10.0, 190.0, 10.0]), "past seam"
         expected = np.concatenate([arr[80:100, 350:360], arr[80:100, 0:10]], axis=-1)
         got = np.asarray(strip.read_array())
         assert np.array_equal(got, expected), "seam values preserved"
@@ -96,5 +94,6 @@ class TestAntimeridianCrop:
             epsg=4326,
             variable_name="v",
         )  # lon 0..50 only
+        var = nc.get_variable("v")
         with pytest.raises(ValueError, match="does not overlap"):
-            nc.get_variable("v").crop(bbox=(170.0, -10.0, -170.0, 10.0))
+            var.crop(bbox=(170.0, -10.0, -170.0, 10.0))

--- a/tests/netcdf/samples/test_selection.py
+++ b/tests/netcdf/samples/test_selection.py
@@ -85,18 +85,18 @@ class TestAntimeridianCrop:
         assert isinstance(out, NetCDF), "normal crop stays a NetCDF"
         assert out.shape == (1, 20, 20), "normal crop shape"
 
-    def test_no_overlap_raises(self):
-        """An antimeridian bbox disjoint from the variable's longitudes raises."""
+    def test_regional_grid_reversed_bbox_raises(self):
+        """A west>east bbox on a regional variable that never reaches the seam raises."""
         arr = np.arange(180 * 50, dtype="float32").reshape(180, 50)
         nc = NetCDF.create_from_array(
             arr=arr,
-            geo=(0.0, 1.0, 0.0, 90.0, 0.0, -1.0),
+            geo=(-10.0, 1.0, 0.0, 90.0, 0.0, -1.0),
             epsg=4326,
             variable_name="v",
-        )  # lon 0..50 only
+        )  # lon -10..40 (Europe): reaches neither +180 nor -180
         var = nc.get_variable("v")
-        with pytest.raises(ValueError, match="does not overlap"):
-            var.crop(bbox=(170.0, -10.0, -170.0, 10.0))
+        with pytest.raises(ValueError, match="transposed|does not reach the 180 seam"):
+            var.crop(bbox=(40.0, -10.0, 10.0, 10.0))
 
     def test_container_fans_out_across_variables(self):
         """A root-container antimeridian crop crops every variable into the seam strip."""

--- a/tests/netcdf/samples/test_selection.py
+++ b/tests/netcdf/samples/test_selection.py
@@ -66,6 +66,9 @@ class TestAntimeridianCrop:
         strip = var.crop(bbox=(170.0, -10.0, -170.0, 10.0))
         assert isinstance(strip, NetCDF), "result stays a NetCDF variable"
         assert strip.shape == (1, 20, 20), "20 lat x 20 lon strip"
+        assert [float(x) for x in strip.bbox] == [170.0, -10.0, 190.0, 10.0], (
+            "extent continues past the 180 seam"
+        )
         expected = np.concatenate([arr[80:100, 350:360], arr[80:100, 0:10]], axis=-1)
         got = np.asarray(strip.read_array())
         assert np.array_equal(got, expected), "seam values preserved"

--- a/tests/netcdf/samples/test_selection.py
+++ b/tests/netcdf/samples/test_selection.py
@@ -1,5 +1,6 @@
 """Selection and subsetting: sel (coordinate-value band selection) and subset (windowed Dataset)."""
 
+import numpy as np
 import pytest
 
 from pyramids.dataset import Dataset
@@ -42,3 +43,55 @@ def test_subset_returns_smaller_dataset(sample):
         assert ds.shape[-1] < full_cols, "bbox subset should reduce the column extent"
     finally:
         nc.close()
+
+
+class TestAntimeridianCrop:
+    """Crop a NetCDF variable with a geographic west > east (antimeridian) bbox."""
+
+    @staticmethod
+    def _global_variable(top_left_x=-180.0):
+        """Return (source array, global NetCDF variable) for the given lon origin."""
+        arr = np.arange(180 * 360, dtype="float32").reshape(180, 360)
+        nc = NetCDF.create_from_array(
+            arr=arr,
+            geo=(top_left_x, 1.0, 0.0, 90.0, 0.0, -1.0),
+            epsg=4326,
+            variable_name="v",
+        )
+        return arr, nc.get_variable("v")
+
+    def test_strip_values_and_extent(self):
+        """A -180..180 variable crop across the dateline stitches a contiguous strip."""
+        arr, var = self._global_variable()
+        strip = var.crop(bbox=(170.0, -10.0, -170.0, 10.0))
+        assert isinstance(strip, NetCDF), "result stays a NetCDF variable"
+        assert strip.shape == (1, 20, 20), "20 lat x 20 lon strip"
+        expected = np.concatenate([arr[80:100, 350:360], arr[80:100, 0:10]], axis=-1)
+        got = np.asarray(strip.read_array())
+        assert np.array_equal(got, expected), "seam values preserved"
+
+    def test_on_0_360_grid(self):
+        """A 0..360 variable crops the same STAC bbox as a contiguous 170..190 strip."""
+        arr, var = self._global_variable(top_left_x=0.0)
+        strip = var.crop(bbox=(170.0, -10.0, -170.0, 10.0))
+        got = np.asarray(strip.read_array())
+        assert np.array_equal(got, arr[80:100, 170:190]), "0..360 values preserved"
+
+    def test_normal_bbox_unchanged(self):
+        """A west < east bbox still crops normally and returns a NetCDF."""
+        _, var = self._global_variable()
+        out = var.crop(bbox=(10.0, -10.0, 30.0, 10.0))
+        assert isinstance(out, NetCDF), "normal crop stays a NetCDF"
+        assert out.shape == (1, 20, 20), "normal crop shape"
+
+    def test_no_overlap_raises(self):
+        """An antimeridian bbox disjoint from the variable's longitudes raises."""
+        arr = np.arange(180 * 50, dtype="float32").reshape(180, 50)
+        nc = NetCDF.create_from_array(
+            arr=arr,
+            geo=(0.0, 1.0, 0.0, 90.0, 0.0, -1.0),
+            epsg=4326,
+            variable_name="v",
+        )  # lon 0..50 only
+        with pytest.raises(ValueError, match="does not overlap"):
+            nc.get_variable("v").crop(bbox=(170.0, -10.0, -170.0, 10.0))

--- a/tests/netcdf/spatial/test_netcdf_bbox.py
+++ b/tests/netcdf/spatial/test_netcdf_bbox.py
@@ -213,17 +213,19 @@ class TestNetCDFCropMutex:
             root_nc.crop()
 
     def test_invalid_bbox_raises_value_error(self, root_nc: NetCDF):
-        """Test ``W>=E`` / ``S>=N`` bbox raises ``ValueError`` via FC.from_bbox.
+        """Test a ``south >= north`` bbox raises ``ValueError`` via FC.from_bbox.
 
         Args:
             root_nc: Module-scope root NetCDF fixture.
 
         Test scenario:
-            Validation lives in ``FeatureCollection.from_bbox``; the
-            NetCDF override must surface that error unchanged.
+            Validation lives in ``FeatureCollection.from_bbox``; the NetCDF
+            override must surface that error unchanged. Uses ``south >= north``
+            (still always invalid) rather than ``west >= east``, which is now the
+            STAC antimeridian convention on a geographic grid.
         """
         with pytest.raises(ValueError):
-            root_nc.crop(bbox=(50.0, -50.0, 10.0, -20.0))  # west >= east
+            root_nc.crop(bbox=(10.0, -20.0, 50.0, -50.0))  # south >= north
 
     def test_crs_less_netcdf_without_epsg_raises(self, root_nc: NetCDF, mocker):
         """Test ``crop(bbox=…)`` on a CRS-less NetCDF raises a clear ``ValueError``.


### PR DESCRIPTION
# Description

`Dataset.crop` / `NetCDF.crop` could not crop with a bounding box straddling the **antimeridian** — a
STAC-convention bbox where `west > east`, e.g. `(170, -10, -170, 10)`. Every bbox was routed through
`FeatureCollection.from_bbox`, which hard-rejects `west >= east` (`ValueError: bbox must satisfy west < east`), so
the `split_antimeridian` primitive (already shipped in `feature/bbox.py`) was wired to nothing.

Both crop paths now detect a **geographic** `west > east` bbox and:
1. split it at the grid's longitude seam (`180` on a `-180..180` grid, `360` on a `0..360` grid — reusing
   `split_antimeridian` for the former),
2. crop each `west < east` half through the normal path,
3. concatenate the halves along longitude into one contiguous strip whose coordinates continue past the seam
   (`170..190`).

Halves outside the dataset's longitude extent are skipped (single-sided overlap returns just that half; a disjoint
bbox raises). A **projected** `west > east` bbox is not an antimeridian case, so `from_bbox` still validates there.

- **`Dataset` / `spatial.crop`** — the affine warp path; the merged strip is built via
  `Dataset.create_from_array` on `west`'s geotransform.
- **`NetCDF` / `selection.crop`** (variable subset) — intercepted before the mask is built; the merged raster is
  re-wrapped via `_preserve_netcdf_metadata` so it stays a `NetCDF` variable (band dims, `sel`).
- **`NetCDF` root container** — the antimeridian bbox fans out across every gridded variable
  (`_apply_to_all_variables`); each variable splits in its own longitude frame and stitches/masks itself, and the
  results reassemble into a container.
- **`NetCDF` curvilinear (2-D coordinate) variable** — there is no affine seam to stitch, so the split halves
  become a polygon mask over the 2-D `lon`/`lat` arrays (a `MultiPolygon` on a `-180..180` grid, one box on a
  `0..360` grid), handed to the existing curvilinear point-in-polygon mask + window. The wrap is handled by the
  mask, so no concatenation is needed; `chunks=` still flows through to the lazy windowed read.

> **Stacked PR:** based on `feat/grib-to-cog` (#690). Re-targets to `main` automatically once that merges.

## Scope

Covers every crop path: `Dataset.crop`, `NetCDF` **variable** crop (rectilinear and curvilinear), and `NetCDF`
**root-container** crop, on `-180..180` and `0..360` grids. The pure seam-split lives in `_split_lon_bbox`, shared
by the rectilinear (affine-frame) and curvilinear (2-D-lon) paths. A **projected** `west > east` bbox is not an
antimeridian case, so `from_bbox` still validates there.

# Issues

- Closes #686

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] `Dataset.crop(bbox=(170,-10,-170,10))` on a global `-180..180` grid returns a contiguous 20×20 strip with
      byte-for-byte correct seam values and a `[170,-10,190,10]` extent; `0..360` grids and multi-band grids too.
- [x] `NetCDF.get_variable(v).crop(bbox=(170,-10,-170,10))` returns a `NetCDF` variable strip with the same
      correct values/extent on `-180..180` and `0..360` grids.
- [x] **Root container:** a container antimeridian crop keeps every variable, each a correct seam strip
      (byte-for-byte on a two-variable global grid); `chunks=` is rejected there.
- [x] **Curvilinear:** the 0..360 rasm grid windows across the 180 seam and stays curvilinear; a synthetic
      `-180..180` grid crossing the dateline masks cells on **both** sides via the `MultiPolygon` split.
- [x] Single-sided overlap returns the one half; a disjoint bbox raises `does not overlap`; a projected
      `west>east` still raises the `west < east` validator; `west < east` crops are unchanged.
- [x] `tests/dataset/spatial/` and `tests/netcdf/samples/` (crop / selection / curvilinear) stay green,
      including doctests on the changed modules (`713 passed, 31 skipped`).

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen handles versions)
- [ ] added changes to History.rst. (changelog is commitizen-generated)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (crop docstrings: bbox note + antimeridian example)

