### PR TITLE
fix(docs): make the shipped docstring examples collect and run under doctest

### DIFF
--- a/src/pyramids/_io.py
+++ b/src/pyramids/_io.py
@@ -242,7 +242,7 @@ def _get_zip_path(path: str, file_i: int = 0):
           >>> rdir = "tests/data/virtual-file-system"
           >>> path = _get_zip_path(f"{rdir}/multiple_compressed_files.zip/1.asc")
           >>> print(path)
-          "/vsizip/tests/data/virtual-file-system/multiple_compressed_files.zip/1.asc"
+          /vsizip/tests/data/virtual-file-system/multiple_compressed_files.zip/1.asc
 
           ```
 
@@ -251,16 +251,16 @@ def _get_zip_path(path: str, file_i: int = 0):
           ```python
           >>> path = _get_zip_path(f"{rdir}/multiple_compressed_files.zip")
           >>> print(path)
-          "/vsizip/tests/data/virtual-file-system/multiple_compressed_files.zip/1.asc"
+          /vsizip/tests/data/virtual-file-system/multiple_compressed_files.zip/1.asc
 
           ```
 
         - Zip file path and an index (one/multiple files inside the compressed file): if you provide the path to the zip file and an index to the file inside the compressed file you want to read
 
           ```python
-          >>> path = _get_zip_path("compressed-file-name.zip", file_i=1)
+          >>> path = _get_zip_path(f"{rdir}/multiple_compressed_files.zip", file_i=1)
           >>> print(path)
-          "/vsizip/tests/data/virtual-file-system/multiple_compressed_files.zip/2.asc"
+          /vsizip/tests/data/virtual-file-system/multiple_compressed_files.zip/2.asc
 
           ```
     """

--- a/src/pyramids/base/_locks.py
+++ b/src/pyramids/base/_locks.py
@@ -111,7 +111,7 @@ class DummyLock:
             ```python
             >>> from pyramids.base._locks import DummyLock
             >>> with DummyLock():
-            ... value = 42
+            ...     value = 42
             >>> value
             42
 

--- a/src/pyramids/base/_raster_meta.py
+++ b/src/pyramids/base/_raster_meta.py
@@ -64,7 +64,7 @@ class RasterMeta:
             ... rows=10, columns=12, band_count=1, dtype="float32",
             ... transform=(0.0, 1.0, 0.0, 10.0, 0.0, -1.0),
             ... crs=CRS.from_epsg(4326),
-            ...)
+            ... )
             >>> meta.epsg
             4326
             >>> meta.shape

--- a/src/pyramids/base/_utils.py
+++ b/src/pyramids/base/_utils.py
@@ -609,11 +609,14 @@ def require_cleopatra(msg: str | None = None) -> None:
             ```python
             >>> import sys, types
             >>> from pyramids.base._utils import require_cleopatra
-            >>> stub = types.ModuleType("cleopatra")
-            >>> sys.modules.setdefault("cleopatra", stub) is not None
-            True
+            >>> _saved = sys.modules.get("cleopatra")
+            >>> sys.modules["cleopatra"] = types.ModuleType("cleopatra")  # pretend installed
             >>> require_cleopatra() is None
             True
+            >>> if _saved is None:  # restore sys.modules so later doctests still see the real cleopatra
+            ...     del sys.modules["cleopatra"]
+            ... else:
+            ...     sys.modules["cleopatra"] = _saved
 
             ```
 

--- a/src/pyramids/base/config.py
+++ b/src/pyramids/base/config.py
@@ -277,12 +277,14 @@ class LoggerManager:
             ```python
             >>> from pyramids.base.config import LoggerManager
             >>> _ = LoggerManager(level="WARNING")  # doctest: +SKIP
+
             ```
 
         - Configure console and file logging
             ```python
             >>> from pyramids.base.config import LoggerManager
             >>> _ = LoggerManager(level="INFO", log_file="pyramids.log")  # doctest: +SKIP
+
             ```
 
         See Also:

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -554,10 +554,11 @@ class RasterBase(ABC):
             - Get the block size of a dataset and print it:
 
               ```python
-              >>> dataset = Dataset.read_file("tests/data/geotiff/era5_land_monthly_averaged.tif")
+              >>> from pyramids.dataset import Dataset
+              >>> dataset = Dataset.read_file("examples/data/acc4000.tif")
               >>> size = dataset.block_size
               >>> print(size)
-              [(128, 128)]
+              [[128, 128]]
 
               ```
         """
@@ -767,7 +768,8 @@ class RasterBase(ABC):
             - Read a 5x5 window from the dataset and print its shape:
 
               ```python
-              >>> dataset = Dataset.read_file("tests/data/geotiff/era5_land_monthly_averaged.tif")
+              >>> from pyramids.dataset import Dataset
+              >>> dataset = Dataset.read_file("examples/data/acc4000.tif")
               >>> arr = dataset.read_array(window=[0, 0, 5, 5])
               >>> print(arr.shape)
               (5, 5)
@@ -1004,8 +1006,10 @@ class RasterBase(ABC):
 
               ```python
               >>> from pyramids.dataset import Dataset
-              >>> dataset = Dataset.read_file("path/raster_name.tif")
+              >>> dataset = Dataset.read_file("examples/data/acc4000.tif")
               >>> reprojected_dataset = dataset.to_crs(to_epsg=3857)
+              >>> reprojected_dataset.epsg
+              3857
 
               ```
         """
@@ -1093,8 +1097,13 @@ class RasterBase(ABC):
             - Save a dataset to a new GeoTIFF file:
 
               ```python
-              >>> dataset = Dataset.read_file("path/to/file/***.tif")
-              >>> dataset.to_file("save_raster_test.tif")
+              >>> import os, tempfile
+              >>> from pyramids.dataset import Dataset
+              >>> dataset = Dataset.read_file("examples/data/acc4000.tif")
+              >>> out_path = os.path.join(tempfile.mkdtemp(), "saved.tif")
+              >>> dataset.to_file(out_path)
+              >>> os.path.exists(out_path)
+              True
 
               ```
 

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -1728,10 +1728,10 @@ class DatasetCollection:
                 the same format (YYYY.MM.DD / YYYY-MM-DD or YYYY_MM_DD). For example:
 
                 ```python
-                >>> "MSWEP_1979.01.01.tif"
-                >>> "MSWEP_1979.01.02.tif"
-                >>> ...
-                >>> "MSWEP_1979.01.20.tif"
+                "MSWEP_1979.01.01.tif"
+                "MSWEP_1979.01.02.tif"
+                ...
+                "MSWEP_1979.01.20.tif"
 
                 ```
 
@@ -1743,6 +1743,7 @@ class DatasetCollection:
                 ```python
                 >>> fname = "MSWEP_YYYY.MM.DD.tif"
                 >>> regex_string = r"\d{4}.\d{2}.\d{2}"
+
                 ```
 
                 - Or:
@@ -1750,6 +1751,7 @@ class DatasetCollection:
                 ```python
                 >>> fname = "MSWEP_YYYY_M_D.tif"
                 >>> regex_string = r"\d{4}_\d{1}_\d{1}"
+
                 ```
 
                 - If there is a number at the beginning of the name:
@@ -1757,6 +1759,7 @@ class DatasetCollection:
                 ```python
                 >>> fname = "1_MSWEP_YYYY_M_D.tif"
                 >>> regex_string = r"\d+"
+
                 ```
 
             date (bool):
@@ -1765,8 +1768,9 @@ class DatasetCollection:
                 If the file names contain a date and you want to read them ordered. Default is None. For example:
 
                 ```python
-                >>> "MSWEP_YYYY.MM.DD.tif"
+                >>> fname = "MSWEP_YYYY.MM.DD.tif"
                 >>> file_name_data_fmt = "%Y.%m.%d"
+
                 ```
 
             start (str):
@@ -1788,8 +1792,9 @@ class DatasetCollection:
             - Read all rasters in a folder:
 
               ```python
+              >>> from pathlib import Path
               >>> from pyramids.dataset import DatasetCollection
-              >>> raster_folder = "examples/GIS/data/raster-folder"
+              >>> raster_folder = "examples/data/geotiff/raster-folder"
               >>> prec = DatasetCollection.read_multiple_files(raster_folder)
 
               ```
@@ -1797,7 +1802,7 @@ class DatasetCollection:
             - Read from a pre-collected list without ordering:
 
               ```python
-              >>> raster_folder = Path("examples/GIS/data/raster-folder")
+              >>> raster_folder = Path("examples/data/geotiff/raster-folder")
               >>> file_list = list(raster_folder.glob("*.tif"))
               >>> prec = DatasetCollection.read_multiple_files(file_list, with_order=False)
 
@@ -2411,9 +2416,17 @@ class DatasetCollection:
             - Save to a file:
 
               ```python
-              >>> raster_obj = Dataset.read_file("path/to/file/***.tif")
-              >>> output_path = "examples/GIS/data/save_raster_test.tif"
-              >>> raster_obj.to_file(output_path)
+              >>> import os, tempfile
+              >>> import numpy as np
+              >>> from pyramids.dataset import Dataset, DatasetCollection
+              >>> src = Dataset.create_from_array(
+              ...     np.ones((5, 5), dtype="float32"), top_left_corner=(0, 5), cell_size=1.0, epsg=4326,
+              ... )
+              >>> collection = DatasetCollection.create_cube(src, 3)
+              >>> out_dir = tempfile.mkdtemp()
+              >>> collection.to_file(out_dir)
+              >>> sorted(os.listdir(out_dir))
+              ['0.tif', '1.tif', '2.tif']
 
               ```
         """
@@ -2665,13 +2678,18 @@ class DatasetCollection:
             `inplace=False`; `None` when `inplace=True`.
 
         Examples:
-            - Crop aligned rasters using a DEM mask:
+            - Crop every timestep against another dataset used as a mask:
 
               ```python
-              >>> dem_path = "examples/GIS/data/acc4000.tif"
-              >>> src_path = "examples/GIS/data/aligned_rasters/"
-              >>> out_path = "examples/GIS/data/crop_aligned_folder/"
-              >>> DatasetCollection.crop(dem_path, src_path, out_path)
+              >>> import numpy as np
+              >>> from pyramids.dataset import Dataset, DatasetCollection
+              >>> mask = Dataset.create_from_array(
+              ...     np.ones((10, 10), dtype="int16"), top_left_corner=(0, 0), cell_size=0.05, epsg=4326,
+              ... )
+              >>> collection = DatasetCollection.create_cube(mask, 3)
+              >>> cropped = collection.crop(mask=mask)
+              >>> cropped.time_length
+              3
 
               ```
 

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -744,6 +744,7 @@ class Dataset(RasterBase):
                 >>> glyph = dataset.plot(band=0, kind="pcolormesh")  # doctest: +SKIP
                 >>> glyph.im.set_clim(0, 100)  # doctest: +SKIP
                 >>> _ = glyph.cbar.set_label("elevation [m]")  # doctest: +SKIP
+
                 ```
 
         Examples:

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -89,6 +89,7 @@ class Analysis(_Engine["Dataset"]):
 
               ```python
               >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.rand(4, 10, 10)
               >>> geotransform = (0, 0.05, 0, 0, 0, -0.05)
               >>> dataset = Dataset.create_from_array(arr, geo=geotransform, epsg=4326)
@@ -225,6 +226,7 @@ class Analysis(_Engine["Dataset"]):
 
               ```python
               >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.uniform(-1, 1, size=(5, 5))
               >>> top_left_corner = (0, 0)
               >>> cell_size = 0.05
@@ -309,6 +311,7 @@ class Analysis(_Engine["Dataset"]):
 
               ```python
               >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.randint(1, 5, size=(5, 5))
               >>> top_left_corner = (0, 0)
               >>> cell_size = 0.05
@@ -376,21 +379,15 @@ class Analysis(_Engine["Dataset"]):
 
                 ```python
                 >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
                 >>> arr = np.random.randint(1, 5, size=(2, 4, 4))
                 >>> top_left_corner = (0, 0)
                 >>> cell_size = 0.05
                 >>> dataset = Dataset.create_from_array(arr, top_left_corner=top_left_corner, cell_size=cell_size, epsg=4326)
-                >>> print(dataset)
-                <BLANKLINE>
-                            Cell size: 0.05
-                            Dimension: 4 * 4
-                            EPSG: 4326
-                            Number of Bands: 2
-                            Band names: ['Band_1', 'Band_2']
-                            Mask: -9999.0
-                            Data type: int32
-                            File:...
-                <BLANKLINE>
+                >>> (dataset.band_count, dataset.rows, dataset.columns)
+                (2, 4, 4)
+                >>> dataset.band_names
+                ['Band_1', 'Band_2']
                 >>> print(dataset.read_array()) # doctest: +SKIP
                 [[[1 3 3 4]
                   [1 4 2 4]
@@ -426,6 +423,7 @@ class Analysis(_Engine["Dataset"]):
               ```python
               >>> import geopandas as gpd
               >>> from shapely.geometry import Point
+
               ```
 
               - Create the points using shapely and GeoPandas to cover the 4 cells with xmin, ymin, xmax, ymax = [0.1, -0.2, 0.2, -0.1]:
@@ -961,36 +959,41 @@ class Analysis(_Engine["Dataset"]):
                 values in the base map.
 
         Examples:
-            - Read the dataset:
+            - Build a small value raster and an aligned class raster in memory:
 
               ```python
-              >>> dataset = Dataset.read_file("examples/data/geotiff/raster-folder/MSWEP_1979.01.01.tif")
-              >>> dataset.plot(figsize=(6, 8)) # doctest: +SKIP
+              >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
+              >>> values = np.array([[10.0, 20.0], [30.0, 40.0]], dtype="float32")
+              >>> dataset = Dataset.create_from_array(
+              ...     values, top_left_corner=(0, 2), cell_size=1.0, epsg=4326
+              ... )
+              >>> class_map = np.array([[1, 1], [2, 2]], dtype="int32")
+              >>> classes = Dataset.create_from_array(
+              ...     class_map, top_left_corner=(0, 2), cell_size=1.0, epsg=4326
+              ... )
 
               ```
 
-              ![rhine-rainfall](./../../_images/dataset/rhine-rainfall.png)
-
-            - Read the classes dataset:
+            - Overlay the value raster with the class raster. The result maps each
+              class to the list of values that fall inside it:
 
               ```python
-              >>> classes = Dataset.read_file("examples/data/geotiff/rhine-classes.tif")
-              >>> classes.plot(figsize=(6, 8), color_scale="boundary-norm", bounds=[1,2,3,4,5,6]) # doctest: +SKIP
+              >>> overlaid = dataset.overlay(classes)
+              >>> sorted(int(key) for key in overlaid)
+              [1, 2]
 
               ```
 
-              ![rhine-classes](./../../_images/dataset/rhine-classes.png)
-
-            - Overlay the dataset with the classes dataset:
+            - Use a class key to read the values that overlay that class:
 
               ```python
-              >>> classes_dict = dataset.overlay(classes)
-              >>> print(classes_dict.keys()) # doctest: +SKIP
-              dict_keys([1, 2, 3, 4, 5])
+              >>> [float(value) for value in sorted(overlaid[1], key=float)]
+              [10.0, 20.0]
+              >>> [float(value) for value in sorted(overlaid[2], key=float)]
+              [30.0, 40.0]
 
               ```
-
-            - You can use the key `1` to get the values that overlay class 1.
         """
         if not self._ds.spatial._check_alignment(classes_map):
             raise AlignmentError(
@@ -1240,40 +1243,38 @@ class Analysis(_Engine["Dataset"]):
                 - if the dataset had separate polygons, each polygon will be in a separate row.
 
         Examples:
-            - The following raster dataset has flood depth stored in its values, and the non-flooded cells are filled with
-              zero, so to extract the flood extent, we need to exclude the zero flood depth cells.
+            - Build a raster whose non-flooded cells are ``0`` and whose flooded cells
+              carry a positive depth. Excluding the zero cells extracts the flood extent
+              as one polygon per connected region:
 
               ```python
-              >>> dataset = Dataset.read_file("examples/data/geotiff/rhine-flood.tif")
-              >>> dataset.plot()
-              (<Figure size 800x800 with 2 Axes>, <Axes: >)
+              >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
+              >>> arr = np.zeros((4, 4), dtype="float32")
+              >>> arr[1:3, 1:3] = 5.0    # a 2x2 block of flooded cells
+              >>> dataset = Dataset.create_from_array(
+              ...     arr, top_left_corner=(0, 4), cell_size=1.0, epsg=4326
+              ... )
 
               ```
 
-            ![dataset-footprint-rhine-flood](./../../_images/dataset/dataset-footprint-rhine-flood.png)
-
-            - Now, to extract the footprint of the dataset band, we need to specify the `exclude_values` parameter with the
-              value of the non-flooded cells.
+            - Extract the footprint of the flooded cells by excluding the zero-depth
+              cells. Covered cells are flagged with the value ``2``:
 
               ```python
               >>> extent = dataset.footprint(band=0, exclude_values=[0])
-              >>> print(extent)
-                 Band_1                                           geometry
-              0     2.0  POLYGON ((4070974.182 3181069.473, 4070974.182...
-              1     2.0  POLYGON ((4077674.182 3181169.473, 4077674.182...
-              2     2.0  POLYGON ((4091174.182 3169169.473, 4091174.182...
-              3     2.0  POLYGON ((4088574.182 3176269.473, 4088574.182...
-              4     2.0  POLYGON ((4082974.182 3167869.473, 4082974.182...
-              5     2.0  POLYGON ((4092274.182 3168269.473, 4092274.182...
-              6     2.0  POLYGON ((4072474.182 3181169.473, 4072474.182...
-
-              >>> extent.plot()
+              >>> extent.shape
+              (1, 2)
+              >>> list(extent.columns)
+              ['Band_1', 'geometry']
+              >>> float(extent["Band_1"].iloc[0])
+              2.0
+              >>> float(extent.geometry.iloc[0].area)
+              4.0
+              >>> extent.plot()  # doctest: +SKIP
               <Axes: >
 
               ```
-
-            ![dataset-footprint-rhine-flood-extent](./../../_images/dataset/dataset-footprint-rhine-flood-extent.png)
-
         """
         arr = self._ds.read_array(band=band)
         no_data_val = self._ds.no_data_value[band]
@@ -1391,6 +1392,7 @@ class Analysis(_Engine["Dataset"]):
 
               ```python
               >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.randint(1, 12, size=(10, 10))
               >>> print(arr)    # doctest: +SKIP
               [[ 4  1  1  2  6  9  2  5  1  8]
@@ -1518,6 +1520,7 @@ class Analysis(_Engine["Dataset"]):
                 >>> ds = Dataset.create_from_array(arr, top_left_corner=(0, 0), cell_size=1.0, epsg=4326)
                 >>> fig, ax, hist = ds.plot_histogram(band=0, bins=8)  # doctest: +SKIP
                 >>> _ = ax.set_title("band 0 distribution")  # doctest: +SKIP
+
                 ```
             - Drop a sentinel value before binning:
 
@@ -1525,6 +1528,7 @@ class Analysis(_Engine["Dataset"]):
                 >>> arr = np.array([[1.0, 2.0, 99.0], [3.0, 4.0, 99.0]], dtype="float32")
                 >>> ds = Dataset.create_from_array(arr, top_left_corner=(0, 0), cell_size=1.0, epsg=4326)
                 >>> fig, ax, hist = ds.plot_histogram(band=0, exclude_value=99.0)  # doctest: +SKIP
+
                 ```
         """
         require_cleopatra()
@@ -1599,6 +1603,7 @@ class Analysis(_Engine["Dataset"]):
                 >>> img.size  # (width, height) == (columns, rows)  # doctest: +SKIP
                 (8, 6)
                 >>> img.save("band0.png")  # doctest: +SKIP
+
                 ```
         """
         require_cleopatra()
@@ -1692,12 +1697,14 @@ class Analysis(_Engine["Dataset"]):
                 >>> uv = rng.standard_normal((2, 6, 6)).astype("float32")
                 >>> ds = Dataset.create_from_array(uv, top_left_corner=(0, 0), cell_size=1.0, epsg=4326)
                 >>> fig, ax, im = ds.plot_vector_field(u_band=0, v_band=1, kind="quiver")  # doctest: +SKIP
+
                 ```
             - Draw streamlines without the magnitude colorbar (e.g. to add a
               shared one later):
 
                 ```python
                 >>> fig, ax, im = ds.plot_vector_field(kind="streamplot", add_colorbar=False)  # doctest: +SKIP
+
                 ```
         """
         require_cleopatra()
@@ -1841,32 +1848,38 @@ class Analysis(_Engine["Dataset"]):
             - Plot a certain band:
               ```python
               >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.rand(4, 10, 10)
               >>> top_left_corner = (0, 0)
               >>> cell_size = 0.05
               >>> dataset = Dataset.create_from_array(arr, top_left_corner=top_left_corner, cell_size=cell_size,epsg=4326)
-              >>> dataset.plot(band=0)
+              >>> dataset.plot(band=0)  # doctest: +SKIP
               (<Figure size 800x800 with 2 Axes>, <Axes: >)
+
               ```
             - plot using power scale.
               ```python
-              >>> dataset.plot(band=0, color_scale="power")
+              >>> dataset.plot(band=0, color_scale="power")  # doctest: +SKIP
               (<Figure size 800x800 with 2 Axes>, <Axes: >)
+
               ```
             - plot using SymLogNorm scale.
               ```python
-              >>> dataset.plot(band=0, color_scale="sym-lognorm")
+              >>> dataset.plot(band=0, color_scale="sym-lognorm")  # doctest: +SKIP
               (<Figure size 800x800 with 2 Axes>, <Axes: >)
+
               ```
             - plot using PowerNorm scale.
               ```python
-              >>> dataset.plot(band=0, color_scale="boundary-norm", bounds=[0, 0.2, 0.4, 0.6, 0.8, 1])
+              >>> dataset.plot(band=0, color_scale="boundary-norm", bounds=[0, 0.2, 0.4, 0.6, 0.8, 1])  # doctest: +SKIP
               (<Figure size 800x800 with 2 Axes>, <Axes: >)
+
               ```
             - plot using BoundaryNorm scale.
               ```python
-              >>> dataset.plot(band=0, color_scale="midpoint")
+              >>> dataset.plot(band=0, color_scale="midpoint")  # doctest: +SKIP
               (<Figure size 800x800 with 2 Axes>, <Axes: >)
+
               ```
         """
         no_data_value = [np.nan if i is None else i for i in self._ds.no_data_value]

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -101,15 +101,18 @@ class Bands(_Engine["Dataset"]):
             - Read a dataset and fetch its attribute table:
 
               ```python
-              >>> dataset = Dataset.read_file("examples/data/geotiff/south-america-mswep_1979010100.tif")
+              >>> from pyramids.dataset import Dataset
+              >>> import pandas as pd
+              >>> dataset = Dataset.create(
+              ...     cell_size=0.05, rows=5, columns=5, dtype="float32", bands=1,
+              ...     top_left_corner=(0, 0), epsg=4326, no_data_value=-9999,
+              ... )
+              >>> dataset.set_attribute_table(
+              ...     pd.DataFrame({"Category": ["Low", "High"], "Description": ["dry", "wet"]})
+              ... )
               >>> df = dataset.get_attribute_table()
-              >>> print(df)
-                Precipitation Range (mm)   Category              Description
-              0                     0-50        Low   Very low precipitation
-              1                   51-100   Moderate   Moderate precipitation
-              2                  101-200       High       High precipitation
-              3                  201-500  Very High  Very high precipitation
-              4                     >500    Extreme    Extreme precipitation
+              >>> df["Category"].tolist()
+              ['Low', 'High']
 
               ```
         """
@@ -148,6 +151,8 @@ class Bands(_Engine["Dataset"]):
             - First create a dataset:
 
               ```python
+              >>> from pyramids.dataset import Dataset
+              >>> import pandas as pd
               >>> dataset = Dataset.create(
               ... cell_size=0.05, rows=10, columns=10, dtype="float32", bands=1,
               ... top_left_corner=(0, 0), epsg=4326, no_data_value=-9999
@@ -348,21 +353,26 @@ class Bands(_Engine["Dataset"]):
             - First create a dataset:
 
               ```python
+              >>> from pyramids.dataset import Dataset
               >>> dataset = Dataset.create(
               ... cell_size=0.05, rows=10, columns=10, dtype="float32", bands=1,
               ... top_left_corner=(0, 0), epsg=4326, no_data_value=-9999
               ... )
-              >>> print(dataset)
+              >>> print(dataset)  # doctest: +NORMALIZE_WHITESPACE
               <BLANKLINE>
+                          Top Left Corner: (0.0, 0.0)
                           Cell size: 0.05
                           Dimension: 10 * 10
                           EPSG: 4326
                           Number of Bands: 1
                           Band names: ['Band_1']
+                          Band colors: {0: 'undefined'}
+                          Band units: ['']
+                          Scale: [1.0]
+                          Offset: [0]
                           Mask: -9999.0
                           Data type: float32
-                          File:...
-              <BLANKLINE>
+                          File:
 
               ```
 
@@ -378,17 +388,21 @@ class Bands(_Engine["Dataset"]):
 
               ```python
               >>> dataset.add_band(array, unit="m", attribute_table=None, inplace=True)
-              >>> print(dataset)
+              >>> print(dataset)  # doctest: +NORMALIZE_WHITESPACE
               <BLANKLINE>
+                          Top Left Corner: (0.0, 0.0)
                           Cell size: 0.05
                           Dimension: 10 * 10
                           EPSG: 4326
                           Number of Bands: 2
                           Band names: ['Band_1', 'Band_2']
+                          Band colors: {0: 'undefined', 1: 'undefined'}
+                          Band units: ['', 'm']
+                          Scale: [1.0, 1.0]
+                          Offset: [0, 0]
                           Mask: -9999.0
                           Data type: float32
-                          File:...
-              <BLANKLINE>
+                          File:
 
               ```
 
@@ -578,6 +592,8 @@ class Bands(_Engine["Dataset"]):
             - Create `Dataset` consisting of 3 bands and assign RGB colors:
 
               ```python
+              >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.randint(1, 3, size=(3, 10, 10))
               >>> top_left_corner = (0, 0)
               >>> cell_size = 0.05
@@ -622,6 +638,7 @@ class Bands(_Engine["Dataset"]):
               ```python
               >>> import numpy as np
               >>> import pandas as pd
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.randint(1, 3, size=(2, 10, 10))
               >>> top_left_corner = (0, 0)
               >>> cell_size = 0.05
@@ -706,6 +723,7 @@ class Bands(_Engine["Dataset"]):
               ```python
               >>> import numpy as np
               >>> import pandas as pd
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.randint(1, 3, size=(2, 10, 10))
               >>> top_left_corner = (0, 0)
               >>> cell_size = 0.05
@@ -749,7 +767,7 @@ class Bands(_Engine["Dataset"]):
               ...     "values": [1, 2, 3, 1, 2, 3],
               ...     "color": ["#709959", "#F2EEA2", "#F2CE85", "#C28C7C", "#D6C19C",
               ...         "#D6C19C"],
-              ...     "alpha": [255, 128 0, 255, 128 0]
+              ...     "alpha": [255, 128, 0, 255, 128, 0]
               ... })
               >>> dataset.color_table = color_table
               >>> print(dataset.color_table)
@@ -1096,6 +1114,7 @@ class Bands(_Engine["Dataset"]):
         Examples:
             - Create a Dataset (4 bands, 10 rows, 10 columns) at lon/lat (0, 0):
               ```python
+              >>> from pyramids.dataset import Dataset
               >>> dataset = Dataset.create(
               ...     cell_size=0.05, rows=3, columns=3, bands=1, top_left_corner=(0, 0),dtype="float32",
               ...     epsg=4326, no_data_value=-9
@@ -1107,6 +1126,7 @@ class Bands(_Engine["Dataset"]):
                [-9. -9. -9.]]
               >>> print(dataset.no_data_value) # doctest: +SKIP
               [-9.0]
+
               ```
             - The dataset is full of the no_data_value. Now change it using `change_no_data_value`:
               ```python
@@ -1118,6 +1138,7 @@ class Bands(_Engine["Dataset"]):
                [-10. -10. -10.]]
               >>> print(new_dataset.no_data_value) # doctest: +SKIP
               [-10.0]
+
               ```
         """
         if not isinstance(new_value, list):

--- a/src/pyramids/dataset/engines/cell.py
+++ b/src/pyramids/dataset/engines/cell.py
@@ -60,6 +60,7 @@ class Cell(_Engine["Dataset"]):
 
               ```python
               >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.randint(1,3, size=(3, 3))
               >>> top_left_corner = (0, 0)
               >>> cell_size = 0.05
@@ -167,6 +168,7 @@ class Cell(_Engine["Dataset"]):
 
               ```python
               >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.randint(1,3, size=(3, 3))
               >>> top_left_corner = (0, 0)
               >>> cell_size = 0.05
@@ -178,7 +180,7 @@ class Cell(_Engine["Dataset"]):
 
               ```python
               >>> gdf = dataset.get_cell_polygons()
-              >>> print(gdf)
+              >>> print(gdf)  # doctest: +NORMALIZE_WHITESPACE
                                                      geometry  id
               0  POLYGON ((0 0, 0.05 0, 0.05 -0.05, 0 -0.05, 0 0))   0
               1  POLYGON ((0.05 0, 0.1 0, 0.1 -0.05, 0.05 -0.05...   1
@@ -189,8 +191,8 @@ class Cell(_Engine["Dataset"]):
               6  POLYGON ((0 -0.1, 0.05 -0.1, 0.05 -0.15, 0 -0....   6
               7  POLYGON ((0.05 -0.1, 0.1 -0.1, 0.1 -0.15, 0.05...   7
               8  POLYGON ((0.1 -0.1, 0.15 -0.1, 0.15 -0.15, 0.1...   8
-              >>> fig, ax = dataset.plot()
-              >>> gdf.plot(ax=ax, facecolor='none', edgecolor="gray", linewidth=2)
+              >>> fig, ax = dataset.plot()  # doctest: +SKIP
+              >>> gdf.plot(ax=ax, facecolor='none', edgecolor="gray", linewidth=2)  # doctest: +SKIP
               <Axes: >
 
               ```
@@ -247,6 +249,7 @@ class Cell(_Engine["Dataset"]):
 
               ```python
               >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.randint(1,3, size=(3, 3))
               >>> top_left_corner = (0, 0)
               >>> cell_size = 0.05
@@ -269,8 +272,8 @@ class Cell(_Engine["Dataset"]):
               6  POINT (0.025 -0.125)   6
               7  POINT (0.075 -0.125)   7
               8  POINT (0.125 -0.125)   8
-              >>> fig, ax = dataset.plot()
-              >>> gdf.plot(ax=ax, facecolor='black', linewidth=2)
+              >>> fig, ax = dataset.plot()  # doctest: +SKIP
+              >>> gdf.plot(ax=ax, facecolor='black', linewidth=2)  # doctest: +SKIP
               <Axes: >
 
               ```
@@ -281,7 +284,7 @@ class Cell(_Engine["Dataset"]):
 
               ```python
               >>> gdf = dataset.get_cell_points(location="corner")
-              >>> print(gdf)
+              >>> print(gdf)  # doctest: +NORMALIZE_WHITESPACE
                           geometry  id
               0         POINT (0 0)   0
               1      POINT (0.05 0)   1
@@ -292,8 +295,8 @@ class Cell(_Engine["Dataset"]):
               6      POINT (0 -0.1)   6
               7   POINT (0.05 -0.1)   7
               8    POINT (0.1 -0.1)   8
-              >>> fig, ax = dataset.plot()
-              >>> gdf.plot(ax=ax, facecolor='black', linewidth=4)
+              >>> fig, ax = dataset.plot()  # doctest: +SKIP
+              >>> gdf.plot(ax=ax, facecolor='black', linewidth=4)  # doctest: +SKIP
               <Axes: >
 
               ```
@@ -335,6 +338,7 @@ class Cell(_Engine["Dataset"]):
               ```python
               >>> import numpy as np
               >>> import pandas as pd
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.randint(1, 3, size=(2, 10, 10))
               >>> top_left_corner = (0, 0)
               >>> cell_size = 0.05

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -552,6 +552,7 @@ class IO(_Engine["Dataset"]):
 
               ```python
               >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.rand(4, 5, 5)
               >>> top_left_corner = (0, 0)
               >>> cell_size = 0.05
@@ -1660,11 +1661,12 @@ class IO(_Engine["Dataset"]):
             - First, create a dataset on disk:
 
               ```python
-              >>> import numpy as np
+              >>> import numpy as np, os, tempfile
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.rand(5, 5)
               >>> top_left_corner = (0, 0)
               >>> cell_size = 0.05
-              >>> path = 'write_array.tif'
+              >>> path = os.path.join(tempfile.mkdtemp(), 'write_array.tif')
               >>> dataset = Dataset.create_from_array(
               ...     arr, top_left_corner=top_left_corner, cell_size=cell_size, epsg=4326, path=path
               ... )
@@ -1814,6 +1816,7 @@ class IO(_Engine["Dataset"]):
 
               ```python
               >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.rand(13, 14)
               >>> top_left_corner = (0, 0)
               >>> cell_size = 0.05
@@ -1914,7 +1917,8 @@ class IO(_Engine["Dataset"]):
             - Create a Dataset with 4 bands, 5 rows, 5 columns, at the point lon/lat (0, 0):
 
               ```python
-              >>> import numpy as np
+              >>> import numpy as np, os, tempfile
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.rand(4, 5, 5)
               >>> top_left_corner = (0, 0)
               >>> cell_size = 0.05
@@ -1927,9 +1931,10 @@ class IO(_Engine["Dataset"]):
             - Now save the dataset as a geotiff file:
 
               ```python
-              >>> dataset.to_file("my-dataset.tif")
-              >>> print(dataset.file_name)
-              my-dataset.tif
+              >>> path = os.path.join(tempfile.mkdtemp(), "my-dataset.tif")
+              >>> dataset.to_file(path)
+              >>> os.path.basename(dataset.file_name)
+              'my-dataset.tif'
 
               ```
         """
@@ -2175,11 +2180,12 @@ class IO(_Engine["Dataset"]):
 
               ```python
               >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.rand(3, 5)
               >>> top_left_corner = (0, 0)
               >>> cell_size = 0.05
               >>> dataset = Dataset.create_from_array(arr, top_left_corner=top_left_corner, cell_size=cell_size, epsg=4326)
-              >>> tile_dimensions = list(dataset._tile_offsets(2))
+              >>> tile_dimensions = list(dataset.io._tile_offsets(2))
               >>> print(tile_dimensions)
               [(0, 0, 2, 2), (2, 0, 2, 2), (4, 0, 1, 2), (0, 2, 2, 1), (2, 2, 2, 1), (4, 2, 1, 1)]
 
@@ -2210,21 +2216,25 @@ class IO(_Engine["Dataset"]):
 
               ```python
               >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.rand(3, 5)
               >>> top_left_corner = (0, 0)
               >>> cell_size = 0.05
               >>> dataset = Dataset.create_from_array(arr, top_left_corner=top_left_corner, cell_size=cell_size, epsg=4326)
-              >>> print(dataset)
-              <BLANKLINE>
-                          Cell size: 0.05
-                          Dimension: 3 * 5
-                          EPSG: 4326
-                          Number of Bands: 1
-                          Band names: ['Band_1']
-                          Mask: -9999.0
-                          Data type: float64
-                          File:...
-              <BLANKLINE>
+              >>> print(dataset)  # doctest: +NORMALIZE_WHITESPACE
+              Top Left Corner: (0.0, 0.0)
+              Cell size: 0.05
+              Dimension: 3 * 5
+              EPSG: 4326
+              Number of Bands: 1
+              Band names: ['Band_1']
+              Band colors: {0: 'undefined'}
+              Band units: ['']
+              Scale: [1.0]
+              Offset: [0]
+              Mask: -9999.0
+              Data type: float64
+              File:
 
               >>> print(dataset.read_array())   # doctest: +SKIP
               [[0.55332314 0.48364841 0.67794589 0.6901816  0.70516817]
@@ -2235,7 +2245,7 @@ class IO(_Engine["Dataset"]):
             - The `get_tile` method splits the domain into tiles of the specified `size` using the `_tile_offsets` function.
 
               ```python
-              >>> tile_dimensions = list(dataset._tile_offsets(2))
+              >>> tile_dimensions = list(dataset.io._tile_offsets(2))
               >>> print(tile_dimensions)
               [(0, 0, 2, 2), (2, 0, 2, 2), (4, 0, 1, 2), (0, 2, 2, 1), (2, 2, 2, 1), (4, 2, 1, 1)]
 
@@ -2331,6 +2341,7 @@ class IO(_Engine["Dataset"]):
 
               ```python
               >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.arange(1, 101, dtype=np.float32).reshape(10, 10)
               >>> dataset = Dataset.create_from_array(
               ...     arr, top_left_corner=(0, 0), cell_size=1.0, epsg=4326
@@ -2420,26 +2431,26 @@ class IO(_Engine["Dataset"]):
                 assign a scale of 0.1 to the dataset.
                 ```python
                 >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
                 >>> arr = np.array([[[1, 2], [3, 4]], [[5, 6], [7, 8]]])
                 >>> top_left_corner = (0, 0)
                 >>> cell_size = 0.05
                 >>> dataset = Dataset.create_from_array(arr, top_left_corner=top_left_corner, cell_size=cell_size,epsg=4326)
-                >>> print(dataset)
-                <BLANKLINE>
-                            Top Left Corner: (0.0, 0.0)
-                            Cell size: 0.05
-                            Dimension: 2 * 2
-                            EPSG: 4326
-                            Number of Bands: 2
-                            Band names: ['Band_1', 'Band_2']
-                            Band colors: {0: 'undefined', 1: 'undefined'}
-                            Band units: ['', '']
-                            Scale: [1.0, 1.0]
-                            Offset: [0, 0]
-                            Mask: -9999.0
-                            Data type: int64
-                            File: ...
-                <BLANKLINE>
+                >>> print(dataset)  # doctest: +NORMALIZE_WHITESPACE
+                Top Left Corner: (0.0, 0.0)
+                Cell size: 0.05
+                Dimension: 2 * 2
+                EPSG: 4326
+                Number of Bands: 2
+                Band names: ['Band_1', 'Band_2']
+                Band colors: {0: 'undefined', 1: 'undefined'}
+                Band units: ['', '']
+                Scale: [1.0, 1.0]
+                Offset: [0, 0]
+                Mask: -9999
+                Data type: int64
+                File:
+
                 >>> df = dataset.to_xyz()
                 >>> print(df)
                      lon    lat  Band_1  Band_2
@@ -2447,6 +2458,7 @@ class IO(_Engine["Dataset"]):
                 1  0.075 -0.025       2       6
                 2  0.025 -0.075       3       7
                 3  0.075 -0.075       4       8
+
                 ```
         """
         if bands is None:
@@ -2819,31 +2831,37 @@ class IO(_Engine["Dataset"]):
             - Create a Dataset with 4 bands, 10 rows, 10 columns, at the point lon/lat (0, 0):
               ```python
               >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.rand(4, 10, 10)
               >>> top_left_corner = (0, 0)
               >>> cell_size = 0.05
               >>> dataset = Dataset.create_from_array(arr, top_left_corner=top_left_corner, cell_size=cell_size, epsg=4326)
+
               ```
             - Now, create overviews using the default parameters:
               ```python
               >>> dataset.create_overviews()
               >>> print(dataset.overview_count)  # doctest: +SKIP
               [4, 4, 4, 4]
+
               ```
             - For each band, there are 4 overview levels you can use to plot the bands:
               ```python
               >>> dataset.plot(band=0, overview=True, overview_index=0) # doctest: +SKIP
+
               ```
               ![overviews-level-0](./../../_images/dataset/overviews-level-0.png)
             - However, the dataset originally is 10*10, but the first overview level (2) displays half of the cells by
               aggregating all the cells using the nearest neighbor. The second level displays only 3 cells in each:
               ```python
               >>> dataset.plot(band=0, overview=True, overview_index=1)   # doctest: +SKIP
+
               ```
               ![overviews-level-1](./../../_images/dataset/overviews-level-1.png)
             - For the third overview level:
               ```python
               >>> dataset.plot(band=0, overview=True, overview_index=2)       # doctest: +SKIP
+
               ```
               ![overviews-level-2](./../../_images/dataset/overviews-level-2.png)
         See Also:
@@ -2926,6 +2944,7 @@ class IO(_Engine["Dataset"]):
             - Create `Dataset` consisting of 4 bands, 10 rows, 10 columns, at lon/lat (0, 0):
               ```python
               >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.randint(1, 10, size=(4, 10, 10))
               >>> print(arr[0, :, :]) # doctest: +SKIP
               array([[6, 3, 3, 7, 4, 8, 4, 3, 8, 7],
@@ -2941,6 +2960,7 @@ class IO(_Engine["Dataset"]):
               >>> top_left_corner = (0, 0)
               >>> cell_size = 0.05
               >>> dataset = Dataset.create_from_array(arr, top_left_corner=top_left_corner, cell_size=cell_size, epsg=4326)
+
               ```
             - Now, create overviews using the default parameters and inspect them:
               ```python
@@ -2968,6 +2988,7 @@ class IO(_Engine["Dataset"]):
               >>> ovr = dataset.get_overview(band=0, overview_index=3)
               >>> ovr.ReadAsArray()  # doctest: +SKIP
               array([[6]], dtype=int32)
+
               ```
         See Also:
             - Dataset.create_overviews: Create the dataset overviews if they exist.
@@ -3005,6 +3026,7 @@ class IO(_Engine["Dataset"]):
             - Create `Dataset` consisting of 4 bands, 10 rows, 10 columns, at lon/lat (0, 0):
               ```python
               >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
               >>> arr = np.random.randint(1, 10, size=(4, 10, 10))
               >>> print(arr[0, :, :])     # doctest: +SKIP
               array([[6, 3, 3, 7, 4, 8, 4, 3, 8, 7],
@@ -3020,6 +3042,7 @@ class IO(_Engine["Dataset"]):
               >>> top_left_corner = (0, 0)
               >>> cell_size = 0.05
               >>> dataset = Dataset.create_from_array(arr, top_left_corner=top_left_corner, cell_size=cell_size, epsg=4326)
+
               ```
             - Create overviews using the default parameters and read overview arrays:
               ```python
@@ -3045,6 +3068,7 @@ class IO(_Engine["Dataset"]):
               >>> arr = dataset.read_overview_array(band=0, overview_index=3)
               >>> print(arr)  # doctest: +SKIP
               array([[6]], dtype=int32)
+
               ```
         See Also:
             - Dataset.create_overviews: Create the dataset overviews.

--- a/src/pyramids/feature/_lazy_collection.py
+++ b/src/pyramids/feature/_lazy_collection.py
@@ -314,7 +314,7 @@ class LazyFeatureCollection(dask_geopandas.GeoDataFrame):
                 ...     dg.from_geopandas(gdf, npartitions=1)
                 ... )
                 >>> xmin, ymin, xmax, ymax = lfc.compute_total_bounds()
-                >>> xmin, ymax
+                >>> float(xmin), float(ymax)
                 (0.0, 20.0)
 
                 ```

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -2703,6 +2703,7 @@ class FeatureCollection(GeoDataFrame):
                 >>> fc = FeatureCollection(gdf)
                 >>> ax = fc.plot(column="v")  # doctest: +SKIP
                 >>> _ = ax.set_title("points")  # doctest: +SKIP
+
                 ```
             - The cleopatra engine returns the glyph, exposing the colorbar:
 
@@ -2714,6 +2715,7 @@ class FeatureCollection(GeoDataFrame):
                 >>> fc = FeatureCollection(gdf)
                 >>> glyph = fc.plot(column="v", engine="cleopatra")  # doctest: +SKIP
                 >>> _ = glyph.cbar.set_label("value")  # doctest: +SKIP
+
                 ```
         """
         if engine == "geopandas":


### PR DESCRIPTION
# Description

A whitespace bug in several docstrings was aborting `pytest --doctest-modules src` **at collection**, so for a long
time **none** of the `src/` doctests ran. Hidden behind that, ~40 shipped `>>>` examples had silently rotted:
missing imports, references to data files that are not in the repo, and stale expected output. This PR repairs the
collection errors and then makes every surfaced example actually run and pass, so the published API-reference
examples are copy-pasteable again.

No library behaviour changes — every edit is inside a docstring.

What changed:

- **Collection fixed (0 → 457 doctests collect):** added the missing blank line before ~30 doctest code-fence
  closes, plus one malformed `...)` continuation, across 8 modules. `--doctest-modules src` no longer aborts.
- **Examples made runnable and verified:** added the missing imports/fixtures, switched to deterministic in-memory
  data, and marked only genuine viz/network calls `# doctest: +SKIP`.
- **No more missing-file references:** the `rhine-classes.tif` (issue #762) and an unnamed `rhine-flood.tif`
  example are rewritten in-memory, and every `examples/GIS/data/...` path (a tree that never existed) is corrected
  to `examples/data/...`. A scan of all `examples/...` string literals in `src/` now resolves to tracked paths
  (0 missing).
- **Two subtle root causes fixed (not papered over):**
  - `require_cleopatra`'s doctest was leaving a locationless `cleopatra` stub in `sys.modules`, which broke every
    later cleopatra doctest in the same process — it now restores `sys.modules`.
  - `get_attribute_table`'s example read a real file whose RAT load depends on GDAL PAM global state set by earlier
    doctests; it is now a self-contained `create → set_attribute_table → get_attribute_table` round-trip.
- Incidental real fixes caught along the way: a copy-paste-breaking typo in `color_table`'s alpha list
  (`[255, 128 0, ...]` → `[255, 128, 0, ...]`), a numpy-2.0 scalar-repr mismatch in `compute_total_bounds`, and an
  `IndentationError` in `_locks.DummyLock`'s example.

Dependencies: none.

# Issues

- Fixes #762

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] `pytest --doctest-modules src` → **384 passed, 73 skipped, 0 failed** (previously: aborted at collection, so
  0 doctests ran). This is exactly the check the repo's `doctest` pre-commit hook runs.
- [x] Runtime regression smoke: `pytest tests/dataset/unit/test_engines.py` → **74 passed** (the changes are
  docstring-only, so runtime behaviour is unchanged).
- [x] Path audit: a scan of every `examples/...` literal in `src/` resolves to a git-tracked path (0 missing).

Reproduce (from the repo root):

```bash
pixi run -e dev python -c "import matplotlib; matplotlib.use('Agg'); import pytest, sys; sys.exit(pytest.main(['--doctest-modules', 'src']))"
```

# Checklist:

- [ ] updated version number in pyproject.toml. — N/A: versioning is handled by commitizen in CI, not by hand.
- [ ] added changes to History.rst. — N/A: the changelog is commitizen-generated.
- [ ] updated the latest version in README file. — N/A.
- [x] I have added tests that prove my fix is effective or that my feature works. — the doctests are now executable
  and pass; they are the tests for these examples.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. — the shipped docstring examples are the documentation being fixed.
