### PR TITLE
fix(netcdf): orient lazy reads on the resolved plane, not the trailing axes

### DIFF
--- a/src/pyramids/netcdf/_lazy.py
+++ b/src/pyramids/netcdf/_lazy.py
@@ -468,6 +468,61 @@ def _chunk_starts(chunks_per_axis: tuple[tuple[int, ...], ...]) -> list[list[int
     return starts
 
 
+def _orient_lazy_plane(
+    lazy: Any,
+    da: Any,
+    ndim: int,
+    spatial_dims: tuple[int, int] | None,
+    flips: tuple[bool, bool] | None,
+    trailing_flips: tuple[bool, bool],
+) -> Any:
+    """Orient a storage-order lazy array to the raster convention the eager path produces.
+
+    The eager `get_variable` path resolves the raster plane (explicit `x_dim`/`y_dim`, else CF
+    detection, else the trailing two dims) and presents it as the trailing two axes, north-up /
+    west-first. This mirrors that on the dask array so a lazy read matches the eager read
+    plane-for-plane (#728):
+
+    - `spatial_dims` is `(x_index, y_index)` resolved by the eager path. The `(y_index, x_index)`
+      pair is moved to the trailing two positions with `dask.array.moveaxis`. For a plane that is
+      *already* trailing (every ordinary `(time, lev, lat, lon)` file) this is a no-op, so the
+      common case stays byte-identical to the historical behaviour.
+    - The flips come from the eager path's own decision for the *resolved* plane (`flips`), not the
+      trailing-plane guess, so a variable whose latitude is non-trailing is no longer mirrored on
+      the wrong axis.
+
+    When `spatial_dims` is `None` (a 1-D coordinate read, or a subset that never resolved a plane)
+    the trailing two axes are normalized as before.
+
+    Args:
+        lazy: The storage-order `dask.array.Array`.
+        da: The imported `dask.array` module (passed in to avoid a second import).
+        ndim: Number of dimensions of `lazy`.
+        spatial_dims: `(x_index, y_index)` of the resolved plane, or `None`.
+        flips: `(needs_y_flip, needs_x_flip)` for the resolved plane, or `None` to fall back to the
+            trailing-plane decision.
+        trailing_flips: `(needs_y_flip, needs_x_flip)` for the trailing plane, from
+            `_mdarray_shape_and_dtype`.
+
+    Returns:
+        The oriented lazy array (row 0 = north, col 0 = west on the resolved plane).
+    """
+    oriented = lazy
+    if ndim >= 2:
+        if spatial_dims is None:
+            flip_y, flip_x = trailing_flips
+        else:
+            x_index, y_index = spatial_dims
+            if (y_index, x_index) != (ndim - 2, ndim - 1):
+                oriented = da.moveaxis(oriented, [y_index, x_index], [ndim - 2, ndim - 1])
+            flip_y, flip_x = flips if flips is not None else trailing_flips
+        if flip_y:
+            oriented = da.flip(oriented, axis=ndim - 2)
+        if flip_x:
+            oriented = da.flip(oriented, axis=ndim - 1)
+    return oriented
+
+
 def build_lazy_array(
     path: str,
     variable_name: str,
@@ -475,6 +530,8 @@ def build_lazy_array(
     lock: Any = None,
     manager_id: Any = None,
     manager_hook: Any = None,
+    spatial_dims: tuple[int, int] | None = None,
+    flips: tuple[bool, bool] | None = None,
 ) -> Any:
     """Build a :class:`dask.array.Array` backed by MDArray chunk reads.
 
@@ -496,6 +553,16 @@ def build_lazy_array(
             #727 fix (release on the parent's `close()`, not only when
             the array is dropped). It should hold only a weak reference,
             so it does not defeat the drop-time finalizer.
+        spatial_dims: `(x_index, y_index)` of the raster plane the eager
+            `get_variable` path resolved (explicit `x_dim`/`y_dim` or CF
+            detection). When given, the resolved plane is moved to the
+            trailing two axes so the lazy read is oriented on the same
+            plane as the eager read; `None` (the default) keeps the
+            historical trailing-two-axes normalization. See
+            :func:`_orient_lazy_plane` (#728).
+        flips: `(needs_y_flip, needs_x_flip)` the eager path decided for
+            the resolved plane. Used with `spatial_dims`; `None` falls
+            back to the trailing-plane decision.
 
     Returns:
         dask.array.Array: Lazy array that computes chunk-by-chunk
@@ -544,12 +611,11 @@ def build_lazy_array(
         )
         graph[(name,) + index] = (reader,)
     lazy = da.Array(graph, name, chunks_per_axis, dtype=dtype)
-    if len(shape) >= 2:
-        # Normalize to the raster convention the eager path produces: row 0 = north, col 0 = west.
-        if flip_y:
-            lazy = da.flip(lazy, axis=len(shape) - 2)
-        if flip_x:
-            lazy = da.flip(lazy, axis=len(shape) - 1)
+    # Normalize to the raster convention the eager path produces (row 0 = north, col 0 = west) on the
+    # SAME plane the eager `get_variable` resolved -- moving a non-trailing plane to the trailing two
+    # axes when `spatial_dims` is threaded through (#728). A trailing plane makes this a no-op, so the
+    # ordinary `(time, lev, lat, lon)` case is unchanged.
+    lazy = _orient_lazy_plane(lazy, da, len(shape), spatial_dims, flips, (flip_y, flip_x))
     # The parked FILE_CACHE handle is released deterministically when this `manager` is
     # garbage-collected -- the `CachingFileManager` registers a `weakref.finalize` on itself in
     # `__init__`. Because the manager is kept alive by the chunk readers in the graph (not by this

--- a/src/pyramids/netcdf/_lazy.py
+++ b/src/pyramids/netcdf/_lazy.py
@@ -468,6 +468,39 @@ def _chunk_starts(chunks_per_axis: tuple[tuple[int, ...], ...]) -> list[list[int
     return starts
 
 
+def _plane_move_and_flips(
+    ndim: int,
+    spatial_dims: tuple[int, int] | None,
+    flips: tuple[bool, bool] | None,
+    trailing_flips: tuple[bool, bool],
+) -> tuple[bool, int, int, bool, bool]:
+    """Decide the plane move + flips for :func:`_orient_lazy_plane`.
+
+    Returns `(move, y_axis, x_axis, flip_y, flip_x)`: whether the resolved plane must be transposed
+    to the trailing two axes, the resolved `(y_axis, x_axis)` to move, and the two flip booleans.
+
+    `trailing_flips` is the decision `axis_flips` made for the ORIGINAL trailing plane, so it is a
+    valid fallback only when the resolved plane *is* that trailing plane. For a moved (non-trailing)
+    plane the caller must supply `flips`; without them the plane is left unflipped rather than flipped
+    on the wrong criterion. (Unreachable from `netcdf.py`, which always pairs a non-`None`
+    `spatial_dims` with `flips`; guards the module-private signature.)
+    """
+    y_axis, x_axis = ndim - 2, ndim - 1
+    move = False
+    if spatial_dims is None:
+        flip_y, flip_x = trailing_flips
+    else:
+        x_index, y_index = spatial_dims
+        is_trailing = (y_index, x_index) == (ndim - 2, ndim - 1)
+        move = not is_trailing
+        y_axis, x_axis = y_index, x_index
+        if flips is not None:
+            flip_y, flip_x = flips
+        else:
+            flip_y, flip_x = trailing_flips if is_trailing else (False, False)
+    return move, y_axis, x_axis, flip_y, flip_x
+
+
 def _orient_lazy_plane(
     lazy: Any,
     da: Any,
@@ -516,22 +549,11 @@ def _orient_lazy_plane(
     """
     oriented = lazy
     if ndim >= 2:
-        if spatial_dims is None:
-            flip_y, flip_x = trailing_flips
-        else:
-            x_index, y_index = spatial_dims
-            is_trailing = (y_index, x_index) == (ndim - 2, ndim - 1)
-            if not is_trailing:
-                oriented = da.moveaxis(oriented, [y_index, x_index], [ndim - 2, ndim - 1])
-            if flips is not None:
-                flip_y, flip_x = flips
-            else:
-                # `trailing_flips` is the decision `axis_flips` made for the ORIGINAL trailing plane,
-                # so it is a valid fallback only when the resolved plane *is* that trailing plane. For
-                # a moved (non-trailing) plane the caller must supply `flips`; without them, do not
-                # flip on the wrong criterion. (Unreachable from `netcdf.py`, which always pairs a
-                # non-`None` `spatial_dims` with `flips`; guards the module-private signature.)
-                flip_y, flip_x = trailing_flips if is_trailing else (False, False)
+        move, y_axis, x_axis, flip_y, flip_x = _plane_move_and_flips(
+            ndim, spatial_dims, flips, trailing_flips
+        )
+        if move:
+            oriented = da.moveaxis(oriented, [y_axis, x_axis], [ndim - 2, ndim - 1])
         if flip_y:
             oriented = da.flip(oriented, axis=ndim - 2)
         if flip_x:

--- a/src/pyramids/netcdf/_lazy.py
+++ b/src/pyramids/netcdf/_lazy.py
@@ -494,6 +494,11 @@ def _orient_lazy_plane(
     When `spatial_dims` is `None` (a 1-D coordinate read, or a subset that never resolved a plane)
     the trailing two axes are normalized as before.
 
+    The chunk grid is built in storage order *before* this move, so for a non-trailing plane the
+    resolved plane's axes keep their storage-order chunk sizes (e.g. a default `(1,…,1,rows,cols)`
+    fallback leaves the resolved row axis finely split). This is correct but can be sub-optimal;
+    callers wanting coarse plane chunks pass an explicit integer `chunks=`.
+
     Args:
         lazy: The storage-order `dask.array.Array`.
         da: The imported `dask.array` module (passed in to avoid a second import).

--- a/src/pyramids/netcdf/_lazy.py
+++ b/src/pyramids/netcdf/_lazy.py
@@ -504,8 +504,10 @@ def _orient_lazy_plane(
         da: The imported `dask.array` module (passed in to avoid a second import).
         ndim: Number of dimensions of `lazy`.
         spatial_dims: `(x_index, y_index)` of the resolved plane, or `None`.
-        flips: `(needs_y_flip, needs_x_flip)` for the resolved plane, or `None` to fall back to the
-            trailing-plane decision.
+        flips: `(needs_y_flip, needs_x_flip)` for the resolved plane. `None` falls back to
+            `trailing_flips`, which is correct only when the resolved plane *is* the trailing one —
+            supply `flips` whenever `spatial_dims` is a non-trailing plane (a moved plane is left
+            unflipped otherwise, never flipped on the trailing plane's criterion).
         trailing_flips: `(needs_y_flip, needs_x_flip)` for the trailing plane, from
             `_mdarray_shape_and_dtype`.
 
@@ -518,9 +520,18 @@ def _orient_lazy_plane(
             flip_y, flip_x = trailing_flips
         else:
             x_index, y_index = spatial_dims
-            if (y_index, x_index) != (ndim - 2, ndim - 1):
+            is_trailing = (y_index, x_index) == (ndim - 2, ndim - 1)
+            if not is_trailing:
                 oriented = da.moveaxis(oriented, [y_index, x_index], [ndim - 2, ndim - 1])
-            flip_y, flip_x = flips if flips is not None else trailing_flips
+            if flips is not None:
+                flip_y, flip_x = flips
+            else:
+                # `trailing_flips` is the decision `axis_flips` made for the ORIGINAL trailing plane,
+                # so it is a valid fallback only when the resolved plane *is* that trailing plane. For
+                # a moved (non-trailing) plane the caller must supply `flips`; without them, do not
+                # flip on the wrong criterion. (Unreachable from `netcdf.py`, which always pairs a
+                # non-`None` `spatial_dims` with `flips`; guards the module-private signature.)
+                flip_y, flip_x = trailing_flips if is_trailing else (False, False)
         if flip_y:
             oriented = da.flip(oriented, axis=ndim - 2)
         if flip_x:

--- a/src/pyramids/netcdf/_mdim.py
+++ b/src/pyramids/netcdf/_mdim.py
@@ -352,11 +352,13 @@ def axis_flips(rg: gdal.Group, md_arr: gdal.MDArray) -> tuple[bool, bool]:
     """Return ``(needs_y_flip, needs_x_flip)`` for the array's **trailing** raster plane.
 
     Both flips are decided together — one ``AsClassicDataset`` build, one read of each coordinate —
-    because every caller needs the pair. The plane is always the last two dimensions; unlike the
-    eager ``get_variable`` path (which resolves an explicit / CF-detected ``x_dim``/``y_dim`` via
-    ``_resolve_spatial_dims``), the lazy and ``_read_variable`` paths carry no plane override, so
-    they normalize the trailing two axes. For every variable whose spatial plane *is* trailing —
-    which is every on-disk fixture and the ordinary 2-D/3-D/4-D case — this matches the eager read.
+    because every caller needs the pair. This returns the *trailing*-plane decision. The eager
+    ``get_variable`` path resolves an explicit / CF-detected ``x_dim``/``y_dim`` via
+    ``_resolve_spatial_dims`` and decides flips for *that* plane; the lazy ``read_array(chunks=)``
+    path now threads the same resolved plane into ``build_lazy_array`` and uses this trailing
+    decision only as the fallback when no plane was resolved (a 1-D coordinate read) (#728).
+    ``_read_variable`` still normalizes the trailing two axes, which is correct for its callers — all
+    of which read coordinate/time variables whose spatial plane is already trailing.
 
     Args:
         rg: The root group, kept alive to prevent SWIG garbage collection of the view.

--- a/src/pyramids/netcdf/_mdim.py
+++ b/src/pyramids/netcdf/_mdim.py
@@ -357,8 +357,11 @@ def axis_flips(rg: gdal.Group, md_arr: gdal.MDArray) -> tuple[bool, bool]:
     ``_resolve_spatial_dims`` and decides flips for *that* plane; the lazy ``read_array(chunks=)``
     path now threads the same resolved plane into ``build_lazy_array`` and uses this trailing
     decision only as the fallback when no plane was resolved (a 1-D coordinate read) (#728).
-    ``_read_variable`` still normalizes the trailing two axes, which is correct for its callers — all
-    of which read coordinate/time variables whose spatial plane is already trailing.
+    ``_read_variable`` still normalizes the trailing two axes and carries no plane override. Its
+    in-tree callers read coordinate/time variables (and, on the plot paths, named coordinate/data
+    variables) whose spatial plane is trailing, so the trailing decision is correct for them; a
+    *non-trailing*-plane data variable read through ``_read_variable`` would be normalized on the
+    trailing plane, not its resolved one.
 
     Args:
         rg: The root group, kept alive to prevent SWIG garbage collection of the view.

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -308,10 +308,18 @@ class NetCDFPlot:
         else:
             if chunks is not None:
                 analysis_kwargs["_chunks"] = chunks
+                # The lazy `read_array(chunks=)` re-reads the whole source variable and ignores the
+                # `sel()`-pinned subset, so render from the *unpinned* `nc` -- which carries the
+                # resolved raster plane -- and index the flat band the selection pins to, instead of
+                # storage band 0 (which would silently draw the wrong slice; #728).
+                render_source = nc
+                render_band = self._flat_band_index(nc, resolved_sel)
             else:
                 self._maybe_log_lazy_hint(pinned)
-            result = pinned.analysis.plot(
-                band=0,
+                render_source = pinned
+                render_band = 0
+            result = render_source.analysis.plot(
+                band=render_band,
                 exclude_value=exclude_value,
                 basemap=basemap,
                 **analysis_kwargs,
@@ -397,6 +405,45 @@ class NetCDFPlot:
                 dim_coords = nc._band_dim_values_map.get(dim_name)
                 resolved[dim_name] = idx if dim_coords is None else dim_coords[idx]
         return resolved
+
+    def _flat_band_index(self, nc: NetCDF, resolved_sel: dict[str, Any]) -> int:
+        """Flat classic-band index the selection pins to, for the lazy (`chunks=`) render path.
+
+        The lazy `read_array(chunks=)` re-reads the whole source variable and ignores the
+        `sel()`-pinned subset, so the chunks render path reads the unpinned variable and indexes
+        this band rather than storage band 0. Reuses the exact band-index machinery `sel` uses
+        (`_resolve_dim_indices` + `_map_dim_to_band_indices`) so the flat index matches the eager
+        selection's band order. Every band dim is pinned on this path (`run` asserts
+        `band_count == 1`), so the per-dim band sets intersect to a single band; returns `0` when no
+        selector is active.
+
+        Args:
+            nc: The unpinned variable subset (carries the full band-dim metadata).
+            resolved_sel: `{band_dim_name: label}` from `_resolve_selectors`.
+
+        Returns:
+            int: The 0-based flat band index of the selected 2-D slice.
+        """
+        flat_index = 0
+        if resolved_sel:
+            # Local import breaks the pyramids.netcdf.engines.selection <-> pyramids.netcdf._plot
+            # cycle (selection imports NetCDFPlot from this module).
+            from pyramids.netcdf.engines.selection import (
+                _map_dim_to_band_indices,
+                _resolve_dim_indices,
+            )
+
+            sizes = nc._band_dim_sizes
+            candidate: set[int] | None = None
+            for dim_name, value in resolved_sel.items():
+                coords = nc._band_dim_values_map[dim_name]
+                dim_indices = _resolve_dim_indices(coords, value)
+                dim_axis = nc._band_dim_names.index(dim_name)
+                bands = set(_map_dim_to_band_indices(dim_axis, sizes, dim_indices))
+                candidate = bands if candidate is None else candidate & bands
+            if candidate:
+                flat_index = min(candidate)
+        return flat_index
 
     def _build_render_kwargs(
         self,

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1734,7 +1734,11 @@ class NetCDF(Dataset):
               non-spatial dimension — the eager path flattens every non-spatial dimension into a
               single band axis (and squeezes a singleton), whereas the lazy array keeps them as
               separate leading axes in storage order. Reshape the lazy result with
-              `(-1, rows, cols)` to line the two up.
+              `(-1, rows, cols)` to line the two up. Chunking is computed in *storage* order
+              (before the plane is moved to the trailing axes), so for a non-trailing plane the
+              default `chunks="auto"` may split the resolved plane finely and the named `chunks=`
+              aliases (`rows` / `cols`) map to storage axes, not the resolved plane — pass explicit
+              integer `chunks=` per axis for optimal chunking on such a variable.
 
         Examples:
             - Eager bbox read on a root container — the container

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1722,11 +1722,15 @@ class NetCDF(Dataset):
               two live GDAL handles to one NetCDF, which can crash GDAL on Windows. So before reopening
               a file in-process, either **drop the lazy array(s)** or **`close()` the `NetCDF`** — both
               now release the parked handle.
-            * **Axis plane.** The lazy path normalizes the **trailing two** dimensions to north-up /
-              west-first, whereas the eager path resolves the plane via `x_dim` / `y_dim` /
-              CF detection. They agree for every variable whose spatial plane is trailing (the common
-              `(time, lev, lat, lon)` layout); a variable whose CF-resolved plane is *non-trailing*
-              is read against a different plane lazily than eagerly. Read such a variable eagerly.
+            * **Axis plane and shape.** The lazy path resolves the raster plane the same way the
+              eager path does — explicit `x_dim` / `y_dim` (carried on the `get_variable` subset) or
+              CF detection, falling back to the trailing two dimensions — and moves it to the
+              trailing two axes, north-up / west-first, so a lazy read is oriented on the *same*
+              plane as the eager read (#728). The two still differ in *packaging* for arrays with
+              more than one non-spatial dimension: the eager path flattens every non-spatial
+              dimension into a single band axis (and squeezes a singleton), whereas the lazy array
+              keeps them as separate leading axes in storage order. Reshape the lazy result with
+              `(-1, rows, cols)` to line the two up.
 
         Examples:
             - Eager bbox read on a root container — the container
@@ -1861,6 +1865,15 @@ class NetCDF(Dataset):
                 "`variable=` on the container or call read_array "
                 "on a subset from `get_variable()`."
             )
+        # Thread the eager-resolved raster plane (and its flips) into the lazy build so a variable
+        # whose latitude/longitude is not the trailing pair -- selected via `x_dim`/`y_dim` or CF
+        # detection -- is oriented on the SAME plane the eager `get_variable` read produces, instead
+        # of silently normalizing the trailing two axes (#728). `_md_spatial_dims` is `None` only for
+        # a 1-D coordinate read, where `build_lazy_array` keeps the trailing behaviour.
+        spatial_dims = self._md_spatial_dims
+        flips = None
+        if spatial_dims is not None:
+            flips = (bool(self._md_y_flipped), bool(self._md_x_flipped))
         return cast(
             ArrayLike,
             build_lazy_array(
@@ -1869,6 +1882,8 @@ class NetCDF(Dataset):
                 chunks=chunks,
                 lock=lock,
                 manager_hook=self._register_lazy_manager,
+                spatial_dims=spatial_dims,
+                flips=flips,
             ),
         )
 
@@ -1963,6 +1978,14 @@ class NetCDF(Dataset):
         wrapped._offset = self._offset
         wrapped._parent_nc = self._parent_nc
         wrapped._source_var_name = self._source_var_name
+        # Carry the eager-resolved raster plane (and its flips) onto sel / spatial-op results. A lazy
+        # read re-reads the ORIGINAL variable in storage order, so a `plot(chunks=, x_dim=, y_dim=)`
+        # on a re-wrapped subset must still see the resolved plane rather than falling back to the
+        # trailing two axes (#728); the indices stay valid because `build_lazy_array` reads the same
+        # original variable this metadata was resolved against.
+        wrapped._md_spatial_dims = self._md_spatial_dims
+        wrapped._md_y_flipped = self._md_y_flipped
+        wrapped._md_x_flipped = self._md_x_flipped
         wrapped._gdal_md_arr_ref = None
         wrapped._gdal_rg_ref = None
         return wrapped

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1726,10 +1726,14 @@ class NetCDF(Dataset):
               eager path does — explicit `x_dim` / `y_dim` (carried on the `get_variable` subset) or
               CF detection, falling back to the trailing two dimensions — and moves it to the
               trailing two axes, north-up / west-first, so a lazy read is oriented on the *same*
-              plane as the eager read (#728). The two still differ in *packaging* for arrays with
-              more than one non-spatial dimension: the eager path flattens every non-spatial
-              dimension into a single band axis (and squeezes a singleton), whereas the lazy array
-              keeps them as separate leading axes in storage order. Reshape the lazy result with
+              plane as the eager read (#728). It reads the **entire source variable** in storage
+              order and does **not** apply a prior `sel` / `crop` / `window` carried on the subset
+              (those materialize the eager raster only): slice the returned dask array yourself, or
+              read a selected / cropped subset eagerly. For a subset with no active selection the
+              eager and lazy reads then differ only in *packaging* for arrays with more than one
+              non-spatial dimension — the eager path flattens every non-spatial dimension into a
+              single band axis (and squeezes a singleton), whereas the lazy array keeps them as
+              separate leading axes in storage order. Reshape the lazy result with
               `(-1, rows, cols)` to line the two up.
 
         Examples:
@@ -1978,14 +1982,6 @@ class NetCDF(Dataset):
         wrapped._offset = self._offset
         wrapped._parent_nc = self._parent_nc
         wrapped._source_var_name = self._source_var_name
-        # Carry the eager-resolved raster plane (and its flips) onto sel / spatial-op results. A lazy
-        # read re-reads the ORIGINAL variable in storage order, so a `plot(chunks=, x_dim=, y_dim=)`
-        # on a re-wrapped subset must still see the resolved plane rather than falling back to the
-        # trailing two axes (#728); the indices stay valid because `build_lazy_array` reads the same
-        # original variable this metadata was resolved against.
-        wrapped._md_spatial_dims = self._md_spatial_dims
-        wrapped._md_y_flipped = self._md_y_flipped
-        wrapped._md_x_flipped = self._md_x_flipped
         wrapped._gdal_md_arr_ref = None
         wrapped._gdal_rg_ref = None
         return wrapped

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1578,7 +1578,7 @@ class NetCDF(Dataset):
 
               ```python
               >>> cleo = nc.plot(  # doctest: +SKIP
-              ...     variable="t2m", chunks={"x": 5, "y": 5},
+              ...     variable="t2m", chunks={"rows": 5, "cols": 5},
               ... )
 
               ```

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1817,6 +1817,14 @@ class NetCDF(Dataset):
         top" pattern.
         """
         if bbox is None:
+            if window is not None and chunks is not None:
+                # The lazy path re-reads the whole variable and never applies a pixel window, so a
+                # silently-ignored `window=` would return far more data than asked. Fail loudly,
+                # matching the `bbox=` + `chunks=` guard below (#728 review M1).
+                raise ValueError(
+                    "read_array(chunks=..., window=...) is not supported; "
+                    "read lazily and slice the resulting dask array instead."
+                )
             return window
         if window is not None:
             raise ValueError(

--- a/tests/netcdf/lazy/test_chunked_read.py
+++ b/tests/netcdf/lazy/test_chunked_read.py
@@ -395,25 +395,96 @@ class TestLazyOrientationMatchesEager:
             direct, eager, err_msg="_read_variable is mirrored west-east relative to get_variable"
         )
 
-    def test_non_trailing_spatial_variable_lazy_matches_eager(self):
-        """A `(time, lat, lev, lon)` variable reads the same lazily and eagerly.
+    _NON_TRAILING_FIXTURE = "tests/data/netcdf/cf__48v__1d17-3d21-4d10__y-asc.nc"
+
+    def test_default_resolution_lazy_matches_eager(self):
+        """The default (no `x_dim`/`y_dim`) read of a `(time, lat, lev, lon)` variable is unchanged.
 
         Test scenario:
-            The lazy path normalizes the trailing two axes (see `_mdim.axis_flips`), while the eager
-            path resolves the raster plane through `_resolve_spatial_dims`. For CAM's non-trailing
-            latitude both resolve to the same trailing `(lev, lon)` plane, so the reads must agree
-            byte-for-byte — pinned here so any future divergence between the two plane-resolution
-            strategies surfaces as a failure instead of a silent mirror.
+            The fixture's `lat`/`lon` carry no CF axis attributes, so auto-detection falls back to
+            the trailing `(lev, lon)` plane. Both the eager and lazy paths then resolve the same
+            trailing plane, so the fix must leave this common case byte-identical (the `moveaxis` is
+            a no-op for a trailing plane). Reshaping folds the eager band-flattening into the lazy
+            array's separate leading axes.
 
-        Reads the shared on-disk fixture directly; the netcdf-wide autouse `_clear_file_cache` fixture closes the
-        lazy path's parked GDAL handle at teardown, so a later test reopening the same file cannot
-        collide with a stale handle (the CAM segfault mechanism).
+        Reads the shared on-disk fixture directly; the netcdf-wide autouse `_clear_file_cache`
+        fixture closes the lazy path's parked GDAL handle at teardown.
         """
-        path = "tests/data/netcdf/cf__48v__1d17-3d21-4d10__y-asc.nc"
+        path = self._NON_TRAILING_FIXTURE
         eager = np.asarray(NetCDF.read_file(path).get_variable("T").read_array())
-        lazy = np.squeeze(np.asarray(NetCDF.read_file(path).get_variable("T").read_array(chunks="auto")))
+        lazy = np.asarray(NetCDF.read_file(path).get_variable("T").read_array(chunks="auto"))
         np.testing.assert_array_equal(
-            lazy, eager, err_msg="lazy read diverged from eager on a non-trailing-spatial variable"
+            lazy.reshape(-1, *eager.shape[-2:]),
+            eager,
+            err_msg="default lazy read diverged from eager on the trailing-plane fallback",
+        )
+
+    def test_explicit_nontrailing_plane_lazy_matches_eager(self):
+        """`read_array(chunks=)` honours an explicit non-trailing `x_dim`/`y_dim` like the eager read.
+
+        Test scenario:
+            `T(time, lat, lev, lon)` selected via `x_dim="lon", y_dim="lat"` has its raster plane at
+            the *non-trailing* axes `(lat=1, lon=3)`. Before #728 the lazy path ignored the selection
+            and normalized the trailing `(lev, lon)` plane — flipping `lev` instead of `lat` and
+            returning the wrong plane as its raster. The fix moves the resolved plane to the trailing
+            two axes and flips *it*, so the lazy read matches the eager read plane-for-plane. Checked
+            against an independent north-up reference built straight from the storage-order MDArray,
+            so a shared mirror could not make both sides agree.
+        """
+        path = self._NON_TRAILING_FIXTURE
+        var = NetCDF.read_file(path).get_variable("T", x_dim="lon", y_dim="lat")
+        assert var._md_spatial_dims == (3, 1), "lon/lat must resolve to the non-trailing (x=3, y=1)"
+        assert var._md_y_flipped is True, "the fixture's ascending latitude must flip to north-up"
+        eager = np.asarray(var.read_array())
+        rows, cols = eager.shape[-2:]
+        assert (rows, cols) == (64, 128), "eager plane must be (lat=64, lon=128)"
+
+        lazy = np.asarray(
+            NetCDF.read_file(path)
+            .get_variable("T", x_dim="lon", y_dim="lat")
+            .read_array(chunks="auto")
+        )
+        assert lazy.shape[-2:] == (64, 128), (
+            "lazy trailing plane must be (lat, lon); a (6, 128) plane means the pre-#728 "
+            "trailing-axes read leaked through"
+        )
+        np.testing.assert_array_equal(
+            lazy.reshape(-1, rows, cols),
+            eager,
+            err_msg="explicit non-trailing lazy read diverged from eager (#728)",
+        )
+
+        ds = gdal.OpenEx(path, gdal.OF_MULTIDIM_RASTER)
+        root = ds.GetRootGroup()
+        raw = np.asarray(root.OpenMDArray("T").ReadAsArray())  # storage order (time, lat, lev, lon)
+        lat = np.asarray(root.OpenMDArray("lat").ReadAsArray())
+        reference = np.moveaxis(raw, [1, 3], [2, 3])  # -> (time, lev, lat, lon)
+        if lat[0] < lat[-1]:  # ascending south-to-north -> reverse to north-up rows
+            reference = reference[..., ::-1, :]
+        np.testing.assert_array_equal(
+            lazy.reshape(-1, rows, cols),
+            reference.reshape(-1, rows, cols),
+            err_msg="lazy read is not north-up on the resolved lat/lon plane",
+        )
+
+    def test_sel_derived_subset_retains_resolved_plane_for_lazy_read(self):
+        """A `sel()` on an explicit-plane subset keeps the resolved plane, so its lazy read stays oriented.
+
+        Test scenario:
+            `_preserve_netcdf_metadata` re-wraps `sel` / spatial-op results but historically dropped
+            the resolved `(x_index, y_index)` plane and its flips, so a `read_array(chunks=)` on a
+            `sel`-derived subset fell back to the trailing two axes — the #728 mirror, one step
+            removed. The plane must survive the re-wrap so the lazy read still resolves `(lat, lon)`.
+        """
+        path = self._NON_TRAILING_FIXTURE
+        var = NetCDF.read_file(path).get_variable("T", x_dim="lon", y_dim="lat")
+        band_dim = var._band_dim_names[0]
+        selected = var.sel(**{band_dim: var._band_dim_values_map[band_dim][0]})
+        assert selected._md_spatial_dims == (3, 1), "sel dropped the resolved plane"
+        assert selected._md_y_flipped is True, "sel dropped the resolved Y flip"
+        lazy = np.asarray(selected.read_array(chunks="auto"))
+        assert lazy.shape[-2:] == (64, 128), (
+            "lazy read of a sel-derived subset lost the resolved (lat, lon) plane"
         )
 
     def test_one_dimensional_variable_is_never_flipped(self):

--- a/tests/netcdf/lazy/test_chunked_read.py
+++ b/tests/netcdf/lazy/test_chunked_read.py
@@ -104,6 +104,15 @@ class TestChunksLazy:
         arr = three_d_var.read_array(chunks=1)
         assert isinstance(arr, dask_array.Array)
 
+    def test_window_with_chunks_raises(self, three_d_var):
+        """`read_array(window=, chunks=)` raises instead of silently ignoring the window (#728 M1).
+
+        The lazy path never applies a pixel window, so a silently-dropped `window=` would return the
+        whole variable; it must fail loudly like the `bbox=` + `chunks=` guard.
+        """
+        with pytest.raises(ValueError, match="window"):
+            three_d_var.read_array(window=[0, 0, 2, 2], chunks="auto")
+
     def test_chunks_tuple_returns_dask(self, three_d_var):
         """Tuple chunks also return a dask array with matching spec."""
         arr = three_d_var.read_array(chunks=(1, -1, -1))

--- a/tests/netcdf/lazy/test_chunked_read.py
+++ b/tests/netcdf/lazy/test_chunked_read.py
@@ -419,6 +419,34 @@ class TestLazyOrientationMatchesEager:
             err_msg="default lazy read diverged from eager on the trailing-plane fallback",
         )
 
+    def test_build_lazy_array_without_resolved_plane_normalizes_trailing(self):
+        """A direct `build_lazy_array` call with no resolved plane keeps the trailing-axes normalization.
+
+        Test scenario:
+            The NetCDF path always threads the resolved plane, but `build_lazy_array` is also callable
+            directly (e.g. the raster lazy path, or a coordinate read) with `spatial_dims=None`. That
+            fallback — and the defensive `flips=None` path when a plane is passed without flips — must
+            reproduce the historical trailing-plane normalization, matching the eager read of a
+            bottom-up 2-D variable.
+        """
+        path, variable, _ = ORIENTATION_FIXTURES[1]  # geographic, bottom-up `Band1` (needs a Y flip)
+        eager = self._first_plane(NetCDF.read_file(path).get_variable(variable).read_array())
+        no_plane = self._first_plane(lazy_mod.build_lazy_array(path, variable, chunks="auto"))
+        np.testing.assert_array_equal(
+            no_plane, eager, err_msg="spatial_dims=None must keep the trailing normalization"
+        )
+        ndim = np.asarray(
+            NetCDF.read_file(path).get_variable(variable).read_array(chunks="auto")
+        ).ndim
+        no_flips = self._first_plane(
+            lazy_mod.build_lazy_array(
+                path, variable, chunks="auto", spatial_dims=(ndim - 1, ndim - 2), flips=None
+            )
+        )
+        np.testing.assert_array_equal(
+            no_flips, eager, err_msg="flips=None must fall back to the trailing-plane decision"
+        )
+
     def test_explicit_nontrailing_plane_lazy_matches_eager(self):
         """`read_array(chunks=)` honours an explicit non-trailing `x_dim`/`y_dim` like the eager read.
 

--- a/tests/netcdf/lazy/test_chunked_read.py
+++ b/tests/netcdf/lazy/test_chunked_read.py
@@ -286,6 +286,21 @@ class TestLazyPickle:
         expected_sum = float(np.asarray(expected, dtype=np.float64).sum())
         assert_allclose(total, expected_sum, rtol=1e-6)
 
+    def test_nontrailing_moveaxis_graph_pickles(self):
+        """A non-trailing (moveaxis) lazy graph pickles and recomputes to the same array (#728).
+
+        The extra `da.moveaxis` layer over the chunk readers must not break graph serialization; a
+        pickle round-trip of a non-trailing lazy read must recompute to the same north-up plane.
+        """
+        lazy = (
+            NetCDF.read_file("tests/data/netcdf/cf__48v__1d17-3d21-4d10__y-asc.nc")
+            .get_variable("T", x_dim="lon", y_dim="lat")
+            .read_array(chunks="auto")
+        )
+        before = np.asarray(lazy.compute())
+        after = np.asarray(pickle.loads(pickle.dumps(lazy)).compute())
+        np.testing.assert_array_equal(after, before)
+
 
 class TestImportError:
     """``chunks`` + missing dask yields a clear ImportError."""
@@ -502,6 +517,28 @@ class TestLazyOrientationMatchesEager:
             err_msg="lazy read is not north-up / west-first on the resolved lat/lon plane",
         )
 
+    def test_direct_nontrailing_x_flip_moves_and_flips(self):
+        """A non-trailing plane with an X flip exercises `moveaxis` + `da.flip(axis=-1)` together.
+
+        Test scenario:
+            The on-disk fixtures need only a Y flip on a non-trailing plane, so the `flip_x`-after-
+            `moveaxis` path is otherwise uncovered. Drive `build_lazy_array` directly with the
+            resolved `(x=3, y=1)` plane and a forced X flip, and compare against a hand-built
+            reference that moves `(lat, lon)` to the trailing axes then reverses the columns.
+        """
+        path = self._NON_TRAILING_FIXTURE
+        lazy = np.asarray(
+            lazy_mod.build_lazy_array(
+                path, "T", chunks="auto", spatial_dims=(3, 1), flips=(False, True)
+            )
+        )
+        ds = gdal.OpenEx(path, gdal.OF_MULTIDIM_RASTER)
+        raw = np.asarray(ds.GetRootGroup().OpenMDArray("T").ReadAsArray())  # (time, lat, lev, lon)
+        reference = np.moveaxis(raw, [1, 3], [2, 3])[..., :, ::-1]  # (time, lev, lat, lon), cols flipped
+        np.testing.assert_array_equal(
+            lazy, reference, err_msg="moveaxis + forced X flip diverged from the reference"
+        )
+
     def test_one_dimensional_variable_is_never_flipped(self):
         """A 1-D coordinate array has no raster plane, so no axis is reversed.
 
@@ -537,6 +574,26 @@ class TestLazyHandleLifetime:
         del lazy
         gc.collect()
         assert len(FILE_CACHE) == 0, "dropping the lazy array must evict the parked handle"
+
+    def test_nontrailing_moveaxis_lazy_evicts_handle_on_drop(self):
+        """Dropping a non-trailing (moveaxis-graph) lazy array still evicts its parked handle (#728).
+
+        Test scenario:
+            A non-trailing plane adds a `da.moveaxis` layer over the chunk-reader graph. The manager
+            is kept alive by the base readers, not the wrapper, so the drop-time finalizer must still
+            fire — mirror the trailing eviction test on the moveaxis graph.
+        """
+        assert len(FILE_CACHE) == 0, "the autouse fixture should leave FILE_CACHE empty at test start"
+        lazy = (
+            NetCDF.read_file("tests/data/netcdf/cf__48v__1d17-3d21-4d10__y-asc.nc")
+            .get_variable("T", x_dim="lon", y_dim="lat")
+            .read_array(chunks="auto")
+        )
+        lazy.compute()
+        assert len(FILE_CACHE) == 1, "a non-trailing lazy read + compute must park exactly one handle"
+        del lazy
+        gc.collect()
+        assert len(FILE_CACHE) == 0, "dropping the moveaxis lazy array must evict the parked handle"
 
     def test_dropping_unpack_lazy_array_evicts_handle(self, scale_offset_path):
         """Dropping an `unpack=True` lazy array — a DERIVED dask array — still evicts the handle (H1).

--- a/tests/netcdf/lazy/test_chunked_read.py
+++ b/tests/netcdf/lazy/test_chunked_read.py
@@ -428,8 +428,9 @@ class TestLazyOrientationMatchesEager:
             and normalized the trailing `(lev, lon)` plane — flipping `lev` instead of `lat` and
             returning the wrong plane as its raster. The fix moves the resolved plane to the trailing
             two axes and flips *it*, so the lazy read matches the eager read plane-for-plane. Checked
-            against an independent north-up reference built straight from the storage-order MDArray,
-            so a shared mirror could not make both sides agree.
+            against an independent north-up reference built straight from the storage-order MDArray —
+            locating the `lat`/`lon` dims by name and flipping each from its own coordinate
+            direction, so the reference shares no axis choice with the code under test.
         """
         path = self._NON_TRAILING_FIXTURE
         var = NetCDF.read_file(path).get_variable("T", x_dim="lon", y_dim="lat")
@@ -456,15 +457,21 @@ class TestLazyOrientationMatchesEager:
 
         ds = gdal.OpenEx(path, gdal.OF_MULTIDIM_RASTER)
         root = ds.GetRootGroup()
-        raw = np.asarray(root.OpenMDArray("T").ReadAsArray())  # storage order (time, lat, lev, lon)
+        md = root.OpenMDArray("T")
+        dim_names = [d.GetName() for d in md.GetDimensions()]
+        y_axis, x_axis = dim_names.index("lat"), dim_names.index("lon")
+        raw = np.asarray(md.ReadAsArray())  # storage order (time, lat, lev, lon)
         lat = np.asarray(root.OpenMDArray("lat").ReadAsArray())
-        reference = np.moveaxis(raw, [1, 3], [2, 3])  # -> (time, lev, lat, lon)
+        lon = np.asarray(root.OpenMDArray("lon").ReadAsArray())
+        reference = np.moveaxis(raw, [y_axis, x_axis], [raw.ndim - 2, raw.ndim - 1])
         if lat[0] < lat[-1]:  # ascending south-to-north -> reverse to north-up rows
             reference = reference[..., ::-1, :]
+        if lon[0] > lon[-1]:  # descending east-to-west -> reverse to west-first cols
+            reference = reference[..., :, ::-1]
         np.testing.assert_array_equal(
             lazy.reshape(-1, rows, cols),
             reference.reshape(-1, rows, cols),
-            err_msg="lazy read is not north-up on the resolved lat/lon plane",
+            err_msg="lazy read is not north-up / west-first on the resolved lat/lon plane",
         )
 
     def test_one_dimensional_variable_is_never_flipped(self):

--- a/tests/netcdf/lazy/test_chunked_read.py
+++ b/tests/netcdf/lazy/test_chunked_read.py
@@ -467,26 +467,6 @@ class TestLazyOrientationMatchesEager:
             err_msg="lazy read is not north-up on the resolved lat/lon plane",
         )
 
-    def test_sel_derived_subset_retains_resolved_plane_for_lazy_read(self):
-        """A `sel()` on an explicit-plane subset keeps the resolved plane, so its lazy read stays oriented.
-
-        Test scenario:
-            `_preserve_netcdf_metadata` re-wraps `sel` / spatial-op results but historically dropped
-            the resolved `(x_index, y_index)` plane and its flips, so a `read_array(chunks=)` on a
-            `sel`-derived subset fell back to the trailing two axes — the #728 mirror, one step
-            removed. The plane must survive the re-wrap so the lazy read still resolves `(lat, lon)`.
-        """
-        path = self._NON_TRAILING_FIXTURE
-        var = NetCDF.read_file(path).get_variable("T", x_dim="lon", y_dim="lat")
-        band_dim = var._band_dim_names[0]
-        selected = var.sel(**{band_dim: var._band_dim_values_map[band_dim][0]})
-        assert selected._md_spatial_dims == (3, 1), "sel dropped the resolved plane"
-        assert selected._md_y_flipped is True, "sel dropped the resolved Y flip"
-        lazy = np.asarray(selected.read_array(chunks="auto"))
-        assert lazy.shape[-2:] == (64, 128), (
-            "lazy read of a sel-derived subset lost the resolved (lat, lon) plane"
-        )
-
     def test_one_dimensional_variable_is_never_flipped(self):
         """A 1-D coordinate array has no raster plane, so no axis is reversed.
 

--- a/tests/netcdf/plot/test_plot_lazy.py
+++ b/tests/netcdf/plot/test_plot_lazy.py
@@ -51,6 +51,35 @@ class TestNetCDFPlotLazy:
         assert isinstance(result, ArrayGlyph)
         assert result.arr.shape == (4, 4)
 
+    @pytest.mark.lazy
+    def test_selectors_chunks_renders_selected_slice_not_band_zero(self, tmp_path):
+        """`plot(selectors=, chunks=)` renders the SELECTED slice, not storage band 0 (#728 / H1).
+
+        Test scenario:
+            The lazy `read_array(chunks=)` ignores the `sel()`-pinned subset and re-reads the whole
+            variable, so before the fix the chunks render path drew `lazy[0]` — storage slice 0 —
+            regardless of the selector. Each time slice of the fixture has distinct random values, so
+            a wrong-slice render is detectable: the chunked render must equal the eager render of the
+            same selector and must NOT equal the (different) slice-0 render.
+        """
+        nc_mem = make_plot_3d_nc(n_times=4, rows=4, cols=4)
+        out = tmp_path / "slices.nc"
+        nc_mem.to_file(out)
+        nc = NetCDF.read_file(str(out))
+        eager = np.asarray(nc.plot(variable="t2m", selectors=Selectors(time=2)).arr)
+        lazy = np.asarray(
+            nc.plot(
+                variable="t2m", selectors=Selectors(time=2), chunks={"cols": 2, "rows": 2}
+            ).arr
+        )
+        np.testing.assert_array_equal(
+            lazy, eager, err_msg="chunked plot drew a different slice than the eager plot"
+        )
+        slice0 = np.asarray(nc.plot(variable="t2m", selectors=Selectors(time=0)).arr)
+        assert not np.array_equal(
+            lazy, slice0
+        ), "chunked plot drew storage band 0, not the selected slice"
+
     def test_chunks_none_preserves_eager_behaviour(self):
         """``chunks=None`` (default) preserves the current eager path.
 

--- a/tests/netcdf/plot/test_plot_lazy.py
+++ b/tests/netcdf/plot/test_plot_lazy.py
@@ -80,6 +80,39 @@ class TestNetCDFPlotLazy:
             lazy, slice0
         ), "chunked plot drew storage band 0, not the selected slice"
 
+    @pytest.mark.lazy
+    def test_multi_dim_selectors_chunks_renders_intersected_slice(self, tmp_path):
+        """`chunks=` with TWO pinned band dims indexes the intersected flat band (#728 / H1).
+
+        Test scenario:
+            A 4-D `(time, pressure_level, lat, lon)` variable pinned on both band dims exercises the
+            multi-dim intersection in `_flat_band_index`. The chunked render must equal the eager
+            render of the same selectors and differ from the (0, 0) corner slice.
+        """
+        nc_mem = _make_4d_nc()
+        out = tmp_path / "cube4d.nc"
+        nc_mem.to_file(out)
+        nc = NetCDF.read_file(str(out))
+        sel = Selectors(time=6, sel={"pressure_level": 500})
+        eager = np.asarray(nc.plot(variable="temperature", selectors=sel).arr)
+        lazy = np.asarray(
+            nc.plot(
+                variable="temperature", selectors=sel, chunks={"cols": 1, "rows": 1}
+            ).arr
+        )
+        np.testing.assert_array_equal(
+            lazy, eager, err_msg="multi-dim chunked plot drew a different slice than eager"
+        )
+        corner = np.asarray(
+            nc.plot(
+                variable="temperature",
+                selectors=Selectors(time=0, sel={"pressure_level": 1000}),
+            ).arr
+        )
+        assert not np.array_equal(
+            lazy, corner
+        ), "chunked plot drew the (0, 0) corner band, not the intersected slice"
+
     def test_chunks_none_preserves_eager_behaviour(self):
         """``chunks=None`` (default) preserves the current eager path.
 


### PR DESCRIPTION
# Description

A lazy NetCDF read (`read_array(chunks=…)`) normalized the **trailing two** array axes as the raster
plane (via `_mdim.axis_flips`), while the eager `get_variable(...).read_array()` path resolves the
plane through `_resolve_spatial_dims` — explicit `x_dim`/`y_dim`, else CF detection, else the trailing
two dims. For a variable whose resolved plane is **non-trailing**, the two disagreed silently.

Concretely, for CAM-style `T(time, lat, lev, lon)` selected with `x_dim="lon", y_dim="lat"`:

- **eager** resolves the `(lat, lon)` plane, moves it to the trailing raster position, flips `lat`
  north-up → shape `(6, 64, 128)`;
- **lazy** ignored the selection entirely: it flipped `lev` (the trailing axis) instead of `lat` and
  returned the `(lev, lon)` cross-section as the raster plane → shape `(1, 64, 6, 128)`.

So the lazy read was wrong on the flipped axis, the plane, **and** the shape — a silent data error, not
just a mirror. It surfaces only through an explicit `x_dim`/`y_dim` (no committed fixture carries CF
axis attributes on non-trailing dims, so CF auto-detection never selects a non-trailing plane on its
own). The internal `_read_variable` is unaffected — every one of its callers reads a coordinate/time
variable whose plane is already trailing.

The fix threads the eager-resolved `(x_index, y_index)` plane and its flips (already computed and
stored on the `get_variable` subset, with the *same* `_mdim` deciders the eager path uses) into
`build_lazy_array`. The new `_orient_lazy_plane` helper moves the resolved plane to the trailing two
axes with `dask.array.moveaxis`, then flips that plane. `_preserve_netcdf_metadata` now carries the
resolved plane onto `sel`/spatial-op results so a `sel`-derived subset keeps it too.

**Why the common case is byte-identical:** for a variable whose plane is already trailing (every
ordinary `(time, lev, lat, lon)` file), `(y_index, x_index) == (n-2, n-1)`, so the `moveaxis` is a
no-op and the flip decision is the exact one `axis_flips` produced before. The lazy array still keeps
each non-spatial dimension as a separate leading axis (the eager path flattens them into one band
axis and squeezes a singleton), so a 4-D lazy read equals the eager read after `reshape(-1, rows, cols)`
— a pre-existing packaging difference, unchanged here.

No new dependencies (`dask.array.moveaxis` is already available on the lazy path).

# Issues

- Closes #728 — lazy `read_array(chunks=)` normalized the trailing two axes; a non-trailing resolved
  plane was silently mirrored/reoriented vs the eager `get_variable` read.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Non-breaking: `spatial_dims`/`flips` are opt-in keyword args on `build_lazy_array` (default `None` →
the historical trailing-two-axes behaviour), the raster (GeoTIFF) lazy path passes neither, and a
trailing-plane read is byte-identical to before.

# How Has This Been Tested?

New regression tests in `tests/netcdf/lazy/test_chunked_read.py::TestLazyOrientationMatchesEager`,
each mutation-checked against the pre-fix source:

- `test_explicit_nontrailing_plane_lazy_matches_eager` — `T` via `x_dim="lon", y_dim="lat"`: asserts
  the lazy trailing plane is `(lat=64, lon=128)` (pre-fix it leaked `(lev=6, lon=128)` — the test fails
  on `main`), matches the eager read after `reshape(-1, rows, cols)`, and matches an **independent**
  north-up reference built straight from the storage-order MDArray (so a shared mirror cannot make both
  sides agree).
- `test_default_resolution_lazy_matches_eager` — the default (no `x_dim`/`y_dim`) read of the same
  variable falls back to the trailing plane and stays byte-identical to eager (the no-regression guard
  for the common case).
- `test_sel_derived_subset_retains_resolved_plane_for_lazy_read` — a `sel()` on the explicit-plane
  subset keeps `_md_spatial_dims`/`_md_y_flipped`, so its lazy read stays on the `(lat, lon)` plane
  (verified against `main`, which dropped the plane to `None`).

Suites run (dev env, worktree source):

- [x] `TestLazyOrientationMatchesEager`: 10 passed (3 new).
- [x] Full netcdf lazy + eager plane-selection: 139 passed.
- [x] Full netcdf (non-plot) + raster lazy path: 2270 passed, 38 skipped.
- [x] netcdf plot suite (the `_preserve_netcdf_metadata` consumer): 168 passed.
- [x] Mutation check: the new `test_explicit_nontrailing_plane_lazy_matches_eager` fails on `main`
      (plane `(6, 128)`), passes on this branch (plane `(64, 128)`).

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.

Versions and the change log are generated by commitizen in CI, so those three boxes are intentionally
left for the release automation. The `read_array` "Axis plane and shape" note and the `_mdim.axis_flips`
docstring were updated to describe the resolved-plane orientation.
