### PR TITLE
fix(ci): pin wheel-build checkouts to the triggering commit, not the …

### DIFF
--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -61,7 +61,11 @@ jobs:
           fetch-depth: 0
           # head_branch (not head_sha) — github-release pushes the bump + lockfile commits AFTER
           # the workflow_run head_sha is captured; we need the branch tip to see them.
-          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.ref }}
+          # The push/dispatch fallback is github.sha (the immutable triggering commit), NOT
+          # github.ref: a branch ref re-resolves per job, so a commit landing mid-run made the
+          # verify jobs check out newer tests than the wheels were built from — an ImportError
+          # on a symbol added by a PR that merged 12 min into run 28900224956.
+          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.sha }}
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
@@ -103,7 +107,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.ref }}
+          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.sha }}
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
@@ -179,7 +183,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.ref }}
+          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.sha }}
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
@@ -270,7 +274,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.ref }}
+          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.sha }}
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
@@ -310,7 +314,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.ref }}
+          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.sha }}
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
@@ -351,7 +355,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
-          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.ref }}
+          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.sha }}
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
@@ -426,7 +430,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.ref }}
+          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.sha }}
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
@@ -477,7 +481,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.ref }}
+          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.sha }}
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -517,7 +521,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.ref }}
+          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.sha }}
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -560,7 +564,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.ref }}
+          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.sha }}
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -608,7 +612,7 @@ jobs:
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.ref }}
+          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.sha }}
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -665,7 +669,7 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.ref }}
+          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.sha }}
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:


### PR DESCRIPTION
…branch ref

Every checkout in bundle-pypi-wheels.yml fell back to `github.ref` on a push/dispatch, which resolves to the branch (refs/heads/main) rather than the commit that triggered the run. Because each job checks out independently, a commit merged mid-run made the later verify jobs pull newer test sources than the wheels the earlier build jobs had produced. In run 28900224956 (#709 at 12868412c) the build jobs finished before #714 merged and the verify jobs started ~7-11 min after it landed, so all four downloaded 12868412c wheels but checked out 9009a01c7 tests — collection failed with `ImportError: cannot import name '_grouped_reduce'` (a symbol #714 added). No bundling logic was wrong; the next push run passed because its tree was self-consistent.

Change the final fallback github.ref -> github.sha on all 12 checkouts: github.sha is the immutable triggering commit and is constant across every job in the run, so build and verify are guaranteed to agree. The workflow_run (release) path keeps head_branch on purpose — github-release pushes the version-bump + lockfile commits after head_sha is captured, so the release build must follow the branch tip to include them — and dispatch keeps inputs.branch.

# Description

- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context.
- List any dependencies that are required for this change.


# Issues
- Fixes # (issue)

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Please describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
