### PR TITLE
ci(wheels): run every main push independently instead of serializing them

### DIFF
--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -26,10 +26,14 @@ on:
         default: false
         type: boolean
 
-# Cancel superseded runs to free the hosted-runner pool, but only for pull_request builds —
-# never cancel a push/workflow_run build, since those can publish wheels to PyPI.
+# Every push / workflow_run runs to completion independently: a merge to main must always
+# be fully built and verified, even if a later commit lands while its pipeline is still
+# running, so nothing ever reaches main unverified. Those events get a per-run group
+# (github.run_id is unique per run) so they never queue behind — or cancel — one another.
+# Only pull_request builds share a per-branch group with cancel-in-progress, so a new push
+# to a PR supersedes its older run and frees the hosted-runner pool.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:

--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -789,7 +789,10 @@ jobs:
       - name: Verify GDAL import + drivers (x86_64 under Rosetta)
         run: |
           set -euo pipefail
-          arch -x86_64 .venv-x86/bin/python -c "import platform;assert platform.machine()=='x86_64'"
+          # Confirm the venv really is x86_64 (not a stray arm64 interpreter)
+          # without `assert`, which `python -O` would strip.
+          M=$(arch -x86_64 .venv-x86/bin/python -c "import platform;print(platform.machine())")
+          [ "$M" = "x86_64" ] || { echo "::error::venv python is $M, expected x86_64"; exit 1; }
           arch -x86_64 .venv-x86/bin/python ci/verify-wheel.py
 
   release:

--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -48,6 +48,13 @@ env:
   # (ci/source-build/) and no longer need them.
   PIXI_VERSION: "0.68.1"
   MICROMAMBA_VERSION: "2.6.1"
+  # x86_64 uv for the Rosetta verify-macos-x86_64 job. Pinned + SHA256-verified
+  # like the other toolchain fetches (never `latest/download`): this job gates
+  # the PyPI publish, so a rolling/tampered binary must not silently pass or
+  # break the wheel verification. Bump both together — the checksum is of
+  # uv-x86_64-apple-darwin.tar.gz for UV_VERSION.
+  UV_VERSION: "0.11.29"
+  UV_SHA256: "c4c4de482da9ccdd076dc4fb5cfe7b740609029385c72f58606be3153602387d"
 
 jobs:
   build-sdist:
@@ -739,11 +746,13 @@ jobs:
       - name: Ensure Rosetta 2 is available
         run: softwareupdate --install-rosetta --agree-to-license || true
 
-      - name: Install an x86_64 uv (runs under Rosetta to manage x86_64 Pythons)
+      - name: Install a pinned, checksummed x86_64 uv (runs under Rosetta)
         run: |
           set -euo pipefail
-          curl -LsSf https://github.com/astral-sh/uv/releases/latest/download/uv-x86_64-apple-darwin.tar.gz \
-            | tar -xz
+          curl -fsSL -o uv-x86_64.tar.gz \
+            "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-apple-darwin.tar.gz"
+          echo "${UV_SHA256}  uv-x86_64.tar.gz" | shasum -a 256 -c -
+          tar -xzf uv-x86_64.tar.gz
           echo "UVX86=$PWD/uv-x86_64-apple-darwin/uv" >> "$GITHUB_ENV"
 
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8

--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -751,7 +751,12 @@ jobs:
       - name: Install the x86_64 wheel into an x86_64 venv (Rosetta)
         run: |
           set -euo pipefail
-          arch -x86_64 "$UVX86" venv --python ${{ matrix.python-version }} .venv-x86
+          # only-managed forces uv to download an x86_64 python-build-standalone
+          # interpreter (uv runs under Rosetta here) instead of reusing a
+          # pre-installed arm64 Homebrew python, which macos-14 ships for some
+          # versions and which would make the x86_64 wheel install as wrong-arch.
+          arch -x86_64 "$UVX86" venv --python-preference only-managed \
+            --python ${{ matrix.python-version }} .venv-x86
           PYTAG="cp$(echo '${{ matrix.python-version }}' | tr -d .)"
           WHEEL=$(ls dist/pyramids_gis-*-${PYTAG}-${PYTAG}-*macosx*x86_64.whl | head -1)
           echo "Installing: $WHEEL"

--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -31,7 +31,9 @@ on:
 # running, so nothing ever reaches main unverified. Those events get a per-run group
 # (github.run_id is unique per run) so they never queue behind — or cancel — one another.
 # Only pull_request builds share a per-branch group with cancel-in-progress, so a new push
-# to a PR supersedes its older run and frees the hosted-runner pool.
+# to a PR supersedes its older run and frees the hosted-runner pool. NOTE: the on.pull_request
+# trigger is currently commented out above, so the PR arm is dormant future-proofing today —
+# every live event resolves to the unique github.run_id group. It activates if that trigger is restored.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -744,7 +744,17 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.sha }}
 
       - name: Ensure Rosetta 2 is available
-        run: softwareupdate --install-rosetta --agree-to-license || true
+        run: |
+          set -euo pipefail
+          # macos-14 arm64 runners generally ship Rosetta 2, so tolerate the
+          # already-installed / no-op case, but then prove x86_64 emulation
+          # actually works — otherwise a genuine failure is swallowed here and
+          # resurfaces as a confusing error in a later `arch -x86_64` step.
+          softwareupdate --install-rosetta --agree-to-license || true
+          arch -x86_64 /usr/bin/true || {
+            echo "::error::Rosetta 2 x86_64 emulation is unavailable on this runner"
+            exit 1
+          }
 
       - name: Install a pinned, checksummed x86_64 uv (runs under Rosetta)
         run: |

--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -411,7 +411,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-14, windows-2022]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-14, macos-13, windows-2022]
         python-version: ["3.11", "3.12", "3.13", "3.14"]
         include:
           - os: ubuntu-latest
@@ -425,6 +425,13 @@ jobs:
           - os: macos-14
             arch: arm64
             artifact: wheels-macos-arm64
+            wheel-tag: macosx
+          # macos-13 is the Intel runner: the x86_64 wheel is cross-compiled on
+          # the arm64 macos-14 host, so cibuildwheel can't execute it and this is
+          # the only place `import pyramids` runs on it before it publishes.
+          - os: macos-13
+            arch: x86_64
+            artifact: wheels-macos-x86_64
             wheel-tag: macosx
           - os: windows-2022
             arch: AMD64

--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -715,9 +715,12 @@ jobs:
   # in practice (an added macos-13 test cell sat queued 12h, never assigned a
   # runner). Verify the wheel here instead by running an x86_64 CPython under
   # Rosetta 2 on this same arm64 runner: install the wheel into an x86_64 venv
-  # and run verify-wheel (GDAL import + drivers + TLS) on every shipped CPython,
-  # plus the hermetic core suite once on 3.12. This is the only place
-  # `import pyramids` runs on the x86_64 wheel before it publishes.
+  # and run verify-wheel (GDAL import + all promised drivers + TLS) on every
+  # shipped CPython. This is the only place `import pyramids` runs on the x86_64
+  # wheel before it publishes. The behavioural pytest suite is arch-independent
+  # and runs natively on the arm64/linux/windows test-wheels cells; re-running it
+  # under Rosetta emulation only adds per-test-timeout flakiness (a heavy
+  # curvilinear read tripped the 60s cap under emulation), so it is omitted here.
   verify-macos-x86_64:
     needs: build-macos-wheels
     runs-on: macos-14
@@ -767,19 +770,6 @@ jobs:
           set -euo pipefail
           arch -x86_64 .venv-x86/bin/python -c "import platform;assert platform.machine()=='x86_64'"
           arch -x86_64 .venv-x86/bin/python ci/verify-wheel.py
-
-      - name: Install test dependencies (3.12 only)
-        if: matrix.python-version == '3.12'
-        run: |
-          arch -x86_64 "$UVX86" pip install --python .venv-x86/bin/python \
-            pytest pytest-env pytest-mock pytest-timeout
-
-      - name: Run hermetic core test suite (3.12 only)
-        if: matrix.python-version == '3.12'
-        timeout-minutes: 15
-        run: >-
-          arch -x86_64 .venv-x86/bin/python -m pytest -vvv -o "pythonpath="
-          --timeout=60 --timeout-method=thread -m "core and not vfs and not slow" tests/
 
   release:
     name: Publish to PyPI + attach to GitHub release

--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -411,7 +411,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-14, macos-13, windows-2022]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-14, windows-2022]
         python-version: ["3.11", "3.12", "3.13", "3.14"]
         include:
           - os: ubuntu-latest
@@ -425,13 +425,6 @@ jobs:
           - os: macos-14
             arch: arm64
             artifact: wheels-macos-arm64
-            wheel-tag: macosx
-          # macos-13 is the Intel runner: the x86_64 wheel is cross-compiled on
-          # the arm64 macos-14 host, so cibuildwheel can't execute it and this is
-          # the only place `import pyramids` runs on it before it publishes.
-          - os: macos-13
-            arch: x86_64
-            artifact: wheels-macos-x86_64
             wheel-tag: macosx
           - os: windows-2022
             arch: AMD64
@@ -717,6 +710,72 @@ jobs:
           pytest -vvv -o "pythonpath=" --timeout=60 --timeout-method=thread
           -m "core and not vfs and not slow" tests/
 
+  # The macOS x86_64 wheel is cross-compiled on this arm64 macos-14 host, so
+  # cibuildwheel can't run it, and GitHub's macos-13 Intel runners are unusable
+  # in practice (an added macos-13 test cell sat queued 12h, never assigned a
+  # runner). Verify the wheel here instead by running an x86_64 CPython under
+  # Rosetta 2 on this same arm64 runner: install the wheel into an x86_64 venv
+  # and run verify-wheel (GDAL import + drivers + TLS) on every shipped CPython,
+  # plus the hermetic core suite once on 3.12. This is the only place
+  # `import pyramids` runs on the x86_64 wheel before it publishes.
+  verify-macos-x86_64:
+    needs: build-macos-wheels
+    runs-on: macos-14
+    permissions:
+      contents: read
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.workflow_run.head_branch || inputs.branch || github.sha }}
+
+      - name: Ensure Rosetta 2 is available
+        run: softwareupdate --install-rosetta --agree-to-license || true
+
+      - name: Install an x86_64 uv (runs under Rosetta to manage x86_64 Pythons)
+        run: |
+          set -euo pipefail
+          curl -LsSf https://github.com/astral-sh/uv/releases/latest/download/uv-x86_64-apple-darwin.tar.gz \
+            | tar -xz
+          echo "UVX86=$PWD/uv-x86_64-apple-darwin/uv" >> "$GITHUB_ENV"
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: wheels-macos-x86_64
+          path: dist
+
+      - name: Install the x86_64 wheel into an x86_64 venv (Rosetta)
+        run: |
+          set -euo pipefail
+          arch -x86_64 "$UVX86" venv --python ${{ matrix.python-version }} .venv-x86
+          PYTAG="cp$(echo '${{ matrix.python-version }}' | tr -d .)"
+          WHEEL=$(ls dist/pyramids_gis-*-${PYTAG}-${PYTAG}-*macosx*x86_64.whl | head -1)
+          echo "Installing: $WHEEL"
+          arch -x86_64 "$UVX86" pip install --python .venv-x86/bin/python "$WHEEL"
+
+      - name: Verify GDAL import + drivers (x86_64 under Rosetta)
+        run: |
+          set -euo pipefail
+          arch -x86_64 .venv-x86/bin/python -c "import platform;assert platform.machine()=='x86_64'"
+          arch -x86_64 .venv-x86/bin/python ci/verify-wheel.py
+
+      - name: Install test dependencies (3.12 only)
+        if: matrix.python-version == '3.12'
+        run: |
+          arch -x86_64 "$UVX86" pip install --python .venv-x86/bin/python \
+            pytest pytest-env pytest-mock pytest-timeout
+
+      - name: Run hermetic core test suite (3.12 only)
+        if: matrix.python-version == '3.12'
+        timeout-minutes: 15
+        run: >-
+          arch -x86_64 .venv-x86/bin/python -m pytest -vvv -o "pythonpath="
+          --timeout=60 --timeout-method=thread -m "core and not vfs and not slow" tests/
+
   release:
     name: Publish to PyPI + attach to GitHub release
     # NOTE: the musl canary wheels stay UNPUBLISHED (their `canary-*`
@@ -728,7 +787,8 @@ jobs:
     # verify-alpine red (a run-level failure is not loud enough).
     needs: [build-sdist, build-linux-wheels, build-macos-wheels,
             build-windows-wheels, test-wheels, verify-debian12, verify-rocky9,
-            verify-rocky9-aarch64, verify-alpine, verify-winarm64]
+            verify-rocky9-aarch64, verify-alpine, verify-winarm64,
+            verify-macos-x86_64]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     # Dry-run path (workflow_dispatch + dry-run-release): executes the

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -35,12 +35,19 @@ jobs:
           # nearest release tag reachable from the checked-out head_branch tip —
           # not `gh release list --limit 1`. The newest release can differ from
           # this run's commit under back-to-back releases and mislabel the image.
-          # --match constrains git describe to X.Y.Z release tags: the repo also
-          # carries non-semver tags (e.g. basemap-data-v1) that would otherwise
-          # be returned and break docker/metadata-action's type=semver parse.
+          # --match constrains git describe to X.Y.Z(prerelease) tags: the repo
+          # also carries non-version tags (e.g. basemap-data-v1) that would
+          # otherwise be returned and break docker/metadata-action's type=semver.
           TAG=$(git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*')
-          if [[ ! "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-            echo "::error::git describe returned a non-semver tag: '$TAG'"
+          # commitizen cuts PEP440 prerelease tags (e.g. 0.47.0rc1); normalize to
+          # SemVer (0.47.0-rc1) so type=semver parses them and prerelease cuts
+          # still produce a correctly-tagged image. Anything else fails loudly.
+          if [[ "$TAG" =~ ^([0-9]+\.[0-9]+\.[0-9]+)((a|b|rc)[0-9]+)?$ ]]; then
+            if [ -n "${BASH_REMATCH[2]}" ]; then
+              TAG="${BASH_REMATCH[1]}-${BASH_REMATCH[2]}"
+            fi
+          else
+            echo "::error::git describe returned an unexpected tag: '$TAG'"
             exit 1
           fi
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -30,11 +30,20 @@ jobs:
         if: github.event_name == 'workflow_run'
         id: get-release
         run: |
+          set -euo pipefail
           # Tag the image with the version of the code we actually built — the
-          # nearest tag reachable from the checked-out head_branch tip — not
-          # `gh release list --limit 1`. The newest release can differ from this
-          # run's commit under back-to-back releases and mislabel the image.
-          echo "tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
+          # nearest release tag reachable from the checked-out head_branch tip —
+          # not `gh release list --limit 1`. The newest release can differ from
+          # this run's commit under back-to-back releases and mislabel the image.
+          # --match constrains git describe to X.Y.Z release tags: the repo also
+          # carries non-semver tags (e.g. basemap-data-v1) that would otherwise
+          # be returned and break docker/metadata-action's type=semver parse.
+          TAG=$(git describe --tags --abbrev=0 --match '[0-9]*.[0-9]*.[0-9]*')
+          if [[ ! "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+            echo "::error::git describe returned a non-semver tag: '$TAG'"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Get repo image name (lowercase)
         shell: bash

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -14,6 +14,7 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event.workflow_run.conclusion == 'success' &&
@@ -23,15 +24,17 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.workflow_run.head_branch || github.ref }}
+          fetch-depth: 0   # need tags for `git describe` below
 
-      - name: Get latest release tag
+      - name: Get release tag
         if: github.event_name == 'workflow_run'
         id: get-release
         run: |
-          LATEST_TAG=$(gh release list --limit 1 --json tagName --jq '.[0].tagName')
-          echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ github.token }}
+          # Tag the image with the version of the code we actually built — the
+          # nearest tag reachable from the checked-out head_branch tip — not
+          # `gh release list --limit 1`. The newest release can differ from this
+          # run's commit under back-to-back releases and mislabel the image.
+          echo "tag=$(git describe --tags --abbrev=0)" >> "$GITHUB_OUTPUT"
 
       - name: Get repo image name (lowercase)
         shell: bash

--- a/.github/workflows/github-pages-mkdocs.yml
+++ b/.github/workflows/github-pages-mkdocs.yml
@@ -33,6 +33,7 @@ jobs:
   deploy-pr:
       if: github.event_name == 'pull_request'
       runs-on: ubuntu-latest
+      timeout-minutes: 30
       permissions:
         contents: write
         pages: write
@@ -60,6 +61,7 @@ jobs:
   deploy-main:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       pages: write
@@ -87,6 +89,7 @@ jobs:
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.head_repository.full_name == github.repository)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -25,16 +25,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check actor is a repository admin
-        run: |
-          PERMISSION=$(gh api \
-            repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission --jq '.permission')
-          echo "Permission level for ${{ github.actor }}: $PERMISSION"
-          if [ "$PERMISSION" != "admin" ]; then
-            echo "::error::${{ github.actor }} is not a repository admin. Only admins can publish."
-            exit 1
-          fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Mirrors github-release.yml's admin gate. Actor/repo are passed via
+          # env (not interpolated into the script body). Distinguish an API
+          # failure (403 scope / rate-limit / transient 5xx) from a genuine
+          # non-admin, so a broken emergency path is not reported as "not admin".
+          if ! PERMISSION=$(gh api "repos/${REPO}/collaborators/${ACTOR}/permission" --jq '.permission'); then
+            echo "::error::could not verify repository permission for ${ACTOR} (GitHub API error)"
+            exit 1
+          fi
+          echo "Permission level for ${ACTOR}: ${PERMISSION}"
+          if [ "${PERMISSION}" != "admin" ]; then
+            echo "::error::${ACTOR} is not a repository admin. Only admins can publish."
+            exit 1
+          fi
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -23,6 +23,13 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # contents: write is required for the admin-gate step below: the
+    # collaborators/{user}/permission REST endpoint needs push access, and the
+    # gate this mirrors in github-release.yml runs under contents: write for the
+    # same reason. Without it the gh api call 403s and the gate fails closed for
+    # everyone, making the emergency publish path inert.
+    permissions:
+      contents: write
     steps:
       - name: Check actor is a repository admin
         env:

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -24,6 +24,18 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      - name: Check actor is a repository admin
+        run: |
+          PERMISSION=$(gh api \
+            repos/${{ github.repository }}/collaborators/${{ github.actor }}/permission --jq '.permission')
+          echo "Permission level for ${{ github.actor }}: $PERMISSION"
+          if [ "$PERMISSION" != "admin" ]; then
+            echo "::error::${{ github.actor }} is not a repository admin. Only admins can publish."
+            exit 1
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -4,11 +4,13 @@ name: pypi-release (emergency sdist-only fallback)
 # when bundle-pypi-wheels.yml is broken and conda-forge needs a new tarball
 # to pick up; do NOT use it for normal releases.
 #
-# The canonical release path is bundle-pypi-wheels.yml's `publish:` job,
-# which builds + tests + publishes sdist plus 20 platform wheels in
-# one workflow. That job fires automatically on `release: types:
-# [released]` (which github-release.yml's commitizen tag emits) and on
-# manual `workflow_dispatch` with `upload-to-pypi: true`.
+# The canonical release path is bundle-pypi-wheels.yml's `release:` job,
+# which builds + tests + publishes the sdist plus 23 platform wheels in
+# one workflow. It runs automatically on `workflow_run` when the
+# `github-release` workflow completes (github-release.yml cuts the tag +
+# release via commitizen). A manual `workflow_dispatch` with
+# `dry_run_release: true` runs the gather + composition gate only and
+# does NOT publish.
 #
 # Trigger this workflow manually: `gh workflow run pypi-release.yml`.
 

--- a/ci/setup-gdal-micromamba.sh
+++ b/ci/setup-gdal-micromamba.sh
@@ -97,13 +97,15 @@ if [[ ! -f "${GDAL_PIN}" ]]; then
 fi
 
 { read -r GDAL_SPEC; read -r LIBGDAL_NETCDF_SPEC; \
-  read -r LIBGDAL_HDF4_SPEC; read -r LIBGDAL_JP2_SPEC; read -r SWIG_SPEC; } \
-  < <(python3 "${GDAL_PIN}" gdal libgdal-netcdf libgdal-hdf4 libgdal-jp2openjpeg swig)
+  read -r LIBGDAL_HDF4_SPEC; read -r LIBGDAL_GRIB_SPEC; \
+  read -r LIBGDAL_JP2_SPEC; read -r SWIG_SPEC; } \
+  < <(python3 "${GDAL_PIN}" gdal libgdal-netcdf libgdal-hdf4 libgdal-grib libgdal-jp2openjpeg swig)
 
 echo "--- Wheel-build pins (from pyproject.toml) ---"
 echo "  gdal${GDAL_SPEC}"
 echo "  libgdal-netcdf${LIBGDAL_NETCDF_SPEC}"
 echo "  libgdal-hdf4${LIBGDAL_HDF4_SPEC}"
+echo "  libgdal-grib${LIBGDAL_GRIB_SPEC}"
 echo "  libgdal-jp2openjpeg${LIBGDAL_JP2_SPEC}"
 echo "  swig${SWIG_SPEC}"
 
@@ -115,6 +117,7 @@ echo "--- Creating ${TARGET_PLATFORM} env at ${PIXI_ENV} ---"
     "gdal${GDAL_SPEC}" \
     "libgdal-netcdf${LIBGDAL_NETCDF_SPEC}" \
     "libgdal-hdf4${LIBGDAL_HDF4_SPEC}" \
+    "libgdal-grib${LIBGDAL_GRIB_SPEC}" \
     "libgdal-jp2openjpeg${LIBGDAL_JP2_SPEC}" \
     "swig${SWIG_SPEC}"
 

--- a/ci/setup-gdal-micromamba.sh
+++ b/ci/setup-gdal-micromamba.sh
@@ -83,13 +83,13 @@ mkdir -p "${MAMBA_ROOT_PREFIX}"
 # pre-mkdir.
 rm -rf "${PIXI_ENV}"
 
-# All four native build/test pins live once in pyproject.toml — the three gdal libs
-# in [tool.pixi.feature.gdal.dependencies], build-only swig in
-# [tool.pixi.feature.wheel-build.dependencies]. ci/gdal-pin.py is the single reader of
-# those tables; calling it here keeps this cross-compile branch from re-encoding (or
-# drifting from) the pins. One subprocess emits all four specs, newline-separated,
-# mapped onto the bash vars via `read`. micromamba accepts a conda match-spec
-# concatenated as ``<name><spec>`` (e.g. ``gdal>=3.13,<3.14``).
+# All the wheel-build GDAL pins live once in pyproject.toml — the gdal-family libs
+# (gdal + libgdal-netcdf/hdf4/grib/jp2openjpeg) in [tool.pixi.feature.gdal.dependencies],
+# build-only swig in [tool.pixi.feature.wheel-build.dependencies]. ci/gdal-pin.py is the
+# single reader of those tables; calling it here keeps this cross-compile branch from
+# re-encoding (or drifting from) the pins. The subprocess emits one spec per requested
+# name, newline-separated, mapped onto the bash vars via `read`. micromamba accepts a
+# conda match-spec concatenated as ``<name><spec>`` (e.g. ``gdal>=3.13,<3.14``).
 GDAL_PIN="$(cd "$(dirname "$0")" && pwd)/gdal-pin.py"
 if [[ ! -f "${GDAL_PIN}" ]]; then
     echo "ERROR: gdal-pin.py not found at ${GDAL_PIN}" >&2


### PR DESCRIPTION
# Description

The bundle workflow's concurrency group was keyed on `github.ref`, so every `push` and `workflow_run` on `main`
shared one group. With `cancel-in-progress` disabled for those events, runs did not cancel — they **queued**: a commit
merged while an earlier commit's pipeline was still running had to wait its turn, and a slow build could hold up the
next merge's verification. A merge to `main` must always be built and verified in full, on its own, so nothing ever
lands unverified.

This keys the group on `github.run_id` (unique per run) for every non-`pull_request` event, so each `push` /
`workflow_run` / `workflow_dispatch` runs in its **own** group — never queued behind, never cancelled by, another run.
`pull_request` builds keep the per-branch group + `cancel-in-progress`, so a new push to a PR still supersedes its
older run and frees the hosted-runner pool.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Note: `workflow_run` (publish) runs are also no longer serialized — a deliberate consequence of "no serialization on
main". Releases are infrequent and each publishes only its own version, so this is a non-issue in practice; a
same-version double-publish would simply be rejected by PyPI.

## Also bundled — CI-hardening from the same workflow audit

- **`bundle-pypi-wheels.yml`**: add a dedicated `verify-macos-x86_64` job that runs the cross-compiled x86_64 wheel
  under Rosetta 2 on the arm64 `macos-14` runner (GitHub's `macos-13` Intel runners are unusable — a `macos-13`
  test cell sat queued 12h without a runner). It asserts x86_64 emulation works, installs a pinned +
  SHA256-verified x86_64 `uv`, builds an x86_64 venv, installs the wheel, and runs `ci/verify-wheel.py` (GDAL
  import + all promised drivers + TLS) on cp311-cp314. The job gates `release`, so a broken x86_64 wheel can no
  longer publish — previously this was the only published wheel never imported. It immediately caught a real
  shipped defect (#772).
- **`ci/setup-gdal-micromamba.sh`**: add `libgdal-grib` to the osx-64 cross-compile GDAL stack — the macOS x86_64
  wheel was shipping with **no GRIB driver** because the script omitted the package that `pyproject.toml` declares
  (the arm64/pixi path installs it, so only x86_64 was affected). Fixes the defect the new verify job surfaced
  (#772).
- **`docker-release.yml`**: derive the image version tag from `git describe` on the built commit (not
  `gh release list --limit 1`, which returns the newest release and can mislabel the image under back-to-back
  releases), constrain it to release tags and normalize PEP440 prereleases to SemVer (`0.47.0rc1` → `0.47.0-rc1`),
  and add `timeout-minutes: 30`.
- **`pypi-release.yml`**: gate the emergency sdist-only publisher behind a repository-admin check (the `publish`
  job is given `contents: write`, which the collaborators-permission API requires), with error handling that
  distinguishes an API failure from a genuine non-admin. Also correct the stale header comment.
- **`github-pages-mkdocs.yml`**: add `timeout-minutes: 30` to the `deploy-pr` / `deploy-main` / `deploy-release`
  jobs so a hung notebook cell can't run to the 6-hour default and block the shared docs-deploy lane.

### Hardening from two review rounds

The diff went through two independent review passes. The actionable findings are folded into the changes above:
pin + SHA256-verify the `uv` fetch (it was the repo's only `latest/download`, inside the publish-gating job);
`set -euo pipefail` plus semver/prerelease guards on the docker tag (the repo carries non-semver tags such as
`basemap-data-v1` that `git describe` would otherwise return); `set -e`, the API-error-vs-non-admin distinction,
and `contents: write` on the pypi admin gate (without it the gate would 403 and fail closed for everyone); assert
Rosetta emulation before use instead of swallowing the failure; and an `assert`-free arch probe. The Rosetta job
verifies imports/drivers only — the behavioural pytest suite tripped the 60s per-test cap under emulation and
already runs natively on the arm64/linux/windows cells.

# Issues

- Closes #765 — admin gate on the emergency `pypi-release.yml` publisher (`71c490cf8`).
- Closes #767 — runtime verification for the macOS x86_64 wheel before publish (`c2aa6276d`, `6b6e7c4f4`).
- Closes #772 — bundle `libgdal-grib` so the macOS x86_64 wheel has the GRIB driver (`d6a32265f`).
- Closes #768 — `timeout-minutes` on the mkdocs deploy jobs (`f9907bea8`).
- Closes #769 — docker-release.yml image tagging + timeout fix (`7c813b8a6`).
- The concurrency change (`104ca81b7`) has no tracking issue; it is a requested change to how merges to `main`
  are verified.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- All five changed files validated: every workflow YAML parses, no added line exceeds 120 chars, and the CI-config
  guard tests (`tests/guards/`, incl. `test_gdal_pin.py`, which checks the GDAL pins the micromamba script edits)
  pass (324).
- Exercised end-to-end via `workflow_dispatch` (`dry_run_release: true`) on `bundle-pypi-wheels.yml`: the new
  `verify-macos-x86_64` job built the wheel, ran it under Rosetta on all four CPython versions, and its driver-set
  check passes with GRIB present — this is the run that first surfaced, then confirmed the fix for, the
  missing-GRIB defect (#772).
- Simulated the concurrency group-selection ternary for every event type: `push` / `workflow_run` /
  `workflow_dispatch` each resolve to a unique `github.run_id` group (independent, never queued/cancelled);
  `pull_request` resolves to the per-branch `github.ref` group with `cancel-in-progress: true`.
- The diff is CI/workflow + shell configuration with no Python runtime source, so there is no unit-test surface; it
  went through two independent review rounds (supply-chain pinning, shell-safety, permission scoping) with every
  finding resolved.

- [x] YAML valid; concurrency expression well-formed; guard tests green (324)
- [x] `verify-macos-x86_64` dry-run green on cp311-cp314 with GRIB present
- [x] Two review rounds; all findings resolved

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen-managed; not applicable)
- [ ] added changes to History.rst. (changelog is commitizen-generated; not applicable)
- [ ] updated the latest version in README file. (not applicable)
- [x] I have added tests that prove my fix is effective or that my feature works. (The new `verify-macos-x86_64`
      CI job is itself the test — it imports the x86_64 wheel and checks its drivers before publish; exercised
      green via the dry-run above. Guard tests pass; no unit-test surface for the workflow YAML.)
- [x] New and existing unit tests pass locally with my changes. (no source touched)
- [ ] documentation are updated. (no user-facing surface)






