### PR TITLE
feat(dataset): add bbox_rounding and fix bbox/polygon window resolution

### DIFF
--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -23,6 +23,7 @@ from geopandas.geodataframe import GeoDataFrame
 from osgeo import gdal
 from osgeo_utils import gdal2xyz
 from pandas import DataFrame
+from pyproj import CRS
 
 from pyramids._io import new_vsimem_path, read_vsi_bytes
 from pyramids.base._domain import is_no_data
@@ -53,6 +54,20 @@ if TYPE_CHECKING:
 from pyramids.dataset.engines._base import _Engine
 
 _VSIMEM_PREFIX = "/vsimem/"
+
+_GRID_SNAP_TOL = 1e-9
+"""Fractional-pixel tolerance for snapping a bbox edge onto an exact cell boundary.
+
+`(coord - origin) / pixel` is IEEE-754 division, so an edge that sits exactly on a cell boundary
+often lands at `k - 1e-16` instead of the integer `k`. Snapping to the nearest integer within this
+tolerance before `floor`/`ceil` stops a grid-aligned bbox from leaking a neighbouring row/column.
+"""
+
+
+def _snap_index(value: float, tol: float = _GRID_SNAP_TOL) -> float:
+    """Snap a fractional pixel index to the nearest integer when within `tol`, else return it as-is."""
+    nearest = round(value)
+    return float(nearest) if abs(value - nearest) <= tol else value
 
 _THREAD_MANAGER_CREATION_LOCK = threading.Lock()
 """Guards the lazy creation of a Dataset's per-thread file manager.
@@ -492,9 +507,13 @@ class IO(_Engine["Dataset"]):
                   giving the tightest window; a partly-covered boundary pixel
                   can be clipped.
 
-                Ignored when `window` is already a pixel window (`Window` or
-                the x-first list) or absent. Any other value raises
-                `ValueError`. Default `"cover"`.
+                A geometry (`bbox=` / polygon `window=`) in a different CRS is
+                reprojected into the raster frame first. The resolved window is
+                clamped to the raster extent, so a bbox that pokes past an edge
+                reads the overlap; a bbox with no overlap raises
+                `OutOfBoundsError`. Ignored when `window` is already a pixel
+                window (`Window` or the x-first list) or absent. Any other
+                value raises `ValueError`. Default `"cover"`.
 
         Returns:
             ArrayLike:
@@ -524,6 +543,9 @@ class IO(_Engine["Dataset"]):
                 `boundless=True` (boundless fills and masking are not
                 combined yet), or `threadsafe=True` (the mask band would
                 be read from the shared handle).
+            OutOfBoundsError: If a `bbox` / geometry `window` does not
+                overlap the raster extent at all, or (for a foreign-CRS
+                bbox) reprojects outside the target CRS's valid domain.
 
         Examples:
             - Create `Dataset` consisting of 4 bands, 5 rows, and 5 columns at the point lon/lat (0, 0):
@@ -855,8 +877,6 @@ class IO(_Engine["Dataset"]):
                 "it with Dataset.read_file first."
             )
         _validate_band_index(band, self._ds.band_count)
-        if isinstance(window, GeoDataFrame):
-            window = self._convert_polygon_to_window(window)
         if isinstance(window, Window):
             # Accept the first-class Window like every other read path does.
             window = list(window.to_read_args())
@@ -995,8 +1015,6 @@ class IO(_Engine["Dataset"]):
             # _band_mask slices the mask band with window[0..3]; a Window is not
             # subscriptable, so normalize it to a pixel list first (mirrors _read_block).
             window = list(window.to_read_args())
-        if isinstance(window, GeoDataFrame):
-            window = self._convert_polygon_to_window(window)
         if arr.ndim == 2:
             indices = [0 if band is None else band]
             slices = [arr]
@@ -1230,8 +1248,6 @@ class IO(_Engine["Dataset"]):
             )
         rows, cols = _validate_out_shape(out_shape)
         alg = _RESAMPLING_ALG[key]
-        if isinstance(window, GeoDataFrame):
-            window = self._convert_polygon_to_window(window)
         if isinstance(window, Window):
             window_args: tuple[int, ...] = window.to_read_args()
         elif window is not None:
@@ -1426,49 +1442,106 @@ class IO(_Engine["Dataset"]):
             )
         poly = FeatureCollection(poly)
         west, south, east, north = poly.total_bounds
-        # The window is computed in the raster's own coordinate frame, so reproject the bbox corners
-        # into the raster CRS when they differ. Without this a foreign-CRS bbox is read against the
-        # wrong axis frame (previously it silently returned an empty window; the geotransform math
-        # below would instead ask for a wildly out-of-bounds window).
-        raster_epsg = self._ds.epsg
-        poly_epsg = poly.epsg
-        if raster_epsg and poly_epsg and int(poly_epsg) != int(raster_epsg):
-            xs, ys = reproject_coordinates(
-                [west, east, west, east],
-                [south, south, north, north],
-                from_crs=poly_epsg,
-                to_crs=raster_epsg,
+        # The window is computed in the raster's own coordinate frame, so reproject the bbox into the
+        # raster CRS whenever the two CRSes differ -- compared through pyproj so a raster CRS that has
+        # no EPSG code (e.g. a geostationary WKT grid) is handled too, not only EPSG<->EPSG. The bbox
+        # edges are densified before transforming so a curved reprojected edge is not under-covered by
+        # a corner-only min/max. Without any of this a foreign-CRS bbox is measured against the wrong
+        # axis frame and yields a nonsensical, out-of-bounds window.
+        if self._crses_differ(poly):
+            n = 9  # samples per edge, incl. endpoints -- enough to bound a curved reprojected edge
+            edge_x = np.concatenate(
+                [
+                    np.linspace(west, east, n),
+                    np.linspace(west, east, n),
+                    np.full(n, west),
+                    np.full(n, east),
+                ]
             )
+            edge_y = np.concatenate(
+                [
+                    np.full(n, north),
+                    np.full(n, south),
+                    np.linspace(south, north, n),
+                    np.linspace(south, north, n),
+                ]
+            )
+            xs, ys = reproject_coordinates(
+                edge_x.tolist(),
+                edge_y.tolist(),
+                from_crs=poly.crs,
+                to_crs=self._ds.crs,
+            )
+            if not all(math.isfinite(v) for v in (*xs, *ys)):
+                raise OutOfBoundsError(
+                    f"bbox reprojected from {poly.crs.to_string()!r} to the raster CRS is not finite; "
+                    "it falls outside the projection's valid domain. Pass a bbox that overlaps the "
+                    "raster, or one already in the raster CRS."
+                )
             west, east = min(xs), max(xs)
             south, north = min(ys), max(ys)
-            if not all(math.isfinite(v) for v in (west, east, south, north)):
-                raise OutOfBoundsError(
-                    f"bbox reprojected from EPSG:{poly_epsg} to the raster CRS EPSG:{raster_epsg} "
-                    "is not finite; it falls outside the projection's valid domain. Pass a bbox that "
-                    "overlaps the raster, or one already in the raster CRS."
-                )
-        origin_x, pixel_x, _, origin_y, _, pixel_y = self._ds.geotransform
-        # Map the bbox corners to fractional pixel indices through the geotransform. `min`/`max`
-        # keep it correct whichever sign the pixel size has (north-up `pixel_y < 0` or flipped).
-        # Deriving the window from map_to_array_coordinates instead snapped each corner to the
-        # nearest cell centre, which both transposed every non-square window and dropped the
-        # boundary row/column of a bbox whose edges fell mid-cell (#719).
-        cols = [(west - origin_x) / pixel_x, (east - origin_x) / pixel_x]
-        rows = [(north - origin_y) / pixel_y, (south - origin_y) / pixel_y]
+        origin_x, pixel_x, row_rot, origin_y, col_rot, pixel_y = self._ds.geotransform
+        if row_rot or col_rot:
+            # Rotated/sheared grids need the full affine inverse; the axis-aligned mapping below is
+            # only approximate for them. Pre-existing limitation (also true of the old code path).
+            warnings.warn(
+                "read_array(bbox=/window=<polygon>) assumes an axis-aligned geotransform; the "
+                "rotation terms are ignored, so the window is approximate on a rotated raster.",
+                stacklevel=2,
+            )
+        # Map the bbox edges to fractional pixel indices through the geotransform, snapping edges that
+        # sit on a cell boundary onto the exact integer first (see `_snap_index`). `min`/`max` keep it
+        # correct whichever sign the pixel size has (north-up `pixel_y < 0` or flipped south-up).
+        # Deriving the window from map_to_array_coordinates instead snapped each corner to the nearest
+        # cell centre, which both transposed every non-square window and dropped the boundary
+        # row/column of a bbox whose edges fell mid-cell (#719).
+        cols = [_snap_index((west - origin_x) / pixel_x), _snap_index((east - origin_x) / pixel_x)]
+        rows = [_snap_index((north - origin_y) / pixel_y), _snap_index((south - origin_y) / pixel_y)]
         if rounding == "cover":
             # Floor the near edge and ceil the far edge, so the window includes every pixel the bbox
             # overlaps -- a geotransform-based numpy crop of the full read. Never drops edge data.
             xoff, x_far = math.floor(min(cols)), math.ceil(max(cols))
             yoff, y_far = math.floor(min(rows)), math.ceil(max(rows))
         else:
-            # Round each corner to the nearest pixel edge (the tightest window). Matches a numpy
-            # crop that indexes with `round((coord - origin) / pixel)`; can clip a partly-covered
-            # boundary pixel.
+            # Round each edge to the nearest pixel boundary (the tightest window); can clip a
+            # partly-covered boundary pixel.
             cols = [round(value) for value in cols]
             rows = [round(value) for value in rows]
             xoff, x_far = min(cols), max(cols)
             yoff, y_far = min(rows), max(rows)
-        return [int(xoff), int(yoff), int(x_far - xoff), int(y_far - yoff)]
+        # A sub-pixel bbox (or a degenerate zero-width/height polygon) can collapse to a zero-size
+        # window -- read at least the single cell it falls in rather than an empty array.
+        x_far = max(x_far, xoff + 1)
+        y_far = max(y_far, yoff + 1)
+        # Clamp to the raster extent so a bbox that pokes past an edge reads the overlap instead of
+        # raising (matching `crop(bbox=)` and the pre-rewrite behaviour); a bbox with no overlap at
+        # all still raises below.
+        columns, rows_total = self._ds.columns, self._ds.rows
+        xoff = min(max(int(xoff), 0), columns)
+        x_far = min(max(int(x_far), 0), columns)
+        yoff = min(max(int(yoff), 0), rows_total)
+        y_far = min(max(int(y_far), 0), rows_total)
+        x_size, y_size = x_far - xoff, y_far - yoff
+        if x_size <= 0 or y_size <= 0:
+            raise OutOfBoundsError(
+                "the bbox does not overlap the raster extent; no pixels to read."
+            )
+        return [xoff, yoff, x_size, y_size]
+
+    def _crses_differ(self, poly: FeatureCollection) -> bool:
+        """Whether `poly`'s CRS differs from the raster's, compared through pyproj (EPSG or WKT).
+
+        Fast-paths identical EPSG codes; otherwise compares the full CRS objects so a raster whose CRS
+        has no EPSG code (e.g. a geostationary WKT grid) is still reprojected against. Returns False
+        when either CRS is unknown -- the bbox is then assumed to already be in the raster frame.
+        """
+        raster_epsg, poly_epsg = self._ds.epsg, poly.epsg
+        if raster_epsg and poly_epsg:
+            return int(raster_epsg) != int(poly_epsg)
+        raster_crs, poly_crs = self._ds.crs, poly.crs
+        if not raster_crs or poly_crs is None:
+            return False
+        return not CRS.from_user_input(poly_crs).equals(CRS.from_user_input(raster_crs))
 
     def read_windows(
         self,

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -1399,11 +1399,15 @@ class IO(_Engine["Dataset"]):
         df = pd.DataFrame(columns=["id", "x", "y"])
         df.loc["top_left", ["x", "y"]] = bounds[0], bounds[3]
         df.loc["bottom_right", ["x", "y"]] = bounds[2], bounds[1]
+        # map_to_array_coordinates returns [row, col] per point, so column 1 is the column
+        # index and column 0 is the row index. The window is [xoff, yoff, x_size, y_size]:
+        # x_size (columns) must come from the column delta and y_size (rows) from the row
+        # delta. Sourcing them the other way round transposed every non-square window (#719).
         arr_indeces = self._ds.map_to_array_coordinates(df)
         xoff = arr_indeces[0, 1]
         yoff = arr_indeces[0, 0]
-        x_size = arr_indeces[1, 0] - arr_indeces[0, 0]
-        y_size = arr_indeces[1, 1] - arr_indeces[0, 1]
+        x_size = arr_indeces[1, 1] - arr_indeces[0, 1]
+        y_size = arr_indeces[1, 0] - arr_indeces[0, 0]
         return [xoff, yoff, x_size, y_size]
 
     def read_windows(

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -492,10 +492,9 @@ class IO(_Engine["Dataset"]):
                   giving the tightest window; a partly-covered boundary pixel
                   can be clipped.
 
-                Ignored when `window` is already a pixel window
-                (:class:`~pyramids.dataset.window.Window` or the x-first list)
-                or absent. Any other value raises :class:`ValueError`. Default
-                `"cover"`.
+                Ignored when `window` is already a pixel window (`Window` or
+                the x-first list) or absent. Any other value raises
+                `ValueError`. Default `"cover"`.
 
         Returns:
             ArrayLike:

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -33,6 +33,7 @@ from pyramids.base._file_manager import (
     gdal_raster_open,
 )
 from pyramids.base._locks import DummyLock, default_lock
+from pyramids.base.crs import reproject_coordinates
 from pyramids.base.protocols import ArrayLike
 from pyramids.base._utils import resolve_resampling
 from pyramids.dataset.abstract_dataset import OVERVIEW_LEVELS, RESAMPLING_METHODS
@@ -335,6 +336,7 @@ class IO(_Engine["Dataset"]):
         fill_value: float | None = None,
         masked: bool = False,
         threadsafe: bool = False,
+        bbox_rounding: str = "cover",
     ) -> ArrayLike:
         """Read the values stored in a given band (eager or lazy).
 
@@ -478,6 +480,22 @@ class IO(_Engine["Dataset"]):
                 flush pending writes (e.g. ``FlushCache``) before reading
                 with `threadsafe=True`. Default `False` (shared-handle
                 behaviour, unchanged).
+            bbox_rounding (str, keyword-only):
+                How a geometry window (`bbox=`, or a polygon `window=`) is
+                snapped to whole pixels:
+
+                - `"cover"` (default): floor the near edge and ceil the far
+                  edge, so the window includes every pixel the geometry
+                  overlaps. A full-extent bbox reads the full raster, and a
+                  partly-covered boundary pixel is kept.
+                - `"nearest"`: round each edge to the closest pixel boundary,
+                  giving the tightest window; a partly-covered boundary pixel
+                  can be clipped.
+
+                Ignored when `window` is already a pixel window
+                (:class:`~pyramids.dataset.window.Window` or the x-first list)
+                or absent. Any other value raises :class:`ValueError`. Default
+                `"cover"`.
 
         Returns:
             ArrayLike:
@@ -494,7 +512,8 @@ class IO(_Engine["Dataset"]):
                 with `boundless=True`, `boundless=True` is given
                 without a pixel window, or `fill_value` is given
                 without `boundless=True` or cannot be represented
-                in the band dtype.
+                in the band dtype, or `bbox_rounding` is neither
+                `"cover"` nor `"nearest"`.
             ImportError: If `chunks` is non-None and `dask` is not
                 installed.
             NotImplementedError: If `out_shape` is combined with `chunks`
@@ -670,6 +689,12 @@ class IO(_Engine["Dataset"]):
                 )
             crs = epsg if epsg is not None else self._ds.epsg
             window = FeatureCollection.from_bbox(bbox, epsg=crs)
+        # Resolve a geometry window (from `bbox=` or a polygon `window=`) to an integer pixel window
+        # once, up front, so `bbox_rounding` applies uniformly no matter which read path runs. The
+        # boundless branch below deliberately rejects geometry windows (they are clipped by
+        # definition), so leave those unconverted for it to reject.
+        if isinstance(window, GeoDataFrame) and not boundless:
+            window = self._convert_polygon_to_window(window, rounding=bbox_rounding)
         if chunks is not None:
             if window is not None:
                 raise ValueError(
@@ -746,11 +771,11 @@ class IO(_Engine["Dataset"]):
                             i + 1
                         ).ReadAsArray()
                 else:
-                    # ``window`` here is a FeatureCollection/GeoDataFrame (built
-                    # from a ``bbox`` or a polygon); its pixel dimensions are not
-                    # known until ``_read_block`` resolves it, and it is not
-                    # integer-indexable, so stack per-band block reads instead of
-                    # pre-allocating from ``window[2]`` / ``window[3]``.
+                    # ``window`` here is a resolved pixel window (``Window`` or
+                    # a ``[col_off, row_off, cols, rows]`` list — any geometry
+                    # window was converted to one above). Stack per-band block
+                    # reads so ``_read_block`` applies the identical window to
+                    # every band without re-parsing its dimensions here.
                     arr = np.stack(
                         [
                             self._read_block(i, window)
@@ -1392,23 +1417,59 @@ class IO(_Engine["Dataset"]):
         return np.asarray(block)
 
     def _convert_polygon_to_window(
-        self, poly: GeoDataFrame | FeatureCollection
+        self,
+        poly: GeoDataFrame | FeatureCollection,
+        rounding: str = "cover",
     ) -> list[Any]:
+        if rounding not in ("cover", "nearest"):
+            raise ValueError(
+                f"rounding must be 'cover' or 'nearest', got {rounding!r}"
+            )
         poly = FeatureCollection(poly)
-        bounds = poly.total_bounds
-        df = pd.DataFrame(columns=["id", "x", "y"])
-        df.loc["top_left", ["x", "y"]] = bounds[0], bounds[3]
-        df.loc["bottom_right", ["x", "y"]] = bounds[2], bounds[1]
-        # map_to_array_coordinates returns [row, col] per point, so column 1 is the column
-        # index and column 0 is the row index. The window is [xoff, yoff, x_size, y_size]:
-        # x_size (columns) must come from the column delta and y_size (rows) from the row
-        # delta. Sourcing them the other way round transposed every non-square window (#719).
-        arr_indeces = self._ds.map_to_array_coordinates(df)
-        xoff = arr_indeces[0, 1]
-        yoff = arr_indeces[0, 0]
-        x_size = arr_indeces[1, 1] - arr_indeces[0, 1]
-        y_size = arr_indeces[1, 0] - arr_indeces[0, 0]
-        return [xoff, yoff, x_size, y_size]
+        west, south, east, north = poly.total_bounds
+        # The window is computed in the raster's own coordinate frame, so reproject the bbox corners
+        # into the raster CRS when they differ. Without this a foreign-CRS bbox is read against the
+        # wrong axis frame (previously it silently returned an empty window; the geotransform math
+        # below would instead ask for a wildly out-of-bounds window).
+        raster_epsg = self._ds.epsg
+        poly_epsg = poly.epsg
+        if raster_epsg and poly_epsg and int(poly_epsg) != int(raster_epsg):
+            xs, ys = reproject_coordinates(
+                [west, east, west, east],
+                [south, south, north, north],
+                from_crs=poly_epsg,
+                to_crs=raster_epsg,
+            )
+            west, east = min(xs), max(xs)
+            south, north = min(ys), max(ys)
+            if not all(math.isfinite(v) for v in (west, east, south, north)):
+                raise OutOfBoundsError(
+                    f"bbox reprojected from EPSG:{poly_epsg} to the raster CRS EPSG:{raster_epsg} "
+                    "is not finite; it falls outside the projection's valid domain. Pass a bbox that "
+                    "overlaps the raster, or one already in the raster CRS."
+                )
+        origin_x, pixel_x, _, origin_y, _, pixel_y = self._ds.geotransform
+        # Map the bbox corners to fractional pixel indices through the geotransform. `min`/`max`
+        # keep it correct whichever sign the pixel size has (north-up `pixel_y < 0` or flipped).
+        # Deriving the window from map_to_array_coordinates instead snapped each corner to the
+        # nearest cell centre, which both transposed every non-square window and dropped the
+        # boundary row/column of a bbox whose edges fell mid-cell (#719).
+        cols = [(west - origin_x) / pixel_x, (east - origin_x) / pixel_x]
+        rows = [(north - origin_y) / pixel_y, (south - origin_y) / pixel_y]
+        if rounding == "cover":
+            # Floor the near edge and ceil the far edge, so the window includes every pixel the bbox
+            # overlaps -- a geotransform-based numpy crop of the full read. Never drops edge data.
+            xoff, x_far = math.floor(min(cols)), math.ceil(max(cols))
+            yoff, y_far = math.floor(min(rows)), math.ceil(max(rows))
+        else:
+            # Round each corner to the nearest pixel edge (the tightest window). Matches a numpy
+            # crop that indexes with `round((coord - origin) / pixel)`; can clip a partly-covered
+            # boundary pixel.
+            cols = [round(value) for value in cols]
+            rows = [round(value) for value in rows]
+            xoff, x_far = min(cols), max(cols)
+            yoff, y_far = min(rows), max(rows)
+        return [int(xoff), int(yoff), int(x_far - xoff), int(y_far - yoff)]
 
     def read_windows(
         self,

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1666,14 +1666,13 @@ class NetCDF(Dataset):
                 raw stored values before any `unpack` scaling, matching CF
                 `_FillValue` semantics; the scale/offset arithmetic
                 preserves the mask. Default is `False`.
-            bbox_rounding (keyword-only): How a ``bbox`` (or geometry
-                ``window``) is snapped to whole pixels — ``"cover"``
+            bbox_rounding (keyword-only): How a `bbox` (or geometry
+                `window`) is snapped to whole pixels — `"cover"`
                 (default; floor/ceil so every overlapping pixel is kept)
-                or ``"nearest"`` (round each edge to the closest pixel
+                or `"nearest"` (round each edge to the closest pixel
                 boundary, the tightest window). Forwarded verbatim to
-                :meth:`pyramids.dataset.Dataset.read_array`; ignored on the
-                lazy path and for pixel windows. Any other value raises
-                :class:`ValueError`.
+                `Dataset.read_array`; ignored on the lazy path and for
+                pixel windows. Any other value raises `ValueError`.
 
         Returns:
             np.ndarray or dask.array.Array: The array data, eager

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1607,6 +1607,7 @@ class NetCDF(Dataset):
         chunks: Any = None,
         lock: Any = None,
         masked: bool = False,
+        bbox_rounding: str = "cover",
     ) -> ArrayLike:
         """Read array from the dataset (eager by default, lazy with `chunks`).
 
@@ -1665,6 +1666,14 @@ class NetCDF(Dataset):
                 raw stored values before any `unpack` scaling, matching CF
                 `_FillValue` semantics; the scale/offset arithmetic
                 preserves the mask. Default is `False`.
+            bbox_rounding (keyword-only): How a ``bbox`` (or geometry
+                ``window``) is snapped to whole pixels — ``"cover"``
+                (default; floor/ceil so every overlapping pixel is kept)
+                or ``"nearest"`` (round each edge to the closest pixel
+                boundary, the tightest window). Forwarded verbatim to
+                :meth:`pyramids.dataset.Dataset.read_array`; ignored on the
+                lazy path and for pixel windows. Any other value raises
+                :class:`ValueError`.
 
         Returns:
             np.ndarray or dask.array.Array: The array data, eager
@@ -1742,6 +1751,7 @@ class NetCDF(Dataset):
                 chunks=chunks,
                 lock=lock,
                 masked=masked,
+                bbox_rounding=bbox_rounding,
             )
         if variable is not None and variable != self._source_var_name:
             raise ValueError(
@@ -1751,7 +1761,7 @@ class NetCDF(Dataset):
                 "instead."
             )
         if chunks is None:
-            result = self._read_array_eager(band, read_window, masked)
+            result = self._read_array_eager(band, read_window, masked, bbox_rounding)
         else:
             result = self._read_array_lazy(chunks, lock, masked)
         if unpack:
@@ -1799,12 +1809,21 @@ class NetCDF(Dataset):
         return FeatureCollection.from_bbox(bbox, epsg=crs)
 
     def _read_array_eager(
-        self, band: int | None, window: Any, masked: bool
+        self,
+        band: int | None,
+        window: Any,
+        masked: bool,
+        bbox_rounding: str = "cover",
     ) -> ArrayLike:
         """Eager (numpy) read through the Dataset mixin."""
         return cast(
             ArrayLike,
-            super().read_array(band=band, window=window, masked=masked),
+            super().read_array(
+                band=band,
+                window=window,
+                masked=masked,
+                bbox_rounding=bbox_rounding,
+            ),
         )
 
     def _read_array_lazy(self, chunks: Any, lock: Any, masked: bool) -> ArrayLike:

--- a/tests/dataset/create/test_dataset_create.py
+++ b/tests/dataset/create/test_dataset_create.py
@@ -486,18 +486,28 @@ class TestSpatialProperties:
         src: gdal.Dataset,
     ):
         dataset = Dataset(src)
+        # These corners are in the raster's own CRS (EPSG:32618) -- they map onto its grid. The
+        # polygon spans a single cell, but its edges sit a sub-millimetre inside the col-5/6 and
+        # row-2/3 boundaries (the geotransform origin is not a whole coordinate), so the default
+        # "cover" rounding includes both straddled cells (a 2x2 window) while "nearest" snaps to the
+        # tightest 1x1 window.
         x_coords = [456968.12, 460968.12, 460968.12, 456968.12, 456968.12]
         y_coords = [508007.788, 508007.788, 504007.788, 504007.788, 508007.788]
         coords = list(zip(x_coords, y_coords))
         gdf = gpd.GeoDataFrame(
-            columns=["id"], geometry=[Polygon(coords)], crs=32632, data=[[0]]
+            columns=["id"], geometry=[Polygon(coords)], crs=32618, data=[[0]]
         )
-        window = dataset.io._convert_polygon_to_window(gdf)
-        assert window == [5, 2, 1, 1]
-        arr = dataset.read_array(band=0, window=window)
-        assert arr[0] == 1
-        arr = dataset.read_array(band=0, window=gdf)
-        assert arr[0] == 1
+        full = dataset.read_array(band=0)
+
+        cover = dataset.io._convert_polygon_to_window(gdf)
+        assert cover == [5, 2, 2, 2]
+        assert np.array_equal(dataset.read_array(band=0, window=cover), full[2:4, 5:7])
+        assert np.array_equal(dataset.read_array(band=0, window=gdf), full[2:4, 5:7])
+
+        nearest = dataset.io._convert_polygon_to_window(gdf, rounding="nearest")
+        assert nearest == [6, 3, 1, 1]
+        arr_near = np.squeeze(dataset.read_array(band=0, window=gdf, bbox_rounding="nearest"))
+        assert np.array_equal(arr_near, full[3, 6])
 
     def test_read_block_bigger_than_array(
         self,

--- a/tests/dataset/create/test_dataset_create.py
+++ b/tests/dataset/create/test_dataset_create.py
@@ -486,28 +486,28 @@ class TestSpatialProperties:
         src: gdal.Dataset,
     ):
         dataset = Dataset(src)
-        # These corners are in the raster's own CRS (EPSG:32618) -- they map onto its grid. The
-        # polygon spans a single cell, but its edges sit a sub-millimetre inside the col-5/6 and
-        # row-2/3 boundaries (the geotransform origin is not a whole coordinate), so the default
-        # "cover" rounding includes both straddled cells (a 2x2 window) while "nearest" snaps to the
-        # tightest 1x1 window.
-        x_coords = [456968.12, 460968.12, 460968.12, 456968.12, 456968.12]
-        y_coords = [508007.788, 508007.788, 504007.788, 504007.788, 508007.788]
-        coords = list(zip(x_coords, y_coords))
+        # Build a polygon covering exactly one cell (row 3, col 6) from the geotransform, in the
+        # raster's own CRS (EPSG:32618). Cell-aligned edges snap to exact integer indices, so both
+        # rounding modes resolve to the same 1x1 window.
+        row, col = 3, 6
+        origin_x, pixel_x, _, origin_y, _, pixel_y = dataset.geotransform
+        west, east = origin_x + col * pixel_x, origin_x + (col + 1) * pixel_x
+        north, south = origin_y + row * pixel_y, origin_y + (row + 1) * pixel_y
         gdf = gpd.GeoDataFrame(
-            columns=["id"], geometry=[Polygon(coords)], crs=32618, data=[[0]]
+            columns=["id"],
+            geometry=[Polygon([(west, north), (east, north), (east, south), (west, south)])],
+            crs=dataset.epsg,
+            data=[[0]],
         )
         full = dataset.read_array(band=0)
-
-        cover = dataset.io._convert_polygon_to_window(gdf)
-        assert cover == [5, 2, 2, 2]
-        assert np.array_equal(dataset.read_array(band=0, window=cover), full[2:4, 5:7])
-        assert np.array_equal(dataset.read_array(band=0, window=gdf), full[2:4, 5:7])
-
-        nearest = dataset.io._convert_polygon_to_window(gdf, rounding="nearest")
-        assert nearest == [6, 3, 1, 1]
-        arr_near = np.squeeze(dataset.read_array(band=0, window=gdf, bbox_rounding="nearest"))
-        assert np.array_equal(arr_near, full[3, 6])
+        for mode in ("cover", "nearest"):
+            assert dataset.io._convert_polygon_to_window(gdf, rounding=mode) == [col, row, 1, 1]
+        assert np.array_equal(
+            np.squeeze(dataset.read_array(band=0, window=[col, row, 1, 1])), full[row, col]
+        )
+        assert np.array_equal(
+            np.squeeze(dataset.read_array(band=0, window=gdf)), full[row, col]
+        )
 
     def test_read_block_bigger_than_array(
         self,

--- a/tests/dataset/io/test_bbox_window_transpose.py
+++ b/tests/dataset/io/test_bbox_window_transpose.py
@@ -1,0 +1,120 @@
+"""Regression tests for #719 — bbox/polygon windows must not transpose non-square reads.
+
+`_convert_polygon_to_window` builds the `[xoff, yoff, x_size, y_size]` window from the array indices
+of the bbox corners. `map_to_array_coordinates` returns `[row, col]` per point, so `x_size` (columns)
+must come from the column delta and `y_size` (rows) from the row delta. Before the fix they were
+sourced the other way round, so any **non-square** window came back with its width and height swapped:
+either an `OutOfBoundsError` when the swapped size overran the raster, or — worse — silently
+transposed, geographically wrong data when the swapped window still fit.
+
+The bug is not geostationary-specific (the issue reported it via a `to_crs()`'d GOES variable, but it
+is a plain `read_array(bbox=)` / `read_array(window=<polygon>)` bug on any raster). A square window
+hides it, which is why it went undetected — every earlier bbox test used a square window or a loose
+`size < full` assertion.
+
+Style: Google-style docstrings, <=120 char lines, no inline imports.
+"""
+
+from __future__ import annotations
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+import pytest
+from shapely.geometry import box
+
+from pyramids.dataset import Dataset
+from pyramids.feature import FeatureCollection
+
+pytestmark = pytest.mark.core
+
+
+@pytest.fixture()
+def non_square_raster() -> Dataset:
+    """A deliberately non-square 10-row x 40-col raster on a unit lon/lat grid.
+
+    Returns:
+        Dataset: Single-band raster, `value == row * 40 + col`, top-left at `(0, 10)`, 1-degree cells.
+    """
+    arr = np.arange(10 * 40, dtype="float32").reshape(10, 40)
+    return Dataset.create_from_array(
+        arr, top_left_corner=(0.0, 10.0), cell_size=1.0, epsg=4326
+    )
+
+
+def _expected_slice(dataset: Dataset, bbox: tuple[float, float, float, float]) -> np.ndarray:
+    """The correct crop of the full array for `bbox`, using the documented `[row, col]` mapping.
+
+    Independent of `_convert_polygon_to_window`: it maps the bbox corners through
+    `map_to_array_coordinates` (which returns `[row, col]`) and slices the full read directly, so it
+    catches a width/height transpose regardless of the boundary-rounding convention.
+    """
+    full = np.squeeze(np.asarray(dataset.read_array()))
+    df = pd.DataFrame(columns=["x", "y"])
+    df.loc["top_left", ["x", "y"]] = bbox[0], bbox[3]
+    df.loc["bottom_right", ["x", "y"]] = bbox[2], bbox[1]
+    idx = dataset.map_to_array_coordinates(df)
+    row_tl, col_tl = int(idx[0, 0]), int(idx[0, 1])
+    row_br, col_br = int(idx[1, 0]), int(idx[1, 1])
+    return full[row_tl:row_br, col_tl:col_br]
+
+
+class TestBboxWindowNonSquare:
+    """A non-square bbox reads the correct, non-transposed sub-window."""
+
+    def test_convert_polygon_to_window_sizes_are_not_swapped(self, non_square_raster):
+        """`x_size` comes from the column delta and `y_size` from the row delta.
+
+        Test scenario:
+            A bbox 19 columns wide and 5 rows tall must yield `x_size=19`, `y_size=5`. The pre-fix
+            code returned `x_size=5`, `y_size=19` — the transpose this test guards against.
+        """
+        bbox = (10.5, 2.5, 29.5, 7.5)  # cols 10..29 (19 wide), rows 2..7 (5 tall) on cell centres
+        fc = FeatureCollection.from_bbox(bbox, epsg=4326)
+        xoff, yoff, x_size, y_size = non_square_raster.io._convert_polygon_to_window(fc)
+        assert (xoff, yoff) == (10, 2), f"offsets should be (col=10, row=2), got ({xoff}, {yoff})"
+        assert x_size == 19, f"x_size must be the column span (19), got {x_size}"
+        assert y_size == 5, f"y_size must be the row span (5), got {y_size}"
+
+    def test_read_array_bbox_matches_numpy_crop(self, non_square_raster):
+        """`read_array(bbox=)` equals a full read cropped with the coordinate mapping.
+
+        Test scenario:
+            The issue's acceptance criterion: a windowed bbox read returns the same shape and values
+            as a full read plus a geotransform-based crop. A transpose would return the (cols, rows)
+            shape and different values.
+        """
+        bbox = (10.5, 2.5, 29.5, 7.5)
+        got = np.squeeze(np.asarray(non_square_raster.read_array(bbox=list(bbox))))
+        expected = _expected_slice(non_square_raster, bbox)
+        assert got.shape == expected.shape, f"transposed: got {got.shape}, expected {expected.shape}"
+        assert got.shape[0] < got.shape[1], "this bbox is wider than it is tall; rows must be < cols"
+        np.testing.assert_array_equal(got, expected, err_msg="bbox read is not the correct sub-window")
+
+    def test_tall_bbox_is_not_transposed(self, non_square_raster):
+        """The mirror case: a taller-than-wide bbox keeps rows > cols.
+
+        Test scenario:
+            A window 3 columns wide and 8 rows tall must read back as `(8, 3)`, not `(3, 8)`.
+        """
+        bbox = (5.5, 0.5, 8.5, 8.5)  # cols 5..8 (3 wide), rows 1..9 (8 tall)
+        got = np.squeeze(np.asarray(non_square_raster.read_array(bbox=list(bbox))))
+        expected = _expected_slice(non_square_raster, bbox)
+        assert got.shape == expected.shape, f"transposed: got {got.shape}, expected {expected.shape}"
+        assert got.shape[0] > got.shape[1], "this bbox is taller than it is wide; rows must be > cols"
+        np.testing.assert_array_equal(got, expected)
+
+    def test_polygon_window_matches_bbox_window(self, non_square_raster):
+        """A `window=<GeoDataFrame>` polygon reads identically to the equivalent `bbox=`.
+
+        Test scenario:
+            `read_array(window=<polygon>)` and `read_array(bbox=)` are the two entries into the same
+            window conversion; a non-square polygon must not transpose either.
+        """
+        bbox = (10.5, 2.5, 29.5, 7.5)
+        gdf = gpd.GeoDataFrame(geometry=[box(bbox[0], bbox[1], bbox[2], bbox[3])], crs=4326)
+        via_polygon = np.squeeze(np.asarray(non_square_raster.read_array(window=gdf)))
+        via_bbox = np.squeeze(np.asarray(non_square_raster.read_array(bbox=list(bbox))))
+        np.testing.assert_array_equal(
+            via_polygon, via_bbox, err_msg="polygon window diverged from the equivalent bbox read"
+        )

--- a/tests/dataset/io/test_bbox_window_transpose.py
+++ b/tests/dataset/io/test_bbox_window_transpose.py
@@ -243,12 +243,12 @@ class TestBboxRounding:
 
     def test_invalid_bbox_rounding_raises(self, non_square_raster):
         """An unknown `bbox_rounding` raises `ValueError`, on both the public and helper surfaces."""
+        bbox = list(self.WIDE_PARTIAL)
+        fc = FeatureCollection.from_bbox(self.WIDE_PARTIAL, epsg=4326)
         with pytest.raises(ValueError, match="cover.*nearest"):
-            non_square_raster.read_array(bbox=list(self.WIDE_PARTIAL), bbox_rounding="bogus")
+            non_square_raster.read_array(bbox=bbox, bbox_rounding="bogus")
         with pytest.raises(ValueError, match="cover.*nearest"):
-            non_square_raster.io._convert_polygon_to_window(
-                FeatureCollection.from_bbox(self.WIDE_PARTIAL, epsg=4326), rounding="bogus"
-            )
+            non_square_raster.io._convert_polygon_to_window(fc, rounding="bogus")
 
 
 class TestBboxReprojection:
@@ -263,10 +263,10 @@ class TestBboxReprojection:
         """
         native_bbox = (10.3, 2.3, 29.7, 7.7)
         foreign = gpd.GeoDataFrame(geometry=[box(*native_bbox)], crs=4326).to_crs(3857)
-        foreign_bbox = tuple(foreign.total_bounds)
-        native = np.asarray(non_square_raster.read_array(bbox=list(native_bbox)))
+        foreign_bbox = foreign.total_bounds.tolist()
+        native = np.asarray(non_square_raster.read_array(bbox=native_bbox))
         reprojected = np.asarray(
-            non_square_raster.read_array(bbox=list(foreign_bbox), epsg=3857)
+            non_square_raster.read_array(bbox=foreign_bbox, epsg=3857)
         )
         np.testing.assert_array_equal(reprojected, native)
 
@@ -283,9 +283,9 @@ class TestBboxReprojection:
             cell_size=1000.0,
             epsg=32618,
         )
-        far_bbox = (456968.0, 504007.0, 460968.0, 508007.0)  # zone-32N easting/northing
+        far_bbox = [456968.0, 504007.0, 460968.0, 508007.0]  # zone-32N easting/northing
         with pytest.raises(OutOfBoundsError, match="not finite"):
-            raster.read_array(bbox=list(far_bbox), epsg=32632)
+            raster.read_array(bbox=far_bbox, epsg=32632)
 
 
 class TestBboxWindowMultiBand:

--- a/tests/dataset/io/test_bbox_window_transpose.py
+++ b/tests/dataset/io/test_bbox_window_transpose.py
@@ -1,28 +1,38 @@
-"""Regression tests for #719 — bbox/polygon windows must not transpose non-square reads.
+"""Regression tests for `read_array(bbox=)` / `read_array(window=<polygon>)` window resolution.
 
-`_convert_polygon_to_window` builds the `[xoff, yoff, x_size, y_size]` window from the array indices
-of the bbox corners. `map_to_array_coordinates` returns `[row, col]` per point, so `x_size` (columns)
-must come from the column delta and `y_size` (rows) from the row delta. Before the fix they were
-sourced the other way round, so any **non-square** window came back with its width and height swapped:
-either an `OutOfBoundsError` when the swapped size overran the raster, or — worse — silently
-transposed, geographically wrong data when the swapped window still fit.
+Three defects are pinned here, all in `_convert_polygon_to_window`
+(`src/pyramids/dataset/engines/io.py`):
 
-The bug is not geostationary-specific (the issue reported it via a `to_crs()`'d GOES variable, but it
-is a plain `read_array(bbox=)` / `read_array(window=<polygon>)` bug on any raster). A square window
-hides it, which is why it went undetected — every earlier bbox test used a square window or a loose
-`size < full` assertion.
+1. Transpose (#719): the window `[xoff, yoff, x_size, y_size]` sourced `x_size` from the row delta
+   and `y_size` from the column delta, so every non-square window came back with its width and
+   height swapped -- either an `OutOfBoundsError` when the swapped size overran the raster or, worse,
+   silently transposed, geographically wrong data. A square window hides it, which is why it went
+   undetected.
+2. Off-by-one at the boundary: the old helper snapped each corner to the nearest cell *centre*, so a
+   full-extent bbox read one row and one column short. The window is now derived from the
+   geotransform, and `bbox_rounding="cover"` (the default) floors the near edge and ceils the far
+   edge, so every overlapping pixel is kept.
+3. Foreign-CRS reprojection: a bbox in a different CRS is reprojected into the raster frame before
+   the window is computed (a mismatched CRS previously produced a nonsensical, often out-of-bounds
+   window). A bbox that reprojects outside the target CRS domain raises `OutOfBoundsError`.
+
+The oracle in this file is deliberately independent of the production code: it derives the expected
+window straight from the geotransform (floor/ceil), and several cases assert hand-computed integer
+windows, so a transpose *or* a boundary/rounding regression is caught.
 
 Style: Google-style docstrings, <=120 char lines, no inline imports.
 """
 
 from __future__ import annotations
 
+import math
+
 import geopandas as gpd
 import numpy as np
-import pandas as pd
 import pytest
 from shapely.geometry import box
 
+from pyramids.base._errors import OutOfBoundsError
 from pyramids.dataset import Dataset
 from pyramids.feature import FeatureCollection
 
@@ -42,79 +52,249 @@ def non_square_raster() -> Dataset:
     )
 
 
-def _expected_slice(dataset: Dataset, bbox: tuple[float, float, float, float]) -> np.ndarray:
-    """The correct crop of the full array for `bbox`, using the documented `[row, col]` mapping.
+@pytest.fixture()
+def multiband_non_square_raster() -> Dataset:
+    """A 3-band, 10-row x 40-col raster; `value == band * 1000 + row * 40 + col`.
 
-    Independent of `_convert_polygon_to_window`: it maps the bbox corners through
-    `map_to_array_coordinates` (which returns `[row, col]`) and slices the full read directly, so it
-    catches a width/height transpose regardless of the boundary-rounding convention.
+    Returns:
+        Dataset: Three-band raster on the same grid as `non_square_raster`, so a per-band bbox read
+        can be checked against a full read without any transpose collapsing the band axis.
     """
-    full = np.squeeze(np.asarray(dataset.read_array()))
-    df = pd.DataFrame(columns=["x", "y"])
-    df.loc["top_left", ["x", "y"]] = bbox[0], bbox[3]
-    df.loc["bottom_right", ["x", "y"]] = bbox[2], bbox[1]
-    idx = dataset.map_to_array_coordinates(df)
-    row_tl, col_tl = int(idx[0, 0]), int(idx[0, 1])
-    row_br, col_br = int(idx[1, 0]), int(idx[1, 1])
-    return full[row_tl:row_br, col_tl:col_br]
+    bands = np.stack(
+        [np.arange(10 * 40, dtype="float32").reshape(10, 40) + b * 1000 for b in range(3)],
+        axis=0,
+    )
+    return Dataset.create_from_array(
+        bands, top_left_corner=(0.0, 10.0), cell_size=1.0, epsg=4326
+    )
+
+
+def _cover_window(dataset: Dataset, bbox: tuple[float, float, float, float]) -> list[int]:
+    """The expected `"cover"` window for `bbox`, derived only from the geotransform.
+
+    Independent of `_convert_polygon_to_window` and of `map_to_array_coordinates`: it maps the bbox
+    corners to fractional pixel indices through the geotransform, then floors the near edge and ceils
+    the far edge. Any width/height transpose or boundary off-by-one in the production helper diverges
+    from this.
+    """
+    west, south, east, north = bbox
+    origin_x, pixel_x, _, origin_y, _, pixel_y = dataset.geotransform
+    cols = [(west - origin_x) / pixel_x, (east - origin_x) / pixel_x]
+    rows = [(north - origin_y) / pixel_y, (south - origin_y) / pixel_y]
+    xoff, x_far = math.floor(min(cols)), math.ceil(max(cols))
+    yoff, y_far = math.floor(min(rows)), math.ceil(max(rows))
+    return [xoff, yoff, x_far - xoff, y_far - yoff]
 
 
 class TestBboxWindowNonSquare:
-    """A non-square bbox reads the correct, non-transposed sub-window."""
+    """A non-square bbox reads the correct, non-transposed sub-window (#719)."""
 
     def test_convert_polygon_to_window_sizes_are_not_swapped(self, non_square_raster):
-        """`x_size` comes from the column delta and `y_size` from the row delta.
+        """`x_size` comes from the column span and `y_size` from the row span.
 
         Test scenario:
-            A bbox 19 columns wide and 5 rows tall must yield `x_size=19`, `y_size=5`. The pre-fix
-            code returned `x_size=5`, `y_size=19` — the transpose this test guards against.
-        """
-        bbox = (10.5, 2.5, 29.5, 7.5)  # cols 10..29 (19 wide), rows 2..7 (5 tall) on cell centres
-        fc = FeatureCollection.from_bbox(bbox, epsg=4326)
-        xoff, yoff, x_size, y_size = non_square_raster.io._convert_polygon_to_window(fc)
-        assert (xoff, yoff) == (10, 2), f"offsets should be (col=10, row=2), got ({xoff}, {yoff})"
-        assert x_size == 19, f"x_size must be the column span (19), got {x_size}"
-        assert y_size == 5, f"y_size must be the row span (5), got {y_size}"
-
-    def test_read_array_bbox_matches_numpy_crop(self, non_square_raster):
-        """`read_array(bbox=)` equals a full read cropped with the coordinate mapping.
-
-        Test scenario:
-            The issue's acceptance criterion: a windowed bbox read returns the same shape and values
-            as a full read plus a geotransform-based crop. A transpose would return the (cols, rows)
-            shape and different values.
+            A bbox 20 columns wide and 6 rows tall must yield `x_size=20`, `y_size=6`. The pre-fix
+            code returned them swapped -- the transpose this test guards against.
         """
         bbox = (10.5, 2.5, 29.5, 7.5)
+        fc = FeatureCollection.from_bbox(bbox, epsg=4326)
+        xoff, yoff, x_size, y_size = non_square_raster.io._convert_polygon_to_window(fc)
+        assert [xoff, yoff, x_size, y_size] == [10, 2, 20, 6]
+        assert x_size > y_size, "this bbox is wider than it is tall; x_size must exceed y_size"
+
+    def test_wide_bbox_read_matches_independent_cover_slice(self, non_square_raster):
+        """A wider-than-tall bbox reads the geotransform-derived sub-window, not its transpose.
+
+        Test scenario:
+            The read equals the full array sliced by the independent `_cover_window`; a transpose
+            would return the `(cols, rows)` shape and different values.
+        """
+        bbox = (10.3, 2.3, 29.7, 7.7)
+        xoff, yoff, x_size, y_size = _cover_window(non_square_raster, bbox)
+        full = np.squeeze(np.asarray(non_square_raster.read_array()))
+        expected = full[yoff : yoff + y_size, xoff : xoff + x_size]
         got = np.squeeze(np.asarray(non_square_raster.read_array(bbox=list(bbox))))
-        expected = _expected_slice(non_square_raster, bbox)
         assert got.shape == expected.shape, f"transposed: got {got.shape}, expected {expected.shape}"
         assert got.shape[0] < got.shape[1], "this bbox is wider than it is tall; rows must be < cols"
-        np.testing.assert_array_equal(got, expected, err_msg="bbox read is not the correct sub-window")
+        np.testing.assert_array_equal(got, expected)
 
-    def test_tall_bbox_is_not_transposed(self, non_square_raster):
+    def test_tall_bbox_read_is_not_transposed(self, non_square_raster):
         """The mirror case: a taller-than-wide bbox keeps rows > cols.
 
         Test scenario:
-            A window 3 columns wide and 8 rows tall must read back as `(8, 3)`, not `(3, 8)`.
+            A window 4 columns wide and 9 rows tall must read back as `(9, 4)`, not `(4, 9)`.
         """
-        bbox = (5.5, 0.5, 8.5, 8.5)  # cols 5..8 (3 wide), rows 1..9 (8 tall)
+        bbox = (5.3, 0.3, 8.7, 8.7)
+        xoff, yoff, x_size, y_size = _cover_window(non_square_raster, bbox)
+        full = np.squeeze(np.asarray(non_square_raster.read_array()))
+        expected = full[yoff : yoff + y_size, xoff : xoff + x_size]
         got = np.squeeze(np.asarray(non_square_raster.read_array(bbox=list(bbox))))
-        expected = _expected_slice(non_square_raster, bbox)
         assert got.shape == expected.shape, f"transposed: got {got.shape}, expected {expected.shape}"
         assert got.shape[0] > got.shape[1], "this bbox is taller than it is wide; rows must be > cols"
         np.testing.assert_array_equal(got, expected)
 
-    def test_polygon_window_matches_bbox_window(self, non_square_raster):
-        """A `window=<GeoDataFrame>` polygon reads identically to the equivalent `bbox=`.
+    def test_polygon_window_matches_bbox_and_oracle(self, non_square_raster):
+        """A `window=<GeoDataFrame>` polygon reads identically to the equivalent `bbox=` and oracle.
 
         Test scenario:
             `read_array(window=<polygon>)` and `read_array(bbox=)` are the two entries into the same
-            window conversion; a non-square polygon must not transpose either.
+            window conversion; both must equal the independent `_cover_window` slice, so the polygon
+            path is pinned on its own rather than only against the (identically-derived) bbox path.
         """
-        bbox = (10.5, 2.5, 29.5, 7.5)
-        gdf = gpd.GeoDataFrame(geometry=[box(bbox[0], bbox[1], bbox[2], bbox[3])], crs=4326)
+        bbox = (10.3, 2.3, 29.7, 7.7)
+        xoff, yoff, x_size, y_size = _cover_window(non_square_raster, bbox)
+        full = np.squeeze(np.asarray(non_square_raster.read_array()))
+        expected = full[yoff : yoff + y_size, xoff : xoff + x_size]
+        gdf = gpd.GeoDataFrame(geometry=[box(*bbox)], crs=4326)
         via_polygon = np.squeeze(np.asarray(non_square_raster.read_array(window=gdf)))
         via_bbox = np.squeeze(np.asarray(non_square_raster.read_array(bbox=list(bbox))))
+        np.testing.assert_array_equal(via_polygon, expected)
+        np.testing.assert_array_equal(via_polygon, via_bbox)
+
+
+class TestBboxWindowBoundary:
+    """`"cover"` keeps every overlapping pixel -- the boundary is not dropped (the old off-by-one)."""
+
+    def test_full_extent_bbox_reads_entire_raster(self, non_square_raster):
+        """A bbox equal to the raster extent reads the whole raster, not one row/column short.
+
+        Test scenario:
+            The pre-fix nearest-centre snapping returned a 39x9 window of this 40x10 raster. `"cover"`
+            must return the full `[0, 0, 40, 10]` window and every cell.
+        """
+        bbox = (0.0, 0.0, 40.0, 10.0)
+        window = non_square_raster.io._convert_polygon_to_window(
+            FeatureCollection.from_bbox(bbox, epsg=4326)
+        )
+        assert window == [0, 0, 40, 10]
+        full = np.squeeze(np.asarray(non_square_raster.read_array()))
+        got = np.squeeze(np.asarray(non_square_raster.read_array(bbox=list(bbox))))
+        assert got.shape == (10, 40)
+        np.testing.assert_array_equal(got, full)
+
+    def test_boundary_cell_present_for_mid_cell_bbox(self, non_square_raster):
+        """A bbox whose far edges fall on cell centres still includes the straddled boundary cell.
+
+        Test scenario:
+            `(10.5, 2.5, 29.5, 7.5)` reaches the centres of col 29 and row 7. Under `"cover"` the
+            window is `[10, 2, 20, 6]`, so the last read cell is `full[7, 29]` -- the exact cell the
+            old nearest-centre window dropped.
+        """
+        bbox = (10.5, 2.5, 29.5, 7.5)
+        full = np.squeeze(np.asarray(non_square_raster.read_array()))
+        got = np.squeeze(np.asarray(non_square_raster.read_array(bbox=list(bbox))))
+        assert got.shape == (6, 20)
+        assert got[-1, -1] == full[7, 29] == 7 * 40 + 29
+
+
+class TestBboxRounding:
+    """`bbox_rounding` selects the cover (default) or nearest snapping convention."""
+
+    WIDE_PARTIAL = (10.7, 2.7, 29.3, 7.3)
+
+    def test_cover_and_nearest_windows_differ_on_partial_cells(self, non_square_raster):
+        """`"cover"` includes partly-overlapped edge cells; `"nearest"` gives the tightest window.
+
+        Test scenario:
+            For a bbox whose edges fall off cell centres, `"cover"` floors/ceils to `[10, 2, 20, 6]`
+            while `"nearest"` rounds each edge to `[11, 3, 18, 4]` -- a strictly smaller window.
+        """
+        fc = FeatureCollection.from_bbox(self.WIDE_PARTIAL, epsg=4326)
+        cover = non_square_raster.io._convert_polygon_to_window(fc, rounding="cover")
+        nearest = non_square_raster.io._convert_polygon_to_window(fc, rounding="nearest")
+        assert cover == [10, 2, 20, 6]
+        assert nearest == [11, 3, 18, 4]
+
+    def test_default_rounding_is_cover(self, non_square_raster):
+        """Omitting `bbox_rounding` reads exactly what `bbox_rounding="cover"` reads.
+
+        Test scenario:
+            The default must not silently change behaviour: the two reads are byte-equal.
+        """
+        default = np.asarray(non_square_raster.read_array(bbox=list(self.WIDE_PARTIAL)))
+        cover = np.asarray(
+            non_square_raster.read_array(bbox=list(self.WIDE_PARTIAL), bbox_rounding="cover")
+        )
+        np.testing.assert_array_equal(default, cover)
+
+    def test_nearest_read_matches_hand_computed_slice(self, non_square_raster):
+        """`bbox_rounding="nearest"` reads the tightest, correctly-shaped sub-window.
+
+        Test scenario:
+            The `[11, 3, 18, 4]` window slices `full[3:7, 11:29]`; the read must equal it exactly and
+            be a `(4, 18)` array (not its transpose).
+        """
+        full = np.squeeze(np.asarray(non_square_raster.read_array()))
+        got = np.squeeze(
+            np.asarray(
+                non_square_raster.read_array(bbox=list(self.WIDE_PARTIAL), bbox_rounding="nearest")
+            )
+        )
+        assert got.shape == (4, 18)
+        np.testing.assert_array_equal(got, full[3:7, 11:29])
+
+    def test_invalid_bbox_rounding_raises(self, non_square_raster):
+        """An unknown `bbox_rounding` raises `ValueError`, on both the public and helper surfaces."""
+        with pytest.raises(ValueError, match="cover.*nearest"):
+            non_square_raster.read_array(bbox=list(self.WIDE_PARTIAL), bbox_rounding="bogus")
+        with pytest.raises(ValueError, match="cover.*nearest"):
+            non_square_raster.io._convert_polygon_to_window(
+                FeatureCollection.from_bbox(self.WIDE_PARTIAL, epsg=4326), rounding="bogus"
+            )
+
+
+class TestBboxReprojection:
+    """A foreign-CRS bbox is reprojected into the raster frame before the window is computed."""
+
+    def test_foreign_crs_bbox_matches_native(self, non_square_raster):
+        """A bbox given in EPSG:3857 reads the same cells as the equivalent native EPSG:4326 bbox.
+
+        Test scenario:
+            The bbox edges sit inside cells (not on boundaries), so the tiny reprojection round-trip
+            error cannot cross a cell edge; the foreign-CRS read must equal the native read.
+        """
+        native_bbox = (10.3, 2.3, 29.7, 7.7)
+        foreign = gpd.GeoDataFrame(geometry=[box(*native_bbox)], crs=4326).to_crs(3857)
+        foreign_bbox = tuple(foreign.total_bounds)
+        native = np.asarray(non_square_raster.read_array(bbox=list(native_bbox)))
+        reprojected = np.asarray(
+            non_square_raster.read_array(bbox=list(foreign_bbox), epsg=3857)
+        )
+        np.testing.assert_array_equal(reprojected, native)
+
+    def test_out_of_domain_bbox_raises_out_of_bounds(self):
+        """A bbox that reprojects outside the raster CRS domain raises `OutOfBoundsError`.
+
+        Test scenario:
+            A UTM-zone-32N bbox reprojected onto a UTM-zone-18N raster lands outside zone 18's valid
+            domain (non-finite coordinates); the helper must raise rather than crash on `inf`.
+        """
+        raster = Dataset.create_from_array(
+            np.zeros((10, 10), dtype="float32"),
+            top_left_corner=(400000.0, 5100000.0),
+            cell_size=1000.0,
+            epsg=32618,
+        )
+        far_bbox = (456968.0, 504007.0, 460968.0, 508007.0)  # zone-32N easting/northing
+        with pytest.raises(OutOfBoundsError, match="not finite"):
+            raster.read_array(bbox=list(far_bbox), epsg=32632)
+
+
+class TestBboxWindowMultiBand:
+    """A multi-band bbox read keeps the band axis and is not transposed (L2 coverage)."""
+
+    def test_multiband_bbox_not_transposed(self, multiband_non_square_raster):
+        """`read_array(bbox=)` with no `band=` returns `(bands, rows, cols)`, correctly sliced.
+
+        Test scenario:
+            Each band of the windowed read must equal the same-band slice of the full read, so a
+            transpose (which would mis-shape the `(bands, rows, cols)` result) is caught per band.
+        """
+        bbox = (10.3, 2.3, 29.7, 7.7)
+        xoff, yoff, x_size, y_size = _cover_window(multiband_non_square_raster, bbox)
+        full = np.asarray(multiband_non_square_raster.read_array())
+        got = np.asarray(multiband_non_square_raster.read_array(bbox=list(bbox)))
+        assert got.shape == (3, y_size, x_size)
         np.testing.assert_array_equal(
-            via_polygon, via_bbox, err_msg="polygon window diverged from the equivalent bbox read"
+            got, full[:, yoff : yoff + y_size, xoff : xoff + x_size]
         )

--- a/tests/dataset/io/test_bbox_window_transpose.py
+++ b/tests/dataset/io/test_bbox_window_transpose.py
@@ -25,11 +25,10 @@ Style: Google-style docstrings, <=120 char lines, no inline imports.
 
 from __future__ import annotations
 
-import math
-
 import geopandas as gpd
 import numpy as np
 import pytest
+from osgeo import gdal, osr
 from shapely.geometry import box
 
 from pyramids.base._errors import OutOfBoundsError
@@ -70,20 +69,29 @@ def multiband_non_square_raster() -> Dataset:
 
 
 def _cover_window(dataset: Dataset, bbox: tuple[float, float, float, float]) -> list[int]:
-    """The expected `"cover"` window for `bbox`, derived only from the geotransform.
+    """The expected `"cover"` window for `bbox`, by enumerating which cells the bbox overlaps.
 
-    Independent of `_convert_polygon_to_window` and of `map_to_array_coordinates`: it maps the bbox
-    corners to fractional pixel indices through the geotransform, then floors the near edge and ceils
-    the far edge. Any width/height transpose or boundary off-by-one in the production helper diverges
-    from this.
+    Deliberately shares no arithmetic with the production `floor`/`ceil` formula (Round-2 N1): it
+    walks every cell, tests whether the cell's own extent overlaps the bbox with positive area, and
+    returns the bounding window of the overlapping cells. A zero-width edge touch (bbox edge exactly
+    on a cell boundary) is excluded, which is the intended `"cover"` semantics. Works for north-up and
+    flipped geotransforms because it compares cell edges via `min`/`max`.
     """
     west, south, east, north = bbox
     origin_x, pixel_x, _, origin_y, _, pixel_y = dataset.geotransform
-    cols = [(west - origin_x) / pixel_x, (east - origin_x) / pixel_x]
-    rows = [(north - origin_y) / pixel_y, (south - origin_y) / pixel_y]
-    xoff, x_far = math.floor(min(cols)), math.ceil(max(cols))
-    yoff, y_far = math.floor(min(rows)), math.ceil(max(rows))
-    return [xoff, yoff, x_far - xoff, y_far - yoff]
+    cols_in = [
+        c
+        for c in range(dataset.columns)
+        if max(origin_x + c * pixel_x, origin_x + (c + 1) * pixel_x) > west
+        and min(origin_x + c * pixel_x, origin_x + (c + 1) * pixel_x) < east
+    ]
+    rows_in = [
+        r
+        for r in range(dataset.rows)
+        if max(origin_y + r * pixel_y, origin_y + (r + 1) * pixel_y) > south
+        and min(origin_y + r * pixel_y, origin_y + (r + 1) * pixel_y) < north
+    ]
+    return [cols_in[0], rows_in[0], cols_in[-1] - cols_in[0] + 1, rows_in[-1] - rows_in[0] + 1]
 
 
 class TestBboxWindowNonSquare:
@@ -298,3 +306,115 @@ class TestBboxWindowMultiBand:
         np.testing.assert_array_equal(
             got, full[:, yoff : yoff + y_size, xoff : xoff + x_size]
         )
+
+
+class TestBboxWindowFloatingPoint:
+    """Grid-aligned bbox edges on a non-integer cell size do not leak a neighbouring pixel (H1)."""
+
+    @pytest.fixture()
+    def fine_raster(self) -> Dataset:
+        """A 6x6 raster on a 0.05-degree grid, where `(coord - origin) / pixel` is FP-inexact."""
+        arr = np.arange(6 * 6, dtype="float32").reshape(6, 6)
+        return Dataset.create_from_array(
+            arr, top_left_corner=(0.0, 0.0), cell_size=0.05, epsg=4326
+        )
+
+    def test_grid_aligned_bbox_does_not_leak_a_column(self, fine_raster):
+        """A bbox exactly equal to one column reads that column only, not its neighbour too.
+
+        Test scenario:
+            `(0.15 - 0) / 0.05` evaluates to 2.9999999999999996 in IEEE-754; without a snap tolerance
+            `floor` gives 2 and the read leaks column 2. The correct `"cover"` window is `[3, 0, 1, 1]`.
+        """
+        bbox = (0.15, -0.05, 0.20, 0.0)  # exactly column 3, row 0
+        window = fine_raster.io._convert_polygon_to_window(
+            FeatureCollection.from_bbox(bbox, epsg=4326)
+        )
+        # The hand-written window is the independent oracle here: a floor/ceil (or cell-enumeration)
+        # oracle inherits the same FP noise (`3 * 0.05 == 0.15000000000000002`), so only an explicit
+        # integer window pins the intended result.
+        assert window == [3, 0, 1, 1]
+        full = np.squeeze(np.asarray(fine_raster.read_array()))
+        got = np.squeeze(np.asarray(fine_raster.read_array(bbox=list(bbox))))
+        np.testing.assert_array_equal(got, full[0:1, 3:4])
+
+
+class TestBboxWindowClamping:
+    """A partly-outside bbox reads the overlap; a fully-outside bbox raises (M1)."""
+
+    def test_partial_overlap_clamps_to_extent(self, non_square_raster):
+        """A bbox poking past the west/north edge reads the in-bounds overlap without raising.
+
+        Test scenario:
+            `(-5, 2, 10, 8)` on the 40x10 raster clamps to `[0, 2, 10, 6]` and returns that overlap;
+            an un-clamped negative offset would raise `OutOfBoundsError`.
+        """
+        bbox = (-5.0, 2.0, 10.0, 8.0)
+        window = non_square_raster.io._convert_polygon_to_window(
+            FeatureCollection.from_bbox(bbox, epsg=4326)
+        )
+        assert window == [0, 2, 10, 6]
+        full = np.squeeze(np.asarray(non_square_raster.read_array()))
+        got = np.squeeze(np.asarray(non_square_raster.read_array(bbox=list(bbox))))
+        assert got.shape == (6, 10)
+        np.testing.assert_array_equal(got, full[2:8, 0:10])
+
+    def test_bbox_fully_outside_raster_raises(self, non_square_raster):
+        """A bbox with no overlap at all raises `OutOfBoundsError`, not an empty read."""
+        with pytest.raises(OutOfBoundsError, match="does not overlap"):
+            non_square_raster.read_array(bbox=[100.0, 2.0, 110.0, 8.0])
+
+
+class TestBboxWindowDegenerate:
+    """Sub-pixel / degenerate windows still read at least one cell instead of an empty array (L1)."""
+
+    def test_nearest_subpixel_bbox_reads_one_cell(self, non_square_raster):
+        """`bbox_rounding="nearest"` on a sub-cell bbox returns the nearest single cell, not empty.
+
+        Test scenario:
+            `(5.1, 5.1, 5.3, 5.3)` is narrower than a cell; `"nearest"` used to round to a zero-size
+            window and return a `(0, 0)` array. It now returns the single cell it falls in.
+        """
+        window = non_square_raster.io._convert_polygon_to_window(
+            FeatureCollection.from_bbox((5.1, 5.1, 5.3, 5.3), epsg=4326), rounding="nearest"
+        )
+        assert window[2] >= 1 and window[3] >= 1
+        got = np.squeeze(
+            np.asarray(
+                non_square_raster.read_array(bbox=[5.1, 5.1, 5.3, 5.3], bbox_rounding="nearest")
+            )
+        )
+        assert got.size == 1
+
+    def test_degenerate_zero_width_polygon_reads_one_cell(self, non_square_raster):
+        """A zero-width polygon window (west == east) resolves to a non-empty window."""
+        line = gpd.GeoDataFrame(geometry=[box(6.0, 3.0, 6.0, 5.0)], crs=4326)
+        window = non_square_raster.io._convert_polygon_to_window(line)
+        assert window[2] >= 1 and window[3] >= 1
+
+
+class TestBboxWindowFlippedGrid:
+    """A south-up (positive pixel-height) geotransform resolves the window correctly (L4)."""
+
+    def test_south_up_grid_window_matches_enumeration(self):
+        """A flipped raster (`pixel_y > 0`, rows increasing northward) yields the enumerated window.
+
+        Test scenario:
+            The `min`/`max` framing must handle a positive y-step; a non-square bbox resolves to the
+            same window the independent cell-enumeration oracle produces, read at the right cells.
+        """
+        arr = np.arange(6 * 8, dtype="float32").reshape(6, 8)
+        mem = gdal.GetDriverByName("MEM").Create("", 8, 6, 1, gdal.GDT_Float32)
+        mem.SetGeoTransform((0.0, 1.0, 0.0, 0.0, 0.0, 1.0))  # origin bottom-left, y increases upward
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(4326)
+        mem.SetProjection(srs.ExportToWkt())
+        mem.GetRasterBand(1).WriteArray(arr)
+        ds = Dataset(mem)
+        bbox = (1.3, 1.3, 6.7, 3.7)
+        window = ds.io._convert_polygon_to_window(FeatureCollection.from_bbox(bbox, epsg=4326))
+        assert window == _cover_window(ds, bbox)
+        xoff, yoff, x_size, y_size = window
+        full = np.squeeze(np.asarray(ds.read_array()))
+        got = np.squeeze(np.asarray(ds.read_array(bbox=list(bbox))))
+        np.testing.assert_array_equal(got, full[yoff : yoff + y_size, xoff : xoff + x_size])

--- a/tests/netcdf/spatial/test_netcdf_bbox.py
+++ b/tests/netcdf/spatial/test_netcdf_bbox.py
@@ -363,6 +363,34 @@ class TestNetCDFReadArrayBbox:
         )
         assert got2d.shape[1] > got2d.shape[0], "bbox spans more lon than lat; cols must exceed rows"
 
+    def test_bbox_rounding_forwarded_to_variable_read(self, root_nc: NetCDF):
+        """Test ``bbox_rounding=`` is forwarded through the NetCDF override to the window resolver.
+
+        Args:
+            root_nc: Module-scope root NetCDF fixture (EPSG:4326).
+
+        Test scenario:
+            For a bbox whose edges fall off cell centres, ``"nearest"`` must read a strictly smaller
+            window than the default ``"cover"``. If the override dropped the argument, both reads
+            would be identical.
+        """
+        var = root_nc.get_variable("Band1")
+        origin_x, pixel_x, _, origin_y, _, pixel_y = var.geotransform
+        west = origin_x + 20.7 * pixel_x
+        east = origin_x + 100.3 * pixel_x
+        north = origin_y + 220.7 * pixel_y
+        south = origin_y + 280.3 * pixel_y
+        cover = root_nc.read_array(variable="Band1", bbox=(west, south, east, north))
+        nearest = root_nc.read_array(
+            variable="Band1", bbox=(west, south, east, north), bbox_rounding="nearest"
+        )
+        assert nearest.shape[-2] < cover.shape[-2], (
+            f"nearest rows should be fewer: cover={cover.shape[-2:]} nearest={nearest.shape[-2:]}"
+        )
+        assert nearest.shape[-1] < cover.shape[-1], (
+            f"nearest cols should be fewer: cover={cover.shape[-2:]} nearest={nearest.shape[-2:]}"
+        )
+
     def test_window_and_bbox_together_raises(self, root_nc: NetCDF):
         """Test ``window=`` + ``bbox=`` together raises ``ValueError``.
 

--- a/tests/netcdf/spatial/test_netcdf_bbox.py
+++ b/tests/netcdf/spatial/test_netcdf_bbox.py
@@ -8,8 +8,6 @@ through to the existing polygon / variable-subset paths.
 
 from __future__ import annotations
 
-import math
-
 import pytest
 
 from pyramids.feature import FeatureCollection
@@ -350,12 +348,12 @@ class TestNetCDFReadArrayBbox:
             from the variable's geotransform -- a transpose would swap the two axes.
         """
         var = root_nc.get_variable("Band1")
-        origin_x, pixel_x, _, origin_y, _, pixel_y = var.geotransform
+        _, pixel_x, _, _, _, pixel_y = var.geotransform
         west, south, east, north = 10.0, -50.0, 90.0, -30.0
-        cols = [(west - origin_x) / pixel_x, (east - origin_x) / pixel_x]
-        rows = [(north - origin_y) / pixel_y, (south - origin_y) / pixel_y]
-        exp_cols = math.ceil(max(cols)) - math.floor(min(cols))
-        exp_rows = math.ceil(max(rows)) - math.floor(min(rows))
+        # These edges are cell-aligned, so the exact cover span is the extent divided by the cell
+        # size -- derived independently of the production floor/ceil index math.
+        exp_cols = round((east - west) / abs(pixel_x))
+        exp_rows = round((north - south) / abs(pixel_y))
         got = var.read_array(bbox=(west, south, east, north))
         got2d = got[got.shape[0] // 2] if got.ndim == 3 else got
         assert got2d.shape == (exp_rows, exp_cols), (

--- a/tests/netcdf/spatial/test_netcdf_bbox.py
+++ b/tests/netcdf/spatial/test_netcdf_bbox.py
@@ -8,6 +8,8 @@ through to the existing polygon / variable-subset paths.
 
 from __future__ import annotations
 
+import math
+
 import pytest
 
 from pyramids.feature import FeatureCollection
@@ -335,6 +337,31 @@ class TestNetCDFReadArrayBbox:
         assert (
             windowed.size < full.size
         ), f"bbox didn't reduce size: full={full.size} windowed={windowed.size}"
+
+    def test_non_square_bbox_variable_not_transposed(self, root_nc: NetCDF):
+        """Test a non-square NetCDF-variable bbox read is not transposed (#719's actual path).
+
+        Args:
+            root_nc: Module-scope root NetCDF fixture (EPSG:4326).
+
+        Test scenario:
+            #719 was reported through a NetCDF variable. A bbox spanning far more longitude than
+            latitude must read back wider than it is tall, matching a window derived independently
+            from the variable's geotransform -- a transpose would swap the two axes.
+        """
+        var = root_nc.get_variable("Band1")
+        origin_x, pixel_x, _, origin_y, _, pixel_y = var.geotransform
+        west, south, east, north = 10.0, -50.0, 90.0, -30.0
+        cols = [(west - origin_x) / pixel_x, (east - origin_x) / pixel_x]
+        rows = [(north - origin_y) / pixel_y, (south - origin_y) / pixel_y]
+        exp_cols = math.ceil(max(cols)) - math.floor(min(cols))
+        exp_rows = math.ceil(max(rows)) - math.floor(min(rows))
+        got = var.read_array(bbox=(west, south, east, north))
+        got2d = got[got.shape[0] // 2] if got.ndim == 3 else got
+        assert got2d.shape == (exp_rows, exp_cols), (
+            f"transposed or mis-sized: got {got2d.shape}, expected {(exp_rows, exp_cols)}"
+        )
+        assert got2d.shape[1] > got2d.shape[0], "bbox spans more lon than lat; cols must exceed rows"
 
     def test_window_and_bbox_together_raises(self, root_nc: NetCDF):
         """Test ``window=`` + ``bbox=`` together raises ``ValueError``.


### PR DESCRIPTION
# Description

`read_array(bbox=…)` / `read_array(window=<polygon>)` resolve a geometry window to a pixel window
through `_convert_polygon_to_window` (`src/pyramids/dataset/engines/io.py`). That resolution had three
defects; this PR fixes all three, hardens the surrounding edge cases, and adds a `bbox_rounding`
control.

**1. Transpose (#719).** The window `[xoff, yoff, x_size, y_size]` sourced `x_size` from the **row**
delta and `y_size` from the **column** delta. Since `map_to_array_coordinates` returns `[row, col]`,
every **non-square** window came back with its width and height swapped — either an `OutOfBoundsError`
when the swapped size overran the raster, or (worse) silently transposed, geographically wrong data
when it still fit. A square window hides it, which is why it shipped.

**2. Boundary off-by-one.** The old helper snapped each corner to the nearest cell **centre**, so a
full-extent bbox read one row and one column short (e.g. a 39×9 read of a 40×10 raster). The window is
now derived from the geotransform corners, and the default `bbox_rounding="cover"` floors the near edge
and ceils the far edge, so **every overlapping pixel is kept** — a full-extent bbox reads the whole
raster.

**3. Foreign-CRS window.** A bbox in a different CRS was measured against the raster's own axis frame,
producing a nonsensical (often far out-of-bounds) window. The bbox is now reprojected into the raster
CRS first — compared through pyproj so a raster CRS with no EPSG code (e.g. a geostationary WKT grid) is
handled too, not only EPSG↔EPSG — with the bbox edges densified so a curved reprojected edge is not
under-covered by a corner-only min/max. A bbox that reprojects outside the target CRS's valid domain
raises a clear `OutOfBoundsError`.

**New `bbox_rounding` parameter.** `read_array(bbox_rounding=…)` (on both `Dataset` and `NetCDF`) lets
callers choose how a geometry window snaps to whole pixels:

- `"cover"` (default) — floor/ceil; the window includes every pixel the bbox overlaps. A full-extent
  bbox reads the full raster; no partly-covered boundary pixel is dropped.
- `"nearest"` — round each edge to the closest pixel boundary; the tightest window, which can clip a
  partly-covered boundary pixel (matches the reporter's workaround in #719).

The geometry window is resolved once at the top of `read_array`, so the choice applies uniformly across
the eager, decimated (`out_shape=`), threadsafe, and masked read paths. The boundless path still
rejects geometry windows (they are clipped by definition).

**Edge-case hardening (from review):**

- **Floating-point tolerance:** a grid-aligned bbox edge that divides to `k − 1e-16` no longer floors
  to `k − 1` and leaks a neighbouring row/column (real on non-integer cell sizes).
- **Extent clamping:** a bbox that pokes past an edge now reads the overlap (matching `crop(bbox=)`)
  instead of raising; a bbox with **no** overlap raises `OutOfBoundsError`.
- **Degenerate windows:** a sub-pixel `"nearest"` bbox or a zero-width/height polygon reads the single
  cell it falls in rather than returning an empty array.
- **Rotated geotransforms:** a warning is emitted (the axis-aligned mapping is approximate there — a
  pre-existing limitation, now surfaced).

Two clarifications from investigating the report:

- **Not geostationary-specific.** #719 reproduced it via a `to_crs()`'d GOES variable and guessed the
  cause was in the geostationary/`#709` path. It is a plain `read_array` window bug on **any** raster
  with a non-square bbox; reprojection only *exposed* it. `bbox_rounding` is exposed on
  `NetCDF.read_array` too, since the reporter's path is a NetCDF variable.
- **`crop(bbox=)` was never affected.** It uses a separate `gdal.Warp` path, not
  `_convert_polygon_to_window`.

No new dependencies (pyproj is already a core dependency).

# Issues

- Closes #719 — bbox/polygon `read_array` transposes non-square windows

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

The default (`bbox_rounding="cover"`) changes only previously-wrong results: a transposed non-square
window is corrected, and a bbox that used to read one row/column short now reads the full overlap.
Cell-edge-aligned bboxes are unchanged. `"nearest"` reproduces the old tightest-window behaviour for
callers who want it. The `read_array` docstrings (Dataset and NetCDF) document the new parameter.

# How Has This Been Tested?

Regression file `tests/dataset/io/test_bbox_window_transpose.py` was rebuilt around an **independent**
oracle (a geotransform-free cell-enumeration) plus hand-written integer windows, so a boundary or
rounding regression is caught, not only a transpose:

- transpose: wide and tall non-square bbox/polygon reads match the independent oracle slice;
- boundary: a full-extent bbox reads the entire raster (`[0,0,40,10]`); a mid-cell bbox keeps the
  straddled boundary cell;
- floating-point: on a non-integer (`0.05`) grid, a grid-aligned bbox reads exactly its column, not the
  neighbour;
- rounding: `"cover"` vs `"nearest"` give the expected `[10,2,20,6]` vs `[11,3,18,4]` windows; the
  default equals `"cover"`; an invalid value raises `ValueError`;
- clamping: a partly-outside bbox reads the overlap; a fully-outside bbox raises `OutOfBoundsError`;
- degenerate: a sub-pixel `"nearest"` bbox and a zero-width polygon each read one cell;
- reprojection: an EPSG:3857 bbox reads the same cells as the equivalent native bbox; an out-of-domain
  bbox raises `OutOfBoundsError`;
- flipped grid: a south-up (`pixel_y > 0`) raster resolves the correct window;
- multi-band: a per-band bbox read keeps the `(bands, rows, cols)` shape, sliced correctly.

NetCDF (`tests/netcdf/spatial/test_netcdf_bbox.py`): the foreign-CRS variable read that previously
failed (14.6 TiB allocation) now reads a real sub-window; a non-square NetCDF-variable test pins the
read shape against a geotransform-derived window on the reporter's actual path; and `bbox_rounding` is
asserted to forward through the NetCDF override.

- [x] Full dataset + netcdf suite: **4537 passed, 0 failed**.
- [x] New/updated tests fail on the pre-fix code and pass after the fix.
- [x] Two review rounds (`planning/pr-diff-review-bbox-window-swap-*.md`) resolved, including a
      floating-point boundary bug caught in round 2.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.

Versions and the change log are generated by commitizen in CI, so those three boxes are intentionally
left for the release automation. The `read_array` docstrings (Dataset and NetCDF) document the new
`bbox_rounding` parameter and the clamp / no-overlap behaviour.
