### PR TITLE
feat(wcs): surface the HTTP response body in WCSError on GetCoverage errors

### DIFF
--- a/src/pyramids/base/_errors.py
+++ b/src/pyramids/base/_errors.py
@@ -190,6 +190,16 @@ class WCSError(_PyramidsError):
         self.status_code = status_code
         self.response_body = response_body
 
+    def __reduce__(self):
+        # Round-trip the extras through pickle / copy: BaseException.__reduce__
+        # rebuilds from self.args (message only), which would reset the keyword-only
+        # status_code / response_body to None when the error crosses a process
+        # boundary (e.g. a multiprocessing worker). The state dict is applied to
+        # __dict__ after reconstruction, restoring both.
+        message = self.args[0] if self.args else ""
+        state = {"status_code": self.status_code, "response_body": self.response_body}
+        return (self.__class__, (message,), state)
+
 
 class WFSError(_PyramidsError):
     """A failure talking to an OGC Web Feature Service (WFS).

--- a/src/pyramids/base/_errors.py
+++ b/src/pyramids/base/_errors.py
@@ -173,10 +173,11 @@ class WCSError(_PyramidsError):
     reports a bad argument as opposed to a service failure.
 
     On a genuine HTTP-error status (a ``GetCapabilities`` / ``GetCoverage`` that
-    returns 4xx/5xx), `status_code` and `response_body` carry the server's status
-    and raw body so a caller can branch on them programmatically; both are `None`
-    for failures that have no HTTP response (transport errors, XML
-    ``ExceptionReport`` bodies returned as HTTP 200, driver-level failures).
+    returns 4xx/5xx), ``status_code`` and ``response_body`` carry the server's
+    status and decoded response body so a caller can branch on them
+    programmatically; both are ``None`` for failures that have no HTTP response
+    (transport errors, XML ``ExceptionReport`` bodies returned as HTTP 200,
+    driver-level failures).
     """
 
     def __init__(

--- a/src/pyramids/base/_errors.py
+++ b/src/pyramids/base/_errors.py
@@ -191,16 +191,6 @@ class WCSError(_PyramidsError):
         self.status_code = status_code
         self.response_body = response_body
 
-    def __reduce__(self):
-        # Round-trip the extras through pickle / copy: BaseException.__reduce__
-        # rebuilds from self.args (message only), which would reset the keyword-only
-        # status_code / response_body to None when the error crosses a process
-        # boundary (e.g. a multiprocessing worker). The state dict is applied to
-        # __dict__ after reconstruction, restoring both.
-        message = self.args[0] if self.args else ""
-        state = {"status_code": self.status_code, "response_body": self.response_body}
-        return (self.__class__, (message,), state)
-
 
 class WFSError(_PyramidsError):
     """A failure talking to an OGC Web Feature Service (WFS).

--- a/src/pyramids/base/_errors.py
+++ b/src/pyramids/base/_errors.py
@@ -171,7 +171,24 @@ class WCSError(_PyramidsError):
     A *missing* coverage (one not advertised by ``GetCapabilities``) raises a
     plain :class:`ValueError` instead, mirroring how the rest of pyramids
     reports a bad argument as opposed to a service failure.
+
+    On a genuine HTTP-error status (a ``GetCapabilities`` / ``GetCoverage`` that
+    returns 4xx/5xx), `status_code` and `response_body` carry the server's status
+    and raw body so a caller can branch on them programmatically; both are `None`
+    for failures that have no HTTP response (transport errors, XML
+    ``ExceptionReport`` bodies returned as HTTP 200, driver-level failures).
     """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        response_body: str | None = None,
+    ):
+        super().__init__(message)
+        self.status_code = status_code
+        self.response_body = response_body
 
 
 class WFSError(_PyramidsError):

--- a/src/pyramids/base/_errors.py
+++ b/src/pyramids/base/_errors.py
@@ -173,11 +173,11 @@ class WCSError(_PyramidsError):
     reports a bad argument as opposed to a service failure.
 
     On a genuine HTTP-error status (a ``GetCapabilities`` / ``GetCoverage`` that
-    returns 4xx/5xx), ``status_code`` and ``response_body`` carry the server's
-    status and decoded response body so a caller can branch on them
-    programmatically; both are ``None`` for failures that have no HTTP response
-    (transport errors, XML ``ExceptionReport`` bodies returned as HTTP 200,
-    driver-level failures).
+    returns 4xx/5xx), ``status_code`` carries the status and ``response_body`` the
+    server's decoded body (the empty string when the error had no body) so a caller
+    can branch on them programmatically. Both are ``None`` for failures that have no
+    HTTP response (transport errors, XML ``ExceptionReport`` bodies returned as HTTP
+    200, driver-level failures).
     """
 
     def __init__(

--- a/src/pyramids/base/_ogc_api.py
+++ b/src/pyramids/base/_ogc_api.py
@@ -154,15 +154,18 @@ def error_text(doc: Any) -> str:
     return message
 
 
-def read_http_error(exc: urllib.error.HTTPError) -> tuple[int | None, str]:
-    """Read an ``HTTPError``'s status code and body text (best-effort, guarded).
+def read_http_error(exc: urllib.error.HTTPError) -> tuple[int | None, bytes, str]:
+    """Read an ``HTTPError``'s status code and body (best-effort, guarded).
 
     A 4xx/5xx response body often carries the server's real explanation, and the
     ``HTTPError`` is a file-like object whose body can be read only **once**.
-    Returns ``(status_code, body)`` where ``body`` is the decoded, stripped
-    response body — or the HTTP reason phrase (then :data:`NO_MESSAGE`) when the
-    body is empty or cannot be read. Shared by :func:`http_error_detail` and the
-    WCS reader so the single read is not duplicated.
+    Returns ``(status_code, raw, text)``: ``raw`` is the undecoded body bytes
+    (empty when the body is missing or unreadable), kept so a caller can parse it
+    at the byte level -- ``json.loads`` auto-detects the JSON encoding from the
+    bytes; ``text`` is the same body decoded as UTF-8 and stripped, falling back
+    to the HTTP reason phrase and then to :data:`NO_MESSAGE`. Shared by
+    :func:`http_error_detail` and the WCS reader so the single read is not
+    duplicated.
     """
     code = getattr(exc, "code", None)
     reason = getattr(exc, "reason", None) or NO_MESSAGE
@@ -171,18 +174,20 @@ def read_http_error(exc: urllib.error.HTTPError) -> tuple[int | None, str]:
     except OSError:
         raw = b""
     text = raw.decode("utf-8", "replace").strip() if raw else ""
-    return code, (text or reason)
+    return code, raw, (text or reason)
 
 
 def http_error_detail(exc: urllib.error.HTTPError) -> str:
     """Best-effort human message from an ``HTTPError`` body (RFC 7807 problem+json).
 
     Reads the error response body and runs a JSON one through :func:`error_text`;
-    falls back to a truncated plain-text body or the HTTP reason phrase.
+    falls back to a truncated plain-text body or the HTTP reason phrase. The JSON
+    parse is done on the raw bytes so ``json.loads`` keeps its byte-level encoding
+    auto-detection (a UTF-16/32 JSON error document is still parsed).
     """
-    _code, body = read_http_error(exc)
+    _code, raw, text = read_http_error(exc)
     try:
-        detail = error_text(json.loads(body))
+        detail = error_text(json.loads(raw))
     except (ValueError, TypeError):
-        detail = body[:200] or NO_MESSAGE
+        detail = text[:200] or NO_MESSAGE
     return detail

--- a/src/pyramids/base/_ogc_api.py
+++ b/src/pyramids/base/_ogc_api.py
@@ -154,21 +154,35 @@ def error_text(doc: Any) -> str:
     return message
 
 
+def read_http_error(exc: urllib.error.HTTPError) -> tuple[int | None, str]:
+    """Read an ``HTTPError``'s status code and body text (best-effort, guarded).
+
+    A 4xx/5xx response body often carries the server's real explanation, and the
+    ``HTTPError`` is a file-like object whose body can be read only **once**.
+    Returns ``(status_code, body)`` where ``body`` is the decoded, stripped
+    response body — or the HTTP reason phrase (then :data:`NO_MESSAGE`) when the
+    body is empty or cannot be read. Shared by :func:`http_error_detail` and the
+    WCS reader so the single read is not duplicated.
+    """
+    code = getattr(exc, "code", None)
+    reason = getattr(exc, "reason", None) or NO_MESSAGE
+    try:
+        raw = exc.read()
+    except OSError:
+        raw = b""
+    text = raw.decode("utf-8", "replace").strip() if raw else ""
+    return code, (text or reason)
+
+
 def http_error_detail(exc: urllib.error.HTTPError) -> str:
     """Best-effort human message from an ``HTTPError`` body (RFC 7807 problem+json).
 
     Reads the error response body and runs a JSON one through :func:`error_text`;
     falls back to a truncated plain-text body or the HTTP reason phrase.
     """
-    detail = exc.reason or NO_MESSAGE
+    _code, body = read_http_error(exc)
     try:
-        body = exc.read()
-    except OSError:
-        body = None
-    if body is not None:
-        try:
-            detail = error_text(json.loads(body))
-        except (ValueError, TypeError):
-            text = body.decode("utf-8", "replace").strip()
-            detail = text[:200] or exc.reason or NO_MESSAGE
+        detail = error_text(json.loads(body))
+    except (ValueError, TypeError):
+        detail = body[:200] or NO_MESSAGE
     return detail

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -197,7 +197,12 @@ def _http_get(
         # message and carry the status + full body on the exception so a caller
         # can branch on them. str(HTTPError) alone is only "HTTP <code>: <reason>".
         code, _raw, body = _read_http_error(exc)
-        shown = body if len(body) <= _ERROR_BODY_CHARS else f"{body[:_ERROR_BODY_CHARS]}…"
+        # Collapse whitespace so a multi-line HTML / pretty JSON error page stays a
+        # single line in the message, and cap its length; the full, untouched body
+        # is still carried on response_body below.
+        shown = " ".join(body.split())
+        if len(shown) > _ERROR_BODY_CHARS:
+            shown = f"{shown[:_ERROR_BODY_CHARS]}…"
         raise WCSError(
             f"WCS {what} request failed for {url!r}: HTTP {code}: {shown}",
             status_code=code,

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -194,7 +194,7 @@ def _http_get(
         # (non-spec shims return e.g. a JSON {"message": ...}); surface it in the
         # message and carry the status + full body on the exception so a caller
         # can branch on them. str(HTTPError) alone is only "HTTP <code>: <reason>".
-        code, body = _read_http_error(exc)
+        code, _raw, body = _read_http_error(exc)
         shown = body if len(body) <= _ERROR_BODY_CHARS else f"{body[:_ERROR_BODY_CHARS]}…"
         raise WCSError(
             f"WCS {what} request failed for {url!r}: HTTP {code}: {shown}",

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -179,7 +179,9 @@ def _http_get(
 
     Shared by the ``GetCapabilities`` (discovery) and direct ``GetCoverage``
     paths. Raises :class:`WCSError` on any transport-level failure so both call
-    sites keep a uniform error contract.
+    sites keep a uniform error contract. On a genuine HTTP-error status (4xx/5xx)
+    the raised :class:`WCSError` also carries the ``status_code`` and the decoded
+    ``response_body`` so a caller can inspect the server's explanation.
     """
     opener = urllib.request.build_opener()
     if auth is not None:

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -196,17 +196,21 @@ def _http_get(
         # (non-spec shims return e.g. a JSON {"message": ...}); surface it in the
         # message and carry the status + full body on the exception so a caller
         # can branch on them. str(HTTPError) alone is only "HTTP <code>: <reason>".
-        code, _raw, body = _read_http_error(exc)
+        code, raw, text = _read_http_error(exc)
+        # `text` is the decoded body, or the HTTP reason phrase when the body is
+        # empty — right for the human message. `response_body` should instead be the
+        # server's actual body (the empty string when there was none), so decode the
+        # raw bytes faithfully rather than reusing the reason-phrase fallback.
+        response_body = raw.decode("utf-8", "replace") if raw else ""
         # Collapse whitespace so a multi-line HTML / pretty JSON error page stays a
-        # single line in the message, and cap its length; the full, untouched body
-        # is still carried on response_body below.
-        shown = " ".join(body.split())
+        # single line in the (capped) message; response_body keeps the faithful body.
+        shown = " ".join(text.split())
         if len(shown) > _ERROR_BODY_CHARS:
             shown = f"{shown[:_ERROR_BODY_CHARS]}…"
         raise WCSError(
             f"WCS {what} request failed for {url!r}: HTTP {code}: {shown}",
             status_code=code,
-            response_body=body,
+            response_body=response_body,
         ) from exc
     except OSError as exc:
         # urllib.error.URLError / timeout / connection reset — no HTTP response body.

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -36,6 +36,7 @@ passes ``coverage_crs`` / ``auth`` as needed.
 from __future__ import annotations
 
 import re
+import urllib.error
 import urllib.parse
 import urllib.request
 import uuid
@@ -54,6 +55,12 @@ from pyramids.base._coverage import resolve_native_srs as _resolve_native_srs_ne
 from pyramids.base._coverage import validate_bbox as _validate_bbox
 from pyramids.base._errors import CoverageError, WCSError
 from pyramids.base._ogc_api import gdal_http_config as _gdal_http_config
+from pyramids.base._ogc_api import read_http_error as _read_http_error
+
+# Cap on how much of an HTTP-error body is inlined into a WCSError message; the
+# full body is still carried on WCSError.response_body. Keeps a multi-KB HTML
+# error page from bloating the exception text.
+_ERROR_BODY_CHARS = 500
 
 # Request KVP keys pyramids sets itself in direct GetCoverage.
 _RESERVED_KVP_KEYS = frozenset(
@@ -182,8 +189,20 @@ def _http_get(
     try:
         with opener.open(url, timeout=timeout) as resp:
             return cast(bytes, resp.read())
+    except urllib.error.HTTPError as exc:
+        # A 4xx/5xx status carries a body with the server's real explanation
+        # (non-spec shims return e.g. a JSON {"message": ...}); surface it in the
+        # message and carry the status + full body on the exception so a caller
+        # can branch on them. str(HTTPError) alone is only "HTTP <code>: <reason>".
+        code, body = _read_http_error(exc)
+        shown = body if len(body) <= _ERROR_BODY_CHARS else f"{body[:_ERROR_BODY_CHARS]}…"
+        raise WCSError(
+            f"WCS {what} request failed for {url!r}: HTTP {code}: {shown}",
+            status_code=code,
+            response_body=body,
+        ) from exc
     except OSError as exc:
-        # urllib.error.URLError / HTTPError both derive from OSError.
+        # urllib.error.URLError / timeout / connection reset — no HTTP response body.
         raise WCSError(f"WCS {what} request failed for {url!r}: {exc}") from exc
 
 

--- a/tests/dataset/remote/test_wcs.py
+++ b/tests/dataset/remote/test_wcs.py
@@ -281,6 +281,22 @@ class TestHttpGet:
         assert len(str(err)) < 1000  # message is bounded
         assert len(err.response_body) == 5000  # full body preserved on the attribute
 
+    def test_http_error_empty_body_reason_in_message_and_empty_response_body(self, monkeypatch):
+        """An empty-body HTTP error shows the reason phrase in the message; response_body is ''."""
+
+        def boom(self, *args, **kwargs):
+            raise urllib.error.HTTPError(
+                "https://wcs.invalid/x", 403, "Forbidden", {}, io.BytesIO(b"")
+            )
+
+        monkeypatch.setattr(_wcs.urllib.request.OpenerDirector, "open", boom)
+        with pytest.raises(WCSError) as excinfo:
+            _wcs._http_get("https://wcs.invalid/x", None, 5.0, "GetCoverage")
+        err = excinfo.value
+        assert err.status_code == 403
+        assert err.response_body == ""
+        assert "Forbidden" in str(err)
+
     def test_non_http_transport_error_leaves_attributes_none(self, monkeypatch):
         """A non-HTTP transport failure keeps its message and leaves status_code/body None."""
 

--- a/tests/dataset/remote/test_wcs.py
+++ b/tests/dataset/remote/test_wcs.py
@@ -17,7 +17,9 @@ is set, so normal CI stays offline.
 from __future__ import annotations
 
 
+import copy
 import io
+import pickle
 import urllib.error
 
 import pytest
@@ -266,6 +268,17 @@ class TestCapabilities:
         assert "request failed" in str(err)
         assert err.status_code is None
         assert err.response_body is None
+
+    def test_wcserror_survives_pickle_and_copy(self):
+        """status_code / response_body round-trip through pickle and copy (cross-process safe)."""
+        err = WCSError("boom", status_code=422, response_body='{"code": "X"}')
+        restored = pickle.loads(pickle.dumps(err))
+        assert str(restored) == "boom"
+        assert restored.status_code == 422
+        assert restored.response_body == '{"code": "X"}'
+        cloned = copy.copy(err)
+        assert cloned.status_code == 422
+        assert cloned.response_body == '{"code": "X"}'
 
     def test_exception_text_falls_back_without_exception_element(self):
         """_exception_text returns body text, or a default when nothing is present."""

--- a/tests/dataset/remote/test_wcs.py
+++ b/tests/dataset/remote/test_wcs.py
@@ -217,6 +217,23 @@ class TestCapabilities:
         with pytest.raises(WCSError, match="request failed"):
             _wcs._get_capabilities("https://wcs.invalid/x", None, None, 5.0)
 
+    def test_get_capabilities_http_error_propagates_status_and_body(self, monkeypatch):
+        """A 4xx GetCapabilities carries status_code/response_body through the real call site."""
+        body = b'{"message": "forbidden zone", "code": "NOPE"}'
+
+        def boom(self, *args, **kwargs):
+            raise urllib.error.HTTPError(
+                "https://wcs.invalid/caps-403", 403, "Forbidden", {}, io.BytesIO(body)
+            )
+
+        monkeypatch.setattr(_wcs.urllib.request.OpenerDirector, "open", boom)
+        with pytest.raises(WCSError) as excinfo:
+            _wcs._get_capabilities("https://wcs.invalid/caps-403", None, None, 5.0)
+        err = excinfo.value
+        assert err.status_code == 403
+        assert "forbidden zone" in err.response_body
+        assert "forbidden zone" in str(err)
+
     def test_http_error_surfaces_body_and_attributes(self, monkeypatch):
         """A 4xx GetCoverage surfaces the server body text and carries status + body on WCSError."""
         body = (

--- a/tests/dataset/remote/test_wcs.py
+++ b/tests/dataset/remote/test_wcs.py
@@ -234,6 +234,15 @@ class TestCapabilities:
         assert "forbidden zone" in err.response_body
         assert "forbidden zone" in str(err)
 
+    def test_exception_text_falls_back_without_exception_element(self):
+        """_exception_text returns body text, or a default when nothing is present."""
+        body = _wcs.ET.fromstring("<ExceptionReport>broken upstream</ExceptionReport>")
+        assert _wcs._exception_text(body) == "broken upstream"
+        empty = _wcs.ET.fromstring("<ExceptionReport></ExceptionReport>")
+        assert _wcs._exception_text(empty) == "no message provided"
+
+
+class TestHttpGet:
     def test_http_error_surfaces_body_and_attributes(self, monkeypatch):
         """A 4xx GetCoverage surfaces the server body text and carries status + body on WCSError."""
         body = (
@@ -296,13 +305,6 @@ class TestCapabilities:
         cloned = copy.copy(err)
         assert cloned.status_code == 422
         assert cloned.response_body == '{"code": "X"}'
-
-    def test_exception_text_falls_back_without_exception_element(self):
-        """_exception_text returns body text, or a default when nothing is present."""
-        body = _wcs.ET.fromstring("<ExceptionReport>broken upstream</ExceptionReport>")
-        assert _wcs._exception_text(body) == "broken upstream"
-        empty = _wcs.ET.fromstring("<ExceptionReport></ExceptionReport>")
-        assert _wcs._exception_text(empty) == "no message provided"
 
 
 class TestOpenService:

--- a/tests/dataset/remote/test_wcs.py
+++ b/tests/dataset/remote/test_wcs.py
@@ -17,6 +17,9 @@ is set, so normal CI stays offline.
 from __future__ import annotations
 
 
+import io
+import urllib.error
+
 import pytest
 from osgeo import gdal, osr
 
@@ -211,6 +214,58 @@ class TestCapabilities:
         monkeypatch.setattr(_wcs.urllib.request.OpenerDirector, "open", boom)
         with pytest.raises(WCSError, match="request failed"):
             _wcs._get_capabilities("https://wcs.invalid/x", None, None, 5.0)
+
+    def test_http_error_surfaces_body_and_attributes(self, monkeypatch):
+        """A 4xx GetCoverage surfaces the server body text and carries status + body on WCSError."""
+        body = (
+            b'{"message": "Requested date 2035-06-11 is outside the available '
+            b'coverage range for SPI ERA5 Short Term.", "code": "DATE_OUT_OF_RANGE"}'
+        )
+
+        def boom(self, *args, **kwargs):
+            raise urllib.error.HTTPError(
+                "https://wcs.invalid/x", 422, "Unprocessable Entity", {}, io.BytesIO(body)
+            )
+
+        monkeypatch.setattr(_wcs.urllib.request.OpenerDirector, "open", boom)
+        with pytest.raises(WCSError) as excinfo:
+            _wcs._http_get("https://wcs.invalid/x", None, 5.0, "GetCoverage")
+        err = excinfo.value
+        assert "outside the available coverage range" in str(err)
+        assert "HTTP 422" in str(err)
+        assert err.status_code == 422
+        assert "DATE_OUT_OF_RANGE" in err.response_body
+
+    def test_http_error_body_truncated_in_message_but_full_on_attribute(self, monkeypatch):
+        """A large error body is truncated in the message yet kept whole on response_body."""
+        body = b"x" * 5000
+
+        def boom(self, *args, **kwargs):
+            raise urllib.error.HTTPError(
+                "https://wcs.invalid/x", 500, "Server Error", {}, io.BytesIO(body)
+            )
+
+        monkeypatch.setattr(_wcs.urllib.request.OpenerDirector, "open", boom)
+        with pytest.raises(WCSError) as excinfo:
+            _wcs._http_get("https://wcs.invalid/x", None, 5.0, "GetCapabilities")
+        err = excinfo.value
+        assert "…" in str(err)  # truncation marker present
+        assert len(str(err)) < 1000  # message is bounded
+        assert len(err.response_body) == 5000  # full body preserved on the attribute
+
+    def test_non_http_transport_error_leaves_attributes_none(self, monkeypatch):
+        """A non-HTTP transport failure keeps its message and leaves status_code/body None."""
+
+        def boom(self, *args, **kwargs):
+            raise urllib.error.URLError("connection reset")
+
+        monkeypatch.setattr(_wcs.urllib.request.OpenerDirector, "open", boom)
+        with pytest.raises(WCSError) as excinfo:
+            _wcs._http_get("https://wcs.invalid/x", None, 5.0, "GetCoverage")
+        err = excinfo.value
+        assert "request failed" in str(err)
+        assert err.status_code is None
+        assert err.response_body is None
 
     def test_exception_text_falls_back_without_exception_element(self):
         """_exception_text returns body text, or a default when nothing is present."""

--- a/tests/feature/test_oapif.py
+++ b/tests/feature/test_oapif.py
@@ -149,6 +149,36 @@ class TestPureHelpers:
 
         assert _ogc_api.http_error_detail(_Plain()) == "upstream exploded"
 
+    def test_read_http_error_returns_code_and_body(self):
+        """read_http_error returns the status code and the decoded, stripped body."""
+        class _Err:
+            code = 422
+            reason = "Unprocessable Entity"
+
+            def read(self):
+                return b'  {"message": "nope"}  '
+
+        assert _ogc_api.read_http_error(_Err()) == (422, '{"message": "nope"}')
+
+    def test_read_http_error_falls_back_to_reason(self):
+        """An empty or unreadable body falls back to the reason phrase."""
+        class _Empty:
+            code = 500
+            reason = "Server Error"
+
+            def read(self):
+                return b""
+
+        class _Unreadable:
+            code = 503
+            reason = "Service Unavailable"
+
+            def read(self):
+                raise OSError("connection gone")
+
+        assert _ogc_api.read_http_error(_Empty()) == (500, "Server Error")
+        assert _ogc_api.read_http_error(_Unreadable()) == (503, "Service Unavailable")
+
 
 class TestCollections:
     def test_parses_collection_ids(self, collections_server):

--- a/tests/feature/test_oapif.py
+++ b/tests/feature/test_oapif.py
@@ -149,8 +149,8 @@ class TestPureHelpers:
 
         assert _ogc_api.http_error_detail(_Plain()) == "upstream exploded"
 
-    def test_read_http_error_returns_code_and_body(self):
-        """read_http_error returns the status code and the decoded, stripped body."""
+    def test_read_http_error_returns_code_raw_and_text(self):
+        """read_http_error returns the status code, the raw bytes, and the decoded stripped text."""
         class _Err:
             code = 422
             reason = "Unprocessable Entity"
@@ -158,10 +158,12 @@ class TestPureHelpers:
             def read(self):
                 return b'  {"message": "nope"}  '
 
-        assert _ogc_api.read_http_error(_Err()) == (422, '{"message": "nope"}')
+        assert _ogc_api.read_http_error(_Err()) == (
+            422, b'  {"message": "nope"}  ', '{"message": "nope"}'
+        )
 
     def test_read_http_error_falls_back_to_reason(self):
-        """An empty or unreadable body falls back to the reason phrase."""
+        """An empty or unreadable body yields empty raw bytes and the reason phrase as text."""
         class _Empty:
             code = 500
             reason = "Server Error"
@@ -176,8 +178,8 @@ class TestPureHelpers:
             def read(self):
                 raise OSError("connection gone")
 
-        assert _ogc_api.read_http_error(_Empty()) == (500, "Server Error")
-        assert _ogc_api.read_http_error(_Unreadable()) == (503, "Service Unavailable")
+        assert _ogc_api.read_http_error(_Empty()) == (500, b"", "Server Error")
+        assert _ogc_api.read_http_error(_Unreadable()) == (503, b"", "Service Unavailable")
 
 
 class TestCollections:

--- a/tests/feature/test_oapif.py
+++ b/tests/feature/test_oapif.py
@@ -149,6 +149,17 @@ class TestPureHelpers:
 
         assert _ogc_api.http_error_detail(_Plain()) == "upstream exploded"
 
+    def test_http_error_detail_json_body_extracts_description(self):
+        """A JSON (RFC 7807) HTTPError body is parsed and its description surfaced."""
+        class _Json:
+            code = 400
+            reason = "Bad Request"
+
+            def read(self):
+                return b'{"description": "coverage gone", "code": "X"}'
+
+        assert _ogc_api.http_error_detail(_Json()) == "coverage gone"
+
     def test_read_http_error_returns_code_raw_and_text(self):
         """read_http_error returns the status code, the raw bytes, and the decoded stripped text."""
         class _Err:

--- a/tests/feature/test_oapif.py
+++ b/tests/feature/test_oapif.py
@@ -160,6 +160,19 @@ class TestPureHelpers:
 
         assert _ogc_api.http_error_detail(_Json()) == "coverage gone"
 
+    def test_http_error_detail_parses_non_utf8_json_body(self):
+        """A UTF-16-encoded JSON body still parses (byte-level json.loads) — the raw-bytes rationale."""
+        payload = json.dumps({"description": "utf16 boom"}).encode("utf-16")
+
+        class _Json16:
+            code = 400
+            reason = "Bad Request"
+
+            def read(self):
+                return payload
+
+        assert _ogc_api.http_error_detail(_Json16()) == "utf16 boom"
+
     def test_read_http_error_returns_code_raw_and_text(self):
         """read_http_error returns the status code, the raw bytes, and the decoded stripped text."""
         class _Err:


### PR DESCRIPTION
# Description

Direct-mode `Dataset.from_wcs(..., direct=True)` drives non-spec WCS shims (e.g. Copernicus EDO/GDO, which
earthlens uses for drought indicators) that explain *why* a request failed in the HTTP-error response body — most
usefully that a requested date is outside a coverage's available range. `_http_get` caught a bare `OSError` and
interpolated `str(HTTPError)`, which is only `"HTTP <code>: <reason>"`, so the server's body was discarded and the
caller saw a bare `HTTP Error 422: Unprocessable Entity`.

This change surfaces the body and carries it on the exception:

- **`base/_ogc_api.py`** — new shared `read_http_error(exc) -> (status_code, body)` primitive: a guarded single
  `.read()` (an `HTTPError` body can be read only once), decoded + stripped, with the HTTP reason phrase as
  fallback. The existing `http_error_detail` is refactored onto it so the body-read logic is not duplicated.
- **`base/_errors.py`** — `WCSError` now accepts keyword-only `status_code` / `response_body` (default `None`) so a
  caller can branch on them programmatically. They are `None` for failures with no HTTP response (transport errors,
  XML `ExceptionReport` returned as HTTP 200, driver-level failures).
- **`dataset/_wcs.py::_http_get`** — special-cases `urllib.error.HTTPError` before the generic `OSError`: inlines
  the body into the `WCSError` message (capped at 500 chars to keep a multi-KB HTML error page from bloating the
  text) and carries the status + **full** body on the exception. Because `_http_get` is shared, the fix improves
  both `GetCapabilities` and direct `GetCoverage`.

Design note: the WCS path surfaces the **raw** body rather than running it through `error_text`. A shim body such
as Copernicus' `{"message": "...outside the available coverage range...", "code": "DATE_OUT_OF_RANGE"}` puts the
human sentence under a `message` key, which `error_text` (description/detail/title/code) does not read — so
extraction would surface only `DATE_OUT_OF_RANGE` and lose exactly the text this issue is about. `http_error_detail`
keeps its RFC-7807 extraction for the OGC-API readers, where that key set is correct.

No new dependency.

# Issues

- Closes #744

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

The `WCSError` change is additive (two optional keyword-only attributes defaulting to `None`); every existing
`WCSError("message")` call site keeps working.

# How Has This Been Tested?

Network-free unit tests (both `_http_get` call sites exercised; the `HTTPError` is constructed with an in-memory
body, no sockets):

- [x] `tests/dataset/remote/test_wcs.py::TestCapabilities::test_http_error_surfaces_body_and_attributes` — a 422
      `GetCoverage` surfaces the server body text and sets `status_code == 422` / `response_body` contains the
      body.
- [x] `test_http_error_body_truncated_in_message_but_full_on_attribute` — a 5000-char body is truncated (with `…`)
      in the message but preserved whole on `response_body`.
- [x] `test_non_http_transport_error_leaves_attributes_none` — a `URLError` keeps its existing message and leaves
      both attributes `None`.
- [x] `tests/feature/test_oapif.py` — new `read_http_error` tests (code+body, reason fallback on empty/unreadable);
      the existing `http_error_detail` tests still pass after the refactor.
- [x] Regression: `tests/feature/test_oapif.py` + `test_wfs.py` + `tests/dataset/remote/test_wcs.py` +
      `test_ogc_coverages.py` → **185 passed**, no regressions.

Reproduce:

```bash
pixi run -e dev pytest tests/feature/test_oapif.py tests/dataset/remote/test_wcs.py -m "not live"
```

# Checklist:

- [ ] updated version number in pyproject.toml. — N/A: commitizen/CI handles versioning.
- [ ] added changes to History.rst. — N/A: commitizen-generated.
- [ ] updated the latest version in README file. — N/A: release workflow.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. — docstrings on `read_http_error`, `WCSError` (the two new attributes), and the
      `_http_get` error branch.
