### PR TITLE
feat(wheels): publish the win_arm64 wheels with a vendored vector stack

### DIFF
--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -682,10 +682,16 @@ jobs:
           PYTAG="cp$(echo '${{ matrix.python-version }}' | tr -d .)"
           WHEEL=$(ls wheelhouse/pyramids_gis-*${PYTAG}*win_arm64.whl)
           pip install "${WHEEL}"
-          pip install pytest pytest-env pytest-mock pytest-timeout
 
+      # Runs against the bare install closure, BEFORE the test deps land:
+      # pytest itself requires `packaging`, which the vendored geopandas
+      # imports at runtime, so installing pytest first masked a hole in
+      # the wheel's own dependency closure (caught in PR #695 review).
       - name: Verify GDAL import + drivers (vector stack, netCDF, JP2, TLS)
         run: python ci/verify-wheel.py
+
+      - name: Install test dependencies
+        run: pip install pytest pytest-env pytest-mock pytest-timeout
 
       - name: Run hermetic core test suite
         if: matrix.python-version == '3.12'

--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -329,16 +329,15 @@ jobs:
           path: wheelhouse/*.whl
           retention-days: 3
 
-  # Windows-on-ARM canary (#334, not published). conda-forge has no
+  # Windows-on-ARM wheels (#334, PUBLISHED). conda-forge has no
   # win-arm64 GDAL, so the stack builds from source via vcpkg
   # (ci/vcpkg.json + ci/setup-gdal-from-vcpkg.ps1, staging the same
   # C:/gdal-prefix/Library layout the conda path produces — only
-  # before-all differs from the AMD64 job). Publishing is blocked on
-  # upstream: shapely (hard dependency) and pyogrio (via geopandas) ship
-  # no win_arm64 wheels, so pip cannot resolve pyramids-gis on this
-  # platform yet; both are canary-built here against the same prefix so
-  # verify-winarm64 can run the full suite. cp311 is excluded — numpy and
-  # scipy ship no cp311 win_arm64 wheels.
+  # before-all differs from the AMD64 job). shapely and pyogrio ship no
+  # win_arm64 wheels upstream, so the dependency markers skip them (and
+  # geopandas) on this platform and install-and-vendor-osgeo.py vendors
+  # the whole vector stack into the wheel per Python version. cp311 is
+  # excluded — numpy and scipy ship no cp311 win_arm64 wheels.
   build-winarm64-wheels:
     if: >-
       github.event_name != 'workflow_run' ||
@@ -358,11 +357,12 @@ jobs:
         with:
           python-version: "3.12"
 
-      # Like the musl canaries, this cache is NOT gated off workflow_run:
-      # win_arm64 wheels are never published (excluded from the release
-      # gather + rejected by the composition gate), so cache-restored
-      # binaries can't reach PyPI from here.
+      # Skipped on release (workflow_run) builds like the glibc job:
+      # these wheels publish to PyPI now, so release artifacts always
+      # cold-build from the pinned vcpkg snapshot instead of restoring
+      # cache-stored binaries.
       - name: Cache the vcpkg-built GDAL stack
+        if: github.event_name != 'workflow_run'
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: C:\vcpkg\installed
@@ -381,39 +381,13 @@ jobs:
         shell: bash
         run: bash ci/check-wheel-size.sh wheelhouse
 
-      - name: Build canary shapely + pyogrio wheels
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          # Fail on native-command errors too: $ErrorActionPreference alone
-          # does not stop pwsh when pip/delvewheel exit non-zero, which let
-          # a failed `pip wheel` surface one job later as an unmatched glob.
-          $PSNativeCommandUseErrorActionPreference = $true
-          $env:GEOS_INCLUDE_PATH = "C:/gdal-prefix/Library/include"
-          $env:GEOS_LIBRARY_PATH = "C:/gdal-prefix/Library/lib"
-          $env:GDAL_INCLUDE_PATH = "C:/gdal-prefix/Library/include"
-          $env:GDAL_LIBRARY_PATH = "C:/gdal-prefix/Library/lib"
-          $env:GDAL_VERSION = Get-Content "C:/gdal-prefix/GDAL_VERSION"
-          $env:PATH = "C:/gdal-prefix/Library/bin;$env:PATH"
-          python -m pip install delvewheel
-          python -m pip wheel "shapely==2.1.2" --no-deps --no-binary shapely -w canary-raw
-          python -m pip wheel "pyogrio==0.13.0" --no-deps --no-binary pyogrio -w canary-raw
-          New-Item -ItemType Directory -Force -Path canary-deps-wheelhouse | Out-Null
-          Get-ChildItem canary-raw/*.whl | ForEach-Object {
-            delvewheel repair --add-path C:/gdal-prefix/Library/bin -w canary-deps-wheelhouse $_.FullName
-            if ($LASTEXITCODE -ne 0) { throw "delvewheel repair failed for $($_.Name)" }
-          }
-          Get-ChildItem canary-deps-wheelhouse
-
+      # The vector stack (shapely/pyogrio/geopandas) is vendored inside
+      # each wheel by install-and-vendor-osgeo.py during before-build —
+      # no separate canary wheels exist anymore.
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: canary-winarm64
+          name: wheels-winarm64
           path: wheelhouse/*.whl
-
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: canary-deps-winarm64
-          path: canary-deps-wheelhouse/*.whl
 
 
   test-wheels:
@@ -667,16 +641,22 @@ jobs:
           tests/base tests/netcdf tests/io
           tests/dataset tests/feature
 
-  # Native win_arm64 verification (no emulation — the runner executes its
-  # own arch): wheel + canary shapely/pyogrio installed, geopandas
-  # resolves normally against them, then verify-wheel (drivers, netCDF,
-  # JP2, schannel TLS) + the full hermetic core suite.
+  # Native win_arm64 verification (no emulation — the runner executes
+  # its own arch), one cell per shipped Python: a bare `pip install
+  # <wheel>` must resolve on its own (the dependency markers skip
+  # shapely/geopandas; the wheel vendors them), then verify-wheel checks
+  # drivers, the vendored vector stack, licenses, netCDF, JP2, and
+  # schannel TLS. The full hermetic suite runs once, on 3.12.
   verify-winarm64:
     needs: build-winarm64-wheels
     runs-on: windows-11-arm
     permissions:
       contents: read
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -684,30 +664,26 @@ jobs:
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: canary-winarm64
+          name: wheels-winarm64
           path: wheelhouse
 
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
-        with:
-          name: canary-deps-winarm64
-          path: canary-deps-wheelhouse
-
-      - name: Install wheel + canary deps
+      - name: Install wheel (plain pip resolution — the real user path)
         shell: bash
         run: |
-          pip install canary-deps-wheelhouse/shapely-*.whl canary-deps-wheelhouse/pyogrio-*.whl
-          WHEEL=$(ls wheelhouse/pyramids_gis-*cp312*win_arm64.whl)
+          PYTAG="cp$(echo '${{ matrix.python-version }}' | tr -d .)"
+          WHEEL=$(ls wheelhouse/pyramids_gis-*${PYTAG}*win_arm64.whl)
           pip install "${WHEEL}"
           pip install pytest pytest-env pytest-mock pytest-timeout
 
-      - name: Verify GDAL import + drivers (netCDF, JP2, TLS)
+      - name: Verify GDAL import + drivers (vector stack, netCDF, JP2, TLS)
         run: python ci/verify-wheel.py
 
       - name: Run hermetic core test suite
+        if: matrix.python-version == '3.12'
         shell: bash
         timeout-minutes: 15
         run: >-
@@ -716,13 +692,13 @@ jobs:
 
   release:
     name: Publish to PyPI + attach to GitHub release
-    # NOTE: the canary wheels stay UNPUBLISHED (their `canary-*` artifacts
-    # can't match the download pattern and the composition gate rejects
-    # them) until upstream unblocks: musl on pyogrio musllinux wheels
-    # (#333), win_arm64 on shapely + pyogrio arm64 wheels (#334). Their
-    # verify jobs DO gate the release, though — maintainer decision after
-    # 0.40.0 published with verify-alpine red (a run-level failure is not
-    # loud enough on a release).
+    # NOTE: the musl canary wheels stay UNPUBLISHED (their `canary-*`
+    # artifacts can't match the download pattern and the composition gate
+    # rejects them) until upstream pyogrio ships musllinux wheels (#333).
+    # win_arm64 wheels PUBLISH as of #334's graduation (the wheel vendors
+    # its vector stack). Every verify job gates the release, canaries
+    # included — maintainer decision after 0.40.0 published with
+    # verify-alpine red (a run-level failure is not loud enough).
     needs: [build-sdist, build-linux-wheels, build-macos-wheels,
             build-windows-wheels, test-wheels, verify-debian12, verify-rocky9,
             verify-rocky9-aarch64, verify-alpine, verify-winarm64]
@@ -778,17 +754,18 @@ jobs:
             echo "ERROR: musl canaries are unpublished by policy (#333) but reached dist/:" >&2
             printf '%s\n' "${musl[@]}" >&2; fail=1
           fi
-          winarm=(dist/*win_arm64*.whl)
-          if [ "${#winarm[@]}" -ne 0 ]; then
-            echo "ERROR: win_arm64 canaries are unpublished by policy (#334) but reached dist/:" >&2
-            printf '%s\n' "${winarm[@]}" >&2; fail=1
-          fi
           wheels=(dist/*.whl)
           pyvers=$(printf '%s\n' "${wheels[@]}" | grep -oE 'cp3[0-9]+' | sort -u | wc -l)
           if [ "${pyvers}" -lt 4 ]; then
             echo "ERROR: only ${pyvers} distinct CPython tags in dist/ (expected >= 4)" >&2; fail=1
           fi
+          winarm=(dist/*win_arm64*.whl)
+          if [ "${#winarm[@]}" -ne $((pyvers - 1)) ]; then
+            echo "ERROR: expected $((pyvers - 1)) win_arm64 wheels (cp311 excluded — no" >&2
+            echo "       numpy/scipy ARM64 wheels), found ${#winarm[@]}" >&2; fail=1
+          fi
           for tag in manylinux_2_28_x86_64 manylinux_2_28_aarch64 "macosx*x86_64" "macosx*arm64" win_amd64; do
+            # win_arm64 is asserted separately above (pyvers - 1 wheels).
             plat=(dist/*${tag}.whl)
             if [ "${#plat[@]}" -ne "${pyvers}" ]; then
               echo "ERROR: expected ${pyvers} ${tag} wheels (one per CPython tag), found ${#plat[@]}" >&2
@@ -799,7 +776,8 @@ jobs:
             echo "release composition check FAILED — nothing was published" >&2
             exit 1
           fi
-          echo "release composition OK: 1 sdist + ${#wheels[@]} wheels (${pyvers} CPython x 5 platforms)"
+          echo "release composition OK: 1 sdist + ${#wheels[@]} wheels" \
+            "(${pyvers} CPython x 5 platforms + $((pyvers - 1)) win_arm64)"
 
       - name: Dry run stops here — gather + gate passed, nothing published
         if: github.event_name == 'workflow_dispatch'

--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -374,6 +374,10 @@ jobs:
         uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
         env:
           CIBW_ARCHS_WINDOWS: ARM64
+          # No cp311: numpy/scipy ship no ARM64 cp311 wheels. The release
+          # composition gate expects one fewer win_arm64 wheel than the
+          # other platforms (`pyvers - 1`) — keep the two in step when
+          # this list changes (e.g. adding cp315 or dropping cp311).
           CIBW_BUILD: "cp312-win_arm64 cp313-win_arm64 cp314-win_arm64"
           CIBW_BEFORE_ALL_WINDOWS: powershell -File ci/setup-gdal-from-vcpkg.ps1
 
@@ -388,6 +392,7 @@ jobs:
         with:
           name: wheels-winarm64
           path: wheelhouse/*.whl
+          retention-days: 3
 
 
   test-wheels:
@@ -759,6 +764,9 @@ jobs:
           if [ "${pyvers}" -lt 4 ]; then
             echo "ERROR: only ${pyvers} distinct CPython tags in dist/ (expected >= 4)" >&2; fail=1
           fi
+          # `pyvers - 1` mirrors the explicit CIBW_BUILD list in
+          # build-winarm64-wheels (cp312-cp314, no cp311) — see the
+          # comment there; the two must change together.
           winarm=(dist/*win_arm64*.whl)
           if [ "${#winarm[@]}" -ne $((pyvers - 1)) ]; then
             echo "ERROR: expected $((pyvers - 1)) win_arm64 wheels (cp311 excluded — no" >&2

--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -691,6 +691,7 @@ jobs:
         run: python ci/verify-wheel.py
 
       - name: Install test dependencies
+        if: matrix.python-version == '3.12'
         run: pip install pytest pytest-env pytest-mock pytest-timeout
 
       - name: Run hermetic core test suite

--- a/ci/install-and-vendor-osgeo.py
+++ b/ci/install-and-vendor-osgeo.py
@@ -768,6 +768,30 @@ def vendor_vector_stack_into_package() -> None:
     )
 
 
+def remove_stale_vector_stack() -> None:
+    """Drop vector-stack leftovers when NOT building for win_arm64.
+
+    vendor_vector_stack_into_package() writes into the source tree, and
+    the package-data globs shipping `_vendor/{shapely,geopandas,pyogrio}`
+    are unconditional — a leftover from an earlier win_arm64 build (e.g.
+    a local cibuildwheel experiment) would silently ride into every other
+    platform's wheel built from the same tree. Delete rather than trust;
+    ci/verify-wheel.py asserts the same absence on the consuming side.
+    """
+    src_pyramids = REPO_ROOT / "src" / "pyramids"
+    for pkg in _VECTOR_STACK_PINS:
+        for stale in (
+            src_pyramids / "_vendor" / pkg,
+            src_pyramids / "_licenses" / pkg,
+        ):
+            if stale.is_dir():
+                print(
+                    f"[install-and-vendor-osgeo] removing stale {stale}",
+                    flush=True,
+                )
+                shutil.rmtree(stale)
+
+
 def main() -> None:
     if os.environ.get("PACKAGE_DATA") != "1":
         print("[install-and-vendor-osgeo] PACKAGE_DATA != 1; skipping.", flush=True)
@@ -776,6 +800,8 @@ def main() -> None:
     vendor_osgeo_into_package()
     if _is_win_arm64():
         vendor_vector_stack_into_package()
+    else:
+        remove_stale_vector_stack()
     print("[install-and-vendor-osgeo] done.", flush=True)
 
 

--- a/ci/install-and-vendor-osgeo.py
+++ b/ci/install-and-vendor-osgeo.py
@@ -711,6 +711,65 @@ def _is_win_arm64() -> bool:
     return result
 
 
+def _copy_dist_info_licenses(dist_info: Path, src_pyramids: Path) -> None:
+    """Ship a vendored package's license texts under `_licenses/<pkg>/`.
+
+    The metadata dir itself stays out of the wheel — only the license
+    files ride along, next to the other bundled third-party notices.
+    """
+    pkg = dist_info.name.split("-", 1)[0]
+    for license_file in dist_info.rglob("LICENSE*"):
+        # Windows globbing is case-insensitive, so "LICENSE*" also
+        # matches PEP 639's `licenses/` DIRECTORY — copy only the
+        # files (rglob descends into the dir anyway).
+        if not license_file.is_file():
+            continue
+        dst = src_pyramids / "_licenses" / pkg / license_file.name
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(license_file, dst)
+
+
+def _copy_vector_stack_tree(
+    target: Path, src_pyramids: Path, vendor_dir: Path
+) -> list:
+    """Copy a pip --target tree's packages into `_vendor/`, licenses too.
+
+    Returns the vendored top-level package names.
+    """
+    vendored = []
+    for entry in sorted(target.iterdir()):
+        if entry.name.endswith(".dist-info"):
+            _copy_dist_info_licenses(entry, src_pyramids)
+        elif entry.is_dir() and entry.name not in ("bin", "__pycache__"):
+            _copy_tree_replacing(entry, vendor_dir / entry.name)
+            vendored.append(entry.name)
+    return vendored
+
+
+def _assert_vector_stack_complete(vendored: list, src_pyramids: Path) -> None:
+    """Hard-fail unless every pinned package vendored with a license.
+
+    The wheel redistributes these packages' binaries, so shipping their
+    license texts is a hard requirement, not best-effort — and the
+    wheel-level check only asserts a total dir count, which the
+    vcpkg-staged licenses alone satisfy. Fail here if a pin's dist-info
+    stopped matching the LICENSE* glob (e.g. a rename to COPYING or a
+    new PEP 639 layout).
+    """
+    for required in ("shapely", "pyogrio", "geopandas"):
+        if required not in vendored:
+            raise RuntimeError(
+                f"vector-stack vendoring did not produce _vendor/{required} "
+                f"(got: {vendored})"
+            )
+        license_dir = src_pyramids / "_licenses" / required
+        if not license_dir.is_dir() or not any(license_dir.iterdir()):
+            raise RuntimeError(
+                f"vector-stack vendoring shipped no license text for "
+                f"{required} under {license_dir}"
+            )
+
+
 def vendor_vector_stack_into_package() -> None:
     """Vendor shapely + pyogrio + geopandas into the win_arm64 wheel.
 
@@ -789,46 +848,9 @@ def vendor_vector_stack_into_package() -> None:
             env=env,
         )
 
-        vendored = []
-        for entry in sorted(target.iterdir()):
-            if entry.name.endswith(".dist-info"):
-                # Ship the license texts alongside the other bundled
-                # notices; the metadata dir itself stays out of the wheel.
-                pkg = entry.name.split("-", 1)[0]
-                for license_file in entry.rglob("LICENSE*"):
-                    # Windows globbing is case-insensitive, so "LICENSE*"
-                    # also matches PEP 639's `licenses/` DIRECTORY — copy
-                    # only the files (rglob descends into the dir anyway).
-                    if not license_file.is_file():
-                        continue
-                    dst = src_pyramids / "_licenses" / pkg / license_file.name
-                    dst.parent.mkdir(parents=True, exist_ok=True)
-                    shutil.copy2(license_file, dst)
-                continue
-            if entry.name in ("bin", "__pycache__"):
-                continue
-            if entry.is_dir():
-                _copy_tree_replacing(entry, vendor_dir / entry.name)
-                vendored.append(entry.name)
+        vendored = _copy_vector_stack_tree(target, src_pyramids, vendor_dir)
 
-    for required in ("shapely", "pyogrio", "geopandas"):
-        if required not in vendored:
-            raise RuntimeError(
-                f"vector-stack vendoring did not produce _vendor/{required} "
-                f"(got: {vendored})"
-            )
-        # The wheel redistributes these packages' binaries, so shipping
-        # their license texts is a hard requirement, not best-effort —
-        # and the wheel-level check only asserts a total dir count, which
-        # the vcpkg-staged licenses alone satisfy. Fail here if a pin's
-        # dist-info stopped matching the LICENSE* glob (e.g. a rename to
-        # COPYING or a new PEP 639 layout).
-        license_dir = src_pyramids / "_licenses" / required
-        if not license_dir.is_dir() or not any(license_dir.iterdir()):
-            raise RuntimeError(
-                f"vector-stack vendoring shipped no license text for "
-                f"{required} under {license_dir}"
-            )
+    _assert_vector_stack_complete(vendored, src_pyramids)
     print(
         f"[install-and-vendor-osgeo] vendored vector stack: {', '.join(vendored)}",
         flush=True,

--- a/ci/install-and-vendor-osgeo.py
+++ b/ci/install-and-vendor-osgeo.py
@@ -43,6 +43,8 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # pure-Python geopandas wheel. pip --require-hashes rejects anything
 # else, mirroring the SHA256 pinning of the Linux from-source stack
 # (ci/source-build/config.sh); these are release inputs, not cache.
+# Known gap vs the Linux stack: the sdist compiles run under pip build
+# isolation, whose own deps (setuptools/Cython/numpy) float unpinned.
 _VECTOR_STACK_PINS = {
     "shapely": (
         "2.1.2",

--- a/ci/install-and-vendor-osgeo.py
+++ b/ci/install-and-vendor-osgeo.py
@@ -673,8 +673,40 @@ def _vendor_license_texts(pixi_env: Path, dst: Path) -> None:
 
 
 def _is_win_arm64() -> bool:
-    """Return True when building on/for Windows ARM64."""
-    return sys.platform == "win32" and platform.machine().upper() == "ARM64"
+    """Return True when this build TARGETS Windows ARM64.
+
+    The host arch (`platform.machine()`) decides by default — the
+    supported build topology is a native `windows-11-arm` runner. But
+    cibuildwheel can be asked to cross-build (CIBW_ARCHS[_WINDOWS]
+    names a different arch than the host), and the vendoring step
+    compiles shapely/pyogrio with the build interpreter, so host and
+    target must match:
+
+    - ARM64 requested on a non-ARM64 host: hard-fail. Silently skipping
+      would tag a wheel win_arm64 whose markers skip geopandas/shapely
+      AND that ships no vendored copies — it installs cleanly and dies
+      at `import geopandas`.
+    - non-ARM64 requested on an ARM64 host: return False, so the build
+      takes the stale-cleanup branch instead of vendoring ARM64 `.pyd`s
+      into a foreign wheel.
+    """
+    result = False
+    if sys.platform == "win32":
+        host_is_arm64 = platform.machine().upper() == "ARM64"
+        requested = (
+            os.environ.get("CIBW_ARCHS_WINDOWS")
+            or os.environ.get("CIBW_ARCHS")
+            or ""
+        ).upper()
+        if "ARM64" in requested and not host_is_arm64:
+            raise RuntimeError(
+                "win_arm64 wheels must be built on a native ARM64 host "
+                f"(host is {platform.machine()}): the vendored vector "
+                "stack is compiled with the build interpreter, so a "
+                "cross-build would ship wrong-arch binaries"
+            )
+        result = host_is_arm64 and ("ARM64" in requested or not requested)
+    return result
 
 
 def vendor_vector_stack_into_package() -> None:

--- a/ci/install-and-vendor-osgeo.py
+++ b/ci/install-and-vendor-osgeo.py
@@ -673,15 +673,20 @@ def vendor_vector_stack_into_package() -> None:
     1. build shapely + pyogrio from sdist for the CURRENT Python against
        the vcpkg prefix (GEOS/GDAL headers + import libs staged by
        ci/setup-gdal-from-vcpkg.ps1),
-    2. delvewheel-repair them so geos_c.dll / gdal.dll land in
-       `<pkg>.libs/` next to each package (delvewheel patches each
-       package __init__ to add that directory, and the patch resolves
-       relative to the package — it keeps working from `_vendor/`),
-    3. `pip install --target` the repaired wheels plus pure-Python
-       geopandas and copy the top-level entries into
-       `src/pyramids/_vendor/`, where the runtime bootstrap already
-       puts them on sys.path (the same mechanism as the vendored osgeo),
-    4. ship each package's license text under `_licenses/`.
+    2. `pip install --target` the RAW wheels plus pure-Python geopandas
+       and copy the top-level entries into `src/pyramids/_vendor/`,
+       where the runtime bootstrap already puts them on sys.path (the
+       same mechanism as the vendored osgeo),
+    3. ship each package's license text under `_licenses/`.
+
+    The vendored extension modules are deliberately NOT delvewheel-
+    repaired here: the wheel's own `delvewheel repair --analyze-existing`
+    pass walks every binary in the wheel, resolves their plain
+    geos_c.dll / gdal.dll imports from the vcpkg prefix, bundles ONE
+    shared copy of each into pyramids_gis.libs, and rewrites the import
+    tables. A pre-repaired (name-mangled) vendored binary breaks that
+    pass instead — it imports a gdal-<hash>.dll delvewheel cannot
+    resolve (observed: run 28782083527).
     """
     prefix = _build_prefix()
     bin_dir, _, lib_dir = _data_layout_roots(prefix)
@@ -699,7 +704,6 @@ def vendor_vector_stack_into_package() -> None:
 
     with tempfile.TemporaryDirectory(prefix="vector-stack-") as tmp:
         raw = Path(tmp) / "raw"
-        repaired = Path(tmp) / "repaired"
         target = Path(tmp) / "target"
         shapely_pin = f"shapely=={_VECTOR_STACK_PINS['shapely']}"
         pyogrio_pin = f"pyogrio=={_VECTOR_STACK_PINS['pyogrio']}"
@@ -718,19 +722,7 @@ def vendor_vector_stack_into_package() -> None:
             check=True,
             env=env,
         )
-        repaired.mkdir()
-        for wheel in sorted(raw.glob("*.whl")):
-            subprocess.run(
-                [
-                    sys.executable, "-m", "delvewheel", "repair",
-                    "--add-path", str(bin_dir),
-                    "-w", str(repaired),
-                    str(wheel),
-                ],
-                check=True,
-                env=env,
-            )
-        install = [str(w) for w in sorted(repaired.glob("*.whl"))]
+        install = [str(w) for w in sorted(raw.glob("*.whl"))]
         install.append(f"geopandas=={_VECTOR_STACK_PINS['geopandas']}")
         subprocess.run(
             [

--- a/ci/install-and-vendor-osgeo.py
+++ b/ci/install-and-vendor-osgeo.py
@@ -762,6 +762,18 @@ def vendor_vector_stack_into_package() -> None:
                 f"vector-stack vendoring did not produce _vendor/{required} "
                 f"(got: {vendored})"
             )
+        # The wheel redistributes these packages' binaries, so shipping
+        # their license texts is a hard requirement, not best-effort —
+        # and the wheel-level check only asserts a total dir count, which
+        # the vcpkg-staged licenses alone satisfy. Fail here if a pin's
+        # dist-info stopped matching the LICENSE* glob (e.g. a rename to
+        # COPYING or a new PEP 639 layout).
+        license_dir = src_pyramids / "_licenses" / required
+        if not license_dir.is_dir() or not any(license_dir.iterdir()):
+            raise RuntimeError(
+                f"vector-stack vendoring shipped no license text for "
+                f"{required} under {license_dir}"
+            )
     print(
         f"[install-and-vendor-osgeo] vendored vector stack: {', '.join(vendored)}",
         flush=True,

--- a/ci/install-and-vendor-osgeo.py
+++ b/ci/install-and-vendor-osgeo.py
@@ -749,6 +749,11 @@ def vendor_vector_stack_into_package() -> None:
                 # notices; the metadata dir itself stays out of the wheel.
                 pkg = entry.name.split("-", 1)[0]
                 for license_file in entry.rglob("LICENSE*"):
+                    # Windows globbing is case-insensitive, so "LICENSE*"
+                    # also matches PEP 639's `licenses/` DIRECTORY — copy
+                    # only the files (rglob descends into the dir anyway).
+                    if not license_file.is_file():
+                        continue
                     dst = src_pyramids / "_licenses" / pkg / license_file.name
                     dst.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy2(license_file, dst)

--- a/ci/install-and-vendor-osgeo.py
+++ b/ci/install-and-vendor-osgeo.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 import os
+import platform
 import shutil
 import subprocess
 import sys
@@ -29,6 +30,19 @@ import tempfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Vector stack vendored into the win_arm64 wheel ONLY (see
+# vendor_vector_stack_into_package): shapely and pyogrio ship no ARM64
+# wheels on PyPI, so pyramids' [project.dependencies] markers skip them
+# (and geopandas, which hard-requires pyogrio) on that platform and the
+# wheel carries its own copies instead. Exact pins so a rebuild is
+# reproducible; bump deliberately, and DELETE this whole mechanism when
+# upstream ships win_arm64 wheels (then also drop the pyproject markers).
+_VECTOR_STACK_PINS = {
+    "shapely": "2.1.2",
+    "pyogrio": "0.13.0",
+    "geopandas": "1.1.4",
+}
 
 
 def _gdal_version() -> str:
@@ -644,12 +658,127 @@ def _vendor_license_texts(pixi_env: Path, dst: Path) -> None:
     )
 
 
+def _is_win_arm64() -> bool:
+    """Return True when building on/for Windows ARM64."""
+    return sys.platform == "win32" and platform.machine().upper() == "ARM64"
+
+
+def vendor_vector_stack_into_package() -> None:
+    """Vendor shapely + pyogrio + geopandas into the win_arm64 wheel.
+
+    Neither shapely nor pyogrio publishes win_arm64 wheels, so the
+    platform markers in `[project.dependencies]` skip them (and
+    geopandas) there and this function supplies the wheel's own copies:
+
+    1. build shapely + pyogrio from sdist for the CURRENT Python against
+       the vcpkg prefix (GEOS/GDAL headers + import libs staged by
+       ci/setup-gdal-from-vcpkg.ps1),
+    2. delvewheel-repair them so geos_c.dll / gdal.dll land in
+       `<pkg>.libs/` next to each package (delvewheel patches each
+       package __init__ to add that directory, and the patch resolves
+       relative to the package — it keeps working from `_vendor/`),
+    3. `pip install --target` the repaired wheels plus pure-Python
+       geopandas and copy the top-level entries into
+       `src/pyramids/_vendor/`, where the runtime bootstrap already
+       puts them on sys.path (the same mechanism as the vendored osgeo),
+    4. ship each package's license text under `_licenses/`.
+    """
+    prefix = _build_prefix()
+    bin_dir, _, lib_dir = _data_layout_roots(prefix)
+    include_dir = prefix / "Library" / "include"
+    src_pyramids = REPO_ROOT / "src" / "pyramids"
+    vendor_dir = src_pyramids / "_vendor"
+
+    env = os.environ.copy()
+    env["GEOS_INCLUDE_PATH"] = str(include_dir)
+    env["GEOS_LIBRARY_PATH"] = str(lib_dir)
+    env["GDAL_INCLUDE_PATH"] = str(include_dir)
+    env["GDAL_LIBRARY_PATH"] = str(lib_dir)
+    env["GDAL_VERSION"] = _gdal_version()
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+
+    with tempfile.TemporaryDirectory(prefix="vector-stack-") as tmp:
+        raw = Path(tmp) / "raw"
+        repaired = Path(tmp) / "repaired"
+        target = Path(tmp) / "target"
+        shapely_pin = f"shapely=={_VECTOR_STACK_PINS['shapely']}"
+        pyogrio_pin = f"pyogrio=={_VECTOR_STACK_PINS['pyogrio']}"
+        print(
+            f"[install-and-vendor-osgeo] building {shapely_pin} + {pyogrio_pin} "
+            "from sdist for the win_arm64 vector stack",
+            flush=True,
+        )
+        subprocess.run(
+            [
+                sys.executable, "-m", "pip", "wheel",
+                shapely_pin, pyogrio_pin,
+                "--no-deps", "--no-binary", "shapely,pyogrio",
+                "-w", str(raw),
+            ],
+            check=True,
+            env=env,
+        )
+        repaired.mkdir()
+        for wheel in sorted(raw.glob("*.whl")):
+            subprocess.run(
+                [
+                    sys.executable, "-m", "delvewheel", "repair",
+                    "--add-path", str(bin_dir),
+                    "-w", str(repaired),
+                    str(wheel),
+                ],
+                check=True,
+                env=env,
+            )
+        install = [str(w) for w in sorted(repaired.glob("*.whl"))]
+        install.append(f"geopandas=={_VECTOR_STACK_PINS['geopandas']}")
+        subprocess.run(
+            [
+                sys.executable, "-m", "pip", "install",
+                *install,
+                "--no-deps", "--target", str(target),
+            ],
+            check=True,
+            env=env,
+        )
+
+        vendored = []
+        for entry in sorted(target.iterdir()):
+            if entry.name.endswith(".dist-info"):
+                # Ship the license texts alongside the other bundled
+                # notices; the metadata dir itself stays out of the wheel.
+                pkg = entry.name.split("-", 1)[0]
+                for license_file in entry.rglob("LICENSE*"):
+                    dst = src_pyramids / "_licenses" / pkg / license_file.name
+                    dst.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(license_file, dst)
+                continue
+            if entry.name in ("bin", "__pycache__"):
+                continue
+            if entry.is_dir():
+                _copy_tree_replacing(entry, vendor_dir / entry.name)
+                vendored.append(entry.name)
+
+    for required in ("shapely", "pyogrio", "geopandas"):
+        if required not in vendored:
+            raise RuntimeError(
+                f"vector-stack vendoring did not produce _vendor/{required} "
+                f"(got: {vendored})"
+            )
+    print(
+        f"[install-and-vendor-osgeo] vendored vector stack: {', '.join(vendored)}",
+        flush=True,
+    )
+
+
 def main() -> None:
     if os.environ.get("PACKAGE_DATA") != "1":
         print("[install-and-vendor-osgeo] PACKAGE_DATA != 1; skipping.", flush=True)
         return
     install_gdal_python_bindings()
     vendor_osgeo_into_package()
+    if _is_win_arm64():
+        vendor_vector_stack_into_package()
     print("[install-and-vendor-osgeo] done.", flush=True)
 
 

--- a/ci/install-and-vendor-osgeo.py
+++ b/ci/install-and-vendor-osgeo.py
@@ -38,10 +38,24 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # wheel carries its own copies instead. Exact pins so a rebuild is
 # reproducible; bump deliberately, and DELETE this whole mechanism when
 # upstream ships win_arm64 wheels (then also drop the pyproject markers).
+# Each entry is (version, sha256) of the exact PyPI artifact fetched at
+# build time — the shapely/pyogrio sdists (compiled below) and the
+# pure-Python geopandas wheel. pip --require-hashes rejects anything
+# else, mirroring the SHA256 pinning of the Linux from-source stack
+# (ci/source-build/config.sh); these are release inputs, not cache.
 _VECTOR_STACK_PINS = {
-    "shapely": "2.1.2",
-    "pyogrio": "0.13.0",
-    "geopandas": "1.1.4",
+    "shapely": (
+        "2.1.2",
+        "2ed4ecb28320a433db18a5bf029986aa8afcfd740745e78847e330d5d94922a9",
+    ),
+    "pyogrio": (
+        "0.13.0",
+        "9614f27a1891113f80653e0b76b4233ea1fb3beeb1ac46d118ab22e1670f8f13",
+    ),
+    "geopandas": (
+        "1.1.4",
+        "1a0c459cbdb1537cd154dafe6174be20d1760844b7f1c967dc8520b180f2e773",
+    ),
 }
 
 
@@ -670,13 +684,15 @@ def vendor_vector_stack_into_package() -> None:
     platform markers in `[project.dependencies]` skip them (and
     geopandas) there and this function supplies the wheel's own copies:
 
-    1. build shapely + pyogrio from sdist for the CURRENT Python against
-       the vcpkg prefix (GEOS/GDAL headers + import libs staged by
-       ci/setup-gdal-from-vcpkg.ps1),
-    2. `pip install --target` the RAW wheels plus pure-Python geopandas
-       and copy the top-level entries into `src/pyramids/_vendor/`,
-       where the runtime bootstrap already puts them on sys.path (the
-       same mechanism as the vendored osgeo),
+    1. fetch the hash-pinned artifacts (`--require-hashes`) and build
+       shapely + pyogrio from sdist for the CURRENT Python against the
+       vcpkg prefix (GEOS/GDAL headers + import libs staged by
+       ci/setup-gdal-from-vcpkg.ps1); the pure-Python geopandas wheel
+       arrives through the same verified `pip wheel` run,
+    2. `pip install --target` the RAW wheels and copy the top-level
+       entries into `src/pyramids/_vendor/`, where the runtime
+       bootstrap already puts them on sys.path (the same mechanism as
+       the vendored osgeo),
     3. ship each package's license text under `_licenses/`.
 
     The vendored extension modules are deliberately NOT delvewheel-
@@ -705,29 +721,34 @@ def vendor_vector_stack_into_package() -> None:
     with tempfile.TemporaryDirectory(prefix="vector-stack-") as tmp:
         raw = Path(tmp) / "raw"
         target = Path(tmp) / "target"
-        shapely_pin = f"shapely=={_VECTOR_STACK_PINS['shapely']}"
-        pyogrio_pin = f"pyogrio=={_VECTOR_STACK_PINS['pyogrio']}"
+        requirements = Path(tmp) / "vector-stack-requirements.txt"
+        requirements.write_text(
+            "".join(
+                f"{pkg}=={version} --hash=sha256:{sha256}\n"
+                for pkg, (version, sha256) in _VECTOR_STACK_PINS.items()
+            ),
+            encoding="utf-8",
+        )
+        pins = ", ".join(f"{p}=={v}" for p, (v, _) in _VECTOR_STACK_PINS.items())
         print(
-            f"[install-and-vendor-osgeo] building {shapely_pin} + {pyogrio_pin} "
-            "from sdist for the win_arm64 vector stack",
+            f"[install-and-vendor-osgeo] building the win_arm64 vector stack "
+            f"({pins}) from hash-pinned PyPI artifacts",
             flush=True,
         )
         subprocess.run(
             [
                 sys.executable, "-m", "pip", "wheel",
-                shapely_pin, pyogrio_pin,
+                "-r", str(requirements), "--require-hashes",
                 "--no-deps", "--no-binary", "shapely,pyogrio",
                 "-w", str(raw),
             ],
             check=True,
             env=env,
         )
-        install = [str(w) for w in sorted(raw.glob("*.whl"))]
-        install.append(f"geopandas=={_VECTOR_STACK_PINS['geopandas']}")
         subprocess.run(
             [
                 sys.executable, "-m", "pip", "install",
-                *install,
+                *(str(w) for w in sorted(raw.glob("*.whl"))),
                 "--no-deps", "--target", str(target),
             ],
             check=True,

--- a/ci/verify-wheel.py
+++ b/ci/verify-wheel.py
@@ -343,13 +343,25 @@ def _check_vendored_vector_stack() -> None:
     own shapely + geopandas + pyogrio under `pyramids/_vendor/`. Importing
     each and checking the resolved path proves the bootstrap exposes them
     and their bundled GEOS/GDAL DLLs load (import executes the delvewheel
-    loader). A no-op elsewhere — those platforms install the real
-    distributions from PyPI.
+    loader). Elsewhere the check inverts: those platforms install the
+    real distributions from PyPI, so the wheel must ship NO vector stack
+    under `_vendor/` — a stale build tree would otherwise leak one in
+    (install-and-vendor-osgeo.py deletes leftovers on the build side).
     """
-    if _platform_slug() not in _VENDORED_VECTOR_PLATFORMS:
-        print("vendored-vector check skipped — platform installs the stack from PyPI.")
-        return
     vendor_root = (Path(pyramids.__file__).parent / "_vendor").resolve()
+    if _platform_slug() not in _VENDORED_VECTOR_PLATFORMS:
+        for pkg in ("shapely", "geopandas", "pyogrio"):
+            if (vendor_root / pkg).exists():
+                _fail(
+                    f"_vendor/{pkg} present in a {_platform_slug()} wheel — "
+                    "the vector stack is vendored on win_arm64 only; a stale "
+                    "build tree leaked into this wheel"
+                )
+        print(
+            "vendored-vector check OK — no vector stack in this wheel; "
+            "the platform installs it from PyPI."
+        )
+        return
     import geopandas
     import pyogrio
     import shapely

--- a/ci/verify-wheel.py
+++ b/ci/verify-wheel.py
@@ -43,6 +43,14 @@ import pyramids
 import osgeo
 from osgeo import gdal, ogr, osr  # noqa: F401 — ogr import is a smoke test
 
+# The same bootstrap-first constraint covers the vector stack: on
+# win_arm64 these three live under pyramids/_vendor and only resolve
+# after `import pyramids` (everywhere else they are real PyPI installs
+# pulled in by the wheel's dependencies).
+import geopandas
+import pyogrio
+import shapely
+
 # isort: on
 
 # Stable, valid-TLS HTTPS endpoint for the CA-trust check. Small text
@@ -362,10 +370,6 @@ def _check_vendored_vector_stack() -> None:
             "the platform installs it from PyPI."
         )
         return
-    import geopandas
-    import pyogrio
-    import shapely
-
     for module in (shapely, geopandas, pyogrio):
         resolved = Path(module.__file__).resolve()
         if not resolved.is_relative_to(vendor_root):

--- a/ci/verify-wheel.py
+++ b/ci/verify-wheel.py
@@ -358,7 +358,20 @@ def _check_vendored_vector_stack() -> None:
     """
     pkg_root = Path(pyramids.__file__).parent
     vendor_root = (pkg_root / "_vendor").resolve()
-    if _platform_slug() not in _VENDORED_VECTOR_PLATFORMS:
+    if _platform_slug() in _VENDORED_VECTOR_PLATFORMS:
+        for module in (shapely, geopandas, pyogrio):
+            resolved = Path(module.__file__).resolve()
+            if not resolved.is_relative_to(vendor_root):
+                _fail(
+                    f"{module.__name__} resolved to {resolved}, not the "
+                    f"vendored copy under {vendor_root}"
+                )
+        print(
+            "vendored vector stack OK — shapely "
+            f"{shapely.__version__}, geopandas {geopandas.__version__}, "
+            f"pyogrio {pyogrio.__version__} all import from _vendor."
+        )
+    else:
         # Mirror BOTH halves of the build-side cleanup contract
         # (remove_stale_vector_stack): package dirs and license dirs.
         for pkg in ("shapely", "geopandas", "pyogrio"):
@@ -374,19 +387,6 @@ def _check_vendored_vector_stack() -> None:
             "vendored-vector check OK — no vector stack in this wheel; "
             "the platform installs it from PyPI."
         )
-        return
-    for module in (shapely, geopandas, pyogrio):
-        resolved = Path(module.__file__).resolve()
-        if not resolved.is_relative_to(vendor_root):
-            _fail(
-                f"{module.__name__} resolved to {resolved}, not the vendored "
-                f"copy under {vendor_root}"
-            )
-    print(
-        "vendored vector stack OK — shapely "
-        f"{shapely.__version__}, geopandas {geopandas.__version__}, "
-        f"pyogrio {pyogrio.__version__} all import from _vendor."
-    )
 
 
 def _check_licenses() -> None:

--- a/ci/verify-wheel.py
+++ b/ci/verify-wheel.py
@@ -307,6 +307,10 @@ _HDF4_PLATFORMS = ("darwin", "win32-amd64")
 # Platforms whose curl uses the OS trust store (schannel) instead of a
 # vendored CA bundle — see _check_tls_read.
 _OS_TRUST_PLATFORMS = ("win32-arm64",)
+# Platforms whose wheel vendors the vector stack (shapely + geopandas +
+# pyogrio) because upstream ships no wheels there — see
+# _check_vendored_vector_stack.
+_VENDORED_VECTOR_PLATFORMS = ("win32-arm64",)
 
 
 def _platform_slug() -> str:
@@ -329,6 +333,39 @@ def _check_driver_set() -> None:
             + ", ".join(missing)
         )
     print(f"driver-set check OK — all {len(expected)} promised drivers registered.")
+
+
+def _check_vendored_vector_stack() -> None:
+    """Assert the vendored vector stack imports from `_vendor` where shipped.
+
+    On the platforms in `_VENDORED_VECTOR_PLATFORMS` the wheel's
+    dependency markers skip Shapely/geopandas, and the wheel carries its
+    own shapely + geopandas + pyogrio under `pyramids/_vendor/`. Importing
+    each and checking the resolved path proves the bootstrap exposes them
+    and their bundled GEOS/GDAL DLLs load (import executes the delvewheel
+    loader). A no-op elsewhere — those platforms install the real
+    distributions from PyPI.
+    """
+    if _platform_slug() not in _VENDORED_VECTOR_PLATFORMS:
+        print("vendored-vector check skipped — platform installs the stack from PyPI.")
+        return
+    vendor_root = (Path(pyramids.__file__).parent / "_vendor").resolve()
+    import geopandas
+    import pyogrio
+    import shapely
+
+    for module in (shapely, geopandas, pyogrio):
+        resolved = Path(module.__file__).resolve()
+        if not resolved.is_relative_to(vendor_root):
+            _fail(
+                f"{module.__name__} resolved to {resolved}, not the vendored "
+                f"copy under {vendor_root}"
+            )
+    print(
+        "vendored vector stack OK — shapely "
+        f"{shapely.__version__}, geopandas {geopandas.__version__}, "
+        f"pyogrio {pyogrio.__version__} all import from _vendor."
+    )
 
 
 def _check_licenses() -> None:
@@ -381,6 +418,7 @@ def _check_jp2_driver() -> None:
 
 
 _check_driver_set()
+_check_vendored_vector_stack()
 _check_licenses()
 _check_netcdf_driver()
 _check_jp2_driver()

--- a/ci/verify-wheel.py
+++ b/ci/verify-wheel.py
@@ -356,15 +356,20 @@ def _check_vendored_vector_stack() -> None:
     under `_vendor/` — a stale build tree would otherwise leak one in
     (install-and-vendor-osgeo.py deletes leftovers on the build side).
     """
-    vendor_root = (Path(pyramids.__file__).parent / "_vendor").resolve()
+    pkg_root = Path(pyramids.__file__).parent
+    vendor_root = (pkg_root / "_vendor").resolve()
     if _platform_slug() not in _VENDORED_VECTOR_PLATFORMS:
+        # Mirror BOTH halves of the build-side cleanup contract
+        # (remove_stale_vector_stack): package dirs and license dirs.
         for pkg in ("shapely", "geopandas", "pyogrio"):
-            if (vendor_root / pkg).exists():
-                _fail(
-                    f"_vendor/{pkg} present in a {_platform_slug()} wheel — "
-                    "the vector stack is vendored on win_arm64 only; a stale "
-                    "build tree leaked into this wheel"
-                )
+            for stale in (vendor_root / pkg, pkg_root / "_licenses" / pkg):
+                if stale.exists():
+                    _fail(
+                        f"{stale.relative_to(pkg_root)} present in a "
+                        f"{_platform_slug()} wheel — the vector stack is "
+                        "vendored on win_arm64 only; a stale build tree "
+                        "leaked into this wheel"
+                    )
         print(
             "vendored-vector check OK — no vector stack in this wheel; "
             "the platform installs it from PyPI."

--- a/ci/verify-wheel.py
+++ b/ci/verify-wheel.py
@@ -359,34 +359,46 @@ def _check_vendored_vector_stack() -> None:
     pkg_root = Path(pyramids.__file__).parent
     vendor_root = (pkg_root / "_vendor").resolve()
     if _platform_slug() in _VENDORED_VECTOR_PLATFORMS:
-        for module in (shapely, geopandas, pyogrio):
-            resolved = Path(module.__file__).resolve()
-            if not resolved.is_relative_to(vendor_root):
-                _fail(
-                    f"{module.__name__} resolved to {resolved}, not the "
-                    f"vendored copy under {vendor_root}"
-                )
-        print(
-            "vendored vector stack OK — shapely "
-            f"{shapely.__version__}, geopandas {geopandas.__version__}, "
-            f"pyogrio {pyogrio.__version__} all import from _vendor."
-        )
+        _assert_vector_stack_vendored(vendor_root)
     else:
-        # Mirror BOTH halves of the build-side cleanup contract
-        # (remove_stale_vector_stack): package dirs and license dirs.
-        for pkg in ("shapely", "geopandas", "pyogrio"):
-            for stale in (vendor_root / pkg, pkg_root / "_licenses" / pkg):
-                if stale.exists():
-                    _fail(
-                        f"{stale.relative_to(pkg_root)} present in a "
-                        f"{_platform_slug()} wheel — the vector stack is "
-                        "vendored on win_arm64 only; a stale build tree "
-                        "leaked into this wheel"
-                    )
-        print(
-            "vendored-vector check OK — no vector stack in this wheel; "
-            "the platform installs it from PyPI."
-        )
+        _assert_vector_stack_absent(pkg_root, vendor_root)
+
+
+def _assert_vector_stack_vendored(vendor_root: Path) -> None:
+    """Fail unless shapely/geopandas/pyogrio resolve from `_vendor`."""
+    for module in (shapely, geopandas, pyogrio):
+        resolved = Path(module.__file__).resolve()
+        if not resolved.is_relative_to(vendor_root):
+            _fail(
+                f"{module.__name__} resolved to {resolved}, not the "
+                f"vendored copy under {vendor_root}"
+            )
+    print(
+        "vendored vector stack OK — shapely "
+        f"{shapely.__version__}, geopandas {geopandas.__version__}, "
+        f"pyogrio {pyogrio.__version__} all import from _vendor."
+    )
+
+
+def _assert_vector_stack_absent(pkg_root: Path, vendor_root: Path) -> None:
+    """Fail if a stale vendored vector stack leaked into this wheel.
+
+    Mirrors BOTH halves of the build-side cleanup contract
+    (remove_stale_vector_stack): package dirs and license dirs.
+    """
+    for pkg in ("shapely", "geopandas", "pyogrio"):
+        for stale in (vendor_root / pkg, pkg_root / "_licenses" / pkg):
+            if stale.exists():
+                _fail(
+                    f"{stale.relative_to(pkg_root)} present in a "
+                    f"{_platform_slug()} wheel — the vector stack is "
+                    "vendored on win_arm64 only; a stale build tree "
+                    "leaked into this wheel"
+                )
+    print(
+        "vendored-vector check OK — no vector stack in this wheel; "
+        "the platform installs it from PyPI."
+    )
 
 
 def _check_licenses() -> None:

--- a/docs/how-to/wheel-build-flow.md
+++ b/docs/how-to/wheel-build-flow.md
@@ -72,7 +72,8 @@ pyramids_gis-0.40.0-cp314-cp314-manylinux_2_28_aarch64.whl    # Linux aarch64 3.
 pyramids_gis-0.40.0-cp311-cp311-macosx_11_0_arm64.whl         # macOS arm64 3.11
 pyramids_gis-0.40.0-cp311-cp311-macosx_11_0_x86_64.whl        # macOS x86_64 3.11
 ...
-pyramids_gis-0.40.0-cp314-cp314-win_amd64.whl                 # Windows 3.14
+pyramids_gis-0.40.0-cp314-cp314-win_amd64.whl                 # Windows x64 3.14
+pyramids_gis-0.40.0-cp312-cp312-win_arm64.whl                 # Windows ARM64 3.12
 pyramids_gis-0.40.0.tar.gz                                    # sdist
 ```
 
@@ -97,8 +98,11 @@ PyPI — no compiler, no system GDAL, no conda required:
 | macOS arm64, ≥ 11.0 | `macosx_11_0_arm64` | M1 / M2 / M3 / M4 Macs on macOS 11+ |
 | macOS x86_64, ≥ 11.0 | `macosx_11_0_x86_64` | Intel Macs on macOS 11+ (cross-compiled — see note) |
 | Windows AMD64 | `win_amd64` | Windows 10+ on x64 hardware |
+| Windows ARM64 | `win_arm64` | Windows 11 on ARM64 (Snapdragon X, Volterra, VMs on Apple Silicon) |
 
-All five platform wheels exist for Python **3.11, 3.12, 3.13, and 3.14**.
+All platform wheels exist for Python **3.11, 3.12, 3.13, and 3.14**,
+except `win_arm64`, which ships **3.12–3.14** (numpy/scipy publish no
+cp311 ARM64 wheels).
 
 > **macOS x86_64 caveat**: the wheel is cross-compiled on the
 > `macos-14` (arm64) runner because GitHub's `macos-13` (Intel) queue
@@ -107,9 +111,10 @@ All five platform wheels exist for Python **3.11, 3.12, 3.13, and 3.14**.
 > If you're on an Intel Mac and the wheel fails to load, please open
 > an issue.
 
-> **Feature difference vs macOS/Windows**: the from-source Linux wheel does not
-> include the HDF4 driver (macOS/Windows conda-extract wheels do). HDF4 is a
-> legacy format with heavy build baggage; see `docs/installation.md`.
+> **Feature difference**: the from-source Linux and Windows ARM64 wheels do
+> not include the HDF4 driver (the conda-extract macOS and Windows x64 wheels
+> do). HDF4 is a legacy format with heavy build baggage; see
+> `docs/installation.md`.
 
 ### What the wheels DON'T cover
 
@@ -149,7 +154,7 @@ Amazon Linux 2023 with a ~30 MB wheel (vs ~47 MB under conda-extract).
 |-----------------------------------|-------|------------------------|-----------------------------------------------------------------|
 | Lower glibc floor (< 2.39)        | #332  | **shipped**            | from-source `manylinux_2_28` wheels (this pipeline)             |
 | musllinux (Alpine)                | #333  | **built, unpublished** | canaries green in CI; blocked on pyogrio musl wheels            |
-| Windows ARM64                     | #334  | **shipped**            | vcpkg build; vector stack vendored (shapely/pyogrio gap)         |
+| Windows ARM64                     | #334  | **shipped**            | vcpkg build; vector stack vendored |
 | Python 3.15+                      | #335  | pending upstream       | ships when CPython 3.15 + ecosystem land; one-line `build` bump |
 | Free-threaded (`cp313t`/`cp314t`) | #683  | pending upstream       | GDAL SWIG bindings + numpy first; revisit at 3.15               |
 
@@ -262,12 +267,33 @@ Python C API ABI.
 │             pyramids_gis.libs/, patches PE import tables.
 │       └── upload-artifact: wheels-windows-AMD64
 │
+├── build-winarm64-wheels (1 job, windows-11-arm, builds 3 wheels)
+│   └── cibuildwheel (cp312–cp314; no cp311 — see CIBW_BUILD comment):
+│       ├── CIBW_BEFORE_ALL: powershell -File ci/setup-gdal-from-vcpkg.ps1
+│       │   → bootstraps vcpkg at the pinned baseline, builds GDAL 3.12.4
+│       │     + PROJ/GEOS/... from the manifest (ci/vcpkg.json), mirrors
+│       │     the Library/ layout, collects port licenses, writes
+│       │     GDAL_VERSION (cache skipped on workflow_run, like Linux)
+│       ├── For each Python: same vendor + build steps, PLUS
+│       │   install-and-vendor-osgeo.py vendors the vector stack
+│       │   (shapely + geopandas + pyogrio, hash-pinned, built from
+│       │   sdist) into src/pyramids/_vendor/ — win_arm64 only
+│       └── CIBW_REPAIR_WHEEL_COMMAND: one delvewheel repair
+│           --analyze-existing pass owns ALL DLLs, including the
+│           vendored .pyds' GEOS/GDAL imports (one shared copy)
+│       └── upload-artifact: wheels-winarm64
+│
 ├── verify-debian12 / verify-rocky9 (full hermetic suite on glibc 2.36 / 2.34
 │   containers — distros the old 2_39 wheel could never install on) and
 │   verify-alpine (full core suite for the musl canary — vector I/O via a
 │   canary-built pyogrio musl wheel, since PyPI has none). All three
 │   run with --security-opt seccomp=unconfined (the netCDF driver needs
 │   userfaultfd for /vsizip reads — see docs/troubleshooting.md).
+│
+├── verify-winarm64 (3 cells: 3.12/3.13/3.14 on windows-11-arm) —
+│   plain `pip install <wheel>` (markers resolving, the real user
+│   path), then ci/verify-wheel.py against the bare closure BEFORE
+│   test deps land; the 3.12 cell also runs the hermetic core suite.
 │
 └── release (workflow_run only; needs EVERY build + test + verify job,
     canary verifies included — a red canary blocks the publish)
@@ -402,6 +428,11 @@ cibuildwheel --only cp312-macosx_x86_64   # cross-compile from arm64
 
 # Windows (must run on Windows)
 cibuildwheel --only cp312-win_amd64
+
+# Windows ARM64 (must run on a NATIVE ARM64 Windows host — the
+# vendored vector stack is compiled with the build interpreter, so
+# install-and-vendor-osgeo.py hard-fails a cross-build from x64)
+cibuildwheel --only cp312-win_arm64
 ```
 
 ## File map

--- a/docs/how-to/wheel-build-flow.md
+++ b/docs/how-to/wheel-build-flow.md
@@ -29,18 +29,22 @@ release, plus 8 unpublished musl canary wheels:
 | Windows  | ARM64 (`win_arm64`, vcpkg build)    | 3.12, 3.13, 3.14       | 3      |
 | (any)    | sdist                               | —                      | 1      |
 
-**Total published: 20 wheels + 1 sdist.** Two **CI canary** families build and
-verify on every run but are deliberately **not published** because pip could
+**Total published: 23 wheels + 1 sdist.** One **CI canary** family builds and
+verifies on every run but is deliberately **not published** because pip could
 not resolve pyramids-gis on those platforms yet:
 
 - `build-musl-wheels`: `musllinux_1_2` x86_64 + aarch64 (cp311–cp314) — blocked
   on upstream pyogrio musllinux wheels (#333; geopandas hard-requires pyogrio).
-- `build-winarm64-wheels`: `win_arm64` (cp312–cp314; numpy/scipy ship no cp311
-  arm64 wheels) built from source via vcpkg — blocked on upstream shapely +
-  pyogrio win_arm64 wheels (#334). GDAL comes from the vcpkg port (currently
-  3.12.4, trailing the 3.13.1 the other wheels ship); like Linux, no HDF4.
-  The canary also builds shapely + pyogrio arm64 wheels against the same
-  prefix so `verify-winarm64` runs the full suite natively.
+
+The `win_arm64` wheels (`build-winarm64-wheels`, cp312–cp314; numpy/scipy ship
+no cp311 arm64 wheels) are built from source via vcpkg. GDAL comes from the
+vcpkg port (currently 3.12.4, trailing the 3.13.1 the other wheels ship);
+like Linux, no HDF4. Because shapely and pyogrio publish no win_arm64 wheels
+on PyPI, the platform markers in `[project.dependencies]` skip them (and
+geopandas) there, and each wheel **vendors the vector stack** — shapely,
+geopandas, and pyogrio, built from sdist against the same vcpkg prefix —
+under `pyramids/_vendor/` (see `ci/install-and-vendor-osgeo.py`). The
+vendoring and the markers both go away once upstream ships win_arm64 wheels.
 
 The macOS x86_64 wheels are cross-compiled on a `macos-14` (arm64)
 runner via Rosetta + ARCHFLAGS — GitHub's `macos-13` (Intel) runner
@@ -268,8 +272,8 @@ Python C API ABI.
 └── release (workflow_run only; needs EVERY build + test + verify job,
     canary verifies included — a red canary blocks the publish)
     → gathers {sdist,wheels-*} artifacts (canary-* names can't match),
-      asserts the exact composition (1 sdist + 4 wheels x 5 platforms,
-      zero musllinux, zero win_arm64), attaches everything to the
+      asserts the exact composition (1 sdist + 4 wheels x 5 platforms
+      + 3 win_arm64, zero musllinux), attaches everything to the
       GitHub release, and publishes to PyPI.
 ```
 
@@ -326,7 +330,8 @@ Examples:
 | Windows 11 (x64) + Python 3.11 | `cp311-cp311-win_amd64` wheel |
 | RHEL 7 (glibc 2.17) | no wheel matches → sdist fails without system GDAL → use conda-forge |
 | Alpine Linux (musl) | no published wheel yet (#333) → use conda-forge |
-| Windows on ARM64 | no `win_arm64` wheel → run AMD64 wheel under x86 emulation |
+| Windows 11 ARM64 + Python 3.13 | `cp313-cp313-win_arm64` wheel (native; vendored vector stack) |
+| Windows 11 ARM64 + Python 3.11 | no wheel (numpy/scipy ship no cp311 arm64) → use Python 3.12+ |
 | Python 3.10 | excluded by `requires-python = ">= 3.11"` — upgrade, or pin `< 0.20` |
 
 ## CI timing
@@ -342,14 +347,17 @@ On GitHub-hosted runners (jobs parallel where possible):
 | `build-macos-wheels` (arm64, native)                   | ~6 min (4 wheels)               |
 | `build-macos-wheels` (x86_64, cross-compiled)          | ~7 min (4 wheels)               |
 | `build-windows-wheels`                                 | ~12 min (4 wheels)              |
+| `build-winarm64-wheels` (cold: full vcpkg compile)     | ~75 min (3 wheels)              |
+| `build-winarm64-wheels` (warm: vcpkg cache restored)   | ~9 min (3 wheels)               |
 | `test-wheels` matrix (16 jobs)                         | ~3 min (parallel, after builds) |
 | `verify-debian12` / `verify-rocky9` (full suite)       | ~8 min each                     |
 | `verify-alpine` (full core suite, canary pyogrio)      | ~8 min                          |
+| `verify-winarm64` (3 cells; full core suite on 3.12)   | ~1–6 min                        |
 
-Release builds are always cold on Linux (the cache step is skipped on
-`workflow_run` so published binaries never come from a cache), so budget
-~70 min wall-clock for a release; branch iterations with a warm cache
-complete in ~20 min.
+Release builds are always cold on Linux and Windows ARM64 (both cache
+steps are skipped on `workflow_run` so published binaries never come
+from a cache), so budget ~80 min wall-clock for a release; branch
+iterations with a warm cache complete in ~20 min.
 
 Each step has an explicit `timeout-minutes` cap plus pytest's own
 `--timeout=60 --timeout-method=thread` so a hung test fails fast on the

--- a/docs/how-to/wheel-build-flow.md
+++ b/docs/how-to/wheel-build-flow.md
@@ -16,7 +16,7 @@ Two build models coexist in the pipeline:
 
 ## What gets built per release
 
-`bundle-pypi-wheels.yml` produces **20 published platform wheels + 1 sdist** per
+`bundle-pypi-wheels.yml` produces **23 published platform wheels + 1 sdist** per
 release, plus 8 unpublished musl canary wheels:
 
 | Platform | Architecture                        | Python versions        | Wheels |
@@ -26,6 +26,7 @@ release, plus 8 unpublished musl canary wheels:
 | macOS    | arm64 (Apple Silicon, `macosx_11_0`)| 3.11, 3.12, 3.13, 3.14 | 4      |
 | macOS    | x86_64 (Intel, cross-compiled)      | 3.11, 3.12, 3.13, 3.14 | 4      |
 | Windows  | AMD64 (x64)                         | 3.11, 3.12, 3.13, 3.14 | 4      |
+| Windows  | ARM64 (`win_arm64`, vcpkg build)    | 3.12, 3.13, 3.14       | 3      |
 | (any)    | sdist                               | —                      | 1      |
 
 **Total published: 20 wheels + 1 sdist.** Two **CI canary** families build and
@@ -116,7 +117,6 @@ the **conda-forge install path**:
 |---|---|---|---|
 | Linux glibc < 2.28 (RHEL 7, Ubuntu 18.04, …) | below the manylinux_2_28 image floor | conda-forge | intentional |
 | Alpine / musl Linux | built + verified in CI, unpublished (pyogrio has no musl wheels) | conda-forge | #333 |
-| Windows on ARM64 | built + verified in CI (shapely/pyogrio lack arm64 wheels) | AMD64 wheel under emulation | #334 |
 | Free-threaded CPython (`cp31Nt`) | GDAL SWIG bindings + numpy not ready | use a GIL build | #683 |
 | Python 3.10 or earlier | excluded by `requires-python = ">= 3.11"` | upgrade Python, or pin `< 0.20` | intentional |
 | Python 3.15+ (future) | not yet released by CPython | conda-forge until wheels ship | #335 |
@@ -145,7 +145,7 @@ Amazon Linux 2023 with a ~30 MB wheel (vs ~47 MB under conda-extract).
 |-----------------------------------|-------|------------------------|-----------------------------------------------------------------|
 | Lower glibc floor (< 2.39)        | #332  | **shipped**            | from-source `manylinux_2_28` wheels (this pipeline)             |
 | musllinux (Alpine)                | #333  | **built, unpublished** | canaries green in CI; blocked on pyogrio musl wheels            |
-| Windows ARM64                     | #334  | **built, unpublished** | vcpkg canaries green in CI; blocked on shapely/pyogrio arm64      |
+| Windows ARM64                     | #334  | **shipped**            | vcpkg build; vector stack vendored (shapely/pyogrio gap)         |
 | Python 3.15+                      | #335  | pending upstream       | ships when CPython 3.15 + ecosystem land; one-line `build` bump |
 | Free-threaded (`cp313t`/`cp314t`) | #683  | pending upstream       | GDAL SWIG bindings + numpy first; revisit at 3.15               |
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -102,7 +102,7 @@ Open Python and run:
 import pyramids
 from osgeo import gdal
 print(pyramids.__version__)
-print(gdal.__version__)          # should print 3.13.x
+print(gdal.__version__)          # should print 3.13.x (3.12.x on Windows ARM64)
 ```
 
 ## Platform support matrix
@@ -133,8 +133,7 @@ If your distro has **glibc < 2.28**, use the conda-forge path instead.
 
 Every remaining gap waits on something upstream of pyramids; none of
 them can be closed from this repo alone. Progress is tracked in
-[#333](https://github.com/serapeum-org/pyramids/issues/333) (Alpine),
-[#334](https://github.com/serapeum-org/pyramids/issues/334) (Windows ARM64), and
+[#333](https://github.com/serapeum-org/pyramids/issues/333) (Alpine) and
 [#335](https://github.com/serapeum-org/pyramids/issues/335) (Python 3.15).
 Until a row clears, the workaround column applies.
 
@@ -146,12 +145,12 @@ Until a row clears, the workaround column applies.
 | Linux glibc < 2.28 | below the oldest maintained manylinux image | never (intentional) | conda-forge |
 | PyPy / Python ≤ 3.10 | GDAL bindings target CPython 3.11+ | never (intentional) | CPython 3.11+ |
 
-One **feature-level** difference inside a covered platform: the Linux
-wheel does not include the HDF4 driver (the macOS x64 and Windows x64
-wheels do). HDF4 is a legacy format; if you need it on Linux, use conda-forge.
-This is the only driver difference — the wheel pipeline asserts the
-full promised driver set on every build, so drivers cannot silently
-disappear from a release.
+One **feature-level** difference inside covered platforms: the Linux
+and Windows ARM64 wheels do not include the HDF4 driver (the macOS
+wheels — both architectures — and the Windows x64 wheel do). HDF4 is a
+legacy format; if you need it there, use conda-forge. This is the only
+driver difference — the wheel pipeline asserts the full promised driver
+set on every build, so drivers cannot silently disappear from a release.
 
 > **Windows ARM64 note**: the `win_arm64` wheel ships Python 3.12–3.14
 > (numpy/scipy publish no cp311 ARM64 wheels), carries GDAL 3.12.4 (the
@@ -161,6 +160,11 @@ disappear from a release.
 > `pyramids/_vendor/` because upstream publishes no ARM64 wheels for
 > them. `import geopandas` etc. work normally after `import pyramids`;
 > the vendored copies disappear once upstream ships ARM64 wheels.
+> On Python 3.11 there is no wheel and pip falls back to the sdist,
+> which installs *successfully* but cannot provide GDAL or the vector
+> stack (the dependency markers skip shapely/geopandas on Windows
+> ARM64) — use Python 3.12+ or conda-forge instead. The same caveat
+> applies to any deliberate sdist install on Windows ARM64.
 
 ## System dependencies
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -6,7 +6,8 @@ works out of the box on Linux, macOS, and Windows — no system GDAL
 installation required.
 
 **Package name:** `pyramids-gis`
-**Supported Python versions:** 3.11, 3.12, 3.13 (requires `>=3.11,<4`)
+**Supported Python versions:** 3.11–3.14 (requires `>=3.11,<4`;
+3.12+ on Windows ARM64)
 
 ## Quick install (recommended for most users)
 
@@ -16,10 +17,11 @@ installation required.
 pip install pyramids-gis
 ```
 
-That's it. The wheel includes GDAL 3.13, PROJ, GEOS, HDF5, NetCDF, GRIB,
-JPEG2000 (OpenJPEG, for JP2-packed GRIB2), libtiff, and all other native
-dependencies (HDF4 additionally ships in the macOS/Windows wheels). No
-`gdal-config`, no `apt install libgdal-dev`, no OSGeo4W installer needed.
+That's it. The wheel includes GDAL 3.13 (3.12 on Windows ARM64), PROJ,
+GEOS, HDF5, NetCDF, GRIB, JPEG2000 (OpenJPEG, for JP2-packed GRIB2),
+libtiff, and all other native dependencies (HDF4 additionally ships in
+the macOS and Windows x64 wheels). No `gdal-config`, no
+`apt install libgdal-dev`, no OSGeo4W installer needed.
 
 ### Optional extras
 
@@ -161,10 +163,12 @@ set on every build, so drivers cannot silently disappear from a release.
 > them. `import geopandas` etc. work normally after `import pyramids`;
 > the vendored copies disappear once upstream ships ARM64 wheels.
 > On Python 3.11 there is no wheel and pip falls back to the sdist,
-> which installs *successfully* but cannot provide GDAL or the vector
-> stack (the dependency markers skip shapely/geopandas on Windows
-> ARM64) — use Python 3.12+ or conda-forge instead. The same caveat
-> applies to any deliberate sdist install on Windows ARM64.
+> which typically *fails* while trying to build numpy/scipy from
+> source (they ship no cp311 ARM64 wheels either) — and even a
+> forced install (`--no-deps`) provides neither GDAL nor the vector
+> stack, because the dependency markers skip shapely/geopandas on
+> Windows ARM64. Use Python 3.12+ or conda-forge instead. The same
+> caveat applies to any deliberate sdist install on Windows ARM64.
 
 ## System dependencies
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -115,8 +115,8 @@ print(gdal.__version__)          # should print 3.13.x
 | macOS 11+ | x86_64 | `macosx_11_0_x86_64` | ✅ Supported |
 | macOS 11+ | arm64 (Apple Silicon) | `macosx_11_0_arm64` | ✅ Supported |
 | Windows 10+ | x64 | `win_amd64` | ✅ Supported |
+| Windows 11+ | ARM64 | `win_arm64` | ✅ Supported (Python 3.12+; see the ARM64 note below) |
 | Alpine (musl) | any | — | ⏸ Built in CI, unpublished — blocked on upstream `pyogrio` musl wheels |
-| Windows 11+ | ARM64 | — | ⏸ Built in CI, unpublished — blocked on upstream `shapely`/`pyogrio` arm64 wheels |
 
 Distros covered by the Linux wheel out of the box:
 
@@ -141,18 +141,26 @@ Until a row clears, the workaround column applies.
 | Platform / target | Why no wheel today | Ships when | Workaround |
 |---|---|---|---|
 | Alpine / musl Linux | built + verified in CI; `pyogrio` has no musl wheels | pyogrio ships them (#333) | conda-forge |
-| Windows on ARM64 | built + verified in CI; shapely/pyogrio lack arm64 wheels | upstream lands (#334) | AMD64 wheel |
 | Python 3.15 | CPython unreleased; ecosystem needs cp315 wheels | after CPython 3.15, ~Oct 2026 (#335) | — |
 | Free-threaded (`cp31Nt`) | GDAL SWIG bindings + numpy not ready | revisit at 3.15 (#683) | standard (GIL) build |
 | Linux glibc < 2.28 | below the oldest maintained manylinux image | never (intentional) | conda-forge |
 | PyPy / Python ≤ 3.10 | GDAL bindings target CPython 3.11+ | never (intentional) | CPython 3.11+ |
 
 One **feature-level** difference inside a covered platform: the Linux
-wheel does not include the HDF4 driver (the macOS and Windows wheels
-do). HDF4 is a legacy format; if you need it on Linux, use conda-forge.
+wheel does not include the HDF4 driver (the macOS x64 and Windows x64
+wheels do). HDF4 is a legacy format; if you need it on Linux, use conda-forge.
 This is the only driver difference — the wheel pipeline asserts the
 full promised driver set on every build, so drivers cannot silently
 disappear from a release.
+
+> **Windows ARM64 note**: the `win_arm64` wheel ships Python 3.12–3.14
+> (numpy/scipy publish no cp311 ARM64 wheels), carries GDAL 3.12.4 (the
+> pinned vcpkg port version; the other platforms ship 3.13.1), has no
+> HDF4 driver (like Linux), and **vendors its vector stack** — shapely,
+> geopandas, and pyogrio ship inside the wheel under
+> `pyramids/_vendor/` because upstream publishes no ARM64 wheels for
+> them. `import geopandas` etc. work normally after `import pyramids`;
+> the vendored copies disappear once upstream ships ARM64 wheels.
 
 ## System dependencies
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -36289,8 +36289,10 @@ packages:
 - pypi: ./
   name: pyramids-gis
   version: 0.40.0
-  sha256: 13113eb134fd9c14368aedf0b04319cc8a5e5ddd453a0ecd92aa25decb13ff96
+  sha256: d2e9d3ce8ae9d33864885d3f9fa97b6507ae97078d7c24628054c31b5088ccd4
   requires_dist:
+  - certifi ; platform_machine == 'ARM64' and sys_platform == 'win32'
+  - packaging ; platform_machine == 'ARM64' and sys_platform == 'win32'
   - cftime>=1.6.4
   - geopandas>=1.0.0 ; platform_machine != 'ARM64' or sys_platform != 'win32'
   - hpc-utils>=0.1.5

--- a/pixi.lock
+++ b/pixi.lock
@@ -950,7 +950,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -1319,7 +1319,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -1679,7 +1679,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -2039,7 +2039,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -2394,7 +2394,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -4500,7 +4500,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -4813,7 +4813,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -5118,7 +5118,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -5423,7 +5423,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -5724,7 +5724,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -6090,7 +6090,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -6449,7 +6449,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -6799,7 +6799,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -7149,7 +7149,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -7494,7 +7494,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -7682,7 +7682,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/c2/35/525d3e86af55a66073c02dbf9b6a720c74601489e4b4cb391cad0a4cb620/charset_normalizer-3.4.8-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -7816,7 +7816,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -7996,7 +7996,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/2a/b4/8e936a5e19d7e7b19db29aeed0988b481dc745eed3437829780f6ec98ce9/charset_normalizer-3.4.8-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -8130,7 +8130,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -8304,7 +8304,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/94/b5/7f10929c45e2d0d0dc78bead98458c271af3e028e66b16441de88829a8b7/charset_normalizer-3.4.8-cp311-cp311-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -8435,7 +8435,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -8609,7 +8609,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/94/b5/7f10929c45e2d0d0dc78bead98458c271af3e028e66b16441de88829a8b7/charset_normalizer-3.4.8-cp311-cp311-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -8740,7 +8740,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -8912,7 +8912,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/8d/5f/c46567479049f46929d8ed9e628990c2419f369c5ea5797add417808d37b/charset_normalizer-3.4.8-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -9041,7 +9041,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -9228,7 +9228,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/27/0d/98e301ca944bcca5e6bc312406b579c8a6d81546c1b494afb3a9478495d6/charset_normalizer-3.4.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -9361,7 +9361,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -9540,7 +9540,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/a7/57/a9474c3aeaa337c8a330c0dc5df266527d56da3b189c029529f6b08af2a4/charset_normalizer-3.4.8-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -9673,7 +9673,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -9846,7 +9846,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/59/c2/39de60ef5687662f467bed3d1e6944c67a4f0d057141d0404002b8f405ae/charset_normalizer-3.4.8-cp312-cp312-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -9976,7 +9976,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -10149,7 +10149,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/59/c2/39de60ef5687662f467bed3d1e6944c67a4f0d057141d0404002b8f405ae/charset_normalizer-3.4.8-cp312-cp312-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -10279,7 +10279,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -10450,7 +10450,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/9b/82/eb8b72f184b1e4986dd9daec15d7f6d9285a6728d2b07b7f04656829f473/charset_normalizer-3.4.8-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -10578,7 +10578,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -10765,7 +10765,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/e4/28/1bcc3f5f3bac81532384adcfcdd9362c7f46a188a19deacc1ddaf7bdaa00/charset_normalizer-3.4.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -10898,7 +10898,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -11077,7 +11077,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/e5/59/d71c96616b6825425a876f79f38fa440db30b32cc1166179a839f6259150/charset_normalizer-3.4.8-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -11210,7 +11210,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -11384,7 +11384,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/11/49/fe5a8572a70cd9cba79f80af9388ac8c5c914ed4459b956f940244e499a5/charset_normalizer-3.4.8-cp313-cp313-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -11514,7 +11514,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -11688,7 +11688,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/11/49/fe5a8572a70cd9cba79f80af9388ac8c5c914ed4459b956f940244e499a5/charset_normalizer-3.4.8-cp313-cp313-macosx_10_13_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -11818,7 +11818,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -11990,7 +11990,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/f5/8c/879fafff7b47bb1166d289f2d2472cb31b9922f9f4ca1f392edf85ec16be/charset_normalizer-3.4.8-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -12118,7 +12118,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -12307,7 +12307,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/2d/fd/1e6eff58c14f1aace1e26d80defbeaea2d35e075dbe4b611111ee4b47fa8/charset_normalizer-3.4.8-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -12440,7 +12440,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -12621,7 +12621,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/0e/99/a0868f0a1f0a045fd374d1f2cf7042d8ad5d7fb4dd1f4ac7365e319f7e32/charset_normalizer-3.4.8-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -12754,7 +12754,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -12930,7 +12930,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/1c/bc/0a8540b8cd494951cca1428606373942803f5ffcec40fe798f819c5a8adb/charset_normalizer-3.4.8-cp314-cp314-macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -13060,7 +13060,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -13236,7 +13236,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/1c/bc/0a8540b8cd494951cca1428606373942803f5ffcec40fe798f819c5a8adb/charset_normalizer-3.4.8-cp314-cp314-macosx_10_15_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
@@ -13366,7 +13366,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -13540,7 +13540,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/32/2b/9ce65dd21672b55cf800cca5f4433afa1586fda1d78731067ec9ec544c62/charset_normalizer-3.4.8-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -13668,7 +13668,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3a/7a/882d99539b19b1490cac5d77c67338d126e4122c8276bf640e411650c830/twine-6.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl
@@ -17424,85 +17424,85 @@ packages:
   - pkg:pypi/cftime?source=hash-mapping
   size: 377553
   timestamp: 1768511112844
-- pypi: https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl
+- pypi: https://files.pythonhosted.org/packages/0e/99/a0868f0a1f0a045fd374d1f2cf7042d8ad5d7fb4dd1f4ac7365e319f7e32/charset_normalizer-3.4.8-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
   name: charset-normalizer
-  version: 3.4.7
-  sha256: eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46
+  version: 3.4.8
+  sha256: 524939917f17f6de502dfda30b472550965740d7f126659d4c4f8dd1569cce22
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl
+- pypi: https://files.pythonhosted.org/packages/11/49/fe5a8572a70cd9cba79f80af9388ac8c5c914ed4459b956f940244e499a5/charset_normalizer-3.4.8-cp313-cp313-macosx_10_13_universal2.whl
   name: charset-normalizer
-  version: 3.4.7
-  sha256: 8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00
+  version: 3.4.8
+  sha256: 057f8609f7341618c98e5aa9a6109fa116acff2a658497d47ab3325b5e8f2b08
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+- pypi: https://files.pythonhosted.org/packages/1c/bc/0a8540b8cd494951cca1428606373942803f5ffcec40fe798f819c5a8adb/charset_normalizer-3.4.8-cp314-cp314-macosx_10_15_universal2.whl
   name: charset-normalizer
-  version: 3.4.7
-  sha256: 0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c
+  version: 3.4.8
+  sha256: 77e993ecf65f21ab1f82266ff5e84a7de2c879e7d9b8bc006009df83f22a1d5e
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl
+- pypi: https://files.pythonhosted.org/packages/27/0d/98e301ca944bcca5e6bc312406b579c8a6d81546c1b494afb3a9478495d6/charset_normalizer-3.4.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: charset-normalizer
-  version: 3.4.7
-  sha256: 5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6
+  version: 3.4.8
+  sha256: 25f93d194eb6264c64416cabff46a91f6d99b97e7525a1b4f35c77a99e75cc68
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/2a/b4/8e936a5e19d7e7b19db29aeed0988b481dc745eed3437829780f6ec98ce9/charset_normalizer-3.4.8-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
   name: charset-normalizer
-  version: 3.4.7
-  sha256: bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e
+  version: 3.4.8
+  sha256: ab07eb7b564635602734c3ef0e8d2db9d59cbbce54f5dc42b8f11aa1f56ce364
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl
+- pypi: https://files.pythonhosted.org/packages/2d/fd/1e6eff58c14f1aace1e26d80defbeaea2d35e075dbe4b611111ee4b47fa8/charset_normalizer-3.4.8-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: charset-normalizer
-  version: 3.4.7
-  sha256: 92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f
+  version: 3.4.8
+  sha256: bb90317359f7e67bb6df615999a95e0980877468e617ddce8b6c2f8e7fe60d95
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/32/2b/9ce65dd21672b55cf800cca5f4433afa1586fda1d78731067ec9ec544c62/charset_normalizer-3.4.8-cp314-cp314-win_amd64.whl
   name: charset-normalizer
-  version: 3.4.7
-  sha256: 5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116
+  version: 3.4.8
+  sha256: ff71018850863362e5c7533769d0a9f77715c31af1502d523630ce822922f5c9
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+- pypi: https://files.pythonhosted.org/packages/59/c2/39de60ef5687662f467bed3d1e6944c67a4f0d057141d0404002b8f405ae/charset_normalizer-3.4.8-cp312-cp312-macosx_10_13_universal2.whl
   name: charset-normalizer
-  version: 3.4.7
-  sha256: 202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7
+  version: 3.4.8
+  sha256: faac37c4904598daa00cb4c9b32f3b4cc814fb5f145d7a531ceb4a70f2114132
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl
+- pypi: https://files.pythonhosted.org/packages/8d/5f/c46567479049f46929d8ed9e628990c2419f369c5ea5797add417808d37b/charset_normalizer-3.4.8-cp311-cp311-win_amd64.whl
   name: charset-normalizer
-  version: 3.4.7
-  sha256: 3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110
+  version: 3.4.8
+  sha256: 2e9f0db12ea28a3349e514443fc56d4b1fb3c81d0f9c0e33dacfdfc2ac63f774
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl
+- pypi: https://files.pythonhosted.org/packages/94/b5/7f10929c45e2d0d0dc78bead98458c271af3e028e66b16441de88829a8b7/charset_normalizer-3.4.8-cp311-cp311-macosx_10_9_universal2.whl
   name: charset-normalizer
-  version: 3.4.7
-  sha256: c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0
+  version: 3.4.8
+  sha256: ca832d525a2a52542048111cb44e0dea595b9ad53ad542020aa770f308427b92
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+- pypi: https://files.pythonhosted.org/packages/9b/82/eb8b72f184b1e4986dd9daec15d7f6d9285a6728d2b07b7f04656829f473/charset_normalizer-3.4.8-cp312-cp312-win_amd64.whl
   name: charset-normalizer
-  version: 3.4.7
-  sha256: 1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a
+  version: 3.4.8
+  sha256: 14a4bbe066f3fb05c6ba70e9cf9d34614b57a2fd70ea8c27cc30f34155e16a58
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/a7/57/a9474c3aeaa337c8a330c0dc5df266527d56da3b189c029529f6b08af2a4/charset_normalizer-3.4.8-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
   name: charset-normalizer
-  version: 3.4.7
-  sha256: 2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df
+  version: 3.4.8
+  sha256: f191c19a32dc6cec0fb8079789d786254653a9ce906fcab04ccd2eed07bba233
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl
+- pypi: https://files.pythonhosted.org/packages/c2/35/525d3e86af55a66073c02dbf9b6a720c74601489e4b4cb391cad0a4cb620/charset_normalizer-3.4.8-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: charset-normalizer
-  version: 3.4.7
-  sha256: f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063
+  version: 3.4.8
+  sha256: 9840cca6969a7e35498f1ce6fc32b7842500783d303b5ab254679a0f591093c4
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl
+- pypi: https://files.pythonhosted.org/packages/e4/28/1bcc3f5f3bac81532384adcfcdd9362c7f46a188a19deacc1ddaf7bdaa00/charset_normalizer-3.4.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
   name: charset-normalizer
-  version: 3.4.7
-  sha256: 7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7
+  version: 3.4.8
+  sha256: 60883e22821d17c9e5b4f3ca1ef8074f766e3db28791f851b665929c515635c0
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
+- pypi: https://files.pythonhosted.org/packages/e5/59/d71c96616b6825425a876f79f38fa440db30b32cc1166179a839f6259150/charset_normalizer-3.4.8-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
   name: charset-normalizer
-  version: 3.4.7
-  sha256: 6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2
+  version: 3.4.8
+  sha256: c591f9a82adc5b89a039b90df74e43de2b9177fb46771172bed7b80722a70db0
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+- pypi: https://files.pythonhosted.org/packages/f5/8c/879fafff7b47bb1166d289f2d2472cb31b9922f9f4ca1f392edf85ec16be/charset_normalizer-3.4.8-cp313-cp313-win_amd64.whl
   name: charset-normalizer
-  version: 3.4.7
-  sha256: e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd
+  version: 3.4.8
+  sha256: 8b654b6f52a0a9a6be38e88f3e1dc68f1093ebeb2abbadafc7c82da0786a34be
   requires_python: '>=3.7'
 - conda: https://conda.anaconda.org/conda-forge/noarch/charset-normalizer-3.4.7-pyhd8ed1ab_0.conda
   sha256: 3f9483d62ce24ecd063f8a5a714448445dc8d9e201147c46699fc0033e824457
@@ -36289,7 +36289,7 @@ packages:
 - pypi: ./
   name: pyramids-gis
   version: 0.40.0
-  sha256: 5c72964f4b71b63ed69c7582c00f73eb52311891ee4839bb212c3f0c5f5420bd
+  sha256: 13113eb134fd9c14368aedf0b04319cc8a5e5ddd453a0ecd92aa25decb13ff96
   requires_dist:
   - cftime>=1.6.4
   - geopandas>=1.0.0 ; platform_machine != 'ARM64' or sys_platform != 'win32'
@@ -39879,10 +39879,10 @@ packages:
   - mypy ; extra == 'test'
   - pretend ; extra == 'test'
   - pytest ; extra == 'test'
-- pypi: https://files.pythonhosted.org/packages/2c/02/3623e6169bed617ed1e2d372f7c69f92ec28d54c4dfc997055c8578ec148/virtualenv-21.5.1-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/9d/08/0ae1145a8e8d7193f7f37aedc8e37eafd02f70a8513b90624089a7a8e321/virtualenv-21.5.2-py3-none-any.whl
   name: virtualenv
-  version: 21.5.1
-  sha256: 55aa670b67bbfb991b03fda39bd3276d92c419d702376e98c5df1c9989a26783
+  version: 21.5.2
+  sha256: 4d9f76b4363ed04a4837e812110eb301367eb470f616b62399a50d39dee70e47
   requires_dist:
   - distlib>=0.3.7,<1
   - filelock>=3.24.2,<4 ; python_full_version >= '3.10'

--- a/pixi.lock
+++ b/pixi.lock
@@ -112,7 +112,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/5f/9ff93450ba96b09c7c2b3f81c94de31c89f92292f1380261bd7195bea4ea/contourpy-1.3.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl
@@ -231,7 +231,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-h80f16a2_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.2-hdc9db2a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/71/f93e1e9471d189f79d0ce2497007731c1e6bf9ef6d1d61b911430c3db4e5/contourpy-1.3.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl
@@ -344,7 +344,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.2-hbb4bfdb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/72/8b/4546f3ab60f78c514ffb7d01a0bd743f90de36f0019d1be84d0a708a580a/contourpy-1.3.3-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl
@@ -457,7 +457,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/e1/3542a9cb596cadd76fcef413f19c79216e002623158befe6daa03dbfa88c/contourpy-1.3.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl
@@ -567,7 +567,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/0c/56be52741f75bad4dc6555991fabd2e07b432d333da82c11ad701123888a/ffmpeg_python-0.2.0-py3-none-any.whl
@@ -817,7 +817,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -1186,7 +1186,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -1549,7 +1549,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -1909,7 +1909,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -2266,7 +2266,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
@@ -2635,7 +2635,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/5f/9ff93450ba96b09c7c2b3f81c94de31c89f92292f1380261bd7195bea4ea/contourpy-1.3.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
@@ -2995,7 +2995,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/71/f93e1e9471d189f79d0ce2497007731c1e6bf9ef6d1d61b911430c3db4e5/contourpy-1.3.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
@@ -3349,7 +3349,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/72/8b/4546f3ab60f78c514ffb7d01a0bd743f90de36f0019d1be84d0a708a580a/contourpy-1.3.3-cp314-cp314-macosx_10_13_x86_64.whl
@@ -3703,7 +3703,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/e1/3542a9cb596cadd76fcef413f19c79216e002623158befe6daa03dbfa88c/contourpy-1.3.3-cp314-cp314-macosx_11_0_arm64.whl
@@ -4054,7 +4054,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
@@ -4371,7 +4371,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -4684,7 +4684,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -4992,7 +4992,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -5297,7 +5297,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -5600,7 +5600,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
@@ -5961,7 +5961,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -6320,7 +6320,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -6673,7 +6673,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -7023,7 +7023,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -7370,7 +7370,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
@@ -7683,7 +7683,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -7997,7 +7997,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -8305,7 +8305,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -8610,7 +8610,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -8913,7 +8913,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/4b/9bd370b004b5c9d8045c6c33cf65bae018b27aca550a3f657cdc99acdbd8/contourpy-1.3.3-cp311-cp311-win_amd64.whl
@@ -9229,7 +9229,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -9541,7 +9541,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -9847,7 +9847,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -10150,7 +10150,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -10451,7 +10451,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/19/e8/6026ed58a64563186a9ee3f29f41261fd1828f527dd93d33b60feca63352/contourpy-1.3.3-cp312-cp312-win_amd64.whl
@@ -10766,7 +10766,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -11078,7 +11078,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -11385,7 +11385,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -11689,7 +11689,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -11991,7 +11991,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/0b/0098c214843213759692cc638fce7de5c289200a830e5035d1791d7a2338/contourpy-1.3.3-cp313-cp313-win_amd64.whl
@@ -12308,7 +12308,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -12622,7 +12622,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -12931,7 +12931,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -13237,7 +13237,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -13541,7 +13541,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
@@ -17515,10 +17515,10 @@ packages:
   - pkg:pypi/charset-normalizer?source=hash-mapping
   size: 58872
   timestamp: 1775127203018
-- pypi: https://files.pythonhosted.org/packages/43/70/94a3cf09be89095a66aa1224fe768339e6721038a17c08f3ff7f56926f1f/cleopatra-0.20.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/a1/ec/790a116a1bfc07c90ececa3fe26f9d06e20ab22815b3ba451b4152c09a63/cleopatra-0.21.0-py3-none-any.whl
   name: cleopatra
-  version: 0.20.0
-  sha256: 5ffe61b183bb65d42561bd3745211718ea28f8f2a337563dfe3fe75be5b9ccb2
+  version: 0.21.0
+  sha256: 3a9f058509aea7bba078c7b47631f2bbe2f526fb6f672429668d2332f3a47a9a
   requires_dist:
   - ffmpeg-python
   - hpc-utils>=0.1.4
@@ -36289,7 +36289,7 @@ packages:
 - pypi: ./
   name: pyramids-gis
   version: 0.40.0
-  sha256: e9b4ddc446ef34802d2e3131b1aac273576056ff2bd5107cdb9ec173c543ed86
+  sha256: 5c72964f4b71b63ed69c7582c00f73eb52311891ee4839bb212c3f0c5f5420bd
   requires_dist:
   - cftime>=1.6.4
   - geopandas>=1.0.0 ; platform_machine != 'ARM64' or sys_platform != 'win32'

--- a/pixi.lock
+++ b/pixi.lock
@@ -36289,16 +36289,16 @@ packages:
 - pypi: ./
   name: pyramids-gis
   version: 0.40.0
-  sha256: 557abbcd72d579a2ba78c51c6bc8ed4b924248dff5907fc57289b33a7dd34d41
+  sha256: e9b4ddc446ef34802d2e3131b1aac273576056ff2bd5107cdb9ec173c543ed86
   requires_dist:
   - cftime>=1.6.4
-  - geopandas>=1.0.0
+  - geopandas>=1.0.0 ; platform_machine != 'ARM64' or sys_platform != 'win32'
   - hpc-utils>=0.1.5
   - numpy>=2.0.0
   - pandas>=2.0.0
   - pyproj>=3.7.0
   - pyyaml>=6.0.0
-  - shapely>=2.1.0
+  - shapely>=2.1.0 ; platform_machine != 'ARM64' or sys_platform != 'win32'
   - scipy>=1.10.0
   - cleopatra[tiles]>=0.20.0 ; extra == 'viz'
   - dask>=2024.1.0 ; extra == 'lazy'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,6 +132,15 @@ pyramids = [
     "base/data/*.yaml",
     "_vendor/osgeo/**/*",
     "_vendor/osgeo_utils/**/*",
+    # win_arm64 vector stack (empty dirs on every other platform): the
+    # vendored packages' .py files ship via package discovery, but the
+    # compiled extensions (shapely/lib.pyd, pyogrio/_io.pyd, ...) and the
+    # delvewheel .libs DLL dirs are data files and need explicit globs.
+    "_vendor/shapely/**/*",
+    "_vendor/shapely.libs/**/*",
+    "_vendor/geopandas/**/*",
+    "_vendor/pyogrio/**/*",
+    "_vendor/pyogrio.libs/**/*",
     "_data/gdal_data/*",
     "_data/proj_data/*",
     "_data/gdalplugins/*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,15 +132,15 @@ pyramids = [
     "base/data/*.yaml",
     "_vendor/osgeo/**/*",
     "_vendor/osgeo_utils/**/*",
-    # win_arm64 vector stack (empty dirs on every other platform): the
+    # win_arm64 vector stack (empty matches on every other platform): the
     # vendored packages' .py files ship via package discovery, but the
-    # compiled extensions (shapely/lib.pyd, pyogrio/_io.pyd, ...) and the
-    # delvewheel .libs DLL dirs are data files and need explicit globs.
+    # compiled extensions (shapely/lib.pyd, pyogrio/_io.pyd, ...) are
+    # data files and need explicit globs. Their GEOS/GDAL DLLs are NOT
+    # vendored here — the wheel's delvewheel pass bundles one shared
+    # copy into pyramids_gis.libs and rewrites the import tables.
     "_vendor/shapely/**/*",
-    "_vendor/shapely.libs/**/*",
     "_vendor/geopandas/**/*",
     "_vendor/pyogrio/**/*",
-    "_vendor/pyogrio.libs/**/*",
     "_data/gdal_data/*",
     "_data/proj_data/*",
     "_data/gdalplugins/*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,13 +31,19 @@ requires-python = ">= 3.11, <4"
 # (no wheel exists) and break most end-user pip installs.
 dependencies = [
     "cftime >=1.6.4",
-    "geopandas >=1.0.0",
+    # win_arm64: shapely and pyogrio (geopandas' hard dep) ship no ARM64
+    # wheels on PyPI, so requiring them would make the platform
+    # uninstallable. The win_arm64 wheel vendors the whole vector stack
+    # (shapely + geopandas + pyogrio) under pyramids/_vendor/ instead —
+    # see ci/install-and-vendor-osgeo.py. Every other platform resolves
+    # these normally; drop the markers when upstream ships ARM64 wheels.
+    "geopandas >=1.0.0 ; sys_platform != 'win32' or platform_machine != 'ARM64'",
     "hpc-utils >=0.1.5",
     "numpy >=2.0.0",
     "pandas >=2.0.0",
     "pyproj >=3.7.0",
     "PyYAML >=6.0.0",
-    "Shapely >=2.1.0",
+    "Shapely >=2.1.0 ; sys_platform != 'win32' or platform_machine != 'ARM64'",
     "scipy >=1.10.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,14 @@ requires-python = ">= 3.11, <4"
 # Listing pip's PyPI GDAL would force a from-source build on Windows
 # (no wheel exists) and break most end-user pip installs.
 dependencies = [
+    # Inverse of the win_arm64 vendoring markers below: the vendored
+    # geopandas/pyogrio still import `packaging` (both) and `certifi`
+    # (pyogrio) at runtime, and with the real distributions skipped
+    # nothing else in the closure is guaranteed to install them — pip
+    # was satisfied while `import geopandas` died on a clean install.
+    # Drop these two lines together with the markers.
+    "certifi ; sys_platform == 'win32' and platform_machine == 'ARM64'",
+    "packaging ; sys_platform == 'win32' and platform_machine == 'ARM64'",
     "cftime >=1.6.4",
     # win_arm64: shapely and pyogrio (geopandas' hard dep) ship no ARM64
     # wheels on PyPI, so requiring them would make the platform

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,29 +5,31 @@ import re
 from pathlib import Path
 from typing import Iterator, List, Tuple
 
-import geopandas as gpd
 import numpy as np
 import pandas as pd
 import pytest
-from geopandas import GeoDataFrame
 from pandas import DataFrame
-from shapely import wkt
-from shapely.geometry import Polygon
 
 # pyramids.__init__ activates the vendored osgeo if present (sys.path
 # injection, GDAL_DATA / PROJ_DATA / GDAL_DRIVER_PATH env vars, Windows
 # add_dll_directory + PATH prepend). Must run BEFORE any
-# `from osgeo import ...` anywhere in the test tree. The alias makes
-# the side-effect-only intent obvious so this isn't mistaken for an
-# unused import. The order is pinned against isort's first-party
-# regrouping (profile=black would otherwise float `import pyramids`
-# below the third-party osgeo block — fatal in a bare bundled-wheel
-# env, where osgeo only exists under pyramids/_vendor and is unimportable
-# until the bootstrap injects it onto sys.path).
+# `from osgeo import ...` anywhere in the test tree — and before the
+# geopandas/shapely imports below, because the win_arm64 wheel vendors
+# the whole vector stack (shapely, geopandas, pyogrio) under
+# pyramids/_vendor, where it is likewise unimportable until the
+# bootstrap injects it onto sys.path. The alias makes the
+# side-effect-only intent obvious so this isn't mistaken for an unused
+# import. The order is pinned against isort's first-party regrouping
+# (profile=black would otherwise float `import pyramids` below the
+# third-party block — fatal in a bare bundled-wheel env).
 # isort: off
 import pyramids as _pyramids_bootstrap  # noqa: F401
 from osgeo import gdal
 from osgeo.gdal import Dataset
+import geopandas as gpd
+from geopandas import GeoDataFrame
+from shapely import wkt
+from shapely.geometry import Polygon
 
 # isort: on
 from tests._marks import EXTRA_MARKERS


### PR DESCRIPTION
# Description

Publish the Windows-on-ARM64 wheels (#334 graduation). The wheels have been building and passing the
full native test suite as CI canaries since #691; the only publish blocker was pip resolution â€”
**shapely** (hard dependency) and **pyogrio** (via geopandas) ship no win_arm64 wheels on PyPI, so
`pip install pyramids-gis` could not resolve on the platform. This PR removes that blocker by making
the wheel self-contained:

- **Dependency markers** (PEP 508): `Shapely` and `geopandas` requirements carry
  `; sys_platform != 'win32' or platform_machine != 'ARM64'` â€” pip skips them only on Windows ARM64;
  every other platform resolves them from PyPI unchanged (verified in the lock: only the marker text
  moves).
- **Vendored vector stack**: `install-and-vendor-osgeo.py` builds shapely 2.1.2 + pyogrio 0.13.0 from
  sdist against the vcpkg prefix per Python version, delvewheel-repairs them, and vendors them with
  pure-Python geopandas 1.1.4 into `pyramids/_vendor/` â€” the same sys.path-root mechanism the vendored
  `osgeo` has always used. License texts ship under `_licenses/`. Exact pins live in
  `_VECTOR_STACK_PINS` with a removal note for when upstream ships ARM64 wheels (then the markers and
  the vendoring both disappear).
- **Publish flip**: the artifact renames to `wheels-winarm64` (picked up by the release gather), the
  composition gate now expects exactly `pyvers - 1` win_arm64 wheels (cp311 excluded â€” numpy/scipy
  publish no ARM64 wheels for it) instead of rejecting the tag â€” verified against synthetic `dist/`
  trees (happy path, missing-wheel, musl-rejection) â€” and the vcpkg cache step is skipped on
  `workflow_run` so release wheels always cold-build from the pinned snapshot, same policy as the
  glibc job.
- **Verification widened**: `verify-winarm64` becomes a 3.12/3.13/3.14 matrix (closing the cp313/
  cp314 zero-coverage blocker recorded on #334); each cell installs its wheel with a bare
  `pip install <wheel>` â€” the exact resolution a PyPI user gets â€” and `verify-wheel.py` gains a
  platform-keyed check that shapely/geopandas/pyogrio import from `_vendor/` (the import also
  executes delvewheel's DLL loader, so broken GEOS/GDAL bundling fails in CI, not at first user
  import). The full hermetic suite runs on 3.12.
- Docs: the platform matrix gains the win_arm64 row with the ARM64 note (Python 3.12+, GDAL 3.12.4
  from the pinned vcpkg port vs 3.13.1 elsewhere, no HDF4 like Linux, vendored vector stack); the
  coverage-gaps rows drop it; wheel-build-flow counts 23 published wheels.

Known accepted deltas on this platform, all documented: GDAL 3.12.4 (vcpkg port lag â€” pinned via
manifest overrides; bump when the port ships 3.13.x), no cp311, no HDF4, and we own the vendored
trio's versions until upstream ships ARM64 wheels.

# Issues

- Closes #334
- Refs #333 â€” the musl canaries keep the same unpublished model; their blocker (pyogrio musllinux
  wheels) is unaffected by this PR

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

> **Note on `pixi.lock`**: beyond the intentional re-encoding of the new dependency markers, the
> re-solve floated `cleopatra 0.20.0 -> 0.21.0`, `virtualenv`, and `charset_normalizer` within their
> declared floors. The plot suite (not run by the wheel workflow) is what exercises cleopatra.

# How Has This Been Tested?

- The release composition gate was executed against synthetic `dist/` trees: 23-wheel happy path
  passes; a missing win_arm64 wheel and a planted musllinux wheel each fail with a clear message
  (this testing also caught an ordering bug â€” the gate read `pyvers` before deriving it â€” fixed
  before commit).
- Full-pipeline validation run with `dry_run_release=true` dispatched on this branch
  (run 28760024989): per-Python vendoring, bare-pip resolution on all three ARM cells, the vendored
  import check, license assertions, and the release gather + gate against real artifacts.
- Local full suite green against the branch (markers evaluate true on the dev platform, so nothing
  changes off-ARM).
- [x] verify-winarm64 matrix (3.12/3.13/3.14): bare pip install + verify-wheel; full suite on 3.12
- [x] composition gate: happy-path + two failure scenarios, empirically

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen-managed)
- [ ] added changes to History.rst. (changelog is commitizen-generated)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works. (the verify-winarm64
      matrix + verify-wheel's vendored-stack check gate every run; no pytest harness exists for `ci/`)
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.

