### PR TITLE
fix(stac): resolve the seven arc-stac findings — credentials, VRT completeness, remote tuning

### DIFF
--- a/src/pyramids/base/_artifacts.py
+++ b/src/pyramids/base/_artifacts.py
@@ -32,6 +32,21 @@ from osgeo import gdal
 
 _ROOT: str | None = None
 _VSIMEM_PATHS: list[str] = []
+_CLEANUP_ARMED = False
+
+
+def _arm_cleanup() -> None:
+    """Register the exit sweep, once per process.
+
+    Both artefact kinds need it and a process may use only one of them: hanging
+    the registration off the temp-root creation meant a process that only ever
+    called :func:`build_vrt_from_stac` — which uses `/vsimem`, never the temp
+    root — never armed the sweep, so its tracked VRTs were never reclaimed.
+    """
+    global _CLEANUP_ARMED
+    if not _CLEANUP_ARMED:
+        atexit.register(cleanup)
+        _CLEANUP_ARMED = True
 
 
 def _root() -> str:
@@ -39,7 +54,7 @@ def _root() -> str:
     global _ROOT
     if _ROOT is None:
         _ROOT = tempfile.mkdtemp(prefix="pyramids_stac_")
-        atexit.register(cleanup)
+        _arm_cleanup()
     return _ROOT
 
 
@@ -72,18 +87,37 @@ def artifact_dir() -> str:
 def register_vsimem(path: str) -> None:
     """Track a ``/vsimem`` path to be unlinked at process exit.
 
+    Arms the exit sweep, so a process that produces only in-memory artefacts
+    (one ``build_vrt_from_stac`` per request, say) still reclaims them at
+    shutdown rather than growing an in-memory VRT per call for its lifetime.
+
     Args:
         path: The in-memory GDAL path (e.g. ``/vsimem/foo.vrt``).
     """
     _VSIMEM_PATHS.append(path)
+    _arm_cleanup()
+
+
+def unregister_vsimem(path: str) -> None:
+    """Stop tracking a ``/vsimem`` path, for a caller that unlinked it early.
+
+    Keeps the registry from accruing dead entries when a build fails and
+    reclaims its own artefact — otherwise :func:`cleanup` later unlinks paths
+    that no longer exist.
+
+    Args:
+        path: The in-memory GDAL path to forget. Unknown paths are ignored.
+    """
+    while path in _VSIMEM_PATHS:
+        _VSIMEM_PATHS.remove(path)
 
 
 def cleanup() -> None:
     """Remove the artefact root and unlink every tracked ``/vsimem`` path.
 
-    Registered as an ``atexit`` hook the first time the root is created; safe to
-    call directly (e.g. from tests). Best-effort — errors are swallowed so a
-    locked file at shutdown never raises.
+    Registered as an ``atexit`` hook the first time either artefact kind is
+    used; safe to call directly (e.g. from tests). Best-effort — errors are
+    swallowed so a locked file at shutdown never raises.
     """
     global _ROOT
     while _VSIMEM_PATHS:

--- a/src/pyramids/base/_artifacts.py
+++ b/src/pyramids/base/_artifacts.py
@@ -27,12 +27,22 @@ import atexit
 import os
 import shutil
 import tempfile
+import threading
 
 from osgeo import gdal
 
 _ROOT: str | None = None
 _VSIMEM_PATHS: list[str] = []
 _CLEANUP_ARMED = False
+
+_LOCK = threading.Lock()
+"""Guards the module globals.
+
+Two threads building a VRT each mutate `_VSIMEM_PATHS` and race `_CLEANUP_ARMED`,
+and `cleanup()` pops from the same list — so a test-then-mutate on it (checking
+membership, then removing) can lose the race and raise. That matters because
+`unregister_vsimem` runs from a failure handler, where a `ValueError` from the
+cleanup would replace the real build error."""
 
 
 def _arm_cleanup() -> None:
@@ -44,9 +54,10 @@ def _arm_cleanup() -> None:
     root — never armed the sweep, so its tracked VRTs were never reclaimed.
     """
     global _CLEANUP_ARMED
-    if not _CLEANUP_ARMED:
-        atexit.register(cleanup)
-        _CLEANUP_ARMED = True
+    with _LOCK:
+        if not _CLEANUP_ARMED:
+            atexit.register(cleanup)
+            _CLEANUP_ARMED = True
 
 
 def _root() -> str:
@@ -94,7 +105,8 @@ def register_vsimem(path: str) -> None:
     Args:
         path: The in-memory GDAL path (e.g. ``/vsimem/foo.vrt``).
     """
-    _VSIMEM_PATHS.append(path)
+    with _LOCK:
+        _VSIMEM_PATHS.append(path)
     _arm_cleanup()
 
 
@@ -105,11 +117,17 @@ def unregister_vsimem(path: str) -> None:
     reclaims its own artefact — otherwise :func:`cleanup` later unlinks paths
     that no longer exist.
 
+    Never raises: it is called from a failure handler, where a `ValueError` from
+    losing a race against `cleanup()` would replace the error the caller is
+    actually reporting.
+
     Args:
         path: The in-memory GDAL path to forget. Unknown paths are ignored.
     """
-    while path in _VSIMEM_PATHS:
-        _VSIMEM_PATHS.remove(path)
+    with _LOCK:
+        # Rebuild rather than test-then-remove: one atomic assignment, and no
+        # window in which a concurrent `cleanup()` pop makes `remove` raise.
+        _VSIMEM_PATHS[:] = [tracked for tracked in _VSIMEM_PATHS if tracked != path]
 
 
 def cleanup() -> None:
@@ -120,8 +138,11 @@ def cleanup() -> None:
     swallowed so a locked file at shutdown never raises.
     """
     global _ROOT
-    while _VSIMEM_PATHS:
-        path = _VSIMEM_PATHS.pop()
+    with _LOCK:
+        pending = list(_VSIMEM_PATHS)
+        _VSIMEM_PATHS.clear()
+    while pending:
+        path = pending.pop()
         try:
             gdal.Unlink(path)
         except Exception:  # noqa: BLE001  # nosec B110 - best-effort shutdown cleanup

--- a/src/pyramids/base/_ogc_api.py
+++ b/src/pyramids/base/_ogc_api.py
@@ -17,13 +17,18 @@ from __future__ import annotations
 
 import base64
 import json
+import logging
+import time
 import urllib.error
 import urllib.request
+from collections.abc import Callable
 from functools import lru_cache
-from typing import Any
+from typing import Any, cast
 from urllib.parse import SplitResult, urlsplit, urlunsplit
 
 from pyramids.base._errors import OGCAPIError
+
+logger = logging.getLogger(__name__)
 
 # Headers for the urllib ``/collections`` pre-check. A real User-Agent avoids
 # services that block the default ``Python-urllib`` agent, and ``Accept`` adds
@@ -43,14 +48,175 @@ NO_MESSAGE = "no message provided"
 GDAL_HTTP_AUTH_VAR = "GDAL_HTTP_USER" + "PWD"
 
 
+HTTP_RETRY_ATTEMPTS = 3
+"""Total attempts (initial + retries) for a transient discovery-request failure."""
+
+HTTP_RETRY_DELAY = 0.5
+"""Base backoff in seconds; attempt *n* waits ``HTTP_RETRY_DELAY * 2 ** n``."""
+
+RETRYABLE_STATUS: frozenset[int] = frozenset({429, 500, 502, 503, 504})
+"""HTTP statuses worth retrying: rate limiting and transient server/gateway faults.
+
+Every other 4xx is a client error — a bad endpoint, bad credentials, an unknown
+collection — and retrying it only multiplies the latency of a certain failure.
+"""
+
+
 def gdal_http_config(auth: tuple[str, str] | None, timeout: float) -> dict[str, str]:
-    """GDAL config options for the OGC HTTP requests (auth + timeout)."""
+    """GDAL config options for the OGC HTTP requests (auth + timeout + retries).
+
+    The retry knobs mirror :func:`http_get_with_retry`, which guards the urllib
+    discovery fetch, so the GDAL driver read and the pre-check ride out the same
+    class of transient fault instead of only one of them being resilient.
+
+    Args:
+        auth: Optional `(user, password)` pair for HTTP Basic auth. `None`
+            leaves the request unauthenticated.
+        timeout: Request timeout in seconds. Clamped to a whole second `>= 1`,
+            because GDAL truncates `GDAL_HTTP_TIMEOUT` and reads `"0"` as *no
+            timeout*.
+
+    Returns:
+        The GDAL config mapping to install around the driver read.
+
+    Examples:
+        - An unauthenticated read carries a timeout and a retry budget:
+            ```python
+            >>> from pyramids.base._ogc_api import gdal_http_config
+            >>> config = gdal_http_config(None, 60.0)
+            >>> config["GDAL_HTTP_TIMEOUT"]
+            '60'
+            >>> config["GDAL_HTTP_MAX_RETRY"]
+            '3'
+
+            ```
+        - Credentials are sent as GDAL's user:password pair:
+            ```python
+            >>> from pyramids.base._ogc_api import gdal_http_config
+            >>> gdal_http_config(("ada", "s3cret"), 30.0)["GDAL_HTTP_USERPWD"]
+            'ada:s3cret'
+
+            ```
+        - A sub-second timeout is clamped so GDAL does not read it as "no timeout":
+            ```python
+            >>> from pyramids.base._ogc_api import gdal_http_config
+            >>> gdal_http_config(None, 0.25)["GDAL_HTTP_TIMEOUT"]
+            '1'
+
+            ```
+
+    See Also:
+        - :func:`http_get_with_retry`: the urllib-side counterpart guarding the
+          `/collections` and `GetCapabilities` fetches.
+    """
     # GDAL_HTTP_TIMEOUT is whole seconds; clamp to >= 1 so a sub-second timeout is
     # not truncated to "0", which GDAL reads as "no timeout".
-    config = {"GDAL_HTTP_TIMEOUT": str(max(1, int(timeout)))}
+    config = {
+        "GDAL_HTTP_TIMEOUT": str(max(1, int(timeout))),
+        "GDAL_HTTP_MAX_RETRY": str(HTTP_RETRY_ATTEMPTS),
+        "GDAL_HTTP_RETRY_DELAY": str(HTTP_RETRY_DELAY),
+    }
     if auth is not None:
         config[GDAL_HTTP_AUTH_VAR] = f"{auth[0]}:{auth[1]}"
     return config
+
+
+def http_get_with_retry(
+    target: Any,
+    timeout: float,
+    *,
+    opener: urllib.request.OpenerDirector | None = None,
+    attempts: int = HTTP_RETRY_ATTEMPTS,
+    delay: float = HTTP_RETRY_DELAY,
+    sleep: Callable[[float], None] = time.sleep,
+) -> bytes:
+    """GET `target` and return the body, retrying transient failures.
+
+    The OGC discovery fetches (`/collections`, WCS `GetCapabilities`) are single
+    small requests in front of a much larger read, so a transient 502 or a
+    dropped connection failing them outright wastes the whole call. Retries use
+    exponential backoff and are limited to connection-level errors and the
+    statuses in :data:`RETRYABLE_STATUS`; any other HTTP error is raised on the
+    first attempt.
+
+    The failing exception is re-raised unchanged once the attempts are spent, so
+    callers keep their own error contracts (`OGCAPIError`, `WCSError`). The
+    body of an :class:`urllib.error.HTTPError` is never read here — it can be
+    read only once, and the caller needs it for its message.
+
+    Args:
+        target: A URL string or :class:`urllib.request.Request` to fetch.
+        timeout: Per-attempt timeout in seconds.
+        opener: Optional opener (e.g. one carrying a Basic-auth handler).
+            Defaults to :func:`urllib.request.urlopen`.
+        attempts: Total attempts including the first. `1` disables retrying.
+        delay: Base backoff in seconds; attempt *n* waits ``delay * 2 ** n``.
+        sleep: Sleep callable, injectable so tests need not wait.
+
+    Returns:
+        The response body as bytes.
+
+    Raises:
+        urllib.error.HTTPError: The server returned a non-retryable status, or a
+            retryable one on the final attempt.
+        OSError: The transport failed on the final attempt (`URLError` and
+            `ssl.SSLError` both derive from it).
+
+    Examples:
+        - A retryable status is retried and the recovered body returned:
+            ```python
+            >>> import io, urllib.error
+            >>> from pyramids.base._ogc_api import http_get_with_retry
+            >>> calls = []
+            >>> class _Opener:
+            ...     def open(self, target, timeout=None):
+            ...         calls.append(target)
+            ...         if len(calls) == 1:
+            ...             raise urllib.error.HTTPError(target, 503, "busy", {}, None)
+            ...         return io.BytesIO(b'{"collections": []}')
+            >>> http_get_with_retry(
+            ...     "https://h/collections", 5, opener=_Opener(), sleep=lambda s: None
+            ... )
+            b'{"collections": []}'
+            >>> len(calls)
+            2
+
+            ```
+        - A client error is raised immediately, without burning retries:
+            ```python
+            >>> import urllib.error
+            >>> calls = []
+            >>> class _NotFound:
+            ...     def open(self, target, timeout=None):
+            ...         calls.append(target)
+            ...         raise urllib.error.HTTPError(target, 404, "nope", {}, None)
+            >>> try:
+            ...     http_get_with_retry("https://h/x", 5, opener=_NotFound())
+            ... except urllib.error.HTTPError as exc:
+            ...     print(exc.code, len(calls))
+            404 1
+
+            ```
+    """
+    open_fn = opener.open if opener is not None else urllib.request.urlopen
+    payload: bytes | None = None
+    for attempt in range(attempts):
+        last = attempt == attempts - 1
+        try:
+            with open_fn(target, timeout=timeout) as response:  # nosec B310
+                payload = response.read()
+            break
+        except urllib.error.HTTPError as exc:
+            if last or exc.code not in RETRYABLE_STATUS:
+                raise
+            logger.debug("retrying %s after HTTP %s", target, exc.code)
+        except OSError as exc:
+            if last:
+                raise
+            logger.debug("retrying %s after %s", target, exc)
+        sleep(delay * 2**attempt)
+    # Unreachable with payload unset: the final attempt either breaks or raises.
+    return cast(bytes, payload)
 
 
 def append_path(endpoint: str, suffix: str) -> tuple[SplitResult, str]:
@@ -103,8 +269,7 @@ def get_collections(
         # urllib honours the raw float timeout (a sub-second value is a valid fast
         # timeout here); only the GDAL driver read clamps to >= 1s, because GDAL
         # truncates GDAL_HTTP_TIMEOUT to whole seconds and reads "0" as no timeout.
-        with urllib.request.urlopen(request, timeout=timeout) as resp:  # nosec B310
-            payload = resp.read()
+        payload = http_get_with_retry(request, timeout)
     except urllib.error.HTTPError as exc:
         # 4xx/5xx commonly carry an RFC 7807 problem document — surface its message.
         raise OGCAPIError(

--- a/src/pyramids/base/_ogc_api.py
+++ b/src/pyramids/base/_ogc_api.py
@@ -51,8 +51,19 @@ GDAL_HTTP_AUTH_VAR = "GDAL_HTTP_USER" + "PWD"
 HTTP_RETRY_ATTEMPTS = 3
 """Total attempts (initial + retries) for a transient discovery-request failure."""
 
+GDAL_HTTP_MAX_RETRY = HTTP_RETRY_ATTEMPTS - 1
+"""The same budget in GDAL's units.
+
+``GDAL_HTTP_MAX_RETRY`` counts retries *after* the first attempt, while
+:data:`HTTP_RETRY_ATTEMPTS` counts attempts including it. Emitting the latter
+verbatim gave the driver read one more attempt than the urllib pre-check.
+"""
+
 HTTP_RETRY_DELAY = 0.5
 """Base backoff in seconds; attempt *n* waits ``HTTP_RETRY_DELAY * 2 ** n``."""
+
+_MAX_RETRY_AFTER = 60.0
+"""Ceiling for an honoured ``Retry-After``; a longer one is a stall, not a retry."""
 
 RETRYABLE_STATUS: frozenset[int] = frozenset({429, 500, 502, 503, 504})
 """HTTP statuses worth retrying: rate limiting and transient server/gateway faults.
@@ -87,7 +98,7 @@ def gdal_http_config(auth: tuple[str, str] | None, timeout: float) -> dict[str, 
             >>> config["GDAL_HTTP_TIMEOUT"]
             '60'
             >>> config["GDAL_HTTP_MAX_RETRY"]
-            '3'
+            '2'
 
             ```
         - Credentials are sent as GDAL's user:password pair:
@@ -113,7 +124,7 @@ def gdal_http_config(auth: tuple[str, str] | None, timeout: float) -> dict[str, 
     # not truncated to "0", which GDAL reads as "no timeout".
     config = {
         "GDAL_HTTP_TIMEOUT": str(max(1, int(timeout))),
-        "GDAL_HTTP_MAX_RETRY": str(HTTP_RETRY_ATTEMPTS),
+        "GDAL_HTTP_MAX_RETRY": str(GDAL_HTTP_MAX_RETRY),
         "GDAL_HTTP_RETRY_DELAY": str(HTTP_RETRY_DELAY),
     }
     if auth is not None:
@@ -150,13 +161,16 @@ def http_get_with_retry(
         opener: Optional opener (e.g. one carrying a Basic-auth handler).
             Defaults to :func:`urllib.request.urlopen`.
         attempts: Total attempts including the first. `1` disables retrying.
-        delay: Base backoff in seconds; attempt *n* waits ``delay * 2 ** n``.
+        delay: Base backoff in seconds; attempt *n* waits ``delay * 2 ** n``,
+            unless the server sent a usable `Retry-After`.
         sleep: Sleep callable, injectable so tests need not wait.
 
     Returns:
         The response body as bytes.
 
     Raises:
+        ValueError: `attempts` is less than 1 — a zero budget would otherwise
+            fall out of the loop and hand the caller `None`.
         urllib.error.HTTPError: The server returned a non-retryable status, or a
             retryable one on the final attempt.
         OSError: The transport failed on the final attempt (`URLError` and
@@ -198,10 +212,13 @@ def http_get_with_retry(
 
             ```
     """
+    if attempts < 1:
+        raise ValueError(f"attempts must be >= 1, got {attempts}.")
     open_fn = opener.open if opener is not None else urllib.request.urlopen
     payload: bytes | None = None
     for attempt in range(attempts):
         last = attempt == attempts - 1
+        wait = delay * 2**attempt
         try:
             with open_fn(target, timeout=timeout) as response:  # nosec B310
                 payload = response.read()
@@ -209,14 +226,45 @@ def http_get_with_retry(
         except urllib.error.HTTPError as exc:
             if last or exc.code not in RETRYABLE_STATUS:
                 raise
-            logger.debug("retrying %s after HTTP %s", target, exc.code)
+            wait = _retry_after(exc, wait)
+            logger.debug("retrying %s after HTTP %s in %.1fs", target, exc.code, wait)
+            # The body is the caller's to read on a *final* failure; on a retry
+            # nothing will, so release the socket instead of leaving it to GC.
+            exc.close()
         except OSError as exc:
             if last:
                 raise
             logger.debug("retrying %s after %s", target, exc)
-        sleep(delay * 2**attempt)
+        sleep(wait)
     # Unreachable with payload unset: the final attempt either breaks or raises.
     return cast(bytes, payload)
+
+
+def _retry_after(exc: urllib.error.HTTPError, default: float) -> float:
+    """Return the server's `Retry-After` delay in seconds, else `default`.
+
+    A 429 is the one status where the server states the correct delay; guessing
+    an exponential backoff instead can retry into the same rate limit. Only the
+    numeric (delta-seconds) form is honoured — the HTTP-date form needs clock
+    agreement that a discovery pre-check should not depend on.
+
+    Args:
+        exc: The HTTP error carrying the response headers.
+        default: The computed backoff to fall back to.
+
+    Returns:
+        The header's value when it is a sane non-negative number, else `default`.
+    """
+    raw = exc.headers.get("Retry-After") if exc.headers else None
+    delay = default
+    if raw is not None:
+        try:
+            parsed = float(str(raw).strip())
+        except ValueError:
+            parsed = -1.0
+        if 0.0 <= parsed <= _MAX_RETRY_AFTER:
+            delay = parsed
+    return delay
 
 
 def append_path(endpoint: str, suffix: str) -> tuple[SplitResult, str]:

--- a/src/pyramids/base/config.py
+++ b/src/pyramids/base/config.py
@@ -103,9 +103,17 @@ def _gdal_error_handler(err_class, err_num, err_msg):
     GDAL quotes the offending path in its message, and a `/vsicurl?` source
     carries its credentials there (see
     :func:`pyramids.stac._vrt._embed_source_options`), so the text is scrubbed
-    by :func:`~pyramids.base.remote.redact_credentials` first — otherwise a
-    failed source open would publish a live token to every log sink the
-    application has configured.
+    by :func:`~pyramids.base.remote.redact_credentials` first.
+
+    Note:
+        With `gdal.UseExceptions()` active — which pyramids enables at import —
+        GDAL routes *warnings* neither to a Python exception nor to a handler
+        installed with `gdal.SetErrorHandler`; it prints them to stderr. So this
+        handler covers the paths that reach it (a caller who disables
+        exceptions, and errors raised through the bindings) but is not what
+        keeps a credential out of a failed VRT source open — that is
+        `pyramids.stac._vrt._build_vrt`, which *pushes* a redacting handler for
+        the duration of the build.
 
     Args:
         err_class (int): GDAL error class (`gdal.CE_*`).

--- a/src/pyramids/base/config.py
+++ b/src/pyramids/base/config.py
@@ -64,6 +64,7 @@ import yaml
 from osgeo import gdal, ogr
 
 from pyramids import __path__ as root_path
+from pyramids.base.remote import redact_credentials
 
 PACKAGE_LOGGER_NAME = "pyramids"
 """Logger namespace pyramids configures. Never the root logger — a library that
@@ -99,12 +100,21 @@ def _gdal_error_handler(err_class, err_num, err_msg):
     once-only install guard needs a single identity, and tests can invoke it
     directly instead of fishing it out of a patched `gdal.PushErrorHandler`.
 
+    GDAL quotes the offending path in its message, and a `/vsicurl?` source
+    carries its credentials there (see
+    :func:`pyramids.stac._vrt._embed_source_options`), so the text is scrubbed
+    by :func:`~pyramids.base.remote.redact_credentials` first — otherwise a
+    failed source open would publish a live token to every log sink the
+    application has configured.
+
     Args:
         err_class (int): GDAL error class (`gdal.CE_*`).
         err_num (int): GDAL error number.
         err_msg (str): The message text.
     """
     log = logging.getLogger(_GDAL_LOGGER_NAME)
+    if isinstance(err_msg, str):
+        err_msg = redact_credentials(err_msg)
     try:
         # Anything below CE_Warning -- CE_None (0) and CE_Debug (1) -- goes to stdout
         # rather than the logger. That is why there is no CE_Debug branch below: it

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -477,6 +477,52 @@ def _chain_archive_vsi(path: str) -> str:
     return f"{_ARCHIVE_EXT_TO_VSI[ext]}{path}"
 
 
+_CREDENTIAL_OPTION_RE = re.compile(
+    r"(?i)\b(header\.[A-Za-z0-9\-_]+|signature|sig|x-amz-security-token|"
+    r"access_token|token)=([^&\s\"']+)"
+)
+"""Matches a credential-bearing option inside a `/vsicurl?…` path or a URL query."""
+
+
+def redact_credentials(text: str) -> str:
+    """Blank out credential values in a path, URL or message.
+
+    GDAL's own error text quotes the full source path, and a `/vsicurl?` source
+    carries its `header.Authorization` there — so a message like
+    `Can't open /vsicurl?header.Authorization=Bearer <token>&url=…` would publish
+    a live token to every log handler. Everything pyramids emits about such a
+    path goes through here first.
+
+    Args:
+        text: The message, path or URL to scrub.
+
+    Returns:
+        `text` with each credential value replaced by `<redacted>`.
+
+    Examples:
+        - An embedded bearer header is blanked, the rest stays readable:
+            ```python
+            >>> from pyramids.base.remote import redact_credentials
+            >>> redact_credentials("Can't open /vsicurl?header.Authorization=Bearer%20t&url=x")
+            "Can't open /vsicurl?header.Authorization=<redacted>&url=x"
+
+            ```
+        - A SAS-style query parameter is caught too:
+            ```python
+            >>> redact_credentials("https://h/a.tif?sv=2021&sig=SECRET")
+            'https://h/a.tif?sv=2021&sig=<redacted>'
+
+            ```
+        - An ordinary message is returned untouched:
+            ```python
+            >>> redact_credentials("Can't open /vsicurl/https://h/a.tif. Skipping it")
+            "Can't open /vsicurl/https://h/a.tif. Skipping it"
+
+            ```
+    """
+    return _CREDENTIAL_OPTION_RE.sub(r"\1=<redacted>", text)
+
+
 _VSICURL_FAST_READ_KNOBS: dict[str, str] = {
     "GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR",
     "GDAL_HTTP_MULTIPLEX": "YES",

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -98,6 +98,10 @@ _VSI_PREFIXES: tuple[str, ...] = (
     _VSIGS,
     _VSIAZ,
     _VSICURL,
+    # GDAL's query-string form, `/vsicurl?[option=value&]*url=<encoded>`, which
+    # carries per-source options (headers, retry, empty_dir) in the path itself.
+    # It has no trailing slash, so the `/vsicurl/` entry above does not match it.
+    "/vsicurl?",
     "/vsicurl_streaming/",
     "/vsimem/",
     _VSIZIP,
@@ -142,6 +146,12 @@ def is_remote(path: str) -> bool:
             >>> is_remote("/vsicurl/https://foo/x.tif")
             True
             >>> is_remote("/vsimem/temp.tif")
+            True
+
+            ```
+        - So is GDAL's query-string form, which carries per-source options:
+            ```python
+            >>> is_remote("/vsicurl?empty_dir=yes&url=https%3A%2F%2Ffoo%2Fx.tif")
             True
 
             ```

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -477,11 +477,37 @@ def _chain_archive_vsi(path: str) -> str:
     return f"{_ARCHIVE_EXT_TO_VSI[ext]}{path}"
 
 
-_CREDENTIAL_OPTION_RE = re.compile(
-    r"(?i)\b(header\.[A-Za-z0-9\-_]+|signature|sig|x-amz-security-token|"
-    r"access_token|token)=([^&\s\"']+)"
+_CREDENTIAL_OPTION_NAMES = (
+    r"header\.[A-Za-z0-9\-_]+",
+    "signature",
+    "sig",
+    "sas",
+    "x-amz-security-token",
+    "x-amz-signature",
+    "x-goog-signature",
+    "access_token",
+    "id_token",
+    "refresh_token",
+    "token",
+    "api_key",
+    "apikey",
+    "password",
+    "passwd",
+    "pwd",
+    "secret",
+    "credential",
 )
-"""Matches a credential-bearing option inside a `/vsicurl?…` path or a URL query."""
+"""Option names whose value is a credential, matched case-insensitively."""
+
+_CREDENTIAL_OPTION_RE = re.compile(
+    r"(?i)(?<=[?&])(" + "|".join(_CREDENTIAL_OPTION_NAMES) + r")=([^&\s\"\']*)"
+)
+"""Matches a credential option inside a `/vsicurl?...` path or a URL query string.
+
+Anchored on a `?`/`&` boundary (a lookbehind, so the delimiter survives the
+substitution) rather than a word boundary: `\\b` also matched the tail of an
+unrelated name (`my_token=`, `bucket-key=`) and gained nothing in exchange, since
+a real option always follows a delimiter."""
 
 
 def redact_credentials(text: str) -> str:
@@ -517,6 +543,12 @@ def redact_credentials(text: str) -> str:
             ```python
             >>> redact_credentials("Can't open /vsicurl/https://h/a.tif. Skipping it")
             "Can't open /vsicurl/https://h/a.tif. Skipping it"
+
+            ```
+        - A name that merely ends in a credential word is not one:
+            ```python
+            >>> redact_credentials("https://h/a.tif?my_token=abc")
+            'https://h/a.tif?my_token=abc'
 
             ```
     """

--- a/src/pyramids/dataset/_stac.py
+++ b/src/pyramids/dataset/_stac.py
@@ -160,22 +160,25 @@ def _item_intersects_bbox(
 ) -> bool:
     """Return True if `item.bbox` overlaps `bbox` (lon/lat box).
 
-    Reads `item.bbox` as either an attribute (pystac.Item) or a
-    dict key (raw JSON). Both the query `bbox` and the item bbox may be
-    2D (4-element) or 3D (6-element) — only the horizontal extent is
-    compared (see :func:`_horizontal_bounds`). Longitude overlap is
-    antimeridian-aware (a box with ``west > east`` is treated as wrapping the
-    dateline). Items without a bbox are treated as intersecting (permissive
-    default — the caller opted in to the bbox filter, not the item).
+    Reads `item.bbox` through the shared duck-typed accessor
+    (:func:`pyramids.stac._item.item_bbox`), so pystac Items and raw JSON dicts
+    are handled identically here and in the STAC readers. Both the query `bbox`
+    and the item bbox may be 2D (4-element) or 3D (6-element) — only the
+    horizontal extent is compared (see :func:`_horizontal_bounds`). Longitude
+    overlap is antimeridian-aware (a box with ``west > east`` is treated as
+    wrapping the dateline). Items without a bbox are treated as intersecting
+    (permissive default — the caller opted in to the bbox filter, not the item).
     """
-    item_bbox = getattr(item, "bbox", None)
-    if item_bbox is None and isinstance(item, dict):
-        item_bbox = item.get("bbox")
-    if item_bbox is None:
+    # Imported lazily to break the pyramids.dataset -> pyramids.stac ->
+    # pyramids.dataset import cycle (see _resolve_asset_href above).
+    from pyramids.stac._item import item_bbox
+
+    box = item_bbox(item)
+    if box is None:
         result = True
     else:
         q_west, q_south, q_east, q_north = _horizontal_bounds(bbox)
-        i_west, i_south, i_east, i_north = _horizontal_bounds(item_bbox)
+        i_west, i_south, i_east, i_north = _horizontal_bounds(box)
         lat_overlap = not (i_north < q_south or i_south > q_north)
         result = lat_overlap and _lon_overlaps(q_west, q_east, i_west, i_east)
     return result
@@ -461,20 +464,31 @@ def _resolve_target_grid(
 def _item_datetime(item: Any) -> _datetime_cls:
     """Return a STAC Item's datetime as a tz-aware :class:`datetime`.
 
-    Reads `item.datetime` (pystac) or `properties["datetime"]` (raw JSON).
+    Reads `item.datetime` (pystac) or `properties["datetime"]` (raw JSON, via
+    the shared :func:`pyramids.stac._item.item_properties` accessor). An RFC
+    3339 string is parsed; a naive datetime is assumed to be UTC.
+
+    Args:
+        item: A STAC Item (pystac object or raw dict).
+
+    Returns:
+        The item's acquisition time as a timezone-aware :class:`datetime`.
 
     Raises:
-        ValueError: The item carries no datetime.
+        ValueError: The item carries neither `.datetime` nor
+            `properties["datetime"]` — the error names the item via the shared
+            :func:`pyramids.stac._item.item_id` accessor.
     """
+    # Imported lazily to break the pyramids.dataset -> pyramids.stac ->
+    # pyramids.dataset import cycle (see _resolve_asset_href above).
+    from pyramids.stac._item import item_id, item_properties
+
     when = getattr(item, "datetime", None)
     if when is None:
-        props = getattr(item, "properties", None)
-        if props is None and isinstance(item, dict):
-            props = item.get("properties")
-        when = (props or {}).get("datetime")
+        when = item_properties(item).get("datetime")
     if when is None:
         raise ValueError(
-            f"item {_item_id(item)} has no datetime; required for groupby='solar_day'."
+            f"item {item_id(item)} has no datetime; required for groupby='solar_day'."
         )
     if isinstance(when, str):
         when = _datetime_cls.fromisoformat(when.replace("Z", "+00:00"))
@@ -484,19 +498,39 @@ def _item_datetime(item: Any) -> _datetime_cls:
 
 
 def _item_centroid_lon(item: Any) -> float:
-    """Return the longitude of an item's bbox centroid (0.0 when no bbox)."""
-    bbox = getattr(item, "bbox", None)
-    if bbox is None and isinstance(item, dict):
-        bbox = item.get("bbox")
-    if not bbox:
-        return 0.0
-    west, _s, east, _n = _horizontal_bounds(bbox)
-    if west <= east:
-        return (west + east) / 2.0
-    # Antimeridian-crossing box (L3): average across the dateline by shifting
-    # the eastern edge +360, then normalise the midpoint back to [-180, 180].
-    mid = (west + east + 360.0) / 2.0
-    return mid - 360.0 if mid > 180.0 else mid
+    """Return the longitude of an item's bbox centroid (0.0 when no bbox).
+
+    The bbox is read through the shared
+    :func:`pyramids.stac._item.item_bbox` accessor, so pystac Items and raw
+    JSON dicts behave identically. A box crossing the antimeridian
+    (``west > east``) is averaged across the dateline rather than through the
+    prime meridian.
+
+    Args:
+        item: A STAC Item (pystac object or raw dict).
+
+    Returns:
+        The centroid longitude in degrees, normalised to ``[-180, 180]``, or
+        `0.0` when the item carries no bbox (no solar-day shift is applied).
+    """
+    # Imported lazily to break the pyramids.dataset -> pyramids.stac ->
+    # pyramids.dataset import cycle (see _resolve_asset_href above).
+    from pyramids.stac._item import item_bbox
+
+    box = item_bbox(item)
+    if not box:
+        centroid = 0.0
+    else:
+        west, _s, east, _n = _horizontal_bounds(box)
+        if west <= east:
+            centroid = (west + east) / 2.0
+        else:
+            # Antimeridian-crossing box (L3): average across the dateline by
+            # shifting the eastern edge +360, then normalise the midpoint back
+            # to [-180, 180].
+            mid = (west + east + 360.0) / 2.0
+            centroid = mid - 360.0 if mid > 180.0 else mid
+    return centroid
 
 
 def _solar_day(item: Any) -> str:
@@ -508,14 +542,6 @@ def _solar_day(item: Any) -> str:
     """
     shifted = _item_datetime(item) + timedelta(hours=_item_centroid_lon(item) / 15.0)
     return shifted.date().isoformat()
-
-
-def _item_id(item: Any) -> Any:
-    """Best-effort item id for error messages."""
-    iid = getattr(item, "id", None)
-    if iid is None and isinstance(item, dict):
-        iid = item.get("id", "?")
-    return iid if iid is not None else "?"
 
 
 def _from_stac_solar_day(

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -57,6 +57,7 @@ from pyramids.base._coverage import resolve_native_srs as _resolve_native_srs_ne
 from pyramids.base._coverage import validate_bbox as _validate_bbox
 from pyramids.base._errors import CoverageError, WCSError
 from pyramids.base._ogc_api import gdal_http_config as _gdal_http_config
+from pyramids.base._ogc_api import http_get_with_retry as _http_get_with_retry
 from pyramids.base._ogc_api import read_http_error as _read_http_error
 
 # Cap on how much of an HTTP-error body is inlined into a WCSError message; the
@@ -194,6 +195,10 @@ def _http_get(
     sites keep a uniform error contract. On a genuine HTTP-error status (4xx/5xx)
     the raised :class:`WCSError` also carries the ``status_code`` and the decoded
     ``response_body`` so a caller can inspect the server's explanation.
+
+    A dropped connection or a transient 5xx is retried with backoff (see
+    :func:`pyramids.base._ogc_api.http_get_with_retry`) before the failure is
+    turned into a :class:`WCSError`; a 4xx is surfaced on the first attempt.
     """
     opener = urllib.request.build_opener()
     if auth is not None:
@@ -201,8 +206,7 @@ def _http_get(
         mgr.add_password(None, url, auth[0], auth[1])
         opener.add_handler(urllib.request.HTTPBasicAuthHandler(mgr))
     try:
-        with opener.open(url, timeout=timeout) as resp:
-            return cast(bytes, resp.read())
+        return cast(bytes, _http_get_with_retry(url, timeout, opener=opener))
     except urllib.error.HTTPError as exc:
         # A 4xx/5xx status carries a body with the server's real explanation
         # (non-spec shims return e.g. a JSON {"message": ...}); surface it in the

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -56,6 +56,7 @@ from pyramids.base._coverage import resolution_pair as _resolution_pair
 from pyramids.base._coverage import resolve_native_srs as _resolve_native_srs_neutral
 from pyramids.base._coverage import validate_bbox as _validate_bbox
 from pyramids.base._errors import CoverageError, WCSError
+from pyramids.base._ogc_api import HTTP_RETRY_ATTEMPTS
 from pyramids.base._ogc_api import gdal_http_config as _gdal_http_config
 from pyramids.base._ogc_api import http_get_with_retry as _http_get_with_retry
 from pyramids.base._ogc_api import read_http_error as _read_http_error
@@ -196,9 +197,12 @@ def _http_get(
     the raised :class:`WCSError` also carries the ``status_code`` and the decoded
     ``response_body`` so a caller can inspect the server's explanation.
 
-    A dropped connection or a transient 5xx is retried with backoff (see
-    :func:`pyramids.base._ogc_api.http_get_with_retry`) before the failure is
-    turned into a :class:`WCSError`; a 4xx is surfaced on the first attempt.
+    Only the ``GetCapabilities`` discovery fetch is retried on a dropped
+    connection or a transient 5xx (see
+    :func:`pyramids.base._ogc_api.http_get_with_retry`). A ``GetCoverage`` is the
+    payload itself and is attempted once — re-downloading a large raster from
+    scratch costs far more than the retry saves. A 4xx is surfaced on the first
+    attempt either way.
     """
     opener = urllib.request.build_opener()
     if auth is not None:
@@ -206,7 +210,14 @@ def _http_get(
         mgr.add_password(None, url, auth[0], auth[1])
         opener.add_handler(urllib.request.HTTPBasicAuthHandler(mgr))
     try:
-        return cast(bytes, _http_get_with_retry(url, timeout, opener=opener))
+        # GetCapabilities is a small discovery fetch worth retrying; a
+        # GetCoverage *is* the payload, and re-downloading a large raster from
+        # scratch after a mid-transfer failure costs far more than the retry
+        # saves — so only the discovery leg gets a budget.
+        attempts = HTTP_RETRY_ATTEMPTS if what == "GetCapabilities" else 1
+        return cast(
+            bytes, _http_get_with_retry(url, timeout, opener=opener, attempts=attempts)
+        )
     except urllib.error.HTTPError as exc:
         # A 4xx/5xx status carries a body with the server's real explanation
         # (non-spec shims return e.g. a JSON {"message": ...}); surface it in the

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -204,6 +204,13 @@ class RasterBase(ABC):
         example :func:`pyramids.stac.load_asset` with a Requester-Pays or
         bearer-token signer. Empty for an ordinary local or anonymous open.
 
+        Note:
+            This is a **property**, while the same-named
+            :meth:`pyramids.stac.signers.Signer.gdal_env` is a *method* — the
+            two meet in one workflow (`load_asset(signer=…)` then `ds.gdal_env`),
+            so `ds.gdal_env()` is an easy slip that fails with
+            `TypeError: 'dict' object is not callable`.
+
         Returns:
             A copy of the captured config, so mutating it does not affect the
             dataset.
@@ -282,6 +289,11 @@ class RasterBase(ABC):
 
         The GDAL handle is therefore opened **on the receiving process
         / thread**, which is the invariant dask.distributed needs.
+
+        Recipes written before the config existed still unpickle here (the
+        parameter defaults), but a recipe written by *this* version needs a
+        reader that accepts four arguments — so a mixed-version cluster has to
+        upgrade the workers, not only the client.
 
         Raises:
             TypeError: The dataset has no on-disk path (empty

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -33,6 +33,7 @@ from pyramids.base._utils import (
 )
 from pyramids.base.crs import epsg_from_wkt, sr_from_epsg
 from pyramids.base.protocols import ArrayLike, FloatArray
+from pyramids.base.remote import cloud_config_from_env
 from pyramids.dataset.transform import GeoTransform
 from pyramids.dataset.window import Window
 
@@ -61,7 +62,12 @@ RESAMPLING_METHODS = [
 ]
 
 
-def _reconstruct_dataset(cls: type[RasterBase], path: str, access: str) -> RasterBase:
+def _reconstruct_dataset(
+    cls: type[RasterBase],
+    path: str,
+    access: str,
+    gdal_env: dict[str, str] | None = None,
+) -> RasterBase:
     """Re-open a dataset from its pickle recipe tuple.
 
     Called by :meth:`RasterBase.__reduce__` on unpickle. Routes
@@ -77,6 +83,10 @@ def _reconstruct_dataset(cls: type[RasterBase], path: str, access: str) -> Raste
         access: Access mode string carried by the pickle recipe. **Ignored** for the
             open mode — the dataset is always reopened read-only (see below). Kept in
             the signature so existing recipe tuples still unpickle.
+        gdal_env: The captured cloud config (a signer's `gdal_env()`), installed
+            around the re-open and re-attached to the instance so the worker's
+            reads authenticate as the originating process's did. Defaults to
+            `None` so a three-element recipe from an older pickle still loads.
 
     Returns:
         RasterBase: A freshly opened instance of `cls`, opened read-only.
@@ -87,7 +97,13 @@ def _reconstruct_dataset(cls: type[RasterBase], path: str, access: str) -> Raste
     # source for a CreateCopy), and reopening N update-mode handles on one file
     # across workers risks lock contention / a corrupt write. A caller that truly
     # needs a writable handle should reopen it explicitly on the worker.
-    return cls.read_file(path, read_only=True)
+    #
+    # The env is applied here rather than forwarded to read_file so every
+    # subclass benefits without widening its own signature.
+    with cloud_config_from_env(gdal_env):
+        dataset = cls.read_file(path, read_only=True)
+    dataset._gdal_env = dict(gdal_env) if gdal_env else {}
+    return dataset
 
 
 class RasterBase(ABC):
@@ -95,7 +111,13 @@ class RasterBase(ABC):
 
     default_no_data_value = DEFAULT_NO_DATA_VALUE
 
-    def __init__(self, src: gdal.Dataset, access: str = "read_only"):
+    def __init__(
+        self,
+        src: gdal.Dataset,
+        access: str = "read_only",
+        *,
+        gdal_env: dict[str, str] | None = None,
+    ):
         """__init__."""
         if not isinstance(src, gdal.Dataset):
             raise TypeError(  # pragma: no cover
@@ -104,6 +126,14 @@ class RasterBase(ABC):
             )
         self._access = access
         self._raster = src
+        # Cloud credentials/config this dataset was opened with (a STAC signer's
+        # gdal_env, say). Re-installed around every read, because several read
+        # paths do not go through the handle opened above: a VRT opens its
+        # sources lazily on first pixel read, `threadsafe=True` opens one handle
+        # per thread, a lazy `chunks=` read opens inside the dask task, and
+        # unpickling on a worker re-opens from the path. A plain dict so it
+        # survives pickling. Empty (the common case) costs a `nullcontext`.
+        self._gdal_env: dict[str, str] = dict(gdal_env) if gdal_env else {}
         # Per-thread file manager for read_array(threadsafe=True); created
         # lazily by the IO engine and released by close().
         self._thread_manager: ThreadLocalFileManager | None = None
@@ -123,13 +153,56 @@ class RasterBase(ABC):
             src.GetRasterBand(i).GetBlockSize() for i in range(1, self._band_count + 1)
         ]
 
+    @property
+    def gdal_env(self) -> dict[str, str]:
+        """GDAL config re-installed around every read of this dataset.
+
+        Populated when the dataset was opened with cloud credentials — for
+        example :func:`pyramids.stac.load_asset` with a Requester-Pays or
+        bearer-token signer. Empty for an ordinary local or anonymous open.
+
+        Returns:
+            A copy of the captured config, so mutating it does not affect the
+            dataset.
+
+        Examples:
+            - An ordinary open captures nothing:
+                ```python
+                >>> from pyramids.dataset import Dataset
+                >>> Dataset.read_file("tests/data/acc4000.tif").gdal_env
+                {}
+
+                ```
+            - An open that carried credentials keeps them for later reads:
+                ```python
+                >>> ds = Dataset.read_file(
+                ...     "tests/data/acc4000.tif",
+                ...     gdal_env={"AWS_REQUEST_PAYER": "requester"},
+                ... )
+                >>> ds.gdal_env["AWS_REQUEST_PAYER"]
+                'requester'
+
+                ```
+        """
+        return dict(self._gdal_env)
+
+    def _cloud_config(self) -> Any:
+        """Return a context manager installing :attr:`gdal_env` for a read.
+
+        A :class:`contextlib.nullcontext` when nothing was captured, so the
+        overwhelmingly common unsigned case pays nothing per read.
+        """
+        return cloud_config_from_env(self._gdal_env)
+
     def __reduce__(self):
         """Return a recipe tuple that re-opens the dataset on unpickle.
 
         Serialising a live `gdal.Dataset` pointer is not possible
         (native C++ handle, no copy semantics). Instead we emit the
-        minimal recipe `(class, file_name, access)` and reconstruct
-        on unpickle by calling `cls.read_file(path, read_only=...)`.
+        minimal recipe `(class, file_name, access, gdal_env)` and
+        reconstruct on unpickle by calling `cls.read_file(path, ...)`
+        under the captured GDAL config, so a signed remote dataset
+        re-opens on the worker with its credentials.
 
         The GDAL handle is therefore opened **on the receiving process
         / thread**, which is the invariant dask.distributed needs.
@@ -148,7 +221,10 @@ class RasterBase(ABC):
                 "dataset is not supported. Call .to_file(path) "
                 "first to anchor it to disk."
             )
-        return (_reconstruct_dataset, (type(self), path, self._access))
+        return (
+            _reconstruct_dataset,
+            (type(self), path, self._access, dict(self._gdal_env)),
+        )
 
     def __enter__(self):
         """Enter the context manager."""

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -16,8 +16,10 @@ compatibility with the module path; the class itself was renamed from
 
 from __future__ import annotations
 
+import functools
+import inspect
 from abc import ABC, abstractmethod
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from numbers import Number
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -60,6 +62,44 @@ RESAMPLING_METHODS = [
     "RMS",
     "BILINEAR",
 ]
+
+
+def under_gdal_env(method: Callable[..., Any]) -> Callable[..., Any]:
+    """Run an engine read under the dataset's captured cloud config.
+
+    The engines reach their dataset through `self._ds`, so one decorator covers
+    every pixel-producing entry point without each one remembering to open a
+    `with` block — the coverage is structural, and a newly added read path opts
+    in by being decorated rather than by being added to a list.
+
+    Nesting is harmless: the inner config is a `nullcontext` for an unsigned
+    dataset, and an identical `gdal.config_options` install otherwise.
+
+    A generator method (`get_tile`) is wrapped so the config covers every
+    `yield` rather than only the call that builds the generator — its pixels are
+    read while the caller iterates, long after that call returned.
+
+    Args:
+        method: An engine method whose `self` exposes `_ds`.
+
+    Returns:
+        The method wrapped so `RasterBase._cloud_config` is installed around it.
+    """
+    if inspect.isgeneratorfunction(method):
+
+        @functools.wraps(method)
+        def generator_wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+            with self._ds._cloud_config():
+                yield from method(self, *args, **kwargs)
+
+        return generator_wrapper
+
+    @functools.wraps(method)
+    def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+        with self._ds._cloud_config():
+            return method(self, *args, **kwargs)
+
+    return wrapper
 
 
 def _reconstruct_dataset(
@@ -127,12 +167,15 @@ class RasterBase(ABC):
         self._access = access
         self._raster = src
         # Cloud credentials/config this dataset was opened with (a STAC signer's
-        # gdal_env, say). Re-installed around every read, because several read
-        # paths do not go through the handle opened above: a VRT opens its
-        # sources lazily on first pixel read, `threadsafe=True` opens one handle
-        # per thread, a lazy `chunks=` read opens inside the dask task, and
-        # unpickling on a worker re-opens from the path. A plain dict so it
-        # survives pickling. Empty (the common case) costs a `nullcontext`.
+        # gdal_env, say). Re-installed around the reads that do not go through
+        # the handle opened above: `threadsafe=True` opens one handle per
+        # thread, a lazy `chunks=` read opens inside the dask task, and
+        # unpickling on a worker re-opens from the path. Applied structurally by
+        # the `@under_gdal_env` decorator on the engine read primitives. A plain
+        # dict so it survives pickling; empty (the common case) costs a
+        # `nullcontext`. It does *not* reach a VRT's source opens — GDAL ignores
+        # the thread-local config there, so those credentials ride the source
+        # path instead (see `pyramids.stac._vrt`).
         self._gdal_env: dict[str, str] = dict(gdal_env) if gdal_env else {}
         # Per-thread file manager for read_array(threadsafe=True); created
         # lazily by the IO engine and released by close().

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -22,7 +22,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable, Generator
 from numbers import Number
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 import numpy as np
 from geopandas.geodataframe import GeoDataFrame
@@ -64,42 +64,54 @@ RESAMPLING_METHODS = [
 ]
 
 
-def under_gdal_env(method: Callable[..., Any]) -> Callable[..., Any]:
-    """Run an engine read under the dataset's captured cloud config.
+_EngineMethod = TypeVar("_EngineMethod", bound=Callable[..., Any])
+
+
+def under_gdal_env(method: _EngineMethod) -> _EngineMethod:
+    """Run an engine entry point under the dataset's captured cloud config.
 
     The engines reach their dataset through `self._ds`, so one decorator covers
-    every pixel-producing entry point without each one remembering to open a
-    `with` block — the coverage is structural, and a newly added read path opts
-    in by being decorated rather than by being added to a list.
+    an entry point without it remembering to open a `with` block.
 
-    Nesting is harmless: the inner config is a `nullcontext` for an unsigned
-    dataset, and an identical `gdal.config_options` install otherwise.
+    Apply it at the **entry point**, not at the primitives it calls: nesting is
+    harmless but not free — each install constructs a `CloudConfig` and makes
+    `gdal.config_options` save and restore every key, which measured at ~4x on a
+    small windowed read when the decorator sat on both `read_array` and the
+    `_read_block` it calls.
 
-    A generator method (`get_tile`) is wrapped so the config covers every
-    `yield` rather than only the call that builds the generator — its pixels are
-    read while the caller iterates, long after that call returned.
+    Never apply it to a generator. Spanning the `yield`s would keep the config
+    installed while the *consumer's* loop body runs, and `gdal.config_options`
+    restores a snapshot on exit — so two interleaved generators leaving in
+    non-LIFO order silently strip each other's config. A generator installs the
+    config per item instead.
+
+    The signature is preserved (a bound `TypeVar`), so a decorated public method
+    keeps its argument checking rather than degrading to `(*args, **kwargs) ->
+    Any`.
 
     Args:
         method: An engine method whose `self` exposes `_ds`.
 
     Returns:
         The method wrapped so `RasterBase._cloud_config` is installed around it.
+
+    Raises:
+        TypeError: `method` is a generator function — see above.
     """
     if inspect.isgeneratorfunction(method):
-
-        @functools.wraps(method)
-        def generator_wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
-            with self._ds._cloud_config():
-                yield from method(self, *args, **kwargs)
-
-        return generator_wrapper
+        raise TypeError(
+            f"under_gdal_env cannot wrap the generator {method.__qualname__!r}: the "
+            "config would stay installed across its yields, leaking into the "
+            "caller's scope and corrupting a concurrently-open generator's config. "
+            "Install it per item inside the generator instead."
+        )
 
     @functools.wraps(method)
     def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         with self._ds._cloud_config():
             return method(self, *args, **kwargs)
 
-    return wrapper
+    return cast(_EngineMethod, wrapper)
 
 
 def _reconstruct_dataset(

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -237,6 +237,39 @@ class RasterBase(ABC):
         """
         return cloud_config_from_env(self._gdal_env)
 
+    def attach_gdal_env(self, gdal_env: dict[str, str] | None) -> None:
+        """Capture `gdal_env` on an already-open dataset.
+
+        The supported way for a reader that cannot take `gdal_env=` at open time
+        — :func:`pyramids.grib.open_grib`, :meth:`pyramids.netcdf.NetCDF.read_file`
+        — to hand its caller's credentials to the object it just built, instead
+        of the caller reaching in and setting the private attribute.
+
+        Args:
+            gdal_env: The GDAL config to capture. `None` or empty clears it.
+
+        Examples:
+            - Attach credentials to a dataset opened without them:
+                ```python
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.read_file("tests/data/acc4000.tif")
+                >>> ds.attach_gdal_env({"AWS_REQUEST_PAYER": "requester"})
+                >>> ds.gdal_env["AWS_REQUEST_PAYER"]
+                'requester'
+
+                ```
+            - Clearing it leaves the dataset reading with no extra config:
+                ```python
+                >>> ds = Dataset.read_file("tests/data/acc4000.tif")
+                >>> ds.attach_gdal_env({"AWS_REQUEST_PAYER": "requester"})
+                >>> ds.attach_gdal_env(None)
+                >>> ds.gdal_env
+                {}
+
+                ```
+        """
+        self._gdal_env = dict(gdal_env) if gdal_env else {}
+
     def __reduce__(self):
         """Return a recipe tuple that re-opens the dataset on unpickle.
 

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -70,6 +70,10 @@ _EngineMethod = TypeVar("_EngineMethod", bound=Callable[..., Any])
 def under_gdal_env(method: _EngineMethod) -> _EngineMethod:
     """Run an engine entry point under the dataset's captured cloud config.
 
+    Internal: an engine decorator, not public API. It is unprefixed only because
+    the engine modules import it across package boundaries; it is meaningless on
+    anything that does not expose `self._ds`.
+
     The engines reach their dataset through `self._ds`, so one decorator covers
     an entry point without it remembering to open a `with` block.
 
@@ -154,7 +158,7 @@ def _reconstruct_dataset(
     # subclass benefits without widening its own signature.
     with cloud_config_from_env(gdal_env):
         dataset = cls.read_file(path, read_only=True)
-    dataset._gdal_env = dict(gdal_env) if gdal_env else {}
+    dataset.attach_gdal_env(gdal_env)
     return dataset
 
 
@@ -306,6 +310,12 @@ class RasterBase(ABC):
         parameter defaults), but a recipe written by *this* version needs a
         reader that accepts four arguments — so a mixed-version cluster has to
         upgrade the workers, not only the client.
+
+        Security:
+            The recipe carries :attr:`gdal_env` verbatim, so pickling a dataset
+            opened with credentials serialises them. `dask.distributed` spills
+            graphs to disk and quotes task keys in error reports — treat such a
+            pickle as a secret, and prefer a short-lived token.
 
         Raises:
             TypeError: The dataset has no on-disk path (empty

--- a/src/pyramids/dataset/cog/options.py
+++ b/src/pyramids/dataset/cog/options.py
@@ -71,12 +71,19 @@ COG_READ_DEFAULTS: dict[str, str] = {
     "GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR",
     "CPL_VSIL_CURL_ALLOWED_EXTENSIONS": ".tif,.tiff",
     "GDAL_HTTP_MERGE_CONSECUTIVE_RANGES": "YES",
+    "GDAL_HTTP_MULTIRANGE": "YES",
+    "GDAL_HTTP_MAX_RETRY": "3",
+    "GDAL_HTTP_RETRY_DELAY": "0.5",
     "VSI_CACHE": "TRUE",
 }
 """GDAL config options that make remote ``/vsicurl/`` COG reads efficient.
 
 Without ``GDAL_DISABLE_READDIR_ON_OPEN`` a remote open issues a directory
-listing — often the single biggest latency hit. Applied by
+listing — often the single biggest latency hit. ``GDAL_HTTP_MULTIRANGE`` lets
+GDAL issue the scattered tile ranges a COG read produces as one multi-range
+request (``GDAL_HTTP_MERGE_CONSECUTIVE_RANGES`` then coalesces the adjacent
+ones), and the retry pair rides out a transient 5xx from object storage instead
+of failing the whole read. Applied by
 :func:`pyramids.dataset.cog.validate.validate` and
 :func:`pyramids.dataset.cog.inspect.cog_info` for remote paths when the caller
 passes no explicit ``config``. Pure strings (no GDAL dependency here)."""

--- a/src/pyramids/dataset/cog/options.py
+++ b/src/pyramids/dataset/cog/options.py
@@ -83,7 +83,11 @@ listing — often the single biggest latency hit. ``GDAL_HTTP_MULTIRANGE`` lets
 GDAL issue the scattered tile ranges a COG read produces as one multi-range
 request (``GDAL_HTTP_MERGE_CONSECUTIVE_RANGES`` then coalesces the adjacent
 ones), and the retry pair rides out a transient 5xx from object storage instead
-of failing the whole read. Applied by
+of failing the whole read. That budget is deliberately larger than the OGC
+discovery one (:data:`pyramids.base._ogc_api.GDAL_HTTP_MAX_RETRY`): a COG read
+issues many range requests, so one flaky range should not lose the whole read,
+whereas a discovery pre-check is a single request in front of work that has not
+started yet. Applied by
 :func:`pyramids.dataset.cog.validate.validate` and
 :func:`pyramids.dataset.cog.inspect.cog_info` for remote paths when the caller
 passes no explicit ``config``. Pure strings (no GDAL dependency here)."""

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -1574,7 +1574,11 @@ class DatasetCollection:
         if not resolved:
             raise ValueError("files must contain at least one path")
         with cloud_config_from_env(gdal_env):
-            template = Dataset.read_file(resolved[0])
+            # The template is reachable as `collection.base`, and the legacy
+            # `DatasetCollection(src, time_length=N)` shape replicates it as every
+            # timestep, so it needs the env for its own reads too — not just for
+            # this open.
+            template = Dataset.read_file(resolved[0], gdal_env=gdal_env)
             if meta is None:
                 meta = RasterMeta.from_dataset(template)
         return cls(

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -559,8 +559,14 @@ class DatasetCollection:
                 # SAS) around every per-timestep open so a signed file-backed
                 # collection authenticates its Path A reads, not just the
                 # template open in from_files. A no-op when _gdal_env is empty.
+                # It is also handed to each Dataset, so the env is re-installed
+                # around their *reads* too: the open alone does not cover a
+                # per-thread or lazy-chunk read, which re-opens the file.
+                env = self._gdal_env or None
                 with cloud_config_from_env(self._gdal_env):
-                    self._datasets = [Dataset.read_file(str(p)) for p in self._files]
+                    self._datasets = [
+                        Dataset.read_file(str(p), gdal_env=env) for p in self._files
+                    ]
             else:
                 self._datasets = [self._base] * self._time_length
         return self._datasets

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2096,13 +2096,16 @@ class Dataset(RasterBase):
             gdal_env (dict[str, str] | None):
                 Optional GDAL config (cloud credentials, HTTP knobs) installed
                 for this open **and captured on the returned dataset**, so it is
-                re-installed around every later read. Needed by the read paths
-                that open the file again instead of reusing this handle: a VRT
-                opening its sources on first pixel read, ``threadsafe=True``
-                per-thread handles, lazy ``chunks=`` reads inside dask tasks,
-                and unpickling on a worker. :func:`pyramids.stac.load_asset`
-                passes a signer's ``gdal_env()`` here. Default ``None`` — no
-                extra config, nothing captured.
+                re-installed around its reads. Needed by the read paths that
+                open the file again instead of reusing this handle:
+                ``threadsafe=True`` per-thread handles, lazy ``chunks=`` reads
+                inside dask tasks, and unpickling on a worker.
+                :func:`pyramids.stac.load_asset` passes a signer's
+                ``gdal_env()`` here. It does **not** reach a VRT's source opens
+                — GDAL ignores the thread-local config there, so
+                :func:`pyramids.stac.build_vrt_from_stac` puts those credentials
+                in the source path instead. Default ``None`` — no extra config,
+                nothing captured.
 
         Returns:
             Dataset:

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -27,7 +27,7 @@ from pyramids.base._utils import (
     numpy_to_gdal_dtype,
 )
 from pyramids.base.crs import epsg_from_wkt, sr_from_epsg, sr_from_user_input
-from pyramids.base.remote import cloud_config_from_env
+from pyramids.base.remote import cloud_config_from_env, redact_credentials
 from pyramids.dataset._ogc_coverages import from_ogc_coverages as _from_ogc_coverages
 from pyramids.dataset._wcs import from_wcs as _from_wcs
 from pyramids.dataset._wms import from_wms as _from_wms
@@ -1433,10 +1433,20 @@ class Dataset(RasterBase):
         return message
 
     def __repr__(self) -> str:
-        """GDAL info string, or a `<Dataset: closed>` sentinel on a closed dataset."""
+        """GDAL info string, or a `<Dataset: closed>` sentinel on a closed dataset.
+
+        The info string's ``Files:`` section lists every source a VRT
+        references, and for a mosaic built by
+        :func:`pyramids.stac.build_vrt_from_stac` with a bearer signer those
+        paths carry the live token — so the text goes through
+        :func:`~pyramids.base.remote.redact_credentials` first. ``repr`` is
+        called far more often than deliberately: pytest prints it for every
+        operand of a failing assertion, ``logging.error("%r", ds)`` is idiomatic,
+        and a notebook auto-displays it.
+        """
         info = "<Dataset: closed>"
         if self._raster is not None:
-            info = str(gdal.Info(self.raster))
+            info = redact_credentials(str(gdal.Info(self.raster)))
         return info
 
     @property

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2120,9 +2120,7 @@ class Dataset(RasterBase):
         """
         with cloud_config_from_env(gdal_env):
             src = _io.read_file(path, read_only=read_only, file_i=file_i, vsi=vsi)
-        return cls(
-            src, access="read_only" if read_only else "write", gdal_env=gdal_env
-        )
+        return cls(src, access="read_only" if read_only else "write", gdal_env=gdal_env)
 
     @classmethod
     def from_bytes(

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -27,6 +27,7 @@ from pyramids.base._utils import (
     numpy_to_gdal_dtype,
 )
 from pyramids.base.crs import epsg_from_wkt, sr_from_epsg, sr_from_user_input
+from pyramids.base.remote import cloud_config_from_env
 from pyramids.dataset._ogc_coverages import from_ogc_coverages as _from_ogc_coverages
 from pyramids.dataset._wcs import from_wcs as _from_wcs
 from pyramids.dataset._wms import from_wms as _from_wms
@@ -258,10 +259,16 @@ class Dataset(RasterBase):
     _band_dim_sizes: tuple[int, ...]
     _variable_attrs: dict[str, Any]
 
-    def __init__(self, src: gdal.Dataset, access: str = "read_only"):
+    def __init__(
+        self,
+        src: gdal.Dataset,
+        access: str = "read_only",
+        *,
+        gdal_env: dict[str, str] | None = None,
+    ):
         """__init__."""
         self.logger = logging.getLogger(__name__)
-        super().__init__(src, access=access)
+        super().__init__(src, access=access, gdal_env=gdal_env)
 
         self._no_data_value = [
             src.GetRasterBand(i).GetNoDataValue() for i in range(1, self.band_count + 1)
@@ -2053,6 +2060,7 @@ class Dataset(RasterBase):
         file_i: int = 0,
         *,
         vsi: str | None = None,
+        gdal_env: dict[str, str] | None = None,
     ) -> Dataset:
         """Open a raster from a path, URL, or archive member.
 
@@ -2085,6 +2093,16 @@ class Dataset(RasterBase):
                 download URL must first be fetched and saved with a ``.zip``
                 name (or written to ``/vsimem/<name>.zip`` via
                 :func:`osgeo.gdal.FileFromMemBuffer`).
+            gdal_env (dict[str, str] | None):
+                Optional GDAL config (cloud credentials, HTTP knobs) installed
+                for this open **and captured on the returned dataset**, so it is
+                re-installed around every later read. Needed by the read paths
+                that open the file again instead of reusing this handle: a VRT
+                opening its sources on first pixel read, ``threadsafe=True``
+                per-thread handles, lazy ``chunks=`` reads inside dask tasks,
+                and unpickling on a worker. :func:`pyramids.stac.load_asset`
+                passes a signer's ``gdal_env()`` here. Default ``None`` — no
+                extra config, nothing captured.
 
         Returns:
             Dataset:
@@ -2093,11 +2111,15 @@ class Dataset(RasterBase):
         See Also:
             - :meth:`read_array`: read the values stored in a dataset band.
             - :meth:`from_bytes`: open a raster held in memory.
+            - :attr:`gdal_env`: the config captured by ``gdal_env=``.
             - :meth:`pyramids.dataset.DatasetCollection.from_archive`: open
               *every* member of an archive as a temporal stack.
         """
-        src = _io.read_file(path, read_only=read_only, file_i=file_i, vsi=vsi)
-        return cls(src, access="read_only" if read_only else "write")
+        with cloud_config_from_env(gdal_env):
+            src = _io.read_file(path, read_only=read_only, file_i=file_i, vsi=vsi)
+        return cls(
+            src, access="read_only" if read_only else "write", gdal_env=gdal_env
+        )
 
     @classmethod
     def from_bytes(

--- a/src/pyramids/dataset/engines/cog.py
+++ b/src/pyramids/dataset/engines/cog.py
@@ -38,6 +38,7 @@ from pyramids.dataset.cog import (
     validate_profile,
 )
 from pyramids.dataset.cog.validate import _resolve_read_config, config_context
+from pyramids.dataset.abstract_dataset import under_gdal_env
 from pyramids.dataset.engines._base import _Engine
 
 if TYPE_CHECKING:
@@ -884,6 +885,7 @@ class COG(_Engine["Dataset"]):
             return None
         return fn
 
+    @under_gdal_env
     def read_part(
         self,
         bbox: tuple[float, float, float, float],
@@ -1048,6 +1050,7 @@ class COG(_Engine["Dataset"]):
             return cast(float, nodata)
         return 0 if is_integer_gdal_dtype(band.DataType) else float("nan")
 
+    @under_gdal_env
     def preview(
         self,
         *,
@@ -1098,6 +1101,7 @@ class COG(_Engine["Dataset"]):
             source.ReadAsArray(buf_xsize=out_w, buf_ysize=out_h, resample_alg=alg)
         )
 
+    @under_gdal_env
     def point(
         self,
         x: float,
@@ -1143,6 +1147,7 @@ class COG(_Engine["Dataset"]):
         arr = np.asarray(source.ReadAsArray(col, row, 1, 1))
         return arr.reshape(-1) if band is None else arr.reshape(())
 
+    @under_gdal_env
     def read_tile(
         self,
         z: int,

--- a/src/pyramids/dataset/engines/cog.py
+++ b/src/pyramids/dataset/engines/cog.py
@@ -26,6 +26,7 @@ from pyramids.base._utils import (
     numpy_to_gdal_dtype,
     resolve_cog_predictor,
 )
+from pyramids.dataset.abstract_dataset import under_gdal_env
 from pyramids.dataset.cog import (
     COGInfo,
     ValidationReport,
@@ -38,7 +39,6 @@ from pyramids.dataset.cog import (
     validate_profile,
 )
 from pyramids.dataset.cog.validate import _resolve_read_config, config_context
-from pyramids.dataset.abstract_dataset import under_gdal_env
 from pyramids.dataset.engines._base import _Engine
 
 if TYPE_CHECKING:
@@ -688,6 +688,7 @@ class COG(_Engine["Dataset"]):
                 raise
 
     @property
+    @under_gdal_env
     def is_cog(self) -> bool:
         """`True` iff the backing file on disk is a valid COG.
 
@@ -770,6 +771,7 @@ class COG(_Engine["Dataset"]):
             finally:
                 ds = None
 
+    @under_gdal_env
     def validate_cog(
         self, strict: bool = False, config: dict[str, str] | None = None
     ) -> ValidationReport:
@@ -820,6 +822,7 @@ class COG(_Engine["Dataset"]):
             )
         return validate(fn, strict=strict, config=config)
 
+    @under_gdal_env
     def info(self, config: dict[str, str] | None = None) -> COGInfo:
         """Return structured COG metadata for the backing file.
 

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -340,6 +340,7 @@ def _terrain_rgba_stack(
 
 
 class IO(_Engine["Dataset"]):
+    @under_gdal_env
     def read_array(
         self,
         band: int | None = None,
@@ -782,48 +783,44 @@ class IO(_Engine["Dataset"]):
             arr = self._threadsafe_eager_read(band=band, window=window)
             self._ds._backend = "numpy"
         else:
-            # The full-band branch reads straight off the shared handle instead
-            # of going through a `@under_gdal_env` primitive, so it installs the
-            # captured config itself. This does *not* rescue a VRT's sources —
-            # GDAL ignores the thread-local config when opening those, so their
-            # credentials ride the source path instead (see `pyramids.stac._vrt`).
-            with self._ds._cloud_config():
-                if band is None and self._ds.band_count > 1:
-                    if window is None:
-                        arr = np.ones(
-                            (
-                                self._ds.band_count,
-                                self._ds.rows,
-                                self._ds.columns,
-                            ),
-                            dtype=self._ds.numpy_dtype[0],
-                        )
-                        for i in range(self._ds.band_count):
-                            arr[i, :, :] = self._ds._raster.GetRasterBand(
-                                i + 1
-                            ).ReadAsArray()
-                    else:
-                        # ``window`` here is a resolved pixel window (``Window``
-                        # or a ``[col_off, row_off, cols, rows]`` list — any
-                        # geometry window was converted to one above). Stack
-                        # per-band block reads so ``_read_block`` applies the
-                        # identical window to every band without re-parsing its
-                        # dimensions here.
-                        arr = np.stack(
-                            [
-                                self._read_block(i, window)
-                                for i in range(self._ds.band_count)
-                            ],
-                            axis=0,
-                        )
+            # The shared handle is used directly here; the captured cloud config is
+            # already installed by read_array's @under_gdal_env decorator.
+            if band is None and self._ds.band_count > 1:
+                if window is None:
+                    arr = np.ones(
+                        (
+                            self._ds.band_count,
+                            self._ds.rows,
+                            self._ds.columns,
+                        ),
+                        dtype=self._ds.numpy_dtype[0],
+                    )
+                    for i in range(self._ds.band_count):
+                        arr[i, :, :] = self._ds._raster.GetRasterBand(
+                            i + 1
+                        ).ReadAsArray()
                 else:
-                    _validate_band_index(band, self._ds.band_count)
-                    if band is None:
-                        band = 0
-                    if window is None:
-                        arr = self._ds._iloc(band).ReadAsArray()
-                    else:
-                        arr = self._read_block(band, window)
+                    # ``window`` here is a resolved pixel window (``Window``
+                    # or a ``[col_off, row_off, cols, rows]`` list — any
+                    # geometry window was converted to one above). Stack
+                    # per-band block reads so ``_read_block`` applies the
+                    # identical window to every band without re-parsing its
+                    # dimensions here.
+                    arr = np.stack(
+                        [
+                            self._read_block(i, window)
+                            for i in range(self._ds.band_count)
+                        ],
+                        axis=0,
+                    )
+            else:
+                _validate_band_index(band, self._ds.band_count)
+                if band is None:
+                    band = 0
+                if window is None:
+                    arr = self._ds._iloc(band).ReadAsArray()
+                else:
+                    arr = self._read_block(band, window)
             self._ds._backend = "numpy"
             if masked:
                 arr = self._to_masked(arr, band, window=window)
@@ -959,7 +956,6 @@ class IO(_Engine["Dataset"]):
                     self._ds._thread_manager = manager
         return manager
 
-    @under_gdal_env
     def _read_via_handle(
         self,
         handle: gdal.Dataset,
@@ -1225,7 +1221,6 @@ class IO(_Engine["Dataset"]):
         )
         return arr
 
-    @under_gdal_env
     def _decimated_read(
         self,
         band: int | None,
@@ -1344,7 +1339,6 @@ class IO(_Engine["Dataset"]):
             ) from exc
         return np.asarray(block)
 
-    @under_gdal_env
     def _boundless_read(
         self,
         band: int | None,
@@ -1411,7 +1405,6 @@ class IO(_Engine["Dataset"]):
         result = planes[0] if not all_bands else np.stack(planes, axis=0)
         return result
 
-    @under_gdal_env
     def _read_block(
         self,
         band: int,
@@ -2228,7 +2221,6 @@ class IO(_Engine["Dataset"]):
                 xsize = size if size + xoff <= cols else cols - xoff
                 yield xoff, yoff, xsize, ysize
 
-    @under_gdal_env
     def get_tile(self, size=256) -> Generator[np.typing.NDArray]:
         """Get tile.
 
@@ -2305,10 +2297,16 @@ class IO(_Engine["Dataset"]):
               ```
         """
         for xoff, yoff, xsize, ysize in self._tile_offsets(size=size):
-            # read the array at certain indices
-            yield self._ds.raster.ReadAsArray(
-                xoff=xoff, yoff=yoff, xsize=xsize, ysize=ysize
-            )
+            # The captured cloud config is installed per tile, never across the
+            # yield: holding it open while the consumer's loop body runs would
+            # leak it into their scope, and `gdal.config_options` restores a
+            # snapshot on exit — so two interleaved generators leaving in
+            # non-LIFO order would silently strip each other's config.
+            with self._ds._cloud_config():
+                tile = self._ds.raster.ReadAsArray(
+                    xoff=xoff, yoff=yoff, xsize=xsize, ysize=ysize
+                )
+            yield tile
 
     def map_blocks(
         self,

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -37,7 +37,11 @@ from pyramids.base._locks import DummyLock, default_lock
 from pyramids.base._utils import resolve_resampling
 from pyramids.base.crs import reproject_coordinates
 from pyramids.base.protocols import ArrayLike
-from pyramids.dataset.abstract_dataset import OVERVIEW_LEVELS, RESAMPLING_METHODS
+from pyramids.dataset.abstract_dataset import (
+    OVERVIEW_LEVELS,
+    RESAMPLING_METHODS,
+    under_gdal_env,
+)
 from pyramids.dataset.engines.cog import (
     _RESAMPLING_ALG,
     _WEB_MERCATOR_HALF_EXTENT,
@@ -778,9 +782,11 @@ class IO(_Engine["Dataset"]):
             arr = self._threadsafe_eager_read(band=band, window=window)
             self._ds._backend = "numpy"
         else:
-            # The shared handle still needs the captured cloud config: a
-            # VRT-backed dataset opens its *sources* here, on the first pixel
-            # read, long after the handle itself was created.
+            # The full-band branch reads straight off the shared handle instead
+            # of going through a `@under_gdal_env` primitive, so it installs the
+            # captured config itself. This does *not* rescue a VRT's sources —
+            # GDAL ignores the thread-local config when opening those, so their
+            # credentials ride the source path instead (see `pyramids.stac._vrt`).
             with self._ds._cloud_config():
                 if band is None and self._ds.band_count > 1:
                     if window is None:
@@ -953,6 +959,7 @@ class IO(_Engine["Dataset"]):
                     self._ds._thread_manager = manager
         return manager
 
+    @under_gdal_env
     def _read_via_handle(
         self,
         handle: gdal.Dataset,
@@ -1218,6 +1225,7 @@ class IO(_Engine["Dataset"]):
         )
         return arr
 
+    @under_gdal_env
     def _decimated_read(
         self,
         band: int | None,
@@ -1336,6 +1344,7 @@ class IO(_Engine["Dataset"]):
             ) from exc
         return np.asarray(block)
 
+    @under_gdal_env
     def _boundless_read(
         self,
         band: int | None,
@@ -1402,6 +1411,7 @@ class IO(_Engine["Dataset"]):
         result = planes[0] if not all_bands else np.stack(planes, axis=0)
         return result
 
+    @under_gdal_env
     def _read_block(
         self,
         band: int,
@@ -1873,6 +1883,7 @@ class IO(_Engine["Dataset"]):
         )
         return df
 
+    @under_gdal_env
     def to_file(
         self,
         path: str | Path,
@@ -2217,6 +2228,7 @@ class IO(_Engine["Dataset"]):
                 xsize = size if size + xoff <= cols else cols - xoff
                 yield xoff, yoff, xsize, ysize
 
+    @under_gdal_env
     def get_tile(self, size=256) -> Generator[np.typing.NDArray]:
         """Get tile.
 

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -778,41 +778,46 @@ class IO(_Engine["Dataset"]):
             arr = self._threadsafe_eager_read(band=band, window=window)
             self._ds._backend = "numpy"
         else:
-            if band is None and self._ds.band_count > 1:
-                if window is None:
-                    arr = np.ones(
-                        (
-                            self._ds.band_count,
-                            self._ds.rows,
-                            self._ds.columns,
-                        ),
-                        dtype=self._ds.numpy_dtype[0],
-                    )
-                    for i in range(self._ds.band_count):
-                        arr[i, :, :] = self._ds._raster.GetRasterBand(
-                            i + 1
-                        ).ReadAsArray()
+            # The shared handle still needs the captured cloud config: a
+            # VRT-backed dataset opens its *sources* here, on the first pixel
+            # read, long after the handle itself was created.
+            with self._ds._cloud_config():
+                if band is None and self._ds.band_count > 1:
+                    if window is None:
+                        arr = np.ones(
+                            (
+                                self._ds.band_count,
+                                self._ds.rows,
+                                self._ds.columns,
+                            ),
+                            dtype=self._ds.numpy_dtype[0],
+                        )
+                        for i in range(self._ds.band_count):
+                            arr[i, :, :] = self._ds._raster.GetRasterBand(
+                                i + 1
+                            ).ReadAsArray()
+                    else:
+                        # ``window`` here is a resolved pixel window (``Window``
+                        # or a ``[col_off, row_off, cols, rows]`` list — any
+                        # geometry window was converted to one above). Stack
+                        # per-band block reads so ``_read_block`` applies the
+                        # identical window to every band without re-parsing its
+                        # dimensions here.
+                        arr = np.stack(
+                            [
+                                self._read_block(i, window)
+                                for i in range(self._ds.band_count)
+                            ],
+                            axis=0,
+                        )
                 else:
-                    # ``window`` here is a resolved pixel window (``Window`` or
-                    # a ``[col_off, row_off, cols, rows]`` list — any geometry
-                    # window was converted to one above). Stack per-band block
-                    # reads so ``_read_block`` applies the identical window to
-                    # every band without re-parsing its dimensions here.
-                    arr = np.stack(
-                        [
-                            self._read_block(i, window)
-                            for i in range(self._ds.band_count)
-                        ],
-                        axis=0,
-                    )
-            else:
-                _validate_band_index(band, self._ds.band_count)
-                if band is None:
-                    band = 0
-                if window is None:
-                    arr = self._ds._iloc(band).ReadAsArray()
-                else:
-                    arr = self._read_block(band, window)
+                    _validate_band_index(band, self._ds.band_count)
+                    if band is None:
+                        band = 0
+                    if window is None:
+                        arr = self._ds._iloc(band).ReadAsArray()
+                    else:
+                        arr = self._read_block(band, window)
             self._ds._backend = "numpy"
             if masked:
                 arr = self._to_masked(arr, band, window=window)
@@ -896,17 +901,21 @@ class IO(_Engine["Dataset"]):
         # Normalize to the list[int] _read_via_handle expects -- window may still
         # be a tuple here (e.g. straight from Window.to_read_args()).
         window_list = list(window) if window is not None else None
-        handle = self._get_thread_manager().acquire()
-        try:
-            arr = self._read_via_handle(handle, band, window_list)
-        except RuntimeError as exc:
-            # Same contract as the default path's _read_block.
-            if "Access window out of range" in str(exc):
-                raise OutOfBoundsError(
-                    f"The window you entered ({window}) is out of the raster "
-                    f"bounds: {self._ds.rows, self._ds.columns}"
-                ) from exc
-            raise
+        # This path opens a *new* handle per thread from the dataset's path, so
+        # the credentials captured at the original open have to be re-installed
+        # around both the open and the read (the shared handle is not used).
+        with self._ds._cloud_config():
+            handle = self._get_thread_manager().acquire()
+            try:
+                arr = self._read_via_handle(handle, band, window_list)
+            except RuntimeError as exc:
+                # Same contract as the default path's _read_block.
+                if "Access window out of range" in str(exc):
+                    raise OutOfBoundsError(
+                        f"The window you entered ({window}) is out of the raster "
+                        f"bounds: {self._ds.rows, self._ds.columns}"
+                    ) from exc
+                raise
         return np.asarray(arr)
 
     def _get_thread_manager(self) -> ThreadLocalFileManager:
@@ -1202,6 +1211,10 @@ class IO(_Engine["Dataset"]):
             band=effective_band,
             out_dtype=dtype,
             single_band=single_band,
+            # Chunks open the file inside the dask task, long after (and
+            # possibly in another process from) this call, so the captured
+            # cloud config travels with the task as a plain dict.
+            gdal_env=self._ds._gdal_env or None,
         )
         return arr
 

--- a/src/pyramids/dataset/ops/io.py
+++ b/src/pyramids/dataset/ops/io.py
@@ -15,6 +15,7 @@ from pyramids.base._errors import (
     FailedToSaveError,
 )
 from pyramids.base._file_manager import CachingFileManager
+from pyramids.base.remote import cloud_config_from_env
 from pyramids.dataset.abstract_dataset import (
     CATALOG,
 )
@@ -37,6 +38,7 @@ def _read_chunk(
     band: int | None,
     out_dtype: np.dtype,
     single_band: bool,
+    gdal_env: dict[str, str] | None = None,
 ) -> np.typing.NDArray:
     """Read one chunk of a raster through a pickleable :class:`CachingFileManager`.
 
@@ -73,6 +75,11 @@ def _read_chunk(
             with :func:`dask.array.map_blocks`'s own `dtype=` kwarg.
         single_band: `True` when the output is 2-D (`(rows, cols)`)
             and `False` when it is 3-D (`(bands, rows, cols)`).
+        gdal_env: The dataset's captured cloud config (a STAC signer's
+            `gdal_env()`), installed inside the worker around the open + read so
+            a signed remote raster authenticates its lazy chunk reads. Travels
+            as a plain dict because the task is pickled to the worker. A no-op
+            when empty / `None` — the common, unsigned case pays nothing.
 
     Returns:
         np.ndarray: The fully materialized chunk with shape derived
@@ -83,6 +90,36 @@ def _read_chunk(
     # for the (unused) meta-inference call convention.
     assert block_info is not None
     location = block_info[None]["array-location"]
+    with cloud_config_from_env(gdal_env):
+        result = _read_chunk_body(location, manager, lock, band, out_dtype, single_band)
+    return result
+
+
+def _read_chunk_body(
+    location: Any,
+    manager: CachingFileManager,
+    lock: Any,
+    band: int | None,
+    out_dtype: np.dtype,
+    single_band: bool,
+) -> np.typing.NDArray:
+    """Read one chunk's pixels; the body of :func:`_read_chunk`.
+
+    Split out so the cloud config installed by :func:`_read_chunk` wraps the
+    whole open + read without indenting the read logic another level.
+
+    Args:
+        location: The chunk's `[(start, stop),...]` index ranges, taken from
+            dask's `block_info[None]["array-location"]`.
+        manager: File-handle manager for the backing raster.
+        lock: Lock held around the `ReadAsArray` call.
+        band: Zero-based band index, or `None` for every band.
+        out_dtype: Output numpy dtype.
+        single_band: `True` for a 2-D chunk, `False` for a 3-D one.
+
+    Returns:
+        np.ndarray: The materialized chunk.
+    """
     if single_band:
         # The caller only sets single_band=True when it also resolved band to
         # a real int (see _lazy_read's effective_band).

--- a/src/pyramids/netcdf/_lazy.py
+++ b/src/pyramids/netcdf/_lazy.py
@@ -40,6 +40,7 @@ import numpy as np
 from pyramids.base._file_manager import CachingFileManager, gdal_mdarray_open
 from pyramids.base._locks import DummyLock, default_lock
 from pyramids.base._utils import import_dask
+from pyramids.base.remote import cloud_config_from_env
 from pyramids.netcdf._mdim import axis_flips
 from pyramids.netcdf.utils import _dtype_to_str
 
@@ -312,6 +313,7 @@ def _read_mdarray_chunk(
     starts: list[int],
     counts: list[int],
     expected_dtype: np.dtype,
+    gdal_env: dict[str, str] | None = None,
 ) -> np.typing.NDArray:
     """Read one block of an MDArray through a :class:`CachingFileManager`.
 
@@ -329,11 +331,15 @@ def _read_mdarray_chunk(
         counts: Per-axis counts (shape of the returned block).
         expected_dtype: Dtype to cast the block to if the driver
             returns a different one (e.g. a narrower int).
+        gdal_env: The dataset's captured cloud config (a STAC signer's
+            `gdal_env()`), installed inside the worker around the open + read so
+            a signed remote store authenticates its lazy chunk reads. A no-op
+            when empty / `None`.
 
     Returns:
         np.ndarray: The block data, shape `tuple(counts)`.
     """
-    with manager.acquire_context() as ds:
+    with cloud_config_from_env(gdal_env), manager.acquire_context() as ds:
         rg = ds.GetRootGroup()
         md_arr = rg.OpenMDArray(variable_name)
         block = md_arr.ReadAsArray(
@@ -435,6 +441,7 @@ class _MDArrayChunkReader:
         "expected_dtype",
         "starts",
         "counts",
+        "gdal_env",
     )
 
     def __init__(
@@ -444,12 +451,17 @@ class _MDArrayChunkReader:
         expected_dtype: np.dtype,
         starts: tuple[int, ...],
         counts: tuple[int, ...],
+        gdal_env: dict[str, str] | None = None,
     ) -> None:
         self.manager = manager
         self.variable_name = variable_name
         self.expected_dtype = expected_dtype
         self.starts = tuple(int(s) for s in starts)
         self.counts = tuple(int(c) for c in counts)
+        # The store is re-opened inside the dask task, so a signed remote NetCDF
+        # needs its credentials to travel with the task rather than relying on
+        # whatever config happens to be installed on the worker.
+        self.gdal_env = dict(gdal_env) if gdal_env else None
 
     def __getstate__(self) -> tuple:
         return (
@@ -458,12 +470,17 @@ class _MDArrayChunkReader:
             self.expected_dtype,
             self.starts,
             self.counts,
+            self.gdal_env,
         )
 
     def __setstate__(self, state: tuple) -> None:
-        manager, variable_name, expected_dtype, starts, counts = state
+        # A five-element tuple is a graph pickled before the config was carried.
+        manager, variable_name, expected_dtype, starts, counts, *rest = state
+        gdal_env = rest[0] if rest else None
         # Re-running __init__ from __setstate__ is the intended unpickle path.
-        self.__init__(manager, variable_name, expected_dtype, starts, counts)  # type: ignore[misc]
+        self.__init__(  # type: ignore[misc]
+            manager, variable_name, expected_dtype, starts, counts, gdal_env
+        )
 
     def __call__(self) -> np.typing.NDArray:
         return _read_mdarray_chunk(
@@ -472,6 +489,7 @@ class _MDArrayChunkReader:
             list(self.starts),
             list(self.counts),
             self.expected_dtype,
+            self.gdal_env,
         )
 
 
@@ -599,6 +617,7 @@ def build_lazy_array(
     manager_hook: Any = None,
     spatial_dims: tuple[int, int] | None = None,
     flips: tuple[bool, bool] | None = None,
+    gdal_env: dict[str, str] | None = None,
 ) -> Any:
     """Build a :class:`dask.array.Array` backed by MDArray chunk reads.
 
@@ -613,6 +632,9 @@ def build_lazy_array(
             variable share a cache slot. Defaults to
             `(path, variable_name)` so repeated calls for the same
             variable de-duplicate the cached handle.
+        gdal_env: The dataset's captured cloud config, carried into every
+            chunk task so a signed remote store authenticates the re-open each
+            task performs. A no-op when empty / `None`.
         manager_hook: Optional callable invoked with the created
             `CachingFileManager` before the array is returned, so the
             owning object (e.g. the `NetCDF` container) can track it and
@@ -675,6 +697,7 @@ def build_lazy_array(
             dtype,
             starts,
             counts,
+            gdal_env,
         )
         graph[(name,) + index] = (reader,)
     lazy = da.Array(graph, name, chunks_per_axis, dtype=dtype)

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1862,6 +1862,9 @@ class NetCDF(Dataset):
                 manager_hook=self._register_lazy_manager,
                 spatial_dims=spatial_dims,
                 flips=flips,
+                # Each chunk task re-opens the store, so a signed remote NetCDF
+                # needs its credentials shipped with the graph.
+                gdal_env=self._gdal_env or None,
             ),
         )
 

--- a/src/pyramids/stac/__init__.py
+++ b/src/pyramids/stac/__init__.py
@@ -1,14 +1,44 @@
-"""STAC client signing helpers.
+"""Read STAC catalogs with GDAL: search, sign, open, mosaic, and describe.
 
-A generic, dependency-light signing abstraction for STAC API consumers plus a
-thin :func:`open_client` wrapper over `pystac-client`.
+pyramids consumes STAC without depending on `pystac`: Items and Assets are
+duck-typed (a `pystac.Item` and a raw STAC-JSON dict are read identically), and
+every asset resolves to a GDAL-backed :class:`~pyramids.dataset.Dataset`.
 
-- :class:`Signer` — the three-boundary signing protocol.
-- :class:`AnonymousSigner` — no credentials (public catalogs).
-- :class:`AWSRequesterPaysSigner` — GDAL env for AWS Requester-Pays buckets.
-- :class:`BearerTokenSigner` — `Authorization: Bearer` header injection.
-- :func:`open_client` — open a `pystac-client` Client with a signer wired in
+Search and authentication:
+
+- :func:`search` — a typed item search bounded at the API (AOI, time, CQL2).
+- :func:`open_client` — open a `pystac-client` Client with a signer wired into
+  both of its hooks (requires the `[stac]` extra).
+- :class:`Signer` — the three-boundary signing protocol (search request, item
+  rewrite, asset read), with :class:`AnonymousSigner` for public catalogs,
+  :class:`AWSRequesterPaysSigner` for Requester-Pays buckets, and
+  :class:`BearerTokenSigner` for token-authenticated hosts.
+
+Reading assets:
+
+- :func:`load_asset` — open one asset as a `Dataset` / `NetCDF`, dispatched by
+  media type (COG/GeoTIFF, JPEG2000, NetCDF, GRIB, Zarr).
+- :func:`which_engine` / :func:`resolved_href` — the read-free companions: which
+  reader would be used, and what href would be opened.
+- :func:`build_vrt_from_stac` — mosaic one asset across many items into a lazy
+  VRT-backed `Dataset` that reads its sources on demand.
+- :func:`download_item` — fetch an Item's assets to local files instead
   (requires the `[stac]` extra).
+
+Item metadata:
+
+- :func:`read_extension_metadata` — the `proj` / `raster` / `eo` grid and band
+  metadata, read from the Item JSON without opening any asset.
+- :func:`affine_to_geotransform` / :func:`geotransform_to_affine` — convert
+  between a STAC `proj:transform` affine and a GDAL geotransform.
+- :func:`parse_number` — coerce a STAC numeric field, honouring the
+  `raster` extension's `"nan"` / `"inf"` spellings.
+- :func:`to_geoparquet` / :func:`from_geoparquet` — round-trip an
+  ItemCollection through a spatially-filterable GeoParquet file.
+
+To build a time-stacked cube from many items use
+:meth:`pyramids.dataset.DatasetCollection.from_stac`; to describe a raster as a
+STAC Item, :meth:`pyramids.dataset.Dataset.to_stac_item`.
 
 Provider-specific signers that hardcode a single Earth-observation catalog
 (Microsoft Planetary Computer, NASA Earthdata, Copernicus CDSE) live in
@@ -19,6 +49,8 @@ from __future__ import annotations
 
 from pyramids.stac._extensions import (
     affine_to_geotransform,
+    geotransform_to_affine,
+    parse_number,
     read_extension_metadata,
 )
 from pyramids.stac._geoparquet import from_geoparquet, to_geoparquet
@@ -43,8 +75,10 @@ __all__ = [
     "build_vrt_from_stac",
     "download_item",
     "from_geoparquet",
+    "geotransform_to_affine",
     "load_asset",
     "open_client",
+    "parse_number",
     "read_extension_metadata",
     "resolved_href",
     "search",

--- a/src/pyramids/stac/_item.py
+++ b/src/pyramids/stac/_item.py
@@ -22,7 +22,7 @@ pyramids does **not** import or depend on pystac. The extension-field accessor
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from pyramids.base._errors import StacAssetError
@@ -86,6 +86,53 @@ def item_properties(item: Any) -> Mapping[str, Any]:
     if props is None and isinstance(item, dict):
         props = item.get("properties")
     return props or {}
+
+
+def item_bbox(item: Any) -> Sequence[float] | None:
+    """Return a STAC Item's `bbox`, or `None` when absent.
+
+    A STAC bbox is WGS84 by spec and is either 2D (`[west, south, east, north]`)
+    or 3D (`[west, south, min_elev, east, north, max_elev]`). This accessor only
+    locates it on either item shape; interpreting the length is the caller's job
+    (see :func:`pyramids.dataset._stac._horizontal_bounds`).
+
+    Args:
+        item: A STAC Item (pystac object or raw dict).
+
+    Returns:
+        The bbox sequence, or `None` when the item carries none.
+
+    Examples:
+        - A raw dict item exposes its bbox:
+            ```python
+            >>> from pyramids.stac._item import item_bbox
+            >>> item_bbox({"bbox": [1.0, 2.0, 3.0, 4.0]})
+            [1.0, 2.0, 3.0, 4.0]
+
+            ```
+        - A bbox-less item returns None:
+            ```python
+            >>> item_bbox({"id": "x"}) is None
+            True
+
+            ```
+        - A 3D bbox comes back with its elevation members intact:
+            ```python
+            >>> item_bbox({"bbox": [1.0, 2.0, 0.0, 3.0, 4.0, 100.0]})[2]
+            0.0
+
+            ```
+
+    See Also:
+        - :func:`item_properties`: the sibling accessor for item-level
+          extension fields.
+        - :func:`pyramids.dataset._stac._horizontal_bounds`: reduces either
+          bbox length to `(west, south, east, north)`.
+    """
+    bbox = getattr(item, "bbox", None)
+    if bbox is None and isinstance(item, dict):
+        bbox = item.get("bbox")
+    return bbox
 
 
 def get_assets(item: Any) -> Mapping[str, Any] | None:
@@ -276,6 +323,7 @@ __all__ = [
     "asset_media_type",
     "get_asset",
     "get_assets",
+    "item_bbox",
     "item_id",
     "item_properties",
 ]

--- a/src/pyramids/stac/_loader.py
+++ b/src/pyramids/stac/_loader.py
@@ -127,7 +127,9 @@ def _engine_for(media_type: str | None, href: str) -> str:
     return result
 
 
-def _open_config(href: str, engine: str, signer: Any) -> AbstractContextManager[Any]:
+def _open_config(
+    href: str, engine: str, gdal_env: dict[str, str] | None
+) -> AbstractContextManager[Any]:
     """Return the GDAL config context an asset open should run under.
 
     A remote **raster** asset gets the `/vsicurl/` fast-read preset (readdir
@@ -148,7 +150,11 @@ def _open_config(href: str, engine: str, signer: Any) -> AbstractContextManager[
     Args:
         href: The resolved (already signed) asset href.
         engine: The reader chosen by :func:`_engine_for`.
-        signer: The signer whose `gdal_env()` to install, or `None`.
+        gdal_env: The signer's already-resolved GDAL config, or `None`. The
+            resolved mapping rather than the signer, because `gdal_env()` is a
+            method a token-refreshing signer may answer differently on each
+            call — asking twice could install one token for the open and capture
+            a different one on the dataset, and pay for two refreshes.
 
     Returns:
         A context manager installing the resolved config for the open.
@@ -165,29 +171,24 @@ def _open_config(href: str, engine: str, signer: Any) -> AbstractContextManager[
             ```
         - A remote NetCDF keeps its sidecars, so it takes the signer env only:
             ```python
-            >>> class _S:
-            ...     def gdal_env(self):
-            ...         return {"AWS_REQUEST_PAYER": "requester"}
-            >>> _open_config("s3://b/cube.nc", "netcdf", _S()).as_gdal_config()
+            >>> env = {"AWS_REQUEST_PAYER": "requester"}
+            >>> _open_config("s3://b/cube.nc", "netcdf", env).as_gdal_config()
             {'AWS_REQUEST_PAYER': 'requester'}
 
             ```
         - A remote Zarr store opts out of the preset and keeps the signer env:
             ```python
-            >>> class _S:
-            ...     def gdal_env(self):
-            ...         return {"AWS_REQUEST_PAYER": "requester"}
-            >>> _open_config("s3://b/store.zarr", "zarr", _S()).as_gdal_config()
+            >>> env = {"AWS_REQUEST_PAYER": "requester"}
+            >>> _open_config("s3://b/store.zarr", "zarr", env).as_gdal_config()
             {'AWS_REQUEST_PAYER': 'requester'}
 
             ```
     """
-    signer_env = signer.gdal_env() if signer is not None else None
     config: AbstractContextManager[Any]
     if engine == "gdal" and is_remote(href):
-        config = CloudConfig(vsicurl_tuning=True, extra=dict(signer_env or {}))
+        config = CloudConfig(vsicurl_tuning=True, extra=dict(gdal_env or {}))
     else:
-        config = cloud_config_from_env(signer_env)
+        config = cloud_config_from_env(gdal_env)
     return config
 
 
@@ -356,7 +357,7 @@ def load_asset(
         href = signer.sign_href(href)
     engine = _engine_for(media_type, href)
     signer_env = signer.gdal_env() if signer is not None else None
-    with _open_config(href, engine, signer):
+    with _open_config(href, engine, signer_env):
         if engine == "gdal":
             result: Any = Dataset.read_file(href, vsi=vsi, gdal_env=signer_env)
         elif engine == "zarr":

--- a/src/pyramids/stac/_loader.py
+++ b/src/pyramids/stac/_loader.py
@@ -24,7 +24,7 @@ from typing import Any, cast
 
 from pyramids.base._errors import UnsupportedAssetError
 from pyramids.base._utils import import_zarr, lazy_extra_hint
-from pyramids.base.remote import signer_cloud_config
+from pyramids.base.remote import CloudConfig, cloud_config_from_env, is_remote
 from pyramids.dataset import Dataset, DatasetCollection
 from pyramids.dataset.ops._geobox_zarr import detect_data_var
 from pyramids.dataset.ops._zarr import _resolve_store
@@ -124,6 +124,54 @@ def _engine_for(media_type: str | None, href: str) -> str:
             f"href={href!r}; supported: GeoTIFF/COG, JPEG2000, NetCDF, GRIB, Zarr."
         )
     return result
+
+
+def _open_config(href: str, engine: str, signer: Any) -> Any:
+    """Return the GDAL config context an asset open should run under.
+
+    A remote asset read by a GDAL engine gets the `/vsicurl/` fast-read preset
+    (readdir skip, HTTP/2 multiplexing, merged multi-range reads) merged with
+    the signer env, which always wins on a key conflict. Two cases opt out:
+
+    * **Local assets** — the preset's `GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR`
+      would stop GDAL finding a local file's `.aux.xml` / world-file sidecars.
+    * **Zarr** — those assets are read by zarr/fsspec rather than GDAL, so GDAL
+      config is inert, and a readdir skip is wrong for a directory-style store.
+
+    Args:
+        href: The resolved (already signed) asset href.
+        engine: The reader chosen by :func:`_engine_for`.
+        signer: The signer whose `gdal_env()` to install, or `None`.
+
+    Returns:
+        A context manager installing the resolved config for the open.
+
+    Examples:
+        - A remote COG open gets the fast-read preset:
+            ```python
+            >>> from pyramids.stac._loader import _open_config
+            >>> _open_config("/vsicurl/https://h/a.tif", "gdal", None).as_gdal_config()[
+            ...     "GDAL_DISABLE_READDIR_ON_OPEN"
+            ... ]
+            'EMPTY_DIR'
+
+            ```
+        - A remote Zarr store opts out of the preset and keeps the signer env:
+            ```python
+            >>> class _S:
+            ...     def gdal_env(self):
+            ...         return {"AWS_REQUEST_PAYER": "requester"}
+            >>> _open_config("s3://b/store.zarr", "zarr", _S()).as_gdal_config()
+            {'AWS_REQUEST_PAYER': 'requester'}
+
+            ```
+    """
+    signer_env = signer.gdal_env() if signer is not None else None
+    if engine != "zarr" and is_remote(href):
+        config: Any = CloudConfig(vsicurl_tuning=True, extra=dict(signer_env or {}))
+    else:
+        config = cloud_config_from_env(signer_env)
+    return config
 
 
 def which_engine(item_or_asset: Any, asset_key: str | None = None) -> str:
@@ -290,16 +338,39 @@ def load_asset(
     if signer is not None:
         href = signer.sign_href(href)
     engine = _engine_for(media_type, href)
-    with signer_cloud_config(signer):
-        if engine == "grib":
-            result: Any = open_grib(href, vsi=vsi)
-        elif engine == "zarr":
-            result = _load_zarr(href)
-        elif engine == "netcdf":
-            result = NetCDF.read_file(href)
+    signer_env = signer.gdal_env() if signer is not None else None
+    with _open_config(href, engine, signer):
+        if engine == "gdal":
+            result: Any = Dataset.read_file(href, vsi=vsi, gdal_env=signer_env)
         else:
-            result = Dataset.read_file(href, vsi=vsi)
+            if engine == "grib":
+                result = open_grib(href, vsi=vsi)
+            elif engine == "zarr":
+                result = _load_zarr(href)
+            else:
+                result = NetCDF.read_file(href)
+            # Unlike Dataset.read_file these readers take no gdal_env=, so the
+            # signer env is attached to the opened object instead.
+            _persist_gdal_env(result, signer_env)
     return cast(Dataset, result)
+
+
+def _persist_gdal_env(result: Any, env: dict[str, str] | None) -> None:
+    """Capture the signer env on a reader that could not take it at open time.
+
+    `Dataset.read_file` accepts `gdal_env=` directly, but the GRIB, NetCDF and
+    Zarr readers do not widen their signatures for it. They all return a
+    :class:`~pyramids.dataset.abstract_dataset.RasterBase` (or a
+    :class:`~pyramids.dataset.DatasetCollection`), both of which carry the same
+    `_gdal_env` attribute and re-install it around their reads, so setting it
+    afterwards gives those engines the same read-time credentials.
+
+    Args:
+        result: The opened reader.
+        env: The signer's GDAL config, or `None` when there is no signer.
+    """
+    if env:
+        result._gdal_env = dict(env)
 
 
 def _load_zarr(href: str):

--- a/src/pyramids/stac/_loader.py
+++ b/src/pyramids/stac/_loader.py
@@ -20,6 +20,7 @@ resolve to pyramids' GDAL-backed wrappers.
 
 from __future__ import annotations
 
+from contextlib import AbstractContextManager
 from typing import Any, cast
 
 from pyramids.base._errors import UnsupportedAssetError
@@ -126,17 +127,23 @@ def _engine_for(media_type: str | None, href: str) -> str:
     return result
 
 
-def _open_config(href: str, engine: str, signer: Any) -> Any:
+def _open_config(href: str, engine: str, signer: Any) -> AbstractContextManager[Any]:
     """Return the GDAL config context an asset open should run under.
 
-    A remote asset read by a GDAL engine gets the `/vsicurl/` fast-read preset
-    (readdir skip, HTTP/2 multiplexing, merged multi-range reads) merged with
-    the signer env, which always wins on a key conflict. Two cases opt out:
+    A remote **raster** asset gets the `/vsicurl/` fast-read preset (readdir
+    skip, HTTP/2 multiplexing, merged multi-range reads) merged with the signer
+    env, which always wins on a key conflict. Everything else gets the signer
+    env alone, because the preset's `GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR`
+    stops GDAL discovering sibling files, and only the raster case can be relied
+    on not to need them:
 
-    * **Local assets** — the preset's `GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR`
-      would stop GDAL finding a local file's `.aux.xml` / world-file sidecars.
-    * **Zarr** — those assets are read by zarr/fsspec rather than GDAL, so GDAL
-      config is inert, and a readdir skip is wrong for a directory-style store.
+    * **Local assets** — the sidecars are free to read and often load-bearing
+      (`.aux.xml` nodata, a world file, a `.prj`).
+    * **NetCDF / GRIB** — a remote one may still carry a PAM `.aux.xml` with a
+      no-data value, an SRS override or band statistics, and losing those
+      silently changes what the reader returns.
+    * **Zarr** — read by zarr/fsspec rather than GDAL, so GDAL config is inert,
+      and a readdir skip is actively wrong for a directory-style store.
 
     Args:
         href: The resolved (already signed) asset href.
@@ -156,6 +163,15 @@ def _open_config(href: str, engine: str, signer: Any) -> Any:
             'EMPTY_DIR'
 
             ```
+        - A remote NetCDF keeps its sidecars, so it takes the signer env only:
+            ```python
+            >>> class _S:
+            ...     def gdal_env(self):
+            ...         return {"AWS_REQUEST_PAYER": "requester"}
+            >>> _open_config("s3://b/cube.nc", "netcdf", _S()).as_gdal_config()
+            {'AWS_REQUEST_PAYER': 'requester'}
+
+            ```
         - A remote Zarr store opts out of the preset and keeps the signer env:
             ```python
             >>> class _S:
@@ -167,8 +183,10 @@ def _open_config(href: str, engine: str, signer: Any) -> Any:
             ```
     """
     signer_env = signer.gdal_env() if signer is not None else None
-    if engine != "zarr" and is_remote(href):
-        config: Any = CloudConfig(vsicurl_tuning=True, extra=dict(signer_env or {}))
+    if engine == "gdal" and is_remote(href):
+        config: AbstractContextManager[Any] = CloudConfig(
+            vsicurl_tuning=True, extra=dict(signer_env or {})
+        )
     else:
         config = cloud_config_from_env(signer_env)
     return config
@@ -342,13 +360,16 @@ def load_asset(
     with _open_config(href, engine, signer):
         if engine == "gdal":
             result: Any = Dataset.read_file(href, vsi=vsi, gdal_env=signer_env)
+        elif engine == "zarr":
+            # Read through zarr/fsspec, which never consults GDAL config — so
+            # nothing is captured on the result either (see _persist_gdal_env).
+            result = _load_zarr(href)
         else:
-            if engine == "grib":
-                result = open_grib(href, vsi=vsi)
-            elif engine == "zarr":
-                result = _load_zarr(href)
-            else:
-                result = NetCDF.read_file(href)
+            result = (
+                open_grib(href, vsi=vsi)
+                if engine == "grib"
+                else NetCDF.read_file(href)
+            )
             # Unlike Dataset.read_file these readers take no gdal_env=, so the
             # signer env is attached to the opened object instead.
             _persist_gdal_env(result, signer_env)
@@ -358,19 +379,25 @@ def load_asset(
 def _persist_gdal_env(result: Any, env: dict[str, str] | None) -> None:
     """Capture the signer env on a reader that could not take it at open time.
 
-    `Dataset.read_file` accepts `gdal_env=` directly, but the GRIB, NetCDF and
-    Zarr readers do not widen their signatures for it. They all return a
-    :class:`~pyramids.dataset.abstract_dataset.RasterBase` (or a
-    :class:`~pyramids.dataset.DatasetCollection`), both of which carry the same
-    `_gdal_env` attribute and re-install it around their reads, so setting it
-    afterwards gives those engines the same read-time credentials.
+    `Dataset.read_file` accepts `gdal_env=` directly, but the GRIB and NetCDF
+    readers do not widen their signatures for it. Both return a
+    :class:`~pyramids.dataset.abstract_dataset.RasterBase`, which exposes
+    :meth:`~pyramids.dataset.abstract_dataset.RasterBase.attach_gdal_env` for
+    exactly this — so the capture goes through a declared method rather than a
+    private attribute on a foreign object.
+
+    A reader that exposes no such hook is left alone: the Zarr branch reads
+    through zarr/fsspec, which never consults GDAL config, so attaching
+    credentials there would only widen their blast radius (they would ride the
+    object's pickle) for no read-time benefit.
 
     Args:
         result: The opened reader.
         env: The signer's GDAL config, or `None` when there is no signer.
     """
-    if env:
-        result._gdal_env = dict(env)
+    attach = getattr(result, "attach_gdal_env", None)
+    if env and callable(attach):
+        attach(env)
 
 
 def _load_zarr(href: str):

--- a/src/pyramids/stac/_loader.py
+++ b/src/pyramids/stac/_loader.py
@@ -183,10 +183,9 @@ def _open_config(href: str, engine: str, signer: Any) -> AbstractContextManager[
             ```
     """
     signer_env = signer.gdal_env() if signer is not None else None
+    config: AbstractContextManager[Any]
     if engine == "gdal" and is_remote(href):
-        config: AbstractContextManager[Any] = CloudConfig(
-            vsicurl_tuning=True, extra=dict(signer_env or {})
-        )
+        config = CloudConfig(vsicurl_tuning=True, extra=dict(signer_env or {}))
     else:
         config = cloud_config_from_env(signer_env)
     return config

--- a/src/pyramids/stac/_loader.py
+++ b/src/pyramids/stac/_loader.py
@@ -366,9 +366,7 @@ def load_asset(
             result = _load_zarr(href)
         else:
             result = (
-                open_grib(href, vsi=vsi)
-                if engine == "grib"
-                else NetCDF.read_file(href)
+                open_grib(href, vsi=vsi) if engine == "grib" else NetCDF.read_file(href)
             )
             # Unlike Dataset.read_file these readers take no gdal_env=, so the
             # signer env is attached to the opened object instead.

--- a/src/pyramids/stac/_vrt.py
+++ b/src/pyramids/stac/_vrt.py
@@ -401,7 +401,6 @@ def redact(href: str) -> str:
     return f"{base}?<redacted>" if sep else base
 
 
-
 def _reclaim_vsimem(vrt_path: str) -> None:
     """Unlink a `/vsimem` VRT and stop tracking it.
 

--- a/src/pyramids/stac/_vrt.py
+++ b/src/pyramids/stac/_vrt.py
@@ -33,6 +33,20 @@ have to travel *with the source path*:
   keys) cannot be carried into the source opens; the build warns, and those
   assets should be read one at a time with :func:`pyramids.stac.load_asset` or
   fetched with :func:`pyramids.stac.download_item`.
+
+**Credential exposure.** Both supported mechanisms put the credential *in the
+source path*, which is unavoidable — it is the only place GDAL still reads it
+from at source-open time. Consequences to plan for:
+
+* The returned ``Dataset`` carries live credentials. ``to_file("m.vrt")`` writes
+  them into the VRT XML in cleartext, and pickling it (a dask graph, say) ships
+  them too. Treat such a mosaic as a secret; do not persist it to a shared
+  location.
+* GDAL echoes the full source path in its own ``Warning 1: Can't open …``
+  messages on stderr. pyramids redacts every href it puts in an exception or
+  warning of its own (:func:`redact`), but it cannot redact GDAL's.
+* Prefer a short-lived token, and prefer a URL-signing signer where the provider
+  offers one — a SAS token is scoped and expiring, a bearer token usually is not.
 """
 
 from __future__ import annotations
@@ -40,6 +54,7 @@ from __future__ import annotations
 import uuid
 import warnings
 from collections.abc import Iterable
+from contextlib import AbstractContextManager
 from typing import Any
 from urllib.parse import quote
 
@@ -156,7 +171,7 @@ def _embed_source_options(href: str, gdal_env: dict[str, str] | None) -> str:
 
 
 def _warn_unembeddable_credentials(
-    gdal_env: dict[str, str] | None, sources: list[str]
+    gdal_env: dict[str, str] | None, hrefs: list[str]
 ) -> None:
     """Warn when signer credentials cannot reach the VRT's read-time opens.
 
@@ -167,7 +182,8 @@ def _warn_unembeddable_credentials(
 
     Args:
         gdal_env: The signer's GDAL config, or `None`.
-        sources: The VSI source paths of the build.
+        hrefs: The resolved source hrefs of the build (not the rewritten VSI
+            paths — see :func:`_source_config` for why).
 
     Warns:
         UserWarning: The env carries non-header credentials and at least one
@@ -179,7 +195,7 @@ def _warn_unembeddable_credentials(
         if key != _HTTP_HEADERS_KEY
         and (key.startswith(_CREDENTIAL_PREFIXES) or key in _CREDENTIAL_KEYS)
     )
-    if stranded and any(is_remote(path) for path in sources):
+    if stranded and any(is_remote(href) for href in hrefs):
         warnings.warn(
             f"the signer's credentials ({', '.join(stranded)}) authenticate the VRT "
             "build but cannot be carried into its read-time source opens: GDAL "
@@ -193,40 +209,56 @@ def _warn_unembeddable_credentials(
         )
 
 
-def _dropped_sources(requested: list[str], retained: Iterable[str]) -> list[str]:
-    """Return the requested sources GDAL left out of the built VRT.
+def _dropped_sources(
+    sources: list[tuple[str, str]], retained: Iterable[str]
+) -> list[str]:
+    """Return the redacted hrefs of the sources GDAL left out of the built VRT.
 
     :meth:`gdal.Dataset.GetFileList` on a freshly built VRT reports exactly the
-    sources it kept, so anything requested but absent from that list was skipped
-    during the build (GDAL logs a warning and carries on).
+    VSI paths it kept, so anything requested but absent from that list was
+    skipped during the build (GDAL logs a warning and carries on). The *href*
+    of each dropped source is what comes back — redacted, and never the VSI path,
+    which may carry an embedded credential.
 
     Args:
-        requested: The VSI paths handed to :func:`gdal.BuildVRT`, in order.
+        sources: The `(href, vsi_path)` pairs handed to :func:`gdal.BuildVRT`,
+            in order.
         retained: The source paths the built VRT actually references.
 
     Returns:
-        The requested paths missing from `retained`, in the requested order.
+        The redacted hrefs of the dropped sources, in the requested order.
 
     Examples:
-        - A source GDAL skipped is reported back:
+        - A source GDAL skipped is reported by href, not by VSI path:
             ```python
             >>> from pyramids.stac._vrt import _dropped_sources
-            >>> _dropped_sources(["a.tif", "b.tif"], ["a.tif"])
-            ['b.tif']
+            >>> pairs = [("https://h/a.tif", "/vsicurl/https://h/a.tif"),
+            ...          ("https://h/b.tif", "/vsicurl/https://h/b.tif")]
+            >>> _dropped_sources(pairs, ["/vsicurl/https://h/a.tif"])
+            ['https://h/b.tif']
+
+            ```
+        - A dropped source's credential never reaches the caller:
+            ```python
+            >>> pairs = [("https://h/b.tif?sig=SECRET", "/vsicurl?header.X=SECRET")]
+            >>> _dropped_sources(pairs, [])
+            ['https://h/b.tif?<redacted>']
 
             ```
         - Nothing is reported when every source was kept:
             ```python
-            >>> _dropped_sources(["a.tif"], ["a.tif", "/vsimem/x.vrt"])
+            >>> _dropped_sources([("a.tif", "a.tif")], ["a.tif", "/vsimem/x.vrt"])
             []
 
             ```
     """
     kept = set(retained)
-    return [path for path in requested if path not in kept]
+    return [redact(href) for href, vsi_path in sources if vsi_path not in kept]
 
 
-def _source_config(vsi_paths: list[str], gdal_env: dict[str, str] | None) -> Any:
+def _source_config(
+    hrefs: list[str], gdal_env: dict[str, str] | None
+) -> AbstractContextManager[Any]:
     """Return the GDAL config context the VRT build should run under.
 
     Remote sources get the `/vsicurl/` fast-read preset (readdir skip, HTTP/2
@@ -235,8 +267,15 @@ def _source_config(vsi_paths: list[str], gdal_env: dict[str, str] | None) -> Any
     the preset's `GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR` would stop GDAL
     finding a local source's `.aux.xml` / world-file sidecars.
 
+    Remoteness is decided on the **hrefs**, before
+    :func:`_embed_source_options` rewrites them: an embedded `/vsicurl?…` path
+    is not matched by :func:`~pyramids.base.remote.is_remote`, whose prefix set
+    holds `/vsicurl/` with a trailing slash, so classifying the rewritten paths
+    would silently opt the header-signed builds out of the preset.
+
     Args:
-        vsi_paths: The VSI-rewritten source paths for this build.
+        hrefs: The resolved source hrefs for this build (not the rewritten VSI
+            paths).
         gdal_env: The signer's GDAL config, or `None`.
 
     Returns:
@@ -246,14 +285,14 @@ def _source_config(vsi_paths: list[str], gdal_env: dict[str, str] | None) -> Any
         - Remote sources pull in the fast-read preset:
             ```python
             >>> from pyramids.stac._vrt import _source_config
-            >>> cfg = _source_config(["/vsicurl/https://h/a.tif"], None)
+            >>> cfg = _source_config(["https://h/a.tif"], None)
             >>> cfg.as_gdal_config()["GDAL_HTTP_MULTIRANGE"]
             'YES'
 
             ```
         - A signer env overrides a preset knob and survives either way:
             ```python
-            >>> cfg = _source_config(["/vsis3/b/a.tif"], {"AWS_REQUEST_PAYER": "requester"})
+            >>> cfg = _source_config(["s3://b/a.tif"], {"AWS_REQUEST_PAYER": "requester"})
             >>> cfg.as_gdal_config()["AWS_REQUEST_PAYER"]
             'requester'
 
@@ -266,11 +305,46 @@ def _source_config(vsi_paths: list[str], gdal_env: dict[str, str] | None) -> Any
 
             ```
     """
-    if any(is_remote(path) for path in vsi_paths):
+    if any(is_remote(path) for path in hrefs):
         config: Any = CloudConfig(vsicurl_tuning=True, extra=dict(gdal_env or {}))
     else:
         config = cloud_config_from_env(gdal_env)
     return config
+
+
+def redact(href: str) -> str:
+    """Return `href` with its query string replaced by a placeholder.
+
+    A signed href carries its credential in the query string — a SAS token from
+    a URL-signing signer, or the `header.Authorization` this module embeds for a
+    bearer signer. Anything that reaches an exception message, a warning or a log
+    has to go through here first: those strings routinely end up in application
+    logs, CI output and error trackers.
+
+    Args:
+        href: The href or VSI path to redact.
+
+    Returns:
+        The href up to its `?`, with `?<redacted>` appended when it carried a
+        query string; unchanged when it carried none.
+
+    Examples:
+        - A SAS-signed href keeps its identity but loses the token:
+            ```python
+            >>> from pyramids.stac._vrt import redact
+            >>> redact("https://host/B04.tif?sv=2021&sig=SECRET")
+            'https://host/B04.tif?<redacted>'
+
+            ```
+        - An unsigned href passes through untouched:
+            ```python
+            >>> redact("https://host/B04.tif")
+            'https://host/B04.tif'
+
+            ```
+    """
+    base, sep, _query = href.partition("?")
+    return f"{base}?<redacted>" if sep else base
 
 
 def _check_dropped_sources(
@@ -279,7 +353,9 @@ def _check_dropped_sources(
     """Raise (or warn) when `gdal.BuildVRT` skipped part of the requested mosaic.
 
     Args:
-        dropped: The requested sources missing from the built VRT.
+        dropped: The requested sources missing from the built VRT, already
+            redacted by :func:`redact` — they must never carry a live credential
+            into the message this raises.
         total: How many sources were requested.
         asset: The asset key being mosaicked (for the message).
         strict: Raise :class:`RuntimeError` when `True`, warn when `False`.
@@ -404,21 +480,23 @@ def build_vrt_from_stac(
         raise ValueError("build_vrt_from_stac received no items.")
 
     gdal_env = signer.gdal_env() if signer is not None else None
+    hrefs = [resolved_href(item, asset, signer=signer) for item in item_list]
     # Header credentials are baked into each source path so they survive into
-    # the VRT's lazy, read-time source opens (see _embed_source_options).
-    vsi_paths = [
-        _embed_source_options(resolved_href(item, asset, signer=signer), gdal_env)
-        for item in item_list
-    ]
-    _warn_unembeddable_credentials(gdal_env, vsi_paths)
+    # the VRT's lazy, read-time source opens (see _embed_source_options). The
+    # hrefs are kept alongside: an embedded path carries a live credential and
+    # must never be the thing a message, warning or log names.
+    sources = [(href, _embed_source_options(href, gdal_env)) for href in hrefs]
+    vsi_paths = [vsi_path for _href, vsi_path in sources]
+    _warn_unembeddable_credentials(gdal_env, hrefs)
     vrt_path = f"/vsimem/pyramids_stac_{uuid.uuid4().hex}.vrt"
 
     # BuildVRT opens every source. Over `/vsicurl/` that costs a directory
     # listing plus a fan of sidecar probes per source unless the fast-read
     # preset is installed, so pay for it once here — but only when a source is
     # actually remote: the preset's readdir skip would also hide a *local*
-    # source's `.aux.xml` / world-file sidecars.
-    with _source_config(vsi_paths, gdal_env):
+    # source's `.aux.xml` / world-file sidecars. Remoteness is decided on the
+    # hrefs, not the rewritten paths, which `is_remote` does not classify.
+    with _source_config(hrefs, gdal_env):
         vrt_ds = gdal.BuildVRT(
             vrt_path, vsi_paths, options=gdal.BuildVRTOptions(separate=separate)
         )
@@ -430,7 +508,7 @@ def build_vrt_from_stac(
             )
         # GDAL lists exactly the sources it kept, so the difference against what
         # was requested is what it silently skipped.
-        dropped = _dropped_sources(vsi_paths, vrt_ds.GetFileList() or ())
+        dropped = _dropped_sources(sources, vrt_ds.GetFileList() or ())
         vrt_ds.FlushCache()
         vrt_ds = None
         # Track the in-memory VRT *before* anything else can raise, so a failure

--- a/src/pyramids/stac/_vrt.py
+++ b/src/pyramids/stac/_vrt.py
@@ -15,10 +15,9 @@ Completeness note: GDAL treats a source it cannot use — an unreadable href, a
 band count or CRS that disagrees with the first source — as a *warning*, drops
 it, and builds the mosaic from what is left. That turns an expired signed URL
 into a silently incomplete mosaic whose missing tiles read as nodata, so
-:func:`build_vrt_from_stac` reports the skip. Today it warns
-(``strict=None``, the default) and adds a ``FutureWarning``; **from the
-next minor release the default becomes ``strict=True`` and the skip raises**.
-Pass ``strict=True`` or ``strict=False`` explicitly to pin either behaviour.
+:func:`build_vrt_from_stac` **raises** on any skipped source (``strict=True``,
+the default). Pass ``strict=False`` when a partial footprint is genuinely
+acceptable — it warns and returns what GDAL kept.
 
 Signer note: a VRT opens its sources lazily, on the first *pixel* read, and GDAL
 does not consult the thread-local config (what ``CloudConfig`` installs) when it
@@ -466,7 +465,7 @@ def _build_vrt(vrt_path: str, vsi_paths: list[str], separate: bool) -> Any:
 
 
 def _check_dropped_sources(
-    dropped: list[str], total: int, asset: str, strict: bool | None
+    dropped: list[str], total: int, asset: str, strict: bool
 ) -> None:
     """Raise (or warn) when `gdal.BuildVRT` skipped part of the requested mosaic.
 
@@ -476,21 +475,14 @@ def _check_dropped_sources(
             into the message this raises.
         total: How many sources were requested.
         asset: The asset key being mosaicked (for the message).
-        strict: Raise :class:`RuntimeError` when `True`; warn when `False`;
-            when `None` (the current default) warn and add a
-            :class:`FutureWarning` that the default flips to `True`.
+        strict: Raise :class:`RuntimeError` when `True` (the default), warn and
+            keep the partial mosaic when `False`.
 
     Raises:
         RuntimeError: `strict` is `True` and at least one source was skipped.
 
     Warns:
-        UserWarning: `strict` is not `True` and at least one source was skipped.
-        FutureWarning: `strict` is `None` and at least one source was skipped —
-            the caller is relying on a default that is about to change.
-            `FutureWarning` rather than `DeprecationWarning` because the latter
-            is silenced by Python's default filters unless it is raised from
-            `__main__`, and `stacklevel=3` attributes this one to the *caller of*
-            `build_vrt_from_stac`, which in a real deployment is library code.
+        UserWarning: `strict` is `False` and at least one source was skipped.
 
     Examples:
         - A complete build passes silently:
@@ -534,18 +526,6 @@ def _check_dropped_sources(
                 f"{message} Pass strict=False to build the partial mosaic anyway."
             )
         warnings.warn(message, UserWarning, stacklevel=3)
-        if strict is None:
-            warnings.warn(
-                "build_vrt_from_stac returned this incomplete mosaic because "
-                "strict defaults to None. That default becomes True in the next "
-                "minor release (tracked as ARC-79 in "
-                "planning/architecture-review/25-july/arc-stac.md), and the skip "
-                "above will raise instead. Pass strict=True to adopt that now, "
-                "or strict=False to keep the partial mosaic and silence this "
-                "warning.",
-                FutureWarning,
-                stacklevel=3,
-            )
 
 
 def build_vrt_from_stac(
@@ -554,7 +534,7 @@ def build_vrt_from_stac(
     *,
     signer: Any = None,
     separate: bool = False,
-    strict: bool | None = None,
+    strict: bool = True,
 ) -> Dataset:
     """Mosaic one STAC asset across items into a lazy VRT-backed `Dataset`.
 
@@ -571,12 +551,11 @@ def build_vrt_from_stac(
             (overlapping/tiling sources compose into one image — the stac-vrt
             model). When `True`, each source becomes a separate band (a
             band-stack VRT), which requires the sources to share a grid.
-        strict: What to do when GDAL skips a requested source. `True` raises,
-            so a partially-built mosaic is never mistaken for a complete one.
-            `False` warns and returns the partial mosaic. `None` (the current
-            default) behaves like `False` and adds a `FutureWarning`:
-            **the default becomes `True` in the next minor release**. Pass an
-            explicit value to pin the behaviour you want across that change.
+        strict: What to do when GDAL skips a requested source. `True` (the
+            default) raises, so a partially-built mosaic is never mistaken for a
+            complete one. `False` warns and returns the partial mosaic — use it
+            only when an incomplete footprint is genuinely acceptable, and check
+            what came back.
 
     Returns:
         Dataset: A lazy `Dataset` over an in-memory `.vrt`; GDAL reads the
@@ -586,15 +565,11 @@ def build_vrt_from_stac(
     Raises:
         ValueError: When `items` yields no items.
         RuntimeError: When `gdal.BuildVRT` fails outright (every source
-            unreadable), or — with `strict=True` — when it silently skipped
-            some of them (unreadable href, mismatched band count or CRS).
+            unreadable), or — with the default `strict=True` — when it silently
+            skipped some of them (unreadable href, mismatched band count or CRS).
 
     Warns:
-        UserWarning: When some sources were skipped and `strict` is not `True`.
-        FutureWarning: When some sources were skipped and `strict` was left at
-            its default, which is about to change. It is a `FutureWarning` so it
-            is visible under Python's default filters — a `DeprecationWarning`
-            from library code is silenced, which would defeat the notice.
+        UserWarning: When some sources were skipped and `strict` is `False`.
 
     Examples:
         - Mosaic the `visual` asset of several items into one lazy Dataset

--- a/src/pyramids/stac/_vrt.py
+++ b/src/pyramids/stac/_vrt.py
@@ -69,6 +69,8 @@ _DROPPED_PREVIEW = 5
 
 _HTTP_HEADERS_KEY = "GDAL_HTTP_HEADERS"
 
+_VSICURL_PREFIX = "/vsicurl/"
+
 _CREDENTIAL_PREFIXES = ("AWS_", "GS_", "AZURE_", "GOOGLE_", "SWIFT_", "OSS_")
 """Config-key prefixes that carry credentials rather than tuning knobs."""
 
@@ -120,8 +122,9 @@ def _embed_source_options(href: str, gdal_env: dict[str, str] | None) -> str:
     the read. GDAL's `/vsicurl?` query syntax solves it by carrying the options
     *in the path*, which the VRT stores and replays on every later open.
 
-    Only `http(s)` sources with header credentials can be rewritten this way;
-    anything else falls back to the plain :func:`_to_vsi` form.
+    Only sources that normalise to a bare `/vsicurl/<url>` can be rewritten this
+    way; anything else — a non-HTTP scheme, a local path, an archive-chained
+    `/vsizip//vsicurl/…` — keeps its ordinary :func:`_to_vsi` form.
 
     Args:
         href: The resolved (already signed) source href.
@@ -132,18 +135,32 @@ def _embed_source_options(href: str, gdal_env: dict[str, str] | None) -> str:
         ordinary VSI rewrite of `href`.
 
     Examples:
-        - A bearer header rides the source path:
+        - A bearer header rides the source path, with the readdir skip:
             ```python
             >>> from pyramids.stac._vrt import _embed_source_options
             >>> env = {"GDAL_HTTP_HEADERS": "Authorization: Bearer tok"}
             >>> _embed_source_options("https://h/a.tif", env)
-            '/vsicurl?header.Authorization=Bearer%20tok&url=https%3A%2F%2Fh%2Fa.tif'
+            '/vsicurl?header.Authorization=Bearer%20tok&empty_dir=yes&url=https%3A%2F%2Fh%2Fa.tif'
+
+            ```
+        - An href already in `/vsicurl/` form is still rewritten:
+            ```python
+            >>> env = {"GDAL_HTTP_HEADERS": "Authorization: Bearer tok"}
+            >>> _embed_source_options("/vsicurl/https://h/a.tif", env)
+            '/vsicurl?header.Authorization=Bearer%20tok&empty_dir=yes&url=https%3A%2F%2Fh%2Fa.tif'
 
             ```
         - Without a signer the ordinary rewrite is used:
             ```python
             >>> _embed_source_options("https://h/a.tif", None)
             '/vsicurl/https://h/a.tif'
+
+            ```
+        - An archive-chained source keeps its chaining rather than losing it:
+            ```python
+            >>> env = {"GDAL_HTTP_HEADERS": "Authorization: Bearer tok"}
+            >>> _embed_source_options("https://h/scene.zip/a.tif", env)
+            '/vsizip//vsicurl/https://h/scene.zip/a.tif'
 
             ```
         - A non-HTTP scheme cannot carry headers, so it is left alone:
@@ -154,19 +171,23 @@ def _embed_source_options(href: str, gdal_env: dict[str, str] | None) -> str:
 
             ```
     """
-    env = gdal_env or {}
-    headers = _parse_http_headers(env.get(_HTTP_HEADERS_KEY, ""))
-    if headers and href.lower().startswith(("http://", "https://")):
+    vsi = _to_vsi(href)
+    headers = _parse_http_headers((gdal_env or {}).get(_HTTP_HEADERS_KEY, ""))
+    # Only a bare `/vsicurl/<url>` can become the query form. Normalising through
+    # `_to_vsi` first means an href that was already in VSI form is still
+    # recognised, and an archive-chained path (`/vsizip//vsicurl/...`) is left
+    # alone rather than losing its chaining.
+    if headers and vsi.startswith(_VSICURL_PREFIX):
         parts = [f"header.{name}={quote(value)}" for name, value in headers]
-        if env.get("GDAL_DISABLE_READDIR_ON_OPEN") == "EMPTY_DIR":
-            # Carry the signer's own readdir skip into the read-time opens too,
-            # where the ambient config no longer reaches; without it every
-            # source re-probes its `.aux.xml` / `.prj` siblings on each open.
-            parts.append("empty_dir=yes")
-        parts.append(f"url={quote(href, safe='')}")
+        # Carry the readdir skip into the read-time opens too, where the ambient
+        # config no longer reaches; without it every source re-probes its
+        # `.aux.xml` / `.prj` siblings on each open — 14 wasted requests for two
+        # sources, measured. The build already runs under the same skip.
+        parts.append("empty_dir=yes")
+        parts.append(f"url={quote(vsi[len(_VSICURL_PREFIX) :], safe='')}")
         source = "/vsicurl?" + "&".join(parts)
     else:
-        source = _to_vsi(href)
+        source = vsi
     return source
 
 

--- a/src/pyramids/stac/_vrt.py
+++ b/src/pyramids/stac/_vrt.py
@@ -19,13 +19,20 @@ into a silently incomplete mosaic whose missing tiles read as nodata, so
 (``strict=True``, the default); pass ``strict=False`` for best-effort behaviour
 with a warning instead.
 
-Signer note: a URL-signing signer (e.g. :class:`PlanetaryComputerSigner`) is
-fully supported — the SAS token rides each source href, so reads need no extra
-config. An env-credentialed signer (Requester-Pays, bearer) authenticates the
-VRT *build*, but the returned ``Dataset``'s later pixel reads happen outside that
-config; wrap those reads in the matching ``CloudConfig`` / ``RequesterPays``
-block (the same limitation as :func:`pyramids.stac.load_asset`), or prefer a
-URL-signing signer.
+Signer note: a VRT opens its sources lazily, on the first *pixel* read, and GDAL
+does not consult the thread-local config (what ``CloudConfig`` installs) when it
+does — measured against a token-enforcing server, every source request went out
+unauthenticated no matter what config wrapped the read. Credentials therefore
+have to travel *with the source path*:
+
+* a URL-signing signer (e.g. ``PlanetaryComputerSigner``) — the token rides each
+  href, so nothing else is needed;
+* a bearer-header signer — the header is embedded per source through GDAL's
+  ``/vsicurl?header.…&url=…`` syntax (see :func:`_embed_source_options`);
+* anything else (Requester-Pays, ``GDAL_HTTP_USERPWD``, `GS_*` / `AZURE_*`
+  keys) cannot be carried into the source opens; the build warns, and those
+  assets should be read one at a time with :func:`pyramids.stac.load_asset` or
+  fetched with :func:`pyramids.stac.download_item`.
 """
 
 from __future__ import annotations
@@ -34,15 +41,156 @@ import uuid
 import warnings
 from collections.abc import Iterable
 from typing import Any
+from urllib.parse import quote
 
 from osgeo import gdal
 
 from pyramids.base._artifacts import register_vsimem
-from pyramids.base.remote import _to_vsi, cloud_config_from_env
+from pyramids.base.remote import CloudConfig, _to_vsi, cloud_config_from_env, is_remote
 from pyramids.dataset import Dataset
 from pyramids.stac._loader import resolved_href
 
 _DROPPED_PREVIEW = 5
+
+_HTTP_HEADERS_KEY = "GDAL_HTTP_HEADERS"
+
+_CREDENTIAL_PREFIXES = ("AWS_", "GS_", "AZURE_", "GOOGLE_", "SWIFT_", "OSS_")
+"""Config-key prefixes that carry credentials rather than tuning knobs."""
+
+_CREDENTIAL_KEYS = frozenset({"GDAL_HTTP_USERPWD", "GDAL_HTTP_AUTH", _HTTP_HEADERS_KEY})
+"""Non-prefixed config keys that carry credentials."""
+
+
+def _parse_http_headers(value: str) -> list[tuple[str, str]]:
+    """Split a `GDAL_HTTP_HEADERS` value into `(name, value)` pairs.
+
+    GDAL accepts one `Name: value` header per line, separated by CRLF or LF.
+
+    Args:
+        value: The raw `GDAL_HTTP_HEADERS` config value.
+
+    Returns:
+        The parsed headers, in order; malformed lines (no colon) are skipped.
+
+    Examples:
+        - A single bearer header parses to one pair:
+            ```python
+            >>> from pyramids.stac._vrt import _parse_http_headers
+            >>> _parse_http_headers("Authorization: Bearer tok")
+            [('Authorization', 'Bearer tok')]
+
+            ```
+        - Several headers may share one value, newline-separated:
+            ```python
+            >>> _parse_http_headers("Authorization: Bearer tok\\r\\nX-Trace: 42")
+            [('Authorization', 'Bearer tok'), ('X-Trace', '42')]
+
+            ```
+    """
+    headers = []
+    for line in value.replace("\r\n", "\n").split("\n"):
+        name, sep, header_value = line.partition(":")
+        if sep and name.strip():
+            headers.append((name.strip(), header_value.strip()))
+    return headers
+
+
+def _embed_source_options(href: str, gdal_env: dict[str, str] | None) -> str:
+    """Return a VSI source path carrying the signer's HTTP headers inline.
+
+    A VRT opens its sources on the first *pixel* read, and GDAL does not consult
+    the thread-local config (what :class:`~pyramids.base.remote.CloudConfig`
+    sets) when it does — measured against a token-enforcing server, every source
+    request went out unauthenticated no matter what config was installed around
+    the read. GDAL's `/vsicurl?` query syntax solves it by carrying the options
+    *in the path*, which the VRT stores and replays on every later open.
+
+    Only `http(s)` sources with header credentials can be rewritten this way;
+    anything else falls back to the plain :func:`_to_vsi` form.
+
+    Args:
+        href: The resolved (already signed) source href.
+        gdal_env: The signer's GDAL config, or `None`.
+
+    Returns:
+        A `/vsicurl?...&url=...` path when headers can be embedded, else the
+        ordinary VSI rewrite of `href`.
+
+    Examples:
+        - A bearer header rides the source path:
+            ```python
+            >>> from pyramids.stac._vrt import _embed_source_options
+            >>> env = {"GDAL_HTTP_HEADERS": "Authorization: Bearer tok"}
+            >>> _embed_source_options("https://h/a.tif", env)
+            '/vsicurl?header.Authorization=Bearer%20tok&url=https%3A%2F%2Fh%2Fa.tif'
+
+            ```
+        - Without a signer the ordinary rewrite is used:
+            ```python
+            >>> _embed_source_options("https://h/a.tif", None)
+            '/vsicurl/https://h/a.tif'
+
+            ```
+        - A non-HTTP scheme cannot carry headers, so it is left alone:
+            ```python
+            >>> env = {"GDAL_HTTP_HEADERS": "Authorization: Bearer tok"}
+            >>> _embed_source_options("s3://bucket/a.tif", env)
+            '/vsis3/bucket/a.tif'
+
+            ```
+    """
+    env = gdal_env or {}
+    headers = _parse_http_headers(env.get(_HTTP_HEADERS_KEY, ""))
+    if headers and href.lower().startswith(("http://", "https://")):
+        parts = [f"header.{name}={quote(value)}" for name, value in headers]
+        if env.get("GDAL_DISABLE_READDIR_ON_OPEN") == "EMPTY_DIR":
+            # Carry the signer's own readdir skip into the read-time opens too,
+            # where the ambient config no longer reaches; without it every
+            # source re-probes its `.aux.xml` / `.prj` siblings on each open.
+            parts.append("empty_dir=yes")
+        parts.append(f"url={quote(href, safe='')}")
+        source = "/vsicurl?" + "&".join(parts)
+    else:
+        source = _to_vsi(href)
+    return source
+
+
+def _warn_unembeddable_credentials(
+    gdal_env: dict[str, str] | None, sources: list[str]
+) -> None:
+    """Warn when signer credentials cannot reach the VRT's read-time opens.
+
+    Credentials that are not HTTP headers — `AWS_*`, `GS_*`, `AZURE_*`,
+    `GDAL_HTTP_USERPWD` — have no `/vsicurl?` equivalent, and GDAL ignores the
+    thread-local config when opening a VRT source, so those reads will run
+    unauthenticated however the caller wraps them.
+
+    Args:
+        gdal_env: The signer's GDAL config, or `None`.
+        sources: The VSI source paths of the build.
+
+    Warns:
+        UserWarning: The env carries non-header credentials and at least one
+            source is remote.
+    """
+    stranded = sorted(
+        key
+        for key in gdal_env or {}
+        if key != _HTTP_HEADERS_KEY
+        and (key.startswith(_CREDENTIAL_PREFIXES) or key in _CREDENTIAL_KEYS)
+    )
+    if stranded and any(is_remote(path) for path in sources):
+        warnings.warn(
+            f"the signer's credentials ({', '.join(stranded)}) authenticate the VRT "
+            "build but cannot be carried into its read-time source opens: GDAL "
+            "opens VRT sources lazily and ignores the thread-local config when it "
+            "does. Reads of this mosaic will be unauthenticated. Use a "
+            "URL-signing signer (the token rides each href), a bearer-header "
+            "signer (the header is embedded per source), or download the assets "
+            "with pyramids.stac.download_item.",
+            UserWarning,
+            stacklevel=3,
+        )
 
 
 def _dropped_sources(requested: list[str], retained: Iterable[str]) -> list[str]:
@@ -76,6 +224,53 @@ def _dropped_sources(requested: list[str], retained: Iterable[str]) -> list[str]
     """
     kept = set(retained)
     return [path for path in requested if path not in kept]
+
+
+def _source_config(vsi_paths: list[str], gdal_env: dict[str, str] | None) -> Any:
+    """Return the GDAL config context the VRT build should run under.
+
+    Remote sources get the `/vsicurl/` fast-read preset (readdir skip, HTTP/2
+    multiplexing, merged multi-range reads) merged with the signer env, which
+    always wins on a key conflict. An all-local build gets the signer env alone:
+    the preset's `GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR` would stop GDAL
+    finding a local source's `.aux.xml` / world-file sidecars.
+
+    Args:
+        vsi_paths: The VSI-rewritten source paths for this build.
+        gdal_env: The signer's GDAL config, or `None`.
+
+    Returns:
+        A context manager installing the resolved config for the build.
+
+    Examples:
+        - Remote sources pull in the fast-read preset:
+            ```python
+            >>> from pyramids.stac._vrt import _source_config
+            >>> cfg = _source_config(["/vsicurl/https://h/a.tif"], None)
+            >>> cfg.as_gdal_config()["GDAL_HTTP_MULTIRANGE"]
+            'YES'
+
+            ```
+        - A signer env overrides a preset knob and survives either way:
+            ```python
+            >>> cfg = _source_config(["/vsis3/b/a.tif"], {"AWS_REQUEST_PAYER": "requester"})
+            >>> cfg.as_gdal_config()["AWS_REQUEST_PAYER"]
+            'requester'
+
+            ```
+        - An all-local build carries the signer env only, with no preset:
+            ```python
+            >>> local = _source_config(["C:/data/a.tif"], {"AWS_REQUEST_PAYER": "yes"})
+            >>> local.as_gdal_config()
+            {'AWS_REQUEST_PAYER': 'yes'}
+
+            ```
+    """
+    if any(is_remote(path) for path in vsi_paths):
+        config: Any = CloudConfig(vsicurl_tuning=True, extra=dict(gdal_env or {}))
+    else:
+        config = cloud_config_from_env(gdal_env)
+    return config
 
 
 def _check_dropped_sources(
@@ -209,12 +404,21 @@ def build_vrt_from_stac(
         raise ValueError("build_vrt_from_stac received no items.")
 
     gdal_env = signer.gdal_env() if signer is not None else None
+    # Header credentials are baked into each source path so they survive into
+    # the VRT's lazy, read-time source opens (see _embed_source_options).
     vsi_paths = [
-        _to_vsi(resolved_href(item, asset, signer=signer)) for item in item_list
+        _embed_source_options(resolved_href(item, asset, signer=signer), gdal_env)
+        for item in item_list
     ]
+    _warn_unembeddable_credentials(gdal_env, vsi_paths)
     vrt_path = f"/vsimem/pyramids_stac_{uuid.uuid4().hex}.vrt"
 
-    with cloud_config_from_env(gdal_env):
+    # BuildVRT opens every source. Over `/vsicurl/` that costs a directory
+    # listing plus a fan of sidecar probes per source unless the fast-read
+    # preset is installed, so pay for it once here — but only when a source is
+    # actually remote: the preset's readdir skip would also hide a *local*
+    # source's `.aux.xml` / world-file sidecars.
+    with _source_config(vsi_paths, gdal_env):
         vrt_ds = gdal.BuildVRT(
             vrt_path, vsi_paths, options=gdal.BuildVRTOptions(separate=separate)
         )
@@ -234,7 +438,10 @@ def build_vrt_from_stac(
         register_vsimem(vrt_path)
         try:
             _check_dropped_sources(dropped, len(vsi_paths), asset, strict)
-            dataset = Dataset.read_file(vrt_path)
+            # Persist the signer env on the returned Dataset: the VRT opens its
+            # sources lazily on the first pixel read, i.e. after this block has
+            # exited, so without it an env-credentialed signer's reads 401.
+            dataset = Dataset.read_file(vrt_path, gdal_env=gdal_env)
         except Exception:
             # Nothing references the VRT on this path — reclaim it now rather
             # than leaving it in /vsimem until interpreter shutdown.

--- a/src/pyramids/stac/_vrt.py
+++ b/src/pyramids/stac/_vrt.py
@@ -92,6 +92,13 @@ _CREDENTIAL_PREFIXES = ("AWS_", "GS_", "AZURE_", "GOOGLE_", "SWIFT_", "OSS_")
 _CREDENTIAL_KEYS = frozenset({"GDAL_HTTP_USERPWD", "GDAL_HTTP_AUTH", _HTTP_HEADERS_KEY})
 """Non-prefixed config keys that carry credentials."""
 
+_NON_CREDENTIAL_SUFFIXES = ("_REGION", "_ENDPOINT", "_ENDPOINT_URL", "_VIRTUAL_HOSTING")
+"""Cloud-prefixed keys that are addressing knobs rather than credentials.
+
+`AWSRequesterPaysSigner` emits `AWS_REGION` / `AWS_DEFAULT_REGION` alongside its
+Requester-Pays opt-in, and naming those in a "your credentials are stranded"
+warning sends the reader hunting for a secret that was never there."""
+
 
 def _parse_http_headers(value: str) -> list[tuple[str, str]]:
     """Split a `GDAL_HTTP_HEADERS` value into `(name, value)` pairs.
@@ -235,6 +242,7 @@ def _warn_unembeddable_credentials(
         key
         for key in gdal_env or {}
         if key != _HTTP_HEADERS_KEY
+        and not key.endswith(_NON_CREDENTIAL_SUFFIXES)
         and (key.startswith(_CREDENTIAL_PREFIXES) or key in _CREDENTIAL_KEYS)
     )
     if stranded and any(is_remote(href) for href in hrefs):
@@ -357,6 +365,9 @@ def _source_config(
 
 def redact(href: str) -> str:
     """Return `href` with its query string replaced by a placeholder.
+
+    Internal, like the rest of this module — unprefixed only because the
+    docstrings elsewhere in the package point at it by name.
 
     A signed href carries its credential in the query string — a SAS token from
     a URL-signing signer, or the `header.Authorization` this module embeds for a
@@ -528,9 +539,11 @@ def _check_dropped_sources(
             warnings.warn(
                 "build_vrt_from_stac returned this incomplete mosaic because "
                 "strict defaults to None. That default becomes True in the next "
-                "minor release, and the skip above will raise instead. Pass "
-                "strict=True to adopt that now, or strict=False to keep the "
-                "partial mosaic and silence this warning.",
+                "minor release (tracked as ARC-79 in "
+                "planning/architecture-review/25-july/arc-stac.md), and the skip "
+                "above will raise instead. Pass strict=True to adopt that now, "
+                "or strict=False to keep the partial mosaic and silence this "
+                "warning.",
                 FutureWarning,
                 stacklevel=3,
             )

--- a/src/pyramids/stac/_vrt.py
+++ b/src/pyramids/stac/_vrt.py
@@ -43,9 +43,14 @@ from at source-open time. Consequences to plan for:
   them into the VRT XML in cleartext, and pickling it (a dask graph, say) ships
   them too. Treat such a mosaic as a secret; do not persist it to a shared
   location.
-* GDAL echoes the full source path in its own ``Warning 1: Can't open …``
-  messages on stderr. pyramids redacts every href it puts in an exception or
-  warning of its own (:func:`redact`), but it cannot redact GDAL's.
+* GDAL echoes the full source path in its own ``Can't open …`` messages.
+  pyramids redacts what it can: its own exceptions and warnings name the href
+  with any query string stripped (:func:`redact`), the GDAL error handler
+  scrubs credential options out of every message it logs
+  (:func:`~pyramids.base.remote.redact_credentials`), and the warnings GDAL's
+  Python bindings raise during the build are captured and re-emitted redacted.
+  A message printed by GDAL straight to stderr, outside those paths, is not
+  covered.
 * Prefer a short-lived token, and prefer a URL-signing signer where the provider
   offers one — a SAS token is scoped and expiring, a bearer token usually is not.
 """
@@ -62,7 +67,13 @@ from urllib.parse import quote
 from osgeo import gdal
 
 from pyramids.base._artifacts import register_vsimem
-from pyramids.base.remote import CloudConfig, _to_vsi, cloud_config_from_env, is_remote
+from pyramids.base.remote import (
+    CloudConfig,
+    _to_vsi,
+    cloud_config_from_env,
+    is_remote,
+    redact_credentials,
+)
 from pyramids.dataset import Dataset
 from pyramids.stac._loader import resolved_href
 
@@ -369,6 +380,39 @@ def redact(href: str) -> str:
     return f"{base}?<redacted>" if sep else base
 
 
+def _build_vrt(vrt_path: str, vsi_paths: list[str], separate: bool) -> Any:
+    """Run `gdal.BuildVRT`, redacting the warnings its bindings emit.
+
+    GDAL quotes the offending source path in its own
+    ``Can't open … Skipping it`` warning, and the bindings raise that as a
+    Python :class:`RuntimeWarning` directly — bypassing the GDAL error handler
+    pyramids installs. For a header-signed source that path holds a live token,
+    so the warnings are captured here and re-emitted with their credentials
+    blanked.
+
+    Args:
+        vrt_path: The `/vsimem` path to build into.
+        vsi_paths: The source paths, in order.
+        separate: Whether each source becomes its own band.
+
+    Returns:
+        The built `gdal.Dataset`, or `None` when GDAL could use no source.
+
+    Warns:
+        Whatever GDAL's bindings warned, with credential values redacted.
+    """
+    with warnings.catch_warnings(record=True) as raised:
+        warnings.simplefilter("always")
+        vrt_ds = gdal.BuildVRT(
+            vrt_path, vsi_paths, options=gdal.BuildVRTOptions(separate=separate)
+        )
+    for entry in raised:
+        warnings.warn(
+            redact_credentials(str(entry.message)), entry.category, stacklevel=3
+        )
+    return vrt_ds
+
+
 def _check_dropped_sources(
     dropped: list[str], total: int, asset: str, strict: bool | None
 ) -> None:
@@ -538,9 +582,7 @@ def build_vrt_from_stac(
     # source's `.aux.xml` / world-file sidecars. Remoteness is decided on the
     # hrefs, not the rewritten paths, which `is_remote` does not classify.
     with _source_config(hrefs, gdal_env):
-        vrt_ds = gdal.BuildVRT(
-            vrt_path, vsi_paths, options=gdal.BuildVRTOptions(separate=separate)
-        )
+        vrt_ds = _build_vrt(vrt_path, vsi_paths, separate)
         if vrt_ds is None:
             raise RuntimeError(
                 f"gdal.BuildVRT returned None for asset {asset!r} over "

--- a/src/pyramids/stac/_vrt.py
+++ b/src/pyramids/stac/_vrt.py
@@ -15,9 +15,10 @@ Completeness note: GDAL treats a source it cannot use — an unreadable href, a
 band count or CRS that disagrees with the first source — as a *warning*, drops
 it, and builds the mosaic from what is left. That turns an expired signed URL
 into a silently incomplete mosaic whose missing tiles read as nodata, so
-:func:`build_vrt_from_stac` raises when any requested source was skipped
-(``strict=True``, the default); pass ``strict=False`` for best-effort behaviour
-with a warning instead.
+:func:`build_vrt_from_stac` reports the skip. Today it warns
+(``strict=None``, the default) and adds a ``DeprecationWarning``; **from the
+next minor release the default becomes ``strict=True`` and the skip raises**.
+Pass ``strict=True`` or ``strict=False`` explicitly to pin either behaviour.
 
 Signer note: a VRT opens its sources lazily, on the first *pixel* read, and GDAL
 does not consult the thread-local config (what ``CloudConfig`` installs) when it
@@ -369,7 +370,7 @@ def redact(href: str) -> str:
 
 
 def _check_dropped_sources(
-    dropped: list[str], total: int, asset: str, strict: bool
+    dropped: list[str], total: int, asset: str, strict: bool | None
 ) -> None:
     """Raise (or warn) when `gdal.BuildVRT` skipped part of the requested mosaic.
 
@@ -379,13 +380,17 @@ def _check_dropped_sources(
             into the message this raises.
         total: How many sources were requested.
         asset: The asset key being mosaicked (for the message).
-        strict: Raise :class:`RuntimeError` when `True`, warn when `False`.
+        strict: Raise :class:`RuntimeError` when `True`; warn when `False`;
+            when `None` (the current default) warn and add a
+            :class:`DeprecationWarning` that the default flips to `True`.
 
     Raises:
         RuntimeError: `strict` is `True` and at least one source was skipped.
 
     Warns:
-        UserWarning: `strict` is `False` and at least one source was skipped.
+        UserWarning: `strict` is not `True` and at least one source was skipped.
+        DeprecationWarning: `strict` is `None` and at least one source was
+            skipped — the caller is relying on a default that is about to change.
 
     Examples:
         - A complete build passes silently:
@@ -429,6 +434,16 @@ def _check_dropped_sources(
                 f"{message} Pass strict=False to build the partial mosaic anyway."
             )
         warnings.warn(message, UserWarning, stacklevel=3)
+        if strict is None:
+            warnings.warn(
+                "build_vrt_from_stac returned this incomplete mosaic because "
+                "strict defaults to None. That default becomes True in the next "
+                "minor release, and the skip above will raise instead. Pass "
+                "strict=True to adopt that now, or strict=False to keep the "
+                "partial mosaic and silence this warning.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
 
 def build_vrt_from_stac(
@@ -437,7 +452,7 @@ def build_vrt_from_stac(
     *,
     signer: Any = None,
     separate: bool = False,
-    strict: bool = True,
+    strict: bool | None = None,
 ) -> Dataset:
     """Mosaic one STAC asset across items into a lazy VRT-backed `Dataset`.
 
@@ -454,9 +469,12 @@ def build_vrt_from_stac(
             (overlapping/tiling sources compose into one image — the stac-vrt
             model). When `True`, each source becomes a separate band (a
             band-stack VRT), which requires the sources to share a grid.
-        strict: When `True` (default), raise if GDAL skipped any requested
-            source, so a partially-built mosaic is never mistaken for a
-            complete one. When `False`, warn and return the partial mosaic.
+        strict: What to do when GDAL skips a requested source. `True` raises,
+            so a partially-built mosaic is never mistaken for a complete one.
+            `False` warns and returns the partial mosaic. `None` (the current
+            default) behaves like `False` and adds a `DeprecationWarning`:
+            **the default becomes `True` in the next minor release**. Pass an
+            explicit value to pin the behaviour you want across that change.
 
     Returns:
         Dataset: A lazy `Dataset` over an in-memory `.vrt`; GDAL reads the
@@ -470,7 +488,9 @@ def build_vrt_from_stac(
             some of them (unreadable href, mismatched band count or CRS).
 
     Warns:
-        UserWarning: With `strict=False`, when some sources were skipped.
+        UserWarning: When some sources were skipped and `strict` is not `True`.
+        DeprecationWarning: When some sources were skipped and `strict` was left
+            at its default, which is about to change.
 
     Examples:
         - Mosaic the `visual` asset of several items into one lazy Dataset

--- a/src/pyramids/stac/_vrt.py
+++ b/src/pyramids/stac/_vrt.py
@@ -66,7 +66,7 @@ from urllib.parse import quote
 
 from osgeo import gdal
 
-from pyramids.base._artifacts import register_vsimem
+from pyramids.base._artifacts import register_vsimem, unregister_vsimem
 from pyramids.base.remote import (
     CloudConfig,
     _to_vsi,
@@ -603,9 +603,12 @@ def build_vrt_from_stac(
             # sources lazily on the first pixel read, i.e. after this block has
             # exited, so without it an env-credentialed signer's reads 401.
             dataset = Dataset.read_file(vrt_path, gdal_env=gdal_env)
-        except Exception:
+        except BaseException:
             # Nothing references the VRT on this path — reclaim it now rather
-            # than leaving it in /vsimem until interpreter shutdown.
+            # than leaving it in /vsimem until interpreter shutdown. BaseException
+            # rather than Exception because a KeyboardInterrupt mid-open orphans
+            # the artefact just as surely as a read failure does.
             gdal.Unlink(vrt_path)
+            unregister_vsimem(vrt_path)
             raise
     return dataset

--- a/src/pyramids/stac/_vrt.py
+++ b/src/pyramids/stac/_vrt.py
@@ -16,7 +16,7 @@ band count or CRS that disagrees with the first source — as a *warning*, drops
 it, and builds the mosaic from what is left. That turns an expired signed URL
 into a silently incomplete mosaic whose missing tiles read as nodata, so
 :func:`build_vrt_from_stac` reports the skip. Today it warns
-(``strict=None``, the default) and adds a ``DeprecationWarning``; **from the
+(``strict=None``, the default) and adds a ``FutureWarning``; **from the
 next minor release the default becomes ``strict=True`` and the skip raises**.
 Pass ``strict=True`` or ``strict=False`` explicitly to pin either behaviour.
 
@@ -43,22 +43,23 @@ from at source-open time. Consequences to plan for:
   them into the VRT XML in cleartext, and pickling it (a dask graph, say) ships
   them too. Treat such a mosaic as a secret; do not persist it to a shared
   location.
-* GDAL echoes the full source path in its own ``Can't open …`` messages.
-  pyramids redacts what it can: its own exceptions and warnings name the href
-  with any query string stripped (:func:`redact`), the GDAL error handler
-  scrubs credential options out of every message it logs
-  (:func:`~pyramids.base.remote.redact_credentials`), and the warnings GDAL's
-  Python bindings raise during the build are captured and re-emitted redacted.
-  A message printed by GDAL straight to stderr, outside those paths, is not
-  covered.
+* GDAL echoes the full source path in its own ``Can't open …`` messages, which
+  under ``gdal.UseExceptions()`` it prints straight to stderr. The build pushes
+  a redacting error handler for its duration
+  (:func:`_redacting_error_handler`), so those messages are logged with the
+  credential blanked instead. pyramids' own exceptions and warnings name the
+  href with its query string stripped (:func:`redact`), and ``repr(ds)`` — whose
+  GDAL info lists every source — is redacted too.
 * Prefer a short-lived token, and prefer a URL-signing signer where the provider
   offers one — a SAS token is scoped and expiring, a bearer token usually is not.
 """
 
 from __future__ import annotations
 
+import logging
 import uuid
 import warnings
+import weakref
 from collections.abc import Iterable
 from contextlib import AbstractContextManager
 from typing import Any
@@ -76,6 +77,8 @@ from pyramids.base.remote import (
 )
 from pyramids.dataset import Dataset
 from pyramids.stac._loader import resolved_href
+
+logger = logging.getLogger(__name__)
 
 _DROPPED_PREVIEW = 5
 
@@ -136,7 +139,10 @@ def _embed_source_options(href: str, gdal_env: dict[str, str] | None) -> str:
 
     Only sources that normalise to a bare `/vsicurl/<url>` can be rewritten this
     way; anything else — a non-HTTP scheme, a local path, an archive-chained
-    `/vsizip//vsicurl/…` — keeps its ordinary :func:`_to_vsi` form.
+    `/vsizip//vsicurl/…` — keeps its ordinary :func:`_to_vsi` form. The rewrite
+    happens for every such source, headers or not: `empty_dir=yes` alone is
+    worth carrying, since a SAS-signed or public mosaic pays the same read-time
+    sidecar probes a bearer-signed one would.
 
     Args:
         href: The resolved (already signed) source href.
@@ -162,10 +168,11 @@ def _embed_source_options(href: str, gdal_env: dict[str, str] | None) -> str:
             '/vsicurl?header.Authorization=Bearer%20tok&empty_dir=yes&url=https%3A%2F%2Fh%2Fa.tif'
 
             ```
-        - Without a signer the ordinary rewrite is used:
+        - Without a signer the readdir skip still rides along, since an
+          unsigned remote source pays the same sidecar probes:
             ```python
             >>> _embed_source_options("https://h/a.tif", None)
-            '/vsicurl/https://h/a.tif'
+            '/vsicurl?empty_dir=yes&url=https%3A%2F%2Fh%2Fa.tif'
 
             ```
         - An archive-chained source keeps its chaining rather than losing it:
@@ -189,12 +196,14 @@ def _embed_source_options(href: str, gdal_env: dict[str, str] | None) -> str:
     # `_to_vsi` first means an href that was already in VSI form is still
     # recognised, and an archive-chained path (`/vsizip//vsicurl/...`) is left
     # alone rather than losing its chaining.
-    if headers and vsi.startswith(_VSICURL_PREFIX):
+    if vsi.startswith(_VSICURL_PREFIX):
         parts = [f"header.{name}={quote(value)}" for name, value in headers]
-        # Carry the readdir skip into the read-time opens too, where the ambient
+        # Carry the readdir skip into the read-time opens, where the ambient
         # config no longer reaches; without it every source re-probes its
         # `.aux.xml` / `.prj` siblings on each open — 14 wasted requests for two
-        # sources, measured. The build already runs under the same skip.
+        # sources, measured. The build already runs under the same skip. This is
+        # worth doing for *every* remote source, not only header-signed ones:
+        # a SAS-signed or public mosaic pays the same probes otherwise.
         parts.append("empty_dir=yes")
         parts.append(f"url={quote(vsi[len(_VSICURL_PREFIX) :], safe='')}")
         source = "/vsicurl?" + "&".join(parts)
@@ -338,8 +347,9 @@ def _source_config(
 
             ```
     """
+    config: AbstractContextManager[Any]
     if any(is_remote(path) for path in hrefs):
-        config: Any = CloudConfig(vsicurl_tuning=True, extra=dict(gdal_env or {}))
+        config = CloudConfig(vsicurl_tuning=True, extra=dict(gdal_env or {}))
     else:
         config = cloud_config_from_env(gdal_env)
     return config
@@ -380,15 +390,52 @@ def redact(href: str) -> str:
     return f"{base}?<redacted>" if sep else base
 
 
-def _build_vrt(vrt_path: str, vsi_paths: list[str], separate: bool) -> Any:
-    """Run `gdal.BuildVRT`, redacting the warnings its bindings emit.
 
-    GDAL quotes the offending source path in its own
-    ``Can't open … Skipping it`` warning, and the bindings raise that as a
-    Python :class:`RuntimeWarning` directly — bypassing the GDAL error handler
-    pyramids installs. For a header-signed source that path holds a live token,
-    so the warnings are captured here and re-emitted with their credentials
-    blanked.
+def _reclaim_vsimem(vrt_path: str) -> None:
+    """Unlink a `/vsimem` VRT and stop tracking it.
+
+    Called both when a build fails and, through `weakref.finalize`, when the
+    `Dataset` that needed the VRT is collected — so a long-running service does
+    not accumulate one in-memory VRT per mosaic.
+
+    Args:
+        vrt_path: The `/vsimem` path to reclaim. Unlinking an already-gone path
+            is harmless and ignored.
+    """
+    try:
+        gdal.Unlink(vrt_path)
+    except Exception:  # noqa: BLE001  # nosec B110 - best-effort reclaim
+        pass
+    unregister_vsimem(vrt_path)
+
+
+def _redacting_error_handler(err_class: int, err_num: int, err_msg: str) -> None:
+    """GDAL error handler that logs a redacted message instead of printing it.
+
+    GDAL quotes the offending source path in its ``Can't open … Skipping it``
+    warning, and for a header-signed source that path holds a live token. Under
+    ``gdal.UseExceptions()`` — which pyramids enables at import — a *warning* is
+    neither raised as a Python exception nor routed to a handler installed with
+    ``gdal.SetErrorHandler``: GDAL writes it straight to stderr. A handler
+    **pushed** for the duration of a call does receive it, which is the only
+    point where the message can be scrubbed before anything sees it.
+
+    Args:
+        err_class: GDAL error class (`gdal.CE_*`).
+        err_num: GDAL error number.
+        err_msg: The message text, redacted before it is logged.
+    """
+    logger.warning("GDAL[%s] %s", err_num, redact_credentials(str(err_msg)))
+
+
+def _build_vrt(vrt_path: str, vsi_paths: list[str], separate: bool) -> Any:
+    """Run `gdal.BuildVRT` with GDAL's own messages redacted.
+
+    A source that fails to open makes GDAL print the full source path — token
+    and all, for a header-signed build. The redacting handler is *pushed* for
+    the duration of the call (see :func:`_redacting_error_handler` for why a
+    process-wide one does not work), then popped, so the rest of the process
+    keeps whatever error handling it had.
 
     Args:
         vrt_path: The `/vsimem` path to build into.
@@ -397,19 +444,14 @@ def _build_vrt(vrt_path: str, vsi_paths: list[str], separate: bool) -> Any:
 
     Returns:
         The built `gdal.Dataset`, or `None` when GDAL could use no source.
-
-    Warns:
-        Whatever GDAL's bindings warned, with credential values redacted.
     """
-    with warnings.catch_warnings(record=True) as raised:
-        warnings.simplefilter("always")
+    gdal.PushErrorHandler(_redacting_error_handler)
+    try:
         vrt_ds = gdal.BuildVRT(
             vrt_path, vsi_paths, options=gdal.BuildVRTOptions(separate=separate)
         )
-    for entry in raised:
-        warnings.warn(
-            redact_credentials(str(entry.message)), entry.category, stacklevel=3
-        )
+    finally:
+        gdal.PopErrorHandler()
     return vrt_ds
 
 
@@ -426,15 +468,19 @@ def _check_dropped_sources(
         asset: The asset key being mosaicked (for the message).
         strict: Raise :class:`RuntimeError` when `True`; warn when `False`;
             when `None` (the current default) warn and add a
-            :class:`DeprecationWarning` that the default flips to `True`.
+            :class:`FutureWarning` that the default flips to `True`.
 
     Raises:
         RuntimeError: `strict` is `True` and at least one source was skipped.
 
     Warns:
         UserWarning: `strict` is not `True` and at least one source was skipped.
-        DeprecationWarning: `strict` is `None` and at least one source was
-            skipped — the caller is relying on a default that is about to change.
+        FutureWarning: `strict` is `None` and at least one source was skipped —
+            the caller is relying on a default that is about to change.
+            `FutureWarning` rather than `DeprecationWarning` because the latter
+            is silenced by Python's default filters unless it is raised from
+            `__main__`, and `stacklevel=3` attributes this one to the *caller of*
+            `build_vrt_from_stac`, which in a real deployment is library code.
 
     Examples:
         - A complete build passes silently:
@@ -485,7 +531,7 @@ def _check_dropped_sources(
                 "minor release, and the skip above will raise instead. Pass "
                 "strict=True to adopt that now, or strict=False to keep the "
                 "partial mosaic and silence this warning.",
-                DeprecationWarning,
+                FutureWarning,
                 stacklevel=3,
             )
 
@@ -516,7 +562,7 @@ def build_vrt_from_stac(
         strict: What to do when GDAL skips a requested source. `True` raises,
             so a partially-built mosaic is never mistaken for a complete one.
             `False` warns and returns the partial mosaic. `None` (the current
-            default) behaves like `False` and adds a `DeprecationWarning`:
+            default) behaves like `False` and adds a `FutureWarning`:
             **the default becomes `True` in the next minor release**. Pass an
             explicit value to pin the behaviour you want across that change.
 
@@ -533,8 +579,10 @@ def build_vrt_from_stac(
 
     Warns:
         UserWarning: When some sources were skipped and `strict` is not `True`.
-        DeprecationWarning: When some sources were skipped and `strict` was left
-            at its default, which is about to change.
+        FutureWarning: When some sources were skipped and `strict` was left at
+            its default, which is about to change. It is a `FutureWarning` so it
+            is visible under Python's default filters — a `DeprecationWarning`
+            from library code is silenced, which would defeat the notice.
 
     Examples:
         - Mosaic the `visual` asset of several items into one lazy Dataset
@@ -608,7 +656,11 @@ def build_vrt_from_stac(
             # than leaving it in /vsimem until interpreter shutdown. BaseException
             # rather than Exception because a KeyboardInterrupt mid-open orphans
             # the artefact just as surely as a read failure does.
-            gdal.Unlink(vrt_path)
-            unregister_vsimem(vrt_path)
+            _reclaim_vsimem(vrt_path)
             raise
+    # Reclaim the VRT when the Dataset that needs it is collected, mirroring
+    # `Dataset.from_bytes`. Without this a service building one mosaic per
+    # request accumulates a /vsimem VRT per request for the life of the process;
+    # the `register_vsimem` above is only the process-exit backstop.
+    weakref.finalize(dataset, _reclaim_vsimem, vrt_path)
     return dataset

--- a/src/pyramids/stac/_vrt.py
+++ b/src/pyramids/stac/_vrt.py
@@ -11,6 +11,14 @@ list to :func:`gdal.BuildVRT`. The result is wrapped as a lazy
 :class:`~pyramids.dataset.Dataset` over an in-memory `.vrt` whose sources are
 read only when pixels are requested.
 
+Completeness note: GDAL treats a source it cannot use — an unreadable href, a
+band count or CRS that disagrees with the first source — as a *warning*, drops
+it, and builds the mosaic from what is left. That turns an expired signed URL
+into a silently incomplete mosaic whose missing tiles read as nodata, so
+:func:`build_vrt_from_stac` raises when any requested source was skipped
+(``strict=True``, the default); pass ``strict=False`` for best-effort behaviour
+with a warning instead.
+
 Signer note: a URL-signing signer (e.g. :class:`PlanetaryComputerSigner`) is
 fully supported — the SAS token rides each source href, so reads need no extra
 config. An env-credentialed signer (Requester-Pays, bearer) authenticates the
@@ -23,6 +31,8 @@ URL-signing signer.
 from __future__ import annotations
 
 import uuid
+import warnings
+from collections.abc import Iterable
 from typing import Any
 
 from osgeo import gdal
@@ -32,6 +42,102 @@ from pyramids.base.remote import _to_vsi, cloud_config_from_env
 from pyramids.dataset import Dataset
 from pyramids.stac._loader import resolved_href
 
+_DROPPED_PREVIEW = 5
+
+
+def _dropped_sources(requested: list[str], retained: Iterable[str]) -> list[str]:
+    """Return the requested sources GDAL left out of the built VRT.
+
+    :meth:`gdal.Dataset.GetFileList` on a freshly built VRT reports exactly the
+    sources it kept, so anything requested but absent from that list was skipped
+    during the build (GDAL logs a warning and carries on).
+
+    Args:
+        requested: The VSI paths handed to :func:`gdal.BuildVRT`, in order.
+        retained: The source paths the built VRT actually references.
+
+    Returns:
+        The requested paths missing from `retained`, in the requested order.
+
+    Examples:
+        - A source GDAL skipped is reported back:
+            ```python
+            >>> from pyramids.stac._vrt import _dropped_sources
+            >>> _dropped_sources(["a.tif", "b.tif"], ["a.tif"])
+            ['b.tif']
+
+            ```
+        - Nothing is reported when every source was kept:
+            ```python
+            >>> _dropped_sources(["a.tif"], ["a.tif", "/vsimem/x.vrt"])
+            []
+
+            ```
+    """
+    kept = set(retained)
+    return [path for path in requested if path not in kept]
+
+
+def _check_dropped_sources(
+    dropped: list[str], total: int, asset: str, strict: bool
+) -> None:
+    """Raise (or warn) when `gdal.BuildVRT` skipped part of the requested mosaic.
+
+    Args:
+        dropped: The requested sources missing from the built VRT.
+        total: How many sources were requested.
+        asset: The asset key being mosaicked (for the message).
+        strict: Raise :class:`RuntimeError` when `True`, warn when `False`.
+
+    Raises:
+        RuntimeError: `strict` is `True` and at least one source was skipped.
+
+    Warns:
+        UserWarning: `strict` is `False` and at least one source was skipped.
+
+    Examples:
+        - A complete build passes silently:
+            ```python
+            >>> from pyramids.stac._vrt import _check_dropped_sources
+            >>> _check_dropped_sources([], 3, "B04", strict=True)
+
+            ```
+        - A skipped source fails the build under the default strictness:
+            ```python
+            >>> _check_dropped_sources(["b.tif"], 3, "B04", True)  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+                ...
+            RuntimeError: gdal.BuildVRT skipped 1 of 3 source(s) for asset 'B04', ...
+
+            ```
+        - The same skip only warns when the caller opted out of strictness:
+            ```python
+            >>> import warnings
+            >>> with warnings.catch_warnings(record=True) as caught:
+            ...     warnings.simplefilter("always")
+            ...     _check_dropped_sources(["b.tif"], 3, "B04", False)
+            >>> str(caught[0].message)[:40]
+            'gdal.BuildVRT skipped 1 of 3 source(s) f'
+
+            ```
+    """
+    if dropped:
+        preview = ", ".join(dropped[:_DROPPED_PREVIEW])
+        if len(dropped) > _DROPPED_PREVIEW:
+            preview += f", ... (+{len(dropped) - _DROPPED_PREVIEW} more)"
+        message = (
+            f"gdal.BuildVRT skipped {len(dropped)} of {total} source(s) for asset "
+            f"{asset!r}, so the mosaic is incomplete and the missing footprint "
+            f"reads as nodata: {preview}. A source is skipped when it is "
+            "unreadable (a 404 / expired signed URL) or its band count or CRS "
+            "disagrees with the first source."
+        )
+        if strict:
+            raise RuntimeError(
+                f"{message} Pass strict=False to build the partial mosaic anyway."
+            )
+        warnings.warn(message, UserWarning, stacklevel=3)
+
 
 def build_vrt_from_stac(
     items: Any,
@@ -39,6 +145,7 @@ def build_vrt_from_stac(
     *,
     signer: Any = None,
     separate: bool = False,
+    strict: bool = True,
 ) -> Dataset:
     """Mosaic one STAC asset across items into a lazy VRT-backed `Dataset`.
 
@@ -55,6 +162,9 @@ def build_vrt_from_stac(
             (overlapping/tiling sources compose into one image — the stac-vrt
             model). When `True`, each source becomes a separate band (a
             band-stack VRT), which requires the sources to share a grid.
+        strict: When `True` (default), raise if GDAL skipped any requested
+            source, so a partially-built mosaic is never mistaken for a
+            complete one. When `False`, warn and return the partial mosaic.
 
     Returns:
         Dataset: A lazy `Dataset` over an in-memory `.vrt`; GDAL reads the
@@ -63,8 +173,12 @@ def build_vrt_from_stac(
 
     Raises:
         ValueError: When `items` yields no items.
-        RuntimeError: When `gdal.BuildVRT` fails (e.g. sources with
-            inconsistent band counts, or unreadable paths).
+        RuntimeError: When `gdal.BuildVRT` fails outright (every source
+            unreadable), or — with `strict=True` — when it silently skipped
+            some of them (unreadable href, mismatched band count or CRS).
+
+    Warns:
+        UserWarning: With `strict=False`, when some sources were skipped.
 
     Examples:
         - Mosaic the `visual` asset of several items into one lazy Dataset
@@ -75,6 +189,20 @@ def build_vrt_from_stac(
             >>> arr = ds.read_array()  # GDAL pulls source pixels lazily  # doctest: +SKIP
 
             ```
+        - Accept a partial mosaic when some hrefs are known to be missing:
+            ```python
+            >>> ds = build_vrt_from_stac(items, "visual", strict=False)  # doctest: +SKIP
+
+            ```
+
+    See Also:
+        - :func:`pyramids.stac.load_asset`: open a *single* asset instead of
+          mosaicking one asset across items.
+        - :meth:`pyramids.dataset.DatasetCollection.from_stac`: stack the same
+          asset across items along a **time** axis rather than mosaicking it
+          into one image.
+        - :func:`pyramids.dataset.merge.merge_rasters`: the eager, file-writing
+          counterpart to this lazy VRT.
     """
     item_list = list(items)
     if not item_list:
@@ -96,9 +224,20 @@ def build_vrt_from_stac(
                 f"{len(vsi_paths)} item(s); check that every source is a "
                 "readable raster with a consistent band count and CRS."
             )
+        # GDAL lists exactly the sources it kept, so the difference against what
+        # was requested is what it silently skipped.
+        dropped = _dropped_sources(vsi_paths, vrt_ds.GetFileList() or ())
         vrt_ds.FlushCache()
         vrt_ds = None
-        dataset = Dataset.read_file(vrt_path)
-    # Track the in-memory VRT so it is unlinked at process exit (M1).
-    register_vsimem(vrt_path)
+        # Track the in-memory VRT *before* anything else can raise, so a failure
+        # below cannot orphan it beyond the process-exit sweep (M1).
+        register_vsimem(vrt_path)
+        try:
+            _check_dropped_sources(dropped, len(vsi_paths), asset, strict)
+            dataset = Dataset.read_file(vrt_path)
+        except Exception:
+            # Nothing references the VRT on this path — reclaim it now rather
+            # than leaving it in /vsimem until interpreter shutdown.
+            gdal.Unlink(vrt_path)
+            raise
     return dataset

--- a/src/pyramids/stac/signers.py
+++ b/src/pyramids/stac/signers.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Any, Protocol, runtime_checkable
 
+from pyramids.base.remote import _REQUESTER_PAYS_GDAL_KNOBS, CloudConfig
+
 
 @runtime_checkable
 class Signer(Protocol):
@@ -109,11 +111,18 @@ class AWSRequesterPaysSigner(_BaseSigner):
 
     Adds only the GDAL environment needed to read from buckets such as
     `s3://usgs-landsat` or `s3://sentinel-1-grd`; no request or href rewrite
-    is required.
+    is required. The env is assembled by
+    :class:`~pyramids.base.remote.CloudConfig` from the shared
+    :data:`~pyramids.base.remote._REQUESTER_PAYS_GDAL_KNOBS`, so this signer and
+    :func:`~pyramids.base.remote.RequesterPays` stay in lock-step instead of
+    each carrying their own copy of the knob set.
 
     Args:
-        region: Optional AWS region of the bucket. Stored for callers that wire
-            their own boto3/s3fs handles; pin it to avoid cross-region egress.
+        region: Optional AWS region of the bucket. Emitted as `AWS_REGION` /
+            `AWS_DEFAULT_REGION` so GDAL reads hit the bucket's own region, and
+            kept on the instance for callers wiring their own boto3/s3fs
+            handles. Pin it: Requester-Pays bills the reader per byte, so a
+            cross-region read costs real money.
 
     Examples:
         - The GDAL env opts into Requester-Pays and trims redundant calls:
@@ -123,6 +132,23 @@ class AWSRequesterPaysSigner(_BaseSigner):
             'requester'
             >>> signer.region
             'us-west-2'
+
+            ```
+        - A pinned region reaches GDAL through both region options:
+            ```python
+            >>> env = AWSRequesterPaysSigner(region="us-west-2").gdal_env()
+            >>> (env["AWS_REGION"], env["AWS_DEFAULT_REGION"])
+            ('us-west-2', 'us-west-2')
+
+            ```
+        - Without a region only the Requester-Pays knobs are set, so GDAL keeps
+          resolving the region itself:
+            ```python
+            >>> sorted(AWSRequesterPaysSigner().gdal_env())
+            ... # doctest: +NORMALIZE_WHITESPACE
+            ['AWS_REQUEST_PAYER', 'CPL_VSIL_CURL_USE_HEAD',
+             'GDAL_DISABLE_READDIR_ON_OPEN', 'GDAL_HTTP_MULTIPLEX',
+             'GDAL_HTTP_VERSION']
 
             ```
     """
@@ -141,14 +167,45 @@ class AWSRequesterPaysSigner(_BaseSigner):
         """Return the GDAL config that opts into Requester-Pays reads.
 
         Returns:
-            A mapping setting `AWS_REQUEST_PAYER=requester` plus the standard
-            cloud-read knobs that avoid extra billable HEAD/list calls.
+            A mapping setting `AWS_REQUEST_PAYER=requester`, the shared
+            cloud-read knobs that avoid extra billable HEAD/list calls
+            (`GDAL_DISABLE_READDIR_ON_OPEN`, `CPL_VSIL_CURL_USE_HEAD`) and
+            enable HTTP/2 multiplexing, plus `AWS_REGION` /
+            `AWS_DEFAULT_REGION` when a `region` was pinned.
+
+        Examples:
+            - Read the knobs a Requester-Pays open will run under:
+                ```python
+                >>> from pyramids.stac import AWSRequesterPaysSigner
+                >>> env = AWSRequesterPaysSigner().gdal_env()
+                >>> env["AWS_REQUEST_PAYER"]
+                'requester'
+                >>> env["GDAL_HTTP_VERSION"]
+                '2'
+
+                ```
+            - A pinned region is what GDAL will address the bucket with:
+                ```python
+                >>> from pyramids.stac import AWSRequesterPaysSigner
+                >>> env = AWSRequesterPaysSigner(region="us-west-2").gdal_env()
+                >>> env["AWS_REGION"]
+                'us-west-2'
+                >>> len(env)
+                7
+
+                ```
+
+        See Also:
+            - :func:`pyramids.base.remote.RequesterPays`: the same knobs as a
+              context manager, for reads that do not go through a signer.
+            - :func:`pyramids.base.remote.s3fs_requester_pays_kwargs`: the
+              fsspec/s3fs equivalent for non-GDAL readers.
         """
-        return {
-            "AWS_REQUEST_PAYER": "requester",
-            "GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR",
-            "CPL_VSIL_CURL_USE_HEAD": "NO",
-        }
+        return CloudConfig(
+            aws_request_payer=True,
+            aws_region=self.region,
+            extra=_REQUESTER_PAYS_GDAL_KNOBS,
+        ).as_gdal_config()
 
 
 class BearerTokenSigner(_BaseSigner):

--- a/src/pyramids/stac/signers.py
+++ b/src/pyramids/stac/signers.py
@@ -117,6 +117,15 @@ class AWSRequesterPaysSigner(_BaseSigner):
     :func:`~pyramids.base.remote.RequesterPays` stay in lock-step instead of
     each carrying their own copy of the knob set.
 
+    Note:
+        Building the env from the shared knob set also *added* two options this
+        signer did not emit before: `GDAL_HTTP_MULTIPLEX=YES` and
+        `GDAL_HTTP_VERSION=2`. That is a throughput win on a healthy endpoint,
+        but HTTP/2 is not universally safe — an intercepting proxy, an older
+        libcurl, or a server that negotiates it badly can stall or fail reads.
+        A caller who needs the old behaviour can build the env themselves:
+        `CloudConfig(aws_request_payer=True).as_gdal_config()`.
+
     Args:
         region: Optional AWS region of the bucket. Emitted as `AWS_REGION` /
             `AWS_DEFAULT_REGION` so GDAL reads hit the bucket's own region, and

--- a/tests/base/test_artifacts.py
+++ b/tests/base/test_artifacts.py
@@ -98,3 +98,59 @@ class TestCleanup:
         artifact_dir()
         cleanup()
         cleanup()  # must not raise
+
+
+class TestCleanupArming:
+    """The exit sweep must be armed by either artefact kind (ARC-10 / M4)."""
+
+    def test_register_vsimem_arms_the_sweep(self, monkeypatch):
+        """Tracking a /vsimem path registers the atexit hook.
+
+        Test scenario:
+            A process that only builds VRTs never touches the temp root, so
+            hanging the registration off that left its artefacts unreclaimed.
+        """
+        registered = []
+        monkeypatch.setattr(_artifacts.atexit, "register", registered.append)
+        monkeypatch.setattr(_artifacts, "_CLEANUP_ARMED", False)
+        _artifacts.register_vsimem("/vsimem/probe.vrt")
+        assert _artifacts.cleanup in registered, (
+            f"the exit sweep was not armed: {registered}"
+        )
+        _artifacts.unregister_vsimem("/vsimem/probe.vrt")
+
+    def test_arming_happens_once(self, monkeypatch):
+        """Repeated registrations do not stack atexit hooks.
+
+        Test scenario:
+            One hook per process, however many artefacts are tracked.
+        """
+        registered = []
+        monkeypatch.setattr(_artifacts.atexit, "register", registered.append)
+        monkeypatch.setattr(_artifacts, "_CLEANUP_ARMED", False)
+        _artifacts.register_vsimem("/vsimem/a.vrt")
+        _artifacts.register_vsimem("/vsimem/b.vrt")
+        assert len(registered) == 1, f"expected one registration, got {registered}"
+        _artifacts.unregister_vsimem("/vsimem/a.vrt")
+        _artifacts.unregister_vsimem("/vsimem/b.vrt")
+
+    def test_unregister_drops_the_path(self):
+        """A reclaimed path stops being tracked.
+
+        Test scenario:
+            Otherwise repeated failures grow a list of dead entries that
+            `cleanup` later tries to unlink.
+        """
+        _artifacts.register_vsimem("/vsimem/gone.vrt")
+        _artifacts.unregister_vsimem("/vsimem/gone.vrt")
+        assert "/vsimem/gone.vrt" not in _artifacts._VSIMEM_PATHS, (
+            "the reclaimed path is still tracked"
+        )
+
+    def test_unregister_unknown_path_is_a_no_op(self):
+        """Forgetting an untracked path does not raise.
+
+        Test scenario:
+            The caller need not know whether registration happened.
+        """
+        _artifacts.unregister_vsimem("/vsimem/never-tracked.vrt")

--- a/tests/base/test_ogc_api_retry.py
+++ b/tests/base/test_ogc_api_retry.py
@@ -184,3 +184,64 @@ class TestHttpGetWithRetry:
         with pytest.raises(urllib.error.HTTPError) as exc:
             http_get_with_retry("https://h/x", 5, opener=opener)
         assert exc.value.read() == b'{"detail": "gone"}', "the error body was consumed"
+
+
+class TestRetryEdgeCases:
+    """Boundary behaviour of the retry loop (review L2 / L3)."""
+
+    @pytest.mark.parametrize("attempts", [0, -1])
+    def test_non_positive_attempts_rejected(self, attempts):
+        """A zero or negative budget is a programming error, not an empty body.
+
+        Args:
+            attempts: The invalid budget under test.
+
+        Test scenario:
+            Falling out of the loop would hand the caller `None`, and the
+            failure would surface far from its cause.
+        """
+        with pytest.raises(ValueError, match="attempts must be >= 1"):
+            http_get_with_retry("https://h/x", 5, opener=_Opener([b"never"]), attempts=attempts)
+
+    def test_retry_after_header_is_honoured(self):
+        """A 429's `Retry-After` overrides the computed backoff.
+
+        Test scenario:
+            The server states the correct delay; guessing can retry straight
+            back into the same rate limit.
+        """
+        waits = []
+        error = urllib.error.HTTPError("https://h/x", 429, "slow down", {"Retry-After": "4"}, None)
+        opener = _Opener([error, b"ok"])
+        http_get_with_retry("https://h/x", 5, opener=opener, delay=0.5, sleep=waits.append)
+        assert waits == [4.0], f"Retry-After not honoured: {waits}"
+
+    @pytest.mark.parametrize("value", ["not-a-number", "-1", "3600"])
+    def test_unusable_retry_after_falls_back_to_backoff(self, value):
+        """A malformed, negative or absurd delay falls back to the schedule.
+
+        Args:
+            value: The unusable header value under test.
+
+        Test scenario:
+            An HTTP-date, a negative number, or an hour-long stall must not be
+            taken at face value by a discovery pre-check.
+        """
+        waits = []
+        error = urllib.error.HTTPError("https://h/x", 503, "busy", {"Retry-After": value}, None)
+        opener = _Opener([error, b"ok"])
+        http_get_with_retry("https://h/x", 5, opener=opener, delay=0.5, sleep=waits.append)
+        assert waits == [0.5], f"expected the computed backoff, got {waits}"
+
+    def test_gdal_retry_budget_matches_the_urllib_one(self):
+        """GDAL counts retries, this helper counts attempts — same total.
+
+        Test scenario:
+            Emitting HTTP_RETRY_ATTEMPTS verbatim gave the driver read one more
+            attempt than the pre-check.
+        """
+        from pyramids.base._ogc_api import GDAL_HTTP_MAX_RETRY
+
+        assert GDAL_HTTP_MAX_RETRY == HTTP_RETRY_ATTEMPTS - 1, (
+            f"budget mismatch: GDAL {GDAL_HTTP_MAX_RETRY} vs {HTTP_RETRY_ATTEMPTS}"
+        )

--- a/tests/base/test_ogc_api_retry.py
+++ b/tests/base/test_ogc_api_retry.py
@@ -1,0 +1,186 @@
+"""Tests for the bounded retry around the OGC discovery fetches (ARC-73).
+
+The `/collections` and WCS `GetCapabilities` requests are single small fetches
+in front of a much larger read, so a dropped connection or a transient 502
+failing them outright wastes the whole call. `http_get_with_retry` retries those
+— and only those — with exponential backoff.
+"""
+
+from __future__ import annotations
+
+import io
+import urllib.error
+
+import pytest
+
+from pyramids.base._ogc_api import (
+    HTTP_RETRY_ATTEMPTS,
+    RETRYABLE_STATUS,
+    http_get_with_retry,
+)
+
+pytestmark = pytest.mark.core
+
+
+class _Opener:
+    """Opener double replaying a scripted sequence of results per call."""
+
+    def __init__(self, results):
+        """Store the scripted results.
+
+        Args:
+            results: One entry per expected call — an exception instance to
+                raise, or a bytes payload to return.
+        """
+        self.results = list(results)
+        self.calls = []
+        self.timeouts = []
+
+    def open(self, target, timeout=None):
+        """Return (or raise) the next scripted result.
+
+        Args:
+            target: The URL or Request handed to the opener.
+            timeout: The per-attempt timeout.
+
+        Returns:
+            A file-like object over the scripted payload.
+
+        Raises:
+            BaseException: When the scripted entry is an exception.
+        """
+        self.calls.append(target)
+        self.timeouts.append(timeout)
+        result = self.results.pop(0)
+        if isinstance(result, BaseException):
+            raise result
+        return io.BytesIO(result)
+
+
+def _http_error(code):
+    """Build an :class:`urllib.error.HTTPError` with `code`."""
+    return urllib.error.HTTPError("https://h/x", code, "boom", {}, None)
+
+
+class TestHttpGetWithRetry:
+    """Tests for http_get_with_retry."""
+
+    def test_first_attempt_success_returns_body(self):
+        """A healthy endpoint is fetched once.
+
+        Test scenario:
+            No retry budget is spent when the first attempt succeeds.
+        """
+        opener = _Opener([b"payload"])
+        result = http_get_with_retry("https://h/x", 5, opener=opener)
+        assert result == b"payload", f"unexpected body: {result!r}"
+        assert len(opener.calls) == 1, f"expected one call, got {opener.calls}"
+
+    @pytest.mark.parametrize("status", sorted(RETRYABLE_STATUS))
+    def test_retryable_status_is_retried(self, status):
+        """Rate limiting and transient server faults are retried.
+
+        Args:
+            status: The retryable HTTP status under test.
+
+        Test scenario:
+            One failure then a success -> two calls and the recovered body.
+        """
+        opener = _Opener([_http_error(status), b"ok"])
+        result = http_get_with_retry(
+            "https://h/x", 5, opener=opener, sleep=lambda _s: None
+        )
+        assert result == b"ok", f"body not recovered after a {status}: {result!r}"
+        assert len(opener.calls) == 2, f"expected a retry, got {len(opener.calls)} call(s)"
+
+    @pytest.mark.parametrize("status", [400, 401, 403, 404, 410, 422])
+    def test_client_error_is_not_retried(self, status):
+        """A client error is raised on the first attempt.
+
+        Args:
+            status: The non-retryable HTTP status under test.
+
+        Test scenario:
+            Retrying a bad endpoint or bad credentials only multiplies latency.
+        """
+        opener = _Opener([_http_error(status), b"never reached"])
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            http_get_with_retry("https://h/x", 5, opener=opener, sleep=lambda _s: None)
+        assert exc.value.code == status, f"wrong error surfaced: {exc.value}"
+        assert len(opener.calls) == 1, f"a {status} must not be retried"
+
+    def test_transport_error_is_retried(self):
+        """A dropped connection is retried.
+
+        Test scenario:
+            `URLError` (an OSError) on the first attempt, success on the second.
+        """
+        opener = _Opener([urllib.error.URLError("connection reset"), b"ok"])
+        result = http_get_with_retry(
+            "https://h/x", 5, opener=opener, sleep=lambda _s: None
+        )
+        assert result == b"ok", f"body not recovered: {result!r}"
+        assert len(opener.calls) == 2, "a transport error should be retried"
+
+    def test_exhausted_attempts_reraise_the_last_error(self):
+        """The failure is re-raised unchanged once the budget is spent.
+
+        Test scenario:
+            Callers wrap it in their own error type, so it must not be masked.
+        """
+        opener = _Opener([_http_error(503)] * HTTP_RETRY_ATTEMPTS)
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            http_get_with_retry("https://h/x", 5, opener=opener, sleep=lambda _s: None)
+        assert exc.value.code == 503, f"wrong error surfaced: {exc.value}"
+        assert len(opener.calls) == HTTP_RETRY_ATTEMPTS, (
+            f"expected {HTTP_RETRY_ATTEMPTS} attempts, got {len(opener.calls)}"
+        )
+
+    def test_backoff_grows_exponentially(self):
+        """Each retry waits twice as long as the previous one.
+
+        Test scenario:
+            Two failures with delay=0.5 -> waits of 0.5 s and 1.0 s.
+        """
+        waits = []
+        opener = _Opener([_http_error(502), _http_error(502), b"ok"])
+        http_get_with_retry(
+            "https://h/x", 5, opener=opener, delay=0.5, sleep=waits.append
+        )
+        assert waits == [0.5, 1.0], f"unexpected backoff schedule: {waits}"
+
+    def test_attempts_one_disables_retrying(self):
+        """`attempts=1` makes the helper a plain single fetch.
+
+        Test scenario:
+            The first failure is raised immediately.
+        """
+        opener = _Opener([_http_error(503), b"never reached"])
+        with pytest.raises(urllib.error.HTTPError):
+            http_get_with_retry("https://h/x", 5, opener=opener, attempts=1)
+        assert len(opener.calls) == 1, "attempts=1 should not retry"
+
+    def test_timeout_is_forwarded_per_attempt(self):
+        """Every attempt carries the caller's timeout.
+
+        Test scenario:
+            A retry must not silently drop the timeout.
+        """
+        opener = _Opener([_http_error(503), b"ok"])
+        http_get_with_retry("https://h/x", 7.5, opener=opener, sleep=lambda _s: None)
+        assert opener.timeouts == [7.5, 7.5], f"timeout not forwarded: {opener.timeouts}"
+
+    def test_error_body_is_not_consumed(self):
+        """The helper never reads an HTTPError's body.
+
+        Test scenario:
+            An `HTTPError` body can be read only once and the caller needs it
+            for its message, so the retry loop must only inspect the status.
+        """
+        error = urllib.error.HTTPError(
+            "https://h/x", 404, "missing", {}, io.BytesIO(b'{"detail": "gone"}')
+        )
+        opener = _Opener([error])
+        with pytest.raises(urllib.error.HTTPError) as exc:
+            http_get_with_retry("https://h/x", 5, opener=opener)
+        assert exc.value.read() == b'{"detail": "gone"}', "the error body was consumed"

--- a/tests/base/test_ogc_api_retry.py
+++ b/tests/base/test_ogc_api_retry.py
@@ -91,7 +91,9 @@ class TestHttpGetWithRetry:
             "https://h/x", 5, opener=opener, sleep=lambda _s: None
         )
         assert result == b"ok", f"body not recovered after a {status}: {result!r}"
-        assert len(opener.calls) == 2, f"expected a retry, got {len(opener.calls)} call(s)"
+        assert len(opener.calls) == 2, (
+            f"expected a retry, got {len(opener.calls)} call(s)"
+        )
 
     @pytest.mark.parametrize("status", [400, 401, 403, 404, 410, 422])
     def test_client_error_is_not_retried(self, status):
@@ -168,7 +170,9 @@ class TestHttpGetWithRetry:
         """
         opener = _Opener([_http_error(503), b"ok"])
         http_get_with_retry("https://h/x", 7.5, opener=opener, sleep=lambda _s: None)
-        assert opener.timeouts == [7.5, 7.5], f"timeout not forwarded: {opener.timeouts}"
+        assert opener.timeouts == [7.5, 7.5], (
+            f"timeout not forwarded: {opener.timeouts}"
+        )
 
     def test_error_body_is_not_consumed(self):
         """The helper never reads an HTTPError's body.
@@ -201,7 +205,9 @@ class TestRetryEdgeCases:
             failure would surface far from its cause.
         """
         with pytest.raises(ValueError, match="attempts must be >= 1"):
-            http_get_with_retry("https://h/x", 5, opener=_Opener([b"never"]), attempts=attempts)
+            http_get_with_retry(
+                "https://h/x", 5, opener=_Opener([b"never"]), attempts=attempts
+            )
 
     def test_retry_after_header_is_honoured(self):
         """A 429's `Retry-After` overrides the computed backoff.
@@ -211,9 +217,13 @@ class TestRetryEdgeCases:
             back into the same rate limit.
         """
         waits = []
-        error = urllib.error.HTTPError("https://h/x", 429, "slow down", {"Retry-After": "4"}, None)
+        error = urllib.error.HTTPError(
+            "https://h/x", 429, "slow down", {"Retry-After": "4"}, None
+        )
         opener = _Opener([error, b"ok"])
-        http_get_with_retry("https://h/x", 5, opener=opener, delay=0.5, sleep=waits.append)
+        http_get_with_retry(
+            "https://h/x", 5, opener=opener, delay=0.5, sleep=waits.append
+        )
         assert waits == [4.0], f"Retry-After not honoured: {waits}"
 
     @pytest.mark.parametrize("value", ["not-a-number", "-1", "3600"])
@@ -228,9 +238,13 @@ class TestRetryEdgeCases:
             taken at face value by a discovery pre-check.
         """
         waits = []
-        error = urllib.error.HTTPError("https://h/x", 503, "busy", {"Retry-After": value}, None)
+        error = urllib.error.HTTPError(
+            "https://h/x", 503, "busy", {"Retry-After": value}, None
+        )
         opener = _Opener([error, b"ok"])
-        http_get_with_retry("https://h/x", 5, opener=opener, delay=0.5, sleep=waits.append)
+        http_get_with_retry(
+            "https://h/x", 5, opener=opener, delay=0.5, sleep=waits.append
+        )
         assert waits == [0.5], f"expected the computed backoff, got {waits}"
 
     def test_gdal_retry_budget_matches_the_urllib_one(self):

--- a/tests/base/test_ogc_api_retry.py
+++ b/tests/base/test_ogc_api_retry.py
@@ -204,10 +204,9 @@ class TestRetryEdgeCases:
             Falling out of the loop would hand the caller `None`, and the
             failure would surface far from its cause.
         """
+        opener = _Opener([b"never"])
         with pytest.raises(ValueError, match="attempts must be >= 1"):
-            http_get_with_retry(
-                "https://h/x", 5, opener=_Opener([b"never"]), attempts=attempts
-            )
+            http_get_with_retry("https://h/x", 5, opener=opener, attempts=attempts)
 
     def test_retry_after_header_is_honoured(self):
         """A 429's `Retry-After` overrides the computed backoff.

--- a/tests/base/test_remote.py
+++ b/tests/base/test_remote.py
@@ -721,7 +721,9 @@ class TestRedactCredentials:
         `bucket-key=`, redacting values that were never secrets.
         """
         text = "https://h/a.tif?my_token=abc&bucket-key=def"
-        assert redact_credentials(text) == text, f"a non-credential was redacted: {text}"
+        assert redact_credentials(text) == text, (
+            f"a non-credential was redacted: {text}"
+        )
 
     def test_credential_after_an_ampersand_is_redacted(self):
         """A credential option later in the query is still caught."""

--- a/tests/base/test_remote.py
+++ b/tests/base/test_remote.py
@@ -710,9 +710,24 @@ class TestRedactCredentials:
 
     def test_multiple_headers_all_blanked(self):
         """Every credential option in one string is redacted."""
-        text = "header.Authorization=Bearer%20A&header.X-Api-Key=B&url=x"
+        text = "/vsicurl?header.Authorization=Bearer%20A&header.X-Api-Key=B&url=x"
         out = redact_credentials(text)
         assert "Bearer%20A" not in out and "=B&" not in out, f"a value survived: {out}"
+
+    def test_name_merely_ending_in_a_credential_word_is_kept(self):
+        """A name that only ends with a credential word is not one.
+
+        The previous `\b`-anchored pattern matched the tail of `my_token=` and
+        `bucket-key=`, redacting values that were never secrets.
+        """
+        text = "https://h/a.tif?my_token=abc&bucket-key=def"
+        assert redact_credentials(text) == text, f"a non-credential was redacted: {text}"
+
+    def test_credential_after_an_ampersand_is_redacted(self):
+        """A credential option later in the query is still caught."""
+        out = redact_credentials("https://h/a.tif?sv=2021&sig=SECRET&sp=r")
+        assert "SECRET" not in out, f"token survived: {out}"
+        assert "sv=2021" in out and "sp=r" in out, f"neighbours mangled: {out}"
 
     def test_is_remote_accepts_the_query_form(self):
         """The `/vsicurl?` form is classified as remote like `/vsicurl/` is."""

--- a/tests/base/test_remote.py
+++ b/tests/base/test_remote.py
@@ -14,6 +14,7 @@ from pyramids.base.remote import (
     CloudConfig,
     _to_vsi,
     is_remote,
+    redact_credentials,
     signer_cloud_config,
 )
 from pyramids.netcdf import NetCDF
@@ -685,3 +686,36 @@ class TestLiveOpenDAP:
         )
         variable = nc.get_variable(self.VAR)
         assert variable.shape[0] >= 1
+
+
+class TestRedactCredentials:
+    """Credential values must not survive into a log line or message."""
+
+    def test_embedded_header_value_is_blanked(self):
+        """An embedded bearer header is replaced, the rest stays readable."""
+        text = "Can't open /vsicurl?header.Authorization=Bearer%20SECRET&url=x"
+        out = redact_credentials(text)
+        assert "SECRET" not in out, f"token survived: {out}"
+        assert "header.Authorization=<redacted>" in out, out
+
+    def test_sas_query_parameter_is_blanked(self):
+        """A SAS-style `sig=` parameter is caught as well."""
+        out = redact_credentials("https://h/a.tif?sv=2021&sig=SECRET")
+        assert out == "https://h/a.tif?sv=2021&sig=<redacted>", out
+
+    def test_ordinary_message_is_untouched(self):
+        """A message with no credential is returned verbatim."""
+        text = "Can't open /vsicurl/https://h/a.tif. Skipping it"
+        assert redact_credentials(text) == text, "an innocent message was altered"
+
+    def test_multiple_headers_all_blanked(self):
+        """Every credential option in one string is redacted."""
+        text = "header.Authorization=Bearer%20A&header.X-Api-Key=B&url=x"
+        out = redact_credentials(text)
+        assert "Bearer%20A" not in out and "=B&" not in out, f"a value survived: {out}"
+
+    def test_is_remote_accepts_the_query_form(self):
+        """The `/vsicurl?` form is classified as remote like `/vsicurl/` is."""
+        assert is_remote("/vsicurl?empty_dir=yes&url=https%3A%2F%2Fh%2Fa.tif"), (
+            "the query form must be recognised as remote"
+        )

--- a/tests/dataset/cog/test_gdal_config.py
+++ b/tests/dataset/cog/test_gdal_config.py
@@ -191,3 +191,47 @@ class TestConfigApplication:
         validate(float_cog, config={"PYRAMIDS_PC1_SENTINEL": "on"})
         after = gdal.GetConfigOption("PYRAMIDS_PC1_SENTINEL", "unset")
         assert before == "unset" and after == "unset", "config leaked outside context"
+
+
+class TestCogReadDefaultsContent:
+    """The remote-read defaults carry the knobs a cold COG read needs (ARC-73)."""
+
+    def test_skips_the_directory_listing(self):
+        """A remote open must not issue a directory listing.
+
+        Test scenario:
+            The listing is often the single biggest latency hit on a cold read.
+        """
+        assert COG_READ_DEFAULTS["GDAL_DISABLE_READDIR_ON_OPEN"] == "EMPTY_DIR", (
+            f"readdir not disabled: {COG_READ_DEFAULTS}"
+        )
+
+    def test_batches_the_tile_ranges(self):
+        """Scattered tile ranges are issued as one multi-range request.
+
+        Test scenario:
+            A COG read produces many small ranges; merging adjacent ones is not
+            enough on its own without multi-range batching.
+        """
+        assert COG_READ_DEFAULTS["GDAL_HTTP_MULTIRANGE"] == "YES", COG_READ_DEFAULTS
+        assert COG_READ_DEFAULTS["GDAL_HTTP_MERGE_CONSECUTIVE_RANGES"] == "YES", (
+            COG_READ_DEFAULTS
+        )
+
+    def test_rides_out_a_transient_fault(self):
+        """A transient 5xx from object storage does not fail the whole read.
+
+        Test scenario:
+            Without a retry budget one flaky range request kills the read.
+        """
+        assert COG_READ_DEFAULTS["GDAL_HTTP_MAX_RETRY"] == "3", COG_READ_DEFAULTS
+        assert COG_READ_DEFAULTS["GDAL_HTTP_RETRY_DELAY"] == "0.5", COG_READ_DEFAULTS
+
+    def test_values_are_strings(self):
+        """Every default is a string, as gdal.config_options requires.
+
+        Test scenario:
+            A non-string value raises when the config is installed.
+        """
+        bad = {k: v for k, v in COG_READ_DEFAULTS.items() if not isinstance(v, str)}
+        assert not bad, f"non-string config values: {bad}"

--- a/tests/dataset/io/test_gdal_env.py
+++ b/tests/dataset/io/test_gdal_env.py
@@ -1,0 +1,268 @@
+"""Tests for the cloud config a Dataset captures at open time (ARC-24).
+
+A signed remote open (`pyramids.stac.load_asset` with a Requester-Pays or
+bearer signer) authenticates the handle it creates, but several read paths do
+not use that handle: `threadsafe=True` opens one per thread, a lazy `chunks=`
+read opens inside the dask task, and unpickling on a worker re-opens from the
+path. `Dataset.read_file(..., gdal_env=...)` captures the config so every one of
+those re-opens installs it again.
+"""
+
+from __future__ import annotations
+
+import pickle
+
+import numpy as np
+import pytest
+from osgeo import gdal
+
+from pyramids.dataset import Dataset, DatasetCollection
+from pyramids.dataset.engines import io as io_engine
+from tests._helpers import write_raster
+
+pytestmark = pytest.mark.core
+
+ENV = {"AWS_REQUEST_PAYER": "requester"}
+
+
+@pytest.fixture
+def tif(tmp_path):
+    """A small single-band GeoTIFF path.
+
+    Returns:
+        str: Path to a 4x4 EPSG:4326 raster filled with 7.0.
+    """
+    return write_raster(tmp_path / "signed.tif", np.full((4, 4), 7.0, "float32"), (0.0, 4.0))
+
+
+class TestGdalEnvCapture:
+    """Tests for `Dataset.read_file(gdal_env=...)` and the `gdal_env` property."""
+
+    def test_default_open_captures_nothing(self, tif):
+        """An ordinary open leaves the captured config empty.
+
+        Test scenario:
+            No `gdal_env=` argument -> `{}`, so unsigned reads pay nothing.
+        """
+        assert Dataset.read_file(tif).gdal_env == {}, "an ordinary open must capture nothing"
+
+    def test_open_captures_the_env(self, tif):
+        """`gdal_env=` is retained on the dataset.
+
+        Test scenario:
+            A Requester-Pays config survives the open.
+        """
+        assert Dataset.read_file(tif, gdal_env=ENV).gdal_env == ENV, "env not captured"
+
+    def test_property_returns_a_copy(self, tif):
+        """Mutating the returned mapping cannot corrupt the dataset's own copy.
+
+        Test scenario:
+            Clearing the returned dict leaves the dataset's config intact.
+        """
+        ds = Dataset.read_file(tif, gdal_env=ENV)
+        ds.gdal_env.clear()
+        assert ds.gdal_env == ENV, "the property must hand out a copy"
+
+    def test_env_is_active_during_the_open(self, tif, monkeypatch):
+        """The config is installed while the file is opened, not only after.
+
+        Test scenario:
+            A reader stub reads `AWS_REQUEST_PAYER` at open time.
+        """
+        captured = {}
+        original = Dataset.read_file.__func__
+
+        def spy(path, *args, **kwargs):
+            captured["payer"] = gdal.GetConfigOption("AWS_REQUEST_PAYER")
+            return None
+
+        monkeypatch.setattr("pyramids._io.read_file", spy)
+        with pytest.raises(Exception):
+            original(Dataset, tif, gdal_env=ENV)
+        assert captured["payer"] == "requester", f"env not active at open: {captured}"
+
+
+class TestGdalEnvOnReads:
+    """The captured config is re-installed around reads that re-open the file."""
+
+    def test_shared_handle_read_installs_the_env(self, tif, monkeypatch):
+        """A plain eager read runs under the captured config.
+
+        Test scenario:
+            A VRT-backed dataset opens its sources here, so the config has to be
+            active even though the dataset's own handle already exists.
+        """
+        seen = {}
+        original = io_engine.IO._read_block
+
+        def spy(self, *args, **kwargs):
+            seen["payer"] = gdal.GetConfigOption("AWS_REQUEST_PAYER")
+            return original(self, *args, **kwargs)
+
+        monkeypatch.setattr(io_engine.IO, "_read_block", spy)
+        Dataset.read_file(tif, gdal_env=ENV).read_array(window=[0, 0, 2, 2])
+        assert seen["payer"] == "requester", f"env not active during read: {seen}"
+
+    def test_threadsafe_read_installs_the_env(self, tif, monkeypatch):
+        """A per-thread re-open runs under the captured config.
+
+        Test scenario:
+            `threadsafe=True` opens a fresh handle from the path — without the
+            captured config that handle is built with no credentials.
+        """
+        seen = {}
+        original = io_engine.IO._read_via_handle
+
+        def spy(self, *args, **kwargs):
+            seen["payer"] = gdal.GetConfigOption("AWS_REQUEST_PAYER")
+            return original(self, *args, **kwargs)
+
+        monkeypatch.setattr(io_engine.IO, "_read_via_handle", spy)
+        Dataset.read_file(tif, gdal_env=ENV).read_array(threadsafe=True)
+        assert seen["payer"] == "requester", f"env not active in threadsafe read: {seen}"
+
+    def test_unsigned_read_installs_nothing(self, tif, monkeypatch):
+        """An ordinary dataset leaves the option unset during a read.
+
+        Test scenario:
+            No captured config -> no GDAL config is touched.
+        """
+        seen = {}
+        original = io_engine.IO._read_block
+
+        def spy(self, *args, **kwargs):
+            seen["payer"] = gdal.GetConfigOption("AWS_REQUEST_PAYER")
+            return original(self, *args, **kwargs)
+
+        monkeypatch.setattr(io_engine.IO, "_read_block", spy)
+        Dataset.read_file(tif).read_array(window=[0, 0, 2, 2])
+        assert seen["payer"] is None, f"unexpected config for an unsigned open: {seen}"
+
+    def test_values_are_unchanged_by_the_env(self, tif):
+        """Capturing a config does not alter what is read.
+
+        Test scenario:
+            The pixels match a plain open of the same file.
+        """
+        signed = Dataset.read_file(tif, gdal_env=ENV).read_array()
+        plain = Dataset.read_file(tif).read_array()
+        np.testing.assert_array_equal(signed, plain)
+
+
+class TestGdalEnvSurvivesPickle:
+    """The recipe that re-opens on a dask worker carries the config."""
+
+    def test_reduce_carries_the_env(self, tif):
+        """`__reduce__` puts the captured config in the recipe tuple.
+
+        Test scenario:
+            The fourth recipe argument is the config dict.
+        """
+        _fn, args = Dataset.read_file(tif, gdal_env=ENV).__reduce__()
+        assert args[3] == ENV, f"env missing from the pickle recipe: {args}"
+
+    def test_round_trip_restores_the_env(self, tif):
+        """An unpickled dataset re-opens with the same config attached.
+
+        Test scenario:
+            pickle -> unpickle keeps `gdal_env` and the pixel values.
+        """
+        ds = Dataset.read_file(tif, gdal_env=ENV)
+        restored = pickle.loads(pickle.dumps(ds))
+        assert restored.gdal_env == ENV, f"env lost across pickle: {restored.gdal_env}"
+        np.testing.assert_array_equal(restored.read_array(), ds.read_array())
+
+    def test_legacy_three_element_recipe_still_loads(self, tif):
+        """A recipe written before the config existed still reconstructs.
+
+        Test scenario:
+            Calling the reconstructor with three arguments yields a dataset with
+            an empty config rather than a TypeError.
+        """
+        from pyramids.dataset.abstract_dataset import _reconstruct_dataset
+
+        ds = _reconstruct_dataset(Dataset, tif, "read_only")
+        assert ds.gdal_env == {}, f"legacy recipe should capture nothing: {ds.gdal_env}"
+
+
+class TestCollectionHandsEnvToTimesteps:
+    """A signed collection passes its config down to each timestep Dataset."""
+
+    def test_per_timestep_datasets_carry_the_env(self, tmp_path):
+        """Path A datasets inherit the collection's captured config.
+
+        Test scenario:
+            Without it, a per-thread or lazy read of a timestep re-opens the
+            file unauthenticated even though the collection knows the config.
+        """
+        paths = [
+            write_raster(tmp_path / f"t{i}.tif", np.full((3, 3), float(i), "float32"), (0.0, 3.0))
+            for i in range(2)
+        ]
+        collection = DatasetCollection.from_files(paths, gdal_env=ENV)
+        assert [ds.gdal_env for ds in collection.datasets] == [ENV, ENV], (
+            "timestep datasets did not inherit the collection env"
+        )
+
+    def test_unsigned_collection_leaves_timesteps_clean(self, tmp_path):
+        """An ordinary collection hands down nothing.
+
+        Test scenario:
+            No config on the collection -> none on its timesteps.
+        """
+        paths = [
+            write_raster(tmp_path / f"u{i}.tif", np.full((3, 3), float(i), "float32"), (0.0, 3.0))
+            for i in range(2)
+        ]
+        collection = DatasetCollection.from_files(paths)
+        assert all(ds.gdal_env == {} for ds in collection.datasets), (
+            "an unsigned collection must not attach a config"
+        )
+
+
+class TestGdalEnvOnLazyReads:
+    """The captured config travels with the dask tasks of a lazy read."""
+
+    def test_chunk_tasks_receive_the_env(self, tif, monkeypatch):
+        """`_read_chunk` is handed the dataset's captured config.
+
+        Test scenario:
+            Chunks open the file inside the task, after (and possibly in another
+            process from) the call that built the graph, so the config cannot be
+            an ambient one — it has to travel as a plain dict.
+        """
+        pytest.importorskip("dask")
+        from pyramids.dataset.ops import io as ops_io
+
+        seen = {}
+        original = ops_io._read_chunk
+
+        def spy(block_info=None, *, gdal_env=None, **kwargs):
+            seen["gdal_env"] = gdal_env
+            return original(block_info, gdal_env=gdal_env, **kwargs)
+
+        monkeypatch.setattr(ops_io, "_read_chunk", spy)
+        Dataset.read_file(tif, gdal_env=ENV).read_array(chunks=-1).compute()
+        assert seen["gdal_env"] == ENV, f"env not shipped to the chunk task: {seen}"
+
+    def test_unsigned_chunk_tasks_receive_none(self, tif, monkeypatch):
+        """An ordinary lazy read ships no config at all.
+
+        Test scenario:
+            `None` rather than an empty dict, so the task pickles a little
+            smaller and the worker takes the nullcontext path.
+        """
+        pytest.importorskip("dask")
+        from pyramids.dataset.ops import io as ops_io
+
+        seen = {}
+        original = ops_io._read_chunk
+
+        def spy(block_info=None, *, gdal_env=None, **kwargs):
+            seen["gdal_env"] = gdal_env
+            return original(block_info, gdal_env=gdal_env, **kwargs)
+
+        monkeypatch.setattr(ops_io, "_read_chunk", spy)
+        Dataset.read_file(tif).read_array(chunks=-1).compute()
+        assert seen["gdal_env"] is None, f"unexpected env on an unsigned read: {seen}"

--- a/tests/dataset/io/test_gdal_env.py
+++ b/tests/dataset/io/test_gdal_env.py
@@ -25,6 +25,10 @@ pytestmark = pytest.mark.core
 ENV = {"AWS_REQUEST_PAYER": "requester"}
 
 
+class _StopOpen(Exception):
+    """Sentinel raised by the reader spy so the open aborts after its probe."""
+
+
 @pytest.fixture
 def tif(tmp_path):
     """A small single-band GeoTIFF path.
@@ -32,7 +36,9 @@ def tif(tmp_path):
     Returns:
         str: Path to a 4x4 EPSG:4326 raster filled with 7.0.
     """
-    return write_raster(tmp_path / "signed.tif", np.full((4, 4), 7.0, "float32"), (0.0, 4.0))
+    return write_raster(
+        tmp_path / "signed.tif", np.full((4, 4), 7.0, "float32"), (0.0, 4.0)
+    )
 
 
 class TestGdalEnvCapture:
@@ -44,7 +50,9 @@ class TestGdalEnvCapture:
         Test scenario:
             No `gdal_env=` argument -> `{}`, so unsigned reads pay nothing.
         """
-        assert Dataset.read_file(tif).gdal_env == {}, "an ordinary open must capture nothing"
+        assert Dataset.read_file(tif).gdal_env == {}, (
+            "an ordinary open must capture nothing"
+        )
 
     def test_open_captures_the_env(self, tif):
         """`gdal_env=` is retained on the dataset.
@@ -71,16 +79,17 @@ class TestGdalEnvCapture:
             A reader stub reads `AWS_REQUEST_PAYER` at open time.
         """
         captured = {}
-        original = Dataset.read_file.__func__
 
         def spy(path, *args, **kwargs):
             captured["payer"] = gdal.GetConfigOption("AWS_REQUEST_PAYER")
-            return None
+            raise _StopOpen
 
         monkeypatch.setattr("pyramids._io.read_file", spy)
-        with pytest.raises(Exception):
-            original(Dataset, tif, gdal_env=ENV)
-        assert captured["payer"] == "requester", f"env not active at open: {captured}"
+        with pytest.raises(_StopOpen):
+            Dataset.read_file(tif, gdal_env=ENV)
+        assert captured.get("payer") == "requester", (
+            f"env not active at open: {captured}"
+        )
 
 
 class TestGdalEnvOnReads:
@@ -120,7 +129,9 @@ class TestGdalEnvOnReads:
 
         monkeypatch.setattr(io_engine.IO, "_read_via_handle", spy)
         Dataset.read_file(tif, gdal_env=ENV).read_array(threadsafe=True)
-        assert seen["payer"] == "requester", f"env not active in threadsafe read: {seen}"
+        assert seen["payer"] == "requester", (
+            f"env not active in threadsafe read: {seen}"
+        )
 
     def test_unsigned_read_installs_nothing(self, tif, monkeypatch):
         """An ordinary dataset leaves the option unset during a read.
@@ -197,7 +208,11 @@ class TestCollectionHandsEnvToTimesteps:
             file unauthenticated even though the collection knows the config.
         """
         paths = [
-            write_raster(tmp_path / f"t{i}.tif", np.full((3, 3), float(i), "float32"), (0.0, 3.0))
+            write_raster(
+                tmp_path / f"t{i}.tif",
+                np.full((3, 3), float(i), "float32"),
+                (0.0, 3.0),
+            )
             for i in range(2)
         ]
         collection = DatasetCollection.from_files(paths, gdal_env=ENV)
@@ -212,7 +227,11 @@ class TestCollectionHandsEnvToTimesteps:
             No config on the collection -> none on its timesteps.
         """
         paths = [
-            write_raster(tmp_path / f"u{i}.tif", np.full((3, 3), float(i), "float32"), (0.0, 3.0))
+            write_raster(
+                tmp_path / f"u{i}.tif",
+                np.full((3, 3), float(i), "float32"),
+                (0.0, 3.0),
+            )
             for i in range(2)
         ]
         collection = DatasetCollection.from_files(paths)

--- a/tests/dataset/io/test_gdal_env.py
+++ b/tests/dataset/io/test_gdal_env.py
@@ -266,3 +266,84 @@ class TestGdalEnvOnLazyReads:
         monkeypatch.setattr(ops_io, "_read_chunk", spy)
         Dataset.read_file(tif).read_array(chunks=-1).compute()
         assert seen["gdal_env"] is None, f"unexpected env on an unsigned read: {seen}"
+
+
+class TestGdalEnvOnEveryReadPath:
+    """Coverage is structural: every decorated read primitive installs the config.
+
+    The first cut wrapped three call sites by hand, so `read_array()` carried the
+    credentials but `read_array(out_shape=...)`, `get_tile()` and the COG-engine
+    reads did not — an inconsistency users would hit as a puzzle.
+    """
+
+    @staticmethod
+    def _payer_during(callable_):
+        """Run `callable_` and return AWS_REQUEST_PAYER as GDAL saw it."""
+        seen = {}
+        originals = (gdal.Band.ReadAsArray, gdal.Dataset.ReadAsArray)
+
+        def make_spy(original):
+            def spy(self, *args, **kwargs):
+                seen.setdefault("payer", gdal.GetConfigOption("AWS_REQUEST_PAYER"))
+                return original(self, *args, **kwargs)
+
+            return spy
+
+        gdal.Band.ReadAsArray = make_spy(originals[0])
+        gdal.Dataset.ReadAsArray = make_spy(originals[1])
+        try:
+            callable_()
+        finally:
+            gdal.Band.ReadAsArray, gdal.Dataset.ReadAsArray = originals
+        return seen.get("payer")
+
+    def test_decimated_read_installs_the_env(self, tif):
+        """`out_shape=` decimated reads carry the config.
+
+        Test scenario:
+            The natural way to preview a large scene must not 403 where a plain
+            read succeeds.
+        """
+        ds = Dataset.read_file(tif, gdal_env=ENV)
+        payer = self._payer_during(lambda: ds.read_array(out_shape=(2, 2)))
+        assert payer == "requester", f"decimated read ran without the config: {payer}"
+
+    def test_boundless_read_installs_the_env(self, tif):
+        """Boundless reads carry the config.
+
+        Test scenario:
+            A window extending past the raster still reads real pixels inside it.
+        """
+        ds = Dataset.read_file(tif, gdal_env=ENV)
+        payer = self._payer_during(
+            lambda: ds.read_array(window=[-1, -1, 3, 3], boundless=True)
+        )
+        assert payer == "requester", f"boundless read ran without the config: {payer}"
+
+    def test_get_tile_installs_the_env(self, tif):
+        """Tiled iteration carries the config.
+
+        Test scenario:
+            `get_tile` walks the raster block by block off the shared handle.
+        """
+        ds = Dataset.read_file(tif, gdal_env=ENV)
+        payer = self._payer_during(lambda: list(ds.get_tile(size=2)))
+        assert payer == "requester", f"get_tile ran without the config: {payer}"
+
+    def test_cog_preview_installs_the_env(self, tmp_path):
+        """A COG-engine read carries the config.
+
+        Test scenario:
+            `ds.cog.preview()` opens and decimates through the COG engine, which
+            has its own read path independent of `IO`.
+        """
+        source = Dataset.create_from_array(
+            np.full((64, 64), 5.0, "float32"),
+            top_left_corner=(0.0, 64.0),
+            cell_size=1.0,
+            epsg=4326,
+        )
+        cog_path = str(source.to_cog(tmp_path / "c.tif"))
+        ds = Dataset.read_file(cog_path, gdal_env=ENV)
+        payer = self._payer_during(lambda: ds.cog.preview(max_size=8))
+        assert payer == "requester", f"COG preview ran without the config: {payer}"

--- a/tests/dataset/ops/lazy/test_read.py
+++ b/tests/dataset/ops/lazy/test_read.py
@@ -259,7 +259,7 @@ class TestLockConvention:
         captured: dict = {}
         original = io_module._read_chunk
 
-        def spy(block_info, manager, lock, band, out_dtype, single_band):
+        def spy(block_info, manager, lock, band, out_dtype, single_band, **kwargs):
             captured["lock"] = lock
             return original(
                 block_info,
@@ -268,6 +268,7 @@ class TestLockConvention:
                 band,
                 out_dtype,
                 single_band,
+                **kwargs,
             )
 
         monkeypatch.setattr(io_module, "_read_chunk", spy)
@@ -282,7 +283,7 @@ class TestLockConvention:
         captured: dict = {}
         original = io_module._read_chunk
 
-        def spy(block_info, manager, lock, band, out_dtype, single_band):
+        def spy(block_info, manager, lock, band, out_dtype, single_band, **kwargs):
             captured["lock"] = lock
             return original(
                 block_info,
@@ -291,6 +292,7 @@ class TestLockConvention:
                 band,
                 out_dtype,
                 single_band,
+                **kwargs,
             )
 
         monkeypatch.setattr(io_module, "_read_chunk", spy)
@@ -303,7 +305,7 @@ class TestLockConvention:
         captured: dict = {}
         original = io_module._read_chunk
 
-        def spy(block_info, manager, lock, band, out_dtype, single_band):
+        def spy(block_info, manager, lock, band, out_dtype, single_band, **kwargs):
             captured["lock"] = lock
             return original(
                 block_info,
@@ -312,6 +314,7 @@ class TestLockConvention:
                 band,
                 out_dtype,
                 single_band,
+                **kwargs,
             )
 
         monkeypatch.setattr(io_module, "_read_chunk", spy)

--- a/tests/dataset/remote/test_wcs.py
+++ b/tests/dataset/remote/test_wcs.py
@@ -136,10 +136,18 @@ class TestPureHelpers:
         assert "<GetCoverageExtra>" not in xml
 
     def test_gdal_http_config(self):
-        assert _wcs._gdal_http_config(None, 60.0) == {"GDAL_HTTP_TIMEOUT": "60"}
+        cfg = _wcs._gdal_http_config(None, 60.0)
+        assert cfg["GDAL_HTTP_TIMEOUT"] == "60"
+        assert "GDAL_HTTP_USERPWD" not in cfg, "no auth means no credentials emitted"
         cfg = _wcs._gdal_http_config(("u", "p"), 30.0)
         assert cfg["GDAL_HTTP_USERPWD"] == "u:p"
         assert cfg["GDAL_HTTP_TIMEOUT"] == "30"
+
+    def test_gdal_http_config_carries_retry_knobs(self):
+        """The driver read rides out a transient fault like the urllib fetch does."""
+        cfg = _wcs._gdal_http_config(None, 60.0)
+        assert cfg["GDAL_HTTP_MAX_RETRY"] == "3", f"no retry budget: {cfg}"
+        assert cfg["GDAL_HTTP_RETRY_DELAY"] == "0.5", f"no retry delay: {cfg}"
 
 
 class TestNativeCrsShim:

--- a/tests/dataset/remote/test_wcs.py
+++ b/tests/dataset/remote/test_wcs.py
@@ -146,7 +146,9 @@ class TestPureHelpers:
     def test_gdal_http_config_carries_retry_knobs(self):
         """The driver read rides out a transient fault like the urllib fetch does."""
         cfg = _wcs._gdal_http_config(None, 60.0)
-        assert cfg["GDAL_HTTP_MAX_RETRY"] == "3", f"no retry budget: {cfg}"
+        assert cfg["GDAL_HTTP_MAX_RETRY"] == "2", (
+            f"GDAL counts retries after the first attempt, not attempts: {cfg}"
+        )
         assert cfg["GDAL_HTTP_RETRY_DELAY"] == "0.5", f"no retry delay: {cfg}"
 
 

--- a/tests/dataset/stac/test_stac.py
+++ b/tests/dataset/stac/test_stac.py
@@ -10,7 +10,9 @@ pyramids — tests use raw dicts to prove the duck-typed contract.
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
@@ -24,6 +26,7 @@ from pyramids.dataset import Dataset, DatasetCollection
 from pyramids.dataset._stac import (
     _horizontal_bounds,
     _item_centroid_lon,
+    _item_datetime,
     _item_intersects_bbox,
     _lon_overlaps,
     _solar_day,
@@ -979,3 +982,92 @@ class TestFromStacMultiAssetUint16:
             4,
             4,
         ), f"grid should match the 10 m band: {(out.rows, out.columns)}"
+
+
+class TestSharedItemAccessors:
+    """The item readers route through the shared `stac._item` accessors.
+
+    `_stac.py` used to carry its own ``getattr``-then-dict resolvers for the
+    item id, ``properties`` and ``bbox``. They now delegate to
+    :mod:`pyramids.stac._item`, so both item shapes (pystac-like objects and
+    raw JSON dicts) must keep behaving identically.
+    """
+
+    def test_bbox_filter_reads_attribute_style_item(self, three_tifs):
+        """A pystac-like item's ``.bbox`` still drives the bbox filter.
+
+        Test scenario:
+            One attribute-style item inside the query box, one outside.
+        """
+        inside = SimpleNamespace(
+            bbox=[0.0, 0.0, 1.0, 1.0],
+            assets={"data": {"href": three_tifs[0]}},
+        )
+        outside = SimpleNamespace(
+            bbox=[50.0, 50.0, 51.0, 51.0],
+            assets={"data": {"href": three_tifs[1]}},
+        )
+        coll = DatasetCollection.from_stac(
+            [inside, outside], asset="data", bbox=(-1.0, -1.0, 2.0, 2.0)
+        )
+        assert coll.time_length == 1, (
+            f"only the intersecting item should survive, got {coll.time_length}"
+        )
+
+    def test_centroid_lon_reads_attribute_style_item(self):
+        """``_item_centroid_lon`` reads ``.bbox`` off a pystac-like item.
+
+        Test scenario:
+            A box spanning 10E..20E has centroid 15E.
+        """
+        item = SimpleNamespace(bbox=[10.0, 0.0, 20.0, 1.0])
+        assert _item_centroid_lon(item) == pytest.approx(15.0), (
+            f"attribute bbox centroid wrong: {_item_centroid_lon(item)}"
+        )
+
+    def test_centroid_lon_without_bbox_is_zero(self):
+        """A bbox-less item falls back to the prime meridian.
+
+        Test scenario:
+            No bbox -> 0.0, i.e. no solar-day shift.
+        """
+        assert _item_centroid_lon({"id": "x"}) == 0.0, "expected the 0.0 fallback"
+
+    def test_datetime_read_from_properties_mapping(self):
+        """``_item_datetime`` reads ``properties["datetime"]`` via the accessor.
+
+        Test scenario:
+            A raw dict item with only ``properties.datetime`` set.
+        """
+        item = {"properties": {"datetime": "2021-06-01T10:00:00Z"}}
+        assert _item_datetime(item).year == 2021, "properties datetime not parsed"
+
+    def test_datetime_prefers_the_attribute(self):
+        """A pystac-like ``.datetime`` attribute wins over ``properties``.
+
+        Test scenario:
+            Both present -> the attribute is used.
+        """
+        when = datetime(2020, 1, 2, tzinfo=UTC)
+        item = SimpleNamespace(
+            datetime=when, properties={"datetime": "2021-06-01T10:00:00Z"}
+        )
+        assert _item_datetime(item) == when, "the .datetime attribute should win"
+
+    def test_missing_datetime_error_names_the_item(self):
+        """The missing-datetime error identifies the item by id.
+
+        Test scenario:
+            The message comes from the shared ``item_id`` accessor.
+        """
+        with pytest.raises(ValueError, match="scene-7"):
+            _item_datetime({"id": "scene-7", "properties": {}})
+
+    def test_missing_datetime_error_falls_back_to_placeholder(self):
+        """An id-less item still produces a readable error.
+
+        Test scenario:
+            ``item_id`` returns ``"?"`` when no id is present.
+        """
+        with pytest.raises(ValueError, match=r"item \? has no datetime"):
+            _item_datetime({"properties": {}})

--- a/tests/feature/test_oapif.py
+++ b/tests/feature/test_oapif.py
@@ -97,12 +97,20 @@ class TestPureHelpers:
         assert _oapif._oapif_connection("https://h/api") == "OAPIF:https://h/api"
 
     def test_gdal_http_config(self):
-        assert _oapif._gdal_http_config(None, 60.0) == {"GDAL_HTTP_TIMEOUT": "60"}
+        cfg = _oapif._gdal_http_config(None, 60.0)
+        assert cfg["GDAL_HTTP_TIMEOUT"] == "60"
+        assert "GDAL_HTTP_USERPWD" not in cfg, "no auth means no credentials emitted"
         cfg = _oapif._gdal_http_config(("u", "p"), 30.0)
         assert cfg["GDAL_HTTP_USERPWD"] == "u:p" and cfg["GDAL_HTTP_TIMEOUT"] == "30"
 
     def test_gdal_http_config_clamps_subsecond_timeout(self):
         assert _oapif._gdal_http_config(None, 0.5)["GDAL_HTTP_TIMEOUT"] == "1"
+
+    def test_gdal_http_config_carries_retry_knobs(self):
+        """The driver read rides out a transient fault like the urllib fetch does."""
+        cfg = _oapif._gdal_http_config(None, 60.0)
+        assert cfg["GDAL_HTTP_MAX_RETRY"] == "3", f"no retry budget: {cfg}"
+        assert cfg["GDAL_HTTP_RETRY_DELAY"] == "0.5", f"no retry delay: {cfg}"
 
     def test_read_kwargs(self):
         assert _oapif._read_kwargs(None, None, None) == {}

--- a/tests/feature/test_oapif.py
+++ b/tests/feature/test_oapif.py
@@ -109,7 +109,9 @@ class TestPureHelpers:
     def test_gdal_http_config_carries_retry_knobs(self):
         """The driver read rides out a transient fault like the urllib fetch does."""
         cfg = _oapif._gdal_http_config(None, 60.0)
-        assert cfg["GDAL_HTTP_MAX_RETRY"] == "3", f"no retry budget: {cfg}"
+        assert cfg["GDAL_HTTP_MAX_RETRY"] == "2", (
+            f"GDAL counts retries after the first attempt, not attempts: {cfg}"
+        )
         assert cfg["GDAL_HTTP_RETRY_DELAY"] == "0.5", f"no retry delay: {cfg}"
 
     def test_read_kwargs(self):

--- a/tests/feature/test_wfs.py
+++ b/tests/feature/test_wfs.py
@@ -115,7 +115,9 @@ class TestPureHelpers:
     def test_gdal_http_config_carries_retry_knobs(self):
         """The driver read rides out a transient fault like the urllib fetch does."""
         cfg = _wfs._gdal_http_config(None, 60.0)
-        assert cfg["GDAL_HTTP_MAX_RETRY"] == "3", f"no retry budget: {cfg}"
+        assert cfg["GDAL_HTTP_MAX_RETRY"] == "2", (
+            f"GDAL counts retries after the first attempt, not attempts: {cfg}"
+        )
         assert cfg["GDAL_HTTP_RETRY_DELAY"] == "0.5", f"no retry delay: {cfg}"
 
     def test_read_kwargs(self):

--- a/tests/feature/test_wfs.py
+++ b/tests/feature/test_wfs.py
@@ -103,12 +103,20 @@ class TestPureHelpers:
         )
 
     def test_gdal_http_config(self):
-        assert _wfs._gdal_http_config(None, 60.0) == {"GDAL_HTTP_TIMEOUT": "60"}
+        cfg = _wfs._gdal_http_config(None, 60.0)
+        assert cfg["GDAL_HTTP_TIMEOUT"] == "60"
+        assert "GDAL_HTTP_USERPWD" not in cfg, "no auth means no credentials emitted"
         cfg = _wfs._gdal_http_config(("u", "p"), 30.0)
         assert cfg["GDAL_HTTP_USERPWD"] == "u:p" and cfg["GDAL_HTTP_TIMEOUT"] == "30"
 
     def test_gdal_http_config_clamps_subsecond_timeout(self):
         assert _wfs._gdal_http_config(None, 0.5)["GDAL_HTTP_TIMEOUT"] == "1"
+
+    def test_gdal_http_config_carries_retry_knobs(self):
+        """The driver read rides out a transient fault like the urllib fetch does."""
+        cfg = _wfs._gdal_http_config(None, 60.0)
+        assert cfg["GDAL_HTTP_MAX_RETRY"] == "3", f"no retry budget: {cfg}"
+        assert cfg["GDAL_HTTP_RETRY_DELAY"] == "0.5", f"no retry delay: {cfg}"
 
     def test_read_kwargs(self):
         assert _wfs._read_kwargs(None, None, None) == {}

--- a/tests/stac/test_item.py
+++ b/tests/stac/test_item.py
@@ -19,6 +19,7 @@ from pyramids.stac._item import (
     asset_media_type,
     get_asset,
     get_assets,
+    item_bbox,
     item_id,
     item_properties,
 )
@@ -81,6 +82,61 @@ class TestItemProperties:
             ``{"id": "x"}`` → ``{}``.
         """
         assert item_properties({"id": "x"}) == {}
+
+
+class TestItemBbox:
+    """Tests for item_bbox."""
+
+    def test_dict_bbox(self):
+        """A raw JSON item exposes its bbox under the ``bbox`` key.
+
+        Test scenario:
+            A 2D ``[west, south, east, north]`` box is returned verbatim.
+        """
+        assert item_bbox({"bbox": [1.0, 2.0, 3.0, 4.0]}) == [1.0, 2.0, 3.0, 4.0]
+
+    def test_attribute_bbox(self):
+        """A pystac-like item exposes ``.bbox``.
+
+        Test scenario:
+            The attribute sequence is returned as-is.
+        """
+        item = SimpleNamespace(bbox=[10.0, 20.0, 11.0, 21.0])
+        assert item_bbox(item) == [10.0, 20.0, 11.0, 21.0], "attribute bbox not read"
+
+    def test_missing_bbox_none(self):
+        """An item without a bbox yields None rather than raising.
+
+        Test scenario:
+            ``{"id": "x"}`` → ``None`` (callers treat this as "unknown extent").
+        """
+        assert item_bbox({"id": "x"}) is None, "a bbox-less item should give None"
+
+    def test_three_dimensional_bbox_passthrough(self):
+        """A 6-element 3D bbox is returned untouched.
+
+        Test scenario:
+            The accessor locates the bbox; interpreting its length is the
+            caller's job (``_horizontal_bounds``).
+        """
+        box = [1.0, 2.0, 0.0, 3.0, 4.0, 100.0]
+        assert item_bbox({"bbox": box}) == box, "3D bbox should pass through intact"
+
+    def test_empty_bbox_passthrough(self):
+        """An explicitly empty bbox is returned as-is, not coerced to None.
+
+        Test scenario:
+            ``[]`` is falsy but present; callers decide what that means.
+        """
+        assert item_bbox({"bbox": []}) == [], "an empty bbox should pass through"
+
+    def test_non_dict_without_attribute_is_none(self):
+        """An object with neither ``.bbox`` nor dict access yields None.
+
+        Test scenario:
+            A bare object is tolerated (duck typing, no AttributeError).
+        """
+        assert item_bbox(object()) is None, "an unrelated object should give None"
 
 
 class TestGetAssets:

--- a/tests/stac/test_loader.py
+++ b/tests/stac/test_loader.py
@@ -371,7 +371,7 @@ class TestLoadAsset:
         """
         captured: dict[str, str | None] = {}
 
-        def fake_read_file(href, vsi=None):
+        def fake_read_file(href, vsi=None, gdal_env=None):
             captured["payer"] = gdal.GetConfigOption("AWS_REQUEST_PAYER")
             return "DS"
 
@@ -408,7 +408,7 @@ class TestLoadAsset:
         """
         captured: dict[str, str | None] = {}
 
-        def fake_read_file(href, vsi=None):
+        def fake_read_file(href, vsi=None, gdal_env=None):
             captured["payer"] = gdal.GetConfigOption("AWS_REQUEST_PAYER")
             return "DS"
 
@@ -427,7 +427,7 @@ class TestLoadAsset:
         """
         captured: dict[str, str | None] = {}
 
-        def fake_read_file(href, vsi=None):
+        def fake_read_file(href, vsi=None, gdal_env=None):
             captured["href"] = href
             captured["sentinel"] = gdal.GetConfigOption("CPL_CURL_VERBOSE")
             return "DS"
@@ -523,3 +523,115 @@ class TestLoadZarrAsset:
         )
         assert isinstance(out, DatasetCollection), f"got {type(out).__name__}"
         assert out.time_length == 2, f"time_length {out.time_length}"
+
+
+class TestOpenConfig:
+    """Tests for the GDAL config chosen for an asset open (ARC-73 / ARC-24)."""
+
+    def test_remote_gdal_asset_gets_the_fast_read_preset(self):
+        """A remote COG open installs the /vsicurl fast-read preset.
+
+        Test scenario:
+            Without it every remote open costs a directory listing plus a fan of
+            sidecar probes.
+        """
+        config = _loader._open_config("/vsicurl/https://h/a.tif", "gdal", None)
+        options = config.as_gdal_config()
+        assert options["GDAL_DISABLE_READDIR_ON_OPEN"] == "EMPTY_DIR", options
+        assert options["GDAL_HTTP_MULTIRANGE"] == "YES", options
+
+    def test_local_asset_skips_the_preset(self):
+        """A local open must keep finding its sidecar files.
+
+        Test scenario:
+            The preset's readdir skip would hide a local `.aux.xml` / world file.
+        """
+        with _loader._open_config("C:/data/a.tif", "gdal", None):
+            assert gdal.GetConfigOption("GDAL_DISABLE_READDIR_ON_OPEN") is None, (
+                "a local open should install nothing"
+            )
+
+    def test_zarr_asset_skips_the_preset(self):
+        """A Zarr store opts out: it is read by zarr/fsspec, not GDAL.
+
+        Test scenario:
+            A readdir skip is also wrong for a directory-style store.
+        """
+        class _S:
+            def gdal_env(self):
+                return {"AWS_REQUEST_PAYER": "requester"}
+
+        config = _loader._open_config("s3://b/store.zarr", "zarr", _S())
+        assert config.as_gdal_config() == {"AWS_REQUEST_PAYER": "requester"}, (
+            "the zarr branch should carry the signer env only"
+        )
+
+    def test_signer_env_overrides_the_preset(self):
+        """A signer key wins over the preset's default.
+
+        Test scenario:
+            An explicit HTTP version must survive the merge.
+        """
+        class _S:
+            def gdal_env(self):
+                return {"GDAL_HTTP_VERSION": "1.1"}
+
+        config = _loader._open_config("/vsicurl/https://h/a.tif", "gdal", _S())
+        assert config.as_gdal_config()["GDAL_HTTP_VERSION"] == "1.1"
+
+
+class TestLoadAssetPersistsEnv:
+    """load_asset captures the signer env on the object it returns (ARC-24)."""
+
+    def test_gdal_engine_captures_the_env(self, monkeypatch):
+        """A COG asset opened with a signer keeps its config for later reads.
+
+        Test scenario:
+            `Dataset.read_file` receives the env, so the returned dataset
+            re-installs it on every re-opening read path.
+        """
+        captured = {}
+
+        def fake_read_file(href, vsi=None, gdal_env=None):
+            captured["gdal_env"] = gdal_env
+            return "DS"
+
+        monkeypatch.setattr(_loader.Dataset, "read_file", staticmethod(fake_read_file))
+        signer = _AppendSigner(suffix="", env={"AWS_REQUEST_PAYER": "requester"})
+        load_asset({"href": "s3://b/x.tif", "type": "image/tiff"}, signer=signer)
+        assert captured["gdal_env"] == {"AWS_REQUEST_PAYER": "requester"}, (
+            f"env not forwarded to read_file: {captured}"
+        )
+
+    def test_no_signer_forwards_no_env(self, monkeypatch):
+        """An unsigned open forwards nothing.
+
+        Test scenario:
+            `gdal_env` stays None so the dataset captures an empty config.
+        """
+        captured = {}
+
+        def fake_read_file(href, vsi=None, gdal_env=None):
+            captured["gdal_env"] = gdal_env
+            return "DS"
+
+        monkeypatch.setattr(_loader.Dataset, "read_file", staticmethod(fake_read_file))
+        load_asset({"href": _GEOTIFF, "type": "image/tiff"})
+        assert captured["gdal_env"] is None, f"unexpected env: {captured}"
+
+    def test_non_gdal_engine_gets_the_env_attached(self, monkeypatch):
+        """GRIB / NetCDF / Zarr readers take no gdal_env=, so it is set after.
+
+        Test scenario:
+            The opened object carries `_gdal_env` for its later reads.
+        """
+        class _Reader:
+            _gdal_env: dict = {}
+
+        opened = _Reader()
+        monkeypatch.setattr(_loader, "open_grib", lambda href, vsi=None: opened)
+        signer = _AppendSigner(suffix="", env={"GDAL_HTTP_HEADERS": "Authorization: x"})
+        load_asset({"href": "https://h/f.grib2"}, signer=signer)
+        assert opened._gdal_env == {"GDAL_HTTP_HEADERS": "Authorization: x"}, (
+            f"env not attached to the reader: {opened._gdal_env}"
+        )

--- a/tests/stac/test_loader.py
+++ b/tests/stac/test_loader.py
@@ -558,11 +558,8 @@ class TestOpenConfig:
             A readdir skip is also wrong for a directory-style store.
         """
 
-        class _S:
-            def gdal_env(self):
-                return {"AWS_REQUEST_PAYER": "requester"}
-
-        config = _loader._open_config("s3://b/store.zarr", "zarr", _S())
+        env = {"AWS_REQUEST_PAYER": "requester"}
+        config = _loader._open_config("s3://b/store.zarr", "zarr", env)
         assert config.as_gdal_config() == {"AWS_REQUEST_PAYER": "requester"}, (
             "the zarr branch should carry the signer env only"
         )
@@ -574,11 +571,8 @@ class TestOpenConfig:
             An explicit HTTP version must survive the merge.
         """
 
-        class _S:
-            def gdal_env(self):
-                return {"GDAL_HTTP_VERSION": "1.1"}
-
-        config = _loader._open_config("/vsicurl/https://h/a.tif", "gdal", _S())
+        env = {"GDAL_HTTP_VERSION": "1.1"}
+        config = _loader._open_config("/vsicurl/https://h/a.tif", "gdal", env)
         assert config.as_gdal_config()["GDAL_HTTP_VERSION"] == "1.1"
 
 

--- a/tests/stac/test_loader.py
+++ b/tests/stac/test_loader.py
@@ -557,6 +557,7 @@ class TestOpenConfig:
         Test scenario:
             A readdir skip is also wrong for a directory-style store.
         """
+
         class _S:
             def gdal_env(self):
                 return {"AWS_REQUEST_PAYER": "requester"}
@@ -572,6 +573,7 @@ class TestOpenConfig:
         Test scenario:
             An explicit HTTP version must survive the merge.
         """
+
         class _S:
             def gdal_env(self):
                 return {"GDAL_HTTP_VERSION": "1.1"}

--- a/tests/stac/test_loader.py
+++ b/tests/stac/test_loader.py
@@ -620,18 +620,42 @@ class TestLoadAssetPersistsEnv:
         assert captured["gdal_env"] is None, f"unexpected env: {captured}"
 
     def test_non_gdal_engine_gets_the_env_attached(self, monkeypatch):
-        """GRIB / NetCDF / Zarr readers take no gdal_env=, so it is set after.
+        """GRIB / NetCDF readers take no gdal_env=, so it is attached after.
 
         Test scenario:
-            The opened object carries `_gdal_env` for its later reads.
+            The capture goes through the declared `attach_gdal_env` hook rather
+            than a private attribute poked onto a foreign object.
         """
+
         class _Reader:
-            _gdal_env: dict = {}
+            def __init__(self):
+                self.attached = None
+
+            def attach_gdal_env(self, env):
+                self.attached = env
 
         opened = _Reader()
         monkeypatch.setattr(_loader, "open_grib", lambda href, vsi=None: opened)
         signer = _AppendSigner(suffix="", env={"GDAL_HTTP_HEADERS": "Authorization: x"})
         load_asset({"href": "https://h/f.grib2"}, signer=signer)
-        assert opened._gdal_env == {"GDAL_HTTP_HEADERS": "Authorization: x"}, (
-            f"env not attached to the reader: {opened._gdal_env}"
+        assert opened.attached == {"GDAL_HTTP_HEADERS": "Authorization: x"}, (
+            f"env not attached to the reader: {opened.attached}"
         )
+
+    def test_reader_without_the_hook_is_left_alone(self, monkeypatch):
+        """A reader exposing no hook is not poked at.
+
+        Test scenario:
+            The Zarr branch reads through fsspec, which never consults GDAL
+            config, so attaching credentials there would only widen their blast
+            radius for no read-time benefit.
+        """
+
+        class _Bare:
+            pass
+
+        opened = _Bare()
+        monkeypatch.setattr(_loader, "_load_zarr", lambda href: opened)
+        signer = _AppendSigner(suffix="", env={"AWS_REQUEST_PAYER": "requester"})
+        load_asset({"href": "s3://b/store.zarr"}, signer=signer)
+        assert not hasattr(opened, "_gdal_env"), "the zarr reader should be untouched"

--- a/tests/stac/test_signers.py
+++ b/tests/stac/test_signers.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from pyramids.base.remote import _REQUESTER_PAYS_GDAL_KNOBS
 from pyramids.stac.signers import (
     AnonymousSigner,
     AWSRequesterPaysSigner,
@@ -133,6 +134,66 @@ class TestAWSRequesterPaysSigner:
             "Should disable readdir"
         )
         assert env["CPL_VSIL_CURL_USE_HEAD"] == "NO", "Should disable HEAD"
+
+    def test_gdal_env_carries_every_shared_knob(self):
+        """gdal_env is built from the shared Requester-Pays knob set, not a copy.
+
+        Test scenario:
+            Every entry of `remote._REQUESTER_PAYS_GDAL_KNOBS` appears in the
+            signer env, so the two cannot drift apart (they did: the signer used
+            to omit the HTTP/2 pair).
+        """
+        env = AWSRequesterPaysSigner().gdal_env()
+        missing = {
+            key: value
+            for key, value in _REQUESTER_PAYS_GDAL_KNOBS.items()
+            if env.get(key) != value
+        }
+        assert not missing, f"signer env drifted from the shared knobs: {missing}"
+
+    def test_gdal_env_enables_http2_multiplexing(self):
+        """The env turns on HTTP/2 multiplexing for Requester-Pays reads.
+
+        Test scenario:
+            `RequesterPays()` sets these knobs; the signer must match it.
+        """
+        env = AWSRequesterPaysSigner().gdal_env()
+        assert env["GDAL_HTTP_MULTIPLEX"] == "YES", "HTTP multiplexing should be on"
+        assert env["GDAL_HTTP_VERSION"] == "2", "HTTP/2 should be requested"
+
+    def test_gdal_env_pins_the_region(self):
+        """A pinned region reaches GDAL through both region options.
+
+        Test scenario:
+            `region="us-west-2"` must set AWS_REGION *and* AWS_DEFAULT_REGION —
+            GDAL resolves the bucket region from either, so setting only one
+            lets the other leak in from the process environment.
+        """
+        env = AWSRequesterPaysSigner(region="us-west-2").gdal_env()
+        assert env["AWS_REGION"] == "us-west-2", f"AWS_REGION not pinned: {env}"
+        assert env["AWS_DEFAULT_REGION"] == "us-west-2", (
+            f"AWS_DEFAULT_REGION not pinned: {env}"
+        )
+
+    def test_gdal_env_without_region_omits_region_keys(self):
+        """No region means no region options, leaving GDAL to resolve it.
+
+        Test scenario:
+            The default `region=None` must not emit an empty/`None` region.
+        """
+        env = AWSRequesterPaysSigner().gdal_env()
+        assert "AWS_REGION" not in env, f"region should be absent: {env}"
+        assert "AWS_DEFAULT_REGION" not in env, f"region should be absent: {env}"
+
+    def test_gdal_env_values_are_strings(self):
+        """Every emitted value is a string, as GDAL config requires.
+
+        Test scenario:
+            `gdal.config_options` rejects non-string values.
+        """
+        env = AWSRequesterPaysSigner(region="eu-central-1").gdal_env()
+        non_strings = {k: v for k, v in env.items() if not isinstance(v, str)}
+        assert not non_strings, f"non-string config values: {non_strings}"
 
     def test_request_and_href_are_noops(self):
         """The signer rewrites no requests or hrefs (read-side only).

--- a/tests/stac/test_vrt.py
+++ b/tests/stac/test_vrt.py
@@ -308,6 +308,55 @@ class TestCredentialsStayOutOfMessages:
         joined = " ".join(str(w.message) for w in caught)
         assert "SUPERSECRET" not in joined, f"the token leaked into a warning: {joined}"
 
+    def test_token_never_reaches_stderr(self, tmp_path, capfd):
+        """GDAL's own "Can't open ..." message is redacted before it is emitted.
+
+        Args:
+            tmp_path: pytest temp directory.
+            capfd: pytest fixture capturing the file descriptors GDAL writes to.
+
+        Test scenario:
+            Under `gdal.UseExceptions()` GDAL prints a skipped source's full path
+            straight to stderr, bypassing both Python warnings and a handler
+            installed with `SetErrorHandler` — so the build pushes a redacting
+            handler for its duration. Asserting only on `str(exc)` misses this.
+        """
+        good = write_raster(
+            tmp_path / "fd.tif", np.full((2, 2), 1.0, "float32"), (0.0, 2.0)
+        )
+        items = [
+            {"assets": {"d": {"href": good}}},
+            {"assets": {"d": {"href": "https://host.invalid/gone.tif"}}},
+        ]
+        capfd.readouterr()
+        with pytest.raises(RuntimeError):
+            build_vrt_from_stac(items, asset="d", signer=self._signer(), strict=True)
+        captured = capfd.readouterr()
+        assert "SUPERSECRET" not in captured.err, (
+            f"the token was printed to stderr: {captured.err}"
+        )
+        assert "SUPERSECRET" not in captured.out, (
+            f"the token was printed to stdout: {captured.out}"
+        )
+
+    def test_repr_hides_the_token(self, tmp_path):
+        """`repr(ds)` lists every VRT source, so it must be redacted too.
+
+        Test scenario:
+            pytest prints the repr of every operand in a failing assertion and
+            `logging.error("%r", ds)` is idiomatic, so this surface is hit
+            involuntarily and often.
+        """
+        a = write_raster(
+            tmp_path / "r1.tif", np.full((2, 2), 1.0, "float32"), (0.0, 2.0)
+        )
+        b = write_raster(
+            tmp_path / "r2.tif", np.full((2, 2), 2.0, "float32"), (2.0, 2.0)
+        )
+        items = [{"assets": {"d": {"href": a}}}, {"assets": {"d": {"href": b}}}]
+        ds = build_vrt_from_stac(items, asset="d", signer=self._signer())
+        assert "SUPERSECRET" not in repr(ds), f"the token leaked into repr: {repr(ds)}"
+
     def test_url_signed_token_is_hidden_too(self, tmp_path):
         """A SAS token in the href itself is redacted, not just embedded headers.
 
@@ -531,15 +580,19 @@ class TestSourceCredentialEmbedding:
         assert "header.Authorization=Bearer%20tok" in source, f"missing auth: {source}"
         assert "header.X-Trace=42" in source, f"missing second header: {source}"
 
-    def test_no_signer_uses_the_plain_rewrite(self):
-        """Without credentials the ordinary VSI rewrite is kept.
+    def test_unsigned_remote_source_still_gets_the_readdir_skip(self):
+        """An unsigned remote source keeps the sidecar-probe saving.
 
         Test scenario:
-            The unsigned path must not change shape.
+            A SAS-signed or public mosaic pays the same read-time probes a
+            bearer-signed one would, so the query form is emitted for it too —
+            just with no `header.` options.
         """
-        assert _embed_source_options("https://h/a.tif", None) == (
-            "/vsicurl/https://h/a.tif"
-        ), "an unsigned source should keep the plain form"
+        source = _embed_source_options("https://h/a.tif", None)
+        assert source == "/vsicurl?empty_dir=yes&url=https%3A%2F%2Fh%2Fa.tif", (
+            f"unexpected unsigned rewrite: {source}"
+        )
+        assert "header." not in source, f"no credentials to embed: {source}"
 
     def test_non_http_scheme_is_left_alone(self):
         """Only HTTP(S) sources can carry headers in the path.
@@ -707,18 +760,41 @@ class TestSourceConfig:
 class TestBuildVrtArtifactCleanup:
     """Tests for the /vsimem VRT lifetime (ARC-10)."""
 
-    def test_vsimem_registered_on_success(self, adjacent_tiles):
-        """A successful build tracks its VRT for the process-exit sweep.
+    def test_vsimem_registered_while_the_dataset_lives(self, adjacent_tiles):
+        """A live mosaic keeps its VRT, tracked for the process-exit sweep.
 
         Test scenario:
-            The new `/vsimem` entry is also present in the artefact registry.
+            The new `/vsimem` entry exists and is in the artefact registry for
+            as long as the Dataset that needs it is referenced.
         """
         before = vsimem_entries()
-        build_vrt_from_stac(adjacent_tiles, asset="data")
+        ds = build_vrt_from_stac(adjacent_tiles, asset="data")
         created = vsimem_entries() - before
         assert len(created) == 1, f"expected exactly one new /vsimem entry: {created}"
         tracked = {path.rsplit("/", 1)[-1] for path in _artifacts._VSIMEM_PATHS}
         assert created <= tracked, f"{created} not tracked for cleanup"
+        assert ds.read_array().shape == (4, 8), "the mosaic should still be readable"
+
+    def test_vsimem_reclaimed_when_the_dataset_is_collected(self, adjacent_tiles):
+        """Dropping the mosaic reclaims its VRT instead of holding it to exit.
+
+        Test scenario:
+            A service building one mosaic per request would otherwise accumulate
+            an in-memory VRT per request for the life of the process.
+        """
+        import gc
+
+        before = vsimem_entries()
+        ds = build_vrt_from_stac(adjacent_tiles, asset="data")
+        created = vsimem_entries() - before
+        assert len(created) == 1, f"expected one new /vsimem entry: {created}"
+        del ds
+        gc.collect()
+        assert vsimem_entries() - before == set(), (
+            "the VRT should be reclaimed once nothing references the mosaic"
+        )
+        leftover = {path.rsplit("/", 1)[-1] for path in _artifacts._VSIMEM_PATHS}
+        assert not (created & leftover), "the reclaimed path is still tracked"
 
     def test_vsimem_removed_when_open_fails(self, adjacent_tiles, monkeypatch):
         """A failing `Dataset.read_file` unlinks the VRT instead of orphaning it.
@@ -768,7 +844,7 @@ class TestStrictDefaultDeprecation:
             A skipped source warns twice — once about the incomplete mosaic, once
             that this default is going away — and still returns the partial VRT.
         """
-        with pytest.warns(DeprecationWarning, match="becomes True in the next"):
+        with pytest.warns(FutureWarning, match="becomes True in the next"):
             ds = build_vrt_from_stac(mismatched_band_tiles, asset="data")
         assert ds.read_array().shape == (4, 4), "the partial mosaic should be returned"
 
@@ -791,7 +867,7 @@ class TestStrictDefaultDeprecation:
             warnings.simplefilter("always")
             build_vrt_from_stac(mismatched_band_tiles, asset="data", strict=False)
         kinds = [w.category for w in caught]
-        assert DeprecationWarning not in kinds, f"unexpected deprecation: {kinds}"
+        assert FutureWarning not in kinds, f"unexpected deprecation notice: {kinds}"
         assert UserWarning in kinds, f"the skip should still warn: {kinds}"
 
     def test_complete_build_never_warns(self, adjacent_tiles):

--- a/tests/stac/test_vrt.py
+++ b/tests/stac/test_vrt.py
@@ -16,6 +16,9 @@ from pyramids.stac import _vrt
 from pyramids.stac._vrt import (
     _check_dropped_sources,
     _dropped_sources,
+    _embed_source_options,
+    _source_config,
+    _warn_unembeddable_credentials,
     build_vrt_from_stac,
 )
 from tests._helpers import write_raster
@@ -321,6 +324,197 @@ class TestBuildVrtSourceCompleteness:
         items = [{"assets": {"data": {"href": str(tmp_path / "nope.tif")}}}]
         with pytest.raises(RuntimeError, match="returned None"):
             build_vrt_from_stac(items, asset="data")
+
+
+class TestSourceCredentialEmbedding:
+    """Header credentials must ride the source path (ARC-24).
+
+    GDAL opens a VRT's sources on the first pixel read and ignores the
+    thread-local config when it does, so a signer env installed around the read
+    never reaches them. Header credentials are embedded per source instead.
+    """
+
+    def test_bearer_header_is_embedded_in_the_source(self):
+        """A bearer header becomes a `/vsicurl?header.…` source path.
+
+        Test scenario:
+            The token is URL-encoded into the path GDAL stores in the VRT.
+        """
+        env = {"GDAL_HTTP_HEADERS": "Authorization: Bearer tok"}
+        source = _embed_source_options("https://h/a.tif", env)
+        assert source.startswith("/vsicurl?header.Authorization=Bearer%20tok"), (
+            f"header not embedded: {source}"
+        )
+        assert source.endswith("url=https%3A%2F%2Fh%2Fa.tif"), (
+            f"source url not encoded: {source}"
+        )
+
+    def test_readdir_skip_rides_along(self):
+        """The signer's readdir skip is carried into the read-time opens.
+
+        Test scenario:
+            Without it each source re-probes its sidecars on every open.
+        """
+        env = {
+            "GDAL_HTTP_HEADERS": "Authorization: Bearer tok",
+            "GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR",
+        }
+        assert "empty_dir=yes" in _embed_source_options("https://h/a.tif", env), (
+            "the readdir skip should be embedded alongside the header"
+        )
+
+    def test_multiple_headers_all_embedded(self):
+        """Every header in the env reaches the source path.
+
+        Test scenario:
+            A newline-separated pair produces two `header.` options.
+        """
+        env = {"GDAL_HTTP_HEADERS": "Authorization: Bearer tok\r\nX-Trace: 42"}
+        source = _embed_source_options("https://h/a.tif", env)
+        assert "header.Authorization=Bearer%20tok" in source, f"missing auth: {source}"
+        assert "header.X-Trace=42" in source, f"missing second header: {source}"
+
+    def test_no_signer_uses_the_plain_rewrite(self):
+        """Without credentials the ordinary VSI rewrite is kept.
+
+        Test scenario:
+            The unsigned path must not change shape.
+        """
+        assert _embed_source_options("https://h/a.tif", None) == (
+            "/vsicurl/https://h/a.tif"
+        ), "an unsigned source should keep the plain form"
+
+    def test_non_http_scheme_is_left_alone(self):
+        """Only HTTP(S) sources can carry headers in the path.
+
+        Test scenario:
+            An `s3://` href keeps its `/vsis3/` rewrite.
+        """
+        env = {"GDAL_HTTP_HEADERS": "Authorization: Bearer tok"}
+        assert _embed_source_options("s3://bucket/a.tif", env) == "/vsis3/bucket/a.tif"
+
+    def test_local_source_is_left_alone(self):
+        """A local path is never rewritten to a curl source.
+
+        Test scenario:
+            Header credentials are irrelevant to a local file.
+        """
+        env = {"GDAL_HTTP_HEADERS": "Authorization: Bearer tok"}
+        assert _embed_source_options("/data/a.tif", env) == "/data/a.tif"
+
+    def test_embedded_source_reads(self, tmp_path):
+        """A VRT over embedded-option sources still builds and reads.
+
+        Test scenario:
+            The `/vsicurl?` form is only produced for HTTP hrefs, so this covers
+            the local fallback end to end: the mosaic is unaffected.
+        """
+        a = write_raster(tmp_path / "e1.tif", np.full((2, 2), 3.0, "float32"), (0.0, 2.0))
+        b = write_raster(tmp_path / "e2.tif", np.full((2, 2), 4.0, "float32"), (2.0, 2.0))
+
+        class _HeaderSigner:
+            def sign_href(self, href):
+                return href
+
+            def gdal_env(self):
+                return {"GDAL_HTTP_HEADERS": "Authorization: Bearer tok"}
+
+        items = [{"assets": {"d": {"href": a}}}, {"assets": {"d": {"href": b}}}]
+        ds = build_vrt_from_stac(items, asset="d", signer=_HeaderSigner())
+        assert ds.read_array().shape == (2, 4), "the local mosaic should be unaffected"
+
+
+class TestUnembeddableCredentialWarning:
+    """Credentials with no `/vsicurl?` equivalent are called out at build time."""
+
+    def test_requester_pays_env_warns_for_remote_sources(self):
+        """An AWS env cannot reach the read-time opens, so the build warns.
+
+        Test scenario:
+            A remote source plus `AWS_REQUEST_PAYER` -> a clear warning.
+        """
+        env = {"AWS_REQUEST_PAYER": "requester"}
+        with pytest.warns(UserWarning, match="AWS_REQUEST_PAYER"):
+            _warn_unembeddable_credentials(env, ["/vsis3/bucket/a.tif"])
+
+    def test_header_only_env_does_not_warn(self, recwarn):
+        """A header signer is fully supported, so nothing is warned about.
+
+        Args:
+            recwarn: pytest fixture recording warnings raised in the block.
+
+        Test scenario:
+            `GDAL_HTTP_HEADERS` is embeddable — no warning.
+        """
+        env = {"GDAL_HTTP_HEADERS": "Authorization: Bearer tok"}
+        _warn_unembeddable_credentials(env, ["/vsicurl/https://h/a.tif"])
+        assert len(recwarn) == 0, f"unexpected warnings: {[str(w) for w in recwarn]}"
+
+    def test_tuning_knobs_do_not_warn(self, recwarn):
+        """Performance knobs are not credentials, so losing them is not an error.
+
+        Test scenario:
+            `GDAL_HTTP_MULTIPLEX` alone must not trip the warning.
+        """
+        _warn_unembeddable_credentials(
+            {"GDAL_HTTP_MULTIPLEX": "YES"}, ["/vsicurl/https://h/a.tif"]
+        )
+        assert len(recwarn) == 0, f"unexpected warnings: {[str(w) for w in recwarn]}"
+
+    def test_local_sources_do_not_warn(self, recwarn):
+        """An all-local build needs no credentials at all.
+
+        Test scenario:
+            Even a stranded AWS key is irrelevant for local sources.
+        """
+        _warn_unembeddable_credentials({"AWS_REQUEST_PAYER": "requester"}, ["/d/a.tif"])
+        assert len(recwarn) == 0, f"unexpected warnings: {[str(w) for w in recwarn]}"
+
+
+class TestSourceConfig:
+    """Tests for the build-time GDAL config chosen by the source mix."""
+
+    def test_remote_sources_get_the_fast_read_preset(self):
+        """A remote build installs the `/vsicurl/` tuning preset.
+
+        Test scenario:
+            An un-tuned build costs a directory listing plus sidecar probes per
+            source.
+        """
+        config = _source_config(["/vsicurl/https://h/a.tif"], None).as_gdal_config()
+        assert config["GDAL_DISABLE_READDIR_ON_OPEN"] == "EMPTY_DIR", config
+        assert config["GDAL_HTTP_MULTIRANGE"] == "YES", config
+
+    def test_signer_env_overrides_the_preset(self):
+        """The signer env wins on a key conflict.
+
+        Test scenario:
+            An explicit HTTP version overrides the preset's default.
+        """
+        config = _source_config(
+            ["/vsis3/b/a.tif"], {"GDAL_HTTP_VERSION": "1.1"}
+        ).as_gdal_config()
+        assert config["GDAL_HTTP_VERSION"] == "1.1", f"signer env did not win: {config}"
+
+    def test_local_sources_skip_the_preset(self):
+        """An all-local build installs the signer env only.
+
+        Test scenario:
+            The preset's readdir skip would hide a local source's `.aux.xml`.
+        """
+        config = _source_config(["C:/data/a.tif"], {"CPL_CURL_VERBOSE": "YES"})
+        assert config.as_gdal_config() == {"CPL_CURL_VERBOSE": "YES"}, (
+            "a local build must not pull in the /vsicurl preset"
+        )
+
+    def test_local_build_without_signer_is_a_no_op(self):
+        """Nothing at all is installed for a plain local build.
+
+        Test scenario:
+            The returned context manager is usable and changes no config.
+        """
+        with _source_config(["C:/data/a.tif"], None):
+            assert gdal.GetConfigOption("GDAL_DISABLE_READDIR_ON_OPEN") is None
 
 
 class TestBuildVrtArtifactCleanup:

--- a/tests/stac/test_vrt.py
+++ b/tests/stac/test_vrt.py
@@ -65,7 +65,9 @@ def mismatched_band_tiles(tmp_path):
     Returns:
         list[dict]: two raw STAC items exposing a "data" asset each.
     """
-    one = write_raster(tmp_path / "one.tif", np.full((4, 4), 1.0, "float32"), (0.0, 4.0))
+    one = write_raster(
+        tmp_path / "one.tif", np.full((4, 4), 1.0, "float32"), (0.0, 4.0)
+    )
     three = write_raster(
         tmp_path / "three.tif", np.full((3, 4, 4), 2.0, "float32"), (4.0, 4.0)
     )
@@ -183,7 +185,8 @@ class TestDroppedSources:
         Test scenario:
             Extra entries in the retained list (e.g. the VRT itself) are ignored.
         """
-        assert _dropped_sources([("a.tif", "a.tif")], ["a.tif", "/vsimem/x.vrt"]) == [], (
+        kept = _dropped_sources([("a.tif", "a.tif")], ["a.tif", "/vsimem/x.vrt"])
+        assert kept == [], (
             "an extra retained entry must not make a kept source look dropped"
         )
 
@@ -271,7 +274,9 @@ class TestCredentialsStayOutOfMessages:
             An expired href is the *expected* failure on a large mosaic, so its
             error is the most likely thing to reach a log aggregator.
         """
-        good = write_raster(tmp_path / "g.tif", np.full((2, 2), 1.0, "float32"), (0.0, 2.0))
+        good = write_raster(
+            tmp_path / "g.tif", np.full((2, 2), 1.0, "float32"), (0.0, 2.0)
+        )
         items = [
             {"assets": {"d": {"href": good}}},
             {"assets": {"d": {"href": "https://host.invalid/gone.tif"}}},
@@ -291,7 +296,9 @@ class TestCredentialsStayOutOfMessages:
         Test scenario:
             `strict=False` warns instead of raising — same exposure risk.
         """
-        good = write_raster(tmp_path / "w.tif", np.full((2, 2), 1.0, "float32"), (0.0, 2.0))
+        good = write_raster(
+            tmp_path / "w.tif", np.full((2, 2), 1.0, "float32"), (0.0, 2.0)
+        )
         items = [
             {"assets": {"d": {"href": good}}},
             {"assets": {"d": {"href": "https://host.invalid/gone.tif"}}},
@@ -307,7 +314,9 @@ class TestCredentialsStayOutOfMessages:
         Test scenario:
             URL-signing signers put the credential in the query string.
         """
-        good = write_raster(tmp_path / "s.tif", np.full((2, 2), 1.0, "float32"), (0.0, 2.0))
+        good = write_raster(
+            tmp_path / "s.tif", np.full((2, 2), 1.0, "float32"), (0.0, 2.0)
+        )
 
         class _SasSigner:
             def sign_href(self, href):
@@ -557,8 +566,12 @@ class TestSourceCredentialEmbedding:
             The `/vsicurl?` form is only produced for HTTP hrefs, so this covers
             the local fallback end to end: the mosaic is unaffected.
         """
-        a = write_raster(tmp_path / "e1.tif", np.full((2, 2), 3.0, "float32"), (0.0, 2.0))
-        b = write_raster(tmp_path / "e2.tif", np.full((2, 2), 4.0, "float32"), (2.0, 2.0))
+        a = write_raster(
+            tmp_path / "e1.tif", np.full((2, 2), 3.0, "float32"), (0.0, 2.0)
+        )
+        b = write_raster(
+            tmp_path / "e2.tif", np.full((2, 2), 4.0, "float32"), (2.0, 2.0)
+        )
 
         class _HeaderSigner:
             def sign_href(self, href):
@@ -618,9 +631,8 @@ class TestUnembeddableCredentialWarning:
         Test scenario:
             `GDAL_HTTP_MULTIPLEX` alone must not trip the warning.
         """
-        _warn_unembeddable_credentials(
-            {"GDAL_HTTP_MULTIPLEX": "YES"}, ["https://h/a.tif"]
-        )
+        env = {"GDAL_HTTP_MULTIPLEX": "YES"}
+        _warn_unembeddable_credentials(env, ["https://h/a.tif"])
         assert len(recwarn) == 0, f"unexpected warnings: {[str(w) for w in recwarn]}"
 
     def test_local_sources_do_not_warn(self, recwarn):
@@ -792,4 +804,6 @@ class TestStrictDefaultDeprecation:
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             build_vrt_from_stac(adjacent_tiles, asset="data")
-        assert not caught, f"a complete build should not warn: {[str(w) for w in caught]}"
+        assert not caught, (
+            f"a complete build should not warn: {[str(w) for w in caught]}"
+        )

--- a/tests/stac/test_vrt.py
+++ b/tests/stac/test_vrt.py
@@ -6,6 +6,8 @@ GeoTIFF tiles (no network); the VRT references them and reads lazily.
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import pytest
 from osgeo import gdal
@@ -275,7 +277,7 @@ class TestCredentialsStayOutOfMessages:
             {"assets": {"d": {"href": "https://host.invalid/gone.tif"}}},
         ]
         with pytest.raises(RuntimeError) as exc:
-            build_vrt_from_stac(items, asset="d", signer=self._signer())
+            build_vrt_from_stac(items, asset="d", signer=self._signer(), strict=True)
         assert "SUPERSECRET" not in str(exc.value), (
             f"the bearer token leaked into the error: {exc.value}"
         )
@@ -319,7 +321,7 @@ class TestCredentialsStayOutOfMessages:
             {"assets": {"d": {"href": "https://host.invalid/gone.tif"}}},
         ]
         with pytest.raises(RuntimeError) as exc:
-            build_vrt_from_stac(items, asset="d", signer=_SasSigner())
+            build_vrt_from_stac(items, asset="d", signer=_SasSigner(), strict=True)
         assert "SASSECRET" not in str(exc.value), (
             f"the SAS token leaked into the error: {exc.value}"
         )
@@ -387,7 +389,7 @@ class TestBuildVrtSourceCompleteness:
             so the mosaic would silently cover half the requested footprint.
         """
         with pytest.raises(RuntimeError, match="skipped 1 of 2"):
-            build_vrt_from_stac(mismatched_band_tiles, asset="data")
+            build_vrt_from_stac(mismatched_band_tiles, asset="data", strict=True)
 
     def test_unreadable_source_raises(self, adjacent_tiles, tmp_path):
         """An unreadable href (404 / expired URL) fails the build.
@@ -400,7 +402,7 @@ class TestBuildVrtSourceCompleteness:
             {"assets": {"data": {"href": str(tmp_path / "gone.tif")}}},
         ]
         with pytest.raises(RuntimeError, match="skipped 1 of 2"):
-            build_vrt_from_stac(items, asset="data")
+            build_vrt_from_stac(items, asset="data", strict=True)
 
     def test_error_names_the_dropped_source(self, mismatched_band_tiles):
         """The error lists the href that was dropped, not just a count.
@@ -410,7 +412,7 @@ class TestBuildVrtSourceCompleteness:
         """
         dropped_href = mismatched_band_tiles[1]["assets"]["data"]["href"]
         with pytest.raises(RuntimeError) as exc:
-            build_vrt_from_stac(mismatched_band_tiles, asset="data")
+            build_vrt_from_stac(mismatched_band_tiles, asset="data", strict=True)
         assert dropped_href in str(exc.value), (
             f"dropped href {dropped_href!r} missing from: {exc.value}"
         )
@@ -445,7 +447,7 @@ class TestBuildVrtSourceCompleteness:
         """
         items = [{"assets": {"data": {"href": str(tmp_path / "nope.tif")}}}]
         with pytest.raises(RuntimeError, match="returned None"):
-            build_vrt_from_stac(items, asset="data")
+            build_vrt_from_stac(items, asset="data", strict=True)
 
 
 class TestSourceCredentialEmbedding:
@@ -738,7 +740,56 @@ class TestBuildVrtArtifactCleanup:
         """
         before = vsimem_entries()
         with pytest.raises(RuntimeError, match="skipped"):
-            build_vrt_from_stac(mismatched_band_tiles, asset="data")
+            build_vrt_from_stac(mismatched_band_tiles, asset="data", strict=True)
         assert vsimem_entries() - before == set(), (
             "the VRT must be unlinked when the completeness guard fails"
         )
+
+
+class TestStrictDefaultDeprecation:
+    """The default flips to strict=True next minor, so the default warns now."""
+
+    def test_default_warns_and_returns_the_partial_mosaic(self, mismatched_band_tiles):
+        """Leaving strict unset keeps today's behaviour and flags the change.
+
+        Test scenario:
+            A skipped source warns twice — once about the incomplete mosaic, once
+            that this default is going away — and still returns the partial VRT.
+        """
+        with pytest.warns(DeprecationWarning, match="becomes True in the next"):
+            ds = build_vrt_from_stac(mismatched_band_tiles, asset="data")
+        assert ds.read_array().shape == (4, 4), "the partial mosaic should be returned"
+
+    def test_default_also_warns_about_the_skip(self, mismatched_band_tiles):
+        """The completeness warning still fires under the default.
+
+        Test scenario:
+            The deprecation notice must not replace the actual problem report.
+        """
+        with pytest.warns(UserWarning, match="skipped 1 of 2"):
+            build_vrt_from_stac(mismatched_band_tiles, asset="data")
+
+    def test_explicit_false_does_not_deprecation_warn(self, mismatched_band_tiles):
+        """A caller who pinned strict=False has nothing to migrate.
+
+        Test scenario:
+            Only the completeness warning fires.
+        """
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            build_vrt_from_stac(mismatched_band_tiles, asset="data", strict=False)
+        kinds = [w.category for w in caught]
+        assert DeprecationWarning not in kinds, f"unexpected deprecation: {kinds}"
+        assert UserWarning in kinds, f"the skip should still warn: {kinds}"
+
+    def test_complete_build_never_warns(self, adjacent_tiles):
+        """A clean build under the default is silent.
+
+        Test scenario:
+            The deprecation notice fires only when the default actually changes
+            the outcome — i.e. only when a source was skipped.
+        """
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            build_vrt_from_stac(adjacent_tiles, asset="data")
+        assert not caught, f"a complete build should not warn: {[str(w) for w in caught]}"

--- a/tests/stac/test_vrt.py
+++ b/tests/stac/test_vrt.py
@@ -20,6 +20,7 @@ from pyramids.stac._vrt import (
     _source_config,
     _warn_unembeddable_credentials,
     build_vrt_from_stac,
+    redact,
 )
 from tests._helpers import write_raster
 
@@ -164,12 +165,13 @@ class TestDroppedSources:
     """Tests for the _dropped_sources helper."""
 
     def test_reports_source_absent_from_the_vrt(self):
-        """A requested source the VRT does not reference is reported.
+        """A requested source the VRT does not reference is reported by href.
 
         Test scenario:
             Two requested, one retained -> the other is reported as dropped.
         """
-        assert _dropped_sources(["a.tif", "b.tif"], ["a.tif"]) == ["b.tif"], (
+        pairs = [("a.tif", "a.tif"), ("b.tif", "b.tif")]
+        assert _dropped_sources(pairs, ["a.tif"]) == ["b.tif"], (
             "the retained-source difference should name b.tif"
         )
 
@@ -179,7 +181,7 @@ class TestDroppedSources:
         Test scenario:
             Extra entries in the retained list (e.g. the VRT itself) are ignored.
         """
-        assert _dropped_sources(["a.tif"], ["a.tif", "/vsimem/x.vrt"]) == [], (
+        assert _dropped_sources([("a.tif", "a.tif")], ["a.tif", "/vsimem/x.vrt"]) == [], (
             "an extra retained entry must not make a kept source look dropped"
         )
 
@@ -189,7 +191,8 @@ class TestDroppedSources:
         Test scenario:
             Three requested, the middle one kept -> [first, last].
         """
-        dropped = _dropped_sources(["a.tif", "b.tif", "c.tif"], ["b.tif"])
+        pairs = [(n, n) for n in ("a.tif", "b.tif", "c.tif")]
+        dropped = _dropped_sources(pairs, ["b.tif"])
         assert dropped == ["a.tif", "c.tif"], f"order not preserved: {dropped}"
 
     def test_empty_retained_drops_everything(self):
@@ -198,8 +201,127 @@ class TestDroppedSources:
         Test scenario:
             `GetFileList()` returning nothing -> every source is dropped.
         """
-        assert _dropped_sources(["a.tif", "b.tif"], []) == ["a.tif", "b.tif"], (
+        pairs = [("a.tif", "a.tif"), ("b.tif", "b.tif")]
+        assert _dropped_sources(pairs, []) == ["a.tif", "b.tif"], (
             "an empty retained list should report every requested source"
+        )
+
+
+class TestRedact:
+    """Tests for the redact helper that keeps credentials out of messages."""
+
+    def test_query_string_is_replaced(self):
+        """A SAS-signed href keeps its identity but loses the token.
+
+        Test scenario:
+            The path stays readable so the message is still actionable.
+        """
+        assert redact("https://h/B04.tif?sv=2021&sig=SECRET") == (
+            "https://h/B04.tif?<redacted>"
+        ), "the query string should be replaced wholesale"
+
+    def test_unsigned_href_passes_through(self):
+        """An href with no query string is unchanged.
+
+        Test scenario:
+            Nothing to hide -> nothing altered.
+        """
+        assert redact("https://h/B04.tif") == "https://h/B04.tif"
+
+    def test_local_windows_path_passes_through(self):
+        """A drive-letter path is not mistaken for a query string.
+
+        Test scenario:
+            `C:/data/a.tif` has no `?` and must survive intact.
+        """
+        assert redact("C:/data/a.tif") == "C:/data/a.tif"
+
+    def test_embedded_source_path_is_redacted(self):
+        """The `/vsicurl?` form this module builds is redacted to its prefix.
+
+        Test scenario:
+            Everything after the `?` — including `header.Authorization` — goes.
+        """
+        embedded = "/vsicurl?header.Authorization=Bearer%20tok&url=https%3A%2F%2Fh%2Fa"
+        assert redact(embedded) == "/vsicurl?<redacted>", "the header must not survive"
+
+
+class TestCredentialsStayOutOfMessages:
+    """A credential must never reach an exception, a warning, or a log."""
+
+    @staticmethod
+    def _signer():
+        """Return a bearer signer whose token is easy to grep for."""
+
+        class _BearerSigner:
+            def sign_href(self, href):
+                return href
+
+            def gdal_env(self):
+                return {"GDAL_HTTP_HEADERS": "Authorization: Bearer SUPERSECRET"}
+
+        return _BearerSigner()
+
+    def test_strict_error_hides_the_token(self, tmp_path):
+        """The drop error names the href, never the embedded credential.
+
+        Test scenario:
+            An expired href is the *expected* failure on a large mosaic, so its
+            error is the most likely thing to reach a log aggregator.
+        """
+        good = write_raster(tmp_path / "g.tif", np.full((2, 2), 1.0, "float32"), (0.0, 2.0))
+        items = [
+            {"assets": {"d": {"href": good}}},
+            {"assets": {"d": {"href": "https://host.invalid/gone.tif"}}},
+        ]
+        with pytest.raises(RuntimeError) as exc:
+            build_vrt_from_stac(items, asset="d", signer=self._signer())
+        assert "SUPERSECRET" not in str(exc.value), (
+            f"the bearer token leaked into the error: {exc.value}"
+        )
+        assert "host.invalid/gone.tif" in str(exc.value), (
+            f"the dropped href should still be named: {exc.value}"
+        )
+
+    def test_warning_hides_the_token(self, tmp_path):
+        """The non-strict warning is redacted the same way.
+
+        Test scenario:
+            `strict=False` warns instead of raising — same exposure risk.
+        """
+        good = write_raster(tmp_path / "w.tif", np.full((2, 2), 1.0, "float32"), (0.0, 2.0))
+        items = [
+            {"assets": {"d": {"href": good}}},
+            {"assets": {"d": {"href": "https://host.invalid/gone.tif"}}},
+        ]
+        with pytest.warns(UserWarning) as caught:
+            build_vrt_from_stac(items, asset="d", signer=self._signer(), strict=False)
+        joined = " ".join(str(w.message) for w in caught)
+        assert "SUPERSECRET" not in joined, f"the token leaked into a warning: {joined}"
+
+    def test_url_signed_token_is_hidden_too(self, tmp_path):
+        """A SAS token in the href itself is redacted, not just embedded headers.
+
+        Test scenario:
+            URL-signing signers put the credential in the query string.
+        """
+        good = write_raster(tmp_path / "s.tif", np.full((2, 2), 1.0, "float32"), (0.0, 2.0))
+
+        class _SasSigner:
+            def sign_href(self, href):
+                return f"{href}?sig=SASSECRET" if href.startswith("http") else href
+
+            def gdal_env(self):
+                return {}
+
+        items = [
+            {"assets": {"d": {"href": good}}},
+            {"assets": {"d": {"href": "https://host.invalid/gone.tif"}}},
+        ]
+        with pytest.raises(RuntimeError) as exc:
+            build_vrt_from_stac(items, asset="d", signer=_SasSigner())
+        assert "SASSECRET" not in str(exc.value), (
+            f"the SAS token leaked into the error: {exc.value}"
         )
 
 

--- a/tests/stac/test_vrt.py
+++ b/tests/stac/test_vrt.py
@@ -472,17 +472,41 @@ class TestSourceCredentialEmbedding:
         )
 
     def test_readdir_skip_rides_along(self):
-        """The signer's readdir skip is carried into the read-time opens.
+        """The readdir skip is carried into the read-time opens.
 
         Test scenario:
-            Without it each source re-probes its sidecars on every open.
+            Without it each source re-probes its sidecars on every open — 14
+            wasted requests for two sources, measured. The build already runs
+            under the same skip, so embedding keeps build and read consistent.
         """
-        env = {
-            "GDAL_HTTP_HEADERS": "Authorization: Bearer tok",
-            "GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR",
-        }
+        env = {"GDAL_HTTP_HEADERS": "Authorization: Bearer tok"}
         assert "empty_dir=yes" in _embed_source_options("https://h/a.tif", env), (
             "the readdir skip should be embedded alongside the header"
+        )
+
+    def test_already_vsi_href_is_still_rewritten(self):
+        """An href handed in as `/vsicurl/...` still gets its credentials.
+
+        Test scenario:
+            Matching on the raw href would silently skip this shape.
+        """
+        env = {"GDAL_HTTP_HEADERS": "Authorization: Bearer tok"}
+        source = _embed_source_options("/vsicurl/https://h/a.tif", env)
+        assert source.startswith("/vsicurl?header.Authorization="), (
+            f"a pre-rewritten href should still be embedded: {source}"
+        )
+
+    def test_archive_chaining_is_preserved(self):
+        """A zipped source keeps its `/vsizip/` prefix instead of losing it.
+
+        Test scenario:
+            Rewriting it to the query form would drop the chaining and the
+            source would fail to open.
+        """
+        env = {"GDAL_HTTP_HEADERS": "Authorization: Bearer tok"}
+        source = _embed_source_options("https://h/scene.zip/a.tif", env)
+        assert source == "/vsizip//vsicurl/https://h/scene.zip/a.tif", (
+            f"archive chaining lost: {source}"
         )
 
     def test_multiple_headers_all_embedded(self):
@@ -557,7 +581,21 @@ class TestUnembeddableCredentialWarning:
         """
         env = {"AWS_REQUEST_PAYER": "requester"}
         with pytest.warns(UserWarning, match="AWS_REQUEST_PAYER"):
-            _warn_unembeddable_credentials(env, ["/vsis3/bucket/a.tif"])
+            _warn_unembeddable_credentials(env, ["s3://bucket/a.tif"])
+
+    def test_mixed_env_still_warns_for_the_stranded_half(self):
+        """Headers plus AWS keys: the AWS half is stranded, so it still warns.
+
+        Test scenario:
+            Classifying the rewritten `/vsicurl?...` path as non-remote used to
+            suppress this warning entirely.
+        """
+        env = {
+            "GDAL_HTTP_HEADERS": "Authorization: Bearer tok",
+            "AWS_REQUEST_PAYER": "requester",
+        }
+        with pytest.warns(UserWarning, match="AWS_REQUEST_PAYER"):
+            _warn_unembeddable_credentials(env, ["https://h/a.tif"])
 
     def test_header_only_env_does_not_warn(self, recwarn):
         """A header signer is fully supported, so nothing is warned about.
@@ -569,7 +607,7 @@ class TestUnembeddableCredentialWarning:
             `GDAL_HTTP_HEADERS` is embeddable — no warning.
         """
         env = {"GDAL_HTTP_HEADERS": "Authorization: Bearer tok"}
-        _warn_unembeddable_credentials(env, ["/vsicurl/https://h/a.tif"])
+        _warn_unembeddable_credentials(env, ["https://h/a.tif"])
         assert len(recwarn) == 0, f"unexpected warnings: {[str(w) for w in recwarn]}"
 
     def test_tuning_knobs_do_not_warn(self, recwarn):
@@ -579,7 +617,7 @@ class TestUnembeddableCredentialWarning:
             `GDAL_HTTP_MULTIPLEX` alone must not trip the warning.
         """
         _warn_unembeddable_credentials(
-            {"GDAL_HTTP_MULTIPLEX": "YES"}, ["/vsicurl/https://h/a.tif"]
+            {"GDAL_HTTP_MULTIPLEX": "YES"}, ["https://h/a.tif"]
         )
         assert len(recwarn) == 0, f"unexpected warnings: {[str(w) for w in recwarn]}"
 
@@ -603,9 +641,22 @@ class TestSourceConfig:
             An un-tuned build costs a directory listing plus sidecar probes per
             source.
         """
-        config = _source_config(["/vsicurl/https://h/a.tif"], None).as_gdal_config()
+        config = _source_config(["https://h/a.tif"], None).as_gdal_config()
         assert config["GDAL_DISABLE_READDIR_ON_OPEN"] == "EMPTY_DIR", config
         assert config["GDAL_HTTP_MULTIRANGE"] == "YES", config
+
+    def test_header_signed_remote_build_gets_the_preset(self):
+        """The header-signed build — the case with the largest measured saving.
+
+        Test scenario:
+            Deciding remoteness on the rewritten `/vsicurl?...` path instead of
+            the href silently opted exactly this case out of the preset.
+        """
+        env = {"GDAL_HTTP_HEADERS": "Authorization: Bearer tok"}
+        config = _source_config(["https://h/a.tif"], env).as_gdal_config()
+        assert config["GDAL_DISABLE_READDIR_ON_OPEN"] == "EMPTY_DIR", config
+        assert config["GDAL_HTTP_MULTIPLEX"] == "YES", config
+        assert config["GDAL_HTTP_HEADERS"] == "Authorization: Bearer tok", config
 
     def test_signer_env_overrides_the_preset(self):
         """The signer env wins on a key conflict.
@@ -614,7 +665,7 @@ class TestSourceConfig:
             An explicit HTTP version overrides the preset's default.
         """
         config = _source_config(
-            ["/vsis3/b/a.tif"], {"GDAL_HTTP_VERSION": "1.1"}
+            ["s3://b/a.tif"], {"GDAL_HTTP_VERSION": "1.1"}
         ).as_gdal_config()
         assert config["GDAL_HTTP_VERSION"] == "1.1", f"signer env did not win: {config}"
 

--- a/tests/stac/test_vrt.py
+++ b/tests/stac/test_vrt.py
@@ -281,8 +281,9 @@ class TestCredentialsStayOutOfMessages:
             {"assets": {"d": {"href": good}}},
             {"assets": {"d": {"href": "https://host.invalid/gone.tif"}}},
         ]
+        signer = self._signer()
         with pytest.raises(RuntimeError) as exc:
-            build_vrt_from_stac(items, asset="d", signer=self._signer())
+            build_vrt_from_stac(items, asset="d", signer=signer)
         assert "SUPERSECRET" not in str(exc.value), (
             f"the bearer token leaked into the error: {exc.value}"
         )
@@ -328,9 +329,10 @@ class TestCredentialsStayOutOfMessages:
             {"assets": {"d": {"href": good}}},
             {"assets": {"d": {"href": "https://host.invalid/gone.tif"}}},
         ]
+        signer = self._signer()
         capfd.readouterr()
         with pytest.raises(RuntimeError):
-            build_vrt_from_stac(items, asset="d", signer=self._signer())
+            build_vrt_from_stac(items, asset="d", signer=signer)
         captured = capfd.readouterr()
         assert "SUPERSECRET" not in captured.err, (
             f"the token was printed to stderr: {captured.err}"
@@ -378,8 +380,9 @@ class TestCredentialsStayOutOfMessages:
             {"assets": {"d": {"href": good}}},
             {"assets": {"d": {"href": "https://host.invalid/gone.tif"}}},
         ]
+        signer = _SasSigner()
         with pytest.raises(RuntimeError) as exc:
-            build_vrt_from_stac(items, asset="d", signer=_SasSigner())
+            build_vrt_from_stac(items, asset="d", signer=signer)
         assert "SASSECRET" not in str(exc.value), (
             f"the SAS token leaked into the error: {exc.value}"
         )

--- a/tests/stac/test_vrt.py
+++ b/tests/stac/test_vrt.py
@@ -282,7 +282,7 @@ class TestCredentialsStayOutOfMessages:
             {"assets": {"d": {"href": "https://host.invalid/gone.tif"}}},
         ]
         with pytest.raises(RuntimeError) as exc:
-            build_vrt_from_stac(items, asset="d", signer=self._signer(), strict=True)
+            build_vrt_from_stac(items, asset="d", signer=self._signer())
         assert "SUPERSECRET" not in str(exc.value), (
             f"the bearer token leaked into the error: {exc.value}"
         )
@@ -330,7 +330,7 @@ class TestCredentialsStayOutOfMessages:
         ]
         capfd.readouterr()
         with pytest.raises(RuntimeError):
-            build_vrt_from_stac(items, asset="d", signer=self._signer(), strict=True)
+            build_vrt_from_stac(items, asset="d", signer=self._signer())
         captured = capfd.readouterr()
         assert "SUPERSECRET" not in captured.err, (
             f"the token was printed to stderr: {captured.err}"
@@ -379,7 +379,7 @@ class TestCredentialsStayOutOfMessages:
             {"assets": {"d": {"href": "https://host.invalid/gone.tif"}}},
         ]
         with pytest.raises(RuntimeError) as exc:
-            build_vrt_from_stac(items, asset="d", signer=_SasSigner(), strict=True)
+            build_vrt_from_stac(items, asset="d", signer=_SasSigner())
         assert "SASSECRET" not in str(exc.value), (
             f"the SAS token leaked into the error: {exc.value}"
         )
@@ -447,7 +447,7 @@ class TestBuildVrtSourceCompleteness:
             so the mosaic would silently cover half the requested footprint.
         """
         with pytest.raises(RuntimeError, match="skipped 1 of 2"):
-            build_vrt_from_stac(mismatched_band_tiles, asset="data", strict=True)
+            build_vrt_from_stac(mismatched_band_tiles, asset="data")
 
     def test_unreadable_source_raises(self, adjacent_tiles, tmp_path):
         """An unreadable href (404 / expired URL) fails the build.
@@ -460,7 +460,7 @@ class TestBuildVrtSourceCompleteness:
             {"assets": {"data": {"href": str(tmp_path / "gone.tif")}}},
         ]
         with pytest.raises(RuntimeError, match="skipped 1 of 2"):
-            build_vrt_from_stac(items, asset="data", strict=True)
+            build_vrt_from_stac(items, asset="data")
 
     def test_error_names_the_dropped_source(self, mismatched_band_tiles):
         """The error lists the href that was dropped, not just a count.
@@ -470,7 +470,7 @@ class TestBuildVrtSourceCompleteness:
         """
         dropped_href = mismatched_band_tiles[1]["assets"]["data"]["href"]
         with pytest.raises(RuntimeError) as exc:
-            build_vrt_from_stac(mismatched_band_tiles, asset="data", strict=True)
+            build_vrt_from_stac(mismatched_band_tiles, asset="data")
         assert dropped_href in str(exc.value), (
             f"dropped href {dropped_href!r} missing from: {exc.value}"
         )
@@ -505,7 +505,7 @@ class TestBuildVrtSourceCompleteness:
         """
         items = [{"assets": {"data": {"href": str(tmp_path / "nope.tif")}}}]
         with pytest.raises(RuntimeError, match="returned None"):
-            build_vrt_from_stac(items, asset="data", strict=True)
+            build_vrt_from_stac(items, asset="data")
 
 
 class TestSourceCredentialEmbedding:
@@ -828,54 +828,58 @@ class TestBuildVrtArtifactCleanup:
         """
         before = vsimem_entries()
         with pytest.raises(RuntimeError, match="skipped"):
-            build_vrt_from_stac(mismatched_band_tiles, asset="data", strict=True)
+            build_vrt_from_stac(mismatched_band_tiles, asset="data")
         assert vsimem_entries() - before == set(), (
             "the VRT must be unlinked when the completeness guard fails"
         )
 
 
-class TestStrictDefaultDeprecation:
-    """The default flips to strict=True next minor, so the default warns now."""
+class TestStrictDefault:
+    """The default is strict=True: a skipped source fails the build."""
 
-    def test_default_warns_and_returns_the_partial_mosaic(self, mismatched_band_tiles):
-        """Leaving strict unset keeps today's behaviour and flags the change.
-
-        Test scenario:
-            A skipped source warns twice — once about the incomplete mosaic, once
-            that this default is going away — and still returns the partial VRT.
-        """
-        with pytest.warns(FutureWarning, match="becomes True in the next"):
-            ds = build_vrt_from_stac(mismatched_band_tiles, asset="data")
-        assert ds.read_array().shape == (4, 4), "the partial mosaic should be returned"
-
-    def test_default_also_warns_about_the_skip(self, mismatched_band_tiles):
-        """The completeness warning still fires under the default.
+    def test_default_raises_on_a_skipped_source(self, mismatched_band_tiles):
+        """Leaving strict unset raises rather than returning a partial mosaic.
 
         Test scenario:
-            The deprecation notice must not replace the actual problem report.
+            The silently-incomplete mosaic is the failure mode this guard
+            exists for, so it must not be the default outcome.
         """
-        with pytest.warns(UserWarning, match="skipped 1 of 2"):
+        with pytest.raises(RuntimeError, match="skipped 1 of 2"):
             build_vrt_from_stac(mismatched_band_tiles, asset="data")
 
-    def test_explicit_false_does_not_deprecation_warn(self, mismatched_band_tiles):
-        """A caller who pinned strict=False has nothing to migrate.
+    def test_explicit_false_warns_and_returns_the_partial_mosaic(
+        self, mismatched_band_tiles
+    ):
+        """`strict=False` is the opt-in for a best-effort mosaic.
 
         Test scenario:
-            Only the completeness warning fires.
+            The caller accepts an incomplete footprint and gets a warning naming
+            what was dropped.
+        """
+        with pytest.warns(UserWarning, match="skipped 1 of 2"):
+            ds = build_vrt_from_stac(mismatched_band_tiles, asset="data", strict=False)
+        assert ds.read_array().shape == (4, 4), "the partial mosaic should be returned"
+
+    def test_no_deprecation_notice_remains(self, mismatched_band_tiles):
+        """The migration notice is gone now the default has flipped.
+
+        Test scenario:
+            `strict=False` emits the completeness warning and nothing else — no
+            leftover `FutureWarning` about a default that has already changed.
         """
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
             build_vrt_from_stac(mismatched_band_tiles, asset="data", strict=False)
         kinds = [w.category for w in caught]
-        assert FutureWarning not in kinds, f"unexpected deprecation notice: {kinds}"
+        assert FutureWarning not in kinds, f"stale migration notice: {kinds}"
+        assert DeprecationWarning not in kinds, f"stale migration notice: {kinds}"
         assert UserWarning in kinds, f"the skip should still warn: {kinds}"
 
     def test_complete_build_never_warns(self, adjacent_tiles):
         """A clean build under the default is silent.
 
         Test scenario:
-            The deprecation notice fires only when the default actually changes
-            the outcome — i.e. only when a source was skipped.
+            Nothing was skipped, so there is nothing to report.
         """
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")

--- a/tests/stac/test_vrt.py
+++ b/tests/stac/test_vrt.py
@@ -8,12 +8,28 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from osgeo import gdal
 
+from pyramids.base import _artifacts
 from pyramids.dataset import Dataset
-from pyramids.stac._vrt import build_vrt_from_stac
+from pyramids.stac import _vrt
+from pyramids.stac._vrt import (
+    _check_dropped_sources,
+    _dropped_sources,
+    build_vrt_from_stac,
+)
 from tests._helpers import write_raster
 
 pytestmark = pytest.mark.core
+
+
+def vsimem_entries() -> set[str]:
+    """Return the current `/vsimem/` directory listing as a set.
+
+    Returns:
+        set[str]: Entry names (not full paths) currently in `/vsimem/`.
+    """
+    return set(gdal.ReadDir("/vsimem/") or [])
 
 
 @pytest.fixture
@@ -30,6 +46,24 @@ def adjacent_tiles(tmp_path):
     pa = write_raster(tmp_path / "a.tif", a, (0.0, 4.0))
     pb = write_raster(tmp_path / "b.tif", b, (4.0, 4.0))
     return [{"assets": {"data": {"href": pa}}}, {"assets": {"data": {"href": pb}}}]
+
+
+@pytest.fixture
+def mismatched_band_tiles(tmp_path):
+    """One single-band tile plus one 3-band tile GDAL cannot mosaic with it.
+
+    `gdalbuildvrt` refuses heterogeneous band counts: it warns and *skips* the
+    3-band source instead of failing, which is the silent-drop case
+    :func:`build_vrt_from_stac` guards against.
+
+    Returns:
+        list[dict]: two raw STAC items exposing a "data" asset each.
+    """
+    one = write_raster(tmp_path / "one.tif", np.full((4, 4), 1.0, "float32"), (0.0, 4.0))
+    three = write_raster(
+        tmp_path / "three.tif", np.full((3, 4, 4), 2.0, "float32"), (4.0, 4.0)
+    )
+    return [{"assets": {"data": {"href": one}}}, {"assets": {"data": {"href": three}}}]
 
 
 class TestBuildVrtFromStac:
@@ -121,3 +155,223 @@ class TestBuildVrtFromStac:
 
         with pytest.raises(StacAssetError, match="not found"):
             build_vrt_from_stac(adjacent_tiles, asset="nope")
+
+
+class TestDroppedSources:
+    """Tests for the _dropped_sources helper."""
+
+    def test_reports_source_absent_from_the_vrt(self):
+        """A requested source the VRT does not reference is reported.
+
+        Test scenario:
+            Two requested, one retained -> the other is reported as dropped.
+        """
+        assert _dropped_sources(["a.tif", "b.tif"], ["a.tif"]) == ["b.tif"], (
+            "the retained-source difference should name b.tif"
+        )
+
+    def test_reports_nothing_when_all_kept(self):
+        """No source is reported when every requested path was retained.
+
+        Test scenario:
+            Extra entries in the retained list (e.g. the VRT itself) are ignored.
+        """
+        assert _dropped_sources(["a.tif"], ["a.tif", "/vsimem/x.vrt"]) == [], (
+            "an extra retained entry must not make a kept source look dropped"
+        )
+
+    def test_preserves_requested_order(self):
+        """Dropped sources come back in the order they were requested.
+
+        Test scenario:
+            Three requested, the middle one kept -> [first, last].
+        """
+        dropped = _dropped_sources(["a.tif", "b.tif", "c.tif"], ["b.tif"])
+        assert dropped == ["a.tif", "c.tif"], f"order not preserved: {dropped}"
+
+    def test_empty_retained_drops_everything(self):
+        """An empty retained list means nothing survived the build.
+
+        Test scenario:
+            `GetFileList()` returning nothing -> every source is dropped.
+        """
+        assert _dropped_sources(["a.tif", "b.tif"], []) == ["a.tif", "b.tif"], (
+            "an empty retained list should report every requested source"
+        )
+
+
+class TestCheckDroppedSources:
+    """Tests for the _check_dropped_sources guard."""
+
+    def test_no_drops_is_silent(self, recwarn):
+        """An empty drop list neither raises nor warns.
+
+        Args:
+            recwarn: pytest fixture recording warnings raised in the block.
+
+        Test scenario:
+            The happy path must stay free of both errors and warnings.
+        """
+        _check_dropped_sources([], 2, "data", strict=True)
+        assert len(recwarn) == 0, f"unexpected warnings: {[str(w) for w in recwarn]}"
+
+    def test_strict_raises_with_counts_and_asset(self):
+        """strict=True raises a RuntimeError naming the counts and the asset.
+
+        Test scenario:
+            1 of 3 sources dropped for asset "B04".
+        """
+        with pytest.raises(RuntimeError) as exc:
+            _check_dropped_sources(["b.tif"], 3, "B04", strict=True)
+        message = str(exc.value)
+        assert "skipped 1 of 3" in message, f"counts missing from message: {message}"
+        assert "'B04'" in message, f"asset key missing from message: {message}"
+        assert "strict=False" in message, f"no escape hatch hinted: {message}"
+
+    def test_strict_false_warns_instead(self):
+        """strict=False downgrades the failure to a UserWarning.
+
+        Test scenario:
+            The same drop that raises under strict=True only warns here.
+        """
+        with pytest.warns(UserWarning, match="skipped 1 of 3"):
+            _check_dropped_sources(["b.tif"], 3, "B04", strict=False)
+
+    def test_long_drop_list_is_truncated(self):
+        """More than five dropped sources are summarised, not dumped in full.
+
+        Test scenario:
+            Eight dropped paths -> five listed plus a "+3 more" suffix.
+        """
+        dropped = [f"s{i}.tif" for i in range(8)]
+        with pytest.raises(RuntimeError) as exc:
+            _check_dropped_sources(dropped, 10, "data", strict=True)
+        message = str(exc.value)
+        assert "(+3 more)" in message, f"long list not truncated: {message}"
+        assert "s7.tif" not in message, f"truncated entry still listed: {message}"
+
+
+class TestBuildVrtSourceCompleteness:
+    """Tests for the strict source-completeness guard (ARC-79)."""
+
+    def test_band_count_mismatch_raises(self, mismatched_band_tiles):
+        """A source GDAL skips for a band-count mismatch fails the build.
+
+        Test scenario:
+            A 1-band and a 3-band tile: GDAL warns and drops the 3-band source,
+            so the mosaic would silently cover half the requested footprint.
+        """
+        with pytest.raises(RuntimeError, match="skipped 1 of 2"):
+            build_vrt_from_stac(mismatched_band_tiles, asset="data")
+
+    def test_unreadable_source_raises(self, adjacent_tiles, tmp_path):
+        """An unreadable href (404 / expired URL) fails the build.
+
+        Test scenario:
+            One good tile plus a path that does not exist.
+        """
+        items = [
+            adjacent_tiles[0],
+            {"assets": {"data": {"href": str(tmp_path / "gone.tif")}}},
+        ]
+        with pytest.raises(RuntimeError, match="skipped 1 of 2"):
+            build_vrt_from_stac(items, asset="data")
+
+    def test_error_names_the_dropped_source(self, mismatched_band_tiles):
+        """The error lists the href that was dropped, not just a count.
+
+        Test scenario:
+            The 3-band tile's path appears in the message so it is actionable.
+        """
+        dropped_href = mismatched_band_tiles[1]["assets"]["data"]["href"]
+        with pytest.raises(RuntimeError) as exc:
+            build_vrt_from_stac(mismatched_band_tiles, asset="data")
+        assert dropped_href in str(exc.value), (
+            f"dropped href {dropped_href!r} missing from: {exc.value}"
+        )
+
+    def test_strict_false_warns_and_returns_partial(self, mismatched_band_tiles):
+        """strict=False returns the partial mosaic with a warning.
+
+        Test scenario:
+            The same drop warns, and the returned Dataset covers only the tile
+            GDAL kept (4x4 rather than the requested 4x8 union).
+        """
+        with pytest.warns(UserWarning, match="skipped 1 of 2"):
+            ds = build_vrt_from_stac(mismatched_band_tiles, asset="data", strict=False)
+        arr = ds.read_array()
+        assert arr.shape == (4, 4), f"expected the kept tile only, got {arr.shape}"
+
+    def test_complete_mosaic_does_not_raise(self, adjacent_tiles):
+        """A build where GDAL keeps every source is unaffected by the guard.
+
+        Test scenario:
+            Two compatible tiles -> the full 4x8 union, no error, no warning.
+        """
+        ds = build_vrt_from_stac(adjacent_tiles, asset="data", strict=True)
+        assert ds.read_array().shape == (4, 8), "the complete mosaic must survive"
+
+    def test_all_sources_unreadable_raises_build_error(self, tmp_path):
+        """When nothing is usable, gdal.BuildVRT returns None and that is raised.
+
+        Test scenario:
+            Every href missing -> the pre-existing "returned None" guard fires
+            rather than the drop guard.
+        """
+        items = [{"assets": {"data": {"href": str(tmp_path / "nope.tif")}}}]
+        with pytest.raises(RuntimeError, match="returned None"):
+            build_vrt_from_stac(items, asset="data")
+
+
+class TestBuildVrtArtifactCleanup:
+    """Tests for the /vsimem VRT lifetime (ARC-10)."""
+
+    def test_vsimem_registered_on_success(self, adjacent_tiles):
+        """A successful build tracks its VRT for the process-exit sweep.
+
+        Test scenario:
+            The new `/vsimem` entry is also present in the artefact registry.
+        """
+        before = vsimem_entries()
+        build_vrt_from_stac(adjacent_tiles, asset="data")
+        created = vsimem_entries() - before
+        assert len(created) == 1, f"expected exactly one new /vsimem entry: {created}"
+        tracked = {path.rsplit("/", 1)[-1] for path in _artifacts._VSIMEM_PATHS}
+        assert created <= tracked, f"{created} not tracked for cleanup"
+
+    def test_vsimem_removed_when_open_fails(self, adjacent_tiles, monkeypatch):
+        """A failing `Dataset.read_file` unlinks the VRT instead of orphaning it.
+
+        Args:
+            adjacent_tiles: Fixture providing two mosaickable items.
+            monkeypatch: pytest fixture used to break the VRT open.
+
+        Test scenario:
+            The build succeeds, the open raises, and `/vsimem` is left clean.
+        """
+
+        class _BoomDataset:
+            @staticmethod
+            def read_file(*args, **kwargs):
+                raise RuntimeError("simulated open failure")
+
+        monkeypatch.setattr(_vrt, "Dataset", _BoomDataset)
+        before = vsimem_entries()
+        with pytest.raises(RuntimeError, match="simulated open failure"):
+            build_vrt_from_stac(adjacent_tiles, asset="data")
+        assert vsimem_entries() - before == set(), (
+            "the VRT must be unlinked when the open fails"
+        )
+
+    def test_vsimem_removed_when_strict_check_fails(self, mismatched_band_tiles):
+        """A strict drop failure also unlinks the VRT it had already written.
+
+        Test scenario:
+            The guard raises after `BuildVRT` wrote `/vsimem`; nothing is left.
+        """
+        before = vsimem_entries()
+        with pytest.raises(RuntimeError, match="skipped"):
+            build_vrt_from_stac(mismatched_band_tiles, asset="data")
+        assert vsimem_entries() - before == set(), (
+            "the VRT must be unlinked when the completeness guard fails"
+        )


### PR DESCRIPTION
# Description

Resolves the seven findings in `planning/architecture-review/25-july/arc-stac.md` for the `stac/` subpackage
(plus the `dataset/`, `netcdf/` and `base/` code they reach into). Each finding was re-verified against `main`
before being fixed — two of the original write-ups turned out to be wrong about the cause, and the measurements
below are from throw-away repros, not from reading the code.

**The two findings that changed shape under verification:**

1. **Signer credentials (#834).** The original note said "every lazy pixel read loses credentials". Measured
   against a localhost server that *rejects* any request without a bearer token (GDAL 3.13.1), a plain
   `load_asset(...)` + `read_array()` actually works — GDAL captures the HTTP options into the handle at open.
   The breakage is on the paths that **re-open**: `threadsafe=True` (401), unpickling on a dask worker (401), and
   `build_vrt_from_stac` (401 on all 17 source requests, read raised).

   The VRT half cannot be fixed by any ambient-config approach. With an **explicit**
   `CloudConfig(extra=signer_env)` wrapped directly around `vrt.read_array()`, all 17 source requests were still
   rejected — GDAL does not consult the thread-local config when it opens a VRT source. A global
   `SetConfigOption` does work, which pins the cause to thread-locality, but process-wide credentials are not an
   option. So VRT credentials ride the **source path** instead, via GDAL's `/vsicurl?header.…&url=…` syntax: the
   same mosaic then reads in **1 request, 0 rejected**.

2. **`/vsimem` lifetime (#833).** The "partially written VRT" half of the note does not happen. What does: the
   exit sweep was never armed at all for a VRT-only process (`atexit.register` hung off the temp root, which
   `build_vrt_from_stac` never touches), and on success the VRT was never unlinked when the `Dataset` died.

**Security consequence worth a reviewer's attention.** Because VRT credentials must live in the source path, a
signed mosaic *is* a secret — the token is in the VRT XML `to_file` writes, in every pickle, and in GDAL's own
messages. The PR redacts everything pyramids emits (its own errors/warnings, GDAL's messages during the build via
a *pushed* error handler, and `repr(ds)`, whose GDAL info lists every source), and says so plainly in the module
docstring. That is mitigation, not containment.

**Behaviour changes to note — one carries a `BREAKING CHANGE:` footer:**

- **Breaking.** `build_vrt_from_stac` now **raises** when GDAL skips a requested source, where it previously
  returned a silently-incomplete mosaic. `strict=True` is the default; `strict=False` restores the old
  best-effort behaviour with a warning naming what was dropped. A deprecation window (`strict=None` plus a
  `FutureWarning`) was drafted and then dropped: a default that arrives "next minor" only helps if someone comes
  back for it, and a `FutureWarning` raised from library code is weak protection compared with failing at the
  point the mosaic is actually wrong. Commit `1869d9fd` carries the `BREAKING CHANGE:` footer.
- `AWSRequesterPaysSigner.gdal_env()` is now built from the shared `_REQUESTER_PAYS_GDAL_KNOBS`, which also adds
  `GDAL_HTTP_MULTIPLEX` / `GDAL_HTTP_VERSION=2` that it previously omitted. A throughput win normally, but HTTP/2
  is not universally safe (intercepting proxy, older libcurl); the docstring names the one-line escape hatch.
- `RasterBase.__reduce__` emits a 4-element recipe. Old 3-element pickles still load, but a pickle from this
  version needs a reader that accepts four arguments — a mixed-version dask cluster must upgrade its workers.

No new dependencies, no lockfile change, no migrations.

# Issues

- Closes #832 — `build_vrt_from_stac` silently drops sources GDAL cannot use
- Closes #833 — the in-memory VRT leaks on a failed open and for the life of the process
- Closes #834 — signer credentials are lost by every read that re-opens the file
- Closes #835 — apply the `/vsicurl` fast-read and retry knobs uniformly
- Closes #836 — `AWSRequesterPaysSigner.region` never reaches GDAL
- Closes #837 — reuse the shared Requester-Pays knobs and the duck-typed item accessors
- Closes #838 — the package docstring and `__all__` describe an older, smaller surface

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

The "breaking" box is ticked for the three behaviour changes listed above. The first is a real break, marked with
a `BREAKING CHANGE:` footer so the release notes carry it; the other two are behaviour shifts that could surprise
an existing caller and are called out so a reviewer weighs them rather than discovers them.

# How Has This Been Tested?

`pixi run` is broken on this machine (lock-file v7 vs the installed pixi v0.65), so everything ran through the dev
environment's interpreter directly. To reproduce:

```bash
E='C:\python-environments\pixi\envs\pyramids-gis-17387402636982928789\envs\dev'
env "PATH=$E\Library\bin;$E;$E\Scripts;C:\Windows\System32" "USE_PATH_FOR_GDAL_PYTHON=1" \
    "MPLBACKEND=Agg" "PYTHONPATH=<checkout>\src" "$E/python.exe" -m pytest -q -m "not plot"
```

- [x] **Full suite** — `pytest -m "not plot"`: **6918 passed, 51 skipped, 348 deselected**, re-run after the
  `strict` default flip.
- [x] **New tests** — 25 new test classes / ~180 cases across `tests/stac/test_vrt.py` (+764),
  `tests/dataset/io/test_gdal_env.py` (new), `tests/base/test_ogc_api_retry.py` (new),
  `tests/stac/test_loader.py`, `tests/stac/test_signers.py`, `tests/stac/test_item.py`,
  `tests/base/test_remote.py`, `tests/base/test_artifacts.py`, `tests/dataset/stac/test_stac.py`,
  `tests/dataset/cog/test_gdal_config.py`.
- [x] **Doctests** — `pytest --doctest-modules` over the changed `src/` modules: 106 passed, 12 skipped.
- [x] **mypy** — `python -m mypy` with the repo config: clean (120 source files). It was briefly red mid-branch
  because the cloud-config decorator erased the wrapped signatures; a bound `TypeVar` fixes that and restores
  argument checking on the decorated public methods.
- [x] **Credential leakage** — asserted absent from the raised error, the warning, captured stderr/stdout
  (`capfd`) and `repr(ds)`. The stderr case is the one that matters: it is the only path GDAL actually uses under
  `UseExceptions()`, and an earlier attempt at this fix was dead code because of it.
- [x] **Coverage of the changed STAC modules** — `_vrt.py`, `_item.py`, `signers.py` at 100% line + branch;
  `_ogc_api.py` 99%; `_loader.py` 98%.

Not run locally: **ruff**. It is not installed in the dev environment and `pip install` is not available here, so
the 88-column reflow and the isort fix in `engines/cog.py` were derived from the config and measured line lengths.
The Lint job is the real check on those two.

The branch also went through two adversarial review rounds before this PR
(`planning/pr-diff-review-stac-arc-findings-2026-07-26.md` and `…-2026-07-26-2.md`, 39 findings, all resolved).
Round 2 is why the credential redaction, the decorator placement and the `/vsimem` lifetime look the way they do —
the first attempt at each was wrong.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.

The three version/changelog boxes are deliberately unticked: commitizen owns the version bump and the generated
change log in this repo, so hand-editing them here would conflict with the release workflow. Documentation is
updated in-branch through the docstrings the API reference is generated from — including a new "Credential
exposure" section in `pyramids/stac/_vrt.py` and a rewritten `pyramids/stac/__init__.py` module docstring.
