### PR TITLE
ci(mkdocs): serialize gh-pages deploys with a concurrency guard

### DIFF
--- a/.github/workflows/github-pages-mkdocs.yml
+++ b/.github/workflows/github-pages-mkdocs.yml
@@ -17,6 +17,18 @@ on:
     workflows: ['github-release']
     types: [completed]
 
+# All jobs in this workflow push the built docs to the single shared `gh-pages`
+# branch via `mike deploy --push`. Without a concurrency guard, deploys from
+# concurrent PRs (and main pushes) race to push `gh-pages` and the loser gets a
+# non-fast-forward rejection ("Updates were rejected because the remote contains
+# work that you do not have locally"). Serialize every run of this workflow onto
+# one lane so the pushes queue instead of colliding. `cancel-in-progress: false`
+# keeps a queued run rather than cancelling an in-flight push (a cancelled
+# `gh-pages` push can leave the branch half-updated).
+concurrency:
+  group: mkdocs-gh-pages-deploy
+  cancel-in-progress: false
+
 jobs:
   deploy-pr:
       if: github.event_name == 'pull_request'


### PR DESCRIPTION
# Description

Every job in the **Deploy MkDocs** workflow (`deploy-pr`, `deploy-main`, `deploy-release`) publishes the built docs
to the single shared `gh-pages` branch via `mike deploy --push`. With no concurrency control, runs triggered close
together — e.g. a PR deploy and a `main` push, or two PRs — race to push `gh-pages`, and the loser's push is
rejected non-fast-forward (`Updates were rejected because the remote contains work that you do not have locally`).
This is the intermittent `deploy-pr` failure seen on recent PRs.

Add a workflow-level `concurrency` group so every run of this workflow serializes onto one lane and the pushes queue
instead of colliding:

```yaml
concurrency:
  group: mkdocs-gh-pages-deploy
  cancel-in-progress: false
```

`cancel-in-progress: false` keeps a queued run rather than cancelling an in-flight deploy — a cancelled `gh-pages`
push can leave the branch half-updated.

No dependencies.

# Issues

- Closes #697

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] YAML-only, CI-config change — no code paths affected; verified the workflow still parses and the added
      `concurrency` block sits at the workflow top level (not per-job).
- [x] Effect will be observable on the next set of overlapping doc deploys: runs queue on the `mkdocs-gh-pages-deploy`
      lane instead of racing the `gh-pages` push.

# Checklist:

- [ ] updated version number in pyproject.toml. (n/a — CI-only)
- [ ] added changes to History.rst. (n/a — change-log is commitizen-generated)
- [ ] updated the latest version in README file. (n/a)
- [ ] I have added tests that prove my fix is effective or that my feature works. (n/a — CI workflow config)
- [x] New and existing unit tests pass locally with my changes. (no code changed)
- [ ] documentation are updated. (n/a)

