### PR TITLE
feat(dataset): add a discovery-less direct GetCoverage mode to from_wcs

### DIFF
--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -55,13 +55,25 @@ from pyramids.base._coverage import validate_bbox as _validate_bbox
 from pyramids.base._errors import CoverageError, WCSError
 from pyramids.base._ogc_api import gdal_http_config as _gdal_http_config
 
+# Request KVP keys pyramids sets itself in direct GetCoverage; an extra_params key
+# colliding with one of these is rejected so it cannot duplicate the request —
+# independent of whether the optional FORMAT was emitted.
+_RESERVED_KVP_KEYS = frozenset(
+    {
+        "SERVICE", "VERSION", "REQUEST", "COVERAGE", "COVERAGEID", "SUBSET",
+        "SUBSETTINGCRS", "CRS", "BBOX", "RESX", "RESY", "FORMAT",
+    }
+)
+
 if TYPE_CHECKING:
     from osgeo import osr
 
     from pyramids.dataset.dataset import Dataset
 
 
-def _http_get(url: str, auth: tuple[str, str] | None, timeout: float, what: str) -> bytes:
+def _http_get(
+    url: str, auth: tuple[str, str] | None, timeout: float, what: str
+) -> bytes:
     """GET ``url`` (optional HTTP Basic auth), returning the raw body.
 
     Shared by the ``GetCapabilities`` (discovery) and direct ``GetCoverage``
@@ -309,9 +321,8 @@ def _getcoverage_url(
     if wcs_format:
         params.append(("FORMAT", wcs_format))
     if extra_params:
-        builtin_keys = {key.upper() for key, _ in params}
         for key, val in extra_params.items():
-            if key.upper() in builtin_keys:
+            if key.upper() in _RESERVED_KVP_KEYS:
                 raise ValueError(
                     f"extra_params key {key!r} collides with a built-in GetCoverage "
                     "parameter; use the dedicated from_wcs argument instead."
@@ -342,7 +353,7 @@ def _open_getcoverage_bytes(payload: bytes, coverage: str) -> "gdal.Dataset":
         WCSError: the body is an exception report / non-raster, or GDAL could not
             read it as a raster.
     """
-    if payload.lstrip()[:1] == b"<":
+    if payload[:64].lstrip()[:1] == b"<":
         try:
             root: ET.Element | None = ET.fromstring(payload)
         except ET.ParseError:
@@ -354,7 +365,11 @@ def _open_getcoverage_bytes(payload: bytes, coverage: str) -> "gdal.Dataset":
             raise WCSError(
                 f"WCS server returned an exception for {coverage!r}: {_exception_text(root)}"
             )
-        raise WCSError(f"WCS GetCoverage returned a non-raster body for {coverage!r}")
+        raise WCSError(
+            f"WCS GetCoverage returned an XML/GML body for {coverage!r} that direct "
+            "mode cannot decode; request a plain binary raster via wcs_format=... "
+            "(e.g. 'GEOTIFF')."
+        )
     vsipath = f"/vsimem/wcs_getcoverage_{uuid.uuid4().hex}.tif"
     gdal.FileFromMemBuffer(vsipath, payload)
     try:
@@ -364,6 +379,7 @@ def _open_getcoverage_bytes(payload: bytes, coverage: str) -> "gdal.Dataset":
             if src is not None
             else None
         )
+        src = None  # release the /vsimem handle before Unlink
     except RuntimeError as exc:
         # GDAL raises (rather than returning None) on a bad file when exceptions
         # are enabled — an HTML error page, truncated body, etc.
@@ -427,14 +443,14 @@ def _finalize(
     within the coverage's own CRS (``native_wkt``); otherwise leave the raster
     as fetched. Write to ``output`` last, only after a valid raster exists.
     """
+    if (output_crs is not None or res) and native_wkt is None:
+        raise WCSError(
+            "reproject/resample requested but the returned coverage has no CRS to "
+            "work from; pass coverage_crs=... so the raster carries a source CRS."
+        )
     if output_crs is not None:
         target: str | None = output_crs
     elif res:
-        if native_wkt is None:
-            raise WCSError(
-                "resolution resample requested but the returned coverage has no CRS "
-                "to resample within; pass coverage_crs=... or output_crs=..."
-            )
         target = native_wkt
     else:
         target = None
@@ -494,6 +510,10 @@ def from_wcs(
             dataset_cls, endpoint, coverage, window, crs, version, wcs_format,
             resolution, subset_axes, coverage_crs, auth, timeout, extra_params,
         )
+        # 1.0.0 direct sends RESX/RESY, so the server already grids to `res`; skip
+        # the redundant client-side resample. 2.0.x has no request-side resolution,
+        # so it resamples client-side in _finalize.
+        finalize_res = None if (version or "2.0.0").startswith("1.0") else res
     else:
         _, coverages = _get_capabilities(endpoint, version, auth, timeout)
         if coverages and coverage not in coverages:
@@ -502,7 +522,9 @@ def from_wcs(
                 f"Available coverages: {sorted(coverages)[:10]}"
                 + (" …" if len(coverages) > 10 else "")
             )
-        descriptor = _service_descriptor(endpoint, coverage, version, wcs_format, extra_params)
+        descriptor = _service_descriptor(
+            endpoint, coverage, version, wcs_format, extra_params
+        )
         config = _gdal_http_config(auth, timeout)
         with gdal.config_options(config):
             src = _open_service(descriptor, coverage)
@@ -514,8 +536,9 @@ def from_wcs(
         ds = dataset_cls(mem, access="write")
         # WKT round-trips more faithfully than proj4 for exotic / compound CRS.
         native_wkt = native_srs.ExportToWkt()
+        finalize_res = res
 
-    return _finalize(ds, output_crs, res, resample, native_wkt, output)
+    return _finalize(ds, output_crs, finalize_res, resample, native_wkt, output)
 
 
 def _translate_window(

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -4,11 +4,11 @@ Implementation behind :meth:`pyramids.dataset.Dataset.from_wcs`. It fetches a
 coverage subset from an OGC WCS server and returns a single-raster
 :class:`~pyramids.dataset.Dataset`.
 
-The transport is **GDAL's native WCS driver** — no ``owslib``, no ``rasterio``.
-GDAL performs ``GetCapabilities`` / ``DescribeCoverage``, negotiates the WCS
-version, and issues the version-correct ``GetCoverage`` (the ``1.0.0`` ``bbox`` +
-``resx/resy`` form versus the ``2.0.x`` ``subsets`` + ``scaling`` form). pyramids
-adds the two things the driver does *not* handle on its own:
+The default transport is **GDAL's native WCS driver** — no ``owslib``, no
+``rasterio``. GDAL performs ``GetCapabilities`` / ``DescribeCoverage``, negotiates
+the WCS version, and issues the version-correct ``GetCoverage`` (the ``1.0.0``
+``bbox`` + ``resx/resy`` form versus the ``2.0.x`` ``subsets`` + ``scaling``
+form). pyramids adds the two things the driver does *not* handle on its own:
 
 * **A CRS shim.** Some servers (e.g. ISRIC SoilGrids) advertise a coverage CRS
   under an authority code that the local PROJ database does not know
@@ -21,6 +21,11 @@ adds the two things the driver does *not* handle on its own:
   dependency) and hand GDAL a native-CRS window. This is what makes subsetting
   land on the right pixels even when the server only honours its native CRS.
 
+For ``GetCoverage``-only "shim" servers that ``502``/``400`` on capabilities /
+describe, ``from_wcs(..., direct=True)`` bypasses GDAL's driver entirely and
+issues a KVP ``GetCoverage`` built here (:func:`_getcoverage_url`), reading the
+returned bytes into a raster (:func:`_open_getcoverage_bytes`).
+
 Scope boundary (see ``docs/SCOPE.md``): this reader takes only generic OGC
 inputs. Provider specifics — SoilGrids' ``map=/map/<property>.map`` URL scheme,
 coverage-name catalogs, the ``EPSG:152160 == IGH`` fact, agency auth endpoints —
@@ -30,6 +35,7 @@ passes ``coverage_crs`` / ``auth`` as needed.
 
 from __future__ import annotations
 
+import re
 import urllib.parse
 import urllib.request
 import uuid
@@ -48,6 +54,11 @@ from pyramids.base._coverage import resolve_native_srs as _resolve_native_srs_ne
 from pyramids.base._coverage import validate_bbox as _validate_bbox
 from pyramids.base._errors import CoverageError, WCSError
 from pyramids.base._ogc_api import gdal_http_config as _gdal_http_config
+
+if TYPE_CHECKING:
+    from osgeo import osr
+
+    from pyramids.dataset.dataset import Dataset
 
 
 def _http_get(url: str, auth: tuple[str, str] | None, timeout: float, what: str) -> bytes:
@@ -68,11 +79,6 @@ def _http_get(url: str, auth: tuple[str, str] | None, timeout: float, what: str)
     except OSError as exc:
         # urllib.error.URLError / HTTPError both derive from OSError.
         raise WCSError(f"WCS {what} request failed for {url!r}: {exc}") from exc
-
-if TYPE_CHECKING:
-    from osgeo import osr
-
-    from pyramids.dataset.dataset import Dataset
 
 
 def _resolve_native_srs(
@@ -232,7 +238,8 @@ def _default_subset_axes(crs: str) -> tuple[str, str]:
     try:
         is_geographic = _PyprojCRS.from_user_input(crs).is_geographic
     except (_PyprojCRSError, ValueError, TypeError):
-        is_geographic = str(crs).strip().upper().endswith(":4326")
+        text = str(crs).strip().upper()
+        is_geographic = text.endswith(":4326") or "CRS84" in text
     return ("Long", "Lat") if is_geographic else ("X", "Y")
 
 
@@ -262,6 +269,11 @@ def _getcoverage_url(
     """
     minx, miny, maxx, maxy = bbox
     ver = version or "2.0.0"
+    if re.fullmatch(r"\d+\.\d+\.\d+", ver) is None:
+        raise ValueError(
+            f"direct GetCoverage needs a full 'x.y.z' WCS version (e.g. '2.0.0' or "
+            f"'1.0.0'); got {ver!r}."
+        )
     params: list[tuple[str, str]] = [
         ("SERVICE", "WCS"),
         ("VERSION", ver),
@@ -297,12 +309,22 @@ def _getcoverage_url(
     if wcs_format:
         params.append(("FORMAT", wcs_format))
     if extra_params:
-        params += list(extra_params.items())
-    # Keep ',():/' literal so CRS shorthand / URIs (EPSG:4326,
-    # http://www.opengis.net/def/crs/…) and SUBSET syntax survive intact — quirky
-    # shim servers often string-match these rather than percent-decode.
+        builtin_keys = {key.upper() for key, _ in params}
+        for key, val in extra_params.items():
+            if key.upper() in builtin_keys:
+                raise ValueError(
+                    f"extra_params key {key!r} collides with a built-in GetCoverage "
+                    "parameter; use the dedicated from_wcs argument instead."
+                )
+            params.append((key, val))
+    # Encode both key and value so a stray '&'/'=' in a caller-supplied key cannot
+    # split the query. Keep ',():/' literal in values so CRS shorthand / URIs
+    # (EPSG:4326, http://www.opengis.net/def/crs/…) and SUBSET syntax survive intact
+    # — quirky shim servers often string-match these rather than percent-decode.
     query = "&".join(
-        f"{key}={urllib.parse.quote(str(val), safe=',():/')}" for key, val in params
+        f"{urllib.parse.quote(str(key), safe='')}="
+        f"{urllib.parse.quote(str(val), safe=',():/')}"
+        for key, val in params
     )
     sep = "&" if "?" in endpoint else "?"
     return f"{endpoint}{sep}{query}"
@@ -407,7 +429,12 @@ def _finalize(
     """
     if output_crs is not None:
         target: str | None = output_crs
-    elif res and native_wkt is not None:
+    elif res:
+        if native_wkt is None:
+            raise WCSError(
+                "resolution resample requested but the returned coverage has no CRS "
+                "to resample within; pass coverage_crs=... or output_crs=..."
+            )
         target = native_wkt
     else:
         target = None

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -30,13 +30,17 @@ passes ``coverage_crs`` / ``auth`` as needed.
 
 from __future__ import annotations
 
+import urllib.parse
 import urllib.request
+import uuid
 from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING
 from xml.etree import ElementTree as ET
 
 from osgeo import gdal
+from pyproj import CRS as _PyprojCRS
+from pyproj.exceptions import CRSError as _PyprojCRSError
 
 from pyramids.base._coverage import native_projwin as _native_projwin
 from pyramids.base._coverage import resolution_pair as _resolution_pair
@@ -44,6 +48,26 @@ from pyramids.base._coverage import resolve_native_srs as _resolve_native_srs_ne
 from pyramids.base._coverage import validate_bbox as _validate_bbox
 from pyramids.base._errors import CoverageError, WCSError
 from pyramids.base._ogc_api import gdal_http_config as _gdal_http_config
+
+
+def _http_get(url: str, auth: tuple[str, str] | None, timeout: float, what: str) -> bytes:
+    """GET ``url`` (optional HTTP Basic auth), returning the raw body.
+
+    Shared by the ``GetCapabilities`` (discovery) and direct ``GetCoverage``
+    paths. Raises :class:`WCSError` on any transport-level failure so both call
+    sites keep a uniform error contract.
+    """
+    opener = urllib.request.build_opener()
+    if auth is not None:
+        mgr = urllib.request.HTTPPasswordMgrWithDefaultRealm()
+        mgr.add_password(None, url, auth[0], auth[1])
+        opener.add_handler(urllib.request.HTTPBasicAuthHandler(mgr))
+    try:
+        with opener.open(url, timeout=timeout) as resp:
+            return resp.read()
+    except OSError as exc:
+        # urllib.error.URLError / HTTPError both derive from OSError.
+        raise WCSError(f"WCS {what} request failed for {url!r}: {exc}") from exc
 
 if TYPE_CHECKING:
     from osgeo import osr
@@ -97,17 +121,7 @@ def _get_capabilities(
             answered with an ``<ows:ExceptionReport>`` / non-XML body.
     """
     url = _capabilities_url(endpoint, version)
-    opener = urllib.request.build_opener()
-    if auth is not None:
-        mgr = urllib.request.HTTPPasswordMgrWithDefaultRealm()
-        mgr.add_password(None, endpoint, auth[0], auth[1])
-        opener.add_handler(urllib.request.HTTPBasicAuthHandler(mgr))
-    try:
-        with opener.open(url, timeout=timeout) as resp:
-            payload = resp.read()
-    except OSError as exc:
-        # urllib.error.URLError / HTTPError both derive from OSError.
-        raise WCSError(f"WCS GetCapabilities request failed for {endpoint!r}: {exc}") from exc
+    payload = _http_get(url, auth, timeout, "GetCapabilities")
 
     try:
         root = ET.fromstring(payload)
@@ -207,6 +221,203 @@ def _open_service(descriptor: str, coverage: str) -> "gdal.Dataset":
     return src
 
 
+def _default_subset_axes(crs: str) -> tuple[str, str]:
+    """Best-effort WCS 2.0 ``SUBSET`` axis labels for ``crs``.
+
+    Geographic CRSs get ``("Long", "Lat")``; everything else ``("X", "Y")``.
+    There is no ``DescribeCoverage`` in direct mode to learn the coverage's real
+    axis names from, so a server that labels them differently needs an explicit
+    ``subset_axes`` override.
+    """
+    try:
+        is_geographic = _PyprojCRS.from_user_input(crs).is_geographic
+    except (_PyprojCRSError, ValueError, TypeError):
+        is_geographic = str(crs).strip().upper().endswith(":4326")
+    return ("Long", "Lat") if is_geographic else ("X", "Y")
+
+
+def _getcoverage_url(
+    endpoint: str,
+    coverage: str,
+    crs: str,
+    bbox: tuple[float, float, float, float],
+    version: str | None,
+    wcs_format: str | None,
+    resolution: float | tuple[float, float] | None,
+    subset_axes: tuple[str, str] | None,
+    extra_params: dict[str, str] | None,
+) -> str:
+    """Build a direct KVP ``GetCoverage`` URL (no capabilities / DescribeCoverage).
+
+    Supports WCS ``2.0.x`` (``COVERAGEID`` + ``SUBSET`` + ``SUBSETTINGCRS`` — the
+    default when ``version`` is omitted) and ``1.0.0`` (``COVERAGE`` + ``CRS`` +
+    ``BBOX`` + ``RESX``/``RESY``). ``bbox`` is ``(minx, miny, maxx, maxy)`` in
+    ``crs``; for ``2.0.x`` the first ``subset_axes`` label takes the x (min-x,
+    max-x) range and the second the y range, so lon/lat values land on the right
+    axis regardless of the CRS's declared axis order.
+
+    Raises:
+        ValueError: the WCS version is unsupported for direct mode, or ``1.0.0``
+            was requested without a ``resolution`` (needed for the output grid).
+    """
+    minx, miny, maxx, maxy = bbox
+    ver = version or "2.0.0"
+    params: list[tuple[str, str]] = [
+        ("SERVICE", "WCS"),
+        ("VERSION", ver),
+        ("REQUEST", "GetCoverage"),
+    ]
+    if ver.startswith("2."):
+        x_axis, y_axis = subset_axes or _default_subset_axes(crs)
+        params += [
+            ("COVERAGEID", coverage),
+            ("SUBSET", f"{x_axis}({minx},{maxx})"),
+            ("SUBSET", f"{y_axis}({miny},{maxy})"),
+            ("SUBSETTINGCRS", crs),
+        ]
+    elif ver.startswith("1.0"):
+        res = _resolution_pair(resolution)
+        if res is None:
+            raise ValueError(
+                "direct WCS 1.0.0 GetCoverage needs an output grid; pass "
+                "resolution=... (mapped to RESX/RESY)."
+            )
+        params += [
+            ("COVERAGE", coverage),
+            ("CRS", crs),
+            ("BBOX", f"{minx},{miny},{maxx},{maxy}"),
+            ("RESX", str(res[0])),
+            ("RESY", str(res[1])),
+        ]
+    else:
+        raise ValueError(
+            f"direct GetCoverage supports WCS 1.0.0 and 2.0.x; got {ver!r}. "
+            "Use discovery mode (direct=False) for other versions."
+        )
+    if wcs_format:
+        params.append(("FORMAT", wcs_format))
+    if extra_params:
+        params += list(extra_params.items())
+    # Keep ',():/' literal so CRS shorthand / URIs (EPSG:4326,
+    # http://www.opengis.net/def/crs/…) and SUBSET syntax survive intact — quirky
+    # shim servers often string-match these rather than percent-decode.
+    query = "&".join(
+        f"{key}={urllib.parse.quote(str(val), safe=',():/')}" for key, val in params
+    )
+    sep = "&" if "?" in endpoint else "?"
+    return f"{endpoint}{sep}{query}"
+
+
+def _open_getcoverage_bytes(payload: bytes, coverage: str) -> "gdal.Dataset":
+    """Read a direct ``GetCoverage`` response into an in-memory raster.
+
+    A non-raster body (an ``<ows:ExceptionReport>``) is caught before it can be
+    opened as a file the caller sees: an XML exception raises :class:`WCSError`
+    with the server message; otherwise the bytes are materialised in ``/vsimem``,
+    opened, copied into ``MEM``, and the temp is unlinked.
+
+    Raises:
+        WCSError: the body is an exception report / non-raster, or GDAL could not
+            read it as a raster.
+    """
+    if payload.lstrip()[:1] == b"<":
+        try:
+            root: ET.Element | None = ET.fromstring(payload)
+        except ET.ParseError:
+            root = None
+        if root is not None and _localname(root.tag) in (
+            "ExceptionReport",
+            "ServiceExceptionReport",
+        ):
+            raise WCSError(
+                f"WCS server returned an exception for {coverage!r}: {_exception_text(root)}"
+            )
+        raise WCSError(f"WCS GetCoverage returned a non-raster body for {coverage!r}")
+    vsipath = f"/vsimem/wcs_getcoverage_{uuid.uuid4().hex}.tif"
+    gdal.FileFromMemBuffer(vsipath, payload)
+    try:
+        src = gdal.Open(vsipath)
+        mem = (
+            gdal.Translate("", src, options=gdal.TranslateOptions(format="MEM"))
+            if src is not None
+            else None
+        )
+    except RuntimeError as exc:
+        # GDAL raises (rather than returning None) on a bad file when exceptions
+        # are enabled — an HTML error page, truncated body, etc.
+        raise WCSError(
+            f"WCS GetCoverage returned no raster for {coverage!r}: {exc}"
+        ) from exc
+    finally:
+        gdal.Unlink(vsipath)
+    if mem is None:
+        raise WCSError(f"WCS GetCoverage returned no raster for {coverage!r}")
+    return mem
+
+
+def _from_wcs_direct(
+    dataset_cls: type["Dataset"],
+    endpoint: str,
+    coverage: str,
+    bbox: tuple[float, float, float, float],
+    crs: str,
+    version: str | None,
+    wcs_format: str | None,
+    resolution: float | tuple[float, float] | None,
+    subset_axes: tuple[str, str] | None,
+    coverage_crs: str | None,
+    auth: tuple[str, str] | None,
+    timeout: float,
+    extra_params: dict[str, str] | None,
+) -> tuple["Dataset", str | None]:
+    """Direct ``GetCoverage`` path: build the KVP request, fetch, wrap.
+
+    Returns ``(ds, native_wkt)`` so the shared finalize step can resample within
+    the coverage's own CRS when only a ``resolution`` was requested. ``native_wkt``
+    is ``None`` when the returned raster carries no CRS and no ``coverage_crs``
+    shim was supplied.
+    """
+    url = _getcoverage_url(
+        endpoint, coverage, crs, bbox, version, wcs_format, resolution,
+        subset_axes, extra_params,
+    )
+    payload = _http_get(url, auth, timeout, "GetCoverage")
+    mem = _open_getcoverage_bytes(payload, coverage)
+    if not mem.GetSpatialRef() and coverage_crs is not None:
+        mem.SetSpatialRef(_resolve_native_srs(mem, coverage_crs))
+    ds = dataset_cls(mem, access="write")
+    native = mem.GetSpatialRef()
+    native_wkt = native.ExportToWkt() if native else None
+    return ds, native_wkt
+
+
+def _finalize(
+    ds: "Dataset",
+    output_crs: str | None,
+    res: tuple[float, float] | None,
+    resample: str,
+    native_wkt: str | None,
+    output: str | Path | None,
+) -> "Dataset":
+    """Apply the optional reproject/resample + write shared by both WCS paths.
+
+    With ``output_crs`` set, reproject to it; with only ``res`` set, resample
+    within the coverage's own CRS (``native_wkt``); otherwise leave the raster
+    as fetched. Write to ``output`` last, only after a valid raster exists.
+    """
+    if output_crs is not None:
+        target: str | None = output_crs
+    elif res and native_wkt is not None:
+        target = native_wkt
+    else:
+        target = None
+    if target is not None:
+        ds = ds.to_crs(target, method=resample, cell_size=res)
+    if output is not None:
+        ds.to_file(output)
+    return ds
+
+
 def from_wcs(
     dataset_cls: type["Dataset"],
     endpoint: str,
@@ -224,6 +435,8 @@ def from_wcs(
     auth: tuple[str, str] | None = None,
     timeout: float = 60.0,
     extra_params: dict[str, str] | None = None,
+    direct: bool = False,
+    subset_axes: tuple[str, str] | None = None,
 ) -> "Dataset":
     """Fetch a WCS coverage subset and return a :class:`Dataset`.
 
@@ -231,49 +444,51 @@ def from_wcs(
     :meth:`pyramids.dataset.Dataset.from_wcs` classmethod, which forwards here.
     See that method for the full parameter documentation.
 
+    With ``direct=False`` (default) the full OGC handshake runs: ``GetCapabilities``
+    validates the coverage, then GDAL's WCS driver negotiates ``DescribeCoverage``
+    before the windowed ``GetCoverage``. With ``direct=True`` both discovery steps
+    are skipped and a KVP ``GetCoverage`` request is issued straight from the
+    caller-supplied parameters — for ``GetCoverage``-only "WCS shim" endpoints that
+    502/400 on capabilities/describe.
+
     Raises:
-        ValueError: ``bbox`` is malformed, ``coverage`` is not advertised by the
-            server, or ``coverage_crs`` cannot be interpreted.
+        ValueError: ``bbox`` is malformed, ``coverage`` is not advertised (discovery
+            mode), ``coverage_crs`` cannot be interpreted, or (direct mode) the WCS
+            version is unsupported / ``1.0.0`` lacks a ``resolution``.
         WCSError: The server could not be reached or returned an error / a
             non-raster body.
     """
     minx, miny, maxx, maxy = _validate_bbox(bbox)
     res = _resolution_pair(resolution)
+    window = (minx, miny, maxx, maxy)
 
-    _, coverages = _get_capabilities(endpoint, version, auth, timeout)
-    if coverages and coverage not in coverages:
-        raise ValueError(
-            f"coverage {coverage!r} is not advertised by {endpoint!r}. "
-            f"Available coverages: {sorted(coverages)[:10]}"
-            + (" …" if len(coverages) > 10 else "")
+    if direct:
+        ds, native_wkt = _from_wcs_direct(
+            dataset_cls, endpoint, coverage, window, crs, version, wcs_format,
+            resolution, subset_axes, coverage_crs, auth, timeout, extra_params,
         )
-
-    descriptor = _service_descriptor(endpoint, coverage, version, wcs_format, extra_params)
-    config = _gdal_http_config(auth, timeout)
-    with gdal.config_options(config):
-        src = _open_service(descriptor, coverage)
-        native_srs = _resolve_native_srs(src, coverage_crs)
-        projwin = _native_projwin((minx, miny, maxx, maxy), crs, native_srs)
-        mem = _translate_window(src, projwin, coverage)
-        src = None
-
-    mem.SetSpatialRef(native_srs)
-    ds = dataset_cls(mem, access="write")
-
-    if output_crs is not None:
-        target = output_crs
-    elif res:
-        # resample within the native CRS when only a resolution was requested;
-        # WKT round-trips more faithfully than proj4 for exotic / compound CRS
-        target = native_srs.ExportToWkt()
     else:
-        target = None
-    if target is not None:
-        ds = ds.to_crs(target, method=resample, cell_size=res)
+        _, coverages = _get_capabilities(endpoint, version, auth, timeout)
+        if coverages and coverage not in coverages:
+            raise ValueError(
+                f"coverage {coverage!r} is not advertised by {endpoint!r}. "
+                f"Available coverages: {sorted(coverages)[:10]}"
+                + (" …" if len(coverages) > 10 else "")
+            )
+        descriptor = _service_descriptor(endpoint, coverage, version, wcs_format, extra_params)
+        config = _gdal_http_config(auth, timeout)
+        with gdal.config_options(config):
+            src = _open_service(descriptor, coverage)
+            native_srs = _resolve_native_srs(src, coverage_crs)
+            projwin = _native_projwin(window, crs, native_srs)
+            mem = _translate_window(src, projwin, coverage)
+            src = None
+        mem.SetSpatialRef(native_srs)
+        ds = dataset_cls(mem, access="write")
+        # WKT round-trips more faithfully than proj4 for exotic / compound CRS.
+        native_wkt = native_srs.ExportToWkt()
 
-    if output is not None:
-        ds.to_file(output)
-    return ds
+    return _finalize(ds, output_crs, res, resample, native_wkt, output)
 
 
 def _translate_window(

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2205,6 +2205,8 @@ class Dataset(RasterBase):
         auth: tuple[str, str] | None = None,
         timeout: float = 60.0,
         extra_params: dict[str, str] | None = None,
+        direct: bool = False,
+        subset_axes: tuple[str, str] | None = None,
     ) -> Dataset:
         """Read a coverage subset from an OGC Web Coverage Service (WCS).
 
@@ -2227,6 +2229,16 @@ class Dataset(RasterBase):
           default) and transformed into the coverage's native CRS with ``pyproj``
           before the request, so subsetting lands on the correct pixels even when
           the server only honours its native CRS.
+
+        For a **``GetCoverage``-only endpoint** — a "WCS shim" that returns
+        ``502``/``400`` for ``GetCapabilities``/``DescribeCoverage`` but serves
+        ``GetCoverage`` (e.g. Copernicus EDO/GDO) — pass ``direct=True``. That skips
+        both discovery steps and issues a KVP ``GetCoverage`` built straight from
+        ``coverage`` / ``crs`` / ``bbox`` / ``wcs_format`` / ``extra_params``, so the
+        caller owns correctness (no capabilities check). For WCS ``2.0.x`` the
+        ``SUBSET`` axis labels default to ``("Long", "Lat")`` for a geographic
+        ``crs`` — override with ``subset_axes`` if the server names its axes
+        differently.
 
         Args:
             endpoint: The WCS service URL, including any server-specific query
@@ -2264,14 +2276,23 @@ class Dataset(RasterBase):
             timeout: HTTP timeout in seconds for the metadata / coverage
                 requests. Defaults to ``60.0``.
             extra_params: Optional extra ``GetCoverage`` query parameters folded
-                into the request (a workaround hook for server quirks).
+                into the request (a workaround hook for server quirks). In direct
+                mode these are appended to the KVP request (e.g. a ``TIME`` axis).
+            direct: When ``True``, skip ``GetCapabilities``/``DescribeCoverage`` and
+                issue a KVP ``GetCoverage`` directly — for shim servers that only
+                implement ``GetCoverage``. Defaults to ``False`` (full handshake).
+            subset_axes: Direct mode, WCS ``2.0.x`` only — the ``(x, y)`` ``SUBSET``
+                axis labels. ``None`` (default) derives them from ``crs``
+                (``("Long", "Lat")`` for geographic, ``("X", "Y")`` otherwise).
 
         Returns:
             Dataset: The fetched coverage subset.
 
         Raises:
-            ValueError: ``bbox`` is malformed, ``coverage`` is not advertised, or
-                ``coverage_crs`` cannot be interpreted.
+            ValueError: ``bbox`` is malformed, ``coverage`` is not advertised
+                (discovery mode), ``coverage_crs`` cannot be interpreted, or (direct
+                mode) the WCS version is unsupported / ``1.0.0`` lacks a
+                ``resolution``.
             pyramids.errors.WCSError: The server could not be reached or returned
                 an error / a non-raster (``<ows:ExceptionReport>``) body.
 
@@ -2285,6 +2306,23 @@ class Dataset(RasterBase):
             ...     coverage="nitrogen_0-5cm_mean",
             ...     bbox=(5.0, 51.0, 6.0, 52.0),
             ...     coverage_crs="+proj=igh +lat_0=0 +lon_0=0 +datum=WGS84 +units=m +no_defs",
+            ... )
+
+            ```
+
+            Direct mode for a ``GetCoverage``-only endpoint (Copernicus EDO/GDO),
+            whose ``GetCapabilities``/``DescribeCoverage`` return ``502``/``400``:
+
+            ```python
+            >>> ds = Dataset.from_wcs(  # doctest: +SKIP
+            ...     "https://.../mapserv?map=GDO_WCS",
+            ...     coverage="spaST",
+            ...     bbox=(-10.0, 35.0, 5.0, 45.0),
+            ...     crs="EPSG:4326",
+            ...     version="2.0.0",
+            ...     wcs_format="GEOTIFF",
+            ...     direct=True,
+            ...     extra_params={"TIME": "2024-06-01", "SELECTED_TIMESCALE": "03"},
             ... )
 
             ```
@@ -2309,6 +2347,8 @@ class Dataset(RasterBase):
             auth=auth,
             timeout=timeout,
             extra_params=extra_params,
+            direct=direct,
+            subset_axes=subset_axes,
         )
 
     @classmethod

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2283,7 +2283,11 @@ class Dataset(RasterBase):
                 implement ``GetCoverage``. Defaults to ``False`` (full handshake).
             subset_axes: Direct mode, WCS ``2.0.x`` only — the ``(x, y)`` ``SUBSET``
                 axis labels. ``None`` (default) derives them from ``crs``
-                (``("Long", "Lat")`` for geographic, ``("X", "Y")`` otherwise).
+                (``("Long", "Lat")`` for geographic, ``("X", "Y")`` otherwise). These
+                defaults are a best-effort guess — direct mode skips the
+                ``DescribeCoverage`` that would reveal the coverage's real (case-
+                sensitive) axis labels — so MapServer-family shims often need
+                ``subset_axes=("x", "y")`` or the server's exact axis names.
 
         Returns:
             Dataset: The fetched coverage subset.

--- a/tests/dataset/remote/test_wcs.py
+++ b/tests/dataset/remote/test_wcs.py
@@ -559,14 +559,45 @@ class TestDirectGetCoverage:
         )
         assert ds.epsg == 4326
 
-    def test_direct_1_0_0_end_to_end(self, monkeypatch, geotiff_bytes):
+    def test_direct_1_0_0_end_to_end_no_client_resample(self, monkeypatch, geotiff_bytes):
+        # 1.0.0 sends RESX/RESY, so the server grids server-side and pyramids does
+        # NOT resample again client-side. The mock returns the native-res fixture,
+        # so the result is the fixture grid unchanged (not resampled to 1.0).
         monkeypatch.setattr(_wcs, "_http_get", lambda *a, **k: geotiff_bytes)
         ds = Dataset.from_wcs(
             self.ENDPOINT, coverage="c", bbox=self.BBOX, crs="EPSG:4326",
             version="1.0.0", resolution=1.0, direct=True,
         )
         assert ds.epsg == 4326
-        assert ds.cell_size == pytest.approx(1.0, abs=0.01)
+        assert ds.shape == (1, 3, 4)  # native fixture grid, no client resample
+
+    def test_direct_forwards_params_into_the_url(self, monkeypatch, geotiff_bytes):
+        captured: dict[str, str] = {}
+
+        def capture(url, *a, **k):
+            captured["url"] = url
+            return geotiff_bytes
+
+        monkeypatch.setattr(_wcs, "_http_get", capture)
+        Dataset.from_wcs(
+            self.ENDPOINT, coverage="spaST", bbox=self.BBOX, crs="EPSG:4326",
+            version="2.0.1", direct=True, subset_axes=("x", "y"),
+            extra_params={"TIME": "2024-06-01"},
+        )
+        url = captured["url"]
+        assert "COVERAGEID=spaST" in url and "VERSION=2.0.1" in url
+        assert "SUBSET=x(-10.0,5.0)" in url and "SUBSET=y(35.0,45.0)" in url
+        assert "TIME=2024-06-01" in url
+
+    def test_direct_output_crs_without_crs_raises(
+        self, monkeypatch, crsless_geotiff_bytes
+    ):
+        monkeypatch.setattr(_wcs, "_http_get", lambda *a, **k: crsless_geotiff_bytes)
+        with pytest.raises(WCSError, match="no CRS"):
+            Dataset.from_wcs(
+                self.ENDPOINT, coverage="c", bbox=self.BBOX,
+                output_crs="EPSG:3857", direct=True,
+            )
 
     def test_direct_resolution_resamples_output(self, monkeypatch, geotiff_bytes):
         monkeypatch.setattr(_wcs, "_http_get", lambda *a, **k: geotiff_bytes)

--- a/tests/dataset/remote/test_wcs.py
+++ b/tests/dataset/remote/test_wcs.py
@@ -434,6 +434,41 @@ class TestGetCoverageUrl:
                 None, None, None, None,
             )
 
+    def test_malformed_version_raises_valueerror(self):
+        with pytest.raises(ValueError, match="x.y.z"):
+            _wcs._getcoverage_url(
+                "https://x", "c", "EPSG:4326", (0.0, 0.0, 1.0, 1.0), "2.0",
+                None, None, None, None,
+            )
+
+    def test_projected_crs_uses_x_y_subset_labels(self):
+        url = _wcs._getcoverage_url(
+            "https://x", "c", "EPSG:3857", (0.0, 1.0, 2.0, 3.0), "2.0.0",
+            None, None, None, None,
+        )
+        assert "SUBSET=X(0.0,2.0)" in url and "SUBSET=Y(1.0,3.0)" in url
+
+    def test_extra_params_value_with_space_is_encoded(self):
+        url = _wcs._getcoverage_url(
+            "https://x", "c", "EPSG:4326", (0.0, 0.0, 1.0, 1.0), "2.0.0",
+            None, None, None, {"TIME": "2024-06-01 00:00"},
+        )
+        assert "TIME=2024-06-01%2000" in url  # the space is percent-encoded
+
+    def test_extra_params_key_with_ampersand_is_encoded(self):
+        url = _wcs._getcoverage_url(
+            "https://x", "c", "EPSG:4326", (0.0, 0.0, 1.0, 1.0), "2.0.0",
+            None, None, None, {"a&b": "v"},
+        )
+        assert "a%26b=v" in url  # '&' in the key cannot split the query
+
+    def test_extra_params_key_colliding_with_builtin_raises(self):
+        with pytest.raises(ValueError, match="collides"):
+            _wcs._getcoverage_url(
+                "https://x", "c", "EPSG:4326", (0.0, 0.0, 1.0, 1.0), "2.0.0",
+                None, None, None, {"VERSION": "1.0.0"},
+            )
+
 
 @pytest.fixture
 def geotiff_bytes():
@@ -444,6 +479,23 @@ def geotiff_bytes():
     srs = osr.SpatialReference()
     srs.ImportFromEPSG(4326)
     src.SetProjection(srs.ExportToWkt())
+    src.GetRasterBand(1).Fill(7)
+    src.FlushCache()
+    src = None
+    stat = gdal.VSIStatL(path)
+    handle = gdal.VSIFOpenL(path, "rb")
+    data = gdal.VSIFReadL(1, stat.size, handle)
+    gdal.VSIFCloseL(handle)
+    gdal.Unlink(path)
+    return bytes(data)
+
+
+@pytest.fixture
+def crsless_geotiff_bytes():
+    """Bytes of a tiny GeoTIFF with a geotransform but NO CRS (a shim response)."""
+    path = "/vsimem/_wcs_crsless_fixture.tif"
+    src = gdal.GetDriverByName("GTiff").Create(path, 4, 3, 1, gdal.GDT_Byte)
+    src.SetGeoTransform([-10.0, 3.75, 0.0, 45.0, 0.0, -10.0 / 3.0])
     src.GetRasterBand(1).Fill(7)
     src.FlushCache()
     src = None
@@ -495,4 +547,41 @@ class TestDirectGetCoverage:
         with pytest.raises(WCSError, match="no raster|could not be read"):
             Dataset.from_wcs(
                 self.ENDPOINT, coverage="c", bbox=(0.0, 0.0, 1.0, 1.0), direct=True,
+            )
+
+    def test_direct_coverage_crs_shim_sets_epsg_on_crsless_raster(
+        self, monkeypatch, crsless_geotiff_bytes
+    ):
+        monkeypatch.setattr(_wcs, "_http_get", lambda *a, **k: crsless_geotiff_bytes)
+        ds = Dataset.from_wcs(
+            self.ENDPOINT, coverage="spaST", bbox=self.BBOX, direct=True,
+            coverage_crs="EPSG:4326",
+        )
+        assert ds.epsg == 4326
+
+    def test_direct_1_0_0_end_to_end(self, monkeypatch, geotiff_bytes):
+        monkeypatch.setattr(_wcs, "_http_get", lambda *a, **k: geotiff_bytes)
+        ds = Dataset.from_wcs(
+            self.ENDPOINT, coverage="c", bbox=self.BBOX, crs="EPSG:4326",
+            version="1.0.0", resolution=1.0, direct=True,
+        )
+        assert ds.epsg == 4326
+        assert ds.cell_size == pytest.approx(1.0, abs=0.01)
+
+    def test_direct_resolution_resamples_output(self, monkeypatch, geotiff_bytes):
+        monkeypatch.setattr(_wcs, "_http_get", lambda *a, **k: geotiff_bytes)
+        ds = Dataset.from_wcs(
+            self.ENDPOINT, coverage="c", bbox=self.BBOX, version="2.0.0",
+            resolution=1.0, direct=True,
+        )
+        assert ds.cell_size == pytest.approx(1.0, abs=0.01)
+
+    def test_direct_resolution_without_crs_raises(
+        self, monkeypatch, crsless_geotiff_bytes
+    ):
+        monkeypatch.setattr(_wcs, "_http_get", lambda *a, **k: crsless_geotiff_bytes)
+        with pytest.raises(WCSError, match="no CRS"):
+            Dataset.from_wcs(
+                self.ENDPOINT, coverage="c", bbox=self.BBOX, resolution=1.0,
+                direct=True,
             )

--- a/tests/dataset/remote/test_wcs.py
+++ b/tests/dataset/remote/test_wcs.py
@@ -376,3 +376,123 @@ class TestLiveSoilGrids:
             output_crs="EPSG:4326",
         )
         assert ds.epsg == 4326
+
+
+class TestDefaultSubsetAxes:
+    def test_geographic_crs_gets_long_lat(self):
+        assert _wcs._default_subset_axes("EPSG:4326") == ("Long", "Lat")
+
+    def test_projected_crs_gets_x_y(self):
+        assert _wcs._default_subset_axes("EPSG:3857") == ("X", "Y")
+
+    def test_unparseable_crs_falls_back_without_raising(self):
+        # a garbage CRS must not raise; it falls back to the non-geographic default
+        assert _wcs._default_subset_axes("not-a-real-crs") == ("X", "Y")
+
+
+class TestGetCoverageUrl:
+    """The direct-mode KVP GetCoverage URL builder (no network)."""
+
+    def test_2_0_x_builds_coverageid_subset_and_subsettingcrs(self):
+        url = _wcs._getcoverage_url(
+            "https://x/mapserv?map=GDO_WCS", "spaST", "EPSG:4326",
+            (-10.0, 35.0, 5.0, 45.0), "2.0.0", "GEOTIFF", None, None,
+            {"TIME": "2024-06-01"},
+        )
+        assert "REQUEST=GetCoverage" in url and "COVERAGEID=spaST" in url
+        assert "SUBSET=Long(-10.0,5.0)" in url  # lon range on the Long axis
+        assert "SUBSET=Lat(35.0,45.0)" in url  # lat range on the Lat axis
+        assert "SUBSETTINGCRS=EPSG:4326" in url  # colon kept literal for shims
+        assert "FORMAT=GEOTIFF" in url and "TIME=2024-06-01" in url
+
+    def test_subset_axes_override_replaces_default_labels(self):
+        url = _wcs._getcoverage_url(
+            "https://x", "c", "EPSG:4326", (0.0, 1.0, 2.0, 3.0), "2.0.1",
+            None, None, ("x", "y"), None,
+        )
+        assert "SUBSET=x(0.0,2.0)" in url and "SUBSET=y(1.0,3.0)" in url
+
+    def test_1_0_0_builds_bbox_and_resx_resy(self):
+        url = _wcs._getcoverage_url(
+            "https://x/wcs", "c", "EPSG:4326", (-10.0, 35.0, 5.0, 45.0),
+            "1.0.0", "GEOTIFF", 0.1, None, None,
+        )
+        assert "COVERAGE=c" in url and "BBOX=-10.0,35.0,5.0,45.0" in url
+        assert "RESX=0.1" in url and "RESY=0.1" in url
+
+    def test_1_0_0_without_resolution_raises_valueerror(self):
+        with pytest.raises(ValueError, match="resolution"):
+            _wcs._getcoverage_url(
+                "https://x", "c", "EPSG:4326", (0.0, 0.0, 1.0, 1.0), "1.0.0",
+                None, None, None, None,
+            )
+
+    def test_unsupported_version_raises_valueerror(self):
+        with pytest.raises(ValueError, match="1.0.0 and 2.0.x"):
+            _wcs._getcoverage_url(
+                "https://x", "c", "EPSG:4326", (0.0, 0.0, 1.0, 1.0), "1.1.0",
+                None, None, None, None,
+            )
+
+
+@pytest.fixture
+def geotiff_bytes():
+    """Bytes of a tiny 4x3 EPSG:4326 GeoTIFF — stands in for a GetCoverage body."""
+    path = "/vsimem/_wcs_direct_fixture.tif"
+    src = gdal.GetDriverByName("GTiff").Create(path, 4, 3, 1, gdal.GDT_Byte)
+    src.SetGeoTransform([-10.0, 3.75, 0.0, 45.0, 0.0, -10.0 / 3.0])
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(4326)
+    src.SetProjection(srs.ExportToWkt())
+    src.GetRasterBand(1).Fill(7)
+    src.FlushCache()
+    src = None
+    stat = gdal.VSIStatL(path)
+    handle = gdal.VSIFOpenL(path, "rb")
+    data = gdal.VSIFReadL(1, stat.size, handle)
+    gdal.VSIFCloseL(handle)
+    gdal.Unlink(path)
+    return bytes(data)
+
+
+class TestDirectGetCoverage:
+    """The ``direct=True`` path: no capabilities/describe, KVP GetCoverage only."""
+
+    ENDPOINT = "https://shim.invalid/mapserv?map=GDO_WCS"
+    BBOX = (-10.0, 35.0, 5.0, 45.0)
+
+    def test_direct_success_returns_dataset(self, monkeypatch, geotiff_bytes):
+        monkeypatch.setattr(_wcs, "_http_get", lambda *a, **k: geotiff_bytes)
+        ds = Dataset.from_wcs(
+            self.ENDPOINT, coverage="spaST", bbox=self.BBOX, crs="EPSG:4326",
+            version="2.0.0", wcs_format="GEOTIFF", direct=True,
+        )
+        assert ds.shape == (1, 3, 4)
+        assert ds.epsg == 4326
+
+    def test_direct_skips_capabilities(self, monkeypatch, geotiff_bytes):
+        def boom(*a, **k):
+            raise AssertionError("GetCapabilities must not be called in direct mode")
+
+        monkeypatch.setattr(_wcs, "_get_capabilities", boom)
+        monkeypatch.setattr(_wcs, "_http_get", lambda *a, **k: geotiff_bytes)
+        ds = Dataset.from_wcs(
+            self.ENDPOINT, coverage="anything", bbox=self.BBOX, direct=True,
+        )
+        assert ds.epsg == 4326
+
+    def test_direct_exception_report_raises_wcserror(self, monkeypatch):
+        monkeypatch.setattr(
+            _wcs, "_http_get", lambda *a, **k: EXCEPTION_REPORT.encode("utf-8")
+        )
+        with pytest.raises(WCSError, match="exception"):
+            Dataset.from_wcs(
+                self.ENDPOINT, coverage="spaST", bbox=self.BBOX, direct=True,
+            )
+
+    def test_direct_non_raster_body_raises_wcserror(self, monkeypatch):
+        monkeypatch.setattr(_wcs, "_http_get", lambda *a, **k: b"not a raster at all")
+        with pytest.raises(WCSError, match="no raster|could not be read"):
+            Dataset.from_wcs(
+                self.ENDPOINT, coverage="c", bbox=(0.0, 0.0, 1.0, 1.0), direct=True,
+            )


### PR DESCRIPTION
# Description

Some WCS endpoints (e.g. Copernicus EDO/GDO) implement `GetCoverage` reliably but return `502`/`400` for
`GetCapabilities`/`DescribeCoverage`, so the full-handshake `from_wcs` cannot target them at all — the caller has
to hand-roll a raw `GetCoverage` download outside pyramids (as the earthlens `drought` backend does today).

Adds `Dataset.from_wcs(..., direct=True)`: it skips both discovery steps and issues a KVP `GetCoverage` built
straight from the caller's `coverage`/`crs`/`bbox`/`wcs_format`/`extra_params`, fetches it, and reuses the
existing validate-in-MEM safety so a non-raster `<ows:ExceptionReport>` body still raises `WCSError` and writes
no file. The new params (`direct: bool = False`, `subset_axes: tuple[str, str] | None = None`) are keyword-only
and default to the existing behaviour, so this is **non-breaking**; the discovery path is unchanged.

Key pieces:

- **Version-validated KVP builder** (`_getcoverage_url`) — WCS `2.0.x` `COVERAGEID` + `SUBSET` + `SUBSETTINGCRS`
  and `1.0.0` `COVERAGE` + `BBOX` + `RESX`/`RESY`; requires a full `x.y.z` version string.
- **Correct axis handling** — each `subset_axes` label takes the bbox's x/y range, so lon/lat land on the right
  axis regardless of the CRS's declared axis order (the classic WCS 2.0 footgun). The 2.0.x default labels
  (`Long`/`Lat` for geographic CRS, `X`/`Y` otherwise) are documented as a best-effort guess — direct mode skips
  `DescribeCoverage`, which would reveal a server's real axis names — overridable via `subset_axes`.
- **Safe encoding** — both keys and values are percent-encoded (a stray `&`/`=` in a caller key can no longer
  split the query), and an `extra_params` key colliding with a reserved request parameter raises instead of
  silently duplicating/corrupting the request.
- **Correct resample semantics** — WCS `1.0.0` direct mode sends `RESX`/`RESY` so the server grids server-side;
  the client-side resample is skipped for `1.0.0` to avoid a redundant double-resample, and a reproject/resample
  request (`output_crs` or `resolution`) against a CRS-less coverage (no `coverage_crs` shim supplied) raises a
  clear `WCSError` instead of leaking a raw pyproj/GDAL error.
- Shared `_http_get` factored out of `_get_capabilities` so both the discovery and direct paths use one HTTP
  transport; the discovery path is behavior-preserved.

# Issues

- Closes #713

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] **Offline unit tests** (`tests/dataset/remote/test_wcs.py`, network-free): the KVP URL builder (both WCS
      versions, axis-order guarantee, `subset_axes` override, projected-CRS labels, malformed/unsupported version
      guards, `extra_params` key/value encoding, built-in-key collision), the axis-label defaults, and the
      `direct=True` path via a mocked `GetCoverage` response — success, skips-capabilities, exception-report,
      non-raster/GML body, `coverage_crs` shim on a CRS-less raster, WCS `1.0.0` end-to-end (no double resample),
      resolution resample, `output_crs` on a CRS-less raster, and an end-to-end URL-forwarding assertion
      (`subset_axes`/`extra_params`/`version` actually reach the request). **62 passed, 2 skipped** (pre-existing
      live SoilGrids tests).
- [x] Broad regression: `tests/dataset/remote/` (WMS/WMTS/WCS/OGC-coverages) stays green — **142 passed**.
- [x] Full suite: `pixi run -e dev pytest -m "not plot"` — **6484 passed, 50 skipped**, no regressions.
- [x] Ran `/review-rounds` (two full rounds) — Round 1: 1 must-fix + 4 should-fix + 4 nits, all resolved. Round 2:
      1 medium + 4 low + 4 nits, all resolved (substantively lighter, as expected). No open must-fix/should-fix
      findings remain in either review file.

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen handles versions)
- [ ] added changes to History.rst. (change-log is commitizen-generated)
- [ ] updated the latest version in README file. (n/a)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (comprehensive `from_wcs` docstring update: `direct`/`subset_axes` params, a
      direct-mode example against a GetCoverage-only endpoint, and the axis-label caveat)