### PR TITLE
fix(io): drop misleading 7z mention from gzip error message

### DIFF
--- a/src/pyramids/_io.py
+++ b/src/pyramids/_io.py
@@ -564,8 +564,8 @@ def read_file(
             path.endswith(i) for i in DOES_NOT_SUPPORT_INTERNAL
         ):
             raise FileFormatNotSupportedError(
-                "File format is not supported, if you provided a gzip/7z compressed file with multiple internal "
-                "files. Currently it is not supported to read gzip/7z files with multiple compressed internal "
+                "File format is not supported, if you provided a gzip compressed file with multiple internal "
+                "files. Currently it is not supported to read gzip files with multiple compressed internal "
                 "files"
             )
         elif str(e).__contains__(" No such file or directory"):


### PR DESCRIPTION
# Description

Corrects a misleading error message in `read_file()` (`src/pyramids/_io.py`). The `FileFormatNotSupportedError` raised
for a gzip archive carrying multiple internal files referred to a "gzip/7z" format, implying a `.7z` capability the
package does not have:

- GDAL ships no `/vsi7z/` handler, so `.7z` archives are not read anywhere in pyramids.
- This branch is only reachable for `.gz` paths — it is guarded by `DOES_NOT_SUPPORT_INTERNAL = [".gz"]` — so "7z"
  could never apply here.

The message is reworded to reference gzip only. This is a pure text change: no behavior, API, or dependency change, and
no new dependencies.

# Issues

- Refs #729 — flagged during that issue's triage (closed as not planned); this is the standalone message cleanup it
  called out. No auto-close keyword, since this PR does not implement `.7z` support.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran the archive-read suite against the change; no test asserts on the message string, so no test update was needed.

- [x] `pytest tests/dataset/io/test_archive_reads.py` — 31 passed
- [ ] N/A

# Checklist:

- [ ] updated version number in pyproject.toml. — handled by commitizen via CI, not edited manually.
- [ ] added changes to History.rst. — changelog is commitizen-generated; no manual entry.
- [ ] updated the latest version in README file. — N/A for a message-only fix.
- [ ] I have added tests that prove my fix is effective or that my feature works. — cosmetic message change with no
  behavior change; nothing asserts the text, existing tests cover the code path.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated. — N/A.
