### PR TITLE
refactor(netcdf): resolve arc-netcdf architecture-review findings

### DIFF
--- a/src/pyramids/netcdf/_axis.py
+++ b/src/pyramids/netcdf/_axis.py
@@ -1,0 +1,61 @@
+"""CF axis-role detection helpers extracted from the NetCDF class (ARC-37).
+
+Pure functions that classify an MDArray dimension as the longitude (``"X"``) or latitude (``"Y"``)
+raster axis from its coordinate variable's CF attributes. This is the first, self-contained slice of
+the planned `AxisResolver` engine; the larger spatial/time axis-resolution cluster
+(`_detect_spatial_axes` and friends) and the other engines (geostationary handling, MDIM read,
+netCDF writer) remain on `NetCDF` pending a dedicated extraction follow-up.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pyramids.netcdf.cf import detect_axis
+from pyramids.netcdf.utils import _read_attributes
+
+
+def axis_role_of_dimension(dim: Any) -> str | None:
+    """Classify a dimension as `"X"` (longitude) or `"Y"` (latitude) from its coordinate CF attributes.
+
+    Reads the CF attributes of the dimension's coordinate (indexing) variable — `axis` (`X`/`Y`),
+    `standard_name` (`longitude`/`latitude`), or `units` (`degrees_east`/`degrees_north`) — and
+    classifies them through the shared `pyramids.netcdf.cf.detect_axis` heuristic. Returns `None` when
+    the role cannot be determined.
+
+    Args:
+        dim: A GDAL MDArray dimension whose indexing variable carries the CF attributes.
+
+    Returns:
+        `"X"`, `"Y"`, or `None`.
+    """
+    indexing_var = dim.GetIndexingVariable()
+    if indexing_var is None:
+        return None
+    # Attribute-only detection (empty `name` disables the name-pattern fallback) so the CF-attribute
+    # vs. dimension-name stages stay separated, matching the historical pipeline. Filter to the
+    # spatial roles this classifier promises (`detect_axis` can also return `"T"`/`"Z"`).
+    role = detect_axis("", _read_attributes(indexing_var))
+    return role if role in ("X", "Y") else None
+
+
+def detect_axis_indices(dims: Any) -> tuple[int | None, int | None]:
+    """Indices of the X (longitude) and Y (latitude) dimensions via CF coordinate attributes.
+
+    Returns the first dimension classified as `"X"` and the first as `"Y"` by
+    `axis_role_of_dimension` (each `None` when undetected).
+
+    Args:
+        dims: The MDArray's dimensions, in storage order.
+
+    Returns:
+        `(x_index, y_index)`, each `None` when the axis is not detected.
+    """
+    detected_x = detected_y = None
+    for i, dim in enumerate(dims):
+        role = axis_role_of_dimension(dim)
+        if role == "X" and detected_x is None:
+            detected_x = i
+        elif role == "Y" and detected_y is None:
+            detected_y = i
+    return detected_x, detected_y

--- a/src/pyramids/netcdf/_kerchunk_facade.py
+++ b/src/pyramids/netcdf/_kerchunk_facade.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import os
+import threading
 import warnings
 from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
@@ -37,6 +38,12 @@ from pyramids.netcdf._kerchunk_builder import build_single_manifest, combine_man
 _KERCHUNK_IMPORT_ERROR = lazy_extra_hint(
     "kerchunk is required for NetCDF → Zarr reference manifests."
 )
+
+# The `_FillValue` shim patches a process-global `encode_fill_value`; serialize the
+# capture / patch / restore so concurrent kerchunk emits cannot race the `finally` restore
+# (a second entrant would otherwise capture the already-patched function as its "original"
+# and leave the global permanently wrapped) (ARC-76).
+_ENCODE_FILL_VALUE_LOCK = threading.Lock()
 
 
 @contextmanager
@@ -78,12 +85,6 @@ def _scalar_fill_value_shim() -> Iterator[None]:
         yield
         return
 
-    # Capture each module's own ``encode_fill_value`` and have its wrapper delegate to
-    # *that* module's original — kerchunk.hdf and zarr.meta currently share one function
-    # object, but if they ever diverge a single shared ``original`` would call the wrong
-    # encoder and the restore would clobber one module with the other's function.
-    originals = {module: module.encode_fill_value for module in modules}
-
     def _make_scalarized(original: Callable[..., Any]) -> Callable[..., Any]:
         def _scalarized(value: Any, dtype: Any, object_codec: Any = None) -> Any:
             if (
@@ -96,13 +97,20 @@ def _scalar_fill_value_shim() -> Iterator[None]:
 
         return _scalarized
 
-    for module, original in originals.items():
-        module.encode_fill_value = _make_scalarized(original)
-    try:
-        yield
-    finally:
+    # Hold the lock across capture + patch + restore. Capturing each module's own
+    # ``encode_fill_value`` under the lock guarantees ``originals`` is the real (unpatched)
+    # function even if another thread is mid-shim — kerchunk.hdf and zarr.meta currently share
+    # one function object, but if they ever diverge a single shared ``original`` would call the
+    # wrong encoder and the restore would clobber one module with the other's function.
+    with _ENCODE_FILL_VALUE_LOCK:
+        originals = {module: module.encode_fill_value for module in modules}
         for module, original in originals.items():
-            module.encode_fill_value = original
+            module.encode_fill_value = _make_scalarized(original)
+        try:
+            yield
+        finally:
+            for module, original in originals.items():
+                module.encode_fill_value = original
 
 
 def _require_kerchunk_single() -> Any:

--- a/src/pyramids/netcdf/_lazy.py
+++ b/src/pyramids/netcdf/_lazy.py
@@ -642,6 +642,7 @@ def build_lazy_array(
     """
     import_dask(_DASK_MISSING_MESSAGE)
     import dask.array as da
+    from dask.base import tokenize
 
     shape, dtype, block_size, flip_y, flip_x = _mdarray_shape_and_dtype(
         path,
@@ -663,7 +664,11 @@ def build_lazy_array(
         manager_hook(manager)
     chunks_per_axis = _expand_chunks(shape, chunk_shape)
     starts_per_axis = _chunk_starts(chunks_per_axis)
-    name = f"pyramids-netcdf-read-{variable_name}-{id(manager)}"
+    # Deterministic, content-addressed graph name (path + variable + chunking + cache key) rather
+    # than `id(manager)`, so two identical lazy reads share a name and dask can dedupe them
+    # (common-subexpression elimination); `id()` gave every read a fresh name and defeated CSE
+    # (ARC-76).
+    name = f"pyramids-netcdf-read-{variable_name}-{tokenize(path, variable_name, chunk_shape, key_id)}"
     graph: dict[tuple, Any] = {}
     grid_shape = tuple(len(sizes) for sizes in chunks_per_axis)
     for index in np.ndindex(*grid_shape):

--- a/src/pyramids/netcdf/_mdim.py
+++ b/src/pyramids/netcdf/_mdim.py
@@ -144,6 +144,30 @@ def scalar_no_data(no_data_value: Any) -> Any:
     return no_data_value
 
 
+def unflatten_band_axes(arr: Any, band_dim_names: Any, band_dim_sizes: Any) -> Any:
+    """Undo GDAL's row-major flatten of a multi-band-dim read: ``(bands, rows, cols)`` back to
+    ``(*band_dim_sizes, rows, cols)``.
+
+    GDAL's classic raster view flattens every non-spatial dimension into one bands axis. When a
+    variable has more than one band dimension, callers rebuild the separate axes with this reshape.
+    It is a no-op for a 2-D array, a single band dimension, or missing sizes. One source for the
+    reshape that the container fan-out, the reduce materialize path, and the variable writer each did
+    inline (ARC-69).
+
+    Args:
+        arr: The read array, `(bands, rows, cols)` when flattened.
+        band_dim_names: The variable's non-spatial dimension names.
+        band_dim_sizes: The non-spatial dimension sizes in storage order.
+
+    Returns:
+        `arr` reshaped to `(*band_dim_sizes, rows, cols)` when it has more than one band dimension and
+        is 3-D; otherwise `arr` unchanged.
+    """
+    if len(band_dim_names) > 1 and getattr(arr, "ndim", 0) == 3 and band_dim_sizes:
+        arr = arr.reshape(*band_dim_sizes, arr.shape[-2], arr.shape[-1])
+    return arr
+
+
 def dataset_is_geostationary(dataset: gdal.Dataset) -> bool:
     """Report whether ``dataset``'s CRS is the CF geostationary projection.
 

--- a/src/pyramids/netcdf/_mfdataset.py
+++ b/src/pyramids/netcdf/_mfdataset.py
@@ -155,7 +155,9 @@ def open_mfdataset(
     # `parallel` flag -- which used to wrap eager reads in `dask.delayed` -- is inert now that the
     # default read is lazy (wrapping a dask array in `from_delayed` would nest a synchronous inner
     # compute per file); it is retained only for backward-compatible call signatures (ARC-48).
-    arrays = [_open_and_extract(p, variable, preprocess, effective_chunks) for p in resolved]
+    arrays = [
+        _open_and_extract(p, variable, preprocess, effective_chunks) for p in resolved
+    ]
     arrays = [
         a if hasattr(a, "dask") else da.from_array(np.asarray(a), chunks="auto")
         for a in arrays

--- a/src/pyramids/netcdf/_mfdataset.py
+++ b/src/pyramids/netcdf/_mfdataset.py
@@ -97,12 +97,10 @@ def open_mfdataset(
             (the default) reads each file lazily with `"auto"`
             (native-ish) chunking so the files are not all materialised
             into RAM before stacking; pass an explicit spec to override.
-        parallel: Retained for API compatibility. Under the default lazy
-            per-file read the per-file arrays are already dask arrays whose
-            chunk reads the scheduler parallelises at compute time, so this
-            flag has no effect there. It only wraps the per-file open in
-            :func:`dask.delayed` when the reads are eager — which the current
-            lazy default never produces.
+        parallel: Retained for API compatibility only; it has no effect.
+            Every per-file read returns a lazy dask array, so the scheduler
+            already parallelises the per-chunk reads at compute time and
+            there is no separate eager `dask.delayed` fan-out to enable.
         preprocess: Optional callable applied to each
             :class:`NetCDF` subset before its array is extracted —
             for example to unpack scale/offset, crop, or drop

--- a/src/pyramids/netcdf/_mfdataset.py
+++ b/src/pyramids/netcdf/_mfdataset.py
@@ -97,9 +97,12 @@ def open_mfdataset(
             (the default) reads each file lazily with `"auto"`
             (native-ish) chunking so the files are not all materialised
             into RAM before stacking; pass an explicit spec to override.
-        parallel: When `True`, wraps the per-file open+extract in
-            :func:`dask.delayed` so the reads fan out across a dask
-            scheduler. Default `False` reads sequentially.
+        parallel: Retained for API compatibility. Under the default lazy
+            per-file read the per-file arrays are already dask arrays whose
+            chunk reads the scheduler parallelises at compute time, so this
+            flag has no effect there. It only wraps the per-file open in
+            :func:`dask.delayed` when the reads are eager — which the current
+            lazy default never produces.
         preprocess: Optional callable applied to each
             :class:`NetCDF` subset before its array is extracted —
             for example to unpack scale/offset, crop, or drop

--- a/src/pyramids/netcdf/_mfdataset.py
+++ b/src/pyramids/netcdf/_mfdataset.py
@@ -94,7 +94,9 @@ def open_mfdataset(
             from :func:`dask.array.stack` at graph-construction time.
         chunks: Chunk specification forwarded to
             :meth:`NetCDF.read_array` when reading each file. `None`
-            uses each variable's native on-disk chunking.
+            (the default) reads each file lazily with `"auto"`
+            (native-ish) chunking so the files are not all materialised
+            into RAM before stacking; pass an explicit spec to override.
         parallel: When `True`, wraps the per-file open+extract in
             :func:`dask.delayed` so the reads fan out across a dask
             scheduler. Default `False` reads sequentially.
@@ -131,26 +133,22 @@ def open_mfdataset(
         raise ImportError(_LAZY_IMPORT_ERROR) from exc
 
     resolved = _resolve_paths(paths)
+    # Default to a lazy per-file read (native-ish `"auto"` chunking) so the stack does not
+    # materialise every file into RAM up front -- opening hundreds of files used to load them all
+    # eagerly before stacking (ARC-48). An explicit `chunks` is honoured as given.
+    effective_chunks = "auto" if chunks is None else chunks
 
-    if parallel:
-        # Probe the first file once for the shared shape/dtype and reuse that array as
-        # element 0, instead of also scheduling a delayed open of the same path (which
-        # opened ``resolved[0]`` a second time).
-        first_probe = _open_and_extract(resolved[0], variable, preprocess, chunks)
-        shape = first_probe.shape
-        dtype = first_probe.dtype
-        # Wrap the already-materialised probe as a single-block delayed array (rather than
-        # ``da.from_array(..., chunks="auto")``) so element 0's chunk structure matches the
-        # ``from_delayed`` frames below — one block per file along the stacked axis. Reuses
-        # the probe, so ``resolved[0]`` is still opened only once.
-        first_arr = (
-            first_probe
-            if hasattr(first_probe, "dask")
-            else da.from_delayed(dask.delayed(first_probe), shape=shape, dtype=dtype)
-        )
+    first_probe = _open_and_extract(resolved[0], variable, preprocess, effective_chunks)
+    reads_are_lazy = hasattr(first_probe, "dask")
+
+    if parallel and not reads_are_lazy:
+        # Eager per-file reads: fan the opens out across the dask scheduler via `dask.delayed`,
+        # reusing the probe as element 0 so `resolved[0]` is opened only once.
+        shape, dtype = first_probe.shape, first_probe.dtype
+        first_arr = da.from_delayed(dask.delayed(first_probe), shape=shape, dtype=dtype)
         rest = [
             da.from_delayed(
-                dask.delayed(_open_and_extract)(p, variable, preprocess, chunks),
+                dask.delayed(_open_and_extract)(p, variable, preprocess, effective_chunks),
                 shape=shape,
                 dtype=dtype,
             )
@@ -158,7 +156,13 @@ def open_mfdataset(
         ]
         arrays = [first_arr, *rest]
     else:
-        arrays = [_open_and_extract(p, variable, preprocess, chunks) for p in resolved]
+        # Lazy reads already return dask arrays; wrapping them in `dask.delayed` would nest a dask
+        # collection inside `from_delayed` and force a synchronous inner compute per file (ARC-48).
+        # Read directly and let dask's scheduler parallelise the chunk reads at compute time.
+        rest = [
+            _open_and_extract(p, variable, preprocess, effective_chunks) for p in resolved[1:]
+        ]
+        arrays = [first_probe, *rest]
         arrays = [
             a if hasattr(a, "dask") else da.from_array(np.asarray(a), chunks="auto")
             for a in arrays

--- a/src/pyramids/netcdf/_mfdataset.py
+++ b/src/pyramids/netcdf/_mfdataset.py
@@ -14,14 +14,16 @@ along time) that narrowness is the whole point — no metadata
 inference means no failure modes when one file has a different
 schema.
 
-`parallel=True` wraps each file's metadata read in
-:func:`dask.delayed`, so opening 500 files on a distributed cluster
-fans out over workers rather than blocking sequentially.
+The `parallel` argument is deprecated and inert: every per-file read
+is already lazy, so dask parallelises the per-chunk reads at compute
+time without an eager `dask.delayed` fan-out. Passing it emits a
+:class:`DeprecationWarning`.
 """
 
 from __future__ import annotations
 
 import glob
+import warnings
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -97,10 +99,11 @@ def open_mfdataset(
             (the default) reads each file lazily with `"auto"`
             (native-ish) chunking so the files are not all materialised
             into RAM before stacking; pass an explicit spec to override.
-        parallel: Retained for API compatibility only; it has no effect.
-            Every per-file read returns a lazy dask array, so the scheduler
-            already parallelises the per-chunk reads at compute time and
-            there is no separate eager `dask.delayed` fan-out to enable.
+        parallel: Deprecated and inert; retained only for backward-compatible
+            call signatures. Every per-file read returns a lazy dask array, so
+            the scheduler already parallelises the per-chunk reads at compute
+            time and there is no separate eager `dask.delayed` fan-out to
+            enable. Passing a truthy value emits a `DeprecationWarning`.
         preprocess: Optional callable applied to each
             :class:`NetCDF` subset before its array is extracted —
             for example to unpack scale/offset, crop, or drop
@@ -131,6 +134,15 @@ def open_mfdataset(
         import dask.array as da
     except ImportError as exc:
         raise ImportError(_LAZY_IMPORT_ERROR) from exc
+
+    if parallel:
+        warnings.warn(
+            "open_mfdataset(parallel=...) is deprecated and has no effect: the default lazy "
+            "per-file read already parallelises chunk reads at compute time. The argument is "
+            "accepted for backward compatibility and will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     resolved = _resolve_paths(paths)
     # Default to a lazy per-file read (native-ish `"auto"` chunking) so the stack does not

--- a/src/pyramids/netcdf/_mfdataset.py
+++ b/src/pyramids/netcdf/_mfdataset.py
@@ -130,7 +130,6 @@ def open_mfdataset(
             ```
     """
     try:
-        import dask
         import dask.array as da
     except ImportError as exc:
         raise ImportError(_LAZY_IMPORT_ERROR) from exc
@@ -141,34 +140,14 @@ def open_mfdataset(
     # eagerly before stacking (ARC-48). An explicit `chunks` is honoured as given.
     effective_chunks = "auto" if chunks is None else chunks
 
-    first_probe = _open_and_extract(resolved[0], variable, preprocess, effective_chunks)
-    reads_are_lazy = hasattr(first_probe, "dask")
-
-    if parallel and not reads_are_lazy:
-        # Eager per-file reads: fan the opens out across the dask scheduler via `dask.delayed`,
-        # reusing the probe as element 0 so `resolved[0]` is opened only once.
-        shape, dtype = first_probe.shape, first_probe.dtype
-        first_arr = da.from_delayed(dask.delayed(first_probe), shape=shape, dtype=dtype)
-        rest = [
-            da.from_delayed(
-                dask.delayed(_open_and_extract)(p, variable, preprocess, effective_chunks),
-                shape=shape,
-                dtype=dtype,
-            )
-            for p in resolved[1:]
-        ]
-        arrays = [first_arr, *rest]
-    else:
-        # Lazy reads already return dask arrays; wrapping them in `dask.delayed` would nest a dask
-        # collection inside `from_delayed` and force a synchronous inner compute per file (ARC-48).
-        # Read directly and let dask's scheduler parallelise the chunk reads at compute time.
-        rest = [
-            _open_and_extract(p, variable, preprocess, effective_chunks) for p in resolved[1:]
-        ]
-        arrays = [first_probe, *rest]
-        arrays = [
-            a if hasattr(a, "dask") else da.from_array(np.asarray(a), chunks="auto")
-            for a in arrays
-        ]
-
+    # Each per-file read already returns a lazy dask array (chunks are never eager here), so the
+    # stack is built directly and dask parallelises the per-chunk reads at compute time. The
+    # `parallel` flag -- which used to wrap eager reads in `dask.delayed` -- is inert now that the
+    # default read is lazy (wrapping a dask array in `from_delayed` would nest a synchronous inner
+    # compute per file); it is retained only for backward-compatible call signatures (ARC-48).
+    arrays = [_open_and_extract(p, variable, preprocess, effective_chunks) for p in resolved]
+    arrays = [
+        a if hasattr(a, "dask") else da.from_array(np.asarray(a), chunks="auto")
+        for a in arrays
+    ]
     return da.stack(arrays, axis=0)

--- a/src/pyramids/netcdf/cf.py
+++ b/src/pyramids/netcdf/cf.py
@@ -932,12 +932,18 @@ def parse_cell_methods(cell_methods_str: str) -> list[dict[str, str]]:
     entry_pattern = r'((?:\w+\s*:\s*)+)(\w+)'
     matches = list(re.finditer(entry_pattern, cell_methods_str))
     for idx, match in enumerate(matches):
-        dims = " ".join(part.strip() for part in match.group(1).split(":") if part.strip())
+        dims = " ".join(
+            part.strip() for part in match.group(1).split(":") if part.strip()
+        )
         entry: dict[str, str] = {
             "dimensions": dims,
             "method": match.group(2),
         }
-        tail_end = matches[idx + 1].start() if idx + 1 < len(matches) else len(cell_methods_str)
+        tail_end = (
+            matches[idx + 1].start()
+            if idx + 1 < len(matches)
+            else len(cell_methods_str)
+        )
         tail = cell_methods_str[match.end() : tail_end]
         where = re.search(r"\bwhere\s+(\w+)", tail)
         if where:

--- a/src/pyramids/netcdf/cf.py
+++ b/src/pyramids/netcdf/cf.py
@@ -904,10 +904,15 @@ def parse_cell_methods(cell_methods_str: str) -> list[dict[str, str]]:
         and optionally `"where"` and `"over"`.
     """
     results: list[dict[str, str]] = []
-    pattern = r'(\w[\w\s]*?):\s+(\w+)(?:\s+where\s+(\w+))?(?:\s+over\s+(\w+))?'
+    # A cell_methods entry is `name: [name: ...] method [where ...] [over ...]` — one OR MORE
+    # `name:` groups precede the method. Capturing them as a single group and splitting on `:` lets
+    # `"lat: lon: mean"` parse to dimensions `lat lon` / method `mean` instead of mis-reading `lon`
+    # as the method (ARC-30).
+    pattern = r'((?:\w+\s*:\s*)+)(\w+)(?:\s+where\s+(\w+))?(?:\s+over\s+(\w+))?'
     for match in re.finditer(pattern, cell_methods_str):
+        dims = " ".join(part.strip() for part in match.group(1).split(":") if part.strip())
         entry: dict[str, str] = {
-            "dimensions": match.group(1).strip(),
+            "dimensions": dims,
             "method": match.group(2),
         }
         if match.group(3):
@@ -1127,7 +1132,9 @@ def _check_coordinate_variable(short: str, var: Any) -> list[str]:
     issues: list[str] = []
     if not var.attributes.get("units") and not var.unit:
         issues.append(f"Coordinate variable '{short}' has no 'units' attribute.")
-    units_val = var.attributes.get("units", "")
+    # A time coordinate may carry its unit only on the MDArray unit slot (`var.unit`), not as a
+    # `units` attribute, so consult both when detecting the `<period> since <epoch>` form (ARC-30).
+    units_val = var.attributes.get("units") or var.unit or ""
     if (
         isinstance(units_val, str)
         and "since" in units_val

--- a/src/pyramids/netcdf/cf.py
+++ b/src/pyramids/netcdf/cf.py
@@ -902,6 +902,26 @@ def parse_cell_methods(cell_methods_str: str) -> list[dict[str, str]]:
     Returns:
         List of dicts with keys `"dimensions"`, `"method"`,
         and optionally `"where"` and `"over"`.
+
+    Examples:
+        - A single dimension and method:
+            ```python
+            >>> parse_cell_methods("time: mean")
+            [{'dimensions': 'time', 'method': 'mean'}]
+
+            ```
+        - Several dimensions sharing one method are all captured:
+            ```python
+            >>> parse_cell_methods("lat: lon: mean")
+            [{'dimensions': 'lat lon', 'method': 'mean'}]
+
+            ```
+        - Independent entries, with a `where` qualifier:
+            ```python
+            >>> parse_cell_methods("time: mean area: sum where land")
+            [{'dimensions': 'time', 'method': 'mean'}, {'dimensions': 'area', 'method': 'sum', 'where': 'land'}]
+
+            ```
     """
     results: list[dict[str, str]] = []
     # A cell_methods entry is `name: [name: ...] method [where ...] [over ...]` — one OR MORE

--- a/src/pyramids/netcdf/cf.py
+++ b/src/pyramids/netcdf/cf.py
@@ -927,18 +927,24 @@ def parse_cell_methods(cell_methods_str: str) -> list[dict[str, str]]:
     # A cell_methods entry is `name: [name: ...] method [where ...] [over ...]` — one OR MORE
     # `name:` groups precede the method. Capturing them as a single group and splitting on `:` lets
     # `"lat: lon: mean"` parse to dimensions `lat lon` / method `mean` instead of mis-reading `lon`
-    # as the method (ARC-30).
-    pattern = r'((?:\w+\s*:\s*)+)(\w+)(?:\s+where\s+(\w+))?(?:\s+over\s+(\w+))?'
-    for match in re.finditer(pattern, cell_methods_str):
+    # as the method (ARC-30). The `where`/`over` qualifiers are parsed from the text between one
+    # method and the next entry so the core pattern stays simple.
+    entry_pattern = r'((?:\w+\s*:\s*)+)(\w+)'
+    matches = list(re.finditer(entry_pattern, cell_methods_str))
+    for idx, match in enumerate(matches):
         dims = " ".join(part.strip() for part in match.group(1).split(":") if part.strip())
         entry: dict[str, str] = {
             "dimensions": dims,
             "method": match.group(2),
         }
-        if match.group(3):
-            entry["where"] = match.group(3)
-        if match.group(4):
-            entry["over"] = match.group(4)
+        tail_end = matches[idx + 1].start() if idx + 1 < len(matches) else len(cell_methods_str)
+        tail = cell_methods_str[match.end() : tail_end]
+        where = re.search(r"\bwhere\s+(\w+)", tail)
+        if where:
+            entry["where"] = where.group(1)
+        over = re.search(r"\bover\s+(\w+)", tail)
+        if over:
+            entry["over"] = over.group(1)
         results.append(entry)
     return results
 

--- a/src/pyramids/netcdf/engines/interop.py
+++ b/src/pyramids/netcdf/engines/interop.py
@@ -255,7 +255,9 @@ def _encode_temporal_array(values: np.ndarray) -> tuple[np.ndarray, dict[str, An
     if np.issubdtype(values.dtype, np.datetime64):
         as_ns = values.astype("datetime64[ns]")
         seconds = as_ns.astype("int64").astype("float64") / 1e9
-        seconds[np.isnat(as_ns)] = np.nan
+        # `np.where` keeps this scalar-safe: a 0-d input's `/ 1e9` is a NumPy scalar that does not
+        # support in-place item assignment (review round-2 M1).
+        seconds = np.where(np.isnat(as_ns), np.nan, seconds)
         return seconds, {
             "units": "seconds since 1970-01-01 00:00:00",
             "calendar": "proleptic_gregorian",
@@ -263,7 +265,7 @@ def _encode_temporal_array(values: np.ndarray) -> tuple[np.ndarray, dict[str, An
     if np.issubdtype(values.dtype, np.timedelta64):
         as_ns = values.astype("timedelta64[ns]")
         seconds = as_ns.astype("int64").astype("float64") / 1e9
-        seconds[np.isnat(as_ns)] = np.nan
+        seconds = np.where(np.isnat(as_ns), np.nan, seconds)
         return seconds, {"units": "seconds"}
     return values, {}
 

--- a/src/pyramids/netcdf/engines/interop.py
+++ b/src/pyramids/netcdf/engines/interop.py
@@ -236,24 +236,34 @@ def _encode_temporal_array(values: np.ndarray) -> tuple[np.ndarray, dict[str, An
     A CF-decoded xarray time axis is `datetime64[ns]`, which `numpy_to_gdal_dtype` cannot map, so
     `from_xarray` crashed on any Dataset opened with the default `decode_cf=True`. Encode such arrays to
     float64 seconds with a CF `units` (and `calendar` for absolute times) so the MDArray stores a
-    numeric axis that CF-decodes back to the same instants (ARC-17).
+    numeric axis that CF-decodes back to the same instants (ARC-17). A `NaT` maps to `NaN` (a missing
+    instant), not the int64 sentinel's bogus ~year-1677 value.
+
+    The CF-portable `seconds since ...` unit is float64, so a timestamp far from the 1970 epoch carries
+    only ~sub-microsecond precision (float64 has ~0.35 µs resolution near 2e9 s); an exact nanosecond
+    round-trip would need a non-portable `nanoseconds since ...` unit.
 
     Args:
         values: The raw coordinate / variable array.
 
     Returns:
         A `(encoded_values, cf_attrs)` pair. For a non-temporal array the values are returned unchanged
-        with an empty attribute dict; for a temporal array the values are float64 seconds and `cf_attrs`
-        carries the CF `units` (plus `calendar` for absolute datetimes).
+        with an empty attribute dict; for a temporal array the values are float64 seconds (`NaN` where
+        the input was `NaT`) and `cf_attrs` carries the CF `units` (plus `calendar` for absolute
+        datetimes).
     """
     if np.issubdtype(values.dtype, np.datetime64):
-        seconds = values.astype("datetime64[ns]").astype("int64").astype("float64") / 1e9
+        as_ns = values.astype("datetime64[ns]")
+        seconds = as_ns.astype("int64").astype("float64") / 1e9
+        seconds[np.isnat(as_ns)] = np.nan
         return seconds, {
             "units": "seconds since 1970-01-01 00:00:00",
             "calendar": "proleptic_gregorian",
         }
     if np.issubdtype(values.dtype, np.timedelta64):
-        seconds = values.astype("timedelta64[ns]").astype("int64").astype("float64") / 1e9
+        as_ns = values.astype("timedelta64[ns]")
+        seconds = as_ns.astype("int64").astype("float64") / 1e9
+        seconds[np.isnat(as_ns)] = np.nan
         return seconds, {"units": "seconds"}
     return values, {}
 

--- a/src/pyramids/netcdf/engines/interop.py
+++ b/src/pyramids/netcdf/engines/interop.py
@@ -230,6 +230,34 @@ def from_xarray(
     return result
 
 
+def _encode_temporal_array(values: np.ndarray) -> tuple[np.ndarray, dict[str, Any]]:
+    """Encode datetime64/timedelta64 arrays to CF-numeric seconds (GDAL has no datetime dtype).
+
+    A CF-decoded xarray time axis is `datetime64[ns]`, which `numpy_to_gdal_dtype` cannot map, so
+    `from_xarray` crashed on any Dataset opened with the default `decode_cf=True`. Encode such arrays to
+    float64 seconds with a CF `units` (and `calendar` for absolute times) so the MDArray stores a
+    numeric axis that CF-decodes back to the same instants (ARC-17).
+
+    Args:
+        values: The raw coordinate / variable array.
+
+    Returns:
+        A `(encoded_values, cf_attrs)` pair. For a non-temporal array the values are returned unchanged
+        with an empty attribute dict; for a temporal array the values are float64 seconds and `cf_attrs`
+        carries the CF `units` (plus `calendar` for absolute datetimes).
+    """
+    if np.issubdtype(values.dtype, np.datetime64):
+        seconds = values.astype("datetime64[ns]").astype("int64").astype("float64") / 1e9
+        return seconds, {
+            "units": "seconds since 1970-01-01 00:00:00",
+            "calendar": "proleptic_gregorian",
+        }
+    if np.issubdtype(values.dtype, np.timedelta64):
+        seconds = values.astype("timedelta64[ns]").astype("int64").astype("float64") / 1e9
+        return seconds, {"units": "seconds"}
+    return values, {}
+
+
 def _build_multidim_from_xarray(dataset: Any) -> gdal.Dataset:
     """Build an in-memory GDAL multidim container from an xarray Dataset.
 
@@ -275,6 +303,7 @@ def _build_multidim_from_xarray(dataset: Any) -> gdal.Dataset:
         if coord_name not in gdal_dims:
             continue
         values = np.asarray(coord.values)
+        values, cf_attrs = _encode_temporal_array(values)
         ext = gdal.ExtendedDataType.Create(numpy_to_gdal_dtype(values))
         md_arr = root.CreateMDArray(
             coord_name,
@@ -282,10 +311,13 @@ def _build_multidim_from_xarray(dataset: Any) -> gdal.Dataset:
             ext,
         )
         md_arr.Write(np.ascontiguousarray(values))
-        _apply_attrs(md_arr, dict(coord.attrs))
+        attrs = dict(coord.attrs)
+        attrs.update(cf_attrs)
+        _apply_attrs(md_arr, attrs)
 
     for var_name, var in dataset.data_vars.items():
         values = np.asarray(var.values)
+        values, cf_attrs = _encode_temporal_array(values)
         ext = gdal.ExtendedDataType.Create(numpy_to_gdal_dtype(values))
         md_arr = root.CreateMDArray(
             var_name,
@@ -293,7 +325,9 @@ def _build_multidim_from_xarray(dataset: Any) -> gdal.Dataset:
             ext,
         )
         md_arr.Write(np.ascontiguousarray(values))
-        _apply_attrs(md_arr, dict(var.attrs))
+        attrs = dict(var.attrs)
+        attrs.update(cf_attrs)
+        _apply_attrs(md_arr, attrs)
 
     if dataset.attrs:
         write_global_attributes(root, dict(dataset.attrs))

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -697,7 +697,9 @@ class Selection(_Engine["NetCDF"]):
         selected = _read_selected_bands(nc, band_indices)
 
         ndv = nc.no_data_value
-        ndv_scalar = ndv[0] if isinstance(ndv, list) and ndv else ndv
+        # no_data_value is a TUPLE; the old `isinstance(ndv, list)` test never fired (ARC-29). Route
+        # through the shared helper (handles list AND tuple) like the reduce path below.
+        ndv_scalar = nc._scalar_no_data_value(ndv)
         ds_result = Dataset.create_from_array(
             selected,
             geo=nc.geotransform,

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -1024,7 +1024,6 @@ class Selection(_Engine["NetCDF"]):
         found = False
         for var_name in spatial_vars:
             var = nc.get_variable(var_name)
-            arr = nc._materialize_variable_array(var)
             band_names = list(var._band_dim_names)
             values_map = dict(var._band_dim_values_map)
             ndv = nc._scalar_no_data_value(var.no_data_value)
@@ -1032,6 +1031,11 @@ class Selection(_Engine["NetCDF"]):
             if dim in band_names:
                 found = True
                 axis = band_names.index(dim)
+                # Stream the reduction over a chunked (dask) read so a large (dim, y, x) cube is
+                # never fully held in RAM; only the small reduced result is computed (ARC-47). The
+                # `np.*`/`np.nan*` reducers dispatch to dask on a dask array, so `_reduce_variable_array`
+                # stays unchanged; `np.asarray` then computes the reduced result.
+                arr = nc._materialize_variable_array(var, lazy=True)
                 arr, band_names, values_map = nc._reduce_variable_array(
                     arr,
                     axis,
@@ -1044,6 +1048,11 @@ class Selection(_Engine["NetCDF"]):
                     groupby,
                     group_positions,
                 )
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore", RuntimeWarning)
+                    arr = np.asarray(arr)
+            else:
+                arr = nc._materialize_variable_array(var)
 
             result = nc._stack_reduced_variable(
                 result,

--- a/src/pyramids/netcdf/engines/variables.py
+++ b/src/pyramids/netcdf/engines/variables.py
@@ -27,6 +27,7 @@ import numpy as np
 from osgeo import gdal
 
 from pyramids.base._utils import numpy_to_gdal_dtype
+from pyramids.netcdf._mdim import scalar_no_data, unflatten_band_axes
 from pyramids.base.crs import sr_from_epsg, sr_from_user_input
 from pyramids.dataset import DEFAULT_NO_DATA_VALUE, Dataset
 from pyramids.dataset.engines._base import _Engine
@@ -348,7 +349,7 @@ def _build_variable_mdarray(
     """
     names, sizes, values_map = band["names"], band["sizes"], band["values_map"]
     if len(names) > 1 and arr.ndim == 3 and sizes:
-        arr = arr.reshape(*sizes, arr.shape[-2], arr.shape[-1])
+        arr = unflatten_band_axes(arr, names, sizes)
         band_dims = _create_multi_band_dims(
             nc, rg, names, sizes, values_map, coord_dtype
         )
@@ -927,11 +928,7 @@ def _create_netcdf_from_array(
     # Tolerate both scalar and per-band sequence inputs since
     # callers often pass `Dataset.no_data_value` (now a tuple)
     # straight through.
-    ndv_scalar = (
-        no_data_value[0]
-        if isinstance(no_data_value, (list, tuple)) and no_data_value
-        else no_data_value
-    )
+    ndv_scalar = scalar_no_data(no_data_value)
     if ndv_scalar is not None:
         md_arr.SetNoDataValueDouble(float(ndv_scalar))
     md_arr.SetSpatialRef(srse)

--- a/src/pyramids/netcdf/engines/variables.py
+++ b/src/pyramids/netcdf/engines/variables.py
@@ -27,10 +27,10 @@ import numpy as np
 from osgeo import gdal
 
 from pyramids.base._utils import numpy_to_gdal_dtype
-from pyramids.netcdf._mdim import scalar_no_data, unflatten_band_axes
 from pyramids.base.crs import sr_from_epsg, sr_from_user_input
 from pyramids.dataset import DEFAULT_NO_DATA_VALUE, Dataset
 from pyramids.dataset.engines._base import _Engine
+from pyramids.netcdf._mdim import scalar_no_data, unflatten_band_axes
 from pyramids.netcdf.cf import (
     srs_to_grid_mapping,
     write_attributes_to_md_array,

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -623,7 +623,9 @@ class LabeledDataset:
             counts = [self._full_sizes[d] for d in dim_names]
             starts[axis] = start
             counts[axis] = count
-            blocks.append(np.asarray(arr.ReadAsArray(array_start_idx=starts, count=counts)))
+            blocks.append(
+                np.asarray(arr.ReadAsArray(array_start_idx=starts, count=counts))
+            )
         combined = blocks[0] if len(blocks) == 1 else np.concatenate(blocks, axis=axis)
         # `combined` is ordered by `uniq` along `axis`; map back to the request order, which may be
         # unsorted or contain duplicates.

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -61,6 +61,47 @@ def _get_attr(obj: Any, name: str) -> Any:
         return None
 
 
+def _contiguous_runs(sorted_idx: np.typing.NDArray) -> list[tuple[int, int]]:
+    """Split a sorted 1-D integer array into ``(start, count)`` runs of consecutive values.
+
+    Used to read only the requested runs of a sparse coordinate selection instead of the whole
+    ``[min, max]`` span (ARC-49).
+
+    Args:
+        sorted_idx: A non-empty sorted 1-D array of unique integer positions.
+
+    Returns:
+        A list of ``(start, count)`` pairs, one per maximal run of consecutive integers.
+
+    Examples:
+        - Two isolated positions become two length-1 runs:
+            ```python
+            >>> import numpy as np
+            >>> _contiguous_runs(np.array([0, 999999]))
+            [(0, 1), (999999, 1)]
+
+            ```
+        - A consecutive block collapses to a single run:
+            ```python
+            >>> import numpy as np
+            >>> _contiguous_runs(np.array([3, 4, 5, 9]))
+            [(3, 3), (9, 1)]
+
+            ```
+    """
+    runs: list[tuple[int, int]] = []
+    start = prev = int(sorted_idx[0])
+    for raw in sorted_idx[1:]:
+        value = int(raw)
+        if value == prev + 1:
+            prev = value
+        else:
+            runs.append((start, prev - start + 1))
+            start = prev = value
+    runs.append((start, prev - start + 1))
+    return runs
+
+
 def _is_remote_url(source: str) -> bool:
     """True for a remote object-store / http URL (not a local filesystem path)."""
     scheme = source.split("://", 1)[0].lower() if "://" in source else ""
@@ -118,6 +159,7 @@ class LabeledDataset:
         index: dict[str, np.ndarray] | None = None,
         scalar_dims: frozenset[str] = frozenset(),
         cloud_config: CloudConfig | None = None,
+        coord_cache: dict[str, np.typing.NDArray] | None = None,
     ) -> None:
         """Low-level constructor. Most callers use :meth:`read_file`.
 
@@ -151,6 +193,12 @@ class LabeledDataset:
         # region, anon) stays live for data GETs, not just the open (#560). An
         # empty CloudConfig is a no-op for local stores.
         self._cloud_config = cloud_config or CloudConfig()
+        # Full (unselected) coordinate arrays are store-invariant, so cache them by name and share
+        # the dict across child views (via `_replace`) — `select` no longer re-reads a coordinate
+        # from the store on every call (ARC-49).
+        self._coord_full_cache: dict[str, np.typing.NDArray] = (
+            coord_cache if coord_cache is not None else {}
+        )
 
     @staticmethod
     def _open_multidim_store(
@@ -452,6 +500,7 @@ class LabeledDataset:
             index=index,
             scalar_dims=scalar_dims,
             cloud_config=self._cloud_config,
+            coord_cache=self._coord_full_cache,
         )
 
     def _selected_size(self, dim: str) -> int:
@@ -532,7 +581,15 @@ class LabeledDataset:
         self, arr: gdal.MDArray, dim_names: list[str]
     ) -> np.typing.NDArray:
         """Strided ``ReadAsArray`` over each selected dim's index span, then a
-        local fancy index to pick the exact requested labels within the span."""
+        local fancy index to pick the exact requested labels within the span.
+
+        When exactly one dimension is selected, read only its contiguous index runs so a sparse
+        selection over a large dimension (e.g. ``[0, 999_999]``) does not read the whole
+        ``[min, max]`` span (ARC-49); multi-dimension selections keep the single bounding-span read.
+        """
+        selected = [d for d in dim_names if self._index.get(d) is not None]
+        if len(selected) == 1:
+            return self._read_runs_along_dim(arr, dim_names, selected[0])
         starts: list[int] = []
         counts: list[int] = []
         local: list[np.typing.NDArray | None] = []
@@ -552,6 +609,26 @@ class LabeledDataset:
             if loc is not None:
                 values = np.take(values, loc, axis=axis)
         return values
+
+    def _read_runs_along_dim(
+        self, arr: gdal.MDArray, dim_names: list[str], dim: str
+    ) -> np.typing.NDArray:
+        """Read the contiguous index runs of a single sparse-selected `dim`, then reorder (ARC-49)."""
+        axis = dim_names.index(dim)
+        idx = np.asarray(self._index[dim])
+        uniq = np.unique(idx)
+        blocks: list[np.typing.NDArray] = []
+        for start, count in _contiguous_runs(uniq):
+            starts = [0] * len(dim_names)
+            counts = [self._full_sizes[d] for d in dim_names]
+            starts[axis] = start
+            counts[axis] = count
+            blocks.append(np.asarray(arr.ReadAsArray(array_start_idx=starts, count=counts)))
+        combined = blocks[0] if len(blocks) == 1 else np.concatenate(blocks, axis=axis)
+        # `combined` is ordered by `uniq` along `axis`; map back to the request order, which may be
+        # unsorted or contain duplicates.
+        remap = np.searchsorted(uniq, idx)
+        return cast("np.typing.NDArray", np.take(combined, remap, axis=axis))
 
     def _squeeze_scalar_dims(
         self, values: np.ndarray, dim_names: list[str]
@@ -593,13 +670,17 @@ class LabeledDataset:
         return decode_cf_time(values, unit, calendar)
 
     def _coord_full(self, name: str) -> np.typing.NDArray:
-        """Read a coordinate's full (unselected) values."""
+        """Read a coordinate's full (unselected) values, memoized by name (ARC-49)."""
+        cached = self._coord_full_cache.get(name)
+        if cached is not None:
+            return cached
         with self._with_store() as grp:
             arr = grp.OpenMDArray(name)
             if arr.GetDataType().GetClass() == gdal.GEDTC_STRING:
                 values = np.asarray(arr.Read(), dtype=object)
             else:
                 values = np.asarray(arr.ReadAsArray())
+        self._coord_full_cache[name] = values
         return values
 
     def _coord_current(self, name: str, dim: str) -> np.typing.NDArray:
@@ -650,17 +731,23 @@ class LabeledDataset:
             # alike (a 0-d ndarray is not iterable, so the isinstance check alone
             # mis-classified it as a sequence and raised on list()).
             is_scalar = np.ndim(values) == 0
-            requested = [values] if is_scalar else list(values)
+            # `.item()` normalizes a 0-d array / numpy scalar to a hashable Python scalar so the
+            # value -> position dict lookup below works (a 0-d ndarray is unhashable).
+            requested = [np.asarray(values).item()] if is_scalar else list(values)
             if not requested:
                 raise ValueError(
                     f"empty selection list for {dim!r}; pass at least one value"
                 )
-            found = np.isin(np.asarray(requested), current)
-            if not found.all():
-                missing = [v for v, ok in zip(requested, found) if not ok]
+            # Build a value -> first-position map once (O(n)) and look each request up in it (O(m)),
+            # instead of a full `np.flatnonzero` scan per requested value (O(n*m)) (ARC-49).
+            position_of: dict[Any, int] = {}
+            for position, value in enumerate(current):
+                position_of.setdefault(value, position)
+            missing = [v for v in requested if v not in position_of]
+            if missing:
                 raise KeyError(f"{dim!r} values not found: {missing}")
             # Positions within the current selection, in REQUEST order.
-            positions = [int(np.flatnonzero(current == v)[0]) for v in requested]
+            positions = [position_of[v] for v in requested]
             base = self._index.get(dim)
             base = (
                 np.arange(self._full_sizes[dim]) if base is None else np.asarray(base)

--- a/src/pyramids/netcdf/metadata.py
+++ b/src/pyramids/netcdf/metadata.py
@@ -829,7 +829,8 @@ def from_json(s: str) -> NetCDFMetadata:
 
     Parses the JSON produced by `to_json` and manually
     reconstructs the dataclass hierarchy (`GroupInfo`,
-    `VariableInfo`, `DimensionInfo`, `StructuralInfo`).
+    `VariableInfo`, `DimensionInfo`, `StructuralInfo`, and the
+    CF cross-reference block `CFInfo` when present).
 
     Only the schema produced by `to_dict` / `to_json` is
     supported; arbitrary JSON will likely raise `KeyError`.

--- a/src/pyramids/netcdf/metadata.py
+++ b/src/pyramids/netcdf/metadata.py
@@ -921,6 +921,20 @@ def from_json(s: str) -> NetCDFMetadata:
             ),
         )
 
+    def build_cf(cd: dict[str, Any] | None) -> CFInfo | None:
+        # Rebuild the CF cross-reference block dropped by earlier round-trips (ARC-25): to_dict
+        # serializes `cf` via asdict, but from_json must restore it or every CF classification vanishes.
+        if cd is None:
+            return None
+        return CFInfo(
+            cf_version=cd.get("cf_version"),
+            conventions=cd.get("conventions", {}),
+            classifications=cd.get("classifications", {}),
+            grid_mappings=cd.get("grid_mappings", {}),
+            bounds_map=cd.get("bounds_map", {}),
+            data_variable_names=[str(x) for x in cd.get("data_variable_names", [])],
+        )
+
     groups = {k: build_group(v) for k, v in d.get("groups", {}).items()}
     variables = {k: build_array(v) for k, v in d.get("variables", {}).items()}
     dims = {k: build_dim(v) for k, v in d.get("dimensions", {}).items()}
@@ -943,6 +957,7 @@ def from_json(s: str) -> NetCDFMetadata:
         dimensions=dims,
         global_attributes=d.get("global_attributes", {}),
         structural=structural_obj,
+        cf=build_cf(d.get("cf")),
         open_options_used=d.get("open_options_used"),
         created_with=d.get("created_with", {}),
     )

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -2256,9 +2256,9 @@ class NetCDF(Dataset):
                     *var._band_dim_sizes, var_arr.shape[-2], var_arr.shape[-1]
                 )
             var_ndv = var_result.no_data_value
-            var_ndv_scalar = (
-                var_ndv[0] if isinstance(var_ndv, list) and var_ndv else var_ndv
-            )
+            # no_data_value is a TUPLE, so the old `isinstance(..., list)` test never fired and the
+            # full per-band tuple leaked into create_from_array (ARC-29). scalar_no_data handles both.
+            var_ndv_scalar = scalar_no_data(var_ndv)
             extra_dims = (
                 [
                     (name, var._band_dim_values_map.get(name))

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -3151,7 +3151,8 @@ class NetCDF(Dataset):
             variable: Name of the variable to extract from each file.
             chunks: Chunk spec forwarded to
                 :meth:`NetCDF.read_array`.
-            parallel: Fan out per-file opens through `dask.delayed`.
+            parallel: Deprecated and inert; kept for backward compatibility.
+                Passing a truthy value emits a `DeprecationWarning`.
             preprocess: Optional callable applied to each
                 :class:`NetCDF` before extraction.
 

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -37,6 +37,7 @@ from pyramids.netcdf._mdim import (
     open_mdarray,
     scalar_no_data,
     scaled_axis_ascends,
+    unflatten_band_axes,
     x_axis_is_right_to_left,
     y_axis_is_bottom_up,
 )
@@ -2254,14 +2255,9 @@ class NetCDF(Dataset):
             # (last non-spatial dim varies fastest, matching GDAL's
             # row-major flatten), so the reshape is the literal
             # inverse of that flatten.
-            if (
-                len(var._band_dim_names) > 1
-                and var_arr.ndim == 3
-                and var._band_dim_sizes
-            ):
-                var_arr = var_arr.reshape(
-                    *var._band_dim_sizes, var_arr.shape[-2], var_arr.shape[-1]
-                )
+            var_arr = unflatten_band_axes(
+                var_arr, var._band_dim_names, var._band_dim_sizes
+            )
             var_ndv = var_result.no_data_value
             # no_data_value is a TUPLE, so the old `isinstance(..., list)` test never fired and the
             # full per-band tuple leaked into create_from_array (ARC-29). scalar_no_data handles both.
@@ -2340,8 +2336,7 @@ class NetCDF(Dataset):
         if var._band_dim_names:
             if arr.ndim == 2:
                 arr = np.expand_dims(arr, axis=0)
-            if len(var._band_dim_names) > 1 and arr.ndim == 3 and var._band_dim_sizes:
-                arr = arr.reshape(*var._band_dim_sizes, arr.shape[-2], arr.shape[-1])
+            arr = unflatten_band_axes(arr, var._band_dim_names, var._band_dim_sizes)
         return cast("np.typing.NDArray", arr)
 
     def _resolve_group_positions(

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -2379,9 +2379,17 @@ class NetCDF(Dataset):
         path = parent._file_name
         if not path:
             return False
-        if path.startswith("NETCDF"):
-            path = path.split(":")[1][1:-1]
-        return os.path.exists(path) or is_remote(path)
+        if path.startswith("NETCDF:"):
+            rest = path[len("NETCDF:") :]
+            if rest.startswith('"'):
+                # NETCDF:"<path>":<var> -- take the quoted path, which may itself contain a colon
+                # (a Windows drive letter `C:\...`), so a naive split(":") is wrong (review L1).
+                closing = rest.rfind('"')
+                path = rest[1:closing] if closing > 0 else rest
+            else:
+                # NETCDF:<path>:<var> -- drop the trailing :<var> from the right.
+                path = rest.rsplit(":", 1)[0]
+        return os.path.isfile(path) or is_remote(path)
 
     @staticmethod
     def _materialize_variable_array(var: NetCDF, lazy: bool = False) -> Any:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -28,6 +28,7 @@ from pyramids.base.remote import is_remote
 from pyramids.dataset import Dataset
 from pyramids.dataset.dataset import _COLLABORATOR_ATTRS
 from pyramids.feature import FeatureCollection
+from pyramids.netcdf._axis import detect_axis_indices
 from pyramids.netcdf._kerchunk_facade import combine_kerchunk, to_kerchunk
 from pyramids.netcdf._lazy import apply_unpack, build_lazy_array
 from pyramids.netcdf._mdim import (
@@ -43,7 +44,6 @@ from pyramids.netcdf._mdim import (
     x_axis_is_right_to_left,
     y_axis_is_bottom_up,
 )
-from pyramids.netcdf._axis import detect_axis_indices
 from pyramids.netcdf._mfdataset import open_mfdataset
 from pyramids.netcdf._plot import NetCDFPlot
 from pyramids.netcdf.cf import (

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1074,6 +1074,52 @@ class NetCDF(Dataset):
                 f"Use nc.get_variable('var_name').{operation}(...) instead."
             )
 
+    # ARC-35 interim guard: a `band_count == 0` container inherits the full single-raster facade
+    # from `Dataset`, where each of these runs on a `(0, rows, cols)` store and produces an opaque
+    # GDAL error or silently wrong output. Route the raster-only surface through
+    # `_check_not_container` so a container fails with the "use get_variable(...)" message instead;
+    # a `Variable` subset (band_count > 0) passes the guard and delegates unchanged. The structural
+    # fix (make `Container` *compose* a spatial-template `Dataset`) is a larger follow-up.
+    def stats(self, *args, **kwargs):  # type: ignore[override]
+        """Container-guarded facade for `Dataset.stats`."""
+        self._check_not_container("stats")
+        return super().stats(*args, **kwargs)
+
+    def slope(self, *args, **kwargs):  # type: ignore[override]
+        """Container-guarded facade for `Dataset.slope`."""
+        self._check_not_container("slope")
+        return super().slope(*args, **kwargs)
+
+    def hillshade(self, *args, **kwargs):  # type: ignore[override]
+        """Container-guarded facade for `Dataset.hillshade`."""
+        self._check_not_container("hillshade")
+        return super().hillshade(*args, **kwargs)
+
+    def write_array(self, *args, **kwargs):  # type: ignore[override]
+        """Container-guarded facade for `Dataset.write_array`."""
+        self._check_not_container("write_array")
+        return super().write_array(*args, **kwargs)
+
+    def to_cog(self, *args, **kwargs):  # type: ignore[override]
+        """Container-guarded facade for `Dataset.to_cog`."""
+        self._check_not_container("to_cog")
+        return super().to_cog(*args, **kwargs)
+
+    def to_feature_collection(self, *args, **kwargs):  # type: ignore[override]
+        """Container-guarded facade for `Dataset.to_feature_collection`."""
+        self._check_not_container("to_feature_collection")
+        return super().to_feature_collection(*args, **kwargs)
+
+    def zonal_stats(self, *args, **kwargs):  # type: ignore[override]
+        """Container-guarded facade for `Dataset.zonal_stats`."""
+        self._check_not_container("zonal_stats")
+        return super().zonal_stats(*args, **kwargs)
+
+    def sample(self, *args, **kwargs):  # type: ignore[override]
+        """Container-guarded facade for `Dataset.sample`."""
+        self._check_not_container("sample")
+        return super().sample(*args, **kwargs)
+
     # NetCDF intentionally exposes a richer, variable/selector-oriented plot
     # signature than the band-oriented Dataset/RasterBase one; the override
     # is deliberate and not Liskov-substitutable.

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import gc
 import itertools
 import math
+import os
 import threading
 import warnings
 import weakref
@@ -23,6 +24,7 @@ from pyramids import _io
 from pyramids.base._utils import DEFAULT_RESAMPLING, numpy_to_gdal_dtype
 from pyramids.base.crs import sr_from_epsg
 from pyramids.base.protocols import ArrayLike
+from pyramids.base.remote import is_remote
 from pyramids.dataset import Dataset
 from pyramids.dataset.dataset import _COLLABORATOR_ATTRS
 from pyramids.feature import FeatureCollection
@@ -2361,6 +2363,27 @@ class NetCDF(Dataset):
         return scalar_no_data(no_data_value)
 
     @staticmethod
+    def _is_file_backed(var: NetCDF) -> bool:
+        """True when the variable's data lives in a reopenable file, so a lazy chunk read is possible.
+
+        An in-memory container (`create_from_array` / `from_xarray`) has no file for the lazy chunk
+        graph to reopen; streaming it saves nothing and the reopen would fail.
+
+        Args:
+            var: The variable subset to probe.
+
+        Returns:
+            True when the source path exists on disk or is a remote (`/vsi*` / cloud) URL.
+        """
+        parent = var._parent_nc if var._parent_nc is not None else var
+        path = parent._file_name
+        if not path:
+            return False
+        if path.startswith("NETCDF"):
+            path = path.split(":")[1][1:-1]
+        return os.path.exists(path) or is_remote(path)
+
+    @staticmethod
     def _materialize_variable_array(var: NetCDF, lazy: bool = False) -> Any:
         """Read a variable as `(*band_dim_sizes, rows, cols)` (or `(rows, cols)`).
 
@@ -2371,14 +2394,15 @@ class NetCDF(Dataset):
         read (undoing `read_array`'s singleton-band squeeze and GDAL's row-major band flatten) when
         `lazy` is False or dask (the `[lazy]` extra) is not installed.
         """
-        if lazy:
+        if lazy and NetCDF._is_file_backed(var):
+            # Only stream a genuinely file-backed variable: an in-memory container has no file for the
+            # chunk graph to reopen and is already fully in RAM, so streaming saves nothing. Checking
+            # file-backing up front (rather than a broad except) lets a real file-backed read error
+            # propagate instead of silently degrading to a whole-cube eager read / OOM (review M1).
             try:
                 return var.read_array(chunks="auto")
-            except (ImportError, RuntimeError, ValueError):
-                # dask missing, or the variable is not file-backed (an in-memory container has no
-                # file for the chunk graph to reopen). An in-memory array is already fully in RAM, so
-                # streaming it would save nothing -- fall through to the eager read.
-                pass
+            except ImportError:
+                pass  # dask (the [lazy] extra) not installed -> eager fallback below
         arr = var.read_array()
         if var._band_dim_names:
             if arr.ndim == 2:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -837,8 +837,15 @@ class NetCDF(Dataset):
             else:
                 y_cell = self.cell_size
                 y_top = float(self.lat[0]) + y_cell / 2
+            # West edge = min(lon) - half a cell, mirroring the north-up lat branch above. Taking
+            # `lon[0]` unguarded put the origin at the EAST edge for a descending-longitude container,
+            # mirroring the X origin (ARC-32).
+            if len(self.lon) >= 2:
+                x_west = min(float(self.lon[0]), float(self.lon[-1])) - x_cell / 2
+            else:
+                x_west = float(self.lon[0]) - x_cell / 2
             return (
-                self.lon[0] - x_cell / 2,
+                x_west,
                 x_cell,
                 0,
                 y_top,

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -41,6 +41,7 @@ from pyramids.netcdf._mdim import (
     x_axis_is_right_to_left,
     y_axis_is_bottom_up,
 )
+from pyramids.netcdf._axis import detect_axis_indices
 from pyramids.netcdf._mfdataset import open_mfdataset
 from pyramids.netcdf._plot import NetCDFPlot
 from pyramids.netcdf.cf import (
@@ -3701,42 +3702,6 @@ class NetCDF(Dataset):
             result = match
         return result
 
-    @staticmethod
-    def _axis_role_of_dimension(dim) -> str | None:
-        """Classify a dimension as ``"X"`` (longitude) or ``"Y"`` (latitude).
-
-        Reads the CF attributes of the dimension's coordinate (indexing) variable —
-        ``axis`` (``X``/``Y``), ``standard_name`` (``longitude``/``latitude``), or
-        ``units`` (``degrees_east``/``degrees_north``) — and classifies them through the
-        shared :func:`pyramids.netcdf.cf.detect_axis` heuristic. Returns ``None`` when the
-        role cannot be determined.
-        """
-        indexing_var = dim.GetIndexingVariable()
-        if indexing_var is None:
-            return None
-        # Attribute-only detection (empty ``name`` disables the name-pattern fallback) so the
-        # CF-attribute vs. dimension-name stages stay separated, matching the historical pipeline.
-        # Filter to the spatial roles this classifier promises (``detect_axis`` can also return
-        # ``"T"``/``"Z"``), mirroring the MDIM ``_axis_role`` sibling so callers see only X/Y/None.
-        role = detect_axis("", _read_attributes(indexing_var))
-        return role if role in ("X", "Y") else None
-
-    @staticmethod
-    def _detect_axis_indices(dims) -> tuple[int | None, int | None]:
-        """Indices of the X (longitude) and Y (latitude) dimensions via CF coordinate attributes.
-
-        Returns the first dimension classified as ``"X"`` and the first as ``"Y"`` by
-        ``_axis_role_of_dimension`` (each ``None`` when undetected).
-        """
-        detected_x = detected_y = None
-        for i, dim in enumerate(dims):
-            role = NetCDF._axis_role_of_dimension(dim)
-            if role == "X" and detected_x is None:
-                detected_x = i
-            elif role == "Y" and detected_y is None:
-                detected_y = i
-        return detected_x, detected_y
-
     def _resolve_spatial_dims(
         self, md_arr, x_dim: str | None = None, y_dim: str | None = None
     ) -> tuple[int, int]:
@@ -3763,7 +3728,7 @@ class NetCDF(Dataset):
                 )
             return explicit_x, explicit_y
 
-        detected_x, detected_y = self._detect_axis_indices(md_arr.GetDimensions())
+        detected_x, detected_y = detect_axis_indices(md_arr.GetDimensions())
         # Adopt detection only when it (combined with any single explicit side) yields a
         # complete, distinct (X, Y) pair — otherwise a partially-detected axis must not
         # collide with the last-two fallback (e.g. a 2-D `lon_bnds(lon, bnds)` variable).

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -2318,12 +2318,24 @@ class NetCDF(Dataset):
         return scalar_no_data(no_data_value)
 
     @staticmethod
-    def _materialize_variable_array(var: NetCDF) -> np.typing.NDArray:
+    def _materialize_variable_array(var: NetCDF, lazy: bool = False) -> Any:
         """Read a variable as `(*band_dim_sizes, rows, cols)` (or `(rows, cols)`).
 
-        Undoes ``read_array``'s singleton-band squeeze and GDAL's row-major
-        flatten of multi-dim band axes, mirroring `_apply_to_all_variables`.
+        With `lazy=True` and dask installed, returns a chunked `dask.array` in that same layout
+        without ever holding the whole variable in RAM — `reduce` streams its reducer over it and
+        computes only the (small) reduced result (ARC-47). The chunked read already keeps each
+        non-spatial dim as its own leading axis, so no reshape is needed. Falls back to the eager
+        read (undoing `read_array`'s singleton-band squeeze and GDAL's row-major band flatten) when
+        `lazy` is False or dask (the `[lazy]` extra) is not installed.
         """
+        if lazy:
+            try:
+                return var.read_array(chunks="auto")
+            except (ImportError, RuntimeError, ValueError):
+                # dask missing, or the variable is not file-backed (an in-memory container has no
+                # file for the chunk graph to reopen). An in-memory array is already fully in RAM, so
+                # streaming it would save nothing -- fall through to the eager read.
+                pass
         arr = var.read_array()
         if var._band_dim_names:
             if arr.ndim == 2:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -2393,6 +2393,10 @@ class NetCDF(Dataset):
         non-spatial dim as its own leading axis, so no reshape is needed. Falls back to the eager
         read (undoing `read_array`'s singleton-band squeeze and GDAL's row-major band flatten) when
         `lazy` is False or dask (the `[lazy]` extra) is not installed.
+
+        Because the streamed reduce tree-reduces per chunk via dask while the eager path reduces in a
+        single pass, a file-backed `mean`/`sum`/`std`/`var` can differ from the same in-memory reduce
+        in the last ULPs (floating-point non-associativity) — equal to `np.allclose`, not bit-for-bit.
         """
         if lazy and NetCDF._is_file_backed(var):
             # Only stream a genuinely file-backed variable: an in-memory container has no file for the

--- a/src/pyramids/netcdf/ugrid/dataset.py
+++ b/src/pyramids/netcdf/ugrid/dataset.py
@@ -13,9 +13,10 @@ from typing import Any, cast
 
 import geopandas as gpd
 import numpy as np
+import shapely
 from osgeo import gdal
 from pyproj import CRS, Transformer
-from shapely.geometry import LineString, Point, box
+from shapely.geometry import LineString, box
 
 from pyramids.base.crs import sr_from_epsg
 from pyramids.dataset import Dataset
@@ -683,22 +684,33 @@ class UgridDataset:
         if location == "face":
             geometries = MeshSpatialIndex(self._mesh).face_polygons
         elif location == "node":
-            geometries = [
-                Point(self._mesh.node_x[i], self._mesh.node_y[i])
-                for i in range(self.n_node)
-            ]
+            # Vectorized point construction — meshes routinely have 1e5-1e7 nodes, so a per-node
+            # Python `Point(...)` loop is a hot spot (ARC-59).
+            geometries = shapely.points(self._mesh.node_x, self._mesh.node_y)
         elif location == "edge":
             if self._mesh.edge_node_connectivity is None:
                 raise ValueError("Edge connectivity not available.")
-            enc = self._mesh.edge_node_connectivity
-            geometries = []
-            for i in range(enc.n_elements):
-                nodes = enc.get_element(i)
-                coords = [(self._mesh.node_x[n], self._mesh.node_y[n]) for n in nodes]
-                geometries.append(LineString(coords))
+            geometries = self._edge_linestrings(self._mesh.edge_node_connectivity)
         else:
             raise ValueError(f"Unknown location: {location}")
         return geometries
+
+    def _edge_linestrings(self, enc: Connectivity) -> Any:
+        """Build one LineString per edge, vectorized for standard 2-node edges (ARC-59)."""
+        node_idx = np.asarray(enc.data)
+        if node_idx.ndim == 2 and node_idx.shape[1] == 2 and bool(
+            np.all(node_idx != enc.fill_value)
+        ):
+            xs = self._mesh.node_x[node_idx]
+            ys = self._mesh.node_y[node_idx]
+            return shapely.linestrings(np.stack([xs, ys], axis=-1))
+        # Rare ragged / filled edge connectivity: fall back to a per-edge build.
+        return [
+            LineString(
+                [(self._mesh.node_x[n], self._mesh.node_y[n]) for n in enc.get_element(i)]
+            )
+            for i in range(enc.n_elements)
+        ]
 
     def to_feature_collection(
         self,

--- a/src/pyramids/netcdf/ugrid/dataset.py
+++ b/src/pyramids/netcdf/ugrid/dataset.py
@@ -979,6 +979,7 @@ def _read_data_variables(
         attrs = _read_attributes(md_arr)
         dims = md_arr.GetDimensions()
         shape = tuple(d.GetSize() for d in dims) if dims else ()
+        dim_names = tuple(d.GetName() for d in dims) if dims else ()
 
         nodata = attrs.get("_FillValue")
         if nodata is not None:
@@ -999,6 +1000,7 @@ def _read_data_variables(
             nodata=nodata,
             units=units,
             standard_name=standard_name,
+            dimensions=dim_names,
             _loader=_make_variable_loader(path, var_name),
             _dtype=dtype,
         )

--- a/src/pyramids/netcdf/ugrid/dataset.py
+++ b/src/pyramids/netcdf/ugrid/dataset.py
@@ -709,7 +709,10 @@ class UgridDataset:
         # Rare ragged / filled edge connectivity: fall back to a per-edge build.
         return [
             LineString(
-                [(self._mesh.node_x[n], self._mesh.node_y[n]) for n in enc.get_element(i)]
+                [
+                    (self._mesh.node_x[n], self._mesh.node_y[n])
+                    for n in enc.get_element(i)
+                ]
             )
             for i in range(enc.n_elements)
         ]

--- a/src/pyramids/netcdf/ugrid/dataset.py
+++ b/src/pyramids/netcdf/ugrid/dataset.py
@@ -685,8 +685,9 @@ class UgridDataset:
             geometries = MeshSpatialIndex(self._mesh).face_polygons
         elif location == "node":
             # Vectorized point construction — meshes routinely have 1e5-1e7 nodes, so a per-node
-            # Python `Point(...)` loop is a hot spot (ARC-59).
-            geometries = shapely.points(self._mesh.node_x, self._mesh.node_y)
+            # Python `Point(...)` loop is a hot spot (ARC-59). `list(...)` keeps the return type
+            # consistent with the face/edge branches (review N2).
+            geometries = list(shapely.points(self._mesh.node_x, self._mesh.node_y))
         elif location == "edge":
             if self._mesh.edge_node_connectivity is None:
                 raise ValueError("Edge connectivity not available.")
@@ -703,7 +704,7 @@ class UgridDataset:
         ):
             xs = self._mesh.node_x[node_idx]
             ys = self._mesh.node_y[node_idx]
-            return shapely.linestrings(np.stack([xs, ys], axis=-1))
+            return list(shapely.linestrings(np.stack([xs, ys], axis=-1)))
         # Rare ragged / filled edge connectivity: fall back to a per-edge build.
         return [
             LineString(

--- a/src/pyramids/netcdf/ugrid/dataset.py
+++ b/src/pyramids/netcdf/ugrid/dataset.py
@@ -699,9 +699,10 @@ class UgridDataset:
     def _edge_linestrings(self, enc: Connectivity) -> Any:
         """Build one LineString per edge, vectorized for standard 2-node edges (ARC-59)."""
         node_idx = np.asarray(enc.data)
-        if node_idx.ndim == 2 and node_idx.shape[1] == 2 and bool(
-            np.all(node_idx != enc.fill_value)
-        ):
+        # A `None` fill means no sentinels are present, so the fast path is valid without an
+        # elementwise `node_idx != None` compare (which NumPy deprecates) (review N3).
+        no_fill = enc.fill_value is None or bool(np.all(node_idx != enc.fill_value))
+        if node_idx.ndim == 2 and node_idx.shape[1] == 2 and no_fill:
             xs = self._mesh.node_x[node_idx]
             ys = self._mesh.node_y[node_idx]
             return list(shapely.linestrings(np.stack([xs, ys], axis=-1)))

--- a/src/pyramids/netcdf/ugrid/interpolation.py
+++ b/src/pyramids/netcdf/ugrid/interpolation.py
@@ -16,6 +16,8 @@ from typing import cast
 
 import numpy as np
 from numpy.typing import NDArray
+from scipy.interpolate import LinearNDInterpolator
+from scipy.spatial import cKDTree
 
 from pyramids.netcdf.ugrid.mesh import Mesh2d
 
@@ -149,8 +151,6 @@ def _interpolate_nearest(
     Returns:
         (M,) array of interpolated values.
     """
-    from scipy.spatial import cKDTree
-
     tree = cKDTree(source_points)
     distances, indices = tree.query(target_points, k=1)
 
@@ -178,8 +178,6 @@ def _interpolate_linear(
     Returns:
         (M,) array of interpolated values.
     """
-    from scipy.interpolate import LinearNDInterpolator
-
     interpolator = LinearNDInterpolator(source_points, source_values, fill_value=nodata)
     result = interpolator(target_points)
 

--- a/src/pyramids/netcdf/ugrid/mesh.py
+++ b/src/pyramids/netcdf/ugrid/mesh.py
@@ -471,8 +471,12 @@ class Mesh2d:
             order = np.argsort(inverse, kind="stable")
             grouped_inverse = inverse[order]
             grouped_faces = face_idx[order]
-            starts = np.searchsorted(grouped_inverse, np.arange(len(unique_edges)), side="left")
-            ends = np.searchsorted(grouped_inverse, np.arange(len(unique_edges)), side="right")
+            starts = np.searchsorted(
+                grouped_inverse, np.arange(len(unique_edges)), side="left"
+            )
+            ends = np.searchsorted(
+                grouped_inverse, np.arange(len(unique_edges)), side="right"
+            )
             return {
                 (int(unique_edges[k, 0]), int(unique_edges[k, 1])): grouped_faces[
                     starts[k] : ends[k]

--- a/src/pyramids/netcdf/ugrid/mesh.py
+++ b/src/pyramids/netcdf/ugrid/mesh.py
@@ -366,29 +366,59 @@ class Mesh2d:
         end = np.array([self._node_x[nodes[1]], self._node_y[nodes[1]]])
         return start, end
 
+    @staticmethod
+    def _uniform_face_edges(
+        fnc: Connectivity,
+    ) -> tuple[np.typing.NDArray, np.typing.NDArray, np.typing.NDArray] | None:
+        """Return the undirected `(lo, hi, face_idx)` edge arrays for a uniform mesh, else `None`.
+
+        When every face has the same node count (no fill columns) the cyclic edges of all faces are
+        built vectorized in face-major, per-face-edge order (`np.roll` for the next node); a ragged /
+        mixed-element mesh returns `None` so callers fall back to the per-face loop (ARC-59). `lo`/`hi`
+        are the sorted node pair of each edge and `face_idx` is the (ascending) owning face.
+        """
+        data = fnc.data
+        if data.ndim != 2 or data.shape[1] < 2:
+            return None
+        width = int(data.shape[1])
+        if not bool(np.all(fnc.nodes_per_element() == width)):
+            return None
+        nxt = np.roll(data, -1, axis=1)
+        lo = np.minimum(data, nxt).reshape(-1).astype(np.intp)
+        hi = np.maximum(data, nxt).reshape(-1).astype(np.intp)
+        face_idx = np.repeat(np.arange(data.shape[0], dtype=np.intp), width)
+        return lo, hi, face_idx
+
     def build_edge_connectivity(self) -> None:
         """Derive edge_node_connectivity from face_node_connectivity.
 
-        Iterates all face edges, deduplicates by sorted node pairs,
-        and builds an edge-to-node connectivity array. Updates the
-        internal edge_node_connectivity attribute.
+        Deduplicates all face edges by sorted node pair (keeping first-seen order) and builds the
+        edge-to-node connectivity array. Uniform meshes take a vectorized `np.unique` path; ragged
+        meshes fall back to the per-face loop (ARC-59). Updates the internal
+        edge_node_connectivity attribute.
         """
-        seen_edges: dict[tuple[int, int], int] = {}
-        edges: list[tuple[int, int]] = []
         fnc = self._face_node_connectivity
+        uniform = self._uniform_face_edges(fnc)
+        if uniform is not None:
+            lo, hi, _ = uniform
+            keys = np.stack([lo, hi], axis=1)
+            unique_edges, first_seen = np.unique(keys, axis=0, return_index=True)
+            edge_data = unique_edges[np.argsort(first_seen)].astype(np.intp)
+        else:
+            seen_edges: dict[tuple[int, int], int] = {}
+            edges: list[tuple[int, int]] = []
+            for i in range(self.n_face):
+                nodes = fnc.get_element(i)
+                n = len(nodes)
+                for j in range(n):
+                    n1 = int(nodes[j])
+                    n2 = int(nodes[(j + 1) % n])
+                    edge_key = (min(n1, n2), max(n1, n2))
+                    if edge_key not in seen_edges:
+                        seen_edges[edge_key] = len(edges)
+                        edges.append(edge_key)
+            edge_data = np.array(edges, dtype=np.intp)
 
-        for i in range(self.n_face):
-            nodes = fnc.get_element(i)
-            n = len(nodes)
-            for j in range(n):
-                n1 = int(nodes[j])
-                n2 = int(nodes[(j + 1) % n])
-                edge_key = (min(n1, n2), max(n1, n2))
-                if edge_key not in seen_edges:
-                    seen_edges[edge_key] = len(edges)
-                    edges.append(edge_key)
-
-        edge_data = np.array(edges, dtype=np.intp)
         self._edge_node_connectivity = Connectivity(
             data=edge_data,
             fill_value=-1,
@@ -430,6 +460,26 @@ class Mesh2d:
             list of face indices that contain that edge.
         """
         fnc = self._face_node_connectivity
+        uniform = self._uniform_face_edges(fnc)
+        if uniform is not None:
+            lo, hi, face_idx = uniform
+            keys = np.stack([lo, hi], axis=1)
+            unique_edges, inverse = np.unique(keys, axis=0, return_inverse=True)
+            inverse = inverse.reshape(-1)
+            # Group the (ascending) face indices by edge: a stable sort on the edge id keeps each
+            # group's faces in ascending order, matching the per-face loop.
+            order = np.argsort(inverse, kind="stable")
+            grouped_inverse = inverse[order]
+            grouped_faces = face_idx[order]
+            starts = np.searchsorted(grouped_inverse, np.arange(len(unique_edges)), side="left")
+            ends = np.searchsorted(grouped_inverse, np.arange(len(unique_edges)), side="right")
+            return {
+                (int(unique_edges[k, 0]), int(unique_edges[k, 1])): grouped_faces[
+                    starts[k] : ends[k]
+                ].tolist()
+                for k in range(len(unique_edges))
+            }
+
         edge_to_faces: dict[tuple[int, int], list[int]] = {}
         for i in range(self.n_face):
             nodes = fnc.get_element(i)

--- a/src/pyramids/netcdf/ugrid/mesh.py
+++ b/src/pyramids/netcdf/ugrid/mesh.py
@@ -284,24 +284,41 @@ class Mesh2d:
                 that this property decomposes.
         """
         if self._cached_fan_triangles is None:
-            fnc = self._face_node_connectivity
-            triangles: list[list[int]] = []
-
-            for i in range(self.n_face):
-                nodes = fnc.get_element(i)
-                n = len(nodes)
-                if n < 3:
-                    continue
-                for j in range(1, n - 1):
-                    triangles.append([int(nodes[0]), int(nodes[j]), int(nodes[j + 1])])
-
-            if not triangles:
-                raise ValueError(
-                    "Cannot create triangulation: no faces with 3 or more nodes."
-                )
-            self._cached_fan_triangles = np.array(triangles, dtype=np.intp)
+            self._cached_fan_triangles = self._compute_fan_triangles(
+                self._face_node_connectivity
+            )
 
         return self._cached_fan_triangles
+
+    @staticmethod
+    def _compute_fan_triangles(fnc: Connectivity) -> np.typing.NDArray:
+        """Fan-triangulate every face: triangles ``[n0, nj, nj+1]`` for ``j`` in ``1..count-2``.
+
+        Vectorized when all faces share a node count (the common all-triangle / all-quad case), laid
+        out face-major to match the per-face fan; ragged meshes fall back to the per-face loop
+        (ARC-59).
+        """
+        data = fnc.data
+        if data.ndim == 2 and data.shape[1] >= 3:
+            width = int(data.shape[1])
+            if bool(np.all(fnc.nodes_per_element() == width)):
+                # count == width means no fill columns, so every row fans cleanly.
+                per_j = [data[:, [0, j, j + 1]] for j in range(1, width - 1)]
+                stacked = np.stack(per_j, axis=1)  # (n_face, width - 2, 3)
+                return stacked.reshape(-1, 3).astype(np.intp)
+        triangles: list[list[int]] = []
+        for i in range(fnc.n_elements):
+            nodes = fnc.get_element(i)
+            n = len(nodes)
+            if n < 3:
+                continue
+            for j in range(1, n - 1):
+                triangles.append([int(nodes[0]), int(nodes[j]), int(nodes[j + 1])])
+        if not triangles:
+            raise ValueError(
+                "Cannot create triangulation: no faces with 3 or more nodes."
+            )
+        return np.array(triangles, dtype=np.intp)
 
     def get_face_nodes(self, face_idx: int) -> np.typing.NDArray:
         """Return valid node indices for a single face.

--- a/src/pyramids/netcdf/ugrid/models.py
+++ b/src/pyramids/netcdf/ugrid/models.py
@@ -93,6 +93,7 @@ class MeshVariable:
     nodata: float | None = None
     units: str | None = None
     standard_name: str | None = None
+    dimensions: tuple[str, ...] = field(default_factory=tuple)
     _data: np.ndarray | None = field(default=None, repr=False)
     _loader: Callable[[], np.ndarray] | None = field(default=None, repr=False)
     _dtype: np.dtype | None = field(default=None, repr=False)
@@ -111,15 +112,39 @@ class MeshVariable:
         return result
 
     @property
+    def time_index(self) -> int | None:
+        """Axis of the real time dimension, or `None` when the variable is not temporal.
+
+        Identifies the time axis by name from `dimensions` (a dimension whose name contains
+        `"time"`, the CF/UGRID convention) rather than assuming any extra axis is time. A
+        non-temporal multi-dimensional variable such as `(n_layers, n_face)` therefore reports
+        `None` (ARC-19). When `dimensions` is unknown — e.g. an array-built variable that carries no
+        dimension names — it falls back to the historical heuristic (leading axis of a >1-D array).
+
+        Returns:
+            The 0-based index of the time axis, or `None` if the variable has no time dimension.
+        """
+        if self.dimensions:
+            for axis, dim in enumerate(self.dimensions):
+                if "time" in dim.lower():
+                    return axis
+            return None
+        return 0 if len(self.shape) > 1 else None
+
+    @property
     def has_time(self) -> bool:
-        """True if the data has a time dimension (2D or higher)."""
-        result = len(self.shape) > 1
-        return result
+        """True when the variable has a real time dimension.
+
+        Unlike a bare `ndim > 1` test, this is driven by `time_index`, so a non-temporal
+        `(n_layers, n_face)` variable is not mis-flagged as temporal (ARC-19).
+        """
+        return self.time_index is not None
 
     @property
     def n_time_steps(self) -> int:
-        """Number of time steps. Returns 0 if no time dimension."""
-        result = self.shape[0] if self.has_time else 0
+        """Number of time steps. Returns 0 if the variable has no time dimension."""
+        idx = self.time_index
+        result = self.shape[idx] if idx is not None and self.shape else 0
         return result
 
     @property
@@ -203,6 +228,7 @@ class MeshVariable:
             nodata=self.nodata,
             units=self.units,
             standard_name=self.standard_name,
+            dimensions=self.dimensions,
             _data=data,
         )
 

--- a/src/pyramids/netcdf/ugrid/models.py
+++ b/src/pyramids/netcdf/ugrid/models.py
@@ -115,18 +115,26 @@ class MeshVariable:
     def time_index(self) -> int | None:
         """Axis of the real time dimension, or `None` when the variable is not temporal.
 
-        Identifies the time axis by name from `dimensions` (a dimension whose name contains
-        `"time"`, the CF/UGRID convention) rather than assuming any extra axis is time. A
-        non-temporal multi-dimensional variable such as `(n_layers, n_face)` therefore reports
-        `None` (ARC-19). When `dimensions` is unknown — e.g. an array-built variable that carries no
-        dimension names — it falls back to the historical heuristic (leading axis of a >1-D array).
+        Identifies the time axis by name from `dimensions` (a dimension named `time`/`t`, or
+        `time…`/`…_time`/`…_time_…` per the CF/UGRID convention) rather than assuming any extra axis
+        is time. The word-boundary match avoids substring false-positives like `runtime` / `lifetime`
+        / `daytime`, and a non-temporal multi-dimensional variable such as `(n_layers, n_face)`
+        reports `None` (ARC-19). When `dimensions` is unknown — e.g. an array-built variable that
+        carries no dimension names — it falls back to the historical heuristic (leading axis of a
+        >1-D array).
 
         Returns:
             The 0-based index of the time axis, or `None` if the variable has no time dimension.
         """
         if self.dimensions:
             for axis, dim in enumerate(self.dimensions):
-                if "time" in dim.lower():
+                lowered = dim.lower()
+                if (
+                    lowered in ("t", "time")
+                    or lowered.startswith("time")
+                    or lowered.endswith("_time")
+                    or "_time_" in lowered
+                ):
                     return axis
             return None
         return 0 if len(self.shape) > 1 else None

--- a/src/pyramids/netcdf/ugrid/spatial.py
+++ b/src/pyramids/netcdf/ugrid/spatial.py
@@ -19,6 +19,7 @@ from typing import Any
 
 import numpy as np
 import shapely
+from scipy.spatial import cKDTree
 from shapely import STRtree
 from shapely.ops import unary_union
 
@@ -53,8 +54,6 @@ class MeshSpatialIndex:
     def node_tree(self) -> Any:
         """KD-tree on node coordinates. Lazy-built on first access."""
         if self._node_tree is None:
-            from scipy.spatial import cKDTree
-
             self._node_tree = cKDTree(
                 np.column_stack([self._mesh.node_x, self._mesh.node_y])
             )
@@ -64,8 +63,6 @@ class MeshSpatialIndex:
     def face_tree(self) -> Any:
         """KD-tree on face centroids. Lazy-built on first access."""
         if self._face_tree is None:
-            from scipy.spatial import cKDTree
-
             cx, cy = self._mesh.face_centroids
             self._face_tree = cKDTree(np.column_stack([cx, cy]))
         return self._face_tree

--- a/src/pyramids/netcdf/utils.py
+++ b/src/pyramids/netcdf/utils.py
@@ -679,7 +679,15 @@ def _datetime_components(value: Any) -> tuple[int, int, int, int, int, int, int]
     )
     if match is None:
         ts = pd.Timestamp(value)
-        return (ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, ts.microsecond)
+        return (
+            ts.year,
+            ts.month,
+            ts.day,
+            ts.hour,
+            ts.minute,
+            ts.second,
+            ts.microsecond,
+        )
     seconds_float = float(match.group(6)) if match.group(6) else 0.0
     whole_seconds = int(seconds_float)
     # Clamp so a value like "59.9999995" whose fraction rounds up to 1_000_000 does not exceed

--- a/src/pyramids/netcdf/utils.py
+++ b/src/pyramids/netcdf/utils.py
@@ -682,6 +682,9 @@ def _datetime_components(value: Any) -> tuple[int, int, int, int, int, int, int]
         return (ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, ts.microsecond)
     seconds_float = float(match.group(6)) if match.group(6) else 0.0
     whole_seconds = int(seconds_float)
+    # Clamp so a value like "59.9999995" whose fraction rounds up to 1_000_000 does not exceed
+    # cftime's microsecond range (0..999_999) and raise (review N1).
+    microsecond = min(int(round((seconds_float - whole_seconds) * 1_000_000)), 999_999)
     return (
         int(match.group(1)),
         int(match.group(2)),
@@ -689,7 +692,7 @@ def _datetime_components(value: Any) -> tuple[int, int, int, int, int, int, int]
         int(match.group(4)) if match.group(4) else 0,
         int(match.group(5)) if match.group(5) else 0,
         whole_seconds,
-        int(round((seconds_float - whole_seconds) * 1_000_000)),
+        microsecond,
     )
 
 

--- a/src/pyramids/netcdf/utils.py
+++ b/src/pyramids/netcdf/utils.py
@@ -632,18 +632,65 @@ def encode_cf_time(value: Any, unit: str, calendar: str = "standard") -> float:
     Returns:
         float: ``value`` expressed in ``unit`` on the given ``calendar``.
     """
-    ts = pd.Timestamp(value)
+    year, month, day, hour, minute, second, microsecond = _datetime_components(value)
     dt = cftime.datetime(
-        ts.year,
-        ts.month,
-        ts.day,
-        ts.hour,
-        ts.minute,
-        ts.second,
-        ts.microsecond,
+        year,
+        month,
+        day,
+        hour,
+        minute,
+        second,
+        microsecond,
         calendar=calendar,
     )
     return float(cftime.date2num(dt, unit, calendar))
+
+
+def _datetime_components(value: Any) -> tuple[int, int, int, int, int, int, int]:
+    """Extract ``(year, month, day, hour, minute, second, microsecond)`` without Gregorian validation.
+
+    ``encode_cf_time`` funnelled its input through ``pandas.Timestamp``, which is proleptic-Gregorian
+    and nanosecond-bounded, so a date valid only on a ``360_day`` / ``noleap`` calendar (e.g. month
+    day 30 in February) raised before it ever reached ``cftime`` (ARC-30). Pull the calendar fields
+    out directly instead: from an object exposing ``year``/``month``/``day`` (``datetime`` /
+    ``cftime.datetime`` / ``pandas.Timestamp``), or by parsing an ISO ``YYYY-MM-DD[ HH:MM:SS]`` string
+    without any Gregorian range check. Only genuinely non-ISO strings fall back to ``pandas``.
+
+    Args:
+        value: A date string, ``datetime``-like object, or ``cftime.datetime``.
+
+    Returns:
+        The seven calendar components as ints.
+    """
+    if hasattr(value, "year") and hasattr(value, "month") and hasattr(value, "day"):
+        return (
+            int(value.year),
+            int(value.month),
+            int(value.day),
+            int(getattr(value, "hour", 0)),
+            int(getattr(value, "minute", 0)),
+            int(getattr(value, "second", 0)),
+            int(getattr(value, "microsecond", 0)),
+        )
+    match = re.match(
+        r"\s*(\d{1,4})-(\d{1,2})-(\d{1,2})"
+        r"(?:[ T](\d{1,2}):(\d{1,2})(?::(\d{1,2}(?:\.\d+)?))?)?\s*$",
+        str(value),
+    )
+    if match is None:
+        ts = pd.Timestamp(value)
+        return (ts.year, ts.month, ts.day, ts.hour, ts.minute, ts.second, ts.microsecond)
+    seconds_float = float(match.group(6)) if match.group(6) else 0.0
+    whole_seconds = int(seconds_float)
+    return (
+        int(match.group(1)),
+        int(match.group(2)),
+        int(match.group(3)),
+        int(match.group(4)) if match.group(4) else 0,
+        int(match.group(5)) if match.group(5) else 0,
+        whole_seconds,
+        int(round((seconds_float - whole_seconds) * 1_000_000)),
+    )
 
 
 def _dtype_to_str(dt: Any) -> str:

--- a/src/pyramids/netcdf/utils.py
+++ b/src/pyramids/netcdf/utils.py
@@ -485,6 +485,27 @@ def _parse_units_origin(units: str) -> tuple[str, datetime]:
     return unit.lower(), origin_dt
 
 
+def _is_standard_calendar(calendar: str | None) -> bool:
+    """True for the Gregorian family (`standard` / `gregorian` / `proleptic_gregorian`), case-insensitive.
+
+    Single source for the standard-vs-non-standard calendar split so the CF time helpers cannot drift on
+    the accepted set or its casing (ARC-69). `create_time_conversion_func` lowercased its check but
+    `decode_cf_time` did not, so a capitalised `"Gregorian"`/`"Standard"` was mis-classified as
+    non-standard by the latter.
+
+    Args:
+        calendar: The CF calendar name (``None`` is treated as ``"standard"``).
+
+    Returns:
+        bool: `True` when `calendar` names a proleptic-Gregorian-compatible calendar.
+    """
+    return (calendar or "standard").lower() in (
+        "standard",
+        "gregorian",
+        "proleptic_gregorian",
+    )
+
+
 def create_time_conversion_func(
     units: str,
     out_format: str = "%Y-%m-%d %H:%M:%S",
@@ -553,7 +574,7 @@ def create_time_conversion_func(
     """
     converter = None
 
-    if calendar.lower() not in ("standard", "proleptic_gregorian", "gregorian"):
+    if not _is_standard_calendar(calendar):
 
         def convert_cftime(value):
             dt = cftime.num2date(value, units, calendar)
@@ -605,7 +626,7 @@ def decode_cf_time(
     """
     if not unit or " since " not in unit:
         return values
-    standard = calendar in ("standard", "gregorian", "proleptic_gregorian")
+    standard = _is_standard_calendar(calendar)
     decoded = np.asarray(
         cftime.num2date(values, unit, calendar, only_use_cftime_datetimes=not standard)
     )

--- a/tests/netcdf/cf/test_cf_classify.py
+++ b/tests/netcdf/cf/test_cf_classify.py
@@ -2,10 +2,13 @@
 cell methods parsing, and valid range masking (CF-5, CF-6, CF-7, CF-10, CF-11).
 """
 
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 
 from pyramids.netcdf.cf import (
+    _check_coordinate_variable,
     apply_valid_range_mask,
     classify_variables,
     detect_axis,
@@ -322,6 +325,33 @@ class TestParseCellMethods:
         """Parse 'area: mean where sea_ice'."""
         result = parse_cell_methods("area: mean where sea_ice")
         assert result[0]["where"] == "sea_ice", f"Got {result[0].get('where')}"
+
+    def test_multiple_dims_before_method(self):
+        """'lat: lon: mean' parses both dims and the method, not lon-as-method (ARC-30)."""
+        result = parse_cell_methods("lat: lon: mean")
+        assert len(result) == 1, f"Expected 1 entry, got {result}"
+        assert result[0]["dimensions"] == "lat lon", f"Got {result[0]['dimensions']}"
+        assert result[0]["method"] == "mean", f"Got {result[0]['method']}"
+
+
+class TestCoordinateUnitCheck:
+    """`_check_coordinate_variable` consults the MDArray unit slot, not only attributes (ARC-30)."""
+
+    def test_since_unit_on_unit_slot_flags_missing_calendar(self):
+        """A time coord whose `since` unit lives on `var.unit` still needs a `calendar` warning."""
+        var = SimpleNamespace(attributes={}, unit="days since 1970-01-01")
+        issues = _check_coordinate_variable("time", var)
+        assert any("calendar" in issue for issue in issues), (
+            f"expected a missing-calendar warning for a unit-slot time coordinate, got {issues}"
+        )
+
+    def test_non_time_unit_slot_not_flagged(self):
+        """A non-time unit on the unit slot raises no missing-calendar warning."""
+        var = SimpleNamespace(attributes={}, unit="m")
+        issues = _check_coordinate_variable("depth", var)
+        assert not any("calendar" in issue for issue in issues), (
+            f"a non-time unit must not trigger a calendar warning, got {issues}"
+        )
 
 
 class TestApplyValidRangeMask:

--- a/tests/netcdf/cf/test_cf_time.py
+++ b/tests/netcdf/cf/test_cf_time.py
@@ -83,6 +83,21 @@ class TestCfTimeRoundTrip:
             f"expected calendar {calendar}, got {back.calendar}"
         )
 
+    def test_360_day_month_day_30_encodes(self):
+        """A 360_day date invalid in the Gregorian calendar (Feb 30) encodes without raising (ARC-30).
+
+        Test scenario:
+            Month day 30 in February exists on a 360_day calendar but ``pandas.Timestamp`` rejects it,
+            so the old Gregorian-first path raised. Encoding it and decoding back must recover the same
+            360_day date.
+        """
+        num = encode_cf_time("2000-02-30", UNIT, "360_day")
+        back = decode_cf_time(np.array([num]), UNIT, "360_day")[0]
+        assert (back.year, back.month, back.day) == (2000, 2, 30), (
+            f"360_day Feb 30 drifted after round-trip: {back}"
+        )
+        assert back.calendar == "360_day", f"expected 360_day, got {back.calendar}"
+
     def test_non_time_unit_passthrough(self):
         """A non-time unit string returns the values unchanged.
 

--- a/tests/netcdf/cf/test_cf_time.py
+++ b/tests/netcdf/cf/test_cf_time.py
@@ -118,7 +118,9 @@ class TestCfTimeRoundTrip:
 class TestStandardCalendarCasing:
     """`decode_cf_time` treats the Gregorian family case-insensitively (ARC-69)."""
 
-    @pytest.mark.parametrize("calendar", ["Gregorian", "STANDARD", "Proleptic_Gregorian"])
+    @pytest.mark.parametrize(
+        "calendar", ["Gregorian", "STANDARD", "Proleptic_Gregorian"]
+    )
     def test_capitalised_standard_calendar_yields_datetime64(self, calendar):
         """A capitalised standard-calendar name decodes to datetime64, not cftime objects.
 

--- a/tests/netcdf/cf/test_cf_time.py
+++ b/tests/netcdf/cf/test_cf_time.py
@@ -113,3 +113,21 @@ class TestCfTimeRoundTrip:
         values = np.array([1.0, 2.0, 3.0])
         np.testing.assert_array_equal(decode_cf_time(values, "m"), values)
         np.testing.assert_array_equal(decode_cf_time(values, None), values)
+
+
+class TestStandardCalendarCasing:
+    """`decode_cf_time` treats the Gregorian family case-insensitively (ARC-69)."""
+
+    @pytest.mark.parametrize("calendar", ["Gregorian", "STANDARD", "Proleptic_Gregorian"])
+    def test_capitalised_standard_calendar_yields_datetime64(self, calendar):
+        """A capitalised standard-calendar name decodes to datetime64, not cftime objects.
+
+        Test scenario:
+            Before ARC-69, `decode_cf_time` compared the raw (non-lowered) calendar against the
+            lowercase set, so `"Gregorian"`/`"STANDARD"` fell through to the cftime branch. The
+            shared `_is_standard_calendar` check now lowercases, so these yield `datetime64[ns]`.
+        """
+        decoded = decode_cf_time(np.array([0.0, 365.0]), UNIT, calendar)
+        assert decoded.dtype == np.dtype("datetime64[ns]"), (
+            f"{calendar!r} should decode to datetime64, got {decoded.dtype}"
+        )

--- a/tests/netcdf/cf/test_cf_time.py
+++ b/tests/netcdf/cf/test_cf_time.py
@@ -98,6 +98,11 @@ class TestCfTimeRoundTrip:
         )
         assert back.calendar == "360_day", f"expected 360_day, got {back.calendar}"
 
+    def test_fractional_second_rounding_does_not_overflow_microseconds(self):
+        """A seconds field whose fraction rounds up to 1e6 µs is clamped, not rejected by cftime (N1)."""
+        num = encode_cf_time("2000-01-01T00:00:59.9999995", UNIT, "360_day")
+        assert np.isfinite(num), f"expected a finite encoded value, got {num}"
+
     def test_non_time_unit_passthrough(self):
         """A non-time unit string returns the values unchanged.
 

--- a/tests/netcdf/lazy/test_chunked_read.py
+++ b/tests/netcdf/lazy/test_chunked_read.py
@@ -104,6 +104,19 @@ class TestChunksLazy:
         arr = three_d_var.read_array(chunks=1)
         assert isinstance(arr, dask_array.Array)
 
+    def test_identical_reads_share_deterministic_graph_name(self, three_d_var):
+        """Two identical lazy reads get the same tokenized graph name so dask can dedupe them (ARC-76).
+
+        The graph name used to embed `id(manager)`, giving every read a fresh name and defeating
+        dask's common-subexpression elimination; a content-addressed token makes identical reads share
+        one name.
+        """
+        first = three_d_var.read_array(chunks="auto")
+        second = three_d_var.read_array(chunks="auto")
+        assert first.name == second.name, (
+            f"identical reads should share a name, got {first.name!r} vs {second.name!r}"
+        )
+
     def test_window_with_chunks_raises(self, three_d_var):
         """`read_array(window=, chunks=)` raises instead of silently ignoring the window (#728 M1).
 

--- a/tests/netcdf/lazy/test_mfdataset.py
+++ b/tests/netcdf/lazy/test_mfdataset.py
@@ -1,8 +1,8 @@
 """Tests for :meth:`NetCDF.open_mfdataset`.
 
 DASK-12: multi-file NetCDF open — stacks one named variable from every
-file into a single lazy :class:`dask.array.Array`. ``parallel=True``
-fans out metadata reads via :func:`dask.delayed`.
+file into a single lazy :class:`dask.array.Array`. ``parallel`` is a
+deprecated, inert flag kept only for backward compatibility.
 """
 
 from __future__ import annotations
@@ -54,7 +54,19 @@ class TestMultiFile:
 
 
 class TestParallelMode:
-    """parallel=True routes per-file opens through dask.delayed."""
+    """`parallel` is a deprecated, inert flag identical to the default lazy path."""
+
+    @requires_dask
+    def test_parallel_true_emits_deprecation_warning(self):
+        """Passing `parallel=True` warns that the flag is deprecated and inert.
+
+        Test scenario:
+            A truthy `parallel` must raise a `DeprecationWarning` mentioning it is deprecated,
+            while still returning the same lazy stack as the default.
+        """
+        with pytest.warns(DeprecationWarning, match="deprecated"):
+            stack = NetCDF.open_mfdataset([FIXTURE], variable="values", parallel=True)
+        assert stack.shape[0] == 1, f"expected a 1-element stack, got {stack.shape}"
 
     @requires_dask
     def test_parallel_equivalent_to_sequential(self):
@@ -63,11 +75,12 @@ class TestParallelMode:
             variable="values",
             parallel=False,
         ).compute()
-        par = NetCDF.open_mfdataset(
-            [FIXTURE, FIXTURE],
-            variable="values",
-            parallel=True,
-        ).compute()
+        with pytest.warns(DeprecationWarning):
+            par = NetCDF.open_mfdataset(
+                [FIXTURE, FIXTURE],
+                variable="values",
+                parallel=True,
+            ).compute()
         assert seq.shape == par.shape
 
     @requires_dask
@@ -75,35 +88,34 @@ class TestParallelMode:
         """With the default (lazy) per-file read, parallel and sequential stacks are identical (ARC-48).
 
         Test scenario:
-            The lazy default returns dask arrays per file; the parallel path must read them directly
-            (not nest them in `dask.delayed`), so both modes compute the same values.
+            The lazy default returns dask arrays per file; the (inert) parallel path reads them
+            directly, so both modes compute the same values.
         """
         seq = NetCDF.open_mfdataset(
             [FIXTURE, FIXTURE], variable="values", parallel=False
         ).compute()
-        par = NetCDF.open_mfdataset(
-            [FIXTURE, FIXTURE], variable="values", parallel=True
-        ).compute()
+        with pytest.warns(DeprecationWarning):
+            par = NetCDF.open_mfdataset(
+                [FIXTURE, FIXTURE], variable="values", parallel=True
+            ).compute()
         np.testing.assert_array_equal(
             par, seq, err_msg="parallel stack diverged from sequential under the lazy default"
         )
 
     @requires_dask
     def test_parallel_frames_have_uniform_chunks(self):
-        """Element 0 has the same chunk structure as the delayed frames (review L3).
+        """Every stacked frame is a single block along the stacked axis (review L3).
 
         Test scenario:
-            In ``parallel=True`` mode element 0 used to be wrapped with
-            ``da.from_array(..., chunks="auto")`` while the other frames came from
-            ``da.from_delayed`` (one block per file). Stack three copies and assert every
-            stacked frame is a single block along the stacked axis, so the chunking is
-            uniform across frames (no element-0 outlier).
+            Stack three copies via the (inert) parallel path and assert every stacked frame is a
+            single block along the stacked axis, so the chunking is uniform across frames.
         """
-        stack = NetCDF.open_mfdataset(
-            [FIXTURE, FIXTURE, FIXTURE],
-            variable="values",
-            parallel=True,
-        )
+        with pytest.warns(DeprecationWarning):
+            stack = NetCDF.open_mfdataset(
+                [FIXTURE, FIXTURE, FIXTURE],
+                variable="values",
+                parallel=True,
+            )
         # da.stack adds the leading axis; one block per file means chunks[0] == (1, 1, 1).
         assert stack.chunks[0] == (
             1,

--- a/tests/netcdf/lazy/test_mfdataset.py
+++ b/tests/netcdf/lazy/test_mfdataset.py
@@ -7,6 +7,7 @@ fans out metadata reads via :func:`dask.delayed`.
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 
 from pyramids.netcdf import NetCDF
@@ -68,6 +69,24 @@ class TestParallelMode:
             parallel=True,
         ).compute()
         assert seq.shape == par.shape
+
+    @requires_dask
+    def test_parallel_and_sequential_values_equal(self):
+        """With the default (lazy) per-file read, parallel and sequential stacks are identical (ARC-48).
+
+        Test scenario:
+            The lazy default returns dask arrays per file; the parallel path must read them directly
+            (not nest them in `dask.delayed`), so both modes compute the same values.
+        """
+        seq = NetCDF.open_mfdataset(
+            [FIXTURE, FIXTURE], variable="values", parallel=False
+        ).compute()
+        par = NetCDF.open_mfdataset(
+            [FIXTURE, FIXTURE], variable="values", parallel=True
+        ).compute()
+        np.testing.assert_array_equal(
+            par, seq, err_msg="parallel stack diverged from sequential under the lazy default"
+        )
 
     @requires_dask
     def test_parallel_frames_have_uniform_chunks(self):

--- a/tests/netcdf/lazy/test_mfdataset.py
+++ b/tests/netcdf/lazy/test_mfdataset.py
@@ -99,7 +99,9 @@ class TestParallelMode:
                 [FIXTURE, FIXTURE], variable="values", parallel=True
             ).compute()
         np.testing.assert_array_equal(
-            par, seq, err_msg="parallel stack diverged from sequential under the lazy default"
+            par,
+            seq,
+            err_msg="parallel stack diverged from sequential under the lazy default",
         )
 
     @requires_dask

--- a/tests/netcdf/lazy/test_xarray_interop.py
+++ b/tests/netcdf/lazy/test_xarray_interop.py
@@ -44,6 +44,20 @@ class TestEncodeTemporalArray:
         assert_allclose(encoded, [1.0, 2.0], err_msg="timedelta64 should map to seconds")
         assert attrs == {"units": "seconds"}, f"unexpected attrs {attrs}"
 
+    def test_datetime64_nat_encodes_to_nan(self):
+        """A NaT encodes to NaN (a missing instant), not a bogus finite ~1677 timestamp (review M2)."""
+        vals = np.array(["2020-01-01", "NaT", "2020-01-03"], dtype="datetime64[ns]")
+        encoded, _ = _encode_temporal_array(vals)
+        assert np.isnan(encoded[1]), f"NaT must encode to NaN, got {encoded[1]}"
+        assert np.isfinite(encoded[0]) and np.isfinite(encoded[2]), "real instants must stay finite"
+
+    def test_timedelta64_nat_encodes_to_nan(self):
+        """A NaT in a timedelta64 array encodes to NaN, not the int64-sentinel value (review M2)."""
+        vals = np.array([1_000_000_000, "NaT"], dtype="timedelta64[ns]")
+        encoded, _ = _encode_temporal_array(vals)
+        assert np.isnan(encoded[1]), f"NaT must encode to NaN, got {encoded[1]}"
+        assert encoded[0] == 1.0, f"real timedelta must stay finite, got {encoded[0]}"
+
     def test_non_temporal_array_passes_through_unchanged(self):
         """A numeric array is returned unchanged with no CF attributes."""
         vals = np.array([1.5, 2.5, 3.5])

--- a/tests/netcdf/lazy/test_xarray_interop.py
+++ b/tests/netcdf/lazy/test_xarray_interop.py
@@ -19,7 +19,37 @@ xr = pytest.importorskip("xarray")
 pytestmark = pytest.mark.xarray
 
 from pyramids.dataset import Dataset
+from pyramids.netcdf.engines.interop import _encode_temporal_array
 from pyramids.netcdf.netcdf import NetCDF
+
+
+class TestEncodeTemporalArray:
+    """_encode_temporal_array encodes temporal dtypes to CF-numeric seconds (ARC-17)."""
+
+    def test_datetime64_encodes_to_seconds_since_epoch(self):
+        """datetime64 becomes float64 seconds with a CF units + calendar attribute."""
+        vals = np.array(
+            ["1970-01-01T00:00:01", "1970-01-01T00:00:02"], dtype="datetime64[ns]"
+        )
+        encoded, attrs = _encode_temporal_array(vals)
+        assert encoded.dtype == np.float64, f"expected float64, got {encoded.dtype}"
+        assert_allclose(encoded, [1.0, 2.0], err_msg="datetime64 should map to seconds since epoch")
+        assert "since" in attrs["units"], f"expected a 'since' unit, got {attrs}"
+        assert attrs["calendar"] == "proleptic_gregorian", f"unexpected calendar in {attrs}"
+
+    def test_timedelta64_encodes_to_seconds(self):
+        """timedelta64 becomes float64 seconds with a plain 'seconds' unit."""
+        vals = np.array([1_000_000_000, 2_000_000_000], dtype="timedelta64[ns]")
+        encoded, attrs = _encode_temporal_array(vals)
+        assert_allclose(encoded, [1.0, 2.0], err_msg="timedelta64 should map to seconds")
+        assert attrs == {"units": "seconds"}, f"unexpected attrs {attrs}"
+
+    def test_non_temporal_array_passes_through_unchanged(self):
+        """A numeric array is returned unchanged with no CF attributes."""
+        vals = np.array([1.5, 2.5, 3.5])
+        encoded, attrs = _encode_temporal_array(vals)
+        assert encoded is vals, "a non-temporal array must be returned unchanged"
+        assert attrs == {}, f"expected no attrs for a non-temporal array, got {attrs}"
 from tests.netcdf.conftest import make_3d_nc
 
 

--- a/tests/netcdf/lazy/test_xarray_interop.py
+++ b/tests/netcdf/lazy/test_xarray_interop.py
@@ -33,15 +33,21 @@ class TestEncodeTemporalArray:
         )
         encoded, attrs = _encode_temporal_array(vals)
         assert encoded.dtype == np.float64, f"expected float64, got {encoded.dtype}"
-        assert_allclose(encoded, [1.0, 2.0], err_msg="datetime64 should map to seconds since epoch")
+        assert_allclose(
+            encoded, [1.0, 2.0], err_msg="datetime64 should map to seconds since epoch"
+        )
         assert "since" in attrs["units"], f"expected a 'since' unit, got {attrs}"
-        assert attrs["calendar"] == "proleptic_gregorian", f"unexpected calendar in {attrs}"
+        assert attrs["calendar"] == "proleptic_gregorian", (
+            f"unexpected calendar in {attrs}"
+        )
 
     def test_timedelta64_encodes_to_seconds(self):
         """timedelta64 becomes float64 seconds with a plain 'seconds' unit."""
         vals = np.array([1_000_000_000, 2_000_000_000], dtype="timedelta64[ns]")
         encoded, attrs = _encode_temporal_array(vals)
-        assert_allclose(encoded, [1.0, 2.0], err_msg="timedelta64 should map to seconds")
+        assert_allclose(
+            encoded, [1.0, 2.0], err_msg="timedelta64 should map to seconds"
+        )
         assert attrs == {"units": "seconds"}, f"unexpected attrs {attrs}"
 
     def test_datetime64_nat_encodes_to_nan(self):
@@ -49,7 +55,9 @@ class TestEncodeTemporalArray:
         vals = np.array(["2020-01-01", "NaT", "2020-01-03"], dtype="datetime64[ns]")
         encoded, _ = _encode_temporal_array(vals)
         assert np.isnan(encoded[1]), f"NaT must encode to NaN, got {encoded[1]}"
-        assert np.isfinite(encoded[0]) and np.isfinite(encoded[2]), "real instants must stay finite"
+        assert np.isfinite(encoded[0]) and np.isfinite(encoded[2]), (
+            "real instants must stay finite"
+        )
 
     def test_timedelta64_nat_encodes_to_nan(self):
         """A NaT in a timedelta64 array encodes to NaN, not the int64-sentinel value (review M2)."""
@@ -60,8 +68,12 @@ class TestEncodeTemporalArray:
 
     def test_scalar_datetime64_encodes_without_crash(self):
         """A 0-d datetime64 encodes to a finite 0-d value (no in-place-assignment crash) (r2 M1)."""
-        encoded, _ = _encode_temporal_array(np.array("2020-06-01", dtype="datetime64[ns]"))
-        assert np.ndim(encoded) == 0, f"expected a 0-d result, got shape {np.shape(encoded)}"
+        encoded, _ = _encode_temporal_array(
+            np.array("2020-06-01", dtype="datetime64[ns]")
+        )
+        assert np.ndim(encoded) == 0, (
+            f"expected a 0-d result, got shape {np.shape(encoded)}"
+        )
         assert np.isfinite(encoded), f"a real instant must encode finite, got {encoded}"
 
     def test_scalar_nat_encodes_to_nan(self):
@@ -75,6 +87,8 @@ class TestEncodeTemporalArray:
         encoded, attrs = _encode_temporal_array(vals)
         assert encoded is vals, "a non-temporal array must be returned unchanged"
         assert attrs == {}, f"expected no attrs for a non-temporal array, got {attrs}"
+
+
 from tests.netcdf.conftest import make_3d_nc
 
 

--- a/tests/netcdf/lazy/test_xarray_interop.py
+++ b/tests/netcdf/lazy/test_xarray_interop.py
@@ -323,6 +323,36 @@ class TestToXarrayFileBacked:
         assert "q" in ds.data_vars, "'q' should be in data_vars"
 
 
+class TestFromXarrayDatetimeCoord:
+    """from_xarray() handles a CF-decoded datetime64 time coordinate (ARC-17)."""
+
+    def test_datetime64_time_coord_does_not_crash(self):
+        """A Dataset with a datetime64[ns] `time` coord builds without raising, preserving the data.
+
+        Test scenario:
+            The default `decode_cf=True` yields a datetime64 time axis, which numpy_to_gdal_dtype
+            cannot map — from_xarray used to raise. The time axis is now encoded to CF-numeric seconds,
+            so the container is created and the data variable round-trips unchanged.
+        """
+        times = np.array(
+            ["2020-01-01", "2020-01-02", "2020-01-03"], dtype="datetime64[ns]"
+        )
+        data = np.arange(3 * 2 * 2, dtype=np.float64).reshape(3, 2, 2)
+        ds = xr.Dataset(
+            {"t2m": (("time", "lat", "lon"), data)},
+            # lat descends (already north-up) so the read is not flipped and the data compares directly.
+            coords={"time": times, "lat": [11.0, 10.0], "lon": [20.0, 21.0]},
+        )
+        nc = NetCDF.from_xarray(ds)
+        assert "t2m" in nc.variable_names, f"expected 't2m' in {nc.variable_names}"
+        got = np.asarray(nc.get_variable("t2m").read_array())
+        assert_allclose(
+            got,
+            data,
+            err_msg="t2m data should survive from_xarray with a datetime64 time coord",
+        )
+
+
 class TestFromXarrayRoundTrip:
     """from_xarray() round-trip data integrity."""
 

--- a/tests/netcdf/lazy/test_xarray_interop.py
+++ b/tests/netcdf/lazy/test_xarray_interop.py
@@ -58,6 +58,17 @@ class TestEncodeTemporalArray:
         assert np.isnan(encoded[1]), f"NaT must encode to NaN, got {encoded[1]}"
         assert encoded[0] == 1.0, f"real timedelta must stay finite, got {encoded[0]}"
 
+    def test_scalar_datetime64_encodes_without_crash(self):
+        """A 0-d datetime64 encodes to a finite 0-d value (no in-place-assignment crash) (r2 M1)."""
+        encoded, _ = _encode_temporal_array(np.array("2020-06-01", dtype="datetime64[ns]"))
+        assert np.ndim(encoded) == 0, f"expected a 0-d result, got shape {np.shape(encoded)}"
+        assert np.isfinite(encoded), f"a real instant must encode finite, got {encoded}"
+
+    def test_scalar_nat_encodes_to_nan(self):
+        """A 0-d NaT encodes to NaN rather than crashing on item assignment (r2 M1)."""
+        encoded, _ = _encode_temporal_array(np.array("NaT", dtype="datetime64[ns]"))
+        assert np.isnan(encoded), f"a 0-d NaT must encode to NaN, got {encoded}"
+
     def test_non_temporal_array_passes_through_unchanged(self):
         """A numeric array is returned unchanged with no CF attributes."""
         vals = np.array([1.5, 2.5, 3.5])

--- a/tests/netcdf/samples/test_container_geotransform.py
+++ b/tests/netcdf/samples/test_container_geotransform.py
@@ -1,0 +1,48 @@
+"""Container geotransform: the derived X origin must be the WEST edge, even for a descending lon.
+
+The root container derives its geotransform from the lon/lat coordinate arrays. The Y branch already
+takes the north edge with ``max(lat[0], lat[-1])``; the X branch used a plain ``lon[0]``, which put the
+origin at the EAST edge for a descending-longitude grid (ARC-32).
+"""
+
+import numpy as np
+import pytest
+from osgeo import gdal, osr
+
+from pyramids.netcdf import NetCDF
+
+pytestmark = pytest.mark.core
+
+
+def _descending_lon_nc(path: str) -> None:
+    """Write a tiny EPSG:4326 netCDF whose lon coordinate descends east->west (centres 29..21)."""
+    src = gdal.GetDriverByName("MEM").Create("", 5, 4, 1, gdal.GDT_Float32)
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(4326)
+    src.SetProjection(srs.ExportToWkt())
+    # Pixel 0 spans [30, 28] -> centre 29; pixel 4 spans [22, 20] -> centre 21. lon = 29,27,25,23,21.
+    src.SetGeoTransform((30.0, -2.0, 0.0, 10.0, 0.0, -1.0))
+    src.GetRasterBand(1).WriteArray(np.arange(20, dtype=np.float32).reshape(4, 5))
+    gdal.Translate(path, src, format="netCDF", creationOptions=["WRITE_BOTTOMUP=NO"])
+    src = None  # noqa: F841 - release the GDAL handle before the file is reopened
+
+
+def test_container_x_origin_is_west_edge_for_descending_lon(tmp_path):
+    """The container geotransform x-origin sits at the west edge, not the east edge (ARC-32)."""
+    path = str(tmp_path / "lon_desc.nc")
+    _descending_lon_nc(path)
+    nc = NetCDF.read_file(path)
+    try:
+        lon = np.asarray(nc.lon, dtype=float)
+        assert lon[0] > lon[-1], "fixture lon must descend east->west"
+        gt = nc.geotransform
+        x_cell = abs(gt[1])
+        west_edge = min(lon[0], lon[-1]) - x_cell / 2
+        east_bug = lon[0] - x_cell / 2  # the pre-ARC-32 value (origin at the EAST edge)
+        assert west_edge != pytest.approx(east_bug), "fixture must separate west/east edges"
+        assert gt[0] == pytest.approx(west_edge, abs=1e-4), (
+            f"x-origin should be the west edge {west_edge}, got {gt[0]} "
+            f"(the pre-ARC-32 east-edge bug would give {east_bug})"
+        )
+    finally:
+        nc.close()

--- a/tests/netcdf/samples/test_container_geotransform.py
+++ b/tests/netcdf/samples/test_container_geotransform.py
@@ -39,7 +39,9 @@ def test_container_x_origin_is_west_edge_for_descending_lon(tmp_path):
         x_cell = abs(gt[1])
         west_edge = min(lon[0], lon[-1]) - x_cell / 2
         east_bug = lon[0] - x_cell / 2  # the pre-ARC-32 value (origin at the EAST edge)
-        assert west_edge != pytest.approx(east_bug), "fixture must separate west/east edges"
+        assert west_edge != pytest.approx(east_bug), (
+            "fixture must separate west/east edges"
+        )
         assert gt[0] == pytest.approx(west_edge, abs=1e-4), (
             f"x-origin should be the west edge {west_edge}, got {gt[0]} "
             f"(the pre-ARC-32 east-edge bug would give {east_bug})"

--- a/tests/netcdf/samples/test_inherited_ops.py
+++ b/tests/netcdf/samples/test_inherited_ops.py
@@ -140,10 +140,31 @@ def test_inherited_footprint(tos_view):
     )
 
 
-def test_recreate_overviews_requires_write(tos_view):
-    """recreate_overviews regenerates overviews and so requires a writable dataset."""
-    with pytest.raises(ReadOnlyError):
-        tos_view.recreate_overviews()
+def test_recreate_overviews_requires_write(sample, tmp_path):
+    """recreate_overviews regenerates existing overviews, so on a read-only dataset it raises.
+
+    Test scenario:
+        Build external overviews on a tmp copy, reopen it read-only, then `recreate_overviews` must
+        raise `ReadOnlyError` (regenerating needs write access). Self-contained on a tmp copy: it no
+        longer depends on another test having built overviews on the shared fixture first, and writes
+        no `.ovr` into tests/data.
+    """
+    work = shutil.copy(sample("cf__7v__1d3-2d3-3d1__y-asc.nc"), tmp_path / "tos.nc")
+
+    builder = NetCDF.read_file(str(work))
+    try:
+        builder.get_variable(
+            "tos"
+        ).create_overviews()  # external .ovr so overviews now exist
+    finally:
+        builder.close()
+
+    nc = NetCDF.read_file(str(work))  # fresh read-only reopen sees the overviews
+    try:
+        with pytest.raises(ReadOnlyError):
+            nc.get_variable("tos").recreate_overviews()
+    finally:
+        nc.close()
 
 
 def test_overview_ops_isolated_to_temp_copy(sample, tmp_path):

--- a/tests/netcdf/samples/test_inherited_ops.py
+++ b/tests/netcdf/samples/test_inherited_ops.py
@@ -6,6 +6,9 @@ property and every zero-argument inherited method against a real variable view t
 breakage (e.g. #588 resample, #592 color_table/footprint), plus a few argument-taking methods.
 """
 
+import shutil
+from pathlib import Path
+
 import numpy as np
 import pytest
 
@@ -57,13 +60,15 @@ INHERITED_PROPERTIES_NULLABLE = [
 
 # Inherited zero-argument methods that should run on a variable view without raising.
 # (plot_histogram / plot_vector_field are exercised in the plot module; footprint has its own test below.)
+# The overview ops (create_overviews / get_overview / read_overview_array) are intentionally excluded:
+# they write an external `.ovr` next to the *source file*, so running them on the shared committed
+# fixture pollutes tests/data/. They get a dedicated tmp_path test below.
 INHERITED_NOARG_METHODS = [
     "aspect",
     "block_windows",
     "to_polygons",
     "wrap_longitude",
     "count_domain_cells",
-    "create_overviews",
     "extract",
     "focal_mean",
     "focal_std",
@@ -74,7 +79,6 @@ INHERITED_NOARG_METHODS = [
     "get_cell_polygons",
     "get_histogram",
     "get_mask",
-    "get_overview",
     "get_tile",
     "hillshade",
     "iter_blocks",
@@ -82,7 +86,6 @@ INHERITED_NOARG_METHODS = [
     "preview",
     "proximity",
     "read_masks",
-    "read_overview_array",
     "slope",
     "stats",
     "to_bytes",
@@ -141,6 +144,41 @@ def test_recreate_overviews_requires_write(tos_view):
     """recreate_overviews regenerates overviews and so requires a writable dataset."""
     with pytest.raises(ReadOnlyError):
         tos_view.recreate_overviews()
+
+
+def test_overview_ops_isolated_to_temp_copy(sample, tmp_path):
+    """The overview ops run on a tmp_path copy so their external `.ovr` never touches tests/data.
+
+    Test scenario:
+        `create_overviews` on a read-only variable view writes an external `<source>.0.ovr` next to
+        the *source file*. Copy the fixture into `tmp_path` first, so the sidecar lands there (and is
+        auto-cleaned); assert the overview family runs, the sidecar is written beside the copy, and no
+        new `.ovr` appears in the committed data dir.
+    """
+    src = sample("cf__7v__1d3-2d3-3d1__y-asc.nc")
+    data_dir = Path(src).parent
+    before = set(data_dir.glob("*.ovr"))
+
+    work = shutil.copy(src, tmp_path / "tos.nc")
+    nc = NetCDF.read_file(str(work))
+    try:
+        view = nc.get_variable("tos")
+        view.create_overviews()
+        assert (tmp_path / "tos.nc.0.ovr").exists(), (
+            "external overview should land beside the tmp copy"
+        )
+        assert view.get_overview() is not None, (
+            "get_overview should return a band after building"
+        )
+        assert view.read_overview_array() is not None, (
+            "read_overview_array should return data"
+        )
+    finally:
+        nc.close()
+
+    assert set(data_dir.glob("*.ovr")) == before, (
+        "overview ops must not write a sidecar into the committed tests/data tree"
+    )
 
 
 def test_inherited_to_cog_writes_file(tos_view, tmp_path):

--- a/tests/netcdf/samples/test_inherited_ops.py
+++ b/tests/netcdf/samples/test_inherited_ops.py
@@ -153,16 +153,16 @@ def test_recreate_overviews_requires_write(sample, tmp_path):
 
     builder = NetCDF.read_file(str(work))
     try:
-        builder.get_variable(
-            "tos"
-        ).create_overviews()  # external .ovr so overviews now exist
+        # build external overviews so they exist on the read-only reopen below
+        builder.get_variable("tos").create_overviews()
     finally:
         builder.close()
 
     nc = NetCDF.read_file(str(work))  # fresh read-only reopen sees the overviews
     try:
+        view = nc.get_variable("tos")
         with pytest.raises(ReadOnlyError):
-            nc.get_variable("tos").recreate_overviews()
+            view.recreate_overviews()
     finally:
         nc.close()
 

--- a/tests/netcdf/samples/test_metadata_serialization.py
+++ b/tests/netcdf/samples/test_metadata_serialization.py
@@ -23,7 +23,9 @@ def test_from_json_without_cf_key_yields_none():
         created_with={},
     )
     restored = from_json(to_json(meta))
-    assert restored.cf is None, f"expected cf None for a cf-less payload, got {restored.cf}"
+    assert restored.cf is None, (
+        f"expected cf None for a cf-less payload, got {restored.cf}"
+    )
 
 
 def test_to_json_is_string_and_parses(sample_name, sample):

--- a/tests/netcdf/samples/test_metadata_serialization.py
+++ b/tests/netcdf/samples/test_metadata_serialization.py
@@ -5,8 +5,25 @@ import json
 import pytest
 
 from pyramids.netcdf import NetCDF, from_json, to_dict, to_json
+from pyramids.netcdf.models import NetCDFMetadata, StructuralInfo
 
 pytestmark = pytest.mark.core
+
+
+def test_from_json_without_cf_key_yields_none():
+    """A metadata payload with no CF block deserializes to ``cf is None`` (ARC-25 build_cf None branch)."""
+    meta = NetCDFMetadata(
+        driver="netCDF",
+        root_group="/",
+        groups={},
+        variables={},
+        dimensions={},
+        global_attributes={},
+        structural=StructuralInfo(driver_name="netCDF"),
+        created_with={},
+    )
+    restored = from_json(to_json(meta))
+    assert restored.cf is None, f"expected cf None for a cf-less payload, got {restored.cf}"
 
 
 def test_to_json_is_string_and_parses(sample_name, sample):

--- a/tests/netcdf/samples/test_metadata_serialization.py
+++ b/tests/netcdf/samples/test_metadata_serialization.py
@@ -39,6 +39,27 @@ def test_from_json_roundtrip_preserves_structure(sample_name, sample):
         nc.close()
 
 
+def test_from_json_roundtrip_preserves_cf(sample_name, sample):
+    """``from_json(to_json(m))`` restores the ``CFInfo`` block (classifications, grid_mappings, …) — ARC-25.
+
+    ``to_dict`` serializes ``cf`` via ``asdict`` but ``from_json`` used to omit ``cf=``, silently dropping
+    every CF classification on a JSON round-trip.
+    """
+    nc = NetCDF.read_file(sample(sample_name))
+    try:
+        meta = nc.get_all_metadata()
+        restored = from_json(to_json(meta))
+        assert (restored.cf is None) == (meta.cf is None), (
+            f"{sample_name}: cf presence changed across round-trip"
+        )
+        if meta.cf is not None:
+            assert restored.cf == meta.cf, (
+                f"{sample_name}: CFInfo dropped or altered across round-trip"
+            )
+    finally:
+        nc.close()
+
+
 def test_to_dict_is_json_serializable(sample_name, sample):
     """``to_dict`` returns a mapping that ``json.dumps`` can serialize without custom encoders."""
     nc = NetCDF.read_file(sample(sample_name))

--- a/tests/netcdf/samples/test_spatial_dim_selection.py
+++ b/tests/netcdf/samples/test_spatial_dim_selection.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from pyramids.netcdf import NetCDF
+from pyramids.netcdf._axis import axis_role_of_dimension
 from tests.netcdf.samples.conftest import AIR as CF
 
 pytestmark = pytest.mark.core
@@ -34,7 +35,7 @@ def test_time_coordinate_dimension_is_not_spatial():
         ``None`` (matching its docstring and the MDIM ``_axis_role`` sibling). Assert a mocked
         time-coordinate dimension yields ``None``.
     """
-    role = NetCDF._axis_role_of_dimension(_mock_time_dimension())
+    role = axis_role_of_dimension(_mock_time_dimension())
     assert role is None, (
         f"a time dimension must not be a spatial axis role, got {role!r}"
     )
@@ -50,7 +51,7 @@ def test_cf_auto_detection_resolves_lat_lon(sample):
     nc = NetCDF.read_file(sample(CF))
     try:
         md = nc._raster.GetRootGroup().OpenMDArray("air")
-        roles = [NetCDF._axis_role_of_dimension(d) for d in md.GetDimensions()]
+        roles = [axis_role_of_dimension(d) for d in md.GetDimensions()]
         assert "X" in roles and "Y" in roles
     finally:
         nc.close()

--- a/tests/netcdf/selection/test_labeled.py
+++ b/tests/netcdf/selection/test_labeled.py
@@ -240,6 +240,20 @@ class TestLabeledDatasetSelect:
             sub["streamflow"].values, store["streamflow"].values[:, [0, 2]]
         )
 
+    def test_select_sparse_unsorted_reads_correct_values(self, nc_store: Path):
+        """A sparse, unsorted single-dim selection reads correct values via per-run reads (ARC-49).
+
+        `feature_id=[303, 101]` maps to positions `[2, 0]` — two non-adjacent runs in reverse order —
+        exercising the contiguous-run read plus the searchsorted remap back to request order.
+        """
+        store = LabeledDataset.read_file(nc_store)
+        sub = store.select(feature_id=[303, 101])
+        np.testing.assert_array_equal(
+            sub["streamflow"].values,
+            store["streamflow"].values[:, [2, 0]],
+            err_msg="sparse/unsorted feature select returned mis-ordered values",
+        )
+
     def test_select_accepts_0d_array_as_scalar(self, nc_store: Path):
         """A 0-d numpy array label selects exactly like a Python scalar (N3).
 

--- a/tests/netcdf/selection/test_reduce.py
+++ b/tests/netcdf/selection/test_reduce.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 
@@ -475,3 +477,21 @@ class TestReduceStreamingLazyPath:
             assert np.allclose(out.reshape(expected.shape), expected), "grouped 4-D streaming reduce mismatch"
         finally:
             nc.close()
+
+
+class TestIsFileBacked:
+    """`NetCDF._is_file_backed` gates the reduce streaming path (review L1)."""
+
+    def test_parses_netcdf_subdataset_spec(self, tmp_path):
+        """A `NETCDF:"path":var` spec (path may hold a Windows drive colon) resolves to the real file."""
+
+        real = tmp_path / "f.nc"
+        real.write_bytes(b"x")
+        var = SimpleNamespace(_parent_nc=SimpleNamespace(_file_name=f'NETCDF:"{real}":temperature'))
+        assert NetCDF._is_file_backed(var) is True, "quoted NETCDF: spec should resolve to the file"
+
+    def test_false_for_in_memory_container(self):
+        """An in-memory container's bare `netcdf` description is not file-backed."""
+
+        var = SimpleNamespace(_parent_nc=SimpleNamespace(_file_name="netcdf"))
+        assert NetCDF._is_file_backed(var) is False, "an in-memory container is not file-backed"

--- a/tests/netcdf/selection/test_reduce.py
+++ b/tests/netcdf/selection/test_reduce.py
@@ -75,6 +75,25 @@ class TestReduceCollapse:
         assert var._band_dim_names == (), f"time should be gone: {var._band_dim_names}"
         assert var.read_array().shape == (3, 5), "result should be 2-D"
 
+    @pytest.mark.parametrize("how, np_func", [("mean", np.mean), ("sum", np.sum), ("max", np.max)])
+    def test_file_backed_collapse_streams_and_matches_numpy(self, how, np_func, tmp_path):
+        """A file-backed reduce streams over a chunked dask read and still matches NumPy (ARC-47).
+
+        Test scenario:
+            An in-memory cube written to a real NetCDF is read back file-backed, so `reduce()` takes
+            the dask-streaming path (`_materialize_variable_array(lazy=True)`) rather than an eager
+            whole-cube read; the collapsed result must equal `np_func(arr, axis=0)`.
+        """
+        arr = np.arange(6 * 3 * 5, dtype="float32").reshape(6, 3, 5)
+        path = str(tmp_path / "cube.nc")
+        _make_time_nc(arr, [0, 1, 2, 3, 4, 5]).to_file(path)
+        nc = NetCDF.read_file(path)
+        try:
+            out = nc.reduce("time", how).get_variable("v").read_array()
+            assert np.allclose(out, np_func(arr, axis=0)), f"{how} file-backed collapse mismatch"
+        finally:
+            nc.close()
+
 
 class TestReduceWindowed:
     """Tests for windowed reduction via explicit labels."""

--- a/tests/netcdf/selection/test_reduce.py
+++ b/tests/netcdf/selection/test_reduce.py
@@ -7,6 +7,7 @@ import pytest
 
 from pyramids.dataset import Dataset
 from pyramids.netcdf import NetCDF
+from tests._marks import requires_dask
 
 pytestmark = pytest.mark.core
 
@@ -423,3 +424,54 @@ class TestReduceMultiBandDim:
             "d2",
         ), f"unexpected band dims: {var._band_dim_names}"
         assert "d0" not in var._band_dim_names, "reduced dim should be gone"
+
+
+@requires_dask
+class TestReduceStreamingLazyPath:
+    """A file-backed reduce takes the dask streaming path and matches numpy across corners (review M3)."""
+
+    @staticmethod
+    def _write_4d(tmp_path):
+        """Write a 4-D `(time, level, y, x)` cube to disk; return `(path, array)`."""
+        arr = np.arange(4 * 2 * 3 * 5, dtype="float64").reshape(4, 2, 3, 5)
+        NetCDF.create_from_array(
+            arr,
+            geo=_GEO,
+            epsg=4326,
+            variable_name="v",
+            extra_dims=[("time", [0, 1, 2, 3]), ("level", [1000, 500])],
+        ).to_file(str(tmp_path / "cube4d.nc"))
+        return str(tmp_path / "cube4d.nc"), arr
+
+    def test_materialize_lazy_returns_dask_for_file_backed(self, tmp_path):
+        """`_materialize_variable_array(lazy=True)` returns a dask array for a file-backed variable."""
+        path, _ = self._write_4d(tmp_path)
+        nc = NetCDF.read_file(path)
+        try:
+            arr = NetCDF._materialize_variable_array(nc.get_variable("v"), lazy=True)
+            assert hasattr(arr, "dask"), f"expected a dask array on the streaming path, got {type(arr)}"
+        finally:
+            nc.close()
+
+    @pytest.mark.parametrize("how, np_func", [("mean", np.mean), ("std", np.std), ("var", np.var)])
+    def test_multi_band_dim_collapse_matches_numpy(self, how, np_func, tmp_path):
+        """A file-backed `(time, level, y, x)` reduce over time streams and matches numpy (incl std/var)."""
+        path, arr = self._write_4d(tmp_path)
+        nc = NetCDF.read_file(path)
+        try:
+            out = np.asarray(nc.reduce("time", how).get_variable("v").read_array())
+            expected = np_func(arr, axis=0)
+            assert np.allclose(out.reshape(expected.shape), expected), f"{how} 4-D streaming collapse mismatch"
+        finally:
+            nc.close()
+
+    def test_windowed_groupby_matches_numpy(self, tmp_path):
+        """A file-backed grouped reduce streams the np.take/np.stack path and matches numpy."""
+        path, arr = self._write_4d(tmp_path)
+        nc = NetCDF.read_file(path)
+        try:
+            out = np.asarray(nc.reduce("time", "mean", groupby=[0, 0, 1, 1]).get_variable("v").read_array())
+            expected = np.stack([arr[[0, 1]].mean(axis=0), arr[[2, 3]].mean(axis=0)], axis=0)
+            assert np.allclose(out.reshape(expected.shape), expected), "grouped 4-D streaming reduce mismatch"
+        finally:
+            nc.close()

--- a/tests/netcdf/selection/test_reduce.py
+++ b/tests/netcdf/selection/test_reduce.py
@@ -495,3 +495,22 @@ class TestIsFileBacked:
 
         var = SimpleNamespace(_parent_nc=SimpleNamespace(_file_name="netcdf"))
         assert NetCDF._is_file_backed(var) is False, "an in-memory container is not file-backed"
+
+    def test_unquoted_netcdf_spec_resolves_path(self, tmp_path):
+        """An unquoted `NETCDF:<path>:var` spec drops the trailing :var via rsplit (drive-safe)."""
+        real = tmp_path / "u.nc"
+        real.write_bytes(b"x")
+        var = SimpleNamespace(_parent_nc=SimpleNamespace(_file_name=f"NETCDF:{real}:temperature"))
+        assert NetCDF._is_file_backed(var) is True, "unquoted spec should resolve to the file"
+
+    def test_empty_file_name_is_not_file_backed(self):
+        """A parent with no `_file_name` is not file-backed."""
+        var = SimpleNamespace(_parent_nc=SimpleNamespace(_file_name=""))
+        assert NetCDF._is_file_backed(var) is False, "an empty file name is not file-backed"
+
+    def test_uses_variable_itself_when_parent_is_none(self, tmp_path):
+        """With no `_parent_nc`, the variable's own `_file_name` is consulted."""
+        real = tmp_path / "self.nc"
+        real.write_bytes(b"x")
+        var = SimpleNamespace(_parent_nc=None, _file_name=str(real))
+        assert NetCDF._is_file_backed(var) is True, "a top-level variable's own file must count"

--- a/tests/netcdf/selection/test_reduce.py
+++ b/tests/netcdf/selection/test_reduce.py
@@ -78,8 +78,12 @@ class TestReduceCollapse:
         assert var._band_dim_names == (), f"time should be gone: {var._band_dim_names}"
         assert var.read_array().shape == (3, 5), "result should be 2-D"
 
-    @pytest.mark.parametrize("how, np_func", [("mean", np.mean), ("sum", np.sum), ("max", np.max)])
-    def test_file_backed_collapse_streams_and_matches_numpy(self, how, np_func, tmp_path):
+    @pytest.mark.parametrize(
+        "how, np_func", [("mean", np.mean), ("sum", np.sum), ("max", np.max)]
+    )
+    def test_file_backed_collapse_streams_and_matches_numpy(
+        self, how, np_func, tmp_path
+    ):
         """A file-backed reduce streams over a chunked dask read and still matches NumPy (ARC-47).
 
         Test scenario:
@@ -93,7 +97,9 @@ class TestReduceCollapse:
         nc = NetCDF.read_file(path)
         try:
             out = nc.reduce("time", how).get_variable("v").read_array()
-            assert np.allclose(out, np_func(arr, axis=0)), f"{how} file-backed collapse mismatch"
+            assert np.allclose(out, np_func(arr, axis=0)), (
+                f"{how} file-backed collapse mismatch"
+            )
         finally:
             nc.close()
 
@@ -451,11 +457,15 @@ class TestReduceStreamingLazyPath:
         nc = NetCDF.read_file(path)
         try:
             arr = NetCDF._materialize_variable_array(nc.get_variable("v"), lazy=True)
-            assert hasattr(arr, "dask"), f"expected a dask array on the streaming path, got {type(arr)}"
+            assert hasattr(arr, "dask"), (
+                f"expected a dask array on the streaming path, got {type(arr)}"
+            )
         finally:
             nc.close()
 
-    @pytest.mark.parametrize("how, np_func", [("mean", np.mean), ("std", np.std), ("var", np.var)])
+    @pytest.mark.parametrize(
+        "how, np_func", [("mean", np.mean), ("std", np.std), ("var", np.var)]
+    )
     def test_multi_band_dim_collapse_matches_numpy(self, how, np_func, tmp_path):
         """A file-backed `(time, level, y, x)` reduce over time streams and matches numpy (incl std/var)."""
         path, arr = self._write_4d(tmp_path)
@@ -463,7 +473,9 @@ class TestReduceStreamingLazyPath:
         try:
             out = np.asarray(nc.reduce("time", how).get_variable("v").read_array())
             expected = np_func(arr, axis=0)
-            assert np.allclose(out.reshape(expected.shape), expected), f"{how} 4-D streaming collapse mismatch"
+            assert np.allclose(out.reshape(expected.shape), expected), (
+                f"{how} 4-D streaming collapse mismatch"
+            )
         finally:
             nc.close()
 
@@ -472,9 +484,17 @@ class TestReduceStreamingLazyPath:
         path, arr = self._write_4d(tmp_path)
         nc = NetCDF.read_file(path)
         try:
-            out = np.asarray(nc.reduce("time", "mean", groupby=[0, 0, 1, 1]).get_variable("v").read_array())
-            expected = np.stack([arr[[0, 1]].mean(axis=0), arr[[2, 3]].mean(axis=0)], axis=0)
-            assert np.allclose(out.reshape(expected.shape), expected), "grouped 4-D streaming reduce mismatch"
+            out = np.asarray(
+                nc.reduce("time", "mean", groupby=[0, 0, 1, 1])
+                .get_variable("v")
+                .read_array()
+            )
+            expected = np.stack(
+                [arr[[0, 1]].mean(axis=0), arr[[2, 3]].mean(axis=0)], axis=0
+            )
+            assert np.allclose(out.reshape(expected.shape), expected), (
+                "grouped 4-D streaming reduce mismatch"
+            )
         finally:
             nc.close()
 
@@ -487,30 +507,44 @@ class TestIsFileBacked:
 
         real = tmp_path / "f.nc"
         real.write_bytes(b"x")
-        var = SimpleNamespace(_parent_nc=SimpleNamespace(_file_name=f'NETCDF:"{real}":temperature'))
-        assert NetCDF._is_file_backed(var) is True, "quoted NETCDF: spec should resolve to the file"
+        var = SimpleNamespace(
+            _parent_nc=SimpleNamespace(_file_name=f'NETCDF:"{real}":temperature')
+        )
+        assert NetCDF._is_file_backed(var) is True, (
+            "quoted NETCDF: spec should resolve to the file"
+        )
 
     def test_false_for_in_memory_container(self):
         """An in-memory container's bare `netcdf` description is not file-backed."""
 
         var = SimpleNamespace(_parent_nc=SimpleNamespace(_file_name="netcdf"))
-        assert NetCDF._is_file_backed(var) is False, "an in-memory container is not file-backed"
+        assert NetCDF._is_file_backed(var) is False, (
+            "an in-memory container is not file-backed"
+        )
 
     def test_unquoted_netcdf_spec_resolves_path(self, tmp_path):
         """An unquoted `NETCDF:<path>:var` spec drops the trailing :var via rsplit (drive-safe)."""
         real = tmp_path / "u.nc"
         real.write_bytes(b"x")
-        var = SimpleNamespace(_parent_nc=SimpleNamespace(_file_name=f"NETCDF:{real}:temperature"))
-        assert NetCDF._is_file_backed(var) is True, "unquoted spec should resolve to the file"
+        var = SimpleNamespace(
+            _parent_nc=SimpleNamespace(_file_name=f"NETCDF:{real}:temperature")
+        )
+        assert NetCDF._is_file_backed(var) is True, (
+            "unquoted spec should resolve to the file"
+        )
 
     def test_empty_file_name_is_not_file_backed(self):
         """A parent with no `_file_name` is not file-backed."""
         var = SimpleNamespace(_parent_nc=SimpleNamespace(_file_name=""))
-        assert NetCDF._is_file_backed(var) is False, "an empty file name is not file-backed"
+        assert NetCDF._is_file_backed(var) is False, (
+            "an empty file name is not file-backed"
+        )
 
     def test_uses_variable_itself_when_parent_is_none(self, tmp_path):
         """With no `_parent_nc`, the variable's own `_file_name` is consulted."""
         real = tmp_path / "self.nc"
         real.write_bytes(b"x")
         var = SimpleNamespace(_parent_nc=None, _file_name=str(real))
-        assert NetCDF._is_file_backed(var) is True, "a top-level variable's own file must count"
+        assert NetCDF._is_file_backed(var) is True, (
+            "a top-level variable's own file must count"
+        )

--- a/tests/netcdf/selection/test_sel.py
+++ b/tests/netcdf/selection/test_sel.py
@@ -81,6 +81,31 @@ class TestSelSingleValue:
         )
 
 
+class TestSelNoData:
+    """sel() collapses the per-band no-data tuple to a scalar (ARC-29)."""
+
+    def test_no_data_value_is_a_tuple(self):
+        """The multi-band variable's no_data_value is a tuple — the value the buggy list test missed."""
+        var = _make_nc().get_variable("temp")
+        assert isinstance(var.no_data_value, tuple), (
+            f"no_data_value must be a tuple, got {type(var.no_data_value).__name__}"
+        )
+
+    def test_sel_result_stores_scalar_nodata(self):
+        """sel() must funnel the per-band tuple through scalar_no_data, storing the scalar sentinel.
+
+        Test scenario:
+            Before ARC-29 the `isinstance(ndv, list)` test never fired for the tuple, so the whole
+            per-band tuple leaked into create_from_array; the selected 1-band result must carry the
+            scalar -9999.0.
+        """
+        var = _make_nc().get_variable("temp")
+        result = var.sel(time=6)
+        assert result.no_data_value == (-9999.0,), (
+            f"sel must collapse the per-band tuple to the scalar sentinel; got {result.no_data_value}"
+        )
+
+
 class TestSelList:
     """sel(dim=[v1, v2, ...]) selects multiple bands by value."""
 

--- a/tests/netcdf/test_container_variable_types.py
+++ b/tests/netcdf/test_container_variable_types.py
@@ -284,8 +284,9 @@ class TestContainerGuard:
             Each raster-only method (band_count == 0 store) must reject the container with the
             "use get_variable(...)" message instead of an opaque GDAL error.
         """
+        bound_method = getattr(container, method)
         with pytest.raises(ValueError, match="get_variable"):
-            getattr(container, method)()
+            bound_method()
 
     def test_variable_allows_read_array(self, variable):
         """A Variable's container guard is a no-op, so read_array works.

--- a/tests/netcdf/test_container_variable_types.py
+++ b/tests/netcdf/test_container_variable_types.py
@@ -261,6 +261,32 @@ class TestContainerGuard:
         with pytest.raises(ValueError, match="get_variable"):
             container.read_array()
 
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "stats",
+            "slope",
+            "hillshade",
+            "to_cog",
+            "to_feature_collection",
+            "zonal_stats",
+            "sample",
+            "write_array",
+        ],
+    )
+    def test_mdim_container_rejects_raster_only_methods(self, container, method):
+        """The inherited single-raster facade raises the guiding ValueError on a container (ARC-35).
+
+        Args:
+            method: A raster-only method inherited from Dataset.
+
+        Test scenario:
+            Each raster-only method (band_count == 0 store) must reject the container with the
+            "use get_variable(...)" message instead of an opaque GDAL error.
+        """
+        with pytest.raises(ValueError, match="get_variable"):
+            getattr(container, method)()
+
     def test_variable_allows_read_array(self, variable):
         """A Variable's container guard is a no-op, so read_array works.
 

--- a/tests/ugrid/test_mesh2d.py
+++ b/tests/ugrid/test_mesh2d.py
@@ -313,6 +313,57 @@ class TestMesh2dBuildConnectivity:
         assert ffc is not None, "Face-face connectivity should be built"
         assert ffc.n_elements == 3, f"Expected 3 faces, got {ffc.n_elements}"
 
+    def test_build_edge_connectivity_vectorized_edges(self, triangle_mesh):
+        """The vectorized (uniform-mesh) path yields the expected first-seen edge set (ARC-59).
+
+        Test scenario:
+            The 2-triangle mesh `[[0,1,2],[1,4,3]]` has all faces of equal node count, so the
+            `np.unique` fast path runs and must produce exactly the six undirected face edges.
+        """
+        triangle_mesh.build_edge_connectivity()
+        enc = triangle_mesh.edge_node_connectivity
+        edges = {tuple(sorted((int(a), int(b)))) for a, b in enc.data}
+        assert edges == {(0, 1), (1, 2), (0, 2), (1, 4), (3, 4), (1, 3)}, (
+            f"unexpected vectorized edge set: {sorted(edges)}"
+        )
+        assert enc.n_elements == 6, f"expected 6 unique edges, got {enc.n_elements}"
+
+    def test_build_edge_connectivity_mixed_fallback(self, mixed_mesh):
+        """A ragged (filled) mesh falls back to the per-face loop and still builds 2-node edges.
+
+        Test scenario:
+            The mixed quad+triangle mesh has fill columns, so `_uniform_face_edges` returns `None`
+            and the loop path runs; the result must still be valid 2-node edge connectivity.
+        """
+        mixed_mesh.build_edge_connectivity()
+        enc = mixed_mesh.edge_node_connectivity
+        assert enc.max_nodes_per_element == 2, "edges must have 2 nodes"
+        assert enc.n_elements > 0, "mixed mesh should still produce edges"
+
+    def test_edge_to_faces_groups_shared_edge_ascending(self):
+        """A shared edge maps to both incident faces in ascending order (ARC-59).
+
+        Test scenario:
+            Two triangles `[[0,1,2],[1,3,2]]` share edge `(1,2)`; the vectorized grouping must map
+            that edge to `[0, 1]` (ascending face indices), matching the per-face loop.
+        """
+        faces = np.array([[0, 1, 2], [1, 3, 2]], dtype=np.intp)
+        mesh = Mesh2d(
+            node_x=np.array([0.0, 1.0, 0.0, 1.0]),
+            node_y=np.array([0.0, 0.0, 1.0, 1.0]),
+            face_node_connectivity=Connectivity(
+                data=faces,
+                fill_value=-1,
+                cf_role="face_node_connectivity",
+                original_start_index=0,
+            ),
+        )
+        edge_to_faces = mesh._build_edge_to_faces()
+        assert edge_to_faces[(1, 2)] == [0, 1], (
+            f"shared edge should list both faces ascending, got {edge_to_faces[(1, 2)]}"
+        )
+        assert edge_to_faces[(0, 1)] == [0], "a boundary edge belongs to one face"
+
 
 class TestMesh2dTriangulation:
     """Tests for Mesh2d.fan_triangles property."""

--- a/tests/ugrid/test_mesh2d.py
+++ b/tests/ugrid/test_mesh2d.py
@@ -336,6 +336,33 @@ class TestMesh2dTriangulation:
         tri = mixed_mesh.fan_triangles
         assert tri.shape[0] == 4, f"Expected 4 triangles, got {tri.shape[0]}"
 
+    def test_triangulation_uniform_quads_vectorized(self):
+        """All-quad (uniform node count) fans to 2 face-major triangles per quad (ARC-59).
+
+        Test scenario:
+            Two quads with no fill columns take the vectorized fan path; the result must be
+            `[0,1,2],[0,2,3]` for the first quad then `[1,4,5],[1,5,2]` for the second (face-major).
+        """
+        node_x = np.array([0.0, 1.0, 1.0, 0.0, 2.0, 2.0])
+        node_y = np.array([0.0, 0.0, 1.0, 1.0, 0.0, 1.0])
+        faces = np.array([[0, 1, 2, 3], [1, 4, 5, 2]], dtype=np.intp)
+        mesh = Mesh2d(
+            node_x=node_x,
+            node_y=node_y,
+            face_node_connectivity=Connectivity(
+                data=faces,
+                fill_value=-1,
+                cf_role="face_node_connectivity",
+                original_start_index=0,
+            ),
+        )
+        expected = np.array(
+            [[0, 1, 2], [0, 2, 3], [1, 4, 5], [1, 5, 2]], dtype=np.intp
+        )
+        np.testing.assert_array_equal(
+            mesh.fan_triangles, expected, err_msg="vectorized quad fan mis-ordered"
+        )
+
     def test_triangulation_cached(self, triangle_mesh):
         """Test triangulation is cached after first computation.
 

--- a/tests/ugrid/test_mesh2d.py
+++ b/tests/ugrid/test_mesh2d.py
@@ -356,9 +356,7 @@ class TestMesh2dTriangulation:
                 original_start_index=0,
             ),
         )
-        expected = np.array(
-            [[0, 1, 2], [0, 2, 3], [1, 4, 5], [1, 5, 2]], dtype=np.intp
-        )
+        expected = np.array([[0, 1, 2], [0, 2, 3], [1, 4, 5], [1, 5, 2]], dtype=np.intp)
         np.testing.assert_array_equal(
             mesh.fan_triangles, expected, err_msg="vectorized quad fan mis-ordered"
         )

--- a/tests/ugrid/test_models.py
+++ b/tests/ugrid/test_models.py
@@ -391,6 +391,30 @@ class TestMeshVariable:
         assert var.has_time is True, "a 2-D variable with unknown dims falls back to temporal"
         assert var.time_index == 0, f"fallback time_index should be 0, got {var.time_index}"
 
+    @pytest.mark.parametrize(
+        "name, is_time",
+        [
+            ("runtime", False),
+            ("lifetime", False),
+            ("daytime", False),
+            ("t", True),
+            ("time", True),
+            ("time1", True),
+            ("nmesh2d_data_time", True),
+        ],
+    )
+    def test_time_dim_name_word_boundary_matching(self, name, is_time):
+        """`t`/`time`/`…_time` are temporal; substring-only names like `runtime` are not (review L3)."""
+        var = MeshVariable(
+            name="v",
+            location="face",
+            mesh_name="m",
+            shape=(2, 3),
+            dimensions=(name, "nmesh2d_face"),
+            _data=np.zeros((2, 3)),
+        )
+        assert var.has_time is is_time, f"{name!r}: expected has_time={is_time}, got {var.has_time}"
+
     def test_n_time_steps_no_time(self, face_var_1d):
         """Test n_time_steps returns 0 for non-temporal variable.
 

--- a/tests/ugrid/test_models.py
+++ b/tests/ugrid/test_models.py
@@ -355,6 +355,42 @@ class TestMeshVariable:
         """
         assert temporal_var.has_time is True, "Expected has_time=True for 2D variable"
 
+    def test_has_time_false_for_nontemporal_2d_dims(self):
+        """A `(n_layers, n_face)` variable with real dim names is NOT flagged temporal (ARC-19)."""
+        var = MeshVariable(
+            name="salinity",
+            location="face",
+            mesh_name="mesh2d",
+            shape=(4, 5),
+            dimensions=("nmesh2d_layer", "nmesh2d_face"),
+            _data=np.zeros((4, 5)),
+        )
+        assert var.has_time is False, "a layered non-temporal variable must not be temporal"
+        assert var.time_index is None, f"time_index should be None, got {var.time_index}"
+        assert var.n_time_steps == 0, f"n_time_steps should be 0, got {var.n_time_steps}"
+
+    def test_has_time_true_for_named_time_dim(self):
+        """A leading `time` dimension is detected as the time axis (ARC-19)."""
+        var = MeshVariable(
+            name="water_level",
+            location="face",
+            mesh_name="mesh2d",
+            shape=(3, 5),
+            dimensions=("time", "nmesh2d_face"),
+            _data=np.zeros((3, 5)),
+        )
+        assert var.has_time is True, "a variable with a 'time' dimension must be temporal"
+        assert var.time_index == 0, f"time_index should be 0, got {var.time_index}"
+        assert var.n_time_steps == 3, f"n_time_steps should be 3, got {var.n_time_steps}"
+
+    def test_has_time_falls_back_to_ndim_without_dim_names(self):
+        """With no dimension names, has_time keeps the historical >1-D heuristic (ARC-19 fallback)."""
+        var = MeshVariable(
+            name="v", location="face", mesh_name="m", shape=(3, 5), _data=np.zeros((3, 5))
+        )
+        assert var.has_time is True, "a 2-D variable with unknown dims falls back to temporal"
+        assert var.time_index == 0, f"fallback time_index should be 0, got {var.time_index}"
+
     def test_n_time_steps_no_time(self, face_var_1d):
         """Test n_time_steps returns 0 for non-temporal variable.
 

--- a/tests/ugrid/test_models.py
+++ b/tests/ugrid/test_models.py
@@ -365,9 +365,15 @@ class TestMeshVariable:
             dimensions=("nmesh2d_layer", "nmesh2d_face"),
             _data=np.zeros((4, 5)),
         )
-        assert var.has_time is False, "a layered non-temporal variable must not be temporal"
-        assert var.time_index is None, f"time_index should be None, got {var.time_index}"
-        assert var.n_time_steps == 0, f"n_time_steps should be 0, got {var.n_time_steps}"
+        assert var.has_time is False, (
+            "a layered non-temporal variable must not be temporal"
+        )
+        assert var.time_index is None, (
+            f"time_index should be None, got {var.time_index}"
+        )
+        assert var.n_time_steps == 0, (
+            f"n_time_steps should be 0, got {var.n_time_steps}"
+        )
 
     def test_has_time_true_for_named_time_dim(self):
         """A leading `time` dimension is detected as the time axis (ARC-19)."""
@@ -379,17 +385,29 @@ class TestMeshVariable:
             dimensions=("time", "nmesh2d_face"),
             _data=np.zeros((3, 5)),
         )
-        assert var.has_time is True, "a variable with a 'time' dimension must be temporal"
+        assert var.has_time is True, (
+            "a variable with a 'time' dimension must be temporal"
+        )
         assert var.time_index == 0, f"time_index should be 0, got {var.time_index}"
-        assert var.n_time_steps == 3, f"n_time_steps should be 3, got {var.n_time_steps}"
+        assert var.n_time_steps == 3, (
+            f"n_time_steps should be 3, got {var.n_time_steps}"
+        )
 
     def test_has_time_falls_back_to_ndim_without_dim_names(self):
         """With no dimension names, has_time keeps the historical >1-D heuristic (ARC-19 fallback)."""
         var = MeshVariable(
-            name="v", location="face", mesh_name="m", shape=(3, 5), _data=np.zeros((3, 5))
+            name="v",
+            location="face",
+            mesh_name="m",
+            shape=(3, 5),
+            _data=np.zeros((3, 5)),
         )
-        assert var.has_time is True, "a 2-D variable with unknown dims falls back to temporal"
-        assert var.time_index == 0, f"fallback time_index should be 0, got {var.time_index}"
+        assert var.has_time is True, (
+            "a 2-D variable with unknown dims falls back to temporal"
+        )
+        assert var.time_index == 0, (
+            f"fallback time_index should be 0, got {var.time_index}"
+        )
 
     @pytest.mark.parametrize(
         "name, is_time",
@@ -413,7 +431,9 @@ class TestMeshVariable:
             dimensions=(name, "nmesh2d_face"),
             _data=np.zeros((2, 3)),
         )
-        assert var.has_time is is_time, f"{name!r}: expected has_time={is_time}, got {var.has_time}"
+        assert var.has_time is is_time, (
+            f"{name!r}: expected has_time={is_time}, got {var.has_time}"
+        )
 
     def test_n_time_steps_no_time(self, face_var_1d):
         """Test n_time_steps returns 0 for non-temporal variable.

--- a/tests/ugrid/test_spatial_return_contract.py
+++ b/tests/ugrid/test_spatial_return_contract.py
@@ -220,3 +220,52 @@ class TestNoImportCycle:
         assert not offenders, (
             f"spatial must not import ugrid.dataset; found: {offenders}"
         )
+
+
+class TestEdgeLinestringsNoneFill:
+    """`_edge_linestrings` handles a directly-built `Connectivity(fill_value=None)` (review N3)."""
+
+    def test_none_fill_takes_vectorized_path_without_warning(self, recwarn):
+        """A `None` fill on a clean 2-node edge connectivity builds LineStrings, warning-free.
+
+        Test scenario:
+            Build a mesh whose ``edge_node_connectivity`` has ``fill_value=None`` (no sentinels)
+            and request the edge geometries; the vectorized branch must run without a NumPy
+            ``!= None`` elementwise-compare warning and yield one 2-point LineString per edge.
+        """
+        from shapely.geometry import LineString
+
+        from pyramids.netcdf.ugrid.connectivity import Connectivity
+        from pyramids.netcdf.ugrid.dataset import UgridDataset
+        from pyramids.netcdf.ugrid.mesh import Mesh2d
+
+        mesh = Mesh2d(
+            node_x=np.array([0.0, 1.0, 0.0, 1.0]),
+            node_y=np.array([0.0, 0.0, 1.0, 1.0]),
+            face_node_connectivity=Connectivity(
+                data=np.array([[0, 1, 2], [1, 3, 2]], dtype=np.intp),
+                fill_value=-1,
+                cf_role="face_node_connectivity",
+                original_start_index=0,
+            ),
+            edge_node_connectivity=Connectivity(
+                data=np.array([[0, 1], [1, 3], [3, 2], [2, 0]], dtype=np.intp),
+                fill_value=None,
+                cf_role="edge_node_connectivity",
+                original_start_index=0,
+            ),
+        )
+        dataset = UgridDataset(mesh=mesh, data_variables={}, global_attributes={})
+
+        gdf = dataset.to_geodataframe(location="edge")
+
+        assert len(gdf) == 4, f"expected 4 edge geometries, got {len(gdf)}"
+        assert all(isinstance(g, LineString) for g in gdf.geometry), (
+            "every edge geometry should be a LineString"
+        )
+        assert list(gdf.geometry.iloc[0].coords) == [(0.0, 0.0), (1.0, 0.0)], (
+            f"first edge should join nodes 0->1, got {list(gdf.geometry.iloc[0].coords)}"
+        )
+        assert not [w for w in recwarn.list if "None" in str(w.message)], (
+            "the None-fill guard must avoid a `!= None` elementwise-compare warning"
+        )


### PR DESCRIPTION
# Description

Implements the verified findings from the `netcdf/` architecture review (the `ARC-*` items). Each finding
was re-confirmed against the code before implementing; fixes landed in batches of three, each with regression
tests, `/test` coverage of the changed branches, and `/docstring` accuracy passes. All 15 findings are addressed.

**Bugs (Phase A):**

- **ARC-25** — `metadata.from_json` reconstructs `CFInfo`, so `to_json`→`from_json` no longer drops the CF block.
- **ARC-29** — per-band no-data collapse routes through `scalar_no_data` (handles the tuple `no_data_value`,
  not the dead `isinstance(list)` branch).
- **ARC-32** — container geotransform west edge uses `min(lon)` (descending-lon fix).
- **ARC-17** — `from_xarray` encodes datetime64/timedelta64 coords to CF-numeric seconds (no more crash on a
  default `decode_cf=True` Dataset).
- **ARC-19** — `MeshVariable` time axis detected by dimension name, not `ndim>1`.
- **ARC-30** — CF `var.unit` fallback for time detection, multi-dim `cell_methods` regex, calendar-safe
  `encode_cf_time` (360_day/noleap dates).

**Performance:**

- **ARC-47** — `reduce` streams over a chunked dask read for file-backed cubes (in-memory / dask-less falls back
  to eager). The crop/to_crs/resample fan-outs read the already-processed per-variable result, so streaming them
  needs lazy spatial ops — a larger change scoped out.
- **ARC-49** — LabeledDataset: memoized coord cache (shared across views), O(n+m) label→position map, per-run
  sparse reads.
- **ARC-59** — ugrid node/edge geometry vectorized (`shapely.points`/`linestrings`), and `fan_triangles`,
  `build_edge_connectivity` and `_build_edge_to_faces` all vectorized for uniform meshes (`np.roll` +
  `np.unique`, first-seen order preserved) with a per-face loop fallback for ragged/filled meshes.
- **ARC-48** — `open_mfdataset` defaults to a lazy per-file read (files not all materialised); the parallel path
  reads dask arrays directly instead of nesting them in `dask.delayed`. The from/to_xarray materialisation is
  left as-is (it operates on already-in-RAM data).
- **ARC-76** — deterministic tokenized lazy graph names (CSE-friendly); the kerchunk fill-value shim is now
  lock-guarded.

**Design / Refactor:**

- **ARC-69** — single-source `unflatten_band_axes` and `scalar_no_data` helpers replace three/four inline copies,
  and the CF standard-calendar check is now single-sourced through `_is_standard_calendar` (so a capitalised
  `Gregorian`/`STANDARD` decodes to `datetime64`, not cftime). The remaining CF *classification* unification
  (`cf.py` vs `labeled.py`) stays deferred as a larger design change.
- **ARC-77** — inline scipy imports hoisted to module top (scipy is a core dep). The `add_colorbar` kwarg belongs
  in cleopatra — upstream issue filed (serapeum-org/cleopatra#219) — so the `cbar.remove()` escape hatch stays
  until it lands.
- **ARC-35** — the inherited single-raster facade (stats/slope/hillshade/write_array/to_cog/to_feature_collection/
  zonal_stats/sample) is guarded through `_check_not_container` on a container. This is the cheap interim; the
  structural fix (Container *composes* a template Dataset) is a follow-up.
- **ARC-37** — first self-contained slice of the `AxisResolver` engine extracted to a new `pyramids.netcdf._axis`
  module. The full god-class split (geostationary / MDIM read / writer engines + reduce/subset relocation) is a
  large dedicated follow-up — rushing a 5.6k-line split here would risk the rest of this branch.

# Post-implementation review

After the `ARC-*` work landed, the branch went through two full independent review rounds (`/review-rounds`) —
each a fresh adversarial pass in an isolated context that writes its own review file — followed by a SonarCloud
sweep. Every finding was fixed, justified as a false positive in writing, or (for the two accepted limitations)
documented; nothing was left open.

**Round 1 — 11 findings (3 Medium, 4 Low, 4 Nit), all resolved.** Hardened the `_is_file_backed` streaming gate
(M1), switched NaT handling to NaN in temporal encoding (M2), added streaming-reduce regression tests (M3),
tightened time-dim detection to word boundaries so `runtime`/`lifetime`/`daytime` are no longer false positives
(L3), and clamped the microsecond field in the datetime parser (N1).

**Round 2 — 7 findings (1 Medium, 3 Low, 3 Nit), all resolved.** Round 2 caught a real regression introduced by
the Round-1 M2 fix:

- **M1** — `_encode_temporal_array` crashed with `TypeError` on a 0-d/scalar `datetime64`/`timedelta64` (in-place
  NaT assignment on a NumPy scalar); reachable via `from_xarray` with a scalar datetime var. Fixed with a
  shape-preserving `np.where(np.isnat(...), np.nan, ...)` in both branches.
- **L1 + N1** — `_is_file_backed` now parses a `NETCDF:"C:\…":var` subdataset spec correctly (the naive
  `split(":")` collapsed a Windows drive-letter path to `''`, silently disabling streaming) and uses
  `os.path.isfile`.
- **L2** — dropped the now-unreachable eager-parallel branch in `open_mfdataset` (the lazy default makes every
  per-file read a dask array, so the `dask.delayed` fan-out was dead code).
- **N3** — `_edge_linestrings` short-circuits a `None` `fill_value` instead of an elementwise `!= None` compare.
- **L3 / N2** — accepted as documented limitations: name-based time detection can't add `nt`/`ntime` without
  re-admitting the `daytime`/`runtime` false positives the word-boundary logic exists to exclude; the
  function-local `tokenize` import mirrors the adjacent deferred `import dask.array as da` behind the
  `[lazy]`-extra guard.

**SonarCloud sweep — 0 unresolved issues on the PR.** Simplified the `parse_cell_methods` regex below the
complexity threshold (S5843), isolated the throwing call inside the `pytest.raises` block (S5778), and — since
dropping the dead branch left `parallel` unused (S1172) — **deprecated** the (released, public)
`open_mfdataset(parallel=...)` flag with a `DeprecationWarning` rather than removing it.

**Post-review follow-ups.** The last per-face loops flagged by ARC-59 were then vectorized
(`build_edge_connectivity` / `_build_edge_to_faces`, with a ragged-mesh fallback); the ARC-69 CF standard-calendar
check was single-sourced through `_is_standard_calendar`, fixing a capitalised-calendar decode drift; an overview
test-hygiene bug was fixed so `create_overviews` / `get_overview` / `read_overview_array` run on a `tmp_path` copy
rather than writing an external `.ovr` into the committed `tests/data/` tree; the branch was run through
`pre-commit run --all-files` (ruff, mypy, bandit, gitleaks, shellcheck — all hooks pass); and the ARC-77 upstream
request was filed as serapeum-org/cleopatra#219.

# Issues

Each architecture-review finding is now tracked as a GitHub issue; this PR closes all 15:

- Closes #817 — ARC-17: from_xarray crashes on any datetime64 CF coordinate
- Closes #818 — ARC-19: MeshVariable.has_time conflates a real time axis with ndim>1
- Closes #819 — ARC-25: metadata from_json drops CFInfo on round-trip
- Closes #820 — ARC-29: scalar-nodata dead branches mishandle per-band no-data
- Closes #821 — ARC-30: CF cell_methods regex, calendar encode, and time-unit detection
- Closes #822 — ARC-32: container geotransform X-origin asymmetric for descending longitude
- Closes #823 — ARC-35: Container inherits the full single-raster API (impedance mismatch)
- Closes #824 — ARC-37: break up the 5.6k-line NetCDF god-class
- Closes #825 — ARC-47: reduce reads every variable fully instead of streaming
- Closes #826 — ARC-48: open_mfdataset eager by default; from_xarray/to_xarray materialize
- Closes #827 — ARC-49: LabeledDataset coord re-read, O(n*m) lookup, whole-span sparse reads
- Closes #828 — ARC-59: vectorize node/edge geometry and per-face topology loops
- Closes #829 — ARC-69: single-source scalar-nodata and band-flatten helpers
- Closes #830 — ARC-76: deterministic dask graph names; lock the kerchunk monkeypatch
- Closes #831 — ARC-77: hoist inline scipy imports; file cleopatra add_colorbar kwarg

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

The refactors preserve the public API. Three behaviour changes convert silent-wrong / opaque / inert states into
loud ones: a container's raster methods now raise a guiding `ValueError`; `open_mfdataset`'s default is now lazy;
and its inert `parallel=` flag now emits a `DeprecationWarning` (still accepted, so non-breaking).

# How Has This Been Tested?

New regression tests per finding and per review finding, plus full-suite verification of the whole branch:

- [x] Full netcdf non-plot suite: **2281 passed, 38 skipped**.
- [x] netcdf plot suite: **171 passed**.
- [x] ugrid + dataset lazy suites: **271 passed**.
- [x] Post-review re-verification (netcdf + ugrid non-plot, after both rounds + the SonarCloud fixes):
      **2531 passed, 38 skipped**.
- [x] SonarCloud on this PR: **0 unresolved issues**.
- [x] `pre-commit run --all-files`: all hooks pass (ruff, mypy, bandit, gitleaks, shellcheck, …).
- [x] ugrid suite re-verified after the ARC-59 vectorization: **238 passed, 20 deselected**.
- [x] Doctests green on the touched modules.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.

Versions and the change log are generated by commitizen in CI, so those three boxes are intentionally left for
the release automation.



