### PR TITLE
Refactor/sonar cognitive complexity

### DIFF
--- a/src/pyramids/_io.py
+++ b/src/pyramids/_io.py
@@ -8,6 +8,7 @@ import time
 import warnings
 import zipfile
 from pathlib import Path
+from typing import NoReturn
 
 import numpy as np
 from osgeo import gdal
@@ -503,6 +504,55 @@ def extract_from_gz(input_file: str | Path, output_file: str | Path, delete=Fals
         input_file.unlink()
 
 
+def _resolve_read_path(path: str | Path, vsi: str | None, file_i: int) -> str:
+    """Resolve ``path`` to the concrete path :func:`read_file` should open.
+
+    When ``vsi`` is given, treat ``path`` as an archive of that kind and return
+    the VSI path of member ``file_i``; otherwise sniff/normalise the path as
+    usual via :func:`_parse_path`.
+    """
+    if vsi is not None:
+        dir_vsi = _archive_dir_vsi(path, vsi)
+        members = _archive_members(dir_vsi)
+        if not 0 <= file_i < len(members):
+            raise FileNotFoundError(
+                f"archive {path!r} has {len(members)} member(s); file_i={file_i} "
+                "is out of range"
+            )
+        resolved = f"{dir_vsi}/{members[file_i]}"
+    else:
+        resolved = _parse_path(path, file_i=file_i)
+    return resolved
+
+
+def _raise_open_error(error: Exception, path: str) -> NoReturn:
+    """Translate a GDAL open failure into a specific pyramids exception.
+
+    Re-raises the original ``error`` when the message is not one of the
+    recognised "unsupported / gzip-multi-member / missing" cases.
+    """
+    message = str(error)
+    if message.__contains__(" not recognized as a supported file format."):
+        if any(path.endswith(i) for i in COMPRESSED_FILES_EXTENSIONS):
+            raise FileFormatNotSupportedError(
+                "File format is not supported if you provided a gzip compressed file with multiple internal "
+                "files. Currently, it is not supported to read gzip files with multiple compressed internal "
+                "files"
+            )
+        raise error
+    if any(path.__contains__(i) for i in DOES_NOT_SUPPORT_INTERNAL) and not any(
+        path.endswith(i) for i in DOES_NOT_SUPPORT_INTERNAL
+    ):
+        raise FileFormatNotSupportedError(
+            "File format is not supported, if you provided a gzip compressed file with multiple internal "
+            "files. Currently it is not supported to read gzip files with multiple compressed internal "
+            "files"
+        )
+    if message.__contains__(" No such file or directory"):
+        raise FileNotFoundError(f"{path} you entered does not exist")
+    raise error
+
+
 def read_file(
     path: str | Path,
     read_only: bool = True,
@@ -533,52 +583,18 @@ def read_file(
         raise TypeError(
             f"the path parameter should be of string or Path type, given: {type(path)}"
         )
-    if vsi is not None:
-        dir_vsi = _archive_dir_vsi(path, vsi)
-        members = _archive_members(dir_vsi)
-        if not 0 <= file_i < len(members):
-            raise FileNotFoundError(
-                f"archive {path!r} has {len(members)} member(s); file_i={file_i} "
-                "is out of range"
-            )
-        path = f"{dir_vsi}/{members[file_i]}"
-    else:
-        path = _parse_path(path, file_i=file_i)
+    path = _resolve_read_path(path, vsi, file_i)
     access = gdal.GA_ReadOnly if read_only else gdal.GA_Update
     try:
-        # get the file extension
-        # Example criteria for using gdal.OpenEx with OF_MULTIDIM_RASTER for complex multi-dimensional formats
-        if (
-            open_as_multi_dimensional
-        ):  # file_extension in ["hdf", "h5", "nc", "nc4", "grib", "grib2", "jp2"]:
-            # Use OpenEx with the OF_MULTIDIM_RASTER flag for formats that often require handling of multi-dimensional
-            # data
+        if open_as_multi_dimensional:
+            # OF_MULTIDIM_RASTER for formats that expose multi-dimensional data
+            # (hdf, h5, nc, nc4, grib, grib2, jp2, ...).
             src = gdal.OpenEx(path, access | gdal.OF_MULTIDIM_RASTER)
         else:
-            # Use OpenShared for potentially frequently accessed raster files
+            # OpenShared for potentially frequently accessed raster files.
             src = gdal.OpenShared(path, access)
     except Exception as e:
-        if str(e).__contains__(" not recognized as a supported file format."):
-            if any(path.endswith(i) for i in COMPRESSED_FILES_EXTENSIONS):
-                raise FileFormatNotSupportedError(
-                    "File format is not supported if you provided a gzip compressed file with multiple internal "
-                    "files. Currently, it is not supported to read gzip files with multiple compressed internal "
-                    "files"
-                )
-            else:
-                raise e
-        elif any(path.__contains__(i) for i in DOES_NOT_SUPPORT_INTERNAL) and not any(
-            path.endswith(i) for i in DOES_NOT_SUPPORT_INTERNAL
-        ):
-            raise FileFormatNotSupportedError(
-                "File format is not supported, if you provided a gzip compressed file with multiple internal "
-                "files. Currently it is not supported to read gzip files with multiple compressed internal "
-                "files"
-            )
-        elif str(e).__contains__(" No such file or directory"):
-            raise FileNotFoundError(f"{path} you entered does not exist")
-        else:
-            raise e
+        _raise_open_error(e, path)
     return src
 
 

--- a/src/pyramids/base/_bootstrap.py
+++ b/src/pyramids/base/_bootstrap.py
@@ -39,6 +39,67 @@ from pathlib import Path
 _DLL_HANDLE = None
 
 
+def _configure_gdal_data_env(data_dir: Path) -> None:
+    """Point GDAL / PROJ / libcurl at the wheel's bundled data directories.
+
+    ``GDAL_DATA`` / ``PROJ_DATA`` / ``PROJ_LIB`` and the CA bundle use
+    ``setdefault`` so a user/system override wins; ``GDAL_DRIVER_PATH`` is
+    forced to the bundled plugins dir (they are ABI-locked to the bundled
+    libgdal) unless ``PYRAMIDS_KEEP_GDAL_ENV=1``.
+    """
+    gdal_data = data_dir / "gdal_data"
+    proj_data = data_dir / "proj_data"
+    gdal_plugins = data_dir / "gdalplugins"
+    ca_bundle = data_dir / "ssl" / "cacert.pem"
+    if gdal_data.is_dir():
+        os.environ.setdefault("GDAL_DATA", str(gdal_data))
+    if proj_data.is_dir():
+        os.environ.setdefault("PROJ_DATA", str(proj_data))
+        os.environ.setdefault("PROJ_LIB", str(proj_data))
+    if gdal_plugins.is_dir():
+        # GDAL_DRIVER_PATH points at compiled driver plugins (gdal_netCDF.so,
+        # gdal_HDF5.so, gdal_GRIB.so, ...) ABI-locked to the exact bundled
+        # libgdal build, so it is FORCED to the bundled dir rather than
+        # setdefault'd — a foreign (e.g. conda-activated) GDAL_DRIVER_PATH is
+        # never safe for the bundled libgdal (issue #465). Power users can set
+        # PYRAMIDS_KEEP_GDAL_ENV=1 to restore "inherited value wins".
+        if os.environ.get("PYRAMIDS_KEEP_GDAL_ENV") == "1":
+            os.environ.setdefault("GDAL_DRIVER_PATH", str(gdal_plugins))
+        else:
+            os.environ["GDAL_DRIVER_PATH"] = str(gdal_plugins)
+    if ca_bundle.is_file():
+        # The bundled libcurl bakes its CA path to the wheel-build prefix,
+        # absent in the consuming env, so /vsicurl HTTPS fails with "error
+        # adding trust anchors". Re-point GDAL / PROJ / libcurl at the vendored
+        # cacert.pem; setdefault keeps any user override authoritative (#412).
+        ca_str = str(ca_bundle)
+        os.environ.setdefault("GDAL_HTTP_CAINFO", ca_str)
+        os.environ.setdefault("PROJ_CURL_CA_BUNDLE", ca_str)
+        os.environ.setdefault("CURL_CA_BUNDLE", ca_str)
+        os.environ.setdefault("SSL_CERT_FILE", ca_str)
+
+
+def _register_windows_dll_dirs(pkg_dir: Path) -> None:  # pragma: no cover
+    """Register the wheel's native DLL directory on Windows.
+
+    delvewheel places DLLs at ``<site-packages>/pyramids_gis.libs/``; this is a
+    safety net for that layout and the older ``pyramids/.libs/`` convention. The
+    dir is also prepended to ``PATH`` because GDAL's native plugin loader uses
+    raw ``LoadLibrary`` (no ``SEARCH_USER_DIRS``), which ignores
+    ``add_dll_directory``. The handle is anchored at module scope so the
+    directory stays registered for the process lifetime.
+    """
+    global _DLL_HANDLE
+    for candidate in (pkg_dir / ".libs", pkg_dir.parent / "pyramids_gis.libs"):
+        if candidate.is_dir():
+            _DLL_HANDLE = os.add_dll_directory(str(candidate))
+            candidate_str = str(candidate)
+            path = os.environ.get("PATH", "")
+            if candidate_str not in path.split(os.pathsep):
+                os.environ["PATH"] = candidate_str + os.pathsep + path
+            break
+
+
 def activate_vendored_osgeo(pkg_dir: Path) -> bool:
     """Activate the vendored osgeo if `_vendor/osgeo/` exists + ABI-matches.
 
@@ -57,7 +118,6 @@ def activate_vendored_osgeo(pkg_dir: Path) -> bool:
         directory exists or if its `_gdal.<EXT>` doesn't match the
         current Python ABI.
     """
-    global _DLL_HANDLE
     vendored_osgeo = pkg_dir / "_vendor" / "osgeo"
 
     if not vendored_osgeo.is_dir():
@@ -79,85 +139,10 @@ def activate_vendored_osgeo(pkg_dir: Path) -> bool:
     if vendor_str not in sys.path:
         sys.path.insert(0, vendor_str)
 
-    data_dir = pkg_dir / "_data"
-    gdal_data = data_dir / "gdal_data"
-    proj_data = data_dir / "proj_data"
-    gdal_plugins = data_dir / "gdalplugins"
-    ca_bundle = data_dir / "ssl" / "cacert.pem"
-    # setdefault for the DATA dirs is intentional: a user-set GDAL_DATA /
-    # PROJ_DATA / PROJ_LIB wins over the wheel's bundled data dirs. These
-    # are version-tolerant resource files, and overriding them is a
-    # legitimate advanced use case (e.g. pointing PROJ at a custom grid
-    # bundle). Side effect: changing these env vars after import has no
-    # effect — the bootstrap reads them once at first `import pyramids`.
-    if gdal_data.is_dir():
-        os.environ.setdefault("GDAL_DATA", str(gdal_data))
-    if proj_data.is_dir():
-        os.environ.setdefault("PROJ_DATA", str(proj_data))
-        os.environ.setdefault("PROJ_LIB", str(proj_data))
-    if gdal_plugins.is_dir():
-        # GDAL_DRIVER_PATH is handled DIFFERENTLY from the data dirs above:
-        # it points at compiled driver plugins (gdal_netCDF.so,
-        # gdal_HDF5.so, gdal_GRIB.so, ...) that are ABI-locked to the exact
-        # bundled libgdal build, so it is FORCED to the bundled dir rather
-        # than setdefault'd. conda-forge now ships these drivers as plugins
-        # on every platform (not statically linked), and we vendor them
-        # into `_data/gdalplugins/`.
-        #
-        # The failure this prevents (issue #465): when the wheel is
-        # imported inside an activated conda env, conda's activate.d already
-        # exports GDAL_DRIVER_PATH pointing at conda's own gdalplugins,
-        # built for a DIFFERENT libgdal version. With setdefault that
-        # inherited value would win, so the bundled libgdal would try to
-        # load conda's mismatched plugins; GDAL refuses to register them
-        # ("Function GDALRegister_netCDF of .../gdal_netCDF.so did not
-        # register a driver netCDF") and every NetCDF/HDF5 read then fails
-        # with "not recognized as being in a supported file format".
-        #
-        # A foreign GDAL_DRIVER_PATH is never safe for the bundled libgdal,
-        # so we override it. Power users who really want the bundled GDAL to
-        # load plugins from an external dir can set PYRAMIDS_KEEP_GDAL_ENV=1
-        # to restore the old "inherited GDAL_DRIVER_PATH wins" behaviour.
-        if os.environ.get("PYRAMIDS_KEEP_GDAL_ENV") == "1":
-            os.environ.setdefault("GDAL_DRIVER_PATH", str(gdal_plugins))
-        else:
-            os.environ["GDAL_DRIVER_PATH"] = str(gdal_plugins)
-    if ca_bundle.is_file():
-        # The bundled libcurl bakes its CA path to the wheel-build
-        # prefix (`.pixi/envs/wheel-build/ssl/cacert.pem`), which is
-        # absent in the consuming env, so GDAL `/vsicurl` HTTPS reads
-        # fail with "error adding trust anchors". Re-point GDAL / PROJ /
-        # libcurl at the cacert.pem we vendor into the wheel. setdefault
-        # keeps any user/system override (CURL_CA_BUNDLE, SSL_CERT_FILE,
-        # certifi) authoritative. See issue #412.
-        ca_str = str(ca_bundle)
-        os.environ.setdefault("GDAL_HTTP_CAINFO", ca_str)
-        os.environ.setdefault("PROJ_CURL_CA_BUNDLE", ca_str)
-        os.environ.setdefault("CURL_CA_BUNDLE", ca_str)
-        os.environ.setdefault("SSL_CERT_FILE", ca_str)
+    _configure_gdal_data_env(pkg_dir / "_data")
 
     if sys.platform == "win32":  # pragma: no cover
-        # delvewheel places DLLs at <site-packages>/pyramids_gis.libs/
-        # (one level up from this package) and injects its own
-        # add_dll_directory call near the top of the vendored
-        # osgeo/__init__.py. The block below is a safety net for both
-        # that layout and the older pyramids/.libs/ convention; the
-        # vendored osgeo/__init__.py also sets the DLL directory on
-        # import so spawn workers that import osgeo without pyramids
-        # first still resolve gdal.dll.
-        #
-        # We also prepend the libs dir to PATH because GDAL's native
-        # plugin loader uses raw LoadLibrary (no SEARCH_USER_DIRS
-        # flag), which doesn't honor add_dll_directory. PATH is the
-        # only env-controlled fallback in the legacy DLL search order.
-        for candidate in (pkg_dir / ".libs", pkg_dir.parent / "pyramids_gis.libs"):
-            if candidate.is_dir():
-                _DLL_HANDLE = os.add_dll_directory(str(candidate))
-                candidate_str = str(candidate)
-                path = os.environ.get("PATH", "")
-                if candidate_str not in path.split(os.pathsep):
-                    os.environ["PATH"] = candidate_str + os.pathsep + path
-                break
+        _register_windows_dll_dirs(pkg_dir)
 
     if os.environ.get("PYRAMIDS_DEBUG_BOOTSTRAP"):  # pragma: no cover
         print(f"[pyramids] vendor dir: {vendor_str}")

--- a/src/pyramids/base/config.py
+++ b/src/pyramids/base/config.py
@@ -718,6 +718,29 @@ class Config:
             gdal.SetConfigOption("GDAL_DRIVER_PATH", str(gdal_plugins_path))
         gdal.AllRegister()
 
+    def _prepend_to_path(self, library_bin_path: Path) -> None:
+        """Prepend ``library_bin_path`` to ``PATH`` (fixes Windows error 126 loading plugins)."""
+        if library_bin_path.exists():
+            current_path = os.environ.get("PATH", "")
+            bin_str = str(library_bin_path)
+            path_parts = current_path.split(os.pathsep) if current_path else []
+            if bin_str not in path_parts:
+                os.environ["PATH"] = bin_str + (
+                    os.pathsep + current_path if current_path else ""
+                )
+                self.logger.debug(f"Prepended to PATH: {bin_str}")
+        else:
+            self.logger.debug(f"Library bin path not found at: {library_bin_path}")
+
+    def _set_env_path(self, env_name: str, path: Path, not_found_label: str) -> None:
+        """Set ``os.environ[env_name]`` to ``path`` if it exists and differs; log otherwise."""
+        if path.exists():
+            if os.environ.get(env_name) != str(path):
+                os.environ[env_name] = str(path)
+                self.logger.debug(f"{env_name} set to: {path}")
+        else:
+            self.logger.debug(f"{not_found_label} path not found at: {path}")
+
     def set_env_conda(self) -> Path | None:
         """Set GDAL-related environment variables in a Conda environment.
 
@@ -761,32 +784,11 @@ class Config:
             )
 
         # Ensure dependent DLLs are on PATH (fixes error 126 on Windows when loading plugins like HDF5)
-        if library_bin_path.exists():
-            current_path = os.environ.get("PATH", "")
-            bin_str = str(library_bin_path)
-            path_parts = current_path.split(os.pathsep) if current_path else []
-            if bin_str not in path_parts:
-                os.environ["PATH"] = bin_str + (
-                    os.pathsep + current_path if current_path else ""
-                )
-                self.logger.debug(f"Prepended to PATH: {bin_str}")
-        else:
-            self.logger.debug(f"Library bin path not found at: {library_bin_path}")
+        self._prepend_to_path(library_bin_path)
 
         # Optionally set GDAL_DATA and PROJ_LIB if available
-        if gdal_data_path.exists():
-            if os.environ.get("GDAL_DATA") != str(gdal_data_path):
-                os.environ["GDAL_DATA"] = str(gdal_data_path)
-                self.logger.debug(f"GDAL_DATA set to: {gdal_data_path}")
-        else:
-            self.logger.debug(f"GDAL data path not found at: {gdal_data_path}")
-
-        if proj_lib_path.exists():
-            if os.environ.get("PROJ_LIB") != str(proj_lib_path):
-                os.environ["PROJ_LIB"] = str(proj_lib_path)
-                self.logger.debug(f"PROJ_LIB set to: {proj_lib_path}")
-        else:
-            self.logger.debug(f"PROJ lib path not found at: {proj_lib_path}")
+        self._set_env_path("GDAL_DATA", gdal_data_path, "GDAL data")
+        self._set_env_path("PROJ_LIB", proj_lib_path, "PROJ lib")
 
         return gdal_plugins_path if gdal_plugins_path.exists() else None
 

--- a/src/pyramids/base/config.py
+++ b/src/pyramids/base/config.py
@@ -792,6 +792,28 @@ class Config:
 
         return gdal_plugins_path if gdal_plugins_path.exists() else None
 
+    @staticmethod
+    def _probe_windows_plugins() -> Path | None:
+        """Probe Python site-packages for a GDAL plugins dir (Windows), last match wins."""
+        found: Path | None = None
+        for site_path in site.getsitepackages():
+            plugins = Plugins(site_packages_path=site_path)
+            path = plugins.check_path()
+            if path:
+                found = path
+        return found
+
+    def _probe_posix_plugins(self) -> Path | None:
+        """Probe typical Linux/macOS gdalplugins locations, setting GDAL_DRIVER_PATH."""
+        found: Path | None = None
+        for candidate in ("/usr/local/lib/gdalplugins", "/usr/lib/gdalplugins"):
+            path = Path(candidate)
+            if path.exists():
+                os.environ["GDAL_DRIVER_PATH"] = str(path)
+                found = path
+                self.logger.debug(f"GDAL_DRIVER_PATH set to: {path}")
+        return found
+
     def dynamic_env_variables(self) -> Path | None:
         """Locate GDAL plugin directories and export GDAL_DRIVER_PATH.
 
@@ -820,30 +842,10 @@ class Config:
         gdal_plugins_path = self.set_env_conda()
 
         if gdal_plugins_path is None:
-
-            # For Windows, check Python site-packages
             if sys.platform == "win32":
-                for site_path in site.getsitepackages():
-                    plugins = Plugins(site_packages_path=site_path)
-                    path = plugins.check_path()
-                    if path:
-                        gdal_plugins_path = path
+                gdal_plugins_path = self._probe_windows_plugins()
             else:
-
-                # Check typical system locations (Linux/MacOS)
-                system_paths = [
-                    "/usr/local/lib/gdalplugins",
-                    "/usr/lib/gdalplugins",
-                ]
-                for path in system_paths:
-                    path = Path(path)
-                    if path.exists():
-                        os.environ["GDAL_DRIVER_PATH"] = str(path)
-                        gdal_plugins_path = path
-                        self.logger.debug(f"GDAL_DRIVER_PATH set to: {path}")
-
-                # If the path is not found
-                # print("GDAL plugins path could not be found. Please check your GDAL installation.")
+                gdal_plugins_path = self._probe_posix_plugins()
         return gdal_plugins_path
 
     def setup_logging(

--- a/src/pyramids/base/config.py
+++ b/src/pyramids/base/config.py
@@ -185,6 +185,72 @@ class LoggerManager:
         self._setup_logging(level=level, log_file=log_file)
         self._set_error_handler()
 
+    def _normalize_level(self, level: int | str) -> int:
+        """Coerce a level name (case-insensitive) or int to a logging level int."""
+        if isinstance(level, str):
+            if level.upper() not in self.LEVELS:
+                raise ValueError(f"Invalid log level: {level}")
+            level = getattr(logging, level.upper(), logging.INFO)
+        return level
+
+    @staticmethod
+    def _existing_handlers(
+        root_logger: logging.Logger,
+    ) -> tuple[logging.Handler | None, set[Path]]:
+        """Return the current console handler (if any) and the set of file-handler paths."""
+        console_handler: logging.Handler | None = None
+        file_paths: set[Path] = set()
+        for h in root_logger.handlers:
+            if isinstance(h, logging.StreamHandler) and not isinstance(
+                h, logging.FileHandler
+            ):
+                console_handler = h
+            if isinstance(h, logging.FileHandler):
+                try:
+                    file_paths.add(Path(h.baseFilename))
+                except Exception:
+                    pass  # nosec B110
+        return console_handler, file_paths
+
+    def _ensure_console_handler(
+        self,
+        root_logger: logging.Logger,
+        console_handler: logging.Handler | None,
+        level: int,
+    ) -> None:
+        """Add a coloured console handler, or update the existing one's level/format."""
+        if console_handler is None:
+            console_handler = logging.StreamHandler()
+            console_handler.setLevel(level)
+            console_handler.setFormatter(
+                ColorFormatter(fmt=self.FMT, datefmt=self.DATE_FMT)
+            )
+            root_logger.addHandler(console_handler)
+        else:
+            console_handler.setLevel(level)
+            if not isinstance(console_handler.formatter, ColorFormatter):
+                console_handler.setFormatter(
+                    ColorFormatter(fmt=self.FMT, datefmt=self.DATE_FMT)
+                )
+
+    def _ensure_file_handler(
+        self,
+        root_logger: logging.Logger,
+        log_file: str | Path | None,
+        level: int,
+        existing_paths: set[Path],
+    ) -> None:
+        """Add a file handler for ``log_file`` if requested and not already present."""
+        if log_file is not None:
+            log_file_path = Path(log_file)
+            if log_file_path not in existing_paths:
+                fh = logging.FileHandler(log_file_path, encoding="utf-8")
+                fh.setLevel(level)
+                fh.setFormatter(
+                    logging.Formatter(fmt=self.FMT, datefmt=self.DATE_FMT)
+                )
+                root_logger.addHandler(fh)
+
     def _setup_logging(
         self,
         level: int | str = logging.INFO,
@@ -222,53 +288,16 @@ class LoggerManager:
         See Also:
             ColorFormatter: Colorizes level names for console output.
         """
-        # Normalize level
-        if isinstance(level, str):
-            if level.upper() not in self.LEVELS:
-                raise ValueError(f"Invalid log level: {level}")
-            level = getattr(logging, level.upper(), logging.INFO)
+        level = self._normalize_level(level)
 
         root_logger = logging.getLogger()
         root_logger.setLevel(level)
 
-        # Determine if a console handler already exists
-        console_handler = None
-        file_handler_exists_for = set()
-        for h in root_logger.handlers:
-            if isinstance(h, logging.StreamHandler) and not isinstance(
-                h, logging.FileHandler
-            ):
-                console_handler = h
-            if isinstance(h, logging.FileHandler):
-                try:
-                    file_handler_exists_for.add(Path(h.baseFilename))
-                except Exception:
-                    pass  # nosec B110
-
-        # Create or update console handler
-        if console_handler is None:
-            console_handler = logging.StreamHandler()
-            console_handler.setLevel(level)
-            console_handler.setFormatter(
-                ColorFormatter(fmt=self.FMT, datefmt=self.DATE_FMT)
-            )
-            root_logger.addHandler(console_handler)
-        else:
-            console_handler.setLevel(level)
-            # Always ensure colored formatter on console
-            if not isinstance(console_handler.formatter, ColorFormatter):
-                console_handler.setFormatter(
-                    ColorFormatter(fmt=self.FMT, datefmt=self.DATE_FMT)
-                )
-
-        # Create file handler if requested and not already present
-        if log_file is not None:
-            log_file_path = Path(log_file)
-            if log_file_path not in file_handler_exists_for:
-                fh = logging.FileHandler(log_file_path, encoding="utf-8")
-                fh.setLevel(level)
-                fh.setFormatter(logging.Formatter(fmt=self.FMT, datefmt=self.DATE_FMT))
-                root_logger.addHandler(fh)
+        console_handler, file_handler_exists_for = self._existing_handlers(root_logger)
+        self._ensure_console_handler(root_logger, console_handler, level)
+        self._ensure_file_handler(
+            root_logger, log_file, level, file_handler_exists_for
+        )
 
         # Reduce noise from common third-party libraries
         for noisy in ("fiona", "rasterio", "shapely", "matplotlib", "urllib3", "osgeo"):

--- a/src/pyramids/dataset/_stac.py
+++ b/src/pyramids/dataset/_stac.py
@@ -880,6 +880,38 @@ def _footprint_4326(
     return geometry, [min(lons), min(lats), max(lons), max(lats)]
 
 
+def _to_iso(value: Any) -> Any:
+    """Serialise a datetime-like value via ``isoformat()``; pass strings/None through."""
+    return value.isoformat() if hasattr(value, "isoformat") else value
+
+
+def _proj_fields(
+    dataset: Any, epsg: Any, native_bbox: list, transform_fn: Any
+) -> dict[str, Any]:
+    """Build the ``proj`` extension property fields from the dataset grid."""
+    return {
+        "proj:epsg": epsg,
+        "proj:code": f"EPSG:{epsg}",
+        "proj:shape": [dataset.rows, dataset.columns],
+        "proj:transform": transform_fn(dataset.geotransform),
+        "proj:bbox": native_bbox,
+    }
+
+
+def _raster_bands(dataset: Any) -> list[dict[str, Any]]:
+    """Build the ``raster:bands`` list (per-band ``data_type`` + optional ``nodata``)."""
+    nodata = dataset.no_data_value
+    dtypes = dataset.dtype
+    bands: list[dict[str, Any]] = []
+    for i in range(dataset.band_count):
+        band: dict[str, Any] = {"data_type": dtypes[i]}
+        nd = nodata[i] if i < len(nodata) else None
+        if nd is not None:
+            band["nodata"] = nd
+        bands.append(band)
+    return bands
+
+
 def to_stac_item(
     dataset: Any,
     item_id: str,
@@ -961,27 +993,22 @@ def to_stac_item(
     native_bbox = list(dataset.bbox)
     geometry, bbox_4326 = _footprint_4326(native_bbox, epsg, precision)
 
-    def _iso(value: Any) -> Any:
-        return value.isoformat() if hasattr(value, "isoformat") else value
-
     # A null `datetime` is only STAC-valid alongside a start/end range. When the
     # caller gives neither, default to "now" so the Item is always valid
     # instead of silently emitting a null-datetime Feature.
     if datetime is None and not (start_datetime and end_datetime):
         datetime = _datetime_cls.now(timezone.utc)
-    properties: dict[str, Any] = {"datetime": _iso(datetime)}
+    properties: dict[str, Any] = {"datetime": _to_iso(datetime)}
     if start_datetime is not None:
-        properties["start_datetime"] = _iso(start_datetime)
+        properties["start_datetime"] = _to_iso(start_datetime)
     if end_datetime is not None:
-        properties["end_datetime"] = _iso(end_datetime)
+        properties["end_datetime"] = _to_iso(end_datetime)
     stac_extensions: list[str] = []
 
     if with_proj and epsg:
-        properties["proj:epsg"] = epsg
-        properties["proj:code"] = f"EPSG:{epsg}"
-        properties["proj:shape"] = [dataset.rows, dataset.columns]
-        properties["proj:transform"] = geotransform_to_affine(dataset.geotransform)
-        properties["proj:bbox"] = native_bbox
+        properties.update(
+            _proj_fields(dataset, epsg, native_bbox, geotransform_to_affine)
+        )
         stac_extensions.append(
             "https://stac-extensions.github.io/projection/v1.1.0/schema.json"
         )
@@ -991,16 +1018,7 @@ def to_stac_item(
         asset["type"] = asset_media_type
 
     if with_raster:
-        nodata = dataset.no_data_value
-        dtypes = dataset.dtype
-        bands = []
-        for i in range(dataset.band_count):
-            band: dict[str, Any] = {"data_type": dtypes[i]}
-            nd = nodata[i] if i < len(nodata) else None
-            if nd is not None:
-                band["nodata"] = nd
-            bands.append(band)
-        asset["raster:bands"] = bands
+        asset["raster:bands"] = _raster_bands(dataset)
         stac_extensions.append(
             "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
         )

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -252,27 +252,42 @@ def _get_capabilities(
     return tuple(sorted(versions)), frozenset(_extract_coverages(root))
 
 
-def _extract_coverages(root: ET.Element) -> set[str]:
-    """Collect coverage identifiers from a ``GetCapabilities`` document.
-
-    WCS 2.0.x / 1.1.x advertise coverages as ``CoverageId`` / ``Identifier``.
-    WCS 1.0.0 uses ``<name>`` — but only the ``<name>`` *inside a coverage
-    offering* is an identifier; the ``<Service><name>`` is the service title, so
-    a blind ``name`` sweep would wrongly admit it. We therefore collect ``name``
-    only when its parent is a ``CoverageOfferingBrief`` / ``CoverageOffering``.
-    """
-    coverages: set[str] = set()
+def _collect_coverage_ids(root: ET.Element) -> set[str]:
+    """Collect WCS 2.0.x / 1.1.x ``CoverageId`` / ``Identifier`` values."""
+    ids: set[str] = set()
     for el in root.iter():
         if _localname(el.tag) in ("CoverageId", "Identifier") and el.text:
-            coverages.add(el.text.strip())
-    if coverages:
-        return coverages
+            ids.add(el.text.strip())
+    return ids
+
+
+def _collect_wcs10_names(root: ET.Element) -> set[str]:
+    """Collect WCS 1.0.0 ``<name>`` values inside coverage offerings only.
+
+    The ``<name>`` inside a ``CoverageOfferingBrief`` / ``CoverageOffering`` is a
+    coverage identifier; the ``<Service><name>`` is the service title, so a blind
+    ``name`` sweep would wrongly admit it.
+    """
+    names: set[str] = set()
     for parent in root.iter():
         if _localname(parent.tag) not in ("CoverageOfferingBrief", "CoverageOffering"):
             continue
         for child in parent:
             if _localname(child.tag) == "name" and child.text:
-                coverages.add(child.text.strip())
+                names.add(child.text.strip())
+    return names
+
+
+def _extract_coverages(root: ET.Element) -> set[str]:
+    """Collect coverage identifiers from a ``GetCapabilities`` document.
+
+    WCS 2.0.x / 1.1.x advertise coverages as ``CoverageId`` / ``Identifier``;
+    WCS 1.0.0 uses ``<name>`` inside a coverage offering (see
+    :func:`_collect_wcs10_names` for why the service title is excluded).
+    """
+    coverages = _collect_coverage_ids(root)
+    if not coverages:
+        coverages = _collect_wcs10_names(root)
     return coverages
 
 

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -1122,6 +1122,52 @@ class Analysis(_Engine["Dataset"]):
             )
         self._ds.raster.CreateMaskBand(gdal.GMF_PER_DATASET if per_dataset else 0)
 
+    def _warn_if_nodata_absent(self, arr: np.ndarray, no_data_val: Any) -> None:
+        """Warn when the band's nodata value does not actually appear in the data."""
+        if no_data_val is None:
+            if not np.isnan(arr).any():
+                self._ds.logger.warning(
+                    "The nodata value stored in the raster does not exist in the raster "
+                    "so either the raster extent is all full of data, or the no_data_value stored in the raster is"
+                    " not correct"
+                )
+        else:
+            if not np.isclose(arr, no_data_val, rtol=0.00001).any():
+                self._ds.logger.warning(
+                    "the nodata value stored in the raster does not exist in the raster "
+                    "so either the raster extent is all full of data, or the no_data_value stored in the raster is"
+                    " not correct"
+                )
+
+    @staticmethod
+    def _apply_exclude_values(
+        arr: np.ndarray, exclude_values: list[Any], no_data_val: Any
+    ) -> np.ndarray:
+        """Set cells matching any exclude value to nodata, promoting to float if needed."""
+        for val in exclude_values:
+            try:
+                # None nodata on an int array raises (None reads as float); promote.
+                arr[np.isclose(arr, val)] = no_data_val
+            except TypeError:
+                arr = arr.astype(np.float32)
+                arr[np.isclose(arr, val)] = no_data_val
+        return arr
+
+    @staticmethod
+    def _coverage_mask(arr: np.ndarray, no_data_val: Any) -> np.ndarray:
+        """Boolean mask of covered (non-nodata) cells; NaN and value fills both handled.
+
+        A NaN fill may be stored as None or a float nan (GDAL returns nan), and
+        ``np.isclose(x, nan)`` is always False, so both go through ``np.isnan``.
+        """
+        if no_data_val is None or (
+            isinstance(no_data_val, float) and np.isnan(no_data_val)
+        ):
+            valid = ~np.isnan(arr)
+        else:
+            valid = ~np.isclose(arr, no_data_val, rtol=0.00001)
+        return valid
+
     def footprint(
         self,
         band: int = 0,
@@ -1192,38 +1238,12 @@ class Analysis(_Engine["Dataset"]):
         arr = self._ds.read_array(band=band)
         no_data_val = self._ds.no_data_value[band]
 
-        if no_data_val is None:
-            if not (np.isnan(arr)).any():
-                self._ds.logger.warning(
-                    "The nodata value stored in the raster does not exist in the raster "
-                    "so either the raster extent is all full of data, or the no_data_value stored in the raster is"
-                    " not correct"
-                )
-        else:
-            if not (np.isclose(arr, no_data_val, rtol=0.00001)).any():
-                self._ds.logger.warning(
-                    "the nodata value stored in the raster does not exist in the raster "
-                    "so either the raster extent is all full of data, or the no_data_value stored in the raster is"
-                    " not correct"
-                )
-        # if you want to exclude_values any value in the raster
+        self._warn_if_nodata_absent(arr, no_data_val)
         if exclude_values:
-            for val in exclude_values:
-                try:
-                    # in case the val2 is None, and the array is int type, the following line will give error as None
-                    # is considered as float
-                    arr[np.isclose(arr, val)] = no_data_val
-                except TypeError:
-                    arr = arr.astype(np.float32)
-                    arr[np.isclose(arr, val)] = no_data_val
+            arr = self._apply_exclude_values(arr, exclude_values, no_data_val)
 
-        # Build the coverage mask: covered cells -> 2, nodata cells -> 0. A NaN fill may
-        # be stored as None or as a float nan (GDAL's GetNoDataValue returns nan), and
-        # np.isclose(x, nan) is always False, so both are compared with np.isnan.
-        if no_data_val is None or (isinstance(no_data_val, float) and np.isnan(no_data_val)):
-            valid = ~np.isnan(arr)
-        else:
-            valid = ~np.isclose(arr, no_data_val, rtol=0.00001)
+        # Build the coverage mask: covered cells -> 2, nodata cells -> 0.
+        valid = self._coverage_mask(arr, no_data_val)
         if not valid.any():
             self._ds.logger.warning("the raster is full of no_data_value")
             return None

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -619,21 +619,7 @@ class Analysis(_Engine["Dataset"]):
                 f"{on_out_of_bounds!r}."
             )
 
-        band_count = self._ds.band_count
-        if bands is None:
-            band_list = list(range(band_count))
-            squeeze = False
-        elif isinstance(bands, int):
-            band_list = [bands]
-            squeeze = True
-        else:
-            band_list = list(bands)
-            squeeze = False
-        for b in band_list:
-            if b < 0 or b >= band_count:
-                raise ValueError(
-                    f"band {b} is out of range for a {band_count}-band dataset."
-                )
+        band_list, squeeze = self._resolve_sample_bands(bands, self._ds.band_count)
 
         xy = self._points_to_xy(points)
         n_points = xy.shape[0]
@@ -658,6 +644,70 @@ class Analysis(_Engine["Dataset"]):
             out_of_bounds = np.zeros(n_points, dtype=bool)
 
         in_bounds_idx = np.flatnonzero(~out_of_bounds)
+        rows_out = self._read_point_samples(
+            band_list, col, row, in_bounds_idx, n_points
+        )
+
+        stacked = np.vstack(rows_out) if rows_out else np.empty((0, n_points))
+        result: np.ndarray = stacked[0] if squeeze else stacked
+        if masked:
+            mask = (
+                out_of_bounds
+                if squeeze
+                else np.broadcast_to(out_of_bounds, result.shape)
+            )
+            result = np.ma.masked_array(result, mask=np.array(mask))
+        return result
+
+    @staticmethod
+    def _resolve_sample_bands(
+        bands: int | list[int] | None, band_count: int
+    ) -> tuple[list[int], bool]:
+        """Resolve the band list and squeeze flag for :meth:`sample`.
+
+        Args:
+            bands: ``None`` (all bands), a single ``int``, or a list of indices.
+            band_count: Number of bands in the dataset.
+
+        Returns:
+            ``(band_list, squeeze)`` — the resolved zero-based band indices and
+            whether a single-``int`` request should collapse the leading axis.
+
+        Raises:
+            ValueError: A requested band is outside ``[0, band_count)``.
+        """
+        if bands is None:
+            band_list = list(range(band_count))
+            squeeze = False
+        elif isinstance(bands, int):
+            band_list = [bands]
+            squeeze = True
+        else:
+            band_list = list(bands)
+            squeeze = False
+        for b in band_list:
+            if b < 0 or b >= band_count:
+                raise ValueError(
+                    f"band {b} is out of range for a {band_count}-band dataset."
+                )
+        return band_list, squeeze
+
+    def _read_point_samples(
+        self,
+        band_list: list[int],
+        col: np.ndarray,
+        row: np.ndarray,
+        in_bounds_idx: np.ndarray,
+        n_points: int,
+    ) -> list[np.ndarray]:
+        """Read a 1x1 window per in-bounds point, for each band in ``band_list``.
+
+        Out-of-bounds points keep the fill value — the band's no-data value, or
+        ``NaN`` when it has none (which promotes an integer band to float).
+
+        Returns:
+            One ``(n_points,)`` array per band, in ``band_list`` order.
+        """
         rows_out: list[np.ndarray] = []
         for b in band_list:
             gdal_band = self._ds.raster.GetRasterBand(b + 1)
@@ -678,17 +728,7 @@ class Analysis(_Engine["Dataset"]):
                 window = gdal_band.ReadAsArray(int(col[i]), int(row[i]), 1, 1)
                 band_values[i] = window[0, 0]
             rows_out.append(band_values)
-
-        stacked = np.vstack(rows_out) if rows_out else np.empty((0, n_points))
-        result: np.ndarray = stacked[0] if squeeze else stacked
-        if masked:
-            mask = (
-                out_of_bounds
-                if squeeze
-                else np.broadcast_to(out_of_bounds, result.shape)
-            )
-            result = np.ma.masked_array(result, mask=np.array(mask))
-        return result
+        return rows_out
 
     def sieve(
         self,
@@ -1848,47 +1888,9 @@ class Analysis(_Engine["Dataset"]):
         injected_extent = kwargs.pop("_extent", None)
         chunks = kwargs.pop("_chunks", None)
         mode = "facet" if facet_kwargs else "plot"
-        if mode == "facet":
-            arr = facet_stack
-        elif chunks is not None:
-            # Lazy read path: build a dask array of the variable, then
-            # materialise only the requested slice via `.compute()`.
-            # `read_array(chunks=...)` is only meaningful on NetCDF —
-            # plain Dataset doesn't support `chunks`. The kwarg arrives
-            # here only because NetCDF.plot injected it, so the call is
-            # safe to issue.
-            lazy = self._ds.read_array(chunks=chunks)
-            if hasattr(lazy, "compute"):
-                if lazy.ndim > 2:
-                    # `read_array(chunks=...)` returns the variable's
-                    # native `(d0, d1, ..., rows, cols)` shape, whereas
-                    # the eager `read_array()` flattens the non-spatial
-                    # dims into a single bands axis. Match that flatten so
-                    # `band` indexes the same slice. The reshape stays
-                    # lazy — `read_array(chunks=...)` already chunks the
-                    # non-spatial dims at size 1, so it's a pure relabel —
-                    # and only the chosen band's chunks get computed.
-                    lazy = lazy.reshape(-1, *lazy.shape[-2:])
-                    arr = np.asarray(lazy[band].compute())
-                else:
-                    arr = np.asarray(lazy.compute())
-            else:
-                arr = lazy if band is None else lazy[band]
-        else:
-            # When ``rgb`` is supplied, cleopatra's ArrayGlyph needs the full
-            # multi-band ``(bands, rows, cols)`` array so it can pick the
-            # colour channels itself. In all other cases we render just the
-            # requested band as a 2-D array.
-            read_band = None if rgb is not None else band
-            if overview:
-                arr = self._ds.read_overview_array(
-                    band=read_band,
-                    overview_index=(
-                        overview_index if overview_index is not None else 0
-                    ),
-                )
-            else:
-                arr = self._ds.read_array(band=read_band)
+        arr = self._resolve_plot_array(
+            band, rgb, overview, overview_index, mode, facet_stack, chunks
+        )
         exclude_value = (
             [no_data_value[band], exclude_value]
             if exclude_value is not None
@@ -1921,6 +1923,61 @@ class Analysis(_Engine["Dataset"]):
             basemap_epsg=self._ds.epsg,
             **kwargs,
         )
+
+    def _resolve_plot_array(
+        self,
+        band: int,
+        rgb: list[int] | None,
+        overview: bool | None,
+        overview_index: int | None,
+        mode: str,
+        facet_stack: Any,
+        chunks: Any,
+    ) -> Any:
+        """Resolve the array to render for :meth:`plot`.
+
+        - ``mode="facet"``: use the caller-injected ``_facet_stack``.
+        - ``_chunks`` injected: lazy-read and materialise only the requested band
+          (see :meth:`_read_plot_lazy_array`).
+        - otherwise: eager-read the band — or the full ``(bands, rows, cols)``
+          array when ``rgb`` is set so cleopatra can pick the colour channels —
+          from an overview when ``overview`` is truthy.
+        """
+        if mode == "facet":
+            arr = facet_stack
+        elif chunks is not None:
+            arr = self._read_plot_lazy_array(band, chunks)
+        else:
+            read_band = None if rgb is not None else band
+            if overview:
+                arr = self._ds.read_overview_array(
+                    band=read_band,
+                    overview_index=(
+                        overview_index if overview_index is not None else 0
+                    ),
+                )
+            else:
+                arr = self._ds.read_array(band=read_band)
+        return arr
+
+    def _read_plot_lazy_array(self, band: int, chunks: Any) -> np.ndarray:
+        """Lazy-read path for :meth:`plot` (``_chunks`` injected by ``NetCDF.plot``).
+
+        Builds a dask array of the variable and materialises only the requested
+        slice. ``read_array(chunks=...)`` keeps the variable's native
+        ``(d0, ..., rows, cols)`` shape, so a >2-D result is reshaped to
+        ``(-1, rows, cols)`` to match the eager ``read_array`` band flattening
+        before ``band`` indexes it; only that band's chunks are computed.
+        """
+        lazy = self._ds.read_array(chunks=chunks)
+        if not hasattr(lazy, "compute"):
+            result = lazy if band is None else lazy[band]
+        elif lazy.ndim > 2:
+            lazy = lazy.reshape(-1, *lazy.shape[-2:])
+            result = np.asarray(lazy[band].compute())
+        else:
+            result = np.asarray(lazy.compute())
+        return result
 
     @staticmethod
     def _process_color_table(color_table: DataFrame) -> DataFrame:

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -852,6 +852,50 @@ class Bands(_Engine["Dataset"]):
 
         return df
 
+    def _coerce_band_no_data(self, i: int, val: Any) -> Any:
+        """Coerce one band's no-data value to its dtype.
+
+        Non-``None``/``NaN`` values cast to the band's numpy dtype (may raise
+        ``OverflowError`` when out of range); ``None``/``NaN`` on an unsigned band
+        uses the dtype max, and passes through unchanged otherwise.
+        """
+        # if not None or np.nan
+        if val is not None and not np.isnan(val):
+            # cast to the band dtype (raises OverflowError when out of range)
+            result = self._ds.numpy_dtype[i](val)
+        elif self._ds.dtype[i].startswith("u"):
+            # None/np.nan on an Unsigned integer band would misbehave; use the
+            # dtype max bound as the no_data_value.
+            result = np.iinfo(self._ds.dtype[i]).max
+        else:
+            # None/np.nan on any non-unsigned dtype: pass through unchanged.
+            result = val
+        return result
+
+    def _fallback_no_data(self, i: int) -> Any:
+        """Pick a dtype-valid no-data sentinel when the requested value overflows.
+
+        The dtype max for unsigned ints (matching the None/NaN branch), the dtype
+        min for signed ints too small to hold the default, and the default for
+        floats (which can always represent it).
+        """
+        np_dtype = np.dtype(self._ds.numpy_dtype[i])
+        # np.issubdtype narrows at runtime but isn't recognised by the numpy
+        # stubs, so cast to the exact integer family each branch just proved.
+        if np.issubdtype(np_dtype, np.unsignedinteger):
+            unsigned_dtype = cast("np.dtype[np.unsignedinteger]", np_dtype)
+            fallback = np_dtype.type(np.iinfo(unsigned_dtype).max)
+        elif np.issubdtype(np_dtype, np.integer):
+            signed_dtype = cast("np.dtype[np.signedinteger]", np_dtype)
+            info = np.iinfo(signed_dtype)
+            if info.min <= DEFAULT_NO_DATA_VALUE <= info.max:
+                fallback = np_dtype.type(DEFAULT_NO_DATA_VALUE)
+            else:
+                fallback = np_dtype.type(info.min)
+        else:
+            fallback = np_dtype.type(DEFAULT_NO_DATA_VALUE)
+        return fallback
+
     def _check_no_data_value(self, no_data_value: list | tuple) -> list:
         """Validate the no_data_value against each band's dtype.
 
@@ -874,57 +918,17 @@ class Bands(_Engine["Dataset"]):
         """
         no_data_value = list(no_data_value)
         # convert the no_data_value based on the dtype of each raster band.
-        for i, val in enumerate(self._ds.gdal_dtype):
+        for i in range(len(self._ds.gdal_dtype)):
             try:
-                val = no_data_value[i]
-                # if not None or np.nan
-                if val is not None and not np.isnan(val):
-                    # if val < np.iinfo(self._ds.dtype[i]).min or val > np.iinfo(self._ds.dtype[i]).max:
-                    # if the no_data_value is out of the range of the data type
-                    no_data_value[i] = self._ds.numpy_dtype[i](val)
-                else:
-                    # None and np.nan
-                    if self._ds.dtype[i].startswith("u"):
-                        # only Unsigned integer data types.
-                        # if None or np.nan it will make a problem with the unsigned integer data type
-                        # use the max bound of the data type as a no_data_value
-                        no_data_value[i] = np.iinfo(self._ds.dtype[i]).max
-                    else:
-                        # no_data_type is None/np,nan and all other data types that is not Unsigned integer
-                        no_data_value[i] = val
+                no_data_value[i] = self._coerce_band_no_data(i, no_data_value[i])
             except OverflowError:
                 # The requested no_data_value does not fit the band dtype (e.g.
-                # the default -9999 on a uint16 band, or -3.4e38 on int64). Fall
-                # back to a dtype-valid sentinel instead of re-casting the same
-                # out-of-range value (which would just re-raise): the dtype max
-                # for unsigned ints (matching the None/NaN branch above), the
-                # dtype min for signed ints too small to hold the default, and
-                # the default for floats (which can always represent it).
-                np_dtype = np.dtype(self._ds.numpy_dtype[i])
-                # np.issubdtype narrows at runtime but isn't recognised by the
-                # numpy stubs, so np.iinfo still sees the full dtype union --
-                # cast to the exact integer family each branch just proved.
-                if np.issubdtype(np_dtype, np.unsignedinteger):
-                    # -9999 (and any negative default) cannot fit an unsigned
-                    # band; use the dtype max, matching the None/NaN branch.
-                    unsigned_dtype = cast("np.dtype[np.unsignedinteger]", np_dtype)
-                    fallback = np_dtype.type(np.iinfo(unsigned_dtype).max)
-                elif np.issubdtype(np_dtype, np.integer):
-                    # Keep the default -9999 when the signed band can hold it
-                    # (int16/int32/int64); only too-small bands (int8) need the
-                    # dtype min. The unsignedinteger branch above already ran,
-                    # so this is provably signedinteger.
-                    signed_dtype = cast("np.dtype[np.signedinteger]", np_dtype)
-                    info = np.iinfo(signed_dtype)
-                    if info.min <= DEFAULT_NO_DATA_VALUE <= info.max:
-                        fallback = np_dtype.type(DEFAULT_NO_DATA_VALUE)
-                    else:
-                        fallback = np_dtype.type(info.min)
-                else:
-                    fallback = np_dtype.type(DEFAULT_NO_DATA_VALUE)
+                # the default -9999 on a uint16 band, or -3.4e38 on int64); fall
+                # back to a dtype-valid sentinel instead of re-casting.
+                fallback = self._fallback_no_data(i)
                 warnings.warn(
                     f"The no_data_value {no_data_value[i]!r} is out of range for band "
-                    f"dtype {np_dtype}; falling back to {fallback}."
+                    f"dtype {np.dtype(self._ds.numpy_dtype[i])}; falling back to {fallback}."
                 )
                 no_data_value[i] = fallback
         return no_data_value

--- a/src/pyramids/dataset/engines/cog.py
+++ b/src/pyramids/dataset/engines/cog.py
@@ -364,26 +364,9 @@ class COG(_Engine["Dataset"]):
         # Resolve a named profile (PB-5): it seeds the compression options;
         # explicit kwargs and `extra` override it. jpeg/webp enforce dtype/band
         # constraints against the *effective* source.
-        profile_opts: dict[str, Any] = {}
-        if profile is not None:
-            validate_profile(
-                profile,
-                gdal.GetDataTypeName(source_band0.DataType),
-                source_ds.RasterCount,
-            )
-            profile_opts = profile_options(profile)
-        eff_compress = (
-            compress
-            if compress is not None
-            else profile_opts.get("COMPRESS", "DEFLATE")
+        eff_compress, eff_level, eff_quality, profile_extra = self._resolve_compression(
+            profile, compress, level, quality, source_ds, source_band0
         )
-        eff_level = level if level is not None else profile_opts.get("LEVEL")
-        eff_quality = quality if quality is not None else profile_opts.get("QUALITY")
-        profile_extra = {
-            k: v
-            for k, v in profile_opts.items()
-            if k not in ("COMPRESS", "LEVEL", "QUALITY")
-        }
 
         # Single house policy lives here (ARC-1): `to_cog` resolves the
         # dtype-dependent defaults so a direct `ds.to_cog(...)` and the
@@ -442,6 +425,56 @@ class COG(_Engine["Dataset"]):
         with config_context(config):
             self._translate_with_statistics_retry(path, options, src=source_ds)
         return Path(path)
+
+    @staticmethod
+    def _resolve_compression(
+        profile: str | None,
+        compress: str | None,
+        level: int | None,
+        quality: int | None,
+        source_ds: gdal.Dataset,
+        source_band0: Any,
+    ) -> tuple[str, int | None, int | None, dict[str, Any]]:
+        """Resolve effective compression options, seeding from a named profile.
+
+        A named `profile` supplies default COMPRESS/LEVEL/QUALITY plus any extra
+        profile options; explicit `compress`/`level`/`quality` kwargs override the
+        seeded defaults. `jpeg`/`webp` profiles validate dtype/band constraints
+        against the effective source before seeding.
+
+        Args:
+            profile: Named compression preset, or None.
+            compress: Explicit compression method override, or None.
+            level: Explicit compression level override, or None.
+            quality: Explicit lossy quality override, or None.
+            source_ds: Effective source dataset (for band-count validation).
+            source_band0: Band 0 of the effective source (for dtype validation).
+
+        Returns:
+            `(eff_compress, eff_level, eff_quality, profile_extra)` where
+            `profile_extra` holds profile options other than COMPRESS/LEVEL/QUALITY.
+        """
+        profile_opts: dict[str, Any] = {}
+        if profile is not None:
+            validate_profile(
+                profile,
+                gdal.GetDataTypeName(source_band0.DataType),
+                source_ds.RasterCount,
+            )
+            profile_opts = profile_options(profile)
+        eff_compress = (
+            compress
+            if compress is not None
+            else profile_opts.get("COMPRESS", "DEFLATE")
+        )
+        eff_level = level if level is not None else profile_opts.get("LEVEL")
+        eff_quality = quality if quality is not None else profile_opts.get("QUALITY")
+        profile_extra = {
+            k: v
+            for k, v in profile_opts.items()
+            if k not in ("COMPRESS", "LEVEL", "QUALITY")
+        }
+        return eff_compress, eff_level, eff_quality, profile_extra
 
     def _effective_source(
         self,

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -1565,35 +1565,9 @@ class IO(_Engine["Dataset"]):
                 "read_only=False to write into it."
             )
 
-        if window is not None:
-            if isinstance(window, Window):
-                xoff, yoff, n_cols, n_rows = window.to_read_args()
-            else:
-                warnings.warn(
-                    "Passing write_array a bare (row_off, col_off, n_rows, "
-                    "n_cols) tuple is deprecated: its y-first order is the "
-                    "opposite of read_array's window. Pass a "
-                    "pyramids.dataset.window.Window (x-first, shared by both "
-                    "methods) instead; the tuple form will be removed in the "
-                    "next major release.",
-                    DeprecationWarning,
-                    stacklevel=3,
-                )
-                if not isinstance(window, (list, tuple)) or len(window) != 4:
-                    raise ValueError(
-                        "write_array window must be a Window or a "
-                        "(row_off, col_off, n_rows, n_cols) tuple of 4 integers, "
-                        f"got {window!r}."
-                    )
-                yoff, xoff, n_rows, n_cols = window
-            if array.shape[-2:] != (n_rows, n_cols):
-                raise ValueError(
-                    f"array spatial shape {array.shape[-2:]} does not match the "
-                    f"window size {(n_rows, n_cols)}."
-                )
-        else:
-            yoff, xoff = (0, 0) if top_left_corner is None else top_left_corner
-            n_rows, n_cols = array.shape[-2], array.shape[-1]
+        yoff, xoff, n_rows, n_cols = self._resolve_write_window(
+            array, top_left_corner, window
+        )
 
         if (
             xoff < 0
@@ -1623,6 +1597,55 @@ class IO(_Engine["Dataset"]):
         else:
             self._ds._raster.WriteArray(array, xoff=xoff, yoff=yoff)
         self._ds._raster.FlushCache()
+
+    @staticmethod
+    def _resolve_write_window(
+        array: np.ndarray,
+        top_left_corner: list[int] | None,
+        window: "Window | tuple[int, int, int, int] | None",
+    ) -> tuple[int, int, int, int]:
+        """Resolve the ``(yoff, xoff, n_rows, n_cols)`` target of a write.
+
+        With a ``window`` the offsets/size come from it — a
+        :class:`~pyramids.dataset.window.Window` is x-first; the deprecated bare
+        ``(row_off, col_off, n_rows, n_cols)`` tuple is y-first — and the array's
+        spatial shape is validated against the window. Otherwise the offset comes
+        from ``top_left_corner`` (default ``[0, 0]``) and the size from the array.
+
+        Raises:
+            ValueError: The bare-tuple window is malformed, or the array's
+                spatial shape does not match the window size.
+        """
+        if window is not None:
+            if isinstance(window, Window):
+                xoff, yoff, n_cols, n_rows = window.to_read_args()
+            else:
+                warnings.warn(
+                    "Passing write_array a bare (row_off, col_off, n_rows, "
+                    "n_cols) tuple is deprecated: its y-first order is the "
+                    "opposite of read_array's window. Pass a "
+                    "pyramids.dataset.window.Window (x-first, shared by both "
+                    "methods) instead; the tuple form will be removed in the "
+                    "next major release.",
+                    DeprecationWarning,
+                    stacklevel=4,
+                )
+                if not isinstance(window, (list, tuple)) or len(window) != 4:
+                    raise ValueError(
+                        "write_array window must be a Window or a "
+                        "(row_off, col_off, n_rows, n_cols) tuple of 4 integers, "
+                        f"got {window!r}."
+                    )
+                yoff, xoff, n_rows, n_cols = window
+            if array.shape[-2:] != (n_rows, n_cols):
+                raise ValueError(
+                    f"array spatial shape {array.shape[-2:]} does not match the "
+                    f"window size {(n_rows, n_cols)}."
+                )
+        else:
+            yoff, xoff = (0, 0) if top_left_corner is None else top_left_corner
+            n_rows, n_cols = array.shape[-2], array.shape[-1]
+        return yoff, xoff, n_rows, n_cols
 
     def get_block_arrangement(
         self,

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1238,6 +1238,50 @@ class Spatial(_Engine["Dataset"]):
                 )
         return src_array
 
+    def _assert_crop_aligned(
+        self, mask: gdal.Dataset | np.ndarray, row: int, col: int
+    ) -> None:
+        """Raise if source and mask differ in size, grid origin/cell size, or CRS."""
+        if row != self._ds.rows or col != self._ds.columns:
+            raise ValueError(
+                "Two rasters have different number of columns or rows, please resample or match both rasters"
+            )
+        if isinstance(mask, RasterBase):
+            if (
+                self._ds.top_left_corner != mask.top_left_corner
+                or self._ds.cell_size != mask.cell_size
+            ):
+                raise ValueError(
+                    "the location of the upper left corner of both rasters is not the same or cell size is "
+                    "different please match both rasters first "
+                )
+            if mask.epsg != self._ds.epsg:
+                raise ValueError(
+                    "Dataset A & B are using different coordinate systems please reproject one of them to "
+                    "the other raster coordinate system"
+                )
+
+    def _apply_mask_nodata(
+        self, src_array: np.ndarray, mask_no_data: np.ndarray, band_count: int
+    ) -> None:
+        """Write the source no-data value into the masked cells (per band)."""
+        if band_count > 1:
+            # check the no_data_value complies with the src dtype before writing it
+            # into cells (a band full of values may never use its no_data_value).
+            no_data_value = self._ds._check_no_data_value(self._ds.no_data_value)
+            for band in range(self._ds.band_count):
+                src_array[band, mask_no_data] = no_data_value[band]
+        else:
+            src_array[mask_no_data] = self._ds.no_data_value[0]
+
+    def _write_bands(self, dst_obj: Any, src_array: np.ndarray, band_count: int) -> None:
+        """Write the (possibly multi-band) array into the destination raster."""
+        if band_count > 1:
+            for band in range(band_count):
+                dst_obj.raster.GetRasterBand(band + 1).WriteArray(src_array[band, :, :])
+        else:
+            dst_obj.raster.GetRasterBand(1).WriteArray(src_array)
+
     def _crop_aligned(
         self,
         mask: gdal.Dataset | np.ndarray,
@@ -1263,7 +1307,6 @@ class Spatial(_Engine["Dataset"]):
         """
         if isinstance(mask, RasterBase):
             mask_gt = mask.geotransform
-            mask_epsg = mask.epsg
             row = mask.rows
             col = mask.columns
             mask_noval = mask.no_data_value[0]
@@ -1289,37 +1332,10 @@ class Spatial(_Engine["Dataset"]):
         # ndarray here (the dask.Array arm of ArrayLike is unreachable).
         src_array = cast(np.typing.NDArray, self._ds.read_array())
 
-        if row != self._ds.rows or col != self._ds.columns:
-            raise ValueError(
-                "Two rasters have different number of columns or rows, please resample or match both rasters"
-            )
-
-        if isinstance(mask, RasterBase):
-            if (
-                self._ds.top_left_corner != mask.top_left_corner
-                or self._ds.cell_size != mask.cell_size
-            ):
-                raise ValueError(
-                    "the location of the upper left corner of both rasters is not the same or cell size is "
-                    "different please match both rasters first "
-                )
-
-            if mask_epsg != self._ds.epsg:
-                raise ValueError(
-                    "Dataset A & B are using different coordinate systems please reproject one of them to "
-                    "the other raster coordinate system"
-                )
+        self._assert_crop_aligned(mask, row, col)
 
         mask_no_data = is_no_data(mask_array, mask_noval)
-        if band_count > 1:
-            # check if the no data value for the src complies with the dtype of the src as sometimes the band is full
-            # of values and the no_data_value is not used at all in the band, and when we try to replace any value in
-            # the array with the no_data_value it will raise an error.
-            no_data_value = self._ds._check_no_data_value(self._ds.no_data_value)
-            for band in range(self._ds.band_count):
-                src_array[band, mask_no_data] = no_data_value[band]
-        else:
-            src_array[mask_no_data] = self._ds.no_data_value[0]
+        self._apply_mask_nodata(src_array, mask_no_data, band_count)
 
         if fill_gaps:
             src_array = self.fill_gaps(mask, src_array)
@@ -1340,11 +1356,7 @@ class Spatial(_Engine["Dataset"]):
         dst_obj = self._ds.__class__(dst)
         # set the no data value
         dst_obj._set_no_data_value(self._ds.no_data_value)
-        if band_count > 1:
-            for band in range(band_count):
-                dst_obj.raster.GetRasterBand(band + 1).WriteArray(src_array[band, :, :])
-        else:
-            dst_obj.raster.GetRasterBand(1).WriteArray(src_array)
+        self._write_bands(dst_obj, src_array, band_count)
         return dst_obj
 
     def _check_alignment(self, mask) -> bool:

--- a/src/pyramids/dataset/engines/vectorize.py
+++ b/src/pyramids/dataset/engines/vectorize.py
@@ -784,18 +784,6 @@ class Vectorize(_Engine["Dataset"]):
         return array
 
     @staticmethod
-    def _is_cluster_candidate(
-        array, ni, nj, rows, cols, lower_bound, upper_bound, cluster
-    ) -> bool:
-        """True if (ni, nj) is in-bounds, unvisited, and within [lower_bound, upper_bound]."""
-        return (
-            0 <= ni < rows
-            and 0 <= nj < cols
-            and cluster[ni, nj] == 0
-            and lower_bound <= array[ni, nj] <= upper_bound
-        )
-
-    @staticmethod
     def _group_neighbours(
         array, i, j, lower_bound, upper_bound, position, values, count, cluster
     ) -> None:
@@ -821,8 +809,11 @@ class Vectorize(_Engine["Dataset"]):
             ci, cj = queue.popleft()
             for di, dj in offsets:
                 ni, nj = ci + di, cj + dj
-                if Vectorize._is_cluster_candidate(
-                    array, ni, nj, rows, cols, lower_bound, upper_bound, cluster
+                if (
+                    0 <= ni < rows
+                    and 0 <= nj < cols
+                    and cluster[ni, nj] == 0
+                    and lower_bound <= array[ni, nj] <= upper_bound
                 ):
                     cluster[ni, nj] = count
                     position.append([ni, nj])

--- a/src/pyramids/dataset/engines/vectorize.py
+++ b/src/pyramids/dataset/engines/vectorize.py
@@ -784,6 +784,18 @@ class Vectorize(_Engine["Dataset"]):
         return array
 
     @staticmethod
+    def _is_cluster_candidate(
+        array, ni, nj, rows, cols, lower_bound, upper_bound, cluster
+    ) -> bool:
+        """True if (ni, nj) is in-bounds, unvisited, and within [lower_bound, upper_bound]."""
+        return (
+            0 <= ni < rows
+            and 0 <= nj < cols
+            and cluster[ni, nj] == 0
+            and lower_bound <= array[ni, nj] <= upper_bound
+        )
+
+    @staticmethod
     def _group_neighbours(
         array, i, j, lower_bound, upper_bound, position, values, count, cluster
     ) -> None:
@@ -799,26 +811,23 @@ class Vectorize(_Engine["Dataset"]):
         neighbor. The caller (cluster) handles truly isolated cells separately.
         """
         rows, cols = array.shape
+        # 8-connected neighbour offsets, in the row-major order of the original
+        # (-1, 0, 1) x (-1, 0, 1) double loop (minus the (0, 0) self-cell).
+        offsets = ((-1, -1), (-1, 0), (-1, 1), (0, -1), (0, 1), (1, -1), (1, 0), (1, 1))
         queue: collections.deque[tuple[int, int]] = collections.deque()
         queue.append((i, j))
 
         while queue:
             ci, cj = queue.popleft()
-            for di in (-1, 0, 1):
-                for dj in (-1, 0, 1):
-                    if di == 0 and dj == 0:
-                        continue
-                    ni, nj = ci + di, cj + dj
-                    if (
-                        0 <= ni < rows
-                        and 0 <= nj < cols
-                        and cluster[ni, nj] == 0
-                        and lower_bound <= array[ni, nj] <= upper_bound
-                    ):
-                        cluster[ni, nj] = count
-                        position.append([ni, nj])
-                        values.append(array[ni, nj])
-                        queue.append((ni, nj))
+            for di, dj in offsets:
+                ni, nj = ci + di, cj + dj
+                if Vectorize._is_cluster_candidate(
+                    array, ni, nj, rows, cols, lower_bound, upper_bound, cluster
+                ):
+                    cluster[ni, nj] = count
+                    position.append([ni, nj])
+                    values.append(array[ni, nj])
+                    queue.append((ni, nj))
 
     def cluster(
         self, lower_bound: Any, upper_bound: Any

--- a/src/pyramids/dataset/ops/io.py
+++ b/src/pyramids/dataset/ops/io.py
@@ -136,17 +136,7 @@ def _write_to_file_sync(
             :meth:`pyramids.dataset.engines.COG.to_cog`).
     """
     if driver == "COG":
-        if band != 0:
-            raise ValueError(
-                "driver='COG' does not support the 'band' argument — "
-                "COG always writes all source bands. Subset the "
-                "dataset first (e.g. Dataset.get_band_subset) if you "
-                "need a single-band output."
-            )
-        cog_kwargs: dict[str, Any] = {"extra": creation_options}
-        if tile_length is not None:
-            cog_kwargs["blocksize"] = tile_length
-        ds.to_cog(path, **cog_kwargs)
+        _write_cog(ds, path, band, tile_length, creation_options)
         return
     if not isinstance(path, (str, Path)):
         raise TypeError(
@@ -154,20 +144,7 @@ def _write_to_file_sync(
         )
 
     path = Path(path)
-    if driver is None:
-        extension = path.suffix[1:]
-        driver = CATALOG.get_driver_name_by_extension(extension)
-    elif not CATALOG.exists(driver):
-        # Accept GDAL driver names (e.g. "GTiff") as well as catalog keys
-        # (e.g. "geotiff") before declaring the driver unknown.
-        catalog_key = CATALOG.get_driver_name(driver)
-        if catalog_key is None:
-            raise DriverNotExistError(
-                f"The driver: {driver!r} is not in the driver catalog. Known "
-                f"driver names: {sorted(CATALOG.drivers)}"
-            )
-        driver = catalog_key
-    driver_name = CATALOG.get_gdal_name(driver)
+    driver, driver_name = _resolve_output_driver(driver, path)
 
     if driver == "ascii":
         arr = ds.read_array(band=band)
@@ -175,60 +152,135 @@ def _write_to_file_sync(
         xmin, ymin, _, _ = ds.bbox
         _io.to_ascii(arr, ds.cell_size, xmin, ymin, no_data_value, path)
     else:
-        # COMPRESS=DEFLATE and the TILED/BLOCK options are GeoTIFF creation
-        # options. Applying them to other drivers is at best ignored and at
-        # worst breaks the output — e.g. on the netCDF driver COMPRESS=DEFLATE
-        # forces the NC4C format, which some GDAL builds cannot read back,
-        # making ``to_file("out.nc")`` produce an unreadable file. Only emit
-        # them for GeoTIFF; user-supplied creation_options always pass through.
-        options: list[str] = []
-        if driver_name != "GTiff" and tile_length is not None:
-            logging.getLogger("pyramids.dataset").warning(
-                "tile_length is a GeoTIFF-only option and is ignored for the "
-                f"{driver_name} driver."
-            )
-        if driver_name == "GTiff":
-            options.append("COMPRESS=DEFLATE")
-            if tile_length is not None:
-                options += [
-                    "TILED=YES",
-                    f"TILE_LENGTH={tile_length}",
-                ]
-                if ds._block_size is not None and ds._block_size != []:
-                    options += [
-                        "BLOCKXSIZE={}".format(ds._block_size[0][0]),
-                        "BLOCKYSIZE={}".format(ds._block_size[0][1]),
-                    ]
-        if creation_options is not None:
-            options += creation_options
-
+        options = _build_creation_options(
+            driver_name, tile_length, creation_options, ds
+        )
         save_error = f"Failed to save the {driver_name} raster to the path: {path}"
-        try:
-            ds.raster.FlushCache()
-            dst = gdal.GetDriverByName(driver_name).CreateCopy(
-                str(path), ds.raster, 0, options=options
+        _create_copy_and_reopen(ds, path, driver_name, options, save_error)
+
+
+def _write_cog(
+    ds: Dataset,
+    path: str | Path,
+    band: int,
+    tile_length: int | None,
+    creation_options: list[str] | None,
+) -> None:
+    """Write ``ds`` via the COG driver (delegates to :meth:`Dataset.to_cog`).
+
+    Raises:
+        ValueError: A non-zero ``band`` was requested — COG always writes all
+            source bands.
+    """
+    if band != 0:
+        raise ValueError(
+            "driver='COG' does not support the 'band' argument — "
+            "COG always writes all source bands. Subset the "
+            "dataset first (e.g. Dataset.get_band_subset) if you "
+            "need a single-band output."
+        )
+    cog_kwargs: dict[str, Any] = {"extra": creation_options}
+    if tile_length is not None:
+        cog_kwargs["blocksize"] = tile_length
+    ds.to_cog(path, **cog_kwargs)
+
+
+def _resolve_output_driver(driver: str | None, path: Path) -> tuple[str, str]:
+    """Resolve the catalog driver key and GDAL driver name for an output path.
+
+    ``None`` infers the driver from the path extension. A given driver is
+    accepted whether it is a catalog key (e.g. ``"geotiff"``) or a GDAL name
+    (e.g. ``"GTiff"``).
+
+    Raises:
+        DriverNotExistError: The driver is neither a catalog key nor a known
+            GDAL driver name.
+    """
+    if driver is None:
+        extension = path.suffix[1:]
+        driver = CATALOG.get_driver_name_by_extension(extension)
+    elif not CATALOG.exists(driver):
+        catalog_key = CATALOG.get_driver_name(driver)
+        if catalog_key is None:
+            raise DriverNotExistError(
+                f"The driver: {driver!r} is not in the driver catalog. Known "
+                f"driver names: {sorted(CATALOG.drivers)}"
             )
-            if dst is None:
-                raise FailedToSaveError(save_error)
-            # Finalize the file on disk before any reader opens it. For a
-            # compressed GeoTIFF (the default COMPRESS=DEFLATE) ``FlushCache``
-            # leaves the compressed strips and the TIFF directory buffered in the
-            # write handle, so a *second* handle that opens the same path reads
-            # back all-nodata on Linux/macOS (#570). Closing the CreateCopy
-            # handle writes everything; reopen the completed file for the
-            # in-place handle swap so the Dataset keeps pointing at it.
-            dst = None
-            reopened = gdal.OpenEx(str(path), gdal.OF_RASTER | gdal.OF_UPDATE)
-            access = "write"
-            if reopened is None:
-                # Some write-once drivers (e.g. AAIGrid) cannot be reopened for
-                # update; fall back to a read-only handle and label it as such so
-                # the Dataset's access mode matches the handle it actually holds.
-                reopened = gdal.OpenEx(str(path), gdal.OF_RASTER)
-                access = "read_only"
-            if reopened is None:
-                raise FailedToSaveError(save_error)
-            ds._update_inplace(reopened, access)
-        except RuntimeError:
-            if not path.exists():
-                raise FailedToSaveError(save_error)
+        driver = catalog_key
+    return driver, CATALOG.get_gdal_name(driver)
+
+
+def _build_creation_options(
+    driver_name: str,
+    tile_length: int | None,
+    creation_options: list[str] | None,
+    ds: Dataset,
+) -> list[str]:
+    """Build GDAL creation options for a raster write.
+
+    ``COMPRESS=DEFLATE`` and the ``TILED``/``BLOCK*`` options are GeoTIFF-only —
+    applying them to other drivers is at best ignored and at worst breaks the
+    output (e.g. netCDF ``COMPRESS=DEFLATE`` forces an NC4C file some GDAL builds
+    cannot read back). They are emitted only for GeoTIFF; user-supplied
+    ``creation_options`` always pass through.
+    """
+    options: list[str] = []
+    if driver_name != "GTiff" and tile_length is not None:
+        logging.getLogger("pyramids.dataset").warning(
+            "tile_length is a GeoTIFF-only option and is ignored for the "
+            f"{driver_name} driver."
+        )
+    if driver_name == "GTiff":
+        options.append("COMPRESS=DEFLATE")
+        if tile_length is not None:
+            options += [
+                "TILED=YES",
+                f"TILE_LENGTH={tile_length}",
+            ]
+            if ds._block_size is not None and ds._block_size != []:
+                options += [
+                    "BLOCKXSIZE={}".format(ds._block_size[0][0]),
+                    "BLOCKYSIZE={}".format(ds._block_size[0][1]),
+                ]
+    if creation_options is not None:
+        options += creation_options
+    return options
+
+
+def _create_copy_and_reopen(
+    ds: Dataset,
+    path: Path,
+    driver_name: str,
+    options: list[str],
+    save_error: str,
+) -> None:
+    """CreateCopy the raster, then reopen the finished file for the in-place swap.
+
+    Closing the ``CreateCopy`` handle before reopening finalises a compressed
+    GeoTIFF on disk, so a second handle does not read back all-nodata (#570).
+    Write-once drivers that cannot reopen for update fall back to a read-only
+    handle (with the access mode labelled to match).
+
+    Raises:
+        FailedToSaveError: The copy failed, the file cannot be reopened, or a
+            GDAL ``RuntimeError`` left no file on disk.
+    """
+    try:
+        ds.raster.FlushCache()
+        dst = gdal.GetDriverByName(driver_name).CreateCopy(
+            str(path), ds.raster, 0, options=options
+        )
+        if dst is None:
+            raise FailedToSaveError(save_error)
+        dst = None
+        reopened = gdal.OpenEx(str(path), gdal.OF_RASTER | gdal.OF_UPDATE)
+        access = "write"
+        if reopened is None:
+            reopened = gdal.OpenEx(str(path), gdal.OF_RASTER)
+            access = "read_only"
+        if reopened is None:
+            raise FailedToSaveError(save_error)
+        ds._update_inplace(reopened, access)
+    except RuntimeError:
+        if not path.exists():
+            raise FailedToSaveError(save_error)

--- a/src/pyramids/dataset/ops/vectorize.py
+++ b/src/pyramids/dataset/ops/vectorize.py
@@ -59,15 +59,7 @@ def rasterize_features(
         CRSError: If the FeatureCollection has no CRS, or
             `template.epsg!= features.epsg`.
     """
-    if cell_size is None and template is None:
-        raise ValueError("You have to enter either cell size or Dataset object.")
-    if cell_size is not None and cell_size <= 0:
-        raise ValueError(f"cell_size must be positive; got {cell_size!r}.")
-    if column_name is not None and not isinstance(column_name, (str, list)):
-        raise TypeError(
-            f"column_name must be str, list[str], or None; "
-            f"got {type(column_name).__name__}."
-        )
+    _validate_rasterize_args(cell_size, template, column_name)
 
     ds_epsg = features.epsg
     if ds_epsg is None:
@@ -76,64 +68,12 @@ def rasterize_features(
             "Set one via `fc.set_crs('EPSG:...')` or construct the FC "
             "with `crs='EPSG:...'`."
         )
-    if template is not None:
-        if not isinstance(template, dataset_cls):
-            raise TypeError(
-                "The template parameter must be a pyramids Dataset "
-                "(see pyramids.dataset.Dataset.read_file)."
-            )
-        if template.epsg != ds_epsg:
-            raise CRSError(
-                f"Dataset and vector are not the same EPSG. "
-                f"{template.epsg} != {ds_epsg}"
-            )
-        xmin, ymax = template.top_left_corner
-        no_data_value = (
-            template.no_data_value[0]
-            if template.no_data_value[0] is not None
-            else np.nan
-        )
-        rows = template.rows
-        columns = template.columns
-        cell_size = template.cell_size
-    else:
-        xmin, ymin, xmax, ymax = features.total_bounds
-        no_data_value = dataset_cls.default_no_data_value
-        columns = int(np.ceil((xmax - xmin) / cell_size))
-        rows = int(np.ceil((ymax - ymin) / cell_size))
 
-    if column_name is None:
-        column_name = [c for c in features.columns if c != "geometry"]
+    xmin, ymax, rows, columns, cell_size, no_data_value = _resolve_raster_geometry(
+        features, dataset_cls, template, cell_size, ds_epsg
+    )
 
-    if isinstance(column_name, list):
-        if not column_name:
-            raise ValueError(
-                "column_name list must be non-empty. Pass None to "
-                "burn every non-geometry column, or name at least "
-                "one column."
-            )
-        missing = [c for c in column_name if c not in features.columns]
-        if missing:
-            raise ValueError(
-                f"column_name references columns not in the "
-                f"FeatureCollection: {missing}. Available columns: "
-                f"{list(features.columns)}."
-            )
-        # Multi-band burn: every band shares the same dataset dtype, so
-        # promote to the smallest dtype that can hold every selected
-        # column without lossy cast. Mixed [int8, float32] â†’ float32,
-        # mixed [int8, int16] â†’ int16, etc. Previously the dtype was
-        # taken from column_name[0] only, which silently truncated
-        # wider columns.
-        numpy_dtype = np.result_type(*[features.dtypes[c] for c in column_name])
-    else:
-        if column_name not in features.columns:
-            raise ValueError(
-                f"column_name {column_name!r} is not in the "
-                f"FeatureCollection. Available columns: "
-                f"{list(features.columns)}."
-            )
-        numpy_dtype = features.dtypes[column_name]
+    column_name, numpy_dtype = _resolve_burn_columns(features, column_name)
 
     # Integer raster dtypes cannot represent NaN. If the template
     # supplied None as no_data_value (defaulted to NaN above) and the
@@ -173,3 +113,120 @@ def rasterize_features(
             gdal.Rasterize(dataset_n.raster, vector_ds, options=rasterize_opts)
 
     return dataset_n
+
+
+def _validate_rasterize_args(
+    cell_size: Any | None,
+    template: Dataset | None,
+    column_name: str | list[str] | None,
+) -> None:
+    """Validate the scalar arguments of :func:`rasterize_features`.
+
+    Raises:
+        ValueError: Neither ``cell_size`` nor ``template`` given, or a
+            non-positive ``cell_size``.
+        TypeError: ``column_name`` is not ``str`` / ``list`` / ``None``.
+    """
+    if cell_size is None and template is None:
+        raise ValueError("You have to enter either cell size or Dataset object.")
+    if cell_size is not None and cell_size <= 0:
+        raise ValueError(f"cell_size must be positive; got {cell_size!r}.")
+    if column_name is not None and not isinstance(column_name, (str, list)):
+        raise TypeError(
+            f"column_name must be str, list[str], or None; "
+            f"got {type(column_name).__name__}."
+        )
+
+
+def _resolve_raster_geometry(
+    features: FeatureCollection,
+    dataset_cls: type[Dataset],
+    template: Dataset | None,
+    cell_size: Any | None,
+    ds_epsg: int,
+) -> tuple[float, float, int, int, Any, Any]:
+    """Resolve the output raster geometry for :func:`rasterize_features`.
+
+    With a ``template`` the geometry (origin, size, cell size, no-data) is
+    inherited from it after validating its type and CRS; otherwise it is derived
+    from the feature bounds and the requested ``cell_size``.
+
+    Returns:
+        ``(xmin, ymax, rows, columns, cell_size, no_data_value)``.
+
+    Raises:
+        TypeError: ``template`` is not an instance of ``dataset_cls``.
+        CRSError: ``template.epsg`` differs from the FeatureCollection's EPSG.
+    """
+    if template is not None:
+        if not isinstance(template, dataset_cls):
+            raise TypeError(
+                "The template parameter must be a pyramids Dataset "
+                "(see pyramids.dataset.Dataset.read_file)."
+            )
+        if template.epsg != ds_epsg:
+            raise CRSError(
+                f"Dataset and vector are not the same EPSG. "
+                f"{template.epsg} != {ds_epsg}"
+            )
+        xmin, ymax = template.top_left_corner
+        no_data_value = (
+            template.no_data_value[0]
+            if template.no_data_value[0] is not None
+            else np.nan
+        )
+        rows = template.rows
+        columns = template.columns
+        cell_size = template.cell_size
+    else:
+        xmin, ymin, xmax, ymax = features.total_bounds
+        no_data_value = dataset_cls.default_no_data_value
+        columns = int(np.ceil((xmax - xmin) / cell_size))
+        rows = int(np.ceil((ymax - ymin) / cell_size))
+    return xmin, ymax, rows, columns, cell_size, no_data_value
+
+
+def _resolve_burn_columns(
+    features: FeatureCollection, column_name: str | list[str] | None
+) -> tuple[str | list[str], Any]:
+    """Resolve and validate the burn column(s) and the output dtype.
+
+    ``None`` expands to every non-geometry column. A list is validated as
+    non-empty and fully present; the dtype is promoted to the smallest that
+    holds every selected column (mixed ``[int8, float32]`` -> ``float32``),
+    fixing the earlier ``column_name[0]``-only dtype that truncated wider
+    columns. A single column is validated as present.
+
+    Returns:
+        ``(column_name, numpy_dtype)`` with ``column_name`` normalised.
+
+    Raises:
+        ValueError: The list is empty, or a named column is missing.
+    """
+    if column_name is None:
+        column_name = [c for c in features.columns if c != "geometry"]
+
+    if isinstance(column_name, list):
+        if not column_name:
+            raise ValueError(
+                "column_name list must be non-empty. Pass None to "
+                "burn every non-geometry column, or name at least "
+                "one column."
+            )
+        missing = [c for c in column_name if c not in features.columns]
+        if missing:
+            raise ValueError(
+                f"column_name references columns not in the "
+                f"FeatureCollection: {missing}. Available columns: "
+                f"{list(features.columns)}."
+            )
+        numpy_dtype = np.result_type(*[features.dtypes[c] for c in column_name])
+    else:
+        if column_name not in features.columns:
+            raise ValueError(
+                f"column_name {column_name!r} is not in the "
+                f"FeatureCollection. Available columns: "
+                f"{list(features.columns)}."
+            )
+        numpy_dtype = features.dtypes[column_name]
+    return column_name, numpy_dtype

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -1956,6 +1956,51 @@ class FeatureCollection(GeoDataFrame):
             kwargs["batch_size"] = batch_size
         return open_arrow(resolved, **kwargs)
 
+    @staticmethod
+    def _read_parquet_dask(
+        resolved: str,
+        *,
+        columns: list[str] | None,
+        split_row_groups: bool | None,
+        filters: list | None,
+        blocksize: int | str | None,
+        storage_options: dict | None,
+        extra_kwargs: dict[str, Any],
+    ) -> "LazyFeatureCollection":
+        """Dask backend for :meth:`read_parquet`: wrap dask_geopandas as a LazyFeatureCollection."""
+        # check deps in order of specificity — the backend request is the more
+        # specific signal, so the dask-geopandas hint beats the generic pyarrow
+        # one. When both are missing, this error names the extra ([parquet]).
+        try:
+            import dask_geopandas
+        except ImportError as exc:
+            raise ImportError(
+                "backend='dask' requires the optional "
+                "'dask-geopandas' dependency. Install with one of:\n"
+                "  - PyPI:        pip install 'pyramids-gis[parquet]'\n"
+                "  - conda-forge: conda install -c conda-forge pyramids-parquet"
+            ) from exc
+        dask_kwargs: dict[str, Any] = {}
+        if columns is not None:
+            dask_kwargs["columns"] = columns
+        if split_row_groups is not None:
+            dask_kwargs["split_row_groups"] = split_row_groups
+        if filters is not None:
+            dask_kwargs["filters"] = filters
+        if blocksize is not None:
+            dask_kwargs["blocksize"] = blocksize
+        if storage_options is not None:
+            dask_kwargs["storage_options"] = storage_options
+        dask_kwargs.update(extra_kwargs)
+        # dask_geopandas is installed → assert pyarrow too, so the user gets the
+        # pyramids-branded hint (not the upstream message). `[parquet]` pulls both.
+        _require_pyarrow()
+        # wrap the lazy return inside the pyramids type system.
+        from pyramids.feature._lazy_collection import LazyFeatureCollection
+
+        dask_gdf = dask_geopandas.read_parquet(resolved, **dask_kwargs)
+        return LazyFeatureCollection.from_dask_gdf(dask_gdf)
+
     @classmethod
     def read_parquet(
         cls,
@@ -2058,43 +2103,15 @@ class FeatureCollection(GeoDataFrame):
         """
         resolved = _pyramids_io._parse_path(path)
         if backend == "dask":
-            # check deps in order of specificity — the backend
-            # request is the more specific signal, so the
-            # dask-geopandas hint beats the generic pyarrow one.
-            # When both are missing, the dask-geopandas error names
-            # the extra that installs both ([parquet]).
-            try:
-                import dask_geopandas
-            except ImportError as exc:
-                raise ImportError(
-                    "backend='dask' requires the optional "
-                    "'dask-geopandas' dependency. Install with one of:\n"
-                    "  - PyPI:        pip install 'pyramids-gis[parquet]'\n"
-                    "  - conda-forge: conda install -c conda-forge pyramids-parquet"
-                ) from exc
-            dask_kwargs: dict[str, Any] = {}
-            if columns is not None:
-                dask_kwargs["columns"] = columns
-            if split_row_groups is not None:
-                dask_kwargs["split_row_groups"] = split_row_groups
-            if filters is not None:
-                dask_kwargs["filters"] = filters
-            if blocksize is not None:
-                dask_kwargs["blocksize"] = blocksize
-            if storage_options is not None:
-                dask_kwargs["storage_options"] = storage_options
-            dask_kwargs.update(kwargs)
-            # dask_geopandas is installed → assert pyarrow too, so
-            # the user gets the pyramids-branded hint (not the
-            # upstream message dask_geopandas would emit when it tries
-            # to read). `[parquet]` pulls both.
-            _require_pyarrow()
-            # wrap the lazy return as a LazyFeatureCollection so the
-            # dask branch stays inside the pyramids type system.
-            from pyramids.feature._lazy_collection import LazyFeatureCollection
-
-            dask_gdf = dask_geopandas.read_parquet(resolved, **dask_kwargs)
-            return LazyFeatureCollection.from_dask_gdf(dask_gdf)
+            return cls._read_parquet_dask(
+                resolved,
+                columns=columns,
+                split_row_groups=split_row_groups,
+                filters=filters,
+                blocksize=blocksize,
+                storage_options=storage_options,
+                extra_kwargs=kwargs,
+            )
         if backend != "pandas":
             raise ValueError(f"backend must be 'pandas' or 'dask', got {backend!r}")
         _require_pyarrow()

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -2026,7 +2026,9 @@ class FeatureCollection(GeoDataFrame):
         # dask_geopandas is installed → assert pyarrow too, so the user gets the
         # pyramids-branded hint (not the upstream message). `[parquet]` pulls both.
         _require_pyarrow()
-        # wrap the lazy return inside the pyramids type system.
+        # Local import breaks the collection <-> _lazy_collection cycle
+        # (_lazy_collection imports FeatureCollection from this module); it wraps
+        # the lazy dask return inside the pyramids type system.
         from pyramids.feature._lazy_collection import LazyFeatureCollection
 
         dask_gdf = dask_geopandas.read_parquet(resolved, **dask_kwargs)

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -894,25 +894,9 @@ class FeatureCollection(GeoDataFrame):
         else:
             batch_size = int(chunksize)
 
-        # D-M3: pin the engine to pyogrio. `skip_features` /
-        # `max_features` are pyogrio-specific (geopandas' fiona
-        # engine silently ignores them, which would turn every chunk
-        # into a full scan). Pinning the engine makes the contract
-        # explicit and fails fast if pyogrio is absent.
-        read_kwargs: dict[str, Any] = {"engine": "pyogrio"}
-        if layer is not None:
-            read_kwargs["layer"] = layer
-        if where is not None:
-            read_kwargs["where"] = where
-
-        # when tile_strategy is "auto"/"rtree"/"row_group",
-        # forward the bbox to pyogrio which transparently uses the
-        # format's spatial index. When "none", hold the bbox back
-        # and apply it in Python after each chunk loads.
-        pushdown_bbox = bbox if tile_strategy != "none" else None
-        python_bbox = bbox if tile_strategy == "none" else None
-        if pushdown_bbox is not None:
-            read_kwargs["bbox"] = pushdown_bbox
+        read_kwargs, python_bbox = cls._build_iter_read_kwargs(
+            layer, where, bbox, tile_strategy
+        )
 
         for start in range(0, total, batch_size):
             gdf_chunk = gpd.read_file(
@@ -921,32 +905,79 @@ class FeatureCollection(GeoDataFrame):
                 max_features=batch_size,
                 **read_kwargs,
             )
-            # remember the absolute row indices before any
-            # bbox-based masking so callers can map yielded features
-            # back to their source rows even after a Python-side filter
-            # has dropped some of them.
-            if include_index:
-                row_indices = list(range(start, start + len(gdf_chunk)))
+            # Absolute row indices captured before any bbox masking, so callers
+            # can map yielded features back to their source rows.
+            row_indices = (
+                list(range(start, start + len(gdf_chunk))) if include_index else None
+            )
             if python_bbox is not None and len(gdf_chunk) > 0:
                 xmin, ymin, xmax, ymax = python_bbox
                 mask = gdf_chunk.intersects(box(xmin, ymin, xmax, ymax))
                 if include_index:
                     row_indices = [ri for ri, keep in zip(row_indices, mask) if keep]
                 gdf_chunk = gdf_chunk[mask]
-            if chunksize is None:
-                iterator = gdf_chunk.iterfeatures(na="null")
-                if include_index:
-                    for ri, feat in zip(row_indices, iterator):
-                        feat["id"] = ri
-                        yield feat
-                else:
-                    for feat in iterator:
-                        yield feat
+            yield from cls._emit_features(
+                gdf_chunk, row_indices, chunksize, include_index
+            )
+
+    @staticmethod
+    def _build_iter_read_kwargs(
+        layer: str | int | None,
+        where: str | None,
+        bbox: tuple[float, float, float, float] | None,
+        tile_strategy: str,
+    ) -> tuple[dict[str, Any], tuple[float, float, float, float] | None]:
+        """Build the pyogrio ``read_file`` kwargs for :meth:`iter_features`.
+
+        The engine is pinned to pyogrio (``skip_features`` / ``max_features`` are
+        pyogrio-specific; the fiona engine silently ignores them, turning every
+        chunk into a full scan). For every ``tile_strategy`` except ``"none"`` the
+        ``bbox`` is pushed down to pyogrio (which uses the format's spatial
+        index); for ``"none"`` it is held back for a post-load Python filter.
+
+        Returns:
+            ``(read_kwargs, python_bbox)`` — the held-back bbox is ``None`` unless
+            ``tile_strategy == "none"``.
+        """
+        read_kwargs: dict[str, Any] = {"engine": "pyogrio"}
+        if layer is not None:
+            read_kwargs["layer"] = layer
+        if where is not None:
+            read_kwargs["where"] = where
+        pushdown_bbox = bbox if tile_strategy != "none" else None
+        python_bbox = bbox if tile_strategy == "none" else None
+        if pushdown_bbox is not None:
+            read_kwargs["bbox"] = pushdown_bbox
+        return read_kwargs, python_bbox
+
+    @classmethod
+    def _emit_features(
+        cls,
+        gdf_chunk: GeoDataFrame,
+        row_indices: list[int] | None,
+        chunksize: int | None,
+        include_index: bool,
+    ) -> Any:
+        """Yield a processed chunk for :meth:`iter_features`.
+
+        With ``chunksize=None`` yields one GeoJSON-style dict per row (stamping
+        an ``"id"`` when ``include_index``); otherwise yields a single
+        :class:`FeatureCollection` chunk (with a ``"_row_index"`` column when
+        ``include_index``).
+        """
+        if chunksize is None:
+            iterator = gdf_chunk.iterfeatures(na="null")
+            if include_index:
+                for ri, feat in zip(row_indices, iterator):
+                    feat["id"] = ri
+                    yield feat
             else:
-                chunk_fc = cls(gdf_chunk)
-                if include_index:
-                    chunk_fc["_row_index"] = row_indices
-                yield chunk_fc
+                yield from iterator
+        else:
+            chunk_fc = cls(gdf_chunk)
+            if include_index:
+                chunk_fc["_row_index"] = row_indices
+            yield chunk_fc
 
     @classmethod
     def read_file(

--- a/src/pyramids/netcdf/_lazy.py
+++ b/src/pyramids/netcdf/_lazy.py
@@ -231,50 +231,83 @@ def _normalize_chunks(
             raise ValueError(f"Unknown chunks string {chunks!r}; expected 'auto'.")
         result = default
     elif isinstance(chunks, int):
-        result = tuple(int(chunks) if chunks > 0 else int(axis) for axis in shape)
+        result = _normalize_chunks_int(chunks, shape)
     elif isinstance(chunks, (tuple, list)):
-        if len(chunks) != len(shape):
-            raise ValueError(
-                f"chunks tuple length {len(chunks)} does not match "
-                f"array ndim {len(shape)}."
-            )
-        normalized: list[int] = []
-        for c, axis in zip(chunks, shape):
-            if c in (None, -1):
-                normalized.append(int(axis))
-            else:
-                normalized.append(int(c))
-        result = tuple(normalized)
+        result = _normalize_chunks_seq(chunks, shape)
     elif isinstance(chunks, dict):
-        name_aliases_3d = {"bands": 0, "rows": 1, "cols": 2, "columns": 2}
-        name_aliases_2d = {"rows": 0, "cols": 1, "columns": 1}
-        aliases = name_aliases_3d if len(shape) == 3 else name_aliases_2d
-        resolved = list(default)
-        for key, value in chunks.items():
-            if isinstance(key, int):
-                axis_idx = key
-            elif isinstance(key, str) and key in aliases:
-                axis_idx = aliases[key]
-            else:
-                raise ValueError(
-                    f"Unknown chunks dict key {key!r}; expected an int "
-                    f"axis index or one of {sorted(aliases)}."
-                )
-            if not 0 <= axis_idx < len(shape):
-                raise ValueError(
-                    f"chunks dict axis {axis_idx} out of range for "
-                    f"ndim={len(shape)}."
-                )
-            resolved[axis_idx] = (
-                int(shape[axis_idx]) if value in (None, -1) else int(value)
-            )
-        result = tuple(resolved)
+        result = _normalize_chunks_dict(chunks, shape, default)
     else:
         raise TypeError(
             f"Unsupported chunks type {type(chunks).__name__}; expected "
             "None, int, tuple, list, dict, or 'auto'."
         )
     return result
+
+
+def _normalize_chunks_int(chunks: int, shape: tuple[int, ...]) -> tuple[int, ...]:
+    """Apply a single ``int`` chunk size to every axis (``<= 0`` means full axis)."""
+    return tuple(int(chunks) if chunks > 0 else int(axis) for axis in shape)
+
+
+def _normalize_chunks_seq(
+    chunks: tuple | list, shape: tuple[int, ...]
+) -> tuple[int, ...]:
+    """Normalize a per-axis ``tuple``/``list`` of chunk sizes.
+
+    Its length must equal ``len(shape)``; ``None``/``-1`` entries mean "full axis".
+
+    Raises:
+        ValueError: The sequence length does not match the array ndim.
+    """
+    if len(chunks) != len(shape):
+        raise ValueError(
+            f"chunks tuple length {len(chunks)} does not match "
+            f"array ndim {len(shape)}."
+        )
+    normalized: list[int] = []
+    for c, axis in zip(chunks, shape):
+        if c in (None, -1):
+            normalized.append(int(axis))
+        else:
+            normalized.append(int(c))
+    return tuple(normalized)
+
+
+def _normalize_chunks_dict(
+    chunks: dict, shape: tuple[int, ...], default: tuple[int, ...]
+) -> tuple[int, ...]:
+    """Normalize a ``dict`` of chunk sizes keyed by axis index or name.
+
+    Keys may be an ``int`` axis index or one of the ``bands``/``rows``/``cols``
+    (``columns``) aliases (3-D or 2-D depending on ``shape``). Axes absent from
+    the dict keep their ``default`` value; ``None``/``-1`` values mean "full axis".
+
+    Raises:
+        ValueError: An unknown key, or an axis index out of range.
+    """
+    name_aliases_3d = {"bands": 0, "rows": 1, "cols": 2, "columns": 2}
+    name_aliases_2d = {"rows": 0, "cols": 1, "columns": 1}
+    aliases = name_aliases_3d if len(shape) == 3 else name_aliases_2d
+    resolved = list(default)
+    for key, value in chunks.items():
+        if isinstance(key, int):
+            axis_idx = key
+        elif isinstance(key, str) and key in aliases:
+            axis_idx = aliases[key]
+        else:
+            raise ValueError(
+                f"Unknown chunks dict key {key!r}; expected an int "
+                f"axis index or one of {sorted(aliases)}."
+            )
+        if not 0 <= axis_idx < len(shape):
+            raise ValueError(
+                f"chunks dict axis {axis_idx} out of range for "
+                f"ndim={len(shape)}."
+            )
+        resolved[axis_idx] = (
+            int(shape[axis_idx]) if value in (None, -1) else int(value)
+        )
+    return tuple(resolved)
 
 
 def _read_mdarray_chunk(

--- a/src/pyramids/netcdf/cf.py
+++ b/src/pyramids/netcdf/cf.py
@@ -340,6 +340,21 @@ def _lcc_params(srs: osr.SpatialReference) -> dict[str, Any]:
     }
 
 
+def _add_scale_and_parallel(srs: osr.SpatialReference, p: dict[str, Any]) -> None:
+    """Add the CF scale-factor / standard-parallel params when they are non-zero.
+
+    Shared by the Mercator and Polar Stereographic projections, which both emit
+    `scale_factor_at_projection_origin` / `standard_parallel` only when the GDAL
+    projection parameter is set (non-zero).
+    """
+    sf = srs.GetProjParm(osr.SRS_PP_SCALE_FACTOR, 0.0)
+    sp = srs.GetProjParm(osr.SRS_PP_STANDARD_PARALLEL_1, 0.0)
+    if not math.isclose(sf, 0.0):
+        p["scale_factor_at_projection_origin"] = sf
+    if not math.isclose(sp, 0.0):
+        p["standard_parallel"] = sp
+
+
 def _mercator_params(srs: osr.SpatialReference) -> dict[str, Any]:
     """CF params for a Mercator projection (scale factor / standard parallel
     are emitted only when non-zero)."""
@@ -348,12 +363,7 @@ def _mercator_params(srs: osr.SpatialReference) -> dict[str, Any]:
             osr.SRS_PP_CENTRAL_MERIDIAN, 0.0
         ),
     }
-    sf = srs.GetProjParm(osr.SRS_PP_SCALE_FACTOR, 0.0)
-    sp = srs.GetProjParm(osr.SRS_PP_STANDARD_PARALLEL_1, 0.0)
-    if not math.isclose(sf, 0.0):
-        p["scale_factor_at_projection_origin"] = sf
-    if not math.isclose(sp, 0.0):
-        p["standard_parallel"] = sp
+    _add_scale_and_parallel(srs, p)
     return p
 
 
@@ -368,12 +378,7 @@ def _polar_stereographic_params(srs: osr.SpatialReference) -> dict[str, Any]:
             osr.SRS_PP_LATITUDE_OF_ORIGIN, 0.0
         ),
     }
-    sf = srs.GetProjParm(osr.SRS_PP_SCALE_FACTOR, 0.0)
-    sp = srs.GetProjParm(osr.SRS_PP_STANDARD_PARALLEL_1, 0.0)
-    if not math.isclose(sf, 0.0):
-        p["scale_factor_at_projection_origin"] = sf
-    if not math.isclose(sp, 0.0):
-        p["standard_parallel"] = sp
+    _add_scale_and_parallel(srs, p)
     return p
 
 

--- a/src/pyramids/netcdf/cf.py
+++ b/src/pyramids/netcdf/cf.py
@@ -639,34 +639,54 @@ def detect_axis(
     if isinstance(axis, str) and axis.strip().upper() in ("X", "Y", "Z", "T"):
         result = axis.strip().upper()
     else:
-        stdname = attrs.get("standard_name")
-        if isinstance(stdname, str):
-            result = _STDNAME_TO_AXIS.get(stdname.lower())
+        result = _detect_axis_from_metadata(name, attrs, units)
 
-        if result is None:
-            unit_str = units or attrs.get("units")
-            if isinstance(unit_str, str):
-                unit_lower = unit_str.lower().strip()
-                if unit_lower in (
-                    "degrees_north",
-                    "degree_north",
-                    "degree_n",
-                    "degrees_n",
-                ):
-                    result = "Y"
-                elif unit_lower in (
-                    "degrees_east",
-                    "degree_east",
-                    "degree_e",
-                    "degrees_e",
-                ):
-                    result = "X"
-                elif "since" in unit_lower:
-                    result = "T"
+    return result
 
-        if result is None:
-            result = _NAME_PATTERNS.get(name.lower().strip())
 
+def _axis_from_units(unit_str: Any) -> str | None:
+    """Map a CF ``units`` string to an axis code (Y/X/T), or None.
+
+    Args:
+        unit_str: A candidate CF ``units`` value.
+
+    Returns:
+        ``"Y"`` for degrees-north units, ``"X"`` for degrees-east units,
+        ``"T"`` for a ``<period> since <epoch>`` time unit, else ``None``.
+    """
+    axis: str | None = None
+    if isinstance(unit_str, str):
+        unit_lower = unit_str.lower().strip()
+        if unit_lower in ("degrees_north", "degree_north", "degree_n", "degrees_n"):
+            axis = "Y"
+        elif unit_lower in ("degrees_east", "degree_east", "degree_e", "degrees_e"):
+            axis = "X"
+        elif "since" in unit_lower:
+            axis = "T"
+    return axis
+
+
+def _detect_axis_from_metadata(
+    name: str, attrs: dict[str, Any], units: str | None
+) -> str | None:
+    """Detect a CF axis from standard_name, then units, then name pattern.
+
+    Applied (in priority order) when no explicit ``axis`` attribute is present.
+
+    Args:
+        name: Variable or dimension short name.
+        attrs: Case-folded attribute dictionary.
+        units: Unit string passed separately from ``attrs``.
+
+    Returns:
+        One of ``"X"``, ``"Y"``, ``"Z"``, ``"T"``, or ``None``.
+    """
+    stdname = attrs.get("standard_name")
+    result = _STDNAME_TO_AXIS.get(stdname.lower()) if isinstance(stdname, str) else None
+    if result is None:
+        result = _axis_from_units(units or attrs.get("units"))
+    if result is None:
+        result = _NAME_PATTERNS.get(name.lower().strip())
     return result
 
 
@@ -885,30 +905,84 @@ def decode_flags(
     # default; every branch below indexes flag_meanings.
     if flag_meanings is not None:
         if flag_masks is not None and flag_values is not None:
-            matched = [
-                flag_meanings[i]
-                for i in range(len(flag_meanings))
-                if i < len(flag_masks)
-                and i < len(flag_values)
-                and (value & flag_masks[i]) == flag_values[i]
-            ]
-            if matched:
-                result = matched
+            matched = _decode_combined(value, flag_values, flag_meanings, flag_masks)
         elif flag_masks is not None:
-            matched = [
-                flag_meanings[i]
-                for i in range(len(flag_meanings))
-                if i < len(flag_masks) and (value & flag_masks[i]) != 0
-            ]
-            if matched:
-                result = matched
+            matched = _decode_bitfield(value, flag_meanings, flag_masks)
         elif flag_values is not None:
-            for i, fv in enumerate(flag_values):
-                if fv == value and i < len(flag_meanings):
-                    result = [flag_meanings[i]]
-                    break
+            matched = _decode_exclusive(value, flag_values, flag_meanings)
+        else:
+            matched = []
+        if matched:
+            result = matched
 
     return result
+
+
+def _decode_combined(
+    value: int,
+    flag_values: list,
+    flag_meanings: list[str],
+    flag_masks: list[int],
+) -> list[str]:
+    """Combined CF flags: meanings where ``(value & mask) == flag_value``.
+
+    Args:
+        value: The integer flag value being decoded.
+        flag_values: Per-flag expected values (1:1 with meanings).
+        flag_meanings: Human-readable meaning strings.
+        flag_masks: Per-flag bit masks (1:1 with meanings).
+
+    Returns:
+        Matching meanings, empty if none match.
+    """
+    return [
+        flag_meanings[i]
+        for i in range(len(flag_meanings))
+        if i < len(flag_masks)
+        and i < len(flag_values)
+        and (value & flag_masks[i]) == flag_values[i]
+    ]
+
+
+def _decode_bitfield(
+    value: int, flag_meanings: list[str], flag_masks: list[int]
+) -> list[str]:
+    """Boolean/bit-field CF flags: meanings whose mask bit is set in ``value``.
+
+    Args:
+        value: The integer flag value being decoded.
+        flag_meanings: Human-readable meaning strings.
+        flag_masks: Per-flag bit masks (1:1 with meanings).
+
+    Returns:
+        Matching meanings, empty if none match.
+    """
+    return [
+        flag_meanings[i]
+        for i in range(len(flag_meanings))
+        if i < len(flag_masks) and (value & flag_masks[i]) != 0
+    ]
+
+
+def _decode_exclusive(
+    value: int, flag_values: list, flag_meanings: list[str]
+) -> list[str]:
+    """Mutually exclusive CF flags: the single meaning matching ``value``.
+
+    Args:
+        value: The integer flag value being decoded.
+        flag_values: Per-flag values (1:1 with meanings).
+        flag_meanings: Human-readable meaning strings.
+
+    Returns:
+        A single-element list with the first matching meaning, empty if none.
+    """
+    matched: list[str] = []
+    for i, fv in enumerate(flag_values):
+        if fv == value and i < len(flag_meanings):
+            matched = [flag_meanings[i]]
+            break
+    return matched
 
 
 def validate_cf(

--- a/src/pyramids/netcdf/cf.py
+++ b/src/pyramids/netcdf/cf.py
@@ -952,15 +952,33 @@ def validate_cf(
     for name, var in variables.items():
         short = name.lstrip("/")
         if short in dim_names:
-            if not var.attributes.get("units") and not var.unit:
-                issues.append(
-                    f"Coordinate variable '{short}' has no 'units' attribute."
-                )
-            units_val = var.attributes.get("units", "")
-            if isinstance(units_val, str) and "since" in units_val:
-                if "calendar" not in var.attributes:
-                    issues.append(
-                        f"Time coordinate '{short}' has no 'calendar' attribute."
-                    )
+            issues.extend(_check_coordinate_variable(short, var))
 
+    return issues
+
+
+def _check_coordinate_variable(short: str, var: Any) -> list[str]:
+    """Return CF issues for a single dimension-coordinate variable.
+
+    Checks that the coordinate carries a ``units`` attribute and, for a
+    time coordinate (``units`` containing ``"since"``), that it also carries
+    a ``calendar`` attribute.
+
+    Args:
+        short: Coordinate variable name with any leading ``/`` stripped.
+        var: The ``VariableInfo`` for the coordinate.
+
+    Returns:
+        List of warning strings for this variable. Empty if compliant.
+    """
+    issues: list[str] = []
+    if not var.attributes.get("units") and not var.unit:
+        issues.append(f"Coordinate variable '{short}' has no 'units' attribute.")
+    units_val = var.attributes.get("units", "")
+    if (
+        isinstance(units_val, str)
+        and "since" in units_val
+        and "calendar" not in var.attributes
+    ):
+        issues.append(f"Time coordinate '{short}' has no 'calendar' attribute.")
     return issues

--- a/src/pyramids/netcdf/cf.py
+++ b/src/pyramids/netcdf/cf.py
@@ -749,53 +749,93 @@ def classify_variables(
         dim_names.add(d.name)
         dim_names.add(d.full_name.lstrip("/"))
 
-    bounds_vars: set[str] = set()
-    cell_measure_vars: set[str] = set()
-    ancillary_vars: set[str] = set()
-    aux_coord_vars: set[str] = set()
+    refs = _collect_reference_vars(variables)
 
+    roles: dict[str, str] = {}
+    for name, var in variables.items():
+        roles[name] = _classify_one(name, var.attributes, dim_names, refs)
+
+    return roles
+
+
+def _parse_cell_measures(cell_measures: Any) -> set[str]:
+    """Parse a CF ``cell_measures`` string into its measure-variable names.
+
+    The standard measure keywords (``area``, ``volume``) are skipped; a
+    non-string input yields an empty set.
+    """
+    result: set[str] = set()
+    if isinstance(cell_measures, str):
+        for token in cell_measures.replace(":", " ").split():
+            if token not in ("area", "volume"):
+                result.add(token)
+    return result
+
+
+def _collect_reference_vars(variables: dict[str, Any]) -> dict[str, set[str]]:
+    """Collect names referenced by other variables, grouped by CF role.
+
+    Scans every variable's attributes and returns the sets of names referenced
+    as ``bounds``, ``cell_measures``, ``ancillary_variables`` and (auxiliary)
+    ``coordinates`` variables.
+
+    Returns:
+        Dict with keys ``"bounds"`` / ``"cell_measure"`` / ``"ancillary"`` /
+        ``"aux_coord"``, each mapping to a set of referenced variable names.
+    """
+    refs: dict[str, set[str]] = {
+        "bounds": set(),
+        "cell_measure": set(),
+        "ancillary": set(),
+        "aux_coord": set(),
+    }
     for var in variables.values():
         attrs = var.attributes
         bounds_ref = attrs.get("bounds")
         if isinstance(bounds_ref, str):
-            bounds_vars.add(bounds_ref)
-        cm = attrs.get("cell_measures")
-        if isinstance(cm, str):
-            for token in cm.replace(":", " ").split():
-                if token not in ("area", "volume"):
-                    cell_measure_vars.add(token)
+            refs["bounds"].add(bounds_ref)
+        refs["cell_measure"] |= _parse_cell_measures(attrs.get("cell_measures"))
         av = attrs.get("ancillary_variables")
         if isinstance(av, str):
-            ancillary_vars.update(av.split())
+            refs["ancillary"].update(av.split())
         coords = attrs.get("coordinates")
         if isinstance(coords, str):
-            aux_coord_vars.update(coords.split())
+            refs["aux_coord"].update(coords.split())
+    return refs
 
-    roles: dict[str, str] = {}
-    for name, var in variables.items():
-        short_name = name.lstrip("/")
-        attrs = var.attributes
 
-        if "grid_mapping_name" in attrs:
-            roles[name] = "grid_mapping"
-        elif short_name in bounds_vars or name in bounds_vars:
-            roles[name] = "bounds"
-        elif short_name in cell_measure_vars or name in cell_measure_vars:
-            roles[name] = "cell_measure"
-        elif short_name in ancillary_vars or name in ancillary_vars:
-            roles[name] = "ancillary"
-        elif _is_mesh_topology(attrs):
-            roles[name] = "mesh_topology"
-        elif _is_connectivity(attrs):
-            roles[name] = "connectivity"
-        elif short_name in dim_names:
-            roles[name] = "coordinate"
-        elif short_name in aux_coord_vars or name in aux_coord_vars:
-            roles[name] = "auxiliary_coordinate"
-        else:
-            roles[name] = "data"
+def _classify_one(
+    name: str,
+    attrs: dict[str, Any],
+    dim_names: set[str],
+    refs: dict[str, set[str]],
+) -> str:
+    """Return the CF role for a single variable.
 
-    return roles
+    Applies the role precedence used by :func:`classify_variables`:
+    grid-mapping, bounds, cell-measure, ancillary, mesh-topology, connectivity,
+    (dimension) coordinate, auxiliary coordinate, then plain data.
+    """
+    short_name = name.lstrip("/")
+    if "grid_mapping_name" in attrs:
+        role = "grid_mapping"
+    elif short_name in refs["bounds"] or name in refs["bounds"]:
+        role = "bounds"
+    elif short_name in refs["cell_measure"] or name in refs["cell_measure"]:
+        role = "cell_measure"
+    elif short_name in refs["ancillary"] or name in refs["ancillary"]:
+        role = "ancillary"
+    elif _is_mesh_topology(attrs):
+        role = "mesh_topology"
+    elif _is_connectivity(attrs):
+        role = "connectivity"
+    elif short_name in dim_names:
+        role = "coordinate"
+    elif short_name in refs["aux_coord"] or name in refs["aux_coord"]:
+        role = "auxiliary_coordinate"
+    else:
+        role = "data"
+    return role
 
 
 def _is_mesh_topology(attrs: dict[str, Any]) -> bool:

--- a/src/pyramids/netcdf/cf.py
+++ b/src/pyramids/netcdf/cf.py
@@ -261,41 +261,11 @@ def _extract_proj_params(srs: osr.SpatialReference, proj_name: str) -> dict[str,
             osr.SRS_PP_SCALE_FACTOR, 1.0
         )
     elif "Lambert_Conformal_Conic" in proj_name:
-        p["latitude_of_projection_origin"] = srs.GetProjParm(
-            osr.SRS_PP_LATITUDE_OF_ORIGIN, 0.0
-        )
-        p["longitude_of_central_meridian"] = srs.GetProjParm(
-            osr.SRS_PP_CENTRAL_MERIDIAN, 0.0
-        )
-        sp1 = srs.GetProjParm(osr.SRS_PP_STANDARD_PARALLEL_1, 0.0)
-        sp2 = srs.GetProjParm(osr.SRS_PP_STANDARD_PARALLEL_2, 0.0)
-        if sp1 == sp2:
-            p["standard_parallel"] = sp1
-        else:
-            p["standard_parallel"] = [sp1, sp2]
+        p.update(_lcc_params(srs))
     elif "Mercator" in proj_name:
-        p["longitude_of_projection_origin"] = srs.GetProjParm(
-            osr.SRS_PP_CENTRAL_MERIDIAN, 0.0
-        )
-        sf = srs.GetProjParm(osr.SRS_PP_SCALE_FACTOR, 0.0)
-        sp = srs.GetProjParm(osr.SRS_PP_STANDARD_PARALLEL_1, 0.0)
-        if not math.isclose(sf, 0.0):
-            p["scale_factor_at_projection_origin"] = sf
-        if not math.isclose(sp, 0.0):
-            p["standard_parallel"] = sp
+        p.update(_mercator_params(srs))
     elif "Polar_Stereographic" in proj_name:
-        p["straight_vertical_longitude_from_pole"] = srs.GetProjParm(
-            osr.SRS_PP_CENTRAL_MERIDIAN, 0.0
-        )
-        p["latitude_of_projection_origin"] = srs.GetProjParm(
-            osr.SRS_PP_LATITUDE_OF_ORIGIN, 0.0
-        )
-        sf = srs.GetProjParm(osr.SRS_PP_SCALE_FACTOR, 0.0)
-        sp = srs.GetProjParm(osr.SRS_PP_STANDARD_PARALLEL_1, 0.0)
-        if not math.isclose(sf, 0.0):
-            p["scale_factor_at_projection_origin"] = sf
-        if not math.isclose(sp, 0.0):
-            p["standard_parallel"] = sp
+        p.update(_polar_stereographic_params(srs))
     elif "Albers" in proj_name:
         p["latitude_of_projection_origin"] = srs.GetProjParm(
             osr.SRS_PP_LATITUDE_OF_ORIGIN, 0.0
@@ -348,6 +318,62 @@ def _extract_proj_params(srs: osr.SpatialReference, proj_name: str) -> dict[str,
         p["perspective_point_height"] = srs.GetProjParm("satellite_height", 35785831.0)
         p["sweep_angle_axis"] = "y"
 
+    return p
+
+
+def _lcc_params(srs: osr.SpatialReference) -> dict[str, Any]:
+    """CF params for a Lambert Conformal Conic projection.
+
+    Collapses the two standard parallels to a single value when they are
+    equal, else emits them as a ``[sp1, sp2]`` pair.
+    """
+    sp1 = srs.GetProjParm(osr.SRS_PP_STANDARD_PARALLEL_1, 0.0)
+    sp2 = srs.GetProjParm(osr.SRS_PP_STANDARD_PARALLEL_2, 0.0)
+    return {
+        "latitude_of_projection_origin": srs.GetProjParm(
+            osr.SRS_PP_LATITUDE_OF_ORIGIN, 0.0
+        ),
+        "longitude_of_central_meridian": srs.GetProjParm(
+            osr.SRS_PP_CENTRAL_MERIDIAN, 0.0
+        ),
+        "standard_parallel": sp1 if sp1 == sp2 else [sp1, sp2],
+    }
+
+
+def _mercator_params(srs: osr.SpatialReference) -> dict[str, Any]:
+    """CF params for a Mercator projection (scale factor / standard parallel
+    are emitted only when non-zero)."""
+    p: dict[str, Any] = {
+        "longitude_of_projection_origin": srs.GetProjParm(
+            osr.SRS_PP_CENTRAL_MERIDIAN, 0.0
+        ),
+    }
+    sf = srs.GetProjParm(osr.SRS_PP_SCALE_FACTOR, 0.0)
+    sp = srs.GetProjParm(osr.SRS_PP_STANDARD_PARALLEL_1, 0.0)
+    if not math.isclose(sf, 0.0):
+        p["scale_factor_at_projection_origin"] = sf
+    if not math.isclose(sp, 0.0):
+        p["standard_parallel"] = sp
+    return p
+
+
+def _polar_stereographic_params(srs: osr.SpatialReference) -> dict[str, Any]:
+    """CF params for a Polar Stereographic projection (scale factor / standard
+    parallel are emitted only when non-zero)."""
+    p: dict[str, Any] = {
+        "straight_vertical_longitude_from_pole": srs.GetProjParm(
+            osr.SRS_PP_CENTRAL_MERIDIAN, 0.0
+        ),
+        "latitude_of_projection_origin": srs.GetProjParm(
+            osr.SRS_PP_LATITUDE_OF_ORIGIN, 0.0
+        ),
+    }
+    sf = srs.GetProjParm(osr.SRS_PP_SCALE_FACTOR, 0.0)
+    sp = srs.GetProjParm(osr.SRS_PP_STANDARD_PARALLEL_1, 0.0)
+    if not math.isclose(sf, 0.0):
+        p["scale_factor_at_projection_origin"] = sf
+    if not math.isclose(sp, 0.0):
+        p["standard_parallel"] = sp
     return p
 
 
@@ -419,23 +445,18 @@ def _build_srs_from_cf_params(
             params.get("false_northing", 0.0),
         )
     elif grid_mapping_name == "lambert_conformal_conic":
-        sp = params.get("standard_parallel", [0.0, 0.0])
-        if isinstance(sp, (int, float)):
-            sp = [sp, sp]
+        sp1, sp2 = _two_standard_parallels(params)
         srs.SetLCC(
-            sp[0],
-            sp[1] if len(sp) > 1 else sp[0],
+            sp1,
+            sp2,
             params.get("latitude_of_projection_origin", 0.0),
             params.get("longitude_of_central_meridian", 0.0),
             params.get("false_easting", 0.0),
             params.get("false_northing", 0.0),
         )
     elif grid_mapping_name == "mercator":
-        sp = params.get("standard_parallel", 0.0)
-        if isinstance(sp, list):
-            sp = sp[0]
         srs.SetMercator(
-            float(sp),
+            _single_standard_parallel(params),
             params.get("longitude_of_projection_origin", 0.0),
             params.get("scale_factor_at_projection_origin", 1.0),
             params.get("false_easting", 0.0),
@@ -450,12 +471,10 @@ def _build_srs_from_cf_params(
             params.get("false_northing", 0.0),
         )
     elif grid_mapping_name == "albers_conical_equal_area":
-        sp = params.get("standard_parallel", [0.0, 0.0])
-        if isinstance(sp, (int, float)):
-            sp = [sp, sp]
+        sp1, sp2 = _two_standard_parallels(params)
         srs.SetACEA(
-            sp[0],
-            sp[1] if len(sp) > 1 else sp[0],
+            sp1,
+            sp2,
             params.get("latitude_of_projection_origin", 0.0),
             params.get("longitude_of_central_meridian", 0.0),
             params.get("false_easting", 0.0),
@@ -506,6 +525,26 @@ def _build_srs_from_cf_params(
         )
 
     return srs
+
+
+def _two_standard_parallels(params: dict[str, Any]) -> tuple[float, float]:
+    """Return the two CF standard parallels, normalizing a scalar to a pair.
+
+    A ``standard_parallel`` given as a scalar becomes ``(sp, sp)``; a
+    single-element list repeats its value for the second parallel.
+    """
+    sp = params.get("standard_parallel", [0.0, 0.0])
+    if isinstance(sp, (int, float)):
+        sp = [sp, sp]
+    return sp[0], (sp[1] if len(sp) > 1 else sp[0])
+
+
+def _single_standard_parallel(params: dict[str, Any]) -> float:
+    """Return the scalar CF standard parallel, taking the first of a list."""
+    sp = params.get("standard_parallel", 0.0)
+    if isinstance(sp, list):
+        sp = sp[0]
+    return float(sp)
 
 
 _STDNAME_TO_AXIS: dict[str, str] = {

--- a/src/pyramids/netcdf/engines/variables.py
+++ b/src/pyramids/netcdf/engines/variables.py
@@ -776,6 +776,29 @@ def _write_blocks_streaming(md_arr: Any, dask_arr: Any) -> None:
         md_arr.Write(block, array_start_idx=starts, count=counts)
 
 
+def _require_create_inputs(
+    variable_name: str | None,
+    geo: tuple[float, float, float, float, float, float] | None,
+    epsg: str | int | None,
+) -> None:
+    """Validate the required inputs for `_create_netcdf_from_array`.
+
+    Args:
+        variable_name: Name of the data variable.
+        geo: Geotransform tuple.
+        epsg: EPSG code or WKT/user-input CRS string.
+
+    Raises:
+        ValueError: If `variable_name`, `geo`, or `epsg` is None.
+    """
+    if variable_name is None:
+        raise ValueError("Variable_name cannot be None")
+    if geo is None:
+        raise ValueError("geo cannot be None")
+    if epsg is None:
+        raise ValueError("epsg cannot be None")
+
+
 def _create_netcdf_from_array(
     arr: np.ndarray,
     variable_name: str,
@@ -833,12 +856,7 @@ def _create_netcdf_from_array(
     # set_variable and other call sites) and are reached through the class.
     from pyramids.netcdf.netcdf import NetCDF
 
-    if variable_name is None:
-        raise ValueError("Variable_name cannot be None")
-    if geo is None:
-        raise ValueError("geo cannot be None")
-    if epsg is None:
-        raise ValueError("epsg cannot be None")
+    _require_create_inputs(variable_name, geo, epsg)
 
     if extra_dims is None:
         extra_dims = []

--- a/src/pyramids/netcdf/metadata.py
+++ b/src/pyramids/netcdf/metadata.py
@@ -999,6 +999,6 @@ def flatten_for_index(metadata: NetCDFMetadata) -> dict[str, Any]:
     for k, v in list(metadata.global_attributes.items())[:MAX_INDEXED_GLOBAL_ATTRS]:
         d[f"global.{k}"] = v
     # include names of variables and dims
-    d["variables"] = sorted([a for a in metadata.variables.keys()])
-    d["dimensions"] = sorted([dname for dname in metadata.dimensions.keys()])
+    d["variables"] = sorted(metadata.variables.keys())
+    d["dimensions"] = sorted(metadata.dimensions.keys())
     return d

--- a/src/pyramids/netcdf/metadata.py
+++ b/src/pyramids/netcdf/metadata.py
@@ -584,43 +584,11 @@ class GroupTraverser:
 
             # Children
             children_full: list[str] = []
-            for cn in _safe_group_names(group):
-                try:
-                    current_group = group.OpenGroup(cn)
-                except RuntimeError as exc:
-                    logger.debug(
-                        "group.OpenGroup(%r) failed in %r: %s",
-                        cn,
-                        group_full_name,
-                        exc,
-                    )
-                    current_group = None
-
-                if current_group is None:
-                    continue
-
-                # Delegate child full-name resolution to GroupInfo
-                try:
-                    child_info = GroupInfo.from_group(
-                        current_group, variables=[], children=[], attributes={}
-                    )
-                    current_group_full_name = child_info.full_name
-                except RuntimeError as exc:
-                    logger.debug(
-                        "GroupInfo.from_group(%r) failed in %r: %s; "
-                        "falling back to path concatenation",
-                        cn,
-                        group_full_name,
-                        exc,
-                    )
-                    current_group_full_name = (
-                        f"{group_full_name}/{cn}"
-                        if group_full_name != "/"
-                        else f"/{cn}"
-                    )
-
-                children_full.append(current_group_full_name)
-                q.append(current_group)
+            for child_full_name, child_group in self._resolve_child_groups(
+                group, group_full_name
+            ):
+                children_full.append(child_full_name)
+                q.append(child_group)
 
             # Record this group entry via GroupInfo factory
             group_info = GroupInfo.from_group(
@@ -632,6 +600,62 @@ class GroupTraverser:
             if gkey != "/":
                 gkey = gkey.lstrip("/")
             self.groups[gkey] = group_info
+
+    def _resolve_child_groups(
+        self, group: gdal.Group, group_full_name: str
+    ) -> list[tuple[str, "gdal.Group"]]:
+        """Open the child groups of *group* and resolve their full names.
+
+        Children that fail to open are skipped. For a child whose
+        `GroupInfo` resolution raises, the full name falls back to
+        concatenating the parent full name with the child's short name.
+
+        Args:
+            group: The parent GDAL group being visited.
+            group_full_name: Full name of the parent group.
+
+        Returns:
+            List of `(child_full_name, child_group)` pairs for every child
+            that opened successfully, in traversal order.
+        """
+        children: list[tuple[str, "gdal.Group"]] = []
+        for cn in _safe_group_names(group):
+            try:
+                current_group = group.OpenGroup(cn)
+            except RuntimeError as exc:
+                logger.debug(
+                    "group.OpenGroup(%r) failed in %r: %s",
+                    cn,
+                    group_full_name,
+                    exc,
+                )
+                current_group = None
+
+            if current_group is None:
+                continue
+
+            # Delegate child full-name resolution to GroupInfo
+            try:
+                child_info = GroupInfo.from_group(
+                    current_group, variables=[], children=[], attributes={}
+                )
+                current_group_full_name = child_info.full_name
+            except RuntimeError as exc:
+                logger.debug(
+                    "GroupInfo.from_group(%r) failed in %r: %s; "
+                    "falling back to path concatenation",
+                    cn,
+                    group_full_name,
+                    exc,
+                )
+                current_group_full_name = (
+                    f"{group_full_name}/{cn}"
+                    if group_full_name != "/"
+                    else f"/{cn}"
+                )
+
+            children.append((current_group_full_name, current_group))
+        return children
 
 
 def get_metadata(

--- a/src/pyramids/netcdf/metadata.py
+++ b/src/pyramids/netcdf/metadata.py
@@ -363,26 +363,41 @@ class MetadataBuilder:
         if any(self._is_classic_dim_attr_key(k) for k in existing):
             result = existing
         else:
-            try:
-                path = self.gdal_dataset.GetDescription()
-            except RuntimeError as exc:
-                logger.debug("GetDescription() failed during dim top-up: %s", exc)
-                path = ""
-            if path:
-                try:
-                    ds = gdal.Open(path)
-                    try:
-                        if ds is not None:
-                            result = ds.GetMetadata() or {}
-                    finally:
-                        ds = None  # explicit release; see review M1
-                except RuntimeError as exc:
-                    logger.debug(
-                        "classic re-open failed during dim top-up (%r): %s",
-                        path,
-                        exc,
-                    )
+            result = self._reopen_classic_metadata()
         self._classic_md_cache = result
+        return result
+
+    def _reopen_classic_metadata(self) -> dict[str, str]:
+        """Re-open the dataset in classic mode to read its flat metadata.
+
+        Opens a transient `gdal.Open(GetDescription())` handle on the same
+        path and returns its `GetMetadata()` dict. Any failure (no path,
+        unreachable file, GDAL error on `GetDescription` / `Open` /
+        `GetMetadata`) yields `{}` so the top-up degrades to a no-op.
+
+        Returns:
+            dict[str, str]: Flat classic-mode metadata, empty on failure.
+        """
+        result: dict[str, str] = {}
+        try:
+            path = self.gdal_dataset.GetDescription()
+        except RuntimeError as exc:
+            logger.debug("GetDescription() failed during dim top-up: %s", exc)
+            path = ""
+        if path:
+            try:
+                ds = gdal.Open(path)
+                try:
+                    if ds is not None:
+                        result = ds.GetMetadata() or {}
+                finally:
+                    ds = None  # explicit release; see review M1
+            except RuntimeError as exc:
+                logger.debug(
+                    "classic re-open failed during dim top-up (%r): %s",
+                    path,
+                    exc,
+                )
         return result
 
 

--- a/src/pyramids/netcdf/models.py
+++ b/src/pyramids/netcdf/models.py
@@ -16,6 +16,7 @@ from pyramids.netcdf.utils import (
     _get_coord_variable_names,
     _get_group_name,
     _read_attributes,
+    _read_dim_names,
     resolve_full_name,
 )
 
@@ -517,17 +518,7 @@ class VariableInfo:
                 shape = []
 
         # dimension names
-        try:
-            dims2 = md_arr.GetDimensions() or []
-            dim_names: list[str] = []
-            for d in dims2:
-                try:
-                    dn = d.GetFullName()
-                except Exception:
-                    dn = d.GetName()
-                dim_names.append(dn)
-        except Exception:
-            dim_names = []
+        dim_names = _read_dim_names(md_arr)
 
         a_attrs = _read_attributes(md_arr)
         try:

--- a/src/pyramids/netcdf/ugrid/dataset.py
+++ b/src/pyramids/netcdf/ugrid/dataset.py
@@ -648,23 +648,7 @@ class UgridDataset:
         Returns:
             geopandas GeoDataFrame.
         """
-        geometries = []
-        if location == "face":
-            spatial_idx = MeshSpatialIndex(self._mesh)
-            geometries = spatial_idx.face_polygons
-        elif location == "node":
-            for i in range(self.n_node):
-                geometries.append(Point(self._mesh.node_x[i], self._mesh.node_y[i]))
-        elif location == "edge":
-            if self._mesh.edge_node_connectivity is None:
-                raise ValueError("Edge connectivity not available.")
-            enc = self._mesh.edge_node_connectivity
-            for i in range(enc.n_elements):
-                nodes = enc.get_element(i)
-                coords = [(self._mesh.node_x[n], self._mesh.node_y[n]) for n in nodes]
-                geometries.append(LineString(coords))
-        else:
-            raise ValueError(f"Unknown location: {location}")
+        geometries = self._build_geometries(location)
 
         data_dict: dict[str, Any] = {}
         if variable_name is not None:
@@ -681,6 +665,42 @@ class UgridDataset:
 
         result = gdf
         return result
+
+    def _build_geometries(self, location: str) -> list:
+        """Build the geometry list for a mesh location.
+
+        Args:
+            location: Mesh location ("face", "node", or "edge").
+
+        Returns:
+            List of shapely geometries — Polygons for "face", Points for
+            "node", LineStrings for "edge".
+
+        Raises:
+            ValueError: If `location` is unknown, or edge connectivity is
+                unavailable for an edge conversion.
+        """
+        if location == "face":
+            geometries = MeshSpatialIndex(self._mesh).face_polygons
+        elif location == "node":
+            geometries = [
+                Point(self._mesh.node_x[i], self._mesh.node_y[i])
+                for i in range(self.n_node)
+            ]
+        elif location == "edge":
+            if self._mesh.edge_node_connectivity is None:
+                raise ValueError("Edge connectivity not available.")
+            enc = self._mesh.edge_node_connectivity
+            geometries = []
+            for i in range(enc.n_elements):
+                nodes = enc.get_element(i)
+                coords = [
+                    (self._mesh.node_x[n], self._mesh.node_y[n]) for n in nodes
+                ]
+                geometries.append(LineString(coords))
+        else:
+            raise ValueError(f"Unknown location: {location}")
+        return geometries
 
     def to_feature_collection(
         self,

--- a/src/pyramids/netcdf/ugrid/mesh.py
+++ b/src/pyramids/netcdf/ugrid/mesh.py
@@ -384,30 +384,10 @@ class Mesh2d:
         Builds the face_face_connectivity array where each row
         contains the indices of neighboring faces, padded with -1.
         """
-        edge_to_faces: dict[tuple[int, int], list[int]] = {}
-        fnc = self._face_node_connectivity
+        edge_to_faces = self._build_edge_to_faces()
+        neighbors = self._neighbours_from_edges(edge_to_faces)
 
-        for i in range(self.n_face):
-            nodes = fnc.get_element(i)
-            n = len(nodes)
-            for j in range(n):
-                n1 = int(nodes[j])
-                n2 = int(nodes[(j + 1) % n])
-                edge_key = (min(n1, n2), max(n1, n2))
-                if edge_key not in edge_to_faces:
-                    edge_to_faces[edge_key] = []
-                edge_to_faces[edge_key].append(i)
-
-        neighbors: list[list[int]] = [[] for _ in range(self.n_face)]
-        for faces_list in edge_to_faces.values():
-            if len(faces_list) == 2:
-                f1, f2 = faces_list
-                if f2 not in neighbors[f1]:
-                    neighbors[f1].append(f2)
-                if f1 not in neighbors[f2]:
-                    neighbors[f2].append(f1)
-
-        max_neighbors = max(len(n) for n in neighbors) if neighbors else 0
+        max_neighbors = max((len(n) for n in neighbors), default=0)
         if max_neighbors == 0:
             max_neighbors = 1
 
@@ -422,6 +402,49 @@ class Mesh2d:
             cf_role="face_face_connectivity",
             original_start_index=0,
         )
+
+    def _build_edge_to_faces(self) -> dict[tuple[int, int], list[int]]:
+        """Map each undirected edge to the faces incident to it.
+
+        Returns:
+            Dict keyed by a sorted `(node_a, node_b)` edge, mapping to the
+            list of face indices that contain that edge.
+        """
+        fnc = self._face_node_connectivity
+        edge_to_faces: dict[tuple[int, int], list[int]] = {}
+        for i in range(self.n_face):
+            nodes = fnc.get_element(i)
+            n = len(nodes)
+            for j in range(n):
+                n1 = int(nodes[j])
+                n2 = int(nodes[(j + 1) % n])
+                edge_key = (min(n1, n2), max(n1, n2))
+                edge_to_faces.setdefault(edge_key, []).append(i)
+        return edge_to_faces
+
+    def _neighbours_from_edges(
+        self, edge_to_faces: dict[tuple[int, int], list[int]]
+    ) -> list[list[int]]:
+        """Build the per-face neighbour adjacency list from shared edges.
+
+        Two faces are neighbours when they share an edge — an edge incident
+        to exactly two faces.
+
+        Args:
+            edge_to_faces: Edge → incident-face-indices map.
+
+        Returns:
+            For each face index, the list of neighbouring face indices.
+        """
+        neighbors: list[list[int]] = [[] for _ in range(self.n_face)]
+        for faces_list in edge_to_faces.values():
+            if len(faces_list) == 2:
+                f1, f2 = faces_list
+                if f2 not in neighbors[f1]:
+                    neighbors[f1].append(f2)
+                if f1 not in neighbors[f2]:
+                    neighbors[f2].append(f1)
+        return neighbors
 
     @classmethod
     def from_gdal_group(

--- a/src/pyramids/netcdf/ugrid/mesh.py
+++ b/src/pyramids/netcdf/ugrid/mesh.py
@@ -478,67 +478,26 @@ class Mesh2d:
         node_x = node_x_arr.ReadAsArray().astype(np.float64)
         node_y = node_y_arr.ReadAsArray().astype(np.float64)
 
-        face_node_conn = None
-        if topo_info.face_node_var:
-            fnc_arr = rg.OpenMDArray(topo_info.face_node_var)
-            if fnc_arr is not None:
-                face_node_conn = Connectivity.from_gdal_array(
-                    fnc_arr, "face_node_connectivity"
-                )
+        face_node_conn = cls._read_connectivity(
+            rg, topo_info.face_node_var, "face_node_connectivity"
+        )
+        edge_node_conn = cls._read_connectivity(
+            rg, topo_info.edge_node_var, "edge_node_connectivity"
+        )
+        face_edge_conn = cls._read_connectivity(
+            rg, topo_info.face_edge_var, "face_edge_connectivity"
+        )
+        face_face_conn = cls._read_connectivity(
+            rg, topo_info.face_face_var, "face_face_connectivity"
+        )
+        edge_face_conn = cls._read_connectivity(
+            rg, topo_info.edge_face_var, "edge_face_connectivity"
+        )
 
-        edge_node_conn = None
-        if topo_info.edge_node_var:
-            enc_arr = rg.OpenMDArray(topo_info.edge_node_var)
-            if enc_arr is not None:
-                edge_node_conn = Connectivity.from_gdal_array(
-                    enc_arr, "edge_node_connectivity"
-                )
-
-        face_edge_conn = None
-        if topo_info.face_edge_var:
-            fec_arr = rg.OpenMDArray(topo_info.face_edge_var)
-            if fec_arr is not None:
-                face_edge_conn = Connectivity.from_gdal_array(
-                    fec_arr, "face_edge_connectivity"
-                )
-
-        face_face_conn = None
-        if topo_info.face_face_var:
-            ffc_arr = rg.OpenMDArray(topo_info.face_face_var)
-            if ffc_arr is not None:
-                face_face_conn = Connectivity.from_gdal_array(
-                    ffc_arr, "face_face_connectivity"
-                )
-
-        edge_face_conn = None
-        if topo_info.edge_face_var:
-            efc_arr = rg.OpenMDArray(topo_info.edge_face_var)
-            if efc_arr is not None:
-                edge_face_conn = Connectivity.from_gdal_array(
-                    efc_arr, "edge_face_connectivity"
-                )
-
-        face_x = None
-        face_y = None
-        if topo_info.face_x_var:
-            fx_arr = rg.OpenMDArray(topo_info.face_x_var)
-            if fx_arr is not None:
-                face_x = fx_arr.ReadAsArray().astype(np.float64)
-        if topo_info.face_y_var:
-            fy_arr = rg.OpenMDArray(topo_info.face_y_var)
-            if fy_arr is not None:
-                face_y = fy_arr.ReadAsArray().astype(np.float64)
-
-        edge_x = None
-        edge_y = None
-        if topo_info.edge_x_var:
-            ex_arr = rg.OpenMDArray(topo_info.edge_x_var)
-            if ex_arr is not None:
-                edge_x = ex_arr.ReadAsArray().astype(np.float64)
-        if topo_info.edge_y_var:
-            ey_arr = rg.OpenMDArray(topo_info.edge_y_var)
-            if ey_arr is not None:
-                edge_y = ey_arr.ReadAsArray().astype(np.float64)
+        face_x = cls._read_coord_array(rg, topo_info.face_x_var)
+        face_y = cls._read_coord_array(rg, topo_info.face_y_var)
+        edge_x = cls._read_coord_array(rg, topo_info.edge_x_var)
+        edge_y = cls._read_coord_array(rg, topo_info.edge_y_var)
 
         crs = None
         if topo_info.crs_wkt:
@@ -567,3 +526,33 @@ class Mesh2d:
             crs=crs,
         )
         return result
+
+    @staticmethod
+    def _read_connectivity(
+        rg: gdal.Group, var_name: str | None, role: str
+    ) -> Connectivity | None:
+        """Read an optional UGRID connectivity array from a GDAL group.
+
+        Returns ``None`` when the variable name is empty or the array cannot be
+        opened, otherwise a :class:`Connectivity` tagged with ``role``.
+        """
+        conn = None
+        if var_name:
+            arr = rg.OpenMDArray(var_name)
+            if arr is not None:
+                conn = Connectivity.from_gdal_array(arr, role)
+        return conn
+
+    @staticmethod
+    def _read_coord_array(rg: gdal.Group, var_name: str | None) -> np.ndarray | None:
+        """Read an optional coordinate array (as ``float64``) from a GDAL group.
+
+        Returns ``None`` when the variable name is empty or the array cannot be
+        opened.
+        """
+        values = None
+        if var_name:
+            arr = rg.OpenMDArray(var_name)
+            if arr is not None:
+                values = arr.ReadAsArray().astype(np.float64)
+        return values

--- a/src/pyramids/netcdf/utils.py
+++ b/src/pyramids/netcdf/utils.py
@@ -209,27 +209,45 @@ def _get_array_nodata(
             if isinstance(v, list):
                 return v[0] if v else None
             return v  # type: ignore[return-value]
-    # Try driver API
+    return _nodata_from_driver_api(mdarr)
+
+
+def _nodata_from_driver_api(mdarr: gdal.MDArray) -> int | float | str | None:
+    """Read a no-data value from the GDAL MDArray driver API.
+
+    Tries the double / int64 / string accessors in order. Some GDAL versions
+    return a ``(value, has_value)`` pair; the value is used only when the flag
+    is set, otherwise the next accessor is tried. Any accessor that raises is
+    skipped.
+
+    Args:
+        mdarr: A GDAL multidimensional array object.
+
+    Returns:
+        The no-data value as an ``int`` / ``float`` / ``str``, or ``None`` if
+        no accessor yields one.
+    """
     for meth in (
         "GetNoDataValueAsDouble",
         "GetNoDataValueAsInt64",
         "GetNoDataValueAsString",
     ):
-        if hasattr(mdarr, meth):
-            try:
-                v = getattr(mdarr, meth)()
-                # Some GDAL versions return (value, hasval)
-                if (
-                    isinstance(v, (list, tuple))
-                    and len(v) == 2
-                    and isinstance(v[1], (bool, int))
-                ):
-                    if v[1]:
-                        return cast(int | float | str | None, _to_py_scalar(v[0]))
-                    continue
-                return cast(int | float | str | None, _to_py_scalar(v))
-            except Exception:
-                continue  # nosec B112
+        if not hasattr(mdarr, meth):
+            continue
+        try:
+            v = getattr(mdarr, meth)()
+            # Some GDAL versions return (value, hasval)
+            if (
+                isinstance(v, (list, tuple))
+                and len(v) == 2
+                and isinstance(v[1], (bool, int))
+            ):
+                if v[1]:
+                    return cast(int | float | str | None, _to_py_scalar(v[0]))
+                continue
+            return cast(int | float | str | None, _to_py_scalar(v))
+        except Exception:
+            continue  # nosec B112
     return None
 
 

--- a/src/pyramids/netcdf/utils.py
+++ b/src/pyramids/netcdf/utils.py
@@ -814,3 +814,29 @@ def _read_attributes(obj: Any) -> dict[str, AttributeValue]:
             # Be robust; don't crash on odd attribute types
             attrs[name] = _normalize_attr_value(None)
     return attrs
+
+
+def _read_dim_names(md_arr: Any) -> list[str]:
+    """Read the ordered dimension names of a GDAL MDArray.
+
+    Prefers each dimension's full name and falls back to its short name.
+    Any failure to enumerate the dimensions yields an empty list so the
+    caller degrades gracefully.
+
+    Args:
+        md_arr: A GDAL `MDArray` supporting `GetDimensions()`.
+
+    Returns:
+        Ordered list of dimension names (full names where available),
+        empty if the dimensions cannot be read.
+    """
+    dim_names: list[str] = []
+    try:
+        for d in md_arr.GetDimensions() or []:
+            try:
+                dim_names.append(d.GetFullName())
+            except Exception:
+                dim_names.append(d.GetName())
+    except Exception:
+        return []
+    return dim_names

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,8 +33,15 @@ from shapely.geometry import Polygon
 
 # isort: on
 from tests._marks import EXTRA_MARKERS
-from tests.dataset.conftest import *
-from tests.feature.conftest import *
+
+# The dataset/ and feature/ conftests auto-provide their fixtures to tests under
+# their own directories. The only cross-directory use is tests/base/test_dtype_conversions.py,
+# which needs `src` and `data_source`, so re-export just those two chains here
+# instead of a blanket `from … import *` (S2208). (`src_path` / `test_vector_path`
+# are the path fixtures they depend on.) A new cross-dir use would fail loudly with
+# "fixture not found", prompting an explicit addition.
+from tests.dataset.conftest import src, src_path  # noqa: F401
+from tests.feature.conftest import data_source, test_vector_path  # noqa: F401
 
 # GDAL_DATA as configured by `import pyramids` above (the vendored
 # `_data/gdal_data` in a bundled wheel, or conda's `share/gdal` in dev).


### PR DESCRIPTION
# Description

Behavior-preserving **round-2 SonarCloud maintainability cleanup** (follow-up to #724). 34 large functions were split
below the `python:S3776` cognitive-complexity threshold (15) by extracting cohesive blocks into private helpers — **no
public API changed**. A few smaller-rule fixes are bundled in:

- **S3776 (×34):** refactor functions across `_io`, `base` (bootstrap, config), `dataset` (_stac, _wcs; engines
  analysis/bands/cog/io/spatial/vectorize; ops io/vectorize), `feature/collection`, and `netcdf` (cf, metadata, models,
  utils, _lazy, engines/variables, ugrid dataset/mesh).
- **S2208 (×2):** replace the wildcard `import *` in `tests/conftest.py` with explicit fixture re-exports.
- **S7500 (×2):** drop redundant identity list-comprehensions in `netcdf.metadata.flatten_for_index`.
- **perf:** inline the cluster BFS neighbour predicate to drop per-call overhead in the hot loop.
- **S100 (×7) + S116 (×1):** marked False Positive in SonarCloud (GDAL/OGR/OSR API-mirroring names on test doubles that
  must match the C++ API the production code calls) — no code change.

This is a behavior-preserving refactor: no functional or API changes, and no new dependencies.

# Issues

- Closes #742 — round-2 SonarCloud cognitive-complexity + maintainability cleanup

## Type of change

Behavior-preserving **refactor** — none of the categories below strictly apply (it is not a bug fix, a new feature, or a
breaking change).

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Full non-plot suite — `pytest -m "not plot"` — **6668 passed**, 51 skipped, 0 failures.
- [x] Two adversarial review rounds (`/review-rounds`) — no correctness regressions; all findings fixed.
- [x] Per-function targeted suites run green after each extraction (cf, io, analysis, ugrid, lazy, feature, …); plot
      paths verified with `MPLBACKEND=Agg`.
- [x] Branch synced with `origin/main` (conflict-free merge); SonarCloud clean on this PR.

# Checklist:

- [ ] updated version number in pyproject.toml. _(handled by commitizen/CI on release)_
- [ ] added changes to History.rst. _(changelog is commitizen-generated)_
- [ ] updated the latest version in README file.
- [ ] I have added tests that prove my fix is effective or that my feature works. _(N/A — behaviour-preserving refactor
      with no new public API; the existing suite already exercises every extracted path, which is how each extraction
      was validated)_
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. _(Google-style docstrings added to every new helper)_
