### PR TITLE
ci(tests): exempt main from the cancel-in-progress concurrency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,11 +8,14 @@ on:
     branches: [main]
   pull_request:
 
-# Cancel superseded runs: a new push to a branch/PR cancels the previous in-progress run
+# Cancel superseded runs on PRs: a new push to a PR cancels the previous in-progress run
 # instead of letting both compete for the (limited, especially macOS) hosted-runner pool.
+# main is exempt — every commit merged to main must run the full suite independently, so a
+# later merge never cancels an earlier commit's verification. main gets a unique run_id group
+# (never shared, never cancelled); PRs keep the per-ref group with cancel-in-progress.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   main-package:


### PR DESCRIPTION
# Description

The `Tests - Suite` workflow keyed its concurrency group on `github.ref` with `cancel-in-progress: true` for every
event. On a push to `main` that resolves to a single group (`Tests - Suite-refs/heads/main`), so merging the next
PR cancelled the still-running suite of the previous `main` commit — that commit's full test run never finished and
code sat on `main` unverified (e.g. run `29651494010`, cancelled when a new commit landed on `main`).

This exempts `main` from cancellation: `main` pushes get a unique `github.run_id` group (never shared, never
cancelled), so every merge runs the suite to completion independently. Pull requests keep the per-ref group with
`cancel-in-progress: true`, so a new push still supersedes the older run and frees the limited (especially macOS)
hosted-runner pool.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}
  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

The other two workflows with concurrency already comply: `bundle-pypi-wheels.yml` exempts `main` via its
non-`pull_request` `run_id` group, and `github-pages-mkdocs.yml` uses `cancel-in-progress: false`, so it never
cancels an in-progress `main` deploy.

# Issues

- Closes #775 — a merge to `main` cancels the previous commit's `Tests - Suite` run, leaving code unverified.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Validated the workflow YAML parses and the concurrency expression is well-formed.
- Reasoned through the group selection: a push to `main` (`github.ref == refs/heads/main`) resolves to a unique
  `run_id` group with `cancel-in-progress: false`, so two `main` runs never share a group and a later merge cannot
  cancel an earlier one; a `pull_request` (`github.ref == refs/pull/N/merge`) resolves to the per-ref group with
  `cancel-in-progress: true`, so a new push supersedes the older PR run.

- [x] YAML valid; concurrency expression well-formed
- [x] Per-event grouping reasoned (main -> unique run_id / no-cancel, PR -> per-ref / cancel)

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen-managed; not applicable)
- [ ] added changes to History.rst. (changelog is commitizen-generated; not applicable)
- [ ] updated the latest version in README file. (not applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works. (CI-config change; no unit-test
      surface)
- [x] New and existing unit tests pass locally with my changes. (no source touched)
- [ ] documentation are updated. (no user-facing surface)
