### PR TITLE
fix(base): clear the six base/ findings from the 2026-07-25 architecture review

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -63,6 +63,11 @@ Option B sets `propagate = False` on the `pyramids` logger, so records are emitt
 handler rather than twice (once more through your root handler). Do not combine it with Option A expecting
 both to print.
 
+Option B is reversible: a bare `Config()` removes the handlers pyramids installed and restores propagation.
+That matters for test suites — pytest's `caplog` attaches to the *root* logger, so while `propagate` is
+`False` a `caplog` assertion on a `pyramids.*` logger captures nothing and passes vacuously. If a dependency
+opts in on your behalf, call `Config()` to hand the namespace back.
+
 **If you relied on the third-party quieting**, pass it explicitly:
 
 ```python

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -25,6 +25,59 @@ warnings.simplefilter("error", DeprecationWarning)
 
 This catches the deprecations; the hard behavior changes do **not** warn — search for them manually.
 
+## base
+
+### 0.46.1
+
+**`import pyramids` no longer configures logging.** Previously, importing the package ran `Config()`, which
+added a handler to the **root** logger, called `root.setLevel(logging.INFO)`, pinned six third-party loggers to
+`WARNING`, and printed `Logging is configured.` to stderr. A library reconfiguring the root logger silently
+takes over logging for the whole host application, so that is gone.
+
+| Change | Kind | What you do |
+|--------|------|-------------|
+| Import no longer installs a console handler | behavior | Configure logging yourself, or ask pyramids for it |
+| Root logger untouched (no handler, no `setLevel`) | behavior | Nothing — this is the fix |
+| `Config` / `LoggerManager` default `level=INFO` → `None` | behavior | Pass a level to get console output |
+| `Logging is configured.` announce moved from INFO to DEBUG | behavior | Nothing |
+| Third-party loggers only quieted on request | behavior | Pass `quiet_third_party=True` to restore |
+
+**If you saw pyramids log lines and want them back**, pick one:
+
+```python
+# Option A — you own logging (recommended for applications)
+import logging
+
+logging.basicConfig(level=logging.INFO)
+import pyramids  # pyramids records propagate to your handler
+```
+
+```python
+# Option B — let pyramids install its coloured console handler
+from pyramids.base.config import Config
+
+Config(level="INFO")
+```
+
+Option B sets `propagate = False` on the `pyramids` logger, so records are emitted once by pyramids' own
+handler rather than twice (once more through your root handler). Do not combine it with Option A expecting
+both to print.
+
+**If you relied on the third-party quieting**, pass it explicitly:
+
+```python
+Config(level="INFO", quiet_third_party=True)  # pins fiona/rasterio/shapely/matplotlib/urllib3/osgeo to WARNING
+```
+
+**Exception types on three dtype helpers changed** to a descriptive `ValueError`, from the incidental error
+that leaked out of an empty table lookup. Only affects code catching the old type:
+
+| Call | Before | After |
+|------|--------|-------|
+| `numpy_to_gdal_dtype(<unmapped dtype>)` | `IndexError` | `ValueError` |
+| `gdal_to_numpy_dtype(gdal.GDT_Unknown)` | `AttributeError` | `ValueError` |
+| `gdal_to_ogr_dtype(<complex band>)` | `TypeError` | `ValueError` |
+
 ## netcdf
 
 ### 0.37.0

--- a/src/pyramids/base/_configure.py
+++ b/src/pyramids/base/_configure.py
@@ -134,6 +134,23 @@ def configure(
     return env
 
 
+def _register_plugin(client: Any, plugin: Any, name: str) -> None:
+    """Register `plugin` on `client`, falling back to the pre-2023 dask API.
+
+    `Client.register_plugin` replaced `Client.register_worker_plugin` in dask
+    2023.9; both registrars below need the same two-step, so it lives here once.
+
+    Args:
+        client: A :class:`dask.distributed.Client`.
+        plugin: The :class:`WorkerPlugin` instance to register.
+        name: Registration name, used by dask to de-duplicate plugins.
+    """
+    try:
+        client.register_plugin(plugin, name=name)
+    except AttributeError:  # pragma: no cover - old dask API
+        client.register_worker_plugin(plugin, name=name)
+
+
 def _register_worker_plugin(client: Any, env: dict[str, str]) -> None:
     """Register a WorkerPlugin that replays `env` on each dask worker."""
     from dask.distributed import WorkerPlugin
@@ -150,11 +167,7 @@ def _register_worker_plugin(client: Any, env: dict[str, str]) -> None:
             for key, value in self._env.items():
                 gdal.SetConfigOption(key, value)
 
-    plugin = PyramidsConfigPlugin(env)
-    try:
-        client.register_plugin(plugin, name="pyramids-configure")
-    except AttributeError:  # pragma: no cover - old dask API
-        client.register_worker_plugin(plugin, name="pyramids-configure")
+    _register_plugin(client, PyramidsConfigPlugin(env), "pyramids-configure")
 
 
 def configure_lazy_vector(
@@ -264,11 +277,8 @@ def _register_lazy_vector_worker_plugin(
                     self._settings["target_bytes_per_partition"]
                 )
 
-    plugin = PyramidsLazyVectorPlugin(settings)
-    try:
-        client.register_plugin(plugin, name="pyramids-configure-lazy-vector")
-    except AttributeError:  # pragma: no cover - old dask API
-        client.register_worker_plugin(
-            plugin,
-            name="pyramids-configure-lazy-vector",
-        )
+    _register_plugin(
+        client,
+        PyramidsLazyVectorPlugin(settings),
+        "pyramids-configure-lazy-vector",
+    )

--- a/src/pyramids/base/_file_manager.py
+++ b/src/pyramids/base/_file_manager.py
@@ -194,6 +194,25 @@ class _LRUCache(MutableMapping):
             ['x']
 
             ```
+        - A pinned key is never the eviction victim; the cache grows
+          past `maxsize` instead of closing a handle mid-read:
+            ```python
+            >>> from pyramids.base._file_manager import _LRUCache
+            >>> evicted = []
+            >>> cache = _LRUCache(maxsize=1, on_evict=lambda k, v: evicted.append(k))
+            >>> cache["x"] = 1
+            >>> cache.pin("x")
+            >>> cache["y"] = 2
+            >>> evicted
+            []
+            >>> sorted(cache)
+            ['x', 'y']
+            >>> cache.unpin("x")
+            >>> cache["z"] = 3
+            >>> evicted
+            ['x', 'y']
+
+            ```
     """
 
     def __init__(
@@ -209,6 +228,11 @@ class _LRUCache(MutableMapping):
         # manager for a key is finalized, so a manager whose array is dropped never evicts a handle
         # another manager (sharing the same `manager_id`) is still reading through.
         self._refcounts: dict[Hashable, int] = {}
+        # Number of in-flight reads holding each key. Distinct from `_refcounts`: a pin is scoped to
+        # one `acquire_context()` block and only makes the slot un-evictable for that window, it
+        # never closes anything. Without it a manager's insert can LRU-evict and `Close()` a handle
+        # another manager is mid-read through, since every manager carries its own lock.
+        self._pins: dict[Hashable, int] = {}
 
     @property
     def maxsize(self) -> int:
@@ -222,6 +246,32 @@ class _LRUCache(MutableMapping):
         self._maxsize = value
         self._enforce_size_limit(value)
 
+    def _select_evictions(self, target: int) -> list[tuple[Hashable, Any]]:
+        """Pop least-recently-used, unpinned entries until `len(self) <= target`.
+
+        The caller must already hold :attr:`_lock`; the popped
+        `(key, value)` pairs are returned so `on_evict` can run
+        outside it. Pinned keys are skipped: a slot with an in-flight
+        read must not be closed underneath the reader, so when every
+        remaining candidate is pinned the cache is allowed to sit
+        above `target` until those reads finish.
+        """
+        evicted: list[tuple[Hashable, Any]] = []
+        for key in list(self._cache):
+            if len(self._cache) <= target:
+                break
+            if self._pins.get(key):
+                continue
+            evicted.append((key, self._cache.pop(key)))
+        if len(self._cache) > target:
+            logger.debug(
+                "file cache is %d entr(ies) over its %d limit: every eviction "
+                "candidate is pinned by an in-flight read",
+                len(self._cache) - target,
+                target,
+            )
+        return evicted
+
     def _enforce_size_limit(self, target: int) -> None:
         """Evict LRU entries until `len(self) <= target`.
 
@@ -231,10 +281,8 @@ class _LRUCache(MutableMapping):
         risking a deadlock against concurrent `acquire()` calls
         on other threads.
         """
-        to_evict: list[tuple[Hashable, Any]] = []
         with self._lock:
-            while len(self._cache) > target:
-                to_evict.append(self._cache.popitem(last=False))
+            to_evict = self._select_evictions(target)
         if self._on_evict is not None:
             for key, value in to_evict:
                 self._on_evict(key, value)
@@ -249,12 +297,20 @@ class _LRUCache(MutableMapping):
         to_evict: list[tuple[Hashable, Any]] = []
         with self._lock:
             if key in self._cache:
+                displaced = self._cache[key]
                 self._cache.move_to_end(key)
                 self._cache[key] = value
-                return
-            while len(self._cache) >= self._maxsize:
-                to_evict.append(self._cache.popitem(last=False))
-            self._cache[key] = value
+                if displaced is not value:
+                    # Overwriting a live key drops the old handle; hand it to `on_evict` or the
+                    # file descriptor leaks. Reachable whenever two managers share a `manager_id`
+                    # with `lock=False` (e.g. `_read_time_step`'s `manager_id=path`): both can
+                    # miss, both open, and both assign.
+                    to_evict.append((key, displaced))
+            else:
+                # Trim to `maxsize - 1` first so the cache lands exactly at `maxsize` after the
+                # insert, and so the entry being added is never itself an eviction candidate.
+                to_evict.extend(self._select_evictions(self._maxsize - 1))
+                self._cache[key] = value
         if self._on_evict is not None:
             for evicted_key, evicted_value in to_evict:
                 self._on_evict(evicted_key, evicted_value)
@@ -274,15 +330,45 @@ class _LRUCache(MutableMapping):
         """Evict every entry, calling `on_evict` for each one.
 
         `on_evict` runs with the cache lock released so callback
-        code can take other locks without deadlock.
+        code can take other locks without deadlock. Unlike LRU
+        eviction this ignores pins — `clear()` is the documented hard
+        reset (interpreter exit, test fixtures), not a size-driven
+        reclaim.
         """
         with self._lock:
             items = list(self._cache.items())
             self._cache.clear()
             self._refcounts.clear()
+            self._pins.clear()
         if self._on_evict is not None:
             for key, value in items:
                 self._on_evict(key, value)
+
+    def pin(self, key: Hashable) -> None:
+        """Protect `key` from LRU eviction until the matching :meth:`unpin`.
+
+        Pins nest: N `pin()` calls need N `unpin()` calls before the
+        slot is evictable again. Pinning a key that is not (yet) in
+        the cache is allowed — :meth:`CachingFileManager.acquire_context`
+        pins before opening so the slot is covered from the moment it
+        lands.
+        """
+        with self._lock:
+            self._pins[key] = self._pins.get(key, 0) + 1
+
+    def unpin(self, key: Hashable) -> None:
+        """Drop one pin from `key`; the slot is evictable again at zero.
+
+        An untracked key -- e.g. wiped by :meth:`clear` while a read
+        was in flight -- is a no-op rather than an underflow.
+        """
+        with self._lock:
+            pinned = self._pins.get(key)
+            if pinned is not None:
+                if pinned > 1:
+                    self._pins[key] = pinned - 1
+                else:
+                    self._pins.pop(key, None)
 
     def retain(self, key: Hashable) -> None:
         """Register one live referent for `key` (see the `_refcounts` note in `__init__`)."""
@@ -554,7 +640,15 @@ class CachingFileManager(FileManager):
         )
 
     def acquire(self) -> Any:
-        """Return the handle, opening it if not already cached."""
+        """Return the handle, opening it if not already cached.
+
+        The returned handle is **not** pinned: it is only guaranteed
+        live for as long as it stays in the cache, and a concurrent
+        `acquire()` on a *different* manager can push it out of the
+        shared LRU and close it. Use :meth:`acquire_context` for any
+        read that outlives this call — it pins the slot for the
+        duration of the `with` block so eviction cannot reclaim it.
+        """
         with self._lock:
             try:
                 handle = self._cache[self._key]
@@ -567,24 +661,35 @@ class CachingFileManager(FileManager):
     def acquire_context(self) -> Iterator[Any]:
         """Context manager yielding the handle; lock is held inside `with`.
 
+        The cache slot is pinned for the whole block, so another
+        manager's insert cannot LRU-evict and `Close()` the handle
+        mid-read (per-manager locks do not protect against that on
+        their own).
+
         On any exception raised inside the `with` block, the handle
         is preserved in the cache (other callers may still need it);
         only explicit :meth:`close` removes it.
         """
         with self._lock:
+            # Pin before the lookup, not after the insert: a freshly opened handle is otherwise
+            # evictable in the window between `__setitem__` returning and the pin landing.
+            self._cache.pin(self._key)
             try:
-                handle = self._cache[self._key]
-                was_cached = True
-            except KeyError:
-                handle = self._opener(self._path, self._access, **self._kwargs)
-                self._cache[self._key] = handle
-                was_cached = False
-            try:
-                yield handle
-            except Exception:
-                if not was_cached:
-                    self._drop()
-                raise
+                try:
+                    handle = self._cache[self._key]
+                    was_cached = True
+                except KeyError:
+                    handle = self._opener(self._path, self._access, **self._kwargs)
+                    self._cache[self._key] = handle
+                    was_cached = False
+                try:
+                    yield handle
+                except Exception:
+                    if not was_cached:
+                        self._drop()
+                    raise
+            finally:
+                self._cache.unpin(self._key)
 
     def _drop(self) -> None:
         """Remove the handle from the cache without calling `on_evict`."""

--- a/src/pyramids/base/_file_manager.py
+++ b/src/pyramids/base/_file_manager.py
@@ -232,6 +232,12 @@ class _LRUCache(MutableMapping):
         # one `acquire_context()` block and only makes the slot un-evictable for that window, it
         # never closes anything. Without it a manager's insert can LRU-evict and `Close()` a handle
         # another manager is mid-read through, since every manager carries its own lock.
+        #
+        # EVERY path that removes or replaces a cached value must consult `_pins` before handing the
+        # old value to `on_evict` -- closing a handle a reader still holds is undefined behaviour in
+        # GDAL, whereas skipping the close only defers it to the reader's own reference. The
+        # size-driven paths (`_select_evictions`) and the overwrite path (`__setitem__`) both do;
+        # `clear()` and `close()` deliberately do not and say so in their docstrings.
         self._pins: dict[Hashable, int] = {}
 
     @property
@@ -300,11 +306,17 @@ class _LRUCache(MutableMapping):
                 displaced = self._cache[key]
                 self._cache.move_to_end(key)
                 self._cache[key] = value
-                if displaced is not value:
+                if displaced is not value and not self._pins.get(key):
                     # Overwriting a live key drops the old handle; hand it to `on_evict` or the
                     # file descriptor leaks. Reachable whenever two managers share a `manager_id`
                     # with `lock=False` (e.g. `_read_time_step`'s `manager_id=path`): both can
                     # miss, both open, and both assign.
+                    #
+                    # A pinned key is exactly that interleaving with a reader inside
+                    # `acquire_context()`, and the handle being displaced is the one it is reading
+                    # through -- closing it there is a use-after-close, strictly worse than the
+                    # descriptor leak. Leave it to the reader's own reference (SWIG closes the
+                    # orphan when the last one drops), the same trade-off `_select_evictions` makes.
                     to_evict.append((key, displaced))
             else:
                 # Trim to `maxsize - 1` first so the cache lands exactly at `maxsize` after the

--- a/src/pyramids/base/_file_manager.py
+++ b/src/pyramids/base/_file_manager.py
@@ -261,6 +261,16 @@ class _LRUCache(MutableMapping):
         read must not be closed underneath the reader, so when every
         remaining candidate is pinned the cache is allowed to sit
         above `target` until those reads finish.
+
+        Args:
+            target: Maximum number of entries to leave behind. Callers
+                inserting a new entry pass `maxsize - 1` so the cache
+                lands exactly at `maxsize` once the insert completes.
+
+        Returns:
+            list[tuple[Hashable, Any]]: The evicted `(key, value)`
+            pairs, in eviction order, for the caller to pass to
+            `on_evict` once the lock is released.
         """
         evicted: list[tuple[Hashable, Any]] = []
         for key in list(self._cache):
@@ -270,11 +280,13 @@ class _LRUCache(MutableMapping):
                 continue
             evicted.append((key, self._cache.pop(key)))
         if len(self._cache) > target:
+            # Report the configured limit, not `target`: an insert passes `maxsize - 1`,
+            # which would otherwise render as "over its 127 limit" on a 128-entry cache.
             logger.debug(
                 "file cache is %d entr(ies) over its %d limit: every eviction "
                 "candidate is pinned by an in-flight read",
                 len(self._cache) - target,
-                target,
+                self._maxsize,
             )
         return evicted
 

--- a/src/pyramids/base/_file_manager.py
+++ b/src/pyramids/base/_file_manager.py
@@ -235,10 +235,15 @@ class _LRUCache(MutableMapping):
         #
         # EVERY path that removes or replaces a cached value must consult `_pins` before handing the
         # old value to `on_evict` -- closing a handle a reader still holds is undefined behaviour in
-        # GDAL, whereas skipping the close only defers it to the reader's own reference. The
-        # size-driven paths (`_select_evictions`) and the overwrite path (`__setitem__`) both do;
-        # `clear()` and `close()` deliberately do not and say so in their docstrings.
+        # GDAL, whereas deferring the close only delays reclaiming a descriptor. The size-driven
+        # paths (`_select_evictions`), the overwrite path (`__setitem__`), the finalizer
+        # (`release`) and explicit teardown (`discard`, used by `CachingFileManager.close`) all do.
+        # `clear()` is the sole exception and says so in its docstring.
         self._pins: dict[Hashable, int] = {}
+        # Values pulled from the cache while pinned, waiting for the last reader to finish. The
+        # final `unpin()` closes them, so an explicit `close()` mid-read still reclaims the handle
+        # deterministically instead of either leaking it or closing it under the reader.
+        self._pending_close: dict[Hashable, Any] = {}
 
     @property
     def maxsize(self) -> int:
@@ -273,12 +278,13 @@ class _LRUCache(MutableMapping):
             `on_evict` once the lock is released.
         """
         evicted: list[tuple[Hashable, Any]] = []
-        for key in list(self._cache):
-            if len(self._cache) <= target:
-                break
-            if self._pins.get(key):
-                continue
-            evicted.append((key, self._cache.pop(key)))
+        if len(self._cache) > target:
+            for key in list(self._cache):
+                if len(self._cache) <= target:
+                    break
+                if self._pins.get(key):
+                    continue
+                evicted.append((key, self._cache.pop(key)))
         if len(self._cache) > target:
             # Report the configured limit, not `target`: an insert passes `maxsize - 1`,
             # which would otherwise render as "over its 127 limit" on a 128-entry cache.
@@ -293,11 +299,18 @@ class _LRUCache(MutableMapping):
     def _enforce_size_limit(self, target: int) -> None:
         """Evict LRU entries until `len(self) <= target`.
 
-        `on_evict` runs OUTSIDE the cache lock so the
-        callback is free to take any other lock (including a
-        :class:`CachingFileManager` per-handle mutex) without
-        risking a deadlock against concurrent `acquire()` calls
-        on other threads.
+        `on_evict` runs OUTSIDE the cache lock, so the callback never
+        deadlocks against another thread waiting on :attr:`_lock`.
+
+        That is the whole guarantee, and it covers the *cache* lock
+        only. It says nothing about the caller's own locks, and one
+        eviction path does hold one: an insert from
+        :meth:`CachingFileManager.acquire` / `acquire_context` reaches
+        `__setitem__` with that manager's mutex held, so `on_evict`
+        runs under it. The `unpin` path deliberately does not (see
+        `acquire_context`). An `on_evict` that takes a
+        `CachingFileManager` mutex is therefore NOT safe — keep
+        callbacks lock-free, as :func:`_close_handle` is.
         """
         with self._lock:
             to_evict = self._select_evictions(target)
@@ -399,7 +412,8 @@ class _LRUCache(MutableMapping):
         Args:
             key: The cache key to release.
         """
-        released = False
+        over_limit = False
+        deferred = None
         with self._lock:
             pinned = self._pins.get(key)
             if pinned is not None:
@@ -407,11 +421,51 @@ class _LRUCache(MutableMapping):
                     self._pins[key] = pinned - 1
                 else:
                     self._pins.pop(key, None)
-                    released = True
+                    # The last reader is leaving, so anything an explicit `close()` or a
+                    # finalizer parked for this key can finally be released.
+                    deferred = self._pending_close.pop(key, None)
+                    # Only worth a sweep when pins actually pushed the cache over the
+                    # limit. Checking here keeps the steady state -- cache at or under
+                    # `maxsize`, which is every read on a warm cache -- free of the
+                    # snapshot allocation and the second lock round trip, and keeps
+                    # `on_evict` off the hot path entirely.
+                    over_limit = len(self._cache) > self._maxsize
         # Outside the lock: `_enforce_size_limit` runs `on_evict` (which closes GDAL
         # handles) with the cache lock released, and re-taking it here would nest.
-        if released:
+        if deferred is not None and self._on_evict is not None:
+            try:
+                self._on_evict(key, deferred)
+            except Exception as exc:  # noqa: BLE001 - a teardown path must not raise
+                logger.warning(
+                    "handle close failed for deferred key %r: %s", key, exc, exc_info=True
+                )
+        if over_limit:
             self._enforce_size_limit(self._maxsize)
+
+    def discard(self, key: Hashable) -> Any | None:
+        """Remove `key` and return its value for the caller to close, if it may.
+
+        Explicit teardown that stays safe against an in-flight read: an
+        unpinned entry is returned so the caller closes it immediately,
+        while a pinned one is parked in `_pending_close` and released
+        by the last :meth:`unpin`. Either way the handle is reclaimed
+        deterministically — never left to the garbage collector, and
+        never closed while a reader is still going through it.
+
+        Args:
+            key: The cache key to remove.
+
+        Returns:
+            Any | None: The removed value when the caller should close
+            it now, or `None` when the entry was absent or its close
+            has been deferred to the last reader.
+        """
+        with self._lock:
+            value = self._cache.pop(key, None)
+            if value is not None and self._pins.get(key):
+                self._pending_close[key] = value
+                value = None
+        return value
 
     def retain(self, key: Hashable) -> None:
         """Register one live referent for `key` (see the `_refcounts` note in `__init__`)."""
@@ -429,11 +483,12 @@ class _LRUCache(MutableMapping):
         manager that survives a `clear()` therefore falls back to pure LRU / interpreter-exit lifetime;
         that is an accepted trade-off, since `clear()` is an explicit hard reset.
 
-        A pinned key is left in the cache untouched. Unlike `close()`, this path is driven by garbage
+        A pinned key has its close deferred rather than skipped. This path is driven by garbage
         collection rather than by a caller saying "I am done", so it can fire at an arbitrary moment --
         including while another manager sharing the slot is mid-read inside `acquire_context()`.
-        Closing there would be a use-after-close, so the refcount is dropped and the entry is left for
-        LRU to reclaim once the reader unpins.
+        Closing there would be a use-after-close, so the entry moves to `_pending_close` and the last
+        `unpin()` releases it; the deterministic-release guarantee this path exists for is preserved
+        rather than downgraded to "whenever LRU pressure happens to arrive".
         """
         handle = None
         with self._lock:
@@ -443,8 +498,10 @@ class _LRUCache(MutableMapping):
                     self._refcounts[key] = tracked - 1
                 else:
                     self._refcounts.pop(key, None)
-                    if not self._pins.get(key):
-                        handle = self._cache.pop(key, None)
+                    handle = self._cache.pop(key, None)
+                    if handle is not None and self._pins.get(key):
+                        self._pending_close[key] = handle
+                        handle = None
         if handle is not None and self._on_evict is not None:
             # release() runs from a `weakref.finalize` callback, which has no caller to surface a close
             # failure to -- so log any error (e.g. an OSError flushing a remote `/vsi` handle, which
@@ -711,27 +768,31 @@ class CachingFileManager(FileManager):
     def acquire_context(self) -> Iterator[Any]:
         """Context manager yielding the handle; lock is held inside `with`.
 
-        The cache slot is pinned for the whole block, so no *implicit*
-        reclaim can `Close()` the handle mid-read: LRU eviction, an
-        overwrite by a manager that lost the open race, and the
-        `auto_release` finalizer all skip pinned keys (per-manager
-        locks do not protect against any of those on their own).
+        The cache slot is pinned for the whole block, so nothing can
+        `Close()` the handle mid-read: LRU eviction, an overwrite by a
+        manager that lost the open race, the `auto_release` finalizer
+        and an explicit :meth:`close` all either skip the slot or defer
+        their close to the final unpin (per-manager locks do not
+        protect against any of them on their own).
 
-        The pin does **not** override an explicit teardown — a
-        concurrent :meth:`close` on a manager sharing this cache key,
-        or :meth:`_LRUCache.clear`, still closes the handle. Both are
-        a caller stating the handle is finished with; do not call
-        either while another thread is reading through the slot.
+        :meth:`_LRUCache.clear` is the one exception — a hard reset
+        that closes everything — and is only used at interpreter exit,
+        after CPython has joined the worker threads.
 
         On any exception raised inside the `with` block, the handle
         is preserved in the cache (other callers may still need it);
         only explicit :meth:`close` removes it.
         """
-        with self._lock:
-            # Pin before the lookup, not after the insert: a freshly opened handle is otherwise
-            # evictable in the window between `__setitem__` returning and the pin landing.
-            self._cache.pin(self._key)
-            try:
+        # Pin and unpin OUTSIDE the manager mutex. `unpin()` can trigger an eviction
+        # sweep, and `on_evict` closes GDAL handles -- a `/vsis3` flush can take
+        # seconds. Doing that while this manager's lock is held would block every
+        # other caller of the same manager on an eviction unrelated to them, and would
+        # deadlock outright for any `on_evict` that takes a manager mutex (the very
+        # pattern `_enforce_size_limit` documents as safe). The pin itself only needs
+        # the cache's own lock, which `pin()` takes.
+        self._cache.pin(self._key)
+        try:
+            with self._lock:
                 try:
                     handle = self._cache[self._key]
                     was_cached = True
@@ -745,8 +806,8 @@ class CachingFileManager(FileManager):
                     if not was_cached:
                         self._drop()
                     raise
-            finally:
-                self._cache.unpin(self._key)
+        finally:
+            self._cache.unpin(self._key)
 
     def _drop(self) -> None:
         """Remove the handle from the cache without calling `on_evict`.
@@ -764,20 +825,18 @@ class CachingFileManager(FileManager):
     def close(self) -> None:
         """Remove the handle from the cache and close it.
 
-        Explicit teardown: this closes the handle even when the slot is
-        pinned by an in-flight :meth:`acquire_context` on a manager
-        sharing the cache key. Pins guard against *implicit* reclaim
-        (LRU pressure, a lost open race, the `auto_release` finalizer),
-        not against a caller declaring the handle finished. Do not call
-        this while another thread is reading through the same slot.
+        Safe to call while another thread is reading through the same
+        cache slot: the entry is removed immediately, so no later
+        caller can reach it, but the actual `Close()` is deferred to
+        the reader's final `unpin` when the slot is pinned. This
+        matters because `close()` is reachable from public API —
+        `NetCDF.close()` walks its lazy managers and calls it — while
+        dask workers may still be inside `acquire_context()`, and a
+        GDAL use-after-close is a segfault rather than an exception.
         """
-        with self._lock:
-            try:
-                handle = self._cache[self._key]
-            except KeyError:
-                return
-            del self._cache[self._key]
-        _close_handle(self._key, handle)
+        handle = self._cache.discard(self._key)
+        if handle is not None:
+            _close_handle(self._key, handle)
 
 
 class _NullLock:

--- a/src/pyramids/base/_file_manager.py
+++ b/src/pyramids/base/_file_manager.py
@@ -815,7 +815,8 @@ class CachingFileManager(FileManager):
         Safe against an in-flight read regardless of pins: the entry
         leaves the cache but the handle is never closed, so a reader
         holding it keeps a live object and later callers simply miss
-        and re-open.
+        and re-open. The reader's own `unpin` clears the pin entry
+        afterwards, so nothing is left behind.
         """
         try:
             del self._cache[self._key]

--- a/src/pyramids/base/_file_manager.py
+++ b/src/pyramids/base/_file_manager.py
@@ -416,6 +416,12 @@ class _LRUCache(MutableMapping):
         accounting for (which could otherwise be a re-opened handle a live array is still reading). A
         manager that survives a `clear()` therefore falls back to pure LRU / interpreter-exit lifetime;
         that is an accepted trade-off, since `clear()` is an explicit hard reset.
+
+        A pinned key is left in the cache untouched. Unlike `close()`, this path is driven by garbage
+        collection rather than by a caller saying "I am done", so it can fire at an arbitrary moment --
+        including while another manager sharing the slot is mid-read inside `acquire_context()`.
+        Closing there would be a use-after-close, so the refcount is dropped and the entry is left for
+        LRU to reclaim once the reader unpins.
         """
         handle = None
         with self._lock:
@@ -425,7 +431,8 @@ class _LRUCache(MutableMapping):
                     self._refcounts[key] = tracked - 1
                 else:
                     self._refcounts.pop(key, None)
-                    handle = self._cache.pop(key, None)
+                    if not self._pins.get(key):
+                        handle = self._cache.pop(key, None)
         if handle is not None and self._on_evict is not None:
             # release() runs from a `weakref.finalize` callback, which has no caller to surface a close
             # failure to -- so log any error (e.g. an OSError flushing a remote `/vsi` handle, which
@@ -692,10 +699,17 @@ class CachingFileManager(FileManager):
     def acquire_context(self) -> Iterator[Any]:
         """Context manager yielding the handle; lock is held inside `with`.
 
-        The cache slot is pinned for the whole block, so another
-        manager's insert cannot LRU-evict and `Close()` the handle
-        mid-read (per-manager locks do not protect against that on
-        their own).
+        The cache slot is pinned for the whole block, so no *implicit*
+        reclaim can `Close()` the handle mid-read: LRU eviction, an
+        overwrite by a manager that lost the open race, and the
+        `auto_release` finalizer all skip pinned keys (per-manager
+        locks do not protect against any of those on their own).
+
+        The pin does **not** override an explicit teardown — a
+        concurrent :meth:`close` on a manager sharing this cache key,
+        or :meth:`_LRUCache.clear`, still closes the handle. Both are
+        a caller stating the handle is finished with; do not call
+        either while another thread is reading through the slot.
 
         On any exception raised inside the `with` block, the handle
         is preserved in the cache (other callers may still need it);
@@ -723,14 +737,28 @@ class CachingFileManager(FileManager):
                 self._cache.unpin(self._key)
 
     def _drop(self) -> None:
-        """Remove the handle from the cache without calling `on_evict`."""
+        """Remove the handle from the cache without calling `on_evict`.
+
+        Safe against an in-flight read regardless of pins: the entry
+        leaves the cache but the handle is never closed, so a reader
+        holding it keeps a live object and later callers simply miss
+        and re-open.
+        """
         try:
             del self._cache[self._key]
         except KeyError:
             pass
 
     def close(self) -> None:
-        """Remove the handle from the cache and close it."""
+        """Remove the handle from the cache and close it.
+
+        Explicit teardown: this closes the handle even when the slot is
+        pinned by an in-flight :meth:`acquire_context` on a manager
+        sharing the cache key. Pins guard against *implicit* reclaim
+        (LRU pressure, a lost open race, the `auto_release` finalizer),
+        not against a caller declaring the handle finished. Do not call
+        this while another thread is reading through the same slot.
+        """
         with self._lock:
             try:
                 handle = self._cache[self._key]

--- a/src/pyramids/base/_file_manager.py
+++ b/src/pyramids/base/_file_manager.py
@@ -439,7 +439,10 @@ class _LRUCache(MutableMapping):
                 self._on_evict(key, deferred)
             except Exception as exc:  # noqa: BLE001 - a teardown path must not raise
                 logger.warning(
-                    "handle close failed for deferred key %r: %s", key, exc, exc_info=True
+                    "handle close failed for deferred key %r: %s",
+                    key,
+                    exc,
+                    exc_info=True,
                 )
         if over_limit:
             self._enforce_size_limit(self._maxsize)

--- a/src/pyramids/base/_file_manager.py
+++ b/src/pyramids/base/_file_manager.py
@@ -364,6 +364,9 @@ class _LRUCache(MutableMapping):
         the cache is allowed — :meth:`CachingFileManager.acquire_context`
         pins before opening so the slot is covered from the moment it
         lands.
+
+        Args:
+            key: The cache key to protect.
         """
         with self._lock:
             self._pins[key] = self._pins.get(key, 0) + 1
@@ -371,9 +374,20 @@ class _LRUCache(MutableMapping):
     def unpin(self, key: Hashable) -> None:
         """Drop one pin from `key`; the slot is evictable again at zero.
 
+        Dropping the last pin re-applies the size limit immediately.
+        Pinned reads are the one thing allowed to push the cache over
+        `maxsize`, so without this the overflow would persist until
+        some *other* key happened to be inserted — on a workload that
+        finishes its reads and stops, that is never, leaving handles
+        open on a cache configured for far fewer.
+
         An untracked key -- e.g. wiped by :meth:`clear` while a read
         was in flight -- is a no-op rather than an underflow.
+
+        Args:
+            key: The cache key to release.
         """
+        released = False
         with self._lock:
             pinned = self._pins.get(key)
             if pinned is not None:
@@ -381,6 +395,11 @@ class _LRUCache(MutableMapping):
                     self._pins[key] = pinned - 1
                 else:
                     self._pins.pop(key, None)
+                    released = True
+        # Outside the lock: `_enforce_size_limit` runs `on_evict` (which closes GDAL
+        # handles) with the cache lock released, and re-taking it here would nest.
+        if released:
+            self._enforce_size_limit(self._maxsize)
 
     def retain(self, key: Hashable) -> None:
         """Register one live referent for `key` (see the `_refcounts` note in `__init__`)."""

--- a/src/pyramids/base/_file_manager.py
+++ b/src/pyramids/base/_file_manager.py
@@ -279,11 +279,13 @@ class _LRUCache(MutableMapping):
         """
         evicted: list[tuple[Hashable, Any]] = []
         if len(self._cache) > target:
-            for key in list(self._cache):
+            # Materialize the candidates before popping any: the comprehension runs
+            # to completion first, so the cache is never mutated mid-iteration.
+            # LRU order is preserved, and pinned keys are excluded outright.
+            candidates = [key for key in self._cache if not self._pins.get(key)]
+            for key in candidates:
                 if len(self._cache) <= target:
                     break
-                if self._pins.get(key):
-                    continue
                 evicted.append((key, self._cache.pop(key)))
         if len(self._cache) > target:
             # Report the configured limit, not `target`: an insert passes `maxsize - 1`,

--- a/src/pyramids/base/_utils.py
+++ b/src/pyramids/base/_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import cast
 
@@ -630,12 +631,76 @@ _DEFAULT_CLEOPATRA_MSG = (
 )
 
 
-def import_cleopatra(message: str):
-    """Import cleopatra."""
+def require_optional(module_name: str, message: str, *, return_module: bool = False):
+    """Import an optional dependency, or raise the extra's install hint.
+
+    One implementation behind every `import_<package>` guard in this module.
+    Each of those had its own copy of the same `try: import X except
+    ImportError: raise OptionalPackageDoesNotExist(message)` body; they are now
+    one-line delegations to this helper, keeping their names so call sites (and
+    the tests that monkeypatch them per module) are unaffected.
+
+    The import goes through the builtin `__import__` rather than
+    `importlib.import_module` so it is exactly the `import <module_name>`
+    statement each guard used to spell out — same module resolution, and still
+    interceptable by call sites and tests that patch `builtins.__import__`.
+
+    Args:
+        module_name: Dotted module path to import, e.g. ``"zarr"`` or
+            ``"cleopatra.tiles"``.
+        message: The install hint raised when the import fails. Compose it with
+            :func:`lazy_extra_hint` for the ``[lazy]`` extra.
+        return_module: When `True` the imported module object is returned so the
+            caller can use it without a bare inline import of its own. The
+            guard-only callers leave it `False` and get `None`.
+
+    Returns:
+        The imported module when `return_module` is `True`, otherwise `None`.
+
+    Raises:
+        OptionalPackageDoesNotExist: When the module cannot be imported.
+
+    Examples:
+        - A module from the standard library always resolves, and the guard-only
+          form returns nothing:
+            ```python
+            >>> from pyramids.base._utils import require_optional
+            >>> require_optional("json", "json is missing") is None
+            True
+
+            ```
+        - Ask for the module object back when the caller needs to use it:
+            ```python
+            >>> from pyramids.base._utils import require_optional
+            >>> mod = require_optional("json", "json is missing", return_module=True)
+            >>> mod.dumps({"a": 1})
+            '{"a": 1}'
+
+            ```
+        - A missing package raises the supplied hint verbatim:
+            ```python
+            >>> from pyramids.base._utils import require_optional
+            >>> from pyramids.base._errors import OptionalPackageDoesNotExist
+            >>> try:
+            ...     require_optional("not_a_real_package", "install the [x] extra")
+            ... except OptionalPackageDoesNotExist as exc:
+            ...     print(exc)
+            install the [x] extra
+
+            ```
+    """
     try:
-        import cleopatra  # noqa
+        __import__(module_name)
     except ImportError:
         raise OptionalPackageDoesNotExist(message)
+    # `__import__` returns the top-level package for a dotted name, so read the
+    # requested module back out of sys.modules instead of using its return value.
+    return sys.modules[module_name] if return_module else None
+
+
+def import_cleopatra(message: str):
+    """Import cleopatra."""
+    return require_optional("cleopatra", message)
 
 
 def require_cleopatra(msg: str | None = None) -> None:
@@ -745,42 +810,27 @@ def lazy_extra_hint(prefix: str) -> str:
 
 def import_zarr(message: str):
     """Import zarr."""
-    try:
-        import zarr  # noqa
-    except ImportError:
-        raise OptionalPackageDoesNotExist(message)
+    return require_optional("zarr", message)
 
 
 def import_dask_geopandas(message: str):
     """Import dask_geopandas."""
-    try:
-        import dask_geopandas  # noqa
-    except ImportError:
-        raise OptionalPackageDoesNotExist(message)
+    return require_optional("dask_geopandas", message)
 
 
 def import_pyarrow(message: str):
     """Import pyarrow."""
-    try:
-        import pyarrow  # noqa
-    except ImportError:
-        raise OptionalPackageDoesNotExist(message)
+    return require_optional("pyarrow", message)
 
 
 def import_pystac_client(message: str):
     """Import pystac_client."""
-    try:
-        import pystac_client  # noqa
-    except ImportError:
-        raise OptionalPackageDoesNotExist(message)
+    return require_optional("pystac_client", message)
 
 
 def import_stac_asset(message: str):
     """Import stac_asset (ships via the optional [stac] extra)."""
-    try:
-        import stac_asset  # noqa
-    except ImportError:
-        raise OptionalPackageDoesNotExist(message)
+    return require_optional("stac_asset", message)
 
 
 def import_dask(message: str):
@@ -790,19 +840,12 @@ def import_dask(message: str):
     their own (dask is optional, so it cannot be a top-level import). Callers
     that only need the guard may ignore the return value.
     """
-    try:
-        import dask
-    except ImportError:
-        raise OptionalPackageDoesNotExist(message)
-    return dask
+    return require_optional("dask", message, return_module=True)
 
 
 def import_kerchunk(message: str):
     """Import kerchunk."""
-    try:
-        import kerchunk  # noqa
-    except ImportError:
-        raise OptionalPackageDoesNotExist(message)
+    return require_optional("kerchunk", message)
 
 
 def import_h5py(message: str):
@@ -821,19 +864,12 @@ def import_h5py(message: str):
     Raises:
         OptionalPackageDoesNotExist: When h5py is not installed.
     """
-    try:
-        import h5py
-    except ImportError:
-        raise OptionalPackageDoesNotExist(message)
-    return h5py
+    return require_optional("h5py", message, return_module=True)
 
 
 def import_basemap(message: str):
     """Import the web-tile basemap backend (``cleopatra.tiles``, the ``[tiles]`` extra)."""
-    try:
-        from cleopatra import tiles  # noqa
-    except ImportError:
-        raise OptionalPackageDoesNotExist(message)
+    return require_optional("cleopatra.tiles", message)
 
 
 def ogr_ds_to_gdal_dataset(ogr_ds: ogr.DataSource) -> gdal.Dataset:

--- a/src/pyramids/base/_utils.py
+++ b/src/pyramids/base/_utils.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Sequence
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 import numpy as np
 import yaml
@@ -99,7 +100,9 @@ DTYPE_CONVERSION_DF = DataFrame(
 )
 
 
-def _first_wins(keys: list, values: list) -> dict:
+def _first_wins(
+    keys: Sequence[Any], values: Sequence[Any]
+) -> dict[Any, Any]:
     """Zip `keys` onto `values`, keeping the first pair for a duplicated key.
 
     Mirrors the ``.values[0]`` semantics of the DataFrame masks these lookup
@@ -109,13 +112,14 @@ def _first_wins(keys: list, values: list) -> dict:
     returning a bogus ``None``.
 
     Args:
-        keys (list): Lookup keys, in table order.
-        values (list): Values positionally paired with `keys`.
+        keys (Sequence[Any]): Lookup keys, in table order.
+        values (Sequence[Any]): Values positionally paired with `keys`.
 
     Returns:
-        dict: The first-wins mapping, with ``None``-bearing pairs removed.
+        dict[Any, Any]: The first-wins mapping, with ``None``-bearing pairs
+        removed.
     """
-    mapping: dict = {}
+    mapping: dict[Any, Any] = {}
     for key, value in zip(keys, values):
         if key is None or value is None:
             continue
@@ -124,21 +128,18 @@ def _first_wins(keys: list, values: list) -> dict:
     return mapping
 
 
-_NUMPY_TO_GDAL: dict = _first_wins(
+# Precomputed dtype lookups. The conversion helpers below used to run a
+# full-column pandas boolean mask over `DTYPE_CONVERSION_DF` on every call --
+# roughly 250 us for what is a fixed 16-row table lookup, paid per band and per
+# timestep. These dicts are built once at import; `DTYPE_CONVERSION_DF` is kept
+# because it is part of the module's public surface and still supplies the
+# "available types" listings in the error messages.
+_NUMPY_TO_GDAL: dict[Any, Any] = _first_wins(
     [None if dtype is None else np.dtype(dtype) for dtype in NUMPY_DTYPE], GDAL_DTYPE
 )
-_GDAL_TO_NUMPY: dict = _first_wins(GDAL_DTYPE, NUMPY_DTYPE)
-_GDAL_TO_OGR: dict = _first_wins(GDAL_DTYPE, OGR_DTYPE)
-_OGR_TO_NUMPY: dict = _first_wins(OGR_DTYPE, NUMPY_DTYPE)
-"""Precomputed dtype lookups.
-
-The conversion helpers below used to run a full-column pandas boolean mask over
-`DTYPE_CONVERSION_DF` on every call — roughly 250 µs for what is a fixed
-16-row table lookup, paid per band and per timestep. These dicts are built once
-at import; `DTYPE_CONVERSION_DF` is kept because it is part of the module's
-public surface and still supplies the "available types" listings in the error
-messages.
-"""
+_GDAL_TO_NUMPY: dict[Any, Any] = _first_wins(GDAL_DTYPE, NUMPY_DTYPE)
+_GDAL_TO_OGR: dict[Any, Any] = _first_wins(GDAL_DTYPE, OGR_DTYPE)
+_OGR_TO_NUMPY: dict[Any, Any] = _first_wins(OGR_DTYPE, NUMPY_DTYPE)
 
 COLOR_INTERPRETATIONS = [
     gdal.GCI_Undefined,  # 0
@@ -661,20 +662,24 @@ def require_optional(module_name: str, message: str, *, return_module: bool = Fa
         OptionalPackageDoesNotExist: When the module cannot be imported.
 
     Examples:
-        - A module from the standard library always resolves, and the guard-only
-          form returns nothing:
+        - An installed dependency resolves, and the guard-only form returns
+          nothing:
             ```python
             >>> from pyramids.base._utils import require_optional
-            >>> require_optional("json", "json is missing") is None
+            >>> require_optional("numpy", "install the [x] extra") is None
             True
 
             ```
-        - Ask for the module object back when the caller needs to use it:
+        - Ask for the module object back when the caller needs to use it. A
+          dotted name resolves to the submodule itself, not its top-level
+          package:
             ```python
             >>> from pyramids.base._utils import require_optional
-            >>> mod = require_optional("json", "json is missing", return_module=True)
-            >>> mod.dumps({"a": 1})
-            '{"a": 1}'
+            >>> mod = require_optional(
+            ...     "numpy.linalg", "install the [x] extra", return_module=True
+            ... )
+            >>> mod.__name__
+            'numpy.linalg'
 
             ```
         - A missing package raises the supplied hint verbatim:
@@ -691,8 +696,8 @@ def require_optional(module_name: str, message: str, *, return_module: bool = Fa
     """
     try:
         __import__(module_name)
-    except ImportError:
-        raise OptionalPackageDoesNotExist(message)
+    except ImportError as exc:
+        raise OptionalPackageDoesNotExist(message) from exc
     # `__import__` returns the top-level package for a dotted name, so read the
     # requested module back out of sys.modules instead of using its return value.
     return sys.modules[module_name] if return_module else None

--- a/src/pyramids/base/_utils.py
+++ b/src/pyramids/base/_utils.py
@@ -100,9 +100,7 @@ DTYPE_CONVERSION_DF = DataFrame(
 )
 
 
-def _first_wins(
-    keys: Sequence[Any], values: Sequence[Any]
-) -> dict[Any, Any]:
+def _first_wins(keys: Sequence[Any], values: Sequence[Any]) -> dict[Any, Any]:
     """Zip `keys` onto `values`, keeping the first pair for a duplicated key.
 
     Mirrors the ``.values[0]`` semantics of the DataFrame masks these lookup
@@ -139,7 +137,9 @@ _NUMPY_TO_GDAL: dict[Any, Any] = _first_wins(
 )
 _GDAL_TO_NUMPY: dict[Any, Any] = _first_wins(GDAL_DTYPE, NUMPY_DTYPE)
 _GDAL_TO_OGR: dict[Any, Any] = _first_wins(GDAL_DTYPE, OGR_DTYPE)
-_OGR_TO_NUMPY: dict[Any, Any] = _first_wins(OGR_DTYPE, NUMPY_DTYPE)
+# No OGR->numpy table: `OGR_DTYPE` holds only OFTInteger (0), OFTReal (2) and
+# OFTInteger64 (12), and `ogr_to_numpy_dtype` answers all three directly, so
+# such a dict could never be read.
 
 COLOR_INTERPRETATIONS = [
     gdal.GCI_Undefined,  # 0
@@ -464,6 +464,10 @@ def ogr_to_numpy_dtype(dtype_code: int):
 
     Returns:
         numpy.dtype: Numpy data type corresponding to the OGR code.
+
+    Raises:
+        ValueError: If `dtype_code` is not one of the three OGR types the
+            conversion table covers.
     """
     # since there are more than one numpy dtype for the ogr.OFTInteger (0), and the ogr.OFTInteger64 (12),
     # we will return int32 for 0 and int64 for 12.
@@ -475,15 +479,12 @@ def ogr_to_numpy_dtype(dtype_code: int):
     elif dtype_code == 2:
         result_dtype = np.float64
     else:
-        matched = _OGR_TO_NUMPY.get(dtype_code)
-
-        if matched is None:
-            raise ValueError(
-                f"The given OGR data type is not supported: {dtype_code}, available types are: "
-                f"{DTYPE_CONVERSION_DF['ogr'].unique().tolist()}"
-            )
-        else:
-            result_dtype = matched
+        # `OGR_DTYPE` contains only these three codes, so anything else is
+        # unsupported by definition -- there is no table left to consult.
+        raise ValueError(
+            f"The given OGR data type is not supported: {dtype_code}, available types are: "
+            f"{DTYPE_CONVERSION_DF['ogr'].unique().tolist()}"
+        )
 
     return result_dtype
 
@@ -642,9 +643,17 @@ def require_optional(module_name: str, message: str, *, return_module: bool = Fa
     the tests that monkeypatch them per module) are unaffected.
 
     The import goes through the builtin `__import__` rather than
-    `importlib.import_module` so it is exactly the `import <module_name>`
-    statement each guard used to spell out — same module resolution, and still
-    interceptable by call sites and tests that patch `builtins.__import__`.
+    `importlib.import_module`, so it stays interceptable by call sites and tests
+    that patch `builtins.__import__` — which several guard tests do to simulate
+    a missing package.
+
+    One nuance for dotted names: `import_basemap` previously spelled
+    `from cleopatra import tiles`, which calls
+    `__import__("cleopatra", ..., fromlist=("tiles",))`. Here it becomes
+    `__import__("cleopatra.tiles")`, so the parent package resolves internally
+    rather than through `builtins.__import__`. A patch keyed on
+    `name == "cleopatra"` no longer intercepts it; key on the dotted name
+    instead. No in-tree test depends on this.
 
     Args:
         module_name: Dotted module path to import, e.g. ``"zarr"`` or
@@ -698,9 +707,17 @@ def require_optional(module_name: str, message: str, *, return_module: bool = Fa
         __import__(module_name)
     except ImportError as exc:
         raise OptionalPackageDoesNotExist(message) from exc
-    # `__import__` returns the top-level package for a dotted name, so read the
-    # requested module back out of sys.modules instead of using its return value.
-    return sys.modules[module_name] if return_module else None
+    module = None
+    if return_module:
+        # `__import__` returns the top-level package for a dotted name, so read the
+        # requested module back out of sys.modules instead of using its return value.
+        # A module that removed itself from sys.modules during import would give a
+        # bare KeyError here; surface the branded error instead.
+        try:
+            module = sys.modules[module_name]
+        except KeyError as exc:
+            raise OptionalPackageDoesNotExist(message) from exc
+    return module
 
 
 def import_cleopatra(message: str):

--- a/src/pyramids/base/_utils.py
+++ b/src/pyramids/base/_utils.py
@@ -97,6 +97,48 @@ DTYPE_CONVERSION_DF = DataFrame(
     data=list(zip(GDAL_DTYPE_CODE, DTYPE_NAMES, NUMPY_DTYPE, GDAL_DTYPE, OGR_DTYPE)),
 )
 
+
+def _first_wins(keys: list, values: list) -> dict:
+    """Zip `keys` onto `values`, keeping the first pair for a duplicated key.
+
+    Mirrors the ``.values[0]`` semantics of the DataFrame masks these lookup
+    tables replace: ``NUMPY_DTYPE`` maps ``np.complex64`` onto three different
+    GDAL codes, and the earliest row wins. Pairs with a ``None`` on either side
+    are dropped so the "unsupported dtype" guards still raise instead of
+    returning a bogus ``None``.
+
+    Args:
+        keys (list): Lookup keys, in table order.
+        values (list): Values positionally paired with `keys`.
+
+    Returns:
+        dict: The first-wins mapping, with ``None``-bearing pairs removed.
+    """
+    mapping: dict = {}
+    for key, value in zip(keys, values):
+        if key is None or value is None:
+            continue
+        if key not in mapping:
+            mapping[key] = value
+    return mapping
+
+
+_NUMPY_TO_GDAL: dict = _first_wins(
+    [None if dtype is None else np.dtype(dtype) for dtype in NUMPY_DTYPE], GDAL_DTYPE
+)
+_GDAL_TO_NUMPY: dict = _first_wins(GDAL_DTYPE, NUMPY_DTYPE)
+_GDAL_TO_OGR: dict = _first_wins(GDAL_DTYPE, OGR_DTYPE)
+_OGR_TO_NUMPY: dict = _first_wins(OGR_DTYPE, NUMPY_DTYPE)
+"""Precomputed dtype lookups.
+
+The conversion helpers below used to run a full-column pandas boolean mask over
+`DTYPE_CONVERSION_DF` on every call — roughly 250 µs for what is a fixed
+16-row table lookup, paid per band and per timestep. These dicts are built once
+at import; `DTYPE_CONVERSION_DF` is kept because it is part of the module's
+public surface and still supplies the "available types" listings in the error
+messages.
+"""
+
 COLOR_INTERPRETATIONS = [
     gdal.GCI_Undefined,  # 0
     gdal.GCI_GrayIndex,  # 1
@@ -373,6 +415,10 @@ def numpy_to_gdal_dtype(arr: np.ndarray | np.dtype | str) -> int:
 
     Returns:
         int: GDAL data type code.
+
+    Raises:
+        ValueError: If the input is not array/dtype/str-like, or if the numpy
+            dtype has no GDAL counterpart.
     """
     if isinstance(arr, np.ndarray):
         np_dtype = arr.dtype
@@ -385,12 +431,13 @@ def numpy_to_gdal_dtype(arr: np.ndarray | np.dtype | str) -> int:
             "The given input is not a numpy array or a numpy data type, please provide a valid input"
         )
     # integer as gdal does not accept the dtype if it is int64
-    gdal_type = int(
-        DTYPE_CONVERSION_DF.loc[
-            DTYPE_CONVERSION_DF["numpy"] == np_dtype, "gdal"
-        ].values[0]
-    )
-    return gdal_type
+    matched = _NUMPY_TO_GDAL.get(np_dtype)
+    if matched is None:
+        raise ValueError(
+            f"The given numpy data type is not supported: {np_dtype}, available types are: "
+            f"{DTYPE_CONVERSION_DF['numpy'].dropna().tolist()}"
+        )
+    return int(matched)
 
 
 def ogr_to_numpy_dtype(dtype_code: int):
@@ -426,17 +473,15 @@ def ogr_to_numpy_dtype(dtype_code: int):
     elif dtype_code == 2:
         result_dtype = np.float64
     else:
-        matched = DTYPE_CONVERSION_DF.loc[
-            DTYPE_CONVERSION_DF["ogr"] == dtype_code, "numpy"
-        ]
+        matched = _OGR_TO_NUMPY.get(dtype_code)
 
-        if len(matched) == 0:
+        if matched is None:
             raise ValueError(
                 f"The given OGR data type is not supported: {dtype_code}, available types are: "
                 f"{DTYPE_CONVERSION_DF['ogr'].unique().tolist()}"
             )
         else:
-            result_dtype = matched.values[0]
+            result_dtype = matched
 
     return result_dtype
 
@@ -449,16 +494,19 @@ def gdal_to_numpy_dtype(dtype: int) -> str:
 
     Returns:
         str: Name of the corresponding numpy dtype.
+
+    Raises:
+        ValueError: If `dtype` has no numpy counterpart — including the
+            placeholder codes ``GDT_Unknown`` and ``GDT_TypeCount``, whose table
+            rows carry no numpy type.
     """
-    matched_dtypes = DTYPE_CONVERSION_DF.loc[
-        DTYPE_CONVERSION_DF["gdal"] == dtype, "numpy"
-    ]
-    if len(matched_dtypes) == 0:
+    matched = _GDAL_TO_NUMPY.get(dtype)
+    if matched is None:
         raise ValueError(
             f"The given GDAL data type is not supported: {dtype}, available types are: "
             f"{DTYPE_CONVERSION_DF['gdal'].unique().tolist()}"
         )
-    result_name = str(matched_dtypes.values[0].__name__)
+    result_name = str(matched.__name__)
     return result_name
 
 
@@ -471,14 +519,21 @@ def gdal_to_ogr_dtype(src: Dataset, band: int = 1):
 
     Returns:
         int: OGR data type code corresponding to the band GDAL dtype.
+
+    Raises:
+        ValueError: If the band's GDAL dtype has no OGR counterpart (the
+            complex types and the ``GDT_Unknown`` / ``GDT_TypeCount``
+            placeholders).
     """
     raster_band = src.GetRasterBand(band)
     gdal_dtype = raster_band.DataType
-    return int(
-        DTYPE_CONVERSION_DF.loc[
-            DTYPE_CONVERSION_DF["gdal"] == gdal_dtype, "ogr"
-        ].values[0]
-    )
+    matched = _GDAL_TO_OGR.get(gdal_dtype)
+    if matched is None:
+        raise ValueError(
+            f"The given GDAL data type has no OGR equivalent: {gdal_dtype}, available types are: "
+            f"{DTYPE_CONVERSION_DF['gdal'].unique().tolist()}"
+        )
+    return int(matched)
 
 
 class Catalog:

--- a/src/pyramids/base/config.py
+++ b/src/pyramids/base/config.py
@@ -406,10 +406,14 @@ class LoggerManager:
             # restore propagation, so `Config()` after a `Config(level=...)` returns
             # to "the host owns logging" rather than leaving the opt-in state stuck
             # for the life of the process.
-            for handler in list(package_logger.handlers):
-                if getattr(handler, _OWNED_HANDLER_FLAG, False):
-                    package_logger.removeHandler(handler)
-                    handler.close()
+            owned = [
+                handler
+                for handler in package_logger.handlers
+                if getattr(handler, _OWNED_HANDLER_FLAG, False)
+            ]
+            for handler in owned:
+                package_logger.removeHandler(handler)
+                handler.close()
             package_logger.propagate = True
         else:
             level = self._normalize_level(level)

--- a/src/pyramids/base/config.py
+++ b/src/pyramids/base/config.py
@@ -81,20 +81,11 @@ _NOISY_THIRD_PARTY_LOGGERS = (
 )
 """Third-party loggers pinned to WARNING when a caller opts into pyramids logging."""
 
-_gdal_error_handler_installed = False
-"""Guard so the GDAL error handler is pushed once per process.
-
-`gdal.PushErrorHandler` stacks and pyramids never calls `PopErrorHandler`, so
-without this every extra `Config()` / `LoggerManager()` construction added another
-handler and every GDAL error was logged once per push.
-"""
-
 _gdal_error_handler_lock = threading.Lock()
-"""Serialises the check-and-set on `_gdal_error_handler_installed`.
+"""Serialises installation of the GDAL error handler.
 
-Two threads constructing `Config()` concurrently would otherwise both read the
-flag as `False` and both push, which is the exact stacking the flag exists to
-prevent.
+`gdal.SetErrorHandler` is itself idempotent, so this only stops two threads
+racing through `_set_error_handler` from interleaving inside GDAL.
 """
 
 
@@ -426,23 +417,27 @@ class LoggerManager:
 
     @staticmethod
     def _set_error_handler() -> None:
-        """Install the GDAL→logging error bridge, exactly once per process.
+        """Install the GDAL→logging error bridge for the whole process.
 
         The handler maps GDAL error classes to Python logging levels. Messages below
         CE_Warning are printed to stdout to preserve expected behaviors in some
         GDAL workflows and tests.
 
-        `gdal.PushErrorHandler` pushes onto a stack and pyramids never pops, so
-        repeated installation made GDAL log each error once per push. The
-        module-level guard makes re-construction of `Config` / `LoggerManager`
-        idempotent, and the lock keeps two threads constructing `Config()`
-        concurrently from both reading the flag as unset and both pushing.
+        Uses `gdal.SetErrorHandler`, not `gdal.PushErrorHandler`. The push variant
+        maps to `CPLPushErrorHandlerEx`, which pushes onto GDAL's **per-thread**
+        error context: it stacks on repeated calls (so every `Config()` made GDAL
+        log each error one more time), and it only ever covers the installing
+        thread — a worker thread's warnings fall straight through to GDAL's default
+        stderr handler, bypassing the `pyramids.base.config.gdal` logger. Verified
+        empirically: with a pushed handler, an error raised on a second thread is
+        not delivered to it.
+
+        `SetErrorHandler` replaces rather than stacks and is process-wide, so it is
+        naturally idempotent and covers every thread. The lock only keeps two
+        racing installers from interleaving inside GDAL.
         """
-        global _gdal_error_handler_installed
         with _gdal_error_handler_lock:
-            if not _gdal_error_handler_installed:
-                gdal.PushErrorHandler(_gdal_error_handler)
-                _gdal_error_handler_installed = True
+            gdal.SetErrorHandler(_gdal_error_handler)
 
 
 @dataclass

--- a/src/pyramids/base/config.py
+++ b/src/pyramids/base/config.py
@@ -51,6 +51,7 @@ import logging
 import os
 import site
 import sys
+import threading
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -65,12 +66,30 @@ adds handlers to root hijacks logging for the whole host application."""
 
 _GDAL_LOGGER_NAME = f"{__name__}.gdal"
 
+_NOISY_THIRD_PARTY_LOGGERS = (
+    "fiona",
+    "rasterio",
+    "shapely",
+    "matplotlib",
+    "urllib3",
+    "osgeo",
+)
+"""Third-party loggers pinned to WARNING when a caller opts into pyramids logging."""
+
 _gdal_error_handler_installed = False
 """Guard so the GDAL error handler is pushed once per process.
 
 `gdal.PushErrorHandler` stacks and pyramids never calls `PopErrorHandler`, so
 without this every extra `Config()` / `LoggerManager()` construction added another
 handler and every GDAL error was logged once per push.
+"""
+
+_gdal_error_handler_lock = threading.Lock()
+"""Serialises the check-and-set on `_gdal_error_handler_installed`.
+
+Two threads constructing `Config()` concurrently would otherwise both read the
+flag as `False` and both push, which is the exact stacking the flag exists to
+prevent.
 """
 
 
@@ -88,14 +107,11 @@ def _gdal_error_handler(err_class, err_num, err_msg):
     """
     log = logging.getLogger(_GDAL_LOGGER_NAME)
     try:
-        # For error classes lower than CE_Warning, print to stdout (expected by tests)
+        # Anything below CE_Warning -- CE_None (0) and CE_Debug (1) -- goes to stdout
+        # rather than the logger. That is why there is no CE_Debug branch below: it
+        # would be unreachable, since this test already swallows the class.
         if err_class is not None and err_class < getattr(gdal, "CE_Warning", 2):
             print(f"GDAL error (class {err_class}, number {err_num}): {err_msg}")
-            return
-
-        # Map GDAL error classes to logging levels
-        if err_class == gdal.CE_Debug:
-            log.debug(f"GDAL[{err_num}] {err_msg}")
         elif err_class == gdal.CE_Warning:
             log.warning(f"GDAL[{err_num}] {err_msg}")
         elif err_class == gdal.CE_Failure:
@@ -362,28 +378,26 @@ class LoggerManager:
         if not any(isinstance(h, logging.NullHandler) for h in package_logger.handlers):
             package_logger.addHandler(logging.NullHandler())
 
-        if level is None:
-            return
+        if level is not None:
+            level = self._normalize_level(level)
+            package_logger.setLevel(level)
 
-        level = self._normalize_level(level)
-        package_logger.setLevel(level)
+            console_handler, file_handler_exists_for = self._existing_handlers(
+                package_logger
+            )
+            self._ensure_console_handler(package_logger, console_handler, level)
+            self._ensure_file_handler(
+                package_logger, log_file, level, file_handler_exists_for
+            )
 
-        console_handler, file_handler_exists_for = self._existing_handlers(
-            package_logger
-        )
-        self._ensure_console_handler(package_logger, console_handler, level)
-        self._ensure_file_handler(
-            package_logger, log_file, level, file_handler_exists_for
-        )
+            # Reduce noise from common third-party libraries
+            for noisy in _NOISY_THIRD_PARTY_LOGGERS:
+                logging.getLogger(noisy).setLevel(logging.WARNING)
 
-        # Reduce noise from common third-party libraries
-        for noisy in ("fiona", "rasterio", "shapely", "matplotlib", "urllib3", "osgeo"):
-            logging.getLogger(noisy).setLevel(logging.WARNING)
-
-        # Announce configuration via the module logger so tests can assert on it. DEBUG,
-        # not INFO: an INFO line here is printed by every caller that opts into logging,
-        # and used to be printed by a bare `import pyramids`.
-        logging.getLogger(__name__).debug("Logging is configured.")
+            # Announce configuration via the module logger so tests can assert on it.
+            # DEBUG, not INFO: an INFO line here is printed by every caller that opts
+            # into logging, and used to be printed by a bare `import pyramids`.
+            logging.getLogger(__name__).debug("Logging is configured.")
 
     @staticmethod
     def _set_error_handler() -> None:
@@ -396,12 +410,14 @@ class LoggerManager:
         `gdal.PushErrorHandler` pushes onto a stack and pyramids never pops, so
         repeated installation made GDAL log each error once per push. The
         module-level guard makes re-construction of `Config` / `LoggerManager`
-        idempotent.
+        idempotent, and the lock keeps two threads constructing `Config()`
+        concurrently from both reading the flag as unset and both pushing.
         """
         global _gdal_error_handler_installed
-        if not _gdal_error_handler_installed:
-            gdal.PushErrorHandler(_gdal_error_handler)
-            _gdal_error_handler_installed = True
+        with _gdal_error_handler_lock:
+            if not _gdal_error_handler_installed:
+                gdal.PushErrorHandler(_gdal_error_handler)
+                _gdal_error_handler_installed = True
 
 
 @dataclass

--- a/src/pyramids/base/config.py
+++ b/src/pyramids/base/config.py
@@ -71,6 +71,9 @@ adds handlers to root hijacks logging for the whole host application."""
 
 _GDAL_LOGGER_NAME = f"{__name__}.gdal"
 
+_OWNED_HANDLER_FLAG = "_pyramids_owned"
+"""Marks a handler pyramids installed, so it never reconfigures a host's own."""
+
 _NOISY_THIRD_PARTY_LOGGERS = (
     "fiona",
     "rasterio",
@@ -283,10 +286,19 @@ class LoggerManager:
     def _existing_handlers(
         package_logger: logging.Logger,
     ) -> tuple[logging.Handler | None, set[Path]]:
-        """Return the current console handler (if any) and the set of file-handler paths."""
+        """Return pyramids' own console handler (if any) and its file-handler paths.
+
+        Only handlers pyramids installed are considered. A host is entitled to
+        attach its own handler to the `"pyramids"` logger -- that is the canonical
+        way to customise a library's output -- and reconfiguring its level or
+        swapping its formatter for the coloured console one would silently undo
+        that.
+        """
         console_handler: logging.Handler | None = None
         file_paths: set[Path] = set()
         for h in package_logger.handlers:
+            if not getattr(h, _OWNED_HANDLER_FLAG, False):
+                continue
             if isinstance(h, logging.StreamHandler) and not isinstance(
                 h, logging.FileHandler
             ):
@@ -307,6 +319,7 @@ class LoggerManager:
         """Add a coloured console handler, or update the existing one's level/format."""
         if console_handler is None:
             console_handler = logging.StreamHandler()
+            setattr(console_handler, _OWNED_HANDLER_FLAG, True)
             console_handler.setLevel(level)
             console_handler.setFormatter(
                 ColorFormatter(fmt=self.FMT, datefmt=self.DATE_FMT)
@@ -331,6 +344,7 @@ class LoggerManager:
             log_file_path = Path(log_file)
             if log_file_path not in existing_paths:
                 fh = logging.FileHandler(log_file_path, encoding="utf-8")
+                setattr(fh, _OWNED_HANDLER_FLAG, True)
                 fh.setLevel(level)
                 fh.setFormatter(logging.Formatter(fmt=self.FMT, datefmt=self.DATE_FMT))
                 package_logger.addHandler(fh)
@@ -387,7 +401,17 @@ class LoggerManager:
         if not any(isinstance(h, logging.NullHandler) for h in package_logger.handlers):
             package_logger.addHandler(logging.NullHandler())
 
-        if level is not None:
+        if level is None:
+            # Handing the namespace back: drop the handlers pyramids installed and
+            # restore propagation, so `Config()` after a `Config(level=...)` returns
+            # to "the host owns logging" rather than leaving the opt-in state stuck
+            # for the life of the process.
+            for handler in list(package_logger.handlers):
+                if getattr(handler, _OWNED_HANDLER_FLAG, False):
+                    package_logger.removeHandler(handler)
+                    handler.close()
+            package_logger.propagate = True
+        else:
             level = self._normalize_level(level)
             package_logger.setLevel(level)
 
@@ -401,9 +425,9 @@ class LoggerManager:
             # pyramids now owns a handler for this namespace, so stop the records
             # from also reaching the host's root handlers -- otherwise every
             # pyramids line is formatted twice for the (very common) application
-            # that called `logging.basicConfig()`. Only done on the opt-in path:
-            # with `level=None` propagation is left alone so a host-configured
-            # root handler still receives pyramids records.
+            # that called `logging.basicConfig()`. Reversible: `Config()` with no
+            # level restores propagation (see the branch above), so a downstream
+            # test suite is not stuck with `caplog` capturing nothing.
             package_logger.propagate = False
 
             if quiet_third_party:

--- a/src/pyramids/base/config.py
+++ b/src/pyramids/base/config.py
@@ -7,6 +7,13 @@ This module exposes helpers to:
 - Initialize GDAL/OGR (errors routed to Python logging).
 - Discover and export environment variables (e.g., GDAL_DRIVER_PATH) across platforms.
 
+Logging is **opt-in**. Importing pyramids runs `Config()` with no `level`, which
+attaches a `logging.NullHandler` to the `"pyramids"` logger and nothing else — the
+root logger is never touched, no handler is installed on it, and nothing is printed.
+Pass an explicit level (`Config(level="INFO")`) to get the coloured console handler,
+or configure logging yourself with `logging.basicConfig()`; pyramids' records
+propagate normally either way.
+
 Examples:
 - Set up logging and route GDAL errors into Python logging
 
@@ -51,6 +58,55 @@ import yaml
 from osgeo import gdal, ogr
 
 from pyramids import __path__ as root_path
+
+PACKAGE_LOGGER_NAME = "pyramids"
+"""Logger namespace pyramids configures. Never the root logger — a library that
+adds handlers to root hijacks logging for the whole host application."""
+
+_GDAL_LOGGER_NAME = f"{__name__}.gdal"
+
+_gdal_error_handler_installed = False
+"""Guard so the GDAL error handler is pushed once per process.
+
+`gdal.PushErrorHandler` stacks and pyramids never calls `PopErrorHandler`, so
+without this every extra `Config()` / `LoggerManager()` construction added another
+handler and every GDAL error was logged once per push.
+"""
+
+
+def _gdal_error_handler(err_class, err_num, err_msg):
+    """Route a GDAL error onto the `pyramids.base.config.gdal` logger.
+
+    Module-level (not a closure) so it is a stable, importable object: the
+    once-only install guard needs a single identity, and tests can invoke it
+    directly instead of fishing it out of a patched `gdal.PushErrorHandler`.
+
+    Args:
+        err_class (int): GDAL error class (`gdal.CE_*`).
+        err_num (int): GDAL error number.
+        err_msg (str): The message text.
+    """
+    log = logging.getLogger(_GDAL_LOGGER_NAME)
+    try:
+        # For error classes lower than CE_Warning, print to stdout (expected by tests)
+        if err_class is not None and err_class < getattr(gdal, "CE_Warning", 2):
+            print(f"GDAL error (class {err_class}, number {err_num}): {err_msg}")
+            return
+
+        # Map GDAL error classes to logging levels
+        if err_class == gdal.CE_Debug:
+            log.debug(f"GDAL[{err_num}] {err_msg}")
+        elif err_class == gdal.CE_Warning:
+            log.warning(f"GDAL[{err_num}] {err_msg}")
+        elif err_class == gdal.CE_Failure:
+            log.error(f"GDAL[{err_num}] {err_msg}")
+        elif err_class == gdal.CE_Fatal:
+            log.critical(f"GDAL[{err_num}] {err_msg}")
+        else:
+            log.error(f"GDAL(class={err_class}, code={err_num}) {err_msg}")
+    except Exception:
+        # Fallback to error level if mapping fails for any reason
+        log.error(f"GDAL(class={err_class}, code={err_num}) {err_msg}")
 
 
 class ColorFormatter(logging.Formatter):
@@ -132,6 +188,16 @@ class LoggerManager:
     configuration class can remain small. It configures a colored console handler,
     an optional file handler, and redirects GDAL errors to the logging subsystem.
 
+    Everything it configures lives under the :data:`PACKAGE_LOGGER_NAME`
+    (`"pyramids"`) namespace. The root logger is never modified: a library that
+    adds a handler to root, or calls `root.setLevel(...)`, silently reconfigures
+    logging for the entire host application.
+
+    Handler installation is **opt-in**. With `level=None` (the default, and what
+    the package import uses) the manager only attaches a `logging.NullHandler`
+    and installs the GDAL error bridge; nothing is printed and no level is
+    changed. Pass an explicit level to get the coloured console handler.
+
     Examples:
     - Basic usage to configure logging and register the GDAL error handler
 
@@ -139,7 +205,6 @@ class LoggerManager:
 
         >>> from pyramids.base.config import LoggerManager
         >>> _ = LoggerManager(level="INFO")  # doctest: +SKIP
-        2025-09-09 23:01:39 | INFO | pyramids.base.config | Logging is configured.
         >>> # - Creates a console handler with colorized levels
         >>> # - Optionally creates a file handler when log_file is provided
         >>> # - Installs a GDAL error handler that forwards messages to logging
@@ -157,16 +222,18 @@ class LoggerManager:
 
     def __init__(
         self,
-        level: int | str = logging.INFO,
+        level: int | str | None = None,
         log_file: str | Path | None = None,
     ):
         """Create a LoggerManager and configure logging.
 
         Args:
-            level (int | str, optional): Logging level as an int (e.g., logging.INFO)
-                or as a case-insensitive string ("DEBUG", "INFO", ...). Defaults to logging.INFO.
+            level (int | str | None, optional): Logging level as an int (e.g., logging.INFO)
+                or as a case-insensitive string ("DEBUG", "INFO", ...). `None` — the default —
+                installs no handlers and changes no level, leaving log configuration entirely
+                to the host application.
             log_file (str | pathlib.Path | None, optional): Optional path to a log file to
-                also write logs to. If None, no file handler is added. Defaults to None.
+                also write logs to. Ignored when `level` is None. Defaults to None.
 
         Raises:
             ValueError: If an invalid level string is provided (e.g., "VERBOS").
@@ -178,7 +245,6 @@ class LoggerManager:
 
             >>> from pyramids.base.config import LoggerManager
             >>> _ = LoggerManager(level="DEBUG", log_file="pyramids.log")  # doctest: +SKIP
-            2025-09-09 23:02:23 | INFO | pyramids.base.config | Logging is configured.
 
             ```
         """
@@ -195,12 +261,12 @@ class LoggerManager:
 
     @staticmethod
     def _existing_handlers(
-        root_logger: logging.Logger,
+        package_logger: logging.Logger,
     ) -> tuple[logging.Handler | None, set[Path]]:
         """Return the current console handler (if any) and the set of file-handler paths."""
         console_handler: logging.Handler | None = None
         file_paths: set[Path] = set()
-        for h in root_logger.handlers:
+        for h in package_logger.handlers:
             if isinstance(h, logging.StreamHandler) and not isinstance(
                 h, logging.FileHandler
             ):
@@ -214,7 +280,7 @@ class LoggerManager:
 
     def _ensure_console_handler(
         self,
-        root_logger: logging.Logger,
+        package_logger: logging.Logger,
         console_handler: logging.Handler | None,
         level: int,
     ) -> None:
@@ -225,7 +291,7 @@ class LoggerManager:
             console_handler.setFormatter(
                 ColorFormatter(fmt=self.FMT, datefmt=self.DATE_FMT)
             )
-            root_logger.addHandler(console_handler)
+            package_logger.addHandler(console_handler)
         else:
             console_handler.setLevel(level)
             if not isinstance(console_handler.formatter, ColorFormatter):
@@ -235,7 +301,7 @@ class LoggerManager:
 
     def _ensure_file_handler(
         self,
-        root_logger: logging.Logger,
+        package_logger: logging.Logger,
         log_file: str | Path | None,
         level: int,
         existing_paths: set[Path],
@@ -247,24 +313,26 @@ class LoggerManager:
                 fh = logging.FileHandler(log_file_path, encoding="utf-8")
                 fh.setLevel(level)
                 fh.setFormatter(logging.Formatter(fmt=self.FMT, datefmt=self.DATE_FMT))
-                root_logger.addHandler(fh)
+                package_logger.addHandler(fh)
 
     def _setup_logging(
         self,
-        level: int | str = logging.INFO,
+        level: int | str | None = None,
         log_file: str | Path | None = None,
     ) -> None:
-        """Configure application-wide logging for Pyramids.
+        """Configure the `"pyramids"` logger, or leave logging alone when `level` is None.
 
         Args:
-            level (int | str, optional): Logging level as an int or one of
+            level (int | str | None, optional): Logging level as an int or one of
                 "FATAL", "CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG" (case-insensitive).
-                Defaults to logging.INFO.
+                `None` (default) installs only a `NullHandler`: no level change, no console
+                handler, no output — the host application keeps full control of logging.
             log_file (str | pathlib.Path | None, optional): Optional path to a log file to
                 write logs to in addition to console output. If None, no file is used.
 
         Returns:
-            None: This method configures the root logger in-place.
+            None: This method configures the `"pyramids"` logger in-place. The root
+                logger is never modified.
 
         Raises:
             ValueError: If an invalid level string is provided.
@@ -288,59 +356,52 @@ class LoggerManager:
         See Also:
             ColorFormatter: Colorizes level names for console output.
         """
+        package_logger = logging.getLogger(PACKAGE_LOGGER_NAME)
+        # A NullHandler on the package root keeps the "No handlers could be found"
+        # warning away without emitting anything or claiming a format.
+        if not any(isinstance(h, logging.NullHandler) for h in package_logger.handlers):
+            package_logger.addHandler(logging.NullHandler())
+
+        if level is None:
+            return
+
         level = self._normalize_level(level)
+        package_logger.setLevel(level)
 
-        root_logger = logging.getLogger()
-        root_logger.setLevel(level)
-
-        console_handler, file_handler_exists_for = self._existing_handlers(root_logger)
-        self._ensure_console_handler(root_logger, console_handler, level)
-        self._ensure_file_handler(root_logger, log_file, level, file_handler_exists_for)
+        console_handler, file_handler_exists_for = self._existing_handlers(
+            package_logger
+        )
+        self._ensure_console_handler(package_logger, console_handler, level)
+        self._ensure_file_handler(
+            package_logger, log_file, level, file_handler_exists_for
+        )
 
         # Reduce noise from common third-party libraries
         for noisy in ("fiona", "rasterio", "shapely", "matplotlib", "urllib3", "osgeo"):
             logging.getLogger(noisy).setLevel(logging.WARNING)
 
-        # Announce configuration via the module logger so tests can assert on it
-        logging.getLogger(__name__).info("Logging is configured.")
+        # Announce configuration via the module logger so tests can assert on it. DEBUG,
+        # not INFO: an INFO line here is printed by every caller that opts into logging,
+        # and used to be printed by a bare `import pyramids`.
+        logging.getLogger(__name__).debug("Logging is configured.")
 
     @staticmethod
     def _set_error_handler() -> None:
-        """Install a GDAL error handler that forwards messages to logging.
+        """Install the GDAL→logging error bridge, exactly once per process.
 
         The handler maps GDAL error classes to Python logging levels. Messages below
         CE_Warning are printed to stdout to preserve expected behaviors in some
         GDAL workflows and tests.
+
+        `gdal.PushErrorHandler` pushes onto a stack and pyramids never pops, so
+        repeated installation made GDAL log each error once per push. The
+        module-level guard makes re-construction of `Config` / `LoggerManager`
+        idempotent.
         """
-        # Use a child of the module logger so it inherits the handlers/format configured in setup_logging()
-        log = logging.getLogger(__name__).getChild("gdal")
-
-        def gdal_error_handler(err_class, err_num, err_msg):
-            """Error handler for GDAL mapped to logging levels."""
-            try:
-                # For error classes lower than CE_Warning, print to stdout (expected by tests)
-                if err_class is not None and err_class < getattr(gdal, "CE_Warning", 2):
-                    print(
-                        f"GDAL error (class {err_class}, number {err_num}): {err_msg}"
-                    )
-                    return
-
-                # Map GDAL error classes to logging levels
-                if err_class == gdal.CE_Debug:
-                    log.debug(f"GDAL[{err_num}] {err_msg}")
-                elif err_class == gdal.CE_Warning:
-                    log.warning(f"GDAL[{err_num}] {err_msg}")
-                elif err_class == gdal.CE_Failure:
-                    log.error(f"GDAL[{err_num}] {err_msg}")
-                elif err_class == gdal.CE_Fatal:
-                    log.critical(f"GDAL[{err_num}] {err_msg}")
-                else:
-                    log.error(f"GDAL(class={err_class}, code={err_num}) {err_msg}")
-            except Exception:
-                # Fallback to error level if mapping fails for any reason
-                log.error(f"GDAL(class={err_class}, code={err_num}) {err_msg}")
-
-        gdal.PushErrorHandler(gdal_error_handler)
+        global _gdal_error_handler_installed
+        if not _gdal_error_handler_installed:
+            gdal.PushErrorHandler(_gdal_error_handler)
+            _gdal_error_handler_installed = True
 
 
 @dataclass
@@ -574,7 +635,8 @@ class Config:
     - Initializing GDAL/OGR and discovering GDAL-related environment variables.
 
     Args:
-        level (int | str, optional): Logging level. Defaults to logging.INFO.
+        level (int | str | None, optional): Logging level. `None` (default) leaves logging
+            configuration to the host application — see the module docstring.
         log_file (str | pathlib.Path | None, optional): Optional path to a file for logs.
         config_file (str, optional): YAML filename to read from the package's base folder.
             Defaults to "config.yaml".
@@ -590,7 +652,6 @@ class Config:
 
         >>> from pyramids.base.config import Config  # doctest: +SKIP
         >>> cfg = Config(level="INFO")  # doctest: +SKIP
-        2025-09-09 23:10:28 | INFO | pyramids.base.config | Logging is configured.
         >>> print(cfg.settings)  # doctest: +SKIP
         {'gdal': {'GDAL_CACHEMAX': '512',
           'GDAL_PAM_ENABLED': 'YES',
@@ -610,15 +671,17 @@ class Config:
 
     def __init__(
         self,
-        level: int | str = logging.INFO,
+        level: int | str | None = None,
         log_file: str | Path | None = None,
         config_file="config.yaml",
     ):
         """Construct a Config, load YAML, configure logging, and initialize GDAL.
 
         Args:
-            level (int | str, optional):
-                Logging level (e.g., logging.INFO or "DEBUG").
+            level (int | str | None, optional):
+                Logging level (e.g., logging.INFO or "DEBUG"). `None` — the default, and
+                what the package import uses — installs no handlers and changes no level,
+                so importing pyramids does not reconfigure the host application's logging.
             log_file (str | pathlib.Path | None, optional):
                 Optional path to a log file.
             config_file (str, optional):
@@ -634,7 +697,6 @@ class Config:
                 ```python
                 >>> from pyramids.base.config import Config  # doctest: +SKIP
                 >>> cfg = Config(level="INFO")  # doctest: +SKIP
-                2025-09-09 23:11:52 | INFO | pyramids.base.config | Logging is configured.
 
                 ```
         """
@@ -848,15 +910,20 @@ class Config:
 
     def setup_logging(
         self,
-        level: int | str = logging.INFO,
+        level: int | str | None = None,
         log_file: str | Path | None = None,
     ):
         """
-        Configure application-wide logging for Pyramids by delegating to LoggerManager.
+        Configure the `"pyramids"` logger by delegating to LoggerManager.
 
         This method preserves the public API while separating responsibilities. It delegates
         the actual logging configuration to the LoggerManager constructor and then sets
         self.logger and self._logging_configured for convenience/compatibility.
+
+        Args:
+            level (int | str | None, optional): Logging level, or `None` (default) to install
+                no handlers and change no level.
+            log_file (str | pathlib.Path | None, optional): Optional log-file path.
         """
         LoggerManager(level=level, log_file=log_file)
         self._logging_configured = True

--- a/src/pyramids/base/config.py
+++ b/src/pyramids/base/config.py
@@ -10,9 +10,14 @@ This module exposes helpers to:
 Logging is **opt-in**. Importing pyramids runs `Config()` with no `level`, which
 attaches a `logging.NullHandler` to the `"pyramids"` logger and nothing else — the
 root logger is never touched, no handler is installed on it, and nothing is printed.
-Pass an explicit level (`Config(level="INFO")`) to get the coloured console handler,
-or configure logging yourself with `logging.basicConfig()`; pyramids' records
-propagate normally either way.
+In that state pyramids' records propagate normally, so `logging.basicConfig()` (or
+any other host configuration) picks them up.
+
+Passing an explicit level (`Config(level="INFO")`) instead hands the namespace to
+pyramids: it installs the coloured console handler, the optional file handler, and
+sets `propagate = False` on the `"pyramids"` logger so records are not *also*
+emitted by the host's root handlers. Choose one or the other — either configure
+logging yourself and leave `level` unset, or let pyramids own its namespace.
 
 Examples:
 - Set up logging and route GDAL errors into Python logging
@@ -240,6 +245,7 @@ class LoggerManager:
         self,
         level: int | str | None = None,
         log_file: str | Path | None = None,
+        quiet_third_party: bool = False,
     ):
         """Create a LoggerManager and configure logging.
 
@@ -250,6 +256,11 @@ class LoggerManager:
                 to the host application.
             log_file (str | pathlib.Path | None, optional): Optional path to a log file to
                 also write logs to. Ignored when `level` is None. Defaults to None.
+            quiet_third_party (bool, optional): Pin the loggers in
+                :data:`_NOISY_THIRD_PARTY_LOGGERS` to WARNING. Off by default: those are
+                other libraries' loggers, and silently reverting a host that deliberately
+                set, say, matplotlib to DEBUG is not pyramids' call to make. Ignored when
+                `level` is None.
 
         Raises:
             ValueError: If an invalid level string is provided (e.g., "VERBOS").
@@ -264,7 +275,9 @@ class LoggerManager:
 
             ```
         """
-        self._setup_logging(level=level, log_file=log_file)
+        self._setup_logging(
+            level=level, log_file=log_file, quiet_third_party=quiet_third_party
+        )
         self._set_error_handler()
 
     def _normalize_level(self, level: int | str) -> int:
@@ -335,6 +348,7 @@ class LoggerManager:
         self,
         level: int | str | None = None,
         log_file: str | Path | None = None,
+        quiet_third_party: bool = False,
     ) -> None:
         """Configure the `"pyramids"` logger, or leave logging alone when `level` is None.
 
@@ -345,10 +359,14 @@ class LoggerManager:
                 handler, no output — the host application keeps full control of logging.
             log_file (str | pathlib.Path | None, optional): Optional path to a log file to
                 write logs to in addition to console output. If None, no file is used.
+            quiet_third_party (bool, optional): Pin the loggers in
+                :data:`_NOISY_THIRD_PARTY_LOGGERS` to WARNING. Off by default.
 
         Returns:
             None: This method configures the `"pyramids"` logger in-place. The root
-                logger is never modified.
+                logger is never modified. When it installs a handler it also sets
+                `propagate = False` on that logger, so records are not emitted a
+                second time by a host that configured root logging.
 
         Raises:
             ValueError: If an invalid level string is provided.
@@ -389,10 +407,17 @@ class LoggerManager:
             self._ensure_file_handler(
                 package_logger, log_file, level, file_handler_exists_for
             )
+            # pyramids now owns a handler for this namespace, so stop the records
+            # from also reaching the host's root handlers -- otherwise every
+            # pyramids line is formatted twice for the (very common) application
+            # that called `logging.basicConfig()`. Only done on the opt-in path:
+            # with `level=None` propagation is left alone so a host-configured
+            # root handler still receives pyramids records.
+            package_logger.propagate = False
 
-            # Reduce noise from common third-party libraries
-            for noisy in _NOISY_THIRD_PARTY_LOGGERS:
-                logging.getLogger(noisy).setLevel(logging.WARNING)
+            if quiet_third_party:
+                for noisy in _NOISY_THIRD_PARTY_LOGGERS:
+                    logging.getLogger(noisy).setLevel(logging.WARNING)
 
             # Announce configuration via the module logger so tests can assert on it.
             # DEBUG, not INFO: an INFO line here is printed by every caller that opts
@@ -690,6 +715,7 @@ class Config:
         level: int | str | None = None,
         log_file: str | Path | None = None,
         config_file="config.yaml",
+        quiet_third_party: bool = False,
     ):
         """Construct a Config, load YAML, configure logging, and initialize GDAL.
 
@@ -702,6 +728,10 @@ class Config:
                 Optional path to a log file.
             config_file (str, optional):
                 Name of the YAML configuration file shipped in pyramids/base. Defaults to "config.yaml".
+            quiet_third_party (bool, optional):
+                Pin fiona / rasterio / shapely / matplotlib / urllib3 / osgeo to WARNING.
+                Off by default — those belong to other libraries, and a host that
+                deliberately raised one of them should keep its setting.
 
         Raises:
             FileNotFoundError: If the YAML file cannot be found.
@@ -716,7 +746,9 @@ class Config:
 
                 ```
         """
-        self.setup_logging(level=level, log_file=log_file)
+        self.setup_logging(
+            level=level, log_file=log_file, quiet_third_party=quiet_third_party
+        )
         self.config_file = config_file
         self.settings = self.load_config()
         self.initialize_gdal()
@@ -928,6 +960,7 @@ class Config:
         self,
         level: int | str | None = None,
         log_file: str | Path | None = None,
+        quiet_third_party: bool = False,
     ):
         """
         Configure the `"pyramids"` logger by delegating to LoggerManager.
@@ -940,7 +973,11 @@ class Config:
             level (int | str | None, optional): Logging level, or `None` (default) to install
                 no handlers and change no level.
             log_file (str | pathlib.Path | None, optional): Optional log-file path.
+            quiet_third_party (bool, optional): Pin the noisy third-party loggers to
+                WARNING. Off by default.
         """
-        LoggerManager(level=level, log_file=log_file)
+        LoggerManager(
+            level=level, log_file=log_file, quiet_third_party=quiet_third_party
+        )
         self._logging_configured = True
         self.logger = logging.getLogger(__name__)

--- a/src/pyramids/base/crs.py
+++ b/src/pyramids/base/crs.py
@@ -664,8 +664,12 @@ def reproject_coordinates(
         to_crs:
             Target CRS, same forms as `from_crs`. Default `3857`.
         precision (int | None):
-            Decimal places to round each returned coordinate to. Pass
-            `None` to disable rounding. Default `6`.
+            Decimal places to round each returned coordinate to, using
+            Python's built-in `round` — correctly rounded in decimal,
+            which is *not* the same as `numpy.round` on values that are
+            not exactly representable (`round(2.675, 2)` is `2.67`,
+            `numpy.round(2.675, 2)` is `2.68`). Pass `None` to disable
+            rounding and get the transformer's full output. Default `6`.
 
     Returns:
         tuple[list[float], list[float]]: `(x, y)` in the target CRS.

--- a/src/pyramids/base/crs.py
+++ b/src/pyramids/base/crs.py
@@ -715,14 +715,20 @@ def reproject_coordinates(
     xs, ys = transformer.transform(
         np.asarray(x, dtype=float), np.asarray(y, dtype=float)
     )
-    xs = np.asarray(xs, dtype=float)
-    ys = np.asarray(ys, dtype=float)
+    out_x = np.asarray(xs, dtype=float).tolist()
+    out_y = np.asarray(ys, dtype=float).tolist()
     if precision is not None:
-        # `np.round` and the built-in `round` both round half-to-even, so the
-        # returned values are unchanged from the per-point implementation.
-        xs = np.round(xs, precision)
-        ys = np.round(ys, precision)
-    return xs.tolist(), ys.tolist()
+        # Round with the built-in, NOT `np.round`. They are not interchangeable:
+        # `round` is correctly rounded in decimal, while `np.round` scales by
+        # `10**precision`, rounds, and divides back, so the two disagree on values
+        # that are not exactly representable -- `round(2.675, 2)` is `2.67` but
+        # `np.round(2.675, 2)` is `2.68`, and at the default `precision=6` they
+        # differ on roughly 1 in 3000 Web-Mercator-magnitude coordinates. Keeping
+        # the built-in preserves the per-point implementation's output exactly;
+        # the expensive part was the PROJ round trip, which is already vectorized.
+        out_x = [round(value, precision) for value in out_x]
+        out_y = [round(value, precision) for value in out_y]
+    return out_x, out_y
 
 
 __all__ = [

--- a/src/pyramids/base/crs.py
+++ b/src/pyramids/base/crs.py
@@ -709,15 +709,19 @@ def reproject_coordinates(
             f"reproject_coordinates failed to parse CRS "
             f"(from_crs={from_crs!r}, to_crs={to_crs!r}): {exc}"
         ) from exc
-    xs = np.full(len(x), np.nan)
-    ys = np.full(len(x), np.nan)
-    for i in range(len(x)):
-        nx, ny = transformer.transform(x[i], y[i])
-        if precision is not None:
-            nx = round(nx, precision)
-            ny = round(ny, precision)
-        xs[i] = nx
-        ys[i] = ny
+    # One vectorized call over the whole arrays rather than one call per point:
+    # `Transformer.transform` accepts array input and does the loop in PROJ, so a
+    # polygon ring with thousands of vertices costs one Python call, not thousands.
+    xs, ys = transformer.transform(
+        np.asarray(x, dtype=float), np.asarray(y, dtype=float)
+    )
+    xs = np.asarray(xs, dtype=float)
+    ys = np.asarray(ys, dtype=float)
+    if precision is not None:
+        # `np.round` and the built-in `round` both round half-to-even, so the
+        # returned values are unchanged from the per-point implementation.
+        xs = np.round(xs, precision)
+        ys = np.round(ys, precision)
     return xs.tolist(), ys.tolist()
 
 

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -328,6 +328,12 @@ def _read_time_step(
     callers passing ``pathlib.Path`` and ``str`` for the same file
     hit one cache slot, not two — avoiding silent FILE_CACHE
     fragmentation under mixed-type call sites.
+
+    The read runs inside :meth:`CachingFileManager.acquire_context`,
+    which pins the cache slot: a cube of more than ``maxsize`` files
+    keeps the LRU under constant pressure, and an unpinned handle can
+    be evicted and closed by another worker's insert while this read
+    is still going through it.
     """
     path = str(path)
     with cloud_config_from_env(gdal_env):
@@ -338,13 +344,13 @@ def _read_time_step(
             lock=False,
             manager_id=path,
         )
-        handle = manager.acquire()
-        band_count = handle.RasterCount
-        if band_count == 1:
-            arr = handle.GetRasterBand(1).ReadAsArray()
-            arr = arr[np.newaxis, :, :]
-        else:
-            arr = handle.ReadAsArray()
+        with manager.acquire_context() as handle:
+            band_count = handle.RasterCount
+            if band_count == 1:
+                arr = handle.GetRasterBand(1).ReadAsArray()
+                arr = arr[np.newaxis, :, :]
+            else:
+                arr = handle.ReadAsArray()
     return np.ascontiguousarray(arr)
 
 

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -1163,10 +1163,11 @@ class IO(_Engine["Dataset"]):
         )
         # The FileManager's own lock must be independent of the IO lock
         # handed to the chunk reader: the reader acquires the IO lock
-        # first, then calls manager.acquire() which grabs the manager
-        # lock. Sharing one non-reentrant lock between the two would
-        # deadlock. Using lock=False here delegates concurrency control
-        # to the outer `with effective_lock` in _io_module._read_chunk.
+        # first, then enters manager.acquire_context() which grabs the
+        # manager lock. Sharing one non-reentrant lock between the two
+        # would deadlock. Using lock=False here delegates concurrency
+        # control to the outer `with effective_lock` in
+        # _io_module._read_chunk.
         if threadsafe:
             # One read-only handle per worker thread: chunk reads never
             # contend, so lock=None resolved to DummyLock above. Reuse the

--- a/src/pyramids/dataset/ops/io.py
+++ b/src/pyramids/dataset/ops/io.py
@@ -59,10 +59,12 @@ def _read_chunk(
             (`SerializableLock`, :class:`DummyLock`, or a
             `dask.distributed.Lock`). Held around the
             :class:`osgeo.gdal.Band.ReadAsArray` call. The manager is
-            entered *inside* it via
-            :meth:`CachingFileManager.acquire_context`, which pins the
-            shared cache slot so a concurrent chunk read on another
-            file cannot LRU-evict and close this handle mid-read.
+            entered *inside* it via `acquire_context`. For the shared
+            :class:`CachingFileManager` that pins the cache slot, so a
+            concurrent chunk read on another file cannot LRU-evict and
+            close this handle mid-read; for the `threadsafe=True`
+            :class:`ThreadLocalFileManager` there is no shared cache to
+            evict from and the context manager is a plain passthrough.
         band: Zero-based band index when reading one band, or
             `None` when every band is read into a 3-D array.
         out_dtype: Output numpy dtype — matches the band dtype so

--- a/src/pyramids/dataset/ops/io.py
+++ b/src/pyramids/dataset/ops/io.py
@@ -90,25 +90,31 @@ def _read_chunk(
         (y_start, y_stop), (x_start, x_stop) = location
         xoff, yoff = x_start, y_start
         xsize, ysize = x_stop - x_start, y_stop - y_start
-        with lock, manager.acquire_context() as handle:
-            gdal_band = handle.GetRasterBand(band + 1)
-            data = gdal_band.ReadAsArray(xoff, yoff, xsize, ysize)
+        # Manager outside, IO lock inside: `acquire_context` exits last, and its
+        # unpin can trigger an eviction whose `Close()` may flush over the network.
+        # Nesting it the other way would hold the shared chunk lock for that flush,
+        # stalling every other chunk read of this dataset on unrelated eviction.
+        with manager.acquire_context() as handle:
+            with lock:
+                gdal_band = handle.GetRasterBand(band + 1)
+                data = gdal_band.ReadAsArray(xoff, yoff, xsize, ysize)
         result = np.asarray(data, dtype=out_dtype)
     else:
         (b_start, b_stop), (y_start, y_stop), (x_start, x_stop) = location
         xoff, yoff = x_start, y_start
         xsize, ysize = x_stop - x_start, y_stop - y_start
-        with lock, manager.acquire_context() as handle:
-            block = np.empty(
-                (b_stop - b_start, ysize, xsize),
-                dtype=out_dtype,
-            )
-            for offset, band_idx in enumerate(range(b_start, b_stop)):
-                gdal_band = handle.GetRasterBand(band_idx + 1)
-                block[offset] = np.asarray(
-                    gdal_band.ReadAsArray(xoff, yoff, xsize, ysize),
+        with manager.acquire_context() as handle:
+            with lock:
+                block = np.empty(
+                    (b_stop - b_start, ysize, xsize),
                     dtype=out_dtype,
                 )
+                for offset, band_idx in enumerate(range(b_start, b_stop)):
+                    gdal_band = handle.GetRasterBand(band_idx + 1)
+                    block[offset] = np.asarray(
+                        gdal_band.ReadAsArray(xoff, yoff, xsize, ysize),
+                        dtype=out_dtype,
+                    )
         result = block
     return result
 

--- a/src/pyramids/dataset/ops/io.py
+++ b/src/pyramids/dataset/ops/io.py
@@ -58,7 +58,11 @@ def _read_chunk(
         lock: Any context-manager / `acquire`-`release` lock
             (`SerializableLock`, :class:`DummyLock`, or a
             `dask.distributed.Lock`). Held around the
-            :class:`osgeo.gdal.Band.ReadAsArray` call.
+            :class:`osgeo.gdal.Band.ReadAsArray` call. The manager is
+            entered *inside* it via
+            :meth:`CachingFileManager.acquire_context`, which pins the
+            shared cache slot so a concurrent chunk read on another
+            file cannot LRU-evict and close this handle mid-read.
         band: Zero-based band index when reading one band, or
             `None` when every band is read into a 3-D array.
         out_dtype: Output numpy dtype — matches the band dtype so
@@ -84,8 +88,7 @@ def _read_chunk(
         (y_start, y_stop), (x_start, x_stop) = location
         xoff, yoff = x_start, y_start
         xsize, ysize = x_stop - x_start, y_stop - y_start
-        with lock:
-            handle = manager.acquire()
+        with lock, manager.acquire_context() as handle:
             gdal_band = handle.GetRasterBand(band + 1)
             data = gdal_band.ReadAsArray(xoff, yoff, xsize, ysize)
         result = np.asarray(data, dtype=out_dtype)
@@ -93,8 +96,7 @@ def _read_chunk(
         (b_start, b_stop), (y_start, y_stop), (x_start, x_stop) = location
         xoff, yoff = x_start, y_start
         xsize, ysize = x_stop - x_start, y_stop - y_start
-        with lock:
-            handle = manager.acquire()
+        with lock, manager.acquire_context() as handle:
             block = np.empty(
                 (b_stop - b_start, ysize, xsize),
                 dtype=out_dtype,

--- a/tests/base/test_crs.py
+++ b/tests/base/test_crs.py
@@ -2,15 +2,17 @@
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 from osgeo import osr
-from pyproj import CRS
+from pyproj import CRS, Transformer
 
 from pyramids.base._errors import CRSError
 from pyramids.base.crs import (
     epsg_from_user_input,
     epsg_from_wkt,
     get_epsg_from_prj,
+    reproject_coordinates,
     sr_from_user_input,
 )
 
@@ -277,4 +279,101 @@ class TestSrFromUserInput:
         assert sr1 is not sr2, "repeated calls must return distinct SRS instances"
         assert sr1.ExportToWkt() == sr2.ExportToWkt(), (
             "distinct instances should still encode the same CRS"
+        )
+
+
+class TestReprojectCoordinatesRoundingParity:
+    """`reproject_coordinates` must round exactly as the per-point loop did.
+
+    The vectorization (ARC-55) replaced a per-point `transformer.transform`
+    loop with one array call. That is value-preserving only if the rounding
+    stays on the built-in `round`: `np.round` scales by `10**precision`,
+    rounds and divides back, so it disagrees with correctly-rounded decimal
+    on values that are not exactly representable.
+    """
+
+    @staticmethod
+    def _per_point_reference(xs, ys, from_crs, to_crs, precision):
+        """Re-implement the pre-vectorization body as the parity oracle."""
+        transformer = Transformer.from_crs(from_crs, to_crs, always_xy=True)
+        out_x, out_y = [], []
+        for x_value, y_value in zip(xs, ys):
+            new_x, new_y = transformer.transform(x_value, y_value)
+            if precision is not None:
+                new_x = round(new_x, precision)
+                new_y = round(new_y, precision)
+            out_x.append(new_x)
+            out_y.append(new_y)
+        return out_x, out_y
+
+    def test_matches_the_per_point_loop_on_a_random_sweep(self):
+        """A 2000-point sweep at the default precision reproduces the old output.
+
+        Test scenario:
+            Draw lon/lat across the full valid domain, reproject to Web
+            Mercator at `precision=6`, and compare element-by-element against
+            the per-point reference. Exact equality is required — a single
+            last-digit drift here is a silent change to every reprojected
+            geometry vertex.
+        """
+        rng = np.random.default_rng(20260725)
+        xs = rng.uniform(-179.0, 179.0, 2000).tolist()
+        ys = rng.uniform(-85.0, 85.0, 2000).tolist()
+        got_x, got_y = reproject_coordinates(xs, ys, from_crs=4326, to_crs=3857)
+        want_x, want_y = self._per_point_reference(xs, ys, 4326, 3857, 6)
+        assert got_x == want_x, "x output must match the per-point loop exactly"
+        assert got_y == want_y, "y output must match the per-point loop exactly"
+
+    # Values on which `round` and `np.round` disagree at the given precision, so
+    # each case genuinely discriminates between the two rounding rules instead of
+    # asserting parity with itself. Fed through an identity transform, which
+    # leaves them untouched for the rounding step. No case exists for
+    # `precision=0`: on integral rounding the two rules agree.
+    @pytest.mark.parametrize(
+        ("precision", "values"),
+        [
+            (1, [0.45, 1.05, 1.6500000000000001]),
+            (2, [0.015, 0.025, 0.065, 2.675]),
+            (3, [0.0025, 0.0055, 0.0075]),
+            (6, [3.5e-06, 4.5e-06, 1.25e-05]),
+        ],
+    )
+    def test_matches_the_per_point_loop_across_precisions(self, precision, values):
+        """Every precision keeps per-point parity on known divergent values."""
+        non_divergent = [
+            value
+            for value in values
+            if round(value, precision) == float(np.round(value, precision))
+        ]
+        assert non_divergent == [], (
+            f"precondition: every case must separate the two rounding rules; "
+            f"these do not: {non_divergent}"
+        )
+        got_x, got_y = reproject_coordinates(
+            values, values, from_crs=4326, to_crs=4326, precision=precision
+        )
+        want_x, want_y = self._per_point_reference(
+            values, values, 4326, 4326, precision
+        )
+        assert (got_x, got_y) == (want_x, want_y), (
+            f"precision={precision} must match the per-point loop"
+        )
+
+    def test_uses_builtin_round_not_numpy_round(self):
+        """The half-way case that separates the two rounding rules.
+
+        Test scenario:
+            `round(x, 2)` and `np.round(x, 2)` disagree on 2.675 (2.67 vs
+            2.68). Feeding a null transform a coordinate that lands on such a
+            value pins the built-in behaviour, so a future refactor cannot
+            swap in `np.round` unnoticed.
+        """
+        assert round(2.675, 2) != float(np.round(2.675, 2)), (
+            "precondition: the two rounding rules must actually differ here"
+        )
+        got_x, _ = reproject_coordinates(
+            [2.675], [8.475], from_crs=4326, to_crs=4326, precision=2
+        )
+        assert got_x[0] == round(2.675, 2), (
+            f"expected built-in rounding {round(2.675, 2)}, got {got_x[0]}"
         )

--- a/tests/base/test_dtype_conversions.py
+++ b/tests/base/test_dtype_conversions.py
@@ -4,14 +4,14 @@ from osgeo import gdal, gdalconst, ogr
 
 from pyramids.base._errors import DriverNotExistError, OptionalPackageDoesNotExist
 from pyramids.base._utils import (
+    _GDAL_TO_NUMPY,
+    _GDAL_TO_OGR,
+    _NUMPY_TO_GDAL,
     DTYPE_CONVERSION_DF,
     GDAL_DTYPE,
     NUMPY_DTYPE,
     OGR_DTYPE,
     Catalog,
-    _GDAL_TO_NUMPY,
-    _GDAL_TO_OGR,
-    _NUMPY_TO_GDAL,
     color_name_to_gdal_constant,
     gdal_constant_to_color_name,
     gdal_to_numpy_dtype,

--- a/tests/base/test_dtype_conversions.py
+++ b/tests/base/test_dtype_conversions.py
@@ -5,9 +5,13 @@ from osgeo import gdal, gdalconst, ogr
 from pyramids.base._errors import DriverNotExistError, OptionalPackageDoesNotExist
 from pyramids.base._utils import (
     DTYPE_CONVERSION_DF,
+    GDAL_DTYPE,
+    NUMPY_DTYPE,
+    OGR_DTYPE,
     Catalog,
     _GDAL_TO_NUMPY,
     _GDAL_TO_OGR,
+    _NUMPY_TO_GDAL,
     color_name_to_gdal_constant,
     gdal_constant_to_color_name,
     gdal_to_numpy_dtype,
@@ -347,6 +351,9 @@ class TestDtypeLookupTables:
             `DTYPE_CONVERSION_DF`, which is still shipped and still used
             for the error messages. Re-deriving each mapping from the
             DataFrame is the direct check that the two never drift.
+            `_NUMPY_TO_GDAL` is included specifically because it is the
+            one table with duplicate keys, so it is the only one where
+            first-wins is more than a formality.
         """
         for column, table in (("numpy", _GDAL_TO_NUMPY), ("ogr", _GDAL_TO_OGR)):
             for gdal_code, expected in table.items():
@@ -357,6 +364,44 @@ class TestDtypeLookupTables:
                     f"{column} lookup for GDAL code {gdal_code} drifted from the "
                     f"table: dict has {expected}, DataFrame has {matched.values[0]}"
                 )
+        for np_dtype, expected in _NUMPY_TO_GDAL.items():
+            matched = DTYPE_CONVERSION_DF.loc[
+                DTYPE_CONVERSION_DF["numpy"] == np_dtype, "gdal"
+            ]
+            assert matched.values[0] == expected, (
+                f"numpy->gdal lookup for {np_dtype} drifted from the table: dict "
+                f"has {expected}, DataFrame has {matched.values[0]}"
+            )
+
+    def test_only_the_none_bearing_rows_are_dropped(self):
+        """`_first_wins` omits exactly the rows with no counterpart.
+
+        Test scenario:
+            The dicts are built by dropping `None`-bearing pairs, which
+            is what makes the "unsupported dtype" guards fire. Checking
+            only the entries the dicts *contain* would never catch a
+            row being dropped that should have been kept, so assert the
+            key sets against the table directly.
+        """
+        # Compare against the source lists, not the DataFrame: pandas coerces the
+        # mixed int/None `ogr` column to float64, turning every None into NaN, so
+        # an `is not None` test there would be vacuously true.
+        expected_gdal_to_numpy = {
+            gdal_code
+            for gdal_code, np_dtype in zip(GDAL_DTYPE, NUMPY_DTYPE)
+            if np_dtype is not None
+        }
+        assert set(_GDAL_TO_NUMPY) == expected_gdal_to_numpy, (
+            "GDAL->numpy keys must be exactly the rows carrying a numpy dtype"
+        )
+        expected_gdal_to_ogr = {
+            gdal_code
+            for gdal_code, ogr_type in zip(GDAL_DTYPE, OGR_DTYPE)
+            if ogr_type is not None
+        }
+        assert set(_GDAL_TO_OGR) == expected_gdal_to_ogr, (
+            "GDAL->OGR keys must be exactly the rows carrying an OGR type"
+        )
 
     def test_unknown_gdal_type_raises_value_error(self):
         """`GDT_Unknown` has no numpy row, so it is reported as unsupported.

--- a/tests/base/test_dtype_conversions.py
+++ b/tests/base/test_dtype_conversions.py
@@ -417,8 +417,9 @@ class TestDtypeLookupTables:
 
     def test_unmapped_numpy_dtype_raises_value_error(self):
         """A numpy dtype with no GDAL counterpart raises, not `IndexError`."""
+        unmapped = np.dtype("float16")
         with pytest.raises(ValueError, match="not supported"):
-            numpy_to_gdal_dtype(np.dtype("float16"))
+            numpy_to_gdal_dtype(unmapped)
 
     def test_complex_band_has_no_ogr_equivalent(self):
         """A complex-typed band raises instead of `int(None)`-ing.

--- a/tests/base/test_dtype_conversions.py
+++ b/tests/base/test_dtype_conversions.py
@@ -1,10 +1,13 @@
 import numpy as np
 import pytest
-from osgeo import gdal, ogr
+from osgeo import gdal, gdalconst, ogr
 
-from pyramids.base._errors import DriverNotExistError
+from pyramids.base._errors import DriverNotExistError, OptionalPackageDoesNotExist
 from pyramids.base._utils import (
+    DTYPE_CONVERSION_DF,
     Catalog,
+    _GDAL_TO_NUMPY,
+    _GDAL_TO_OGR,
     color_name_to_gdal_constant,
     gdal_constant_to_color_name,
     gdal_to_numpy_dtype,
@@ -12,6 +15,7 @@ from pyramids.base._utils import (
     numpy_to_gdal_dtype,
     ogr_ds_to_gdal_dataset,
     ogr_to_numpy_dtype,
+    require_optional,
 )
 
 pytestmark = pytest.mark.core
@@ -313,3 +317,107 @@ class TestRequireCleopatra:
         assert str(exc.value) == _DEFAULT_CLEOPATRA_MSG, (
             f"Expected default message; got {exc.value!r}"
         )
+
+
+class TestDtypeLookupTables:
+    """ARC-62: the precomputed dicts must reproduce the old DataFrame masks."""
+
+    def test_complex64_keeps_the_first_matching_gdal_code(self):
+        """`np.complex64` maps to GDT_CInt16, the first of its three rows.
+
+        Test scenario:
+            `NUMPY_DTYPE` lists `np.complex64` against GDT_CInt16,
+            GDT_CInt32 and GDT_CFloat32. The old lookup took `.values[0]`,
+            so the first row won. A plain dict comprehension would have
+            kept the *last* and silently returned GDT_CFloat32 — this
+            pins the first-wins invariant the rewrite depends on.
+        """
+        assert numpy_to_gdal_dtype(np.dtype(np.complex64)) == gdalconst.GDT_CInt16, (
+            "first-wins must select GDT_CInt16 for complex64"
+        )
+        assert numpy_to_gdal_dtype("complex64") == gdalconst.GDT_CInt16, (
+            "the string spelling must resolve to the same first-wins entry"
+        )
+
+    def test_every_lookup_matches_the_source_dataframe(self):
+        """Each dict agrees with a fresh `.values[0]` scan of the table.
+
+        Test scenario:
+            The dicts exist purely as a fast path for
+            `DTYPE_CONVERSION_DF`, which is still shipped and still used
+            for the error messages. Re-deriving each mapping from the
+            DataFrame is the direct check that the two never drift.
+        """
+        for column, table in (("numpy", _GDAL_TO_NUMPY), ("ogr", _GDAL_TO_OGR)):
+            for gdal_code, expected in table.items():
+                matched = DTYPE_CONVERSION_DF.loc[
+                    DTYPE_CONVERSION_DF["gdal"] == gdal_code, column
+                ]
+                assert matched.values[0] == expected, (
+                    f"{column} lookup for GDAL code {gdal_code} drifted from the "
+                    f"table: dict has {expected}, DataFrame has {matched.values[0]}"
+                )
+
+    def test_unknown_gdal_type_raises_value_error(self):
+        """`GDT_Unknown` has no numpy row, so it is reported as unsupported.
+
+        Test scenario:
+            The old code indexed an all-`None` match and died with
+            `AttributeError: 'NoneType' object has no attribute
+            '__name__'`. The dict drops `None`-valued rows so the
+            existing "not supported" guard fires instead.
+        """
+        with pytest.raises(ValueError, match="not supported"):
+            gdal_to_numpy_dtype(gdalconst.GDT_Unknown)
+
+    def test_unmapped_numpy_dtype_raises_value_error(self):
+        """A numpy dtype with no GDAL counterpart raises, not `IndexError`."""
+        with pytest.raises(ValueError, match="not supported"):
+            numpy_to_gdal_dtype(np.dtype("float16"))
+
+    def test_complex_band_has_no_ogr_equivalent(self):
+        """A complex-typed band raises instead of `int(None)`-ing.
+
+        Test scenario:
+            `gdal_to_ogr_dtype` previously did `int(...values[0])` on an
+            OGR column whose complex rows are `None`, producing
+            `TypeError`. It now reports the missing mapping explicitly.
+        """
+        src = gdal.GetDriverByName("MEM").Create("", 2, 2, 1, gdal.GDT_CFloat32)
+        with pytest.raises(ValueError, match="no OGR equivalent"):
+            gdal_to_ogr_dtype(src)
+
+
+class TestRequireOptional:
+    """ARC-67: the single guard behind the ten `import_*` helpers."""
+
+    def test_returns_none_for_guard_only_callers(self):
+        """The guard form returns nothing when the module imports."""
+        assert require_optional("numpy", "unused") is None
+
+    def test_returns_the_submodule_for_a_dotted_name(self):
+        """A dotted name yields the submodule, not its top-level package.
+
+        Test scenario:
+            `__import__("a.b")` returns `a`, so the helper reads
+            `sys.modules[name]` back instead. `import_basemap` passes
+            `cleopatra.tiles`, and only this path distinguishes the two.
+        """
+        module = require_optional("numpy.linalg", "unused", return_module=True)
+        assert module.__name__ == "numpy.linalg", (
+            f"expected the submodule, got {module.__name__}"
+        )
+
+    def test_missing_module_raises_the_supplied_hint(self):
+        """The install hint is raised verbatim, chained to the ImportError."""
+        with pytest.raises(OptionalPackageDoesNotExist, match="install the extra"):
+            require_optional("pyramids_not_a_real_module", "install the extra")
+
+    def test_missing_module_chains_the_original_importerror(self):
+        """The raised error keeps `__cause__` so the real reason survives."""
+        try:
+            require_optional("pyramids_not_a_real_module", "install the extra")
+        except OptionalPackageDoesNotExist as exc:
+            assert isinstance(exc.__cause__, ImportError), (
+                f"expected a chained ImportError, got {exc.__cause__!r}"
+            )

--- a/tests/base/test_file_manager.py
+++ b/tests/base/test_file_manager.py
@@ -695,7 +695,7 @@ class TestCachingFileManagerEvictionSafety:
         with pytest.raises(RuntimeError):
             with fm.acquire_context():
                 raise RuntimeError("boom")
-        assert cache._pins.get(fm._key) in (None, 0), (
+        assert cache._pins.get(fm._key) is None, (
             f"the pin must be dropped on the error path, got {cache._pins}"
         )
 
@@ -710,7 +710,7 @@ class TestCachingFileManagerEvictionSafety:
         with pytest.raises(OSError):
             with fm.acquire_context():
                 pass
-        assert cache._pins.get(fm._key) in (None, 0), (
+        assert cache._pins.get(fm._key) is None, (
             f"a failed open must not leak a pin, got {cache._pins}"
         )
 

--- a/tests/base/test_file_manager.py
+++ b/tests/base/test_file_manager.py
@@ -156,22 +156,43 @@ class TestLRUCache:
         with pytest.raises(ValueError, match="maxsize must be >= 1"):
             cache.maxsize = 0
 
-    def test_setitem_existing_key_updates_in_place(self):
-        """Re-setting an existing key updates the value without evicting.
+    def test_setitem_existing_key_closes_displaced_value(self):
+        """ARC-11: overwriting a live key hands the displaced value to `on_evict`.
 
         Test scenario:
-            The LRU must bump the key to most-recently-used and swap
-            the stored value, without firing `on_evict` — because no
-            entry actually leaves the cache. This covers the `if key
-            in self._cache` fast-return branch.
+            The LRU must bump the key to most-recently-used and swap the
+            stored value — but the value it replaced is a GDAL handle
+            nobody else will ever close. Pre-fix the overwrite dropped
+            it silently, leaking a file descriptor; the displaced value
+            must now be released while the key itself stays cached.
         """
         evicted: list = []
-        cache = _LRUCache(maxsize=2, on_evict=lambda k, v: evicted.append(k))
+        cache = _LRUCache(maxsize=2, on_evict=lambda k, v: evicted.append((k, v)))
         cache["a"] = 1
         cache["b"] = 2
         cache["a"] = 99
         assert cache["a"] == 99, f"Expected updated value 99, got {cache['a']}"
-        assert evicted == [], f"No eviction expected on in-place update, got {evicted}"
+        assert evicted == [("a", 1)], (
+            f"The displaced value must be released exactly once, got {evicted}"
+        )
+        assert "b" in cache, "Overwriting one key must not evict another"
+
+    def test_setitem_same_object_is_a_noop(self):
+        """Re-setting the identical object releases nothing.
+
+        Test scenario:
+            `acquire()` re-assigning the handle it just read back would
+            otherwise close the handle it is about to return. Identity
+            (not equality) is the guard, so re-setting the same object
+            must not fire `on_evict`.
+        """
+        evicted: list = []
+        cache = _LRUCache(maxsize=2, on_evict=lambda k, v: evicted.append(k))
+        handle = object()
+        cache["a"] = handle
+        cache["a"] = handle
+        assert evicted == [], f"Re-setting the same object must not evict, got {evicted}"
+        assert cache["a"] is handle
 
     def test_iter_yields_keys_in_lru_order(self):
         """Iterating the cache returns keys snapshot-safely.
@@ -387,6 +408,139 @@ class TestCachingFileManagerLRUEviction:
             assert handles[2].closed is False
         finally:
             FILE_CACHE.maxsize = 128
+
+
+class TestLRUCachePinning:
+    """ARC-4: pinned slots survive eviction pressure."""
+
+    def test_pinned_key_is_not_evicted(self):
+        """A pinned entry is skipped and the cache overflows instead.
+
+        Test scenario:
+            Correctness beats the soft size bound: closing a handle a
+            reader is mid-way through is a use-after-close, whereas
+            holding one extra descriptor for the length of that read is
+            merely untidy.
+        """
+        evicted: list = []
+        cache = _LRUCache(maxsize=1, on_evict=lambda k, v: evicted.append(k))
+        cache["a"] = 1
+        cache.pin("a")
+        cache["b"] = 2
+        assert evicted == [], f"A pinned key must not be evicted, got {evicted}"
+        assert sorted(cache) == ["a", "b"], (
+            f"Both entries must remain while 'a' is pinned, got {sorted(cache)}"
+        )
+
+    def test_unpin_makes_the_slot_evictable_again(self):
+        """After the last `unpin` the LRU reclaims the slot normally."""
+        evicted: list = []
+        cache = _LRUCache(maxsize=1, on_evict=lambda k, v: evicted.append(k))
+        cache["a"] = 1
+        cache.pin("a")
+        cache["b"] = 2
+        cache.unpin("a")
+        cache["c"] = 3
+        assert evicted == ["a", "b"], (
+            f"Both unpinned entries must be reclaimed, got {evicted}"
+        )
+
+    def test_pins_nest(self):
+        """N pins need N unpins before the slot is evictable."""
+        evicted: list = []
+        cache = _LRUCache(maxsize=1, on_evict=lambda k, v: evicted.append(k))
+        cache["a"] = 1
+        cache.pin("a")
+        cache.pin("a")
+        cache.unpin("a")
+        cache["b"] = 2
+        assert evicted == [], f"One unpin of two must keep 'a' pinned, got {evicted}"
+
+    def test_unpin_untracked_key_is_a_noop(self):
+        """`unpin` on a key wiped by `clear()` must not underflow."""
+        cache = _LRUCache(maxsize=2)
+        cache["a"] = 1
+        cache.pin("a")
+        cache.clear()
+        cache.unpin("a")
+        cache.unpin("never-pinned")
+
+    def test_maxsize_setter_skips_pinned_entries(self):
+        """Shrinking `maxsize` also honours pins."""
+        evicted: list = []
+        cache = _LRUCache(maxsize=4, on_evict=lambda k, v: evicted.append(k))
+        for key in ("a", "b", "c", "d"):
+            cache[key] = key
+        cache.pin("a")
+        cache.maxsize = 1
+        assert "a" in cache, "The pinned entry must survive a maxsize shrink"
+        assert sorted(evicted) == ["b", "c", "d"], (
+            f"Every unpinned entry must be reclaimed, got {evicted}"
+        )
+
+
+class TestCachingFileManagerEvictionSafety:
+    """ARC-4: `acquire_context` protects the handle for the whole read."""
+
+    def test_acquire_context_handle_survives_cross_manager_pressure(self):
+        """Another manager's insert cannot close a handle being read.
+
+        Test scenario:
+            Manager A holds its handle inside `acquire_context()`.
+            Manager B — a different cache key, therefore a different
+            per-manager lock — inserts into the full shared cache.
+            Pre-fix B's insert evicted and `Close()`d A's handle
+            mid-read; post-fix the pin makes A's slot ineligible.
+        """
+        cache = _LRUCache(maxsize=1, on_evict=_close_handle)
+        first = CachingFileManager(_fake_opener, "a.tif", cache=cache, lock=False)
+        second = CachingFileManager(_fake_opener, "b.tif", cache=cache, lock=False)
+        with first.acquire_context() as handle:
+            second.acquire()
+            assert handle.closed is False, (
+                "a handle held inside acquire_context() must not be closed by "
+                "another manager's cache insert"
+            )
+
+    def test_slot_is_evictable_again_after_the_block(self):
+        """The pin is released on exit, so the LRU bound is restored."""
+        cache = _LRUCache(maxsize=1, on_evict=_close_handle)
+        first = CachingFileManager(_fake_opener, "a.tif", cache=cache, lock=False)
+        second = CachingFileManager(_fake_opener, "b.tif", cache=cache, lock=False)
+        with first.acquire_context() as handle:
+            pass
+        second.acquire()
+        assert handle.closed is True, (
+            "once the read finishes the handle must be reclaimable by the LRU"
+        )
+        assert len(cache) == 1, f"cache must be back at maxsize, got {len(cache)}"
+
+    def test_pin_is_released_when_the_block_raises(self):
+        """An exception inside the block still unpins the slot."""
+        cache = _LRUCache(maxsize=2, on_evict=_close_handle)
+        fm = CachingFileManager(_fake_opener, "a.tif", cache=cache, lock=False)
+        fm.acquire()  # pre-cache so the failure path keeps the handle
+        with pytest.raises(RuntimeError):
+            with fm.acquire_context():
+                raise RuntimeError("boom")
+        assert cache._pins.get(fm._key) in (None, 0), (
+            f"the pin must be dropped on the error path, got {cache._pins}"
+        )
+
+    def test_pin_is_released_when_the_opener_raises(self):
+        """A failure to open must not leave the key pinned forever."""
+
+        def _broken_opener(path, access="read_only", **kwargs):
+            raise OSError("cannot open")
+
+        cache = _LRUCache(maxsize=2, on_evict=_close_handle)
+        fm = CachingFileManager(_broken_opener, "a.tif", cache=cache, lock=False)
+        with pytest.raises(OSError):
+            with fm.acquire_context():
+                pass
+        assert cache._pins.get(fm._key) in (None, 0), (
+            f"a failed open must not leak a pin, got {cache._pins}"
+        )
 
 
 class TestThreadLocalFileManager:

--- a/tests/base/test_file_manager.py
+++ b/tests/base/test_file_manager.py
@@ -515,14 +515,57 @@ class TestLRUCachePinning:
         cache["b"] = 2
         assert evicted == [], f"One unpin of two must keep 'a' pinned, got {evicted}"
 
+    def test_all_pinned_overflow_logs_the_configured_limit(self, caplog):
+        """The over-limit DEBUG line names `maxsize`, not the insert's target.
+
+        Test scenario:
+            `__setitem__` trims to `maxsize - 1` so the new entry lands
+            at exactly `maxsize`, but that internal target must not
+            reach the operator: on a 128-entry cache the message would
+            otherwise read "over its 127 limit". Filling a cache with
+            pinned entries is the only way to reach the branch.
+        """
+        cache = _LRUCache(maxsize=2, on_evict=lambda k, v: None)
+        for key in ("a", "b"):
+            cache[key] = key
+            cache.pin(key)
+        with caplog.at_level("DEBUG", logger="pyramids.base._file_manager"):
+            cache["c"] = "c"
+        messages = [
+            r.getMessage() for r in caplog.records if "file cache is" in r.getMessage()
+        ]
+        assert messages, (
+            f"the all-pinned overflow must log at DEBUG; got {[r.getMessage() for r in caplog.records]}"
+        )
+        assert "over its 2 limit" in messages[0], (
+            f"the message must report maxsize=2, got {messages[0]!r}"
+        )
+
     def test_unpin_untracked_key_is_a_noop(self):
-        """`unpin` on a key wiped by `clear()` must not underflow."""
+        """`unpin` on a key wiped by `clear()` must not underflow.
+
+        Test scenario:
+            `clear()` drops the pin table wholesale, so a reader still
+            inside `acquire_context()` unpins a key the cache no longer
+            tracks. That must leave the pin count absent rather than
+            going negative — a negative count would read as truthy and
+            silently make the key permanently un-evictable.
+        """
         cache = _LRUCache(maxsize=2)
         cache["a"] = 1
         cache.pin("a")
         cache.clear()
         cache.unpin("a")
         cache.unpin("never-pinned")
+        assert cache._pins == {}, (
+            f"an untracked unpin must not record a count, got {cache._pins}"
+        )
+        cache["a"] = 1
+        cache["b"] = 2
+        cache["c"] = 3
+        assert "a" not in cache, (
+            "the post-clear key must be evictable, not stuck behind a stale pin"
+        )
 
     def test_maxsize_setter_skips_pinned_entries(self):
         """Shrinking `maxsize` also honours pins."""

--- a/tests/base/test_file_manager.py
+++ b/tests/base/test_file_manager.py
@@ -561,6 +561,53 @@ class TestCachingFileManagerEvictionSafety:
                 "another manager's cache insert"
             )
 
+    def test_auto_release_finalizer_leaves_a_pinned_slot_alone(self):
+        """The GC-driven `release()` path must not close a handle being read.
+
+        Test scenario:
+            `release()` fires from a `weakref.finalize`, so it lands at
+            an arbitrary moment — including while a manager sharing the
+            cache key is mid-read inside `acquire_context()`. Unlike
+            `close()`, nobody asked for teardown here, so a pinned slot
+            must survive and be left for the LRU.
+        """
+        cache = _LRUCache(maxsize=8, on_evict=_close_handle)
+        owner = CachingFileManager(
+            _fake_opener, "a.tif", cache=cache, manager_id="k", auto_release=True
+        )
+        reader = CachingFileManager(
+            _fake_opener, "a.tif", cache=cache, manager_id="k", lock=False
+        )
+        with reader.acquire_context() as handle:
+            del owner
+            gc.collect()
+            assert handle.closed is False, (
+                "the auto-release finalizer must not close a pinned handle"
+            )
+            assert reader._key in cache, "the pinned entry must stay cached"
+
+    def test_close_still_tears_down_a_pinned_slot(self):
+        """`close()` is explicit teardown and deliberately overrides the pin.
+
+        Test scenario:
+            Pins guard against implicit reclaim, not against a caller
+            declaring the handle finished. This documents the sharp
+            edge that `close()` and `clear()` retain, so the behaviour
+            is a decision rather than an oversight.
+        """
+        cache = _LRUCache(maxsize=8, on_evict=_close_handle)
+        first = CachingFileManager(
+            _fake_opener, "a.tif", cache=cache, manager_id="k", lock=False
+        )
+        second = CachingFileManager(
+            _fake_opener, "a.tif", cache=cache, manager_id="k", lock=False
+        )
+        with first.acquire_context() as handle:
+            second.close()
+            assert handle.closed is True, (
+                "close() is explicit teardown and overrides the pin by design"
+            )
+
     def test_slot_is_evictable_again_after_the_block(self):
         """The pin is released on exit, so the LRU bound is restored."""
         cache = _LRUCache(maxsize=1, on_evict=_close_handle)

--- a/tests/base/test_file_manager.py
+++ b/tests/base/test_file_manager.py
@@ -475,6 +475,35 @@ class TestLRUCachePinning:
             f"Both unpinned entries must be reclaimed, got {evicted}"
         )
 
+    def test_releasing_the_last_pin_trims_the_overflow_immediately(self):
+        """Dropping the last pin restores `maxsize` without waiting for an insert.
+
+        Test scenario:
+            Pinned reads are the one thing allowed to push the cache
+            past its limit. If the trim only ran on the next insert, a
+            workload that finishes its reads and stops would hold every
+            over-limit handle open forever — 20 GDAL datasets on a cache
+            configured for 2. Releasing the pins must reclaim them there
+            and then.
+        """
+        evicted: list = []
+        cache = _LRUCache(maxsize=2, on_evict=lambda k, v: evicted.append(k))
+        for index in range(6):
+            key = f"k{index}"
+            cache[key] = index
+            cache.pin(key)
+        assert len(cache) == 6, (
+            f"pinned reads must be allowed to exceed maxsize, got {len(cache)}"
+        )
+        for index in range(6):
+            cache.unpin(f"k{index}")
+        assert len(cache) == 2, (
+            f"the cache must be back at maxsize once unpinned, got {len(cache)}"
+        )
+        assert evicted == ["k0", "k1", "k2", "k3"], (
+            f"the four least-recently-used entries must be released, got {evicted}"
+        )
+
     def test_pins_nest(self):
         """N pins need N unpins before the slot is evictable."""
         evicted: list = []

--- a/tests/base/test_file_manager.py
+++ b/tests/base/test_file_manager.py
@@ -703,8 +703,9 @@ class TestCachingFileManagerEvictionSafety:
         cache = _LRUCache(maxsize=2, on_evict=_close_handle)
         fm = CachingFileManager(_fake_opener, "a.tif", cache=cache, lock=False)
         fm.acquire()  # pre-cache so the failure path keeps the handle
+        boom = RuntimeError("boom")
         with pytest.raises(RuntimeError):
-            _raise_inside_acquire_context(fm, RuntimeError("boom"))
+            _raise_inside_acquire_context(fm, boom)
         assert cache._pins.get(fm._key) is None, (
             f"the pin must be dropped on the error path, got {cache._pins}"
         )
@@ -717,8 +718,9 @@ class TestCachingFileManagerEvictionSafety:
 
         cache = _LRUCache(maxsize=2, on_evict=_close_handle)
         fm = CachingFileManager(_broken_opener, "a.tif", cache=cache, lock=False)
+        context = fm.acquire_context()
         with pytest.raises(OSError):
-            fm.acquire_context().__enter__()
+            context.__enter__()
         assert cache._pins.get(fm._key) is None, (
             f"a failed open must not leak a pin, got {cache._pins}"
         )

--- a/tests/base/test_file_manager.py
+++ b/tests/base/test_file_manager.py
@@ -191,7 +191,9 @@ class TestLRUCache:
         handle = object()
         cache["a"] = handle
         cache["a"] = handle
-        assert evicted == [], f"Re-setting the same object must not evict, got {evicted}"
+        assert evicted == [], (
+            f"Re-setting the same object must not evict, got {evicted}"
+        )
         assert cache["a"] is handle
 
     def test_iter_yields_keys_in_lru_order(self):

--- a/tests/base/test_file_manager.py
+++ b/tests/base/test_file_manager.py
@@ -196,6 +196,34 @@ class TestLRUCache:
         )
         assert cache["a"] is handle
 
+    def test_setitem_does_not_close_a_pinned_displaced_value(self):
+        """Overwriting a *pinned* key must not release what it displaces.
+
+        Test scenario:
+            The overwrite path exists because two managers sharing a
+            `manager_id` can both miss, both open and both assign. When
+            the first of them is inside `acquire_context()` the handle
+            being displaced is the one it is actively reading through,
+            so closing it is a use-after-close — strictly worse than the
+            descriptor leak the release was added to prevent. The pin
+            must suppress the release exactly as it does for LRU
+            eviction.
+        """
+        evicted: list = []
+        cache = _LRUCache(maxsize=4, on_evict=lambda k, v: evicted.append((k, v)))
+        cache["a"] = 1
+        cache.pin("a")
+        cache["a"] = 99
+        assert evicted == [], (
+            f"A pinned key's displaced value must not be released, got {evicted}"
+        )
+        assert cache["a"] == 99, "the new value must still be installed"
+        cache.unpin("a")
+        cache["a"] = 100
+        assert evicted == [("a", 99)], (
+            f"Once unpinned the overwrite releases again, got {evicted}"
+        )
+
     def test_iter_yields_keys_in_lru_order(self):
         """Iterating the cache returns keys snapshot-safely.
 

--- a/tests/base/test_file_manager.py
+++ b/tests/base/test_file_manager.py
@@ -61,6 +61,17 @@ class _FakeHandle:
         return f"_FakeHandle({self.tag!r})"
 
 
+def _raise_inside_acquire_context(manager, error):
+    """Enter `manager`'s context and raise `error` from inside the block.
+
+    Module-level so the `pytest.raises` blocks below wrap a single call:
+    entering the context manager can itself raise, and a `raises` block
+    containing two throwing statements cannot show which one fired.
+    """
+    with manager.acquire_context():
+        raise error
+
+
 _counter = {"n": 0}
 
 
@@ -693,8 +704,7 @@ class TestCachingFileManagerEvictionSafety:
         fm = CachingFileManager(_fake_opener, "a.tif", cache=cache, lock=False)
         fm.acquire()  # pre-cache so the failure path keeps the handle
         with pytest.raises(RuntimeError):
-            with fm.acquire_context():
-                raise RuntimeError("boom")
+            _raise_inside_acquire_context(fm, RuntimeError("boom"))
         assert cache._pins.get(fm._key) is None, (
             f"the pin must be dropped on the error path, got {cache._pins}"
         )
@@ -708,8 +718,7 @@ class TestCachingFileManagerEvictionSafety:
         cache = _LRUCache(maxsize=2, on_evict=_close_handle)
         fm = CachingFileManager(_broken_opener, "a.tif", cache=cache, lock=False)
         with pytest.raises(OSError):
-            with fm.acquire_context():
-                pass
+            fm.acquire_context().__enter__()
         assert cache._pins.get(fm._key) is None, (
             f"a failed open must not leak a pin, got {cache._pins}"
         )

--- a/tests/base/test_file_manager.py
+++ b/tests/base/test_file_manager.py
@@ -604,15 +604,16 @@ class TestCachingFileManagerEvictionSafety:
                 "another manager's cache insert"
             )
 
-    def test_auto_release_finalizer_leaves_a_pinned_slot_alone(self):
-        """The GC-driven `release()` path must not close a handle being read.
+    def test_auto_release_finalizer_defers_the_close_of_a_pinned_slot(self):
+        """The GC-driven `release()` must defer, not skip, a pinned handle's close.
 
         Test scenario:
             `release()` fires from a `weakref.finalize`, so it lands at
             an arbitrary moment — including while a manager sharing the
-            cache key is mid-read inside `acquire_context()`. Unlike
-            `close()`, nobody asked for teardown here, so a pinned slot
-            must survive and be left for the LRU.
+            cache key is mid-read. Closing there is a use-after-close;
+            merely leaving the entry behind would forfeit the
+            deterministic release this path exists for. It must park
+            the handle and let the last reader release it.
         """
         cache = _LRUCache(maxsize=8, on_evict=_close_handle)
         owner = CachingFileManager(
@@ -627,16 +628,23 @@ class TestCachingFileManagerEvictionSafety:
             assert handle.closed is False, (
                 "the auto-release finalizer must not close a pinned handle"
             )
-            assert reader._key in cache, "the pinned entry must stay cached"
+        assert handle.closed is True, (
+            "the deferred close must run once the last reader unpins"
+        )
+        assert cache._pending_close == {}, (
+            f"the deferred entry must be drained, got {cache._pending_close}"
+        )
 
-    def test_close_still_tears_down_a_pinned_slot(self):
-        """`close()` is explicit teardown and deliberately overrides the pin.
+    def test_close_defers_teardown_of_a_pinned_slot(self):
+        """`close()` unpublishes immediately but closes only after the read ends.
 
         Test scenario:
-            Pins guard against implicit reclaim, not against a caller
-            declaring the handle finished. This documents the sharp
-            edge that `close()` and `clear()` retain, so the behaviour
-            is a decision rather than an oversight.
+            `close()` is reachable from public API — `NetCDF.close()`
+            walks its lazy managers and calls it — while dask workers
+            may still be inside `acquire_context()`. A GDAL
+            use-after-close is a segfault, not an exception, so the
+            handle must outlive the call; the slot still has to leave
+            the cache at once so no new caller picks it up.
         """
         cache = _LRUCache(maxsize=8, on_evict=_close_handle)
         first = CachingFileManager(
@@ -647,9 +655,24 @@ class TestCachingFileManagerEvictionSafety:
         )
         with first.acquire_context() as handle:
             second.close()
-            assert handle.closed is True, (
-                "close() is explicit teardown and overrides the pin by design"
+            assert handle.closed is False, (
+                "close() must not close a handle another reader is using"
             )
+            assert first._key not in cache, (
+                "the slot must leave the cache immediately so no new caller finds it"
+            )
+        assert handle.closed is True, (
+            "the deferred close must run once the reader unpins"
+        )
+
+    def test_close_of_an_unpinned_slot_is_immediate(self):
+        """With no reader present `close()` still closes on the spot."""
+        cache = _LRUCache(maxsize=8, on_evict=_close_handle)
+        fm = CachingFileManager(_fake_opener, "a.tif", cache=cache, lock=False)
+        handle = fm.acquire()
+        fm.close()
+        assert handle.closed is True, "an unpinned close must not be deferred"
+        assert cache._pending_close == {}, "nothing should be parked"
 
     def test_slot_is_evictable_again_after_the_block(self):
         """The pin is released on exit, so the LRU bound is restored."""

--- a/tests/config/test_logger.py
+++ b/tests/config/test_logger.py
@@ -7,38 +7,56 @@ from unittest.mock import patch
 import pytest
 from osgeo import gdal
 
-from pyramids.base.config import Config, LoggerManager
+from pyramids.base import config as config_mod
+from pyramids.base.config import (
+    PACKAGE_LOGGER_NAME,
+    Config,
+    LoggerManager,
+    _gdal_error_handler,
+)
 
 pytestmark = pytest.mark.core
 
 
 @contextmanager
-def isolated_root_logging():
+def isolated_package_logging():
     """
-    Temporarily isolate root logger handlers and level so tests don't
-    interfere with each other or the global test suite.
+    Temporarily isolate the ``pyramids`` logger's handlers and level so tests
+    don't interfere with each other or the global test suite.
+
+    ARC-40: pyramids configures its own namespace, never the root logger, so the
+    isolation target is ``logging.getLogger("pyramids")``.
     """
-    root = logging.getLogger()
-    old_level = root.level
-    old_handlers = list(root.handlers)
+    package_logger = logging.getLogger(PACKAGE_LOGGER_NAME)
+    old_level = package_logger.level
+    old_handlers = list(package_logger.handlers)
     try:
-        for h in root.handlers[:]:
-            root.removeHandler(h)
-        yield root
+        for h in package_logger.handlers[:]:
+            package_logger.removeHandler(h)
+        yield package_logger
     finally:
-        # Clear any handlers added by the test
-        for h in root.handlers[:]:
-            root.removeHandler(h)
-        # Restore originals
+        for h in package_logger.handlers[:]:
+            package_logger.removeHandler(h)
         for h in old_handlers:
-            root.addHandler(h)
-        root.setLevel(old_level)
+            package_logger.addHandler(h)
+        package_logger.setLevel(old_level)
+
+
+@contextmanager
+def reinstallable_error_handler():
+    """Let a test observe ``_set_error_handler`` installing, then restore the guard."""
+    saved = config_mod._gdal_error_handler_installed
+    config_mod._gdal_error_handler_installed = False
+    try:
+        yield
+    finally:
+        config_mod._gdal_error_handler_installed = saved
 
 
 def test_console_logging_colored_and_message(capsys):
-    with isolated_root_logging():
-        # Configure logging at INFO level using LoggerManager
-        LoggerManager(level="INFO")
+    with isolated_package_logging():
+        # An explicit level opts into the coloured console handler.
+        LoggerManager(level="DEBUG")
 
         # Emitted by setup_logging
         out = capsys.readouterr()
@@ -48,21 +66,64 @@ def test_console_logging_colored_and_message(capsys):
         assert "Logging is configured." in stderr_text
         assert "pyramids.base.config" in stderr_text  # logger name
 
-        # Also test that subsequent logs go to the console
-        logging.getLogger(__name__).info("hello world")
+        # Also test that subsequent pyramids logs go to the console
+        logging.getLogger("pyramids.tests.console").info("hello world")
         out2 = capsys.readouterr()
         assert "hello world" in out2.err
         assert "\x1b[" in out2.err  # colored level name
 
 
+def test_default_level_configures_nothing(capsys):
+    """ARC-40: ``LoggerManager()`` with no level installs only a NullHandler.
+
+    Test scenario:
+        Importing pyramids runs ``Config()``. That must not print anything, must
+        not add a console handler, and must not set a level — logging policy
+        belongs to the host application.
+    """
+    with isolated_package_logging() as package_logger:
+        LoggerManager()
+        out = capsys.readouterr()
+        assert out.err == "", f"default LoggerManager must be silent; got {out.err!r}"
+        assert out.out == "", f"default LoggerManager must be silent; got {out.out!r}"
+        assert all(
+            isinstance(h, logging.NullHandler) for h in package_logger.handlers
+        ), (
+            "default LoggerManager must add only a NullHandler; got "
+            f"{[type(h).__name__ for h in package_logger.handlers]}"
+        )
+        assert package_logger.level == logging.NOTSET, (
+            "default LoggerManager must not set a level on the pyramids logger"
+        )
+
+
+def test_root_logger_is_never_touched():
+    """ARC-40: no pyramids handler ever lands on the root logger.
+
+    Test scenario:
+        Configuring pyramids at DEBUG must leave the root logger's handler list
+        and level exactly as they were — a library that adds a root handler
+        silently reconfigures logging for the whole application.
+    """
+    root = logging.getLogger()
+    handlers_before = list(root.handlers)
+    level_before = root.level
+    with isolated_package_logging():
+        LoggerManager(level="DEBUG", log_file=None)
+    assert list(root.handlers) == handlers_before, (
+        "pyramids must not add or remove root logger handlers"
+    )
+    assert root.level == level_before, "pyramids must not change the root logger level"
+
+
 def test_file_logging_no_colors_and_writes(tmp_path: Path):
     log_file = tmp_path / "test.log"
-    with isolated_root_logging():
+    with isolated_package_logging():
         LoggerManager(level=logging.DEBUG, log_file=log_file)
 
         # setup_logging should log a message already
         # Now log something extra
-        logging.getLogger("tests.config.test_logger").debug("file handler check")
+        logging.getLogger("pyramids.tests.file_handler").debug("file handler check")
 
     # Read file and assert contents
     text = log_file.read_text(encoding="utf-8")
@@ -74,7 +135,7 @@ def test_file_logging_no_colors_and_writes(tmp_path: Path):
 
 def test_idempotent_handlers(tmp_path: Path):
     log_file = tmp_path / "dup.log"
-    with isolated_root_logging() as root:
+    with isolated_package_logging() as package_logger:
         LoggerManager(level="INFO", log_file=log_file)
         # Call again with the same parameters
         LoggerManager(level="INFO", log_file=log_file)
@@ -82,27 +143,24 @@ def test_idempotent_handlers(tmp_path: Path):
         # Expect exactly one StreamHandler (console) and one FileHandler
         stream_handlers = [
             h
-            for h in root.handlers
+            for h in package_logger.handlers
             if isinstance(h, logging.StreamHandler)
             and not isinstance(h, logging.FileHandler)
         ]
-        file_handlers = [h for h in root.handlers if isinstance(h, logging.FileHandler)]
+        file_handlers = [
+            h for h in package_logger.handlers if isinstance(h, logging.FileHandler)
+        ]
         assert len(stream_handlers) == 1
         assert len(file_handlers) == 1
         # And that file handler targets the same file
         assert Path(file_handlers[0].baseFilename) == log_file
 
 
-@patch("osgeo.gdal.PushErrorHandler")
-def test_set_error_handler_prints_for_low_error_class(mock_push):
-    # Install the handler via LoggerManager and capture it from the patched GDAL entry point
-    LoggerManager()
-    handler = mock_push.call_args[0][0]
-
+def test_set_error_handler_prints_for_low_error_class():
     # Invoke the handler with an error class lower than CE_Warning to trigger printing
     buf = io.StringIO()
     with redirect_stdout(buf):
-        handler(0, 42, "oops")
+        _gdal_error_handler(0, 42, "oops")
     out = buf.getvalue().strip()
 
     assert out == "GDAL error (class 0, number 42): oops"
@@ -112,21 +170,18 @@ def _collect_log_messages(records, logger_name: str):
     return [r for r in records if r.name == logger_name]
 
 
-@patch("osgeo.gdal.PushErrorHandler")
-def test_set_error_handler_logs_severities(mock_push, capsys):
-    # Isolate root logging and configure
-    with isolated_root_logging():
+def test_set_error_handler_logs_severities(capsys):
+    # Isolate pyramids logging and configure
+    with isolated_package_logging():
         LoggerManager(level="DEBUG")
-
-        # Capture the handler installed during construction
-        handler = mock_push.call_args[0][0]
+        capsys.readouterr()  # drop the "Logging is configured." line
 
         # Emit messages: warning and higher are routed to the configured logger -> console (stderr)
-        handler(gdal.CE_Warning, 22, "warn msg")
-        handler(gdal.CE_Failure, 33, "fail msg")
-        handler(gdal.CE_Fatal, 44, "fatal msg")
+        _gdal_error_handler(gdal.CE_Warning, 22, "warn msg")
+        _gdal_error_handler(gdal.CE_Failure, 33, "fail msg")
+        _gdal_error_handler(gdal.CE_Fatal, 44, "fatal msg")
         # Unknown class -> ERROR fallback
-        handler(999, 55, "unknown class msg")
+        _gdal_error_handler(999, 55, "unknown class msg")
 
         out = capsys.readouterr()
         err_text = out.err
@@ -140,8 +195,34 @@ def test_set_error_handler_logs_severities(mock_push, capsys):
         )
 
 
+@patch("osgeo.gdal.PushErrorHandler")
+def test_error_handler_installed_only_once(mock_push):
+    """ARC-40: repeated construction must not stack GDAL error handlers.
+
+    Test scenario:
+        ``gdal.PushErrorHandler`` pushes onto a stack that pyramids never pops,
+        so an unguarded install made GDAL log every error once per push. Two
+        LoggerManager constructions must produce at most one push.
+    """
+    with reinstallable_error_handler(), isolated_package_logging():
+        LoggerManager()
+        LoggerManager()
+    assert mock_push.call_count == 1, (
+        f"expected exactly one PushErrorHandler call, got {mock_push.call_count}"
+    )
+    assert mock_push.call_args[0][0] is _gdal_error_handler
+
+
+@patch("osgeo.gdal.PushErrorHandler")
+def test_error_handler_not_reinstalled_when_already_present(mock_push):
+    """The install guard short-circuits once the handler is in place."""
+    with isolated_package_logging():
+        LoggerManager()
+    mock_push.assert_not_called()
+
+
 def test_setup_logging_invalid_level_string_raises():
-    with isolated_root_logging():
+    with isolated_package_logging():
         with pytest.raises(ValueError):
             LoggerManager(level="NOT_A_LEVEL")
 
@@ -191,14 +272,12 @@ def test_initialize_gdal_sets_options_and_conditional_driver_path(
     mock_register.assert_called()
 
 
-@patch("osgeo.gdal.PushErrorHandler")
-def test_error_handler_exception_fallback_logs_error(mock_push, capsys):
+def test_error_handler_exception_fallback_logs_error(capsys):
     # Install handler via LoggerManager
-    with isolated_root_logging():
+    with isolated_package_logging():
         LoggerManager(level="DEBUG")
-        handler = mock_push.call_args[0][0]
         # Cause a TypeError inside the handler's try block by passing a non-orderable err_class
-        handler(object(), 66, "boom")
+        _gdal_error_handler(object(), 66, "boom")
         err = capsys.readouterr().err
     # The fallback except path logs an error with the generic format
     assert "GDAL(class=" in err

--- a/tests/config/test_logger.py
+++ b/tests/config/test_logger.py
@@ -401,3 +401,62 @@ def test_third_party_loggers_untouched_by_default():
         )
     finally:
         victim.setLevel(saved)
+
+
+def test_opt_in_is_reversible_with_a_bare_config():
+    """S2: `LoggerManager()` hands the namespace back after an opt-in.
+
+    Test scenario:
+        Without a way back, one `Config(level=...)` anywhere in a
+        downstream conftest leaves `propagate` False for the process, and
+        every `caplog`-based assertion on a pyramids logger silently
+        captures nothing — a vacuous pass, not a loud failure.
+    """
+    with isolated_package_logging() as package_logger:
+        LoggerManager(level="INFO")
+        assert package_logger.propagate is False, "precondition: opt-in disables it"
+        owned = [
+            h
+            for h in package_logger.handlers
+            if getattr(h, config_mod._OWNED_HANDLER_FLAG, False)
+        ]
+        assert owned, "precondition: pyramids installed a handler"
+
+        LoggerManager()
+        assert package_logger.propagate is True, (
+            "a bare LoggerManager() must restore propagation"
+        )
+        assert not [
+            h
+            for h in package_logger.handlers
+            if getattr(h, config_mod._OWNED_HANDLER_FLAG, False)
+        ], "a bare LoggerManager() must remove the handlers pyramids installed"
+
+
+def test_host_installed_handler_is_left_alone():
+    """S7: pyramids only reconfigures handlers it installed itself.
+
+    Test scenario:
+        Attaching a handler to `logging.getLogger("pyramids")` is the
+        canonical way for an application to capture a library's output.
+        Opting into pyramids logging must not overwrite that handler's
+        level or swap its formatter for the coloured console one.
+    """
+    with isolated_package_logging() as package_logger:
+        host_handler = logging.StreamHandler(io.StringIO())
+        host_formatter = logging.Formatter("HOST:%(message)s")
+        host_handler.setFormatter(host_formatter)
+        host_handler.setLevel(logging.CRITICAL)
+        package_logger.addHandler(host_handler)
+
+        LoggerManager(level="DEBUG")
+
+        assert host_handler.formatter is host_formatter, (
+            "the host's formatter must survive pyramids' opt-in"
+        )
+        assert host_handler.level == logging.CRITICAL, (
+            f"the host's handler level must survive; got {host_handler.level}"
+        )
+        assert host_handler in package_logger.handlers, (
+            "the host's handler must not be removed"
+        )

--- a/tests/config/test_logger.py
+++ b/tests/config/test_logger.py
@@ -48,17 +48,6 @@ def isolated_package_logging():
         package_logger.propagate = old_propagate
 
 
-@contextmanager
-def reinstallable_error_handler():
-    """Let a test observe ``_set_error_handler`` installing, then restore the guard."""
-    saved = config_mod._gdal_error_handler_installed
-    config_mod._gdal_error_handler_installed = False
-    try:
-        yield
-    finally:
-        config_mod._gdal_error_handler_installed = saved
-
-
 def test_console_logging_colored_and_message(capsys):
     with isolated_package_logging():
         # An explicit level opts into the coloured console handler.
@@ -88,18 +77,22 @@ def test_default_level_configures_nothing(capsys):
         belongs to the host application.
     """
     with isolated_package_logging() as package_logger:
+        # Establish a non-default level so "unchanged" is a real assertion rather
+        # than a statement about whatever the session happened to leave behind.
+        package_logger.setLevel(logging.WARNING)
         LoggerManager()
         out = capsys.readouterr()
         assert out.err == "", f"default LoggerManager must be silent; got {out.err!r}"
         assert out.out == "", f"default LoggerManager must be silent; got {out.out!r}"
-        assert all(
-            isinstance(h, logging.NullHandler) for h in package_logger.handlers
-        ), (
-            "default LoggerManager must add only a NullHandler; got "
+        assert len(package_logger.handlers) == 1, (
+            "expected exactly one handler (the NullHandler); got "
             f"{[type(h).__name__ for h in package_logger.handlers]}"
         )
-        assert package_logger.level == logging.NOTSET, (
-            "default LoggerManager must not set a level on the pyramids logger"
+        assert isinstance(package_logger.handlers[0], logging.NullHandler), (
+            f"expected a NullHandler, got {type(package_logger.handlers[0]).__name__}"
+        )
+        assert package_logger.level == logging.WARNING, (
+            "default LoggerManager must leave the existing level untouched"
         )
 
 
@@ -201,68 +194,66 @@ def test_set_error_handler_logs_severities(capsys):
         )
 
 
-@patch("osgeo.gdal.PushErrorHandler")
-def test_error_handler_installed_only_once(mock_push):
-    """ARC-40: repeated construction must not stack GDAL error handlers.
+@patch("osgeo.gdal.SetErrorHandler")
+def test_error_handler_uses_the_process_wide_setter(mock_set):
+    """ARC-40: the bridge is installed with SetErrorHandler, not PushErrorHandler.
 
     Test scenario:
-        ``gdal.PushErrorHandler`` pushes onto a stack that pyramids never pops,
-        so an unguarded install made GDAL log every error once per push. Two
-        LoggerManager constructions must produce at most one push.
+        ``PushErrorHandler`` maps to ``CPLPushErrorHandlerEx``, which pushes
+        onto GDAL's *per-thread* error context: it stacks on every
+        construction, and it only covers the installing thread. ``SetErrorHandler``
+        replaces process-wide, so it is idempotent and reaches every thread.
     """
-    with reinstallable_error_handler(), isolated_package_logging():
+    with patch("osgeo.gdal.PushErrorHandler") as mock_push, isolated_package_logging():
         LoggerManager()
         LoggerManager()
-    assert mock_push.call_count == 1, (
-        f"expected exactly one PushErrorHandler call, got {mock_push.call_count}"
+    assert mock_push.call_count == 0, (
+        "the thread-local PushErrorHandler must not be used"
     )
-    assert mock_push.call_args[0][0] is _gdal_error_handler
+    assert mock_set.call_count == 2, (
+        f"each construction installs process-wide; got {mock_set.call_count}"
+    )
+    assert mock_set.call_args[0][0] is _gdal_error_handler
 
 
-@patch("osgeo.gdal.PushErrorHandler")
-def test_error_handler_not_reinstalled_when_already_present(mock_push):
-    """The install guard short-circuits once the handler is in place.
-
-    Test scenario:
-        Set the flag explicitly rather than relying on the package import
-        having already set it — asserting against ambient module state
-        would pass just as happily against a `_set_error_handler` that did
-        nothing at all.
-    """
-    with reinstallable_error_handler():
-        config_mod._gdal_error_handler_installed = True
-        with isolated_package_logging():
-            LoggerManager()
-    mock_push.assert_not_called()
-
-
-def test_error_handler_install_is_serialised_across_threads():
-    """Concurrent `Config()` construction still pushes exactly one handler.
+def test_error_handler_reaches_every_thread():
+    """The installed bridge routes GDAL errors raised on worker threads.
 
     Test scenario:
-        The guard is a check-then-set on a module global. Without the lock,
-        several threads can all read it as unset and each push a handler —
-        reintroducing the stacking (and the duplicated GDAL log lines) the
-        guard exists to prevent.
+        This is the invariant the push-based install silently broke — GDAL's
+        handler *stack* is per-thread, so a pushed handler leaves every thread
+        but the installer falling through to the default stderr handler. Raise
+        a GDAL warning on a worker and assert the pyramids logger sees it.
+
+        `gdal.Error()` is only delivered to a custom handler while exceptions
+        are disabled (with `UseExceptions()`, which pyramids enables at import,
+        the binding raises instead), so the probe toggles that off and restores
+        it — otherwise the test would pass vacuously.
     """
-    pushed: list = []
-    barrier = threading.Barrier(8)
-
-    def install():
-        barrier.wait()
-        LoggerManager._set_error_handler()
-
-    with reinstallable_error_handler(), patch(
-        "osgeo.gdal.PushErrorHandler", side_effect=lambda h: pushed.append(h)
-    ):
-        config_mod._gdal_error_handler_installed = False
-        threads = [threading.Thread(target=install) for _ in range(8)]
-        for thread in threads:
+    records: list = []
+    sink = logging.Handler()
+    sink.emit = records.append
+    gdal_logger = logging.getLogger("pyramids.base.config.gdal")
+    exceptions_were_enabled = gdal.GetUseExceptions()
+    with isolated_package_logging():
+        LoggerManager(level="DEBUG")
+        gdal_logger.addHandler(sink)
+        if exceptions_were_enabled:
+            gdal.DontUseExceptions()
+        try:
+            LoggerManager._set_error_handler()
+            thread = threading.Thread(
+                target=lambda: gdal.Error(gdal.CE_Warning, 77, "from-a-worker")
+            )
             thread.start()
-        for thread in threads:
             thread.join()
-    assert len(pushed) == 1, (
-        f"8 racing installs must push exactly one handler, got {len(pushed)}"
+        finally:
+            if exceptions_were_enabled:
+                gdal.UseExceptions()
+            gdal_logger.removeHandler(sink)
+    assert any("from-a-worker" in r.getMessage() for r in records), (
+        "a worker thread's GDAL error must reach the bridge; got "
+        f"{[r.getMessage() for r in records]}"
     )
 
 

--- a/tests/config/test_logger.py
+++ b/tests/config/test_logger.py
@@ -31,6 +31,10 @@ def isolated_package_logging():
     package_logger = logging.getLogger(PACKAGE_LOGGER_NAME)
     old_level = package_logger.level
     old_handlers = list(package_logger.handlers)
+    # `propagate` must be restored too: opting into logging sets it False, and
+    # leaking that would silently cut pytest's caplog (whose handler lives on the
+    # root logger) off from every pyramids record for the rest of the session.
+    old_propagate = package_logger.propagate
     try:
         for h in package_logger.handlers[:]:
             package_logger.removeHandler(h)
@@ -41,6 +45,7 @@ def isolated_package_logging():
         for h in old_handlers:
             package_logger.addHandler(h)
         package_logger.setLevel(old_level)
+        package_logger.propagate = old_propagate
 
 
 @contextmanager
@@ -323,3 +328,85 @@ def test_error_handler_exception_fallback_logs_error(capsys):
     assert "GDAL(class=" in err
     assert "code=66" in err
     assert "boom" in err
+
+
+def test_opt_in_logging_does_not_double_print_under_basicconfig(capsys):
+    """S3: pyramids records reach the console once, not twice.
+
+    Test scenario:
+        A host that ran ``logging.basicConfig()`` has a root handler. With
+        pyramids' own handler on the ``pyramids`` logger and propagation
+        left on, every record was formatted by both. Owning a handler must
+        therefore also stop propagation.
+    """
+    root = logging.getLogger()
+    saved_handlers = list(root.handlers)
+    saved_level = root.level
+    stream = io.StringIO()
+    host_handler = logging.StreamHandler(stream)
+    host_handler.setFormatter(logging.Formatter("ROOT:%(name)s:%(message)s"))
+    try:
+        for handler in root.handlers[:]:
+            root.removeHandler(handler)
+        root.addHandler(host_handler)
+        root.setLevel(logging.DEBUG)
+        with isolated_package_logging():
+            LoggerManager(level="INFO")
+            capsys.readouterr()
+            logging.getLogger("pyramids.tests.double").info("only once please")
+            captured = capsys.readouterr()
+    finally:
+        for handler in root.handlers[:]:
+            root.removeHandler(handler)
+        for handler in saved_handlers:
+            root.addHandler(handler)
+        root.setLevel(saved_level)
+
+    assert captured.err.count("only once please") == 1, (
+        f"pyramids' own handler must emit the record exactly once, got {captured.err!r}"
+    )
+    assert "only once please" not in stream.getvalue(), (
+        "the record must not also reach the host's root handler; got "
+        f"{stream.getvalue()!r}"
+    )
+
+
+def test_default_level_leaves_propagation_intact():
+    """With no level, host-configured root logging still sees pyramids records.
+
+    Test scenario:
+        The import path must not claim the namespace. Propagation stays on
+        so an application that configures root logging keeps receiving
+        pyramids output — the whole point of the opt-in default.
+    """
+    with isolated_package_logging() as package_logger:
+        package_logger.propagate = True
+        LoggerManager()
+        assert package_logger.propagate is True, (
+            "the no-level path must leave propagation alone"
+        )
+
+
+def test_third_party_loggers_untouched_by_default():
+    """S5: opting into pyramids logging does not re-level other libraries.
+
+    Test scenario:
+        A host that deliberately set matplotlib to DEBUG must keep it.
+        The convenience is still available, but only when asked for.
+    """
+    victim = logging.getLogger("matplotlib")
+    saved = victim.level
+    try:
+        victim.setLevel(logging.DEBUG)
+        with isolated_package_logging():
+            LoggerManager(level="INFO")
+        assert victim.level == logging.DEBUG, (
+            "the host's third-party log level must survive by default"
+        )
+        with isolated_package_logging():
+            LoggerManager(level="INFO", quiet_third_party=True)
+        assert victim.level == logging.WARNING, (
+            "quiet_third_party=True must still pin the noisy loggers"
+        )
+    finally:
+        victim.setLevel(saved)

--- a/tests/config/test_logger.py
+++ b/tests/config/test_logger.py
@@ -1,5 +1,6 @@
 import io
 import logging
+import threading
 from contextlib import contextmanager, redirect_stdout
 from pathlib import Path
 from unittest.mock import patch
@@ -215,10 +216,49 @@ def test_error_handler_installed_only_once(mock_push):
 
 @patch("osgeo.gdal.PushErrorHandler")
 def test_error_handler_not_reinstalled_when_already_present(mock_push):
-    """The install guard short-circuits once the handler is in place."""
-    with isolated_package_logging():
-        LoggerManager()
+    """The install guard short-circuits once the handler is in place.
+
+    Test scenario:
+        Set the flag explicitly rather than relying on the package import
+        having already set it — asserting against ambient module state
+        would pass just as happily against a `_set_error_handler` that did
+        nothing at all.
+    """
+    with reinstallable_error_handler():
+        config_mod._gdal_error_handler_installed = True
+        with isolated_package_logging():
+            LoggerManager()
     mock_push.assert_not_called()
+
+
+def test_error_handler_install_is_serialised_across_threads():
+    """Concurrent `Config()` construction still pushes exactly one handler.
+
+    Test scenario:
+        The guard is a check-then-set on a module global. Without the lock,
+        several threads can all read it as unset and each push a handler —
+        reintroducing the stacking (and the duplicated GDAL log lines) the
+        guard exists to prevent.
+    """
+    pushed: list = []
+    barrier = threading.Barrier(8)
+
+    def install():
+        barrier.wait()
+        LoggerManager._set_error_handler()
+
+    with reinstallable_error_handler(), patch(
+        "osgeo.gdal.PushErrorHandler", side_effect=lambda h: pushed.append(h)
+    ):
+        config_mod._gdal_error_handler_installed = False
+        threads = [threading.Thread(target=install) for _ in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+    assert len(pushed) == 1, (
+        f"8 racing installs must push exactly one handler, got {len(pushed)}"
+    )
 
 
 def test_setup_logging_invalid_level_string_raises():


### PR DESCRIPTION
# Description

Clears the six findings in the `base/` slice of the 2026-07-25 architecture review, plus everything two rounds of
independent review turned up on top of them. Each finding — original or review-raised — was reproduced with a
standalone script before any code changed, and the fixes were verified the same way.

25 commits, 13 files, +1734/−292.

## The six original findings

- **ARC-4 (P1, bug), #799 — `CachingFileManager` cross-manager eviction use-after-close.** `acquire()` returned a handle
  protected only by its own per-manager lock, so a concurrent `acquire()` on a *different* manager could LRU-evict
  that slot and `Close()` the handle mid-read. The existing `retain`/`release` refcount gives no protection — it is
  consulted only in `release()`, never during eviction. Reachable on two production paths:
  `DatasetCollection._read_time_step` over more than `maxsize` files, and the raster lazy chunk reader.

  `_LRUCache` gains `pin()`/`unpin()`. Every path that can remove or replace a cached value now consults `_pins`,
  and `acquire_context()` pins across its block. Note that "share one lock per cache key" — the fix the review
  originally suggested — does *not* work: the two managers hold different keys, and `_close_handle` runs outside
  the cache lock without taking the evicted key's lock at all.

- **ARC-11 (P3, bug), #800 — `_LRUCache` overwrite leaked the displaced handle.** Filed as latent; it is not.
  Two managers
  sharing a `manager_id` with `lock=False` — the shape of `_read_time_step` — reach it by both missing, both
  opening and both assigning.

- **ARC-40 (P2, design), #801 — root-logger hijack, stacked `PushErrorHandler`, import-time announce.** Importing
  pyramids
  ran `Config()`, which added a handler to the **root** logger, called `root.setLevel(...)`, pinned six third-party
  loggers to WARNING and printed `Logging is configured.` — reconfiguring logging for the whole host application as
  a side effect of an import. Now confined to the `"pyramids"` logger, silent by default, opt-in via an explicit
  level.

- **ARC-55 (P2, perf), #802 — per-point reprojection loop.** One `transformer.transform` call per vertex became one
  vectorized call over the whole array.

- **ARC-62 (P3, perf), #803 — dtype conversions ran a pandas full-column mask per call.** Measured at **~250 µs**
  against
  ~0.1 µs for a dict lookup, paid per band and per timestep across 34 call sites. Replaced with four dicts computed
  once at import.

- **ARC-67 (P2, refactor), #804 — ten duplicated optional-import guards + a duplicated dask plugin fallback.**
  Consolidated
  into `require_optional()` and `_register_plugin()`.

**One correction to the review:** ARC-40 claimed `Config()` is "invoked again at `stac/download.py:78`". That line
constructs `stac_asset.Config`, an unrelated class. `pyramids.base.config.Config` is instantiated in exactly one
place.

## What the review rounds changed

Two independent reviews ran against the branch. The second did **not** report less than the first, because the
first round's own fixes introduced two of the second round's must-fixes. Both are fixed and regression-tested.

**Round 1 (2 must / 6 should / 8 nits)** — the headline: the ARC-11 fix re-opened ARC-4. Releasing the displaced
handle on overwrite did not check `_pins`, turning a benign descriptor leak into a use-after-close on a handle a
reader was holding. Also: `np.round` is **not** interchangeable with the built-in `round` (`round(2.675, 2)` is
`2.67`, `np.round(2.675, 2)` is `2.68`; they differ on ~1 in 3000 Web-Mercator coordinates at the default
`precision=6`), so the "vectorization changes no values" claim was false — rounding moved back to the built-in and
is now covered by parity tests against a per-point oracle, verified by mutation.

**Round 2 (2 must / 8 should / 7 nits)** — the round-1 lesson repeated: making `unpin()` trim the cache put GDAL
`Close()` inside the caller's manager mutex *and* the shared dask chunk lock, where a `/vsis3` flush would stall
every other chunk read. Eviction now happens off both locks, and the sweep is skipped entirely when the cache is
within its limit (**27.9 ms → 4.9 ms** per 2000 reads).

Round 2 also caught that **`gdal.PushErrorHandler` is thread-local** (`CPLPushErrorHandlerEx` pushes onto the
per-thread error context), so guarding it with a process-global "installed" flag meant only the *first* thread ever
got the GDAL→logging bridge — every other thread's warnings fell through to stderr. The reviewer flagged this as
unverified; I confirmed it empirically, then switched to `gdal.SetErrorHandler`, which is process-wide *and*
idempotent — the alternative ARC-40 originally suggested.

Remaining round-2 fixes: `NetCDF.close()` could close a pinned handle mid-read from public API (now deferred to the
last reader via `_pending_close`); `propagate = False` was a one-way door that would silently make downstream
`caplog` assertions vacuous (now reversible with a bare `Config()`); the opt-in rewrote a host's own handler on the
`pyramids` logger (now only pyramids-tagged handlers are touched); dead code removed; a `ruff format` break that had
already failed CI.

## Behaviour changes

Logging is the user-visible one, and it is documented in `docs/migration.md`:

| Change | What you do |
|--------|-------------|
| `import pyramids` no longer configures logging | `logging.basicConfig(...)`, or `Config(level="INFO")` |
| Root logger untouched (no handler, no `setLevel`) | nothing — this is the fix |
| `Config` / `LoggerManager` default `level=INFO` → `None` | pass a level to get console output |
| Third-party loggers only quieted on request | `Config(level=..., quiet_third_party=True)` |
| The three dtype converters raise `ValueError` | was `IndexError` / `AttributeError` / `TypeError` |

Shipping as a **patch** bump with a migration entry rather than a `BREAKING CHANGE:` footer (which would force
0.x → 1.0.0) — a deliberate maintainer decision, not an oversight.

No new dependencies. No lockfile, schema, auth or CI changes.

# Issues

- Closes #799 — ARC-4: pin cached GDAL handles so cross-manager eviction cannot close a live read
- Closes #800 — ARC-11: release the handle displaced by an `_LRUCache` overwrite
- Closes #801 — ARC-40: stop configuring the root logger at import and stacking GDAL error handlers
- Closes #802 — ARC-55: vectorize `reproject_coordinates` over whole coordinate arrays
- Closes #803 — ARC-62: replace the per-call dtype DataFrame scans with precomputed dicts
- Closes #804 — ARC-67: consolidate ten optional-dependency guards into `require_optional`

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

On the breaking-change box: no API is removed and no signature narrows, but an application that relied on
`import pyramids` giving it console output will now see nothing until it configures logging. That is observable, so
it is called out here and in the migration guide even though it is a fix for a library that should never have owned
the root logger.

# How Has This Been Tested?

Run from the branch's worktree against the `dev` environment. Every run targets the worktree's `src/` — verified
explicitly, since a `--rootdir` shortcut silently tests the main checkout's copy instead.

- [x] Full suite, `-m "not plot and not xarray"`, every test directory: **6560 passed, 51 skipped, 0 failed**.
- [x] Doctest sweep matching the pre-commit hook (`pytest --doctest-modules src`): **385 passed, 73 skipped**.
- [x] **SonarCloud: 0 open issues** (4 raised on this PR, all fixed — none were false positives).
- [x] **Differential child-class check**: exported pristine `main`'s `src/` and ran an identical 13-check probe
      against both trees — `Dataset` / `NetCDF` / `Container` / `Variable` / `DatasetCollection` /
      `ThreadLocalFileManager` / `FeatureCollection` / `Coords` / dtype / logging. Outcomes **identical**, so no
      inherited behaviour changed. Separately, a concurrent `NetCDF.close()` during an 8192-partition lazy compute
      completed with no errors and all 32768 values correct.
- [x] **Mutation-checked** the two highest-risk new test groups: the reprojection parity tests all fail if
      `np.round` is reinstated, and the GDAL-bridge test fails if `PushErrorHandler` is reinstated.

Reproduce:

```bash
pixi run -e dev main
pixi run -e dev pytest --doctest-modules src
```

New tests, by the defect they pin:

- `TestLRUCachePinning` / `TestCachingFileManagerEvictionSafety` — pins survive eviction pressure and a `maxsize`
  shrink; a pinned overwrite does not release; the cache trims back on the last unpin; `close()` and the
  `auto_release` finalizer defer rather than close a pinned slot; pins are released on both error paths.
- `TestReprojectCoordinatesRoundingParity` — parity against a per-point oracle on values chosen to separate the two
  rounding rules at each precision.
- `TestDtypeLookupTables` / `TestRequireOptional` — the first-wins invariant (`complex64` → `GDT_CInt16`, which a
  naive dict comprehension would silently remap), dict-vs-DataFrame parity, the three new `ValueError` paths, and
  `require_optional`'s dotted-name and exception-chaining behaviour.
- Logging — the quiet default, root untouchedness, process-wide handler install with per-thread delivery, no
  double-printing under `basicConfig()`, reversibility, and `quiet_third_party`.

Two pre-existing issues were found while testing and deliberately **not** touched, since neither is caused by this
branch (both reproduce on `main`):

- `NetCDF.close()` does not fully unlock every NetCDF fixture, despite its docstring citing #564 and promising
  immediate release. May deserve its own issue.
- Running `tests/config` before `tests/base` fails 17 tests with `PROJ: proj_identify: Cannot find proj.db` —
  `tests/config/test_config.py` patches `os.environ` with a bare `dict`, wiping `PROJ_LIB`. CI's alphabetical order
  runs `base` first, so it never triggers there.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.

The first three are intentionally unchecked: versioning is commitizen's job via the release workflow, and
`docs/change-log.md` is generated by `cz changelog` rather than hand-edited. Documentation here means
`docs/migration.md` (new `base` section) plus the module and method docstrings, updated in place — including a
module-level note in `base/config.py` stating that logging is opt-in.
