### PR TITLE
fix(dataset): resolve 116 mypy errors and two bugs they surfaced

### DIFF
--- a/src/pyramids/base/_domain.py
+++ b/src/pyramids/base/_domain.py
@@ -25,11 +25,21 @@ to zero where the relative tolerance is too loose.
 
 from __future__ import annotations
 
+from typing import overload
+
 import numpy as np
 
 DEFAULT_RTOL: float = 0.001
 
 
+@overload
+def is_no_data(
+    arr: np.ndarray, no_data_value: float | None, *, rtol: float = DEFAULT_RTOL
+) -> np.typing.NDArray: ...
+@overload
+def is_no_data(
+    arr: float, no_data_value: float | None, *, rtol: float = DEFAULT_RTOL
+) -> bool: ...
 def is_no_data(
     arr: np.ndarray | float,
     no_data_value: float | None,

--- a/src/pyramids/base/_domain.py
+++ b/src/pyramids/base/_domain.py
@@ -39,17 +39,17 @@ def is_no_data(
 @overload
 def is_no_data(
     arr: float, no_data_value: float | None, *, rtol: float = DEFAULT_RTOL
-) -> bool: ...
+) -> np.bool_: ...
 def is_no_data(
     arr: np.ndarray | float,
     no_data_value: float | None,
     *,
     rtol: float = DEFAULT_RTOL,
-) -> np.typing.NDArray | bool:
+) -> np.typing.NDArray | np.bool_:
     """Boolean mask: True where `arr` cells equal `no_data_value`.
 
-    NaN- and None-safe. Works on scalars (returns `bool`) and
-    arrays (returns `np.ndarray` of bool).
+    NaN- and None-safe. Works on scalars (returns `np.bool_`, which behaves
+    as a `bool`) and arrays (returns `np.ndarray` of bool).
 
     Args:
         arr: Cell value(s) to test. Either a numpy array or a scalar.
@@ -60,7 +60,7 @@ def is_no_data(
             Default `0.001`.
 
     Returns:
-        Boolean mask shaped like `arr` (or `bool` when `arr` is a
+        Boolean mask shaped like `arr` (or `np.bool_` when `arr` is a
         scalar). `True` where the cell matches `no_data_value`.
 
     Examples:
@@ -100,7 +100,7 @@ def inside_domain(
     no_data_value: float | None,
     *,
     rtol: float = DEFAULT_RTOL,
-) -> np.typing.NDArray | bool:
+) -> np.typing.NDArray | np.bool_:
     """Boolean mask: True where `arr` cells are inside the domain.
 
     Inverse of :func:`is_no_data`; same NaN/None handling.

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -515,6 +515,10 @@ def render_array(
         # test-time ``patch("pyramids.basemap.basemap.add_basemap")`` is
         # honoured (the patch swaps the module attribute, not any
         # pre-bound reference this helper might hold).
+        # Only called when basemap is truthy, and the guard above already
+        # proved basemap_epsg is set in that case; mypy does not track that
+        # implication into this closure.
+        assert basemap_epsg is not None
         _basemap_module.add_basemap(
             target_ax,
             crs=basemap_epsg,
@@ -544,7 +548,9 @@ def render_array(
         # option that ``ArrayGlyph.plot`` does (it allocates one Axes
         # per panel and calls ``imshow``/``pcolormesh`` under the hood).
         # Forward only the render-call-only set; the rest is already on
-        # the constructor.
+        # the constructor. The guard at the top of this function already
+        # proved facet_kwargs is set for mode == "facet".
+        assert facet_kwargs is not None
         result = cleo.facet(**facet_kwargs, **render_kwargs)
         if basemap:
             # Every facet panel renders the same spatial domain (cleopatra
@@ -658,6 +664,9 @@ def mesh_render(
 
     result = plot_mesh_data(mesh, data, location=location, **kwargs)
     if basemap:
+        # The guard above already proved basemap_epsg is set when basemap is
+        # truthy.
+        assert basemap_epsg is not None
         source = basemap if isinstance(basemap, str) else None
         ax = result.ax if hasattr(result, "ax") else result
         _basemap_module.add_basemap(ax, crs=basemap_epsg, source=source)

--- a/src/pyramids/dataset/_reduce_ops.py
+++ b/src/pyramids/dataset/_reduce_ops.py
@@ -8,7 +8,7 @@ convention.
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import Any, Callable, cast
 
 _SUPPORTED_OPS = ("mean", "sum", "min", "max", "std", "var")
 _NAN_TABLE = {op: f"nan{op}" for op in _SUPPORTED_OPS}
@@ -48,4 +48,6 @@ def resolve_dask_op(op_name: str, *, skipna: bool) -> Callable[..., Any]:
             "  - conda-forge: conda install -c conda-forge pyramids-lazy"
         ) from exc
     name = _NAN_TABLE[op_name] if skipna else op_name
-    return getattr(da, name)
+    # getattr on a module is untyped; every name in _NAN_TABLE / _SUPPORTED_OPS
+    # names a real dask.array reduction function.
+    return cast("Callable[..., Any]", getattr(da, name))

--- a/src/pyramids/dataset/_stac.py
+++ b/src/pyramids/dataset/_stac.py
@@ -22,7 +22,7 @@ from collections import defaultdict
 from collections.abc import Sequence
 from datetime import datetime as _datetime_cls
 from datetime import timedelta, timezone
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 from osgeo import osr
 
@@ -375,7 +375,9 @@ def from_stac(
         )
 
     if target_grid is not None:
-        collection = collection.align(target_grid)
+        # align()'s default inplace=False (used here) always returns a new
+        # collection; only inplace=True returns None.
+        collection = cast("DatasetCollection", collection.align(target_grid))
     return collection
 
 
@@ -418,6 +420,8 @@ def _resolve_target_grid(
         )
     if anchor != "edge":
         raise ValueError(f"anchor must be 'edge', got {anchor!r}.")
+    # The two guards above already proved none of the trio is None.
+    assert crs is not None and resolution is not None and bounds is not None
 
     import math
 
@@ -559,7 +563,9 @@ def _from_stac_solar_day(
         merge_rasters(groups[day], out_path, method="first", signer=signer)
         per_day_paths.append(out_path)
 
-    return collection_cls.from_files(per_day_paths)
+    # collection_cls is always the real DatasetCollection class (passed by every
+    # caller); typed Any here only to dodge the import cycle noted above.
+    return cast("DatasetCollection", collection_cls.from_files(per_day_paths))
 
 
 def _from_stac_multi_asset(
@@ -621,7 +627,9 @@ def _from_stac_multi_asset(
             "from_stac produced no items (all were missing a requested asset "
             "or filtered out)."
         )
-    return collection_cls.from_files(per_item_paths)
+    # collection_cls is always the real DatasetCollection class (passed by every
+    # caller); typed Any here only to dodge the import cycle noted above.
+    return cast("DatasetCollection", collection_cls.from_files(per_item_paths))
 
 
 DEFAULT_STAC_URL = "https://planetarycomputer.microsoft.com/api/stac/v1"

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -41,7 +41,7 @@ import urllib.request
 import uuid
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from xml.etree import ElementTree as ET
 
 from osgeo import gdal
@@ -87,7 +87,7 @@ def _http_get(
         opener.add_handler(urllib.request.HTTPBasicAuthHandler(mgr))
     try:
         with opener.open(url, timeout=timeout) as resp:
-            return resp.read()
+            return cast(bytes, resp.read())
     except OSError as exc:
         # urllib.error.URLError / HTTPError both derive from OSError.
         raise WCSError(f"WCS {what} request failed for {url!r}: {exc}") from exc

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -709,7 +709,7 @@ class RasterBase(ABC):
             yield block, array
 
     @property
-    def file_name(self):
+    def file_name(self) -> str:
         """File name."""
         return self._file_name
 

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from numbers import Number
 from pathlib import Path
-from typing import Any, Generator, cast
+from typing import TYPE_CHECKING, Any, Generator, cast
 
 import numpy as np
 from geopandas.geodataframe import GeoDataFrame
@@ -32,6 +32,9 @@ from pyramids.base.crs import epsg_from_wkt, sr_from_epsg
 from pyramids.base.protocols import ArrayLike, FloatArray
 from pyramids.dataset.transform import GeoTransform
 from pyramids.dataset.window import Window
+
+if TYPE_CHECKING:
+    from pyramids.base._file_manager import ThreadLocalFileManager
 from pyramids.feature import FeatureCollection
 
 DEFAULT_NO_DATA_VALUE = -9999
@@ -93,12 +96,12 @@ class RasterBase(ABC):
         self._raster = src
         # Per-thread file manager for read_array(threadsafe=True); created
         # lazily by the IO engine and released by close().
-        self._thread_manager = None
+        self._thread_manager: ThreadLocalFileManager | None = None
         self._geotransform: tuple[float, float, float, float, float, float] = (
             src.GetGeoTransform()
         )
         self._cell_size = self._geotransform[1]
-        self._file_name = src.GetDescription()
+        self._file_name: str = src.GetDescription()
         # the epsg property returns the value of the _epsg attribute, so if the projection changes in any function, the
         # function should also change the value of the _epsg attribute.
         self._epsg = self._get_epsg()

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from numbers import Number
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any, Generator, cast
 
 import numpy as np
 from geopandas.geodataframe import GeoDataFrame
@@ -54,7 +54,7 @@ RESAMPLING_METHODS = [
 ]
 
 
-def _reconstruct_dataset(cls: type, path: str, access: str) -> RasterBase:
+def _reconstruct_dataset(cls: type[RasterBase], path: str, access: str) -> RasterBase:
     """Re-open a dataset from its pickle recipe tuple.
 
     Called by :meth:`RasterBase.__reduce__` on unpickle. Routes
@@ -154,6 +154,16 @@ class RasterBase(ABC):
         return False
 
     @abstractmethod
+    def close(self) -> None:
+        """Close the dataset and release the underlying handle."""
+        pass
+
+    @abstractmethod
+    def align(self, *args, **kwargs):
+        """Align this dataset to another dataset's grid."""
+        pass
+
+    @abstractmethod
     def __str__(self):
         """__str__."""
         pass
@@ -189,6 +199,24 @@ class RasterBase(ABC):
     @abstractmethod
     def shape(self):
         """Shape (bands, rows, columns)."""
+        pass
+
+    @property
+    @abstractmethod
+    def band_count(self) -> int:
+        """Number of bands in the raster."""
+        pass
+
+    @property
+    @abstractmethod
+    def band_names(self) -> list[str]:
+        """Band names."""
+        pass
+
+    @property
+    @abstractmethod
+    def bbox(self) -> list:
+        """Bound box [xmin, ymin, xmax, ymax]."""
         pass
 
     @property
@@ -281,7 +309,9 @@ class RasterBase(ABC):
         """
         # np.ndim == 0 treats Python scalars, NumPy scalars, and 0-d arrays
         # alike; np.isscalar misses 0-d arrays (np.isscalar(np.array(5)) is False).
-        scalar = np.ndim(rows) == 0 and np.ndim(cols) == 0
+        # cast: the numpy stub's np.ndim overload set doesn't recognise
+        # numbers.Number, though it accepts any Number instance at runtime.
+        scalar = np.ndim(cast(Any, rows)) == 0 and np.ndim(cast(Any, cols)) == 0
         rows_arr = np.atleast_1d(np.asarray(rows, dtype=float))
         cols_arr = np.atleast_1d(np.asarray(cols, dtype=float))
         shift = 0.5 if center else 0.0
@@ -357,7 +387,9 @@ class RasterBase(ABC):
         """
         # np.ndim == 0 treats Python scalars, NumPy scalars, and 0-d arrays
         # alike; np.isscalar misses 0-d arrays (np.isscalar(np.array(5)) is False).
-        scalar = np.ndim(x) == 0 and np.ndim(y) == 0
+        # cast: the numpy stub's np.ndim overload set doesn't recognise
+        # numbers.Number, though it accepts any Number instance at runtime.
+        scalar = np.ndim(cast(Any, x)) == 0 and np.ndim(cast(Any, y)) == 0
         x_arr = np.atleast_1d(np.asarray(x, dtype=float))
         y_arr = np.atleast_1d(np.asarray(y, dtype=float))
         inv = self.transform.inverse
@@ -365,6 +397,7 @@ class RasterBase(ABC):
         rows_f = inv.y_origin + x_arr * inv.column_rotation + y_arr * inv.pixel_height
         rows_idx = np.floor(rows_f).astype(int)
         cols_idx = np.floor(cols_f).astype(int)
+        result: tuple[Any, Any]
         if scalar:
             result = (int(rows_idx[0]), int(cols_idx[0]))
         else:
@@ -614,9 +647,10 @@ class RasterBase(ABC):
                     rows=min(block_y, self.rows - row),
                 )
                 if window is not None:
-                    block = block.intersection(window)
-                    if block is None:
+                    intersected = block.intersection(window)
+                    if intersected is None:
                         continue
+                    block = intersected
                 yield block
 
     def iter_blocks(
@@ -664,7 +698,10 @@ class RasterBase(ABC):
             block_windows: The windows-only variant (no pixel reads).
         """
         for block in self.block_windows(band, window=window):
-            yield block, self.read_array(band=band, window=block)
+            # This iterator never passes chunks=, so read_array always returns a
+            # plain ndarray here (the dask.Array arm of ArrayLike is unreachable).
+            array = cast(np.typing.NDArray, self.read_array(band=band, window=block))
+            yield block, array
 
     @property
     def file_name(self):
@@ -696,7 +733,9 @@ class RasterBase(ABC):
 
     @abstractmethod
     def read_array(
-        self, band: int | None = None, window: list[int] | None = None
+        self,
+        band: int | None = None,
+        window: Window | GeoDataFrame | list[int] | None = None,
     ) -> ArrayLike:
         """Read Array.
 

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -256,8 +256,8 @@ class RasterBase(ABC):
 
     def xy(
         self,
-        rows: Number | list[Number] | np.ndarray,
-        cols: Number | list[Number] | np.ndarray,
+        rows: np.typing.ArrayLike,
+        cols: np.typing.ArrayLike,
         *,
         center: bool = True,
     ) -> tuple[Any, Any]:
@@ -314,9 +314,7 @@ class RasterBase(ABC):
         """
         # np.ndim == 0 treats Python scalars, NumPy scalars, and 0-d arrays
         # alike; np.isscalar misses 0-d arrays (np.isscalar(np.array(5)) is False).
-        # cast: the numpy stub's np.ndim overload set doesn't recognise
-        # numbers.Number, though it accepts any Number instance at runtime.
-        scalar = np.ndim(cast(Any, rows)) == 0 and np.ndim(cast(Any, cols)) == 0
+        scalar = np.ndim(rows) == 0 and np.ndim(cols) == 0
         rows_arr = np.atleast_1d(np.asarray(rows, dtype=float))
         cols_arr = np.atleast_1d(np.asarray(cols, dtype=float))
         shift = 0.5 if center else 0.0
@@ -338,8 +336,8 @@ class RasterBase(ABC):
 
     def rowcol(
         self,
-        x: Number | list[Number] | np.ndarray,
-        y: Number | list[Number] | np.ndarray,
+        x: np.typing.ArrayLike,
+        y: np.typing.ArrayLike,
     ) -> tuple[Any, Any]:
         """Return the array indices ``(row, col)`` of map coordinates.
 
@@ -392,9 +390,7 @@ class RasterBase(ABC):
         """
         # np.ndim == 0 treats Python scalars, NumPy scalars, and 0-d arrays
         # alike; np.isscalar misses 0-d arrays (np.isscalar(np.array(5)) is False).
-        # cast: the numpy stub's np.ndim overload set doesn't recognise
-        # numbers.Number, though it accepts any Number instance at runtime.
-        scalar = np.ndim(cast(Any, x)) == 0 and np.ndim(cast(Any, y)) == 0
+        scalar = np.ndim(x) == 0 and np.ndim(y) == 0
         x_arr = np.atleast_1d(np.asarray(x, dtype=float))
         y_arr = np.atleast_1d(np.asarray(y, dtype=float))
         inv = self.transform.inverse

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -94,7 +94,9 @@ class RasterBase(ABC):
         # Per-thread file manager for read_array(threadsafe=True); created
         # lazily by the IO engine and released by close().
         self._thread_manager = None
-        self._geotransform = src.GetGeoTransform()
+        self._geotransform: tuple[float, float, float, float, float, float] = (
+            src.GetGeoTransform()
+        )
         self._cell_size = self._geotransform[1]
         self._file_name = src.GetDescription()
         # the epsg property returns the value of the _epsg attribute, so if the projection changes in any function, the
@@ -220,7 +222,7 @@ class RasterBase(ABC):
         pass
 
     @property
-    def geotransform(self):
+    def geotransform(self) -> tuple[float, float, float, float, float, float]:
         """WKT projection.(x, cell_size, 0, y, 0, -cell_size)."""
         return self._geotransform
 

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -1612,8 +1612,9 @@ class DatasetCollection:
         time_length, bands, rows, cols = (int(v) for v in data_arr.shape)
         # These attrs are always written by _finalize_collection_metadata /
         # _finalize_append_metadata with the concrete types cast here, never any
-        # other JSON shape.
-        time_length = cast(int, root.attrs.get("time_length", time_length))
+        # other JSON shape. The int() is kept (a cast is a no-op at runtime) so a
+        # legacy store holding time_length as a JSON float/str still coerces.
+        time_length = int(cast("int | float | str", root.attrs.get("time_length", time_length)))
 
         nodata_list = cast("list | None", data_attrs.get("nodata"))
         if nodata_list and any(v is not None for v in nodata_list):

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -8,7 +8,7 @@ import tempfile
 import warnings
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 import numpy as np
 import pandas as pd
@@ -241,7 +241,9 @@ def _finalize_append_metadata(
 
     root = zarr.open_group(resolved_store, mode="a")
     root.attrs["time_length"] = int(new_time_length)
-    existing_files = list(root.attrs.get("pyramids_file_list", []))
+    # pyramids_file_list is always written as list(files) by
+    # _finalize_collection_metadata, never any other JSON shape.
+    existing_files = list(cast(list, root.attrs.get("pyramids_file_list", [])))
     root.attrs["pyramids_file_list"] = existing_files + list(added_files)
     # zarr v3 emits a ZarrUserWarning that consolidated metadata isn't yet in the
     # spec; suppress it here so the append finalizer matches the other writer
@@ -780,7 +782,9 @@ class DatasetCollection:
         reduced = getattr(self.groupby(window_labels), op)(skipna=skipna)
 
         geo = self._base.geotransform
-        epsg = self._base.epsg
+        # epsg is None for a no-EPSG CRS (e.g. geostationary); fall back to the WKT
+        # so create_from_array still preserves it instead of defaulting to 4326 (#706).
+        epsg = self._base.epsg or self._base.crs
         no_data_value = self._base.no_data_value[0]
         result: list[tuple[Any, Dataset]] = []
         for label in sorted(reduced):
@@ -868,6 +872,9 @@ class DatasetCollection:
             # Zarr-backed cube (from_zarr): read the 4-D (T, B, R, C) array
             # lazily straight from the store — no per-file stacking.
             return da.from_zarr(self._zarr_store, component="data")
+        # The guard above already proved self._files is non-empty when
+        # self._zarr_store is None.
+        assert self._files is not None
         meta = self._meta
         shape = meta.shape
         dtype = np.dtype(meta.dtype)
@@ -1070,12 +1077,20 @@ class DatasetCollection:
         import dask
         import zarr
 
+        # to_zarr (the only caller) already checked self._files is non-empty.
+        assert self._files is not None
+
         if append_dim != "time":
             raise ValueError(
                 f"append_dim must be 'time' for a (T, B, Y, X) cube; got {append_dim!r}"
             )
         root = zarr.open_group(resolved_store, mode="a")
         existing = root["data"]
+        if not isinstance(existing, zarr.Array):
+            raise TypeError(
+                f"expected the 'data' node in {resolved_store!r} to be a zarr "
+                f"Array, got a Group -- the store is not a pyramids cube"
+            )
         old_t = int(existing.shape[0])
         new_total = old_t + int(data.shape[0])
         existing.resize((new_total, *existing.shape[1:]))
@@ -1276,6 +1291,7 @@ class DatasetCollection:
         y_coord = np.asarray(self._base.y)
         x_coord = np.asarray(self._base.x)
 
+        data_vars: dict[str, tuple[tuple[str, ...], np.ndarray]]
         if var_per_band:
             data_vars = {
                 names[i]: ((time_dim, "y", "x"), cube[:, i, :, :])
@@ -1507,7 +1523,7 @@ class DatasetCollection:
     @classmethod
     def from_files(
         cls,
-        files: list[str | Path],
+        files: Sequence[str | Path],
         *,
         meta: RasterMeta | None = None,
         gdal_env: dict[str, str] | None = None,
@@ -1584,27 +1600,40 @@ class DatasetCollection:
 
         resolved = _resolve_store(store, storage_options)
         root = zarr.open_group(resolved, mode="r")
-        data_attrs = dict(root["data"].attrs)
+        data_arr = root["data"]
+        if not isinstance(data_arr, zarr.Array):
+            raise TypeError(
+                f"expected the 'data' node in {resolved!r} to be a zarr Array, "
+                f"got a Group -- the store is not a pyramids cube"
+            )
+        data_attrs = dict(data_arr.attrs)
         geobox = read_geobox(root, data_name="data")
-        time_length, bands, rows, cols = (int(v) for v in root["data"].shape)
-        time_length = int(root.attrs.get("time_length", time_length))
+        time_length, bands, rows, cols = (int(v) for v in data_arr.shape)
+        # These attrs are always written by _finalize_collection_metadata /
+        # _finalize_append_metadata with the concrete types cast here, never any
+        # other JSON shape.
+        time_length = cast(int, root.attrs.get("time_length", time_length))
 
-        nodata_list = data_attrs.get("nodata")
+        nodata_list = cast("list | None", data_attrs.get("nodata"))
         if nodata_list and any(v is not None for v in nodata_list):
             no_data_value: Any = list(nodata_list)
         else:
             no_data_value = None
-        dtype = np.dtype(data_attrs.get("dtype", "float32"))
+        dtype = np.dtype(cast(str, data_attrs.get("dtype", "float32")))
         template_arr = np.zeros((bands, rows, cols), dtype=dtype)
+        geo_6 = cast(
+            "tuple[float, float, float, float, float, float]",
+            tuple(float(v) for v in geobox["geotransform"]),
+        )
         template = Dataset.create_from_array(
             template_arr if bands > 1 else template_arr[0],
-            geo=tuple(float(v) for v in geobox["geotransform"]),
+            geo=geo_6,
             epsg=geobox["epsg"] or 4326,
             no_data_value=no_data_value,
         )
         if geobox["crs_wkt"]:
             template.crs = geobox["crs_wkt"]
-        band_names = data_attrs.get("band_names") or []
+        band_names = cast("list | None", data_attrs.get("band_names")) or []
         if band_names and len(band_names) == template.band_count:
             template.band_names = list(band_names)
         meta = RasterMeta.from_dataset(template)
@@ -1815,8 +1844,15 @@ class DatasetCollection:
                     )
             else:
                 if date:
+                    # Reachable only when NOT(date and file_name_data_fmt is
+                    # None) (the elif above) and date is True here, so
+                    # file_name_data_fmt is guaranteed not None. Bind a
+                    # narrowed local so the lambda closure captures a plain
+                    # str, not the Optional parameter.
+                    assert file_name_data_fmt is not None
+                    date_fmt: str = file_name_data_fmt
                     fn: Callable[[Any], Any] = lambda x: dt.datetime.strptime(
-                        x.group(), file_name_data_fmt
+                        x.group(), date_fmt
                     )
                 else:
                     fn = lambda x: int(x.group())
@@ -1925,7 +1961,9 @@ class DatasetCollection:
             ds = _Dataset.create_from_array(
                 arr=val[i],
                 geo=self._base.geotransform,
-                epsg=self._base.epsg,
+                # epsg is None for a no-EPSG CRS (e.g. geostationary); fall back to
+                # the WKT so this preserves it instead of defaulting to 4326 (#706).
+                epsg=self._base.epsg or self._base.crs,
                 no_data_value=self._base.no_data_value[0],
             )
             new_datasets.append(ds)
@@ -1967,9 +2005,12 @@ class DatasetCollection:
         Returns:
             np.ndarray: A 2D array (single int) or a 3D array (slice).
         """
+        # read_array() is called with no chunks=, so it always returns a plain
+        # ndarray (the dask.Array arm of ArrayLike is unreachable here); numpy's
+        # __getitem__ stub returns Any for a general index.
         if isinstance(key, int):
-            return self.datasets[key].read_array(band=0)
-        return self.values[key]
+            return cast(np.typing.NDArray, self.datasets[key].read_array(band=0))
+        return cast(np.typing.NDArray, self.values[key])
 
     def __setitem__(self, key: int, value: np.ndarray) -> None:
         """Replace a single timestep's Dataset with a MEM Dataset built from ``value``.
@@ -1998,7 +2039,9 @@ class DatasetCollection:
         datasets[key] = _Dataset.create_from_array(
             arr=value,
             geo=self._base.geotransform,
-            epsg=self._base.epsg,
+            # epsg is None for a no-EPSG CRS (e.g. geostationary); fall back to the
+            # WKT so this preserves it instead of defaulting to 4326 (#706).
+            epsg=self._base.epsg or self._base.crs,
             no_data_value=self._base.no_data_value[0],
         )
         # The mutation breaks the disk correspondence for that slot;
@@ -2051,7 +2094,8 @@ class DatasetCollection:
         Cheaper than ``self.values[0]`` because it only reads one
         timestep instead of the full cube.
         """
-        return self.datasets[0].read_array(band=0)
+        # No chunks=, so this always returns a plain ndarray.
+        return cast(np.typing.NDArray, self.datasets[0].read_array(band=0))
 
     def last(self) -> np.typing.NDArray:
         """Last timestep array (2D).
@@ -2059,7 +2103,8 @@ class DatasetCollection:
         Cheaper than ``self.values[-1]`` because it only reads one
         timestep instead of the full cube.
         """
-        return self.datasets[-1].read_array(band=0)
+        # No chunks=, so this always returns a plain ndarray.
+        return cast(np.typing.NDArray, self.datasets[-1].read_array(band=0))
 
     def iloc(self, i: int) -> Dataset:
         """Return the ``Dataset`` at position ``i``.
@@ -2390,7 +2435,9 @@ class DatasetCollection:
             transient = Dataset.create_from_array(
                 arr=arr,
                 geo=src.geotransform,
-                epsg=src.epsg,
+                # epsg is None for a no-EPSG CRS (e.g. geostationary); fall back to
+                # the WKT so this preserves it instead of defaulting to 4326 (#706).
+                epsg=src.epsg or src.crs,
                 no_data_value=src.no_data_value[0],
             )
             transient.to_file(path[i], band=band)

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -782,8 +782,9 @@ class DatasetCollection:
         reduced = getattr(self.groupby(window_labels), op)(skipna=skipna)
 
         geo = self._base.geotransform
-        # epsg is None for a no-EPSG CRS (e.g. geostationary); fall back to the WKT
-        # so create_from_array still preserves it instead of defaulting to 4326 (#706).
+        # epsg is None only for a no-EPSG CRS reported as such (a NetCDF geostationary
+        # grid); create_from_array raises CRSError on None, so fall back to the WKT.
+        # A no-EPSG plain Dataset reports 4326, where this is a no-op (#706).
         epsg = self._base.epsg or self._base.crs
         no_data_value = self._base.no_data_value[0]
         result: list[tuple[Any, Dataset]] = []
@@ -1961,8 +1962,9 @@ class DatasetCollection:
             ds = _Dataset.create_from_array(
                 arr=val[i],
                 geo=self._base.geotransform,
-                # epsg is None for a no-EPSG CRS (e.g. geostationary); fall back to
-                # the WKT so this preserves it instead of defaulting to 4326 (#706).
+                # epsg is None only for a no-EPSG CRS reported as such (a NetCDF
+                # geostationary grid); create_from_array raises CRSError on None, so
+                # fall back to the WKT. No-op for a plain Dataset (reports 4326) (#706).
                 epsg=self._base.epsg or self._base.crs,
                 no_data_value=self._base.no_data_value[0],
             )
@@ -2039,8 +2041,9 @@ class DatasetCollection:
         datasets[key] = _Dataset.create_from_array(
             arr=value,
             geo=self._base.geotransform,
-            # epsg is None for a no-EPSG CRS (e.g. geostationary); fall back to the
-            # WKT so this preserves it instead of defaulting to 4326 (#706).
+            # epsg is None only for a no-EPSG CRS reported as such (a NetCDF
+            # geostationary grid); create_from_array raises CRSError on None, so fall
+            # back to the WKT. No-op for a plain Dataset (reports 4326) (#706).
             epsg=self._base.epsg or self._base.crs,
             no_data_value=self._base.no_data_value[0],
         )
@@ -2435,8 +2438,9 @@ class DatasetCollection:
             transient = Dataset.create_from_array(
                 arr=arr,
                 geo=src.geotransform,
-                # epsg is None for a no-EPSG CRS (e.g. geostationary); fall back to
-                # the WKT so this preserves it instead of defaulting to 4326 (#706).
+                # epsg is None only for a no-EPSG CRS reported as such (a NetCDF
+                # geostationary grid); create_from_array raises CRSError on None, so
+                # fall back to the WKT. No-op for a plain Dataset (reports 4326) (#706).
                 epsg=src.epsg or src.crs,
                 no_data_value=src.no_data_value[0],
             )

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import warnings
 import weakref
+from collections.abc import Sequence
 from numbers import Number
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -3515,7 +3516,7 @@ class Dataset(RasterBase):
     @classmethod
     def from_band_files(
         cls,
-        files: list[str | Path],
+        files: Sequence[str | Path],
         *,
         band_names: list[str] | None = None,
         align: bool = False,

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -3715,9 +3715,10 @@ class Dataset(RasterBase):
                 grid_template = cls.create_from_array(
                     template.read_array(band=0).astype(target_np_dtype, copy=False),
                     geo=template.geotransform,
-                    # epsg is None for a no-EPSG CRS (e.g. geostationary); fall
-                    # back to the WKT so this preserves it instead of
-                    # defaulting to 4326 (#706).
+                    # epsg is None only for a no-EPSG CRS reported as such (a
+                    # NetCDF geostationary grid); create_from_array raises
+                    # CRSError on None, so fall back to the WKT. No-op for a
+                    # plain Dataset (reports 4326) (#706).
                     epsg=template.epsg or template.crs,
                     no_data_value=resolved_nd,
                 )

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -13,7 +13,7 @@ import weakref
 from collections.abc import Sequence
 from numbers import Number
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import geopandas as gpd
 import numpy as np
@@ -640,7 +640,10 @@ class Dataset(RasterBase):
                         )
                         resolved_rgb = [2, 1, 0]
                     else:
-                        resolved_rgb = [int(v) for v in candidate]
+                        # None NOT in candidate here, so every element is a
+                        # plain int -- mypy does not narrow list contents from
+                        # an `in` check.
+                        resolved_rgb = [int(v) for v in cast("list[int]", candidate)]
                 else:
                     resolved_rgb = rgb
                 resolved_band = int(resolved_rgb[0])
@@ -1220,7 +1223,7 @@ class Dataset(RasterBase):
         gdf.set_crs(self.epsg or self.crs, inplace=True)
         return gdf
 
-    def _get_band_names(self):
+    def _get_band_names(self) -> list[str]:
         """Concrete override of :meth:`RasterBase._get_band_names`.
 
         Defined directly on Dataset (not via the bands collaborator)
@@ -1228,7 +1231,7 @@ class Dataset(RasterBase):
         before the `Bands` collaborator is wired up. Mirrors
         :meth:`Bands._get_band_names`.
         """
-        names = []
+        names: list[str] = []
         for i in range(1, self.band_count + 1):
             band = self.raster.GetRasterBand(i)
             if band.GetDescription():
@@ -1724,7 +1727,7 @@ class Dataset(RasterBase):
         self._block_size = value
 
     @property
-    def file_name(self):
+    def file_name(self) -> str:
         """File name."""
         return super().file_name
 
@@ -3712,7 +3715,10 @@ class Dataset(RasterBase):
                 grid_template = cls.create_from_array(
                     template.read_array(band=0).astype(target_np_dtype, copy=False),
                     geo=template.geotransform,
-                    epsg=template.epsg,
+                    # epsg is None for a no-EPSG CRS (e.g. geostationary); fall
+                    # back to the WKT so this preserves it instead of
+                    # defaulting to 4326 (#706).
+                    epsg=template.epsg or template.crs,
                     no_data_value=resolved_nd,
                 )
                 # Dataset.align uses the source's no_data_value to fill the warp

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pandas as pd
@@ -197,7 +197,7 @@ class Analysis(_Engine["Dataset"]):
         )
         return int(domain_count)
 
-    def apply(self, func, band: int = 0, inplace: bool = False) -> Dataset:
+    def apply(self, func, band: int = 0, inplace: bool = False) -> Dataset | None:
         """Apply a function to all domain cells.
 
         - apply method executes a mathematical operation on the raster array.
@@ -213,8 +213,12 @@ class Analysis(_Engine["Dataset"]):
                 Default is False.
 
         Returns:
-            Dataset:
-                A new Dataset with the function applied. If inplace is True, returns self.
+            Dataset | None:
+                A new Dataset with the function applied, or ``None`` when
+                ``inplace=True`` -- the :meth:`Dataset.apply` facade
+                substitutes the real ``self`` in that case (this collaborator
+                only holds a ``weakref.proxy`` back-reference, so it cannot
+                satisfy an ``is`` identity check itself).
 
         Examples:
             - Create a dataset from an array filled with values between -1 and 1:
@@ -282,7 +286,7 @@ class Analysis(_Engine["Dataset"]):
 
     def fill(
         self, value: float | int, inplace: bool = False, path: str | Path | None = None
-    ) -> Dataset:
+    ) -> Dataset | None:
         """Fill the domain cells with a certain value.
 
             Fill takes a raster and fills it with one value
@@ -296,8 +300,9 @@ class Analysis(_Engine["Dataset"]):
                 Path including the extension (.tif).
 
         Returns:
-            Dataset:
-                A new Dataset with cells filled. If inplace is True, returns self.
+            Dataset | None:
+                A new Dataset with cells filled, or ``None`` when
+                ``inplace=True`` -- see :meth:`apply` for why.
 
         Examples:
             - Create a Dataset with 1 band, 5 rows, 5 columns, at the point lon/lat (0, 0):
@@ -488,16 +493,16 @@ class Analysis(_Engine["Dataset"]):
         """
         if isinstance(points, FeatureCollection):
             verts = points.with_coordinates()
-            return verts.loc[:, ["x", "y"]].to_numpy(dtype=float)
+            return cast(np.typing.NDArray, verts.loc[:, ["x", "y"]].to_numpy(dtype=float))
         if isinstance(points, GeoDataFrame):
             verts = FeatureCollection(points).with_coordinates()
-            return verts.loc[:, ["x", "y"]].to_numpy(dtype=float)
+            return cast(np.typing.NDArray, verts.loc[:, ["x", "y"]].to_numpy(dtype=float))
         if isinstance(points, DataFrame):
             if not all(col in points.columns for col in ("x", "y")):
                 raise ValueError(
                     "If the input is a DataFrame, it must have 'x' and 'y' columns."
                 )
-            return points.loc[:, ["x", "y"]].to_numpy(dtype=float)
+            return cast(np.typing.NDArray, points.loc[:, ["x", "y"]].to_numpy(dtype=float))
         raise TypeError(
             "points must be a FeatureCollection, GeoDataFrame, or DataFrame with "
             f"x/y columns - given {type(points)}."

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -1063,9 +1063,9 @@ class Bands(_Engine["Dataset"]):
             - Change the no_data_value in the array in all bands.
         Args:
             new_value (numeric):
-                No data value to set in the raster bands. A `list` is read per band and must have
-                `band_count` entries; any other value (including a `tuple` or array) is treated as a
-                single scalar applied to every band.
+                No data value to set in the raster bands. Only a `list` is read per band, and it must
+                have `band_count` entries; any other value takes the scalar path and is applied to every
+                band, so it must be a numeric scalar. A `tuple` of per-band values is not supported.
             old_value (numeric):
                 Old no data value that is already in the raster bands. Follows the same per-band `list`
                 convention as `new_value`.

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -1079,7 +1079,9 @@ class Bands(_Engine["Dataset"]):
             NoDataValueError:
                 If `new_value` cannot be stored in a band's dtype — e.g. `None` or `NaN`
                 given for an integer band — the dtype mismatch is reported instead of
-                leaking a raw numpy `TypeError`/`ValueError`.
+                leaking a raw numpy `TypeError`/`ValueError`. Also raised when
+                `old_value` is given as a list whose length does not match
+                `band_count`.
 
         Warning:
             The `change_no_data_value` method creates a new dataset in memory in order to change the `no_data_value` in the raster bands.
@@ -1114,6 +1116,11 @@ class Bands(_Engine["Dataset"]):
             new_value = [new_value] * self._ds.band_count
         if old_value is not None and not isinstance(old_value, list):
             old_value = [old_value] * self._ds.band_count
+        if old_value is not None and len(old_value) != self._ds.band_count:
+            raise NoDataValueError(
+                f"old_value must be a scalar or a list of length band_count "
+                f"({self._ds.band_count}); got a list of length {len(old_value)}."
+            )
         dst = gdal.GetDriverByName("MEM").CreateCopy("", self._ds.raster, 0)
         # create a new dataset
         new_dataset = self._ds.__class__(dst, "write")

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import geopandas as gpd
 import numpy as np
@@ -894,15 +894,17 @@ class Bands(_Engine["Dataset"]):
                 # dtype min for signed ints too small to hold the default, and
                 # the default for floats (which can always represent it).
                 np_dtype = np.dtype(self._ds.numpy_dtype[i])
+                # np.issubdtype narrows at runtime but isn't recognised by the
+                # numpy stubs, so np.iinfo still sees the full dtype union.
                 if np.issubdtype(np_dtype, np.unsignedinteger):
                     # -9999 (and any negative default) cannot fit an unsigned
                     # band; use the dtype max, matching the None/NaN branch.
-                    fallback = np_dtype.type(np.iinfo(np_dtype).max)
+                    fallback = np_dtype.type(np.iinfo(cast(Any, np_dtype)).max)
                 elif np.issubdtype(np_dtype, np.integer):
                     # Keep the default -9999 when the signed band can hold it
                     # (int16/int32/int64); only too-small bands (int8) need the
                     # dtype min.
-                    info = np.iinfo(np_dtype)
+                    info = np.iinfo(cast(Any, np_dtype))
                     if info.min <= DEFAULT_NO_DATA_VALUE <= info.max:
                         fallback = np_dtype.type(DEFAULT_NO_DATA_VALUE)
                     else:
@@ -1050,7 +1052,7 @@ class Bands(_Engine["Dataset"]):
 
     def change_no_data_value(
         self, new_value: Any, old_value: Any | None = None, inplace: bool = False
-    ) -> Dataset:
+    ) -> Dataset | None:
         """Change No Data Value.
             - Set the no data value in all raster bands.
             - Fill the whole raster with the no_data_value.
@@ -1065,8 +1067,9 @@ class Bands(_Engine["Dataset"]):
                 Default is False.
 
         Returns:
-            Dataset:
-                A new Dataset with the updated no-data value. If inplace is True, returns self.
+            Dataset | None:
+                A new Dataset with the updated no-data value, or ``None``
+                when ``inplace=True`` -- see :meth:`Analysis.apply` for why.
 
         Raises:
             NoDataValueError:
@@ -1118,9 +1121,13 @@ class Bands(_Engine["Dataset"]):
         new_value = new_dataset.no_data_value
         for band in range(self._ds.band_count):
             arr = self._ds.read_array(band)
+            # old_value is normalized to a per-band list above (matching
+            # new_value); index it per-band here too instead of comparing
+            # against the whole list.
+            band_old_value = old_value[band] if old_value is not None else None
             try:
                 with np.errstate(invalid="raise"):
-                    arr[is_no_data(arr, old_value)] = new_value[band]
+                    arr[is_no_data(arr, band_old_value)] = new_value[band]
             # A dtype mismatch surfaces differently across numpy paths: a None value
             # is not subscriptable (TypeError), a NaN cast into an integer band raises
             # ValueError ("cannot convert float NaN to integer"), and an invalid

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -1080,8 +1080,8 @@ class Bands(_Engine["Dataset"]):
                 If `new_value` cannot be stored in a band's dtype — e.g. `None` or `NaN`
                 given for an integer band — the dtype mismatch is reported instead of
                 leaking a raw numpy `TypeError`/`ValueError`. Also raised when
-                `old_value` is given as a list whose length does not match
-                `band_count`.
+                `new_value` or `old_value` is given as a list whose length does not
+                match `band_count`.
 
         Warning:
             The `change_no_data_value` method creates a new dataset in memory in order to change the `no_data_value` in the raster bands.
@@ -1114,6 +1114,11 @@ class Bands(_Engine["Dataset"]):
         """
         if not isinstance(new_value, list):
             new_value = [new_value] * self._ds.band_count
+        if len(new_value) != self._ds.band_count:
+            raise NoDataValueError(
+                f"new_value must be a scalar or a list of length band_count "
+                f"({self._ds.band_count}); got a list of length {len(new_value)}."
+            )
         if old_value is not None and not isinstance(old_value, list):
             old_value = [old_value] * self._ds.band_count
         if old_value is not None and len(old_value) != self._ds.band_count:

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -895,16 +895,20 @@ class Bands(_Engine["Dataset"]):
                 # the default for floats (which can always represent it).
                 np_dtype = np.dtype(self._ds.numpy_dtype[i])
                 # np.issubdtype narrows at runtime but isn't recognised by the
-                # numpy stubs, so np.iinfo still sees the full dtype union.
+                # numpy stubs, so np.iinfo still sees the full dtype union --
+                # cast to the exact integer family each branch just proved.
                 if np.issubdtype(np_dtype, np.unsignedinteger):
                     # -9999 (and any negative default) cannot fit an unsigned
                     # band; use the dtype max, matching the None/NaN branch.
-                    fallback = np_dtype.type(np.iinfo(cast(Any, np_dtype)).max)
+                    unsigned_dtype = cast("np.dtype[np.unsignedinteger]", np_dtype)
+                    fallback = np_dtype.type(np.iinfo(unsigned_dtype).max)
                 elif np.issubdtype(np_dtype, np.integer):
                     # Keep the default -9999 when the signed band can hold it
                     # (int16/int32/int64); only too-small bands (int8) need the
-                    # dtype min.
-                    info = np.iinfo(cast(Any, np_dtype))
+                    # dtype min. The unsignedinteger branch above already ran,
+                    # so this is provably signedinteger.
+                    signed_dtype = cast("np.dtype[np.signedinteger]", np_dtype)
+                    info = np.iinfo(signed_dtype)
                     if info.min <= DEFAULT_NO_DATA_VALUE <= info.max:
                         fallback = np_dtype.type(DEFAULT_NO_DATA_VALUE)
                     else:

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -1063,9 +1063,12 @@ class Bands(_Engine["Dataset"]):
             - Change the no_data_value in the array in all bands.
         Args:
             new_value (numeric):
-                No data value to set in the raster bands.
+                No data value to set in the raster bands. A `list` is read per band and must have
+                `band_count` entries; any other value (including a `tuple` or array) is treated as a
+                single scalar applied to every band.
             old_value (numeric):
-                Old no data value that is already in the raster bands.
+                Old no data value that is already in the raster bands. Follows the same per-band `list`
+                convention as `new_value`.
             inplace (bool):
                 If True, the original dataset will be modified. If False, a new dataset will be created.
                 Default is False.

--- a/src/pyramids/dataset/engines/cell.py
+++ b/src/pyramids/dataset/engines/cell.py
@@ -213,12 +213,12 @@ class Cell(_Engine["Dataset"]):
 
         coords_tuples = [list(zip(x[:, i], y[:, i])) for i in range(4)]
         polys_coords = [
-            (
+            [
                 coords_tuples[0][i],
                 coords_tuples[1][i],
                 coords_tuples[2][i],
                 coords_tuples[3][i],
-            )
+            ]
             for i in range(len(x))
         ]
         polygons = list(map(create_polygon, polys_coords))

--- a/src/pyramids/dataset/engines/cog.py
+++ b/src/pyramids/dataset/engines/cog.py
@@ -11,7 +11,7 @@ import math
 import uuid
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Mapping
+from typing import TYPE_CHECKING, Any, Mapping, cast
 
 import numpy as np
 from osgeo import gdal
@@ -1010,7 +1010,7 @@ class COG(_Engine["Dataset"]):
         """
         nodata = band.GetNoDataValue()
         if nodata is not None:
-            return nodata
+            return cast(float, nodata)
         return 0 if is_integer_gdal_dtype(band.DataType) else float("nan")
 
     def preview(

--- a/src/pyramids/dataset/engines/georef.py
+++ b/src/pyramids/dataset/engines/georef.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 from uuid import uuid4
 
 from osgeo import gdal
@@ -90,7 +90,7 @@ class Georef(_Engine["Dataset"]):
         Returns:
             int: the GCP count.
         """
-        return self._ds.raster.GetGCPCount()
+        return cast(int, self._ds.raster.GetGCPCount())
 
     @property
     def gcp_projection(self: Georef) -> str | None:
@@ -109,7 +109,7 @@ class Georef(_Engine["Dataset"]):
         Returns:
             bool: whether any GCP is attached.
         """
-        return self._ds.raster.GetGCPCount() > 0
+        return cast(int, self._ds.raster.GetGCPCount()) > 0
 
     @property
     def rpcs(self: Georef) -> dict[str, str] | None:

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -15,7 +15,7 @@ import warnings
 from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Generator
+from typing import TYPE_CHECKING, Any, Generator, cast
 
 import numpy as np
 import pandas as pd
@@ -237,8 +237,11 @@ def _encode_terrain_rgb(
             ```
     """
     if encoding == "mapbox":
-        packed = np.round((np.asarray(elevation, dtype=float) - base_val) / interval)
-        packed = np.clip(packed, 0, 2**24 - 1).astype(np.uint32)
+        rounded = np.round((np.asarray(elevation, dtype=float) - base_val) / interval)
+        packed = cast(
+            "np.typing.NDArray[np.uint32]",
+            np.clip(rounded, 0, 2**24 - 1).astype(np.uint32),
+        )
         red = ((packed >> 16) & 0xFF).astype(np.uint8)
         green = ((packed >> 8) & 0xFF).astype(np.uint8)
         blue = (packed & 0xFF).astype(np.uint8)
@@ -766,7 +769,9 @@ class IO(_Engine["Dataset"]):
             self._ds._backend = "numpy"
             if masked:
                 arr = self._to_masked(arr, band, window=window)
-        return arr
+        # arr is assembled through many untyped GDAL/dask branches above; this
+        # is the method's own declared contract.
+        return cast("ArrayLike", arr)
 
     def _require_reopenable_path(self) -> str:
         """Return the dataset's path if per-thread handles can reopen it.
@@ -844,9 +849,12 @@ class IO(_Engine["Dataset"]):
                 f"window must be a list of 4 integers [xoff, yoff, xsize, ysize], "
                 f"got {len(window)}: {window}"
             )
+        # Normalize to the list[int] _read_via_handle expects -- window may still
+        # be a tuple here (e.g. straight from Window.to_read_args()).
+        window_list = list(window) if window is not None else None
         handle = self._get_thread_manager().acquire()
         try:
-            arr = self._read_via_handle(handle, band, window)
+            arr = self._read_via_handle(handle, band, window_list)
         except RuntimeError as exc:
             # Same contract as the default path's _read_block.
             if "Access window out of range" in str(exc):
@@ -924,7 +932,9 @@ class IO(_Engine["Dataset"]):
         else:
             effective_band = 0 if band is None else band
             arr = handle.GetRasterBand(effective_band + 1).ReadAsArray(*window_args)
-        return arr
+        # arr comes from GDAL's untyped ReadAsArray/np.stack; this method's own
+        # declared contract is a plain ndarray.
+        return cast(np.typing.NDArray, arr)
 
     def _to_masked(
         self,
@@ -2179,6 +2189,7 @@ class IO(_Engine["Dataset"]):
                 bands = self._ds.band_count
                 gdal_dtype = self._ds.gdal_dtype[0]
 
+            no_data: list | tuple
             if band is not None:
                 no_data = [self._ds.no_data_value[band]]
             else:
@@ -2263,7 +2274,7 @@ class IO(_Engine["Dataset"]):
                 ```
         """
         if bands is None:
-            bands = range(1, self._ds.band_count + 1)
+            bands = list(range(1, self._ds.band_count + 1))
         elif isinstance(bands, int):
             bands = [bands + 1]
         elif isinstance(bands, list):

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -8,7 +8,7 @@ Owns the Spatial family of operations on a Dataset. Accessed as
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast, overload
 from xml.sax.saxutils import escape
 
 import numpy as np
@@ -61,6 +61,12 @@ def _dst_srs_arg(dst_sr: osr.SpatialReference) -> str:
     return srs_arg
 
 
+@overload
+def _resolve_resolution(
+    cell_size: float | tuple[float, float] | list[float],
+) -> tuple[float, float]: ...
+@overload
+def _resolve_resolution(cell_size: None) -> tuple[None, None]: ...
 def _resolve_resolution(
     cell_size: float | tuple[float, float] | list[float] | None,
 ) -> tuple[float | None, float | None]:
@@ -78,6 +84,7 @@ def _resolve_resolution(
     Raises:
         ValueError: If the pair is not length 2, or any resolution is not positive.
     """
+    result: tuple[float | None, float | None]
     if cell_size is None:
         result = (None, None)
     else:
@@ -1205,7 +1212,9 @@ class Spatial(_Engine["Dataset"]):
         # and now has to be filled with values
         # compare no of element that is not no_data_value in both rasters to make sure they are matched
         # if both inputs are rasters
-        mask_array = mask.read_array()
+        # read_array() is called with no chunks=, so it always returns a plain
+        # ndarray here (the dask.Array arm of ArrayLike is unreachable).
+        mask_array = cast(np.typing.NDArray, mask.read_array())
         mask_noval = mask.no_data_value[0]
 
         if isinstance(mask, RasterBase) and isinstance(self._ds, RasterBase):
@@ -1255,7 +1264,9 @@ class Spatial(_Engine["Dataset"]):
             row = mask.rows
             col = mask.columns
             mask_noval = mask.no_data_value[0]
-            mask_array = mask.read_array(band=0)
+            # read_array() is called with no chunks=, so it always returns a plain
+            # ndarray here (the dask.Array arm of ArrayLike is unreachable).
+            mask_array = cast(np.typing.NDArray, mask.read_array(band=0))
         elif isinstance(mask, np.ndarray):
             if mask_noval is None:
                 raise ValueError(
@@ -1271,7 +1282,9 @@ class Spatial(_Engine["Dataset"]):
 
         band_count = self._ds.band_count
         src_sref = sr_from_wkt(self._ds.crs)
-        src_array = self._ds.read_array()
+        # read_array() is called with no chunks=, so it always returns a plain
+        # ndarray here (the dask.Array arm of ArrayLike is unreachable).
+        src_array = cast(np.typing.NDArray, self._ds.read_array())
 
         if not row == self._ds.rows or not col == self._ds.columns:
             raise ValueError(
@@ -1524,7 +1537,10 @@ class Spatial(_Engine["Dataset"]):
                 multithread=True,
             )
             dst = gdal.Warp("", self._ds.raster, options=warp_options)
-            dst_obj = base_cls(dst)
+            # base_cls is a dynamic MRO walk that always resolves to Dataset itself
+            # (the class directly above RasterBase; see the comment above), never a
+            # subclass, so this is guaranteed to actually be a Dataset at runtime.
+            dst_obj = cast("Dataset", base_cls(dst))
             if touch:
                 dst_obj = Spatial._correct_wrap_cutline_error(dst_obj)
 
@@ -1650,11 +1666,17 @@ class Spatial(_Engine["Dataset"]):
         Raises:
             ValueError: The bbox does not overlap the dataset's longitude extent.
         """
-        return _crop_seam_halves(
-            self._ds,
-            bbox,
-            lambda half: self.crop(bbox=half, epsg=crs, touch=touch),
-            self._merge_lon_halves,
+        # _crop_seam_halves is shared with the NetCDF Selection engine and returns
+        # Any accordingly; here crop_half/merge_halves are both Dataset-returning,
+        # so the result is a Dataset.
+        return cast(
+            "Dataset",
+            _crop_seam_halves(
+                self._ds,
+                bbox,
+                lambda half: self.crop(bbox=half, epsg=crs, touch=touch),
+                self._merge_lon_halves,
+            ),
         )
 
     def _merge_lon_halves(self, west_part: Dataset, east_part: Dataset) -> Dataset:
@@ -1880,8 +1902,11 @@ class Spatial(_Engine["Dataset"]):
             ds_epsg = self._ds.epsg
             ds_geo = ds_epsg is not None and sr_from_user_input(ds_epsg).IsGeographic()
             if west > east and crs_geo and ds_geo:
-                _require_antimeridian_seam(self._ds, tuple(bbox))
-                return self._crop_antimeridian(tuple(bbox), crs, touch)
+                # bbox is validated 4-long above; tuple(bbox) loses that fixed
+                # arity statically (it may start as a list), so restore it.
+                bbox_4 = cast(tuple[float, float, float, float], tuple(bbox))
+                _require_antimeridian_seam(self._ds, bbox_4)
+                return self._crop_antimeridian(bbox_4, crs, touch)
             mask = FeatureCollection.from_bbox(bbox, epsg=crs)
         if mask is None:
             raise TypeError(

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -327,7 +327,9 @@ def _stitch_lon_halves(ds: RasterBase, west_part: Any, east_part: Any) -> "Datas
     out = Dataset.create_from_array(
         merged,
         geo=west_part.geotransform,
-        epsg=west_part.epsg,
+        # epsg is None for a no-EPSG CRS (e.g. geostationary); fall back to
+        # the WKT so this preserves it instead of defaulting to 4326 (#706).
+        epsg=west_part.epsg or west_part.crs,
         no_data_value=west_part.no_data_value,
     )
     out.band_names = ds.band_names

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -327,8 +327,9 @@ def _stitch_lon_halves(ds: RasterBase, west_part: Any, east_part: Any) -> "Datas
     out = Dataset.create_from_array(
         merged,
         geo=west_part.geotransform,
-        # epsg is None for a no-EPSG CRS (e.g. geostationary); fall back to
-        # the WKT so this preserves it instead of defaulting to 4326 (#706).
+        # epsg is None only for a no-EPSG CRS reported as such (a NetCDF
+        # geostationary grid); create_from_array raises CRSError on None, so fall
+        # back to the WKT. No-op for a plain Dataset (reports 4326) (#706).
         epsg=west_part.epsg or west_part.crs,
         no_data_value=west_part.no_data_value,
     )

--- a/src/pyramids/dataset/engines/vectorize.py
+++ b/src/pyramids/dataset/engines/vectorize.py
@@ -171,6 +171,8 @@ class Vectorize(_Engine["Dataset"]):
         if interval is not None:
             options += [f"LEVEL_INTERVAL={interval}", f"LEVEL_BASE={base}"]
         else:
+            # The exactly-one-of guard above proves fixed_levels is not None here.
+            assert fixed_levels is not None
             options.append("FIXED_LEVELS=" + ",".join(str(lvl) for lvl in fixed_levels))
 
         no_data_value = gdal_band.GetNoDataValue()
@@ -797,7 +799,7 @@ class Vectorize(_Engine["Dataset"]):
         neighbor. The caller (cluster) handles truly isolated cells separately.
         """
         rows, cols = array.shape
-        queue = collections.deque()
+        queue: collections.deque[tuple[int, int]] = collections.deque()
         queue.append((i, j))
 
         while queue:

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -10,6 +10,7 @@
 from __future__ import annotations
 
 import warnings
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -32,7 +33,7 @@ _cloud_config = signer_cloud_config
 
 
 def merge_rasters(
-    src: list[str | Path],
+    src: Sequence[str | Path],
     dst: str | Path,
     no_data_value: float | int | str = "0",
     init: float | int | str = "nan",

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -57,8 +57,8 @@ def merge_rasters(
       numpy.
 
     Args:
-        src (list[str | Path]):
-            List of paths to all input rasters.
+        src (Sequence[str | Path]):
+            Paths to all input rasters.
         dst (str | Path):
             Path to the output raster.
         no_data_value (float | int | str):

--- a/src/pyramids/dataset/ops/_zonal.py
+++ b/src/pyramids/dataset/ops/_zonal.py
@@ -26,7 +26,7 @@ then reduce.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 import numpy as np
 import pandas as pd
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     from pyramids.feature import FeatureCollection
 
 
-_STAT_FUNCS = {
+_STAT_FUNCS: dict[str, Callable[[np.ndarray], Any]] = {
     "mean": np.nanmean,
     "sum": np.nansum,
     "min": np.nanmin,

--- a/src/pyramids/dataset/ops/io.py
+++ b/src/pyramids/dataset/ops/io.py
@@ -72,8 +72,15 @@ def _read_chunk(
         np.ndarray: The fully materialized chunk with shape derived
         from the `block_info` slice, dtype equal to `dtype`.
     """
+    # dask.array.map_blocks always supplies a real dict here for a function
+    # parameter literally named block_info; None is only dask's static type
+    # for the (unused) meta-inference call convention.
+    assert block_info is not None
     location = block_info[None]["array-location"]
     if single_band:
+        # The caller only sets single_band=True when it also resolved band to
+        # a real int (see _lazy_read's effective_band).
+        assert band is not None
         (y_start, y_stop), (x_start, x_stop) = location
         xoff, yoff = x_start, y_start
         xsize, ysize = x_stop - x_start, y_stop - y_start

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4720,12 +4720,12 @@ class NetCDF(Dataset):
         materialized = Dataset.create_from_array(
             cast("np.typing.NDArray", arr),
             geo=reprojected.geotransform,
-            # epsg is None for a no-EPSG CRS (e.g. geostationary); fall back
-            # to the WKT so this preserves it instead of defaulting to 4326
-            # (#706). to_crs(to_epsg: int, ...) always targets a concrete
-            # EPSG here, so epsg is provably non-None -- the fallback is
-            # defense-in-depth, matching the pattern used throughout
-            # pyramids.dataset.
+            # epsg is None only for a no-EPSG CRS reported as such (a NetCDF
+            # geostationary grid), and create_from_array raises CRSError on
+            # None, so fall back to the WKT (#706). to_crs(to_epsg: int, ...)
+            # always targets a concrete EPSG here, so epsg is provably
+            # non-None -- the fallback is defense-in-depth, matching the
+            # pattern used throughout pyramids.dataset.
             epsg=reprojected.epsg or reprojected.crs,
             no_data_value=ndv_scalar,
         )

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4720,7 +4720,13 @@ class NetCDF(Dataset):
         materialized = Dataset.create_from_array(
             cast("np.typing.NDArray", arr),
             geo=reprojected.geotransform,
-            epsg=reprojected.epsg,
+            # epsg is None for a no-EPSG CRS (e.g. geostationary); fall back
+            # to the WKT so this preserves it instead of defaulting to 4326
+            # (#706). to_crs(to_epsg: int, ...) always targets a concrete
+            # EPSG here, so epsg is provably non-None -- the fallback is
+            # defense-in-depth, matching the pattern used throughout
+            # pyramids.dataset.
+            epsg=reprojected.epsg or reprojected.crs,
             no_data_value=ndv_scalar,
         )
         NetCDF._copy_band_dim_metadata(materialized, var)

--- a/tests/dataset/collection/test_zarr.py
+++ b/tests/dataset/collection/test_zarr.py
@@ -184,6 +184,25 @@ class TestFromZarrRoundtrip:
         assert rt.meta.epsg == 4326, f"epsg {rt.meta.epsg}"
 
     @requires_zarr
+    def test_roundtrip_coerces_non_int_time_length(self, three_files_ramp, tmp_path):
+        """from_zarr coerces a non-int time_length attr to int.
+
+        Test scenario:
+            A store whose ``time_length`` attr is a JSON float (a legacy or
+            externally-authored cube) reopens with an ``int`` time_length, so
+            ``range(time_length)`` downstream still works.
+        """
+        out = str(tmp_path / "float_tl.zarr")
+        DatasetCollection.from_files(three_files_ramp).to_zarr(out)
+        root = zarr.open_group(out, mode="a")
+        root.attrs["time_length"] = 3.0
+        rt = DatasetCollection.from_zarr(out)
+        assert isinstance(
+            rt.time_length, int
+        ), f"time_length not coerced: {type(rt.time_length)}"
+        assert rt.time_length == 3, f"time_length {rt.time_length}"
+
+    @requires_zarr
     def test_data_is_lazy_and_values_match(self, three_files_ramp, tmp_path):
         """from_zarr.data is a lazy dask cube whose values match the source.
 

--- a/tests/dataset/unit/test_unit_nodata.py
+++ b/tests/dataset/unit/test_unit_nodata.py
@@ -323,8 +323,15 @@ class TestChangeNoDataValueNan:
         assert np.allclose(result[0], [[-1.0, 2.0], [3.0, -1.0]]), "Band 0 replaced by its own sentinel"
         assert np.allclose(result[1], [[1.0, -1.0], [-1.0, 4.0]]), "Band 1 replaced by its own sentinel"
 
-    def test_change_nodata_old_value_wrong_length_raises(self):
-        """A mismatched-length old_value list raises NoDataValueError, not IndexError."""
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            pytest.param({"new_value": -1.0, "old_value": [-9999.0]}, id="old_value"),
+            pytest.param({"new_value": [1.0], "old_value": -9999.0}, id="new_value"),
+        ],
+    )
+    def test_change_nodata_wrong_length_raises(self, kwargs):
+        """A mismatched-length new_value/old_value list raises NoDataValueError, not IndexError."""
         arr = np.stack(
             [
                 np.array([[-9999.0, 2.0], [3.0, -9999.0]], dtype=np.float32),
@@ -339,25 +346,7 @@ class TestChangeNoDataValueNan:
             no_data_value=-9999.0,
         )
         with pytest.raises(NoDataValueError, match="length"):
-            ds.change_no_data_value(-1.0, old_value=[-9999.0])
-
-    def test_change_nodata_new_value_wrong_length_raises(self):
-        """A mismatched-length new_value list raises NoDataValueError, not IndexError."""
-        arr = np.stack(
-            [
-                np.array([[-9999.0, 2.0], [3.0, -9999.0]], dtype=np.float32),
-                np.array([[1.0, -8888.0], [-8888.0, 4.0]], dtype=np.float32),
-            ]
-        )
-        ds = Dataset.create_from_array(
-            arr,
-            top_left_corner=(0.0, 0.0),
-            cell_size=0.05,
-            epsg=4326,
-            no_data_value=-9999.0,
-        )
-        with pytest.raises(NoDataValueError, match="length"):
-            ds.change_no_data_value([1.0], old_value=-9999.0)
+            ds.change_no_data_value(**kwargs)
 
 
 class TestFillNanNodata:

--- a/tests/dataset/unit/test_unit_nodata.py
+++ b/tests/dataset/unit/test_unit_nodata.py
@@ -324,13 +324,17 @@ class TestChangeNoDataValueNan:
         assert np.allclose(result[1], [[1.0, -1.0], [-1.0, 4.0]]), "Band 1 replaced by its own sentinel"
 
     @pytest.mark.parametrize(
-        "kwargs",
+        ("kwargs", "expected"),
         [
-            pytest.param({"new_value": -1.0, "old_value": [-9999.0]}, id="old_value"),
-            pytest.param({"new_value": [1.0], "old_value": -9999.0}, id="new_value"),
+            pytest.param(
+                {"new_value": -1.0, "old_value": [-9999.0]}, "old_value", id="old_value"
+            ),
+            pytest.param(
+                {"new_value": [1.0], "old_value": -9999.0}, "new_value", id="new_value"
+            ),
         ],
     )
-    def test_change_nodata_wrong_length_raises(self, kwargs):
+    def test_change_nodata_wrong_length_raises(self, kwargs, expected):
         """A mismatched-length new_value/old_value list raises NoDataValueError, not IndexError."""
         arr = np.stack(
             [
@@ -345,7 +349,7 @@ class TestChangeNoDataValueNan:
             epsg=4326,
             no_data_value=-9999.0,
         )
-        with pytest.raises(NoDataValueError, match="length"):
+        with pytest.raises(NoDataValueError, match=rf"{expected} must be .* length"):
             ds.change_no_data_value(**kwargs)
 
 

--- a/tests/dataset/unit/test_unit_nodata.py
+++ b/tests/dataset/unit/test_unit_nodata.py
@@ -297,6 +297,50 @@ class TestChangeNoDataValueNan:
             result[0, 0], -1.0
         ), "Old nodata cells should be replaced with list old"
 
+    def test_change_nodata_multiband_distinct_old_values(self):
+        """Each band's cells are matched against its own old_value entry.
+
+        Regression test: a per-band old_value list was previously compared
+        against the whole list at once instead of being indexed per band,
+        which raises a numpy broadcast error (or silently mismatches) on
+        multi-band data with distinct per-band sentinels.
+        """
+        arr = np.stack(
+            [
+                np.array([[-9999.0, 2.0], [3.0, -9999.0]], dtype=np.float32),
+                np.array([[1.0, -8888.0], [-8888.0, 4.0]], dtype=np.float32),
+            ]
+        )
+        ds = Dataset.create_from_array(
+            arr,
+            top_left_corner=(0.0, 0.0),
+            cell_size=0.05,
+            epsg=4326,
+            no_data_value=-9999.0,
+        )
+        new_ds = ds.change_no_data_value(-1.0, old_value=[-9999.0, -8888.0])
+        result = new_ds.read_array()
+        assert np.allclose(result[0], [[-1.0, 2.0], [3.0, -1.0]]), "Band 0 replaced by its own sentinel"
+        assert np.allclose(result[1], [[1.0, -1.0], [-1.0, 4.0]]), "Band 1 replaced by its own sentinel"
+
+    def test_change_nodata_old_value_wrong_length_raises(self):
+        """A mismatched-length old_value list raises NoDataValueError, not IndexError."""
+        arr = np.stack(
+            [
+                np.array([[-9999.0, 2.0], [3.0, -9999.0]], dtype=np.float32),
+                np.array([[1.0, -8888.0], [-8888.0, 4.0]], dtype=np.float32),
+            ]
+        )
+        ds = Dataset.create_from_array(
+            arr,
+            top_left_corner=(0.0, 0.0),
+            cell_size=0.05,
+            epsg=4326,
+            no_data_value=-9999.0,
+        )
+        with pytest.raises(NoDataValueError, match="length"):
+            ds.change_no_data_value(-1.0, old_value=[-9999.0])
+
 
 class TestFillNanNodata:
     """Tests for fill method with NaN no_data_value."""

--- a/tests/dataset/unit/test_unit_nodata.py
+++ b/tests/dataset/unit/test_unit_nodata.py
@@ -341,6 +341,24 @@ class TestChangeNoDataValueNan:
         with pytest.raises(NoDataValueError, match="length"):
             ds.change_no_data_value(-1.0, old_value=[-9999.0])
 
+    def test_change_nodata_new_value_wrong_length_raises(self):
+        """A mismatched-length new_value list raises NoDataValueError, not IndexError."""
+        arr = np.stack(
+            [
+                np.array([[-9999.0, 2.0], [3.0, -9999.0]], dtype=np.float32),
+                np.array([[1.0, -8888.0], [-8888.0, 4.0]], dtype=np.float32),
+            ]
+        )
+        ds = Dataset.create_from_array(
+            arr,
+            top_left_corner=(0.0, 0.0),
+            cell_size=0.05,
+            epsg=4326,
+            no_data_value=-9999.0,
+        )
+        with pytest.raises(NoDataValueError, match="length"):
+            ds.change_no_data_value([1.0], old_value=-9999.0)
+
 
 class TestFillNanNodata:
     """Tests for fill method with NaN no_data_value."""


### PR DESCRIPTION
# Description

Resolves all 116 mypy errors reported for `pyramids.dataset` (the whole subpackage: `abstract_dataset.py`,
`dataset.py`, `collection.py`, `merge.py`, the engine collaborators under `engines/`, `ops/_zonal.py`,
`ops/io.py`, `_stac.py`, `_wcs.py`, `_plot_helpers.py`, `base/_domain.py`, plus one line in
`netcdf/netcdf.py`) down to zero, by declaring real type contracts rather than suppressing the checker —
no `# type: ignore` was added anywhere, and no `cast(Any, ...)` remains in the diff (all six were replaced
with precise types).

Two structural gaps accounted for most of the errors: `RasterBase` (the shared ABC) was missing several
abstract members that both concrete subclasses already implement informally, and `collection.py`'s zarr
`Group | Array` / recursive JSON-attrs unions were unnarrowed. The rest were one-off patterns: `@overload`
splits where a function's return type depends on whether its input was array-like or scalar, targeted
`assert`s proving invariants mypy can't trace across a closure boundary, and `cast()` calls verified
against the real call graph.

Tracing why several of these types were `Optional` surfaced two genuine, previously-invisible bugs, fixed
alongside the typing work (not hidden inside it):

- `Bands.change_no_data_value` compared each band's pixels against the *entire* `old_value` list instead
  of indexing it per band — invisible on every existing test because they all use single-band data (where
  size-1-list broadcasting hides the bug). Fixed, with a regression test on distinct per-band sentinels,
  plus explicit length validation for both `old_value` and `new_value` (a mismatched-length list previously
  raised an uncaught `IndexError` instead of the method's documented `NoDataValueError`).
- Seven `create_from_array(epsg=X.epsg, ...)` call sites passed a possibly-`None` `epsg` into a parameter
  typed `str | int`, which raises `CRSError` on `None`. `.epsg` is `None` exactly when the object reports a
  no-EPSG CRS — a `NetCDF` geostationary grid (`NetCDF._get_epsg`) — so those paths crashed rather than
  preserving the grid's CRS. Fixed uniformly with `epsg=X.epsg or X.crs`, falling back to the WKT string
  (`create_from_array` accepts one), across `collection.py`, `dataset.py`, `engines/spatial.py`, and
  `netcdf/netcdf.py`. For a plain `Dataset` the fallback is a no-op, since `Dataset._get_epsg` resolves
  through `epsg_from_wkt`, whose `4326` default means `.epsg` is never `None` — re-tagging a no-EPSG raster
  opened as a plain `Dataset` remains out of scope (see #706).

One annotation correction is worth calling out because it touches a shared helper: `is_no_data`'s scalar
overload (and `inside_domain`, whose return is its inverse) declared `-> bool`, but `np.isnan` / `np.isclose`
on a scalar return `np.bool_`, which does not subclass `bool`. Both now say `np.bool_`. Annotations only —
the runtime values are unchanged.

Beyond the above: no new features, no schema/config changes.

## Breaking change

`Bands.change_no_data_value` now requires a `list` `new_value` / `old_value` to have exactly `band_count`
entries, raising `NoDataValueError` otherwise. Previously a **single-element** list such as
`ds.change_no_data_value(-1.0, old_value=[-9999])` broadcast across all bands on a multi-band raster and
worked; it now raises. This is deliberate: the length-1 broadcast was a side effect of the whole-list
comparison bug fixed here, and silently accepting a wrong-length list is what produced corrupted output for
genuine per-band lists. Pass the bare scalar (`old_value=-9999`, which still broadcasts) or a full per-band
list instead.

# Issues

- Closes #723 — resolve all 116 mypy errors in `pyramids.dataset`, plus the two bugs the typing surfaced.
- Refs #654 — first scoped increment of the mypy CI gate; `pyramids.dataset` becomes allowlist-ready. The
  remaining errors outside this subpackage, and the CI wiring itself, stay with that issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- `pixi run -e dev mypy -p pyramids.dataset --show-error-codes --no-incremental` → **0 errors** in 41
  source files (down from 116 on `main`).
- `pixi run -e dev pytest -m "not plot" -q` → **6488 passed, 50 skipped, 320 deselected**, re-run green
  after every commit on the branch.
- New regression tests, each verified to actually fail against the un-fixed code (not just to pass):
  - `tests/dataset/unit/test_unit_nodata.py::test_change_nodata_multiband_distinct_old_values` — reproduces
    the per-band indexing bug.
  - `tests/dataset/unit/test_unit_nodata.py::test_change_nodata_wrong_length_raises` — parametrized over
    `old_value` and `new_value`, each asserting the specific guard that fired.
  - `tests/dataset/collection/test_zarr.py::test_roundtrip_coerces_non_int_time_length` — a store holding
    `time_length` as a JSON float reopens as an `int`.
- Four full, independent review rounds (each a fresh, isolated pass over the whole diff) traced every
  `assert`, `cast(...)`, and `epsg or crs` fallback back to the specific invariant/guard it relies on. All
  findings were fixed; none were suppressed or left open. Notably they caught a `cast(int, ...)` that had
  replaced a runtime `int(...)` coercion on the zarr `time_length` attribute (a `cast` is a no-op at
  runtime, so the coercion had silently vanished), and several inline comments that mis-described what the
  `epsg or crs` fallback actually does.
- Every added `assert` was traced to the `if ... raise` guard that already enforces it, confirming none is
  load-bearing under `python -O`; every `cast()` naming a `TYPE_CHECKING`-only class uses the string form,
  so none can raise `NameError` at runtime.
- SonarCloud on this PR: **0 unresolved issues, quality gate OK** on all five conditions (an earlier
  new-code duplication flag from two near-identical tests was resolved by parametrizing them into one).

- [x] Full non-plot test suite (`pytest -m "not plot"`)
- [x] `mypy -p pyramids.dataset` strict pass
- [x] Doctests for the touched modules

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen bumps this automatically on release)
- [ ] added changes to History.rst. (commitizen-generated; not hand-edited)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.
