### PR TITLE
feat(netcdf): lazy to_xarray(chunks=) and shared NETCDF: subdataset-prefix helper

### DIFF
--- a/src/pyramids/netcdf/_lazy.py
+++ b/src/pyramids/netcdf/_lazy.py
@@ -599,6 +599,7 @@ def build_lazy_array(
     manager_hook: Any = None,
     spatial_dims: tuple[int, int] | None = None,
     flips: tuple[bool, bool] | None = None,
+    orient: bool = True,
 ) -> Any:
     """Build a :class:`dask.array.Array` backed by MDArray chunk reads.
 
@@ -630,6 +631,11 @@ def build_lazy_array(
         flips: `(needs_y_flip, needs_x_flip)` the eager path decided for
             the resolved plane. Used with `spatial_dims`; `None` falls
             back to the trailing-plane decision.
+        orient: When `True` (the default) the block is normalized to the
+            raster convention (row 0 = north, col 0 = west) like the eager
+            `get_variable` read. Pass `False` for a raw read in the file's
+            native axis order (e.g. `to_xarray`, whose coordinate arrays are
+            also read raw, so the data must not be flipped relative to them).
 
     Returns:
         dask.array.Array: Lazy array that computes chunk-by-chunk
@@ -686,10 +692,12 @@ def build_lazy_array(
     # Normalize to the raster convention the eager path produces (row 0 = north, col 0 = west) on the
     # SAME plane the eager `get_variable` resolved -- moving a non-trailing plane to the trailing two
     # axes when `spatial_dims` is threaded through (#728). A trailing plane makes this a no-op, so the
-    # ordinary `(time, lev, lat, lon)` case is unchanged.
-    lazy = _orient_lazy_plane(
-        lazy, da, len(shape), spatial_dims, flips, (flip_y, flip_x)
-    )
+    # ordinary `(time, lev, lat, lon)` case is unchanged. Skipped for a raw read (`orient=False`),
+    # which must return the file's native axis order (ARC-48 `to_xarray`).
+    if orient:
+        lazy = _orient_lazy_plane(
+            lazy, da, len(shape), spatial_dims, flips, (flip_y, flip_x)
+        )
     # The parked FILE_CACHE handle is released deterministically when this `manager` is
     # garbage-collected -- the `CachingFileManager` registers a `weakref.finalize` on itself in
     # `__init__`. Because the manager is kept alive by the chunk readers in the graph (not by this

--- a/src/pyramids/netcdf/_mdim.py
+++ b/src/pyramids/netcdf/_mdim.py
@@ -168,6 +168,30 @@ def unflatten_band_axes(arr: Any, band_dim_names: Any, band_dim_sizes: Any) -> A
     return arr
 
 
+def strip_netcdf_subdataset_prefix(path: str) -> str:
+    """Return the bare file path from a GDAL ``NETCDF:"<path>":<var>`` subdataset spec.
+
+    GDAL names a NetCDF subdataset as ``NETCDF:"C:\\data\\f.nc":temperature``; the quoted path can
+    itself hold a colon (a Windows drive letter), so a naive ``split(":")`` mis-parses it. Parse the
+    quoted remainder with ``rfind('"')`` and the rare unquoted ``NETCDF:<path>:<var>`` form with a
+    right split. A path without the prefix is returned unchanged. Single source for the three call
+    sites (`_is_file_backed`, the lazy read, and `to_xarray`) that used to strip it inline (review L1).
+
+    Args:
+        path: A file path or a ``NETCDF:`` subdataset spec.
+
+    Returns:
+        str: The bare, reopenable file path.
+    """
+    if not path or not path.startswith("NETCDF:"):
+        return path
+    rest = path[len("NETCDF:") :]
+    if rest.startswith('"'):
+        closing = rest.rfind('"')
+        return rest[1:closing] if closing > 0 else rest
+    return rest.rsplit(":", 1)[0]
+
+
 def dataset_is_geostationary(dataset: gdal.Dataset) -> bool:
     """Report whether ``dataset``'s CRS is the CF geostationary projection.
 

--- a/src/pyramids/netcdf/engines/interop.py
+++ b/src/pyramids/netcdf/engines/interop.py
@@ -199,12 +199,17 @@ def _lazy_var_data(ds: NetCDF, var_name: str, chunks: Any, md_arr: Any) -> Any:
     A variable whose dtype a chunked read cannot represent (e.g. a string MDArray such as a CF
     ``expver`` label) falls back to the eager read, matching the default ``to_xarray`` path -- one
     non-chunkable variable must not fail the whole lazy conversion.
+
+    The container's captured cloud config (``_gdal_env``) is carried into the read so each chunk
+    task re-opens a signed remote store with the same credentials, matching ``_read_array_lazy`` (#839).
     """
     path = _reopenable_path(ds)
     if path is None:
         return ds._md_array_to_numpy(md_arr)
     try:
-        return build_lazy_array(path, var_name, chunks, orient=False)
+        return build_lazy_array(
+            path, var_name, chunks, orient=False, gdal_env=ds._gdal_env or None
+        )
     except ValueError:
         return ds._md_array_to_numpy(md_arr)
 

--- a/src/pyramids/netcdf/engines/interop.py
+++ b/src/pyramids/netcdf/engines/interop.py
@@ -22,7 +22,10 @@ from osgeo import gdal
 
 from pyramids.base._errors import OptionalPackageDoesNotExist
 from pyramids.base._utils import numpy_to_gdal_dtype
+from pyramids.base.remote import is_remote
 from pyramids.dataset.engines._base import _Engine
+from pyramids.netcdf._lazy import build_lazy_array
+from pyramids.netcdf._mdim import strip_netcdf_subdataset_prefix
 from pyramids.netcdf.cf import write_attributes_to_md_array, write_global_attributes
 from pyramids.netcdf.utils import _read_attributes
 
@@ -40,27 +43,36 @@ class Interop(_Engine["NetCDF"]):
     than on this instance-bound engine.
     """
 
-    def to_xarray(self) -> Any:
+    def to_xarray(self, chunks: dict | str | int | None = None) -> Any:
         """Convert this NetCDF container to an `xarray.Dataset`.
 
-        Builds an in-memory `xarray.Dataset` that mirrors the
-        variables, coordinates, dimensions, and global attributes of
-        this pyramids NetCDF container.
+        Builds an `xarray.Dataset` that mirrors the variables,
+        coordinates, dimensions, and global attributes of this pyramids
+        NetCDF container.
 
         The entire conversion goes through GDAL's Multidimensional
         API — the same reader the rest of pyramids' NetCDF code uses.
         No xarray engine plugin (`netcdf4`, `h5netcdf`,
         `scipy.io.netcdf`) is involved, so xarray does not need to
-        pull a NetCDF backend: pyramids is the backend. The returned
-        `xr.Dataset` holds already-
-        materialised numpy arrays; for lazy reads use
-        :meth:`read_array(chunks=...)` and wrap the result in
-        :class:`xarray.DataArray` yourself.
+        pull a NetCDF backend: pyramids is the backend.
+
+        With the default `chunks=None` the returned `xr.Dataset` holds
+        already-materialised numpy arrays. Pass `chunks` (a dict / int /
+        `"auto"`) to build each data variable as a lazy dask-backed
+        `DataArray` in the file's native axis order, so the dataset is
+        assembled without loading every variable into RAM (ARC-48).
+        Lazy reads need the optional `[lazy]` (dask) extra and a
+        file-backed container; an in-memory container ignores `chunks`
+        (its data is already resident).
 
         Requires the optional `xarray` package. Install with one of:
 
         - PyPI: ``pip install xarray``
         - conda-forge: ``conda install -c conda-forge xarray``
+
+        Args:
+            chunks: Chunk spec forwarded to the lazy reader per data
+                variable. `None` (default) reads eagerly.
 
         Returns:
             xarray.Dataset: An xarray Dataset with the same
@@ -69,6 +81,8 @@ class Interop(_Engine["NetCDF"]):
         Raises:
             pyramids.base._errors.OptionalPackageDoesNotExist:
                 If `xarray` is not installed.
+            ImportError: If `chunks` is given but the `[lazy]` (dask)
+                extra is not installed.
             ValueError: If the underlying GDAL handle is not a
                 multidimensional container (open the file with
                 `open_as_multi_dimensional=True`).
@@ -79,6 +93,11 @@ class Interop(_Engine["NetCDF"]):
                 nc = NetCDF.read_file("temperature.nc")
                 ds = nc.to_xarray()
                 print(ds)
+
+            Build a lazy (dask-backed) dataset::
+
+                lazy = nc.to_xarray(chunks="auto")
+                lazy["temperature"].data  # dask.array.Array
         """
         ds = self._ds
         try:
@@ -98,7 +117,7 @@ class Interop(_Engine["NetCDF"]):
             )
 
         return xr.Dataset(
-            data_vars=_data_vars_from_arrays(rg, ds),
+            data_vars=_data_vars_from_arrays(rg, ds, chunks),
             coords=_coords_from_dimensions(rg, ds),
             attrs=ds.global_attributes,
         )
@@ -135,18 +154,59 @@ def _coords_from_dimensions(rg: Any, ds: NetCDF) -> dict[str, Any]:
     return coords
 
 
-def _data_vars_from_arrays(rg: Any, ds: NetCDF) -> dict[str, Any]:
-    """Build the ``xr.Dataset`` ``data_vars`` mapping from the container's variables."""
+def _data_vars_from_arrays(rg: Any, ds: NetCDF, chunks: Any = None) -> dict[str, Any]:
+    """Build the ``xr.Dataset`` ``data_vars`` mapping from the container's variables.
+
+    With ``chunks=None`` each variable is read eagerly; otherwise it is read lazily (dask) in the
+    file's native axis order via :func:`_lazy_var_data` (ARC-48).
+    """
     data_vars: dict[str, Any] = {}
     for var_name in ds.variable_names:
         md_arr = rg.OpenMDArray(var_name)
         if md_arr is None:
             continue
         arr_dim_names = [ad.GetName() for ad in md_arr.GetDimensions() or []]
-        arr_data = ds._md_array_to_numpy(md_arr)
+        if chunks is None:
+            arr_data = ds._md_array_to_numpy(md_arr)
+        else:
+            arr_data = _lazy_var_data(ds, var_name, chunks, md_arr)
         var_attrs = _merge_unit(_read_attributes(md_arr), md_arr)
         data_vars[var_name] = (arr_dim_names, arr_data, var_attrs)
     return data_vars
+
+
+def _reopenable_path(ds: NetCDF) -> str | None:
+    """Return the bare, reopenable file path of a file-backed container, else ``None``.
+
+    Strips any ``NETCDF:"…":var`` subdataset prefix and confirms the path exists on disk or is a
+    remote (`/vsi*` / cloud) URL; an in-memory container has no such path.
+    """
+    path = strip_netcdf_subdataset_prefix(getattr(ds, "_file_name", "") or "")
+    if path and (os.path.isfile(path) or is_remote(path)):
+        return path
+    return None
+
+
+def _lazy_var_data(ds: NetCDF, var_name: str, chunks: Any, md_arr: Any) -> Any:
+    """Return a dask-backed raw read of ``var_name`` in the file's native axis order (ARC-48).
+
+    Deferred counterpart of :meth:`NetCDF._md_array_to_numpy`, so ``to_xarray(chunks=...)`` assembles
+    a lazy dataset without materialising every variable. A file-backed container reads through
+    :func:`build_lazy_array` with ``orient=False`` (raw, matching the raw coordinate arrays); an
+    in-memory container has no file to reopen and its data is already resident, so the eager array is
+    returned unchanged (``chunks`` has no benefit there).
+
+    A variable whose dtype a chunked read cannot represent (e.g. a string MDArray such as a CF
+    ``expver`` label) falls back to the eager read, matching the default ``to_xarray`` path -- one
+    non-chunkable variable must not fail the whole lazy conversion.
+    """
+    path = _reopenable_path(ds)
+    if path is None:
+        return ds._md_array_to_numpy(md_arr)
+    try:
+        return build_lazy_array(path, var_name, chunks, orient=False)
+    except ValueError:
+        return ds._md_array_to_numpy(md_arr)
 
 
 def from_xarray(

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -40,6 +40,7 @@ from pyramids.netcdf._mdim import (
     open_mdarray,
     scalar_no_data,
     scaled_axis_ascends,
+    strip_netcdf_subdataset_prefix,
     unflatten_band_axes,
     x_axis_is_right_to_left,
     y_axis_is_bottom_up,
@@ -1890,9 +1891,7 @@ class NetCDF(Dataset):
                 "chunks=; read eagerly, or mask the dask array yourself."
             )
         parent = self._parent_nc if self._parent_nc is not None else self
-        path = parent._file_name
-        if path.startswith("NETCDF"):
-            path = path.split(":")[1][1:-1]
+        path = strip_netcdf_subdataset_prefix(parent._file_name)
         var_name = self._source_var_name
         if var_name is None:
             raise ValueError(
@@ -2379,16 +2378,7 @@ class NetCDF(Dataset):
         path = parent._file_name
         if not path:
             return False
-        if path.startswith("NETCDF:"):
-            rest = path[len("NETCDF:") :]
-            if rest.startswith('"'):
-                # NETCDF:"<path>":<var> -- take the quoted path, which may itself contain a colon
-                # (a Windows drive letter `C:\...`), so a naive split(":") is wrong (review L1).
-                closing = rest.rfind('"')
-                path = rest[1:closing] if closing > 0 else rest
-            else:
-                # NETCDF:<path>:<var> -- drop the trailing :<var> from the right.
-                path = rest.rsplit(":", 1)[0]
+        path = strip_netcdf_subdataset_prefix(path)
         return os.path.isfile(path) or is_remote(path)
 
     @staticmethod

--- a/tests/dataset/io/test_window.py
+++ b/tests/dataset/io/test_window.py
@@ -92,9 +92,15 @@ class TestWindow:
         """Windows are frozen value objects.
 
         Test scenario:
-            Equal fields compare equal; assignment raises.
+            Two separately-built windows with equal fields compare equal, differing fields do not,
+            and field assignment raises.
         """
-        assert Window(0, 0, 2, 2) == Window(0, 0, 2, 2), "value equality must hold"
+        a = Window(0, 0, 2, 2)
+        b = Window(0, 0, 2, 2)
+        assert a == b, "two windows with equal fields must compare equal"
+        assert a != Window(0, 0, 2, 3), (
+            "windows with differing fields must not compare equal"
+        )
         with pytest.raises(AttributeError):
             Window(0, 0, 2, 2).cols = 5
 

--- a/tests/dataset/ops/test_focal.py
+++ b/tests/dataset/ops/test_focal.py
@@ -396,8 +396,14 @@ class TestSentinelMatchingIsExact:
         )
 
 
+@pytest.mark.lazy
 class TestEagerAndLazyAgree:
-    """L4/S4: `chunks=` is a memory choice, not a change of result."""
+    """L4/S4: `chunks=` is a memory choice, not a change of result.
+
+    Every method exercises the `chunks=` (dask) path, so the class is tagged `@pytest.mark.lazy`
+    like its sibling lazy tests — the conftest hook then auto-skips it when the `[lazy]` extra is
+    absent (e.g. the wheels verify jobs), instead of raising an `ImportError`.
+    """
 
     @pytest.fixture(scope="function")
     def dem(self, tmp_path) -> Dataset:

--- a/tests/netcdf/lazy/test_xarray_interop.py
+++ b/tests/netcdf/lazy/test_xarray_interop.py
@@ -873,3 +873,35 @@ class TestToXarrayLazy:
         assert not hasattr(ds["temperature"].data, "dask"), (
             "in-memory container should ignore chunks and stay eager"
         )
+
+    @requires_dask
+    def test_lazy_read_threads_gdal_env(self, monkeypatch):
+        """The container's `_gdal_env` is carried into the lazy read so a signed remote store
+        re-opens authenticated (#839).
+
+        Test scenario:
+            Attach a `gdal_env` to a file-backed container and spy on `build_lazy_array`;
+            `_lazy_var_data` must forward that env (and ``orient=False``) to the chunk graph.
+        """
+        from pyramids.netcdf.engines import interop as interop_mod
+
+        captured = {}
+
+        def _spy(path, variable_name, chunks, orient=True, gdal_env=None):
+            captured["gdal_env"] = gdal_env
+            captured["orient"] = orient
+            return object()  # stand-in lazy array; _lazy_var_data returns it unchanged
+
+        monkeypatch.setattr(interop_mod, "build_lazy_array", _spy)
+        nc = NetCDF.read_file(GEOG_3D_NC)
+        try:
+            nc.attach_gdal_env({"AWS_REQUEST_PAYER": "requester"})
+            interop_mod._lazy_var_data(nc, "t2m", "auto", None)
+        finally:
+            nc.close()
+        assert captured["gdal_env"] == {"AWS_REQUEST_PAYER": "requester"}, (
+            f"container gdal_env must be threaded into the lazy read, got {captured}"
+        )
+        assert captured["orient"] is False, (
+            "lazy to_xarray read must be raw (orient=False)"
+        )

--- a/tests/netcdf/lazy/test_xarray_interop.py
+++ b/tests/netcdf/lazy/test_xarray_interop.py
@@ -21,6 +21,9 @@ pytestmark = pytest.mark.xarray
 from pyramids.dataset import Dataset
 from pyramids.netcdf.engines.interop import _encode_temporal_array
 from pyramids.netcdf.netcdf import NetCDF
+from tests._marks import requires_dask
+
+GEOG_3D_NC = "tests/data/netcdf/cf__5v__1d4-3d1__geog__y-desc.nc"
 
 
 class TestEncodeTemporalArray:
@@ -782,4 +785,91 @@ class TestInteropEngineBranches:
         via_facade = nc.to_xarray()
         assert set(via_engine.data_vars) == set(via_facade.data_vars), (
             "engine and façade disagree on variables"
+        )
+
+
+class TestToXarrayLazy:
+    """to_xarray(chunks=...) builds dask-backed data variables in native order (ARC-48)."""
+
+    @requires_dask
+    def test_numeric_var_is_dask_backed(self):
+        """A numeric data variable is dask-backed when chunks= is given.
+
+        Test scenario:
+            to_xarray(chunks="auto") on a file-backed container returns the numeric ``t2m`` as a dask
+            array rather than an eagerly-materialised numpy array.
+        """
+        nc = NetCDF.read_file(GEOG_3D_NC)
+        try:
+            lazy = nc.to_xarray(chunks="auto")
+            assert hasattr(lazy["t2m"].data, "dask"), (
+                "numeric var should be dask-backed"
+            )
+        finally:
+            nc.close()
+
+    @requires_dask
+    def test_lazy_values_match_eager(self):
+        """Computed lazy values equal the eager to_xarray values (raw orientation preserved).
+
+        Test scenario:
+            The lazy read uses ``orient=False``, so it must not be flipped relative to the raw
+            coordinate arrays; computing it reproduces the eager numpy result exactly.
+        """
+        nc = NetCDF.read_file(GEOG_3D_NC)
+        try:
+            eager = nc.to_xarray()
+            lazy = nc.to_xarray(chunks="auto")
+            assert_allclose(
+                np.asarray(lazy["t2m"].compute().values),
+                np.asarray(eager["t2m"].values),
+                equal_nan=True,
+            )
+        finally:
+            nc.close()
+
+    @requires_dask
+    def test_string_var_falls_back_to_eager(self):
+        """A non-chunkable string variable is read eagerly, not as dask, and still matches.
+
+        Test scenario:
+            ``expver`` is a string MDArray a chunked read cannot represent; to_xarray(chunks=) must
+            fall back to the eager read for it instead of failing the whole conversion.
+        """
+        nc = NetCDF.read_file(GEOG_3D_NC)
+        try:
+            eager = nc.to_xarray()
+            lazy = nc.to_xarray(chunks="auto")
+            assert not hasattr(lazy["expver"].data, "dask"), (
+                "string var must fall back to eager"
+            )
+            assert_array_equal(
+                np.asarray(lazy["expver"].values), np.asarray(eager["expver"].values)
+            )
+        finally:
+            nc.close()
+
+    def test_default_is_eager(self):
+        """Without chunks=, data variables stay eager numpy arrays (unchanged default)."""
+        nc = NetCDF.read_file(GEOG_3D_NC)
+        try:
+            eager = nc.to_xarray()
+            assert not hasattr(eager["t2m"].data, "dask"), (
+                "default to_xarray stays eager"
+            )
+        finally:
+            nc.close()
+
+    @requires_dask
+    def test_in_memory_container_ignores_chunks(self):
+        """An in-memory container has no file to reopen, so chunks= falls back to eager.
+
+        Test scenario:
+            A ``create_from_array`` container's data is already resident; to_xarray(chunks="auto")
+            returns eager numpy arrays rather than raising or attempting a lazy reopen.
+        """
+        nc = _make_3d_nc(variable_name="temperature")
+        ds = nc.to_xarray(chunks="auto")
+        assert not hasattr(ds["temperature"].data, "dask"), (
+            "in-memory container should ignore chunks and stay eager"
         )

--- a/tests/netcdf/structure/test_mdim.py
+++ b/tests/netcdf/structure/test_mdim.py
@@ -18,6 +18,7 @@ from pyramids.netcdf._mdim import (
     open_mdarray,
     root_group,
     scalar_no_data,
+    strip_netcdf_subdataset_prefix,
 )
 
 pytestmark = pytest.mark.core
@@ -198,3 +199,34 @@ class TestNeedsYFlip:
         md_arr.GetDimensions.return_value = [Mock(), Mock()]
         md_arr.AsClassicDataset.side_effect = RuntimeError("cannot view")
         assert needs_y_flip(Mock(), md_arr) is False, "probe failure should not flip"
+
+
+class TestStripNetcdfSubdatasetPrefix:
+    """strip_netcdf_subdataset_prefix unwraps a GDAL NETCDF: subdataset spec (review L1)."""
+
+    @pytest.mark.parametrize(
+        "spec, expected",
+        [
+            (r'NETCDF:"C:\data\f.nc":temperature', r"C:\data\f.nc"),
+            ('NETCDF:"/data/f.nc":t', "/data/f.nc"),
+            ("NETCDF:/data/f.nc:t", "/data/f.nc"),
+            ("/plain/path.nc", "/plain/path.nc"),
+            ("", ""),
+            (r"C:\plain\path.nc", r"C:\plain\path.nc"),
+        ],
+    )
+    def test_parse(self, spec, expected):
+        """Each spec resolves to its bare, reopenable file path.
+
+        Args:
+            spec: A file path or a ``NETCDF:`` subdataset spec.
+            expected: The bare path the helper should return.
+
+        Test scenario:
+            The quoted form keeps a Windows drive-letter colon (the naive ``split(":")`` bug); the
+            unquoted form drops the trailing ``:var``; plain and empty paths pass through unchanged.
+        """
+        result = strip_netcdf_subdataset_prefix(spec)
+        assert result == expected, (
+            f"strip({spec!r}) -> {result!r}, expected {expected!r}"
+        )


### PR DESCRIPTION
# Description

Adds lazy `to_xarray(chunks=)` to the NetCDF container and single-sources the GDAL `NETCDF:` subdataset-prefix
parsing. Follow-up to #816 that lands the **`to_xarray` half of ARC-48** deferred there (only the `open_mfdataset`
half shipped). The branch is current with `main` (merged #839 and #840) and also carries two small test fixes that
un-break `main`'s CI.

**1. Lazy `to_xarray(chunks=)` (ARC-48).** `NetCDF.to_xarray()` materialised every variable into RAM. It now
accepts `chunks` (a dict / int / `"auto"`); when given, each data variable is built as a **dask-backed
`DataArray`** via a *raw* (`orient=False`) lazy read, so a file-backed container is assembled without loading
everything up front. The raw read is deliberate — `to_xarray` reads coordinate arrays in the file's native axis
order, so the data must **not** be flipped relative to them. Fallbacks: a variable a chunked read cannot represent
(e.g. a string MDArray like a CF `expver` label) and an in-memory container both fall back to the eager read. The
container's captured cloud config (`_gdal_env`) is threaded into the lazy read so a **signed remote store** re-opens
authenticated (matching `_read_array_lazy`, #839). Lazy reads need the optional `[lazy]` (dask) extra; without
`chunks` the default is unchanged (eager).

**2. Single-source `strip_netcdf_subdataset_prefix` helper.** The GDAL `NETCDF:"path":var` prefix parsing was
duplicated inline across three call sites. It is now one helper in `_mdim.py`, used by `_is_file_backed`, the lazy
read, and `to_xarray`. This also **fixes a latent bug**: `_read_array_lazy` still used the naive
`path.split(":")[1][1:-1]`, which collapses a Windows drive-letter spec (`NETCDF:"C:\…":var`) to an empty path.

**3. Two inherited CI fixes (un-break `main`).** Merging `main` (#840) brought in two failing tests:

- `tests/dataset/ops/test_focal.py::TestEagerAndLazyAgree` used `chunks=` (dask) without `@pytest.mark.lazy`, so
  the no-`[lazy]` wheel `verify-*` / `test-wheels` jobs raised `ImportError` instead of skipping — tagged it
  `@pytest.mark.lazy`.
- `tests/dataset/io/test_window.py::test_equality_and_immutability` had a tautological assertion
  (`Window(0,0,2,2) == Window(0,0,2,2)`) — the sole new bug failing `main`'s SonarCloud reliability gate (S5863);
  rewrote it to compare two distinct instances plus an inequality check.

No dependencies added.

# Issues

- Refs #826 — ARC-48 (completes the deferred `to_xarray` lazy half; the `open_mfdataset` half shipped in #816)

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Non-breaking: `chunks` defaults to `None` (the prior eager behaviour); the public API only gains an optional keyword.

# How Has This Been Tested?

- [x] `tests/netcdf/lazy/test_xarray_interop.py::TestToXarrayLazy` — numeric var dask-backed, computed lazy values
      equal eager (raw orientation preserved), string-var eager fallback, in-memory container ignores `chunks`, and
      the `gdal_env` threading.
- [x] `tests/netcdf/structure/test_mdim.py::TestStripNetcdfSubdatasetPrefix` — quoted Windows/POSIX, unquoted, and
      plain/empty specs.
- [x] `TestEagerAndLazyAgree` runs and passes with dask and auto-skips without it; the `test_window` fix passes and
      clears S5863.
- [x] Full `netcdf` non-plot suite green on this branch; `ruff-check` + `ruff-format` clean.
- [x] Current with `main` (0 behind); #864 CI green including SonarCloud.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.

Versions and the change log are generated by commitizen in CI, so those three boxes are intentionally left for the
release automation.
