### PR TITLE
feat(crs): add a public UTM zone/EPSG helper

### DIFF
--- a/docs/reference/utm.md
+++ b/docs/reference/utm.md
@@ -1,0 +1,34 @@
+# UTM Zone & EPSG Helpers
+
+UTM helpers in `pyramids.utm` for resolving the UTM zone / EPSG code of a WGS84
+point or vector layer — used for per-tile reprojection, local-metre areas of
+interest, and STAC point cubes.
+
+These return the **EPSG-correct** zone: the plain 6°-wide longitude bands, with
+the hemisphere selecting the `326xx` (north) or `327xx` (south) band. The
+Norway/Svalbard zone shifts are the MGRS grid-zone lettering convention, *not* the
+UTM CRS definitions, so they are deliberately not applied — EPSG:32631 (0°E–6°E) is
+the zone whose area of use covers Bergen at 5°E, while EPSG:32632 (6°E–12°E) does
+not. The values here agree with `pyproj.database.query_utm_crs_info`.
+
+## Functions
+
+::: pyramids.utm.utm_zone
+    options:
+        show_root_heading: true
+        heading_level: 3
+
+::: pyramids.utm.utm_epsg
+    options:
+        show_root_heading: true
+        heading_level: 3
+
+::: pyramids.utm.utm_epsg_for_polygon
+    options:
+        show_root_heading: true
+        heading_level: 3
+
+::: pyramids.utm.project_to_utm
+    options:
+        show_root_heading: true
+        heading_level: 3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -210,6 +210,7 @@ nav:
       - Overview: reference/feature/index.md
       - Geometry helpers: reference/feature/geometry.md
     - CRS helpers: reference/base/crs.md
+    - UTM helpers: reference/utm.md
     - Basemap: reference/basemap.md
     - STAC:
       - Overview: reference/stac/index.md

--- a/src/pyramids/dataset/_stac.py
+++ b/src/pyramids/dataset/_stac.py
@@ -28,6 +28,7 @@ from osgeo import osr
 
 from pyramids.base._artifacts import artifact_dir
 from pyramids.base._errors import StacAssetError
+from pyramids.utm import utm_epsg
 
 if TYPE_CHECKING:
     from pyramids.dataset.collection import DatasetCollection
@@ -646,6 +647,9 @@ _MAX_TEMPLATE_PIXELS = 250_000_000
 def _utm_epsg(lon: float, lat: float) -> int:
     """Return the EPSG code of the UTM zone containing `(lon, lat)`.
 
+    Thin private wrapper delegating to the public :func:`pyramids.utm.utm_epsg`, so
+    the STAC point-cube path and the public helper stay in lock-step.
+
     Args:
         lon: Longitude in degrees.
         lat: Latitude in degrees.
@@ -668,9 +672,7 @@ def _utm_epsg(lon: float, lat: float) -> int:
 
             ```
     """
-    zone = int((lon + 180.0) / 6.0) + 1
-    zone = min(max(zone, 1), 60)
-    return (32600 if lat >= 0 else 32700) + zone
+    return utm_epsg(lon, lat)
 
 
 def _point_aoi_bbox(

--- a/src/pyramids/dataset/_stac.py
+++ b/src/pyramids/dataset/_stac.py
@@ -25,6 +25,7 @@ from datetime import timedelta, timezone
 from typing import TYPE_CHECKING, Any, Callable, cast
 
 from osgeo import osr
+from pyproj import Transformer
 
 from pyramids.base._artifacts import artifact_dir
 from pyramids.base._errors import StacAssetError
@@ -705,8 +706,6 @@ def _point_aoi_bbox(
     """
     if units not in ("px", "m"):
         raise ValueError(f"units must be 'px' or 'm', got {units!r}.")
-    from pyproj import Transformer
-
     epsg = _utm_epsg(lon, lat)
     to_utm = Transformer.from_crs(4326, epsg, always_xy=True)
     cx, cy = to_utm.transform(lon, lat)

--- a/src/pyramids/dataset/_stac.py
+++ b/src/pyramids/dataset/_stac.py
@@ -707,15 +707,15 @@ def _point_aoi_bbox(
         raise ValueError(f"units must be 'px' or 'm', got {units!r}.")
     from pyproj import Transformer
 
-    utm_epsg = _utm_epsg(lon, lat)
-    to_utm = Transformer.from_crs(4326, utm_epsg, always_xy=True)
+    epsg = _utm_epsg(lon, lat)
+    to_utm = Transformer.from_crs(4326, epsg, always_xy=True)
     cx, cy = to_utm.transform(lon, lat)
     cx = round(cx / resolution) * resolution
     cy = round(cy / resolution) * resolution
     half = (edge_size / 2.0) * resolution if units == "px" else edge_size / 2.0
     utm_bbox = (cx - half, cy - half, cx + half, cy + half)
 
-    to_wgs = Transformer.from_crs(utm_epsg, 4326, always_xy=True)
+    to_wgs = Transformer.from_crs(epsg, 4326, always_xy=True)
     minx, miny, maxx, maxy = utm_bbox
     corners = [(minx, miny), (maxx, miny), (maxx, maxy), (minx, maxy)]
     lons, lats = [], []
@@ -723,7 +723,7 @@ def _point_aoi_bbox(
         clon, clat = to_wgs.transform(x, y)
         lons.append(clon)
         lats.append(clat)
-    return utm_epsg, (min(lons), min(lats), max(lons), max(lats))
+    return epsg, (min(lons), min(lats), max(lons), max(lats))
 
 
 def from_point(

--- a/src/pyramids/utm.py
+++ b/src/pyramids/utm.py
@@ -1,0 +1,141 @@
+"""Public UTM zone / EPSG helpers for WGS84 points and vector layers.
+
+Computing the UTM zone or EPSG code for a location is a recurring need — per-tile
+reprojection, local-metre areas of interest, STAC point cubes. These helpers give
+the EPSG-correct zone: the plain 6°-wide longitude bands, with the hemisphere
+picking the `326xx` (north) or `327xx` (south) band.
+
+The Norway/Svalbard zone shifts (zone 32 extended west of 6°E; Svalbard's
+31/33/35/37 arc) are deliberately **not** applied. Those belong to the MGRS
+grid-zone lettering convention, not the UTM CRS definitions: EPSG:32631 (0°E–6°E)
+is the zone whose official area of use covers Bergen at 5°E, while EPSG:32632
+(6°E–12°E) does not. Applying the MGRS shift would assign a point to a CRS outside
+its area of use. `pyproj.database.query_utm_crs_info` agrees with the values here.
+"""
+
+from __future__ import annotations
+
+import math
+
+from geopandas import GeoDataFrame
+
+from pyramids.base._errors import CRSError
+
+_WGS84_EPSG = 4326
+_UTM_NORTH_BASE = 32600
+_UTM_SOUTH_BASE = 32700
+
+
+def utm_zone(lon: float) -> int:
+    """Return the UTM zone number (1-60) for a longitude.
+
+    The zone is a plain 6°-wide band: zone 1 starts at 180°W, and each zone spans
+    6° of longitude. The value depends only on `lon`; latitude selects the
+    hemisphere band in `utm_epsg`, not the zone number.
+
+    Args:
+        lon: Longitude in degrees. Values outside `[-180, 180]` are clamped to the
+            valid zone range `1..60`.
+
+    Returns:
+        int: The UTM zone number, `1..60`.
+
+    Examples:
+        - Greenwich sits at the zone 30/31 boundary and lands in zone 31:
+            ```python
+            >>> from pyramids.utm import utm_zone
+            >>> utm_zone(0.0)
+            31
+
+            ```
+        - Bergen (5°E) is zone 31 — the plain band, not the MGRS zone-32 shift:
+            ```python
+            >>> utm_zone(5.0)
+            31
+
+            ```
+    """
+    zone = int(math.floor((lon + 180.0) / 6.0) + 1)
+    zone = min(max(zone, 1), 60)
+    return zone
+
+
+def utm_epsg(lon: float, lat: float) -> int:
+    """Return the EPSG code of the UTM zone containing `(lon, lat)`.
+
+    Args:
+        lon: Longitude in degrees.
+        lat: Latitude in degrees. Only its sign is used, to pick the northern
+            (`326xx`) or southern (`327xx`) band.
+
+    Returns:
+        int: `326NN` (northern hemisphere) or `327NN` (southern) for UTM zone `NN`.
+
+    Examples:
+        - Bergen, Norway resolves to UTM 31N — matching `pyproj` and the EPSG area
+          of use, not the MGRS zone-32 convention:
+            ```python
+            >>> from pyramids.utm import utm_epsg
+            >>> utm_epsg(5.0, 60.0)
+            32631
+
+            ```
+        - A southern-hemisphere point uses the `327xx` band:
+            ```python
+            >>> utm_epsg(31.25, -25.0)
+            32736
+
+            ```
+    """
+    base = _UTM_NORTH_BASE if lat >= 0 else _UTM_SOUTH_BASE
+    return base + utm_zone(lon)
+
+
+def utm_epsg_for_polygon(gdf: GeoDataFrame) -> int:
+    """Return the UTM EPSG for a vector layer, from the centroid of its bounds.
+
+    The layer is reprojected to WGS84 (a no-op when it is already `EPSG:4326`), its
+    total bounds' centre is taken, and that lon/lat is passed to `utm_epsg`.
+
+    Args:
+        gdf: A `GeoDataFrame` with a defined CRS.
+
+    Returns:
+        int: The EPSG code of the UTM zone covering the layer's centre.
+
+    Raises:
+        CRSError: `gdf` has no CRS (so its coordinates cannot be placed on Earth).
+    """
+    if gdf.crs is None:
+        raise CRSError(
+            "gdf has no CRS; set one (gdf.set_crs / gdf.crs = ...) before computing "
+            "a UTM zone."
+        )
+    wgs84 = gdf.to_crs(_WGS84_EPSG)
+    minx, miny, maxx, maxy = wgs84.total_bounds
+    return utm_epsg((minx + maxx) / 2.0, (miny + maxy) / 2.0)
+
+
+def project_to_utm(gdf: GeoDataFrame) -> tuple[GeoDataFrame, int]:
+    """Reproject a vector layer to its local UTM zone.
+
+    Args:
+        gdf: A `GeoDataFrame` with a defined CRS.
+
+    Returns:
+        tuple[GeoDataFrame, int]: The layer reprojected to its UTM zone, and that
+        zone's EPSG code.
+
+    Raises:
+        CRSError: `gdf` has no CRS.
+    """
+    epsg = utm_epsg_for_polygon(gdf)
+    return gdf.to_crs(epsg), epsg
+
+
+__all__ = [
+    "utm_zone",
+    "utm_epsg",
+    "utm_epsg_for_polygon",
+    "project_to_utm",
+]

--- a/src/pyramids/utm.py
+++ b/src/pyramids/utm.py
@@ -55,7 +55,7 @@ def utm_zone(lon: float) -> int:
 
             ```
     """
-    zone = int(math.floor((lon + 180.0) / 6.0) + 1)
+    zone = math.floor((lon + 180.0) / 6.0) + 1
     zone = min(max(zone, 1), 60)
     return zone
 
@@ -92,19 +92,29 @@ def utm_epsg(lon: float, lat: float) -> int:
 
 
 def utm_epsg_for_polygon(gdf: GeoDataFrame) -> int:
-    """Return the UTM EPSG for a vector layer, from the centroid of its bounds.
+    """Return the UTM EPSG for a vector layer, from the centre of its bounds.
 
-    The layer is reprojected to WGS84 (a no-op when it is already `EPSG:4326`), its
-    total bounds' centre is taken, and that lon/lat is passed to `utm_epsg`.
+    The layer is reprojected to WGS84 (a no-op when it is already `EPSG:4326`), the
+    centre of its total bounds is taken, and that lon/lat is passed to `utm_epsg`.
+    Any geometry type is accepted (points, lines, polygons); the zone is chosen from
+    the bounds centre, not a true geometric centroid.
+
+    A single UTM zone only makes sense for a reasonably local extent, so a layer
+    whose bounds span more than 180° of longitude — a dateline-crossing layer, whose
+    total bounds spuriously spans `-180…180`, or a genuinely half-globe extent — is
+    rejected rather than silently assigned the wrong (mid-span) zone.
 
     Args:
-        gdf: A `GeoDataFrame` with a defined CRS.
+        gdf: A `GeoDataFrame` with a defined CRS and at least one finite-bounds
+            geometry.
 
     Returns:
-        int: The EPSG code of the UTM zone covering the layer's centre.
+        int: The EPSG code of the UTM zone covering the layer's bounds centre.
 
     Raises:
         CRSError: `gdf` has no CRS (so its coordinates cannot be placed on Earth).
+        ValueError: `gdf` is empty / has no finite bounds, or its bounds span more
+            than 180° of longitude (no single UTM zone applies).
     """
     if gdf.crs is None:
         raise CRSError(
@@ -113,6 +123,16 @@ def utm_epsg_for_polygon(gdf: GeoDataFrame) -> int:
         )
     wgs84 = gdf.to_crs(_WGS84_EPSG)
     minx, miny, maxx, maxy = wgs84.total_bounds
+    if not all(math.isfinite(v) for v in (minx, miny, maxx, maxy)):
+        raise ValueError(
+            "gdf has no finite bounds (it is empty or all its geometries are null); "
+            "cannot compute a UTM zone."
+        )
+    if maxx - minx > 180.0:
+        raise ValueError(
+            f"gdf bounds span {maxx - minx:.1f}° of longitude (a dateline crossing "
+            "or a half-globe extent); no single UTM zone applies."
+        )
     return utm_epsg((minx + maxx) / 2.0, (miny + maxy) / 2.0)
 
 
@@ -123,11 +143,13 @@ def project_to_utm(gdf: GeoDataFrame) -> tuple[GeoDataFrame, int]:
         gdf: A `GeoDataFrame` with a defined CRS.
 
     Returns:
-        tuple[GeoDataFrame, int]: The layer reprojected to its UTM zone, and that
-        zone's EPSG code.
+        tuple[GeoDataFrame, int]: The layer reprojected to its UTM zone (a fresh
+        `GeoDataFrame`; the input is not modified), and that zone's EPSG code.
 
     Raises:
         CRSError: `gdf` has no CRS.
+        ValueError: `gdf` is empty / has no finite bounds, or its bounds span more
+            than 180° of longitude (see :func:`utm_epsg_for_polygon`).
     """
     epsg = utm_epsg_for_polygon(gdf)
     return gdf.to_crs(epsg), epsg

--- a/src/pyramids/utm.py
+++ b/src/pyramids/utm.py
@@ -34,8 +34,9 @@ def utm_zone(lon: float) -> int:
     hemisphere band in `utm_epsg`, not the zone number.
 
     Args:
-        lon: Longitude in degrees. Values outside `[-180, 180]` are clamped to the
-            valid zone range `1..60`.
+        lon: Longitude in degrees. A longitude outside `[-180, 180]` — e.g. the
+            `0..360` convention common in climate/ocean grids — is wrapped into
+            `[-180, 180]` first, so `200` is treated as `-160`.
 
     Returns:
         int: The UTM zone number, `1..60`.
@@ -54,7 +55,15 @@ def utm_zone(lon: float) -> int:
             31
 
             ```
+        - A `0..360` longitude is wrapped, so 200°E resolves like 160°W:
+            ```python
+            >>> utm_zone(200.0)
+            4
+
+            ```
     """
+    if lon < -180.0 or lon > 180.0:
+        lon = ((lon + 180.0) % 360.0) - 180.0
     zone = math.floor((lon + 180.0) / 6.0) + 1
     zone = min(max(zone, 1), 60)
     return zone
@@ -64,9 +73,11 @@ def utm_epsg(lon: float, lat: float) -> int:
     """Return the EPSG code of the UTM zone containing `(lon, lat)`.
 
     Args:
-        lon: Longitude in degrees.
-        lat: Latitude in degrees. Only its sign is used, to pick the northern
-            (`326xx`) or southern (`327xx`) band.
+        lon: Longitude in degrees (wrapped into `[-180, 180]`; see `utm_zone`).
+        lat: Latitude in degrees. Only its sign is used (the equator is treated as
+            northern) to pick the northern (`326xx`) or southern (`327xx`) band. UTM
+            is defined for roughly `80°S..84°N`; a latitude outside that band still
+            returns a code, but the poles are properly the domain of UPS, not UTM.
 
     Returns:
         int: `326NN` (northern hemisphere) or `327NN` (southern) for UTM zone `NN`.
@@ -99,17 +110,20 @@ def utm_epsg_for_polygon(gdf: GeoDataFrame) -> int:
     Any geometry type is accepted (points, lines, polygons); the zone is chosen from
     the bounds centre, not a true geometric centroid.
 
-    A single UTM zone only makes sense for a reasonably local extent, so a layer
-    whose bounds span more than 180° of longitude — a dateline-crossing layer, whose
-    total bounds spuriously spans `-180…180`, or a genuinely half-globe extent — is
-    rejected rather than silently assigned the wrong (mid-span) zone.
+    The single zone returned is the one at the bounds centre; it is exact only for a
+    layer that fits within one 6°-wide zone, and is a best-effort choice for a wider
+    layer (which spans several zones). Only the clearly-nonsensical case is rejected:
+    bounds spanning more than 180° of longitude — a dateline-crossing layer (whose
+    total bounds spuriously spans `-180…180`), a near-polar extent (whose longitudes
+    fan out around the pole), or a genuinely half-globe span — where the mid-span
+    centre would name a zone covering none of the data.
 
     Args:
         gdf: A `GeoDataFrame` with a defined CRS and at least one finite-bounds
             geometry.
 
     Returns:
-        int: The EPSG code of the UTM zone covering the layer's bounds centre.
+        int: The EPSG code of the UTM zone at the layer's bounds centre.
 
     Raises:
         CRSError: `gdf` has no CRS (so its coordinates cannot be placed on Earth).
@@ -130,8 +144,8 @@ def utm_epsg_for_polygon(gdf: GeoDataFrame) -> int:
         )
     if maxx - minx > 180.0:
         raise ValueError(
-            f"gdf bounds span {maxx - minx:.1f}° of longitude (a dateline crossing "
-            "or a half-globe extent); no single UTM zone applies."
+            f"gdf bounds span {maxx - minx:.1f}° of longitude (a dateline crossing, "
+            "a near-polar extent, or a half-globe span); no single UTM zone applies."
         )
     return utm_epsg((minx + maxx) / 2.0, (miny + maxy) / 2.0)
 

--- a/tests/test_utm.py
+++ b/tests/test_utm.py
@@ -32,14 +32,19 @@ class TestUtmZone:
             (11.0, 32),
             (-76.2, 18),
             (-180.0, 1),  # first zone
-            (180.0, 60),  # clamped to the last zone
-            (200.0, 60),  # out-of-range clamps to 60
-            (-200.0, 1),  # out-of-range clamps to 1
+            (180.0, 60),  # last zone (in-range boundary)
+            (200.0, 4),  # 0..360 longitude wraps: 200E == 160W -> zone 4
+            (-200.0, 57),  # -200 wraps to 160E -> zone 57
         ],
     )
     def test_zone_number(self, lon, expected):
-        """Longitude maps to the plain 6-degree UTM band, clamped to 1..60."""
+        """Longitude maps to the plain 6-degree UTM band; out-of-range wraps first."""
         assert utm_zone(lon) == expected
+
+    def test_out_of_range_longitude_wraps(self):
+        """A 0..360 longitude resolves to the same zone as its [-180,180] equivalent."""
+        assert utm_zone(200.0) == utm_zone(-160.0)
+        assert utm_zone(360.0) == utm_zone(0.0)
 
 
 class TestUtmEpsg:
@@ -54,12 +59,12 @@ class TestUtmEpsg:
             (31.25, -25.0, 32736),  # southern hemisphere -> 327xx band
             (11.0, 46.0, 32632),  # Italian Alps
             (-58.0, -34.0, 32721),  # Buenos Aires
-            (200.0, 10.0, 32660),  # out-of-range lon clamps to zone 60N
-            (-200.0, -10.0, 32701),  # out-of-range lon clamps to zone 1S
+            (200.0, 10.0, 32604),  # 0..360 lon wraps: 200E == 160W -> zone 4N
+            (-200.0, -10.0, 32757),  # -200 wraps to 160E -> zone 57S
         ],
     )
     def test_epsg_code(self, lon, lat, expected):
-        """Each point resolves to its EPSG-correct UTM zone (lon clamped to 1..60)."""
+        """Each point resolves to its EPSG-correct UTM zone (lon wrapped to [-180,180])."""
         assert utm_epsg(lon, lat) == expected
 
     @pytest.mark.parametrize(

--- a/tests/test_utm.py
+++ b/tests/test_utm.py
@@ -1,0 +1,119 @@
+"""Tests for the public UTM helpers in `pyramids.utm`."""
+
+from __future__ import annotations
+
+import geopandas as gpd
+import pytest
+from pyproj.aoi import AreaOfInterest
+from pyproj.database import query_utm_crs_info
+from shapely.geometry import box
+
+from pyramids.base._errors import CRSError
+from pyramids.dataset._stac import _utm_epsg
+from pyramids.utm import project_to_utm, utm_epsg, utm_epsg_for_polygon, utm_zone
+
+
+def _pyproj_utm_epsg(lon: float, lat: float, d: float = 0.01) -> int:
+    """Reference UTM EPSG for a point via pyproj's own query, as an oracle."""
+    infos = query_utm_crs_info(
+        "WGS 84", AreaOfInterest(lon - d, lat - d, lon + d, lat + d)
+    )
+    return int(infos[0].code)
+
+
+class TestUtmZone:
+    """The lon-only UTM zone number."""
+
+    @pytest.mark.parametrize(
+        "lon, expected",
+        [
+            (0.0, 31),  # zone 31 spans 0-6E (western boundary inclusive)
+            (5.0, 31),  # Bergen longitude — plain band, not the MGRS zone-32 shift
+            (11.0, 32),
+            (-76.2, 18),
+            (-180.0, 1),  # first zone
+            (180.0, 60),  # clamped to the last zone
+            (200.0, 60),  # out-of-range clamps to 60
+            (-200.0, 1),  # out-of-range clamps to 1
+        ],
+    )
+    def test_zone_number(self, lon, expected):
+        """Longitude maps to the plain 6-degree UTM band, clamped to 1..60."""
+        assert utm_zone(lon) == expected
+
+
+class TestUtmEpsg:
+    """The EPSG code for a point, and agreement with pyproj / EPSG."""
+
+    @pytest.mark.parametrize(
+        "lon, lat, expected",
+        [
+            (5.0, 60.0, 32631),  # Bergen, Norway (EPSG-correct, not MGRS 32632)
+            (7.0, 78.0, 32632),  # Svalbard west (EPSG-correct, not MGRS 32631)
+            (31.25, 30.05, 32636),  # Cairo
+            (31.25, -25.0, 32736),  # southern hemisphere -> 327xx band
+            (11.0, 46.0, 32632),  # Italian Alps
+            (-58.0, -34.0, 32721),  # Buenos Aires
+        ],
+    )
+    def test_epsg_code(self, lon, lat, expected):
+        """Each point resolves to its EPSG-correct UTM zone."""
+        assert utm_epsg(lon, lat) == expected
+
+    @pytest.mark.parametrize(
+        "lon, lat",
+        [(5.0, 60.0), (7.0, 78.0), (31.25, 30.05), (31.25, -25.0), (11.0, 46.0)],
+    )
+    def test_agrees_with_pyproj(self, lon, lat):
+        """The helper matches pyproj's own UTM-CRS lookup for interior points."""
+        assert utm_epsg(lon, lat) == _pyproj_utm_epsg(lon, lat)
+
+    def test_no_norway_mgrs_exception(self):
+        """Bergen stays in zone 31 (its EPSG area of use), not the MGRS zone 32."""
+        assert utm_epsg(5.0, 60.0) == 32631
+        assert utm_epsg(5.0, 60.0) != 32632
+
+    def test_no_svalbard_mgrs_exception(self):
+        """Svalbard-west stays in zone 32, not the MGRS zone 31."""
+        assert utm_epsg(7.0, 78.0) == 32632
+        assert utm_epsg(7.0, 78.0) != 32631
+
+
+class TestStacDelegation:
+    """The private STAC helper delegates to the public one, unchanged."""
+
+    @pytest.mark.parametrize(
+        "lon, lat", [(5.0, 60.0), (11.0, 46.0), (-58.0, -34.0), (0.0, 0.0)]
+    )
+    def test_stac_utm_epsg_delegates(self, lon, lat):
+        """`_stac._utm_epsg` returns exactly `pyramids.utm.utm_epsg`."""
+        assert _utm_epsg(lon, lat) == utm_epsg(lon, lat)
+
+
+class TestPolygonHelpers:
+    """UTM selection and reprojection for vector layers."""
+
+    def test_epsg_for_polygon_4326(self):
+        """A 4326 layer around Bergen selects UTM 31N from its bounds centre."""
+        gdf = gpd.GeoDataFrame(geometry=[box(4.5, 59.5, 5.5, 60.5)], crs="EPSG:4326")
+        assert utm_epsg_for_polygon(gdf) == 32631
+
+    def test_epsg_for_polygon_reprojects_non_4326(self):
+        """A non-4326 layer is reprojected to 4326 before the centroid lookup."""
+        gdf = gpd.GeoDataFrame(
+            geometry=[box(4.5, 59.5, 5.5, 60.5)], crs="EPSG:4326"
+        ).to_crs(3857)
+        assert utm_epsg_for_polygon(gdf) == 32631
+
+    def test_epsg_for_polygon_without_crs_raises(self):
+        """A layer with no CRS raises CRSError rather than guessing."""
+        gdf = gpd.GeoDataFrame(geometry=[box(4.5, 59.5, 5.5, 60.5)])
+        with pytest.raises(CRSError, match="no CRS"):
+            utm_epsg_for_polygon(gdf)
+
+    def test_project_to_utm_returns_reprojected_and_epsg(self):
+        """`project_to_utm` returns the layer in its UTM zone and that EPSG."""
+        gdf = gpd.GeoDataFrame(geometry=[box(4.5, 59.5, 5.5, 60.5)], crs="EPSG:4326")
+        projected, epsg = project_to_utm(gdf)
+        assert epsg == 32631
+        assert projected.crs.to_epsg() == 32631

--- a/tests/test_utm.py
+++ b/tests/test_utm.py
@@ -54,10 +54,12 @@ class TestUtmEpsg:
             (31.25, -25.0, 32736),  # southern hemisphere -> 327xx band
             (11.0, 46.0, 32632),  # Italian Alps
             (-58.0, -34.0, 32721),  # Buenos Aires
+            (200.0, 10.0, 32660),  # out-of-range lon clamps to zone 60N
+            (-200.0, -10.0, 32701),  # out-of-range lon clamps to zone 1S
         ],
     )
     def test_epsg_code(self, lon, lat, expected):
-        """Each point resolves to its EPSG-correct UTM zone."""
+        """Each point resolves to its EPSG-correct UTM zone (lon clamped to 1..60)."""
         assert utm_epsg(lon, lat) == expected
 
     @pytest.mark.parametrize(
@@ -111,9 +113,30 @@ class TestPolygonHelpers:
         with pytest.raises(CRSError, match="no CRS"):
             utm_epsg_for_polygon(gdf)
 
+    def test_epsg_for_polygon_empty_raises(self):
+        """An empty (finite-bounds-less) layer raises a clear ValueError, not NaN."""
+        gdf = gpd.GeoDataFrame(geometry=[], crs="EPSG:4326")
+        with pytest.raises(ValueError, match="no finite bounds"):
+            utm_epsg_for_polygon(gdf)
+
+    def test_epsg_for_polygon_antimeridian_raises(self):
+        """A layer whose bounds span >180° of longitude is rejected, not mis-zoned."""
+        gdf = gpd.GeoDataFrame(
+            geometry=[box(179.0, 0.0, 179.9, 1.0), box(-179.9, 0.0, -179.0, 1.0)],
+            crs="EPSG:4326",
+        )
+        with pytest.raises(ValueError, match="no single UTM zone"):
+            utm_epsg_for_polygon(gdf)
+
     def test_project_to_utm_returns_reprojected_and_epsg(self):
         """`project_to_utm` returns the layer in its UTM zone and that EPSG."""
         gdf = gpd.GeoDataFrame(geometry=[box(4.5, 59.5, 5.5, 60.5)], crs="EPSG:4326")
         projected, epsg = project_to_utm(gdf)
         assert epsg == 32631
         assert projected.crs.to_epsg() == 32631
+
+    def test_project_to_utm_does_not_mutate_input(self):
+        """`project_to_utm` leaves the input layer's CRS untouched."""
+        gdf = gpd.GeoDataFrame(geometry=[box(4.5, 59.5, 5.5, 60.5)], crs="EPSG:4326")
+        project_to_utm(gdf)
+        assert gdf.crs.to_epsg() == 4326


### PR DESCRIPTION
# Description

Adds a public `pyramids.utm` module for resolving the UTM zone / EPSG of a WGS84 point or vector layer —
`utm_zone(lon)`, `utm_epsg(lon, lat)`, `utm_epsg_for_polygon(gdf)`, `project_to_utm(gdf)` — and points the
pre-existing private `_stac.py::_utm_epsg` at it (previously the only UTM logic was that private, STAC-internal
function). No new dependencies (geopandas/pyproj are already core).

Issue #726 was originally filed as a bug ("wrong zone near Norway/Svalbard") and then retracted: the private
helper is already **EPSG-correct**. This PR implements the corrected scope — expose the helper publicly, keep the
EPSG-correct behaviour, and deliberately **omit** the Norway/Svalbard zone shifts. Those are the MGRS grid-zone
lettering convention, not the UTM CRS definitions: EPSG:32631 (0°E–6°E) is the zone whose area of use covers
Bergen at 5°E, while EPSG:32632 (6°E–12°E) does not — applying the shift would assign a point to a CRS outside
its area of use. The returned values agree with `pyproj.database.query_utm_crs_info`, which the tests cross-check
against.

Robustness of the new public surface:

- A longitude outside `[-180, 180]` — the `0..360` convention common in climate/ocean grids, which pyramids reads
  from NetCDF — is wrapped into range rather than clamped to a wrong zone, so `200°E` resolves like `160°W`.
- `utm_epsg_for_polygon` picks the zone at the bounds centre and rejects a `>180°` longitude span (a dateline
  crossing, near-polar, or half-globe extent) instead of silently returning a meaningless mid-span zone; an empty
  layer raises a clear error rather than a cryptic `NaN`.
- `project_to_utm` returns a fresh reprojected layer without mutating its input.

The `_stac._utm_epsg` delegation is behaviour-preserving — STAC point cubes only ever pass in-range lon/lat, for
which the new helper returns identical values (verified across a dense sweep).

# Issues

- Closes #726 — expose a public, EPSG-correct UTM zone/EPSG helper.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- New `tests/test_utm.py`: zone/EPSG values, agreement with `pyproj.database.query_utm_crs_info`, explicit
  no-Norway / no-Svalbard MGRS assertions, the STAC-delegation equivalence, longitude wrapping, and the polygon
  helpers (4326 + reprojected input, no-CRS → `CRSError`, empty/`>180°` → `ValueError`, no-mutation).
- `pixi run -e dev pytest -m "not plot" -q` → **6598 passed, 51 skipped, 320 deselected**.
- `pyramids/utm.py`: **100 %** line + branch coverage.
- `pixi run -e dev mypy -m pyramids.utm` → 0 errors; `pixi run -e dev mypy -p pyramids.dataset` → 0 errors (the
  delegation site keeps the dataset subpackage's mypy gate clean); doctests green.
- Two full independent review rounds; every finding fixed (or documented as a deliberate design choice). The
  helper's EPSG-correctness was independently re-verified against pyproj and the EPSG area-of-use polygons in
  both rounds.

- [x] Full non-plot test suite (`pytest -m "not plot"`)
- [x] `mypy -m pyramids.utm` and `mypy -p pyramids.dataset` strict pass
- [x] Doctests for `pyramids.utm`

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen bumps this automatically on release)
- [ ] added changes to History.rst. (commitizen-generated; not hand-edited)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (new `docs/reference/utm.md` + mkdocs nav entry)
