### PR TITLE
refactor(feature): arc-feature architecture-review findings

### DIFF
--- a/src/pyramids/base/_configure.py
+++ b/src/pyramids/base/_configure.py
@@ -237,7 +237,7 @@ def configure_lazy_vector(
         dask.config.set(scheduler=scheduler)
         applied["scheduler"] = scheduler
     if target_bytes_per_partition is not None:
-        from pyramids.feature import collection as _fc_mod
+        from pyramids.feature import _read as _fc_mod
 
         _fc_mod._LAZY_TARGET_BYTES_PER_PARTITION = int(target_bytes_per_partition)
         applied["target_bytes_per_partition"] = int(target_bytes_per_partition)
@@ -271,7 +271,7 @@ def _register_lazy_vector_worker_plugin(
 
                 dask.config.set(scheduler=self._settings["scheduler"])
             if "target_bytes_per_partition" in self._settings:
-                from pyramids.feature import collection as _fc_mod
+                from pyramids.feature import _read as _fc_mod
 
                 _fc_mod._LAZY_TARGET_BYTES_PER_PARTITION = int(
                     self._settings["target_bytes_per_partition"]

--- a/src/pyramids/feature/_analysis.py
+++ b/src/pyramids/feature/_analysis.py
@@ -36,8 +36,12 @@ def with_coordinates(fc: FeatureCollection) -> FeatureCollection:
     gdf = _geom.explode_gdf(gpd.GeoDataFrame(fc, copy=True), geometry="multipolygon")
     gdf = _geom.explode_gdf(gdf, geometry="geometrycollection")
     result = type(fc)(gdf)
-    result["x"] = result.apply(_geom.get_coords, geom_col="geometry", coord_type="x", axis=1)
-    result["y"] = result.apply(_geom.get_coords, geom_col="geometry", coord_type="y", axis=1)
+    result["x"] = result.apply(
+        _geom.get_coords, geom_col="geometry", coord_type="x", axis=1
+    )
+    result["y"] = result.apply(
+        _geom.get_coords, geom_col="geometry", coord_type="y", axis=1
+    )
     result.reset_index(drop=True, inplace=True)
     return result
 
@@ -88,11 +92,15 @@ def interpolate_to_raster(
             "geostatistics tier)."
         )
     if len(fc) < 3:
-        raise ValueError(f"interpolate_to_raster: need at least 3 points, got {len(fc)}")
+        raise ValueError(
+            f"interpolate_to_raster: need at least 3 points, got {len(fc)}"
+        )
     try:
         values = fc[column].to_numpy(dtype=float)
     except (TypeError, ValueError) as exc:
-        raise ValueError(f"interpolate_to_raster: column {column!r} must be numeric") from exc
+        raise ValueError(
+            f"interpolate_to_raster: column {column!r} must be numeric"
+        ) from exc
     if np.isnan(values).all():
         raise ValueError(f"interpolate_to_raster: column {column!r} is all-NaN")
     if n_neighbors is not None:
@@ -102,7 +110,9 @@ def interpolate_to_raster(
     # local import: pyramids.dataset imports pyramids.feature, so import here to break the cycle.
     from pyramids.dataset import Dataset
 
-    return Dataset.from_points(fc, column, algorithm=algorithm, cell_size=cell_size, bbox=bounds)
+    return Dataset.from_points(
+        fc, column, algorithm=algorithm, cell_size=cell_size, bbox=bounds
+    )
 
 
 def h3_cells(fc: FeatureCollection, resolution: int, op: str) -> list[str]:
@@ -111,7 +121,9 @@ def h3_cells(fc: FeatureCollection, resolution: int, op: str) -> list[str]:
     if not 0 <= resolution <= 15:
         raise ValueError(f"{op}: resolution must be 0-15, got {resolution}")
     if fc.crs is None:
-        raise ValueError(f"{op}: a CRS is required to convert points to lat/lng for H3 indexing")
+        raise ValueError(
+            f"{op}: a CRS is required to convert points to lat/lng for H3 indexing"
+        )
     pts = fc if fc.epsg == 4326 else fc.to_crs(4326)
     return [_h3.latlng_to_cell(geom.y, geom.x, resolution) for geom in pts.geometry]
 
@@ -124,7 +136,9 @@ def to_h3(fc: FeatureCollection, resolution: int) -> FeatureCollection:
     return result
 
 
-def h3_bin(fc: FeatureCollection, resolution: int, *, agg: Any, column: str | None) -> FeatureCollection:
+def h3_bin(
+    fc: FeatureCollection, resolution: int, *, agg: Any, column: str | None
+) -> FeatureCollection:
     """Aggregate points into H3 hexagon cells; one polygon per occupied cell (EPSG:4326)."""
     fc._require_column("h3_bin", column)
     cells = h3_cells(fc, resolution, "h3_bin")
@@ -149,5 +163,7 @@ def h3_bin(fc: FeatureCollection, resolution: int, *, agg: Any, column: str | No
         geometries.append(Polygon([(lng, lat) for (lat, lng) in boundary]))
         idx.append(cell)
         agg_values.append(value)
-    frame = gpd.GeoDataFrame({"h3": idx, name: agg_values}, geometry=geometries, crs="EPSG:4326")
+    frame = gpd.GeoDataFrame(
+        {"h3": idx, name: agg_values}, geometry=geometries, crs="EPSG:4326"
+    )
     return type(fc)(frame)

--- a/src/pyramids/feature/_analysis.py
+++ b/src/pyramids/feature/_analysis.py
@@ -14,7 +14,7 @@ silently desync). This mirrors the existing `from_wfs`->`_wfs` delegation.
 from __future__ import annotations
 
 import warnings
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import geopandas as gpd
 import numpy as np
@@ -26,8 +26,12 @@ from pyramids.feature import _h3
 from pyramids.feature import geometry as _geom
 from pyramids.feature import tessellation as _tess
 
+if TYPE_CHECKING:
+    from pyramids.dataset import Dataset
+    from pyramids.feature.collection import FeatureCollection
 
-def with_coordinates(fc: Any) -> Any:
+
+def with_coordinates(fc: FeatureCollection) -> FeatureCollection:
     """Explode multi-geometries and attach per-vertex ``x`` / ``y`` columns."""
     gdf = _geom.explode_gdf(gpd.GeoDataFrame(fc, copy=True), geometry="multipolygon")
     gdf = _geom.explode_gdf(gdf, geometry="geometrycollection")
@@ -38,7 +42,7 @@ def with_coordinates(fc: Any) -> Any:
     return result
 
 
-def with_centroid(fc: Any) -> Any:
+def with_centroid(fc: FeatureCollection) -> FeatureCollection:
     """Attach a ``center_point`` column from the mean of each row's coordinates."""
     result = with_coordinates(fc)
     result["avg_x"] = result["x"].map(np.mean)
@@ -64,7 +68,7 @@ def with_centroid(fc: Any) -> Any:
 
 
 def interpolate_to_raster(
-    fc: Any,
+    fc: FeatureCollection,
     column: str,
     *,
     method: str,
@@ -73,7 +77,7 @@ def interpolate_to_raster(
     power: float,
     n_neighbors: int | None,
     nodata: float,
-) -> Any:
+) -> Dataset:
     """Interpolate a numeric point column to a single-band raster via IDW (gdal.Grid)."""
     fc._require_point_geometry("interpolate_to_raster")
     fc._require_column("interpolate_to_raster", column)
@@ -101,7 +105,7 @@ def interpolate_to_raster(
     return Dataset.from_points(fc, column, algorithm=algorithm, cell_size=cell_size, bbox=bounds)
 
 
-def h3_cells(fc: Any, resolution: int, op: str) -> list[str]:
+def h3_cells(fc: FeatureCollection, resolution: int, op: str) -> list[str]:
     """Return the H3 cell index of each point at ``resolution`` (in EPSG:4326)."""
     fc._require_point_geometry(op)
     if not 0 <= resolution <= 15:
@@ -112,7 +116,7 @@ def h3_cells(fc: Any, resolution: int, op: str) -> list[str]:
     return [_h3.latlng_to_cell(geom.y, geom.x, resolution) for geom in pts.geometry]
 
 
-def to_h3(fc: Any, resolution: int) -> Any:
+def to_h3(fc: FeatureCollection, resolution: int) -> FeatureCollection:
     """Attach each point's H3 cell index as an ``h3`` column."""
     cells = h3_cells(fc, resolution, "to_h3")
     result = type(fc)(fc.copy())
@@ -120,7 +124,7 @@ def to_h3(fc: Any, resolution: int) -> Any:
     return result
 
 
-def h3_bin(fc: Any, resolution: int, *, agg: Any, column: str | None) -> Any:
+def h3_bin(fc: FeatureCollection, resolution: int, *, agg: Any, column: str | None) -> FeatureCollection:
     """Aggregate points into H3 hexagon cells; one polygon per occupied cell (EPSG:4326)."""
     fc._require_column("h3_bin", column)
     cells = h3_cells(fc, resolution, "h3_bin")

--- a/src/pyramids/feature/_analysis.py
+++ b/src/pyramids/feature/_analysis.py
@@ -1,0 +1,149 @@
+"""Analysis engine for :class:`~pyramids.feature.FeatureCollection` (ARC-36).
+
+Module-level implementations of the collection's analysis operations -- coordinate
+and centroid derivation, IDW point->raster interpolation, and H3 indexing/binning.
+The `FeatureCollection` methods are thin facades over these functions.
+
+Because a `FeatureCollection` *is-a* `GeoDataFrame` (pandas rebuilds instances on
+every slice; only `_metadata` survives `__finalize__`), the engine is a set of free
+functions that take the collection as their first argument and build results via
+`type(fc)(...)`, never stored instance state (an `ds.cog`-style engine object would
+silently desync). This mirrors the existing `from_wfs`->`_wfs` delegation.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+import geopandas as gpd
+import numpy as np
+import pandas as pd
+from shapely.geometry import Point, Polygon
+
+from pyramids.base._errors import GeometryWarning
+from pyramids.feature import _h3
+from pyramids.feature import geometry as _geom
+from pyramids.feature import tessellation as _tess
+
+
+def with_coordinates(fc: Any) -> Any:
+    """Explode multi-geometries and attach per-vertex ``x`` / ``y`` columns."""
+    gdf = _geom.explode_gdf(gpd.GeoDataFrame(fc, copy=True), geometry="multipolygon")
+    gdf = _geom.explode_gdf(gdf, geometry="geometrycollection")
+    result = type(fc)(gdf)
+    result["x"] = result.apply(_geom.get_coords, geom_col="geometry", coord_type="x", axis=1)
+    result["y"] = result.apply(_geom.get_coords, geom_col="geometry", coord_type="y", axis=1)
+    result.reset_index(drop=True, inplace=True)
+    return result
+
+
+def with_centroid(fc: Any) -> Any:
+    """Attach a ``center_point`` column from the mean of each row's coordinates."""
+    result = with_coordinates(fc)
+    result["avg_x"] = result["x"].map(np.mean)
+    result["avg_y"] = result["y"].map(np.mean)
+    avg_x = result["avg_x"].to_numpy()
+    avg_y = result["avg_y"].to_numpy()
+    bad_mask = np.isnan(avg_x) | np.isnan(avg_y)
+    if bad_mask.any():
+        bad_idx = [int(i) for i, is_bad in enumerate(bad_mask) if is_bad]
+        warnings.warn(
+            f"with_centroid: {len(bad_idx)} row(s) yielded NaN centroids (rows {bad_idx}). "
+            "Their `center_point` is an empty shapely.Point. Drop or repair those rows before "
+            "running a method that requires a valid centroid (e.g. reproject, distance).",
+            GeometryWarning,
+            stacklevel=3,
+        )
+    cleaned: list[Any] = [
+        Point() if bad else Point(ax, ay)
+        for ax, ay, bad in zip(avg_x.tolist(), avg_y.tolist(), bad_mask.tolist())
+    ]
+    result["center_point"] = cleaned
+    return result
+
+
+def interpolate_to_raster(
+    fc: Any,
+    column: str,
+    *,
+    method: str,
+    cell_size: float | None,
+    bounds: tuple[float, float, float, float] | None,
+    power: float,
+    n_neighbors: int | None,
+    nodata: float,
+) -> Any:
+    """Interpolate a numeric point column to a single-band raster via IDW (gdal.Grid)."""
+    fc._require_point_geometry("interpolate_to_raster")
+    fc._require_column("interpolate_to_raster", column)
+    if method != "idw":
+        raise ValueError(
+            f"interpolate_to_raster: method {method!r} is not supported; only 'idw' is available. "
+            "Kriging is out of scope for pyramids -- see the geostatista package (the serapeum "
+            "geostatistics tier)."
+        )
+    if len(fc) < 3:
+        raise ValueError(f"interpolate_to_raster: need at least 3 points, got {len(fc)}")
+    try:
+        values = fc[column].to_numpy(dtype=float)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"interpolate_to_raster: column {column!r} must be numeric") from exc
+    if np.isnan(values).all():
+        raise ValueError(f"interpolate_to_raster: column {column!r} is all-NaN")
+    if n_neighbors is not None:
+        algorithm = f"invdistnn:power={power}:max_points={n_neighbors}:nodata={nodata}"
+    else:
+        algorithm = f"invdist:power={power}:smoothing=0.0:nodata={nodata}"
+    # local import: pyramids.dataset imports pyramids.feature, so import here to break the cycle.
+    from pyramids.dataset import Dataset
+
+    return Dataset.from_points(fc, column, algorithm=algorithm, cell_size=cell_size, bbox=bounds)
+
+
+def h3_cells(fc: Any, resolution: int, op: str) -> list[str]:
+    """Return the H3 cell index of each point at ``resolution`` (in EPSG:4326)."""
+    fc._require_point_geometry(op)
+    if not 0 <= resolution <= 15:
+        raise ValueError(f"{op}: resolution must be 0-15, got {resolution}")
+    if fc.crs is None:
+        raise ValueError(f"{op}: a CRS is required to convert points to lat/lng for H3 indexing")
+    pts = fc if fc.epsg == 4326 else fc.to_crs(4326)
+    return [_h3.latlng_to_cell(geom.y, geom.x, resolution) for geom in pts.geometry]
+
+
+def to_h3(fc: Any, resolution: int) -> Any:
+    """Attach each point's H3 cell index as an ``h3`` column."""
+    cells = h3_cells(fc, resolution, "to_h3")
+    result = type(fc)(fc.copy())
+    result["h3"] = cells
+    return result
+
+
+def h3_bin(fc: Any, resolution: int, *, agg: Any, column: str | None) -> Any:
+    """Aggregate points into H3 hexagon cells; one polygon per occupied cell (EPSG:4326)."""
+    fc._require_column("h3_bin", column)
+    cells = h3_cells(fc, resolution, "h3_bin")
+    if column is None:
+        counts = pd.Series(cells, dtype="object").value_counts()
+        items: list[tuple[Any, float]] = [(cell, int(n)) for cell, n in counts.items()]
+        name = "count"
+    else:
+        reducer = _tess.resolve_reducer(agg)
+        try:
+            values = fc[column].to_numpy(dtype=float)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"h3_bin: column {column!r} must be numeric") from exc
+        grouped = pd.DataFrame({"_cell": cells, "_v": values}).groupby("_cell")["_v"]
+        items = [(cell, float(reducer(grp.to_numpy()))) for cell, grp in grouped]
+        name = column
+    geometries: list = []
+    idx: list = []
+    agg_values: list = []
+    for cell, value in items:
+        boundary = _h3.cell_to_boundary(cell)
+        geometries.append(Polygon([(lng, lat) for (lat, lng) in boundary]))
+        idx.append(cell)
+        agg_values.append(value)
+    frame = gpd.GeoDataFrame({"h3": idx, name: agg_values}, geometry=geometries, crs="EPSG:4326")
+    return type(fc)(frame)

--- a/src/pyramids/feature/_lazy_collection.py
+++ b/src/pyramids/feature/_lazy_collection.py
@@ -107,7 +107,10 @@ class LazyFeatureCollection(dask_geopandas.GeoDataFrame):
             ):
                 from pyramids.feature.collection import FeatureCollection
 
-                result = FeatureCollection(result)
+                # Skip the wrap when the method (e.g. an overridden `compute`) already
+                # returned a FeatureCollection, avoiding a redundant double-wrap (ARC-63).
+                if not isinstance(result, FeatureCollection):
+                    result = FeatureCollection(result)
             return result
 
         return wrapper

--- a/src/pyramids/feature/_oapif.py
+++ b/src/pyramids/feature/_oapif.py
@@ -26,13 +26,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import geopandas as gpd
-from osgeo import gdal
-
 from pyramids.base._errors import OGCAPIError
-from pyramids.base._ogc_api import gdal_http_config as _gdal_http_config
 from pyramids.base._ogc_api import get_collections as _get_collections
 from pyramids.feature._ogc import read_kwargs as _read_kwargs
+from pyramids.feature._ogc import read_ogc_layer as _read_ogc_layer
+from pyramids.feature._ogc import require_advertised as _require_advertised
 
 if TYPE_CHECKING:
     from pyramids.feature.collection import FeatureCollection
@@ -73,29 +71,17 @@ def from_ogc_features(
     )  # validate inputs before any network call
 
     collections = _get_collections(endpoint, auth, timeout)
-    if collections and collection not in collections:
-        raise ValueError(
-            f"collection {collection!r} is not advertised by {endpoint!r}. "
-            f"Available collections: {sorted(collections)[:10]}"
-            + (" …" if len(collections) > 10 else "")
-        )
+    _require_advertised(collection, collections, noun="collection", endpoint=endpoint)
 
-    connection = _oapif_connection(endpoint)
-    config = _gdal_http_config(auth, timeout)
-    with gdal.config_options(config):
-        try:
-            gdf = gpd.read_file(connection, layer=collection, **read_kwargs)
-        except Exception as exc:  # noqa: BLE001 — normalise any read failure to OGCAPIError
-            raise OGCAPIError(
-                f"OGC API items request failed for {collection!r}: {exc}"
-            ) from exc
-
-    fc = featurecollection_cls(gdf)
-    if output_crs is not None:
-        if fc.crs is None:
-            raise OGCAPIError(
-                f"cannot reproject {collection!r} to {output_crs!r}: the service returned "
-                "features without a CRS"
-            )
-        fc = fc.to_crs(output_crs)  # to_crs preserves the FeatureCollection subclass
-    return fc
+    # The read tail is shared with from_wfs via feature/_ogc.read_ogc_layer (ARC-64).
+    return _read_ogc_layer(
+        featurecollection_cls,
+        _oapif_connection(endpoint),
+        collection,
+        read_kwargs=read_kwargs,
+        auth=auth,
+        timeout=timeout,
+        error_cls=OGCAPIError,
+        read_fail_prefix="OGC API items request failed for",
+        output_crs=output_crs,
+    )

--- a/src/pyramids/feature/_ogc.py
+++ b/src/pyramids/feature/_ogc.py
@@ -17,12 +17,13 @@ from osgeo import gdal
 
 from pyramids.base._ogc_api import gdal_http_config
 
-
 if TYPE_CHECKING:
     from pyramids.feature.collection import FeatureCollection
 
 
-def require_advertised(name: str, advertised: frozenset[str], *, noun: str, endpoint: str) -> None:
+def require_advertised(
+    name: str, advertised: frozenset[str], *, noun: str, endpoint: str
+) -> None:
     """Raise ``ValueError`` if ``name`` is absent from a non-empty advertised set.
 
     Shared advertised-name pre-check for the OGC vector readers (WFS feature types,
@@ -44,7 +45,8 @@ def require_advertised(name: str, advertised: frozenset[str], *, noun: str, endp
         available = sorted(advertised)
         raise ValueError(
             f"{noun} {name!r} is not advertised by {endpoint!r}. "
-            f"Available {noun}s: {available[:10]}" + (" …" if len(available) > 10 else "")
+            f"Available {noun}s: {available[:10]}"
+            + (" …" if len(available) > 10 else "")
         )
 
 

--- a/src/pyramids/feature/_ogc.py
+++ b/src/pyramids/feature/_ogc.py
@@ -12,6 +12,95 @@ from __future__ import annotations
 
 from typing import Any
 
+import geopandas as gpd
+from osgeo import gdal
+
+from pyramids.base._ogc_api import gdal_http_config
+
+
+def require_advertised(name: str, advertised: frozenset[str], *, noun: str, endpoint: str) -> None:
+    """Raise ``ValueError`` if ``name`` is absent from a non-empty advertised set.
+
+    Shared advertised-name pre-check for the OGC vector readers (WFS feature types,
+    OGC API collections). An empty ``advertised`` means the discovery document did
+    not enumerate names, so the check is skipped and the driver read is left to
+    fail if the name is truly unknown.
+
+    Args:
+        name: The requested feature type / collection identifier.
+        advertised: The set the discovery document advertised.
+        noun: Singular label for the identifier (``"feature type"`` / ``"collection"``);
+            the message pluralises it with a trailing ``s``.
+        endpoint: The service endpoint, for the message.
+
+    Raises:
+        ValueError: ``advertised`` is non-empty and does not contain ``name``.
+    """
+    if advertised and name not in advertised:
+        available = sorted(advertised)
+        raise ValueError(
+            f"{noun} {name!r} is not advertised by {endpoint!r}. "
+            f"Available {noun}s: {available[:10]}" + (" …" if len(available) > 10 else "")
+        )
+
+
+def read_ogc_layer(
+    fc_cls: type,
+    connection: str,
+    layer: str,
+    *,
+    read_kwargs: dict[str, Any],
+    auth: tuple[str, str] | None,
+    timeout: float,
+    error_cls: type[Exception],
+    read_fail_prefix: str,
+    output_crs: str | None,
+) -> Any:
+    """Read a layer through the GDAL OGR HTTP driver and wrap it as a FeatureCollection.
+
+    The tail shared verbatim by :func:`pyramids.feature._wfs.from_wfs` and
+    :func:`pyramids.feature._oapif.from_ogc_features`: install the GDAL HTTP config
+    (auth + timeout + retries), read the ``connection`` with the assembled filters,
+    normalise any read failure to ``error_cls``, wrap the frame, and optionally
+    reproject. Only the connection string, discovery step, error class and
+    failure-message wording differ between the two readers.
+
+    Args:
+        fc_cls: The ``FeatureCollection`` class to construct.
+        connection: The GDAL OGR connection string (``WFS:…`` / ``OAPIF:…``).
+        layer: The layer / collection to read.
+        read_kwargs: The assembled pyogrio/GDAL read filters (see :func:`read_kwargs`).
+        auth: Optional ``(user, password)`` for HTTP Basic auth.
+        timeout: Request timeout in seconds.
+        error_cls: Exception type to raise on read failure / missing CRS.
+        read_fail_prefix: Message prefix for a read failure (kept per-reader so the
+            existing wording — ``"WFS GetFeature failed for"`` / ``"OGC API items
+            request failed for"`` — is preserved).
+        output_crs: Optional CRS to reproject to; ``None`` leaves the server CRS.
+
+    Returns:
+        FeatureCollection: The read features, reprojected to ``output_crs`` if given.
+
+    Raises:
+        Exception: ``error_cls`` — the read failed, or ``output_crs`` was requested
+            but the result carries no CRS.
+    """
+    config = gdal_http_config(auth, timeout)
+    with gdal.config_options(config):
+        try:
+            gdf = gpd.read_file(connection, layer=layer, **read_kwargs)
+        except Exception as exc:  # noqa: BLE001 — normalise any read failure to error_cls
+            raise error_cls(f"{read_fail_prefix} {layer!r}: {exc}") from exc
+    fc = fc_cls(gdf)
+    if output_crs is not None:
+        if fc.crs is None:
+            raise error_cls(
+                f"cannot reproject {layer!r} to {output_crs!r}: the OGC service "
+                "returned features without a CRS"
+            )
+        fc = fc.to_crs(output_crs)  # to_crs preserves the FeatureCollection subclass
+    return fc
+
 
 def read_kwargs(
     bbox: tuple[float, float, float, float] | None,

--- a/src/pyramids/feature/_ogc.py
+++ b/src/pyramids/feature/_ogc.py
@@ -10,12 +10,16 @@ lives here once instead of being copied into each reader. The GDAL HTTP config
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import geopandas as gpd
 from osgeo import gdal
 
 from pyramids.base._ogc_api import gdal_http_config
+
+
+if TYPE_CHECKING:
+    from pyramids.feature.collection import FeatureCollection
 
 
 def require_advertised(name: str, advertised: frozenset[str], *, noun: str, endpoint: str) -> None:
@@ -45,7 +49,7 @@ def require_advertised(name: str, advertised: frozenset[str], *, noun: str, endp
 
 
 def read_ogc_layer(
-    fc_cls: type,
+    fc_cls: type[FeatureCollection],
     connection: str,
     layer: str,
     *,
@@ -55,7 +59,7 @@ def read_ogc_layer(
     error_cls: type[Exception],
     read_fail_prefix: str,
     output_crs: str | None,
-) -> Any:
+) -> FeatureCollection:
     """Read a layer through the GDAL OGR HTTP driver and wrap it as a FeatureCollection.
 
     The tail shared verbatim by :func:`pyramids.feature._wfs.from_wfs` and

--- a/src/pyramids/feature/_plot.py
+++ b/src/pyramids/feature/_plot.py
@@ -1,0 +1,103 @@
+"""Plot engine for :class:`~pyramids.feature.FeatureCollection` (ARC-36).
+
+Module-level implementations of the collection's rendering, kept out of the
+god-class as free functions that take the collection as their first argument. The
+`FeatureCollection.plot` method is a thin facade over :func:`plot`. All actual
+drawing goes through geopandas (``engine="geopandas"``) or cleopatra glyphs
+(``engine="cleopatra"``); pyramids owns no matplotlib drawing code.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any
+
+import geopandas as gpd
+import numpy as np
+
+from pyramids.base._errors import CRSError, GeometryWarning
+from pyramids.base._utils import require_cleopatra
+from pyramids.basemap.basemap import add_basemap
+
+
+def plot(fc: Any, *, column: str | None = None, basemap: Any = None, engine: str = "geopandas", **kwargs: Any) -> Any:
+    """Render `fc` via geopandas or cleopatra, optionally over a web-tile basemap."""
+    if engine == "geopandas":
+        # geopandas' `.plot` is a CachedAccessor: `GeoDataFrame.plot` is the accessor
+        # class, so construct it bound to `fc` and then call it. This reaches geopandas'
+        # implementation while bypassing FeatureCollection's `plot` facade override —
+        # equivalent to the original in-class `super().plot(...)`.
+        result = gpd.GeoDataFrame.plot(fc)(column=column, **kwargs)
+        ax = result
+    elif engine == "cleopatra":
+        result, ax = plot_cleopatra(fc, column=column, **kwargs)
+    else:
+        raise ValueError(f"Unsupported engine {engine!r}; choose 'geopandas' or 'cleopatra'.")
+    if basemap:
+        if fc.epsg is None:
+            raise CRSError("FeatureCollection must have a CRS (epsg) to use basemap.")
+        source = basemap if isinstance(basemap, str) else None
+        add_basemap(ax, crs=fc.epsg, source=source)
+    return result
+
+
+def plot_cleopatra(fc: Any, column: str | None = None, **kwargs: Any) -> Any:
+    """Build and draw the cleopatra glyph for `fc`, returning ``(glyph, ax)``."""
+    require_cleopatra()
+    if column is not None and column not in fc.columns:
+        raise ValueError(f"Column {column!r} not found; available columns: {list(fc.columns)}.")
+    values = fc[column].to_numpy() if column is not None else None
+    geom_types = fc._geom_types()
+    if geom_types <= {"Point"}:
+        glyph = scatter_glyph(fc, values, **kwargs)
+    elif geom_types <= {"Polygon", "MultiPolygon"}:
+        glyph = polygon_glyph(fc, values, **kwargs)
+    else:
+        raise ValueError(
+            "engine='cleopatra' supports single Point or Polygon/MultiPolygon geometries; got "
+            f"{sorted(geom_types)} (MultiPoint is not supported)."
+        )
+    _fig, ax, _coll = glyph.plot()
+    return glyph, ax
+
+
+def scatter_glyph(fc: Any, values: Any, **kwargs: Any) -> Any:
+    """Build a cleopatra ScatterGlyph from `fc`'s point coordinates."""
+    require_cleopatra()
+    from cleopatra.scatter_glyph import ScatterGlyph
+
+    return ScatterGlyph(
+        fc.geometry.x.to_numpy(),
+        fc.geometry.y.to_numpy(),
+        values=values,
+        **ScatterGlyph.filter_kwargs(kwargs),
+    )
+
+
+def polygon_glyph(fc: Any, values: Any, **kwargs: Any) -> Any:
+    """Build a cleopatra PolygonGlyph from `fc`'s polygon exterior rings."""
+    require_cleopatra()
+    from cleopatra.polygon_glyph import PolygonGlyph
+
+    polygons: list = []
+    poly_values: list | None = [] if values is not None else None
+    has_holes = False
+    for idx, geom in enumerate(fc.geometry):
+        # A plain Polygon has no ``.geoms``; a MultiPolygon does.
+        for part in getattr(geom, "geoms", [geom]):
+            polygons.append(np.asarray(part.exterior.coords))
+            has_holes = has_holes or bool(part.interiors)
+            if poly_values is not None:
+                poly_values.append(values[idx])
+    if has_holes:
+        warnings.warn(
+            "engine='cleopatra' renders only polygon exterior rings; interior rings (holes) are "
+            "dropped and will appear filled. Use engine='geopandas' to render holes.",
+            GeometryWarning,
+            stacklevel=3,
+        )
+    return PolygonGlyph(
+        polygons,
+        values=np.asarray(poly_values) if poly_values is not None else None,
+        **PolygonGlyph.filter_kwargs(kwargs),
+    )

--- a/src/pyramids/feature/_plot.py
+++ b/src/pyramids/feature/_plot.py
@@ -47,7 +47,13 @@ def plot_cleopatra(fc: Any, column: str | None = None, **kwargs: Any) -> Any:
     if column is not None and column not in fc.columns:
         raise ValueError(f"Column {column!r} not found; available columns: {list(fc.columns)}.")
     values = fc[column].to_numpy() if column is not None else None
-    geom_types = fc._geom_types()
+    # The plot path must stay NaN-aware — unlike `_geom_types()`, which drops nulls
+    # for `schema` / the rasterize guard. A null geometry can't be rendered, so it
+    # must fail the subset checks below and route to the ValueError, rather than slip
+    # through and have `polygon_glyph` / `scatter_glyph` dereference a `None` geometry
+    # (which would raise a cryptic AttributeError instead). `key=str` keeps the message
+    # sortable when a `nan` is present.
+    geom_types = set(fc.geom_type.unique())
     if geom_types <= {"Point"}:
         glyph = scatter_glyph(fc, values, **kwargs)
     elif geom_types <= {"Polygon", "MultiPolygon"}:
@@ -55,7 +61,7 @@ def plot_cleopatra(fc: Any, column: str | None = None, **kwargs: Any) -> Any:
     else:
         raise ValueError(
             "engine='cleopatra' supports single Point or Polygon/MultiPolygon geometries; got "
-            f"{sorted(geom_types)} (MultiPoint is not supported)."
+            f"{sorted(geom_types, key=str)} (MultiPoint is not supported)."
         )
     _fig, ax, _coll = glyph.plot()
     return glyph, ax

--- a/src/pyramids/feature/_plot.py
+++ b/src/pyramids/feature/_plot.py
@@ -20,7 +20,14 @@ from pyramids.base._utils import require_cleopatra
 from pyramids.basemap.basemap import add_basemap
 
 
-def plot(fc: Any, *, column: str | None = None, basemap: Any = None, engine: str = "geopandas", **kwargs: Any) -> Any:
+def plot(
+    fc: Any,
+    *,
+    column: str | None = None,
+    basemap: Any = None,
+    engine: str = "geopandas",
+    **kwargs: Any,
+) -> Any:
     """Render `fc` via geopandas or cleopatra, optionally over a web-tile basemap."""
     if engine == "geopandas":
         # geopandas' `.plot` is a CachedAccessor: `GeoDataFrame.plot` is the accessor
@@ -32,7 +39,9 @@ def plot(fc: Any, *, column: str | None = None, basemap: Any = None, engine: str
     elif engine == "cleopatra":
         result, ax = plot_cleopatra(fc, column=column, **kwargs)
     else:
-        raise ValueError(f"Unsupported engine {engine!r}; choose 'geopandas' or 'cleopatra'.")
+        raise ValueError(
+            f"Unsupported engine {engine!r}; choose 'geopandas' or 'cleopatra'."
+        )
     if basemap:
         if fc.epsg is None:
             raise CRSError("FeatureCollection must have a CRS (epsg) to use basemap.")
@@ -45,7 +54,9 @@ def plot_cleopatra(fc: Any, column: str | None = None, **kwargs: Any) -> Any:
     """Build and draw the cleopatra glyph for `fc`, returning ``(glyph, ax)``."""
     require_cleopatra()
     if column is not None and column not in fc.columns:
-        raise ValueError(f"Column {column!r} not found; available columns: {list(fc.columns)}.")
+        raise ValueError(
+            f"Column {column!r} not found; available columns: {list(fc.columns)}."
+        )
     values = fc[column].to_numpy() if column is not None else None
     # The plot path must stay NaN-aware — unlike `_geom_types()`, which drops nulls
     # for `schema` / the rasterize guard. A null geometry can't be rendered, so it

--- a/src/pyramids/feature/_plot.py
+++ b/src/pyramids/feature/_plot.py
@@ -96,11 +96,15 @@ def polygon_glyph(fc: Any, values: Any, **kwargs: Any) -> Any:
             if poly_values is not None:
                 poly_values.append(values[idx])
     if has_holes:
+        # Chain to user code: polygon_glyph -> plot_cleopatra -> plot ->
+        # FeatureCollection.plot facade -> caller. The extraction added the facade
+        # frame, so the warning needs stacklevel=5 (was 3 in-class) to point at the
+        # user's fc.plot(...) call rather than an internal _plot frame.
         warnings.warn(
             "engine='cleopatra' renders only polygon exterior rings; interior rings (holes) are "
             "dropped and will appear filled. Use engine='geopandas' to render holes.",
             GeometryWarning,
-            stacklevel=3,
+            stacklevel=5,
         )
     return PolygonGlyph(
         polygons,

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -1,0 +1,137 @@
+"""I/O reader engine for :class:`~pyramids.feature.FeatureCollection` (ARC-36).
+
+Module-level implementations of the collection's readers, kept out of the
+god-class as free functions that take the `FeatureCollection` class (`fc_cls`) or a
+collection (`fc`) as their first argument. The `FeatureCollection` reader methods
+are thin facades over these functions; the full docstrings/doctests stay on the
+facades (the public API).
+
+Part 1 covers layer listing (with its LRU cache) and the web readers (ArcGIS
+FeatureServer pagination, GPX sub-layers). The web readers call back through the
+`fc_cls` facades (`fc_cls.read_file`, `fc_cls._read_featureserver_page`) so existing
+tests that monkeypatch those class methods still intercept.
+"""
+
+from __future__ import annotations
+
+import warnings
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode
+
+import geopandas as gpd
+import pandas as pd
+
+from pyramids import _io as _pyramids_io
+from pyramids.base.remote import is_remote
+
+
+@lru_cache(maxsize=128)
+def _list_layers_cached(resolved_path: str) -> tuple[str, ...]:
+    """Return a tuple of layer names for a resolved path (memoised)."""
+    import pyogrio
+
+    arr = pyogrio.list_layers(resolved_path)
+    return tuple(str(row[0]) for row in arr)
+
+
+def list_layers(fc_cls: type, path: str | Path) -> list[str]:
+    """List every vector-layer name in `path`, memoised (see FeatureCollection.list_layers)."""
+    path_str = str(path)
+    if not is_remote(path_str):
+        local = Path(path_str)
+        if not local.exists():
+            raise FileNotFoundError(f"list_layers: no file at {path_str!r}.")
+    resolved = str(_pyramids_io._parse_path(path))
+    return list(_list_layers_cached(resolved))
+
+
+def list_layers_cache_clear() -> None:
+    """Clear the LRU cache backing :func:`list_layers`."""
+    _list_layers_cached.cache_clear()
+
+
+def read_gpx_layers(fc_cls: type, path: str | Path) -> dict[str, Any]:
+    """Read every non-empty GPX sub-layer into a dict (see FeatureCollection.read_gpx_layers)."""
+    result: dict[str, Any] = {}
+    for name in fc_cls.list_layers(path):
+        fc = fc_cls.read_file(path, layer=name)
+        if len(fc) > 0:
+            result[name] = fc
+    return result
+
+
+def read_featureserver_page(fc_cls: type, page_url: str) -> Any:
+    """Read one ESRIJSON page from an ArcGIS FeatureServer query URL."""
+    return fc_cls.read_file(page_url)
+
+
+def from_featureserver(
+    fc_cls: type,
+    url: str,
+    *,
+    where: str = "1=1",
+    out_fields: str = "*",
+    max_records: int | None = None,
+    page_size: int = 1000,
+    max_pages: int = 1000,
+) -> Any:
+    """Read a paged ArcGIS FeatureServer layer (see FeatureCollection.from_featureserver)."""
+    if page_size < 1:
+        raise ValueError(f"from_featureserver: page_size must be >= 1, got {page_size}")
+    if max_records is not None and max_records < 0:
+        raise ValueError(f"from_featureserver: max_records must be >= 0 or None, got {max_records}")
+    base = url.split("?", 1)[0].rstrip("/")
+    if not base.lower().endswith("/query"):
+        base = f"{base}/query"
+    pages, first_crs = collect_featureserver_pages(fc_cls, base, where, out_fields, max_records, page_size, max_pages)
+    # Concatenate in one pass (pd.concat preserves the shared CRS); repeatedly calling .concat()
+    # re-sets the CRS and trips a geopandas DeprecationWarning.
+    if pages:
+        return fc_cls(pd.concat(pages, ignore_index=True))
+    return fc_cls(gpd.GeoDataFrame(geometry=[], crs=first_crs))
+
+
+def collect_featureserver_pages(
+    fc_cls: type, base: str, where: str, out_fields: str, max_records: int | None, page_size: int, max_pages: int
+) -> tuple[list, Any]:
+    """Page through a FeatureServer /query endpoint; return (pages, first_crs)."""
+    pages: list = []
+    first_crs = None
+    offset = 0
+    fetched = 0
+    page_index = 0
+    while max_records is None or fetched < max_records:
+        if page_index >= max_pages:
+            warnings.warn(
+                f"from_featureserver: stopped after {max_pages} pages (max_pages). The server may not "
+                "honour resultOffset paging; raise max_pages or set max_records if more features are "
+                "expected.",
+                stacklevel=2,
+            )
+            break
+        this_page = page_size if max_records is None else min(page_size, max_records - fetched)
+        query = urlencode(
+            {
+                "where": where,
+                "outFields": out_fields,
+                "f": "json",
+                "resultOffset": offset,
+                "resultRecordCount": this_page,
+            }
+        )
+        # Call the facade so tests that monkeypatch FeatureCollection._read_featureserver_page intercept.
+        page = fc_cls._read_featureserver_page(f"{base}?{query}")
+        if first_crs is None:
+            first_crs = page.crs
+        count = len(page)
+        if count == 0:
+            break
+        pages.append(page)
+        fetched += count
+        offset += count
+        page_index += 1
+        if count < this_page:  # last (short) page
+            break
+    return pages, first_crs

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -305,18 +305,16 @@ def read_file(
     return fc_cls(gdf)
 
 
-def iter_features(
+def _validate_iter_features_args(
     fc_cls: type[FeatureCollection],
-    path: str | Path,
     *,
-    layer: str | int | None = None,
-    bbox: tuple[float, float, float, float] | None = None,
-    where: str | None = None,
-    chunksize: int | None = None,
-    tile_strategy: str = "auto",
-    include_index: bool = False,
-) -> Iterator[dict[str, Any] | FeatureCollection]:
-    """Stream features from `path` without materialising the file (see FeatureCollection.iter_features)."""
+    chunksize: int | None,
+    tile_strategy: str,
+    where: str | None,
+    bbox: tuple[float, float, float, float] | None,
+    include_index: bool,
+) -> None:
+    """Validate :func:`iter_features` arguments (raises before any I/O)."""
     if chunksize is not None and chunksize < 1:
         raise ValueError(f"chunksize must be >= 1 when supplied; got {chunksize}.")
     if tile_strategy not in fc_cls._VALID_TILE_STRATEGIES:
@@ -336,6 +334,30 @@ def iter_features(
             "because the emitted id is the absolute source-file row position: pass where=None "
             "and either bbox=None or tile_strategy='none' (Python-side bbox)."
         )
+
+
+def iter_features(
+    fc_cls: type[FeatureCollection],
+    path: str | Path,
+    *,
+    layer: str | int | None = None,
+    bbox: tuple[float, float, float, float] | None = None,
+    where: str | None = None,
+    chunksize: int | None = None,
+    tile_strategy: str = "auto",
+    include_index: bool = False,
+) -> Iterator[dict[str, Any] | FeatureCollection]:
+    """Stream features from `path` without materialising the file (see FeatureCollection.iter_features)."""
+    # Runs lazily on first iteration (iter_features is a generator), preserving the
+    # fiona-style "validate on first next()" behaviour.
+    _validate_iter_features_args(
+        fc_cls,
+        chunksize=chunksize,
+        tile_strategy=tile_strategy,
+        where=where,
+        bbox=bbox,
+        include_index=include_index,
+    )
 
     import pyogrio
 

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -1,21 +1,23 @@
-"""I/O reader engine for :class:`~pyramids.feature.FeatureCollection` (ARC-36).
+"""Input / constructor engine for :class:`~pyramids.feature.FeatureCollection` (ARC-36).
 
-Module-level implementations of the collection's readers, kept out of the
-god-class as free functions that take the `FeatureCollection` class (`fc_cls`) or a
-collection (`fc`) as their first argument. The `FeatureCollection` reader methods
-are thin facades over these functions; the full docstrings/doctests stay on the
-facades (the public API).
+Module-level implementations of every way to *build* a FeatureCollection, kept out
+of the god-class as free functions that take the `FeatureCollection` class (`fc_cls`)
+or a collection (`fc`) as their first argument. The `FeatureCollection` methods are
+thin facades over these functions; the full docstrings/doctests stay on the facades
+(the public API). The symmetric output side lives in :mod:`pyramids.feature._write`.
 
 Covers layer listing (with its LRU cache), the web readers (ArcGIS FeatureServer
-pagination, GPX sub-layers), and the file readers (vector files, GeoParquet, the
+pagination, GPX sub-layers), the file readers (vector files, GeoParquet, the
 streaming ``iter_features`` / ``open_arrow`` paths) plus the eager/lazy backend
-dispatch shared by ``read_file`` and ``read_parquet``. The web readers call back
-through the `fc_cls` facades (`fc_cls.read_file`, `fc_cls._read_featureserver_page`)
-so existing tests that monkeypatch those class methods still intercept.
+dispatch shared by ``read_file`` and ``read_parquet``, and the in-memory
+constructors (``from_features``, ``from_bbox``, ``from_records``). The web readers
+call back through the `fc_cls` facades (`fc_cls.read_file`,
+`fc_cls._read_featureserver_page`) so existing tests that monkeypatch those class
+methods still intercept.
 
 ``_LAZY_TARGET_BYTES_PER_PARTITION`` is the tunable knob behind
 :func:`_resolve_lazy_partitioning`; :func:`pyramids.configure_lazy_vector` patches it
-here (the reader engine owns it).
+here (the input engine owns it).
 """
 
 from __future__ import annotations
@@ -23,6 +25,7 @@ from __future__ import annotations
 import math
 import os
 import warnings
+from collections.abc import Iterable
 from functools import lru_cache
 from pathlib import Path
 from typing import Any
@@ -33,6 +36,7 @@ import pandas as pd
 from shapely.geometry import box
 
 from pyramids import _io as _pyramids_io
+from pyramids.base._errors import FeatureError
 from pyramids.base._utils import import_pyarrow
 from pyramids.base.remote import is_remote
 
@@ -498,3 +502,87 @@ def read_parquet(
         passthrough["storage_options"] = storage_options
     gdf = gpd.read_parquet(resolved, **passthrough)
     return fc_cls(gdf)
+
+
+def from_features(fc_cls: type, features: Iterable[Any], *, crs: Any = None, columns: list[str] | None = None) -> Any:
+    """Build an FC from feature-shaped inputs (see FeatureCollection.from_features)."""
+    # Materialise the iterator so we can detect the empty case before handing off
+    # to geopandas: gpd.from_features([]) returns a GeoDataFrame with no geometry
+    # column, which breaks every pyramids op that assumes the column exists.
+    features_list = list(features)
+    if not features_list:
+        raise ValueError(
+            "from_features requires at least one feature. An empty "
+            "iterable would produce a GeoDataFrame with no geometry "
+            "column, which breaks downstream pyramids methods."
+        )
+    gdf = gpd.GeoDataFrame.from_features(features_list, crs=crs, columns=columns)
+    return fc_cls(gdf)
+
+
+def from_bbox(fc_cls: type, bbox: tuple[float, float, float, float] | list[float], *, epsg: Any) -> Any:
+    """Build a one-row FC from a (west, south, east, north) bbox (see FeatureCollection.from_bbox)."""
+    if epsg is None:
+        raise ValueError(
+            "from_bbox requires an explicit epsg= for the bbox CRS; "
+            "a bbox without a CRS is ambiguous"
+        )
+    try:
+        seq = list(bbox)
+    except TypeError as exc:
+        raise ValueError(
+            f"bbox must be a 4-element (west, south, east, north) sequence; got {bbox!r}"
+        ) from exc
+    if len(seq) != 4:
+        raise ValueError(
+            f"bbox must have exactly 4 elements (west, south, east, north); got {len(seq)}: {seq!r}"
+        )
+    try:
+        w, s, e, n = (float(v) for v in seq)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"bbox elements must be numbers; got {seq!r}") from exc
+    # NaN slips past the ordering checks below (nan >= x is False), so reject it
+    # explicitly — e.g. an empty frame's all-NaN total_bounds.
+    if any(math.isnan(v) for v in (w, s, e, n)):
+        raise ValueError(f"bbox coordinates must not be NaN; got {seq!r}")
+    if w >= e:
+        raise ValueError(f"bbox must satisfy west < east; got west={w}, east={e}")
+    if s >= n:
+        raise ValueError(f"bbox must satisfy south < north; got south={s}, north={n}")
+    return fc_cls(geometry=[box(w, s, e, n)], crs=epsg)
+
+
+def from_records(
+    fc_cls: type, records: Any, *, geometry: str = "geometry", crs: Any = None, orient: str = "records"
+) -> Any:
+    """Build an FC from dict records or a columnar dict (see FeatureCollection.from_records)."""
+
+    def _empty_fc() -> Any:
+        # Both empty-input branches build a single-column frame whose column name
+        # matches the geometry= kwarg, so GeoDataFrame(..., geometry=…) sets it as
+        # the active geometry column and the returned FC has geometry.name == geometry.
+        return fc_cls(gpd.GeoDataFrame({geometry: []}, geometry=geometry, crs=crs))
+
+    if orient == "records":
+        records_list = list(records)
+        if not records_list:
+            return _empty_fc()
+        df = pd.DataFrame.from_records(records_list)
+    elif orient == "list":
+        # Columnar dict of equal-length lists. pd.DataFrame accepts this shape
+        # natively and raises ValueError on mismatched lengths (propagated as-is).
+        if not isinstance(records, dict):
+            raise ValueError(
+                f"orient='list' expects a dict of column → list; got {type(records).__name__}."
+            )
+        df = pd.DataFrame(records)
+        if len(df) == 0:
+            return _empty_fc()
+    else:
+        raise ValueError(f"orient must be 'records' or 'list'; got {orient!r}.")
+    if geometry not in df.columns:
+        raise FeatureError(
+            f"records missing required geometry column {geometry!r}; "
+            f"columns present: {list(df.columns)}"
+        )
+    return fc_cls(gpd.GeoDataFrame(df, geometry=geometry, crs=crs))

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -73,7 +73,9 @@ def list_layers_cache_clear() -> None:
     _list_layers_cached.cache_clear()
 
 
-def read_gpx_layers(fc_cls: type[FeatureCollection], path: str | Path) -> dict[str, FeatureCollection]:
+def read_gpx_layers(
+    fc_cls: type[FeatureCollection], path: str | Path
+) -> dict[str, FeatureCollection]:
     """Read every non-empty GPX sub-layer into a dict (see FeatureCollection.read_gpx_layers)."""
     result: dict[str, Any] = {}
     for name in fc_cls.list_layers(path):
@@ -83,7 +85,9 @@ def read_gpx_layers(fc_cls: type[FeatureCollection], path: str | Path) -> dict[s
     return result
 
 
-def read_featureserver_page(fc_cls: type[FeatureCollection], page_url: str) -> FeatureCollection:
+def read_featureserver_page(
+    fc_cls: type[FeatureCollection], page_url: str
+) -> FeatureCollection:
     """Read one ESRIJSON page from an ArcGIS FeatureServer query URL."""
     return fc_cls.read_file(page_url)
 
@@ -102,11 +106,15 @@ def from_featureserver(
     if page_size < 1:
         raise ValueError(f"from_featureserver: page_size must be >= 1, got {page_size}")
     if max_records is not None and max_records < 0:
-        raise ValueError(f"from_featureserver: max_records must be >= 0 or None, got {max_records}")
+        raise ValueError(
+            f"from_featureserver: max_records must be >= 0 or None, got {max_records}"
+        )
     base = url.split("?", 1)[0].rstrip("/")
     if not base.lower().endswith("/query"):
         base = f"{base}/query"
-    pages, first_crs = collect_featureserver_pages(fc_cls, base, where, out_fields, max_records, page_size, max_pages)
+    pages, first_crs = collect_featureserver_pages(
+        fc_cls, base, where, out_fields, max_records, page_size, max_pages
+    )
     # Concatenate in one pass (pd.concat preserves the shared CRS); repeatedly calling .concat()
     # re-sets the CRS and trips a geopandas DeprecationWarning.
     if pages:
@@ -138,7 +146,9 @@ def collect_featureserver_pages(
                 stacklevel=2,
             )
             break
-        this_page = page_size if max_records is None else min(page_size, max_records - fetched)
+        this_page = (
+            page_size if max_records is None else min(page_size, max_records - fetched)
+        )
         query = urlencode(
             {
                 "where": where,
@@ -164,7 +174,9 @@ def collect_featureserver_pages(
     return pages, first_crs
 
 
-def _resolve_lazy_partitioning(path: str, npartitions: int | None, chunksize: int | None) -> dict[str, Any]:
+def _resolve_lazy_partitioning(
+    path: str, npartitions: int | None, chunksize: int | None
+) -> dict[str, Any]:
     """Default `npartitions` from file size when neither knob is given (see FeatureCollection.read_file)."""
     kwargs: dict[str, Any] = {}
     if npartitions is not None:
@@ -180,7 +192,9 @@ def _resolve_lazy_partitioning(path: str, npartitions: int | None, chunksize: in
         except OSError:
             kwargs["npartitions"] = 1
         else:
-            kwargs["npartitions"] = max(1, math.ceil(size / _LAZY_TARGET_BYTES_PER_PARTITION))
+            kwargs["npartitions"] = max(
+                1, math.ceil(size / _LAZY_TARGET_BYTES_PER_PARTITION)
+            )
     return kwargs
 
 
@@ -328,7 +342,9 @@ def _validate_iter_features_args(
     # so the positions would be wrong. Refuse that combination rather than emit wrong ids
     # (ARC-31). The Python-side bbox path (tile_strategy="none") reads full chunks and masks
     # row_indices afterwards, so it stays correct.
-    if include_index and (where is not None or (bbox is not None and tile_strategy != "none")):
+    if include_index and (
+        where is not None or (bbox is not None and tile_strategy != "none")
+    ):
         raise ValueError(
             "iter_features(include_index=True) is incompatible with driver-side filtering "
             "because the emitted id is the absolute source-file row position: pass where=None "
@@ -387,14 +403,18 @@ def iter_features(
         )
         # Absolute row indices captured before any bbox masking, so callers
         # can map yielded features back to their source rows.
-        row_indices = list(range(start, start + len(gdf_chunk))) if include_index else None
+        row_indices = (
+            list(range(start, start + len(gdf_chunk))) if include_index else None
+        )
         if python_bbox is not None and len(gdf_chunk) > 0:
             xmin, ymin, xmax, ymax = python_bbox
             mask = gdf_chunk.intersects(box(xmin, ymin, xmax, ymax))
             if row_indices is not None:
                 row_indices = [ri for ri, keep in zip(row_indices, mask) if keep]
             gdf_chunk = gdf_chunk[mask]
-        yield from emit_features(fc_cls, gdf_chunk, row_indices, chunksize, include_index)
+        yield from emit_features(
+            fc_cls, gdf_chunk, row_indices, chunksize, include_index
+        )
 
 
 def build_iter_read_kwargs(

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -6,14 +6,22 @@ collection (`fc`) as their first argument. The `FeatureCollection` reader method
 are thin facades over these functions; the full docstrings/doctests stay on the
 facades (the public API).
 
-Part 1 covers layer listing (with its LRU cache) and the web readers (ArcGIS
-FeatureServer pagination, GPX sub-layers). The web readers call back through the
-`fc_cls` facades (`fc_cls.read_file`, `fc_cls._read_featureserver_page`) so existing
-tests that monkeypatch those class methods still intercept.
+Covers layer listing (with its LRU cache), the web readers (ArcGIS FeatureServer
+pagination, GPX sub-layers), and the file readers (vector files, GeoParquet, the
+streaming ``iter_features`` / ``open_arrow`` paths) plus the eager/lazy backend
+dispatch shared by ``read_file`` and ``read_parquet``. The web readers call back
+through the `fc_cls` facades (`fc_cls.read_file`, `fc_cls._read_featureserver_page`)
+so existing tests that monkeypatch those class methods still intercept.
+
+``_LAZY_TARGET_BYTES_PER_PARTITION`` is the tunable knob behind
+:func:`_resolve_lazy_partitioning`; :func:`pyramids.configure_lazy_vector` patches it
+here (the reader engine owns it).
 """
 
 from __future__ import annotations
 
+import math
+import os
 import warnings
 from functools import lru_cache
 from pathlib import Path
@@ -22,9 +30,14 @@ from urllib.parse import urlencode
 
 import geopandas as gpd
 import pandas as pd
+from shapely.geometry import box
 
 from pyramids import _io as _pyramids_io
+from pyramids.base._utils import import_pyarrow
 from pyramids.base.remote import is_remote
+
+_DEFAULT_ITER_BATCH_SIZE: int = 1000
+_LAZY_TARGET_BYTES_PER_PARTITION: int = 128 * 1024 * 1024
 
 
 @lru_cache(maxsize=128)
@@ -135,3 +148,353 @@ def collect_featureserver_pages(
         if count < this_page:  # last (short) page
             break
     return pages, first_crs
+
+
+def _resolve_lazy_partitioning(path: str, npartitions: int | None, chunksize: int | None) -> dict[str, Any]:
+    """Default `npartitions` from file size when neither knob is given (see FeatureCollection.read_file)."""
+    kwargs: dict[str, Any] = {}
+    if npartitions is not None:
+        kwargs["npartitions"] = npartitions
+    elif chunksize is not None:
+        kwargs["chunksize"] = chunksize
+    elif path.startswith(("/vsi", "http://", "https://", "s3://", "gs://", "az://")):
+        # Remote / VFS path — no cheap size probe. Fall back to 1.
+        kwargs["npartitions"] = 1
+    else:
+        try:
+            size = os.path.getsize(path)
+        except OSError:
+            kwargs["npartitions"] = 1
+        else:
+            kwargs["npartitions"] = max(1, math.ceil(size / _LAZY_TARGET_BYTES_PER_PARTITION))
+    return kwargs
+
+
+def _require_pyarrow() -> None:
+    """Raise a pyramids-branded ImportError if pyarrow is absent."""
+    import_pyarrow(
+        "GeoParquet support requires the optional 'pyarrow' "
+        "dependency. Install with one of:\n"
+        "  - PyPI:        pip install 'pyramids-gis[parquet]'\n"
+        "  - conda-forge: conda install -c conda-forge pyramids-parquet"
+    )
+
+
+def _compact(mapping: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of `mapping` with the ``None``-valued entries removed (ARC-72)."""
+    return {key: value for key, value in mapping.items() if value is not None}
+
+
+def _import_dask_geopandas():
+    """Import and return ``dask_geopandas`` or raise a pyramids-branded ImportError (ARC-72)."""
+    try:
+        import dask_geopandas
+    except ImportError as exc:
+        raise ImportError(
+            "backend='dask' requires the optional "
+            "'dask-geopandas' dependency. Install with one of:\n"
+            "  - PyPI:        pip install 'pyramids-gis[parquet]'\n"
+            "  - conda-forge: conda install -c conda-forge pyramids-parquet"
+        ) from exc
+    return dask_geopandas
+
+
+def read_file(
+    fc_cls: type,
+    path: str | Path,
+    *,
+    layer: str | int | None = None,
+    bbox: Any = None,
+    mask: Any = None,
+    rows: slice | int | None = None,
+    columns: list[str] | None = None,
+    where: str | None = None,
+    backend: str = "pandas",
+    npartitions: int | None = None,
+    chunksize: int | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Read a vector file into a FeatureCollection (see FeatureCollection.read_file)."""
+    resolved = _pyramids_io._parse_path(path)
+    if backend == "dask":
+        # dask_geopandas.read_file does NOT forward pyogrio filter kwargs
+        # (bbox / mask / rows / columns / where) — silently dropping them was the
+        # bug. Raise a clear ValueError instead so users know to pre-filter or
+        # call .compute() and filter eagerly.
+        unsupported = {
+            "bbox": bbox,
+            "mask": mask,
+            "rows": rows,
+            "columns": columns,
+            "where": where,
+            "layer": layer,
+        }
+        supplied = [k for k, v in unsupported.items() if v is not None]
+        if supplied:
+            raise ValueError(
+                f"backend='dask' does not support filter kwargs "
+                f"{supplied}. dask_geopandas.read_file has no "
+                "pushdown story for these. Either omit them and "
+                "filter post-load via .clip / .loc / .compute, or "
+                "switch to read_parquet(backend='dask', filters=...)"
+            )
+        dask_geopandas = _import_dask_geopandas()
+        partition_kwargs = _resolve_lazy_partitioning(resolved, npartitions, chunksize)
+        # Local import breaks the collection <-> _lazy_collection cycle
+        # (_lazy_collection imports FeatureCollection from collection).
+        from pyramids.feature._lazy_collection import LazyFeatureCollection
+
+        dask_gdf = dask_geopandas.read_file(resolved, **partition_kwargs)
+        return LazyFeatureCollection.from_dask_gdf(dask_gdf)
+    if backend != "pandas":
+        raise ValueError(f"backend must be 'pandas' or 'dask', got {backend!r}")
+    # Only pass kwargs that were actually supplied — passing the unset
+    # defaults (None) confuses some geopandas engines (ARC-72).
+    passthrough = _compact(
+        {
+            "layer": layer,
+            "bbox": bbox,
+            "mask": mask,
+            "rows": rows,
+            "columns": columns,
+            "where": where,
+        }
+    )
+    passthrough.update(kwargs)
+    gdf = gpd.read_file(resolved, **passthrough)
+    return fc_cls(gdf)
+
+
+def iter_features(
+    fc_cls: type,
+    path: str | Path,
+    *,
+    layer: str | int | None = None,
+    bbox: tuple[float, float, float, float] | None = None,
+    where: str | None = None,
+    chunksize: int | None = None,
+    tile_strategy: str = "auto",
+    include_index: bool = False,
+) -> Any:
+    """Stream features from `path` without materialising the file (see FeatureCollection.iter_features)."""
+    if chunksize is not None and chunksize < 1:
+        raise ValueError(f"chunksize must be >= 1 when supplied; got {chunksize}.")
+    if tile_strategy not in fc_cls._VALID_TILE_STRATEGIES:
+        raise ValueError(
+            f"tile_strategy must be one of "
+            f"{fc_cls._VALID_TILE_STRATEGIES}; got {tile_strategy!r}."
+        )
+    # The emitted id / _row_index is the absolute source-file row position, computed as
+    # range(start, start + len(chunk)). That only holds when nothing filters at the driver
+    # level: a pushed-down `where` or `bbox` makes skip_features count over the filtered set,
+    # so the positions would be wrong. Refuse that combination rather than emit wrong ids
+    # (ARC-31). The Python-side bbox path (tile_strategy="none") reads full chunks and masks
+    # row_indices afterwards, so it stays correct.
+    if include_index and (where is not None or (bbox is not None and tile_strategy != "none")):
+        raise ValueError(
+            "iter_features(include_index=True) is incompatible with driver-side filtering "
+            "because the emitted id is the absolute source-file row position: pass where=None "
+            "and either bbox=None or tile_strategy='none' (Python-side bbox)."
+        )
+
+    import pyogrio
+
+    resolved = str(_pyramids_io._parse_path(path))
+
+    # pyogrio's read_info is O(1); use it to size the layer so we can
+    # iterate in fixed-size batches via skip_features / max_features.
+    info_kwargs: dict[str, Any] = {}
+    if layer is not None:
+        info_kwargs["layer"] = layer
+    info = pyogrio.read_info(resolved, **info_kwargs)
+    total = int(info["features"])
+
+    if chunksize is None:
+        batch_size = _DEFAULT_ITER_BATCH_SIZE
+    else:
+        batch_size = int(chunksize)
+
+    read_kwargs, python_bbox = build_iter_read_kwargs(layer, where, bbox, tile_strategy)
+
+    for start in range(0, total, batch_size):
+        gdf_chunk = gpd.read_file(
+            resolved,
+            skip_features=start,
+            max_features=batch_size,
+            **read_kwargs,
+        )
+        # Absolute row indices captured before any bbox masking, so callers
+        # can map yielded features back to their source rows.
+        row_indices = list(range(start, start + len(gdf_chunk))) if include_index else None
+        if python_bbox is not None and len(gdf_chunk) > 0:
+            xmin, ymin, xmax, ymax = python_bbox
+            mask = gdf_chunk.intersects(box(xmin, ymin, xmax, ymax))
+            if row_indices is not None:
+                row_indices = [ri for ri, keep in zip(row_indices, mask) if keep]
+            gdf_chunk = gdf_chunk[mask]
+        yield from emit_features(fc_cls, gdf_chunk, row_indices, chunksize, include_index)
+
+
+def build_iter_read_kwargs(
+    layer: str | int | None,
+    where: str | None,
+    bbox: tuple[float, float, float, float] | None,
+    tile_strategy: str,
+) -> tuple[dict[str, Any], tuple[float, float, float, float] | None]:
+    """Build the pyogrio ``read_file`` kwargs for :func:`iter_features`.
+
+    The engine is pinned to pyogrio (``skip_features`` / ``max_features`` are
+    pyogrio-specific; the fiona engine silently ignores them). For every
+    ``tile_strategy`` except ``"none"`` the ``bbox`` is pushed down to pyogrio;
+    for ``"none"`` it is held back for a post-load Python filter.
+    """
+    read_kwargs: dict[str, Any] = {"engine": "pyogrio"}
+    if layer is not None:
+        read_kwargs["layer"] = layer
+    if where is not None:
+        read_kwargs["where"] = where
+    pushdown_bbox = bbox if tile_strategy != "none" else None
+    python_bbox = bbox if tile_strategy == "none" else None
+    if pushdown_bbox is not None:
+        read_kwargs["bbox"] = pushdown_bbox
+    return read_kwargs, python_bbox
+
+
+def emit_features(
+    fc_cls: type,
+    gdf_chunk: Any,
+    row_indices: list[int] | None,
+    chunksize: int | None,
+    include_index: bool,
+) -> Any:
+    """Yield a processed chunk for :func:`iter_features` (per-feature dicts or FC chunks)."""
+    if chunksize is None:
+        iterator = gdf_chunk.iterfeatures(na="null")
+        if include_index and row_indices is not None:
+            for ri, feat in zip(row_indices, iterator):
+                feat["id"] = ri
+                yield feat
+        else:
+            yield from iterator
+    else:
+        chunk_fc = fc_cls(gdf_chunk)
+        if include_index:
+            chunk_fc["_row_index"] = row_indices
+        yield chunk_fc
+
+
+def open_arrow(
+    path: str | Path,
+    *,
+    layer: str | int | None = None,
+    columns: list[str] | None = None,
+    bbox: tuple[float, float, float, float] | None = None,
+    where: str | None = None,
+    batch_size: int | None = None,
+) -> Any:
+    """Open a vector file as a streaming pyarrow RecordBatchReader (see FeatureCollection.open_arrow)."""
+    try:
+        from pyogrio.raw import open_arrow as _pyogrio_open_arrow
+    except ImportError as exc:
+        raise ImportError(
+            "open_arrow requires the optional 'pyogrio' dependency. "
+            "Install with one of:\n"
+            "  - PyPI:        pip install pyogrio\n"
+            "  - conda-forge: conda install -c conda-forge pyogrio"
+        ) from exc
+    resolved = _pyramids_io._parse_path(path)
+    kwargs: dict[str, Any] = {}
+    if layer is not None:
+        kwargs["layer"] = layer
+    if columns is not None:
+        kwargs["columns"] = columns
+    if bbox is not None:
+        kwargs["bbox"] = bbox
+    if where is not None:
+        kwargs["where"] = where
+    if batch_size is not None:
+        kwargs["batch_size"] = batch_size
+    return _pyogrio_open_arrow(resolved, **kwargs)
+
+
+def read_parquet_dask(
+    resolved: str,
+    *,
+    columns: list[str] | None,
+    split_row_groups: bool | None,
+    filters: list | None,
+    blocksize: int | str | None,
+    storage_options: dict | None,
+    extra_kwargs: dict[str, Any],
+) -> Any:
+    """Dask backend for :func:`read_parquet`: wrap dask_geopandas as a LazyFeatureCollection."""
+    # Check deps in order of specificity — the dask-geopandas hint beats the
+    # generic pyarrow one. When both are missing, this error names the extra.
+    dask_geopandas = _import_dask_geopandas()
+    dask_kwargs = _compact(
+        {
+            "columns": columns,
+            "split_row_groups": split_row_groups,
+            "filters": filters,
+            "blocksize": blocksize,
+            "storage_options": storage_options,
+        }
+    )
+    dask_kwargs.update(extra_kwargs)
+    # dask_geopandas is installed → assert pyarrow too, so the user gets the
+    # pyramids-branded hint (not the upstream message). `[parquet]` pulls both.
+    _require_pyarrow()
+    # Local import breaks the collection <-> _lazy_collection cycle.
+    from pyramids.feature._lazy_collection import LazyFeatureCollection
+
+    dask_gdf = dask_geopandas.read_parquet(resolved, **dask_kwargs)
+    return LazyFeatureCollection.from_dask_gdf(dask_gdf)
+
+
+def read_parquet(
+    fc_cls: type,
+    path: str | Path,
+    *,
+    columns: list[str] | None = None,
+    bbox: tuple[float, float, float, float] | None = None,
+    backend: str = "pandas",
+    split_row_groups: bool | None = None,
+    filters: list | None = None,
+    blocksize: int | str | None = None,
+    storage_options: dict | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Read a GeoParquet file into a FeatureCollection (see FeatureCollection.read_parquet)."""
+    # geopandas and dask-geopandas read Parquet through pyarrow + fsspec, which
+    # speak s3://, gs:// and az:// natively. Unlike GDAL they do not understand
+    # the /vsis3/ form _parse_path produces, and on Windows a leading "/vsis3/"
+    # resolves against the drive root, so the read dies with FileNotFoundError.
+    # Hand fsspec the URL untouched; local paths still go through _parse_path.
+    path_str = str(path)
+    resolved = path_str if is_remote(path_str) else _pyramids_io._parse_path(path)
+    if backend == "dask":
+        return read_parquet_dask(
+            resolved,
+            columns=columns,
+            split_row_groups=split_row_groups,
+            filters=filters,
+            blocksize=blocksize,
+            storage_options=storage_options,
+            extra_kwargs=kwargs,
+        )
+    if backend != "pandas":
+        raise ValueError(f"backend must be 'pandas' or 'dask', got {backend!r}")
+    _require_pyarrow()
+    # geopandas 1.x forwards **kwargs into pyarrow.parquet.read_table, which has
+    # never accepted the pandas-style `engine=` kwarg; _require_pyarrow() above
+    # hard-guarantees the pyarrow backend, so no injection is needed here.
+    passthrough: dict[str, Any] = {}
+    passthrough.update(kwargs)
+    if columns is not None:
+        passthrough["columns"] = columns
+    if bbox is not None:
+        passthrough["bbox"] = bbox
+    if storage_options is not None:
+        passthrough["storage_options"] = storage_options
+    gdf = gpd.read_parquet(resolved, **passthrough)
+    return fc_cls(gdf)

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -25,10 +25,10 @@ from __future__ import annotations
 import math
 import os
 import warnings
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from functools import lru_cache
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlencode
 
 import geopandas as gpd
@@ -39,6 +39,10 @@ from pyramids import _io as _pyramids_io
 from pyramids.base._errors import FeatureError
 from pyramids.base._utils import import_pyarrow
 from pyramids.base.remote import is_remote
+
+if TYPE_CHECKING:
+    from pyramids.feature._lazy_collection import LazyFeatureCollection
+    from pyramids.feature.collection import FeatureCollection
 
 _DEFAULT_ITER_BATCH_SIZE: int = 1000
 _LAZY_TARGET_BYTES_PER_PARTITION: int = 128 * 1024 * 1024
@@ -69,7 +73,7 @@ def list_layers_cache_clear() -> None:
     _list_layers_cached.cache_clear()
 
 
-def read_gpx_layers(fc_cls: type, path: str | Path) -> dict[str, Any]:
+def read_gpx_layers(fc_cls: type[FeatureCollection], path: str | Path) -> dict[str, FeatureCollection]:
     """Read every non-empty GPX sub-layer into a dict (see FeatureCollection.read_gpx_layers)."""
     result: dict[str, Any] = {}
     for name in fc_cls.list_layers(path):
@@ -79,13 +83,13 @@ def read_gpx_layers(fc_cls: type, path: str | Path) -> dict[str, Any]:
     return result
 
 
-def read_featureserver_page(fc_cls: type, page_url: str) -> Any:
+def read_featureserver_page(fc_cls: type[FeatureCollection], page_url: str) -> FeatureCollection:
     """Read one ESRIJSON page from an ArcGIS FeatureServer query URL."""
     return fc_cls.read_file(page_url)
 
 
 def from_featureserver(
-    fc_cls: type,
+    fc_cls: type[FeatureCollection],
     url: str,
     *,
     where: str = "1=1",
@@ -93,7 +97,7 @@ def from_featureserver(
     max_records: int | None = None,
     page_size: int = 1000,
     max_pages: int = 1000,
-) -> Any:
+) -> FeatureCollection:
     """Read a paged ArcGIS FeatureServer layer (see FeatureCollection.from_featureserver)."""
     if page_size < 1:
         raise ValueError(f"from_featureserver: page_size must be >= 1, got {page_size}")
@@ -111,8 +115,14 @@ def from_featureserver(
 
 
 def collect_featureserver_pages(
-    fc_cls: type, base: str, where: str, out_fields: str, max_records: int | None, page_size: int, max_pages: int
-) -> tuple[list, Any]:
+    fc_cls: type[FeatureCollection],
+    base: str,
+    where: str,
+    out_fields: str,
+    max_records: int | None,
+    page_size: int,
+    max_pages: int,
+) -> tuple[list[FeatureCollection], Any]:
     """Page through a FeatureServer /query endpoint; return (pages, first_crs)."""
     pages: list = []
     first_crs = None
@@ -214,7 +224,7 @@ def read_file_dask(
     where: str | None,
     npartitions: int | None,
     chunksize: int | None,
-) -> Any:
+) -> LazyFeatureCollection:
     """Dask backend for :func:`read_file`: reject unsupported filters, wrap as LazyFC."""
     # dask_geopandas.read_file does NOT forward pyogrio filter kwargs
     # (bbox / mask / rows / columns / where) — silently dropping them was the bug.
@@ -248,7 +258,7 @@ def read_file_dask(
 
 
 def read_file(
-    fc_cls: type,
+    fc_cls: type[FeatureCollection],
     path: str | Path,
     *,
     layer: str | int | None = None,
@@ -261,7 +271,7 @@ def read_file(
     npartitions: int | None = None,
     chunksize: int | None = None,
     **kwargs: Any,
-) -> Any:
+) -> FeatureCollection | LazyFeatureCollection:
     """Read a vector file into a FeatureCollection (see FeatureCollection.read_file)."""
     resolved = _pyramids_io._parse_path(path)
     if backend == "dask":
@@ -296,7 +306,7 @@ def read_file(
 
 
 def iter_features(
-    fc_cls: type,
+    fc_cls: type[FeatureCollection],
     path: str | Path,
     *,
     layer: str | int | None = None,
@@ -305,7 +315,7 @@ def iter_features(
     chunksize: int | None = None,
     tile_strategy: str = "auto",
     include_index: bool = False,
-) -> Any:
+) -> Iterator[dict[str, Any] | FeatureCollection]:
     """Stream features from `path` without materialising the file (see FeatureCollection.iter_features)."""
     if chunksize is not None and chunksize < 1:
         raise ValueError(f"chunksize must be >= 1 when supplied; got {chunksize}.")
@@ -391,12 +401,12 @@ def build_iter_read_kwargs(
 
 
 def emit_features(
-    fc_cls: type,
+    fc_cls: type[FeatureCollection],
     gdf_chunk: Any,
     row_indices: list[int] | None,
     chunksize: int | None,
     include_index: bool,
-) -> Any:
+) -> Iterator[dict[str, Any] | FeatureCollection]:
     """Yield a processed chunk for :func:`iter_features` (per-feature dicts or FC chunks)."""
     if chunksize is None:
         iterator = gdf_chunk.iterfeatures(na="null")
@@ -456,7 +466,7 @@ def read_parquet_dask(
     blocksize: int | str | None,
     storage_options: dict | None,
     extra_kwargs: dict[str, Any],
-) -> Any:
+) -> LazyFeatureCollection:
     """Dask backend for :func:`read_parquet`: wrap dask_geopandas as a LazyFeatureCollection."""
     # Check deps in order of specificity — the dask-geopandas hint beats the
     # generic pyarrow one. When both are missing, this error names the extra.
@@ -482,7 +492,7 @@ def read_parquet_dask(
 
 
 def read_parquet(
-    fc_cls: type,
+    fc_cls: type[FeatureCollection],
     path: str | Path,
     *,
     columns: list[str] | None = None,
@@ -493,7 +503,7 @@ def read_parquet(
     blocksize: int | str | None = None,
     storage_options: dict | None = None,
     **kwargs: Any,
-) -> Any:
+) -> FeatureCollection | LazyFeatureCollection:
     """Read a GeoParquet file into a FeatureCollection (see FeatureCollection.read_parquet)."""
     # geopandas and dask-geopandas read Parquet through pyarrow + fsspec, which
     # speak s3://, gs:// and az:// natively. Unlike GDAL they do not understand
@@ -530,7 +540,13 @@ def read_parquet(
     return fc_cls(gdf)
 
 
-def from_features(fc_cls: type, features: Iterable[Any], *, crs: Any = None, columns: list[str] | None = None) -> Any:
+def from_features(
+    fc_cls: type[FeatureCollection],
+    features: Iterable[Any],
+    *,
+    crs: Any = None,
+    columns: list[str] | None = None,
+) -> FeatureCollection:
     """Build an FC from feature-shaped inputs (see FeatureCollection.from_features)."""
     # Materialise the iterator so we can detect the empty case before handing off
     # to geopandas: gpd.from_features([]) returns a GeoDataFrame with no geometry
@@ -546,7 +562,12 @@ def from_features(fc_cls: type, features: Iterable[Any], *, crs: Any = None, col
     return fc_cls(gdf)
 
 
-def from_bbox(fc_cls: type, bbox: tuple[float, float, float, float] | list[float], *, epsg: Any) -> Any:
+def from_bbox(
+    fc_cls: type[FeatureCollection],
+    bbox: tuple[float, float, float, float] | list[float],
+    *,
+    epsg: Any,
+) -> FeatureCollection:
     """Build a one-row FC from a (west, south, east, north) bbox (see FeatureCollection.from_bbox)."""
     if epsg is None:
         raise ValueError(
@@ -579,11 +600,16 @@ def from_bbox(fc_cls: type, bbox: tuple[float, float, float, float] | list[float
 
 
 def from_records(
-    fc_cls: type, records: Any, *, geometry: str = "geometry", crs: Any = None, orient: str = "records"
-) -> Any:
+    fc_cls: type[FeatureCollection],
+    records: Any,
+    *,
+    geometry: str = "geometry",
+    crs: Any = None,
+    orient: str = "records",
+) -> FeatureCollection:
     """Build an FC from dict records or a columnar dict (see FeatureCollection.from_records)."""
 
-    def _empty_fc() -> Any:
+    def _empty_fc() -> FeatureCollection:
         # Both empty-input branches build a single-column frame whose column name
         # matches the geometry= kwarg, so GeoDataFrame(..., geometry=…) sets it as
         # the active geometry column and the returned FC has geometry.name == geometry.

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -53,7 +53,7 @@ def _list_layers_cached(resolved_path: str) -> tuple[str, ...]:
     return tuple(str(row[0]) for row in arr)
 
 
-def list_layers(fc_cls: type, path: str | Path) -> list[str]:
+def list_layers(path: str | Path) -> list[str]:
     """List every vector-layer name in `path`, memoised (see FeatureCollection.list_layers)."""
     path_str = str(path)
     if not is_remote(path_str):
@@ -203,6 +203,50 @@ def _import_dask_geopandas():
     return dask_geopandas
 
 
+def read_file_dask(
+    resolved: str,
+    *,
+    layer: str | int | None,
+    bbox: Any,
+    mask: Any,
+    rows: slice | int | None,
+    columns: list[str] | None,
+    where: str | None,
+    npartitions: int | None,
+    chunksize: int | None,
+) -> Any:
+    """Dask backend for :func:`read_file`: reject unsupported filters, wrap as LazyFC."""
+    # dask_geopandas.read_file does NOT forward pyogrio filter kwargs
+    # (bbox / mask / rows / columns / where) — silently dropping them was the bug.
+    # Raise a clear ValueError instead so users know to pre-filter or call .compute()
+    # and filter eagerly.
+    unsupported = {
+        "bbox": bbox,
+        "mask": mask,
+        "rows": rows,
+        "columns": columns,
+        "where": where,
+        "layer": layer,
+    }
+    supplied = [k for k, v in unsupported.items() if v is not None]
+    if supplied:
+        raise ValueError(
+            f"backend='dask' does not support filter kwargs "
+            f"{supplied}. dask_geopandas.read_file has no "
+            "pushdown story for these. Either omit them and "
+            "filter post-load via .clip / .loc / .compute, or "
+            "switch to read_parquet(backend='dask', filters=...)"
+        )
+    dask_geopandas = _import_dask_geopandas()
+    partition_kwargs = _resolve_lazy_partitioning(resolved, npartitions, chunksize)
+    # Local import breaks the collection <-> _lazy_collection cycle
+    # (_lazy_collection imports FeatureCollection from collection).
+    from pyramids.feature._lazy_collection import LazyFeatureCollection
+
+    dask_gdf = dask_geopandas.read_file(resolved, **partition_kwargs)
+    return LazyFeatureCollection.from_dask_gdf(dask_gdf)
+
+
 def read_file(
     fc_cls: type,
     path: str | Path,
@@ -221,35 +265,17 @@ def read_file(
     """Read a vector file into a FeatureCollection (see FeatureCollection.read_file)."""
     resolved = _pyramids_io._parse_path(path)
     if backend == "dask":
-        # dask_geopandas.read_file does NOT forward pyogrio filter kwargs
-        # (bbox / mask / rows / columns / where) — silently dropping them was the
-        # bug. Raise a clear ValueError instead so users know to pre-filter or
-        # call .compute() and filter eagerly.
-        unsupported = {
-            "bbox": bbox,
-            "mask": mask,
-            "rows": rows,
-            "columns": columns,
-            "where": where,
-            "layer": layer,
-        }
-        supplied = [k for k, v in unsupported.items() if v is not None]
-        if supplied:
-            raise ValueError(
-                f"backend='dask' does not support filter kwargs "
-                f"{supplied}. dask_geopandas.read_file has no "
-                "pushdown story for these. Either omit them and "
-                "filter post-load via .clip / .loc / .compute, or "
-                "switch to read_parquet(backend='dask', filters=...)"
-            )
-        dask_geopandas = _import_dask_geopandas()
-        partition_kwargs = _resolve_lazy_partitioning(resolved, npartitions, chunksize)
-        # Local import breaks the collection <-> _lazy_collection cycle
-        # (_lazy_collection imports FeatureCollection from collection).
-        from pyramids.feature._lazy_collection import LazyFeatureCollection
-
-        dask_gdf = dask_geopandas.read_file(resolved, **partition_kwargs)
-        return LazyFeatureCollection.from_dask_gdf(dask_gdf)
+        return read_file_dask(
+            resolved,
+            layer=layer,
+            bbox=bbox,
+            mask=mask,
+            rows=rows,
+            columns=columns,
+            where=where,
+            npartitions=npartitions,
+            chunksize=chunksize,
+        )
     if backend != "pandas":
         raise ValueError(f"backend must be 'pandas' or 'dask', got {backend!r}")
     # Only pass kwargs that were actually supplied — passing the unset

--- a/src/pyramids/feature/_wfs.py
+++ b/src/pyramids/feature/_wfs.py
@@ -29,14 +29,11 @@ from functools import lru_cache
 from typing import TYPE_CHECKING
 from xml.etree import ElementTree as ET  # nosec B405 - server XML; DoS accepted, no XXE
 
-import geopandas as gpd
-from osgeo import gdal
-
 from pyramids.base._errors import WFSError
-from pyramids.base._ogc_api import DISCOVERY_HEADERS
-from pyramids.base._ogc_api import gdal_http_config as _gdal_http_config
-from pyramids.base._ogc_api import http_error_detail, http_get_with_retry
+from pyramids.base._ogc_api import DISCOVERY_HEADERS, http_error_detail, http_get_with_retry
 from pyramids.feature._ogc import read_kwargs as _read_kwargs
+from pyramids.feature._ogc import read_ogc_layer as _read_ogc_layer
+from pyramids.feature._ogc import require_advertised as _require_advertised
 
 if TYPE_CHECKING:
     from pyramids.feature.collection import FeatureCollection
@@ -185,27 +182,19 @@ def from_wfs(
             f"WFS version {version!r} is not advertised by {endpoint!r}. "
             f"Available versions: {list(versions)}"
         )
-    if typenames and typename not in typenames:
-        raise ValueError(
-            f"feature type {typename!r} is not advertised by {endpoint!r}. "
-            f"Available feature types: {sorted(typenames)[:10]}"
-            + (" …" if len(typenames) > 10 else "")
-        )
+    _require_advertised(typename, typenames, noun="feature type", endpoint=endpoint)
 
-    connection = _wfs_connection(endpoint, version)
-    config = _gdal_http_config(auth, timeout)
-    with gdal.config_options(config):
-        try:
-            gdf = gpd.read_file(connection, layer=typename, **read_kwargs)
-        except Exception as exc:  # noqa: BLE001 — normalise any read failure to WFSError
-            raise WFSError(f"WFS GetFeature failed for {typename!r}: {exc}") from exc
-
-    fc = featurecollection_cls(gdf)
-    if output_crs is not None:
-        if fc.crs is None:
-            raise WFSError(
-                f"cannot reproject {typename!r} to {output_crs!r}: the server returned "
-                "features without a CRS"
-            )
-        fc = fc.to_crs(output_crs)  # to_crs preserves the FeatureCollection subclass
-    return fc
+    # The read tail (GDAL HTTP config + read_file + wrap + reproject) is shared with
+    # from_ogc_features via feature/_ogc.read_ogc_layer (ARC-64); only the connection
+    # string, discovery, error class and failure wording differ.
+    return _read_ogc_layer(
+        featurecollection_cls,
+        _wfs_connection(endpoint, version),
+        typename,
+        read_kwargs=read_kwargs,
+        auth=auth,
+        timeout=timeout,
+        error_cls=WFSError,
+        read_fail_prefix="WFS GetFeature failed for",
+        output_crs=output_crs,
+    )

--- a/src/pyramids/feature/_wfs.py
+++ b/src/pyramids/feature/_wfs.py
@@ -30,7 +30,11 @@ from typing import TYPE_CHECKING
 from xml.etree import ElementTree as ET  # nosec B405 - server XML; DoS accepted, no XXE
 
 from pyramids.base._errors import WFSError
-from pyramids.base._ogc_api import DISCOVERY_HEADERS, http_error_detail, http_get_with_retry
+from pyramids.base._ogc_api import (
+    DISCOVERY_HEADERS,
+    http_error_detail,
+    http_get_with_retry,
+)
 from pyramids.feature._ogc import read_kwargs as _read_kwargs
 from pyramids.feature._ogc import read_ogc_layer as _read_ogc_layer
 from pyramids.feature._ogc import require_advertised as _require_advertised

--- a/src/pyramids/feature/_wfs.py
+++ b/src/pyramids/feature/_wfs.py
@@ -22,6 +22,8 @@ non-PROJ CRS — live in the downstream consumer (``earthlens``), which calls
 
 from __future__ import annotations
 
+import base64
+import urllib.error
 import urllib.request
 from functools import lru_cache
 from typing import TYPE_CHECKING
@@ -31,7 +33,9 @@ import geopandas as gpd
 from osgeo import gdal
 
 from pyramids.base._errors import WFSError
+from pyramids.base._ogc_api import DISCOVERY_HEADERS
 from pyramids.base._ogc_api import gdal_http_config as _gdal_http_config
+from pyramids.base._ogc_api import http_error_detail, http_get_with_retry
 from pyramids.feature._ogc import read_kwargs as _read_kwargs
 
 if TYPE_CHECKING:
@@ -67,16 +71,27 @@ def _get_capabilities(
             answered with an ``<ows:ExceptionReport>`` / non-XML body.
     """
     url = _capabilities_url(endpoint, version)
-    opener = urllib.request.build_opener()
+    headers = dict(DISCOVERY_HEADERS)
     if auth is not None:
-        mgr = urllib.request.HTTPPasswordMgrWithDefaultRealm()
-        mgr.add_password(None, endpoint, auth[0], auth[1])
-        opener.add_handler(urllib.request.HTTPBasicAuthHandler(mgr))
+        # Send Basic credentials preemptively (matching the GDAL WFS read's
+        # GDAL_HTTP_USERPWD), plus a real User-Agent: a server that 403s without a
+        # 401 challenge, or blocks the default urllib UA, still gets valid
+        # credentials. The old reactive HTTPBasicAuthHandler only reacted to a 401,
+        # so such servers failed the pre-check even with correct auth (ARC-34). The
+        # shared retry also rides out transient discovery faults, as OAPIF already
+        # does (ARC-64).
+        token = base64.b64encode(f"{auth[0]}:{auth[1]}".encode()).decode()
+        headers["Authorization"] = f"Basic {token}"
+    request = urllib.request.Request(url, headers=headers)
     try:
-        with opener.open(url, timeout=timeout) as resp:
-            payload = resp.read()
+        payload = http_get_with_retry(request, timeout)
+    except urllib.error.HTTPError as exc:
+        raise WFSError(
+            f"WFS GetCapabilities request failed for {endpoint!r}: "
+            f"HTTP {exc.code} {http_error_detail(exc)}"
+        ) from exc
     except OSError as exc:
-        # urllib.error.URLError / HTTPError both derive from OSError.
+        # urllib.error.URLError and other transport errors derive from OSError.
         raise WFSError(
             f"WFS GetCapabilities request failed for {endpoint!r}: {exc}"
         ) from exc

--- a/src/pyramids/feature/_write.py
+++ b/src/pyramids/feature/_write.py
@@ -25,7 +25,13 @@ _CATALOG = Catalog(raster_driver=False)
 
 
 def to_file(
-    fc: Any, path: str | Path, driver: str = "geojson", *, layer: str | None = None, mode: str = "w", **creation_options: Any
+    fc: Any,
+    path: str | Path,
+    driver: str = "geojson",
+    *,
+    layer: str | None = None,
+    mode: str = "w",
+    **creation_options: Any,
 ) -> None:
     """Write `fc` to a vector file via the pyogrio engine (raw write; the facade clears the cache)."""
     if mode not in ("w", "a"):
@@ -43,7 +49,14 @@ def to_file(
     gpd.GeoDataFrame.to_file(fc, path, **passthrough)
 
 
-def to_parquet(fc: Any, path: str | Path, *, compression: str = "snappy", index: bool | None = None, **kwargs: Any) -> None:
+def to_parquet(
+    fc: Any,
+    path: str | Path,
+    *,
+    compression: str = "snappy",
+    index: bool | None = None,
+    **kwargs: Any,
+) -> None:
     """Write `fc` to GeoParquet, raising a pyramids-branded ImportError if pyarrow is absent."""
     import_pyarrow(
         "GeoParquet support requires the optional 'pyarrow' dependency. Install with one of:\n"
@@ -54,7 +67,14 @@ def to_parquet(fc: Any, path: str | Path, *, compression: str = "snappy", index:
 
 
 def to_vector_tiles(
-    fc: Any, path: str | Path, driver: str, *, min_zoom: int, max_zoom: int | None, layer_name: str | None, **creation_options: Any
+    fc: Any,
+    path: str | Path,
+    driver: str,
+    *,
+    min_zoom: int,
+    max_zoom: int | None,
+    layer_name: str | None,
+    **creation_options: Any,
 ) -> Path:
     """Write `fc` as a tiled-vector pyramid (PMTiles / MVT) via ``fc.to_file``, returning the path."""
     options = dict(creation_options)
@@ -67,7 +87,13 @@ def to_vector_tiles(
 
 
 def to_pmtiles(
-    fc: Any, path: str | Path, *, min_zoom: int = 0, max_zoom: int | None = None, layer_name: str | None = None, **creation_options: Any
+    fc: Any,
+    path: str | Path,
+    *,
+    min_zoom: int = 0,
+    max_zoom: int | None = None,
+    layer_name: str | None = None,
+    **creation_options: Any,
 ) -> Path:
     """Write `fc` as a single ``.pmtiles`` archive."""
     return to_vector_tiles(
@@ -76,7 +102,13 @@ def to_pmtiles(
 
 
 def to_mvt(
-    fc: Any, path: str | Path, *, min_zoom: int = 0, max_zoom: int | None = None, layer_name: str | None = None, **creation_options: Any
+    fc: Any,
+    path: str | Path,
+    *,
+    min_zoom: int = 0,
+    max_zoom: int | None = None,
+    layer_name: str | None = None,
+    **creation_options: Any,
 ) -> Path:
     """Write `fc` as an MVT ``{z}/{x}/{y}.pbf`` tile tree."""
     return to_vector_tiles(

--- a/src/pyramids/feature/_write.py
+++ b/src/pyramids/feature/_write.py
@@ -1,0 +1,84 @@
+"""I/O writer engine for :class:`~pyramids.feature.FeatureCollection` (ARC-36).
+
+Module-level implementations of the collection's writers (vector file, GeoParquet,
+PMTiles / MVT vector tiles), kept out of the god-class as free functions that take
+the collection as their first argument. The `FeatureCollection` write methods are
+thin facades over these functions.
+
+The underlying geopandas writers are real methods (not accessors), so they are
+called unbound as ``gpd.GeoDataFrame.to_file(fc, ...)`` -- equivalent to the old
+in-class ``super().to_file(...)`` while bypassing the FeatureCollection facade. The
+``list_layers`` cache invalidation (ARC-42) stays in the ``to_file`` facade;
+:func:`to_vector_tiles` therefore calls ``fc.to_file`` (the facade) so it still fires.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import geopandas as gpd
+
+from pyramids.base._utils import Catalog, import_pyarrow
+
+_CATALOG = Catalog(raster_driver=False)
+
+
+def to_file(
+    fc: Any, path: str | Path, driver: str = "geojson", *, layer: str | None = None, mode: str = "w", **creation_options: Any
+) -> None:
+    """Write `fc` to a vector file via the pyogrio engine (raw write; the facade clears the cache)."""
+    if mode not in ("w", "a"):
+        raise ValueError(f"mode must be 'w' (write) or 'a' (append); got {mode!r}.")
+    try:
+        resolved = _CATALOG.get_gdal_name(driver) or driver
+    except AttributeError:
+        resolved = driver
+    # Pin the engine to pyogrio to match read_file / iter_features; callers can override
+    # via engine="fiona" in creation_options.
+    passthrough: dict[str, Any] = {"driver": resolved, "mode": mode, "engine": "pyogrio"}
+    if layer is not None:
+        passthrough["layer"] = layer
+    passthrough.update(creation_options)
+    gpd.GeoDataFrame.to_file(fc, path, **passthrough)
+
+
+def to_parquet(fc: Any, path: str | Path, *, compression: str = "snappy", index: bool | None = None, **kwargs: Any) -> None:
+    """Write `fc` to GeoParquet, raising a pyramids-branded ImportError if pyarrow is absent."""
+    import_pyarrow(
+        "GeoParquet support requires the optional 'pyarrow' dependency. Install with one of:\n"
+        "  - PyPI:        pip install 'pyramids-gis[parquet]'\n"
+        "  - conda-forge: conda install -c conda-forge pyramids-parquet"
+    )
+    gpd.GeoDataFrame.to_parquet(fc, path, compression=compression, index=index, **kwargs)
+
+
+def to_vector_tiles(
+    fc: Any, path: str | Path, driver: str, *, min_zoom: int, max_zoom: int | None, layer_name: str | None, **creation_options: Any
+) -> Path:
+    """Write `fc` as a tiled-vector pyramid (PMTiles / MVT) via ``fc.to_file``, returning the path."""
+    options = dict(creation_options)
+    options["MINZOOM"] = min_zoom
+    if max_zoom is not None:
+        options["MAXZOOM"] = max_zoom
+    # Call the facade (not the raw writer) so the list_layers cache invalidation runs.
+    fc.to_file(path, driver=driver, layer=layer_name, **options)
+    return Path(path)
+
+
+def to_pmtiles(
+    fc: Any, path: str | Path, *, min_zoom: int = 0, max_zoom: int | None = None, layer_name: str | None = None, **creation_options: Any
+) -> Path:
+    """Write `fc` as a single ``.pmtiles`` archive."""
+    return to_vector_tiles(
+        fc, path, "PMTiles", min_zoom=min_zoom, max_zoom=max_zoom, layer_name=layer_name, **creation_options
+    )
+
+
+def to_mvt(
+    fc: Any, path: str | Path, *, min_zoom: int = 0, max_zoom: int | None = None, layer_name: str | None = None, **creation_options: Any
+) -> Path:
+    """Write `fc` as an MVT ``{z}/{x}/{y}.pbf`` tile tree."""
+    return to_vector_tiles(
+        fc, path, "MVT", min_zoom=min_zoom, max_zoom=max_zoom, layer_name=layer_name, **creation_options
+    )

--- a/src/pyramids/feature/_write.py
+++ b/src/pyramids/feature/_write.py
@@ -42,7 +42,11 @@ def to_file(
         resolved = driver
     # Pin the engine to pyogrio to match read_file / iter_features; callers can override
     # via engine="fiona" in creation_options.
-    passthrough: dict[str, Any] = {"driver": resolved, "mode": mode, "engine": "pyogrio"}
+    passthrough: dict[str, Any] = {
+        "driver": resolved,
+        "mode": mode,
+        "engine": "pyogrio",
+    }
     if layer is not None:
         passthrough["layer"] = layer
     passthrough.update(creation_options)
@@ -63,7 +67,9 @@ def to_parquet(
         "  - PyPI:        pip install 'pyramids-gis[parquet]'\n"
         "  - conda-forge: conda install -c conda-forge pyramids-parquet"
     )
-    gpd.GeoDataFrame.to_parquet(fc, path, compression=compression, index=index, **kwargs)
+    gpd.GeoDataFrame.to_parquet(
+        fc, path, compression=compression, index=index, **kwargs
+    )
 
 
 def to_vector_tiles(
@@ -97,7 +103,13 @@ def to_pmtiles(
 ) -> Path:
     """Write `fc` as a single ``.pmtiles`` archive."""
     return to_vector_tiles(
-        fc, path, "PMTiles", min_zoom=min_zoom, max_zoom=max_zoom, layer_name=layer_name, **creation_options
+        fc,
+        path,
+        "PMTiles",
+        min_zoom=min_zoom,
+        max_zoom=max_zoom,
+        layer_name=layer_name,
+        **creation_options,
     )
 
 
@@ -112,5 +124,11 @@ def to_mvt(
 ) -> Path:
     """Write `fc` as an MVT ``{z}/{x}/{y}.pbf`` tile tree."""
     return to_vector_tiles(
-        fc, path, "MVT", min_zoom=min_zoom, max_zoom=max_zoom, layer_name=layer_name, **creation_options
+        fc,
+        path,
+        "MVT",
+        min_zoom=min_zoom,
+        max_zoom=max_zoom,
+        layer_name=layer_name,
+        **creation_options,
     )

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -143,6 +143,36 @@ def _require_pyarrow() -> None:
     )
 
 
+def _compact(mapping: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of `mapping` with the ``None``-valued entries removed (ARC-72).
+
+    Read filters are passed to geopandas/pyogrio only when supplied — passing the
+    unset defaults (`None`) is fine for some engines but confuses others. Callers
+    build the full mapping and hand it here instead of repeating a per-key
+    ``if v is not None: kw[k] = v`` block.
+    """
+    return {key: value for key, value in mapping.items() if value is not None}
+
+
+def _import_dask_geopandas():
+    """Import and return ``dask_geopandas`` or raise a pyramids-branded ImportError (ARC-72).
+
+    Centralises the ``backend='dask'`` optional-dependency check that
+    :meth:`FeatureCollection.read_file` and :meth:`FeatureCollection.read_parquet`
+    both need, so the install instruction lives in one place.
+    """
+    try:
+        import dask_geopandas
+    except ImportError as exc:
+        raise ImportError(
+            "backend='dask' requires the optional "
+            "'dask-geopandas' dependency. Install with one of:\n"
+            "  - PyPI:        pip install 'pyramids-gis[parquet]'\n"
+            "  - conda-forge: conda install -c conda-forge pyramids-parquet"
+        ) from exc
+    return dask_geopandas
+
+
 # module-level LRU cache backing `FeatureCollection.list_layers`.
 # Keyed on the already-resolved `str` path (post `_parse_path`). The
 # tuple return type plays nicely with `functools.lru_cache` (lists are
@@ -1119,15 +1149,7 @@ class FeatureCollection(GeoDataFrame):
                     "filter post-load via .clip / .loc / .compute, or "
                     "switch to read_parquet(backend='dask', filters=...)"
                 )
-            try:
-                import dask_geopandas
-            except ImportError as exc:
-                raise ImportError(
-                    "backend='dask' requires the optional "
-                    "'dask-geopandas' dependency. Install with one of:\n"
-                    "  - PyPI:        pip install 'pyramids-gis[parquet]'\n"
-                    "  - conda-forge: conda install -c conda-forge pyramids-parquet"
-                ) from exc
+            dask_geopandas = _import_dask_geopandas()
             # default npartitions from file size when neither
             # kwarg was supplied; one-partition fallback defeats the
             # point of going lazy.
@@ -1144,22 +1166,18 @@ class FeatureCollection(GeoDataFrame):
             return LazyFeatureCollection.from_dask_gdf(dask_gdf)
         if backend != "pandas":
             raise ValueError(f"backend must be 'pandas' or 'dask', got {backend!r}")
-        # Only pass kwargs that were actually supplied — passing the
-        # defaults (None) is fine for some geopandas engines but
-        # confuses others. Build a clean kwargs dict.
-        passthrough: dict[str, Any] = {}
-        if layer is not None:
-            passthrough["layer"] = layer
-        if bbox is not None:
-            passthrough["bbox"] = bbox
-        if mask is not None:
-            passthrough["mask"] = mask
-        if rows is not None:
-            passthrough["rows"] = rows
-        if columns is not None:
-            passthrough["columns"] = columns
-        if where is not None:
-            passthrough["where"] = where
+        # Only pass kwargs that were actually supplied — passing the unset
+        # defaults (None) confuses some geopandas engines (ARC-72).
+        passthrough = _compact(
+            {
+                "layer": layer,
+                "bbox": bbox,
+                "mask": mask,
+                "rows": rows,
+                "columns": columns,
+                "where": where,
+            }
+        )
         passthrough.update(kwargs)
         gdf = gpd.read_file(resolved, **passthrough)
         return cls(gdf)
@@ -1363,6 +1381,15 @@ class FeatureCollection(GeoDataFrame):
             f"columns={self.columns.tolist()}, epsg={self.epsg})"
         )
 
+    def _geom_types(self) -> set[str]:
+        """Return the distinct non-null geometry-type names present (ARC-72).
+
+        One place for the "what geometry types are in this frame" inspection that
+        `schema`, the rasterize guard and the vector-field classifier each did a
+        slightly different way. `None` geometries are ignored.
+        """
+        return set(self.geom_type.dropna().unique())
+
     @property
     def schema(self) -> dict:
         """Fiona-style schema: geometry type + field-type dict.
@@ -1439,7 +1466,7 @@ class FeatureCollection(GeoDataFrame):
 
                 ```
         """
-        geom_types = {g.geom_type for g in self.geometry if g is not None}
+        geom_types = self._geom_types()
         if len(geom_types) == 1:
             (geom_type,) = geom_types
         else:
@@ -2038,26 +2065,16 @@ class FeatureCollection(GeoDataFrame):
         # check deps in order of specificity — the backend request is the more
         # specific signal, so the dask-geopandas hint beats the generic pyarrow
         # one. When both are missing, this error names the extra ([parquet]).
-        try:
-            import dask_geopandas
-        except ImportError as exc:
-            raise ImportError(
-                "backend='dask' requires the optional "
-                "'dask-geopandas' dependency. Install with one of:\n"
-                "  - PyPI:        pip install 'pyramids-gis[parquet]'\n"
-                "  - conda-forge: conda install -c conda-forge pyramids-parquet"
-            ) from exc
-        dask_kwargs: dict[str, Any] = {}
-        if columns is not None:
-            dask_kwargs["columns"] = columns
-        if split_row_groups is not None:
-            dask_kwargs["split_row_groups"] = split_row_groups
-        if filters is not None:
-            dask_kwargs["filters"] = filters
-        if blocksize is not None:
-            dask_kwargs["blocksize"] = blocksize
-        if storage_options is not None:
-            dask_kwargs["storage_options"] = storage_options
+        dask_geopandas = _import_dask_geopandas()
+        dask_kwargs = _compact(
+            {
+                "columns": columns,
+                "split_row_groups": split_row_groups,
+                "filters": filters,
+                "blocksize": blocksize,
+                "storage_options": storage_options,
+            }
+        )
         dask_kwargs.update(extra_kwargs)
         # dask_geopandas is installed → assert pyarrow too, so the user gets the
         # pyramids-branded hint (not the upstream message). `[parquet]` pulls both.
@@ -2825,7 +2842,7 @@ class FeatureCollection(GeoDataFrame):
                 f"Column {column!r} not found; available columns: {list(self.columns)}."
             )
         values = self[column].to_numpy() if column is not None else None
-        geom_types = set(self.geom_type.unique())
+        geom_types = self._geom_types()
         if geom_types <= {"Point"}:
             glyph = self._cleopatra_scatter_glyph(values, **kwargs)
         elif geom_types <= {"Polygon", "MultiPolygon"}:
@@ -3117,7 +3134,7 @@ class FeatureCollection(GeoDataFrame):
         Raises:
             InvalidGeometryError: If the collection holds any non-``Point`` geometry (or is empty).
         """
-        geom_types = sorted(set(self.geom_type.dropna().unique()))
+        geom_types = sorted(self._geom_types())
         if geom_types != ["Point"]:
             raise InvalidGeometryError(
                 f"{op}: requires all-Point geometries, got {geom_types or 'an empty collection'}"

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -44,7 +44,6 @@ from pyramids.base._errors import (
     CRSError,
     InvalidGeometryError,
 )
-from pyramids.base._utils import Catalog
 from pyramids.feature import _analysis
 from pyramids.feature import _plot
 from pyramids.feature import _read
@@ -53,8 +52,6 @@ from pyramids.feature import geometry as _geom
 from pyramids.feature import tessellation as _tess
 from pyramids.feature._oapif import from_ogc_features as _from_ogc_features
 from pyramids.feature._wfs import from_wfs as _from_wfs
-
-CATALOG = Catalog(raster_driver=False)
 
 
 class FeatureCollection(GeoDataFrame):

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -24,15 +24,12 @@ internal only; see :mod:`pyramids.feature._ogr`.
 
 from __future__ import annotations
 
-import functools
 import math
 import os
-import warnings
 from collections.abc import Callable, Iterable, Iterator
 from numbers import Number
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
-from urllib.parse import urlencode
 
 if TYPE_CHECKING:
     from pyramids.dataset import Dataset
@@ -55,6 +52,7 @@ from pyramids.base._utils import Catalog, import_pyarrow
 from pyramids.base.remote import is_remote
 from pyramids.feature import _analysis
 from pyramids.feature import _plot
+from pyramids.feature import _read
 from pyramids.feature import _write
 from pyramids.feature import geometry as _geom
 from pyramids.feature import tessellation as _tess
@@ -171,19 +169,6 @@ def _import_dask_geopandas():
             "  - conda-forge: conda install -c conda-forge pyramids-parquet"
         ) from exc
     return dask_geopandas
-
-
-# module-level LRU cache backing `FeatureCollection.list_layers`.
-# Keyed on the already-resolved `str` path (post `_parse_path`). The
-# tuple return type plays nicely with `functools.lru_cache` (lists are
-# unhashable and would break LRU internals if returned directly).
-@functools.lru_cache(maxsize=128)
-def _list_layers_cached(resolved_path: str) -> tuple[str, ...]:
-    """Return a tuple of layer names for a resolved path (memoised)."""
-    import pyogrio
-
-    arr = pyogrio.list_layers(resolved_path)
-    return tuple(str(row[0]) for row in arr)
 
 
 class FeatureCollection(GeoDataFrame):
@@ -1553,20 +1538,8 @@ class FeatureCollection(GeoDataFrame):
 
                 ```
         """
-        # pre-check local-path existence so the caller sees
-        # a `FileNotFoundError` naming the path instead of a generic
-        # driver-open failure. Defer to `base.remote.is_remote` as
-        # the single source of truth for which schemes are remote —
-        # the previous hardcoded prefix tuple would silently treat any
-        # future scheme as local and raise a misleading error.
-        path_str = str(path)
-        if not is_remote(path_str):
-            local = Path(path_str)
-            if not local.exists():
-                raise FileNotFoundError(f"list_layers: no file at {path_str!r}.")
+        return _read.list_layers(cls, path)
 
-        resolved = str(_pyramids_io._parse_path(path))
-        return list(_list_layers_cached(resolved))
 
     @classmethod
     def list_layers_cache_clear(cls) -> None:
@@ -1608,7 +1581,8 @@ class FeatureCollection(GeoDataFrame):
 
                 ```
         """
-        _list_layers_cached.cache_clear()
+        _read.list_layers_cache_clear()
+
 
     @classmethod
     def read_gpx_layers(cls, path: str | Path) -> dict[str, FeatureCollection]:
@@ -1648,12 +1622,8 @@ class FeatureCollection(GeoDataFrame):
 
                 ```
         """
-        result: dict[str, FeatureCollection] = {}
-        for name in cls.list_layers(path):
-            fc = cls.read_file(path, layer=name)
-            if len(fc) > 0:
-                result[name] = fc
-        return result
+        return _read.read_gpx_layers(cls, path)
+
 
     @classmethod
     def _read_featureserver_page(cls, page_url: str) -> FeatureCollection:
@@ -1667,7 +1637,8 @@ class FeatureCollection(GeoDataFrame):
         Returns:
             FeatureCollection: The features in this page (possibly empty).
         """
-        return cls.read_file(page_url)
+        return _read.read_featureserver_page(cls, page_url)
+
 
     @classmethod
     def from_featureserver(
@@ -1714,27 +1685,11 @@ class FeatureCollection(GeoDataFrame):
 
                 ```
         """
-        if page_size < 1:
-            raise ValueError(
-                f"from_featureserver: page_size must be >= 1, got {page_size}"
-            )
-        if max_records is not None and max_records < 0:
-            raise ValueError(
-                f"from_featureserver: max_records must be >= 0 or None, got {max_records}"
-            )
-        base = url.split("?", 1)[0].rstrip("/")
-        if not base.lower().endswith("/query"):
-            base = f"{base}/query"
-        pages, first_crs = cls._collect_featureserver_pages(
-            base, where, out_fields, max_records, page_size, max_pages
+        return _read.from_featureserver(
+            cls, url, where=where, out_fields=out_fields, max_records=max_records,
+            page_size=page_size, max_pages=max_pages,
         )
-        # Concatenate in one pass (pd.concat preserves the shared CRS) — repeatedly calling .concat()
-        # re-sets the CRS and trips a geopandas DeprecationWarning.
-        if pages:
-            combined = FeatureCollection(pd.concat(pages, ignore_index=True))
-        else:
-            combined = cls(gpd.GeoDataFrame(geometry=[], crs=first_crs))
-        return combined
+
 
     @classmethod
     def from_wfs(
@@ -1953,47 +1908,10 @@ class FeatureCollection(GeoDataFrame):
         Returns:
             tuple: ``(pages, first_crs)`` — the non-empty page collections and the CRS of the first page read.
         """
-        pages: list[FeatureCollection] = []
-        first_crs = None
-        offset = 0
-        fetched = 0
-        page_index = 0
-        while max_records is None or fetched < max_records:
-            if page_index >= max_pages:
-                warnings.warn(
-                    f"from_featureserver: stopped after {max_pages} pages (max_pages). The server may not "
-                    "honour resultOffset paging; raise max_pages or set max_records if more features are "
-                    "expected.",
-                    stacklevel=2,
-                )
-                break
-            this_page = (
-                page_size
-                if max_records is None
-                else min(page_size, max_records - fetched)
-            )
-            query = urlencode(
-                {
-                    "where": where,
-                    "outFields": out_fields,
-                    "f": "json",
-                    "resultOffset": offset,
-                    "resultRecordCount": this_page,
-                }
-            )
-            page = cls._read_featureserver_page(f"{base}?{query}")
-            if first_crs is None:
-                first_crs = page.crs
-            count = len(page)
-            if count == 0:
-                break
-            pages.append(page)
-            fetched += count
-            offset += count
-            page_index += 1
-            if count < this_page:  # last (short) page
-                break
-        return pages, first_crs
+        return _read.collect_featureserver_pages(
+            cls, base, where, out_fields, max_records, page_size, max_pages
+        )
+
 
     @classmethod
     def open_arrow(
@@ -2437,7 +2355,7 @@ class FeatureCollection(GeoDataFrame):
                 ```
         """
         _write.to_file(self, path, driver=driver, layer=layer, mode=mode, **creation_options)
-        _list_layers_cached.cache_clear()
+        _read.list_layers_cache_clear()
 
     def _to_vector_tiles(
         self,

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -24,7 +24,6 @@ internal only; see :mod:`pyramids.feature._ogr`.
 
 from __future__ import annotations
 
-import math
 from collections.abc import Callable, Iterable, Iterator
 from numbers import Number
 from pathlib import Path
@@ -43,7 +42,6 @@ from shapely.geometry import box
 
 from pyramids.base._errors import (
     CRSError,
-    FeatureError,
     InvalidGeometryError,
 )
 from pyramids.base._utils import Catalog
@@ -329,19 +327,8 @@ class FeatureCollection(GeoDataFrame):
 
                 ```
         """
-        # materialise an iterator so we can detect the empty case
-        # before handing off to geopandas. `geopandas.from_features([])`
-        # returns a GeoDataFrame with no `geometry` column, which
-        # breaks every pyramids op that assumes the column exists.
-        features_list = list(features)
-        if not features_list:
-            raise ValueError(
-                "from_features requires at least one feature. An empty "
-                "iterable would produce a GeoDataFrame with no geometry "
-                "column, which breaks downstream pyramids methods."
-            )
-        gdf = gpd.GeoDataFrame.from_features(features_list, crs=crs, columns=columns)
-        return cls(gdf)
+        return _read.from_features(cls, features, crs=crs, columns=columns)
+
 
     @classmethod
     def from_bbox(
@@ -427,38 +414,8 @@ class FeatureCollection(GeoDataFrame):
               ``bbox=`` / ``epsg=`` directly and routes through this helper.
             - :meth:`pyramids.dataset.engines.io.IO.read_array`: same.
         """
-        if epsg is None:
-            raise ValueError(
-                "from_bbox requires an explicit epsg= for the bbox CRS; "
-                "a bbox without a CRS is ambiguous"
-            )
-        try:
-            seq = list(bbox)
-        except TypeError as exc:
-            raise ValueError(
-                f"bbox must be a 4-element (west, south, east, north) sequence; "
-                f"got {bbox!r}"
-            ) from exc
-        if len(seq) != 4:
-            raise ValueError(
-                f"bbox must have exactly 4 elements (west, south, east, north); "
-                f"got {len(seq)}: {seq!r}"
-            )
-        try:
-            w, s, e, n = (float(v) for v in seq)
-        except (TypeError, ValueError) as exc:
-            raise TypeError(f"bbox elements must be numbers; got {seq!r}") from exc
-        # NaN slips past the ordering checks below (nan >= x is False), so reject it
-        # explicitly — e.g. an empty frame's all-NaN ``total_bounds``.
-        if any(math.isnan(v) for v in (w, s, e, n)):
-            raise ValueError(f"bbox coordinates must not be NaN; got {seq!r}")
-        if w >= e:
-            raise ValueError(f"bbox must satisfy west < east; got west={w}, east={e}")
-        if s >= n:
-            raise ValueError(
-                f"bbox must satisfy south < north; got south={s}, north={n}"
-            )
-        return cls(geometry=[box(w, s, e, n)], crs=epsg)
+        return _read.from_bbox(cls, bbox, epsg=epsg)
+
 
     @classmethod
     def fishnet(
@@ -601,41 +558,9 @@ class FeatureCollection(GeoDataFrame):
 
                 ```
         """
-
-        # empty-input branches both build a single-column frame
-        # whose column name matches the `geometry=` kwarg, so
-        # `GeoDataFrame(..., geometry=…)` sets it as the active
-        # geometry column and the returned FC has
-        # `geometry.name == geometry`.
-        def _empty_fc() -> FeatureCollection:
-            return cls(gpd.GeoDataFrame({geometry: []}, geometry=geometry, crs=crs))
-
-        if orient == "records":
-            records_list = list(records)
-            if not records_list:
-                return _empty_fc()
-            df = pd.DataFrame.from_records(records_list)
-        elif orient == "list":
-            # columnar dict of equal-length lists. Straight into
-            # `pd.DataFrame` which accepts this shape natively and
-            # raises `ValueError` on mismatched lengths (propagated
-            # to the caller as-is — the pandas message is already clear).
-            if not isinstance(records, dict):
-                raise ValueError(
-                    f"orient='list' expects a dict of column → list; "
-                    f"got {type(records).__name__}."
-                )
-            df = pd.DataFrame(records)
-            if len(df) == 0:
-                return _empty_fc()
-        else:
-            raise ValueError(f"orient must be 'records' or 'list'; got {orient!r}.")
-        if geometry not in df.columns:
-            raise FeatureError(
-                f"records missing required geometry column {geometry!r}; "
-                f"columns present: {list(df.columns)}"
-            )
-        return cls(gpd.GeoDataFrame(df, geometry=geometry, crs=crs))
+        return _read.from_records(
+            cls, records, geometry=geometry, crs=crs, orient=orient,
+        )
 
     _VALID_TILE_STRATEGIES: tuple[str, ...] = (
         "auto",

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -2831,4 +2831,3 @@ class FeatureCollection(GeoDataFrame):
                 ```
         """
         return _analysis.h3_bin(self, resolution, agg=agg, column=column)
-

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -2448,6 +2448,11 @@ class FeatureCollection(GeoDataFrame):
             passthrough["layer"] = layer
         passthrough.update(creation_options)
         super().to_file(path, **passthrough)
+        # This write can add or replace a layer at `path`, so drop the list_layers
+        # cache — otherwise a later list_layers(path) returns a stale layer set that
+        # omits what we just wrote (ARC-42). lru_cache has no per-key eviction, so
+        # clear all; to_file writes are rare, not a hot path.
+        _list_layers_cached.cache_clear()
 
     def _to_vector_tiles(
         self,

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -55,6 +55,7 @@ from pyramids.base._errors import (
 from pyramids.base._utils import Catalog, import_pyarrow, require_cleopatra
 from pyramids.base.remote import is_remote
 from pyramids.basemap.basemap import add_basemap
+from pyramids.feature import _analysis
 from pyramids.feature import _h3
 from pyramids.feature import geometry as _geom
 from pyramids.feature import tessellation as _tess
@@ -2719,20 +2720,7 @@ class FeatureCollection(GeoDataFrame):
 
                 ```
         """
-        gdf = _geom.explode_gdf(
-            gpd.GeoDataFrame(self, copy=True), geometry="multipolygon"
-        )
-        gdf = _geom.explode_gdf(gdf, geometry="geometrycollection")
-
-        fc = FeatureCollection(gdf)
-        fc["x"] = fc.apply(
-            _geom.get_coords, geom_col="geometry", coord_type="x", axis=1
-        )
-        fc["y"] = fc.apply(
-            _geom.get_coords, geom_col="geometry", coord_type="y", axis=1
-        )
-        fc.reset_index(drop=True, inplace=True)
-        return fc
+        return _analysis.with_coordinates(self)
 
     def plot(
         self,
@@ -3102,44 +3090,7 @@ class FeatureCollection(GeoDataFrame):
 
                 ```
         """
-        fc = self.with_coordinates()
-        # Vectorized per-cell mean over the (scalar-for-Point / list-for-ring) x/y
-        # columns, replacing an iterrows + scalar `.loc` assignment loop (ARC-63).
-        fc["avg_x"] = fc["x"].map(np.mean)
-        fc["avg_y"] = fc["y"].map(np.mean)
-
-        # detect rows whose averaged coordinate could not be
-        # computed (empty geometry, all-NaN rings, etc.). Emit a single
-        # summary warning and substitute an empty Point so the column
-        # does not expose a `(NaN, NaN)` Point that would then crash
-        # downstream reprojections.
-        avg_x = fc["avg_x"].to_numpy()
-        avg_y = fc["avg_y"].to_numpy()
-        bad_mask = np.isnan(avg_x) | np.isnan(avg_y)
-        if bad_mask.any():
-            bad_idx = [int(i) for i, is_bad in enumerate(bad_mask) if is_bad]
-            warnings.warn(
-                f"with_centroid: {len(bad_idx)} row(s) yielded NaN centroids "
-                f"(rows {bad_idx}). Their `center_point` is an empty "
-                f"shapely.Point. Drop or repair those rows before running "
-                f"a method that requires a valid centroid (e.g. reproject, "
-                f"distance).",
-                GeometryWarning,
-                stacklevel=2,
-            )
-
-        # single-pass build. The previous implementation built a
-        # throwaway `coords_list` (with NaN placeholders for the bad
-        # rows), called `create_points` on it, then iterated the
-        # result a second time to substitute empty Points for the bad
-        # rows. Skip both intermediates — write the final column value
-        # directly.
-        cleaned: list[Any] = [
-            Point() if bad else Point(ax, ay)
-            for ax, ay, bad in zip(avg_x.tolist(), avg_y.tolist(), bad_mask.tolist())
-        ]
-        fc["center_point"] = cleaned
-        return fc
+        return _analysis.with_centroid(self)
 
     def _require_point_geometry(self, op: str) -> None:
         """Raise :class:`InvalidGeometryError` unless every geometry is a single ``Point``.
@@ -3405,37 +3356,15 @@ class FeatureCollection(GeoDataFrame):
             - :meth:`pyramids.dataset.Dataset.from_points`: the underlying ``gdal.Grid`` interpolation this
               method delegates to (accepts any ``gdal.Grid`` algorithm string).
         """
-        self._require_point_geometry("interpolate_to_raster")
-        self._require_column("interpolate_to_raster", column)
-        if method != "idw":
-            raise ValueError(
-                f"interpolate_to_raster: method {method!r} is not supported; only 'idw' is available. "
-                "Kriging is out of scope for pyramids — see the geostatista package (the serapeum "
-                "geostatistics tier)."
-            )
-        if len(self) < 3:
-            raise ValueError(
-                f"interpolate_to_raster: need at least 3 points, got {len(self)}"
-            )
-        try:
-            values = self[column].to_numpy(dtype=float)
-        except (TypeError, ValueError) as exc:
-            raise ValueError(
-                f"interpolate_to_raster: column {column!r} must be numeric"
-            ) from exc
-        if np.isnan(values).all():
-            raise ValueError(f"interpolate_to_raster: column {column!r} is all-NaN")
-        if n_neighbors is not None:
-            algorithm = (
-                f"invdistnn:power={power}:max_points={n_neighbors}:nodata={nodata}"
-            )
-        else:
-            algorithm = f"invdist:power={power}:smoothing=0.0:nodata={nodata}"
-        # local import: pyramids.dataset imports pyramids.feature, so import here to break the cycle.
-        from pyramids.dataset import Dataset
-
-        return Dataset.from_points(
-            self, column, algorithm=algorithm, cell_size=cell_size, bbox=bounds
+        return _analysis.interpolate_to_raster(
+            self,
+            column,
+            method=method,
+            cell_size=cell_size,
+            bounds=bounds,
+            power=power,
+            n_neighbors=n_neighbors,
+            nodata=nodata,
         )
 
     def _h3_cells(self, resolution: int, op: str) -> list[str]:
@@ -3452,15 +3381,7 @@ class FeatureCollection(GeoDataFrame):
             InvalidGeometryError: If the geometries are not all ``Point``.
             ValueError: If ``resolution`` is outside 0-15, or the collection has no CRS.
         """
-        self._require_point_geometry(op)
-        if not 0 <= resolution <= 15:
-            raise ValueError(f"{op}: resolution must be 0-15, got {resolution}")
-        if self.crs is None:
-            raise ValueError(
-                f"{op}: a CRS is required to convert points to lat/lng for H3 indexing"
-            )
-        pts = self if self.epsg == 4326 else self.to_crs(4326)
-        return [_h3.latlng_to_cell(geom.y, geom.x, resolution) for geom in pts.geometry]
+        return _analysis.h3_cells(self, resolution, op)
 
     def to_h3(self, resolution: int) -> FeatureCollection:
         """Attach the H3 cell index of each point as an ``h3`` column.
@@ -3498,10 +3419,7 @@ class FeatureCollection(GeoDataFrame):
 
                 ```
         """
-        cells = self._h3_cells(resolution, "to_h3")
-        result = FeatureCollection(self.copy())
-        result["h3"] = cells
-        return result
+        return _analysis.to_h3(self, resolution)
 
     def h3_bin(
         self,
@@ -3556,34 +3474,5 @@ class FeatureCollection(GeoDataFrame):
 
                 ```
         """
-        self._require_column("h3_bin", column)
-        cells = self._h3_cells(resolution, "h3_bin")
-        if column is None:
-            counts = pd.Series(cells, dtype="object").value_counts()
-            items: list[tuple[Any, float]] = [
-                (cell, int(n)) for cell, n in counts.items()
-            ]
-            name = "count"
-        else:
-            reducer = _tess.resolve_reducer(agg)
-            try:
-                values = self[column].to_numpy(dtype=float)
-            except (TypeError, ValueError) as exc:
-                raise ValueError(f"h3_bin: column {column!r} must be numeric") from exc
-            grouped = pd.DataFrame({"_cell": cells, "_v": values}).groupby("_cell")[
-                "_v"
-            ]
-            items = [(cell, float(reducer(grp.to_numpy()))) for cell, grp in grouped]
-            name = column
-        geometries: list = []
-        idx: list = []
-        agg_values: list = []
-        for cell, value in items:
-            boundary = _h3.cell_to_boundary(cell)
-            geometries.append(Polygon([(lng, lat) for (lat, lng) in boundary]))
-            idx.append(cell)
-            agg_values.append(value)
-        frame = gpd.GeoDataFrame(
-            {"h3": idx, name: agg_values}, geometry=geometries, crs="EPSG:4326"
-        )
-        return FeatureCollection(frame)
+        return _analysis.h3_bin(self, resolution, agg=agg, column=column)
+

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -3088,9 +3088,10 @@ class FeatureCollection(GeoDataFrame):
                 ```
         """
         fc = self.with_coordinates()
-        for i, row_i in fc.iterrows():
-            fc.loc[i, "avg_x"] = np.mean(row_i["x"])
-            fc.loc[i, "avg_y"] = np.mean(row_i["y"])
+        # Vectorized per-cell mean over the (scalar-for-Point / list-for-ring) x/y
+        # columns, replacing an iterrows + scalar `.loc` assignment loop (ARC-63).
+        fc["avg_x"] = fc["x"].map(np.mean)
+        fc["avg_y"] = fc["y"].map(np.mean)
 
         # detect rows whose averaged coordinate could not be
         # computed (empty geometry, all-NaN rings, etc.). Emit a single

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -815,8 +815,13 @@ class FeatureCollection(GeoDataFrame):
             otherwise.
 
         Raises:
-            ValueError: If `chunksize` is given but `< 1`, or if
-                `tile_strategy` is not one of the accepted values.
+            ValueError: If `chunksize` is given but `< 1`; if
+                `tile_strategy` is not one of the accepted values; or if
+                `include_index=True` is combined with driver-side
+                filtering (`where`, or a pushed-down `bbox` — i.e. a
+                `bbox` with any `tile_strategy` other than `"none"`),
+                since the emitted `id` is the absolute source-file row
+                position and would be wrong under such filtering.
 
         Examples:
             - Stream features one at a time as GeoJSON-style dicts:
@@ -880,6 +885,18 @@ class FeatureCollection(GeoDataFrame):
             raise ValueError(
                 f"tile_strategy must be one of "
                 f"{cls._VALID_TILE_STRATEGIES}; got {tile_strategy!r}."
+            )
+        # The emitted id / _row_index is the absolute source-file row position, computed as
+        # range(start, start + len(chunk)). That only holds when nothing filters at the driver
+        # level: a pushed-down `where` or `bbox` makes skip_features count over the filtered set,
+        # so the positions would be wrong. Refuse that combination rather than emit wrong ids
+        # (ARC-31). The Python-side bbox path (tile_strategy="none") reads full chunks and masks
+        # row_indices afterwards, so it stays correct.
+        if include_index and (where is not None or (bbox is not None and tile_strategy != "none")):
+            raise ValueError(
+                "iter_features(include_index=True) is incompatible with driver-side filtering "
+                "because the emitted id is the absolute source-file row position: pass where=None "
+                "and either bbox=None or tile_strategy='none' (Python-side bbox)."
             )
 
         import pyogrio
@@ -1427,8 +1444,13 @@ class FeatureCollection(GeoDataFrame):
             (geom_type,) = geom_types
         else:
             geom_type = "Unknown"
+        # exclude the ACTIVE geometry column by its real name, not the literal
+        # "geometry": a renamed geometry column (e.g. "geom") would otherwise leak
+        # into properties, and a non-geometry column literally named "geometry"
+        # would be wrongly dropped (ARC-31).
+        geom_col = self.geometry.name
         properties = {
-            col: str(dt) for col, dt in self.dtypes.items() if col != "geometry"
+            col: str(dt) for col, dt in self.dtypes.items() if col != geom_col
         }
         return {
             "geometry": geom_type,

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -43,20 +43,18 @@ import numpy as np
 import pandas as pd
 from geopandas import GeoDataFrame
 from osgeo import gdal, ogr
-from shapely.geometry import Point, Polygon, box
+from shapely.geometry import box
 
 from pyramids import _io as _pyramids_io
 from pyramids.base._errors import (
     CRSError,
     FeatureError,
-    GeometryWarning,
     InvalidGeometryError,
 )
-from pyramids.base._utils import Catalog, import_pyarrow, require_cleopatra
+from pyramids.base._utils import Catalog, import_pyarrow
 from pyramids.base.remote import is_remote
-from pyramids.basemap.basemap import add_basemap
 from pyramids.feature import _analysis
-from pyramids.feature import _h3
+from pyramids.feature import _plot
 from pyramids.feature import geometry as _geom
 from pyramids.feature import tessellation as _tess
 from pyramids.feature._oapif import from_ogc_features as _from_ogc_features
@@ -2791,25 +2789,7 @@ class FeatureCollection(GeoDataFrame):
 
                 ```
         """
-        if engine == "geopandas":
-            result = super().plot(column=column, **kwargs)
-            ax = result
-        elif engine == "cleopatra":
-            result, ax = self._plot_cleopatra(column=column, **kwargs)
-        else:
-            raise ValueError(
-                f"Unsupported engine {engine!r}; choose 'geopandas' or 'cleopatra'."
-            )
-
-        if basemap:
-            if self.epsg is None:
-                raise CRSError(
-                    "FeatureCollection must have a CRS (epsg) to use basemap."
-                )
-            source = basemap if isinstance(basemap, str) else None
-            add_basemap(ax, crs=self.epsg, source=source)
-
-        return result
+        return _plot.plot(self, column=column, basemap=basemap, engine=engine, **kwargs)
 
     def _plot_cleopatra(self, column: str | None = None, **kwargs: Any):
         """Render via cleopatra ``PolygonGlyph``/``ScatterGlyph``.
@@ -2838,26 +2818,7 @@ class FeatureCollection(GeoDataFrame):
                 the geometry is neither all single-``Point`` nor all-polygon
                 (``MultiPoint`` is not supported).
         """
-        require_cleopatra()
-
-        if column is not None and column not in self.columns:
-            raise ValueError(
-                f"Column {column!r} not found; available columns: {list(self.columns)}."
-            )
-        values = self[column].to_numpy() if column is not None else None
-        geom_types = self._geom_types()
-        if geom_types <= {"Point"}:
-            glyph = self._cleopatra_scatter_glyph(values, **kwargs)
-        elif geom_types <= {"Polygon", "MultiPolygon"}:
-            glyph = self._cleopatra_polygon_glyph(values, **kwargs)
-        else:
-            raise ValueError(
-                "engine='cleopatra' supports single Point or "
-                "Polygon/MultiPolygon geometries; got "
-                f"{sorted(geom_types)} (MultiPoint is not supported)."
-            )
-        _fig, ax, _coll = glyph.plot()
-        return glyph, ax
+        return _plot.plot_cleopatra(self, column=column, **kwargs)
 
     def _cleopatra_scatter_glyph(self, values: Any, **kwargs: Any) -> Any:
         """Build a ``ScatterGlyph`` from this collection's point geometries.
@@ -2869,15 +2830,7 @@ class FeatureCollection(GeoDataFrame):
         Returns:
             cleopatra.scatter_glyph.ScatterGlyph: The point glyph.
         """
-        require_cleopatra()
-        from cleopatra.scatter_glyph import ScatterGlyph
-
-        return ScatterGlyph(
-            self.geometry.x.to_numpy(),
-            self.geometry.y.to_numpy(),
-            values=values,
-            **ScatterGlyph.filter_kwargs(kwargs),
-        )
+        return _plot.scatter_glyph(self, values, **kwargs)
 
     def _cleopatra_polygon_glyph(self, values: Any, **kwargs: Any) -> Any:
         """Build a ``PolygonGlyph`` from polygon exterior rings.
@@ -2895,32 +2848,7 @@ class FeatureCollection(GeoDataFrame):
         Returns:
             cleopatra.polygon_glyph.PolygonGlyph: The polygon glyph.
         """
-        require_cleopatra()
-        from cleopatra.polygon_glyph import PolygonGlyph
-
-        polygons: list = []
-        poly_values: list | None = [] if values is not None else None
-        has_holes = False
-        for idx, geom in enumerate(self.geometry):
-            # A plain Polygon has no ``.geoms``; a MultiPolygon does.
-            for part in getattr(geom, "geoms", [geom]):
-                polygons.append(np.asarray(part.exterior.coords))
-                has_holes = has_holes or bool(part.interiors)
-                if poly_values is not None:
-                    poly_values.append(values[idx])
-        if has_holes:
-            warnings.warn(
-                "engine='cleopatra' renders only polygon exterior rings; "
-                "interior rings (holes) are dropped and will appear "
-                "filled. Use engine='geopandas' to render holes.",
-                GeometryWarning,
-                stacklevel=2,
-            )
-        return PolygonGlyph(
-            polygons,
-            values=np.asarray(poly_values) if poly_values is not None else None,
-            **PolygonGlyph.filter_kwargs(kwargs),
-        )
+        return _plot.polygon_glyph(self, values, **kwargs)
 
     def concat(self, other: GeoDataFrame) -> FeatureCollection:
         """Concatenate another GeoDataFrame onto this FeatureCollection.

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -28,7 +28,7 @@ import functools
 import math
 import os
 import warnings
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Iterable, Iterator
 from numbers import Number
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -782,8 +782,13 @@ class FeatureCollection(GeoDataFrame):
         chunksize: int | None = None,
         tile_strategy: str = "auto",
         include_index: bool = False,
-    ) -> Any:
+    ) -> Iterator[dict[str, Any] | FeatureCollection]:
         """Stream features from `path` without materializing the full file.
+
+        Return type varies by `chunksize` (ARC-38): `chunksize=None` yields
+        per-feature `dict`s, an `int` yields :class:`FeatureCollection` chunks — a
+        single generator type documented in Yields below rather than split into two
+        methods (which would break the fiona-style single entry point).
 
         . Two orthogonal knobs:
 
@@ -1112,8 +1117,11 @@ class FeatureCollection(GeoDataFrame):
                 `use_arrow=True`, driver-specific creation options).
 
         Returns:
-            FeatureCollection: The (possibly filtered) features
-            wrapped as a FeatureCollection.
+            FeatureCollection | LazyFeatureCollection: The (possibly filtered)
+            features. The return type varies by `backend` (ARC-38):
+            `backend="pandas"` (default) returns an eager
+            :class:`FeatureCollection`; `backend="dask"` returns a lazy
+            :class:`LazyFeatureCollection`.
 
         Examples:
             - Load a GeoJSON file:
@@ -2138,8 +2146,10 @@ class FeatureCollection(GeoDataFrame):
                 (`storage_options=` for fsspec, etc.).
 
         Returns:
-            FeatureCollection: The file's features wrapped as a
-            FeatureCollection.
+            FeatureCollection | LazyFeatureCollection: The file's features. The
+            return type varies by `backend` (ARC-38): `backend="pandas"` (default)
+            returns an eager :class:`FeatureCollection`; `backend="dask"` returns a
+            lazy :class:`LazyFeatureCollection`.
 
         Raises:
             ImportError: If :mod:`pyarrow` is not installed, with a

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -25,7 +25,6 @@ internal only; see :mod:`pyramids.feature._ogr`.
 from __future__ import annotations
 
 import math
-import os
 from collections.abc import Callable, Iterable, Iterator
 from numbers import Number
 from pathlib import Path
@@ -42,14 +41,12 @@ from geopandas import GeoDataFrame
 from osgeo import gdal, ogr
 from shapely.geometry import box
 
-from pyramids import _io as _pyramids_io
 from pyramids.base._errors import (
     CRSError,
     FeatureError,
     InvalidGeometryError,
 )
-from pyramids.base._utils import Catalog, import_pyarrow
-from pyramids.base.remote import is_remote
+from pyramids.base._utils import Catalog
 from pyramids.feature import _analysis
 from pyramids.feature import _plot
 from pyramids.feature import _read
@@ -60,115 +57,6 @@ from pyramids.feature._oapif import from_ogc_features as _from_ogc_features
 from pyramids.feature._wfs import from_wfs as _from_wfs
 
 CATALOG = Catalog(raster_driver=False)
-
-# default per-chunk batch size for `iter_features` when the
-# user does not pass `chunksize`. Matches pyogrio's own
-# `read_dataframe` default for row-group streaming, so the fast
-# path (GeoParquet + row_group tile strategy) does not re-chunk.
-_DEFAULT_ITER_BATCH_SIZE: int = 1000
-
-
-# target bytes per partition when read_file(backend="dask") is
-# called with neither npartitions nor chunksize. 128 MiB is
-# dask-geopandas' own read_parquet default and a reasonable size for
-# shapely-heavy geometry ops on modern cores. Small enough that even a
-# 1 GiB shapefile gets 8 partitions; large enough to avoid one-partition-
-# per-10-rows pathologies on huge feature counts.
-_LAZY_TARGET_BYTES_PER_PARTITION: int = 128 * 1024 * 1024
-
-
-def _resolve_lazy_partitioning(
-    path: str,
-    npartitions: int | None,
-    chunksize: int | None,
-) -> dict[str, Any]:
-    """default `npartitions` from file size when not given.
-
-    Called by `read_file(backend="dask")`. If the caller supplies
-    either `npartitions` or `chunksize` we honor it verbatim. If
-    they supply neither, we stat the resolved path and pick
-    `npartitions = max(1, ceil(size / 128 MiB))`.
-
-    On cloud / virtual-FS paths (`/vsi*`, `http(s)://`, `s3://`,
-    etc.) `os.stat` can't size the file cheaply — there we fall
-    back to `npartitions=1` rather than emit a pre-flight HEAD
-    request with ambiguous semantics. Users who want more partitions
-    on cloud-hosted files should pass `npartitions=` explicitly.
-
-    Args:
-        path: The already-`_to_vsi`-resolved path string.
-        npartitions: User-supplied partition count, if any.
-        chunksize: User-supplied rows-per-partition, if any.
-
-    Returns:
-        dict: kwargs to forward to :func:`dask_geopandas.read_file`.
-        Exactly one of `npartitions` / `chunksize` is populated.
-    """
-    kwargs: dict[str, Any] = {}
-    if npartitions is not None:
-        kwargs["npartitions"] = npartitions
-    elif chunksize is not None:
-        kwargs["chunksize"] = chunksize
-    elif path.startswith(("/vsi", "http://", "https://", "s3://", "gs://", "az://")):
-        # Remote / VFS path — no cheap size probe. Fall back to 1.
-        kwargs["npartitions"] = 1
-    else:
-        try:
-            size = os.path.getsize(path)
-        except OSError:
-            kwargs["npartitions"] = 1
-        else:
-            kwargs["npartitions"] = max(
-                1,
-                math.ceil(size / _LAZY_TARGET_BYTES_PER_PARTITION),
-            )
-    return kwargs
-
-
-def _require_pyarrow() -> None:
-    """Raise a pyramids-branded ImportError if pyarrow is absent.
-
-    `geopandas.read_parquet` / `GeoDataFrame.to_parquet` raise a
-    generic ImportError that mentions neither `pyramids-gis` nor
-    the `[parquet]` extra. This helper surfaces the install
-    instruction up front so the Raises docstring is truthful.
-    """
-    import_pyarrow(
-        "GeoParquet support requires the optional 'pyarrow' "
-        "dependency. Install with one of:\n"
-        "  - PyPI:        pip install 'pyramids-gis[parquet]'\n"
-        "  - conda-forge: conda install -c conda-forge pyramids-parquet"
-    )
-
-
-def _compact(mapping: dict[str, Any]) -> dict[str, Any]:
-    """Return a copy of `mapping` with the ``None``-valued entries removed (ARC-72).
-
-    Read filters are passed to geopandas/pyogrio only when supplied — passing the
-    unset defaults (`None`) is fine for some engines but confuses others. Callers
-    build the full mapping and hand it here instead of repeating a per-key
-    ``if v is not None: kw[k] = v`` block.
-    """
-    return {key: value for key, value in mapping.items() if value is not None}
-
-
-def _import_dask_geopandas():
-    """Import and return ``dask_geopandas`` or raise a pyramids-branded ImportError (ARC-72).
-
-    Centralises the ``backend='dask'`` optional-dependency check that
-    :meth:`FeatureCollection.read_file` and :meth:`FeatureCollection.read_parquet`
-    both need, so the install instruction lives in one place.
-    """
-    try:
-        import dask_geopandas
-    except ImportError as exc:
-        raise ImportError(
-            "backend='dask' requires the optional "
-            "'dask-geopandas' dependency. Install with one of:\n"
-            "  - PyPI:        pip install 'pyramids-gis[parquet]'\n"
-            "  - conda-forge: conda install -c conda-forge pyramids-parquet"
-        ) from exc
-    return dask_geopandas
 
 
 class FeatureCollection(GeoDataFrame):
@@ -899,128 +787,11 @@ class FeatureCollection(GeoDataFrame):
 
                 ```
         """
-        if chunksize is not None and chunksize < 1:
-            raise ValueError(f"chunksize must be >= 1 when supplied; got {chunksize}.")
-        if tile_strategy not in cls._VALID_TILE_STRATEGIES:
-            raise ValueError(
-                f"tile_strategy must be one of "
-                f"{cls._VALID_TILE_STRATEGIES}; got {tile_strategy!r}."
-            )
-        # The emitted id / _row_index is the absolute source-file row position, computed as
-        # range(start, start + len(chunk)). That only holds when nothing filters at the driver
-        # level: a pushed-down `where` or `bbox` makes skip_features count over the filtered set,
-        # so the positions would be wrong. Refuse that combination rather than emit wrong ids
-        # (ARC-31). The Python-side bbox path (tile_strategy="none") reads full chunks and masks
-        # row_indices afterwards, so it stays correct.
-        if include_index and (where is not None or (bbox is not None and tile_strategy != "none")):
-            raise ValueError(
-                "iter_features(include_index=True) is incompatible with driver-side filtering "
-                "because the emitted id is the absolute source-file row position: pass where=None "
-                "and either bbox=None or tile_strategy='none' (Python-side bbox)."
-            )
-
-        import pyogrio
-
-        resolved = str(_pyramids_io._parse_path(path))
-
-        # Determine how many features are in the layer so we can
-        # iterate in fixed-size batches via skip_features / max_features.
-        # pyogrio's read_info is O(1) per call.
-        info_kwargs: dict[str, Any] = {}
-        if layer is not None:
-            info_kwargs["layer"] = layer
-        info = pyogrio.read_info(resolved, **info_kwargs)
-        total = int(info["features"])
-
-        if chunksize is None:
-            batch_size = _DEFAULT_ITER_BATCH_SIZE
-        else:
-            batch_size = int(chunksize)
-
-        read_kwargs, python_bbox = cls._build_iter_read_kwargs(
-            layer, where, bbox, tile_strategy
+        yield from _read.iter_features(
+            cls, path, layer=layer, bbox=bbox, where=where, chunksize=chunksize,
+            tile_strategy=tile_strategy, include_index=include_index,
         )
 
-        for start in range(0, total, batch_size):
-            gdf_chunk = gpd.read_file(
-                resolved,
-                skip_features=start,
-                max_features=batch_size,
-                **read_kwargs,
-            )
-            # Absolute row indices captured before any bbox masking, so callers
-            # can map yielded features back to their source rows.
-            row_indices = (
-                list(range(start, start + len(gdf_chunk))) if include_index else None
-            )
-            if python_bbox is not None and len(gdf_chunk) > 0:
-                xmin, ymin, xmax, ymax = python_bbox
-                mask = gdf_chunk.intersects(box(xmin, ymin, xmax, ymax))
-                if row_indices is not None:
-                    row_indices = [ri for ri, keep in zip(row_indices, mask) if keep]
-                gdf_chunk = gdf_chunk[mask]
-            yield from cls._emit_features(
-                gdf_chunk, row_indices, chunksize, include_index
-            )
-
-    @staticmethod
-    def _build_iter_read_kwargs(
-        layer: str | int | None,
-        where: str | None,
-        bbox: tuple[float, float, float, float] | None,
-        tile_strategy: str,
-    ) -> tuple[dict[str, Any], tuple[float, float, float, float] | None]:
-        """Build the pyogrio ``read_file`` kwargs for :meth:`iter_features`.
-
-        The engine is pinned to pyogrio (``skip_features`` / ``max_features`` are
-        pyogrio-specific; the fiona engine silently ignores them, turning every
-        chunk into a full scan). For every ``tile_strategy`` except ``"none"`` the
-        ``bbox`` is pushed down to pyogrio (which uses the format's spatial
-        index); for ``"none"`` it is held back for a post-load Python filter.
-
-        Returns:
-            ``(read_kwargs, python_bbox)`` — the held-back bbox is ``None`` unless
-            ``tile_strategy == "none"``.
-        """
-        read_kwargs: dict[str, Any] = {"engine": "pyogrio"}
-        if layer is not None:
-            read_kwargs["layer"] = layer
-        if where is not None:
-            read_kwargs["where"] = where
-        pushdown_bbox = bbox if tile_strategy != "none" else None
-        python_bbox = bbox if tile_strategy == "none" else None
-        if pushdown_bbox is not None:
-            read_kwargs["bbox"] = pushdown_bbox
-        return read_kwargs, python_bbox
-
-    @classmethod
-    def _emit_features(
-        cls,
-        gdf_chunk: GeoDataFrame,
-        row_indices: list[int] | None,
-        chunksize: int | None,
-        include_index: bool,
-    ) -> Any:
-        """Yield a processed chunk for :meth:`iter_features`.
-
-        With ``chunksize=None`` yields one GeoJSON-style dict per row (stamping
-        an ``"id"`` when ``include_index``); otherwise yields a single
-        :class:`FeatureCollection` chunk (with a ``"_row_index"`` column when
-        ``include_index``).
-        """
-        if chunksize is None:
-            iterator = gdf_chunk.iterfeatures(na="null")
-            if include_index and row_indices is not None:
-                for ri, feat in zip(row_indices, iterator):
-                    feat["id"] = ri
-                    yield feat
-            else:
-                yield from iterator
-        else:
-            chunk_fc = cls(gdf_chunk)
-            if include_index:
-                chunk_fc["_row_index"] = row_indices
-            yield chunk_fc
 
     @classmethod
     def read_file(
@@ -1118,62 +889,11 @@ class FeatureCollection(GeoDataFrame):
 
                 ```
         """
-        resolved = _pyramids_io._parse_path(path)
-        if backend == "dask":
-            # dask_geopandas.read_file does NOT forward pyogrio
-            # filter kwargs (bbox / mask / rows / columns / where) —
-            # silently dropping them was the bug. Raise a clear
-            # ValueError instead so users know to either pre-filter
-            # or call .compute() and filter eagerly.
-            unsupported = {
-                "bbox": bbox,
-                "mask": mask,
-                "rows": rows,
-                "columns": columns,
-                "where": where,
-                "layer": layer,
-            }
-            supplied = [k for k, v in unsupported.items() if v is not None]
-            if supplied:
-                raise ValueError(
-                    f"backend='dask' does not support filter kwargs "
-                    f"{supplied}. dask_geopandas.read_file has no "
-                    "pushdown story for these. Either omit them and "
-                    "filter post-load via .clip / .loc / .compute, or "
-                    "switch to read_parquet(backend='dask', filters=...)"
-                )
-            dask_geopandas = _import_dask_geopandas()
-            # default npartitions from file size when neither
-            # kwarg was supplied; one-partition fallback defeats the
-            # point of going lazy.
-            partition_kwargs = _resolve_lazy_partitioning(
-                resolved,
-                npartitions,
-                chunksize,
-            )
-            # wrap the lazy return as a LazyFeatureCollection so the
-            # dask branch stays inside the pyramids type system.
-            from pyramids.feature._lazy_collection import LazyFeatureCollection
-
-            dask_gdf = dask_geopandas.read_file(resolved, **partition_kwargs)
-            return LazyFeatureCollection.from_dask_gdf(dask_gdf)
-        if backend != "pandas":
-            raise ValueError(f"backend must be 'pandas' or 'dask', got {backend!r}")
-        # Only pass kwargs that were actually supplied — passing the unset
-        # defaults (None) confuses some geopandas engines (ARC-72).
-        passthrough = _compact(
-            {
-                "layer": layer,
-                "bbox": bbox,
-                "mask": mask,
-                "rows": rows,
-                "columns": columns,
-                "where": where,
-            }
+        return _read.read_file(
+            cls, path, layer=layer, bbox=bbox, mask=mask, rows=rows, columns=columns,
+            where=where, backend=backend, npartitions=npartitions, chunksize=chunksize, **kwargs,
         )
-        passthrough.update(kwargs)
-        gdf = gpd.read_file(resolved, **passthrough)
-        return cls(gdf)
+
 
     @property
     def epsg(self) -> int | None:
@@ -1953,65 +1673,10 @@ class FeatureCollection(GeoDataFrame):
         Raises:
             ImportError: If :mod:`pyogrio` is not installed.
         """
-        try:
-            from pyogrio.raw import open_arrow
-        except ImportError as exc:
-            raise ImportError(
-                "open_arrow requires the optional 'pyogrio' dependency. "
-                "Install with one of:\n"
-                "  - PyPI:        pip install pyogrio\n"
-                "  - conda-forge: conda install -c conda-forge pyogrio"
-            ) from exc
-        resolved = _pyramids_io._parse_path(path)
-        kwargs: dict[str, Any] = {}
-        if layer is not None:
-            kwargs["layer"] = layer
-        if columns is not None:
-            kwargs["columns"] = columns
-        if bbox is not None:
-            kwargs["bbox"] = bbox
-        if where is not None:
-            kwargs["where"] = where
-        if batch_size is not None:
-            kwargs["batch_size"] = batch_size
-        return open_arrow(resolved, **kwargs)
-
-    @staticmethod
-    def _read_parquet_dask(
-        resolved: str,
-        *,
-        columns: list[str] | None,
-        split_row_groups: bool | None,
-        filters: list | None,
-        blocksize: int | str | None,
-        storage_options: dict | None,
-        extra_kwargs: dict[str, Any],
-    ) -> LazyFeatureCollection:
-        """Dask backend for :meth:`read_parquet`: wrap dask_geopandas as a LazyFeatureCollection."""
-        # check deps in order of specificity — the backend request is the more
-        # specific signal, so the dask-geopandas hint beats the generic pyarrow
-        # one. When both are missing, this error names the extra ([parquet]).
-        dask_geopandas = _import_dask_geopandas()
-        dask_kwargs = _compact(
-            {
-                "columns": columns,
-                "split_row_groups": split_row_groups,
-                "filters": filters,
-                "blocksize": blocksize,
-                "storage_options": storage_options,
-            }
+        return _read.open_arrow(
+            path, layer=layer, columns=columns, bbox=bbox, where=where, batch_size=batch_size,
         )
-        dask_kwargs.update(extra_kwargs)
-        # dask_geopandas is installed → assert pyarrow too, so the user gets the
-        # pyramids-branded hint (not the upstream message). `[parquet]` pulls both.
-        _require_pyarrow()
-        # Local import breaks the collection <-> _lazy_collection cycle
-        # (_lazy_collection imports FeatureCollection from this module); it wraps
-        # the lazy dask return inside the pyramids type system.
-        from pyramids.feature._lazy_collection import LazyFeatureCollection
 
-        dask_gdf = dask_geopandas.read_parquet(resolved, **dask_kwargs)
-        return LazyFeatureCollection.from_dask_gdf(dask_gdf)
 
     @classmethod
     def read_parquet(
@@ -2115,43 +1780,12 @@ class FeatureCollection(GeoDataFrame):
 
                 ```
         """
-        # geopandas and dask-geopandas read Parquet through pyarrow + fsspec, which
-        # speak s3://, gs:// and az:// natively. Unlike GDAL they do not understand
-        # the /vsis3/ form _parse_path produces, and on Windows a leading "/vsis3/"
-        # resolves against the drive root ("C:/vsis3/..."), so the read dies with
-        # FileNotFoundError. Hand fsspec the URL untouched; local paths still go
-        # through _parse_path for its zip/tar handling.
-        path_str = str(path)
-        resolved = path_str if is_remote(path_str) else _pyramids_io._parse_path(path)
-        if backend == "dask":
-            return cls._read_parquet_dask(
-                resolved,
-                columns=columns,
-                split_row_groups=split_row_groups,
-                filters=filters,
-                blocksize=blocksize,
-                storage_options=storage_options,
-                extra_kwargs=kwargs,
-            )
-        if backend != "pandas":
-            raise ValueError(f"backend must be 'pandas' or 'dask', got {backend!r}")
-        _require_pyarrow()
-        # geopandas 1.x forwards **kwargs straight into
-        # `pyarrow.parquet.read_table`, which has never accepted the
-        # pandas-style `engine=` kwarg. `_require_pyarrow()` above
-        # already hard-guarantees the pyarrow backend, so no injection
-        # is needed here. If geopandas ever reintroduces a fastparquet
-        # path it will be opt-in via a new kwarg, not a silent switch.
-        passthrough: dict[str, Any] = {}
-        passthrough.update(kwargs)
-        if columns is not None:
-            passthrough["columns"] = columns
-        if bbox is not None:
-            passthrough["bbox"] = bbox
-        if storage_options is not None:
-            passthrough["storage_options"] = storage_options
-        gdf = gpd.read_parquet(resolved, **passthrough)
-        return cls(gdf)
+        return _read.read_parquet(
+            cls, path, columns=columns, bbox=bbox, backend=backend,
+            split_row_groups=split_row_groups, filters=filters, blocksize=blocksize,
+            storage_options=storage_options, **kwargs,
+        )
+
 
     def to_parquet(
         self,

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -55,6 +55,7 @@ from pyramids.base._utils import Catalog, import_pyarrow
 from pyramids.base.remote import is_remote
 from pyramids.feature import _analysis
 from pyramids.feature import _plot
+from pyramids.feature import _write
 from pyramids.feature import geometry as _geom
 from pyramids.feature import tessellation as _tess
 from pyramids.feature._oapif import from_ogc_features as _from_ogc_features
@@ -2313,8 +2314,7 @@ class FeatureCollection(GeoDataFrame):
 
                 ```
         """
-        _require_pyarrow()
-        super().to_parquet(path, compression=compression, index=index, **kwargs)
+        _write.to_parquet(self, path, compression=compression, index=index, **kwargs)
 
     def to_file(
         self,
@@ -2436,31 +2436,7 @@ class FeatureCollection(GeoDataFrame):
 
                 ```
         """
-        if mode not in ("w", "a"):
-            raise ValueError(f"mode must be 'w' (write) or 'a' (append); got {mode!r}.")
-        try:
-            resolved = CATALOG.get_gdal_name(driver) or driver
-        except AttributeError:
-            resolved = driver
-
-        # pin the engine to pyogrio to match :meth:`read_file` and
-        # :meth:`iter_features`. Callers who want fiona for some reason
-        # can override via `engine="fiona"` in creation_options, but
-        # the default gets the fast path and the pyogrio-specific
-        # unknown-option validation.
-        passthrough: dict[str, Any] = {
-            "driver": resolved,
-            "mode": mode,
-            "engine": "pyogrio",
-        }
-        if layer is not None:
-            passthrough["layer"] = layer
-        passthrough.update(creation_options)
-        super().to_file(path, **passthrough)
-        # This write can add or replace a layer at `path`, so drop the list_layers
-        # cache — otherwise a later list_layers(path) returns a stale layer set that
-        # omits what we just wrote (ARC-42). lru_cache has no per-key eviction, so
-        # clear all; to_file writes are rare, not a hot path.
+        _write.to_file(self, path, driver=driver, layer=layer, mode=mode, **creation_options)
         _list_layers_cached.cache_clear()
 
     def _to_vector_tiles(
@@ -2488,12 +2464,10 @@ class FeatureCollection(GeoDataFrame):
         Returns:
             Path: The written ``path``.
         """
-        options = dict(creation_options)
-        options["MINZOOM"] = min_zoom
-        if max_zoom is not None:
-            options["MAXZOOM"] = max_zoom
-        self.to_file(path, driver=driver, layer=layer_name, **options)
-        return Path(path)
+        return _write.to_vector_tiles(
+            self, path, driver, min_zoom=min_zoom, max_zoom=max_zoom, layer_name=layer_name,
+            **creation_options,
+        )
 
     def to_pmtiles(
         self,
@@ -2543,13 +2517,8 @@ class FeatureCollection(GeoDataFrame):
 
                 ```
         """
-        return self._to_vector_tiles(
-            path,
-            "PMTiles",
-            min_zoom=min_zoom,
-            max_zoom=max_zoom,
-            layer_name=layer_name,
-            **creation_options,
+        return _write.to_pmtiles(
+            self, path, min_zoom=min_zoom, max_zoom=max_zoom, layer_name=layer_name, **creation_options
         )
 
     def to_mvt(
@@ -2598,24 +2567,9 @@ class FeatureCollection(GeoDataFrame):
 
                 ```
         """
-        return self._to_vector_tiles(
-            path,
-            "MVT",
-            min_zoom=min_zoom,
-            max_zoom=max_zoom,
-            layer_name=layer_name,
-            **creation_options,
+        return _write.to_mvt(
+            self, path, min_zoom=min_zoom, max_zoom=max_zoom, layer_name=layer_name, **creation_options
         )
-
-    # FeatureCollection.to_dataset was moved to
-    # Dataset.from_features(features,...) to break the circular import
-    # that used to force a CLAUDE.md-violating inline
-    # `from pyramids.dataset import Dataset` inside the method body.
-    # Callers should migrate:
-    # fc.to_dataset(dataset=ds, column_name="pop")
-    # → Dataset.from_features(fc, template=ds, column_name="pop")
-    # fc.to_dataset(cell_size=10)
-    # → Dataset.from_features(fc, cell_size=10)
 
     def explode(self, geometry: str = "multipolygon") -> FeatureCollection:
         """Explode multi-geometry rows into per-row single geometries.

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -1180,7 +1180,7 @@ class FeatureCollection(GeoDataFrame):
 
                 ```
         """
-        return _read.list_layers(cls, path)
+        return _read.list_layers(path)
 
 
     @classmethod

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -44,10 +44,7 @@ from pyramids.base._errors import (
     CRSError,
     InvalidGeometryError,
 )
-from pyramids.feature import _analysis
-from pyramids.feature import _plot
-from pyramids.feature import _read
-from pyramids.feature import _write
+from pyramids.feature import _analysis, _plot, _read, _write
 from pyramids.feature import geometry as _geom
 from pyramids.feature import tessellation as _tess
 from pyramids.feature._oapif import from_ogc_features as _from_ogc_features
@@ -326,7 +323,6 @@ class FeatureCollection(GeoDataFrame):
         """
         return _read.from_features(cls, features, crs=crs, columns=columns)
 
-
     @classmethod
     def from_bbox(
         cls,
@@ -412,7 +408,6 @@ class FeatureCollection(GeoDataFrame):
             - :meth:`pyramids.dataset.engines.io.IO.read_array`: same.
         """
         return _read.from_bbox(cls, bbox, epsg=epsg)
-
 
     @classmethod
     def fishnet(
@@ -556,7 +551,11 @@ class FeatureCollection(GeoDataFrame):
                 ```
         """
         return _read.from_records(
-            cls, records, geometry=geometry, crs=crs, orient=orient,
+            cls,
+            records,
+            geometry=geometry,
+            crs=crs,
+            orient=orient,
         )
 
     _VALID_TILE_STRATEGIES: tuple[str, ...] = (
@@ -710,10 +709,15 @@ class FeatureCollection(GeoDataFrame):
                 ```
         """
         yield from _read.iter_features(
-            cls, path, layer=layer, bbox=bbox, where=where, chunksize=chunksize,
-            tile_strategy=tile_strategy, include_index=include_index,
+            cls,
+            path,
+            layer=layer,
+            bbox=bbox,
+            where=where,
+            chunksize=chunksize,
+            tile_strategy=tile_strategy,
+            include_index=include_index,
         )
-
 
     @classmethod
     def read_file(
@@ -812,10 +816,19 @@ class FeatureCollection(GeoDataFrame):
                 ```
         """
         return _read.read_file(
-            cls, path, layer=layer, bbox=bbox, mask=mask, rows=rows, columns=columns,
-            where=where, backend=backend, npartitions=npartitions, chunksize=chunksize, **kwargs,
+            cls,
+            path,
+            layer=layer,
+            bbox=bbox,
+            mask=mask,
+            rows=rows,
+            columns=columns,
+            where=where,
+            backend=backend,
+            npartitions=npartitions,
+            chunksize=chunksize,
+            **kwargs,
         )
-
 
     @property
     def epsg(self) -> int | None:
@@ -1182,7 +1195,6 @@ class FeatureCollection(GeoDataFrame):
         """
         return _read.list_layers(path)
 
-
     @classmethod
     def list_layers_cache_clear(cls) -> None:
         """Clear the C15 LRU cache backing :meth:`list_layers`.
@@ -1225,7 +1237,6 @@ class FeatureCollection(GeoDataFrame):
         """
         _read.list_layers_cache_clear()
 
-
     @classmethod
     def read_gpx_layers(cls, path: str | Path) -> dict[str, FeatureCollection]:
         """Read every non-empty sub-layer of a GPX file into a dict of FeatureCollections.
@@ -1266,7 +1277,6 @@ class FeatureCollection(GeoDataFrame):
         """
         return _read.read_gpx_layers(cls, path)
 
-
     @classmethod
     def _read_featureserver_page(cls, page_url: str) -> FeatureCollection:
         """Read one ESRIJSON page from an ArcGIS FeatureServer query URL.
@@ -1280,7 +1290,6 @@ class FeatureCollection(GeoDataFrame):
             FeatureCollection: The features in this page (possibly empty).
         """
         return _read.read_featureserver_page(cls, page_url)
-
 
     @classmethod
     def from_featureserver(
@@ -1328,10 +1337,14 @@ class FeatureCollection(GeoDataFrame):
                 ```
         """
         return _read.from_featureserver(
-            cls, url, where=where, out_fields=out_fields, max_records=max_records,
-            page_size=page_size, max_pages=max_pages,
+            cls,
+            url,
+            where=where,
+            out_fields=out_fields,
+            max_records=max_records,
+            page_size=page_size,
+            max_pages=max_pages,
         )
-
 
     @classmethod
     def from_wfs(
@@ -1554,7 +1567,6 @@ class FeatureCollection(GeoDataFrame):
             cls, base, where, out_fields, max_records, page_size, max_pages
         )
 
-
     @classmethod
     def open_arrow(
         cls,
@@ -1596,9 +1608,13 @@ class FeatureCollection(GeoDataFrame):
             ImportError: If :mod:`pyogrio` is not installed.
         """
         return _read.open_arrow(
-            path, layer=layer, columns=columns, bbox=bbox, where=where, batch_size=batch_size,
+            path,
+            layer=layer,
+            columns=columns,
+            bbox=bbox,
+            where=where,
+            batch_size=batch_size,
         )
-
 
     @classmethod
     def read_parquet(
@@ -1703,11 +1719,17 @@ class FeatureCollection(GeoDataFrame):
                 ```
         """
         return _read.read_parquet(
-            cls, path, columns=columns, bbox=bbox, backend=backend,
-            split_row_groups=split_row_groups, filters=filters, blocksize=blocksize,
-            storage_options=storage_options, **kwargs,
+            cls,
+            path,
+            columns=columns,
+            bbox=bbox,
+            backend=backend,
+            split_row_groups=split_row_groups,
+            filters=filters,
+            blocksize=blocksize,
+            storage_options=storage_options,
+            **kwargs,
         )
-
 
     def to_parquet(
         self,
@@ -1910,7 +1932,9 @@ class FeatureCollection(GeoDataFrame):
 
                 ```
         """
-        _write.to_file(self, path, driver=driver, layer=layer, mode=mode, **creation_options)
+        _write.to_file(
+            self, path, driver=driver, layer=layer, mode=mode, **creation_options
+        )
         _read.list_layers_cache_clear()
 
     def _to_vector_tiles(
@@ -1939,7 +1963,12 @@ class FeatureCollection(GeoDataFrame):
             Path: The written ``path``.
         """
         return _write.to_vector_tiles(
-            self, path, driver, min_zoom=min_zoom, max_zoom=max_zoom, layer_name=layer_name,
+            self,
+            path,
+            driver,
+            min_zoom=min_zoom,
+            max_zoom=max_zoom,
+            layer_name=layer_name,
             **creation_options,
         )
 
@@ -1992,7 +2021,12 @@ class FeatureCollection(GeoDataFrame):
                 ```
         """
         return _write.to_pmtiles(
-            self, path, min_zoom=min_zoom, max_zoom=max_zoom, layer_name=layer_name, **creation_options
+            self,
+            path,
+            min_zoom=min_zoom,
+            max_zoom=max_zoom,
+            layer_name=layer_name,
+            **creation_options,
         )
 
     def to_mvt(
@@ -2042,7 +2076,12 @@ class FeatureCollection(GeoDataFrame):
                 ```
         """
         return _write.to_mvt(
-            self, path, min_zoom=min_zoom, max_zoom=max_zoom, layer_name=layer_name, **creation_options
+            self,
+            path,
+            min_zoom=min_zoom,
+            max_zoom=max_zoom,
+            layer_name=layer_name,
+            **creation_options,
         )
 
     def explode(self, geometry: str = "multipolygon") -> FeatureCollection:

--- a/src/pyramids/feature/geometry.py
+++ b/src/pyramids/feature/geometry.py
@@ -684,7 +684,8 @@ def create_points(coords: Iterable[tuple[float, ...]]) -> list[Point]:
     coords_list = list(coords)
     if not coords_list:
         return []
-    return shapely.points(np.asarray(coords_list, dtype=float)).tolist()
+    points: list[Any] = shapely.points(np.asarray(coords_list, dtype=float)).tolist()
+    return points
 
 
 def point_collection(coords: Iterable[tuple[float, ...]], crs: Any) -> GeoDataFrame:

--- a/src/pyramids/feature/geometry.py
+++ b/src/pyramids/feature/geometry.py
@@ -324,7 +324,10 @@ def explode_gdf(gdf: GeoDataFrame, geometry: str = "multipolygon") -> GeoDataFra
     matching = gdf[is_match]
     if matching.empty:
         return preserved.reset_index(drop=True)
-    exploded = matching.explode(index_parts=False)
+    # Call geopandas' explode UNBOUND: `matching` may be a FeatureCollection, whose
+    # own `explode(geometry=…)` override would otherwise shadow the vectorized
+    # GeoDataFrame.explode(index_parts=…) we want here (the FC is-a GeoDataFrame trap).
+    exploded = GeoDataFrame.explode(matching, index_parts=False)
     result = gpd.GeoDataFrame(pd.concat([preserved, exploded]), crs=gdf.crs)
     return result.reset_index(drop=True)
 

--- a/src/pyramids/feature/geometry.py
+++ b/src/pyramids/feature/geometry.py
@@ -28,7 +28,9 @@ from collections.abc import Iterable
 from typing import Any, cast
 
 import geopandas as gpd
+import numpy as np
 import pandas as pd
+import shapely
 from geopandas import GeoDataFrame
 from shapely.geometry import LineString, Point, Polygon
 from shapely.geometry.multilinestring import MultiLineString
@@ -675,7 +677,11 @@ def create_points(coords: Iterable[tuple[float, ...]]) -> list[Point]:
 
             ```
     """
-    return list(map(Point, coords))
+    # Vectorized in shapely (runs in C) rather than a Python map(Point, …) (ARC-56).
+    coords_list = list(coords)
+    if not coords_list:
+        return []
+    return shapely.points(np.asarray(coords_list, dtype=float)).tolist()
 
 
 def point_collection(coords: Iterable[tuple[float, ...]], crs: Any) -> GeoDataFrame:

--- a/src/pyramids/feature/geometry.py
+++ b/src/pyramids/feature/geometry.py
@@ -250,8 +250,8 @@ def explode_gdf(gdf: GeoDataFrame, geometry: str = "multipolygon") -> GeoDataFra
             (`"multipolygon"` or `"geometrycollection"`).
 
     Returns:
-        GeoDataFrame: A new GeoDataFrame with exploded rows first and
-        the preserved (non-matching) rows after.
+        GeoDataFrame: A new GeoDataFrame with the preserved (non-matching)
+        rows first, then the exploded child rows.
 
     Examples:
         - Explode a two-row frame that mixes one MultiPolygon with a
@@ -309,31 +309,22 @@ def explode_gdf(gdf: GeoDataFrame, geometry: str = "multipolygon") -> GeoDataFra
 
             ```
     """
-    # work against a copy so the caller's frame is untouched.
+    # Work against a copy so the caller's frame is untouched. Rows to explode are
+    # selected by a boolean MASK, never by index label: on a non-unique index —
+    # routine after filtering / pd.concat / OGC-WFS reads — a label-based
+    # `drop(labels=…)` deletes every row sharing a matched label, silently losing
+    # data (ARC-16). The matching subset is expanded with native, vectorized
+    # `GeoDataFrame.explode` (runs in C; ARC-56); the non-matching rows are
+    # preserved and come first in the result.
     gdf = gdf.copy()
-    # accumulate per-child rows into a Python list and do ONE
-    # final `pd.concat` at the end. The old implementation rebuilt
-    # `new_gdf` on every iteration via `pd.concat([new_gdf, row]*n)`,
-    # producing O(N²) copying on multi-geometry-heavy frames.
-    exploded_rows: list = []
-    to_drop: list[int] = []
-    for idx, row in gdf.iterrows():
-        geom_type = row.geometry.geom_type.lower()
-        if geom_type == geometry:
-            for child in row.geometry.geoms:
-                new_row = row.copy()
-                new_row["geometry"] = child
-                exploded_rows.append(new_row)
-            to_drop.append(idx)
-
-    gdf = gdf.drop(labels=to_drop, axis=0)
-    if exploded_rows:
-        exploded_gdf = gpd.GeoDataFrame(exploded_rows).reset_index(drop=True)
-        result = gpd.GeoDataFrame(pd.concat([gdf, exploded_gdf]))
-    else:
-        result = gdf
-    result.reset_index(drop=True, inplace=True)
-    return result
+    is_match = gdf.geometry.geom_type.str.lower() == geometry
+    preserved = gdf[~is_match]
+    matching = gdf[is_match]
+    if matching.empty:
+        return preserved.reset_index(drop=True)
+    exploded = matching.explode(index_parts=False)
+    result = gpd.GeoDataFrame(pd.concat([preserved, exploded]), crs=gdf.crs)
+    return result.reset_index(drop=True)
 
 
 def multi_geom_handler(

--- a/src/pyramids/feature/tessellation.py
+++ b/src/pyramids/feature/tessellation.py
@@ -14,6 +14,7 @@ from collections.abc import Callable
 from typing import Any, cast
 
 import numpy as np
+import shapely
 from shapely import voronoi_polygons
 from shapely.geometry import MultiPoint, box
 
@@ -215,9 +216,13 @@ def fishnet_cells(
     ny = math.ceil((maxy - miny) / cell_size)
     xs0 = minx + np.arange(nx) * cell_size
     ys0 = miny + np.arange(ny) * cell_size
-    polygons = [box(x, y, x + cell_size, y + cell_size) for y in ys0 for x in xs0]
-    rows = [r for r in range(ny) for _ in range(nx)]
-    cols = [c for _ in range(ny) for c in range(nx)]
+    # Vectorized in shapely (runs in C): meshgrid the corners row-major (y slow, x fast)
+    # and build every cell in one `shapely.box` call rather than an nx*ny Python loop (ARC-56).
+    gx, gy = np.meshgrid(xs0, ys0)
+    xr, yr = gx.ravel(), gy.ravel()
+    polygons = shapely.box(xr, yr, xr + cell_size, yr + cell_size).tolist()
+    rows = np.repeat(np.arange(ny), nx).tolist()
+    cols = np.tile(np.arange(nx), ny).tolist()
     return polygons, rows, cols
 
 

--- a/src/pyramids/feature/tessellation.py
+++ b/src/pyramids/feature/tessellation.py
@@ -16,7 +16,7 @@ from typing import Any, cast
 import numpy as np
 import shapely
 from shapely import voronoi_polygons
-from shapely.geometry import MultiPoint, box
+from shapely.geometry import MultiPoint
 
 NAN_REDUCERS: dict[str, Callable[..., Any]] = {
     "mean": np.nanmean,

--- a/tests/basemap/test_feature_plot.py
+++ b/tests/basemap/test_feature_plot.py
@@ -69,7 +69,7 @@ class TestFeatureCollectionPlot:
         with pytest.raises(TypeError, match="no longer accepts"):
             FeatureCollection(ds)
 
-    @patch("pyramids.feature.collection.add_basemap")
+    @patch("pyramids.feature._plot.add_basemap")
     def test_plot_with_basemap_calls_add_basemap(
         self, mock_add_basemap: MagicMock, gdf_fc: FeatureCollection
     ):
@@ -87,7 +87,7 @@ class TestFeatureCollectionPlot:
             f"Expected crs=4326, got {call_kwargs[1]['crs']}"
         )
 
-    @patch("pyramids.feature.collection.add_basemap")
+    @patch("pyramids.feature._plot.add_basemap")
     def test_plot_with_basemap_string_passes_source(
         self, mock_add_basemap: MagicMock, gdf_fc: FeatureCollection
     ):

--- a/tests/config/test_configure_lazy_vector.py
+++ b/tests/config/test_configure_lazy_vector.py
@@ -19,7 +19,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from pyramids import configure_lazy_vector
-from pyramids.feature import collection as _fc_mod
+from pyramids.feature import _read as _fc_mod
 
 # The whole module exercises dask internals. The ``lazy`` marker gates
 # the tests to the env where dask is installed; we therefore cannot

--- a/tests/feature/lazy/test_partitioning.py
+++ b/tests/feature/lazy/test_partitioning.py
@@ -1,6 +1,6 @@
 """ARC-V6: default ``npartitions`` heuristic for ``read_file(backend="dask")``.
 
-Pins the behaviour of :func:`pyramids.feature.collection._resolve_lazy_partitioning`:
+Pins the behaviour of :func:`pyramids.feature._read._resolve_lazy_partitioning`:
 
 * Caller supplies ``npartitions`` → honoured verbatim.
 * Caller supplies ``chunksize`` → honoured verbatim.
@@ -21,7 +21,7 @@ from pathlib import Path
 
 import pytest
 
-from pyramids.feature.collection import (
+from pyramids.feature._read import (
     _LAZY_TARGET_BYTES_PER_PARTITION,
     _resolve_lazy_partitioning,
 )

--- a/tests/feature/test_arc_feature_fixes.py
+++ b/tests/feature/test_arc_feature_fixes.py
@@ -44,6 +44,21 @@ class TestArc16ExplodeGdf:
         _ = explode_gdf(gdf, "multipolygon")
         assert gdf.iloc[0].geometry.geom_type == "MultiPolygon", "input frame was mutated"
 
+    def test_explode_on_featurecollection_uses_geopandas_explode(self):
+        """A FeatureCollection input does not shadow geopandas' explode with its own override.
+
+        Test scenario:
+            FeatureCollection.explode → explode_gdf(self, …); the internal `.explode(index_parts=…)` must reach
+            GeoDataFrame.explode, not FeatureCollection.explode(geometry=…) (the FC is-a GeoDataFrame trap).
+        """
+        multi = MultiPolygon(
+            [Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]), Polygon([(5, 5), (7, 5), (7, 7), (5, 7)])]
+        )
+        fc = FeatureCollection(gpd.GeoDataFrame({"n": ["m"]}, geometry=[multi], crs="EPSG:4326"))
+        result = fc.explode("multipolygon")
+        assert len(result) == 2, f"expected 2 exploded polygons, got {len(result)}"
+        assert set(result.geom_type) == {"Polygon"}
+
 
 class TestArc31Schema:
     """ARC-31: schema excludes the active geometry column by name, not the literal 'geometry'."""

--- a/tests/feature/test_arc_feature_fixes.py
+++ b/tests/feature/test_arc_feature_fixes.py
@@ -28,23 +28,35 @@ class TestArc16ExplodeGdf:
             polygon; the mask-based selection keeps it (preserved rows first, then the exploded children).
         """
         multi = MultiPolygon(
-            [Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]), Polygon([(5, 5), (7, 5), (7, 7), (5, 7)])]
+            [
+                Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]),
+                Polygon([(5, 5), (7, 5), (7, 7), (5, 7)]),
+            ]
         )
         plain = Polygon([(10, 10), (11, 10), (11, 11), (10, 11)])
-        gdf = gpd.GeoDataFrame({"name": ["multi", "plain"]}, geometry=[multi, plain], crs="EPSG:4326")
+        gdf = gpd.GeoDataFrame(
+            {"name": ["multi", "plain"]}, geometry=[multi, plain], crs="EPSG:4326"
+        )
         gdf.index = [0, 0]
         result = explode_gdf(gdf, "multipolygon")
-        assert list(result["name"]) == ["plain", "multi", "multi"], f"lost data: {list(result['name'])}"
+        assert list(result["name"]) == ["plain", "multi", "multi"], (
+            f"lost data: {list(result['name'])}"
+        )
         assert len(result) == 3, f"expected 3 rows, got {len(result)}"
 
     def test_input_not_mutated(self):
         """The caller's frame is untouched by the explode."""
         multi = MultiPolygon(
-            [Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]), Polygon([(2, 2), (3, 2), (3, 3), (2, 3)])]
+            [
+                Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]),
+                Polygon([(2, 2), (3, 2), (3, 3), (2, 3)]),
+            ]
         )
         gdf = gpd.GeoDataFrame(geometry=[multi], crs="EPSG:4326")
         _ = explode_gdf(gdf, "multipolygon")
-        assert gdf.iloc[0].geometry.geom_type == "MultiPolygon", "input frame was mutated"
+        assert gdf.iloc[0].geometry.geom_type == "MultiPolygon", (
+            "input frame was mutated"
+        )
 
     def test_explode_on_featurecollection_uses_geopandas_explode(self):
         """A FeatureCollection input does not shadow geopandas' explode with its own override.
@@ -54,9 +66,14 @@ class TestArc16ExplodeGdf:
             GeoDataFrame.explode, not FeatureCollection.explode(geometry=…) (the FC is-a GeoDataFrame trap).
         """
         multi = MultiPolygon(
-            [Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]), Polygon([(5, 5), (7, 5), (7, 7), (5, 7)])]
+            [
+                Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]),
+                Polygon([(5, 5), (7, 5), (7, 7), (5, 7)]),
+            ]
         )
-        fc = FeatureCollection(gpd.GeoDataFrame({"n": ["m"]}, geometry=[multi], crs="EPSG:4326"))
+        fc = FeatureCollection(
+            gpd.GeoDataFrame({"n": ["m"]}, geometry=[multi], crs="EPSG:4326")
+        )
         result = fc.explode("multipolygon")
         assert len(result) == 2, f"expected 2 exploded polygons, got {len(result)}"
         assert set(result.geom_type) == {"Polygon"}
@@ -68,10 +85,14 @@ class TestArc31Schema:
     def test_renamed_geometry_column_excluded(self):
         """A renamed active geometry column is excluded; a real non-geometry column stays."""
         fc = FeatureCollection(
-            gpd.GeoDataFrame({"v": [1]}, geometry=gpd.GeoSeries([Point(0, 0)], name="geom"), crs=4326)
+            gpd.GeoDataFrame(
+                {"v": [1]}, geometry=gpd.GeoSeries([Point(0, 0)], name="geom"), crs=4326
+            )
         )
         props = fc.schema["properties"]
-        assert props == {"v": "int64"}, f"renamed geometry column leaked or column dropped: {props}"
+        assert props == {"v": "int64"}, (
+            f"renamed geometry column leaked or column dropped: {props}"
+        )
 
 
 class TestArc31IterFeaturesIndexGuard:
@@ -106,13 +127,22 @@ class TestArc56Vectorized:
         """fishnet_cells returns the same grid, cell bounds and row/col order as the loop version."""
         polys, rows, cols = fishnet_cells((0.0, 0.0, 1.0, 1.0), 0.5)
         assert len(polys) == 4, f"expected 4 cells, got {len(polys)}"
-        assert (rows, cols) == ([0, 0, 1, 1], [0, 1, 0, 1]), f"row/col order changed: {rows} {cols}"
-        assert polys[0].bounds == (0.0, 0.0, 0.5, 0.5), f"first cell bounds wrong: {polys[0].bounds}"
+        assert (rows, cols) == ([0, 0, 1, 1], [0, 1, 0, 1]), (
+            f"row/col order changed: {rows} {cols}"
+        )
+        assert polys[0].bounds == (0.0, 0.0, 0.5, 0.5), (
+            f"first cell bounds wrong: {polys[0].bounds}"
+        )
 
     def test_create_points_parity(self):
         """create_points matches map(Point, …) for lists, generators and the empty case."""
-        assert [p.wkt for p in create_points([(0, 0), (1, 1)])] == ["POINT (0 0)", "POINT (1 1)"]
-        assert create_points((c for c in [(10.5, -3.25)]))[0].x == 10.5, "generator input broke"
+        assert [p.wkt for p in create_points([(0, 0), (1, 1)])] == [
+            "POINT (0 0)",
+            "POINT (1 1)",
+        ]
+        assert create_points((c for c in [(10.5, -3.25)]))[0].x == 10.5, (
+            "generator input broke"
+        )
         assert create_points([]) == [], "empty input should return []"
 
 
@@ -140,10 +170,16 @@ class TestArc34WfsPreemptiveAuth:
 
         monkeypatch.setattr(_wfs, "http_get_with_retry", fake_get)
         _wfs._get_capabilities.cache_clear()
-        versions, typenames = _wfs._get_capabilities("https://demo/wfs", None, ("ada", "s3cret"), 60.0)
+        versions, typenames = _wfs._get_capabilities(
+            "https://demo/wfs", None, ("ada", "s3cret"), 60.0
+        )
         expected = "Basic " + base64.b64encode(b"ada:s3cret").decode()
-        assert captured["headers"].get("authorization") == expected, "credentials not sent preemptively"
-        assert "urllib" not in captured["headers"].get("user-agent", "").lower(), "default urllib UA not replaced"
+        assert captured["headers"].get("authorization") == expected, (
+            "credentials not sent preemptively"
+        )
+        assert "urllib" not in captured["headers"].get("user-agent", "").lower(), (
+            "default urllib UA not replaced"
+        )
         assert typenames == frozenset({"topp:states"})
 
 
@@ -161,9 +197,15 @@ class TestArc42ListLayersCache:
             follow-up list_layers sees both layers, not the stale single-layer set.
         """
         path = tmp_path / "layers.gpkg"
-        fc = FeatureCollection(gpd.GeoDataFrame({"id": [1]}, geometry=[Point(0, 0)], crs="EPSG:4326"))
+        fc = FeatureCollection(
+            gpd.GeoDataFrame({"id": [1]}, geometry=[Point(0, 0)], crs="EPSG:4326")
+        )
         fc.to_file(path, driver="gpkg", layer="a", mode="w")
-        assert FeatureCollection.list_layers(path) == ["a"], "first write should list one layer"
+        assert FeatureCollection.list_layers(path) == ["a"], (
+            "first write should list one layer"
+        )
         fc.to_file(path, driver="gpkg", layer="b", mode="a")
         layers = FeatureCollection.list_layers(path)
-        assert set(layers) == {"a", "b"}, f"stale list_layers cache after write: {layers}"
+        assert set(layers) == {"a", "b"}, (
+            f"stale list_layers cache after write: {layers}"
+        )

--- a/tests/feature/test_arc_feature_fixes.py
+++ b/tests/feature/test_arc_feature_fixes.py
@@ -6,11 +6,13 @@ silently regress. Grouped by ARC id.
 
 from __future__ import annotations
 
+import base64
+
 import geopandas as gpd
 import pytest
 from shapely.geometry import MultiPolygon, Point, Polygon
 
-from pyramids.feature import FeatureCollection
+from pyramids.feature import FeatureCollection, _wfs
 from pyramids.feature.geometry import create_points, explode_gdf
 from pyramids.feature.tessellation import fishnet_cells
 
@@ -112,3 +114,34 @@ class TestArc56Vectorized:
         assert [p.wkt for p in create_points([(0, 0), (1, 1)])] == ["POINT (0 0)", "POINT (1 1)"]
         assert create_points((c for c in [(10.5, -3.25)]))[0].x == 10.5, "generator input broke"
         assert create_points([]) == [], "empty input should return []"
+
+
+_WFS_CAPS = (
+    b'<wfs:WFS_Capabilities version="2.0.0" xmlns:wfs="x">'
+    b"<FeatureType><Name>topp:states</Name></FeatureType></wfs:WFS_Capabilities>"
+)
+
+
+class TestArc34WfsPreemptiveAuth:
+    """ARC-34: WFS GetCapabilities must send Basic credentials preemptively, not reactively."""
+
+    def test_get_capabilities_sends_preemptive_basic_and_real_ua(self, monkeypatch):
+        """_get_capabilities builds an Authorization: Basic request with a non-urllib User-Agent.
+
+        Test scenario:
+            A server that 403s without a 401 challenge still receives credentials, and the default
+            'Python-urllib' UA (which some servers block) is replaced.
+        """
+        captured: dict[str, dict[str, str]] = {}
+
+        def fake_get(request, timeout):
+            captured["headers"] = {k.lower(): v for k, v in request.header_items()}
+            return _WFS_CAPS
+
+        monkeypatch.setattr(_wfs, "http_get_with_retry", fake_get)
+        _wfs._get_capabilities.cache_clear()
+        versions, typenames = _wfs._get_capabilities("https://demo/wfs", None, ("ada", "s3cret"), 60.0)
+        expected = "Basic " + base64.b64encode(b"ada:s3cret").decode()
+        assert captured["headers"].get("authorization") == expected, "credentials not sent preemptively"
+        assert "urllib" not in captured["headers"].get("user-agent", "").lower(), "default urllib UA not replaced"
+        assert typenames == frozenset({"topp:states"})

--- a/tests/feature/test_arc_feature_fixes.py
+++ b/tests/feature/test_arc_feature_fixes.py
@@ -1,0 +1,99 @@
+"""Regression tests for the arc-feature architecture-review fixes.
+
+Each test pins a specific finding from ``planning/architecture-review/25-july/arc-feature.md`` so the fix cannot
+silently regress. Grouped by ARC id.
+"""
+
+from __future__ import annotations
+
+import geopandas as gpd
+import pytest
+from shapely.geometry import MultiPolygon, Point, Polygon
+
+from pyramids.feature import FeatureCollection
+from pyramids.feature.geometry import create_points, explode_gdf
+from pyramids.feature.tessellation import fishnet_cells
+
+
+class TestArc16ExplodeGdf:
+    """ARC-16: explode_gdf must select rows by mask, not index label."""
+
+    def test_non_unique_index_preserves_all_rows(self):
+        """A non-matching row sharing a duplicate index label is not dropped.
+
+        Test scenario:
+            A dup-index frame [MultiPolygon, Polygon] both labelled 0 — the old label-drop deleted the plain
+            polygon; the mask-based selection keeps it (preserved rows first, then the exploded children).
+        """
+        multi = MultiPolygon(
+            [Polygon([(0, 0), (2, 0), (2, 2), (0, 2)]), Polygon([(5, 5), (7, 5), (7, 7), (5, 7)])]
+        )
+        plain = Polygon([(10, 10), (11, 10), (11, 11), (10, 11)])
+        gdf = gpd.GeoDataFrame({"name": ["multi", "plain"]}, geometry=[multi, plain], crs="EPSG:4326")
+        gdf.index = [0, 0]
+        result = explode_gdf(gdf, "multipolygon")
+        assert list(result["name"]) == ["plain", "multi", "multi"], f"lost data: {list(result['name'])}"
+        assert len(result) == 3, f"expected 3 rows, got {len(result)}"
+
+    def test_input_not_mutated(self):
+        """The caller's frame is untouched by the explode."""
+        multi = MultiPolygon(
+            [Polygon([(0, 0), (1, 0), (1, 1), (0, 1)]), Polygon([(2, 2), (3, 2), (3, 3), (2, 3)])]
+        )
+        gdf = gpd.GeoDataFrame(geometry=[multi], crs="EPSG:4326")
+        _ = explode_gdf(gdf, "multipolygon")
+        assert gdf.iloc[0].geometry.geom_type == "MultiPolygon", "input frame was mutated"
+
+
+class TestArc31Schema:
+    """ARC-31: schema excludes the active geometry column by name, not the literal 'geometry'."""
+
+    def test_renamed_geometry_column_excluded(self):
+        """A renamed active geometry column is excluded; a real non-geometry column stays."""
+        fc = FeatureCollection(
+            gpd.GeoDataFrame({"v": [1]}, geometry=gpd.GeoSeries([Point(0, 0)], name="geom"), crs=4326)
+        )
+        props = fc.schema["properties"]
+        assert props == {"v": "int64"}, f"renamed geometry column leaked or column dropped: {props}"
+
+
+class TestArc31IterFeaturesIndexGuard:
+    """ARC-31: include_index is incompatible with driver-side filtering (it would emit wrong ids)."""
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"where": "a=1"},
+            {"bbox": (0.0, 0.0, 1.0, 1.0)},
+            {"bbox": (0.0, 0.0, 1.0, 1.0), "tile_strategy": "rtree"},
+        ],
+    )
+    def test_include_index_with_driver_filter_raises(self, kwargs):
+        """include_index combined with a where / pushed-down bbox raises ValueError on first iteration.
+
+        Args:
+            kwargs: A driver-side-filter combination that would misalign the emitted id.
+
+        Test scenario:
+            The generator raises when first advanced, rather than emitting wrong absolute row positions.
+        """
+        gen = FeatureCollection.iter_features("x", include_index=True, **kwargs)
+        with pytest.raises(ValueError, match="incompatible with driver-side"):
+            next(gen)
+
+
+class TestArc56Vectorized:
+    """ARC-56: vectorized fishnet / create_points keep the exact prior semantics."""
+
+    def test_fishnet_cells_grid(self):
+        """fishnet_cells returns the same grid, cell bounds and row/col order as the loop version."""
+        polys, rows, cols = fishnet_cells((0.0, 0.0, 1.0, 1.0), 0.5)
+        assert len(polys) == 4, f"expected 4 cells, got {len(polys)}"
+        assert (rows, cols) == ([0, 0, 1, 1], [0, 1, 0, 1]), f"row/col order changed: {rows} {cols}"
+        assert polys[0].bounds == (0.0, 0.0, 0.5, 0.5), f"first cell bounds wrong: {polys[0].bounds}"
+
+    def test_create_points_parity(self):
+        """create_points matches map(Point, …) for lists, generators and the empty case."""
+        assert [p.wkt for p in create_points([(0, 0), (1, 1)])] == ["POINT (0 0)", "POINT (1 1)"]
+        assert create_points((c for c in [(10.5, -3.25)]))[0].x == 10.5, "generator input broke"
+        assert create_points([]) == [], "empty input should return []"

--- a/tests/feature/test_arc_feature_fixes.py
+++ b/tests/feature/test_arc_feature_fixes.py
@@ -145,3 +145,25 @@ class TestArc34WfsPreemptiveAuth:
         assert captured["headers"].get("authorization") == expected, "credentials not sent preemptively"
         assert "urllib" not in captured["headers"].get("user-agent", "").lower(), "default urllib UA not replaced"
         assert typenames == frozenset({"topp:states"})
+
+
+class TestArc42ListLayersCache:
+    """ARC-42: list_layers must not return a stale layer set after this class's own writes."""
+
+    def test_to_file_invalidates_list_layers_cache(self, tmp_path):
+        """Appending a layer via to_file invalidates the cached list_layers result.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            list_layers is LRU-cached; writing a second layer to the same GPKG must drop the cache so the
+            follow-up list_layers sees both layers, not the stale single-layer set.
+        """
+        path = tmp_path / "layers.gpkg"
+        fc = FeatureCollection(gpd.GeoDataFrame({"id": [1]}, geometry=[Point(0, 0)], crs="EPSG:4326"))
+        fc.to_file(path, driver="gpkg", layer="a", mode="w")
+        assert FeatureCollection.list_layers(path) == ["a"], "first write should list one layer"
+        fc.to_file(path, driver="gpkg", layer="b", mode="a")
+        layers = FeatureCollection.list_layers(path)
+        assert set(layers) == {"a", "b"}, f"stale list_layers cache after write: {layers}"

--- a/tests/feature/test_feature_unit.py
+++ b/tests/feature/test_feature_unit.py
@@ -693,7 +693,7 @@ class TestReadParquetBboxKwarg:
             return None  # pretend pyarrow is available
 
         monkeypatch.setattr(
-            "pyramids.feature.collection._require_pyarrow",
+            "pyramids.feature._read._require_pyarrow",
             _fake_require,
         )
         monkeypatch.setattr(geopandas, "read_parquet", _spy)
@@ -721,7 +721,7 @@ class TestReadParquetBboxKwarg:
             return gpd.GeoDataFrame({"v": []}, geometry=[], crs="EPSG:4326")
 
         monkeypatch.setattr(
-            "pyramids.feature.collection._require_pyarrow",
+            "pyramids.feature._read._require_pyarrow",
             lambda: None,
         )
         monkeypatch.setattr(geopandas, "read_parquet", _spy)

--- a/tests/feature/test_oapif.py
+++ b/tests/feature/test_oapif.py
@@ -26,7 +26,7 @@ from shapely.geometry import Point
 
 from pyramids.base import _ogc_api
 from pyramids.errors import OGCAPIError
-from pyramids.feature import FeatureCollection, _oapif
+from pyramids.feature import FeatureCollection, _oapif, _ogc
 from tests.http_mock import make_fixed_body_server
 
 COLLECTIONS_DOC = json.dumps(
@@ -97,18 +97,18 @@ class TestPureHelpers:
         assert _oapif._oapif_connection("https://h/api") == "OAPIF:https://h/api"
 
     def test_gdal_http_config(self):
-        cfg = _oapif._gdal_http_config(None, 60.0)
+        cfg = _ogc.gdal_http_config(None, 60.0)
         assert cfg["GDAL_HTTP_TIMEOUT"] == "60"
         assert "GDAL_HTTP_USERPWD" not in cfg, "no auth means no credentials emitted"
-        cfg = _oapif._gdal_http_config(("u", "p"), 30.0)
+        cfg = _ogc.gdal_http_config(("u", "p"), 30.0)
         assert cfg["GDAL_HTTP_USERPWD"] == "u:p" and cfg["GDAL_HTTP_TIMEOUT"] == "30"
 
     def test_gdal_http_config_clamps_subsecond_timeout(self):
-        assert _oapif._gdal_http_config(None, 0.5)["GDAL_HTTP_TIMEOUT"] == "1"
+        assert _ogc.gdal_http_config(None, 0.5)["GDAL_HTTP_TIMEOUT"] == "1"
 
     def test_gdal_http_config_carries_retry_knobs(self):
         """The driver read rides out a transient fault like the urllib fetch does."""
-        cfg = _oapif._gdal_http_config(None, 60.0)
+        cfg = _ogc.gdal_http_config(None, 60.0)
         assert cfg["GDAL_HTTP_MAX_RETRY"] == "2", (
             f"GDAL counts retries after the first attempt, not attempts: {cfg}"
         )
@@ -398,7 +398,7 @@ class TestFromOgcApiFeatures:
     def test_returns_featurecollection(self, monkeypatch):
         """A successful read is wrapped into a FeatureCollection."""
         self._patch_collections(monkeypatch)
-        monkeypatch.setattr(_oapif.gpd, "read_file", lambda *a, **k: _sample_gdf())
+        monkeypatch.setattr(_ogc.gpd, "read_file", lambda *a, **k: _sample_gdf())
         fc = FeatureCollection.from_ogc_features("https://h/api", collection="lakes")
         assert isinstance(fc, FeatureCollection)
         assert len(fc) == 2 and fc.crs.to_epsg() == 4326
@@ -413,7 +413,7 @@ class TestFromOgcApiFeatures:
             captured["kwargs"] = kwargs
             return _sample_gdf()
 
-        monkeypatch.setattr(_oapif.gpd, "read_file", fake_read)
+        monkeypatch.setattr(_ogc.gpd, "read_file", fake_read)
         FeatureCollection.from_ogc_features(
             "https://h/api",
             collection="lakes",
@@ -429,7 +429,7 @@ class TestFromOgcApiFeatures:
 
     def test_output_crs_reprojects(self, monkeypatch):
         self._patch_collections(monkeypatch)
-        monkeypatch.setattr(_oapif.gpd, "read_file", lambda *a, **k: _sample_gdf())
+        monkeypatch.setattr(_ogc.gpd, "read_file", lambda *a, **k: _sample_gdf())
         fc = FeatureCollection.from_ogc_features(
             "https://h/api", collection="lakes", output_crs="EPSG:3857"
         )
@@ -439,7 +439,7 @@ class TestFromOgcApiFeatures:
         """output_crs on a CRS-less result raises OGCAPIError instead of silently dropping it."""
         self._patch_collections(monkeypatch)
         crsless = gpd.GeoDataFrame({"name": ["a"]}, geometry=[Point(5.0, 52.0)])
-        monkeypatch.setattr(_oapif.gpd, "read_file", lambda *a, **k: crsless)
+        monkeypatch.setattr(_ogc.gpd, "read_file", lambda *a, **k: crsless)
         with pytest.raises(OGCAPIError, match="without a CRS"):
             FeatureCollection.from_ogc_features(
                 "https://h/api", collection="lakes", output_crs="EPSG:3857"
@@ -456,7 +456,7 @@ class TestFromOgcApiFeatures:
         def boom(*a, **k):
             raise RuntimeError("driver said no")
 
-        monkeypatch.setattr(_oapif.gpd, "read_file", boom)
+        monkeypatch.setattr(_ogc.gpd, "read_file", boom)
         with pytest.raises(OGCAPIError, match="items request failed"):
             FeatureCollection.from_ogc_features("https://h/api", collection="lakes")
 
@@ -466,11 +466,11 @@ class TestFromOgcApiFeatures:
         seen = {}
 
         def fake_read(connection, **kwargs):
-            seen["userpwd"] = _oapif.gdal.GetConfigOption("GDAL_HTTP_USERPWD")
-            seen["timeout"] = _oapif.gdal.GetConfigOption("GDAL_HTTP_TIMEOUT")
+            seen["userpwd"] = _ogc.gdal.GetConfigOption("GDAL_HTTP_USERPWD")
+            seen["timeout"] = _ogc.gdal.GetConfigOption("GDAL_HTTP_TIMEOUT")
             return _sample_gdf()
 
-        monkeypatch.setattr(_oapif.gpd, "read_file", fake_read)
+        monkeypatch.setattr(_ogc.gpd, "read_file", fake_read)
         FeatureCollection.from_ogc_features(
             "https://h/api", collection="lakes", auth=("u", "p"), timeout=42.0
         )

--- a/tests/feature/test_plot_cleopatra.py
+++ b/tests/feature/test_plot_cleopatra.py
@@ -193,3 +193,23 @@ class TestFeatureCollectionCleopatraEngine:
         )
         with pytest.raises(ValueError, match="Point or Polygon"):
             fc.plot(column="v", engine="cleopatra")
+
+    @pytest.mark.parametrize("valid_geom", [Point(0, 0), box(1, 1, 2, 2)])
+    def test_null_geometry_raises_clean_value_error(self, valid_geom):
+        """A ``None`` geometry mixed with a valid one raises a clean ``ValueError``.
+
+        Test scenario:
+            The plot path stays NaN-aware (it must not use the null-dropping
+            ``_geom_types`` helper): a null geometry fails the subset checks and
+            hits the "Point or Polygon" ``ValueError`` instead of letting the glyph
+            builders dereference the ``None`` and raise a cryptic ``AttributeError``.
+        """
+        fc = FeatureCollection(
+            gpd.GeoDataFrame(
+                {"v": [1.0, 2.0]},
+                geometry=[valid_geom, None],
+                crs="EPSG:4326",
+            )
+        )
+        with pytest.raises(ValueError, match="Point or Polygon"):
+            fc.plot(column="v", engine="cleopatra")

--- a/tests/feature/test_plot_cleopatra.py
+++ b/tests/feature/test_plot_cleopatra.py
@@ -147,7 +147,7 @@ class TestFeatureCollectionCleopatraEngine:
                 crs="EPSG:4326",
             )
         )
-        with patch("pyramids.feature.collection.add_basemap") as mock_add:
+        with patch("pyramids.feature._plot.add_basemap") as mock_add:
             glyph = fc.plot(column="v", engine="cleopatra", basemap=True)
         assert isinstance(glyph, ScatterGlyph)
         mock_add.assert_called_once()

--- a/tests/feature/test_wfs.py
+++ b/tests/feature/test_wfs.py
@@ -17,7 +17,7 @@ import pytest
 from shapely.geometry import Point
 
 from pyramids.errors import WFSError
-from pyramids.feature import FeatureCollection, _wfs
+from pyramids.feature import FeatureCollection, _ogc, _wfs
 from tests.http_mock import make_fixed_body_server
 
 CAPS_2_0_0 = """<?xml version="1.0" encoding="UTF-8"?>
@@ -103,18 +103,18 @@ class TestPureHelpers:
         )
 
     def test_gdal_http_config(self):
-        cfg = _wfs._gdal_http_config(None, 60.0)
+        cfg = _ogc.gdal_http_config(None, 60.0)
         assert cfg["GDAL_HTTP_TIMEOUT"] == "60"
         assert "GDAL_HTTP_USERPWD" not in cfg, "no auth means no credentials emitted"
-        cfg = _wfs._gdal_http_config(("u", "p"), 30.0)
+        cfg = _ogc.gdal_http_config(("u", "p"), 30.0)
         assert cfg["GDAL_HTTP_USERPWD"] == "u:p" and cfg["GDAL_HTTP_TIMEOUT"] == "30"
 
     def test_gdal_http_config_clamps_subsecond_timeout(self):
-        assert _wfs._gdal_http_config(None, 0.5)["GDAL_HTTP_TIMEOUT"] == "1"
+        assert _ogc.gdal_http_config(None, 0.5)["GDAL_HTTP_TIMEOUT"] == "1"
 
     def test_gdal_http_config_carries_retry_knobs(self):
         """The driver read rides out a transient fault like the urllib fetch does."""
-        cfg = _wfs._gdal_http_config(None, 60.0)
+        cfg = _ogc.gdal_http_config(None, 60.0)
         assert cfg["GDAL_HTTP_MAX_RETRY"] == "2", (
             f"GDAL counts retries after the first attempt, not attempts: {cfg}"
         )
@@ -230,7 +230,7 @@ class TestFromWfs:
     def test_returns_featurecollection(self, monkeypatch):
         """A successful read is wrapped into a FeatureCollection."""
         self._patch_caps(monkeypatch)
-        monkeypatch.setattr(_wfs.gpd, "read_file", lambda *a, **k: _sample_gdf())
+        monkeypatch.setattr(_ogc.gpd, "read_file", lambda *a, **k: _sample_gdf())
         fc = FeatureCollection.from_wfs("https://h/ows", typename="topp:states")
         assert isinstance(fc, FeatureCollection)
         assert len(fc) == 2 and fc.crs.to_epsg() == 4326
@@ -245,7 +245,7 @@ class TestFromWfs:
             captured["kwargs"] = kwargs
             return _sample_gdf()
 
-        monkeypatch.setattr(_wfs.gpd, "read_file", fake_read)
+        monkeypatch.setattr(_ogc.gpd, "read_file", fake_read)
         FeatureCollection.from_wfs(
             "https://h/ows",
             typename="topp:states",
@@ -262,7 +262,7 @@ class TestFromWfs:
 
     def test_output_crs_reprojects(self, monkeypatch):
         self._patch_caps(monkeypatch)
-        monkeypatch.setattr(_wfs.gpd, "read_file", lambda *a, **k: _sample_gdf())
+        monkeypatch.setattr(_ogc.gpd, "read_file", lambda *a, **k: _sample_gdf())
         fc = FeatureCollection.from_wfs(
             "https://h/ows", typename="topp:states", output_crs="EPSG:3857"
         )
@@ -272,7 +272,7 @@ class TestFromWfs:
         """output_crs on a CRS-less result raises WFSError instead of silently dropping it."""
         self._patch_caps(monkeypatch)
         crsless = gpd.GeoDataFrame({"name": ["a"]}, geometry=[Point(5.0, 52.0)])
-        monkeypatch.setattr(_wfs.gpd, "read_file", lambda *a, **k: crsless)
+        monkeypatch.setattr(_ogc.gpd, "read_file", lambda *a, **k: crsless)
         with pytest.raises(WFSError, match="without a CRS"):
             FeatureCollection.from_wfs(
                 "https://h/ows", typename="topp:states", output_crs="EPSG:3857"
@@ -297,7 +297,7 @@ class TestFromWfs:
             "_get_capabilities",
             lambda *a, **k: (("1.1.0", "2.0.0"), frozenset({"topp:states"})),
         )
-        monkeypatch.setattr(_wfs.gpd, "read_file", lambda *a, **k: _sample_gdf())
+        monkeypatch.setattr(_ogc.gpd, "read_file", lambda *a, **k: _sample_gdf())
         fc = FeatureCollection.from_wfs(
             "https://h/ows", typename="topp:states", version="2.0.0"
         )
@@ -314,7 +314,7 @@ class TestFromWfs:
         def boom(*a, **k):
             raise RuntimeError("driver said no")
 
-        monkeypatch.setattr(_wfs.gpd, "read_file", boom)
+        monkeypatch.setattr(_ogc.gpd, "read_file", boom)
         with pytest.raises(WFSError, match="GetFeature failed"):
             FeatureCollection.from_wfs("https://h/ows", typename="topp:states")
 


### PR DESCRIPTION
# Description

Works the `feature/` findings from the 2026-07-25 architecture review
(`planning/architecture-review/25-july/arc-feature.md`) â€” one finding per commit on a single branch. All 10
findings were re-verified against `main` first (see the plan's Verdict section). **All 10 are now landed.**

Bugs â†’ design â†’ refactor â†’ performance:

- **ARC-16** (bug) â€” `explode_gdf` dropped rows by index **label**, so a non-unique index (routine after
  filtering / `pd.concat` / OGC-WFS reads) deleted every row sharing a matched label, losing data. Now selects by
  boolean mask and expands with the native, vectorized `GeoDataFrame.explode` (called unbound to bypass the
  `FeatureCollection` override).
- **ARC-31** (bug) â€” `schema` excluded the literal `"geometry"` instead of the active geometry column name (a
  renamed geometry column leaked in; a real column named `"geometry"` was dropped); and
  `iter_features(include_index=True)` stamped absolute row positions that were wrong under a pushed-down
  `where`/`bbox` â€” now guarded with a clear `ValueError`.
- **ARC-34** (bug) â€” WFS reactive auth only fired on a `401`, so a server answering an unauthenticated
  `GetCapabilities` with `403` never retried. Discovery now sends preemptive Basic auth + retry headers via the
  shared OGC HTTP helper.
- **ARC-38** (design) â€” return-type-varies-by-kwarg made explicit in the docstrings/signatures for
  `read_file`/`read_parquet` (`backend=`), `iter_features` (`chunksize=`), and `plot` (`engine=`).
- **ARC-42** (design) â€” the `list_layers` LRU cache was not invalidated by this class's own `to_file` writes
  (a new layer stayed invisible); the `to_file` facade now clears it. The vestigial `__enter__`/`__exit__`/`close`
  surface is documented as advisory.
- **ARC-64** (refactor) â€” WFS and OGC API-Features duplicated their entire read flow verbatim. Unified onto a
  shared `feature/_ogc.py` core (`read_ogc_layer` + `require_advertised`), preserving every error message.
- **ARC-72** (refactor) â€” collapsed the repeated `if v is not None: kw[k]=v` blocks into `_compact(...)`, the
  duplicated dask-geopandas ImportError block into `_import_dask_geopandas()`, and unified geometry-type inspection.
- **ARC-63** (perf) â€” `with_centroid` / `with_coordinates` replaced `iterrows` + per-row `.apply` with vectorized
  shapely-2 coordinate arrays and list-comprehension assignment; the `LazyFeatureCollection` wrapper caches by name
  and skips re-wrapping an already-`FeatureCollection` result.
- **ARC-56** (perf) â€” vectorized `fishnet` and `create_points` with shapely 2 (`shapely.box` over `np.meshgrid`,
  `shapely.points(coords)`); the explode part came with ARC-16.
- **ARC-36** (refactor) â€” **the FeatureCollection god-class is decomposed** (Option B, full). Every engine now lives
  in its own module of **module-level free functions** taking `fc`/`fc_cls`, with `FeatureCollection` keeping thin
  facades that carry the public docstrings/doctests. This shape is mandatory because a `FeatureCollection` *is-a*
  `GeoDataFrame`: pandas rebuilds instances on every slice and only `_metadata` survives `__finalize__`, so a
  stored `ds.cog`-style engine object would silently desync/vanish. Extracted modules:
  - `feature/_read.py` â€” **input / constructor engine**: layer listing (+ LRU cache), the ArcGIS FeatureServer /
    GPX web readers, `read_file` / `read_parquet` / `iter_features` / `open_arrow` (eager + dask backends, incl. the
    `_LAZY_TARGET_BYTES_PER_PARTITION` knob that `configure_lazy_vector` now patches here), and the
    `from_features` / `from_bbox` / `from_records` constructors.
  - `feature/_write.py` â€” **output engine**: vector file / GeoParquet / PMTiles / MVT.
  - `feature/_plot.py` â€” rendering via geopandas / cleopatra glyphs.
  - `feature/_analysis.py` â€” coordinates / centroid, IDW pointâ†’raster, H3 indexing / binning.
  - `feature/tessellation.py` â€” fishnet / H3 binning geometry.
  - `feature/_wfs.py` / `_oapif.py` / `_ogc.py` â€” the OGC services core (ARC-64).

  `collection.py` drops from ~3534 to 2831 lines. Where an engine needs geopandas' own implementation rather than
  the `FeatureCollection` override, it calls the method unbound (`GeoDataFrame.explode(fc, â€¦)`,
  `GeoDataFrame.plot(fc)(â€¦)`, `GeoDataFrame.to_file(fc, â€¦)`).

# Issues

Per-finding tracking issues (filed retrospectively from the review; auto-close on merge):

- Closes #875 — ARC-16: explode_gdf drops rows by index label (data loss on non-unique index)
- Closes #876 — ARC-31: schema hardcodes "geometry"; iter_features(include_index) mis-numbers filtered rows
- Closes #877 — ARC-34: WFS reactive auth never retries on a 403-without-401 GetCapabilities
- Closes #878 — ARC-38: read_file/iter_features/plot return type varies silently by kwarg
- Closes #879 — ARC-42: list_layers cache not invalidated by the class's own to_file writes
- Closes #880 — ARC-56: vectorize fishnet / create_points / explode with shapely 2
- Closes #881 — ARC-63: with_centroid/with_coordinates iterrows/apply; lazy wrapper re-allocates
- Closes #882 — ARC-64: unify WFS/OAPIF readers onto a shared OGC read core
- Closes #883 — ARC-72: extract compact-kwargs / dask-import / geom-type helpers
- Closes #884 — ARC-36: decompose the FeatureCollection god-class into module-level engines

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (no functional change â€” public API and behavior preserved via facades)
- [x] This change requires a documentation update (docstrings updated inline)

# How Has This Been Tested?

The whole change set is behavior-preserving â€” the extracted engines are exercised through the existing facades by
the existing suite:

- `pixi run -e dev pytest tests/feature/ -m "not plot"` + `collection.py` / `_read.py` doctests â€”
  **711 passed, 5 skipped**.
- `tests/config/test_configure_lazy_vector.py` + `tests/feature/lazy/` (the moved `_resolve_lazy_partitioning` /
  `_LAZY_TARGET_BYTES_PER_PARTITION` / `_require_pyarrow` symbols and the dask parquet reads) â€” **33 passed**.
- `tests/dataset/` crop / read_array (the `from_bbox` cross-module consumer) â€” **180 passed**.
- Regression suite `tests/feature/test_arc_feature_fixes.py` pins the bug fixes (dup-index explode, renamed-geometry
  schema, `include_index` guard, WFS preemptive auth, `list_layers` cache invalidation, vectorized parity).

- [x] Regression tests for each fix
- [x] Existing feature + dataset + config suites and all doctests green

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen/CI)
- [ ] added changes to History.rst. (commitizen-generated)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (Google-style docstrings preserved on the public facades; engines carry concise
  summaries)
