### PR TITLE
fix(collection): resolve arc-collection datacube refactor, correctness, and robustness findings

### DIFF
--- a/src/pyramids/base/_locks.py
+++ b/src/pyramids/base/_locks.py
@@ -144,7 +144,7 @@ class DummyLock:
         return False
 
 
-def default_lock() -> Any:
+def default_lock(token: str | None = None) -> Any:
     """Return the right lock for the current execution context.
 
     Probes for a running :class:`dask.distributed.Client`; if one is
@@ -155,6 +155,15 @@ def default_lock() -> Any:
     Does **not** import `dask.distributed` unless a client is
     actually probed, so calling this in a dask-free environment is
     free.
+
+    Args:
+        token: Optional stable identity for the lock. When given, every
+            call with the same `token` resolves to the **same** underlying
+            mutex in this process — a `SerializableLock` sharing one
+            `threading.Lock` via `_LOCKS`, or a distributed `Lock` sharing
+            one cluster-wide name. Pass a resource key (e.g. a file path) so
+            independent callers that touch the same resource serialise on one
+            lock. When `None` (default) a fresh, independent lock is returned.
 
     Returns:
         A lock-protocol object supporting `acquire`, `release`,
@@ -169,6 +178,15 @@ def default_lock() -> Any:
             True
 
             ```
+        - Same token → same underlying mutex, distinct instances aside:
+            ```python
+            >>> from pyramids.base._locks import default_lock
+            >>> default_lock("path/a").lock is default_lock("path/a").lock
+            True
+            >>> default_lock("path/a").lock is default_lock("path/b").lock
+            False
+
+            ```
     """
     try:
         from dask.distributed import Lock as _DistributedLock
@@ -178,9 +196,10 @@ def default_lock() -> Any:
         # is none, which selects the single-process SerializableLock below.
         get_client()
     except (ImportError, ValueError):
-        lock: Any = SerializableLock()
+        lock: Any = SerializableLock(token)
     else:
         # `distributed.Lock` takes no `client` kwarg -- it resolves the ambient
-        # client itself (the same one `get_client()` just returned).
-        lock = _DistributedLock(name=f"pyramids-{uuid.uuid4()}")
+        # client itself (the same one `get_client()` just returned). A stable
+        # `token` names the lock so cluster-wide callers on one resource share it.
+        lock = _DistributedLock(name=f"pyramids-{token or uuid.uuid4()}")
     return lock

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -797,20 +797,9 @@ class DatasetCollection:
 
         reduced = getattr(self.groupby(window_labels), op)(skipna=skipna)
 
-        geo = self._base.geotransform
-        # epsg is None only for a no-EPSG CRS reported as such (a NetCDF geostationary
-        # grid); create_from_array raises CRSError on None, so fall back to the WKT.
-        # A no-EPSG plain Dataset reports 4326, where this is a no-op (#706).
-        epsg = self._base.epsg or self._base.crs
-        no_data_value = self._base.no_data_value[0]
         result: list[tuple[Any, Dataset]] = []
         for label in sorted(reduced):
-            dataset = Dataset.create_from_array(
-                np.asarray(reduced[label]),
-                geo=geo,
-                epsg=epsg,
-                no_data_value=no_data_value,
-            )
+            dataset = self._mem_dataset_from_array(np.asarray(reduced[label]))
             result.append((label, dataset))
         return result
 
@@ -819,6 +808,54 @@ class DatasetCollection:
         func = resolve_dask_op(op_name, skipna=skipna)
         result = func(self.data, axis=0)
         return np.asarray(result.compute())
+
+    def _mem_dataset_from_array(
+        self, arr: np.typing.NDArray, source: Dataset | None = None
+    ) -> Dataset:
+        """Build an in-memory ``Dataset`` from ``arr``, reusing a source's georef.
+
+        Preserves ``arr``'s own dtype — cloning the template would cast through the
+        base's dtype and silently lossy-round (e.g. a float32 base rounding a float64
+        input). ``source`` defaults to the collection's base template; pass a
+        per-timestep dataset (e.g. from :meth:`iloc`) when writing slices at their
+        own georeferencing.
+
+        Args:
+            arr: The array to wrap.
+            source: The ``Dataset`` whose geotransform / CRS / no-data value are
+                copied. Defaults to ``self._base``.
+
+        Returns:
+            Dataset: A new in-memory dataset carrying ``arr``'s dtype and
+            ``source``'s georeferencing.
+        """
+        src = self._base if source is None else source
+        # epsg is None only for a no-EPSG CRS reported as such (a NetCDF geostationary
+        # grid); create_from_array raises CRSError on None, so fall back to the WKT.
+        # No-op for a plain Dataset (reports 4326) (#706).
+        return Dataset.create_from_array(
+            arr,
+            geo=src.geotransform,
+            epsg=src.epsg or src.crs,
+            no_data_value=src.no_data_value[0],
+        )
+
+    def _require_files(self, method: str) -> None:
+        """Guard a method that needs a file-backed collection.
+
+        Args:
+            method: The public method name, interpolated into the error message.
+
+        Raises:
+            RuntimeError: The collection has no ``files`` list (a legacy in-memory
+                cube). The ``data`` property, which also accepts a Zarr-backed cube,
+                keeps its own broader guard.
+        """
+        if self._files is None or len(self._files) == 0:
+            raise RuntimeError(
+                f"DatasetCollection.{method} requires a file-backed collection. "
+                "Use DatasetCollection.from_files(...) to construct one."
+            )
 
     def mean(self, *, skipna: bool = True) -> np.typing.NDArray:
         """Element-wise mean across the time axis.
@@ -944,12 +981,7 @@ class DatasetCollection:
             ImportError: When kerchunk is not installed.
             RuntimeError: When the collection has no files list.
         """
-        if self._files is None or len(self._files) == 0:
-            raise RuntimeError(
-                "DatasetCollection.to_kerchunk requires a file-backed "
-                "collection. Use DatasetCollection.from_files(...) to "
-                "construct one."
-            )
+        self._require_files("to_kerchunk")
         # current backend only handles HDF5 / NetCDF. Detect
         # GeoTIFF inputs and raise a clear NotImplementedError rather
         # than letting kerchunk.hdf produce a confusing failure mode.
@@ -1026,12 +1058,7 @@ class DatasetCollection:
                 installed.
             RuntimeError: When the collection has no files list.
         """
-        if self._files is None or len(self._files) == 0:
-            raise RuntimeError(
-                "DatasetCollection.to_zarr requires a file-backed "
-                "collection. Use DatasetCollection.from_files(...) to "
-                "construct one."
-            )
+        self._require_files("to_zarr")
         import_zarr(
             lazy_extra_hint(
                 "DatasetCollection.to_zarr requires the optional 'zarr' dependency."
@@ -1976,26 +2003,12 @@ class DatasetCollection:
                 f"({self._time_length}, {self.rows}, {self.columns}); "
                 f"please redefine the base Dataset and dataset_length first"
             )
-        # Build a fresh MEM Dataset per timestep using the INPUT
-        # dtype (not the base template's). Cloning the base preserves
-        # geo-ref but forces a dtype cast that silently lossy-rounds
-        # if the base is e.g. float32 and the input is float64.
-        # Using ``Dataset.create_from_array`` gives us the input
-        # dtype back verbatim and reuses the base's georef explicitly.
-        from pyramids.dataset.dataset import Dataset as _Dataset
-
-        new_datasets = []
-        for i in range(val.shape[0]):
-            ds = _Dataset.create_from_array(
-                arr=val[i],
-                geo=self._base.geotransform,
-                # epsg is None only for a no-EPSG CRS reported as such (a NetCDF
-                # geostationary grid); create_from_array raises CRSError on None, so
-                # fall back to the WKT. No-op for a plain Dataset (reports 4326) (#706).
-                epsg=self._base.epsg or self._base.crs,
-                no_data_value=self._base.no_data_value[0],
-            )
-            new_datasets.append(ds)
+        # Build a fresh MEM Dataset per timestep from the INPUT array via
+        # _mem_dataset_from_array (preserves the input dtype instead of casting
+        # through the base template's dtype).
+        new_datasets = [
+            self._mem_dataset_from_array(val[i]) for i in range(val.shape[0])
+        ]
         self._datasets = new_datasets
         self._time_length = val.shape[0]
         self._files = None
@@ -2058,22 +2071,11 @@ class DatasetCollection:
                 f"index along the time axis; got {type(key).__name__}. "
                 f"Rebuild the collection if you need bulk replacement."
             )
-        # Materialise the cache (so we have a list to modify) without
-        # building the full cube. Use ``create_from_array`` so the
-        # input array's dtype is preserved (CreateCopy on the base
-        # would cast through whatever dtype the base happened to use).
-        from pyramids.dataset.dataset import Dataset as _Dataset
-
+        # Materialise the cache (so we have a list to modify) without building the
+        # full cube. _mem_dataset_from_array preserves the input array's dtype (a
+        # CreateCopy on the base would cast through the base's dtype).
         datasets = self.datasets
-        datasets[key] = _Dataset.create_from_array(
-            arr=value,
-            geo=self._base.geotransform,
-            # epsg is None only for a no-EPSG CRS reported as such (a NetCDF
-            # geostationary grid); create_from_array raises CRSError on None, so fall
-            # back to the WKT. No-op for a plain Dataset (reports 4326) (#706).
-            epsg=self._base.epsg or self._base.crs,
-            no_data_value=self._base.no_data_value[0],
-        )
+        datasets[key] = self._mem_dataset_from_array(value)
         # The mutation breaks the disk correspondence for that slot;
         # if the user mutates any timestep, the lazy reductions can no
         # longer trust ``_files``. Drop the path list so they fall
@@ -2461,16 +2463,7 @@ class DatasetCollection:
 
         for i in range(self.time_length):
             src = self.iloc(i)
-            arr = src.read_array()
-            transient = Dataset.create_from_array(
-                arr=arr,
-                geo=src.geotransform,
-                # epsg is None only for a no-EPSG CRS reported as such (a NetCDF
-                # geostationary grid); create_from_array raises CRSError on None, so
-                # fall back to the WKT. No-op for a plain Dataset (reports 4326) (#706).
-                epsg=src.epsg or src.crs,
-                no_data_value=src.no_data_value[0],
-            )
+            transient = self._mem_dataset_from_array(src.read_array(), source=src)
             transient.to_file(path[i], band=band)
             transient.close()
         self._datasets = None

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -354,6 +354,11 @@ def _read_time_step(
     return np.ascontiguousarray(arr)
 
 
+# Above this in-RAM (T, B, Y, X) size, DatasetCollection.to_netcdf warns and points
+# the caller at the streaming to_zarr writer (ARC-46). Default 2 GiB.
+_TO_NETCDF_WARN_BYTES = 2 * 1024**3
+
+
 class DatasetCollection:
     """Time-stacked collection of co-registered rasters.
 
@@ -1323,6 +1328,20 @@ class DatasetCollection:
             else [f"band_{i + 1}" for i in range(band_count)]
         )
 
+        # ARC-46: this writer stacks the whole (T, B, Y, X) cube in RAM and xarray
+        # copies it again. Warn (pointing at the streaming to_zarr writer) when that
+        # allocation would be large, rather than OOM without explanation.
+        est_bytes = (
+            self.time_length * int(np.prod(meta.shape)) * np.dtype(meta.dtype).itemsize
+        )
+        if est_bytes > _TO_NETCDF_WARN_BYTES:
+            warnings.warn(
+                f"DatasetCollection.to_netcdf materialises the full (T, B, Y, X) cube "
+                f"in memory (~{est_bytes / 1024**3:.1f} GiB here, then copied again by "
+                f"xarray). For large cubes prefer DatasetCollection.to_zarr, which "
+                f"streams the cube chunk-by-chunk.",
+                stacklevel=2,
+            )
         # Per-timestep read_array() returns (rows, cols) for a single-band
         # dataset and (bands, rows, cols) for multi-band, so np.stack gives
         # (T, rows, cols) or (T, bands, rows, cols). Insert a length-1 band
@@ -2091,8 +2110,23 @@ class DatasetCollection:
         for ds in self.datasets:
             yield ds.read_array(band=0)
 
+    def _stack_band0(self, datasets: list[Dataset]) -> np.typing.NDArray:
+        """Stack band 0 of each dataset into a ``(len, rows, cols)`` cube.
+
+        Empty-safe: an empty selection returns a ``(0, rows, cols)`` array rather
+        than tripping ``np.stack``'s "need at least one array" error. Lets
+        :meth:`head`/:meth:`tail` read only the selected timesteps instead of
+        materialising the whole cube via :attr:`values`.
+        """
+        if not datasets:
+            return np.empty((0, self.rows, self.columns))
+        return np.stack([ds.read_array(band=0) for ds in datasets], axis=0)
+
     def head(self, n: int = 5) -> np.typing.NDArray:
         """First ``n`` timestep arrays as a 3D numpy slice.
+
+        Reads only the first ``n`` timesteps (slicing :attr:`datasets` before
+        reading), not the whole cube.
 
         Args:
             n (int): Number of timesteps. Defaults to 5.
@@ -2100,25 +2134,27 @@ class DatasetCollection:
         Returns:
             np.ndarray: ``(min(n, time_length), rows, cols)`` array.
         """
-        return self.values[:n]
+        return self._stack_band0(self.datasets[:n])
 
     def tail(self, n: int = -5) -> np.typing.NDArray:
-        """Last ``-n`` timestep arrays as a 3D numpy slice.
+        """Last ``abs(n)`` timestep arrays as a 3D numpy slice.
 
-        Matches the legacy signature: a NEGATIVE ``n`` (the default
-        ``-5``) means "last 5". Implementation simply does
-        ``self.values[n:]``, so a positive ``n`` would skip the first
-        ``n`` rows instead — that's the legacy behaviour and left as
-        is for back-compat.
+        Returns the last ``abs(n)`` timesteps regardless of the sign of ``n`` — so
+        both ``tail(5)`` and the legacy default ``tail(-5)`` give the last 5 — and
+        reads only those timesteps rather than materialising the whole cube.
+
+        Note: this corrects the previous behaviour where a *positive* ``n`` skipped
+        the first ``n`` rows instead of returning the last ``n`` (ARC-46).
 
         Args:
-            n (int): Negative integer giving the offset from the
-                end. Defaults to ``-5`` (last 5).
+            n (int): Number of trailing timesteps; the sign is ignored. Defaults to
+                ``-5`` (last 5).
 
         Returns:
-            np.ndarray: ``(abs(n), rows, cols)`` array (when ``n < 0``).
+            np.ndarray: ``(min(abs(n), time_length), rows, cols)`` array.
         """
-        return self.values[n:]
+        keep = min(abs(n), self.time_length)
+        return self._stack_band0(self.datasets[self.time_length - keep :])
 
     def first(self) -> np.typing.NDArray:
         """First timestep array (2D).

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -1777,33 +1777,46 @@ class DatasetCollection:
     def _validate_headers(
         files: list[str], meta: RasterMeta, gdal_env: dict[str, str] | None
     ) -> None:
-        """Check every file's ``(band, rows, cols)`` shape and dtype match ``meta``.
+        """Check every file's header (shape, dtype, geotransform, CRS) matches ``meta``.
 
         Reads each file's header only (no pixels) and raises :class:`AlignmentError`
-        on the first mismatch, naming the offending path — so a heterogeneous input
-        fails at construction instead of silently corrupting the lazy cube (the dask
-        assembly trusts the first file's shape/dtype). Opt-in via
+        on the first mismatch, naming the offending path — so a heterogeneous or
+        misaligned input fails at construction instead of silently corrupting the lazy
+        cube (which stacks per-file pixels positionally and stamps only the first
+        file's geobox on every timestep). Geotransform and CRS are checked as well as
+        shape/dtype, since two same-shape rasters with a shifted extent or a different
+        CRS would otherwise mis-georeference the cube. Opt-in via
         ``from_files(validate=True)`` because it touches every file.
 
         Raises:
-            AlignmentError: A file's header does not match ``meta``.
+            AlignmentError: A file's shape, dtype, geotransform, or CRS does not match
+                the template.
         """
-        expected = (meta.shape, str(np.dtype(meta.dtype)))
+        expected_dtype = str(np.dtype(meta.dtype))
         with cloud_config_from_env(gdal_env):
             for path in files:
                 ds = Dataset.read_file(path, gdal_env=gdal_env)
                 try:
-                    file_meta = RasterMeta.from_dataset(ds)
+                    fm = RasterMeta.from_dataset(ds)
                 finally:
                     ds.close()
-                got = (file_meta.shape, str(np.dtype(file_meta.dtype)))
-                if got != expected:
-                    raise AlignmentError(
-                        f"header mismatch in {path!r}: shape/dtype {got[0]}/{got[1]} "
-                        f"does not match the collection template "
-                        f"{expected[0]}/{expected[1]}. All files in a "
-                        f"DatasetCollection must share (band, rows, cols) and dtype."
-                    )
+                if fm.shape != meta.shape:
+                    mismatch = f"shape {fm.shape} != {meta.shape}"
+                elif str(np.dtype(fm.dtype)) != expected_dtype:
+                    mismatch = f"dtype {np.dtype(fm.dtype)} != {expected_dtype}"
+                elif not np.allclose(
+                    fm.transform, meta.transform, rtol=1e-9, atol=1e-6
+                ):
+                    mismatch = f"geotransform {fm.transform} != {meta.transform}"
+                elif fm.crs != meta.crs:
+                    mismatch = f"CRS {fm.crs.to_string()} != {meta.crs.to_string()}"
+                else:
+                    continue
+                raise AlignmentError(
+                    f"header mismatch in {path!r}: {mismatch}. All files in a "
+                    f"DatasetCollection must share (band, rows, cols), dtype, "
+                    f"geotransform, and CRS."
+                )
 
     @classmethod
     def from_zarr(

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -14,7 +14,7 @@ import numpy as np
 import pandas as pd
 
 from pyramids import _io
-from pyramids.base._errors import OptionalPackageDoesNotExist
+from pyramids.base._errors import AlignmentError, OptionalPackageDoesNotExist
 from pyramids.base._file_manager import CachingFileManager, gdal_raster_open
 from pyramids.base._raster_meta import RasterMeta
 from pyramids.base._utils import (
@@ -259,12 +259,28 @@ def _finalize_append_metadata(
         zarr.consolidate_metadata(resolved_store)
 
 
-def _finalize_append_after_write(
-    data_result, resolved_store, new_time_length, added_files
+def _append_region(
+    data, resolved_store, old_t: int, new_total: int, slices, added_files
 ) -> None:
-    """Run :func:`_finalize_append_metadata` after the appended data write."""
-    del data_result
-    _finalize_append_metadata(resolved_store, new_time_length, added_files)
+    """Atomically grow, write, and finalize a zarr time-append (ARC-75a).
+
+    The deferred (``compute=False``) append routes through this single task so the
+    store's ``data`` shape only grows when the append actually runs; on any failure
+    the resize is rolled back, so the store never advertises a larger shape than it
+    holds. ``data`` (one collection's block) is materialised here before the write.
+    Module-level so the :func:`dask.delayed` graph can pickle it.
+    """
+    import zarr
+
+    root = zarr.open_group(resolved_store, mode="a")
+    arr = root["data"]
+    arr.resize((new_total, *arr.shape[1:]))
+    try:
+        arr[slices] = np.asarray(data)
+        _finalize_append_metadata(resolved_store, new_total, added_files)
+    except Exception:
+        arr.resize((old_t, *arr.shape[1:]))
+        raise
 
 
 def _region_to_slices(region: dict, ndim: int) -> tuple:
@@ -1142,20 +1158,26 @@ class DatasetCollection:
             )
         old_t = int(existing.shape[0])
         new_total = old_t + int(data.shape[0])
-        existing.resize((new_total, *existing.shape[1:]))
         slices = (slice(old_t, new_total),) + (slice(None),) * (data.ndim - 1)
-        # dask's region write targets the zarr.Array directly (not store+component).
-        write_result = data.to_zarr(
-            existing,
-            region=slices,
-            overwrite=False,
-            compute=compute,
-        )
+
         if compute:
-            _finalize_append_metadata(resolved_store, new_total, self._files)
+            # Grow the time axis, stream the append, then finalize. On any failure
+            # roll the resize back so the store never advertises a larger shape than
+            # it holds (ARC-75a). dask's region write targets the zarr.Array directly.
+            existing.resize((new_total, *existing.shape[1:]))
+            try:
+                data.to_zarr(existing, region=slices, overwrite=False, compute=True)
+                _finalize_append_metadata(resolved_store, new_total, self._files)
+            except Exception:
+                existing.resize((old_t, *existing.shape[1:]))
+                raise
             return None
-        return dask.delayed(_finalize_append_after_write)(
-            write_result, resolved_store, new_total, self._files
+
+        # compute=False: defer the resize+write+finalize into one delayed so the
+        # store's shape only grows when the append actually runs (rolling back on
+        # failure) — no window where a grown-but-empty store is visible (ARC-75a).
+        return dask.delayed(_append_region)(
+            data, resolved_store, old_t, new_total, slices, self._files
         )
 
     def to_netcdf(
@@ -1590,6 +1612,7 @@ class DatasetCollection:
         *,
         meta: RasterMeta | None = None,
         gdal_env: dict[str, str] | None = None,
+        validate: bool = False,
     ) -> DatasetCollection:
         """Build a collection from a list of files without pre-opening all.
 
@@ -1608,6 +1631,12 @@ class DatasetCollection:
                 files, including the eager template open below. Persisted
                 on the collection for the lazy read paths. `None` (default)
                 installs no extra config.
+            validate: When `True`, open every file's header (no pixel read) and check
+                its `(band, rows, cols)` shape and dtype against the template — a
+                heterogeneous file raises `AlignmentError` at construction instead of
+                silently corrupting the lazy cube (whose dask assembly trusts the
+                first file's shape/dtype). Defaults to `False`, preserving the lazy
+                "only open the first file" design.
 
         Returns:
             DatasetCollection: A new collection whose `time_length`
@@ -1615,6 +1644,8 @@ class DatasetCollection:
 
         Raises:
             ValueError: When `files` is empty.
+            AlignmentError: When `validate=True` and a file's header does not match
+                the template's shape/dtype.
         """
         resolved = [str(p) for p in files]
         if not resolved:
@@ -1627,9 +1658,43 @@ class DatasetCollection:
             template = Dataset.read_file(resolved[0], gdal_env=gdal_env)
             if meta is None:
                 meta = RasterMeta.from_dataset(template)
+        if validate:
+            cls._validate_headers(resolved, meta, gdal_env)
         return cls(
             template, len(resolved), files=resolved, meta=meta, gdal_env=gdal_env
         )
+
+    @staticmethod
+    def _validate_headers(
+        files: list[str], meta: RasterMeta, gdal_env: dict[str, str] | None
+    ) -> None:
+        """Check every file's ``(band, rows, cols)`` shape and dtype match ``meta``.
+
+        Reads each file's header only (no pixels) and raises :class:`AlignmentError`
+        on the first mismatch, naming the offending path — so a heterogeneous input
+        fails at construction instead of silently corrupting the lazy cube (the dask
+        assembly trusts the first file's shape/dtype). Opt-in via
+        ``from_files(validate=True)`` because it touches every file.
+
+        Raises:
+            AlignmentError: A file's header does not match ``meta``.
+        """
+        expected = (meta.shape, str(np.dtype(meta.dtype)))
+        with cloud_config_from_env(gdal_env):
+            for path in files:
+                ds = Dataset.read_file(path, gdal_env=gdal_env)
+                try:
+                    file_meta = RasterMeta.from_dataset(ds)
+                finally:
+                    ds.close()
+                got = (file_meta.shape, str(np.dtype(file_meta.dtype)))
+                if got != expected:
+                    raise AlignmentError(
+                        f"header mismatch in {path!r}: shape/dtype {got[0]}/{got[1]} "
+                        f"does not match the collection template "
+                        f"{expected[0]}/{expected[1]}. All files in a "
+                        f"DatasetCollection must share (band, rows, cols) and dtype."
+                    )
 
     @classmethod
     def from_zarr(

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -2858,7 +2858,10 @@ class DatasetCollection:
                 the whole reproject into one `dask.delayed.Delayed` that builds the
                 reprojected `DatasetCollection` when computed — so a many-raster
                 collection reprojects in a single graph (ARC-54). Keyword-only;
-                cannot be combined with `inplace=True`.
+                cannot be combined with `inplace=True`. The deferred results are
+                MEM-backed (in-memory GDAL warps) and so cannot be pickled to
+                `dask.distributed` workers — compute it on the local / threaded
+                scheduler.
 
         Returns:
             DatasetCollection | None | dask.delayed.Delayed: A new collection when
@@ -3016,7 +3019,9 @@ class DatasetCollection:
                 If True (default), align every timestep eagerly. If False, defer the
                 whole align into one `dask.delayed.Delayed` that builds the aligned
                 `DatasetCollection` when computed (ARC-54). Keyword-only; cannot be
-                combined with `inplace=True`.
+                combined with `inplace=True`. The deferred results are MEM-backed and
+                cannot be pickled to `dask.distributed` workers — compute it on the
+                local / threaded scheduler.
 
         Returns:
             DatasetCollection | None | dask.delayed.Delayed: A new collection when

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -272,9 +272,18 @@ def _append_region(
     store's ``data`` shape only grows when the append actually runs; on any failure
     the resize is rolled back, so the store never advertises a larger shape than it
     holds. ``data`` stays a lazy dask array and is **streamed** into the region via
-    ``data.to_zarr(..., compute=True)`` — never materialising the whole appended cube
-    (M2). The caller must keep ``data`` lazy (capture it in a closure), not pass it as
-    a delayed argument (which dask would compute up front).
+    ``to_zarr(..., compute=False)`` (never materialising the whole appended cube, M2).
+    The caller must keep ``data`` lazy (capture it in a closure), not pass it as a
+    delayed argument (which dask would compute up front).
+
+    This function runs *inside* a ``dask.delayed`` task, so it drives the region write
+    with an explicit ``scheduler="synchronous"`` compute: a nested threaded /
+    distributed compute from within a running task can deadlock (a worker thread
+    blocking on the same pool while several deferred appends are computed together).
+    The synchronous scheduler runs the write inline in this task's thread — still
+    streaming tile-by-tile — so the deferred append is safe under any outer scheduler
+    (M1). Passing the scheduler to ``.compute`` keeps the choice call-local (no global
+    ``dask.config`` mutation that could race with sibling tasks).
     """
     import zarr
 
@@ -286,7 +295,8 @@ def _append_region(
         raise TypeError(f"expected a zarr Array at 'data' in {resolved_store!r}")
     arr.resize((new_total, *arr.shape[1:]))
     try:
-        data.to_zarr(arr, region=slices, overwrite=False, compute=True)
+        store_task = data.to_zarr(arr, region=slices, overwrite=False, compute=False)
+        store_task.compute(scheduler="synchronous")
         _finalize_append_metadata(resolved_store, new_total, added_files)
     except Exception:
         arr.resize((old_t, *arr.shape[1:]))
@@ -1125,7 +1135,11 @@ class DatasetCollection:
         Args:
             store: Target store (path, fsspec URL, or zarr.Store).
             compute: `True` (default) writes immediately; `False`
-                returns a :class:`dask.delayed.Delayed`.
+                returns a :class:`dask.delayed.Delayed`. For an ``append_dim``
+                write the deferred task streams the region write on the
+                synchronous scheduler internally, so the returned `Delayed` is
+                safe to compute under any scheduler (threaded / distributed)
+                without a nested-compute deadlock.
             mode: Zarr open mode. ``"w"`` (default) writes a fresh cube;
                 ``"a"`` is only valid together with ``append_dim`` or ``region``
                 (incremental writes — see those args). ``mode="a"`` on its own
@@ -1249,7 +1263,9 @@ class DatasetCollection:
         # `data` in a closure so it stays a lazy dask array streamed inside the write
         # (M2) — passing it as a delayed argument would make dask compute the whole
         # appended cube into memory first. No window where a grown-but-empty store is
-        # visible, and rollback on failure (ARC-75a).
+        # visible, and rollback on failure (ARC-75a). _append_region drives the inner
+        # write with scheduler="synchronous" so computing this Delayed can't deadlock
+        # under a threaded/distributed outer scheduler (M1).
         files = self._files
 
         @dask.delayed

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -284,6 +284,11 @@ def _append_region(
     streaming tile-by-tile — so the deferred append is safe under any outer scheduler
     (M1). Passing the scheduler to ``.compute`` keeps the choice call-local (no global
     ``dask.config`` mutation that could race with sibling tasks).
+
+    Idempotent under recompute: a dask ``Delayed`` re-executes on every ``.compute()``.
+    If a prior successful compute already grew the store to ``new_total``, this returns
+    early instead of re-writing and double-appending to ``pyramids_file_list`` (L2); a
+    prior *failed* compute rolled the resize back to ``old_t``, so a retry proceeds.
     """
     import zarr
 
@@ -293,6 +298,13 @@ def _append_region(
         arr, zarr.Array
     ):  # to_zarr writes 'data' as an Array, not a Group
         raise TypeError(f"expected a zarr Array at 'data' in {resolved_store!r}")
+    if int(arr.shape[0]) == new_total:
+        # dask Delayeds re-execute on every .compute(); a prior successful compute of
+        # THIS append already grew the store to new_total and finalized. Make a
+        # recompute a no-op so it doesn't double-append to pyramids_file_list (L2). A
+        # failed prior compute rolled the resize back to old_t, so a retry still finds
+        # old_t here and proceeds normally.
+        return
     arr.resize((new_total, *arr.shape[1:]))
     try:
         store_task = data.to_zarr(arr, region=slices, overwrite=False, compute=False)

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -274,6 +274,10 @@ def _append_region(
 
     root = zarr.open_group(resolved_store, mode="a")
     arr = root["data"]
+    if not isinstance(
+        arr, zarr.Array
+    ):  # to_zarr writes 'data' as an Array, not a Group
+        raise TypeError(f"expected a zarr Array at 'data' in {resolved_store!r}")
     arr.resize((new_total, *arr.shape[1:]))
     try:
         arr[slices] = np.asarray(data)
@@ -861,11 +865,15 @@ class DatasetCollection:
             no_data_value=src.no_data_value[0],
         )
 
-    def _require_files(self, method: str) -> None:
+    def _require_files(self, method: str) -> list[str]:
         """Guard a method that needs a file-backed collection.
 
         Args:
             method: The public method name, interpolated into the error message.
+
+        Returns:
+            list[str]: The collection's non-empty ``files`` list (also narrows the
+            type for the caller).
 
         Raises:
             RuntimeError: The collection has no ``files`` list (a legacy in-memory
@@ -877,6 +885,7 @@ class DatasetCollection:
                 f"DatasetCollection.{method} requires a file-backed collection. "
                 "Use DatasetCollection.from_files(...) to construct one."
             )
+        return self._files
 
     def mean(self, *, skipna: bool = True) -> np.typing.NDArray:
         """Element-wise mean across the time axis.
@@ -1002,14 +1011,14 @@ class DatasetCollection:
             ImportError: When kerchunk is not installed.
             RuntimeError: When the collection has no files list.
         """
-        self._require_files("to_kerchunk")
+        files = self._require_files("to_kerchunk")
         # current backend only handles HDF5 / NetCDF. Detect
         # GeoTIFF inputs and raise a clear NotImplementedError rather
         # than letting kerchunk.hdf produce a confusing failure mode.
         geotiff_exts = {".tif", ".tiff", ".cog"}
         geotiff_files = [
             p
-            for p in self._files
+            for p in files
             if any(str(p).lower().endswith(ext) for ext in geotiff_exts)
         ]
         if geotiff_files:
@@ -1023,7 +1032,7 @@ class DatasetCollection:
         from pyramids.netcdf._kerchunk_facade import combine_kerchunk
 
         return combine_kerchunk(
-            self._files,
+            files,
             output_path,
             concat_dims=(concat_dim,),
             identical_dims=(),
@@ -1079,7 +1088,7 @@ class DatasetCollection:
                 installed.
             RuntimeError: When the collection has no files list.
         """
-        self._require_files("to_zarr")
+        files = self._require_files("to_zarr")
         import_zarr(
             lazy_extra_hint(
                 "DatasetCollection.to_zarr requires the optional 'zarr' dependency."
@@ -1118,7 +1127,7 @@ class DatasetCollection:
             **codec_kwargs,
         )
         if compute:
-            _finalize_collection_metadata(resolved_store, self._meta, self._files)
+            _finalize_collection_metadata(resolved_store, self._meta, files)
             result: Any = None
         else:
             import dask
@@ -1127,7 +1136,7 @@ class DatasetCollection:
                 write_result,
                 resolved_store,
                 self._meta,
-                self._files,
+                files,
             )
         return result
 

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -17,6 +17,7 @@ from pyproj import CRS
 from pyramids import _io
 from pyramids.base._errors import AlignmentError, OptionalPackageDoesNotExist
 from pyramids.base._file_manager import CachingFileManager, gdal_raster_open
+from pyramids.base._locks import default_lock
 from pyramids.base._raster_meta import RasterMeta
 from pyramids.base._utils import (
     DEFAULT_RESAMPLING,
@@ -39,6 +40,7 @@ from pyramids.dataset.ops._geobox_zarr import (
     read_geobox,
 )
 from pyramids.dataset.ops._zarr import _resolve_store
+from pyramids.dataset.ops.io import _read_chunk
 from pyramids.feature import FeatureCollection
 
 if TYPE_CHECKING:
@@ -377,7 +379,9 @@ def _read_time_step(
     return np.ascontiguousarray(arr)
 
 
-def _lazy_timestep(path: str | Path, meta: RasterMeta, gdal_env: dict[str, str] | None):
+def _lazy_timestep(
+    path: str | Path, meta: RasterMeta, gdal_env: dict[str, str] | None, lock: Any
+):
     """Build a spatially-tiled ``(B, Y, X)`` dask array for one timestep (ARC-45).
 
     Reuses :func:`pyramids.dataset.ops.io._read_chunk`, so each dask block reads only
@@ -394,15 +398,15 @@ def _lazy_timestep(path: str | Path, meta: RasterMeta, gdal_env: dict[str, str] 
             block size), assumed uniform across timesteps.
         gdal_env: The collection's persisted signer GDAL config, installed inside each
             worker around the open + read (a no-op when empty).
+        lock: The IO lock guarding this file's shared GDAL handle. Callers pass one
+            lock per distinct path so duplicate-path timesteps (which share a
+            `FILE_CACHE` slot) serialise their tile reads on the same handle (L4).
 
     Returns:
         dask.array.Array: A lazy ``(B, Y, X)`` array tiled on the spatial axes.
     """
     import dask.array as da
     from dask.array.core import normalize_chunks
-
-    from pyramids.base._locks import default_lock
-    from pyramids.dataset.ops.io import _read_chunk
 
     band_count, rows, cols = meta.shape
     dtype = np.dtype(meta.dtype)
@@ -422,7 +426,7 @@ def _lazy_timestep(path: str | Path, meta: RasterMeta, gdal_env: dict[str, str] 
         dtype=dtype,
         meta=np.empty((0, 0, 0), dtype=dtype),
         manager=manager,
-        lock=default_lock(),
+        lock=lock,
         band=None,
         out_dtype=dtype,
         single_band=False,
@@ -670,6 +674,9 @@ class DatasetCollection:
                     ]
             else:
                 self._datasets = [self._base] * self._time_length
+            # The bulk list supersedes the per-index point-accessor cache; drop it so
+            # a file opened by first/last/iloc is not held open twice (L2).
+            self._handle_cache.clear()
         return self._datasets
 
     def _dataset_at(self, i: int) -> Dataset:
@@ -1067,7 +1074,18 @@ class DatasetCollection:
         # ARC-45: build each timestep as a spatially-tiled dask array (windowed reads
         # via _read_chunk) and stack along time, so a reduction tiles spatially and a
         # single raster larger than RAM is read tile-by-tile instead of all at once.
-        per_step = [_lazy_timestep(path, meta, self._gdal_env) for path in self._files]
+        # One IO lock per distinct path (L4): duplicate paths share a FILE_CACHE
+        # handle, so their tile reads must serialise on the same lock.
+        path_locks: dict[str, Any] = {}
+        per_step = [
+            _lazy_timestep(
+                path,
+                meta,
+                self._gdal_env,
+                path_locks.setdefault(str(path), default_lock()),
+            )
+            for path in self._files
+        ]
         return da.stack(per_step, axis=0)
 
     @property

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -322,64 +322,6 @@ def _finalize_after_write(data_result, resolved_store, meta, files) -> None:
     _finalize_collection_metadata(resolved_store, meta, files)
 
 
-def _read_time_step(
-    path: str | Path, gdal_env: dict[str, str] | None = None
-) -> np.typing.NDArray:
-    """Synchronous per-file reader used by the lazy `data` dask graph.
-
-    Module-level (not a closure) so each
-    :func:`dask.delayed` task pickles as `(_read_time_step, path, gdal_env)`
-    — no live GDAL handle crosses the wire, only the path and a plain
-    config dict.
-
-    Args:
-        path: The backing file path for this timestep.
-        gdal_env: H4 — the collection's persisted signer GDAL config
-            (Requester-Pays / bearer / SAS), installed inside the worker
-            around the open + read so a signed file-backed collection
-            authenticates its Path B reads. A no-op when empty/`None`
-            (the common, unsigned case pays nothing).
-
-    Routes the per-file open through a fresh
-    :class:`CachingFileManager` whose `manager_id` is the path
-    itself, so two calls for the same path resolve to the same
-    :data:`FILE_CACHE` slot and share one cached `gdal.Dataset`.
-    The shared LRU bounds open file descriptors (default 128,
-    overridable via `PYRAMIDS_FILE_CACHE_MAXSIZE`) and evicts the
-    least-recently-used handle when full — so a long-running
-    process scanning many file lists no longer leaks handles or
-    manager objects.
-
-    The path is normalised to ``str`` before key construction so
-    callers passing ``pathlib.Path`` and ``str`` for the same file
-    hit one cache slot, not two — avoiding silent FILE_CACHE
-    fragmentation under mixed-type call sites.
-
-    The read runs inside :meth:`CachingFileManager.acquire_context`,
-    which pins the cache slot: a cube of more than ``maxsize`` files
-    keeps the LRU under constant pressure, and an unpinned handle can
-    be evicted and closed by another worker's insert while this read
-    is still going through it.
-    """
-    path = str(path)
-    with cloud_config_from_env(gdal_env):
-        manager = CachingFileManager(
-            gdal_raster_open,
-            path,
-            "read_only",
-            lock=False,
-            manager_id=path,
-        )
-        with manager.acquire_context() as handle:
-            band_count = handle.RasterCount
-            if band_count == 1:
-                arr = handle.GetRasterBand(1).ReadAsArray()
-                arr = arr[np.newaxis, :, :]
-            else:
-                arr = handle.ReadAsArray()
-    return np.ascontiguousarray(arr)
-
-
 def _lazy_timestep(
     path: str | Path, meta: RasterMeta, gdal_env: dict[str, str] | None, lock: Any
 ):
@@ -501,8 +443,8 @@ class DatasetCollection:
     Path B — dask graph over file paths (``self._files``)
         Backing store is a list of file path strings. The ``data``
         property assembles a ``dask.array.Array`` of shape
-        ``(time, bands, rows, cols)`` from
-        ``[dask.delayed(_read_time_step)(p) for p in self._files]``.
+        ``(time, bands, rows, cols)`` by stacking a spatially-tiled
+        per-timestep array (:func:`_lazy_timestep`) along time.
         Workers re-open each path on demand via a process-cached
         ``CachingFileManager`` — gdal handles never cross the
         pickle boundary, only path strings do. This is what makes

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -374,6 +374,59 @@ def _read_time_step(
     return np.ascontiguousarray(arr)
 
 
+def _lazy_timestep(path: str | Path, meta: RasterMeta, gdal_env: dict[str, str] | None):
+    """Build a spatially-tiled ``(B, Y, X)`` dask array for one timestep (ARC-45).
+
+    Reuses :func:`pyramids.dataset.ops.io._read_chunk`, so each dask block reads only
+    its own window (``ReadAsArray(xoff, yoff, xsize, ysize)``) through a path-keyed
+    :class:`CachingFileManager`. Stacking these along time gives a ``(T, B, Y, X)``
+    cube tiled on ``(Y, X)`` — so a time-axis reduction tiles spatially instead of
+    holding whole rasters, and a single raster larger than RAM is read tile-by-tile
+    instead of failing outright. Module-level so the graph stays pickle-safe (only
+    the path + config dict cross the wire).
+
+    Args:
+        path: The backing file for this timestep.
+        meta: The collection's picklable :class:`RasterMeta` (shape / dtype / native
+            block size), assumed uniform across timesteps.
+        gdal_env: The collection's persisted signer GDAL config, installed inside each
+            worker around the open + read (a no-op when empty).
+
+    Returns:
+        dask.array.Array: A lazy ``(B, Y, X)`` array tiled on the spatial axes.
+    """
+    import dask.array as da
+    from dask.array.core import normalize_chunks
+
+    from pyramids.base._locks import default_lock
+    from pyramids.dataset.ops.io import _read_chunk
+
+    band_count, rows, cols = meta.shape
+    dtype = np.dtype(meta.dtype)
+    block_w, block_h = meta.block_size[0] if meta.block_size else (cols, rows)
+    normalized = normalize_chunks(
+        "auto",
+        shape=(band_count, rows, cols),
+        dtype=dtype,
+        previous_chunks=(1, block_h, block_w),
+    )
+    manager = CachingFileManager(
+        gdal_raster_open, str(path), "read_only", lock=False, manager_id=str(path)
+    )
+    return da.map_blocks(
+        _read_chunk,
+        chunks=normalized,
+        dtype=dtype,
+        meta=np.empty((0, 0, 0), dtype=dtype),
+        manager=manager,
+        lock=default_lock(),
+        band=None,
+        out_dtype=dtype,
+        single_band=False,
+        gdal_env=gdal_env or None,
+    )
+
+
 # Above this in-RAM (T, B, Y, X) size, DatasetCollection.to_netcdf warns and points
 # the caller at the streaming to_zarr writer (ARC-46). Default 2 GiB.
 _TO_NETCDF_WARN_BYTES = 2 * 1024**3
@@ -958,12 +1011,12 @@ class DatasetCollection:
     def data(self) -> Any:
         """Return a lazy `dask.array.Array` of shape `(T, B, R, C)`.
 
-        Each per-file read is scheduled as a
-        :func:`dask.delayed` task that opens the file via
-        :class:`~pyramids.base._file_manager.CachingFileManager`
-         and reads its full array. Workers therefore never
-        serialise a `gdal.Dataset` — only the file path crosses the
-        pickle boundary, which keeps the graph safe under dask.distributed.
+        Each timestep is a spatially-tiled dask array whose blocks read only their
+        own window via :class:`~pyramids.base._file_manager.CachingFileManager`
+        (see :func:`_lazy_timestep`), stacked along time — so a time-axis reduction
+        tiles spatially and a raster larger than RAM is read tile-by-tile rather than
+        all at once. Workers never serialise a `gdal.Dataset`; only the file path
+        crosses the pickle boundary, keeping the graph safe under dask.distributed.
 
         Raises:
             ImportError: If the optional `dask` extra is not
@@ -978,7 +1031,6 @@ class DatasetCollection:
                 "DatasetCollection.from_zarr(...) to construct one."
             )
         try:
-            import dask
             import dask.array as da
         except ImportError as exc:
             raise OptionalPackageDoesNotExist(
@@ -994,13 +1046,11 @@ class DatasetCollection:
         # self._zarr_store is None.
         assert self._files is not None
         meta = self._meta
-        shape = meta.shape
-        dtype = np.dtype(meta.dtype)
-        delayed_reads = [
-            dask.delayed(_read_time_step)(path, self._gdal_env) for path in self._files
-        ]
-        arrays = [da.from_delayed(d, shape=shape, dtype=dtype) for d in delayed_reads]
-        return da.stack(arrays, axis=0)
+        # ARC-45: build each timestep as a spatially-tiled dask array (windowed reads
+        # via _read_chunk) and stack along time, so a reduction tiles spatially and a
+        # single raster larger than RAM is read tile-by-tile instead of all at once.
+        per_step = [_lazy_timestep(path, meta, self._gdal_env) for path in self._files]
+        return da.stack(per_step, axis=0)
 
     @property
     def meta(self) -> RasterMeta:

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -547,6 +547,10 @@ class DatasetCollection:
         self._datasets: list[Dataset] | None = (
             list(datasets) if datasets is not None else None
         )
+        # Lazy per-index handle cache for the point accessors (first/last/iloc/[i]),
+        # so reading one timestep opens one file instead of all N via `datasets`
+        # (ARC-44). Only used before the bulk `_datasets` list is materialised.
+        self._handle_cache: dict[int, Dataset] = {}
 
     def __getstate__(self):
         """Pickle state — drop the lazy `_datasets` cache.
@@ -558,6 +562,7 @@ class DatasetCollection:
         """
         state = self.__dict__.copy()
         state["_datasets"] = None
+        state["_handle_cache"] = {}
         return state
 
     @property
@@ -595,6 +600,35 @@ class DatasetCollection:
             else:
                 self._datasets = [self._base] * self._time_length
         return self._datasets
+
+    def _dataset_at(self, i: int) -> Dataset:
+        """Return the single timestep at index ``i``, opening only that file (ARC-44).
+
+        For a file-backed collection this opens (and caches) just index ``i``'s
+        handle instead of materialising all N via the :attr:`datasets` property — so
+        :meth:`first` / :meth:`last` / :meth:`iloc` / ``collection[i]`` read one file,
+        not the whole set. Once the bulk cache exists (or for a legacy in-memory
+        collection) it defers to that.
+
+        Args:
+            i: Timestep index; negatives count from the end.
+
+        Returns:
+            Dataset: The handle at position ``i``.
+        """
+        if self._datasets is not None:
+            return self._datasets[i]
+        if self._files is None:
+            # Legacy `DatasetCollection(src, time_length=N)`: every slot is the base.
+            return self._base
+        idx = range(self._time_length)[i]  # normalise negatives + bounds-check
+        handle = self._handle_cache.get(idx)
+        if handle is None:
+            env = self._gdal_env or None
+            with cloud_config_from_env(self._gdal_env):
+                handle = Dataset.read_file(str(self._files[idx]), gdal_env=env)
+            self._handle_cache[idx] = handle
+        return handle
 
     def __str__(self):
         """__str__."""
@@ -2144,7 +2178,7 @@ class DatasetCollection:
         # ndarray (the dask.Array arm of ArrayLike is unreachable here); numpy's
         # __getitem__ stub returns Any for a general index.
         if isinstance(key, int):
-            return cast(np.typing.NDArray, self.datasets[key].read_array(band=0))
+            return cast(np.typing.NDArray, self._dataset_at(key).read_array(band=0))
         return cast(np.typing.NDArray, self.values[key])
 
     def __setitem__(self, key: int, value: np.ndarray) -> None:
@@ -2208,7 +2242,9 @@ class DatasetCollection:
         Returns:
             np.ndarray: ``(min(n, time_length), rows, cols)`` array.
         """
-        return self._stack_band0(self.datasets[:n])
+        return self._stack_band0(
+            [self._dataset_at(j) for j in range(self._time_length)[:n]]
+        )
 
     def tail(self, n: int = -5) -> np.typing.NDArray:
         """Last ``abs(n)`` timestep arrays as a 3D numpy slice.
@@ -2228,7 +2264,8 @@ class DatasetCollection:
             np.ndarray: ``(min(abs(n), time_length), rows, cols)`` array.
         """
         keep = min(abs(n), self.time_length)
-        return self._stack_band0(self.datasets[self.time_length - keep :])
+        indices = range(self.time_length - keep, self.time_length)
+        return self._stack_band0([self._dataset_at(j) for j in indices])
 
     def first(self) -> np.typing.NDArray:
         """First timestep array (2D).
@@ -2237,7 +2274,7 @@ class DatasetCollection:
         timestep instead of the full cube.
         """
         # No chunks=, so this always returns a plain ndarray.
-        return cast(np.typing.NDArray, self.datasets[0].read_array(band=0))
+        return cast(np.typing.NDArray, self._dataset_at(0).read_array(band=0))
 
     def last(self) -> np.typing.NDArray:
         """Last timestep array (2D).
@@ -2246,7 +2283,7 @@ class DatasetCollection:
         timestep instead of the full cube.
         """
         # No chunks=, so this always returns a plain ndarray.
-        return cast(np.typing.NDArray, self.datasets[-1].read_array(band=0))
+        return cast(np.typing.NDArray, self._dataset_at(-1).read_array(band=0))
 
     def iloc(self, i: int) -> Dataset:
         """Return the ``Dataset`` at position ``i``.
@@ -2260,7 +2297,7 @@ class DatasetCollection:
             Pixel values are not loaded — they're read on demand when
             the caller invokes a method on the returned Dataset.
         """
-        return self.datasets[i]
+        return self._dataset_at(i)
 
     def plot(
         self,

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -2302,12 +2302,16 @@ class DatasetCollection:
         """Stack band 0 of each dataset into a ``(len, rows, cols)`` cube.
 
         Empty-safe: an empty selection returns a ``(0, rows, cols)`` array rather
-        than tripping ``np.stack``'s "need at least one array" error. Lets
-        :meth:`head`/:meth:`tail` read only the selected timesteps instead of
-        materialising the whole cube via :attr:`values`.
+        than tripping ``np.stack``'s "need at least one array" error. The empty
+        array carries the collection's own dtype (from :attr:`meta`), not NumPy's
+        default float64, so ``head(0)``/``tail(0)`` match the dtype of a non-empty
+        selection (N1). Lets :meth:`head`/:meth:`tail` read only the selected
+        timesteps instead of materialising the whole cube via :attr:`values`.
         """
         if not datasets:
-            return np.empty((0, self.rows, self.columns))
+            return np.empty(
+                (0, self.rows, self.columns), dtype=np.dtype(self._meta.dtype)
+            )
         return np.stack([ds.read_array(band=0) for ds in datasets], axis=0)
 
     def head(self, n: int = 5) -> np.typing.NDArray:
@@ -2335,7 +2339,9 @@ class DatasetCollection:
         reads only those timesteps rather than materialising the whole cube.
 
         Note: this corrects the previous behaviour where a *positive* ``n`` skipped
-        the first ``n`` rows instead of returning the last ``n`` (ARC-46).
+        the first ``n`` rows instead of returning the last ``n`` (ARC-46). ``tail(0)``
+        returns an empty ``(0, rows, cols)`` array ("last zero"), whereas the old
+        ``values[0:]`` returned every timestep.
 
         Args:
             n (int): Number of trailing timesteps; the sign is ignored. Defaults to

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -2299,8 +2299,9 @@ class DatasetCollection:
     def head(self, n: int = 5) -> np.typing.NDArray:
         """First ``n`` timestep arrays as a 3D numpy slice.
 
-        Reads only the first ``n`` timesteps (slicing :attr:`datasets` before
-        reading), not the whole cube.
+        Reads only the first ``n`` timesteps — each opened on demand via
+        :meth:`_dataset_at`, so a file-backed collection opens ``n`` files rather
+        than all ``time_length`` — instead of materialising the whole cube.
 
         Args:
             n (int): Number of timesteps. Defaults to 5.

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -3137,7 +3137,10 @@ class DatasetCollection:
                 )
             ) from exc
         delayeds = [per_step(ds, False) for ds in self.datasets]
-        return dask.delayed(DatasetCollection._collection_from_datasets)(delayeds)
+        return cast(
+            "Delayed",
+            dask.delayed(DatasetCollection._collection_from_datasets)(delayeds),
+        )
 
     @staticmethod
     def _collection_from_datasets(datasets: list[Dataset]) -> DatasetCollection:

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -263,13 +263,15 @@ def _finalize_append_metadata(
 def _append_region(
     data, resolved_store, old_t: int, new_total: int, slices, added_files
 ) -> None:
-    """Atomically grow, write, and finalize a zarr time-append (ARC-75a).
+    """Atomically grow, stream-write, and finalize a zarr time-append (ARC-75a).
 
     The deferred (``compute=False``) append routes through this single task so the
     store's ``data`` shape only grows when the append actually runs; on any failure
     the resize is rolled back, so the store never advertises a larger shape than it
-    holds. ``data`` (one collection's block) is materialised here before the write.
-    Module-level so the :func:`dask.delayed` graph can pickle it.
+    holds. ``data`` stays a lazy dask array and is **streamed** into the region via
+    ``data.to_zarr(..., compute=True)`` — never materialising the whole appended cube
+    (M2). The caller must keep ``data`` lazy (capture it in a closure), not pass it as
+    a delayed argument (which dask would compute up front).
     """
     import zarr
 
@@ -281,7 +283,7 @@ def _append_region(
         raise TypeError(f"expected a zarr Array at 'data' in {resolved_store!r}")
     arr.resize((new_total, *arr.shape[1:]))
     try:
-        arr[slices] = np.asarray(data)
+        data.to_zarr(arr, region=slices, overwrite=False, compute=True)
         _finalize_append_metadata(resolved_store, new_total, added_files)
     except Exception:
         arr.resize((old_t, *arr.shape[1:]))
@@ -1282,12 +1284,18 @@ class DatasetCollection:
                 raise
             return None
 
-        # compute=False: defer the resize+write+finalize into one delayed so the
-        # store's shape only grows when the append actually runs (rolling back on
-        # failure) — no window where a grown-but-empty store is visible (ARC-75a).
-        return dask.delayed(_append_region)(
-            data, resolved_store, old_t, new_total, slices, self._files
-        )
+        # compute=False: defer the resize+write+finalize into one task, capturing
+        # `data` in a closure so it stays a lazy dask array streamed inside the write
+        # (M2) — passing it as a delayed argument would make dask compute the whole
+        # appended cube into memory first. No window where a grown-but-empty store is
+        # visible, and rollback on failure (ARC-75a).
+        files = self._files
+
+        @dask.delayed
+        def _deferred_append() -> None:
+            _append_region(data, resolved_store, old_t, new_total, slices, files)
+
+        return _deferred_append()
 
     def to_netcdf(
         self,

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -236,6 +236,23 @@ def _finalize_collection_metadata(resolved_store, meta, files: list) -> None:
     )
 
 
+def _crs_equal(a: CRS, b: CRS) -> bool:
+    """Return True if two CRS describe the same reference system (N2).
+
+    ``pyproj.CRS.__eq__`` is strict: a file carrying an EPSG code and one carrying
+    only an equivalent WKT string — so :meth:`RasterMeta.from_dataset` builds one via
+    ``CRS.from_epsg`` and the other via ``CRS.from_wkt`` — can compare unequal even
+    though the grids are co-registered. Treat them as equal when both resolve to the
+    same EPSG code, falling back to pyproj's own equality otherwise. Used by
+    :meth:`DatasetCollection._validate_headers` so a valid input is not rejected on a
+    cosmetic CRS-encoding difference.
+    """
+    if a == b:
+        return True
+    epsg_a, epsg_b = a.to_epsg(), b.to_epsg()
+    return epsg_a is not None and epsg_a == epsg_b
+
+
 def _finalize_append_metadata(
     resolved_store, new_time_length: int, added_files: list
 ) -> None:
@@ -1809,7 +1826,7 @@ class DatasetCollection:
                     fm.transform, meta.transform, rtol=1e-9, atol=1e-6
                 ):
                     mismatch = f"geotransform {fm.transform} != {meta.transform}"
-                elif fm.crs != meta.crs:
+                elif not _crs_equal(fm.crs, meta.crs):
                     mismatch = f"CRS {fm.crs.to_string()} != {meta.crs.to_string()}"
                 else:
                     continue

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -1028,14 +1028,18 @@ class DatasetCollection:
         # via _read_chunk) and stack along time, so a reduction tiles spatially and a
         # single raster larger than RAM is read tile-by-tile instead of all at once.
         # One IO lock per distinct path (L4): duplicate paths share a FILE_CACHE
-        # handle, so their tile reads must serialise on the same lock.
+        # handle, so their tile reads must serialise on the same lock. The lock is
+        # keyed by a path-derived token (L1) so *separate* `.data` graphs over the
+        # same path share one underlying mutex too (SerializableLock dedupes by
+        # token process-wide) — not just chunks within this one graph. The local
+        # dict keeps object identity within this graph.
         path_locks: dict[str, Any] = {}
         per_step = [
             _lazy_timestep(
                 path,
                 meta,
                 self._gdal_env,
-                path_locks.setdefault(str(path), default_lock()),
+                path_locks.setdefault(str(path), default_lock(f"data:{path}")),
             )
             for path in self._files
         ]

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 import pandas as pd
+from pyproj import CRS
 
 from pyramids import _io
 from pyramids.base._errors import AlignmentError, OptionalPackageDoesNotExist
@@ -430,6 +431,21 @@ def _lazy_timestep(path: str | Path, meta: RasterMeta, gdal_env: dict[str, str] 
 # Above this in-RAM (T, B, Y, X) size, DatasetCollection.to_netcdf warns and points
 # the caller at the streaming to_zarr writer (ARC-46). Default 2 GiB.
 _TO_NETCDF_WARN_BYTES = 2 * 1024**3
+
+
+def _target_epsg(to_epsg: int | str | Any) -> int | None:
+    """Return the integer EPSG for ``to_epsg``, or ``None`` for a non-EPSG CRS.
+
+    Lets :meth:`DatasetCollection.to_crs` decide whether the plan-once
+    :class:`~pyramids.dataset.ops.reproject.Reprojector` (int-EPSG only) applies, or
+    the direct per-timestep path must handle a target CRS with no EPSG code (ARC-54).
+    """
+    if isinstance(to_epsg, int):
+        return to_epsg
+    try:
+        return CRS.from_user_input(to_epsg).to_epsg()
+    except Exception:  # pragma: no cover - defensive against odd CRS inputs
+        return None
 
 
 class DatasetCollection:
@@ -2789,7 +2805,9 @@ class DatasetCollection:
         method: str = DEFAULT_RESAMPLING,
         maintain_alignment: bool = False,
         inplace: bool = False,
-    ) -> DatasetCollection | None:
+        *,
+        compute: bool = True,
+    ) -> DatasetCollection | None | Any:
         """Reproject every timestep to a target CRS.
 
         Args:
@@ -2813,10 +2831,17 @@ class DatasetCollection:
             inplace (bool):
                 If True, mutate this collection in place and return None.
                 If False (default), return a new `DatasetCollection`.
+            compute (bool):
+                If True (default), reproject every timestep eagerly. If False, defer
+                the whole reproject into one `dask.delayed.Delayed` that builds the
+                reprojected `DatasetCollection` when computed — so a many-raster
+                collection reprojects in a single graph (ARC-54). Keyword-only;
+                cannot be combined with `inplace=True`.
 
         Returns:
-            DatasetCollection | None: New collection when
-            `inplace=False`; `None` when `inplace=True`.
+            DatasetCollection | None | dask.delayed.Delayed: A new collection when
+            `inplace=False`; `None` when `inplace=True`; a `Delayed` when
+            `compute=False`.
 
         Examples:
             - Reproject every timestep to EPSG:3857 and keep the result:
@@ -2832,13 +2857,32 @@ class DatasetCollection:
 
               ```
         """
-        new_datasets = self._apply_per_timestep(
-            "to_crs",
-            to_epsg,
-            method=method,
-            maintain_alignment=maintain_alignment,
-        )
-        return self._finalize_per_timestep_result(new_datasets, inplace=inplace)
+        from pyramids.dataset.ops.reproject import Reprojector
+
+        epsg = _target_epsg(to_epsg)
+        if epsg is not None:
+            # Plan-once: build one Reprojector and reuse it across every timestep, so
+            # a compute=False call defers the whole reproject into one dask graph
+            # (ARC-54).
+            op = Reprojector(epsg, method=method, maintain_alignment=maintain_alignment)
+
+            def per_step(ds: Dataset, do_compute: bool) -> Any:
+                return op(ds, compute=do_compute)
+        else:
+            # A target CRS with no EPSG code (orthographic / Robinson / …) cannot go
+            # through Reprojector (int-EPSG only); reproject each timestep directly.
+            def per_step(ds: Dataset, do_compute: bool) -> Any:
+                if do_compute:
+                    return ds.to_crs(
+                        to_epsg, method=method, maintain_alignment=maintain_alignment
+                    )
+                import dask
+
+                return dask.delayed(ds.to_crs)(
+                    to_epsg, method=method, maintain_alignment=maintain_alignment
+                )
+
+        return self._apply_operator(per_step, inplace=inplace, compute=compute)
 
     def crop(
         self,
@@ -2933,8 +2977,8 @@ class DatasetCollection:
         return self._finalize_per_timestep_result(new_datasets, inplace=inplace)
 
     def align(
-        self, alignment_src: Dataset, inplace: bool = False
-    ) -> DatasetCollection | None:
+        self, alignment_src: Dataset, inplace: bool = False, *, compute: bool = True
+    ) -> DatasetCollection | None | Any:
         """Align every timestep to `alignment_src`.
 
         Matches the coordinate system, the number of rows and columns,
@@ -2946,10 +2990,16 @@ class DatasetCollection:
             inplace (bool):
                 If True, mutate this collection in place and return None.
                 If False (default), return a new `DatasetCollection`.
+            compute (bool):
+                If True (default), align every timestep eagerly. If False, defer the
+                whole align into one `dask.delayed.Delayed` that builds the aligned
+                `DatasetCollection` when computed (ARC-54). Keyword-only; cannot be
+                combined with `inplace=True`.
 
         Returns:
-            DatasetCollection | None: New collection when
-            `inplace=False`; `None` when `inplace=True`.
+            DatasetCollection | None | dask.delayed.Delayed: A new collection when
+            `inplace=False`; `None` when `inplace=True`; a `Delayed` when
+            `compute=False`.
 
         Examples:
             - Align every timestep to a DEM template:
@@ -2961,8 +3011,24 @@ class DatasetCollection:
         """
         if not isinstance(alignment_src, Dataset):
             raise TypeError("alignment_src input should be a Dataset object")
-        new_datasets = self._apply_per_timestep("align", alignment_src)
-        return self._finalize_per_timestep_result(new_datasets, inplace=inplace)
+        from pyramids.dataset.ops.reproject import Aligner
+
+        if alignment_src.epsg is not None:
+            # Plan-once: one Aligner reused across every timestep (ARC-54).
+            op = Aligner(alignment_src)
+
+            def per_step(ds: Dataset, do_compute: bool) -> Any:
+                return op(ds, compute=do_compute)
+        else:
+            # A reference with no EPSG code can't go through Aligner; align directly.
+            def per_step(ds: Dataset, do_compute: bool) -> Any:
+                if do_compute:
+                    return ds.align(alignment_src)
+                import dask
+
+                return dask.delayed(ds.align)(alignment_src)
+
+        return self._apply_operator(per_step, inplace=inplace, compute=compute)
 
     def _finalize_per_timestep_result(
         self,
@@ -2992,6 +3058,50 @@ class DatasetCollection:
             new_datasets[0],
             time_length=len(new_datasets),
             datasets=new_datasets,
+        )
+
+    def _apply_operator(
+        self, per_step: Any, *, inplace: bool, compute: bool
+    ) -> DatasetCollection | None | Any:
+        """Apply a per-timestep reproject/align op, eagerly or as a deferred graph.
+
+        ``per_step(ds, compute)`` returns a :class:`~pyramids.dataset.Dataset` when
+        ``compute`` is ``True`` and a :class:`dask.delayed.Delayed` when ``False``.
+        Eager results are finalised into a collection (respecting ``inplace``); the
+        deferred path returns a ``Delayed`` that builds the whole reprojected /
+        aligned collection when computed — so a 365-raster reproject is assembled into
+        one dask graph and computed once (ARC-54).
+
+        Raises:
+            ValueError: ``compute=False`` combined with ``inplace=True``.
+            OptionalPackageDoesNotExist: ``compute=False`` without the ``dask`` extra.
+        """
+        if compute:
+            new_datasets = [per_step(ds, True) for ds in self.datasets]
+            return self._finalize_per_timestep_result(new_datasets, inplace=inplace)
+        if inplace:
+            raise ValueError("compute=False cannot be combined with inplace=True.")
+        try:
+            import dask
+        except ImportError as exc:
+            raise OptionalPackageDoesNotExist(
+                lazy_extra_hint(
+                    "DatasetCollection.to_crs / align (compute=False) requires the "
+                    "optional 'dask' dependency."
+                )
+            ) from exc
+        delayeds = [per_step(ds, False) for ds in self.datasets]
+        return dask.delayed(DatasetCollection._collection_from_datasets)(delayeds)
+
+    @staticmethod
+    def _collection_from_datasets(datasets: list[Dataset]) -> DatasetCollection:
+        """Wrap computed per-timestep Datasets into a collection (compute=False path).
+
+        A staticmethod so the ``compute=False`` reproject / align
+        :func:`dask.delayed` can pickle it by qualified name.
+        """
+        return DatasetCollection(
+            datasets[0], time_length=len(datasets), datasets=datasets
         )
 
     def merge(

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -45,6 +45,7 @@ from pyramids.feature import FeatureCollection
 
 if TYPE_CHECKING:
     from cleopatra.array_glyph import ArrayGlyph
+    from dask.delayed import Delayed
 
 
 class _GroupedCollection:
@@ -2847,7 +2848,7 @@ class DatasetCollection:
         inplace: bool = False,
         *,
         compute: bool = True,
-    ) -> DatasetCollection | None | Any:
+    ) -> DatasetCollection | None | Delayed:
         """Reproject every timestep to a target CRS.
 
         Args:
@@ -3021,7 +3022,7 @@ class DatasetCollection:
 
     def align(
         self, alignment_src: Dataset, inplace: bool = False, *, compute: bool = True
-    ) -> DatasetCollection | None | Any:
+    ) -> DatasetCollection | None | Delayed:
         """Align every timestep to `alignment_src`.
 
         Matches the coordinate system, the number of rows and columns,
@@ -3107,7 +3108,7 @@ class DatasetCollection:
 
     def _apply_operator(
         self, per_step: Any, *, inplace: bool, compute: bool
-    ) -> DatasetCollection | None | Any:
+    ) -> DatasetCollection | None | Delayed:
         """Apply a per-timestep reproject/align op, eagerly or as a deferred graph.
 
         ``per_step(ds, compute)`` returns a :class:`~pyramids.dataset.Dataset` when

--- a/tests/dataset/collection/test_dataset_collection_unit.py
+++ b/tests/dataset/collection/test_dataset_collection_unit.py
@@ -732,6 +732,26 @@ class TestFromFilesValidate:
         col = DatasetCollection.from_files([t0, t1], validate=True)
         assert col.time_length == 2, f"expected 2 timesteps, got {col.time_length}"
 
+    def test_crs_equal_treats_same_epsg_encodings_as_equal(self):
+        """_crs_equal treats same-EPSG CRS as equal across encodings (N2).
+
+        Test scenario:
+            An EPSG:4326 CRS vs an equivalent proj4 longlat-WGS84 CRS (which
+            ``pyproj``'s strict ``==`` reports unequal) — expected: ``_crs_equal``
+            returns True via the shared EPSG code, so validation does not reject a
+            co-registered file on a cosmetic encoding difference; a genuinely
+            different system (EPSG:3857) still returns False.
+        """
+        from pyproj import CRS
+
+        from pyramids.dataset.collection import _crs_equal
+
+        epsg = CRS.from_epsg(4326)
+        proj4 = CRS.from_proj4("+proj=longlat +datum=WGS84 +no_defs")
+        assert epsg != proj4, "precondition: pyproj's == is strict for this pair"
+        assert _crs_equal(epsg, proj4), "same-EPSG encodings should compare equal"
+        assert not _crs_equal(epsg, CRS.from_epsg(3857)), "different CRS must differ"
+
     def test_validate_true_shape_mismatch_raises(self, tmp_path):
         """A file with a different (rows, cols) raises AlignmentError naming it.
 

--- a/tests/dataset/collection/test_dataset_collection_unit.py
+++ b/tests/dataset/collection/test_dataset_collection_unit.py
@@ -22,7 +22,9 @@ import numpy as np
 import pytest
 from osgeo import gdal
 
+from pyramids.base._errors import AlignmentError
 from pyramids.dataset import Dataset, DatasetCollection
+from tests.dataset.collection._helpers import make_int16_collection
 
 
 def _make_mem_dataset(
@@ -467,3 +469,316 @@ class TestAlignErrors:
         """Passing a non-Dataset as alignment_src should raise TypeError."""
         with pytest.raises(TypeError, match="Dataset object"):
             cube_with_values.align("not_a_dataset")
+
+
+def _write_geotiff(
+    path,
+    arr: np.ndarray,
+    *,
+    top_left: tuple = (0.0, 4.0),
+    cell_size: float = 1.0,
+    epsg: int = 4326,
+    no_data: float = -9999.0,
+) -> str:
+    """Write ``arr`` to a GeoTIFF at ``path`` and return the path as a string."""
+    Dataset.create_from_array(
+        arr,
+        top_left_corner=top_left,
+        cell_size=cell_size,
+        epsg=epsg,
+        no_data_value=no_data,
+        path=str(path),
+    ).close()
+    return str(path)
+
+
+class TestMemDatasetFromArray:
+    """Tests for ``_mem_dataset_from_array`` (ARC-70)."""
+
+    @pytest.fixture()
+    def collection(self) -> DatasetCollection:
+        """A single-timestep in-memory collection whose base is float32."""
+        base = Dataset.create_from_array(
+            np.ones((3, 4), dtype="float32"),
+            top_left_corner=(0.0, 3.0),
+            cell_size=1.0,
+            epsg=4326,
+            no_data_value=-9999.0,
+        )
+        return DatasetCollection(base, time_length=1)
+
+    def test_default_source_uses_base_georef(self, collection: DatasetCollection):
+        """With no ``source`` the result inherits the base's geotransform + EPSG.
+
+        Test scenario:
+            Wrap an array without ``source`` — expected: geotransform equals the
+            base template's and the EPSG is the base's 4326.
+        """
+        arr = np.arange(12, dtype="float64").reshape(3, 4)
+        result = collection._mem_dataset_from_array(arr)
+        assert result.geotransform == pytest.approx(collection.base.geotransform), (
+            f"geotransform not copied from base: {result.geotransform}"
+        )
+        assert result.epsg == 4326, f"expected epsg 4326, got {result.epsg}"
+
+    def test_preserves_input_array_dtype(self, collection: DatasetCollection):
+        """A float64 input is not down-cast through the float32 base dtype.
+
+        Test scenario:
+            Wrap a float64 array over a float32 base — expected: the result reads
+            back as float64 (the base dtype does not silently round it).
+        """
+        arr = np.arange(12, dtype="float64").reshape(3, 4)
+        result = collection._mem_dataset_from_array(arr)
+        assert result.read_array().dtype == np.float64, (
+            f"input dtype not preserved: {result.read_array().dtype}"
+        )
+
+    def test_values_round_trip(self, collection: DatasetCollection):
+        """The wrapped array reads back element-for-element.
+
+        Test scenario:
+            Wrap a non-trivial float64 array — expected: ``read_array`` returns
+            the same values.
+        """
+        arr = np.arange(12, dtype="float64").reshape(3, 4) * 1.5
+        result = collection._mem_dataset_from_array(arr)
+        np.testing.assert_array_equal(
+            result.read_array(), arr, err_msg="values not preserved by wrap"
+        )
+
+    def test_explicit_source_overrides_base_georef(self, collection: DatasetCollection):
+        """Passing ``source=`` copies that dataset's georef, not the base's.
+
+        Test scenario:
+            Wrap an array with an explicit ``source`` on a different grid —
+            expected: geotransform matches the source, not the collection base.
+        """
+        other = Dataset.create_from_array(
+            np.ones((3, 4), dtype="float32"),
+            top_left_corner=(100.0, 50.0),
+            cell_size=2.0,
+            epsg=4326,
+            no_data_value=-1.0,
+        )
+        arr = np.zeros((3, 4), dtype="float32")
+        result = collection._mem_dataset_from_array(arr, source=other)
+        assert result.geotransform == pytest.approx(other.geotransform), (
+            f"source georef not used: {result.geotransform}"
+        )
+        assert result.geotransform != pytest.approx(collection.base.geotransform), (
+            "result should not carry the base georef when source is given"
+        )
+
+
+class TestRequireFiles:
+    """Tests for the ``_require_files`` file-backed guard (ARC-70)."""
+
+    def test_returns_files_list_for_file_backed(self, tmp_path):
+        """A file-backed collection returns its own ``files`` list unchanged.
+
+        Test scenario:
+            Guard a file-backed collection — expected: the live ``files`` list is
+            returned (same object), not a copy.
+        """
+        col, paths = make_int16_collection(tmp_path, count=2)
+        result = col._require_files("to_zarr")
+        assert result == paths, f"expected {paths}, got {result}"
+        assert result is col.files, "should return the live files list, not a copy"
+
+    def test_none_files_raises_naming_method(self, base_dataset: Dataset):
+        """An in-memory collection (files=None) raises RuntimeError naming the method.
+
+        Test scenario:
+            Guard an in-memory collection — expected: RuntimeError whose message
+            names the offending method and mentions ``file-backed``.
+        """
+        col = DatasetCollection(base_dataset, time_length=2)
+        with pytest.raises(RuntimeError, match="to_kerchunk") as exc:
+            col._require_files("to_kerchunk")
+        assert "file-backed" in str(exc.value), f"unexpected message: {exc.value}"
+
+    def test_empty_files_list_raises(self, base_dataset: Dataset):
+        """An empty files list is guarded the same as None (the len == 0 branch).
+
+        Test scenario:
+            Guard a collection built with ``files=[]`` — expected: RuntimeError
+            naming the method.
+        """
+        col = DatasetCollection(base_dataset, time_length=0, files=[])
+        with pytest.raises(RuntimeError, match="to_zarr"):
+            col._require_files("to_zarr")
+
+
+class TestTailHeadRegression:
+    """Tests for the ARC-46 head/tail fix and empty-safe ``_stack_band0``."""
+
+    @pytest.fixture()
+    def expected(self) -> np.ndarray:
+        """The (3, 5, 6) cube backing the ``cube_with_values`` fixture."""
+        return np.arange(3 * 5 * 6, dtype=np.float64).reshape(3, 5, 6)
+
+    def test_tail_positive_n_returns_last_n(
+        self, cube_with_values: DatasetCollection, expected: np.ndarray
+    ):
+        """tail(2) returns the LAST 2 timesteps (ARC-46: no longer skips the first n).
+
+        Test scenario:
+            ``tail(2)`` on a 3-step cube — expected: shape (2, 5, 6) equal to the
+            last two source slices, not the tail-after-skipping-2 single slice.
+        """
+        result = cube_with_values.tail(2)
+        assert result.shape == (2, 5, 6), f"expected (2,5,6), got {result.shape}"
+        np.testing.assert_array_equal(
+            result, expected[1:], err_msg="tail(2) is not the last 2 timesteps"
+        )
+
+    def test_tail_both_signs_equal(self, cube_with_values: DatasetCollection):
+        """tail(3) == tail(-3): the sign of ``n`` is ignored.
+
+        Test scenario:
+            Compare positive and negative ``n`` — expected: identical arrays.
+        """
+        np.testing.assert_array_equal(
+            cube_with_values.tail(3),
+            cube_with_values.tail(-3),
+            err_msg="tail(n) and tail(-n) disagree",
+        )
+
+    def test_tail_clamps_to_time_length(
+        self, cube_with_values: DatasetCollection, expected: np.ndarray
+    ):
+        """tail(99) clamps to all available timesteps.
+
+        Test scenario:
+            ``abs(n)`` larger than ``time_length`` — expected: the full cube.
+        """
+        result = cube_with_values.tail(99)
+        assert result.shape == (3, 5, 6), f"expected full cube, got {result.shape}"
+        np.testing.assert_array_equal(result, expected)
+
+    def test_tail_zero_is_empty(self, cube_with_values: DatasetCollection):
+        """tail(0) returns an empty (0, rows, cols) cube, not a stack error.
+
+        Test scenario:
+            ``n == 0`` — expected: a (0, 5, 6) array via the empty-safe path.
+        """
+        result = cube_with_values.tail(0)
+        assert result.shape == (0, 5, 6), f"expected (0,5,6), got {result.shape}"
+
+    def test_head_zero_is_empty(self, cube_with_values: DatasetCollection):
+        """head(0) returns an empty (0, rows, cols) cube, not a stack error.
+
+        Test scenario:
+            ``n == 0`` — expected: a (0, 5, 6) array via the empty-safe path.
+        """
+        result = cube_with_values.head(0)
+        assert result.shape == (0, 5, 6), f"expected (0,5,6), got {result.shape}"
+
+    def test_stack_band0_empty_selection(self, cube_with_values: DatasetCollection):
+        """_stack_band0([]) returns a (0, rows, cols) array (empty-safe).
+
+        Test scenario:
+            Stack an empty selection — expected: a (0, 5, 6) array instead of the
+            ``np.stack`` "need at least one array" error.
+        """
+        result = cube_with_values._stack_band0([])
+        assert result.shape == (0, 5, 6), f"expected (0,5,6), got {result.shape}"
+
+    def test_stack_band0_non_empty(
+        self, cube_with_values: DatasetCollection, expected: np.ndarray
+    ):
+        """_stack_band0 over all datasets reproduces the full cube.
+
+        Test scenario:
+            Stack every timestep's band 0 — expected: the (3, 5, 6) source cube.
+        """
+        result = cube_with_values._stack_band0(cube_with_values.datasets)
+        assert result.shape == (3, 5, 6), f"expected (3,5,6), got {result.shape}"
+        np.testing.assert_array_equal(result, expected)
+
+
+class TestFromFilesValidate:
+    """Tests for ``from_files(validate=...)`` + ``_validate_headers`` (ARC-75b)."""
+
+    def test_validate_true_matching_files_succeeds(self, tmp_path):
+        """Homogeneous files pass validation and build the collection.
+
+        Test scenario:
+            Two same-shape / same-dtype int16 files with ``validate=True`` —
+            expected: a 2-timestep collection, no error.
+        """
+        t0 = _write_geotiff(
+            tmp_path / "t0.tif", np.arange(20, dtype="int16").reshape(4, 5)
+        )
+        t1 = _write_geotiff(
+            tmp_path / "t1.tif", np.arange(20, dtype="int16").reshape(4, 5) + 5
+        )
+        col = DatasetCollection.from_files([t0, t1], validate=True)
+        assert col.time_length == 2, f"expected 2 timesteps, got {col.time_length}"
+
+    def test_validate_true_shape_mismatch_raises(self, tmp_path):
+        """A file with a different (rows, cols) raises AlignmentError naming it.
+
+        Test scenario:
+            Template (4, 5) + a (3, 5) file with ``validate=True`` — expected:
+            AlignmentError whose message names the offending path.
+        """
+        t0 = _write_geotiff(tmp_path / "t0.tif", np.zeros((4, 5), dtype="int16"))
+        bad = _write_geotiff(tmp_path / "bad.tif", np.zeros((3, 5), dtype="int16"))
+        with pytest.raises(AlignmentError, match="bad.tif") as exc:
+            DatasetCollection.from_files([t0, bad], validate=True)
+        assert "does not match" in str(exc.value), f"unexpected message: {exc.value}"
+
+    def test_validate_true_dtype_mismatch_raises(self, tmp_path):
+        """A file with a different dtype raises AlignmentError naming it.
+
+        Test scenario:
+            Template int16 + a float64 file (same shape) with ``validate=True`` —
+            expected: AlignmentError naming the offending path.
+        """
+        t0 = _write_geotiff(tmp_path / "t0.tif", np.zeros((4, 5), dtype="int16"))
+        bad = _write_geotiff(tmp_path / "bad.tif", np.zeros((4, 5), dtype="float64"))
+        with pytest.raises(AlignmentError, match="bad.tif"):
+            DatasetCollection.from_files([t0, bad], validate=True)
+
+    def test_validate_false_does_not_open_other_files(self, tmp_path, monkeypatch):
+        """validate=False (default) opens only the first file, never the rest.
+
+        Test scenario:
+            Spy on ``Dataset.read_file`` — expected: only the template path is
+            opened; the second file is left untouched.
+        """
+        t0 = _write_geotiff(tmp_path / "t0.tif", np.zeros((4, 5), dtype="int16"))
+        t1 = _write_geotiff(tmp_path / "t1.tif", np.zeros((4, 5), dtype="int16"))
+        opened: list[str] = []
+        orig = Dataset.read_file
+
+        def spy(path, *args, **kwargs):
+            opened.append(str(path))
+            return orig(path, *args, **kwargs)
+
+        monkeypatch.setattr(Dataset, "read_file", staticmethod(spy))
+        DatasetCollection.from_files([t0, t1], validate=False)
+        assert t0 in opened, f"template file was not opened: {opened}"
+        assert t1 not in opened, f"validate=False opened a non-template file: {opened}"
+
+    def test_validate_true_opens_every_file(self, tmp_path, monkeypatch):
+        """validate=True opens every file's header (the opt-in cost).
+
+        Test scenario:
+            Spy on ``Dataset.read_file`` with ``validate=True`` — expected: the
+            second file is opened too.
+        """
+        t0 = _write_geotiff(tmp_path / "t0.tif", np.zeros((4, 5), dtype="int16"))
+        t1 = _write_geotiff(tmp_path / "t1.tif", np.zeros((4, 5), dtype="int16"))
+        opened: list[str] = []
+        orig = Dataset.read_file
+
+        def spy(path, *args, **kwargs):
+            opened.append(str(path))
+            return orig(path, *args, **kwargs)
+
+        monkeypatch.setattr(Dataset, "read_file", staticmethod(spy))
+        DatasetCollection.from_files([t0, t1], validate=True)
+        assert t1 in opened, f"validate=True did not open the second file: {opened}"

--- a/tests/dataset/collection/test_dataset_collection_unit.py
+++ b/tests/dataset/collection/test_dataset_collection_unit.py
@@ -671,6 +671,25 @@ class TestTailHeadRegression:
         result = cube_with_values.head(0)
         assert result.shape == (0, 5, 6), f"expected (0,5,6), got {result.shape}"
 
+    def test_empty_selection_matches_cube_dtype(self, tmp_path):
+        """head(0)/tail(0) carry the cube's dtype, not NumPy's default float64 (N1).
+
+        Test scenario:
+            An int16-backed collection — expected: ``head(0)`` and ``tail(0)`` are
+            int16 (matching a non-empty selection), not the float64 that an
+            untyped ``np.empty`` would give.
+        """
+        collection, _ = make_int16_collection(tmp_path)
+        assert collection.head(0).dtype == np.int16, (
+            f"head(0) dtype {collection.head(0).dtype} != int16"
+        )
+        assert collection.tail(0).dtype == np.int16, (
+            f"tail(0) dtype {collection.tail(0).dtype} != int16"
+        )
+        assert collection.head(1).dtype == np.int16, (
+            "non-empty head should be int16 too"
+        )
+
     def test_stack_band0_empty_selection(self, cube_with_values: DatasetCollection):
         """_stack_band0([]) returns a (0, rows, cols) array (empty-safe).
 

--- a/tests/dataset/collection/test_dataset_collection_unit.py
+++ b/tests/dataset/collection/test_dataset_collection_unit.py
@@ -14,6 +14,7 @@ Targets untested / low-coverage code paths in
 - Error paths for ``__getitem__``, ``__setitem__``, ``open_multi_dataset``
 """
 
+import pickle
 import shutil
 import tempfile
 from pathlib import Path
@@ -22,8 +23,9 @@ import numpy as np
 import pytest
 from osgeo import gdal
 
-from pyramids.base._errors import AlignmentError
+from pyramids.base._errors import AlignmentError, OptionalPackageDoesNotExist
 from pyramids.dataset import Dataset, DatasetCollection
+from pyramids.dataset.collection import _target_epsg
 from tests.dataset.collection._helpers import make_int16_collection
 
 
@@ -782,3 +784,244 @@ class TestFromFilesValidate:
         monkeypatch.setattr(Dataset, "read_file", staticmethod(spy))
         DatasetCollection.from_files([t0, t1], validate=True)
         assert t1 in opened, f"validate=True did not open the second file: {opened}"
+
+
+class TestDatasetAtLazyHandles:
+    """Tests for ``_dataset_at`` + the per-index ``_handle_cache`` (ARC-44)."""
+
+    def test_first_opens_only_one_file(self, tmp_path):
+        """``first()`` on a file-backed cube opens one file, not all N.
+
+        Test scenario:
+            A 3-file collection, then ``first()`` — expected: the bulk
+            ``_datasets`` list is still ``None`` and exactly one handle is
+            cached (only index 0 was opened).
+        """
+        col, _ = make_int16_collection(tmp_path, count=3)
+        result = col.first()
+        assert col._datasets is None, "first() must not materialise the bulk list"
+        assert len(col._handle_cache) == 1, (
+            f"first() should open one file; cached {len(col._handle_cache)}"
+        )
+        assert set(col._handle_cache) == {0}, (
+            f"expected index 0, got {set(col._handle_cache)}"
+        )
+        np.testing.assert_array_equal(
+            result,
+            np.arange(20, dtype="int16").reshape(4, 5),
+            err_msg="first() returned the wrong timestep array",
+        )
+
+    def test_first_then_last_caches_two(self, tmp_path):
+        """``first()`` then ``last()`` caches exactly two handles.
+
+        Test scenario:
+            A 3-file collection — expected: after ``first()`` + ``last()`` the
+            handle cache holds indices ``{0, 2}`` and the bulk list stays lazy.
+        """
+        col, _ = make_int16_collection(tmp_path, count=3)
+        col.first()
+        col.last()
+        assert col._datasets is None, (
+            "point accessors must not materialise the bulk list"
+        )
+        assert len(col._handle_cache) == 2, (
+            f"first()+last() should cache 2 handles; got {len(col._handle_cache)}"
+        )
+        assert set(col._handle_cache) == {0, 2}, (
+            f"expected indices {{0, 2}}, got {set(col._handle_cache)}"
+        )
+
+    def test_negative_index_normalises(self, tmp_path):
+        """A negative index reads from the end and caches the normalised slot.
+
+        Test scenario:
+            ``_dataset_at(-1)`` on a 3-file cube — expected: the same handle as
+            index 2, cached under key 2 (negative normalised via ``range``).
+        """
+        col, _ = make_int16_collection(tmp_path, count=3)
+        last = col._dataset_at(-1)
+        assert set(col._handle_cache) == {2}, (
+            f"negative index not normalised: {set(col._handle_cache)}"
+        )
+        assert col._dataset_at(2) is last, (
+            "negative and positive index disagree on the handle"
+        )
+
+    def test_handle_reused_within_instance(self, tmp_path):
+        """Repeated access to the same index returns the cached handle.
+
+        Test scenario:
+            Two ``_dataset_at(0)`` calls — expected: the identical ``Dataset``
+            object, proving the cache slot is reused, not reopened.
+        """
+        col, _ = make_int16_collection(tmp_path, count=2)
+        first = col._dataset_at(0)
+        again = col._dataset_at(0)
+        assert first is again, "the same index should return one cached handle"
+        assert len(col._handle_cache) == 1, "a re-read must not add a cache slot"
+
+    def test_getitem_int_uses_handle_cache(self, tmp_path):
+        """``collection[i]`` (int) reads one file through the handle cache.
+
+        Test scenario:
+            ``col[1]`` on a 3-file cube — expected: a 2D array equal to the
+            second timestep, with only index 1 cached and the bulk list lazy.
+        """
+        col, _ = make_int16_collection(tmp_path, count=3)
+        arr = col[1]
+        assert arr.shape == (4, 5), f"expected a 2D (4,5) slice, got {arr.shape}"
+        assert col._datasets is None, (
+            "__getitem__[int] must not materialise the bulk list"
+        )
+        assert set(col._handle_cache) == {1}, (
+            f"expected index 1 cached, got {set(col._handle_cache)}"
+        )
+        np.testing.assert_array_equal(
+            arr, np.arange(20, dtype="int16").reshape(4, 5) + 100
+        )
+
+    def test_defers_to_bulk_once_materialised(self, tmp_path):
+        """Once ``.datasets`` is built, ``_dataset_at`` returns from that list.
+
+        Test scenario:
+            Access ``.datasets`` to materialise the bulk cache — expected:
+            ``_dataset_at(i)`` returns the same object as ``datasets[i]`` and no
+            per-index handle cache is populated.
+        """
+        col, _ = make_int16_collection(tmp_path, count=3)
+        bulk = col.datasets
+        assert col._dataset_at(1) is bulk[1], (
+            "should defer to the materialised bulk list"
+        )
+        assert col._handle_cache == {}, (
+            "the per-index cache must stay empty after bulk build"
+        )
+
+    def test_legacy_in_memory_returns_base(self, base_dataset: Dataset):
+        """A legacy ``files=None`` collection returns the base at every index.
+
+        Test scenario:
+            ``DatasetCollection(base, time_length=3)`` with no files/datasets —
+            expected: every ``_dataset_at`` returns the shared base template.
+        """
+        col = DatasetCollection(base_dataset, time_length=3)
+        assert col._dataset_at(0) is base_dataset, "legacy cube should return the base"
+        assert col._dataset_at(2) is base_dataset, "legacy cube should return the base"
+        assert col._handle_cache == {}, "legacy path must not open files"
+
+    def test_getstate_drops_handle_cache_on_pickle(self, tmp_path):
+        """Pickling drops the live-handle ``_handle_cache`` (ARC-44 + pickle).
+
+        Test scenario:
+            Populate the cache via ``first()`` then pickle round-trip —
+            expected: no ``gdal.Dataset`` in the payload, and the unpickled
+            instance starts with an empty cache and a lazy bulk list.
+        """
+        col, _ = make_int16_collection(tmp_path, count=2)
+        col.first()
+        assert len(col._handle_cache) == 1, "precondition: one cached handle"
+        payload = pickle.dumps(col)
+        assert b"gdal.Dataset" not in payload, (
+            "a live gdal handle leaked into the pickle"
+        )
+        restored = pickle.loads(payload)
+        assert restored._handle_cache == {}, "unpickled cache should be empty"
+        assert restored._datasets is None, "unpickled bulk list should be lazy"
+        assert restored.time_length == 2, "time_length should survive the round-trip"
+
+
+class TestTargetEpsg:
+    """Tests for the module-level ``_target_epsg`` helper (ARC-54)."""
+
+    def test_int_passthrough(self):
+        """An integer EPSG is returned unchanged.
+
+        Test scenario:
+            ``_target_epsg(3857)`` — expected: ``3857`` without a pyproj lookup.
+        """
+        assert _target_epsg(3857) == 3857, "an int EPSG should pass through unchanged"
+
+    def test_authority_string_resolves(self):
+        """An ``EPSG:`` authority string resolves to its integer code.
+
+        Test scenario:
+            ``_target_epsg("EPSG:4326")`` — expected: ``4326``.
+        """
+        assert _target_epsg("EPSG:4326") == 4326, (
+            "authority string should resolve to 4326"
+        )
+
+    def test_non_epsg_crs_returns_none(self):
+        """A CRS with no EPSG code (proj4 Robinson) returns ``None``.
+
+        Test scenario:
+            A proj4 string with no registered EPSG — expected: ``None`` so
+            ``to_crs`` takes the direct per-timestep fallback.
+        """
+        proj4 = "+proj=laea +lat_0=0 +lon_0=0 +datum=WGS84 +units=m +no_defs"
+        assert _target_epsg(proj4) is None, "a no-EPSG CRS should return None"
+
+
+class TestToCrsEager:
+    """Eager ``to_crs`` routing through the plan-once + fallback paths (ARC-54)."""
+
+    def test_epsg_target_returns_reprojected_collection(self, tmp_path):
+        """``to_crs(epsg)`` (non-inplace) returns a new reprojected collection.
+
+        Test scenario:
+            A 4326 file-backed cube reprojected to 3857 — expected: a distinct
+            ``DatasetCollection`` at EPSG 3857 with the same ``time_length``.
+        """
+        col, _ = make_int16_collection(tmp_path, count=2)
+        out = col.to_crs(3857)
+        assert isinstance(out, DatasetCollection), (
+            f"expected a collection, got {type(out)}"
+        )
+        assert out is not col, "non-inplace to_crs should return a new collection"
+        assert out.base.epsg == 3857, f"expected EPSG 3857, got {out.base.epsg}"
+        assert out.time_length == 2, (
+            f"time_length should be preserved, got {out.time_length}"
+        )
+
+    def test_non_epsg_target_reprojects_eagerly(self, tmp_path):
+        """A no-EPSG target still reprojects eagerly via the direct fallback.
+
+        Test scenario:
+            ``to_crs`` to a proj4 LAEA CRS (no EPSG code) — expected: a
+            ``DatasetCollection`` with the same ``time_length``; ``_target_epsg``
+            returned ``None`` so the ``Reprojector`` plan-once path was skipped.
+        """
+        proj4 = "+proj=laea +lat_0=0 +lon_0=0 +datum=WGS84 +units=m +no_defs"
+        assert _target_epsg(proj4) is None, (
+            "precondition: the target must have no EPSG code"
+        )
+        col, _ = make_int16_collection(tmp_path, count=2)
+        out = col.to_crs(proj4)
+        assert isinstance(out, DatasetCollection), (
+            f"expected a collection, got {type(out)}"
+        )
+        assert out.time_length == 2, (
+            f"time_length should be preserved, got {out.time_length}"
+        )
+
+    def test_compute_false_without_dask_raises(self, tmp_path, monkeypatch):
+        """``compute=False`` without dask raises ``OptionalPackageDoesNotExist``.
+
+        Test scenario:
+            Simulate a missing dask import — expected: the ``[lazy]`` extra error
+            from ``_apply_operator``'s deferred branch, naming the extra.
+        """
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "dask" or name.startswith("dask."):
+                raise ImportError("no dask")
+            return real_import(name, *args, **kwargs)
+
+        col, _ = make_int16_collection(tmp_path, count=2)
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        with pytest.raises(OptionalPackageDoesNotExist, match="lazy"):
+            col.to_crs(3857, compute=False)

--- a/tests/dataset/collection/test_dataset_collection_unit.py
+++ b/tests/dataset/collection/test_dataset_collection_unit.py
@@ -28,6 +28,8 @@ from pyramids.dataset import Dataset, DatasetCollection
 from pyramids.dataset.collection import _target_epsg
 from tests.dataset.collection._helpers import make_int16_collection
 
+pytestmark = pytest.mark.core
+
 
 def _make_mem_dataset(
     rows: int = 5,
@@ -341,14 +343,6 @@ class TestIloc:
         np.testing.assert_array_almost_equal(
             arr, expected, decimal=4, err_msg="iloc array should match values slice"
         )
-
-
-import datetime as dt
-import re
-
-from pyramids.base._errors import DatasetNotFoundError
-
-pytestmark = pytest.mark.core
 
 
 class TestReadMultipleFilesErrors:

--- a/tests/dataset/collection/test_dataset_collection_unit.py
+++ b/tests/dataset/collection/test_dataset_collection_unit.py
@@ -730,7 +730,7 @@ class TestFromFilesValidate:
         bad = _write_geotiff(tmp_path / "bad.tif", np.zeros((3, 5), dtype="int16"))
         with pytest.raises(AlignmentError, match="bad.tif") as exc:
             DatasetCollection.from_files([t0, bad], validate=True)
-        assert "does not match" in str(exc.value), f"unexpected message: {exc.value}"
+        assert "must share" in str(exc.value), f"unexpected message: {exc.value}"
 
     def test_validate_true_dtype_mismatch_raises(self, tmp_path):
         """A file with a different dtype raises AlignmentError naming it.
@@ -742,6 +742,25 @@ class TestFromFilesValidate:
         t0 = _write_geotiff(tmp_path / "t0.tif", np.zeros((4, 5), dtype="int16"))
         bad = _write_geotiff(tmp_path / "bad.tif", np.zeros((4, 5), dtype="float64"))
         with pytest.raises(AlignmentError, match="bad.tif"):
+            DatasetCollection.from_files([t0, bad], validate=True)
+
+    def test_validate_true_shifted_extent_raises(self, tmp_path):
+        """A same-shape raster with a shifted extent raises on the geotransform (M1)."""
+        t0 = _write_geotiff(tmp_path / "t0.tif", np.zeros((4, 5), dtype="int16"))
+        bad = _write_geotiff(
+            tmp_path / "bad.tif", np.zeros((4, 5), dtype="int16"), top_left=(100.0, 4.0)
+        )
+        with pytest.raises(AlignmentError, match="geotransform") as exc:
+            DatasetCollection.from_files([t0, bad], validate=True)
+        assert "bad.tif" in str(exc.value), f"path not named: {exc.value}"
+
+    def test_validate_true_crs_mismatch_raises(self, tmp_path):
+        """A same-shape/geotransform raster in a different CRS raises on CRS (M1)."""
+        t0 = _write_geotiff(tmp_path / "t0.tif", np.zeros((4, 5), dtype="int16"))
+        bad = _write_geotiff(
+            tmp_path / "bad.tif", np.zeros((4, 5), dtype="int16"), epsg=3857
+        )
+        with pytest.raises(AlignmentError, match="CRS"):
             DatasetCollection.from_files([t0, bad], validate=True)
 
     def test_validate_false_does_not_open_other_files(self, tmp_path, monkeypatch):

--- a/tests/dataset/collection/test_lazy.py
+++ b/tests/dataset/collection/test_lazy.py
@@ -179,6 +179,55 @@ class TestTiledDataCube:
         )
 
 
+class TestDuplicatePathSharedLock:
+    """A path repeated in the file list shares one IO lock across its timesteps (L4)."""
+
+    @requires_dask
+    def test_duplicate_path_data_computes_and_shares_lock(self, tmp_path, monkeypatch):
+        """`from_files([p, p])` computes a correct 2-step cube sharing one lock.
+
+        Test scenario:
+            A single GeoTIFF listed twice — expected: ``.data`` is a ``(2, 1, 4, 5)``
+            cube whose two timesteps equal the source array, and both timesteps were
+            built with the *same* lock object (one IO lock per distinct path, so
+            duplicate paths that share a FILE_CACHE handle serialise on one lock).
+        """
+        from pyramids.dataset import collection as coll_mod
+
+        arr = np.arange(20, dtype=np.float32).reshape(4, 5)
+        ds = Dataset.create_from_array(
+            arr,
+            top_left_corner=(0.0, 4.0),
+            cell_size=1.0,
+            epsg=4326,
+        )
+        p = str(tmp_path / "dup.tif")
+        ds.to_file(p)
+
+        captured: list[Any] = []
+        real = coll_mod._lazy_timestep
+
+        def spy(path, meta, gdal_env, lock):
+            captured.append(lock)
+            return real(path, meta, gdal_env, lock)
+
+        monkeypatch.setattr(coll_mod, "_lazy_timestep", spy)
+        collection = DatasetCollection.from_files([p, p])
+        got = collection.data.compute()
+
+        assert got.shape == (2, 1, 4, 5), f"expected (2, 1, 4, 5), got {got.shape}"
+        np.testing.assert_array_equal(
+            got[0, 0], arr, err_msg="first duplicate timestep differs from source"
+        )
+        np.testing.assert_array_equal(
+            got[1, 0], arr, err_msg="second duplicate timestep differs from source"
+        )
+        assert len(captured) == 2, f"expected two timesteps, got {len(captured)}"
+        assert captured[0] is captured[1], (
+            "duplicate paths must share one IO lock, got distinct lock objects"
+        )
+
+
 class TestErrors:
     def test_no_files_raises(self):
         arr = np.zeros((4, 5), dtype=np.float32)

--- a/tests/dataset/collection/test_lazy.py
+++ b/tests/dataset/collection/test_lazy.py
@@ -139,6 +139,73 @@ class TestManagerCaching:
         )
 
 
+class TestTiledDataCube:
+    """The `data` cube stacks per-timestep tiled dask arrays (ARC-45).
+
+    Each timestep is built by :func:`_lazy_timestep` (windowed
+    ``_read_chunk`` reads) and stacked along time, so a reduction tiles
+    spatially instead of holding whole rasters. A tiny raster stays a
+    single spatial chunk — these tests assert the *correctness* of the
+    tiled read path, not that it is multi-chunk.
+    """
+
+    @requires_dask
+    def test_data_matches_eager_stack(self, three_files):
+        """`data.compute()` equals the old-style eager per-file stack.
+
+        Test scenario:
+            Compare band 0 of the lazy cube against
+            ``np.stack([Dataset.read_file(p).read_array() for p in paths])`` —
+            expected: element-for-element equality.
+        """
+        collection = DatasetCollection.from_files(three_files)
+        expected = np.stack(
+            [Dataset.read_file(p).read_array() for p in three_files], axis=0
+        )
+        got = collection.data.compute()
+        assert got.shape == (3, 1, 4, 5), f"expected (3, 1, 4, 5), got {got.shape}"
+        np.testing.assert_array_equal(
+            got[:, 0, :, :],
+            expected,
+            err_msg="tiled cube values differ from the eager stack",
+        )
+
+    @requires_dask
+    def test_data_is_time_stacked_dask_array(self, three_files):
+        """`data` is a `(T, B, Y, X)` dask array stacked along time.
+
+        Test scenario:
+            Inspect ``collection.data`` — expected: a dask array of shape
+            ``(3, 1, 4, 5)`` whose leading axis has one block per timestep.
+        """
+        collection = DatasetCollection.from_files(three_files)
+        data = collection.data
+        assert hasattr(data, "dask"), "data should be a lazy dask array"
+        assert data.shape == (3, 1, 4, 5), f"expected (3, 1, 4, 5), got {data.shape}"
+        assert data.numblocks[0] == 3, (
+            f"time axis should be stacked one block per timestep, got {data.numblocks[0]}"
+        )
+
+    @requires_dask
+    def test_reduction_matches_numpy(self, three_files):
+        """A time-axis reduction over the tiled cube matches numpy.
+
+        Test scenario:
+            ``collection.mean()`` vs the eager stack's ``mean(axis=0)`` —
+            expected: identical values (the tiled read path does not perturb
+            the reduction).
+        """
+        collection = DatasetCollection.from_files(three_files)
+        expected = np.stack(
+            [Dataset.read_file(p).read_array() for p in three_files], axis=0
+        ).mean(axis=0)
+        got = collection.mean()
+        assert got.shape == (1, 4, 5), f"expected (1, 4, 5), got {got.shape}"
+        np.testing.assert_allclose(
+            np.squeeze(got), expected, err_msg="tiled reduction differs from numpy mean"
+        )
+
+
 class TestErrors:
     def test_no_files_raises(self):
         arr = np.zeros((4, 5), dtype=np.float32)

--- a/tests/dataset/collection/test_lazy.py
+++ b/tests/dataset/collection/test_lazy.py
@@ -111,33 +111,6 @@ class TestManagerCaching:
                 "Repeated compute should reuse the cached gdal.Dataset"
             )
 
-    def test_path_and_str_share_cache_slot(self, three_files):
-        """M1 regression: `_read_time_step` normalises Path → str.
-
-        Pre-fix passing `Path("foo.tif")` and `"foo.tif"` produced
-        two distinct `FILE_CACHE` slots (the cache key is built
-        from the literal `manager_id`, and Path/str hash to
-        different keys). Post-fix the function calls `str(path)`
-        before constructing the manager, so both forms collapse
-        to a single slot.
-        """
-        from pathlib import Path
-
-        from pyramids.base._file_manager import FILE_CACHE
-        from pyramids.dataset.collection import _read_time_step
-
-        first_path = three_files[0]
-        for key in [k for k in FILE_CACHE._cache if first_path in tuple(k)]:
-            del FILE_CACHE._cache[key]
-
-        _read_time_step(first_path)
-        _read_time_step(Path(first_path))
-        path_keys = [k for k in FILE_CACHE._cache if first_path in tuple(k)]
-        assert len(path_keys) == 1, (
-            f"Path and str inputs should share a FILE_CACHE slot; got "
-            f"{len(path_keys)} entries: {path_keys}"
-        )
-
 
 class TestTiledDataCube:
     """The `data` cube stacks per-timestep tiled dask arrays (ARC-45).

--- a/tests/dataset/collection/test_lazy.py
+++ b/tests/dataset/collection/test_lazy.py
@@ -117,9 +117,10 @@ class TestTiledDataCube:
 
     Each timestep is built by :func:`_lazy_timestep` (windowed
     ``_read_chunk`` reads) and stacked along time, so a reduction tiles
-    spatially instead of holding whole rasters. A tiny raster stays a
-    single spatial chunk — these tests assert the *correctness* of the
-    tiled read path, not that it is multi-chunk.
+    spatially instead of holding whole rasters. The tiny fixtures stay a
+    single spatial chunk; ``test_multichunk_data_matches_eager`` forces a
+    tiny dask chunk-size so a raster actually splits into several Y/X
+    blocks, proving the multi-block tiles reassemble exactly.
     """
 
     @requires_dask
@@ -176,6 +177,44 @@ class TestTiledDataCube:
         assert got.shape == (1, 4, 5), f"expected (1, 4, 5), got {got.shape}"
         np.testing.assert_allclose(
             np.squeeze(got), expected, err_msg="tiled reduction differs from numpy mean"
+        )
+
+    @requires_dask
+    def test_multichunk_data_matches_eager(self, tmp_path):
+        """A raster that tiles into >1 spatial block reassembles exactly (ARC-45).
+
+        Test scenario:
+            With dask's array chunk-size forced tiny, a single-timestep cube over
+            an 8x10 raster builds multiple Y/X blocks — expected: the spatial axes
+            split into more than one block and ``data.compute()`` still equals the
+            whole-raster read, proving the windowed ``_read_chunk`` tiles reassemble
+            to the exact array (the 4x5 fixtures stay single-chunk and never exercise
+            this multi-block path).
+        """
+        import dask
+
+        arr = np.arange(80, dtype=np.float32).reshape(8, 10)
+        ds = Dataset.create_from_array(
+            arr,
+            top_left_corner=(0.0, 8.0),
+            cell_size=1.0,
+            epsg=4326,
+        )
+        p = str(tmp_path / "big.tif")
+        ds.to_file(p)
+        collection = DatasetCollection.from_files([p])
+        with dask.config.set({"array.chunk-size": "256B"}):
+            data = collection.data
+            got = data.compute()
+        spatial_blocks = data.numblocks[2] * data.numblocks[3]
+        assert spatial_blocks > 1, (
+            f"expected >1 spatial block, got numblocks {data.numblocks}"
+        )
+        assert got.shape == (1, 1, 8, 10), f"expected (1, 1, 8, 10), got {got.shape}"
+        np.testing.assert_array_equal(
+            got[0, 0],
+            arr,
+            err_msg="multi-block tiled assembly differs from the eager read",
         )
 
 

--- a/tests/dataset/collection/test_lazy.py
+++ b/tests/dataset/collection/test_lazy.py
@@ -227,6 +227,48 @@ class TestDuplicatePathSharedLock:
             "duplicate paths must share one IO lock, got distinct lock objects"
         )
 
+    @requires_dask
+    def test_separate_data_graphs_share_underlying_lock(self, tmp_path, monkeypatch):
+        """Two `.data` graphs over one path share a single underlying mutex (L1).
+
+        Test scenario:
+            Build two separate collections over the same file and access `.data`
+            on each — expected: the IO locks handed to `_lazy_timestep` are
+            distinct objects but resolve to the *same* underlying `threading.Lock`
+            (keyed by a path token), so concurrent reads on the shared FILE_CACHE
+            handle serialise across graphs, not just within one graph.
+        """
+        from pyramids.dataset import collection as coll_mod
+
+        arr = np.arange(20, dtype=np.float32).reshape(4, 5)
+        ds = Dataset.create_from_array(
+            arr,
+            top_left_corner=(0.0, 4.0),
+            cell_size=1.0,
+            epsg=4326,
+        )
+        p = str(tmp_path / "shared.tif")
+        ds.to_file(p)
+
+        captured: list[Any] = []
+        real = coll_mod._lazy_timestep
+
+        def spy(path, meta, gdal_env, lock):
+            captured.append(lock)
+            return real(path, meta, gdal_env, lock)
+
+        monkeypatch.setattr(coll_mod, "_lazy_timestep", spy)
+        _ = DatasetCollection.from_files([p]).data
+        _ = DatasetCollection.from_files([p]).data
+
+        assert len(captured) == 2, f"expected two graphs, got {len(captured)}"
+        assert captured[0] is not captured[1], (
+            "separate graphs should build distinct lock objects"
+        )
+        assert captured[0].lock is captured[1].lock, (
+            "distinct graphs over one path must share the underlying mutex"
+        )
+
 
 class TestErrors:
     def test_no_files_raises(self):

--- a/tests/dataset/collection/test_reproject_compute.py
+++ b/tests/dataset/collection/test_reproject_compute.py
@@ -1,0 +1,158 @@
+"""Tests for the deferred ``compute=False`` reproject / align path (ARC-54).
+
+``DatasetCollection.to_crs`` and ``align`` plan the operation once (a single
+``Reprojector`` / ``Aligner`` reused across every timestep) and, with
+``compute=False``, defer the whole thing into one :class:`dask.delayed.Delayed`
+that builds the reprojected / aligned collection when computed. These tests
+cover the deferred branch: the returned ``Delayed``, its computed result, the
+``inplace`` conflict guard, and the no-EPSG fallback under ``compute=False``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pyramids.dataset import Dataset, DatasetCollection
+from tests._marks import requires_dask
+
+pytestmark = pytest.mark.lazy
+
+
+@pytest.fixture
+def align_ref() -> Dataset:
+    """A 2x3 EPSG:4326 template used as the alignment reference (differs in size)."""
+    return Dataset.create_from_array(
+        np.zeros((2, 3), dtype=np.float32),
+        top_left_corner=(0.0, 4.0),
+        cell_size=2.0,
+        epsg=4326,
+    )
+
+
+class TestToCrsCompute:
+    """Deferred ``to_crs(compute=False)`` over the plan-once EPSG path."""
+
+    @requires_dask
+    def test_returns_delayed(self, three_files):
+        """``compute=False`` returns a ``dask.delayed.Delayed``, not a collection.
+
+        Test scenario:
+            ``to_crs(3857, compute=False)`` — expected: a ``Delayed`` object
+            (the whole reproject deferred into one graph).
+        """
+        from dask.delayed import Delayed
+
+        collection = DatasetCollection.from_files(three_files)
+        deferred = collection.to_crs(3857, compute=False)
+        assert isinstance(deferred, Delayed), (
+            f"expected a Delayed, got {type(deferred)}"
+        )
+
+    @requires_dask
+    def test_delayed_compute_reprojects(self, three_files):
+        """Computing the ``Delayed`` yields a reprojected collection.
+
+        Test scenario:
+            ``to_crs(3857, compute=False).compute()`` — expected: a
+            ``DatasetCollection`` at EPSG 3857 with the source ``time_length``.
+        """
+        collection = DatasetCollection.from_files(three_files)
+        result = collection.to_crs(3857, compute=False).compute()
+        assert isinstance(result, DatasetCollection), (
+            f"expected a collection, got {type(result)}"
+        )
+        assert result.base.epsg == 3857, f"expected EPSG 3857, got {result.base.epsg}"
+        assert result.time_length == 3, (
+            f"time_length should be preserved, got {result.time_length}"
+        )
+
+    @requires_dask
+    def test_compute_false_with_inplace_raises(self, three_files):
+        """``compute=False`` combined with ``inplace=True`` raises ``ValueError``.
+
+        Test scenario:
+            Both flags together — expected: a ``ValueError`` (a deferred graph
+            cannot mutate the collection in place).
+        """
+        collection = DatasetCollection.from_files(three_files)
+        with pytest.raises(
+            ValueError, match="compute=False cannot be combined with inplace"
+        ):
+            collection.to_crs(3857, inplace=True, compute=False)
+
+    @requires_dask
+    def test_non_epsg_target_deferred(self, three_files):
+        """A no-EPSG target under ``compute=False`` defers the direct fallback.
+
+        Test scenario:
+            ``to_crs(<proj4 LAEA>, compute=False).compute()`` — expected: a
+            ``DatasetCollection`` with the source ``time_length`` (the per-step
+            ``dask.delayed(ds.to_crs)`` fallback ran, not the ``Reprojector``).
+        """
+        proj4 = "+proj=laea +lat_0=0 +lon_0=0 +datum=WGS84 +units=m +no_defs"
+        collection = DatasetCollection.from_files(three_files)
+        result = collection.to_crs(proj4, compute=False).compute()
+        assert isinstance(result, DatasetCollection), (
+            f"expected a collection, got {type(result)}"
+        )
+        assert result.time_length == 3, (
+            f"time_length should be preserved, got {result.time_length}"
+        )
+
+
+class TestAlignCompute:
+    """Deferred ``align(compute=False)`` over the plan-once ``Aligner`` path."""
+
+    @requires_dask
+    def test_returns_delayed(self, three_files, align_ref):
+        """``align(ref, compute=False)`` returns a ``dask.delayed.Delayed``.
+
+        Test scenario:
+            ``align(ref, compute=False)`` — expected: a ``Delayed`` object.
+        """
+        from dask.delayed import Delayed
+
+        collection = DatasetCollection.from_files(three_files)
+        deferred = collection.align(align_ref, compute=False)
+        assert isinstance(deferred, Delayed), (
+            f"expected a Delayed, got {type(deferred)}"
+        )
+
+    @requires_dask
+    def test_delayed_compute_aligns(self, three_files, align_ref):
+        """Computing the ``Delayed`` yields a collection aligned to the reference.
+
+        Test scenario:
+            ``align(ref, compute=False).compute()`` — expected: a
+            ``DatasetCollection`` whose grid matches ``ref`` (rows/cols) with the
+            source ``time_length``.
+        """
+        collection = DatasetCollection.from_files(three_files)
+        result = collection.align(align_ref, compute=False).compute()
+        assert isinstance(result, DatasetCollection), (
+            f"expected a collection, got {type(result)}"
+        )
+        assert result.base.rows == align_ref.rows, (
+            f"aligned rows {result.base.rows} != reference {align_ref.rows}"
+        )
+        assert result.base.columns == align_ref.columns, (
+            f"aligned columns {result.base.columns} != reference {align_ref.columns}"
+        )
+        assert result.time_length == 3, (
+            f"time_length should be preserved, got {result.time_length}"
+        )
+
+    @requires_dask
+    def test_compute_false_with_inplace_raises(self, three_files, align_ref):
+        """``align(compute=False, inplace=True)`` raises ``ValueError``.
+
+        Test scenario:
+            Both flags together — expected: a ``ValueError`` from the shared
+            ``_apply_operator`` guard.
+        """
+        collection = DatasetCollection.from_files(three_files)
+        with pytest.raises(
+            ValueError, match="compute=False cannot be combined with inplace"
+        ):
+            collection.align(align_ref, inplace=True, compute=False)

--- a/tests/dataset/collection/test_to_netcdf.py
+++ b/tests/dataset/collection/test_to_netcdf.py
@@ -643,6 +643,45 @@ class TestToNetcdfNoFilesPath:
 
 
 @pytest.mark.xarray
+class TestToNetcdfLargeCubeWarning:
+    """ARC-46: ``to_netcdf`` warns (pointing at ``to_zarr``) for an oversized cube."""
+
+    def test_warns_when_estimate_exceeds_threshold(self, tmp_path, monkeypatch):
+        """A cube above ``_TO_NETCDF_WARN_BYTES`` emits a UserWarning naming to_zarr.
+
+        Args:
+            tmp_path: pytest temp directory.
+            monkeypatch: pytest monkeypatch fixture.
+
+        Test scenario:
+            Shrink the module warn-threshold to 1 byte so the tiny fixture cube
+            trips it — expected: a UserWarning steering the caller at ``to_zarr``.
+        """
+        col, _ = _make_int16_collection(tmp_path, count=2)
+        monkeypatch.setattr("pyramids.dataset.collection._TO_NETCDF_WARN_BYTES", 1)
+        with pytest.warns(UserWarning, match="to_zarr"):
+            col.to_netcdf(str(tmp_path / "warn.nc"))
+
+    def test_no_warning_for_small_cube(self, tmp_path):
+        """A small cube (default 2 GiB threshold) emits no size warning.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            Default threshold, tiny fixture cube — expected: none of the emitted
+            warnings mention the streaming ``to_zarr`` guidance.
+        """
+        col, _ = _make_int16_collection(tmp_path, count=2)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            col.to_netcdf(str(tmp_path / "ok.nc"))
+        assert not any("streams the cube" in str(w.message) for w in caught), (
+            f"unexpected size warning: {[str(w.message) for w in caught]}"
+        )
+
+
+@pytest.mark.xarray
 class TestToNetcdfRoundTrip:
     """End-to-end: re-open the written file via :class:`NetCDF` and compare."""
 

--- a/tests/dataset/collection/test_zarr.py
+++ b/tests/dataset/collection/test_zarr.py
@@ -288,3 +288,104 @@ class TestAppendAndRegion:
         cube = DatasetCollection.from_zarr(store).data.compute()
         means = [float(cube[i].mean()) for i in range(3)]
         assert means == [1.0, 9.0, 1.0], f"region write wrong: {means}"
+
+
+class TestAppendAtomicity:
+    """ARC-75a: deferred (compute=False) append behaviour and rollback atomicity."""
+
+    def _col(self, tmp_path, vals, tag):
+        paths = []
+        for i, v in enumerate(vals):
+            ds = Dataset.create_from_array(
+                np.full((3, 4), float(v), dtype=np.float32),
+                top_left_corner=(0.0, 3.0),
+                cell_size=1.0,
+                epsg=4326,
+            )
+            p = str(tmp_path / f"{tag}_{v}_{i}.tif")
+            ds.to_file(p)
+            paths.append(p)
+        return DatasetCollection.from_files(paths)
+
+    @staticmethod
+    def _boom(*args, **kwargs):
+        """Stand-in finalize that fails after the region write has grown the store."""
+        raise RuntimeError("boom during finalize")
+
+    @requires_zarr
+    def test_compute_true_rolls_back_shape_on_failure(self, tmp_path, monkeypatch):
+        """A finalize failure during a compute=True append leaves the shape unchanged.
+
+        Test scenario:
+            Append onto a 2-step store with the finalize monkeypatched to raise —
+            expected: the exception propagates and the store's ``data`` array is
+            resized back to its original 2-step shape (never left grown-but-empty).
+        """
+        store = str(tmp_path / "atomic_true.zarr")
+        self._col(tmp_path, [1, 2], "a").to_zarr(store)
+        before = zarr.open_group(store, mode="r")["data"].shape
+        monkeypatch.setattr(
+            "pyramids.dataset.collection._finalize_append_metadata", self._boom
+        )
+        with pytest.raises(RuntimeError, match="boom"):
+            self._col(tmp_path, [3, 4, 5], "b").to_zarr(
+                store, mode="a", append_dim="time"
+            )
+        after = zarr.open_group(store, mode="r")["data"].shape
+        assert after == before, f"shape not rolled back: {before} -> {after}"
+
+    @requires_zarr
+    def test_compute_false_rolls_back_shape_on_failure(self, tmp_path, monkeypatch):
+        """A finalize failure while computing the deferred append also rolls back.
+
+        Test scenario:
+            Build the ``compute=False`` delayed, then compute it with the finalize
+            monkeypatched to raise — expected: the exception propagates from
+            ``_append_region`` and the store's ``data`` shape is rolled back.
+        """
+        store = str(tmp_path / "atomic_false.zarr")
+        self._col(tmp_path, [1, 2], "a").to_zarr(store)
+        before = zarr.open_group(store, mode="r")["data"].shape
+        monkeypatch.setattr(
+            "pyramids.dataset.collection._finalize_append_metadata", self._boom
+        )
+        delayed = self._col(tmp_path, [3, 4, 5], "b").to_zarr(
+            store, mode="a", append_dim="time", compute=False
+        )
+        with pytest.raises(RuntimeError, match="boom"):
+            delayed.compute(scheduler="synchronous")
+        after = zarr.open_group(store, mode="r")["data"].shape
+        assert after == before, f"shape not rolled back: {before} -> {after}"
+
+    @requires_zarr
+    def test_compute_false_append_succeeds(self, tmp_path):
+        """Computing the deferred append grows the store and updates time_length.
+
+        Test scenario:
+            Build the ``compute=False`` delayed and compute it (no injected
+            failure) — expected: the store round-trips 5 ordered timesteps, so the
+            ``_append_region`` success path and its finalize both ran.
+        """
+        store = str(tmp_path / "deferred_ok.zarr")
+        self._col(tmp_path, [1, 2], "a").to_zarr(store)
+        delayed = self._col(tmp_path, [3, 4, 5], "b").to_zarr(
+            store, mode="a", append_dim="time", compute=False
+        )
+        delayed.compute(scheduler="synchronous")
+        rt = DatasetCollection.from_zarr(store)
+        assert rt.time_length == 5, f"time_length {rt.time_length}"
+        means = [float(rt.data.compute()[i].mean()) for i in range(5)]
+        assert means == [1.0, 2.0, 3.0, 4.0, 5.0], f"means {means}"
+
+    @requires_zarr
+    def test_append_dim_not_time_raises(self, tmp_path):
+        """An append_dim other than 'time' raises ValueError (a (T,B,Y,X) cube guard).
+
+        Test scenario:
+            ``append_dim='band'`` on an existing store — expected: ValueError
+            stating the append dim must be ``'time'``.
+        """
+        store = str(tmp_path / "wrong_dim.zarr")
+        self._col(tmp_path, [1, 2], "a").to_zarr(store)
+        with pytest.raises(ValueError, match="append_dim must be 'time'"):
+            self._col(tmp_path, [3], "b").to_zarr(store, mode="a", append_dim="band")

--- a/tests/dataset/collection/test_zarr.py
+++ b/tests/dataset/collection/test_zarr.py
@@ -378,6 +378,29 @@ class TestAppendAtomicity:
         assert means == [1.0, 2.0, 3.0, 4.0, 5.0], f"means {means}"
 
     @requires_zarr
+    def test_compute_false_append_default_scheduler(self, tmp_path):
+        """The deferred append computes under the default scheduler without deadlock.
+
+        Test scenario:
+            Compute the ``compute=False`` delayed with a bare ``.compute()`` (the
+            default threaded scheduler a real caller gets, not ``scheduler=
+            "synchronous"``) — expected: it returns and the store round-trips 5
+            ordered timesteps. ``_append_region`` drives its inner write on the
+            synchronous scheduler, so the nested compute cannot deadlock the outer
+            worker pool (M1).
+        """
+        store = str(tmp_path / "deferred_default.zarr")
+        self._col(tmp_path, [1, 2], "a").to_zarr(store)
+        delayed = self._col(tmp_path, [3, 4, 5], "b").to_zarr(
+            store, mode="a", append_dim="time", compute=False
+        )
+        delayed.compute()
+        rt = DatasetCollection.from_zarr(store)
+        assert rt.time_length == 5, f"time_length {rt.time_length}"
+        means = [float(rt.data.compute()[i].mean()) for i in range(5)]
+        assert means == [1.0, 2.0, 3.0, 4.0, 5.0], f"means {means}"
+
+    @requires_zarr
     def test_append_dim_not_time_raises(self, tmp_path):
         """An append_dim other than 'time' raises ValueError (a (T,B,Y,X) cube guard).
 

--- a/tests/dataset/collection/test_zarr.py
+++ b/tests/dataset/collection/test_zarr.py
@@ -327,10 +327,9 @@ class TestAppendAtomicity:
         monkeypatch.setattr(
             "pyramids.dataset.collection._finalize_append_metadata", self._boom
         )
+        col = self._col(tmp_path, [3, 4, 5], "b")
         with pytest.raises(RuntimeError, match="boom"):
-            self._col(tmp_path, [3, 4, 5], "b").to_zarr(
-                store, mode="a", append_dim="time"
-            )
+            col.to_zarr(store, mode="a", append_dim="time")
         after = zarr.open_group(store, mode="r")["data"].shape
         assert after == before, f"shape not rolled back: {before} -> {after}"
 
@@ -437,5 +436,6 @@ class TestAppendAtomicity:
         """
         store = str(tmp_path / "wrong_dim.zarr")
         self._col(tmp_path, [1, 2], "a").to_zarr(store)
+        col = self._col(tmp_path, [3], "b")
         with pytest.raises(ValueError, match="append_dim must be 'time'"):
-            self._col(tmp_path, [3], "b").to_zarr(store, mode="a", append_dim="band")
+            col.to_zarr(store, mode="a", append_dim="band")

--- a/tests/dataset/collection/test_zarr.py
+++ b/tests/dataset/collection/test_zarr.py
@@ -378,6 +378,33 @@ class TestAppendAtomicity:
         assert means == [1.0, 2.0, 3.0, 4.0, 5.0], f"means {means}"
 
     @requires_zarr
+    def test_compute_false_recompute_is_idempotent(self, tmp_path):
+        """Computing the deferred append twice does not double-append (L2).
+
+        Test scenario:
+            Build the ``compute=False`` delayed and compute it twice — expected: a
+            recompute is a no-op, so the store stays at 5 ordered timesteps with a
+            5-entry ``pyramids_file_list``, not a grown shape or duplicated file list.
+        """
+        store = str(tmp_path / "recompute.zarr")
+        self._col(tmp_path, [1, 2], "a").to_zarr(store)
+        delayed = self._col(tmp_path, [3, 4, 5], "b").to_zarr(
+            store, mode="a", append_dim="time", compute=False
+        )
+        delayed.compute(scheduler="synchronous")
+        delayed.compute(scheduler="synchronous")
+        rt = DatasetCollection.from_zarr(store)
+        assert rt.time_length == 5, f"time_length {rt.time_length}"
+        file_list = list(
+            zarr.open_group(store, mode="r").attrs.get("pyramids_file_list", [])
+        )
+        assert len(file_list) == 5, (
+            f"file list should stay length 5, got {len(file_list)}"
+        )
+        means = [float(rt.data.compute()[i].mean()) for i in range(5)]
+        assert means == [1.0, 2.0, 3.0, 4.0, 5.0], f"means {means}"
+
+    @requires_zarr
     def test_compute_false_append_default_scheduler(self, tmp_path):
         """The deferred append computes under the default scheduler without deadlock.
 

--- a/tests/dataset/stac/test_stac.py
+++ b/tests/dataset/stac/test_stac.py
@@ -276,12 +276,12 @@ class TestCollectionGdalEnvLazyReads:
             f"unexpected env without signer: {seen}"
         )
 
-    def test_path_b_read_time_step_installs_env(self, three_tifs, monkeypatch):
-        """Path B: `_read_time_step` installs the env around the worker open.
+    def test_path_b_lazy_data_installs_env(self, three_tifs, monkeypatch):
+        """Path B: the tiled `data` graph installs the collection's env around each open.
 
         Test scenario:
-            A spy on the module-level opener records the sentinel option; calling
-            _read_time_step with an env must see it active.
+            A spy on the module-level opener records the sentinel option; computing the
+            tiled `data` cube for an env-carrying collection must see it active.
         """
         from pyramids.dataset import collection as coll_mod
 
@@ -293,21 +293,11 @@ class TestCollectionGdalEnvLazyReads:
             return real_open(*args, **kwargs)
 
         monkeypatch.setattr(coll_mod, "gdal_raster_open", spy)
-        coll_mod._read_time_step(three_tifs[0], {"PYRAMIDS_TEST_KEY": "on"})
-        assert captured["v"] == "on", f"env not active during Path B open: {captured}"
-
-    def test_path_b_read_time_step_reads_array(self, three_tifs):
-        """Path B: `_read_time_step` returns a (1, R, C) array for a 1-band file.
-
-        Test scenario:
-            The reader still works (env defaults to None) and shapes correctly.
-        """
-        from pyramids.dataset.collection import _read_time_step
-
-        arr = _read_time_step(three_tifs[0])
-        assert arr.shape[0] == 1, (
-            f"single-band read should be (1, R, C), got {arr.shape}"
+        coll = coll_mod.DatasetCollection.from_files(
+            three_tifs, gdal_env={"PYRAMIDS_TEST_KEY": "on"}
         )
+        coll.data.compute()
+        assert captured["v"] == "on", f"env not active during Path B open: {captured}"
 
     def test_gdal_env_survives_pickle(self, three_tifs):
         """H4: the persisted env survives pickling (so it reaches dask workers).


### PR DESCRIPTION
# Description

Resolves the actionable findings from the `dataset/collection.py` architecture review
(`planning/architecture-review/25-july/arc-collection.md`) — the `DatasetCollection` time-series datacube, the
package's designated big-data object. Each finding was independently re-verified against `main` (three read-only
deep dives, line numbers re-anchored) before being fixed; several premises were corrected during verification
(noted below).

This PR resolves six findings spanning **refactor, correctness, robustness, and out-of-core performance**.

**Refactor — ARC-70**

- Extracted `DatasetCollection._mem_dataset_from_array(arr, source=None)` (dedupes 4 near-identical
  `create_from_array` sites; `source=` covers the per-slice `to_file` case that uses `iloc(i)`, not the base) and
  `_require_files("<method>")` (dedupes the `to_kerchunk`/`to_zarr` file-backed guards; the zarr-aware `data` guard
  is intentionally left broader). *Verification corrected sub-claim 3: the zarr geobox scaffolding is already
  shared in `ops/_geobox_zarr.py`, so only the thin write/finalize wrappers were duplicated.*

**Correctness + memory — ARC-46**

- `tail(n)` now returns the last `abs(n)` timesteps regardless of sign — fixing the previous behaviour where a
  positive `n` skipped the *first* `n` — and reads only the selected timesteps via an empty-safe `_stack_band0`
  (so does `head`). *Verification corrected the plan's proposed `self.values[-abs(n):]`, which fixes the sign but
  not the memory (it still stacks all N first); the fix slices the handles.*
- `to_netcdf` now warns (pointing at the streaming `to_zarr`) when the in-RAM `(T, B, Y, X)` cube would exceed
  `_TO_NETCDF_WARN_BYTES` (2 GiB), instead of OOM-ing without explanation.

**Robustness — ARC-75 (a) and (b)**, the two embedded sub-issues of the (deferred) XL `LazyDatasetCollection`:

- `_append_to_zarr` is now atomic: the time-axis resize is rolled back on any write failure, on both the
  `compute=True` streamed path and the deferred `compute=False` path (which now defers the resize+write+finalize
  into a single delayed) — so the store is never left advertising a grown-but-empty shape.
- `from_files(..., validate=True)` opts into a per-file header check that raises `AlignmentError` naming the
  offending path when a file's `(band, rows, cols)` shape or dtype differs from the template, instead of the lazy
  dask cube silently trusting the first file. The default (`validate=False`) preserves the "open only the first
  file" design.

**Out-of-core performance — ARC-44 / ARC-45 / ARC-54**

- **ARC-44** — the point accessors (`first` / `last` / `iloc` / `collection[i]`) opened **all N** per-timestep GDAL
  handles (via the bulk `datasets` property) just to read one, exhausting file descriptors at 1000+ steps. A new
  lazy `_dataset_at(i)` + `_handle_cache` opens exactly one file per single-timestep access; the bulk consumers are
  unchanged.
- **ARC-45** — the lazy `data` cube read each timestep as one un-tiled block (whole-raster `ReadAsArray`), so a
  time-axis reduction held several full rasters and a single raster larger than RAM failed outright. Each timestep
  is now a **spatially-tiled** dask array (windowed reads reusing `ops/io.py::_read_chunk`) stacked along time, so
  reductions tile spatially and a raster is read tile-by-tile. Values are identical to the old path (verified).
- **ARC-54** — `to_crs` / `align` looped per-timestep and never used the "plan-once, apply-many"
  `Reprojector` / `Aligner`. They now build one operator and reuse it across timesteps, and gain a keyword-only
  `compute=` option: `compute=False` defers the whole reproject/align into a single `dask.delayed` that builds the
  new collection when computed. Non-EPSG target CRSes / references (which the int-EPSG operators can't take) fall
  back to the direct per-timestep path, preserving the existing generality.

The XL `LazyDatasetCollection` itself (ARC-75 main) is deferred to a tracked follow-up.

**Behavior change (bug fix):** `DatasetCollection.tail(n)` now returns the last `abs(n)` timesteps for a *positive*
`n` too — previously a positive `n` skipped the *first* `n` rows (a latent bug; `grep` finds no internal caller
that relied on it). The documented default form `tail(-n)` is unchanged.

No new dependencies.

# Issues

Resolves the `arc-collection` architecture review
(`planning/architecture-review/25-july/arc-collection.md`):

- Closes #869 — ARC-44: point accessors open all N files (FD exhaustion)
- Closes #870 — ARC-45: lazy timesteps read as un-tiled whole-raster blocks
- Closes #871 — ARC-46: to_netcdf/tail build the full (T,B,Y,X) cube in RAM; tail sign fix
- Closes #872 — ARC-54: to_crs/align bypass Reprojector/Aligner
- Closes #873 — ARC-70: create_from_array / file-backed guard / zarr scaffolding duplication
- Refs #874 — ARC-75: atomic zarr append + `validate=True` headers land here (sub-issues a/b);
  the XL `LazyDatasetCollection` formalisation stays tracked in that issue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality) — the `validate=` opt-in and the `to_netcdf` warning
- [x] This change requires a documentation update

# How Has This Been Tested?

- `pixi run -e dev pytest -m "not plot" -q` → **7176 passed**, 51 skipped.
- `pixi run -e dev mypy` → **0 errors** (123 files).
- ~55 new collection tests across both batches: the ARC-70 helpers, the `tail` sign regression + head/tail
  empty-safety (dtype-preserving), the `to_netcdf` large-cube warning, atomic `_append_to_zarr` rollback-on-failure
  (compute True/False) + deferred-append default-scheduler + recompute-idempotency, `from_files(validate=True)`
  shape/dtype/geotransform/CRS-mismatch `AlignmentError`, the ARC-44 one-file-per-access lazy handles (and
  pickle-drop), the ARC-45 tiled-`data` value-equivalence + multi-block assembly + reduction + per-path shared IO
  lock, and the ARC-54 `compute=False` reproject/align `Delayed` (plus the inplace-conflict and non-EPSG-fallback
  paths).
- Two adversarial review rounds (`planning/pr-diff-review-fix-collection-datacube-perf-2026-07-27{,-2}.md`) plus a
  SonarCloud sweep: all findings resolved; PR quality gate green.

- [x] Full non-plot suite (`pytest -m "not plot"`)
- [x] `mypy` clean

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen bumps this automatically on release)
- [ ] added changes to History.rst. (commitizen-generated; not hand-edited)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (docstrings on every touched symbol)

