### PR TITLE
feat(dataset): let direct from_wcs override built-in KVP keys for shims

### DIFF
--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -55,15 +55,93 @@ from pyramids.base._coverage import validate_bbox as _validate_bbox
 from pyramids.base._errors import CoverageError, WCSError
 from pyramids.base._ogc_api import gdal_http_config as _gdal_http_config
 
-# Request KVP keys pyramids sets itself in direct GetCoverage; an extra_params key
-# colliding with one of these is rejected so it cannot duplicate the request —
-# independent of whether the optional FORMAT was emitted.
+# Request KVP keys pyramids sets itself in direct GetCoverage.
 _RESERVED_KVP_KEYS = frozenset(
     {
         "SERVICE", "VERSION", "REQUEST", "COVERAGE", "COVERAGEID", "SUBSET",
         "SUBSETTINGCRS", "CRS", "BBOX", "RESX", "RESY", "FORMAT",
     }
 )
+
+# The fixed protocol call itself (SUBSET is multi-valued): an extra_params key
+# targeting one of these is always a mistake, so it stays rejected even in direct
+# mode. Every other reserved key is overridable — a caller can hand a
+# non-conformant shim its exact spelling (see _merge_direct_kvp).
+_PROTOCOL_KVP_KEYS = frozenset({"SERVICE", "VERSION", "REQUEST", "SUBSET"})
+_OVERRIDABLE_KVP_KEYS = _RESERVED_KVP_KEYS - _PROTOCOL_KVP_KEYS
+
+# The request CRS is spelled SUBSETTINGCRS in WCS 2.0.x and CRS in 1.0.0; a shim
+# may want the other spelling on either version, so both collapse to one logical
+# slot — overriding with either replaces whichever the builder emitted.
+_CRS_KVP_KEYS = frozenset({"CRS", "SUBSETTINGCRS"})
+
+
+def _kvp_slot(key: str) -> str:
+    """Normalised override slot for a KVP key (CRS and SUBSETTINGCRS share one)."""
+    upper = key.upper()
+    slot = "CRS" if upper in _CRS_KVP_KEYS else upper
+    return slot
+
+
+def _merge_direct_kvp(
+    params: list[tuple[str, str]], extra_params: dict[str, str] | None
+) -> list[tuple[str, str]]:
+    """Fold ``extra_params`` into the built-in direct-GetCoverage KVP list.
+
+    In direct mode the caller owns the wire request. An ``extra_params`` key that
+    matches a built-in KVP *replaces* it — case-insensitively, and with ``CRS`` and
+    ``SUBSETTINGCRS`` sharing one slot — using the caller's exact key spelling and
+    value. This lets a non-conformant shim be handed its exact tokens: a lowercase
+    ``coverageID`` key, or the WCS-1.x ``CRS=`` on a WCS-2.0 request (the two quirks
+    of the Copernicus EDO/GDO MapServer, which ``500``s on the spec spellings). A
+    key that matches nothing built-in is appended verbatim, as before. ``SERVICE`` /
+    ``VERSION`` / ``REQUEST`` / ``SUBSET`` stay locked — they are the fixed protocol
+    call (or multi-valued), so overriding them is always an error.
+
+    Args:
+        params: The KVP pairs the builder assembled, in order.
+        extra_params: Caller-supplied query parameters, or ``None``.
+
+    Returns:
+        The merged KVP pairs: built-ins with any matching override substituted in
+        place, followed by the non-colliding extras.
+
+    Raises:
+        ValueError: an ``extra_params`` key targets a locked protocol parameter.
+    """
+    result = list(params)
+    if extra_params:
+        overrides: dict[str, tuple[str, str]] = {}
+        appended: list[tuple[str, str]] = []
+        for key, val in extra_params.items():
+            upper = key.upper()
+            if upper in _PROTOCOL_KVP_KEYS:
+                raise ValueError(
+                    f"extra_params key {key!r} is a fixed WCS protocol parameter and "
+                    "cannot be overridden; set it via the from_wcs arguments instead."
+                )
+            if upper in _OVERRIDABLE_KVP_KEYS:
+                overrides[_kvp_slot(key)] = (key, val)
+            else:
+                appended.append((key, val))
+        merged: list[tuple[str, str]] = []
+        used: set[str] = set()
+        for k, v in result:
+            slot = _kvp_slot(k)
+            replacement = overrides.get(slot)
+            if replacement is None:
+                merged.append((k, v))
+            elif slot not in used:
+                merged.append(replacement)
+                used.add(slot)
+            # else: drop a duplicate built-in of an already-replaced slot.
+        # An override that matched no built-in (e.g. RESX on a 2.0 request) is kept
+        # as a plain extra rather than silently dropped.
+        for slot, kv in overrides.items():
+            if slot not in used:
+                appended.append(kv)
+        result = merged + appended
+    return result
 
 if TYPE_CHECKING:
     from osgeo import osr
@@ -275,9 +353,16 @@ def _getcoverage_url(
     max-x) range and the second the y range, so lon/lat values land on the right
     axis regardless of the CRS's declared axis order.
 
+    ``extra_params`` may override a built-in KVP by matching its key (see
+    :func:`_merge_direct_kvp`), so a non-conformant shim can be served its exact
+    spelling (e.g. ``{"coverageID": "spaST", "CRS": "EPSG:4326"}`` to send a
+    lowercase key and the WCS-1.x CRS token on a WCS-2.0 request).
+
     Raises:
-        ValueError: the WCS version is unsupported for direct mode, or ``1.0.0``
-            was requested without a ``resolution`` (needed for the output grid).
+        ValueError: the WCS version is unsupported for direct mode, ``1.0.0`` was
+            requested without a ``resolution`` (needed for the output grid), or an
+            ``extra_params`` key targets a locked protocol parameter
+            (``SERVICE`` / ``VERSION`` / ``REQUEST`` / ``SUBSET``).
     """
     minx, miny, maxx, maxy = bbox
     ver = version or "2.0.0"
@@ -320,14 +405,7 @@ def _getcoverage_url(
         )
     if wcs_format:
         params.append(("FORMAT", wcs_format))
-    if extra_params:
-        for key, val in extra_params.items():
-            if key.upper() in _RESERVED_KVP_KEYS:
-                raise ValueError(
-                    f"extra_params key {key!r} collides with a built-in GetCoverage "
-                    "parameter; use the dedicated from_wcs argument instead."
-                )
-            params.append((key, val))
+    params = _merge_direct_kvp(params, extra_params)
     # Encode both key and value so a stray '&'/'=' in a caller-supplied key cannot
     # split the query. Keep ',():/' literal in values so CRS shorthand / URIs
     # (EPSG:4326, http://www.opengis.net/def/crs/…) and SUBSET syntax survive intact

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -70,10 +70,13 @@ _RESERVED_KVP_KEYS = frozenset(
 _PROTOCOL_KVP_KEYS = frozenset({"SERVICE", "VERSION", "REQUEST", "SUBSET"})
 _OVERRIDABLE_KVP_KEYS = _RESERVED_KVP_KEYS - _PROTOCOL_KVP_KEYS
 
-# The request CRS is spelled SUBSETTINGCRS in WCS 2.0.x and CRS in 1.0.0; a shim
-# may want the other spelling on either version, so both collapse to one logical
-# slot — overriding with either replaces whichever the builder emitted.
+# Two request parameters are spelled differently across WCS versions: the CRS is
+# SUBSETTINGCRS in 2.0.x and CRS in 1.0.0, and the coverage id is COVERAGEID in
+# 2.0.x and COVERAGE in 1.0.0. A shim may want the other spelling on either
+# version, so each pair collapses to one logical slot — overriding with either
+# spelling replaces whichever the builder emitted (see _kvp_slot).
 _CRS_KVP_KEYS = frozenset({"CRS", "SUBSETTINGCRS"})
+_COVERAGE_KVP_KEYS = frozenset({"COVERAGE", "COVERAGEID"})
 
 
 if TYPE_CHECKING:
@@ -83,9 +86,19 @@ if TYPE_CHECKING:
 
 
 def _kvp_slot(key: str) -> str:
-    """Normalised override slot for a KVP key (CRS and SUBSETTINGCRS share one)."""
+    """Normalised override slot for a KVP key.
+
+    The two cross-version pairs collapse to one slot each so an override bridges the
+    WCS spellings: ``CRS``/``SUBSETTINGCRS`` -> ``CRS`` and
+    ``COVERAGE``/``COVERAGEID`` -> ``COVERAGE``. Every other key is its own slot.
+    """
     upper = key.upper()
-    slot = "CRS" if upper in _CRS_KVP_KEYS else upper
+    if upper in _CRS_KVP_KEYS:
+        slot = "CRS"
+    elif upper in _COVERAGE_KVP_KEYS:
+        slot = "COVERAGE"
+    else:
+        slot = upper
     return slot
 
 
@@ -116,8 +129,9 @@ def _merge_direct_kvp(
 
     Raises:
         ValueError: an ``extra_params`` key targets a locked protocol parameter, or
-            two ``extra_params`` keys target the same GetCoverage parameter (e.g.
-            both ``CRS`` and ``SUBSETTINGCRS``, or case-variant duplicates).
+            two ``extra_params`` keys target the same built-in GetCoverage parameter
+            (e.g. both ``CRS`` and ``SUBSETTINGCRS``, or case-variant duplicates of a
+            built-in key such as ``coverageID`` and ``COVERAGEID``).
     """
     result = list(params)
     if extra_params:
@@ -141,6 +155,11 @@ def _merge_direct_kvp(
                 overrides[slot] = (key, val)
             else:
                 appended.append((key, val))
+        # Substitute each override into its matching built-in position. Safe as a
+        # single pass because no overridable slot is ever emitted twice in `params`:
+        # the only duplicated built-in slot is SUBSET (two axes on 2.0.x), and SUBSET
+        # is a protocol key that can never populate `overrides`. If a future builder
+        # emits a duplicated overridable slot, dedupe here before substituting.
         merged = [overrides.get(_kvp_slot(k), (k, v)) for k, v in result]
         result = merged + appended
     return result

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -76,6 +76,12 @@ _OVERRIDABLE_KVP_KEYS = _RESERVED_KVP_KEYS - _PROTOCOL_KVP_KEYS
 _CRS_KVP_KEYS = frozenset({"CRS", "SUBSETTINGCRS"})
 
 
+if TYPE_CHECKING:
+    from osgeo import osr
+
+    from pyramids.dataset.dataset import Dataset
+
+
 def _kvp_slot(key: str) -> str:
     """Normalised override slot for a KVP key (CRS and SUBSETTINGCRS share one)."""
     upper = key.upper()
@@ -89,14 +95,16 @@ def _merge_direct_kvp(
     """Fold ``extra_params`` into the built-in direct-GetCoverage KVP list.
 
     In direct mode the caller owns the wire request. An ``extra_params`` key that
-    matches a built-in KVP *replaces* it — case-insensitively, and with ``CRS`` and
-    ``SUBSETTINGCRS`` sharing one slot — using the caller's exact key spelling and
-    value. This lets a non-conformant shim be handed its exact tokens: a lowercase
-    ``coverageID`` key, or the WCS-1.x ``CRS=`` on a WCS-2.0 request (the two quirks
-    of the Copernicus EDO/GDO MapServer, which ``500``s on the spec spellings). A
-    key that matches nothing built-in is appended verbatim, as before. ``SERVICE`` /
-    ``VERSION`` / ``REQUEST`` / ``SUBSET`` stay locked — they are the fixed protocol
-    call (or multi-valued), so overriding them is always an error.
+    matches a built-in KVP *replaces* it in place — case-insensitively, and with
+    ``CRS`` and ``SUBSETTINGCRS`` sharing one slot — using the caller's exact key
+    spelling and value. This lets a non-conformant shim be handed its exact tokens:
+    a lowercase ``coverageID`` key, or the WCS-1.x ``CRS=`` on a WCS-2.0 request (the
+    two quirks of the Copernicus EDO/GDO MapServer, which ``500``s on the spec
+    spellings). A key that matches no built-in is appended verbatim, in caller order.
+    ``SERVICE`` / ``VERSION`` / ``REQUEST`` / ``SUBSET`` stay locked — they are the
+    fixed protocol call (or multi-valued), so overriding them is always an error;
+    additional WCS-2.0 ``SUBSET`` axes (e.g. a temporal subset) therefore cannot be
+    added in direct mode, only in discovery mode.
 
     Args:
         params: The KVP pairs the builder assembled, in order.
@@ -104,13 +112,16 @@ def _merge_direct_kvp(
 
     Returns:
         The merged KVP pairs: built-ins with any matching override substituted in
-        place, followed by the non-colliding extras.
+        place, followed by the non-colliding extras in caller order.
 
     Raises:
-        ValueError: an ``extra_params`` key targets a locked protocol parameter.
+        ValueError: an ``extra_params`` key targets a locked protocol parameter, or
+            two ``extra_params`` keys target the same GetCoverage parameter (e.g.
+            both ``CRS`` and ``SUBSETTINGCRS``, or case-variant duplicates).
     """
     result = list(params)
     if extra_params:
+        builtin_slots = {_kvp_slot(key) for key, _ in result}
         overrides: dict[str, tuple[str, str]] = {}
         appended: list[tuple[str, str]] = []
         for key, val in extra_params.items():
@@ -120,33 +131,19 @@ def _merge_direct_kvp(
                     f"extra_params key {key!r} is a fixed WCS protocol parameter and "
                     "cannot be overridden; set it via the from_wcs arguments instead."
                 )
-            if upper in _OVERRIDABLE_KVP_KEYS:
-                overrides[_kvp_slot(key)] = (key, val)
+            slot = _kvp_slot(key)
+            if upper in _OVERRIDABLE_KVP_KEYS and slot in builtin_slots:
+                if slot in overrides:
+                    raise ValueError(
+                        f"extra_params keys {overrides[slot][0]!r} and {key!r} both "
+                        "target the same GetCoverage parameter; pass only one."
+                    )
+                overrides[slot] = (key, val)
             else:
                 appended.append((key, val))
-        merged: list[tuple[str, str]] = []
-        used: set[str] = set()
-        for k, v in result:
-            slot = _kvp_slot(k)
-            replacement = overrides.get(slot)
-            if replacement is None:
-                merged.append((k, v))
-            elif slot not in used:
-                merged.append(replacement)
-                used.add(slot)
-            # else: drop a duplicate built-in of an already-replaced slot.
-        # An override that matched no built-in (e.g. RESX on a 2.0 request) is kept
-        # as a plain extra rather than silently dropped.
-        for slot, kv in overrides.items():
-            if slot not in used:
-                appended.append(kv)
+        merged = [overrides.get(_kvp_slot(k), (k, v)) for k, v in result]
         result = merged + appended
     return result
-
-if TYPE_CHECKING:
-    from osgeo import osr
-
-    from pyramids.dataset.dataset import Dataset
 
 
 def _http_get(

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2296,7 +2296,10 @@ class Dataset(RasterBase):
                 instead of ``SUBSETTINGCRS``. Non-matching keys are appended (e.g. a
                 ``TIME`` axis). The fixed protocol keys ``SERVICE`` / ``VERSION`` /
                 ``REQUEST`` / ``SUBSET`` cannot be overridden and raise
-                :class:`ValueError`.
+                :class:`ValueError`; because ``SUBSET`` is locked, an additional
+                WCS-2.0 ``SUBSET`` axis (e.g. a temporal subset) cannot be added in
+                direct mode — use discovery mode for that. Two keys targeting the
+                same parameter (e.g. both ``CRS`` and ``SUBSETTINGCRS``) also raise.
             direct: When ``True``, skip ``GetCapabilities``/``DescribeCoverage`` and
                 issue a KVP ``GetCoverage`` directly — for shim servers that only
                 implement ``GetCoverage``. Defaults to ``False`` (full handshake).

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2244,6 +2244,14 @@ class Dataset(RasterBase):
         ``crs`` — override with ``subset_axes`` if the server names its axes
         differently.
 
+        A non-conformant shim may also reject the spec KVP spellings themselves: the
+        Copernicus EDO/GDO MapServer ``500``s on the uppercase ``COVERAGEID`` key and
+        on ``SUBSETTINGCRS=`` (it wants a lowercase ``coverageID`` and the WCS-1.x
+        ``CRS=``). In direct mode ``extra_params`` can override a built-in KVP by key,
+        so pass ``extra_params={"coverageID": <id>, "CRS": <crs>}`` to hand such a
+        server its exact spelling — the override replaces the built-in rather than
+        duplicating it.
+
         Args:
             endpoint: The WCS service URL, including any server-specific query
                 prefix (e.g. ``"https://maps.isric.org/mapserv?map=/map/nitrogen.map"``).
@@ -2281,7 +2289,14 @@ class Dataset(RasterBase):
                 requests. Defaults to ``60.0``.
             extra_params: Optional extra ``GetCoverage`` query parameters folded
                 into the request (a workaround hook for server quirks). In direct
-                mode these are appended to the KVP request (e.g. a ``TIME`` axis).
+                mode a key that matches a built-in KVP (case-insensitively, with
+                ``CRS`` and ``SUBSETTINGCRS`` treated as one) *overrides* it with the
+                given spelling and value — e.g. ``{"coverageID": "spaST"}`` sends a
+                lowercase key, ``{"CRS": "EPSG:4326"}`` sends the WCS-1.x CRS token
+                instead of ``SUBSETTINGCRS``. Non-matching keys are appended (e.g. a
+                ``TIME`` axis). The fixed protocol keys ``SERVICE`` / ``VERSION`` /
+                ``REQUEST`` / ``SUBSET`` cannot be overridden and raise
+                :class:`ValueError`.
             direct: When ``True``, skip ``GetCapabilities``/``DescribeCoverage`` and
                 issue a KVP ``GetCoverage`` directly — for shim servers that only
                 implement ``GetCoverage``. Defaults to ``False`` (full handshake).
@@ -2299,8 +2314,9 @@ class Dataset(RasterBase):
         Raises:
             ValueError: ``bbox`` is malformed, ``coverage`` is not advertised
                 (discovery mode), ``coverage_crs`` cannot be interpreted, or (direct
-                mode) the WCS version is unsupported / ``1.0.0`` lacks a
-                ``resolution``.
+                mode) the WCS version is unsupported, ``1.0.0`` lacks a
+                ``resolution``, or an ``extra_params`` key targets a locked protocol
+                parameter.
             pyramids.errors.WCSError: The server could not be reached or returned
                 an error / a non-raster (``<ows:ExceptionReport>``) body.
 
@@ -2319,18 +2335,26 @@ class Dataset(RasterBase):
             ```
 
             Direct mode for a ``GetCoverage``-only endpoint (Copernicus EDO/GDO),
-            whose ``GetCapabilities``/``DescribeCoverage`` return ``502``/``400``:
+            whose ``GetCapabilities``/``DescribeCoverage`` return ``502``/``400``.
+            EDO also rejects the spec KVP spellings, so override the coverage key and
+            CRS token via ``extra_params`` to send the lowercase ``coverageID`` and
+            the WCS-1.x ``CRS=`` it accepts:
 
             ```python
             >>> ds = Dataset.from_wcs(  # doctest: +SKIP
-            ...     "https://.../mapserv?map=GDO_WCS",
+            ...     "https://drought.emergency.copernicus.eu/api/wcs?map=DO_WCS",
             ...     coverage="spaST",
-            ...     bbox=(-10.0, 35.0, 5.0, 45.0),
+            ...     bbox=(10.0, 45.0, 15.0, 48.0),
             ...     crs="EPSG:4326",
             ...     version="2.0.0",
             ...     wcs_format="GEOTIFF",
             ...     direct=True,
-            ...     extra_params={"TIME": "2024-06-01", "SELECTED_TIMESCALE": "03"},
+            ...     extra_params={
+            ...         "coverageID": "spaST",
+            ...         "CRS": "EPSG:4326",
+            ...         "TIME": "2023-06-01",
+            ...         "SELECTED_TIMESCALE": "01",
+            ...     },
             ... )
 
             ```

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2289,17 +2289,19 @@ class Dataset(RasterBase):
                 requests. Defaults to ``60.0``.
             extra_params: Optional extra ``GetCoverage`` query parameters folded
                 into the request (a workaround hook for server quirks). In direct
-                mode a key that matches a built-in KVP (case-insensitively, with
-                ``CRS`` and ``SUBSETTINGCRS`` treated as one) *overrides* it with the
-                given spelling and value — e.g. ``{"coverageID": "spaST"}`` sends a
-                lowercase key, ``{"CRS": "EPSG:4326"}`` sends the WCS-1.x CRS token
-                instead of ``SUBSETTINGCRS``. Non-matching keys are appended (e.g. a
-                ``TIME`` axis). The fixed protocol keys ``SERVICE`` / ``VERSION`` /
-                ``REQUEST`` / ``SUBSET`` cannot be overridden and raise
+                mode a key that matches a built-in KVP (case-insensitively, with the
+                cross-version pairs ``CRS``/``SUBSETTINGCRS`` and
+                ``COVERAGE``/``COVERAGEID`` each treated as one) *overrides* it with
+                the given spelling and value — e.g. ``{"coverageID": "spaST"}`` sends
+                a lowercase key, ``{"CRS": "EPSG:4326"}`` sends the WCS-1.x CRS token
+                instead of ``SUBSETTINGCRS``. Non-matching keys are appended in caller
+                order (e.g. a ``TIME`` axis). The fixed protocol keys ``SERVICE`` /
+                ``VERSION`` / ``REQUEST`` / ``SUBSET`` cannot be overridden and raise
                 :class:`ValueError`; because ``SUBSET`` is locked, an additional
                 WCS-2.0 ``SUBSET`` axis (e.g. a temporal subset) cannot be added in
                 direct mode — use discovery mode for that. Two keys targeting the
-                same parameter (e.g. both ``CRS`` and ``SUBSETTINGCRS``) also raise.
+                same built-in parameter (e.g. both ``CRS`` and ``SUBSETTINGCRS``) also
+                raise.
             direct: When ``True``, skip ``GetCapabilities``/``DescribeCoverage`` and
                 issue a KVP ``GetCoverage`` directly — for shim servers that only
                 implement ``GetCoverage``. Defaults to ``False`` (full handshake).

--- a/tests/dataset/remote/test_wcs.py
+++ b/tests/dataset/remote/test_wcs.py
@@ -462,12 +462,75 @@ class TestGetCoverageUrl:
         )
         assert "a%26b=v" in url  # '&' in the key cannot split the query
 
-    def test_extra_params_key_colliding_with_builtin_raises(self):
-        with pytest.raises(ValueError, match="collides"):
+    @pytest.mark.parametrize("key", ["VERSION", "SERVICE", "REQUEST", "SUBSET"])
+    def test_extra_params_protocol_key_raises(self, key):
+        with pytest.raises(ValueError, match="fixed WCS protocol parameter"):
             _wcs._getcoverage_url(
                 "https://x", "c", "EPSG:4326", (0.0, 0.0, 1.0, 1.0), "2.0.0",
-                None, None, None, {"VERSION": "1.0.0"},
+                None, None, None, {key: "x"},
             )
+
+    def test_extra_params_lowercase_coverageid_overrides_builtin(self):
+        # A shim that is case-sensitive on the key (Copernicus EDO/GDO) needs the
+        # lowercase spelling; the override replaces COVERAGEID, not duplicates it.
+        url = _wcs._getcoverage_url(
+            "https://x", "spaST", "EPSG:4326", (10.0, 45.0, 15.0, 48.0), "2.0.0",
+            "GEOTIFF", None, None, {"coverageID": "spaST"},
+        )
+        assert "coverageID=spaST" in url
+        assert "COVERAGEID=spaST" not in url
+
+    def test_extra_params_crs_overrides_subsettingcrs(self):
+        # WCS-1.x CRS= on a 2.0 request: the override replaces SUBSETTINGCRS and no
+        # SUBSETTINGCRS token survives (the two share one CRS slot).
+        url = _wcs._getcoverage_url(
+            "https://x", "c", "EPSG:4326", (10.0, 45.0, 15.0, 48.0), "2.0.0",
+            None, None, None, {"CRS": "EPSG:4326"},
+        )
+        assert "&CRS=EPSG:4326" in url
+        assert "SUBSETTINGCRS" not in url
+
+    def test_extra_params_edo_dialect_builds_request_a(self):
+        # Both quirks together must reproduce the exact request EDO/GDO answers 200:
+        # lowercase coverageID + CRS= + WCS-2.0 SUBSET syntax, extras preserved.
+        url = _wcs._getcoverage_url(
+            "https://drought.emergency.copernicus.eu/api/wcs?map=DO_WCS",
+            "spaST", "EPSG:4326", (10.0, 45.0, 15.0, 48.0), "2.0.0", "GEOTIFF",
+            None, None,
+            {"coverageID": "spaST", "CRS": "EPSG:4326",
+             "TIME": "2023-06-01", "SELECTED_TIMESCALE": "01"},
+        )
+        assert "coverageID=spaST" in url and "COVERAGEID=spaST" not in url
+        assert "&CRS=EPSG:4326" in url and "SUBSETTINGCRS" not in url
+        assert "SUBSET=Long(10.0,15.0)" in url and "SUBSET=Lat(45.0,48.0)" in url
+        assert "TIME=2023-06-01" in url and "SELECTED_TIMESCALE=01" in url
+
+    def test_extra_params_non_matching_key_is_appended(self):
+        url = _wcs._getcoverage_url(
+            "https://x", "c", "EPSG:4326", (0.0, 0.0, 1.0, 1.0), "2.0.0",
+            None, None, None, {"SELECTED_TIMESCALE": "03"},
+        )
+        assert "SELECTED_TIMESCALE=03" in url
+        assert "COVERAGEID=c" in url  # built-ins untouched
+
+    def test_extra_params_override_case_insensitive(self):
+        # A mixed-case override key still matches the built-in it targets ('/' is kept
+        # literal in values, like CRS URIs, so the MIME type is not percent-encoded).
+        url = _wcs._getcoverage_url(
+            "https://x", "c", "EPSG:4326", (0.0, 0.0, 1.0, 1.0), "2.0.0",
+            "GEOTIFF", None, None, {"Format": "image/tiff"},
+        )
+        assert "Format=image/tiff" in url
+        assert "FORMAT=GEOTIFF" not in url
+
+    def test_extra_params_overridable_key_without_builtin_is_appended(self):
+        # RESX is overridable but a 2.0 request emits no RESX built-in, so it must be
+        # kept as a plain extra rather than silently dropped.
+        url = _wcs._getcoverage_url(
+            "https://x", "c", "EPSG:4326", (0.0, 0.0, 1.0, 1.0), "2.0.0",
+            None, None, None, {"RESX": "0.1"},
+        )
+        assert "RESX=0.1" in url
 
 
 @pytest.fixture
@@ -616,3 +679,88 @@ class TestDirectGetCoverage:
                 self.ENDPOINT, coverage="c", bbox=self.BBOX, resolution=1.0,
                 direct=True,
             )
+
+    @pytest.mark.parametrize(
+        ("dialect", "extra_params"),
+        [
+            pytest.param("compliant", None, id="compliant-COVERAGEID-SUBSETTINGCRS"),
+            pytest.param(
+                "edo",
+                {"coverageID": "spaST", "CRS": "EPSG:4326"},
+                id="edo-coverageID-CRS",
+            ),
+        ],
+    )
+    def test_direct_serves_both_wcs_dialects(
+        self, monkeypatch, geotiff_bytes, dialect, extra_params
+    ):
+        # A fake server that returns a raster only for its own KVP dialect (else an
+        # exception report -> WCSError). direct=True must retrieve a raster from
+        # each: the spec spellings with no override, and the EDO shim spellings via
+        # extra_params. Proves the override reproduces the shim dialect without
+        # regressing the compliant path.
+        monkeypatch.setattr(
+            _wcs, "_http_get",
+            lambda url, *a, **k: _dialect_body(url, geotiff_bytes, dialect),
+        )
+        ds = Dataset.from_wcs(
+            self.ENDPOINT, coverage="spaST", bbox=self.BBOX, crs="EPSG:4326",
+            version="2.0.0", wcs_format="GEOTIFF", direct=True,
+            extra_params=extra_params,
+        )
+        assert ds.shape == (1, 3, 4)
+        assert ds.epsg == 4326
+
+
+def _dialect_body(url: str, raster: bytes, dialect: str) -> bytes:
+    """Fake GetCoverage body: the raster iff ``url`` matches ``dialect``, else a 500.
+
+    Models the two WCS KVP dialects a direct request can target — the spec-compliant
+    ``COVERAGEID`` + ``SUBSETTINGCRS`` and the Copernicus EDO/GDO shim's lowercase
+    ``coverageID`` + WCS-1.x ``CRS=`` — returning an ``<ows:ExceptionReport>`` (which
+    surfaces as :class:`WCSError`) when the request does not match the served dialect.
+    """
+    if dialect == "edo":
+        matched = (
+            "coverageID=" in url
+            and "COVERAGEID=" not in url
+            and "&CRS=" in url
+            and "SUBSETTINGCRS" not in url
+        )
+    else:
+        matched = "COVERAGEID=" in url and "SUBSETTINGCRS=" in url
+    return raster if matched else EXCEPTION_REPORT.encode("utf-8")
+
+
+@pytest.mark.slow
+@pytest.mark.live
+class TestLiveEdoDirect:
+    """Live direct GetCoverage against the Copernicus EDO/GDO WCS shim (#713).
+
+    The shim ``500``s on the spec ``COVERAGEID`` / ``SUBSETTINGCRS`` spellings, so
+    the request overrides both via ``extra_params`` to the lowercase ``coverageID``
+    and the WCS-1.x ``CRS=`` it accepts. ``TIME=2023-06-01`` is a published EDO dekad.
+    """
+
+    def test_direct_edo_override_returns_reference_raster(self):
+        ds = Dataset.from_wcs(
+            "https://drought.emergency.copernicus.eu/api/wcs?map=DO_WCS",
+            coverage="spaST",
+            bbox=(10.0, 45.0, 15.0, 48.0),
+            crs="EPSG:4326",
+            version="2.0.0",
+            wcs_format="GEOTIFF",
+            direct=True,
+            extra_params={
+                "coverageID": "spaST",
+                "CRS": "EPSG:4326",
+                "TIME": "2023-06-01",
+                "SELECTED_TIMESCALE": "01",
+            },
+            timeout=45,
+        )
+        assert ds.shape == (1, 12, 1440)
+        assert ds.geotransform == pytest.approx((-180.0, 0.25, 0.0, 48.0, 0.0, -0.25))
+        assert ds.epsg == 4326
+        arr = ds.read_array()
+        assert float(arr.min()) >= 0.0 and float(arr.max()) <= 3.0

--- a/tests/dataset/remote/test_wcs.py
+++ b/tests/dataset/remote/test_wcs.py
@@ -524,6 +524,26 @@ class TestGetCoverageUrl:
         )
         assert url.count("CRS=") == 1 and "CRS=EPSG:3857" in url
 
+    def test_1_0_0_coverageid_override_replaces_coverage(self):
+        # The coverage id spelling collapses across versions: a 2.0 `coverageID`
+        # override replaces the 1.0.0 built-in `COVERAGE`, not appends beside it.
+        url = _wcs._getcoverage_url(
+            "https://x", "c", "EPSG:4326", (0.0, 0.0, 1.0, 1.0), "1.0.0",
+            None, 0.1, None, {"coverageID": "c"},
+        )
+        assert "coverageID=c" in url and "COVERAGE=c" not in url
+
+    def test_extra_params_appended_keep_caller_order(self):
+        # Non-matching extras (and overridable-but-unmatched keys) append after the
+        # built-ins in caller order; regression guard for the ordering guarantee.
+        url = _wcs._getcoverage_url(
+            "https://x", "c", "EPSG:4326", (0.0, 0.0, 1.0, 1.0), "2.0.0",
+            None, None, None, {"BB": "2", "coverageID": "c", "AA": "1"},
+        )
+        tail = url.split("REQUEST=GetCoverage", 1)[1]
+        assert tail.index("BB=2") < tail.index("AA=1")  # caller order preserved
+        assert tail.index("coverageID=c") < tail.index("BB=2")  # built-ins first
+
     def test_extra_params_non_matching_key_is_appended(self):
         url = _wcs._getcoverage_url(
             "https://x", "c", "EPSG:4326", (0.0, 0.0, 1.0, 1.0), "2.0.0",

--- a/tests/dataset/remote/test_wcs.py
+++ b/tests/dataset/remote/test_wcs.py
@@ -490,7 +490,7 @@ class TestGetCoverageUrl:
         assert "&CRS=EPSG:4326" in url
         assert "SUBSETTINGCRS" not in url
 
-    def test_extra_params_edo_dialect_builds_request_a(self):
+    def test_extra_params_edo_dialect_reproduces_shim_request(self):
         # Both quirks together must reproduce the exact request EDO/GDO answers 200:
         # lowercase coverageID + CRS= + WCS-2.0 SUBSET syntax, extras preserved.
         url = _wcs._getcoverage_url(
@@ -504,6 +504,25 @@ class TestGetCoverageUrl:
         assert "&CRS=EPSG:4326" in url and "SUBSETTINGCRS" not in url
         assert "SUBSET=Long(10.0,15.0)" in url and "SUBSET=Lat(45.0,48.0)" in url
         assert "TIME=2023-06-01" in url and "SELECTED_TIMESCALE=01" in url
+
+    def test_extra_params_conflicting_slot_raises(self):
+        # Two keys collapsing to one slot (CRS + SUBSETTINGCRS) is contradictory
+        # input and must fail loud rather than silently drop one.
+        with pytest.raises(ValueError, match="same GetCoverage parameter"):
+            _wcs._getcoverage_url(
+                "https://x", "c", "EPSG:4326", (0.0, 0.0, 1.0, 1.0), "2.0.0",
+                None, None, None,
+                {"CRS": "EPSG:4326", "SUBSETTINGCRS": "EPSG:3857"},
+            )
+
+    def test_1_0_0_crs_override_replaces_not_duplicates(self):
+        # On a 1.0.0 request the built-in already emits CRS; an override must
+        # replace it in place, leaving exactly one CRS token.
+        url = _wcs._getcoverage_url(
+            "https://x", "c", "EPSG:4326", (0.0, 0.0, 1.0, 1.0), "1.0.0",
+            None, 0.1, None, {"CRS": "EPSG:3857"},
+        )
+        assert url.count("CRS=") == 1 and "CRS=EPSG:3857" in url
 
     def test_extra_params_non_matching_key_is_appended(self):
         url = _wcs._getcoverage_url(
@@ -695,7 +714,7 @@ class TestDirectGetCoverage:
         self, monkeypatch, geotiff_bytes, dialect, extra_params
     ):
         # A fake server that returns a raster only for its own KVP dialect (else an
-        # exception report -> WCSError). direct=True must retrieve a raster from
+        # exception-report body -> WCSError). direct=True must retrieve a raster from
         # each: the spec spellings with no override, and the EDO shim spellings via
         # extra_params. Proves the override reproduces the shim dialect without
         # regressing the compliant path.
@@ -713,7 +732,7 @@ class TestDirectGetCoverage:
 
 
 def _dialect_body(url: str, raster: bytes, dialect: str) -> bytes:
-    """Fake GetCoverage body: the raster iff ``url`` matches ``dialect``, else a 500.
+    """Fake GetCoverage body: the raster iff ``url`` matches ``dialect``, else an error.
 
     Models the two WCS KVP dialects a direct request can target — the spec-compliant
     ``COVERAGEID`` + ``SUBSETTINGCRS`` and the Copernicus EDO/GDO shim's lowercase


### PR DESCRIPTION
# Description

`Dataset.from_wcs(direct=True)` issues a KVP `GetCoverage` with no `GetCapabilities`/`DescribeCoverage`, for
"WCS shim" endpoints that only implement `GetCoverage`. #718 shipped that path but validated it only against a
*spec-compliant* GetCoverage-only server; it was never driven against the real endpoint #713 was filed for. The
Copernicus EDO/GDO MapServer shim rejects the WCS-2.0 spellings the builder hard-codes: it is case-sensitive on
the coverage-id key (wants lowercase `coverageID`, `500`s on `COVERAGEID`) and only understands the WCS-1.x
`CRS=` token (`500`s on `SUBSETTINGCRS=`). Both keys were locked behind the reserved-key guard, so `direct=True`
could not reach EDO and `extra_params` could not patch it — hence the reopen.

This makes `extra_params` able to **override** a built-in KVP in direct mode:

- A key that matches a built-in KVP replaces it in place — case-insensitively, and with the two cross-version
  pairs `CRS`/`SUBSETTINGCRS` and `COVERAGE`/`COVERAGEID` each collapsed to one logical slot — using the
  caller's exact spelling and value. So `extra_params={"coverageID": "spaST", "CRS": "EPSG:4326"}` hands EDO its
  exact tokens without duplicating the request.
- A non-matching key is appended in caller order, as before (e.g. a `TIME` axis).
- The fixed protocol keys `SERVICE`/`VERSION`/`REQUEST`/`SUBSET` stay locked and raise `ValueError`; because
  `SUBSET` is locked, an extra WCS-2.0 `SUBSET` axis can't be added in direct mode (use discovery mode). Two
  `extra_params` keys targeting the same built-in parameter (e.g. both `CRS` and `SUBSETTINGCRS`) also raise,
  rather than silently dropping one.

The query encoder is unchanged, so relaxing the reserved-key guard does not weaken injection defenses (`&`/`=`
in a caller key/value are still percent-encoded). The default (`direct=False`) and the compliant direct path
are byte-for-byte unchanged. No new dependencies.

# Issues

- Closes #713 — direct `from_wcs` can now reach the Copernicus EDO/GDO WCS shim.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- **Live, end-to-end against the real endpoint.** `Dataset.from_wcs(direct=True, extra_params={"coverageID":
  "spaST", "CRS": "EPSG:4326", "TIME": "2023-06-01", "SELECTED_TIMESCALE": "01"}, ...)` against
  `https://drought.emergency.copernicus.eu/api/wcs?map=DO_WCS` returns the reference raster from #713's
  acceptance criteria: single-band **12 × 1440**, geotransform `(-180.0, 0.25, 0.0, 48.0, 0.0, -0.25)`, value
  range `[0.0, 3.0]`, EPSG 4326. Covered by `TestLiveEdoDirect`, behind the `live` pytest marker
  (`-m live`), so normal CI stays offline.
- **Both-dialects regression test.** A parametrized fake server returns a raster only for its own KVP dialect
  (spec `COVERAGEID`+`SUBSETTINGCRS` vs EDO `coverageID`+`CRS`), proving the override reproduces the shim
  dialect and the compliant path does not regress.
- **URL-builder unit tests** for every override path: coverage/CRS override, cross-version slot collapse,
  case-insensitive match, non-matching append + caller order, protocol-key lock, and same-slot collision raise.
- `pixi run -e dev pytest -m "not plot" -q` → **6503 passed, 51 skipped, 320 deselected**.
- `pixi run -e dev mypy -p pyramids.dataset --no-incremental` → **0 errors** (41 files).
- Two full independent review rounds; all findings fixed. SonarCloud on this PR: **0 unresolved issues, quality
  gate OK**.

- [x] Full non-plot suite (`pytest -m "not plot"`)
- [x] Live EDO end-to-end (`-m live`) + both-dialects fake-server test
- [x] `mypy -p pyramids.dataset` strict pass

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen bumps this automatically on release)
- [ ] added changes to History.rst. (commitizen-generated; not hand-edited)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.
