### PR TITLE
feat(bbox): add estimate_pixel_dims and read_bbox_dict helpers

### DIFF
--- a/src/pyramids/feature/bbox.py
+++ b/src/pyramids/feature/bbox.py
@@ -260,7 +260,8 @@ def estimate_pixel_dims(bbox: Bbox, scale_m: float) -> tuple[int, int]:
         A `(width_px, height_px)` tuple; each dimension is at least 1.
 
     Raises:
-        ValueError: If `scale_m <= 0`, or if `north < south` (an inverted latitude range).
+        ValueError: If `scale_m` is not positive (zero, negative, or NaN), or if `north < south` (an inverted
+            latitude range).
 
     Examples:
         - A ~1 km grid over Europe:

--- a/src/pyramids/feature/bbox.py
+++ b/src/pyramids/feature/bbox.py
@@ -34,7 +34,10 @@ Bbox = tuple[float, float, float, float]
 _CONVENTIONS = ("-180..180", "0..360")
 
 METRES_PER_DEGREE = 111_319.49
-"""Equatorial metres per degree of arc on WGS84 — the basis of the equatorial pixel-dimension upper bound."""
+"""Equatorial length of a degree of longitude on WGS84 — the E-W (width) pixel-dimension upper-bound basis."""
+
+MAX_METRES_PER_LAT_DEGREE = 111_694.0
+"""Maximum (polar) length of a degree of latitude on WGS84 — the N-S (height) pixel-dimension upper-bound basis."""
 
 _BBOX_KEY_ALIASES: dict[str, tuple[str, ...]] = {
     "west": ("min_lon", "lonmin", "minlon", "minx", "west"),
@@ -233,11 +236,12 @@ def to_shapely(bbox: Bbox) -> Polygon:
 def estimate_pixel_dims(bbox: Bbox, scale_m: float) -> tuple[int, int]:
     """Estimate the `(width, height)` in pixels of a WGS84 bbox at a target ground resolution.
 
-    This is a deliberate **equatorial** approximation: it converts the bbox's degree span to pixels using the
-    equatorial metres-per-degree (`METRES_PER_DEGREE`) with no latitude convergence. Because a degree of longitude
-    is widest at the equator, the result is an **upper bound** on the true pixel count — which is exactly what a
-    "will this export exceed the provider's pixel cap?" pre-check wants. For a latitude-accurate count, reproject
-    to a metric CRS first (see :func:`transform`).
+    This is a deliberate worst-case approximation with no latitude convergence: the width uses the equatorial
+    degree of longitude (`METRES_PER_DEGREE`, which is widest at the equator) and the height uses the maximum,
+    polar degree of latitude (`MAX_METRES_PER_LAT_DEGREE`), so **both dimensions are a true upper bound** on the
+    pixel count — never an under-estimate, which is exactly what a "will this export exceed the provider's pixel
+    cap?" pre-check wants. The bound is loose away from those latitudes (there is no `cos(latitude)` narrowing);
+    for a tight, latitude-accurate count, reproject to a metric CRS first (see :func:`transform`).
 
     A bbox with `west > east` is treated as an antimeridian crossing (this module's convention) and its longitude
     span is measured the short way across the 180 deg meridian.
@@ -257,19 +261,19 @@ def estimate_pixel_dims(bbox: Bbox, scale_m: float) -> tuple[int, int]:
         - A ~1 km grid over Europe:
             ```python
             >>> estimate_pixel_dims((-10.0, 35.0, 30.0, 60.0), 1000.0)
-            (4453, 2783)
+            (4453, 2793)
 
             ```
         - A 1 deg square at 100 m:
             ```python
             >>> estimate_pixel_dims((0.0, 0.0, 1.0, 1.0), 100.0)
-            (1114, 1114)
+            (1114, 1117)
 
             ```
         - An antimeridian-crossing bbox (`west > east`) spans the short way across 180 deg:
             ```python
             >>> estimate_pixel_dims((175.0, -22.0, -175.0, -12.0), 1000.0)
-            (1114, 1114)
+            (1114, 1117)
 
             ```
         - A non-positive resolution is rejected:
@@ -291,9 +295,8 @@ def estimate_pixel_dims(bbox: Bbox, scale_m: float) -> tuple[int, int]:
     if north < south:
         raise ValueError(f"estimate_pixel_dims: north ({north}) must be >= south ({south})")
     lon_span = east - west if east >= west else east - west + 360.0
-    deg_per_px = scale_m / METRES_PER_DEGREE
-    width = max(math.ceil(lon_span / deg_per_px), 1)
-    height = max(math.ceil((north - south) / deg_per_px), 1)
+    width = max(math.ceil(lon_span * METRES_PER_DEGREE / scale_m), 1)
+    height = max(math.ceil((north - south) * MAX_METRES_PER_LAT_DEGREE / scale_m), 1)
     return width, height
 
 

--- a/src/pyramids/feature/bbox.py
+++ b/src/pyramids/feature/bbox.py
@@ -298,7 +298,7 @@ def estimate_pixel_dims(bbox: Bbox, scale_m: float) -> tuple[int, int]:
     west, south, east, north = bbox
     if not all(math.isfinite(v) for v in (west, south, east, north)):
         raise ValueError(f"estimate_pixel_dims: bbox coordinates must be finite, got {bbox!r}")
-    if not scale_m > 0:  # also rejects NaN (all NaN comparisons are False)
+    if scale_m <= 0 or math.isnan(scale_m):  # isnan needed since NaN <= 0 is False
         raise ValueError(f"estimate_pixel_dims: scale_m must be positive, got {scale_m}")
     if north < south:
         raise ValueError(f"estimate_pixel_dims: north ({north}) must be >= south ({south})")

--- a/src/pyramids/feature/bbox.py
+++ b/src/pyramids/feature/bbox.py
@@ -21,6 +21,8 @@ including interior rings; it does not attempt pole-enclosing geometries.
 
 from __future__ import annotations
 
+import math
+
 from pyproj import CRS, Transformer
 from shapely.affinity import translate
 from shapely.geometry import MultiPolygon, Polygon, box
@@ -30,6 +32,17 @@ Bbox = tuple[float, float, float, float]
 """A `(west, south, east, north)` bounding box in degrees."""
 
 _CONVENTIONS = ("-180..180", "0..360")
+
+METRES_PER_DEGREE = 111_319.49
+"""Equatorial metres per degree of arc on WGS84 — the basis of the equatorial pixel-dimension upper bound."""
+
+_BBOX_KEY_ALIASES: dict[str, tuple[str, ...]] = {
+    "west": ("min_lon", "lonmin", "minlon", "minx", "west"),
+    "south": ("min_lat", "latmin", "minlat", "miny", "south"),
+    "east": ("max_lon", "lonmax", "maxlon", "maxx", "east"),
+    "north": ("max_lat", "latmax", "maxlat", "maxy", "north"),
+}
+"""Accepted key spellings per bbox edge (GeoJSON, eodag, shapely/geopandas, compass), matched case-insensitively."""
 
 
 def split_antimeridian(bbox: Bbox) -> list[Bbox]:
@@ -215,6 +228,127 @@ def to_shapely(bbox: Bbox) -> Polygon:
     """
     west, south, east, north = bbox
     return box(west, south, east, north)
+
+
+def estimate_pixel_dims(west: float, south: float, east: float, north: float, scale_m: float) -> tuple[int, int]:
+    """Estimate the `(width, height)` in pixels of a WGS84 bbox at a target ground resolution.
+
+    This is a deliberate **equatorial** approximation: it converts the bbox's degree span to pixels using the
+    equatorial metres-per-degree (`METRES_PER_DEGREE`) with no latitude convergence. Because a degree of longitude
+    is widest at the equator, the result is an **upper bound** on the true pixel count — which is exactly what a
+    "will this export exceed the provider's pixel cap?" pre-check wants. For a latitude-accurate count, reproject
+    to a metric CRS first (see :func:`transform`).
+
+    A bbox with `west > east` is treated as an antimeridian crossing (this module's convention) and its longitude
+    span is measured the short way across the 180 deg meridian.
+
+    Args:
+        west: Western longitude in degrees.
+        south: Southern latitude in degrees.
+        east: Eastern longitude in degrees (may be `< west` for an antimeridian-crossing bbox).
+        north: Northern latitude in degrees.
+        scale_m: Target ground resolution in metres per pixel; must be positive.
+
+    Returns:
+        A `(width_px, height_px)` tuple; each dimension is at least 1.
+
+    Raises:
+        ValueError: If `scale_m <= 0`, or if `north < south` (an inverted latitude range).
+
+    Examples:
+        - A ~1 km grid over Europe:
+            ```python
+            >>> estimate_pixel_dims(-10.0, 35.0, 30.0, 60.0, 1000.0)
+            (4453, 2783)
+
+            ```
+        - A 1 deg square at 100 m:
+            ```python
+            >>> estimate_pixel_dims(0.0, 0.0, 1.0, 1.0, 100.0)
+            (1114, 1114)
+
+            ```
+        - An antimeridian-crossing bbox (`west > east`) spans the short way across 180 deg:
+            ```python
+            >>> estimate_pixel_dims(175.0, -22.0, -175.0, -12.0, 1000.0)
+            (1114, 1114)
+
+            ```
+        - A non-positive resolution is rejected:
+            ```python
+            >>> estimate_pixel_dims(0.0, 0.0, 1.0, 1.0, 0.0)
+            Traceback (most recent call last):
+                ...
+            ValueError: estimate_pixel_dims: scale_m must be positive, got 0.0
+
+            ```
+
+    See Also:
+        transform: Reproject a bbox to a metric CRS for latitude-accurate dimensions.
+    """
+    if scale_m <= 0:
+        raise ValueError(f"estimate_pixel_dims: scale_m must be positive, got {scale_m}")
+    if north < south:
+        raise ValueError(f"estimate_pixel_dims: north ({north}) must be >= south ({south})")
+    lon_span = east - west if east >= west else east - west + 360.0
+    deg_per_px = scale_m / METRES_PER_DEGREE
+    width = max(math.ceil(lon_span / deg_per_px), 1)
+    height = max(math.ceil((north - south) / deg_per_px), 1)
+    return width, height
+
+
+def read_bbox_dict(bbox: dict) -> Bbox:
+    """Read a `(west, south, east, north)` bbox from a mapping, accepting many key spellings.
+
+    Each edge is resolved to the first present alias from `_BBOX_KEY_ALIASES` (GeoJSON `min_lon`, eodag `lonmin`,
+    shapely/geopandas `minx`, compass `west`, ...). Keys are matched case-insensitively and values are coerced to
+    `float`. Reading a bbox from an ordered list/tuple is out of scope — those already carry a clear edge order.
+
+    Args:
+        bbox: A mapping holding the four bbox edges under any accepted alias spelling.
+
+    Returns:
+        A `(west, south, east, north)` tuple of floats.
+
+    Raises:
+        ValueError: If no key is present for one of the four edges.
+
+    Examples:
+        - eodag-style keys:
+            ```python
+            >>> read_bbox_dict({"lonmin": -10.0, "latmin": 35.0, "lonmax": 30.0, "latmax": 60.0})
+            (-10.0, 35.0, 30.0, 60.0)
+
+            ```
+        - shapely / geopandas keys:
+            ```python
+            >>> read_bbox_dict({"minx": -10.0, "miny": 35.0, "maxx": 30.0, "maxy": 60.0})
+            (-10.0, 35.0, 30.0, 60.0)
+
+            ```
+        - compass keys (case-insensitive):
+            ```python
+            >>> read_bbox_dict({"West": -10.0, "South": 35.0, "East": 30.0, "North": 60.0})
+            (-10.0, 35.0, 30.0, 60.0)
+
+            ```
+        - a missing edge is reported:
+            ```python
+            >>> read_bbox_dict({"minx": -10.0, "miny": 35.0, "maxx": 30.0})
+            Traceback (most recent call last):
+                ...
+            ValueError: read_bbox_dict: no key found for the 'north' edge
+
+            ```
+    """
+    lowered = {str(key).lower(): value for key, value in bbox.items()}
+    edges: dict[str, float] = {}
+    for edge, aliases in _BBOX_KEY_ALIASES.items():
+        match = next((lowered[alias] for alias in aliases if alias in lowered), None)
+        if match is None:
+            raise ValueError(f"read_bbox_dict: no key found for the {edge!r} edge")
+        edges[edge] = float(match)
+    return edges["west"], edges["south"], edges["east"], edges["north"]
 
 
 def _ring_crosses_antimeridian(coords: list[tuple[float, float]]) -> bool:

--- a/src/pyramids/feature/bbox.py
+++ b/src/pyramids/feature/bbox.py
@@ -230,7 +230,7 @@ def to_shapely(bbox: Bbox) -> Polygon:
     return box(west, south, east, north)
 
 
-def estimate_pixel_dims(west: float, south: float, east: float, north: float, scale_m: float) -> tuple[int, int]:
+def estimate_pixel_dims(bbox: Bbox, scale_m: float) -> tuple[int, int]:
     """Estimate the `(width, height)` in pixels of a WGS84 bbox at a target ground resolution.
 
     This is a deliberate **equatorial** approximation: it converts the bbox's degree span to pixels using the
@@ -243,10 +243,8 @@ def estimate_pixel_dims(west: float, south: float, east: float, north: float, sc
     span is measured the short way across the 180 deg meridian.
 
     Args:
-        west: Western longitude in degrees.
-        south: Southern latitude in degrees.
-        east: Eastern longitude in degrees (may be `< west` for an antimeridian-crossing bbox).
-        north: Northern latitude in degrees.
+        bbox: A `(west, south, east, north)` bounding box in degrees; `east < west` denotes an
+            antimeridian-crossing bbox.
         scale_m: Target ground resolution in metres per pixel; must be positive.
 
     Returns:
@@ -258,25 +256,25 @@ def estimate_pixel_dims(west: float, south: float, east: float, north: float, sc
     Examples:
         - A ~1 km grid over Europe:
             ```python
-            >>> estimate_pixel_dims(-10.0, 35.0, 30.0, 60.0, 1000.0)
+            >>> estimate_pixel_dims((-10.0, 35.0, 30.0, 60.0), 1000.0)
             (4453, 2783)
 
             ```
         - A 1 deg square at 100 m:
             ```python
-            >>> estimate_pixel_dims(0.0, 0.0, 1.0, 1.0, 100.0)
+            >>> estimate_pixel_dims((0.0, 0.0, 1.0, 1.0), 100.0)
             (1114, 1114)
 
             ```
         - An antimeridian-crossing bbox (`west > east`) spans the short way across 180 deg:
             ```python
-            >>> estimate_pixel_dims(175.0, -22.0, -175.0, -12.0, 1000.0)
+            >>> estimate_pixel_dims((175.0, -22.0, -175.0, -12.0), 1000.0)
             (1114, 1114)
 
             ```
         - A non-positive resolution is rejected:
             ```python
-            >>> estimate_pixel_dims(0.0, 0.0, 1.0, 1.0, 0.0)
+            >>> estimate_pixel_dims((0.0, 0.0, 1.0, 1.0), 0.0)
             Traceback (most recent call last):
                 ...
             ValueError: estimate_pixel_dims: scale_m must be positive, got 0.0
@@ -285,7 +283,9 @@ def estimate_pixel_dims(west: float, south: float, east: float, north: float, sc
 
     See Also:
         transform: Reproject a bbox to a metric CRS for latitude-accurate dimensions.
+        read_bbox_dict: Build a `(west, south, east, north)` tuple from a dict of edge keys to pass here.
     """
+    west, south, east, north = bbox
     if scale_m <= 0:
         raise ValueError(f"estimate_pixel_dims: scale_m must be positive, got {scale_m}")
     if north < south:

--- a/src/pyramids/feature/bbox.py
+++ b/src/pyramids/feature/bbox.py
@@ -260,8 +260,8 @@ def estimate_pixel_dims(bbox: Bbox, scale_m: float) -> tuple[int, int]:
         A `(width_px, height_px)` tuple; each dimension is at least 1.
 
     Raises:
-        ValueError: If `scale_m` is not positive (zero, negative, or NaN), or if `north < south` (an inverted
-            latitude range).
+        ValueError: If any bbox coordinate is non-finite, if `scale_m` is not positive (zero, negative, or NaN),
+            or if `north < south` (an inverted latitude range).
 
     Examples:
         - A ~1 km grid over Europe:
@@ -296,6 +296,8 @@ def estimate_pixel_dims(bbox: Bbox, scale_m: float) -> tuple[int, int]:
         read_bbox_dict: Build a `(west, south, east, north)` tuple from a dict of edge keys to pass here.
     """
     west, south, east, north = bbox
+    if not all(math.isfinite(v) for v in (west, south, east, north)):
+        raise ValueError(f"estimate_pixel_dims: bbox coordinates must be finite, got {bbox!r}")
     if not scale_m > 0:  # also rejects NaN (all NaN comparisons are False)
         raise ValueError(f"estimate_pixel_dims: scale_m must be positive, got {scale_m}")
     if north < south:

--- a/src/pyramids/feature/bbox.py
+++ b/src/pyramids/feature/bbox.py
@@ -295,7 +295,7 @@ def estimate_pixel_dims(bbox: Bbox, scale_m: float) -> tuple[int, int]:
         read_bbox_dict: Build a `(west, south, east, north)` tuple from a dict of edge keys to pass here.
     """
     west, south, east, north = bbox
-    if scale_m <= 0:
+    if not scale_m > 0:  # also rejects NaN (all NaN comparisons are False)
         raise ValueError(f"estimate_pixel_dims: scale_m must be positive, got {scale_m}")
     if north < south:
         raise ValueError(f"estimate_pixel_dims: north ({north}) must be >= south ({south})")

--- a/src/pyramids/feature/bbox.py
+++ b/src/pyramids/feature/bbox.py
@@ -314,7 +314,7 @@ def read_bbox_dict(bbox: dict) -> Bbox:
         A `(west, south, east, north)` tuple of floats.
 
     Raises:
-        ValueError: If no key is present for one of the four edges.
+        ValueError: If no key is present for one of the four edges, or an edge's value is not numeric.
 
     Examples:
         - eodag-style keys:
@@ -347,10 +347,13 @@ def read_bbox_dict(bbox: dict) -> Bbox:
     lowered = {str(key).lower(): value for key, value in bbox.items()}
     edges: dict[str, float] = {}
     for edge, aliases in _BBOX_KEY_ALIASES.items():
-        match = next((lowered[alias] for alias in aliases if alias in lowered), None)
-        if match is None:
+        key = next((alias for alias in aliases if alias in lowered), None)
+        if key is None:
             raise ValueError(f"read_bbox_dict: no key found for the {edge!r} edge")
-        edges[edge] = float(match)
+        try:
+            edges[edge] = float(lowered[key])
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"read_bbox_dict: the {edge!r} edge value {lowered[key]!r} is not numeric") from exc
     return edges["west"], edges["south"], edges["east"], edges["north"]
 
 

--- a/src/pyramids/feature/bbox.py
+++ b/src/pyramids/feature/bbox.py
@@ -34,11 +34,14 @@ Bbox = tuple[float, float, float, float]
 
 _CONVENTIONS = ("-180..180", "0..360")
 
-METRES_PER_DEGREE = 111_319.49
-"""Equatorial length of a degree of longitude on WGS84 — the E-W (width) pixel-dimension upper-bound basis."""
+METRES_PER_DEGREE = 111_319.4909
+"""Equatorial length of a degree of longitude on WGS84, rounded up — the E-W (width) upper-bound basis.
+
+Rounded up from the exact `a * pi / 180 = 111_319.49079` so the width stays a strict upper bound (never an
+under-estimate) for equator-touching bboxes."""
 
 MAX_METRES_PER_LAT_DEGREE = 111_694.0
-"""Maximum (polar) length of a degree of latitude on WGS84 — the N-S (height) pixel-dimension upper-bound basis."""
+"""Maximum (polar) length of a degree of latitude on WGS84, rounded up — the N-S (height) upper-bound basis."""
 
 _BBOX_KEY_ALIASES: dict[str, tuple[str, ...]] = {
     "west": ("min_lon", "lonmin", "minlon", "minx", "west"),

--- a/src/pyramids/feature/bbox.py
+++ b/src/pyramids/feature/bbox.py
@@ -22,6 +22,7 @@ including interior rings; it does not attempt pole-enclosing geometries.
 from __future__ import annotations
 
 import math
+from collections.abc import Mapping
 
 from pyproj import CRS, Transformer
 from shapely.affinity import translate
@@ -244,7 +245,8 @@ def estimate_pixel_dims(bbox: Bbox, scale_m: float) -> tuple[int, int]:
     for a tight, latitude-accurate count, reproject to a metric CRS first (see :func:`transform`).
 
     A bbox with `west > east` is treated as an antimeridian crossing (this module's convention) and its longitude
-    span is measured the short way across the 180 deg meridian.
+    span is measured the wrapping way across the 180 deg meridian (`east - west + 360`), consistent with
+    :func:`split_antimeridian`.
 
     Args:
         bbox: A `(west, south, east, north)` bounding box in degrees; `east < west` denotes an
@@ -270,7 +272,7 @@ def estimate_pixel_dims(bbox: Bbox, scale_m: float) -> tuple[int, int]:
             (1114, 1117)
 
             ```
-        - An antimeridian-crossing bbox (`west > east`) spans the short way across 180 deg:
+        - An antimeridian-crossing bbox (`west > east`) wraps across 180 deg:
             ```python
             >>> estimate_pixel_dims((175.0, -22.0, -175.0, -12.0), 1000.0)
             (1114, 1117)
@@ -300,7 +302,7 @@ def estimate_pixel_dims(bbox: Bbox, scale_m: float) -> tuple[int, int]:
     return width, height
 
 
-def read_bbox_dict(bbox: dict) -> Bbox:
+def read_bbox_dict(bbox: Mapping[str, float]) -> Bbox:
     """Read a `(west, south, east, north)` bbox from a mapping, accepting many key spellings.
 
     Each edge is resolved to the first present alias from `_BBOX_KEY_ALIASES` (GeoJSON `min_lon`, eodag `lonmin`,

--- a/tests/feature/test_bbox.py
+++ b/tests/feature/test_bbox.py
@@ -506,3 +506,21 @@ class TestReadBboxDict:
         """
         with pytest.raises(ValueError, match="'north' edge"):
             read_bbox_dict({"minx": -10.0, "miny": 35.0, "maxx": 30.0})
+
+    def test_present_none_value_reports_non_numeric_not_missing(self):
+        """A present-but-None edge value is reported as non-numeric, not as a missing key (review L1).
+
+        Test scenario:
+            minx=None names the 'west' edge value as non-numeric rather than raising 'no key found'.
+        """
+        with pytest.raises(ValueError, match="'west' edge value None is not numeric"):
+            read_bbox_dict({"minx": None, "miny": 35.0, "maxx": 30.0, "maxy": 60.0})
+
+    def test_non_numeric_value_raises_naming_edge(self):
+        """A non-coercible edge value raises a ValueError naming the offending edge (review L2).
+
+        Test scenario:
+            A string south value reports the 'south' edge value as non-numeric.
+        """
+        with pytest.raises(ValueError, match="'south' edge value 'abc' is not numeric"):
+            read_bbox_dict({"minx": -10.0, "miny": "abc", "maxx": 30.0, "maxy": 60.0})

--- a/tests/feature/test_bbox.py
+++ b/tests/feature/test_bbox.py
@@ -9,7 +9,9 @@ from pyramids.feature.bbox import (
     _crosses_antimeridian,
     _ring_crosses_antimeridian,
     _unwrap_polygon,
+    estimate_pixel_dims,
     normalise_longitude,
+    read_bbox_dict,
     split_antimeridian,
     split_polygon_antimeridian,
     to_shapely,
@@ -382,3 +384,104 @@ class TestSplitPolygonAntimeridian:
         """
         with pytest.raises(TypeError, match="expects a Polygon or MultiPolygon"):
             split_polygon_antimeridian("not a polygon")
+
+
+class TestEstimatePixelDims:
+    """Tests for estimate_pixel_dims."""
+
+    @pytest.mark.parametrize(
+        "west, south, east, north, scale_m, expected",
+        [
+            (-10.0, 35.0, 30.0, 60.0, 1000.0, (4453, 2783)),
+            (0.0, 0.0, 1.0, 1.0, 100.0, (1114, 1114)),
+            (175.0, -22.0, -175.0, -12.0, 1000.0, (1114, 1114)),
+        ],
+    )
+    def test_known_dimensions(self, west, south, east, north, scale_m, expected):
+        """Estimate matches the documented equatorial upper-bound values, including an antimeridian bbox.
+
+        Args:
+            west: Western longitude in degrees.
+            south: Southern latitude in degrees.
+            east: Eastern longitude in degrees.
+            north: Northern latitude in degrees.
+            scale_m: Ground resolution in metres per pixel.
+            expected: Expected (width_px, height_px).
+
+        Test scenario:
+            The Europe/1 km and 1 deg/100 m cases from the issue, plus a west>east antimeridian span.
+        """
+        result = estimate_pixel_dims(west, south, east, north, scale_m)
+        assert result == expected, f"Expected {expected}, got {result}"
+
+    def test_minimum_one_pixel(self):
+        """A degenerate (zero-area) bbox still returns at least one pixel per dimension.
+
+        Test scenario:
+            A point bbox at a coarse resolution floors to (1, 1) rather than (0, 0).
+        """
+        result = estimate_pixel_dims(0.0, 0.0, 0.0, 0.0, 1000.0)
+        assert result == (1, 1), f"Expected (1, 1), got {result}"
+
+    def test_non_positive_scale_raises(self):
+        """A non-positive resolution raises ValueError.
+
+        Test scenario:
+            scale_m == 0 is rejected with a message naming scale_m.
+        """
+        with pytest.raises(ValueError, match="scale_m must be positive"):
+            estimate_pixel_dims(0.0, 0.0, 1.0, 1.0, 0.0)
+
+    def test_inverted_latitude_raises(self):
+        """An inverted latitude range (north < south) raises ValueError.
+
+        Test scenario:
+            north < south is a genuine error (unlike west > east, which is a valid antimeridian crossing).
+        """
+        with pytest.raises(ValueError, match="north .* must be >= south"):
+            estimate_pixel_dims(0.0, 60.0, 1.0, 35.0, 1000.0)
+
+
+class TestReadBboxDict:
+    """Tests for read_bbox_dict."""
+
+    @pytest.mark.parametrize(
+        "bbox",
+        [
+            {"min_lon": -10.0, "min_lat": 35.0, "max_lon": 30.0, "max_lat": 60.0},
+            {"lonmin": -10.0, "latmin": 35.0, "lonmax": 30.0, "latmax": 60.0},
+            {"minx": -10.0, "miny": 35.0, "maxx": 30.0, "maxy": 60.0},
+            {"west": -10.0, "south": 35.0, "east": 30.0, "north": 60.0},
+            {"West": -10.0, "South": 35.0, "East": 30.0, "North": 60.0},
+        ],
+    )
+    def test_alias_spellings(self, bbox):
+        """Every accepted key spelling resolves to the same (west, south, east, north) tuple.
+
+        Args:
+            bbox: A bbox mapping using one of the supported alias conventions.
+
+        Test scenario:
+            GeoJSON, eodag, shapely/geopandas, and (case-insensitive) compass keys all parse identically.
+        """
+        result = read_bbox_dict(bbox)
+        assert result == (-10.0, 35.0, 30.0, 60.0), f"Unexpected bbox: {result}"
+
+    def test_values_coerced_to_float(self):
+        """Integer inputs are coerced to float.
+
+        Test scenario:
+            An int-valued dict yields a tuple of floats.
+        """
+        result = read_bbox_dict({"minx": -10, "miny": 35, "maxx": 30, "maxy": 60})
+        assert result == (-10.0, 35.0, 30.0, 60.0), f"Unexpected bbox: {result}"
+        assert all(isinstance(v, float) for v in result), f"Expected floats, got {result}"
+
+    def test_missing_edge_raises(self):
+        """A dict missing one edge raises ValueError naming that edge.
+
+        Test scenario:
+            Omitting the north key is reported as the 'north' edge being absent.
+        """
+        with pytest.raises(ValueError, match="'north' edge"):
+            read_bbox_dict({"minx": -10.0, "miny": 35.0, "maxx": 30.0})

--- a/tests/feature/test_bbox.py
+++ b/tests/feature/test_bbox.py
@@ -512,6 +512,20 @@ class TestEstimatePixelDims:
         with pytest.raises(ValueError, match="scale_m must be positive"):
             estimate_pixel_dims((0.0, 0.0, 1.0, 1.0), float("nan"))
 
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf")])
+    def test_non_finite_bbox_coord_raises(self, bad):
+        """A non-finite bbox coordinate is rejected with a ValueError, not a downstream ceil/overflow error.
+
+        Args:
+            bad: A non-finite edge value (NaN or inf).
+
+        Test scenario:
+            NaN/inf edges slip past `north < south`; an explicit isfinite check raises the documented ValueError
+            (e.g. shapely's empty-geometry `.bounds` is all-NaN). (review round 4 N1)
+        """
+        with pytest.raises(ValueError, match="coordinates must be finite"):
+            estimate_pixel_dims((0.0, 0.0, bad, 1.0), 1000.0)
+
     def test_inverted_latitude_raises(self):
         """An inverted latitude range (north < south) raises ValueError.
 

--- a/tests/feature/test_bbox.py
+++ b/tests/feature/test_bbox.py
@@ -507,10 +507,11 @@ class TestEstimatePixelDims:
         """A NaN scale_m is rejected by the scale_m guard, not by a downstream math.ceil error (review N1).
 
         Test scenario:
-            NaN slips past `<= 0` (NaN comparisons are False); `not scale_m > 0` catches it with the clear message.
+            NaN slips past `<= 0` (NaN comparisons are False); an explicit `math.isnan` check catches it.
         """
+        nan_scale = float("nan")
         with pytest.raises(ValueError, match="scale_m must be positive"):
-            estimate_pixel_dims((0.0, 0.0, 1.0, 1.0), float("nan"))
+            estimate_pixel_dims((0.0, 0.0, 1.0, 1.0), nan_scale)
 
     @pytest.mark.parametrize("bad", [float("nan"), float("inf")])
     def test_non_finite_bbox_coord_raises(self, bad):

--- a/tests/feature/test_bbox.py
+++ b/tests/feature/test_bbox.py
@@ -462,6 +462,34 @@ class TestEstimatePixelDims:
             true_width = math.ceil(ground_m / scale_m)
             assert est_width >= true_width, f"width {est_width} under-counts true {true_width} at lon_span={lon_span}"
 
+    @pytest.mark.parametrize(
+        "bbox, axis",
+        [
+            ((10.0, 0.0, 10.0, 1.0), 0),
+            ((0.0, 5.0, 1.0, 5.0), 1),
+        ],
+    )
+    def test_zero_span_axis_floors_to_one(self, bbox, axis):
+        """A collapsed longitude or latitude span still yields at least one pixel on that axis.
+
+        Args:
+            bbox: A bbox with one axis collapsed (west==east or north==south).
+            axis: Index of the collapsed axis (0=width, 1=height).
+
+        Test scenario:
+            A zero-width (west==east) or zero-height (north==south) bbox floors that axis to 1 px.
+        """
+        assert estimate_pixel_dims(bbox, 1000.0)[axis] == 1, f"collapsed axis {axis} should floor to 1"
+
+    def test_integer_scale_m_accepted(self):
+        """An integer scale_m produces the same result as the equivalent float.
+
+        Test scenario:
+            estimate_pixel_dims accepts an int resolution (1000) identically to 1000.0.
+        """
+        bbox = (-10.0, 35.0, 30.0, 60.0)
+        assert estimate_pixel_dims(bbox, 1000) == estimate_pixel_dims(bbox, 1000.0), "int scale_m must match float"
+
     @pytest.mark.parametrize("scale_m", [0.0, -1.0])
     def test_non_positive_scale_raises(self, scale_m):
         """A non-positive resolution raises ValueError.

--- a/tests/feature/test_bbox.py
+++ b/tests/feature/test_bbox.py
@@ -411,7 +411,7 @@ class TestEstimatePixelDims:
         Test scenario:
             The Europe/1 km and 1 deg/100 m cases from the issue, plus a west>east antimeridian span.
         """
-        result = estimate_pixel_dims(west, south, east, north, scale_m)
+        result = estimate_pixel_dims((west, south, east, north), scale_m)
         assert result == expected, f"Expected {expected}, got {result}"
 
     def test_minimum_one_pixel(self):
@@ -420,7 +420,7 @@ class TestEstimatePixelDims:
         Test scenario:
             A point bbox at a coarse resolution floors to (1, 1) rather than (0, 0).
         """
-        result = estimate_pixel_dims(0.0, 0.0, 0.0, 0.0, 1000.0)
+        result = estimate_pixel_dims((0.0, 0.0, 0.0, 0.0), 1000.0)
         assert result == (1, 1), f"Expected (1, 1), got {result}"
 
     def test_non_positive_scale_raises(self):
@@ -430,7 +430,7 @@ class TestEstimatePixelDims:
             scale_m == 0 is rejected with a message naming scale_m.
         """
         with pytest.raises(ValueError, match="scale_m must be positive"):
-            estimate_pixel_dims(0.0, 0.0, 1.0, 1.0, 0.0)
+            estimate_pixel_dims((0.0, 0.0, 1.0, 1.0), 0.0)
 
     def test_inverted_latitude_raises(self):
         """An inverted latitude range (north < south) raises ValueError.
@@ -439,7 +439,7 @@ class TestEstimatePixelDims:
             north < south is a genuine error (unlike west > east, which is a valid antimeridian crossing).
         """
         with pytest.raises(ValueError, match="north .* must be >= south"):
-            estimate_pixel_dims(0.0, 60.0, 1.0, 35.0, 1000.0)
+            estimate_pixel_dims((0.0, 60.0, 1.0, 35.0), 1000.0)
 
 
 class TestReadBboxDict:

--- a/tests/feature/test_bbox.py
+++ b/tests/feature/test_bbox.py
@@ -444,14 +444,18 @@ class TestEstimatePixelDims:
         true_height = math.ceil(ground_m / scale_m)
         assert est_height >= true_height, f"height {est_height} under-counts true {true_height} for {south}->{north}"
 
-    def test_non_positive_scale_raises(self):
+    @pytest.mark.parametrize("scale_m", [0.0, -1.0])
+    def test_non_positive_scale_raises(self, scale_m):
         """A non-positive resolution raises ValueError.
 
+        Args:
+            scale_m: The rejected resolution (zero and negative).
+
         Test scenario:
-            scale_m == 0 is rejected with a message naming scale_m.
+            scale_m <= 0 is rejected with a message naming scale_m.
         """
         with pytest.raises(ValueError, match="scale_m must be positive"):
-            estimate_pixel_dims((0.0, 0.0, 1.0, 1.0), 0.0)
+            estimate_pixel_dims((0.0, 0.0, 1.0, 1.0), scale_m)
 
     def test_inverted_latitude_raises(self):
         """An inverted latitude range (north < south) raises ValueError.
@@ -471,6 +475,7 @@ class TestReadBboxDict:
         [
             {"min_lon": -10.0, "min_lat": 35.0, "max_lon": 30.0, "max_lat": 60.0},
             {"lonmin": -10.0, "latmin": 35.0, "lonmax": 30.0, "latmax": 60.0},
+            {"minlon": -10.0, "minlat": 35.0, "maxlon": 30.0, "maxlat": 60.0},
             {"minx": -10.0, "miny": 35.0, "maxx": 30.0, "maxy": 60.0},
             {"west": -10.0, "south": 35.0, "east": 30.0, "north": 60.0},
             {"West": -10.0, "South": 35.0, "East": 30.0, "North": 60.0},
@@ -498,14 +503,27 @@ class TestReadBboxDict:
         assert result == (-10.0, 35.0, 30.0, 60.0), f"Unexpected bbox: {result}"
         assert all(isinstance(v, float) for v in result), f"Expected floats, got {result}"
 
-    def test_missing_edge_raises(self):
-        """A dict missing one edge raises ValueError naming that edge.
+    @pytest.mark.parametrize(
+        "bbox, edge",
+        [
+            ({"miny": 35.0, "maxx": 30.0, "maxy": 60.0}, "west"),
+            ({"minx": -10.0, "maxx": 30.0, "maxy": 60.0}, "south"),
+            ({"minx": -10.0, "miny": 35.0, "maxy": 60.0}, "east"),
+            ({"minx": -10.0, "miny": 35.0, "maxx": 30.0}, "north"),
+        ],
+    )
+    def test_missing_edge_raises(self, bbox, edge):
+        """A dict missing any one edge raises ValueError naming that edge.
+
+        Args:
+            bbox: A bbox mapping with one edge omitted.
+            edge: The name of the omitted edge.
 
         Test scenario:
-            Omitting the north key is reported as the 'north' edge being absent.
+            Omitting west/south/east/north each reports that specific edge as absent.
         """
-        with pytest.raises(ValueError, match="'north' edge"):
-            read_bbox_dict({"minx": -10.0, "miny": 35.0, "maxx": 30.0})
+        with pytest.raises(ValueError, match=f"'{edge}' edge"):
+            read_bbox_dict(bbox)
 
     def test_present_none_value_reports_non_numeric_not_missing(self):
         """A present-but-None edge value is reported as non-numeric, not as a missing key (review L1).

--- a/tests/feature/test_bbox.py
+++ b/tests/feature/test_bbox.py
@@ -503,6 +503,15 @@ class TestEstimatePixelDims:
         with pytest.raises(ValueError, match="scale_m must be positive"):
             estimate_pixel_dims((0.0, 0.0, 1.0, 1.0), scale_m)
 
+    def test_nan_scale_raises_with_guard_message(self):
+        """A NaN scale_m is rejected by the scale_m guard, not by a downstream math.ceil error (review N1).
+
+        Test scenario:
+            NaN slips past `<= 0` (NaN comparisons are False); `not scale_m > 0` catches it with the clear message.
+        """
+        with pytest.raises(ValueError, match="scale_m must be positive"):
+            estimate_pixel_dims((0.0, 0.0, 1.0, 1.0), float("nan"))
+
     def test_inverted_latitude_raises(self):
         """An inverted latitude range (north < south) raises ValueError.
 

--- a/tests/feature/test_bbox.py
+++ b/tests/feature/test_bbox.py
@@ -444,6 +444,24 @@ class TestEstimatePixelDims:
         true_height = math.ceil(ground_m / scale_m)
         assert est_height >= true_height, f"height {est_height} under-counts true {true_height} for {south}->{north}"
 
+    def test_width_is_true_upper_bound_at_equator(self):
+        """The estimated width never under-counts the true geodesic E-W span at the equator (review L1/L2).
+
+        Test scenario:
+            Across a dense sweep of longitude spans at 1 m/px on the equator (where a degree of longitude is
+            longest and the width bound is tightest), estimate_pixel_dims width >= ceil(WGS84 parallel distance /
+            scale_m). The width analogue of the height property; catches a width constant rounded below the true
+            equatorial degree.
+        """
+        geod = Geod(ellps="WGS84")
+        scale_m = 1.0
+        for i in range(1, 2001):
+            lon_span = i * 0.01
+            est_width = estimate_pixel_dims((0.0, 0.0, lon_span, 0.0), scale_m)[0]
+            _, _, ground_m = geod.inv(0.0, 0.0, lon_span, 0.0)
+            true_width = math.ceil(ground_m / scale_m)
+            assert est_width >= true_width, f"width {est_width} under-counts true {true_width} at lon_span={lon_span}"
+
     @pytest.mark.parametrize("scale_m", [0.0, -1.0])
     def test_non_positive_scale_raises(self, scale_m):
         """A non-positive resolution raises ValueError.

--- a/tests/feature/test_bbox.py
+++ b/tests/feature/test_bbox.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import math
+
 import pytest
+from pyproj import Geod
 from shapely.geometry import MultiPolygon, Polygon
 
 from pyramids.feature.bbox import (
@@ -392,13 +395,13 @@ class TestEstimatePixelDims:
     @pytest.mark.parametrize(
         "west, south, east, north, scale_m, expected",
         [
-            (-10.0, 35.0, 30.0, 60.0, 1000.0, (4453, 2783)),
-            (0.0, 0.0, 1.0, 1.0, 100.0, (1114, 1114)),
-            (175.0, -22.0, -175.0, -12.0, 1000.0, (1114, 1114)),
+            (-10.0, 35.0, 30.0, 60.0, 1000.0, (4453, 2793)),
+            (0.0, 0.0, 1.0, 1.0, 100.0, (1114, 1117)),
+            (175.0, -22.0, -175.0, -12.0, 1000.0, (1114, 1117)),
         ],
     )
     def test_known_dimensions(self, west, south, east, north, scale_m, expected):
-        """Estimate matches the documented equatorial upper-bound values, including an antimeridian bbox.
+        """Estimate matches the documented upper-bound values, including an antimeridian bbox.
 
         Args:
             west: Western longitude in degrees.
@@ -422,6 +425,24 @@ class TestEstimatePixelDims:
         """
         result = estimate_pixel_dims((0.0, 0.0, 0.0, 0.0), 1000.0)
         assert result == (1, 1), f"Expected (1, 1), got {result}"
+
+    @pytest.mark.parametrize("south, north", [(0.0, 1.0), (35.0, 60.0), (60.0, 89.0), (80.0, 89.0)])
+    def test_height_is_true_upper_bound(self, south, north):
+        """The estimated height never under-counts the true geodesic pixel span, incl. high latitudes.
+
+        Args:
+            south: Southern latitude in degrees.
+            north: Northern latitude in degrees.
+
+        Test scenario:
+            estimate_pixel_dims height >= ceil(WGS84 meridian distance / scale_m) across a latitude spread —
+            the property that the equatorial constant alone violated above ~55 deg (review M1).
+        """
+        scale_m = 1000.0
+        est_height = estimate_pixel_dims((0.0, south, 1.0, north), scale_m)[1]
+        _, _, ground_m = Geod(ellps="WGS84").inv(0.0, south, 0.0, north)
+        true_height = math.ceil(ground_m / scale_m)
+        assert est_height >= true_height, f"height {est_height} under-counts true {true_height} for {south}->{north}"
 
     def test_non_positive_scale_raises(self):
         """A non-positive resolution raises ValueError.


### PR DESCRIPTION
# Description

Adds two small, provider-agnostic bounding-box helpers to `pyramids.feature.bbox` (issue #730), porting utilities
that earthlens carried so it can drop its copies:

- `estimate_pixel_dims(bbox, scale_m) -> (width_px, height_px)` — a worst-case estimate of a WGS84 bbox's pixel
  dimensions at a target ground resolution, for pre-checking an export against a provider pixel cap (e.g. GEE's
  32768-px guard). It is a **true upper bound on both axes**: width uses the equatorial degree of longitude
  (`METRES_PER_DEGREE`, rounded up), height the maximum polar degree of latitude (`MAX_METRES_PER_LAT_DEGREE`), so
  it never under-counts. Antimeridian-aware (`west > east` wraps across 180 deg); raises on `scale_m <= 0` and
  `north < south`. For a tight, latitude-accurate count, reproject to a metric CRS first (`transform`).
- `read_bbox_dict(mapping) -> Bbox` — reads a `(west, south, east, north)` tuple from a dict under any accepted key
  spelling (GeoJSON `min_lon`, eodag `lonmin`, shapely/geopandas `minx`, compass `west`), matched
  case-insensitively; raises a `ValueError` naming the edge for a missing key or a non-numeric value.

Both compose directly: `estimate_pixel_dims(read_bbox_dict(d), scale_m)`. No new dependencies (`pyproj` is already
required). The two-axis upper-bound guarantee is verified against `pyproj.Geod` (WGS84) ground truth in the tests.

# Issues

- Closes #730 — public `estimate_pixel_dims` + bbox-dict alias reader helpers

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- `pixi run -e dev pytest tests/feature/test_bbox.py` — 60 unit tests: documented values, every alias spelling,
  each missing edge, `None`/non-numeric edge values, and geodesic upper-bound property tests for **both** axes
  (equator sweep for width, 0-89 deg for height).
- `pixi run -e dev pytest --doctest-modules src/pyramids/feature/bbox.py` — module doctests pass.
- `pixi run -e dev pytest tests/feature/ -m "not plot"` — full feature suite green (649 passed, 3 skipped).

- [x] Unit + property tests for both new functions (`tests/feature/test_bbox.py`)
- [x] Doctests on both new functions

# Checklist:

- [ ] updated version number in pyproject.toml. (handled by commitizen/CI)
- [ ] added changes to History.rst. (changelog is commitizen-generated)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (Google-style docstrings + doctests on both functions and the new constants)
