### PR TITLE
ci(vcpkg): fetch libaec from GitHub via an overlay port to dodge DKRZ 429s

### DIFF
--- a/ci/setup-gdal-from-vcpkg.ps1
+++ b/ci/setup-gdal-from-vcpkg.ps1
@@ -27,6 +27,10 @@ if ($VcpkgRoot -ne "C:\vcpkg") {
 }
 $InstallRoot = Join-Path $VcpkgRoot "installed"
 $ManifestRoot = $PSScriptRoot   # this script lives in ci/, next to vcpkg.json
+# Overlay ports override the builtin registry's copy of a port. libaec/ here
+# fetches its source from GitHub instead of the upstream port's gitlab.dkrz.de,
+# which persistently 429s CI runners (see ci/vcpkg-ports/libaec/portfile.cmake).
+$OverlayPorts = Join-Path $ManifestRoot "vcpkg-ports"
 
 Write-Host "=== vcpkg GDAL stack: triplet=$Triplet -> $BuildPrefix ==="
 
@@ -65,6 +69,7 @@ if ($LASTEXITCODE -ne 0) { throw "bootstrap-vcpkg failed ($LASTEXITCODE)" }
     --triplet $Triplet `
     --x-manifest-root=$ManifestRoot `
     --x-install-root=$InstallRoot `
+    --overlay-ports=$OverlayPorts `
     --feature-flags=versions,manifests
 if ($LASTEXITCODE -ne 0) { throw "vcpkg install failed ($LASTEXITCODE)" }
 

--- a/ci/vcpkg-ports/libaec/portfile.cmake
+++ b/ci/vcpkg-ports/libaec/portfile.cmake
@@ -1,0 +1,55 @@
+# Overlay port for libaec — download source ONLY differs from the upstream
+# vcpkg port at baseline dfcb04008a. Upstream fetches the v1.1.6 archive from
+# gitlab.dkrz.de (vcpkg_from_gitlab), which persistently rate-limits CI runners
+# with HTTP 429 and blocked the win_arm64 release build (bundle-pypi-wheels
+# runs 29292442829 and its re-run — every other port downloads from GitHub and
+# succeeds; only this one, from DKRZ, fails). Fetch the byte-identical 1.1.6
+# release tarball from the maintainer's GitHub mirror instead — the same source
+# ci/source-build/config.sh already uses for the Linux wheels. All build steps
+# below are copied verbatim from the baseline port; only the acquisition above
+# changed. Delete this overlay once the upstream port moves off DKRZ (or a
+# vcpkg asset cache seeded with the DKRZ bytes becomes available).
+vcpkg_download_distfile(ARCHIVE
+    URLS "https://github.com/MathisRosenhauer/libaec/releases/download/v${VERSION}/libaec-${VERSION}.tar.gz"
+    FILENAME "libaec-${VERSION}.tar.gz"
+    SHA512 97f05f6c80c32a9378e7bf8698053c1ee57d852ba988df9f052f3ac66b2f698b7cf7a0ea490c3ee6a5f4b0decac75b5f4fa11ea7a80c477aae5ef28e0a8b9b08
+)
+vcpkg_extract_source_archive(SOURCE_PATH ARCHIVE "${ARCHIVE}")
+
+string(COMPARE EQUAL "${VCPKG_LIBRARY_LINKAGE}" "static" BUILD_STATIC)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DBUILD_STATIC_LIBS=${BUILD_STATIC}
+        -Dlibaec_INSTALL_CMAKEDIR=share/${PORT}
+)
+vcpkg_cmake_install()
+vcpkg_copy_pdbs()
+vcpkg_cmake_config_fixup()
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/libaec/libaec-config.cmake"
+    "if(libaec_USE_STATIC_LIBS)"
+    "if(\"${BUILD_STATIC}\") # forced by vcpkg"
+)
+
+# Compatibility with user's CMake < 3.18 (vcpkg claims support for >= 3.16):
+# Make imported targets global so that libaec-config.cmake can create ALIAS targets.
+set(_target_file "libaec_shared-targets")
+if(BUILD_STATIC)
+    set(_target_file "libaec_static-targets")
+endif()
+file(READ "${CURRENT_PACKAGES_DIR}/share/libaec/${_target_file}.cmake" libaec_targets)
+string(REGEX REPLACE " (SHARED|STATIC) IMPORTED" " \\1 IMPORTED \${libaec_maybe_global}"
+    libaec_targets "${libaec_targets}")
+file(WRITE "${CURRENT_PACKAGES_DIR}/share/libaec/${_target_file}.cmake" "set(libaec_maybe_global \"\")
+if(CMAKE_VERSION VERSION_LESS 3.18)
+    set(libaec_maybe_global \"GLOBAL\")
+endif()
+${libaec_targets}
+"
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+file(INSTALL "${CURRENT_PORT_DIR}/usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}")
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE.txt")

--- a/ci/vcpkg-ports/libaec/usage
+++ b/ci/vcpkg-ports/libaec/usage
@@ -1,0 +1,7 @@
+libaec provides CMake targets:
+
+  find_package(libaec CONFIG REQUIRED)
+  # libaec API
+  target_link_libraries(main PRIVATE libaec::aec)
+  # szip compatible API
+  target_link_libraries(main PRIVATE libaec::sz)

--- a/ci/vcpkg-ports/libaec/vcpkg.json
+++ b/ci/vcpkg-ports/libaec/vcpkg.json
@@ -1,0 +1,17 @@
+{
+  "name": "libaec",
+  "version": "1.1.6",
+  "description": "Adaptive Entropy Coding library",
+  "homepage": "https://gitlab.dkrz.de/k202009/libaec",
+  "license": "BSD-2-Clause",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ]
+}


### PR DESCRIPTION
# Description

The `win_arm64` wheels build their GDAL native stack from source with vcpkg. vcpkg's `libaec` port downloads the
v1.1.6 source archive from `gitlab.dkrz.de`, which persistently rate-limits CI runners with HTTP 429 â€” it blocked the
`build-winarm64-wheels` job on the release path twice (runs
[29292442829](https://github.com/serapeum-org/pyramids/actions/runs/29292442829) and its re-run), and 429s even from a
local machine, so it is not a transient a re-run can clear. In the same builds every other vcpkg port downloads from
GitHub and succeeds; `libaec` is the only port fetched from DKRZ.

This adds a vcpkg **overlay port** (`ci/vcpkg-ports/libaec`) that changes **only** the source acquisition: it fetches
the byte-identical 1.1.6 release tarball from the maintainer's GitHub mirror
(`github.com/MathisRosenhauer/libaec`) instead of DKRZ. That is the same source `ci/source-build/config.sh` already
uses for the Linux wheels (its trusted SHA256 matches this asset exactly), so it is a proven-reliable source, not a
guess. Every build step below the download is copied verbatim from the upstream port at the pinned
`builtin-baseline`; the overlay is wired in through `--overlay-ports` in `ci/setup-gdal-from-vcpkg.ps1`.

An asset cache cannot substitute here: seeding one needs a single successful download of the exact DKRZ bytes (vcpkg
keys distfiles by the upstream port's SHA512), which nothing â€” CI or local â€” can currently obtain while DKRZ is
blocking. The overlay should be removed once the upstream vcpkg port moves off DKRZ.

# Issues

- Closes #753 — win_arm64 release build fails when vcpkg fetches libaec from gitlab.dkrz.de (HTTP 429)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Dispatched a dry-run bundle build against this branch (run
  [29355843545](https://github.com/serapeum-org/pyramids/actions/runs/29355843545), `dry_run_release=true`): the full
  matrix built, every verify job passed, and the release composition gate passed â€” upload/publish skipped by the dry
  run.
- Confirmed the overlay took effect (not DKRZ recovering) from the `build-winarm64-wheels` log:
  `ci/vcpkg-ports/libaec: info: installing overlay port from here` followed by
  `Downloading https://github.com/MathisRosenhauer/libaec/releases/download/v1.1.6/libaec-1.1.6.tar.gz`.
- Verified locally that the GitHub release asset matches the SHA256 `ci/source-build/config.sh` already trusts, and
  pinned its SHA512 for vcpkg.

- [x] Full win_arm64 build + verify (cp312 hermetic core suite) green on the dry run
- [x] Overlay source confirmed as GitHub in the build log

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen-managed; not applicable)
- [ ] added changes to History.rst. (changelog is commitizen-generated; not applicable)
- [ ] updated the latest version in README file. (not applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works. (CI-infra change; validated by the
      dry-run bundle build, no unit-test surface)
- [x] New and existing unit tests pass locally with my changes. (win_arm64 core suite green on the dry run)
- [ ] documentation are updated. (no user-facing surface)

