### PR TITLE
fix(netcdf): preserve no-EPSG CRS in set_variable and bbox reads

### DIFF
--- a/src/pyramids/dataset/_stac.py
+++ b/src/pyramids/dataset/_stac.py
@@ -841,8 +841,9 @@ def _footprint_4326(
     minx, miny, maxx, maxy = native_bbox
     if not epsg:
         warnings.warn(
-            "Dataset has no CRS; setting the STAC geometry/bbox to the world "
-            "extent (-180, -90, 180, 90).",
+            "Cannot reproject the footprint to EPSG:4326 (the dataset has no "
+            "EPSG code); setting the STAC geometry/bbox to the world extent "
+            "(-180, -90, 180, 90).",
             stacklevel=3,
         )
         world = [-180.0, -90.0, 180.0, 90.0]

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -384,8 +384,8 @@ class RasterBase(ABC):
 
     @property
     @abstractmethod
-    def epsg(self):
-        """EPSG number."""
+    def epsg(self) -> int | None:
+        """EPSG number, or ``None`` for a CRS with no EPSG code (e.g. geostationary)."""
         pass
 
     @property

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -241,7 +241,7 @@ def _finalize_collection_metadata(resolved_store, meta, files: list) -> None:
             "pyramids_file_list": list(files),
         },
         data_attrs={
-            "epsg": int(meta.epsg) if meta.epsg else None,
+            "epsg": int(meta.epsg or 0),
             "GeoTransform": " ".join(str(v) for v in meta.geotransform),
             "crs_wkt": meta.crs.to_wkt(),
             "nodata": [None if v is None else float(v) for v in meta.nodata],

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1872,9 +1872,11 @@ class Spatial(_Engine["Dataset"]):
         if bbox is not None:
             if mask is not None:
                 raise ValueError("crop accepts either `mask` or `bbox`, not both")
-            crs = epsg if epsg is not None else self._ds.epsg
+            # `.epsg` is None for a no-EPSG CRS (e.g. geostationary); fall back to
+            # the WKT so a bbox in the grid's own CRS is still honoured (#706).
+            crs = epsg if epsg is not None else (self._ds.epsg or self._ds.crs)
             west, _, east, _ = bbox
-            crs_geo = crs is not None and sr_from_user_input(crs).IsGeographic()
+            crs_geo = bool(crs) and sr_from_user_input(crs).IsGeographic()
             ds_epsg = self._ds.epsg
             ds_geo = ds_epsg is not None and sr_from_user_input(ds_epsg).IsGeographic()
             if west > east and crs_geo and ds_geo:

--- a/src/pyramids/dataset/ops/_zarr.py
+++ b/src/pyramids/dataset/ops/_zarr.py
@@ -66,7 +66,9 @@ def _metadata_dict(ds: Dataset) -> dict[str, Any]:
     # through the WKT `spatial_ref` and record epsg 0 (the geobox convention for
     # "no authority code") so `to_zarr` does not crash on `int(None)` (#706).
     epsg_code = int(ds.epsg) if ds.epsg else 0
-    crs_wkt = ds.crs or sr_from_epsg(epsg_code).ExportToWkt()
+    # A normal dataset keeps the canonical EPSG WKT (unchanged); a no-EPSG CRS
+    # (e.g. geostationary) carries its own WKT so its `spatial_ref` is preserved.
+    crs_wkt = sr_from_epsg(epsg_code).ExportToWkt() if ds.epsg else (ds.crs or "")
     nodata_tuple = ds.no_data_value
     return {
         "spatial_ref": crs_wkt,

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -407,12 +407,13 @@ class Selection(_Engine["NetCDF"]):
         if bbox is not None:
             if mask is not None:
                 raise ValueError("crop accepts either `mask` or `bbox`, not both")
-            crs = epsg if epsg is not None else self._ds.epsg
-            if crs is None:
+            # `.epsg` is None for a no-EPSG CRS (e.g. geostationary); fall back to
+            # the WKT so a bbox in the grid's own CRS is still honoured (#706).
+            crs = epsg if epsg is not None else (self._ds.epsg or self._ds.crs)
+            if not crs:
                 raise ValueError(
                     "crop(bbox=…) requires an explicit `epsg=` when the "
-                    "NetCDF itself has no CRS (self.epsg is None) — a "
-                    "bbox without a CRS is ambiguous"
+                    "NetCDF has no CRS at all — a bbox without a CRS is ambiguous"
                 )
             mask = FeatureCollection.from_bbox(bbox, epsg=crs)
         if mask is None:

--- a/src/pyramids/netcdf/engines/variables.py
+++ b/src/pyramids/netcdf/engines/variables.py
@@ -151,9 +151,13 @@ class Variables(_Engine["NetCDF"]):
             band,
         )
 
-        # Set spatial reference (RT-7: attribute copying)
+        # Set spatial reference (RT-7: attribute copying). Carry a no-EPSG CRS
+        # (e.g. geostationary) through its WKT so set_variable / add_variable does
+        # not silently erase the georeference (#706).
         if dataset.epsg:
             md_arr.SetSpatialRef(sr_from_epsg(dataset.epsg))
+        elif dataset.crs:
+            md_arr.SetSpatialRef(sr_from_user_input(dataset.crs))
 
         # Set no-data value
         if dataset.no_data_value and dataset.no_data_value[0] is not None:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1740,12 +1740,13 @@ class NetCDF(Dataset):
                 "read_array(chunks=..., bbox=...) is not supported; "
                 "read lazily and slice the resulting dask array instead."
             )
-        crs = epsg if epsg is not None else self.epsg
-        if crs is None:
+        # `.epsg` is None for a no-EPSG CRS (e.g. geostationary); fall back to the
+        # WKT so a bbox in the grid's own CRS is still honoured (#706).
+        crs = epsg if epsg is not None else (self.epsg or self.crs)
+        if not crs:
             raise ValueError(
-                "read_array(bbox=…) requires an explicit `epsg=` when "
-                "the NetCDF itself has no CRS (self.epsg is None) — a "
-                "bbox without a CRS is ambiguous"
+                "read_array(bbox=…) requires an explicit `epsg=` when the "
+                "NetCDF has no CRS at all — a bbox without a CRS is ambiguous"
             )
         return FeatureCollection.from_bbox(bbox, epsg=crs)
 

--- a/tests/dataset/stac/test_to_stac_item.py
+++ b/tests/dataset/stac/test_to_stac_item.py
@@ -167,8 +167,8 @@ class TestToStacItem:
             item = to_stac_item(ds, "x", asset_href="s.tif")
         assert item["bbox"] == [-180.0, -90.0, 180.0, 90.0], f"bbox: {item['bbox']}"
         assert any(
-            "no CRS" in str(w.message) for w in caught
-        ), "expected a no-CRS warning"
+            "no EPSG code" in str(w.message) for w in caught
+        ), "expected a no-EPSG-code warning"
         assert not any(
             k.startswith("proj:") for k in item["properties"]
         ), f"a CRS-less item must not advertise proj:* fields: {item['properties']}"

--- a/tests/netcdf/spatial/test_geostationary_crs.py
+++ b/tests/netcdf/spatial/test_geostationary_crs.py
@@ -184,6 +184,34 @@ class TestGeostationaryContainerOps:
         assert any("Geostationary_Satellite" in open(f, encoding="utf-8").read() for f in meta)
 
 
+    def test_set_variable_preserves_geostationary_crs(self, tmp_path):
+        """`set_variable` carries the geostationary WKT instead of erasing it."""
+        path = str(tmp_path / "geos.nc")
+        _write_geostationary_mdim(path)
+        container = NetCDF.read_file(path)
+        container.set_variable("CMI_copy", container.get_variable("CMI_C02"))
+        copy = container.get_variable("CMI_copy")
+        assert copy.epsg is None
+        assert "Geostationary_Satellite" in copy.crs
+
+    def test_bounds_carries_geostationary_crs(self, tmp_path):
+        """`.bounds` attaches the geostationary CRS rather than a CRS-less frame."""
+        path = str(tmp_path / "geos.nc")
+        _write_geostationary_mdim(path)
+        var = NetCDF.read_file(path).get_variable("CMI_C02")
+        assert var.bounds.crs is not None
+
+    def test_aligner_rejects_geostationary_reference(self, tmp_path):
+        """Constructing an `Aligner` on a no-EPSG reference raises a clear error."""
+        from pyramids.dataset.ops.reproject import Aligner
+
+        path = str(tmp_path / "geos.nc")
+        _write_geostationary_mdim(path)
+        var = NetCDF.read_file(path).get_variable("CMI_C02")
+        with pytest.raises(ValueError, match=r"no EPSG code"):
+            Aligner(var)
+
+
 class TestNonGeostationaryEpsgUnaffected:
     """The `None`-for-geostationary rule must not touch ordinary CRSs."""
 

--- a/tests/netcdf/spatial/test_netcdf_bbox.py
+++ b/tests/netcdf/spatial/test_netcdf_bbox.py
@@ -235,10 +235,11 @@ class TestNetCDFCropMutex:
             mocker: pytest-mock fixture.
 
         Test scenario:
-            When the dataset has no CRS (``self.epsg is None``) and the
-            caller didn't pass ``epsg=``, the upfront guard must fire
-            with a message that names ``epsg=`` and ``self.epsg``
-            (better than the deeper ``from_bbox`` ``ValueError``).
+            When the dataset has no CRS at all (``epsg`` None *and* an empty
+            ``crs`` WKT) and the caller didn't pass ``epsg=``, the upfront guard
+            must fire (better than the deeper ``from_bbox`` ``ValueError``). A
+            geostationary grid — ``epsg is None`` but a present WKT — is not
+            CRS-less and must not hit this branch.
         """
         mocker.patch.object(
             type(root_nc),
@@ -246,7 +247,13 @@ class TestNetCDFCropMutex:
             new_callable=mocker.PropertyMock,
             return_value=None,
         )
-        with pytest.raises(ValueError, match=r"explicit `epsg=`.*self\.epsg is None"):
+        mocker.patch.object(
+            type(root_nc),
+            "crs",
+            new_callable=mocker.PropertyMock,
+            return_value="",
+        )
+        with pytest.raises(ValueError, match=r"explicit `epsg=`.*no CRS at all"):
             root_nc.crop(bbox=INSIDE_BBOX)
 
     def test_crs_less_netcdf_explicit_epsg_works(self, root_nc: NetCDF, mocker):
@@ -383,7 +390,13 @@ class TestNetCDFReadArrayBbox:
             new_callable=mocker.PropertyMock,
             return_value=None,
         )
-        with pytest.raises(ValueError, match=r"explicit `epsg=`.*self\.epsg is None"):
+        mocker.patch.object(
+            type(root_nc),
+            "crs",
+            new_callable=mocker.PropertyMock,
+            return_value="",
+        )
+        with pytest.raises(ValueError, match=r"explicit `epsg=`.*no CRS at all"):
             root_nc.read_array(variable="Band1", bbox=INSIDE_BBOX)
 
     def test_fc_built_once_at_netcdf_level(self, root_nc: NetCDF, mocker):


### PR DESCRIPTION
# Description

Post-merge follow-up to #707 (geostationary `NetCDF.epsg` → `None`). A further review pass found more
consumers that assumed `.epsg` is always a usable int and misbehave now that it can be `None` for a
geostationary CRS. The most important is a **data-integrity bug that shipped in #707**:
`set_variable` / `add_variable` **silently erase** a geostationary CRS.

Everywhere `.epsg` was used as the CRS carrier, fall back to the `.crs` WKT when there is no EPSG code:

- **`set_variable` / `add_variable`** now write the spatial reference from the WKT when `.epsg` is `None`,
  instead of skipping `SetSpatialRef` and dropping the georeference (was: `.crs` → `''`, `.epsg` → `4326`).
- **`read_array(bbox=)` / `crop(bbox=)`** (NetCDF and `Dataset` paths) fall back to `.crs` and only refuse
  when there is no CRS at all; the error no longer claims a geostationary grid is CRS-less.
- **`to_zarr`** keeps the canonical EPSG WKT for normal datasets and the dataset's own WKT for a no-EPSG CRS.
- **STAC** warns "no EPSG code" (accurate for a geostationary CRS) instead of "no CRS".
- Widen the abstract `epsg` getter annotation to `int | None` and unify the `DatasetCollection` no-EPSG
  sentinel to `0` (matching the geobox convention).

# Issues

- Refs #706, #707

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- New tests in `tests/netcdf/spatial/test_geostationary_crs.py`: `set_variable` preserves the geostationary
  CRS, `.bounds` carries it, and `Aligner` on a no-EPSG reference raises a clear error.
- Updated `tests/netcdf/spatial/test_netcdf_bbox.py` and `tests/dataset/stac/test_to_stac_item.py` for the
  corrected semantics (`epsg is None` is not the same as "no CRS"; the truly-CRS-less case mocks both a `None`
  `epsg` and an empty `crs`).
- Affected suites green on the current `main` base: `test_geostationary_crs.py`, `test_netcdf_bbox.py`,
  `test_to_stac_item.py` — **45 passed**. The full `tests/netcdf` + `tests/dataset` (`-m "not plot"`) suite was
  green on the source branch (**4317 passed**) before rebasing these changes onto `main`.

- [x] Test A — new set_variable / .bounds / Aligner regression tests
- [x] Test B — updated CRS-less bbox + STAC tests for the epsg-None semantics

# Checklist:

- [ ] updated version number in pyproject.toml. — handled automatically by commitizen in CI, not bumped manually
- [ ] added changes to History.rst. — changelog is commitizen-generated in CI
- [ ] updated the latest version in README file. — handled by the release workflow
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated. — no user-facing docs change; behaviour is covered by the `.epsg` docstring
