### PR TITLE
fix(netcdf): release lazy read GDAL handles on array drop and on NetCDF.close()

### DIFF
--- a/src/pyramids/base/_file_manager.py
+++ b/src/pyramids/base/_file_manager.py
@@ -303,15 +303,26 @@ class _LRUCache(MutableMapping):
         handle = None
         with self._lock:
             tracked = self._refcounts.get(key)
-            if tracked is None:
-                pass
-            elif tracked - 1 > 0:
-                self._refcounts[key] = tracked - 1
-            else:
-                self._refcounts.pop(key, None)
-                handle = self._cache.pop(key, None)
+            if tracked is not None:
+                if tracked - 1 > 0:
+                    self._refcounts[key] = tracked - 1
+                else:
+                    self._refcounts.pop(key, None)
+                    handle = self._cache.pop(key, None)
         if handle is not None and self._on_evict is not None:
-            self._on_evict(key, handle)
+            # release() runs from a `weakref.finalize` callback, which has no caller to surface a close
+            # failure to -- so log any error (e.g. an OSError flushing a remote `/vsi` handle, which
+            # `_close_handle` deliberately re-raises on a normal call stack) rather than let it become
+            # an "unraisable" exception reported during GC.
+            try:
+                self._on_evict(key, handle)
+            except Exception as exc:  # noqa: BLE001 - a finalizer path must not raise
+                logger.warning(
+                    "handle close failed during finalizer release for key %r: %s",
+                    key,
+                    exc,
+                    exc_info=True,
+                )
 
 
 def _close_handle(_key: Hashable | None, handle: Any) -> None:
@@ -459,7 +470,11 @@ class CachingFileManager(FileManager):
             manager's lifetime should own the handle — e.g. a lazy
             dask read whose manager is kept alive by the graph. The
             default `False` keeps the handle under pure LRU lifetime,
-            reusable by later managers with the same `manager_id`.
+            reusable by later managers with the same `manager_id`. Do
+            not share one `manager_id` between an `auto_release` and a
+            non-`auto_release` manager: the refcount counts only the
+            auto-release ones, so dropping one could close a handle the
+            other still relies on.
 
     The manager is picklable. On unpickle, the new instance starts
     with no cached handle and opens fresh on first :meth:`acquire`;

--- a/src/pyramids/base/_file_manager.py
+++ b/src/pyramids/base/_file_manager.py
@@ -285,24 +285,29 @@ class _LRUCache(MutableMapping):
                 self._on_evict(key, value)
 
     def retain(self, key: Hashable) -> None:
-        """Register one live referent for `key` (see :attr:`_refcounts`)."""
+        """Register one live referent for `key` (see the `_refcounts` note in `__init__`)."""
         with self._lock:
             self._refcounts[key] = self._refcounts.get(key, 0) + 1
 
     def release(self, key: Hashable) -> None:
         """Drop one referent for `key`; evict and close the handle when the last one is gone.
 
-        Safe to call from a :class:`weakref.finalize` callback on any thread: it holds no reference
-        to the releasing manager, and closes the handle outside the cache lock (like `on_evict`).
+        Safe to call from a `weakref.finalize` callback on any thread: it holds no reference to the
+        releasing manager and closes the handle outside the cache lock (like `on_evict`). A key that
+        is no longer tracked -- e.g. wiped by `clear()` while this manager was still alive -- is
+        treated as a no-op, so a stale finalizer never closes a handle the refcount is no longer
+        accounting for (which could otherwise be a re-opened handle a live array is still reading).
         """
         handle = None
         with self._lock:
-            remaining = self._refcounts.get(key, 0) - 1
-            if remaining > 0:
-                self._refcounts[key] = remaining
-                return
-            self._refcounts.pop(key, None)
-            handle = self._cache.pop(key, None)
+            tracked = self._refcounts.get(key)
+            if tracked is None:
+                pass
+            elif tracked - 1 > 0:
+                self._refcounts[key] = tracked - 1
+            else:
+                self._refcounts.pop(key, None)
+                handle = self._cache.pop(key, None)
         if handle is not None and self._on_evict is not None:
             self._on_evict(key, handle)
 
@@ -514,7 +519,9 @@ class CachingFileManager(FileManager):
 
     def __setstate__(self, state: tuple) -> None:
         # Tolerate the pre-`auto_release` 6-tuple so a manager pickled by an older pyramids (or a
-        # differently-versioned dask worker) still unpickles, defaulting `auto_release` to False.
+        # differently-versioned dask worker) still unpickles, defaulting `auto_release` to False. The
+        # reverse -- an old worker receiving the new 7-tuple -- cannot be helped from here and is
+        # intentionally unsupported (mixed-version dask.distributed clusters are not a target).
         opener, path, access, kwargs, lock, manager_id, *rest = state
         auto_release = rest[0] if rest else False
         self.__init__(

--- a/src/pyramids/base/_file_manager.py
+++ b/src/pyramids/base/_file_manager.py
@@ -31,6 +31,7 @@ import logging
 import os
 import threading
 import uuid
+import weakref
 from abc import ABC, abstractmethod
 from collections import OrderedDict
 from contextlib import contextmanager
@@ -204,6 +205,10 @@ class _LRUCache(MutableMapping):
         self._maxsize = maxsize
         self._on_evict = on_evict
         self._lock = threading.RLock()
+        # Number of live managers interested in each key. The handle is closed only when the last
+        # manager for a key is finalized, so a manager whose array is dropped never evicts a handle
+        # another manager (sharing the same `manager_id`) is still reading through.
+        self._refcounts: dict[Hashable, int] = {}
 
     @property
     def maxsize(self) -> int:
@@ -274,9 +279,32 @@ class _LRUCache(MutableMapping):
         with self._lock:
             items = list(self._cache.items())
             self._cache.clear()
+            self._refcounts.clear()
         if self._on_evict is not None:
             for key, value in items:
                 self._on_evict(key, value)
+
+    def retain(self, key: Hashable) -> None:
+        """Register one live referent for `key` (see :attr:`_refcounts`)."""
+        with self._lock:
+            self._refcounts[key] = self._refcounts.get(key, 0) + 1
+
+    def release(self, key: Hashable) -> None:
+        """Drop one referent for `key`; evict and close the handle when the last one is gone.
+
+        Safe to call from a :class:`weakref.finalize` callback on any thread: it holds no reference
+        to the releasing manager, and closes the handle outside the cache lock (like `on_evict`).
+        """
+        handle = None
+        with self._lock:
+            remaining = self._refcounts.get(key, 0) - 1
+            if remaining > 0:
+                self._refcounts[key] = remaining
+                return
+            self._refcounts.pop(key, None)
+            handle = self._cache.pop(key, None)
+        if handle is not None and self._on_evict is not None:
+            self._on_evict(key, handle)
 
 
 def _close_handle(_key: Hashable | None, handle: Any) -> None:
@@ -433,6 +461,7 @@ class CachingFileManager(FileManager):
         lock: Any = None,
         cache: _LRUCache | None = None,
         manager_id: Hashable | None = None,
+        auto_release: bool = False,
     ) -> None:
         self._opener = opener
         self._path = path
@@ -447,9 +476,20 @@ class CachingFileManager(FileManager):
             self._lock = lock
         self._cache = cache if cache is not None else FILE_CACHE
         self._manager_id = manager_id if manager_id is not None else str(uuid.uuid4())
+        self._auto_release = auto_release
         self._key = _make_cache_key(
             opener, path, access, self._kwargs, self._manager_id
         )
+        if auto_release:
+            # Release the parked handle deterministically when this manager is garbage-collected --
+            # i.e. when the lazy array holding its chunk readers is dropped -- instead of relying on
+            # LRU pressure or interpreter exit (#727). Bound to the manager, not the returned array,
+            # so it still fires for derived arrays (unpack / mfdataset / plot) whose graph keeps only
+            # the readers -> manager alive. The callback holds no reference to `self`, so it cannot
+            # keep the manager alive; the refcount stops it evicting a slot another auto-release
+            # manager still shares. Managers without `auto_release` keep the pure LRU lifetime.
+            self._cache.retain(self._key)
+            weakref.finalize(self, self._cache.release, self._key)
 
     def __getstate__(self) -> tuple:
         lock = None if self._use_default_lock else self._lock
@@ -460,10 +500,14 @@ class CachingFileManager(FileManager):
             self._kwargs,
             lock,
             self._manager_id,
+            self._auto_release,
         )
 
     def __setstate__(self, state: tuple) -> None:
-        opener, path, access, kwargs, lock, manager_id = state
+        # Tolerate the pre-`auto_release` 6-tuple so a manager pickled by an older pyramids (or a
+        # differently-versioned dask worker) still unpickles, defaulting `auto_release` to False.
+        opener, path, access, kwargs, lock, manager_id, *rest = state
+        auto_release = rest[0] if rest else False
         self.__init__(
             opener,
             path,
@@ -471,6 +515,7 @@ class CachingFileManager(FileManager):
             kwargs,
             lock=lock,
             manager_id=manager_id,
+            auto_release=auto_release,
         )
 
     def acquire(self) -> Any:

--- a/src/pyramids/base/_file_manager.py
+++ b/src/pyramids/base/_file_manager.py
@@ -296,7 +296,9 @@ class _LRUCache(MutableMapping):
         releasing manager and closes the handle outside the cache lock (like `on_evict`). A key that
         is no longer tracked -- e.g. wiped by `clear()` while this manager was still alive -- is
         treated as a no-op, so a stale finalizer never closes a handle the refcount is no longer
-        accounting for (which could otherwise be a re-opened handle a live array is still reading).
+        accounting for (which could otherwise be a re-opened handle a live array is still reading). A
+        manager that survives a `clear()` therefore falls back to pure LRU / interpreter-exit lifetime;
+        that is an accepted trade-off, since `clear()` is an explicit hard reset.
         """
         handle = None
         with self._lock:

--- a/src/pyramids/base/_file_manager.py
+++ b/src/pyramids/base/_file_manager.py
@@ -444,6 +444,15 @@ class CachingFileManager(FileManager):
             otherwise hash identically. Defaults to a fresh UUID so
             two managers built from identical arguments do not share
             a cache slot; pass an explicit value to *share* one.
+        auto_release: When `True`, register a `weakref.finalize` on
+            the manager that releases its cached handle (evicting the
+            slot and closing the handle) as soon as the manager is
+            garbage-collected, refcounted so a shared slot closes only
+            when its last manager is finalized. Use this when the
+            manager's lifetime should own the handle — e.g. a lazy
+            dask read whose manager is kept alive by the graph. The
+            default `False` keeps the handle under pure LRU lifetime,
+            reusable by later managers with the same `manager_id`.
 
     The manager is picklable. On unpickle, the new instance starts
     with no cached handle and opens fresh on first :meth:`acquire`;

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -1142,6 +1142,11 @@ class IO(_Engine["Dataset"]):
                 self._ds._file_name,
                 "read_only",
                 lock=False,
+                # Release the parked handle when the returned dask array (which keeps this manager
+                # alive through its chunk tasks) is dropped, rather than leaving it until LRU
+                # pressure or interpreter exit -- the same #727 handle lifetime the NetCDF lazy
+                # path fixes, applied to the raster lazy reader.
+                auto_release=True,
             )
         meta = np.empty((0,) * len(shape), dtype=dtype)
         arr = da.map_blocks(

--- a/src/pyramids/netcdf/_lazy.py
+++ b/src/pyramids/netcdf/_lazy.py
@@ -474,6 +474,7 @@ def build_lazy_array(
     chunks: Any,
     lock: Any = None,
     manager_id: Any = None,
+    manager_hook: Any = None,
 ) -> Any:
     """Build a :class:`dask.array.Array` backed by MDArray chunk reads.
 
@@ -488,6 +489,13 @@ def build_lazy_array(
             variable share a cache slot. Defaults to
             `(path, variable_name)` so repeated calls for the same
             variable de-duplicate the cached handle.
+        manager_hook: Optional callable invoked with the created
+            `CachingFileManager` before the array is returned, so the
+            owning object (e.g. the `NetCDF` container) can track it and
+            release its handle from `close()` -- the second half of the
+            #727 fix (release on the parent's `close()`, not only when
+            the array is dropped). It should hold only a weak reference,
+            so it does not defeat the drop-time finalizer.
 
     Returns:
         dask.array.Array: Lazy array that computes chunk-by-chunk
@@ -517,6 +525,8 @@ def build_lazy_array(
         manager_id=key_id,
         auto_release=True,
     )
+    if manager_hook is not None:
+        manager_hook(manager)
     chunks_per_axis = _expand_chunks(shape, chunk_shape)
     starts_per_axis = _chunk_starts(chunks_per_axis)
     name = f"pyramids-netcdf-read-{variable_name}-{id(manager)}"

--- a/src/pyramids/netcdf/_lazy.py
+++ b/src/pyramids/netcdf/_lazy.py
@@ -33,6 +33,7 @@ callers without the `[lazy]` extra installed get a clear
 
 from __future__ import annotations
 
+import weakref
 from typing import Any
 
 import numpy as np
@@ -539,4 +540,10 @@ def build_lazy_array(
             lazy = da.flip(lazy, axis=len(shape) - 2)
         if flip_x:
             lazy = da.flip(lazy, axis=len(shape) - 1)
+    # Release the parked FILE_CACHE handle deterministically when the returned lazy array is dropped,
+    # instead of waiting for LRU eviction or interpreter exit. Without this, reopening the same NetCDF
+    # in-process while the handle is still parked opens a second live MDIM handle and crashes GDAL on
+    # Windows (#727). The finalizer is attached to the array the caller receives, and manager.close()
+    # is idempotent, so a prior LRU eviction (or a second finalizer run) is harmless.
+    weakref.finalize(lazy, manager.close)
     return lazy

--- a/src/pyramids/netcdf/_lazy.py
+++ b/src/pyramids/netcdf/_lazy.py
@@ -33,7 +33,6 @@ callers without the `[lazy]` extra installed get a clear
 
 from __future__ import annotations
 
-import weakref
 from typing import Any
 
 import numpy as np
@@ -516,6 +515,7 @@ def build_lazy_array(
         {},
         lock=resolved_lock,
         manager_id=key_id,
+        auto_release=True,
     )
     chunks_per_axis = _expand_chunks(shape, chunk_shape)
     starts_per_axis = _chunk_starts(chunks_per_axis)
@@ -540,10 +540,9 @@ def build_lazy_array(
             lazy = da.flip(lazy, axis=len(shape) - 2)
         if flip_x:
             lazy = da.flip(lazy, axis=len(shape) - 1)
-    # Release the parked FILE_CACHE handle deterministically when the returned lazy array is dropped,
-    # instead of waiting for LRU eviction or interpreter exit. Without this, reopening the same NetCDF
-    # in-process while the handle is still parked opens a second live MDIM handle and crashes GDAL on
-    # Windows (#727). The finalizer is attached to the array the caller receives, and manager.close()
-    # is idempotent, so a prior LRU eviction (or a second finalizer run) is harmless.
-    weakref.finalize(lazy, manager.close)
+    # The parked FILE_CACHE handle is released deterministically when this `manager` is
+    # garbage-collected -- the `CachingFileManager` registers a `weakref.finalize` on itself in
+    # `__init__`. Because the manager is kept alive by the chunk readers in the graph (not by this
+    # `lazy` object), that release still fires for derived arrays -- `unpack=True`, `open_mfdataset`,
+    # `plot(chunks=)` -- whose graph keeps only the readers, not this wrapper (#727).
     return lazy

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -620,6 +620,11 @@ class NetCDF(Dataset):
         (#564). Doing it here makes ``close()`` honour its contract — the file is
         unlocked immediately. Safe to call more than once.
         """
+        # Release handles parked by this container's lazy reads (#727): a lazy dask array can be held
+        # alive across close() (the finalizer only fires on drop), so close() explicitly evicts them
+        # here so a subsequent reopen of the same file does not leave two live handles. The lazy array
+        # stays usable -- its CachingFileManager re-opens on the next chunk read.
+        self._release_lazy_managers()
         cached = self._cached_variables
         if cached is not None:
             # Only the materialised children (bypass the lazy dict's loading
@@ -1691,20 +1696,19 @@ class NetCDF(Dataset):
 
             * **Open-handle lifetime.** A lazy read parks a live GDAL handle in the process-global
               `pyramids.base._file_manager.FILE_CACHE` (via `CachingFileManager`) so later chunk reads
-              can reuse it. The handle is released when the lazy read's result — **and every array
-              derived from it** (`unpack=True`, an `open_mfdataset` stack, a `plot(chunks=)`, a slice
-              or dask-arithmetic result) — is dropped or garbage-collected: a `weakref.finalize` on the
-              manager (kept alive by the chunk readers in the dask graph, not by the returned wrapper)
-              evicts its `FILE_CACHE` slot and closes it. It is also released under LRU pressure or at
-              interpreter exit. `close()` on this `NetCDF` object does not evict it: the handle's
-              lifetime follows the lazy data, not this object (#727).
+              can reuse it. It is released two ways (#727): when the lazy read's result — **and every
+              array derived from it** (`unpack=True`, an `open_mfdataset` stack, a `plot(chunks=)`, a
+              slice or dask-arithmetic result) — is dropped or garbage-collected (a `weakref.finalize`
+              on the manager, kept alive by the chunk readers in the dask graph, evicts and closes it);
+              **and** when this `NetCDF`'s `close()` is called, which evicts the handles its lazy reads
+              parked even while a lazy array from it is still alive. It is also released under LRU
+              pressure or at interpreter exit. A lazy array stays usable after `close()` — its manager
+              re-opens the handle on the next chunk read.
 
-              A live lazy array's handle *must* stay open to serve its future chunk reads, so opening
-              the **same file again in the same process while a lazy array from it is still alive**
-              leaves two live GDAL handles to one NetCDF, which can crash GDAL on Windows. A finalizer
-              cannot cover that ordering — so **drop (or compute and then drop) the lazy array before
-              reopening the file.** (Fully closing this held-alive-then-reopen case would require a
-              process-global shared-handle registry; it is a known GDAL-on-Windows limitation.)
+              Opening the **same file again in the same process while a handle is still parked** leaves
+              two live GDAL handles to one NetCDF, which can crash GDAL on Windows. So before reopening
+              a file in-process, either **drop the lazy array(s)** or **`close()` the `NetCDF`** — both
+              now release the parked handle.
             * **Axis plane.** The lazy path normalizes the **trailing two** dimensions to north-up /
               west-first, whereas the eager path resolves the plane via `x_dim` / `y_dim` /
               CF detection. They agree for every variable whose spatial plane is trailing (the common
@@ -1841,8 +1845,29 @@ class NetCDF(Dataset):
                 variable_name=var_name,
                 chunks=chunks,
                 lock=lock,
+                manager_hook=parent._register_lazy_manager,
             ),
         )
+
+    def _register_lazy_manager(self, manager: Any) -> None:
+        """Track (weakly) a lazy read's file manager so `close()` can release its handle (#727).
+
+        A weak reference is used deliberately: the manager's own drop-time finalizer must still fire
+        when the lazy array is dropped, so this container must not keep the manager alive.
+        """
+        managers = getattr(self, "_lazy_managers", None)
+        if managers is None:
+            managers = []
+            self._lazy_managers = managers
+        managers.append(weakref.ref(manager))
+
+    def _release_lazy_managers(self) -> None:
+        """Close every still-alive tracked lazy manager, releasing its parked handle."""
+        for ref in getattr(self, "_lazy_managers", ()):
+            manager = ref()
+            if manager is not None:
+                manager.close()
+        self._lazy_managers = []
 
     def _preserve_netcdf_metadata(self, result: Dataset) -> NetCDF:
         """Wrap a Dataset result as a NetCDF, preserving variable-subset metadata.

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1690,12 +1690,14 @@ class NetCDF(Dataset):
             Two limitations are specific to the lazy (`chunks`) path:
 
             * **Open-handle lifetime.** A lazy read parks a live GDAL handle in the process-global
-              `pyramids.base._file_manager.FILE_CACHE` (via `CachingFileManager`) and keeps it open
-              for later chunk reads. `close()` on this object does not evict it — the handle lives in
-              the dask graph — so it is released only under LRU pressure or at interpreter exit.
-              Opening the *same file again in the same process* while a lazy handle is parked leaves
-              two live handles to one NetCDF, which can crash GDAL on Windows. Compute (or drop) the
-              lazy array before reopening the file.
+              `pyramids.base._file_manager.FILE_CACHE` (via `CachingFileManager`) so later chunk reads
+              can reuse it. The handle is released when the returned lazy array is dropped or garbage
+              collected — a finalizer evicts its `FILE_CACHE` slot and closes it — and also under LRU
+              pressure or at interpreter exit. `close()` on this `NetCDF` object does not evict it: the
+              handle's lifetime is tied to the lazy array, not to this object. Opening the *same file
+              again in the same process* while a handle is still parked leaves two live handles to one
+              NetCDF, which can crash GDAL on Windows, so **drop (or compute and then drop) the lazy
+              array before reopening the file** (#727).
             * **Axis plane.** The lazy path normalizes the **trailing two** dimensions to north-up /
               west-first, whereas the eager path resolves the plane via `x_dim` / `y_dim` /
               CF detection. They agree for every variable whose spatial plane is trailing (the common

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1691,13 +1691,20 @@ class NetCDF(Dataset):
 
             * **Open-handle lifetime.** A lazy read parks a live GDAL handle in the process-global
               `pyramids.base._file_manager.FILE_CACHE` (via `CachingFileManager`) so later chunk reads
-              can reuse it. The handle is released when the returned lazy array is dropped or garbage
-              collected — a finalizer evicts its `FILE_CACHE` slot and closes it — and also under LRU
-              pressure or at interpreter exit. `close()` on this `NetCDF` object does not evict it: the
-              handle's lifetime is tied to the lazy array, not to this object. Opening the *same file
-              again in the same process* while a handle is still parked leaves two live handles to one
-              NetCDF, which can crash GDAL on Windows, so **drop (or compute and then drop) the lazy
-              array before reopening the file** (#727).
+              can reuse it. The handle is released when the lazy read's result — **and every array
+              derived from it** (`unpack=True`, an `open_mfdataset` stack, a `plot(chunks=)`, a slice
+              or dask-arithmetic result) — is dropped or garbage-collected: a `weakref.finalize` on the
+              manager (kept alive by the chunk readers in the dask graph, not by the returned wrapper)
+              evicts its `FILE_CACHE` slot and closes it. It is also released under LRU pressure or at
+              interpreter exit. `close()` on this `NetCDF` object does not evict it: the handle's
+              lifetime follows the lazy data, not this object (#727).
+
+              A live lazy array's handle *must* stay open to serve its future chunk reads, so opening
+              the **same file again in the same process while a lazy array from it is still alive**
+              leaves two live GDAL handles to one NetCDF, which can crash GDAL on Windows. A finalizer
+              cannot cover that ordering — so **drop (or compute and then drop) the lazy array before
+              reopening the file.** (Fully closing this held-alive-then-reopen case would require a
+              process-global shared-handle registry; it is a known GDAL-on-Windows limitation.)
             * **Axis plane.** The lazy path normalizes the **trailing two** dimensions to north-up /
               west-first, whereas the eager path resolves the plane via `x_dim` / `y_dim` /
               CF detection. They agree for every variable whose spatial plane is trailing (the common

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -11,6 +11,7 @@ import itertools
 import math
 import os
 import tempfile
+import threading
 import warnings
 import weakref
 from numbers import Number
@@ -58,6 +59,10 @@ from pyramids.netcdf.metadata import get_metadata
 from pyramids.netcdf.models import NetCDFMetadata
 from pyramids.netcdf.plot_options import ColorOpts, FacetSpec, Selectors
 from pyramids.netcdf.utils import _read_attributes, create_time_conversion_func
+
+# Guards the per-container `_lazy_managers` WeakSet against a concurrent lazy `read_array` (which adds)
+# and `close()` (which snapshots) on the same container from different threads.
+_LAZY_MANAGERS_LOCK = threading.Lock()
 
 # GDAL integer dtype codes, used to pick the right typed Attribute.Write* call
 # when copying variable attributes (numeric tuples can't go through Write/WriteRaw).
@@ -1845,29 +1850,40 @@ class NetCDF(Dataset):
                 variable_name=var_name,
                 chunks=chunks,
                 lock=lock,
-                manager_hook=parent._register_lazy_manager,
+                manager_hook=self._register_lazy_manager,
             ),
         )
 
     def _register_lazy_manager(self, manager: Any) -> None:
         """Track (weakly) a lazy read's file manager so `close()` can release its handle (#727).
 
-        A weak reference is used deliberately: the manager's own drop-time finalizer must still fire
-        when the lazy array is dropped, so this container must not keep the manager alive.
+        Registered on both this object and its root container (`_parent_nc`), so closing either a
+        `get_variable()` subset or the root releases the handle. A `weakref.WeakSet` is used
+        deliberately: the manager's drop-time finalizer must still fire when the lazy array is dropped
+        (so tracking must not keep the manager alive), and the set auto-prunes collected managers so a
+        long-lived container in a read loop does not accumulate dead entries.
         """
-        managers = getattr(self, "_lazy_managers", None)
-        if managers is None:
-            managers = []
-            self._lazy_managers = managers
-        managers.append(weakref.ref(manager))
+        with _LAZY_MANAGERS_LOCK:
+            for owner in (self, self._parent_nc):
+                if owner is None:
+                    continue
+                managers = getattr(owner, "_lazy_managers", None)
+                if managers is None:
+                    managers = weakref.WeakSet()
+                    owner._lazy_managers = managers
+                managers.add(manager)
 
     def _release_lazy_managers(self) -> None:
-        """Close every still-alive tracked lazy manager, releasing its parked handle."""
-        for ref in getattr(self, "_lazy_managers", ()):
-            manager = ref()
-            if manager is not None:
-                manager.close()
-        self._lazy_managers = []
+        """Close every still-alive tracked lazy manager, releasing its parked handle.
+
+        The set is not cleared: `manager.close()` is idempotent, and a still-alive manager stays
+        tracked so a handle it re-parks (a `compute()` after `close()`) is released by a later
+        `close()` too. Dead managers drop out of the `WeakSet` on their own.
+        """
+        with _LAZY_MANAGERS_LOCK:
+            managers = list(getattr(self, "_lazy_managers", ()))
+        for manager in managers:
+            manager.close()
 
     def _preserve_netcdf_metadata(self, result: Dataset) -> NetCDF:
         """Wrap a Dataset result as a NetCDF, preserving variable-subset metadata.

--- a/tests/base/test_file_manager.py
+++ b/tests/base/test_file_manager.py
@@ -722,3 +722,17 @@ class TestCachingFileManagerAutoRelease:
         gc.collect()
         assert reopened.closed is False, "a stale post-clear finalizer must not close the re-opened handle"
         assert len(cache) == 1, "the re-opened handle survives an untracked release"
+
+    def test_release_logs_close_error_instead_of_raising(self, caplog):
+        """A close failure during finalizer-invoked `release()` is logged, not left unraisable (L1)."""
+        def boom(_key, _handle):
+            raise OSError("simulated remote /vsi flush failure")
+
+        cache = _LRUCache(maxsize=4, on_evict=boom)
+        cache.retain("k")
+        cache._cache["k"] = object()
+        with caplog.at_level("WARNING", logger="pyramids.base._file_manager"):
+            cache.release("k")
+        assert any(
+            "handle close failed during finalizer release" in r.getMessage() for r in caplog.records
+        ), "the finalizer-invoked close error must be logged at WARNING"

--- a/tests/base/test_file_manager.py
+++ b/tests/base/test_file_manager.py
@@ -699,3 +699,26 @@ class TestCachingFileManagerAutoRelease:
         clone = CachingFileManager.__new__(CachingFileManager)
         clone.__setstate__(legacy)
         assert clone._auto_release is False, "legacy 6-tuple must default auto_release to False"
+
+    def test_stale_finalizer_after_clear_does_not_close_reopened_handle(self):
+        """A finalizer firing after `clear()` must not close a handle re-opened for a live sibling.
+
+        `clear()` wipes both the cache and the refcounts. A manager alive across the clear still holds
+        a pending finalizer; when it fires, `release` must treat the now-untracked key as a no-op
+        rather than underflowing the count and closing a handle another live manager just re-parked.
+        """
+        cache = _LRUCache(maxsize=8, on_evict=_close_handle)
+        first = CachingFileManager(
+            _fake_opener, "a.tif", cache=cache, manager_id="k", auto_release=True
+        )
+        second = CachingFileManager(
+            _fake_opener, "a.tif", cache=cache, manager_id="k", auto_release=True
+        )
+        first.acquire()
+        cache.clear()
+        reopened = second.acquire()
+        assert len(cache) == 1 and reopened.closed is False
+        del first
+        gc.collect()
+        assert reopened.closed is False, "a stale post-clear finalizer must not close the re-opened handle"
+        assert len(cache) == 1, "the re-opened handle survives an untracked release"

--- a/tests/base/test_file_manager.py
+++ b/tests/base/test_file_manager.py
@@ -23,6 +23,7 @@ These tests cover:
 
 from __future__ import annotations
 
+import gc
 import pickle
 import threading
 
@@ -648,3 +649,53 @@ class TestOpenersE2E:
             assert ds is not None, "ogr_open with access='w' must return a datasource"
         finally:
             ds = None
+
+
+class TestCachingFileManagerAutoRelease:
+    """`auto_release` ties the cached handle to the manager's lifetime, refcounted per slot (#727)."""
+
+    def test_handle_closed_when_manager_is_collected(self):
+        """An auto-release manager evicts and closes its handle when garbage-collected."""
+        cache = _LRUCache(maxsize=8, on_evict=_close_handle)
+        fm = CachingFileManager(_fake_opener, "a.tif", cache=cache, auto_release=True)
+        handle = fm.acquire()
+        assert len(cache) == 1 and handle.closed is False
+        del fm
+        gc.collect()
+        assert len(cache) == 0, "manager GC must evict the slot"
+        assert handle.closed is True, "manager GC must close the handle"
+
+    def test_shared_slot_closes_only_after_last_manager(self):
+        """Two auto-release managers sharing a `manager_id` keep the handle until both are collected."""
+        cache = _LRUCache(maxsize=8, on_evict=_close_handle)
+        first = CachingFileManager(
+            _fake_opener, "a.tif", cache=cache, manager_id="k", auto_release=True
+        )
+        second = CachingFileManager(
+            _fake_opener, "a.tif", cache=cache, manager_id="k", auto_release=True
+        )
+        handle = first.acquire()
+        assert second.acquire() is handle, "same manager_id shares one cached handle"
+        del first
+        gc.collect()
+        assert handle.closed is False and len(cache) == 1, "one manager gone: shared handle stays open"
+        del second
+        gc.collect()
+        assert handle.closed is True and len(cache) == 0, "last manager gone: handle closed"
+
+    def test_without_auto_release_handle_survives_manager_gc(self):
+        """A default (non-auto-release) manager leaves its handle under pure LRU lifetime."""
+        cache = _LRUCache(maxsize=8, on_evict=_close_handle)
+        fm = CachingFileManager(_fake_opener, "a.tif", cache=cache)
+        handle = fm.acquire()
+        del fm
+        gc.collect()
+        assert handle.closed is False and len(cache) == 1, "LRU lifetime: handle survives manager GC"
+
+    def test_setstate_tolerates_legacy_six_tuple(self):
+        """A manager pickled by the pre-`auto_release` 6-tuple format still unpickles (defaults False)."""
+        fm = CachingFileManager(_fake_opener, "a.tif", auto_release=True)
+        legacy = (fm._opener, fm._path, fm._access, fm._kwargs, None, fm._manager_id)
+        clone = CachingFileManager.__new__(CachingFileManager)
+        clone.__setstate__(legacy)
+        assert clone._auto_release is False, "legacy 6-tuple must default auto_release to False"

--- a/tests/dataset/ops/lazy/test_read.py
+++ b/tests/dataset/ops/lazy/test_read.py
@@ -34,6 +34,7 @@ extra is not installed.
 from __future__ import annotations
 
 import builtins
+import gc
 import os
 import pickle
 import subprocess
@@ -45,7 +46,11 @@ import numpy as np
 import pytest
 from osgeo import gdal, osr
 
-from pyramids.base._file_manager import CachingFileManager, gdal_raster_open
+from pyramids.base._file_manager import (
+    FILE_CACHE,
+    CachingFileManager,
+    gdal_raster_open,
+)
 from pyramids.base._locks import DummyLock, SerializableLock
 from pyramids.dataset import Dataset
 from pyramids.dataset.ops import io as io_module
@@ -436,3 +441,26 @@ class TestE2EFixtureTiff:
         assert computed.dtype == np.float32
         assert computed[0, 0, 0] == pytest.approx(0.0)
         assert computed[1, 0, 0] == pytest.approx(1000.0)
+
+
+@requires_dask
+class TestRasterLazyHandleRelease:
+    """A raster lazy read releases its parked handle when the array is dropped (#727, GeoTIFF)."""
+
+    def test_dropping_lazy_array_releases_handle(self, tiled_tif_path: Path):
+        """Dropping the returned dask array evicts the manager's parked FILE_CACHE handle.
+
+        The raster lazy reader now passes `auto_release=True`, so the handle follows the dask array's
+        lifetime instead of lingering until LRU pressure or interpreter exit.
+        """
+        FILE_CACHE.clear()
+        try:
+            ds = Dataset.read_file(str(tiled_tif_path))
+            lazy = ds.read_array(chunks="auto")
+            lazy.compute()
+            assert len(FILE_CACHE) >= 1, "a lazy raster read + compute must park a handle"
+            del lazy
+            gc.collect()
+            assert len(FILE_CACHE) == 0, "dropping the lazy array must evict the parked handle"
+        finally:
+            FILE_CACHE.clear()

--- a/tests/netcdf/lazy/test_chunked_read.py
+++ b/tests/netcdf/lazy/test_chunked_read.py
@@ -486,6 +486,48 @@ class TestLazyHandleLifetime:
         assert len(FILE_CACHE) == 0, "close() must release the parked handle even while the array is alive"
         assert lazy.compute().size > 0, "the lazy array stays usable after close() (its manager re-opens)"
 
+    def test_closing_variable_subset_releases_its_handle(self, three_d_path):
+        """Closing a `get_variable()` subset directly releases the handle it parked (M1).
+
+        Test scenario:
+            The manager is tracked on both the subset and the root container, so closing the subset —
+            not only the root — evicts its parked handle before any reopen.
+        """
+        nc = NetCDF.read_file(three_d_path, open_as_multi_dimensional=True)
+        var = nc.get_variable(nc.variable_names[0])
+        lazy = var.read_array(chunks="auto")
+        lazy.compute()
+        assert len(FILE_CACHE) == 1, "the subset lazy read parks a handle"
+        var.close()
+        assert len(FILE_CACHE) == 0, "closing the subset must release its parked handle"
+
+    def test_second_close_releases_handle_reparked_after_close(self, three_d_path):
+        """A handle re-parked by a `compute()` after `close()` is released by a later `close()` (M2).
+
+        Test scenario:
+            `close()` keeps tracking still-alive managers, so the documented "recompute after close"
+            sequence followed by another `close()` still releases the re-parked handle.
+        """
+        nc = NetCDF.read_file(three_d_path, open_as_multi_dimensional=True)
+        lazy = nc.get_variable(nc.variable_names[0]).read_array(chunks="auto")
+        lazy.compute()
+        nc.close()
+        assert len(FILE_CACHE) == 0, "the first close releases the parked handle"
+        lazy.compute()
+        assert len(FILE_CACHE) == 1, "recomputing after close re-parks a handle (manager re-opens)"
+        nc.close()
+        assert len(FILE_CACHE) == 0, "a second close must release the re-parked handle"
+
+    def test_tracking_does_not_accumulate_dead_managers(self, three_d_var):
+        """Dropped lazy reads' managers auto-prune from the tracking `WeakSet` — no unbounded growth (L1)."""
+        for _ in range(10):
+            lazy = three_d_var.read_array(chunks="auto")
+            lazy.compute()
+            del lazy
+        gc.collect()
+        tracked = getattr(three_d_var, "_lazy_managers", ())
+        assert len(tracked) <= 1, f"dead managers must not accumulate in the WeakSet; tracked={len(tracked)}"
+
     def test_shared_slot_kept_until_last_manager_released(self, three_d_var):
         """Two reads of the same variable share one slot; the handle survives until BOTH drop (M2).
 

--- a/tests/netcdf/lazy/test_chunked_read.py
+++ b/tests/netcdf/lazy/test_chunked_read.py
@@ -25,6 +25,7 @@ single return statement, descriptive assertion messages.
 from __future__ import annotations
 
 import builtins
+import gc
 import multiprocessing
 import pickle
 
@@ -33,6 +34,7 @@ import pytest
 from numpy.testing import assert_allclose
 from osgeo import gdal, osr
 
+from pyramids.base._file_manager import FILE_CACHE
 from pyramids.netcdf import _lazy as lazy_mod
 from pyramids.netcdf.netcdf import NetCDF
 from tests._marks import requires_dask
@@ -427,3 +429,44 @@ class TestLazyOrientationMatchesEager:
         assert lazy.ndim == 1, f"expected a 1-D lazy array, got {lazy.ndim}-D"
         eager = np.asarray(NetCDF.read_file(path)._read_variable("lat"))
         np.testing.assert_array_equal(np.asarray(lazy), eager)
+
+
+@requires_dask
+class TestLazyHandleLifetime:
+    """The parked FILE_CACHE handle is released when the lazy array is dropped (#727)."""
+
+    def test_dropping_lazy_array_evicts_parked_handle(self, three_d_var):
+        """A lazy read parks a handle; dropping the returned array evicts it.
+
+        Test scenario:
+            A lazy read parks a live MDIM handle in the process-global FILE_CACHE for chunk reuse.
+            Before #727 that handle survived until LRU pressure or interpreter exit; now a finalizer
+            on the returned array evicts its slot when the array is dropped, so reopening the same
+            NetCDF in-process does not leave two live handles (a Windows GDAL crash).
+        """
+        assert len(FILE_CACHE) == 0, "the autouse fixture should leave FILE_CACHE empty at test start"
+        lazy = three_d_var.read_array(chunks="auto")
+        lazy.compute()
+        assert len(FILE_CACHE) >= 1, "a lazy read + compute must park a handle"
+        del lazy
+        gc.collect()
+        assert len(FILE_CACHE) == 0, "dropping the lazy array must evict the parked handle"
+
+    def test_reopen_same_file_after_dropping_lazy_array(self, three_d_path):
+        """The documented contract: drop the lazy array, then reopen the same file and read eagerly.
+
+        Test scenario:
+            Reproduces #727's sequence with the handle released first — a lazy read + compute, drop
+            the array, then reopen the same path in-process and read a variable eagerly. The parked
+            handle is gone, so there is no second live handle to the same NetCDF.
+        """
+        first = NetCDF.read_file(three_d_path, open_as_multi_dimensional=True)
+        variable = first.variable_names[0]
+        lazy = first.get_variable(variable).read_array(chunks="auto")
+        lazy.compute()
+        del lazy
+        gc.collect()
+        assert len(FILE_CACHE) == 0, "the parked handle must be released before reopening"
+        reopened = NetCDF.read_file(three_d_path, open_as_multi_dimensional=True)
+        eager = np.asarray(reopened.get_variable(variable).read_array())
+        assert eager.size > 0, "the eager reopen read should return data"

--- a/tests/netcdf/lazy/test_chunked_read.py
+++ b/tests/netcdf/lazy/test_chunked_read.py
@@ -469,6 +469,23 @@ class TestLazyHandleLifetime:
         gc.collect()
         assert len(FILE_CACHE) == 0, "dropping a derived (unpack) lazy array must evict the handle"
 
+    def test_close_releases_parked_handle_while_array_alive(self, three_d_path):
+        """`nc.close()` releases the lazy handle even while the array is alive — #727's exact repro.
+
+        Test scenario:
+            The issue's reproduction holds the lazy array alive across a reopen but calls `nc.close()`
+            first. `close()` now evicts the handles its lazy reads parked (via weakly-tracked
+            managers), so the parked handle is gone before any reopen — and the lazy array stays usable
+            because its manager re-opens on the next chunk read.
+        """
+        nc = NetCDF.read_file(three_d_path, open_as_multi_dimensional=True)
+        lazy = nc.get_variable(nc.variable_names[0]).read_array(chunks="auto")
+        lazy.compute()
+        assert len(FILE_CACHE) == 1, "the lazy read parks a handle"
+        nc.close()
+        assert len(FILE_CACHE) == 0, "close() must release the parked handle even while the array is alive"
+        assert lazy.compute().size > 0, "the lazy array stays usable after close() (its manager re-opens)"
+
     def test_shared_slot_kept_until_last_manager_released(self, three_d_var):
         """Two reads of the same variable share one slot; the handle survives until BOTH drop (M2).
 

--- a/tests/netcdf/lazy/test_chunked_read.py
+++ b/tests/netcdf/lazy/test_chunked_read.py
@@ -441,16 +441,55 @@ class TestLazyHandleLifetime:
         Test scenario:
             A lazy read parks a live MDIM handle in the process-global FILE_CACHE for chunk reuse.
             Before #727 that handle survived until LRU pressure or interpreter exit; now a finalizer
-            on the returned array evicts its slot when the array is dropped, so reopening the same
-            NetCDF in-process does not leave two live handles (a Windows GDAL crash).
+            on the read's manager (kept alive by the dask graph) evicts its slot when the array is
+            dropped, so reopening the same NetCDF in-process does not leave two live handles.
         """
         assert len(FILE_CACHE) == 0, "the autouse fixture should leave FILE_CACHE empty at test start"
         lazy = three_d_var.read_array(chunks="auto")
         lazy.compute()
-        assert len(FILE_CACHE) >= 1, "a lazy read + compute must park a handle"
+        assert len(FILE_CACHE) == 1, "a lazy read + compute must park exactly one handle"
         del lazy
         gc.collect()
         assert len(FILE_CACHE) == 0, "dropping the lazy array must evict the parked handle"
+
+    def test_dropping_unpack_lazy_array_evicts_handle(self, scale_offset_path):
+        """Dropping an `unpack=True` lazy array — a DERIVED dask array — still evicts the handle (H1).
+
+        Test scenario:
+            `read_array(unpack=True)` returns `scale * x + offset`, a derived dask array that keeps
+            only the graph layers, not the inner wrapper. Because the finalizer is bound to the
+            manager (kept alive by the readers), dropping the derived array releases the handle — the
+            path a wrapper-bound finalizer silently leaked (cache stayed at 1).
+        """
+        nc = NetCDF.read_file(scale_offset_path, open_as_multi_dimensional=True)
+        lazy = nc.get_variable(nc.variable_names[0]).read_array(chunks="auto", unpack=True)
+        lazy.compute()
+        assert len(FILE_CACHE) == 1, "a lazy unpack read + compute must park exactly one handle"
+        del lazy
+        gc.collect()
+        assert len(FILE_CACHE) == 0, "dropping a derived (unpack) lazy array must evict the handle"
+
+    def test_shared_slot_kept_until_last_manager_released(self, three_d_var):
+        """Two reads of the same variable share one slot; the handle survives until BOTH drop (M2).
+
+        Test scenario:
+            The lazy `manager_id` is `(path, variable)`, so two reads share one FILE_CACHE slot. A
+            per-slot refcount must keep the handle open until the last manager is finalized, so a
+            finalizer close can never yank a handle the other array is still reading through.
+        """
+        assert len(FILE_CACHE) == 0
+        first = three_d_var.read_array(chunks="auto")
+        second = three_d_var.read_array(chunks="auto")
+        first.compute()
+        second.compute()
+        assert len(FILE_CACHE) == 1, "two reads of one variable share a single slot"
+        del first
+        gc.collect()
+        assert len(FILE_CACHE) == 1, "dropping one array must NOT evict the shared handle"
+        assert second.compute().size > 0, "the surviving array must still read"
+        del second
+        gc.collect()
+        assert len(FILE_CACHE) == 0, "dropping the last array evicts the shared handle"
 
     def test_reopen_same_file_after_dropping_lazy_array(self, three_d_path):
         """The documented contract: drop the lazy array, then reopen the same file and read eagerly.


### PR DESCRIPTION
# Description

A lazy NetCDF read (`read_array(chunks=…)`, or `crop(…, chunks=…)`) parks a live GDAL multidimensional
handle in the process-global `FILE_CACHE` (`pyramids/base/_file_manager.py`) via `CachingFileManager`,
and nothing evicted it when the returned dask array was computed, dropped, or garbage-collected;
`NetCDF.close()` had no reference to the manager either. So the handle survived until LRU pressure
(default `maxsize=128`) or interpreter exit. Reopening the **same file in the same process** while that
handle was still parked opened a second live MDIM handle to one NetCDF, which crashes GDAL with an
access violation on **Windows** (exit 139). This is the production analogue of the CI segfault that
#722 isolated test-side (an autouse `FILE_CACHE.clear()`) without changing the library.

This PR implements **both halves of the issue's own suggested fix** so the handle is released
deterministically, on either of the two paths a user can reach:

**1. On array drop — a manager-bound finalizer (all derived-array paths).** `build_lazy_array` opens
through a `CachingFileManager` with a new opt-in `auto_release=True`, which registers a
`weakref.finalize` on the **manager**. The manager is kept alive by the chunk readers in the dask
graph, so the finalizer fires when the lazy read's result **and every array derived from it** —
`unpack=True`, an `open_mfdataset` stack, a `plot(chunks=)`, a slice or dask-arithmetic result — is
dropped or garbage-collected. (An earlier finalizer bound to the returned array was silently defeated
on those derived paths: the inner array was collected before `compute()` parked a handle.) A per-slot
**refcount** in `_LRUCache` closes the handle only when the last manager sharing a
`manager_id=(path, variable)` slot is finalized, so a drop never closes a handle another array is
mid-read on.

**2. On `NetCDF.close()` — the issue's posted reproduction.** #727's repro keeps the lazy array alive
and calls `nc.close()` before reopening. `NetCDF` now weakly tracks (`weakref.WeakSet`) the managers
its lazy reads create, registered on **both** the `get_variable()` subset and the root container, and
`close()` releases them — so the parked handle is evicted even while a lazy array is still alive, and
closing either the subset or the root works. The reference is weak so the drop-time finalizer still
fires; the lazy array stays usable after `close()` (its manager re-opens the handle on the next chunk
read).

The raster (GeoTIFF) lazy path (`Dataset.read_array(chunks=)`) also opts into `auto_release`, so its
handle follows the array's lifetime too. Hardening: the finalizer-invoked close logs a remote-`/vsi`
flush error rather than leaving it unraisable; a manager surviving an explicit `FILE_CACHE.clear()`
falls back to LRU lifetime; and the pickle format tolerates the pre-`auto_release` state.

The `read_array` "Open-handle lifetime" docstring documents the two release paths and the guidance to
drop the lazy array or `close()` the NetCDF before reopening a file in-process. This is the lazy
analogue of #564 (which fixed the eager `NetCDF.close()` handle release on Windows).

No new dependencies (`weakref` is stdlib).

# Issues

- Closes #727

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Non-breaking: `auto_release` is opt-in (only the lazy readers set it), so managers without it keep the
pure-LRU lifetime, and existing `CachingFileManager` behaviour is unchanged. Lazy reads, chunk reuse
during compute, and a lazy array outliving its parent `NetCDF` all still work.

# How Has This Been Tested?

New regression tests, each mutation-checked against the pre-fix code:

- `tests/netcdf/lazy/test_chunked_read.py::TestLazyHandleLifetime` — drop releases the handle on the
  plain and **`unpack=True`** (derived-array) paths; a shared slot stays open until the last manager is
  released; `nc.close()` releases the handle **while the array is alive** and the array stays usable;
  closing a **subset** releases its handle; a second `close()` releases a handle re-parked by a
  post-`close()` compute; dropped reads don't accumulate dead weakrefs.
- `tests/base/test_file_manager.py::TestCachingFileManagerAutoRelease` — handle closed on manager GC;
  per-slot refcount across a shared `manager_id`; non-`auto_release` keeps LRU lifetime; the tolerant
  6-tuple `__setstate__`; a stale post-`clear()` finalizer does not close a re-opened handle; a
  finalizer-invoked close error is logged, not raised.
- `tests/dataset/ops/lazy/test_read.py::TestRasterLazyHandleRelease` — the GeoTIFF lazy path releases
  on drop.

- [x] Full dataset + netcdf + base suites: **5021 passed** (the single `test_pickle_then_compute_across_process`
      failure is a worktree-vs-installed version skew — parent pickles the new 7-tuple, the spawned
      subprocess imports the older installed 6-tuple `__setstate__`; it passes when both run the branch
      code and resolves on merge).
- [x] Reviewed across four adversarial rounds (`planning/pr-diff-review-netcdf-lazy-handle-*.md`);
      every finding resolved.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.

Versions and the change log are generated by commitizen in CI, so those three boxes are intentionally
left for the release automation. The `NetCDF.read_array` open-handle-lifetime note and the
`CachingFileManager` `auto_release` docstring document the new behaviour.
