### PR TITLE
ci(wheels): harden pip installs with --only-binary and pin the uv download to https

### DIFF
--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -460,7 +460,7 @@ jobs:
           PYTAG=$(python -c "import sys; print(f'cp{sys.version_info.major}{sys.version_info.minor}')")
           WHEEL=$(ls dist/pyramids_gis-*-${PYTAG}-${PYTAG}-*${{ matrix.wheel-tag }}*.whl | head -1)
           echo "Installing: $WHEEL"
-          pip install "$WHEEL"
+          pip install "$WHEEL" --only-binary=:all:
           pip install pytest pytest-env pytest-mock pytest-timeout --only-binary=:all:
 
       - name: Verify GDAL import
@@ -513,7 +513,7 @@ jobs:
         shell: bash
         run: |
           WHEEL=$(ls wheelhouse/pyramids_gis-*cp312*manylinux_2_28_x86_64.whl)
-          pip install "${WHEEL}"
+          pip install "${WHEEL}" --only-binary=:all:
           pip install pytest pytest-env pytest-mock pytest-timeout --only-binary=:all:
 
       - name: Verify GDAL import + drivers (netCDF, JP2, TLS)
@@ -550,7 +550,7 @@ jobs:
         shell: bash
         run: |
           WHEEL=$(ls wheelhouse/pyramids_gis-*cp312*manylinux_2_28_x86_64.whl)
-          python3.12 -m pip install "${WHEEL}"
+          python3.12 -m pip install "${WHEEL}" --only-binary=:all:
           python3.12 -m pip install pytest pytest-env pytest-mock pytest-timeout --only-binary=:all:
 
       - name: Verify GDAL import + drivers (netCDF, JP2, TLS)
@@ -593,7 +593,7 @@ jobs:
         shell: bash
         run: |
           WHEEL=$(ls wheelhouse/pyramids_gis-*cp312*manylinux_2_28_aarch64.whl)
-          python3.12 -m pip install "${WHEEL}"
+          python3.12 -m pip install "${WHEEL}" --only-binary=:all:
           python3.12 -m pip install pytest pytest-env pytest-mock pytest-timeout --only-binary=:all:
 
       - name: Verify GDAL import + drivers (netCDF, JP2, TLS)
@@ -698,7 +698,7 @@ jobs:
         run: |
           PYTAG="cp$(echo '${{ matrix.python-version }}' | tr -d .)"
           WHEEL=$(ls wheelhouse/pyramids_gis-*${PYTAG}*win_arm64.whl)
-          pip install "${WHEEL}"
+          pip install "${WHEEL}" --only-binary=:all:
 
       # Runs against the bare install closure, BEFORE the test deps land:
       # pytest itself requires `packaging`, which the vendored geopandas
@@ -784,7 +784,7 @@ jobs:
           PYTAG="cp$(echo '${{ matrix.python-version }}' | tr -d .)"
           WHEEL=$(ls dist/pyramids_gis-*-${PYTAG}-${PYTAG}-*macosx*x86_64.whl | head -1)
           echo "Installing: $WHEEL"
-          arch -x86_64 "$UVX86" pip install --python .venv-x86/bin/python "$WHEEL"
+          arch -x86_64 "$UVX86" pip install --only-binary=:all: --python .venv-x86/bin/python "$WHEEL"
 
       - name: Verify GDAL import + drivers (x86_64 under Rosetta)
         run: |

--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -551,7 +551,7 @@ jobs:
         run: |
           WHEEL=$(ls wheelhouse/pyramids_gis-*cp312*manylinux_2_28_x86_64.whl)
           python3.12 -m pip install "${WHEEL}"
-          python3.12 -m pip install pytest pytest-env pytest-mock pytest-timeout
+          python3.12 -m pip install pytest pytest-env pytest-mock pytest-timeout --only-binary=:all:
 
       - name: Verify GDAL import + drivers (netCDF, JP2, TLS)
         run: python3.12 ci/verify-wheel.py
@@ -594,7 +594,7 @@ jobs:
         run: |
           WHEEL=$(ls wheelhouse/pyramids_gis-*cp312*manylinux_2_28_aarch64.whl)
           python3.12 -m pip install "${WHEEL}"
-          python3.12 -m pip install pytest pytest-env pytest-mock pytest-timeout
+          python3.12 -m pip install pytest pytest-env pytest-mock pytest-timeout --only-binary=:all:
 
       - name: Verify GDAL import + drivers (netCDF, JP2, TLS)
         run: python3.12 ci/verify-wheel.py
@@ -709,7 +709,7 @@ jobs:
 
       - name: Install test dependencies
         if: matrix.python-version == '3.12'
-        run: pip install pytest pytest-env pytest-mock pytest-timeout
+        run: "pip install pytest pytest-env pytest-mock pytest-timeout --only-binary=:all:"
 
       - name: Run hermetic core test suite
         if: matrix.python-version == '3.12'

--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -664,9 +664,9 @@ jobs:
           tests/dataset tests/feature
 
   # Native win_arm64 verification (no emulation — the runner executes
-  # its own arch), one cell per shipped Python: a bare `pip install
-  # <wheel>` must resolve on its own (the dependency markers skip
-  # shapely/geopandas; the wheel vendors them), then verify-wheel checks
+  # its own arch), one cell per shipped Python: `pip install <wheel>`
+  # resolves the closure wheels-only (--only-binary; the dependency markers
+  # skip shapely/geopandas, which the wheel vendors), then verify-wheel checks
   # drivers, the vendored vector stack, licenses, netCDF, JP2, and
   # schannel TLS. The full hermetic suite runs once, on 3.12.
   verify-winarm64:
@@ -693,7 +693,7 @@ jobs:
           name: wheels-winarm64
           path: wheelhouse
 
-      - name: Install wheel (plain pip resolution — the real user path)
+      - name: Install wheel (wheels-only resolution — no source builds)
         shell: bash
         run: |
           PYTAG="cp$(echo '${{ matrix.python-version }}' | tr -d .)"

--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Build sdist
         run: |
-          pip install build
+          pip install build --only-binary=:all:
           python -m build --sdist
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -461,7 +461,7 @@ jobs:
           WHEEL=$(ls dist/pyramids_gis-*-${PYTAG}-${PYTAG}-*${{ matrix.wheel-tag }}*.whl | head -1)
           echo "Installing: $WHEEL"
           pip install "$WHEEL"
-          pip install pytest pytest-env pytest-mock pytest-timeout
+          pip install pytest pytest-env pytest-mock pytest-timeout --only-binary=:all:
 
       - name: Verify GDAL import
         run: python ci/verify-wheel.py
@@ -514,7 +514,7 @@ jobs:
         run: |
           WHEEL=$(ls wheelhouse/pyramids_gis-*cp312*manylinux_2_28_x86_64.whl)
           pip install "${WHEEL}"
-          pip install pytest pytest-env pytest-mock pytest-timeout
+          pip install pytest pytest-env pytest-mock pytest-timeout --only-binary=:all:
 
       - name: Verify GDAL import + drivers (netCDF, JP2, TLS)
         run: python ci/verify-wheel.py
@@ -648,10 +648,10 @@ jobs:
         run: |
           WHEEL=$(ls wheelhouse/pyramids_gis-*cp312*musllinux_1_2_x86_64.whl)
           pip install "${WHEEL}" --no-deps
-          pip install pyogrio-wheelhouse/pyogrio-*.whl
-          pip install numpy pandas scipy shapely pyproj PyYAML cftime hpc-utils packaging
-          pip install geopandas
-          pip install pytest pytest-env pytest-mock pytest-timeout
+          pip install pyogrio-wheelhouse/pyogrio-*.whl --only-binary=:all:
+          pip install numpy pandas scipy shapely pyproj PyYAML cftime hpc-utils packaging --only-binary=:all:
+          pip install geopandas --only-binary=:all:
+          pip install pytest pytest-env pytest-mock pytest-timeout --only-binary=:all:
 
       - name: Verify GDAL import + drivers (netCDF, JP2, TLS)
         run: python ci/verify-wheel.py
@@ -761,7 +761,7 @@ jobs:
       - name: Install a pinned, checksummed x86_64 uv (runs under Rosetta)
         run: |
           set -euo pipefail
-          curl -fsSL -o uv-x86_64.tar.gz \
+          curl -fsSL --proto '=https' --proto-redir '=https' -o uv-x86_64.tar.gz \
             "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-apple-darwin.tar.gz"
           echo "${UV_SHA256}  uv-x86_64.tar.gz" | shasum -a 256 -c -
           tar -xzf uv-x86_64.tar.gz

--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -784,7 +784,7 @@ jobs:
           PYTAG="cp$(echo '${{ matrix.python-version }}' | tr -d .)"
           WHEEL=$(ls dist/pyramids_gis-*-${PYTAG}-${PYTAG}-*macosx*x86_64.whl | head -1)
           echo "Installing: $WHEEL"
-          arch -x86_64 "$UVX86" pip install --only-binary=:all: --python .venv-x86/bin/python "$WHEEL"
+          arch -x86_64 "$UVX86" pip install --python .venv-x86/bin/python "$WHEEL" --only-binary=:all:
 
       - name: Verify GDAL import + drivers (x86_64 under Rosetta)
         run: |

--- a/.github/workflows/pure-wheel-test.yml
+++ b/.github/workflows/pure-wheel-test.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Install wheel (no extras)
         shell: bash -el {0}
-        run: pip install dist/*.whl
+        run: "pip install dist/*.whl --only-binary=:all:"
 
       - name: Verify package import
         shell: bash -el {0}
@@ -116,7 +116,7 @@ jobs:
 
       - name: Install test runner
         shell: bash -el {0}
-        run: pip install pytest pytest-env pytest-mock
+        run: "pip install pytest pytest-env pytest-mock --only-binary=:all:"
 
       - name: Run core tests
         shell: bash -el {0}
@@ -213,7 +213,7 @@ jobs:
 
       - name: Install test runner
         shell: bash -el {0}
-        run: pip install pytest pytest-env pytest-mock
+        run: "pip install pytest pytest-env pytest-mock --only-binary=:all:"
 
       - name: Run ${{ matrix.extra.marker }}-marked tests
         shell: bash -el {0}

--- a/.github/workflows/pure-wheel-test.yml
+++ b/.github/workflows/pure-wheel-test.yml
@@ -201,10 +201,10 @@ jobs:
         shell: bash -el {0}
         run: |
           WHEEL=$(ls dist/*.whl)
-          pip install "${WHEEL}[${{ matrix.extra.pip_extra }}]"
+          pip install "${WHEEL}[${{ matrix.extra.pip_extra }}]" --only-binary=:all:
           # Peer interop deps that are not pyramids extras (e.g. xarray).
           if [ -n "${{ matrix.extra.extra_pip }}" ]; then
-            pip install "${{ matrix.extra.extra_pip }}"
+            pip install "${{ matrix.extra.extra_pip }}" --only-binary=:all:
           fi
 
       - name: Verify package import

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -620,9 +620,6 @@ class Bands(_Engine["Dataset"]):
             band = colors.index(color_name)
         return band
 
-    # TODO: find a better way to handle the color table in accordance with attribute_table
-    # and figure out how to take a color ramp and convert it to a color table.
-    # use the SetColorInterpretation method to assign the color (R/G/B) to a band.
     @property
     def color_table(self) -> DataFrame:
         """Color table.

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -2919,11 +2919,6 @@ class IO(_Engine["Dataset"]):
                 band = self._ds._iloc(i)
                 for j in range(self.overview_count[i]):
                     ovr = self.get_overview(i, j)
-                    # TODO: if this method takes a long time, we can use the gdal.RegenerateOverviews() method
-                    #  which is faster but it does not give the option to choose the resampling method. and the
-                    #  overviews has to be given to the function as a list.
-                    #  overviews = [band.GetOverview(i) for i in range(band.GetOverviewCount())]
-                    #  band.RegenerateOverviews(overviews) or gdal.RegenerateOverviews(overviews)
                     gdal.RegenerateOverview(band, ovr, resampling_method)
         except RuntimeError:
             raise ReadOnlyError(
@@ -3005,8 +3000,6 @@ class IO(_Engine["Dataset"]):
             )
         if overview_index >= n_views:
             raise ValueError(f"overview_level should be less than {n_views}")
-        # TODO:find away to create a Dataset object from the overview band and to return the Dataset object instead
-        #  of the gdal band.
         return band_obj.GetOverview(overview_index)
 
     def read_overview_array(


### PR DESCRIPTION
# Description

The SonarCloud quality gate on `main` was failing on **C Security Rating on New Code**, driven by 27
`VULNERABILITY` findings in the wheel-build/test GitHub Actions workflows (`bundle-pypi-wheels.yml`,
`pure-wheel-test.yml`). These are pre-existing CI findings surfaced by main's broad "new code" window — not
introduced by any single feature PR (PR #777's own new code was clean).

This PR resolves them, and (after review) applies the wheel-install hardening uniformly:

- **S8541 — `pip install` can execute an sdist's `setup.py`.** Added `--only-binary=:all:` to **every**
  dependency-resolving `pip` / `uv pip` install across both workflows — the build-tool installs, the pyramids
  `$WHEEL` installs in every verify job (test-wheels, verify-debian12, verify-rocky9, verify-rocky9-aarch64,
  verify-winarm64, and the Rosetta verify-macos-x86_64 install), the alpine dep installs, and the pure-wheel
  extras installs — not just the originally-flagged subset. For a binary-first package, no CI install should
  fall back to a source build; a missing wheel now fails fast instead of silently compiling. Every runtime and
  extras dependency was verified to ship a wheel on all targets before hardening: glibc x86_64/aarch64, macOS
  x86_64/arm64, Windows x86_64, win_arm64 (cp312-314, where the vendored shapely/geopandas are marker-skipped),
  and the full extras tree on linux-x64 cp313 (68 wheels, no sdist fallback). The only installs deliberately
  left natural are the alpine `pip install "${WHEEL}" --no-deps` (resolves nothing) and the pyogrio
  build-from-source canary. Single-line `run:` scalars containing `:all:` are quoted — an unquoted trailing
  `:all:` is a YAML `ScannerError`.
- **S6506 — download not enforcing HTTPS.** The uv binary download used `curl -fsSL` (follows redirects)
  without constraining the protocol; added `--proto '=https' --proto-redir '=https'` so the request and every
  redirect stay https (the download is already SHA256-verified).
- **S8544 — "pin resolved versions" (16 findings): accepted in SonarCloud, not code-fixable.** 7 are
  local-`.whl` installs (a local wheel has no PyPI version to pin — false positives); 9 are runtime/test deps
  the wheel test intentionally resolves to **current** versions so the built wheel is validated against today's
  dependency set. Marked Accepted via the SonarCloud API, matching the `S7631` false-positive precedent on this
  same file (PR #520). `--only-binary=:all:` (S8541) is orthogonal to version pinning: those installs still
  resolve to current versions, just wheels-only — so the S8544 acceptance still stands.
- **S1135 — stale `TODO` comments.** Removed three stale `# TODO` comment blocks from
  `src/pyramids/dataset/engines/bands.py` and `src/pyramids/dataset/engines/io.py` (comment-only; the
  forward-looking items are tracked as separate issues). No code touched.

Together this takes the new-code security rating back to A.

# Issues

- Closes #793 — wheels-only (`--only-binary=:all:`) hardening of the wheel-build/test workflows (S8541).
- Closes #794 — HTTPS-only enforcement on the uv binary download (S6506).

This also clears the SonarCloud `new_security_rating` gate on `main`. The stale-TODO cleanup (S1135) removed here
is the forward-looking work already tracked in #782, #783, #784; the S8544 "pin versions" findings are accepted
in SonarCloud (see the Description).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) — CI-workflow hardening + comment cleanup; no library,
  runtime, or public-API change.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Both workflows parse (`yaml.safe_load`) and pass `actionlint`; no changed line exceeds 120 chars.
- [x] Wheel-availability verified for the extended hardening (so `--only-binary=:all:` cannot break a job):
  win_arm64 cp312-314, macOS x86_64 cp311-314, and the full extras dependency tree on linux-x64 cp313 (68
  wheels) all resolve wheels-only — no source build.
- [x] Reviewed across two independent review rounds; every finding resolved (guard suite green).
- Note: `bundle-pypi-wheels.yml` / `pure-wheel-test.yml` run on release/push, not on PRs, so their full matrix
  is not exercised here — the wheels-only invariant was validated by the resolution checks above; the first
  release run is the live confirmation.

# Checklist:

- [ ] updated version number in pyproject.toml. — N/A: versioning is handled by commitizen in CI.
- [ ] added changes to History.rst. — N/A: the changelog is commitizen-generated.
- [ ] updated the latest version in README file. — N/A.
- [x] I have added tests that prove my fix is effective. — N/A: CI-workflow + comment-only change; verified by
  actionlint, YAML parse, and the wheel-availability resolution checks.
- [x] New and existing unit tests pass locally with my changes. — no library code changed (guard suite green).
- [ ] documentation are updated. — N/A: no user-facing documentation changes.

