### PR TITLE
feat(plot): expose cleopatra data-style presets and hillshade from .plot/.animate

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -112,7 +112,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/yaml-0.2.5-h280c20c_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zlib-1.3.2-h25fd6f3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/5f/9ff93450ba96b09c7c2b3f81c94de31c89f92292f1380261bd7195bea4ea/contourpy-1.3.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/36/e1/a8933a72c45a87177fbde2696e0d0755c8c9062f8c077a961c6215fa27b1/fonttools-4.63.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
@@ -230,7 +230,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/yaml-0.2.5-h80f16a2_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zlib-1.3.2-hdc9db2a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/71/f93e1e9471d189f79d0ce2497007731c1e6bf9ef6d1d61b911430c3db4e5/contourpy-1.3.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/dd/87/64cfa18a7a1621d17b7f4502b2b0ed8a135a90c3db51ea590ee99043e76b/fonttools-4.63.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
@@ -342,7 +342,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/yaml-0.2.5-h4132b18_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zlib-1.3.2-hbb4bfdb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/72/8b/4546f3ab60f78c514ffb7d01a0bd743f90de36f0019d1be84d0a708a580a/contourpy-1.3.3-cp314-cp314-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cd/58/7dfa0c761cb3b2964e2a84c4dc986c926a87de0cb9fb60d5b28ded3f2914/fonttools-4.63.0-cp314-cp314-macosx_10_15_x86_64.whl
@@ -454,7 +454,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/yaml-0.2.5-h925e9cb_3.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/e1/3542a9cb596cadd76fcef413f19c79216e002623158befe6daa03dbfa88c/contourpy-1.3.3-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/d2/23d25e3f247b328be58d04a4c9f894178a0d1eda7d42867cfb388adaf416/fonttools-4.63.0-cp314-cp314-macosx_10_15_universal2.whl
@@ -563,7 +563,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/yaml-0.2.5-h6a83c73_3.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.2-hfd05255_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/d4/98078064ccc76b45cb0f6c002452011e93c4bd26f6850344f0951cc1fe89/fonttools-4.63.0-cp314-cp314-win_amd64.whl
@@ -810,7 +810,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -1176,7 +1176,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -1536,7 +1536,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -1893,7 +1893,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -2247,7 +2247,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
@@ -2612,7 +2612,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/5f/9ff93450ba96b09c7c2b3f81c94de31c89f92292f1380261bd7195bea4ea/contourpy-1.3.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
@@ -2969,7 +2969,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/71/f93e1e9471d189f79d0ce2497007731c1e6bf9ef6d1d61b911430c3db4e5/contourpy-1.3.3-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
@@ -3320,7 +3320,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/72/8b/4546f3ab60f78c514ffb7d01a0bd743f90de36f0019d1be84d0a708a580a/contourpy-1.3.3-cp314-cp314-macosx_10_13_x86_64.whl
@@ -3671,7 +3671,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fd/e1/3542a9cb596cadd76fcef413f19c79216e002623158befe6daa03dbfa88c/contourpy-1.3.3-cp314-cp314-macosx_11_0_arm64.whl
@@ -4019,7 +4019,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/58/9d/40b6267367182187139a4000b82a3b287d84d745bccd808e75d916920e9d/bleach-6.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/e7/05/c19819d5e3d95294a6f5947fb9b9629efb316b96de511b418c53d245aae6/cycler-0.12.1-py3-none-any.whl
@@ -4334,7 +4334,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -4644,7 +4644,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -4949,7 +4949,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -5251,7 +5251,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -5551,7 +5551,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
@@ -5909,7 +5909,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -6265,7 +6265,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -6615,7 +6615,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -6962,7 +6962,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -7306,7 +7306,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
@@ -7615,7 +7615,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/fb/d2/4398416cd699b35167947c6e22aca52c47e69ad5695073c9f1f2c52e04aa/cffi-2.1.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a5/34/49b9060e8418b14fb5cba9cf6bfb383111e2538a03a1fb18e66a95aeb3d5/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -7926,7 +7926,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/22/d7/1a74539db16d8bfd839ff1515948948efbb162e574650fd3d846896eea95/cffi-2.1.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c3/69/2a5385192e67175f7d8bd5ce4f57c24bc956439adeae5c13a99aa28a53d1/charset_normalizer-3.4.9-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -8231,7 +8231,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d3/67/85c89a59ba36a671e79638f44d466749f08179266a57e4f2ffdf92174072/cffi-2.1.0-cp311-cp311-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/e3/85ec501f206fb049259288c1f3506e53876937fb00edb47009348e66756b/charset_normalizer-3.4.9-cp311-cp311-macosx_10_9_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -8533,7 +8533,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ea/dd/e3b0baa2d3d6a857ac72b7efbf18e32e487c9cdafcc13049ad765495b15e/cffi-2.1.0-cp311-cp311-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0b/e3/85ec501f206fb049259288c1f3506e53876937fb00edb47009348e66756b/charset_normalizer-3.4.9-cp311-cp311-macosx_10_9_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -8832,7 +8832,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/f9/c8/6c2de1d55cf35ef8b92885d5ef280790f0fb9634d87ea1cc315176aecd61/cffi-2.1.0-cp311-cp311-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ed/a1/e29995109e455dc8eff8d0fac6ae509be39561318a7cfeac5d33ad029213/charset_normalizer-3.4.9-cp311-cp311-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/98/4b/9bd370b004b5c9d8045c6c33cf65bae018b27aca550a3f657cdc99acdbd8/contourpy-1.3.3-cp311-cp311-win_amd64.whl
@@ -9146,7 +9146,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/62/f2/c9522a81c32132799a1972c39f5c5f8b4c8b9f00488a23feaa6c06f07741/cffi-2.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/01/c4/4fa4c8b3097a11f3c5f09a35b72ed6855fb1d332469504962ab7bafcc702/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -9455,7 +9455,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1b/dc/5620cf930688be01f2d673804291de757a934c90b946dbdc3d84130c2ea4/cffi-2.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ec/96/5d9364e3342d69f3a045e1777bc47c85c383e6e9466d561b33fdb419d1f9/charset_normalizer-3.4.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -9758,7 +9758,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1e/85/990925db5df586ec90beb97529c853497e7f85ba0234830447faf41c3057/cffi-2.1.0-cp312-cp312-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -10058,7 +10058,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4b/92/e7bb136ad6b5352603732cf907ef862ca103f20f2031c1735a46300c20c9/cffi-2.1.0-cp312-cp312-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/70/4a/ecbd131485c07fcdfad54e28946d513e3da22ef3b4bd854dcafae54ec739/charset_normalizer-3.4.9-cp312-cp312-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -10355,7 +10355,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/a8/eb/f636456ff21a83fc13c032b58cc5dde061691546ac79efa284b2989b7982/cffi-2.1.0-cp312-cp312-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/80/cc/f920afd1a23c58ccd53c1d36085a71893a4737ff5e66e0371efab6809850/charset_normalizer-3.4.9-cp312-cp312-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/19/e8/6026ed58a64563186a9ee3f29f41261fd1828f527dd93d33b60feca63352/contourpy-1.3.3-cp312-cp312-win_amd64.whl
@@ -10668,7 +10668,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -10977,7 +10977,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -11281,7 +11281,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8c/e9/45c3a76ad8d43ad9261f4c95436da61128d3ca545d72b9612c0ab5be0b1c/cffi-2.1.0-cp313-cp313-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -11582,7 +11582,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/84/4c/82f132cb4418ee6d953d982b19191e87e2a6372c8a4ce36e50b69d6ade4a/cffi-2.1.0-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -11880,7 +11880,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5a/47/59eb7975cb0e4ef0afa764ea945b29a5bb4537a9f771cb7d6c8a5dd74c95/cffi-2.1.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/18/0b/0098c214843213759692cc638fce7de5c289200a830e5035d1791d7a2338/contourpy-1.3.3-cp313-cp313-win_amd64.whl
@@ -12195,7 +12195,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/cc/d7/97d3136f81db489ec8d1d67748c110d6c994268fd7528014aa9f2b085e4e/cffi-2.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f4/c4/b3e049d2aa3766180c78507110543d9d50894cc97f57de543f1be521dcdc/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -12506,7 +12506,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2e/d2/065fcae1c73979fac8e054462478d0ff8a29c40cdc2ed7ea5676a061df53/cffi-2.1.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2b/f9/ef4a69ea338ad3c0deceea0f5f7d2380ae8b52132b06d652cb0d2cd86706/charset_normalizer-3.4.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -12812,7 +12812,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/20/71/7c8372d30e42415602ed9f268f7cfd66f1b855fed881ecd168bcb45dbc0b/cffi-2.1.0-cp314-cp314-macosx_10_15_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -13115,7 +13115,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/d6/5c/584e626835f0375c928176c04137c96927165cb8733cdb3150ec04e5ee5e/cffi-2.1.0-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/8d/496817fa0944239ecae662dd57ea765cfeaec6a735f9f025d4b7b72e7143/charset_normalizer-3.4.9-cp314-cp314-macosx_10_15_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
@@ -13415,7 +13415,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/41/de/92b9eeed4ae4a21d6fd9b2a2c8505cbed573299902ea73981cc13f7ff62c/cffi-2.1.0-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/49/fd/a1d26144398c67486422a72bf5812cda22cb4ccfcd95a290fb41ceb4b8e2/charset_normalizer-3.4.9-cp314-cp314-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2f/8f/496168ab853b325f62075e78ceb611d975ffc58116e4fabcca17725ac53c/commitizen-4.16.4-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/c2/57f54b03d0f22d4044b8afb9ca0e184f8b1afd57b4f735c2fa70883dc601/contourpy-1.3.3-cp314-cp314-win_amd64.whl
@@ -17390,10 +17390,10 @@ packages:
   - pkg:pypi/charset-normalizer?source=compressed-mapping
   size: 61278
   timestamp: 1783374645872
-- pypi: https://files.pythonhosted.org/packages/9a/2d/c4c923b05ed6eea1ef5578e0bdf81cd49f42738fef26c4e1db36e83ff182/cleopatra-0.22.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/e1/65/d2ac5edbbaa505d21e9c1f974e3d5e46c05674d13565c7cdf4559ee42bdd/cleopatra-0.24.0-py3-none-any.whl
   name: cleopatra
-  version: 0.22.0
-  sha256: 0ef3b95548d596ae7afb0c3a58473275071d7f30934d962811bb12cced4d3d3c
+  version: 0.24.0
+  sha256: 618595f1f53a49392e93d267271118103e814d6e14abf339db2349c8ff0e0ece
   requires_dist:
   - hpc-utils>=0.1.4
   - imageio-ffmpeg>=0.4.9
@@ -37205,7 +37205,7 @@ packages:
 - pypi: ./
   name: pyramids-gis
   version: 0.44.0
-  sha256: a3a398714b476de1368f8acfbb006c9e723deb403ac3ecfe591bbea8cb8778ee
+  sha256: 743f62c4f2cfa694d4998567dd2262bda188c37db2c13aca1b94c5e3c9c1fc69
   requires_dist:
   - certifi ; platform_machine == 'ARM64' and sys_platform == 'win32'
   - packaging ; platform_machine == 'ARM64' and sys_platform == 'win32'
@@ -37218,7 +37218,7 @@ packages:
   - pyyaml>=6.0.0
   - shapely>=2.1.0 ; platform_machine != 'ARM64' or sys_platform != 'win32'
   - scipy>=1.10.0
-  - cleopatra[tiles]>=0.22.0 ; extra == 'viz'
+  - cleopatra[tiles]>=0.24.0 ; extra == 'viz'
   - dask>=2024.1.0 ; extra == 'lazy'
   - distributed>=2024.1.0 ; extra == 'lazy'
   - zarr>=3 ; extra == 'lazy'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-viz = ["cleopatra[tiles]>=0.22.0"]
+viz = ["cleopatra[tiles]>=0.24.0"]
 lazy = [
     "dask>=2024.1.0",
     "distributed>=2024.1.0",

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -156,6 +156,49 @@ def _unwrap_geographic_longitude(
     return result
 
 
+def _guard_style_hillshade(kwargs: dict[str, Any], option_keys: Any) -> None:
+    """Normalise and version-gate the ``style`` / ``hillshade`` plot presets.
+
+    Shared by the raster (:func:`render_array`, ``ArrayGlyph``) and mesh
+    (:func:`mesh_render`, ``MeshGlyph``) dispatch so both paths handle cleopatra's
+    data-style presets identically.
+
+    ``style`` / ``hillshade`` were added to cleopatra's glyphs in 0.24. On an older
+    cleopatra the kwargs would fall through to a cryptic "Unknown option" error deep
+    in the render call; feature-detect each key against ``option_keys`` and raise a
+    clear upgrade hint instead.
+
+    A ``None`` / ``False`` ``hillshade`` requests no shading, so it is popped from
+    ``kwargs`` in place — making it a true no-op on ANY cleopatra version (a pre-0.24
+    build that rejects the unknown kwarg included). ``{}`` is falsy but is an
+    affirmative "shade with default parameters", so the drop uses identity (only
+    ``None`` / ``False``), not truthiness — an empty-dict ``hillshade`` is still
+    gated/forwarded. Each key is checked against its own ``option_keys`` membership
+    so a build shipping only one of the two features is handled precisely. An invalid
+    ``style`` *name* is left to cleopatra, which already raises a ``ValueError``
+    listing the valid ``DATA_STYLES`` keys. (issue #737)
+
+    Args:
+        kwargs: The render kwargs; mutated in place to drop a no-op ``hillshade``.
+        option_keys: The glyph's declared option set (``<Glyph>.option_keys()``).
+
+    Raises:
+        OptionalPackageDoesNotExist: A ``style`` / ``hillshade`` preset was
+            requested but the installed cleopatra's glyph does not support it.
+    """
+    hillshade = kwargs.get("hillshade")
+    if hillshade is None or hillshade is False:
+        kwargs.pop("hillshade", None)
+    style_unsupported = kwargs.get("style") is not None and "style" not in option_keys
+    hillshade_unsupported = "hillshade" in kwargs and "hillshade" not in option_keys
+    if style_unsupported or hillshade_unsupported:
+        raise OptionalPackageDoesNotExist(
+            "`style=` / `hillshade=` plot presets require cleopatra >= 0.24. "
+            "Upgrade with: pip install -U 'pyramids-gis[viz]' (or "
+            "pip install -U 'cleopatra>=0.24')."
+        )
+
+
 def render_array(
     *,
     arr: np.ndarray | None,
@@ -421,32 +464,11 @@ def render_array(
                 f"Unsupported color_scale {color_scale!r}; valid options: {valid}."
             ) from None
 
-    # ``style`` / ``hillshade`` data-style presets were added to ``ArrayGlyph``
-    # in cleopatra 0.24. On an older cleopatra the kwargs would fall through to a
-    # cryptic "Unknown option" error deep in the render call; feature-detect
-    # each key against ``option_keys()`` and raise a clear upgrade hint instead.
-    #
-    # A ``None``/``False`` ``hillshade`` requests no shading — drop it so it
-    # never reaches cleopatra, making it a true no-op on ANY version (a pre-0.24
-    # build that rejects the unknown kwarg included). Note ``{}`` is falsy but is
-    # an affirmative "shade with default parameters", so the drop uses identity
-    # (only ``None``/``False``), not truthiness — an empty-dict ``hillshade`` is
-    # still gated/forwarded. Each key is checked against its own ``option_keys()``
-    # membership so a build shipping only one of the two features is handled
-    # precisely. An invalid ``style`` *name* is left to cleopatra, which already
-    # raises a ValueError listing the valid ``DATA_STYLES`` keys. (issue #737)
-    _hillshade = kwargs.get("hillshade")
-    if _hillshade is None or _hillshade is False:
-        kwargs.pop("hillshade", None)
+    # Normalise + version-gate the style/hillshade presets (shared with the mesh
+    # path). Mutates kwargs to drop a no-op hillshade; raises a clear upgrade hint
+    # on a cleopatra whose ArrayGlyph lacks the presets. (issue #737)
     option_keys = ArrayGlyph.option_keys()
-    _style_unsupported = kwargs.get("style") is not None and "style" not in option_keys
-    _hillshade_unsupported = "hillshade" in kwargs and "hillshade" not in option_keys
-    if _style_unsupported or _hillshade_unsupported:
-        raise OptionalPackageDoesNotExist(
-            "`style=` / `hillshade=` plot presets require cleopatra >= 0.24. "
-            "Upgrade with: pip install -U 'pyramids-gis[viz]' (or "
-            "pip install -U 'cleopatra>=0.24')."
-        )
+    _guard_style_hillshade(kwargs, option_keys)
 
     # Unwrap a wrapping geographic longitude before handing curvilinear coords
     # to cleopatra, so its pcolormesh doesn't smear a ~178-degree quad across
@@ -690,7 +712,14 @@ def mesh_render(
     if basemap and basemap_epsg is None:
         raise ValueError("Dataset must have a CRS (epsg) to use basemap.")
     require_cleopatra()
+    from cleopatra.mesh_glyph import MeshGlyph
+
     from pyramids.netcdf.ugrid.plot import plot_mesh_data
+
+    # Normalise + version-gate the style/hillshade presets against MeshGlyph, the
+    # same way render_array does against ArrayGlyph, so the mesh path exposes
+    # cleopatra's data-style presets with a clean upgrade hint on older cleopatra.
+    _guard_style_hillshade(kwargs, MeshGlyph.option_keys())
 
     result = plot_mesh_data(mesh, data, location=location, **kwargs)
     if basemap:

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -173,13 +173,16 @@ def _guard_style_hillshade(kwargs: dict[str, Any], option_keys: Any) -> None:
     build that rejects the unknown kwarg included). ``{}`` is falsy but is an
     affirmative "shade with default parameters", so the drop uses identity (only
     ``None`` / ``False``), not truthiness — an empty-dict ``hillshade`` is still
-    gated/forwarded. Each key is checked against its own ``option_keys`` membership
-    so a build shipping only one of the two features is handled precisely. An invalid
-    ``style`` *name* is left to cleopatra, which already raises a ``ValueError``
-    listing the valid ``DATA_STYLES`` keys. (issue #737)
+    gated/forwarded. An explicit ``style=None`` requests no preset and is likewise
+    popped in place, symmetric with the ``hillshade`` drop. Each remaining key is
+    checked against its own ``option_keys`` membership so a build shipping only one
+    of the two features is handled precisely. An invalid ``style`` *name* is left to
+    cleopatra, which already raises a ``ValueError`` listing the valid ``DATA_STYLES``
+    keys. (issue #737)
 
     Args:
-        kwargs: The render kwargs; mutated in place to drop a no-op ``hillshade``.
+        kwargs: The render kwargs; mutated in place to drop a no-op ``style`` /
+            ``hillshade``.
         option_keys: The glyph's declared option set (``<Glyph>.option_keys()``).
 
     Raises:
@@ -724,6 +727,10 @@ def mesh_render(
     # Normalise + version-gate the style/hillshade presets against MeshGlyph, the
     # same way render_array does against ArrayGlyph, so the mesh path exposes
     # cleopatra's data-style presets with a clean upgrade hint on older cleopatra.
+    # Note: unlike the raster path (where style is an ArrayGlyph *constructor*
+    # option), plot_mesh_data forwards style/hillshade to MeshGlyph.plot(), not the
+    # constructor. Feature-detecting against option_keys() therefore assumes cleopatra
+    # declares them there in lock-step with .plot() accepting them (true on 0.24).
     _guard_style_hillshade(kwargs, MeshGlyph.option_keys())
 
     result = plot_mesh_data(mesh, data, location=location, **kwargs)

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -186,10 +186,15 @@ def _guard_style_hillshade(kwargs: dict[str, Any], option_keys: Any) -> None:
         OptionalPackageDoesNotExist: A ``style`` / ``hillshade`` preset was
             requested but the installed cleopatra's glyph does not support it.
     """
+    if kwargs.get("style") is None:
+        # An explicit ``style=None`` requests no preset — drop it so it never
+        # reaches cleopatra (a true no-op on any version), symmetric with the
+        # ``hillshade`` handling below.
+        kwargs.pop("style", None)
     hillshade = kwargs.get("hillshade")
     if hillshade is None or hillshade is False:
         kwargs.pop("hillshade", None)
-    style_unsupported = kwargs.get("style") is not None and "style" not in option_keys
+    style_unsupported = "style" in kwargs and "style" not in option_keys
     hillshade_unsupported = "hillshade" in kwargs and "hillshade" not in option_keys
     if style_unsupported or hillshade_unsupported:
         raise OptionalPackageDoesNotExist(

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -425,15 +425,22 @@ def render_array(
     # in cleopatra 0.24. On an older cleopatra the kwargs would fall through to a
     # cryptic "Unknown option" error deep in the render call; feature-detect
     # each key against ``option_keys()`` and raise a clear upgrade hint instead.
-    # Scoped to when a preset is actually requested — a falsy ``hillshade``
-    # (e.g. ``hillshade=False``) asks for nothing, so it is not gated, and each
-    # key is checked against its own ``option_keys()`` membership so a build
-    # that ships only one of the two features is handled precisely. An invalid
-    # ``style`` *name* is left to cleopatra, which already raises a ValueError
-    # listing the valid ``DATA_STYLES`` keys. (issue #737)
+    #
+    # A ``None``/``False`` ``hillshade`` requests no shading — drop it so it
+    # never reaches cleopatra, making it a true no-op on ANY version (a pre-0.24
+    # build that rejects the unknown kwarg included). Note ``{}`` is falsy but is
+    # an affirmative "shade with default parameters", so the drop uses identity
+    # (only ``None``/``False``), not truthiness — an empty-dict ``hillshade`` is
+    # still gated/forwarded. Each key is checked against its own ``option_keys()``
+    # membership so a build shipping only one of the two features is handled
+    # precisely. An invalid ``style`` *name* is left to cleopatra, which already
+    # raises a ValueError listing the valid ``DATA_STYLES`` keys. (issue #737)
+    _hillshade = kwargs.get("hillshade")
+    if _hillshade is None or _hillshade is False:
+        kwargs.pop("hillshade", None)
     option_keys = ArrayGlyph.option_keys()
     _style_unsupported = kwargs.get("style") is not None and "style" not in option_keys
-    _hillshade_unsupported = kwargs.get("hillshade") and "hillshade" not in option_keys
+    _hillshade_unsupported = "hillshade" in kwargs and "hillshade" not in option_keys
     if _style_unsupported or _hillshade_unsupported:
         raise OptionalPackageDoesNotExist(
             "`style=` / `hillshade=` plot presets require cleopatra >= 0.24. "

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -490,7 +490,9 @@ def render_array(
     # ``title`` arg is not ``None``, so a constructor-set title survives and
     # routing it to the constructor (via ``option_keys()``) is correct.
     RENDER_ONLY_OVERRIDES = {"kind"}
-    ctor_option_keys = ArrayGlyph.option_keys()
+    # Reuse the option set resolved for the style/hillshade guard above — it is
+    # cleopatra's declared constructor options and does not change within a call.
+    ctor_option_keys = option_keys
     ctor_kwargs: dict[str, Any] = {}
     render_kwargs: dict[str, Any] = {}
     for key, value in kwargs.items():

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -424,14 +424,17 @@ def render_array(
     # ``style`` / ``hillshade`` data-style presets were added to ``ArrayGlyph``
     # in cleopatra 0.24. On an older cleopatra the kwargs would fall through to a
     # cryptic "Unknown option" error deep in the render call; feature-detect
-    # (``"style"`` is absent from ``option_keys()`` before 0.24) and raise a
-    # clear upgrade hint instead. Scoped to when the preset kwargs are actually
-    # used, so basic plotting on an older cleopatra is unaffected. An invalid
+    # each key against ``option_keys()`` and raise a clear upgrade hint instead.
+    # Scoped to when a preset is actually requested — a falsy ``hillshade``
+    # (e.g. ``hillshade=False``) asks for nothing, so it is not gated, and each
+    # key is checked against its own ``option_keys()`` membership so a build
+    # that ships only one of the two features is handled precisely. An invalid
     # ``style`` *name* is left to cleopatra, which already raises a ValueError
     # listing the valid ``DATA_STYLES`` keys. (issue #737)
-    if (
-        kwargs.get("style") is not None or kwargs.get("hillshade") is not None
-    ) and "style" not in ArrayGlyph.option_keys():
+    option_keys = ArrayGlyph.option_keys()
+    _style_unsupported = kwargs.get("style") is not None and "style" not in option_keys
+    _hillshade_unsupported = kwargs.get("hillshade") and "hillshade" not in option_keys
+    if _style_unsupported or _hillshade_unsupported:
         raise OptionalPackageDoesNotExist(
             "`style=` / `hillshade=` plot presets require cleopatra >= 0.24. "
             "Upgrade with: pip install -U 'pyramids-gis[viz]' (or "

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -65,6 +65,7 @@ import numpy as np
 from pyproj import CRS
 from pyproj.exceptions import CRSError
 
+from pyramids.base._errors import OptionalPackageDoesNotExist
 from pyramids.base._utils import require_cleopatra
 
 # `add_basemap` is imported at top-level so existing test patches that
@@ -419,6 +420,23 @@ def render_array(
             raise ValueError(
                 f"Unsupported color_scale {color_scale!r}; valid options: {valid}."
             ) from None
+
+    # ``style`` / ``hillshade`` data-style presets were added to ``ArrayGlyph``
+    # in cleopatra 0.24. On an older cleopatra the kwargs would fall through to a
+    # cryptic "Unknown option" error deep in the render call; feature-detect
+    # (``"style"`` is absent from ``option_keys()`` before 0.24) and raise a
+    # clear upgrade hint instead. Scoped to when the preset kwargs are actually
+    # used, so basic plotting on an older cleopatra is unaffected. An invalid
+    # ``style`` *name* is left to cleopatra, which already raises a ValueError
+    # listing the valid ``DATA_STYLES`` keys. (issue #737)
+    if (
+        kwargs.get("style") is not None or kwargs.get("hillshade") is not None
+    ) and "style" not in ArrayGlyph.option_keys():
+        raise OptionalPackageDoesNotExist(
+            "`style=` / `hillshade=` plot presets require cleopatra >= 0.24. "
+            "Upgrade with: pip install -U 'pyramids-gis[viz]' (or "
+            "pip install -U 'cleopatra>=0.24')."
+        )
 
     # Unwrap a wrapping geographic longitude before handing curvilinear coords
     # to cleopatra, so its pcolormesh doesn't smear a ~178-degree quad across

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -415,9 +415,10 @@ class NetCDFPlot:
         Starts from ``base_kwargs`` (the caller's ``**kwargs`` pass-through
         to cleopatra), then layers on: the non-default :class:`ColorOpts`
         fields (``cmap`` / ``vmin`` / ``vmax`` / ``levels`` / ``norm`` /
-        ``center`` / ``extend`` / ``cbar_kwargs``, plus ``robust`` only
-        when explicitly enabled — ``add_colorbar`` is intentionally *not*
-        forwarded; it's applied post-render via :meth:`_remove_colorbar`);
+        ``center`` / ``extend`` / ``cbar_kwargs`` / ``style`` / ``hillshade``,
+        plus ``robust`` only when explicitly enabled — ``add_colorbar`` is
+        intentionally *not* forwarded; it's applied post-render via
+        :meth:`_remove_colorbar`);
         ``ax`` / ``figsize`` / ``title``; the curvilinear coord pair when
         one resolves; and the ``kind`` dispatch hint. A ``rgb=None``
         default is set so the engine's RGB branch stays off.
@@ -448,6 +449,8 @@ class NetCDFPlot:
             ("center", colour.center),
             ("extend", colour.extend),
             ("cbar_kwargs", colour.cbar_kwargs),
+            ("style", colour.style),
+            ("hillshade", colour.hillshade),
             ("ax", ax),
             ("figsize", figsize),
             ("title", title),

--- a/src/pyramids/netcdf/plot_options.py
+++ b/src/pyramids/netcdf/plot_options.py
@@ -143,8 +143,8 @@ class ColorOpts:
             result. Defaults to True.
         cbar_kwargs: Extra dict forwarded to :meth:`Figure.colorbar`.
             Defaults to None.
-        style: Name of a cleopatra data-style preset (from
-            ``cleopatra.styles.DATA_STYLES`` — e.g. ``"flow_accumulation"``,
+        style: Name of a cleopatra data-style preset (a key of
+            ``cleopatra.array_glyph.DATA_STYLES`` — e.g. ``"flow_accumulation"``,
             ``"topography"``) to colour the variable by. Forwarded to
             :class:`~cleopatra.array_glyph.ArrayGlyph`; requires
             cleopatra >= 0.24. Defaults to None (no preset).

--- a/src/pyramids/netcdf/plot_options.py
+++ b/src/pyramids/netcdf/plot_options.py
@@ -143,6 +143,17 @@ class ColorOpts:
             result. Defaults to True.
         cbar_kwargs: Extra dict forwarded to :meth:`Figure.colorbar`.
             Defaults to None.
+        style: Name of a cleopatra data-style preset (from
+            ``cleopatra.styles.DATA_STYLES`` — e.g. ``"flow_accumulation"``,
+            ``"topography"``) to colour the variable by. Forwarded to
+            :class:`~cleopatra.array_glyph.ArrayGlyph`; requires
+            cleopatra >= 0.24. Defaults to None (no preset).
+        hillshade: Relief-shade the rendered field. ``True`` blends a
+            default hillshade over the colours; a dict passes hillshade
+            parameters through (e.g. ``{"vert_exag": 8}``). Distinct from
+            :meth:`pyramids.dataset.Dataset.hillshade`, which *returns* a
+            shaded-relief array — this is a render-time blend. Forwarded to
+            cleopatra; requires cleopatra >= 0.24. Defaults to None.
 
     Examples:
         - The default constructor is a no-op forward — every colour
@@ -194,6 +205,8 @@ class ColorOpts:
     extend: str | None = None
     add_colorbar: bool = True
     cbar_kwargs: dict | None = None
+    style: str | None = None
+    hillshade: bool | dict | None = None
 
 
 @dataclass(frozen=True)

--- a/src/pyramids/netcdf/ugrid/dataset.py
+++ b/src/pyramids/netcdf/ugrid/dataset.py
@@ -807,7 +807,13 @@ class UgridDataset:
                 (forwarded to plot_mesh_data). Notably ``colorbar``
                 (``bool``, default ``True``): pass ``colorbar=False`` to
                 suppress the per-mesh colorbar when you want to attach a
-                custom or shared one to ``glyph.ax``.
+                custom or shared one to ``glyph.ax``. Also ``style`` (name of
+                a cleopatra ``DATA_STYLES`` preset, e.g. ``"flow_accumulation"``)
+                and ``hillshade`` (``True`` or a params dict) to colour / relief-
+                shade the mesh; both require cleopatra >= 0.24 (``hillshade``
+                needs node-centered data). Distinct from
+                :meth:`pyramids.dataset.Dataset.hillshade`, which *returns* a
+                shaded-relief array.
 
         Returns:
             cleopatra.mesh_glyph.MeshGlyph instance with the plot

--- a/src/pyramids/netcdf/ugrid/plot.py
+++ b/src/pyramids/netcdf/ugrid/plot.py
@@ -119,7 +119,11 @@ def plot_mesh_data(
             `color_scale` (`"linear"`, `"power"`,
             `"sym-lognorm"`, `"boundary-norm"`, `"midpoint"`),
             `gamma`, `midpoint`, `bounds`, `ticks_spacing`,
-            `cbar_orientation`, `cbar_label`, and `figsize`.
+            `cbar_orientation`, `cbar_label`, and `figsize`. Also
+            `style` (a cleopatra `DATA_STYLES` preset name) and
+            `hillshade` (`True` or a params dict) — data-style presets
+            requiring cleopatra >= 0.24 (`hillshade` needs
+            `location="node"`).
 
     Returns:
         cleopatra.mesh_glyph.MeshGlyph: The MeshGlyph instance with

--- a/tests/dataset/plot/test_plot_engine.py
+++ b/tests/dataset/plot/test_plot_engine.py
@@ -385,6 +385,79 @@ class TestStyleHillshadePresets:
     @pytest.mark.skipif(
         not _supports_style, reason="cleopatra < 0.24 has no style presets"
     )
+    def test_dict_hillshade_renders(self):
+        """A dict ``hillshade`` (parameter passthrough) renders end to end."""
+        rng = np.random.default_rng(742)
+        arr = rng.random((6, 6)).astype("float32")
+        glyph = render_array(
+            arr=arr,
+            extent=[0.0, 0.0, 1.0, 1.0],
+            mode="plot",
+            hillshade={"vert_exag": 8},
+        )
+        assert isinstance(glyph, ArrayGlyph)
+
+    @pytest.mark.skipif(
+        not _supports_style, reason="cleopatra < 0.24 has no style presets"
+    )
+    def test_style_and_hillshade_animate_renders(self):
+        """``style`` + ``hillshade`` render through the real animate path.
+
+        Test scenario:
+            Unlike the mocked NetCDF forwarding test, this drives cleopatra
+            0.24's ``ArrayGlyph.animate(style=..., hillshade=...)`` for real
+            over a ``(time, rows, cols)`` stack, guarding the advertised
+            animated-shaded path against a future cleopatra signature change.
+        """
+        rng = np.random.default_rng(743)
+        stack = rng.random((3, 6, 6)).astype("float32")
+        glyph = render_array(
+            arr=stack,
+            extent=[0.0, 0.0, 1.0, 1.0],
+            mode="animate",
+            animation_axis_values=[0, 1, 2],
+            style="flow_accumulation",
+            hillshade=True,
+        )
+        assert isinstance(glyph, ArrayGlyph)
+
+    def test_hillshade_only_on_old_cleopatra_raises_upgrade_hint(self):
+        """``hillshade=`` alone on a build lacking it raises the upgrade hint.
+
+        Test scenario:
+            The guard checks each key independently. Simulate a cleopatra that
+            supports ``style`` but not ``hillshade``; a truthy ``hillshade=``
+            with no ``style=`` must still raise the >= 0.24 upgrade error.
+        """
+        rng = np.random.default_rng(744)
+        arr = rng.random((5, 5)).astype("float32")
+        style_only = (ArrayGlyph.option_keys() - {"hillshade"}) | {"style"}
+        with patch.object(ArrayGlyph, "option_keys", return_value=style_only):
+            with pytest.raises(OptionalPackageDoesNotExist, match="cleopatra >= 0.24"):
+                render_array(
+                    arr=arr, extent=[0.0, 0.0, 1.0, 1.0], mode="plot", hillshade=True
+                )
+
+    def test_falsy_hillshade_on_old_cleopatra_not_guarded(self):
+        """``hillshade=False`` asks for nothing, so the guard does not fire.
+
+        Test scenario:
+            With preset support hidden (simulated old cleopatra), an explicit
+            ``hillshade=False`` requests no shading and must render normally
+            rather than raising the >= 0.24 upgrade error.
+        """
+        rng = np.random.default_rng(745)
+        arr = rng.random((5, 5)).astype("float32")
+        old_keys = ArrayGlyph.option_keys() - {"style", "hillshade"}
+        with patch.object(ArrayGlyph, "option_keys", return_value=old_keys):
+            glyph = render_array(
+                arr=arr, extent=[0.0, 0.0, 1.0, 1.0], mode="plot", hillshade=False
+            )
+        assert isinstance(glyph, ArrayGlyph)
+
+    @pytest.mark.skipif(
+        not _supports_style, reason="cleopatra < 0.24 has no style presets"
+    )
     def test_unknown_style_name_surfaces_cleopatra_valueerror(self):
         """An unknown ``style`` name is rejected by cleopatra with the valid list.
 

--- a/tests/dataset/plot/test_plot_engine.py
+++ b/tests/dataset/plot/test_plot_engine.py
@@ -438,22 +438,61 @@ class TestStyleHillshadePresets:
                     arr=arr, extent=[0.0, 0.0, 1.0, 1.0], mode="plot", hillshade=True
                 )
 
-    def test_falsy_hillshade_on_old_cleopatra_not_guarded(self):
-        """``hillshade=False`` asks for nothing, so the guard does not fire.
+    @pytest.mark.parametrize("value", [False, None])
+    def test_falsy_hillshade_is_dropped_not_forwarded(self, value):
+        """A ``None``/``False`` ``hillshade`` is dropped, never reaching cleopatra.
 
         Test scenario:
-            With preset support hidden (simulated old cleopatra), an explicit
-            ``hillshade=False`` requests no shading and must render normally
-            rather than raising the >= 0.24 upgrade error.
+            A falsy hillshade requests no shading, so ``render_array`` must pop
+            it before the ctor/render split — making it a true no-op on any
+            cleopatra version, not merely one that happens to accept the kwarg.
+            A fake glyph captures what actually reaches the constructor / plot
+            call, so this is independent of the installed cleopatra.
         """
+        fake_cls, ctor, plot, *_ = TestRenderArrayKwargRouting._capture_calls()
         rng = np.random.default_rng(745)
+        arr = rng.random((5, 5)).astype("float32")
+        with patch("cleopatra.array_glyph.ArrayGlyph", new=fake_cls):
+            render_array(
+                arr=arr, extent=[0.0, 0.0, 1.0, 1.0], mode="plot", hillshade=value
+            )
+        assert "hillshade" not in ctor, f"hillshade={value!r} must not reach the ctor"
+        assert "hillshade" not in plot, f"hillshade={value!r} must not reach plot"
+
+    def test_empty_dict_hillshade_is_forwarded(self):
+        """An affirmative ``hillshade={}`` (default params) reaches the glyph.
+
+        Test scenario:
+            ``{}`` is falsy but documented as "shade with default parameters",
+            so unlike ``False`` it must NOT be dropped — it flows to the glyph
+            constructor like any other affirmative hillshade request.
+        """
+        fake_cls, ctor, _plot, *_ = TestRenderArrayKwargRouting._capture_calls()
+        rng = np.random.default_rng(746)
+        arr = rng.random((5, 5)).astype("float32")
+        with patch("cleopatra.array_glyph.ArrayGlyph", new=fake_cls):
+            render_array(
+                arr=arr, extent=[0.0, 0.0, 1.0, 1.0], mode="plot", hillshade={}
+            )
+        assert ctor.get("hillshade") == {}, "affirmative hillshade={} must be forwarded"
+
+    def test_empty_dict_hillshade_on_old_cleopatra_raises_upgrade_hint(self):
+        """``hillshade={}`` on a build lacking hillshade raises the upgrade hint.
+
+        Test scenario:
+            The affirmative empty-dict form must be gated exactly like
+            ``hillshade=True`` — an old cleopatra (``hillshade`` absent from
+            ``option_keys()``) yields the clear >= 0.24 error, not the cryptic
+            downstream "Unknown option".
+        """
+        rng = np.random.default_rng(747)
         arr = rng.random((5, 5)).astype("float32")
         old_keys = ArrayGlyph.option_keys() - {"style", "hillshade"}
         with patch.object(ArrayGlyph, "option_keys", return_value=old_keys):
-            glyph = render_array(
-                arr=arr, extent=[0.0, 0.0, 1.0, 1.0], mode="plot", hillshade=False
-            )
-        assert isinstance(glyph, ArrayGlyph)
+            with pytest.raises(OptionalPackageDoesNotExist, match="cleopatra >= 0.24"):
+                render_array(
+                    arr=arr, extent=[0.0, 0.0, 1.0, 1.0], mode="plot", hillshade={}
+                )
 
     @pytest.mark.skipif(
         not _supports_style, reason="cleopatra < 0.24 has no style presets"

--- a/tests/dataset/plot/test_plot_engine.py
+++ b/tests/dataset/plot/test_plot_engine.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
+from pyramids.base._errors import OptionalPackageDoesNotExist
 from pyramids.dataset import Dataset
 from pyramids.dataset._plot_helpers import render_array
 from pyramids.dataset.engines import Analysis
@@ -339,6 +340,102 @@ class TestRenderArrayKwargRouting:
                 mode="plot",
                 bogus=1,
             )
+
+
+class TestStyleHillshadePresets:
+    """``style=`` / ``hillshade=`` presets route to cleopatra (#737).
+
+    The presets ship in cleopatra >= 0.24. These tests render against the real
+    installed cleopatra when it supports them, and simulate an older cleopatra
+    (by hiding ``style`` from ``option_keys()``) to exercise the upgrade guard.
+    """
+
+    _supports_style = "style" in ArrayGlyph.option_keys()
+
+    @pytest.mark.skipif(
+        not _supports_style, reason="cleopatra < 0.24 has no style presets"
+    )
+    def test_style_preset_renders(self):
+        """A valid ``style`` preset name renders end to end.
+
+        Test scenario:
+            ``render_array(..., style="flow_accumulation")`` auto-routes the
+            preset to ``ArrayGlyph`` (``style`` is in ``option_keys()``) and
+            returns a rendered glyph — no pyramids-side handling needed.
+        """
+        rng = np.random.default_rng(737)
+        arr = rng.random((6, 6)).astype("float32")
+        glyph = render_array(
+            arr=arr, extent=[0.0, 0.0, 1.0, 1.0], mode="plot", style="flow_accumulation"
+        )
+        assert isinstance(glyph, ArrayGlyph)
+
+    @pytest.mark.skipif(
+        not _supports_style, reason="cleopatra < 0.24 has no hillshade"
+    )
+    def test_hillshade_renders(self):
+        """A ``hillshade`` blend renders end to end."""
+        rng = np.random.default_rng(738)
+        arr = rng.random((6, 6)).astype("float32")
+        glyph = render_array(
+            arr=arr, extent=[0.0, 0.0, 1.0, 1.0], mode="plot", hillshade=True
+        )
+        assert isinstance(glyph, ArrayGlyph)
+
+    @pytest.mark.skipif(
+        not _supports_style, reason="cleopatra < 0.24 has no style presets"
+    )
+    def test_unknown_style_name_surfaces_cleopatra_valueerror(self):
+        """An unknown ``style`` name is rejected by cleopatra with the valid list.
+
+        Test scenario:
+            pyramids does not duplicate the preset-name check; an invalid name
+            defers to cleopatra, which raises ``ValueError`` naming the valid
+            ``DATA_STYLES`` keys.
+        """
+        rng = np.random.default_rng(739)
+        arr = rng.random((5, 5)).astype("float32")
+        with pytest.raises(ValueError, match="style"):
+            render_array(
+                arr=arr,
+                extent=[0.0, 0.0, 1.0, 1.0],
+                mode="plot",
+                style="definitely_not_a_style",
+            )
+
+    def test_style_on_old_cleopatra_raises_upgrade_hint(self):
+        """``style=`` on a cleopatra without preset support raises a clear hint.
+
+        Test scenario:
+            Simulate cleopatra < 0.24 by hiding ``style`` from
+            ``option_keys()``. The scoped guard in ``render_array`` must raise
+            :class:`OptionalPackageDoesNotExist` pointing at the >= 0.24 upgrade
+            instead of letting a cryptic "Unknown option" surface deep in the
+            render call.
+        """
+        rng = np.random.default_rng(740)
+        arr = rng.random((5, 5)).astype("float32")
+        old_keys = ArrayGlyph.option_keys() - {"style", "hillshade"}
+        with patch.object(ArrayGlyph, "option_keys", return_value=old_keys):
+            with pytest.raises(OptionalPackageDoesNotExist, match="cleopatra >= 0.24"):
+                render_array(
+                    arr=arr, extent=[0.0, 0.0, 1.0, 1.0], mode="plot", style="topography"
+                )
+
+    def test_no_preset_kwargs_unaffected_on_old_cleopatra(self):
+        """Basic plotting is untouched by the guard on an older cleopatra.
+
+        Test scenario:
+            With ``style`` hidden from ``option_keys()`` (simulated old
+            cleopatra) but no ``style`` / ``hillshade`` passed, ``render_array``
+            renders normally — the guard is scoped to preset use only.
+        """
+        rng = np.random.default_rng(741)
+        arr = rng.random((5, 5)).astype("float32")
+        old_keys = ArrayGlyph.option_keys() - {"style", "hillshade"}
+        with patch.object(ArrayGlyph, "option_keys", return_value=old_keys):
+            glyph = render_array(arr=arr, extent=[0.0, 0.0, 1.0, 1.0], mode="plot")
+        assert isinstance(glyph, ArrayGlyph)
 
 
 class TestMeshRenderHelper:

--- a/tests/dataset/plot/test_plot_engine.py
+++ b/tests/dataset/plot/test_plot_engine.py
@@ -459,6 +459,23 @@ class TestStyleHillshadePresets:
         assert "hillshade" not in ctor, f"hillshade={value!r} must not reach the ctor"
         assert "hillshade" not in plot, f"hillshade={value!r} must not reach plot"
 
+    def test_none_style_is_dropped_not_forwarded(self):
+        """An explicit ``style=None`` is dropped, never reaching cleopatra.
+
+        Test scenario:
+            ``style=None`` requests no preset, so ``render_array`` must pop it
+            before the ctor/render split — a true no-op on any cleopatra version,
+            symmetric with the falsy-``hillshade`` drop. A fake glyph captures
+            what actually reaches the constructor / plot call.
+        """
+        fake_cls, ctor, plot, *_ = TestRenderArrayKwargRouting._capture_calls()
+        rng = np.random.default_rng(748)
+        arr = rng.random((5, 5)).astype("float32")
+        with patch("cleopatra.array_glyph.ArrayGlyph", new=fake_cls):
+            render_array(arr=arr, extent=[0.0, 0.0, 1.0, 1.0], mode="plot", style=None)
+        assert "style" not in ctor, "style=None must not reach the ctor"
+        assert "style" not in plot, "style=None must not reach plot"
+
     def test_empty_dict_hillshade_is_forwarded(self):
         """An affirmative ``hillshade={}`` (default params) reaches the glyph.
 

--- a/tests/netcdf/plot/test_plot_options.py
+++ b/tests/netcdf/plot/test_plot_options.py
@@ -17,9 +17,10 @@ from unittest.mock import patch
 import pytest
 
 import pyramids
-from pyramids.netcdf import ColourOpts, FacetSpec, Selectors
+from pyramids.netcdf import ColorOpts, ColourOpts, FacetSpec, Selectors
 from pyramids.netcdf.netcdf import NetCDF
 from tests.netcdf.conftest import make_plot_3d_nc
+from tests.netcdf.plot._plot_helpers import _make_fake_render
 
 
 class TestPlotOptionDataclasses:
@@ -59,6 +60,8 @@ class TestPlotOptionDataclasses:
         assert colour.extend is None
         assert colour.add_colorbar is True
         assert colour.cbar_kwargs is None
+        assert colour.style is None
+        assert colour.hillshade is None
 
     def test_facet_spec_defaults_are_all_none(self):
         """``FacetSpec()`` constructs with every field ``None``.
@@ -208,3 +211,68 @@ class TestPlotConsumesOptionDataclasses:
             mock_plot.return_value = "ok"
             var.plot(variable="t2m", facet=None)
         assert "_facet_stack" not in mock_plot.call_args.kwargs
+
+    def test_style_and_hillshade_forwarded_to_engine(self):
+        """``ColorOpts(style=..., hillshade=...)`` forwards both flattened (#737).
+
+        Test scenario:
+            The cleopatra data-style preset name and the hillshade blend
+            are ``ColorOpts`` fields; the dataclass unpacking inside
+            ``NetCDF.plot`` must hand the engine flat ``style=`` /
+            ``hillshade=`` kwargs (the raster paths already auto-route
+            them to the glyph via ``render_array``).
+        """
+        nc = make_plot_3d_nc()
+        var = nc.get_variable("t2m")
+        with patch.object(type(var.analysis), "plot", autospec=True) as mock_plot:
+            mock_plot.return_value = "ok"
+            var.plot(
+                variable="t2m",
+                colour=ColorOpts(style="flow_accumulation", hillshade={"vert_exag": 8}),
+            )
+        forwarded = mock_plot.call_args.kwargs
+        assert forwarded["style"] == "flow_accumulation"
+        assert forwarded["hillshade"] == {"vert_exag": 8}
+
+    def test_style_and_hillshade_default_not_forwarded(self):
+        """An unset ``style`` / ``hillshade`` leaks no kwarg to the engine.
+
+        Test scenario:
+            Both fields default to ``None``, and ``_build_render_kwargs``
+            only forwards non-``None`` colour fields, so a plain
+            ``ColorOpts()`` must not inject ``style=`` / ``hillshade=``.
+        """
+        nc = make_plot_3d_nc()
+        var = nc.get_variable("t2m")
+        with patch.object(type(var.analysis), "plot", autospec=True) as mock_plot:
+            mock_plot.return_value = "ok"
+            var.plot(variable="t2m", colour=ColorOpts())
+        forwarded = mock_plot.call_args.kwargs
+        assert "style" not in forwarded
+        assert "hillshade" not in forwarded
+
+    def test_style_and_hillshade_survive_animate(self):
+        """``style`` / ``hillshade`` reach the animate render call (#737).
+
+        Test scenario:
+            The animate path drops the static-only kwargs listed in
+            ``_ANIMATE_DROP_KWARGS`` before calling ``render_array`` with
+            ``mode="animate"``. ``style`` / ``hillshade`` are *not* in
+            that drop-set, so a ``ColorOpts(style=..., hillshade=...)``
+            must survive into the animated frames (cleopatra >= 0.24
+            shades every frame).
+        """
+        nc = make_plot_3d_nc(n_times=3)
+        captured: dict = {}
+        with patch(
+            "pyramids.netcdf._plot._render_array",
+            side_effect=_make_fake_render(captured),
+        ):
+            nc.plot(
+                variable="t2m",
+                animate=True,
+                colour=ColorOpts(style="topography", hillshade=True),
+            )
+        assert captured["kw"]["mode"] == "animate"
+        assert captured["kw"]["style"] == "topography"
+        assert captured["kw"]["hillshade"] is True

--- a/tests/ugrid/test_plot.py
+++ b/tests/ugrid/test_plot.py
@@ -223,3 +223,83 @@ class TestUgridDatasetPlotMethods:
                 with pytest.raises(ValueError, match=r"CRS"):
                     ds.plot("depth", basemap=True)
             mock_render.assert_not_called()
+
+
+_mesh_supports_style = "style" in MeshGlyph.option_keys()
+
+
+@pytest.mark.plot
+class TestMeshStyleHillshade:
+    """cleopatra data-style presets on the UGRID mesh path (#737).
+
+    The presets ship in cleopatra >= 0.24 on ``MeshGlyph`` too, so the mesh
+    facade forwards ``style=`` / ``hillshade=`` through ``mesh_render`` and gates
+    them with the same upgrade guard as the raster path.
+    """
+
+    @staticmethod
+    def _dataset(location="face"):
+        """Build a single-face UgridDataset carrying a ``depth`` variable."""
+        data = np.array([5.0]) if location == "face" else np.array([0.0, 1.0, 2.0])
+        return UgridDataset.create_from_arrays(
+            node_x=np.array([0.0, 1.0, 0.5]),
+            node_y=np.array([0.0, 0.0, 1.0]),
+            face_node_connectivity=np.array([[0, 1, 2]]),
+            data={"depth": data},
+            data_locations={"depth": location},
+        )
+
+    @pytest.mark.skipif(
+        not _mesh_supports_style, reason="cleopatra < 0.24 has no MeshGlyph style"
+    )
+    def test_dataset_plot_style_renders(self):
+        """``UgridDataset.plot(style=...)`` renders a styled MeshGlyph."""
+        result = self._dataset("face").plot("depth", style="flow_accumulation")
+        assert isinstance(result, MeshGlyph)
+
+    @pytest.mark.skipif(
+        not _mesh_supports_style, reason="cleopatra < 0.24 has no MeshGlyph hillshade"
+    )
+    def test_dataset_plot_hillshade_node_renders(self):
+        """``hillshade=`` renders on node-centered mesh data.
+
+        cleopatra requires node-centered elevation for hillshade, so a
+        node-location variable is used.
+        """
+        result = self._dataset("node").plot("depth", hillshade=True)
+        assert isinstance(result, MeshGlyph)
+
+    def test_style_forwarded_to_mesh_render(self):
+        """``UgridDataset.plot`` forwards ``style`` / ``hillshade`` to the helper."""
+        from unittest.mock import patch
+
+        ds = self._dataset("face")
+        with patch(
+            "pyramids.netcdf.ugrid.dataset._mesh_render", return_value="sentinel"
+        ) as mock_render:
+            ds.plot("depth", style="topography", hillshade=True)
+        kw = mock_render.call_args.kwargs
+        assert kw.get("style") == "topography"
+        assert kw.get("hillshade") is True
+
+    def test_style_on_old_cleopatra_raises_upgrade_hint(self):
+        """``style=`` on a MeshGlyph lacking preset support raises the >= 0.24 hint."""
+        from unittest.mock import patch
+
+        from pyramids.base._errors import OptionalPackageDoesNotExist
+
+        ds = self._dataset("face")
+        old_keys = MeshGlyph.option_keys() - {"style", "hillshade"}
+        with patch.object(MeshGlyph, "option_keys", return_value=old_keys):
+            with pytest.raises(OptionalPackageDoesNotExist, match="cleopatra >= 0.24"):
+                ds.plot("depth", style="topography")
+
+    def test_falsy_hillshade_not_guarded_on_old_cleopatra(self):
+        """``hillshade=False`` is dropped, so the mesh guard does not fire."""
+        from unittest.mock import patch
+
+        ds = self._dataset("face")
+        old_keys = MeshGlyph.option_keys() - {"style", "hillshade"}
+        with patch.object(MeshGlyph, "option_keys", return_value=old_keys):
+            result = ds.plot("depth", hillshade=False)
+        assert isinstance(result, MeshGlyph)

--- a/tests/ugrid/test_plot.py
+++ b/tests/ugrid/test_plot.py
@@ -272,6 +272,9 @@ class TestMeshStyleHillshade:
         result = self._dataset("node").plot("depth", hillshade=True)
         assert isinstance(result, MeshGlyph)
 
+    @pytest.mark.skipif(
+        not _mesh_supports_style, reason="cleopatra < 0.24 has no MeshGlyph style"
+    )
     def test_style_and_hillshade_reach_mesh_glyph_plot(self):
         """The presets are actually applied to ``MeshGlyph.plot`` (not just returned).
 

--- a/tests/ugrid/test_plot.py
+++ b/tests/ugrid/test_plot.py
@@ -6,6 +6,8 @@ MeshGlyph and returns MeshGlyph instances (not raw Axes).
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 
@@ -13,6 +15,7 @@ mesh_glyph = pytest.importorskip(
     "cleopatra.mesh_glyph", reason="cleopatra not installed"
 )
 MeshGlyph = mesh_glyph.MeshGlyph
+from pyramids.base._errors import OptionalPackageDoesNotExist
 from pyramids.netcdf.ugrid.dataset import UgridDataset
 from pyramids.netcdf.ugrid.plot import plot_mesh_data, plot_mesh_outline
 
@@ -269,10 +272,25 @@ class TestMeshStyleHillshade:
         result = self._dataset("node").plot("depth", hillshade=True)
         assert isinstance(result, MeshGlyph)
 
+    def test_style_and_hillshade_reach_mesh_glyph_plot(self):
+        """The presets are actually applied to ``MeshGlyph.plot`` (not just returned).
+
+        Test scenario:
+            ``isinstance(result, MeshGlyph)`` alone would still pass if the preset
+            were silently dropped between ``mesh_render`` and the glyph. Spy on
+            ``MeshGlyph.plot`` and assert ``style`` / ``hillshade`` arrive in its
+            call kwargs, proving the full facade -> mesh_render -> plot_mesh_data
+            -> MeshGlyph.plot leg forwards them.
+        """
+        ds = self._dataset("face")
+        with patch.object(MeshGlyph, "plot") as mock_plot:
+            ds.plot("depth", style="flow_accumulation", hillshade=True)
+        kw = mock_plot.call_args.kwargs
+        assert kw.get("style") == "flow_accumulation"
+        assert kw.get("hillshade") is True
+
     def test_style_forwarded_to_mesh_render(self):
         """``UgridDataset.plot`` forwards ``style`` / ``hillshade`` to the helper."""
-        from unittest.mock import patch
-
         ds = self._dataset("face")
         with patch(
             "pyramids.netcdf.ugrid.dataset._mesh_render", return_value="sentinel"
@@ -284,10 +302,6 @@ class TestMeshStyleHillshade:
 
     def test_style_on_old_cleopatra_raises_upgrade_hint(self):
         """``style=`` on a MeshGlyph lacking preset support raises the >= 0.24 hint."""
-        from unittest.mock import patch
-
-        from pyramids.base._errors import OptionalPackageDoesNotExist
-
         ds = self._dataset("face")
         old_keys = MeshGlyph.option_keys() - {"style", "hillshade"}
         with patch.object(MeshGlyph, "option_keys", return_value=old_keys):
@@ -296,8 +310,6 @@ class TestMeshStyleHillshade:
 
     def test_falsy_hillshade_not_guarded_on_old_cleopatra(self):
         """``hillshade=False`` is dropped, so the mesh guard does not fire."""
-        from unittest.mock import patch
-
         ds = self._dataset("face")
         old_keys = MeshGlyph.option_keys() - {"style", "hillshade"}
         with patch.object(MeshGlyph, "option_keys", return_value=old_keys):


### PR DESCRIPTION
# Description

Exposes cleopatra 0.24's data-style presets and hillshade blend from the pyramids raster plot paths
(`Dataset.plot` / `DatasetCollection.plot` / `Analysis.plot` / `NetCDF.plot`), for both static and animated
renders.

cleopatra 0.24 added `DATA_STYLES` presets and a `hillshade` option to `ArrayGlyph`, both keyed in
`ArrayGlyph.option_keys()`. pyramids' `render_array` auto-routes any kwarg in that set to the glyph, so the
Dataset / DatasetCollection / Analysis paths gain `style=` / `hillshade=` **for free** (verified end to end).
Two gaps blocked a complete, consistent experience, both fixed here:

- **NetCDF didn't passthrough.** `NetCDF.plot` uses the structured, frozen `ColorOpts` dataclass forwarded by
  an explicit allow-list, so `style` / `hillshade` were silently dropped. Added both as `ColorOpts` fields and
  forwarded them in `_build_render_kwargs`; they are absent from `_ANIMATE_DROP_KWARGS`, so they survive the
  animate path too.
- **No version floor.** On a cleopatra older than 0.24 the kwargs fell through to a cryptic "Unknown option"
  error. Added a **scoped, feature-detected** guard in `render_array` (fires only when `style` / `hillshade` is
  actually used and the installed cleopatra lacks it) that raises a clear "upgrade cleopatra >= 0.24" hint, and
  bumped the `[viz]` extra floor to `cleopatra[tiles]>=0.24.0` (lock updated to 0.24.0).

Documented the `hillshade=` render-time blend versus the `Dataset.hillshade()` DEM method (which returns a
shaded-relief array) on `ColorOpts`.

## Deviations from the issue (both deliberate, verified)

- **No pyramids-side style-name validation.** cleopatra 0.24 already raises
  `ValueError: unknown data style 'X'; valid styles are [...]` with the full list, so duplicating it in
  pyramids would only risk drift. (The issue marked this item "optional".)
- **Scoped guard, not a global `require_cleopatra` bump.** A blanket floor would regress plain `ds.plot()` on an
  older cleopatra; the scoped guard fires only for `style` / `hillshade` use. Same clear-upgrade-hint intent,
  no blast radius on basic plotting.
- Note: the registry is `cleopatra.array_glyph.DATA_STYLES` (95 presets), not `cleopatra.styles.DATA_STYLES` as
  the issue assumed — not hardcoded here since cleopatra self-validates.

No new dependency; no public signature change (additive `ColorOpts` fields + auto-routed kwargs).

# Issues

- Closes #737 — expose cleopatra data-style presets and hillshade from `.plot` / `.animate`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] `pytest tests/dataset/plot/test_plot_engine.py -m plot` — 5 new tests: a real `style="flow_accumulation"`
      render and a real `hillshade=True` render against cleopatra 0.24; the unknown-name path (cleopatra's
      `ValueError`); the scoped upgrade guard; and a no-regression check that plain plotting is unaffected when
      preset support is absent.
- [x] `pytest tests/netcdf/plot/test_plot_options.py` — 5 new tests: `style` / `hillshade` forwarded flat on
      the static path, survive the animate path, and are not injected when unset.
- [x] End-to-end smoke (real cleopatra 0.24, Agg): `ds.plot(style=...)`, `ds.plot(hillshade=True)`, and
      `collection.plot(style=..., hillshade=True)` (animated) all render.
- [x] Doctests + full `tests/netcdf/plot/` + `tests/dataset/plot/test_plot_engine.py` → 208 passed. No
      line-length violations.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.
