### PR TITLE
docs: clarify kriging guidance

### DIFF
--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -3251,7 +3251,8 @@ class FeatureCollection(GeoDataFrame):
         Reads ``column`` as the z-value at each point geometry and grids it with ``gdal.Grid`` via
         :meth:`pyramids.dataset.Dataset.from_points`. This is distinct from the inherited geopandas
         ``GeoSeries.interpolate`` (which is 1-D interpolation *along* a line). Only inverse-distance weighting
-        (``method="idw"``) is available here; kriging needs the optional ``pykrige`` dependency.
+        (``method="idw"``) is available here. Kriging is out of scope for pyramids; use the
+        ``geostatista`` package instead.
 
         IDW extrapolates across the whole output extent (no convex-hull mask), so ``nodata`` only appears in
         cells ``gdal.Grid`` cannot estimate. Coincident (duplicate) points are not pre-averaged — they are
@@ -3305,8 +3306,8 @@ class FeatureCollection(GeoDataFrame):
         self._require_column("interpolate_to_raster", column)
         if method != "idw":
             raise ValueError(
-                f"interpolate_to_raster: method {method!r} is not supported; only 'idw' is available "
-                "(kriging needs the optional 'pykrige' dependency)"
+                f"interpolate_to_raster: method {method!r} is not supported; only 'idw' is available. "
+                "Kriging is out of scope for pyramids; use the geostatista package instead."
             )
         if len(self) < 3:
             raise ValueError(f"interpolate_to_raster: need at least 3 points, got {len(self)}")

--- a/tests/feature/test_feature_gaps.py
+++ b/tests/feature/test_feature_gaps.py
@@ -126,8 +126,8 @@ class TestInterpolateToRaster:
         assert surface.shape == (1, 2, 2), f"unexpected shape {surface.shape}"
 
     def test_unknown_method_raises(self, corner_points: FeatureCollection) -> None:
-        """A non-idw method is rejected and points at the optional kriging dependency."""
-        with pytest.raises(ValueError, match="pykrige"):
+        """A non-IDW method is rejected and points users to the kriging package."""
+        with pytest.raises(ValueError, match="geostatista"):
             corner_points.interpolate_to_raster("rain", method="kriging")
 
     def test_too_few_points_raises(self) -> None:


### PR DESCRIPTION
## Summary
Corrects the `FeatureCollection.interpolate_to_raster` documentation and unsupported-method error so they no longer advise installing `pykrige`, which is neither a dependency nor supported by pyramids.

## Changes
- Direct users seeking kriging to the `geostatista` package.
- Update the focused regression assertion for the error guidance.

## Related issue
Closes #770

## Validation
- `git diff --check` — passed.
- `python3 -m py_compile src/pyramids/feature/collection.py tests/feature/test_feature_gaps.py` — passed.
- Focused AST assertions confirmed the method contains `geostatista` guidance and no `pykrige` reference.
- `flake8 src/pyramids/feature/collection.py tests/feature/test_feature_gaps.py` — passed.
- Attempted `uv run --with pytest --with pyramids-gis pytest tests/feature/test_feature_gaps.py::TestInterpolateToRaster::test_unknown_method_raises -q`; collection is blocked in this host because the project source requires GDAL's `osgeo` module, and the documented Pixi environment is unavailable here.

## Notes
This is a minimal documentation/error-message correction only; it does not add kriging support or dependencies. Prepared with automated assistance and submitted for maintainer review.
