### PR TITLE
fix(io): collapse the sniff engines and clear the arc-io-cli resource-handle findings

### DIFF
--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -142,7 +142,7 @@ jobs:
             hashFiles('ci/source-build/config.sh', 'ci/source-build/build-gdal-stack.sh') }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+        uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
         env:
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           # The before-all script persists the compiled-stack tar through
@@ -215,7 +215,7 @@ jobs:
             hashFiles('ci/source-build/config.sh', 'ci/source-build/build-gdal-stack.sh') }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+        uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
         env:
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           # The before-all script persists the compiled-stack tar through
@@ -294,7 +294,7 @@ jobs:
           python-version: "3.12"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+        uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
         env:
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
 
@@ -334,7 +334,7 @@ jobs:
           python-version: "3.12"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+        uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
         env:
           CIBW_ARCHS_WINDOWS: ${{ matrix.arch }}
 
@@ -388,7 +388,7 @@ jobs:
             hashFiles('ci/vcpkg.json', 'ci/setup-gdal-from-vcpkg.ps1') }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55 # v4.1.0
+        uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
         env:
           CIBW_ARCHS_WINDOWS: ARM64
           # No cp311: numpy/scipy ship no ARM64 cp311 wheels. The release

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -63,7 +63,7 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/src/pyramids/_io.py
+++ b/src/pyramids/_io.py
@@ -273,9 +273,12 @@ def _get_zip_path(path: str, file_i: int = 0):
     if path.__contains__(".zip") and not path.endswith(".zip"):
         vsi_path = f"{_VSIZIP}{path}"
     else:
-        # Context-managed: an unclosed ZipFile keeps the archive's file descriptor
-        # open until the temporary is garbage-collected, which on Windows also
-        # blocks deleting or overwriting the archive.
+        # Close deterministically instead of relying on the temporary's refcount
+        # dropping to zero. CPython happens to release it immediately, but that
+        # is an implementation detail — under a non-refcounting runtime (PyPy) or
+        # if this expression is ever held in a traceback frame, the descriptor
+        # survives, and on Windows an open handle blocks deleting or overwriting
+        # the archive.
         with zipfile.ZipFile(path) as archive:
             file_list = archive.namelist()
         vsi_path = f"{_VSIZIP}{path}/{file_list[file_i]}"

--- a/src/pyramids/_io.py
+++ b/src/pyramids/_io.py
@@ -268,7 +268,11 @@ def _get_zip_path(path: str, file_i: int = 0):
     if path.__contains__(".zip") and not path.endswith(".zip"):
         vsi_path = f"{_VSIZIP}{path}"
     else:
-        file_list = zipfile.ZipFile(path).namelist()
+        # Context-managed: an unclosed ZipFile keeps the archive's file descriptor
+        # open until the temporary is garbage-collected, which on Windows also
+        # blocks deleting or overwriting the archive.
+        with zipfile.ZipFile(path) as archive:
+            file_list = archive.namelist()
         vsi_path = f"{_VSIZIP}{path}/{file_list[file_i]}"
     return vsi_path
 
@@ -590,9 +594,15 @@ def read_file(
             # OF_MULTIDIM_RASTER for formats that expose multi-dimensional data
             # (hdf, h5, nc, nc4, grib, grib2, jp2, ...).
             src = gdal.OpenEx(path, access | gdal.OF_MULTIDIM_RASTER)
-        else:
+        elif read_only:
             # OpenShared for potentially frequently accessed raster files.
             src = gdal.OpenShared(path, access)
+        else:
+            # Update mode must NOT share: GDAL returns one handle per
+            # path+access+thread, so two update-mode Datasets on the same file
+            # would hold the same mutable handle with independent finalizers —
+            # one closing it flushes/invalidates the other's writes.
+            src = gdal.Open(path, access)
     except Exception as e:
         _raise_open_error(e, path)
     return src

--- a/src/pyramids/_io.py
+++ b/src/pyramids/_io.py
@@ -228,6 +228,11 @@ def _is_tar(path: str):
 def _get_zip_path(path: str, file_i: int = 0):
     """Get Zip Path.
 
+    When the archive has to be listed to resolve a member, it is opened under a
+    context manager and closed before returning — an unclosed handle would
+    survive until garbage collection and, on Windows, block deleting or
+    overwriting the archive.
+
     Args:
         path (str): Path to the zip file.
         file_i (int): Index to the file inside the compressed file you want to read.
@@ -569,11 +574,22 @@ def read_file(
 
     - For GeoTIFF and ASCII files.
 
+    Handle sharing depends on the access mode. Read-only opens go through
+    :func:`osgeo.gdal.OpenShared`, so repeated reads of the same path reuse one
+    handle — the intended benefit for frequently accessed rasters. Update-mode
+    opens go through :func:`osgeo.gdal.Open` instead: GDAL's shared cache is
+    keyed on path + access + thread, so two update-mode datasets would otherwise
+    receive the *same* mutable handle with independent finalizers, letting one
+    flush or invalidate the other's writes.
+
     Args:
         path (str): Path of file to open (works for ASCII, GeoTIFF).
         read_only (bool): File mode; set to False to open in "update" mode.
-        open_as_multi_dimensional (bool): If True, opens using OF_MULTIDIM_RASTER for multi-dimensional formats. Default is False.
-        file_i (int): Index to the file inside the compressed file you want to read (default 0). If the compressed file has only one file, the first file is used.
+        open_as_multi_dimensional (bool): If True, opens using OF_MULTIDIM_RASTER
+            for multi-dimensional formats. Default is False.
+        file_i (int): Index to the file inside the compressed file you want to
+            read (default 0). If the compressed file has only one file, the first
+            file is used.
         vsi (str | None): When given, treat ``path`` as an archive of this kind
             (``"zip"`` / ``"tar"`` / ``"gzip"`` / ``"auto"``) and open member
             ``file_i`` from inside it — even when the path/URL has no archive
@@ -582,6 +598,18 @@ def read_file(
 
     Returns:
         gdal.Dataset: Opened dataset.
+
+    Raises:
+        TypeError: ``path`` is neither a :class:`str` nor a :class:`~pathlib.Path`.
+        FileNotFoundError: The path does not exist, or ``vsi`` was given and
+            ``file_i`` is out of range for the archive's member list.
+        FileFormatNotSupportedError: GDAL cannot open the format — notably a
+            gzip archive holding several internal files, which has no addressable
+            single member.
+
+    See Also:
+        bytes_to_gdal: Open an in-memory byte string through ``/vsimem/``.
+        _archive_dir_vsi: Resolve the ``/vsi*`` directory path used when ``vsi`` is given.
     """
     if not isinstance(path, (str, Path)):
         raise TypeError(

--- a/src/pyramids/_io.py
+++ b/src/pyramids/_io.py
@@ -581,9 +581,13 @@ def read_file(
     :func:`osgeo.gdal.OpenShared`, so repeated reads of the same path reuse one
     handle — the intended benefit for frequently accessed rasters. Update-mode
     opens go through :func:`osgeo.gdal.Open` instead: GDAL's shared cache is
-    keyed on path + access + thread, so two update-mode datasets would otherwise
-    receive the *same* mutable handle with independent finalizers, letting one
-    flush or invalidate the other's writes.
+    keyed on path + access + thread, so two update-mode opens of the same file
+    return **one and the same** ``GDALDataset`` — two wrappers that look
+    independent but are a single mutable object, each with its own finalizer and
+    its own idea of when it may be closed. `gdal.Open` gives each writer its own
+    dataset instead. (Note this is about handle identity, not visibility: GDAL's
+    block cache makes an unflushed write on one handle visible through another
+    on the same file under *either* opener.)
 
     Args:
         path (str): Path of file to open (works for ASCII, GeoTIFF).
@@ -631,8 +635,9 @@ def read_file(
         else:
             # Update mode must NOT share: GDAL returns one handle per
             # path+access+thread, so two update-mode Datasets on the same file
-            # would hold the same mutable handle with independent finalizers —
-            # one closing it flushes/invalidates the other's writes.
+            # would alias one another — a write through one immediately visible
+            # through the other, and a flush/close on either committing the
+            # other's in-flight edits.
             src = gdal.Open(path, access)
     except Exception as e:
         _raise_open_error(e, path)

--- a/src/pyramids/_resource.py
+++ b/src/pyramids/_resource.py
@@ -279,6 +279,7 @@ def sniff_format(path: str | Path) -> str:
         result = _EXT_TO_FORMAT.get(Path(path).suffix.lower(), "unknown")
     return result
 
+
 # kind → the suffix set used to pick the matching member inside an archive.
 _KIND_SUFFIXES: dict[ResourceKind, set[str]] = {
     "raster": _RASTER_SUFFIXES,

--- a/src/pyramids/_resource.py
+++ b/src/pyramids/_resource.py
@@ -63,6 +63,139 @@ _VECTOR_SUFFIXES = {
 }
 _TABULAR_SUFFIXES = {".csv", ".tsv", ".xlsx", ".xls", ".parquet", ".pq"}
 
+# --- shared format detection -------------------------------------------------
+# One detection core for both public readers (`read_resource` here and
+# `pyramids.io.load_resource`, which adapts these helpers). Previously each
+# module carried its own suffix table and its own sniffing rules, so the two
+# drifted apart; keep new formats in these tables only.
+
+# Extension -> normalised format token. Broader than the family suffix sets
+# above because it also names the *container* (`zip`) and distinguishes formats
+# that share a family (`nc` vs `tif` vs `grib` are all rasters).
+_EXT_TO_FORMAT: dict[str, str] = {
+    ".shp": "shp",
+    ".gpkg": "gpkg",
+    ".geojson": "geojson",
+    ".json": "geojson",
+    ".csv": "csv",
+    ".tsv": "csv",
+    ".parquet": "parquet",
+    ".pq": "parquet",
+    ".xlsx": "excel",
+    ".xls": "excel",
+    ".nc": "nc",
+    ".nc4": "nc",
+    ".cdf": "nc",
+    ".tif": "tif",
+    ".tiff": "tif",
+    ".grib": "grib",
+    ".grib2": "grib",
+    ".grb": "grib",
+    ".grb2": "grib",
+    ".zip": "zip",
+}
+
+# Leading magic bytes -> format token, longest-first so `SQLite format 3` is
+# tested before shorter prefixes. TIFF needs an exact 4-byte window (both byte
+# orders) rather than a prefix test, so it is handled separately below.
+_MAGIC_TO_FORMAT: tuple[tuple[bytes, str], ...] = (
+    (b"SQLite format 3", "gpkg"),
+    (b"PK\x03\x04", "zip"),
+    (b"\x89HDF", "nc"),
+    (b"GRIB", "grib"),
+    (b"PAR1", "parquet"),
+    (b"CDF", "nc"),
+)
+_TIFF_MAGIC = (b"II*\x00", b"MM\x00*")
+
+# Format token -> resource family, for callers that work in `ResourceKind`.
+_FORMAT_TO_KIND: dict[str, ResourceKind] = {
+    "shp": "vector",
+    "gpkg": "vector",
+    "geojson": "vector",
+    "csv": "tabular",
+    "excel": "tabular",
+    "parquet": "tabular",
+    "nc": "raster",
+    "tif": "raster",
+    "grib": "raster",
+}
+
+
+def sniff_magic(path: str | Path) -> str | None:
+    """Classify a file by its leading magic bytes.
+
+    Reads the first 16 bytes only. Unlike :func:`sniff_kind` this performs I/O,
+    but it is authoritative where the name lies — a portal resource declared
+    ``CSV`` that is really a ``.shp.zip``, for instance.
+
+    Args:
+        path: Path to a local file.
+
+    Returns:
+        str | None: A format token (see :data:`_EXT_TO_FORMAT` for the
+        vocabulary), or `None` when the file is unreadable or unrecognised.
+    """
+    try:
+        with open(path, "rb") as handle:
+            head = handle.read(16)
+    except OSError:
+        head = b""
+
+    result: str | None = None
+    if head[:4] in _TIFF_MAGIC:
+        result = "tif"
+    else:
+        for signature, fmt in _MAGIC_TO_FORMAT:
+            if head.startswith(signature):
+                result = fmt
+                break
+    return result
+
+
+def sniff_format(path: str | Path) -> str:
+    """Classify a file's format from its magic bytes, then its extension.
+
+    Magic-byte detection takes precedence over the extension, so a mis-named
+    resource is still classified correctly. No `python-magic` dependency.
+
+    Args:
+        path: Path to a local file.
+
+    Returns:
+        str: A normalised format token, or `"unknown"` when neither the magic
+        bytes nor the extension identify the file.
+
+    Examples:
+        - A GeoTIFF is detected from its `II*\\0` / `MM\\0*` magic bytes:
+            ```python
+            >>> from pyramids._resource import sniff_format
+            >>> sniff_format("tests/data/geotiff/era5_land_monthly_averaged.tif")
+            'tif'
+
+            ```
+        - A NetCDF file is detected (HDF5 or classic-CDF magic):
+            ```python
+            >>> sniff_format("tests/data/netcdf/cf__6v__1d2-2d4__geog__y-asc.nc")
+            'nc'
+
+            ```
+        - An unknown / missing file is reported as `"unknown"`:
+            ```python
+            >>> sniff_format("does-not-exist.bin")
+            'unknown'
+
+            ```
+
+    See Also:
+        sniff_magic: The magic-byte half, without the extension fallback.
+        sniff_kind: The pure name-based family classifier (no I/O).
+    """
+    result = sniff_magic(path)
+    if result is None:
+        result = _EXT_TO_FORMAT.get(Path(path).suffix.lower(), "unknown")
+    return result
+
 # kind → the suffix set used to pick the matching member inside an archive.
 _KIND_SUFFIXES: dict[ResourceKind, set[str]] = {
     "raster": _RASTER_SUFFIXES,
@@ -240,11 +373,19 @@ def _sniff_from_archive(path: Path) -> ResourceKind | None:
 
 
 def _determine_kind(path: Path, fmt: str | None) -> ResourceKind:
-    """Resolve the family from name + ``fmt``, peeking into archives as needed."""
+    """Resolve the family from name + ``fmt``, then bytes, then archive members.
+
+    Order is cheapest-first: the pure name/``fmt`` lookup, then the magic-byte
+    sniff (one 16-byte read, which also identifies an extension-less download),
+    then peeking inside a container. Magic bytes are consulted only when the name
+    is inconclusive, so a correctly-named resource keeps its existing answer.
+    """
     try:
         kind = sniff_kind(path, fmt=fmt)
     except ValueError:
-        sniffed = _sniff_from_archive(path)
+        sniffed = _FORMAT_TO_KIND.get(sniff_format(path) or "")
+        if sniffed is None:
+            sniffed = _sniff_from_archive(path)
         if sniffed is None:
             raise
         kind = sniffed

--- a/src/pyramids/_resource.py
+++ b/src/pyramids/_resource.py
@@ -107,6 +107,60 @@ _EXT_TO_TABULAR_READER: dict[str, str] = {
     ".pq": "parquet",
 }
 
+# Format label -> the pandas reader to use. Keys are normalised (lower-cased,
+# leading dot stripped) so the CKAN spellings that portals actually publish —
+# "CSV", "Excel", ".xlsx" — all resolve. Both public readers funnel their
+# caller-supplied format through this, so neither can accept a vocabulary the
+# other rejects.
+_FMT_TO_TABULAR_READER: dict[str, str] = {
+    "csv": "csv",
+    "tsv": "tsv",
+    "excel": "excel",
+    "xlsx": "excel",
+    "xls": "excel",
+    "parquet": "parquet",
+    "pq": "parquet",
+}
+
+
+def normalise_format(value: str | None) -> str | None:
+    """Normalise a format label for lookup, or `None` when there is none.
+
+    Portals publish the same format under many spellings — `"CSV"`, `"csv"`,
+    `".csv"`, `"GeoTIFF"`. Case and a leading dot carry no meaning, so strip
+    them once here rather than at each comparison. A blank label is treated as
+    absent, so `fmt=""` behaves like `fmt=None` instead of silently skipping an
+    override the caller believed they had set.
+
+    Args:
+        value: A format label, or `None`.
+
+    Returns:
+        str | None: The lower-cased, de-dotted label, or `None` when `value` is
+        `None` or blank.
+
+    Examples:
+        - Spelling variants collapse to one token:
+            ```python
+            >>> from pyramids._resource import normalise_format
+            >>> [normalise_format(v) for v in ("CSV", "csv", ".Csv", "  csv ")]
+            ['csv', 'csv', 'csv', 'csv']
+
+            ```
+        - A missing or blank label is reported as absent:
+            ```python
+            >>> from pyramids._resource import normalise_format
+            >>> normalise_format(None) is None and normalise_format("  ") is None
+            True
+
+            ```
+    """
+    result: str | None = None
+    if value is not None:
+        cleaned = value.strip().lower().lstrip(".")
+        result = cleaned or None
+    return result
+
 # Leading magic bytes -> format token. `SQLite format 3` is listed first so it
 # is tested before any shorter prefix that could overlap. TIFF needs an exact
 # 4-byte window (both byte orders) rather than a prefix test, so it is handled
@@ -115,11 +169,15 @@ _MAGIC_TO_FORMAT: tuple[tuple[bytes, str], ...] = (
     (b"SQLite format 3", "gpkg"),
     (b"PK\x03\x04", "zip"),
     (b"\x89HDF", "nc"),
-    (b"GRIB", "grib"),
     (b"PAR1", "parquet"),
-    (b"CDF", "nc"),
 )
 _TIFF_MAGIC = (b"II*\x00", b"MM\x00*")
+# Classic-netCDF format version byte following the `CDF` prefix: 1 (classic),
+# 2 (64-bit offset), 5 (CDF-5). Checked so a text file starting "CDF" is not
+# claimed as netCDF -- see `sniff_magic`.
+_CDF_VERSIONS = (b"\x01", b"\x02", b"\x05")
+# GRIB edition byte at offset 7: 1 or 2. Same reasoning as `_CDF_VERSIONS`.
+_GRIB_EDITIONS = (b"\x01", b"\x02")
 
 # Format token -> resource family, for callers that work in `ResourceKind`.
 _FORMAT_TO_KIND: dict[str, ResourceKind] = {
@@ -158,6 +216,16 @@ def sniff_magic(path: str | Path) -> str | None:
     result: str | None = None
     if head[:4] in _TIFF_MAGIC:
         result = "tif"
+    elif head[:3] == b"CDF" and head[3:4] in _CDF_VERSIONS:
+        # Classic netCDF is `CDF` + a one-byte version. Testing the prefix alone
+        # would claim any text file whose first line begins "CDF..." — a CSV with
+        # a column called CDF, say — as netCDF.
+        result = "nc"
+    elif head[:4] == b"GRIB" and head[7:8] in _GRIB_EDITIONS:
+        # GRIB is `GRIB` + 3 reserved/length bytes + a one-byte edition number.
+        # Same reasoning: the four-letter prefix on its own is a plausible CSV
+        # header.
+        result = "grib"
     else:
         for signature, fmt in _MAGIC_TO_FORMAT:
             if head.startswith(signature):
@@ -524,10 +592,25 @@ def read_tabular(path: Path, fmt: str | None = None) -> pd.DataFrame:
     """
     source = str(path)
     ext = Path(_strip_compression(path.name)).suffix.lower()
-    # An explicit token wins over the name; the name wins over the bytes. The
-    # magic-byte tail is what lets an extension-less Parquet download resolve
-    # instead of dead-ending on an empty suffix.
-    token = fmt or _EXT_TO_TABULAR_READER.get(ext) or sniff_format(path)
+    label = normalise_format(fmt)
+    if label is not None:
+        # An explicit label wins over the name — but only if it names a reader.
+        # Falling through to the suffix here would silently ignore the override
+        # and then blame the file's extension for the failure.
+        token = _FMT_TO_TABULAR_READER.get(label)
+        if token is None:
+            raise ValueError(
+                f"unsupported tabular format {fmt!r} for {source!r}; expected one "
+                f"of {sorted(set(_FMT_TO_TABULAR_READER))}."
+            )
+    else:
+        # The name wins over the bytes. The magic-byte tail is what lets an
+        # extension-less Parquet download resolve instead of dead-ending on an
+        # empty suffix; it is mapped through the same table so a non-tabular
+        # token (`"zip"`, `"tif"`, `"unknown"`) cannot leak through as a reader.
+        token = _EXT_TO_TABULAR_READER.get(ext) or _FMT_TO_TABULAR_READER.get(
+            sniff_format(path)
+        )
     result: pd.DataFrame
     if token == "csv":
         result = pd.read_csv(source)
@@ -629,7 +712,14 @@ def read_resource(
     elif resolved_kind == "vector":
         result = _read_vector(path, layer)
     elif resolved_kind == "tabular":
-        result = read_tabular(path)
+        # Forward the declared label when it names a tabular reader, so an
+        # extension-less download resolves here exactly as it does through
+        # `load_resource`. A non-tabular label (a raster/vector `fmt` paired with
+        # an explicit `kind="tabular"`) is dropped rather than rejected, leaving
+        # the suffix and magic bytes to decide as before.
+        result = read_tabular(
+            path, fmt=_FMT_TO_TABULAR_READER.get(normalise_format(fmt) or "")
+        )
     else:
         raise ValueError(
             f"unsupported resource kind {resolved_kind!r}; expected one of "

--- a/src/pyramids/_resource.py
+++ b/src/pyramids/_resource.py
@@ -162,6 +162,7 @@ def normalise_format(value: str | None) -> str | None:
         result = cleaned or None
     return result
 
+
 # Leading magic bytes -> format token. `SQLite format 3` is listed first so it
 # is tested before any shorter prefix that could overlap. TIFF needs an exact
 # 4-byte window (both byte orders) rather than a prefix test, so it is handled
@@ -253,7 +254,7 @@ def sniff_format(path: str | Path) -> str:
     Examples:
         - A GeoTIFF is detected from its `II*\\0` / `MM\\0*` magic bytes:
             ```python
-            >>> from pyramids._resource import sniff_format
+            >>> from pyramids.io import sniff_format
             >>> sniff_format("tests/data/geotiff/era5_land_monthly_averaged.tif")
             'tif'
 

--- a/src/pyramids/_resource.py
+++ b/src/pyramids/_resource.py
@@ -176,8 +176,10 @@ def sniff_format(path: str | Path) -> str:
         path: Path to a local file.
 
     Returns:
-        str: A normalised format token, or `"unknown"` when neither the magic
-        bytes nor the extension identify the file.
+        str: One of `"shp"`, `"gpkg"`, `"geojson"`, `"csv"`, `"tsv"`,
+        `"parquet"`, `"nc"`, `"tif"`, `"grib"`, `"zip"`, or `"unknown"` when
+        neither the magic bytes nor the extension identify the file. Excel is
+        deliberately absent — see the note on :data:`_EXT_TO_FORMAT`.
 
     Examples:
         - A GeoTIFF is detected from its `II*\\0` / `MM\\0*` magic bytes:

--- a/src/pyramids/_resource.py
+++ b/src/pyramids/_resource.py
@@ -61,7 +61,10 @@ _VECTOR_SUFFIXES = {
     ".fgb",
     ".gml",
 }
-_TABULAR_SUFFIXES = {".csv", ".tsv", ".xlsx", ".xls", ".parquet", ".pq"}
+# Named once and reused across the three tables below, which all key on it
+# (S1192).
+_PARQUET_SUFFIX = ".parquet"
+_TABULAR_SUFFIXES = {".csv", ".tsv", ".xlsx", ".xls", _PARQUET_SUFFIX, ".pq"}
 
 # One detection core for both public readers (`read_resource` here and
 # `pyramids.io.load_resource`, which adapts these helpers). Previously each
@@ -82,7 +85,7 @@ _EXT_TO_FORMAT: dict[str, str] = {
     ".json": "geojson",
     ".csv": "csv",
     ".tsv": "tsv",
-    ".parquet": "parquet",
+    _PARQUET_SUFFIX: "parquet",
     ".pq": "parquet",
     ".nc": "nc",
     ".nc4": "nc",
@@ -104,7 +107,7 @@ _EXT_TO_TABULAR_READER: dict[str, str] = {
     ".tsv": "tsv",
     ".xlsx": "excel",
     ".xls": "excel",
-    ".parquet": "parquet",
+    _PARQUET_SUFFIX: "parquet",
     ".pq": "parquet",
 }
 

--- a/src/pyramids/_resource.py
+++ b/src/pyramids/_resource.py
@@ -581,7 +581,7 @@ def read_tabular(path: str | Path, fmt: str | None = None) -> pd.DataFrame:
 
     Args:
         path: Path to the tabular resource.
-        fmt: Optional reader token (`"csv"`, `"tsv"`, `"excel"`, `"parquet"`)
+        fmt: Optional reader reader (`"csv"`, `"tsv"`, `"excel"`, `"parquet"`)
             that **overrides** the suffix. Required for a resource whose name
             carries no usable extension — a portal download named by id, say —
             where the caller knows the declared format. When omitted the suffix
@@ -606,8 +606,8 @@ def read_tabular(path: str | Path, fmt: str | None = None) -> pd.DataFrame:
         # An explicit label wins over the name — but only if it names a reader.
         # Falling through to the suffix here would silently ignore the override
         # and then blame the file's extension for the failure.
-        token = _FMT_TO_TABULAR_READER.get(label)
-        if token is None:
+        reader = _FMT_TO_TABULAR_READER.get(label)
+        if reader is None:
             raise ValueError(
                 f"unsupported tabular format {fmt!r} for {source!r}; expected one "
                 f"of {sorted(set(_FMT_TO_TABULAR_READER))}."
@@ -616,16 +616,16 @@ def read_tabular(path: str | Path, fmt: str | None = None) -> pd.DataFrame:
         # The name wins over the bytes. The magic-byte tail is what lets an
         # extension-less Parquet download resolve instead of dead-ending on an
         # empty suffix; it is mapped through the same table so a non-tabular
-        # token (`"zip"`, `"tif"`, `"unknown"`) cannot leak through as a reader.
-        token = _EXT_TO_TABULAR_READER.get(ext) or _FMT_TO_TABULAR_READER.get(
+        # reader (`"zip"`, `"tif"`, `"unknown"`) cannot leak through as a reader.
+        reader = _EXT_TO_TABULAR_READER.get(ext) or _FMT_TO_TABULAR_READER.get(
             sniff_format(path)
         )
     result: pd.DataFrame
-    if token == "csv":
+    if reader == "csv":
         result = pd.read_csv(source)
-    elif token == "tsv":
+    elif reader == "tsv":
         result = pd.read_csv(source, sep="\t")
-    elif token == "excel":
+    elif reader == "excel":
         try:
             result = pd.read_excel(source)
         except ImportError as exc:  # openpyxl (.xlsx) / xlrd (.xls) not installed
@@ -634,7 +634,7 @@ def read_tabular(path: str | Path, fmt: str | None = None) -> pd.DataFrame:
                 "for .xlsx, xlrd for legacy .xls); install it into the environment "
                 "to read this resource."
             ) from exc
-    elif token == "parquet":
+    elif reader == "parquet":
         try:
             result = pd.read_parquet(source)
         except ImportError as exc:  # pyarrow / fastparquet not installed

--- a/src/pyramids/_resource.py
+++ b/src/pyramids/_resource.py
@@ -72,8 +72,9 @@ _TABULAR_SUFFIXES = {".csv", ".tsv", ".xlsx", ".xls", ".parquet", ".pq"}
 # a zip container, so its magic resolves to `"zip"` and an `"excel"` token would
 # be unreachable by sniffing anyway, while adding `.xls` would turn a resource
 # that used to come back as raw bytes into a hard ImportError (no Excel engine
-# is a declared dependency). `read_resource` still reads Excel through its own
-# `_TABULAR_SUFFIXES` path, where the caller has already chosen that family.
+# is a declared dependency). Excel is still reachable deliberately — via
+# `read_resource`'s `_TABULAR_SUFFIXES` family lookup, or by passing an explicit
+# `fmt=`/`kind=` — just never by sniffing.
 _EXT_TO_FORMAT: dict[str, str] = {
     ".shp": "shp",
     ".gpkg": "gpkg",
@@ -566,7 +567,7 @@ def _read_vector(path: Path, layer: str | int | None) -> FeatureCollection:
     return FeatureCollection.read_file(source, layer=passthrough_layer)
 
 
-def read_tabular(path: Path, fmt: str | None = None) -> pd.DataFrame:
+def read_tabular(path: str | Path, fmt: str | None = None) -> pd.DataFrame:
     """Read a tabular resource into a :class:`pandas.DataFrame`.
 
     ``pandas`` infers ``.gz`` / ``.zip`` / ``.tar`` compression from the suffix,
@@ -591,6 +592,9 @@ def read_tabular(path: Path, fmt: str | None = None) -> pd.DataFrame:
         ImportError: The chosen reader needs an optional engine that is not
             installed (`openpyxl`/`xlrd` for Excel, `pyarrow` for Parquet).
     """
+    # Accept a plain string too: this is public-named and reached from both
+    # readers, so it must not depend on the caller having wrapped the path.
+    path = Path(path)
     source = str(path)
     ext = Path(_strip_compression(path.name)).suffix.lower()
     label = normalise_format(fmt)

--- a/src/pyramids/_resource.py
+++ b/src/pyramids/_resource.py
@@ -63,26 +63,26 @@ _VECTOR_SUFFIXES = {
 }
 _TABULAR_SUFFIXES = {".csv", ".tsv", ".xlsx", ".xls", ".parquet", ".pq"}
 
-# --- shared format detection -------------------------------------------------
 # One detection core for both public readers (`read_resource` here and
 # `pyramids.io.load_resource`, which adapts these helpers). Previously each
 # module carried its own suffix table and its own sniffing rules, so the two
 # drifted apart; keep new formats in these tables only.
-
-# Extension -> normalised format token. Broader than the family suffix sets
-# above because it also names the *container* (`zip`) and distinguishes formats
-# that share a family (`nc` vs `tif` vs `grib` are all rasters).
+#
+# Deliberately NOT a superset of the two originals. Excel is absent: `.xlsx` is
+# a zip container, so its magic resolves to `"zip"` and an `"excel"` token would
+# be unreachable by sniffing anyway, while adding `.xls` would turn a resource
+# that used to come back as raw bytes into a hard ImportError (no Excel engine
+# is a declared dependency). `read_resource` still reads Excel through its own
+# `_TABULAR_SUFFIXES` path, where the caller has already chosen that family.
 _EXT_TO_FORMAT: dict[str, str] = {
     ".shp": "shp",
     ".gpkg": "gpkg",
     ".geojson": "geojson",
     ".json": "geojson",
     ".csv": "csv",
-    ".tsv": "csv",
+    ".tsv": "tsv",
     ".parquet": "parquet",
     ".pq": "parquet",
-    ".xlsx": "excel",
-    ".xls": "excel",
     ".nc": "nc",
     ".nc4": "nc",
     ".cdf": "nc",
@@ -95,9 +95,22 @@ _EXT_TO_FORMAT: dict[str, str] = {
     ".zip": "zip",
 }
 
-# Leading magic bytes -> format token, longest-first so `SQLite format 3` is
-# tested before shorter prefixes. TIFF needs an exact 4-byte window (both byte
-# orders) rather than a prefix test, so it is handled separately below.
+# Extension -> the pandas reader `read_tabular` should use. Separate from
+# `_EXT_TO_FORMAT` because it covers the Excel suffixes that deliberately stay
+# out of the sniffing vocabulary above.
+_EXT_TO_TABULAR_READER: dict[str, str] = {
+    ".csv": "csv",
+    ".tsv": "tsv",
+    ".xlsx": "excel",
+    ".xls": "excel",
+    ".parquet": "parquet",
+    ".pq": "parquet",
+}
+
+# Leading magic bytes -> format token. `SQLite format 3` is listed first so it
+# is tested before any shorter prefix that could overlap. TIFF needs an exact
+# 4-byte window (both byte orders) rather than a prefix test, so it is handled
+# separately below.
 _MAGIC_TO_FORMAT: tuple[tuple[bytes, str], ...] = (
     (b"SQLite format 3", "gpkg"),
     (b"PK\x03\x04", "zip"),
@@ -114,7 +127,7 @@ _FORMAT_TO_KIND: dict[str, ResourceKind] = {
     "gpkg": "vector",
     "geojson": "vector",
     "csv": "tabular",
-    "excel": "tabular",
+    "tsv": "tabular",
     "parquet": "tabular",
     "nc": "raster",
     "tif": "raster",
@@ -383,7 +396,7 @@ def _determine_kind(path: Path, fmt: str | None) -> ResourceKind:
     try:
         kind = sniff_kind(path, fmt=fmt)
     except ValueError:
-        sniffed = _FORMAT_TO_KIND.get(sniff_format(path) or "")
+        sniffed = _FORMAT_TO_KIND.get(sniff_format(path))
         if sniffed is None:
             sniffed = _sniff_from_archive(path)
         if sniffed is None:
@@ -482,31 +495,52 @@ def _read_vector(path: Path, layer: str | int | None) -> FeatureCollection:
     return FeatureCollection.read_file(source, layer=passthrough_layer)
 
 
-def _read_tabular(path: Path) -> pd.DataFrame:
+def read_tabular(path: Path, fmt: str | None = None) -> pd.DataFrame:
     """Read a tabular resource into a :class:`pandas.DataFrame`.
 
     ``pandas`` infers ``.gz`` / ``.zip`` / ``.tar`` compression from the suffix,
     so the path is passed through verbatim. ``.xlsx`` needs ``openpyxl`` and
     ``.parquet`` needs ``pyarrow`` — when missing, the underlying
     :class:`ImportError` is re-raised with install guidance.
+
+    Args:
+        path: Path to the tabular resource.
+        fmt: Optional reader token (`"csv"`, `"tsv"`, `"excel"`, `"parquet"`)
+            that **overrides** the suffix. Required for a resource whose name
+            carries no usable extension — a portal download named by id, say —
+            where the caller knows the declared format. When omitted the suffix
+            decides, falling back to the magic bytes.
+
+    Returns:
+        pandas.DataFrame: The parsed table.
+
+    Raises:
+        ValueError: Neither `fmt`, the suffix, nor the magic bytes identify a
+            supported tabular format.
+        ImportError: The chosen reader needs an optional engine that is not
+            installed (`openpyxl`/`xlrd` for Excel, `pyarrow` for Parquet).
     """
     source = str(path)
     ext = Path(_strip_compression(path.name)).suffix.lower()
+    # An explicit token wins over the name; the name wins over the bytes. The
+    # magic-byte tail is what lets an extension-less Parquet download resolve
+    # instead of dead-ending on an empty suffix.
+    token = fmt or _EXT_TO_TABULAR_READER.get(ext) or sniff_format(path)
     result: pd.DataFrame
-    if ext == ".csv":
+    if token == "csv":
         result = pd.read_csv(source)
-    elif ext == ".tsv":
+    elif token == "tsv":
         result = pd.read_csv(source, sep="\t")
-    elif ext in {".xlsx", ".xls"}:
+    elif token == "excel":
         try:
             result = pd.read_excel(source)
         except ImportError as exc:  # openpyxl (.xlsx) / xlrd (.xls) not installed
             raise ImportError(
-                f"reading {ext} files needs an Excel engine (openpyxl for .xlsx, "
-                "xlrd for legacy .xls); install it into the environment to read "
-                "this resource."
+                f"reading {ext or 'excel'} files needs an Excel engine (openpyxl "
+                "for .xlsx, xlrd for legacy .xls); install it into the environment "
+                "to read this resource."
             ) from exc
-    elif ext in {".parquet", ".pq"}:
+    elif token == "parquet":
         try:
             result = pd.read_parquet(source)
         except ImportError as exc:  # pyarrow / fastparquet not installed
@@ -517,7 +551,8 @@ def _read_tabular(path: Path) -> pd.DataFrame:
     else:
         raise ValueError(
             f"unsupported tabular suffix {ext!r} for {source!r}; expected one of "
-            f"{sorted(_TABULAR_SUFFIXES)}."
+            f"{sorted(_TABULAR_SUFFIXES)}, or pass an explicit fmt= when the name "
+            "carries no usable extension."
         )
     return result
 
@@ -592,7 +627,7 @@ def read_resource(
     elif resolved_kind == "vector":
         result = _read_vector(path, layer)
     elif resolved_kind == "tabular":
-        result = _read_tabular(path)
+        result = read_tabular(path)
     else:
         raise ValueError(
             f"unsupported resource kind {resolved_kind!r}; expected one of "

--- a/src/pyramids/base/_artifacts.py
+++ b/src/pyramids/base/_artifacts.py
@@ -1,4 +1,4 @@
-"""Process-scoped scratch artefacts for materialising readers (M1).
+"""Process-scoped scratch artefacts for readers that must outlive their call.
 
 Several STAC readers must materialise intermediate rasters that have to outlive
 the call because the returned object is *file-backed* by them: multi-asset
@@ -138,8 +138,12 @@ def cleanup() -> None:
     """Remove the artefact root and unlink every tracked ``/vsimem`` path.
 
     Registered as an ``atexit`` hook the first time either artefact kind is
-    used; safe to call directly (e.g. from tests). Best-effort — errors are
-    swallowed so a locked file at shutdown never raises.
+    used. Best-effort — errors are swallowed so a locked file at shutdown
+    never raises.
+
+    Calling this directly removes the root shared by *every* consumer in the
+    process (the STAC readers and ``pyramids.io``'s zip extraction among
+    them), so a test that invokes it must isolate itself first.
     """
     global _ROOT
     with _LOCK:

--- a/src/pyramids/base/_artifacts.py
+++ b/src/pyramids/base/_artifacts.py
@@ -64,7 +64,11 @@ def _root() -> str:
     """Return the shared process artefact root, creating it on first use."""
     global _ROOT
     if _ROOT is None:
-        _ROOT = tempfile.mkdtemp(prefix="pyramids_stac_")
+        # Generic prefix: the registry started out serving the STAC readers but
+        # is now the shared scratch space for anything whose artefacts must
+        # outlive the call (zip extraction in pyramids.io among them), so the
+        # directory name should not imply a single consumer.
+        _ROOT = tempfile.mkdtemp(prefix="pyramids_scratch_")
         _arm_cleanup()
     return _ROOT
 

--- a/src/pyramids/cli.py
+++ b/src/pyramids/cli.py
@@ -263,7 +263,11 @@ def _cmd_bounds(args: argparse.Namespace) -> int:
         xs = [corner[0] for corner in corners]
         ys = [corner[1] for corner in corners]
         min_x, min_y, max_x, max_y = min(xs), min(ys), max(xs), max(ys)
-    payload = {"bounds": [min_x, min_y, max_x, max_y]}
+    # Reprojecting a corner that falls outside the target CRS's domain yields
+    # HUGE_VAL, and json.dumps writes that as a bare `Infinity` — not valid JSON,
+    # so strict consumers such as `jq` reject the whole document. Map non-finite
+    # corners to null instead (ARC-26).
+    payload = {"bounds": [_json_safe(value) for value in (min_x, min_y, max_x, max_y)]}
     if args.json:
         print(json.dumps(payload))
     else:

--- a/src/pyramids/cli.py
+++ b/src/pyramids/cli.py
@@ -216,13 +216,16 @@ def _cmd_raster_info(args: argparse.Namespace) -> int:
         "bands": ds.band_count,
         "rows": ds.rows,
         "columns": ds.columns,
-        "cell_size": ds.cell_size,
+        "cell_size": _json_safe(float(ds.cell_size)),
         "dtype": list(ds.dtype),
         "no_data_value": [
             None if value is None else _json_safe(float(value))
             for value in ds.no_data_value
         ],
-        "bounds": [float(value) for value in ds.bbox],
+        # Same guard as `bounds --json`: a degenerate geotransform can yield a
+        # non-finite cell size or bound, and `json.dumps` writes those as bare
+        # `Infinity` / `NaN`, which is not valid JSON.
+        "bounds": [_json_safe(float(value)) for value in ds.bbox],
     }
     if args.json:
         print(json.dumps(payload))

--- a/src/pyramids/io/__init__.py
+++ b/src/pyramids/io/__init__.py
@@ -1,5 +1,29 @@
 """I/O helpers: resource format sniffing and dispatch (CKAN/HDX-style)."""
 
-from pyramids.io.sniff import load_resource, sniff_format
+from __future__ import annotations
+
+# `load_resource` / `sniff_format` live in `pyramids.io.sniff`, which imports the
+# Dataset, FeatureCollection and NetCDF readers (and, transitively, geopandas).
+# Expose them lazily via PEP 562 module `__getattr__` so a bare `import
+# pyramids.io` stays light — that heavy stack is only pulled in when these
+# symbols are first accessed, mirroring what `pyramids/__init__.py` already does
+# for `read_resource` / `sniff_kind`.
+_LAZY_SNIFF_EXPORTS = frozenset({"load_resource", "sniff_format"})
+
+
+def __getattr__(name: str):
+    """Lazily import the sniff/dispatch exports on first access (PEP 562)."""
+    if name in _LAZY_SNIFF_EXPORTS:
+        from pyramids.io.sniff import load_resource, sniff_format
+
+        globals().update(load_resource=load_resource, sniff_format=sniff_format)
+        return globals()[name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Include the lazily-exported names in ``dir(pyramids.io)``."""
+    return sorted(set(globals()) | _LAZY_SNIFF_EXPORTS)
+
 
 __all__ = ["load_resource", "sniff_format"]

--- a/src/pyramids/io/__init__.py
+++ b/src/pyramids/io/__init__.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 # pyramids.io` stays light — that heavy stack is only pulled in when these
 # symbols are first accessed, mirroring what `pyramids/__init__.py` already does
 # for `read_resource` / `sniff_kind`.
-_LAZY_SNIFF_EXPORTS = frozenset({"load_resource", "sniff_format"})
+_LAZY_SNIFF_EXPORTS = frozenset({"load_resource", "sniff_format", "sniff_magic"})
 # `sniff` itself is resolved lazily too: the eager `from .sniff import ...` used
 # to register the submodule as an attribute of this package, so `import
 # pyramids.io; pyramids.io.sniff` worked. Dropping the eager import would break
@@ -25,6 +25,7 @@ def __getattr__(name: str):
             sniff=sniff,
             load_resource=sniff.load_resource,
             sniff_format=sniff.sniff_format,
+            sniff_magic=sniff.sniff_magic,
         )
         return globals()[name]
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
@@ -35,4 +36,4 @@ def __dir__() -> list[str]:
     return sorted(set(globals()) | _LAZY_NAMES)
 
 
-__all__ = ["load_resource", "sniff_format"]
+__all__ = ["load_resource", "sniff_format", "sniff_magic"]

--- a/src/pyramids/io/__init__.py
+++ b/src/pyramids/io/__init__.py
@@ -9,21 +9,30 @@ from __future__ import annotations
 # symbols are first accessed, mirroring what `pyramids/__init__.py` already does
 # for `read_resource` / `sniff_kind`.
 _LAZY_SNIFF_EXPORTS = frozenset({"load_resource", "sniff_format"})
+# `sniff` itself is resolved lazily too: the eager `from .sniff import ...` used
+# to register the submodule as an attribute of this package, so `import
+# pyramids.io; pyramids.io.sniff` worked. Dropping the eager import would break
+# that without this entry.
+_LAZY_NAMES = _LAZY_SNIFF_EXPORTS | {"sniff"}
 
 
 def __getattr__(name: str):
-    """Lazily import the sniff/dispatch exports on first access (PEP 562)."""
-    if name in _LAZY_SNIFF_EXPORTS:
-        from pyramids.io.sniff import load_resource, sniff_format
+    """Lazily import the sniff submodule and its exports on first access (PEP 562)."""
+    if name in _LAZY_NAMES:
+        import pyramids.io.sniff as sniff
 
-        globals().update(load_resource=load_resource, sniff_format=sniff_format)
+        globals().update(
+            sniff=sniff,
+            load_resource=sniff.load_resource,
+            sniff_format=sniff.sniff_format,
+        )
         return globals()[name]
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def __dir__() -> list[str]:
     """Include the lazily-exported names in ``dir(pyramids.io)``."""
-    return sorted(set(globals()) | _LAZY_SNIFF_EXPORTS)
+    return sorted(set(globals()) | _LAZY_NAMES)
 
 
 __all__ = ["load_resource", "sniff_format"]

--- a/src/pyramids/io/sniff.py
+++ b/src/pyramids/io/sniff.py
@@ -20,8 +20,9 @@ CKAN/HDX API client itself stays in the consumer; this module is the generic
 format-detection + dispatch primitive.
 
 Detection itself lives in :mod:`pyramids._resource`, which both public readers
-share; this module is the dispatch adapter over it and owns no format table of
-its own. Add new formats to `_resource._EXT_TO_FORMAT` / `_MAGIC_TO_FORMAT`.
+share, so add a new *format* to `_resource._EXT_TO_FORMAT` / `_MAGIC_TO_FORMAT`.
+The tables that remain here are *dispatch policy*, not detection: which tokens
+this module can honour, and which archive members count as the one to load.
 """
 
 from __future__ import annotations

--- a/src/pyramids/io/sniff.py
+++ b/src/pyramids/io/sniff.py
@@ -22,13 +22,13 @@ format-detection + dispatch primitive.
 
 from __future__ import annotations
 
-import tempfile
 import zipfile
 from pathlib import Path
 from typing import Any
 
 import pandas as pd
 
+from pyramids.base._artifacts import artifact_dir
 from pyramids.base._utils import import_pyarrow
 from pyramids.dataset import Dataset
 from pyramids.feature import FeatureCollection
@@ -177,14 +177,20 @@ def _load_zip(path: Path, extract_to: Path | None) -> Any:
 
     Args:
         path: Path to a `.zip` file.
-        extract_to: Directory to extract into; a temp dir is used when `None`.
+        extract_to: Directory to extract into; when `None` a directory under the
+            process-scoped artefact root is used (reclaimed at interpreter exit).
 
     Returns:
         The loaded resource (re-dispatched through :func:`load_resource`) when a
         single primary data file is found, otherwise the :class:`~pathlib.Path`
         of the extraction directory.
     """
-    dest = Path(extract_to) if extract_to is not None else Path(tempfile.mkdtemp())
+    # `artifact_dir()` rather than a bare `tempfile.mkdtemp()`: the extracted
+    # files must outlive this call (GDAL/geopandas read them lazily, so a
+    # `TemporaryDirectory` would delete them mid-read), but an untracked mkdtemp
+    # is never reclaimed — every load_resource(<zip>) leaked one. The shared
+    # artefact root is swept by an atexit hook.
+    dest = Path(extract_to) if extract_to is not None else Path(artifact_dir())
     with zipfile.ZipFile(path) as archive:
         members = [n for n in archive.namelist() if not n.endswith("/")]
         archive.extractall(dest)

--- a/src/pyramids/io/sniff.py
+++ b/src/pyramids/io/sniff.py
@@ -32,7 +32,12 @@ from typing import Any
 
 import pandas as pd
 
-from pyramids._resource import read_tabular, sniff_format, sniff_magic
+from pyramids._resource import (
+    normalise_format,
+    read_tabular,
+    sniff_format,
+    sniff_magic,
+)
 from pyramids.base._artifacts import artifact_dir
 from pyramids.base._utils import import_pyarrow
 from pyramids.dataset import Dataset
@@ -43,6 +48,14 @@ __all__ = ["load_resource", "sniff_format", "sniff_magic"]
 
 _VECTOR_FORMATS = frozenset({"shp", "gpkg", "geojson"})
 _TABULAR_FORMATS = frozenset({"csv", "tsv"})
+# Every token this dispatcher understands, so an `expected_format=` it cannot
+# honour is rejected instead of silently returning raw bytes. Derived from the
+# branches below plus the shared detection vocabulary.
+_KNOWN_FORMATS = (
+    _VECTOR_FORMATS
+    | _TABULAR_FORMATS
+    | frozenset({"parquet", "nc", "tif", "grib", "zip", "unknown"})
+)
 # Data extensions a ZIP may wrap and that `_load_zip` re-dispatches to a reader.
 #
 # Intentionally listed rather than derived from `_EXT_TO_FORMAT`, and
@@ -197,7 +210,18 @@ def load_resource(
             ```
     """
     p = Path(path)
-    fmt = expected_format or sniff_format(p)
+    # Normalise the caller's label: portals publish "CSV" / "GeoJSON" / ".csv",
+    # and an unnormalised value used to miss every branch below and fall through
+    # to the raw-bytes default — a silent wrong return type on the documented
+    # extension-less path. An unrecognised label is rejected outright rather than
+    # degraded to bytes.
+    declared = normalise_format(expected_format)
+    if declared is not None and declared not in _KNOWN_FORMATS:
+        raise ValueError(
+            f"unknown expected_format {expected_format!r}; expected one of "
+            f"{sorted(_KNOWN_FORMATS)} (case-insensitive), or omit it to sniff."
+        )
+    fmt = declared or sniff_format(p)
 
     if fmt in _VECTOR_FORMATS:
         result: Any = FeatureCollection.read_file(str(p))

--- a/src/pyramids/io/sniff.py
+++ b/src/pyramids/io/sniff.py
@@ -32,7 +32,7 @@ from typing import Any
 
 import pandas as pd
 
-from pyramids._resource import _EXT_TO_FORMAT, _read_tabular, sniff_format
+from pyramids._resource import read_tabular, sniff_format
 from pyramids.base._artifacts import artifact_dir
 from pyramids.base._utils import import_pyarrow
 from pyramids.dataset import Dataset
@@ -40,20 +40,40 @@ from pyramids.feature import FeatureCollection
 from pyramids.netcdf import NetCDF
 
 _VECTOR_FORMATS = frozenset({"shp", "gpkg", "geojson"})
-_TABULAR_FORMATS = frozenset({"csv", "excel"})
-# Data extensions a ZIP may wrap and that `_load_zip` re-dispatches to a reader:
-# every extension the shared table knows except the archive container itself.
-# Derived rather than restated, so a format added to `_EXT_TO_FORMAT` is picked
-# up here automatically instead of silently falling through to raw bytes.
+_TABULAR_FORMATS = frozenset({"csv", "tsv"})
+# Data extensions a ZIP may wrap and that `_load_zip` re-dispatches to a reader.
+#
+# Intentionally listed rather than derived from `_EXT_TO_FORMAT`, and
+# intentionally narrower than it: this set decides whether an archive has
+# exactly ONE primary member. Widening it changes which archives resolve to a
+# loaded object versus the extraction directory — adding `.tsv` alone would make
+# a zip of `grid.tif` + `meta.tsv` return a directory where it used to return
+# the Dataset. Add an extension here only with that trade-off in mind.
 _PRIMARY_EXTS = frozenset(
-    ext for ext, fmt in _EXT_TO_FORMAT.items() if fmt != "zip"
+    {
+        ".shp",
+        ".gpkg",
+        ".geojson",
+        ".json",
+        ".csv",
+        ".parquet",
+        ".pq",
+        ".tif",
+        ".tiff",
+        ".nc",
+        ".nc4",
+        ".cdf",
+        ".grib",
+        ".grib2",
+        ".grb",
+        ".grb2",
+    }
 )
 _PARQUET_EXTRA_HINT = (
     "Reading Parquet requires the optional 'pyarrow' dependency. Install with one of:\n"
     "  - PyPI:        pip install 'pyramids-gis[parquet]'\n"
     "  - conda-forge: conda install -c conda-forge pyramids-parquet"
 )
-
 
 
 def _load_parquet(path: Path) -> FeatureCollection | pd.DataFrame:
@@ -174,10 +194,11 @@ def load_resource(
     if fmt in _VECTOR_FORMATS:
         result: Any = FeatureCollection.read_file(str(p))
     elif fmt in _TABULAR_FORMATS:
-        # Shared tabular reader, so `.tsv` and Excel work here too rather than
-        # falling through to raw bytes as they did while this module carried its
-        # own dispatch table.
-        result = _read_tabular(p)
+        # Shared tabular reader, so `.tsv` works here too rather than falling
+        # through to raw bytes as it did while this module carried its own
+        # dispatch table. `fmt` is forwarded so an explicit `expected_format=`
+        # still wins on a resource whose name has no usable extension.
+        result = read_tabular(p, fmt=fmt)
     elif fmt == "parquet":
         result = _load_parquet(p)
     elif fmt == "nc":

--- a/src/pyramids/io/sniff.py
+++ b/src/pyramids/io/sniff.py
@@ -32,12 +32,14 @@ from typing import Any
 
 import pandas as pd
 
-from pyramids._resource import read_tabular, sniff_format
+from pyramids._resource import read_tabular, sniff_format, sniff_magic
 from pyramids.base._artifacts import artifact_dir
 from pyramids.base._utils import import_pyarrow
 from pyramids.dataset import Dataset
 from pyramids.feature import FeatureCollection
 from pyramids.netcdf import NetCDF
+
+__all__ = ["load_resource", "sniff_format", "sniff_magic"]
 
 _VECTOR_FORMATS = frozenset({"shp", "gpkg", "geojson"})
 _TABULAR_FORMATS = frozenset({"csv", "tsv"})
@@ -151,9 +153,13 @@ def load_resource(
     Args:
         path: Path to the downloaded resource.
         expected_format: Optional format override (one of the
-            :func:`sniff_format` strings); skips sniffing when given.
-        extract_to: Directory to extract a ZIP into; a temp dir is used when
-            `None`.
+            :func:`sniff_format` tokens); skips sniffing when given. Use it when
+            the name carries no usable extension — a portal download named by id
+            — since the override is forwarded to the reader rather than
+            re-derived from the suffix.
+        extract_to: Directory to extract a ZIP into. When `None` a directory
+            under the process-scoped artefact root is used, which is swept at
+            interpreter exit rather than left behind.
 
     Returns:
         The most natural object for the format: a
@@ -167,6 +173,8 @@ def load_resource(
     Raises:
         OptionalPackageDoesNotExist: A Parquet resource is read without the
             `[parquet]` extra installed.
+        ValueError: A tabular resource whose format cannot be determined from
+            `expected_format`, its suffix, or its magic bytes.
 
     Examples:
         - Load a GeoTIFF resource as a Dataset:

--- a/src/pyramids/io/sniff.py
+++ b/src/pyramids/io/sniff.py
@@ -56,14 +56,15 @@ _KNOWN_FORMATS = (
     | _TABULAR_FORMATS
     | frozenset({"parquet", "nc", "tif", "grib", "zip", "unknown"})
 )
-# Data extensions a ZIP may wrap and that `_load_zip` re-dispatches to a reader.
+# Data extensions a ZIP may wrap and that `_load_zip` re-dispatches to a reader,
+# in two tiers. Both are listed rather than derived from `_EXT_TO_FORMAT`,
+# because this is a dispatch policy rather than a detection vocabulary.
 #
-# Intentionally listed rather than derived from `_EXT_TO_FORMAT`, and
-# intentionally narrower than it: this set decides whether an archive has
-# exactly ONE primary member. Widening it changes which archives resolve to a
-# loaded object versus the extraction directory — adding `.tsv` alone would make
-# a zip of `grid.tif` + `meta.tsv` return a directory where it used to return
-# the Dataset. Add an extension here only with that trade-off in mind.
+# The tiers exist because "exactly one primary member" is ambiguous when an
+# archive ships data plus a tabular sidecar. A zip of `grid.tif` + `meta.tsv`
+# must resolve to the raster, but a zip holding only `table.tsv` should still
+# load that table. So geospatial members are considered first, and the tabular
+# tier is consulted only when the archive contains no geospatial member at all.
 _PRIMARY_EXTS = frozenset(
     {
         ".shp",
@@ -84,6 +85,10 @@ _PRIMARY_EXTS = frozenset(
         ".grb2",
     }
 )
+# Tabular formats that count only when nothing in `_PRIMARY_EXTS` is present.
+# `.csv` stays in the primary tier for backwards compatibility — it was there
+# before the tiering and archives relying on it must keep resolving.
+_SECONDARY_EXTS = frozenset({".tsv", ".xlsx", ".xls"})
 _PARQUET_EXTRA_HINT = (
     "Reading Parquet requires the optional 'pyarrow' dependency. Install with one of:\n"
     "  - PyPI:        pip install 'pyramids-gis[parquet]'\n"
@@ -138,6 +143,11 @@ def _load_zip(path: Path, extract_to: Path | None) -> Any:
         archive.extractall(dest)
 
     primaries = [m for m in members if Path(m).suffix.lower() in _PRIMARY_EXTS]
+    if not primaries:
+        # No geospatial/CSV member: fall back to the tabular tier so an archive
+        # that holds only a spreadsheet still resolves to a frame rather than to
+        # the extraction directory.
+        primaries = [m for m in members if Path(m).suffix.lower() in _SECONDARY_EXTS]
     shapefiles = [m for m in primaries if m.lower().endswith(".shp")]
 
     target: str | None = None

--- a/src/pyramids/io/sniff.py
+++ b/src/pyramids/io/sniff.py
@@ -18,6 +18,10 @@ matching pyramids/pandas reader and returns the most natural object:
 Detection uses magic bytes + extension only — no `python-magic` dependency. The
 CKAN/HDX API client itself stays in the consumer; this module is the generic
 format-detection + dispatch primitive.
+
+Detection itself lives in :mod:`pyramids._resource`, which both public readers
+share; this module is the dispatch adapter over it and owns no format table of
+its own. Add new formats to `_resource._EXT_TO_FORMAT` / `_MAGIC_TO_FORMAT`.
 """
 
 from __future__ import annotations
@@ -28,55 +32,21 @@ from typing import Any
 
 import pandas as pd
 
+from pyramids._resource import _EXT_TO_FORMAT, _read_tabular, sniff_format
 from pyramids.base._artifacts import artifact_dir
 from pyramids.base._utils import import_pyarrow
 from pyramids.dataset import Dataset
 from pyramids.feature import FeatureCollection
 from pyramids.netcdf import NetCDF
 
-_EXT_FORMAT: dict[str, str] = {
-    ".shp": "shp",
-    ".gpkg": "gpkg",
-    ".geojson": "geojson",
-    ".json": "geojson",
-    ".csv": "csv",
-    ".parquet": "parquet",
-    ".pq": "parquet",
-    ".nc": "nc",
-    ".nc4": "nc",
-    ".cdf": "nc",
-    ".tif": "tif",
-    ".tiff": "tif",
-    ".grib": "grib",
-    ".grib2": "grib",
-    ".grb": "grib",
-    ".grb2": "grib",
-    ".zip": "zip",
-}
-
 _VECTOR_FORMATS = frozenset({"shp", "gpkg", "geojson"})
-# Data extensions a ZIP may wrap and that `_load_zip` re-dispatches to a reader.
-# Kept in sync with the data formats in `_EXT_FORMAT` (everything except the
-# ``.zip`` archive container itself).
+_TABULAR_FORMATS = frozenset({"csv", "excel"})
+# Data extensions a ZIP may wrap and that `_load_zip` re-dispatches to a reader:
+# every extension the shared table knows except the archive container itself.
+# Derived rather than restated, so a format added to `_EXT_TO_FORMAT` is picked
+# up here automatically instead of silently falling through to raw bytes.
 _PRIMARY_EXTS = frozenset(
-    {
-        ".shp",
-        ".gpkg",
-        ".geojson",
-        ".json",
-        ".csv",
-        ".parquet",
-        ".pq",
-        ".tif",
-        ".tiff",
-        ".nc",
-        ".nc4",
-        ".cdf",
-        ".grib",
-        ".grib2",
-        ".grb",
-        ".grb2",
-    }
+    ext for ext, fmt in _EXT_TO_FORMAT.items() if fmt != "zip"
 )
 _PARQUET_EXTRA_HINT = (
     "Reading Parquet requires the optional 'pyarrow' dependency. Install with one of:\n"
@@ -84,69 +54,6 @@ _PARQUET_EXTRA_HINT = (
     "  - conda-forge: conda install -c conda-forge pyramids-parquet"
 )
 
-
-def sniff_format(path: str | Path) -> str:
-    """Classify a file's format from its magic bytes, then its extension.
-
-    Magic-byte detection (ZIP, TIFF, HDF5/NetCDF, Parquet, GeoPackage/SQLite)
-    takes precedence over the extension, so a mis-named resource is still
-    classified correctly. No `python-magic` dependency.
-
-    Args:
-        path: Path to a local file.
-
-    Returns:
-        A normalised format string: one of `"shp"`, `"gpkg"`,
-        `"geojson"`, `"csv"`, `"parquet"`, `"nc"`, `"tif"`,
-        `"grib"`, `"zip"`, or `"unknown"`.
-
-    Examples:
-        - A GeoTIFF is detected from its `II*\\0` / `MM\\0*` magic bytes:
-            ```python
-            >>> from pyramids.io import sniff_format
-            >>> sniff_format("tests/data/geotiff/era5_land_monthly_averaged.tif")
-            'tif'
-
-            ```
-        - A NetCDF file is detected (HDF5 or classic-CDF magic):
-            ```python
-            >>> sniff_format("tests/data/netcdf/cf__6v__1d2-2d4__geog__y-asc.nc")
-            'nc'
-
-            ```
-        - An unknown / missing file is reported as `"unknown"`:
-            ```python
-            >>> sniff_format("does-not-exist.bin")
-            'unknown'
-
-            ```
-    """
-    p = Path(path)
-    head = b""
-    try:
-        with open(p, "rb") as handle:
-            head = handle.read(16)
-    except OSError:
-        head = b""
-
-    result = "unknown"
-    if head.startswith(b"PK\x03\x04"):
-        result = "zip"
-    elif head[:4] in (b"II*\x00", b"MM\x00*"):
-        result = "tif"
-    elif head.startswith(b"\x89HDF"):
-        result = "nc"
-    elif head[:3] == b"CDF":
-        result = "nc"
-    elif head.startswith(b"GRIB"):
-        result = "grib"
-    elif head.startswith(b"PAR1"):
-        result = "parquet"
-    elif head.startswith(b"SQLite format 3"):
-        result = "gpkg"
-    elif p.suffix.lower() in _EXT_FORMAT:
-        result = _EXT_FORMAT[p.suffix.lower()]
-    return result
 
 
 def _load_parquet(path: Path) -> FeatureCollection | pd.DataFrame:
@@ -266,8 +173,11 @@ def load_resource(
 
     if fmt in _VECTOR_FORMATS:
         result: Any = FeatureCollection.read_file(str(p))
-    elif fmt == "csv":
-        result = pd.read_csv(p)
+    elif fmt in _TABULAR_FORMATS:
+        # Shared tabular reader, so `.tsv` and Excel work here too rather than
+        # falling through to raw bytes as they did while this module carried its
+        # own dispatch table.
+        result = _read_tabular(p)
     elif fmt == "parquet":
         result = _load_parquet(p)
     elif fmt == "nc":

--- a/src/pyramids/stac/_vrt.py
+++ b/src/pyramids/stac/_vrt.py
@@ -608,7 +608,7 @@ def build_vrt_from_stac(
     sources = [(href, _embed_source_options(href, gdal_env)) for href in hrefs]
     vsi_paths = [vsi_path for _href, vsi_path in sources]
     _warn_unembeddable_credentials(gdal_env, hrefs)
-    vrt_path = f"/vsimem/pyramids_stac_{uuid.uuid4().hex}.vrt"
+    vrt_path = f"/vsimem/pyramids_scratch_{uuid.uuid4().hex}.vrt"
 
     # BuildVRT opens every source. Over `/vsicurl/` that costs a directory
     # listing plus a fan of sidecar probes per source unless the fast-read

--- a/tests/base/test_resource.py
+++ b/tests/base/test_resource.py
@@ -19,11 +19,11 @@ from pyramids import read_resource, sniff_kind
 from pyramids._resource import (
     _archive_members_for_kind,
     _is_archive,
-    read_tabular,
     _select_vector_member,
     _sniff_from_archive,
     _strip_compression,
     _warn_if_multilayer,
+    read_tabular,
 )
 from pyramids.dataset import Dataset
 from pyramids.feature import FeatureCollection

--- a/tests/base/test_resource.py
+++ b/tests/base/test_resource.py
@@ -19,7 +19,7 @@ from pyramids import read_resource, sniff_kind
 from pyramids._resource import (
     _archive_members_for_kind,
     _is_archive,
-    _read_tabular,
+    read_tabular,
     _select_vector_member,
     _sniff_from_archive,
     _strip_compression,
@@ -461,19 +461,19 @@ class TestHelperRobustness:
 
 
 class TestReadTabularBranches:
-    """`_read_tabular` per-suffix dispatch and engine-missing handling."""
+    """`read_tabular` per-suffix dispatch and engine-missing handling."""
 
     def test_unsupported_suffix_raises(self, tmp_path: Path):
         f = tmp_path / "weird.dat"
         f.write_text("junk")
         with pytest.raises(ValueError, match="unsupported tabular suffix"):
-            _read_tabular(f)
+            read_tabular(f)
 
     def test_parquet_round_trip(self, tmp_path: Path):
         pytest.importorskip("pyarrow")
         pq = tmp_path / "t.parquet"
         pd.DataFrame({"a": [1, 2]}).to_parquet(pq)
-        df = _read_tabular(pq)
+        df = read_tabular(pq)
         assert list(df["a"]) == [1, 2]
 
     def test_xlsx_engine_missing_reraises_with_hint(self, tmp_path: Path, monkeypatch):
@@ -486,7 +486,7 @@ class TestReadTabularBranches:
         f = tmp_path / "survey.xlsx"
         f.write_bytes(b"stub")
         with pytest.raises(ImportError, match="Excel engine"):
-            _read_tabular(f)
+            read_tabular(f)
 
     def test_parquet_engine_missing_reraises_with_hint(
         self, tmp_path: Path, monkeypatch
@@ -498,4 +498,4 @@ class TestReadTabularBranches:
         f = tmp_path / "t.parquet"
         f.write_bytes(b"stub")
         with pytest.raises(ImportError, match="parquet engine"):
-            _read_tabular(f)
+            read_tabular(f)

--- a/tests/cli/test_bounds_json.py
+++ b/tests/cli/test_bounds_json.py
@@ -14,6 +14,8 @@ from pyramids import cli
 from pyramids.cli import main
 from pyramids.dataset import Dataset
 
+pytestmark = pytest.mark.core
+
 
 @pytest.fixture(scope="function")
 def wgs84_raster(tmp_path: Path) -> str:

--- a/tests/cli/test_bounds_json.py
+++ b/tests/cli/test_bounds_json.py
@@ -64,7 +64,11 @@ def failing_transform(monkeypatch: pytest.MonkeyPatch):
 class TestBoundsJson:
     """Tests for `_cmd_bounds` JSON output."""
 
-    def test_payload_is_valid_json(self, wgs84_raster: str, capsys: pytest.CaptureFixture):
+    def test_payload_is_valid_json(
+        self,
+        wgs84_raster: str,
+        capsys: pytest.CaptureFixture,
+    ):
         """`bounds --json` emits a document a strict parser accepts.
 
         Test scenario:
@@ -73,9 +77,16 @@ class TestBoundsJson:
         """
         main(["bounds", wgs84_raster, "--json"])
         payload = json.loads(capsys.readouterr().out)
-        assert len(payload["bounds"]) == 4, f"expected four bounds, got {payload['bounds']}"
+        assert len(payload["bounds"]) == 4, (
+            f"expected four bounds, got {payload['bounds']}"
+        )
 
-    def test_non_finite_corner_becomes_null(self, wgs84_raster: str, capsys: pytest.CaptureFixture, failing_transform):
+    def test_non_finite_corner_becomes_null(
+        self,
+        wgs84_raster: str,
+        capsys: pytest.CaptureFixture,
+        failing_transform,
+    ):
         """Out-of-domain reprojected corners serialise as null, not `Infinity`.
 
         Test scenario:
@@ -92,9 +103,16 @@ class TestBoundsJson:
 
         payload = json.loads(raw, parse_constant=_reject)
         for value in payload["bounds"]:
-            assert value is None or isinstance(value, (int, float)), f"unexpected bound {value!r}"
+            assert value is None or isinstance(value, (int, float)), (
+                f"unexpected bound {value!r}"
+            )
 
-    def test_output_parses_with_a_strict_external_parser(self, wgs84_raster: str, capsys: pytest.CaptureFixture, failing_transform):
+    def test_output_parses_with_a_strict_external_parser(
+        self,
+        wgs84_raster: str,
+        capsys: pytest.CaptureFixture,
+        failing_transform,
+    ):
         """The emitted text is accepted by a strict, non-Python JSON reader.
 
         Test scenario:
@@ -114,4 +132,6 @@ class TestBoundsJson:
         completed = subprocess.run(
             [sys.executable, "-c", code], input=raw, capture_output=True, text=True
         )
-        assert completed.returncode == 0, f"strict parse failed: {completed.stdout}{completed.stderr}"
+        assert completed.returncode == 0, (
+            f"strict parse failed: {completed.stdout}{completed.stderr}"
+        )

--- a/tests/cli/test_bounds_json.py
+++ b/tests/cli/test_bounds_json.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from pyramids import cli
 from pyramids.cli import main
 from pyramids.dataset import Dataset
 
@@ -36,6 +37,28 @@ def wgs84_raster(tmp_path: Path) -> str:
     return path
 
 
+@pytest.fixture(scope="function")
+def failing_transform(monkeypatch: pytest.MonkeyPatch):
+    """Force the corner reprojection to return GDAL's failure sentinel.
+
+    GDAL documents `HUGE_VAL` as the coordinate returned when a point cannot be
+    transformed. Current PROJ extrapolates rather than failing for most
+    out-of-domain inputs, so no real CRS pair reliably produces it — patch the
+    transformer instead, which exercises the guard deterministically and on
+    every platform.
+
+    Args:
+        monkeypatch: pytest monkeypatch fixture.
+    """
+
+    class _Failing:
+        def TransformPoints(self, points):
+            """Return one non-finite corner and three ordinary ones."""
+            return [(float("inf"), float("inf"))] + [(1.0, 2.0)] * (len(points) - 1)
+
+    monkeypatch.setattr(cli.osr, "CoordinateTransformation", lambda *a, **k: _Failing())
+
+
 class TestBoundsJson:
     """Tests for `_cmd_bounds` JSON output."""
 
@@ -50,7 +73,7 @@ class TestBoundsJson:
         payload = json.loads(capsys.readouterr().out)
         assert len(payload["bounds"]) == 4, f"expected four bounds, got {payload['bounds']}"
 
-    def test_non_finite_corner_becomes_null(self, wgs84_raster: str, capsys: pytest.CaptureFixture):
+    def test_non_finite_corner_becomes_null(self, wgs84_raster: str, capsys: pytest.CaptureFixture, failing_transform):
         """Out-of-domain reprojected corners serialise as null, not `Infinity`.
 
         Test scenario:
@@ -69,7 +92,7 @@ class TestBoundsJson:
         for value in payload["bounds"]:
             assert value is None or isinstance(value, (int, float)), f"unexpected bound {value!r}"
 
-    def test_output_parses_with_a_strict_external_parser(self, wgs84_raster: str, capsys: pytest.CaptureFixture):
+    def test_output_parses_with_a_strict_external_parser(self, wgs84_raster: str, capsys: pytest.CaptureFixture, failing_transform):
         """The emitted text is accepted by a strict, non-Python JSON reader.
 
         Test scenario:

--- a/tests/cli/test_bounds_json.py
+++ b/tests/cli/test_bounds_json.py
@@ -1,0 +1,92 @@
+"""Tests for JSON safety of the `pyramids bounds --json` payload."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from pyramids.cli import main
+from pyramids.dataset import Dataset
+
+
+@pytest.fixture(scope="function")
+def wgs84_raster(tmp_path: Path) -> str:
+    """Create a small WGS84 raster on disk.
+
+    Args:
+        tmp_path: pytest temporary directory.
+
+    Returns:
+        str: Path to the created GeoTIFF.
+    """
+    path = str(tmp_path / "bounds.tif")
+    Dataset.create_from_array(
+        np.ones((8, 8), dtype="float32"),
+        top_left_corner=(-10.0, 50.0),
+        cell_size=0.5,
+        epsg=4326,
+        driver_type="GTiff",
+        path=path,
+    )
+    return path
+
+
+class TestBoundsJson:
+    """Tests for `_cmd_bounds` JSON output."""
+
+    def test_payload_is_valid_json(self, wgs84_raster: str, capsys: pytest.CaptureFixture):
+        """`bounds --json` emits a document a strict parser accepts.
+
+        Test scenario:
+            The four bounds are finite here, so the payload round-trips through
+            `json.loads` unchanged.
+        """
+        main(["bounds", wgs84_raster, "--json"])
+        payload = json.loads(capsys.readouterr().out)
+        assert len(payload["bounds"]) == 4, f"expected four bounds, got {payload['bounds']}"
+
+    def test_non_finite_corner_becomes_null(self, wgs84_raster: str, capsys: pytest.CaptureFixture):
+        """Out-of-domain reprojected corners serialise as null, not `Infinity`.
+
+        Test scenario:
+            Reprojecting a global-ish WGS84 extent into a CRS with a limited
+            domain can push a corner to HUGE_VAL. `json.dumps` would write that
+            as a bare `Infinity`, which is not valid JSON — the guard maps it to
+            null so `json.loads(..., parse_constant=...)` never sees a constant.
+        """
+        main(["bounds", wgs84_raster, "--json", "--crs", "EPSG:3857"])
+        raw = capsys.readouterr().out
+
+        def _reject(constant: str):
+            raise AssertionError(f"payload contained the bare JSON constant {constant!r}: {raw!r}")
+
+        payload = json.loads(raw, parse_constant=_reject)
+        for value in payload["bounds"]:
+            assert value is None or isinstance(value, (int, float)), f"unexpected bound {value!r}"
+
+    def test_output_parses_with_a_strict_external_parser(self, wgs84_raster: str, capsys: pytest.CaptureFixture):
+        """The emitted text is accepted by a strict, non-Python JSON reader.
+
+        Test scenario:
+            Python's own `json.loads` accepts `Infinity` by default, which is
+            exactly why the bug went unnoticed; re-parse in a subprocess with
+            constants rejected to prove the text is portable.
+        """
+        main(["bounds", wgs84_raster, "--json", "--crs", "EPSG:3857"])
+        raw = capsys.readouterr().out.strip()
+        code = (
+            "import json,sys\n"
+            "def reject(c):\n"
+            "    raise SystemExit('bare constant: ' + c)\n"
+            "json.loads(sys.stdin.read(), parse_constant=reject)\n"
+            "print('ok')\n"
+        )
+        completed = subprocess.run(
+            [sys.executable, "-c", code], input=raw, capture_output=True, text=True
+        )
+        assert completed.returncode == 0, f"strict parse failed: {completed.stdout}{completed.stderr}"

--- a/tests/cli/test_bounds_json.py
+++ b/tests/cli/test_bounds_json.py
@@ -55,8 +55,13 @@ def failing_transform(monkeypatch: pytest.MonkeyPatch):
 
     class _Failing:
         def TransformPoints(self, points):
-            """Return one non-finite corner and three ordinary ones."""
-            return [(float("inf"), float("inf"))] + [(1.0, 2.0)] * (len(points) - 1)
+            """Return one non-finite corner and three ordinary ones.
+
+            GDAL hands back 3-tuples (x, y, z), so mirror that shape rather than
+            the 2-tuples the caller happens to index.
+            """
+            failed = (float("inf"), float("inf"), 0.0)
+            return [failed] + [(1.0, 2.0, 0.0)] * (len(points) - 1)
 
     monkeypatch.setattr(cli.osr, "CoordinateTransformation", lambda *a, **k: _Failing())
 

--- a/tests/cli/test_bounds_json.py
+++ b/tests/cli/test_bounds_json.py
@@ -104,7 +104,9 @@ class TestBoundsJson:
         raw = capsys.readouterr().out
 
         def _reject(constant: str):
-            raise AssertionError(f"payload contained the bare JSON constant {constant!r}: {raw!r}")
+            raise AssertionError(
+                f"payload contained the bare JSON constant {constant!r}: {raw!r}"
+            )
 
         payload = json.loads(raw, parse_constant=_reject)
         for value in payload["bounds"]:

--- a/tests/guards/test_runnable_doctests.py
+++ b/tests/guards/test_runnable_doctests.py
@@ -19,6 +19,7 @@ DOCTEST_MODULES = [
     "pyramids.base.crs",
     "pyramids.base.config",
     "pyramids.io.sniff",
+    "pyramids._resource",
 ]
 
 

--- a/tests/io/test_detection_core.py
+++ b/tests/io/test_detection_core.py
@@ -40,17 +40,32 @@ class TestSharedCore:
 
         assert exported is sniff_format, "pyramids.io must re-export the core sniffer, not reimplement it"
 
-    def test_primary_exts_track_the_shared_table(self):
-        """`_PRIMARY_EXTS` is derived from the shared extension table.
+    def test_primary_exts_excludes_sidecar_only_formats(self):
+        """`_PRIMARY_EXTS` stays narrower than the detection table.
 
         Test scenario:
-            Every non-archive extension in the shared table must be treated as a
-            primary member, so a newly added format is picked up automatically.
+            `_PRIMARY_EXTS` decides whether an archive has exactly one primary
+            member. Sidecar-ish formats must stay out: with `.tsv` included, a
+            zip of `grid.tif` + `meta.tsv` would have two primaries and return
+            the extraction directory instead of the raster.
         """
         from pyramids.io.sniff import _PRIMARY_EXTS
 
-        expected = {ext for ext, fmt in _EXT_TO_FORMAT.items() if fmt != "zip"}
-        assert set(_PRIMARY_EXTS) == expected, f"_PRIMARY_EXTS drifted from the shared table: {_PRIMARY_EXTS}"
+        for ext in (".tsv", ".xlsx", ".xls"):
+            assert ext not in _PRIMARY_EXTS, f"{ext} must not count as a primary archive member"
+
+    def test_primary_exts_are_all_known_formats(self):
+        """Every primary extension is one the detection core can classify.
+
+        Test scenario:
+            A primary member is re-dispatched through `load_resource`, so an
+            extension listed here that the shared table cannot name would fall
+            through to raw bytes.
+        """
+        from pyramids.io.sniff import _PRIMARY_EXTS
+
+        unknown = sorted(ext for ext in _PRIMARY_EXTS if ext not in _EXT_TO_FORMAT)
+        assert not unknown, f"primary extensions unknown to the detection table: {unknown}"
 
 
 class TestSniffMagic:
@@ -187,6 +202,55 @@ class TestLoadResourceTabularCoverage:
         result = load_resource(table)
         assert isinstance(result, pd.DataFrame), f"expected a DataFrame for .tsv, got {type(result).__name__}"
         assert list(result.columns) == ["a", "b"], f"expected columns ['a', 'b'], got {list(result.columns)}"
+
+    def test_expected_format_overrides_a_missing_extension(self, tmp_path: Path):
+        """`expected_format=` wins when the name carries no usable suffix.
+
+        Test scenario:
+            The case this module exists for — a portal download named by id,
+            where the declared format is the only reliable signal. Dispatching
+            on the extension instead would raise.
+        """
+        from pyramids.io.sniff import load_resource
+
+        blob = tmp_path / "resource_12345"
+        blob.write_text("a,b\n1,2\n", encoding="utf-8")
+        result = load_resource(blob, expected_format="csv")
+        assert list(result.columns) == ["a", "b"], f"expected columns ['a', 'b'], got {list(result.columns)}"
+
+    def test_zip_with_a_tabular_sidecar_still_loads_the_raster(self, tmp_path: Path):
+        """A sidecar next to the data file does not defeat re-dispatch.
+
+        Test scenario:
+            A zip of `grid.tif` + `meta.tsv` must resolve to the raster. If
+            `.tsv` counted as a primary member the archive would have two, and
+            `_load_zip` would return the extraction directory instead.
+        """
+        from pyramids.io.sniff import load_resource
+
+        shutil.copy(_GEOTIFF, tmp_path / "grid.tif")
+        (tmp_path / "meta.tsv").write_text("k\tv\n1\t2\n", encoding="utf-8")
+        archive = tmp_path / "bundle.zip"
+        with zipfile.ZipFile(archive, "w") as handle:
+            handle.write(tmp_path / "grid.tif", arcname="grid.tif")
+            handle.write(tmp_path / "meta.tsv", arcname="meta.tsv")
+
+        result = load_resource(archive, extract_to=tmp_path / "out")
+        assert getattr(result, "band_count", None) == 9, f"expected the 9-band raster, got {type(result).__name__}"
+
+    def test_legacy_xls_is_not_forced_through_an_excel_engine(self, tmp_path: Path):
+        """`.xls` keeps its previous raw-bytes behaviour.
+
+        Test scenario:
+            No Excel engine is a declared dependency, so classifying `.xls` as a
+            tabular format would turn a resource that used to come back as bytes
+            into a hard ImportError.
+        """
+        from pyramids.io.sniff import load_resource
+
+        legacy = tmp_path / "legacy.xls"
+        legacy.write_bytes(b"\xd0\xcf\x11\xe0stub")
+        assert isinstance(load_resource(legacy), bytes), "unrecognised .xls should still return raw bytes"
 
     def test_csv_still_reads_as_a_frame(self, tmp_path: Path):
         """The pre-existing CSV behaviour is preserved.

--- a/tests/io/test_detection_core.py
+++ b/tests/io/test_detection_core.py
@@ -40,7 +40,9 @@ class TestSharedCore:
         """
         from pyramids.io import sniff_format as exported
 
-        assert exported is sniff_format, "pyramids.io must re-export the core sniffer, not reimplement it"
+        assert exported is sniff_format, (
+            "pyramids.io must re-export the core sniffer, not reimplement it"
+        )
 
     def test_primary_exts_excludes_sidecar_only_formats(self):
         """`_PRIMARY_EXTS` stays narrower than the detection table.
@@ -54,7 +56,9 @@ class TestSharedCore:
         from pyramids.io.sniff import _PRIMARY_EXTS
 
         for ext in (".tsv", ".xlsx", ".xls"):
-            assert ext not in _PRIMARY_EXTS, f"{ext} must not count as a primary archive member"
+            assert ext not in _PRIMARY_EXTS, (
+                f"{ext} must not count as a primary archive member"
+            )
 
     def test_primary_exts_are_all_known_formats(self):
         """Every primary extension is one the detection core can classify.
@@ -67,7 +71,9 @@ class TestSharedCore:
         from pyramids.io.sniff import _PRIMARY_EXTS
 
         unknown = sorted(ext for ext in _PRIMARY_EXTS if ext not in _EXT_TO_FORMAT)
-        assert not unknown, f"primary extensions unknown to the detection table: {unknown}"
+        assert not unknown, (
+            f"primary extensions unknown to the detection table: {unknown}"
+        )
 
 
 class TestSniffMagic:
@@ -81,7 +87,8 @@ class TestSniffMagic:
             (b"MM\x00*rest", "tif"),
             (b"\x89HDF\r\n\x1a\n", "nc"),
             (b"CDF\x01rest", "nc"),
-            (b"GRIB0000", "grib"),
+            (b"CDF\x02rest", "nc"),
+            (b"GRIB\x00\x00\x00\x02", "grib"),
             (b"PAR1data", "parquet"),
             (b"SQLite format 3\x00", "gpkg"),
         ],
@@ -100,7 +107,35 @@ class TestSniffMagic:
         """
         probe = tmp_path / "probe.bin"
         probe.write_bytes(payload)
-        assert sniff_magic(probe) == expected, f"expected {expected} for {payload[:8]!r}"
+        assert sniff_magic(probe) == expected, (
+            f"expected {expected} for {payload[:8]!r}"
+        )
+
+    @pytest.mark.parametrize(
+        "header",
+        [b"CDF,value,date\n1,2,3\n", b"GRIB,station,value\n1,2,3\n"],
+    )
+    def test_text_headers_are_not_mistaken_for_binary_formats(
+        self,
+        tmp_path: Path,
+        header: bytes,
+    ):
+        """A CSV whose first column is named `CDF` or `GRIB` is not binary.
+
+        Args:
+            tmp_path: pytest temporary directory.
+            header: Leading bytes of a plain-text CSV.
+
+        Test scenario:
+            Both signatures are short ASCII prefixes, so testing them alone would
+            claim ordinary text. The version/edition byte that follows must be
+            checked too.
+        """
+        probe = tmp_path / "table.csv"
+        probe.write_bytes(header)
+        assert sniff_magic(probe) is None, (
+            f"{header[:6]!r} is a text header, not a binary signature"
+        )
 
     def test_unrecognised_payload_returns_none(self, tmp_path: Path):
         """Unknown leading bytes yield `None` so the caller can fall back.
@@ -119,7 +154,9 @@ class TestSniffMagic:
         Test scenario:
             Detection must stay non-fatal for callers probing untrusted input.
         """
-        assert sniff_magic(tmp_path / "absent.bin") is None, "a missing file should return None"
+        assert sniff_magic(tmp_path / "absent.bin") is None, (
+            "a missing file should return None"
+        )
 
 
 class TestSniffFormat:
@@ -145,7 +182,9 @@ class TestSniffFormat:
         """
         table = tmp_path / "table.csv"
         table.write_text("a,b\n1,2\n", encoding="utf-8")
-        assert sniff_format(table) == "csv", "a signature-less CSV should fall back to its extension"
+        assert sniff_format(table) == "csv", (
+            "a signature-less CSV should fall back to its extension"
+        )
 
     def test_unknown_when_neither_identifies(self, tmp_path: Path):
         """An unrecognised name and payload yield `"unknown"`.
@@ -155,7 +194,9 @@ class TestSniffFormat:
         """
         blob = tmp_path / "mystery.bin"
         blob.write_bytes(b"nothing recognisable")
-        assert sniff_format(blob) == "unknown", "unidentifiable input should be 'unknown'"
+        assert sniff_format(blob) == "unknown", (
+            "unidentifiable input should be 'unknown'"
+        )
 
 
 class TestReadResourceMagicFallback:
@@ -172,7 +213,9 @@ class TestReadResourceMagicFallback:
         blob = tmp_path / "downloaded_blob"
         shutil.copy(_GEOTIFF, blob)
         result = read_resource(blob)
-        assert result.band_count == 9, f"expected the 9-band ERA5 raster, got {result.band_count} bands"
+        assert result.band_count == 9, (
+            f"expected the 9-band ERA5 raster, got {result.band_count} bands"
+        )
 
     def test_named_resource_keeps_its_name_based_answer(self, tmp_path: Path):
         """A correctly named resource is unaffected by the new fallback.
@@ -184,7 +227,9 @@ class TestReadResourceMagicFallback:
         table = tmp_path / "values.csv"
         table.write_text("a,b\n5,6\n", encoding="utf-8")
         result = read_resource(table)
-        assert list(result.columns) == ["a", "b"], f"expected columns ['a', 'b'], got {list(result.columns)}"
+        assert list(result.columns) == ["a", "b"], (
+            f"expected columns ['a', 'b'], got {list(result.columns)}"
+        )
 
 
 class TestLoadResourceTabularCoverage:
@@ -202,8 +247,12 @@ class TestLoadResourceTabularCoverage:
         table = tmp_path / "values.tsv"
         table.write_text("a\tb\n7\t8\n", encoding="utf-8")
         result = load_resource(table)
-        assert isinstance(result, pd.DataFrame), f"expected a DataFrame for .tsv, got {type(result).__name__}"
-        assert list(result.columns) == ["a", "b"], f"expected columns ['a', 'b'], got {list(result.columns)}"
+        assert isinstance(result, pd.DataFrame), (
+            f"expected a DataFrame for .tsv, got {type(result).__name__}"
+        )
+        assert list(result.columns) == ["a", "b"], (
+            f"expected columns ['a', 'b'], got {list(result.columns)}"
+        )
 
     def test_expected_format_overrides_a_missing_extension(self, tmp_path: Path):
         """`expected_format=` wins when the name carries no usable suffix.
@@ -218,7 +267,9 @@ class TestLoadResourceTabularCoverage:
         blob = tmp_path / "resource_12345"
         blob.write_text("a,b\n1,2\n", encoding="utf-8")
         result = load_resource(blob, expected_format="csv")
-        assert list(result.columns) == ["a", "b"], f"expected columns ['a', 'b'], got {list(result.columns)}"
+        assert list(result.columns) == ["a", "b"], (
+            f"expected columns ['a', 'b'], got {list(result.columns)}"
+        )
 
     def test_zip_with_a_tabular_sidecar_still_loads_the_raster(self, tmp_path: Path):
         """A sidecar next to the data file does not defeat re-dispatch.
@@ -238,7 +289,9 @@ class TestLoadResourceTabularCoverage:
             handle.write(tmp_path / "meta.tsv", arcname="meta.tsv")
 
         result = load_resource(archive, extract_to=tmp_path / "out")
-        assert getattr(result, "band_count", None) == 9, f"expected the 9-band raster, got {type(result).__name__}"
+        assert getattr(result, "band_count", None) == 9, (
+            f"expected the 9-band raster, got {type(result).__name__}"
+        )
 
     def test_legacy_xls_is_not_forced_through_an_excel_engine(self, tmp_path: Path):
         """`.xls` keeps its previous raw-bytes behaviour.
@@ -252,7 +305,9 @@ class TestLoadResourceTabularCoverage:
 
         legacy = tmp_path / "legacy.xls"
         legacy.write_bytes(b"\xd0\xcf\x11\xe0stub")
-        assert isinstance(load_resource(legacy), bytes), "unrecognised .xls should still return raw bytes"
+        assert isinstance(load_resource(legacy), bytes), (
+            "unrecognised .xls should still return raw bytes"
+        )
 
     def test_csv_still_reads_as_a_frame(self, tmp_path: Path):
         """The pre-existing CSV behaviour is preserved.
@@ -266,4 +321,6 @@ class TestLoadResourceTabularCoverage:
         table = tmp_path / "values.csv"
         table.write_text("a,b\n1,2\n", encoding="utf-8")
         result = load_resource(table)
-        assert list(result.columns) == ["a", "b"], f"expected columns ['a', 'b'], got {list(result.columns)}"
+        assert list(result.columns) == ["a", "b"], (
+            f"expected columns ['a', 'b'], got {list(result.columns)}"
+        )

--- a/tests/io/test_detection_core.py
+++ b/tests/io/test_detection_core.py
@@ -23,6 +23,8 @@ from pyramids._resource import (
     sniff_magic,
 )
 
+pytestmark = pytest.mark.core
+
 _GEOTIFF = "tests/data/geotiff/era5_land_monthly_averaged.tif"
 
 

--- a/tests/io/test_detection_core.py
+++ b/tests/io/test_detection_core.py
@@ -74,6 +74,28 @@ class TestSharedCore:
             f"primary extensions unknown to the detection table: {unknown}"
         )
 
+    def test_every_data_extension_is_dispatchable_from_an_archive(self):
+        """No data format is silently undispatchable inside a zip.
+
+        Test scenario:
+            The subset check above catches drift in one direction only. A format
+            added to the detection table but to neither dispatch tier would make
+            an archive containing just that file return the extraction directory,
+            with nothing failing. Pin the other direction too.
+        """
+        from pyramids.io.sniff import _SECONDARY_EXTS
+
+        dispatchable = _PRIMARY_EXTS | _SECONDARY_EXTS
+        # `.zip` is the container itself, never a member to re-dispatch.
+        orphans = sorted(
+            ext
+            for ext, fmt in _EXT_TO_FORMAT.items()
+            if fmt != "zip" and ext not in dispatchable
+        )
+        assert not orphans, (
+            f"data extensions in the detection table that no tier dispatches: {orphans}"
+        )
+
 
 class TestSniffMagic:
     """Tests for `sniff_magic`."""

--- a/tests/io/test_detection_core.py
+++ b/tests/io/test_detection_core.py
@@ -1,0 +1,203 @@
+"""Tests for the shared format-detection core in `pyramids._resource`.
+
+The magic-byte and extension tables used to be duplicated between `_resource`
+and `pyramids.io.sniff`, which let the two drift. These tests pin the single
+core: that both public readers resolve through it, that magic bytes beat a lying
+extension, and that `read_resource` can fall back to bytes when a name carries no
+usable suffix.
+"""
+
+from __future__ import annotations
+
+import shutil
+import zipfile
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from pyramids._resource import (
+    _EXT_TO_FORMAT,
+    read_resource,
+    sniff_format,
+    sniff_magic,
+)
+
+_GEOTIFF = "tests/data/geotiff/era5_land_monthly_averaged.tif"
+
+
+class TestSharedCore:
+    """Tests that both readers resolve through one detection implementation."""
+
+    def test_io_sniff_format_is_the_core_function(self):
+        """`pyramids.io.sniff_format` is the very object defined in `_resource`.
+
+        Test scenario:
+            Identity — not merely equal behaviour — proves there is a single
+            implementation rather than two that can drift.
+        """
+        from pyramids.io import sniff_format as exported
+
+        assert exported is sniff_format, "pyramids.io must re-export the core sniffer, not reimplement it"
+
+    def test_primary_exts_track_the_shared_table(self):
+        """`_PRIMARY_EXTS` is derived from the shared extension table.
+
+        Test scenario:
+            Every non-archive extension in the shared table must be treated as a
+            primary member, so a newly added format is picked up automatically.
+        """
+        from pyramids.io.sniff import _PRIMARY_EXTS
+
+        expected = {ext for ext, fmt in _EXT_TO_FORMAT.items() if fmt != "zip"}
+        assert set(_PRIMARY_EXTS) == expected, f"_PRIMARY_EXTS drifted from the shared table: {_PRIMARY_EXTS}"
+
+
+class TestSniffMagic:
+    """Tests for `sniff_magic`."""
+
+    @pytest.mark.parametrize(
+        "payload, expected",
+        [
+            (b"PK\x03\x04rest", "zip"),
+            (b"II*\x00rest", "tif"),
+            (b"MM\x00*rest", "tif"),
+            (b"\x89HDF\r\n\x1a\n", "nc"),
+            (b"CDF\x01rest", "nc"),
+            (b"GRIB0000", "grib"),
+            (b"PAR1data", "parquet"),
+            (b"SQLite format 3\x00", "gpkg"),
+        ],
+    )
+    def test_recognised_signatures(self, tmp_path: Path, payload: bytes, expected: str):
+        """Each known signature maps to its format token.
+
+        Args:
+            tmp_path: pytest temporary directory.
+            payload: Leading bytes written to the probe file.
+            expected: Format token the sniffer should return.
+
+        Test scenario:
+            Only the first 16 bytes are read, so a stub file carrying just the
+            signature is enough to classify it.
+        """
+        probe = tmp_path / "probe.bin"
+        probe.write_bytes(payload)
+        assert sniff_magic(probe) == expected, f"expected {expected} for {payload[:8]!r}"
+
+    def test_unrecognised_payload_returns_none(self, tmp_path: Path):
+        """Unknown leading bytes yield `None` so the caller can fall back.
+
+        Test scenario:
+            `sniff_magic` reports "I don't know" rather than guessing, leaving the
+            extension fallback to `sniff_format`.
+        """
+        probe = tmp_path / "plain.bin"
+        probe.write_bytes(b"just some text")
+        assert sniff_magic(probe) is None, "unrecognised bytes should return None"
+
+    def test_missing_file_returns_none(self, tmp_path: Path):
+        """A missing path is reported as unknown rather than raising.
+
+        Test scenario:
+            Detection must stay non-fatal for callers probing untrusted input.
+        """
+        assert sniff_magic(tmp_path / "absent.bin") is None, "a missing file should return None"
+
+
+class TestSniffFormat:
+    """Tests for `sniff_format`."""
+
+    def test_magic_beats_a_lying_extension(self, tmp_path: Path):
+        """Magic bytes win over a mis-named file.
+
+        Test scenario:
+            A zip archive named `.csv` — the portal case this core exists for —
+            must still be classified as a zip.
+        """
+        liar = tmp_path / "resource.csv"
+        with zipfile.ZipFile(liar, "w") as archive:
+            archive.writestr("inner.txt", "data")
+        assert sniff_format(liar) == "zip", "magic bytes should override the extension"
+
+    def test_extension_used_when_bytes_are_inconclusive(self, tmp_path: Path):
+        """The extension is the fallback when the bytes say nothing.
+
+        Test scenario:
+            A plain-text CSV has no magic signature, so the `.csv` suffix decides.
+        """
+        table = tmp_path / "table.csv"
+        table.write_text("a,b\n1,2\n", encoding="utf-8")
+        assert sniff_format(table) == "csv", "a signature-less CSV should fall back to its extension"
+
+    def test_unknown_when_neither_identifies(self, tmp_path: Path):
+        """An unrecognised name and payload yield `"unknown"`.
+
+        Test scenario:
+            Neither the bytes nor the suffix identify the file.
+        """
+        blob = tmp_path / "mystery.bin"
+        blob.write_bytes(b"nothing recognisable")
+        assert sniff_format(blob) == "unknown", "unidentifiable input should be 'unknown'"
+
+
+class TestReadResourceMagicFallback:
+    """Tests for magic-byte resolution inside `read_resource`."""
+
+    def test_extensionless_raster_resolves_via_magic(self, tmp_path: Path):
+        """An extension-less download is resolved from its bytes.
+
+        Test scenario:
+            A GeoTIFF saved without any suffix carries no name-based hint, so the
+            name/fmt lookup fails; the magic-byte fallback must classify it as a
+            raster and read it.
+        """
+        blob = tmp_path / "downloaded_blob"
+        shutil.copy(_GEOTIFF, blob)
+        result = read_resource(blob)
+        assert result.band_count == 9, f"expected the 9-band ERA5 raster, got {result.band_count} bands"
+
+    def test_named_resource_keeps_its_name_based_answer(self, tmp_path: Path):
+        """A correctly named resource is unaffected by the new fallback.
+
+        Test scenario:
+            The magic sniff runs only when the name is inconclusive, so a plain
+            `.csv` still resolves through the tabular branch.
+        """
+        table = tmp_path / "values.csv"
+        table.write_text("a,b\n5,6\n", encoding="utf-8")
+        result = read_resource(table)
+        assert list(result.columns) == ["a", "b"], f"expected columns ['a', 'b'], got {list(result.columns)}"
+
+
+class TestLoadResourceTabularCoverage:
+    """Tests for the tabular formats `load_resource` gained from the shared reader."""
+
+    def test_tsv_is_read_as_a_frame(self, tmp_path: Path):
+        """A `.tsv` resource now returns a DataFrame instead of raw bytes.
+
+        Test scenario:
+            Tab-separated data was absent from this module's old dispatch table
+            and fell through to the raw-bytes branch.
+        """
+        from pyramids.io.sniff import load_resource
+
+        table = tmp_path / "values.tsv"
+        table.write_text("a\tb\n7\t8\n", encoding="utf-8")
+        result = load_resource(table)
+        assert isinstance(result, pd.DataFrame), f"expected a DataFrame for .tsv, got {type(result).__name__}"
+        assert list(result.columns) == ["a", "b"], f"expected columns ['a', 'b'], got {list(result.columns)}"
+
+    def test_csv_still_reads_as_a_frame(self, tmp_path: Path):
+        """The pre-existing CSV behaviour is preserved.
+
+        Test scenario:
+            Routing CSV through the shared tabular reader must not change what
+            callers already received.
+        """
+        from pyramids.io.sniff import load_resource
+
+        table = tmp_path / "values.csv"
+        table.write_text("a,b\n1,2\n", encoding="utf-8")
+        result = load_resource(table)
+        assert list(result.columns) == ["a", "b"], f"expected columns ['a', 'b'], got {list(result.columns)}"

--- a/tests/io/test_detection_core.py
+++ b/tests/io/test_detection_core.py
@@ -293,6 +293,27 @@ class TestLoadResourceTabularCoverage:
             f"expected the 9-band raster, got {type(result).__name__}"
         )
 
+    def test_zip_of_only_a_tsv_still_loads_the_table(self, tmp_path: Path):
+        """An archive holding just a spreadsheet resolves to a frame.
+
+        Test scenario:
+            The mirror of the sidecar case: `.tsv` is deliberately not a primary
+            member so it cannot outvote a raster, but with nothing else in the
+            archive it must still be read rather than yielding the extraction
+            directory.
+        """
+        from pyramids.io.sniff import load_resource
+
+        (tmp_path / "table.tsv").write_text("a\tb\n1\t2\n", encoding="utf-8")
+        archive = tmp_path / "only.zip"
+        with zipfile.ZipFile(archive, "w") as handle:
+            handle.write(tmp_path / "table.tsv", arcname="table.tsv")
+
+        result = load_resource(archive, extract_to=tmp_path / "solo")
+        assert isinstance(result, pd.DataFrame), (
+            f"a zip of one .tsv should load it, got {type(result).__name__}"
+        )
+
     def test_legacy_xls_is_not_forced_through_an_excel_engine(self, tmp_path: Path):
         """`.xls` keeps its previous raw-bytes behaviour.
 

--- a/tests/io/test_detection_core.py
+++ b/tests/io/test_detection_core.py
@@ -22,6 +22,7 @@ from pyramids._resource import (
     sniff_format,
     sniff_magic,
 )
+from pyramids.io.sniff import _PRIMARY_EXTS, load_resource
 
 pytestmark = pytest.mark.core
 
@@ -53,7 +54,6 @@ class TestSharedCore:
             zip of `grid.tif` + `meta.tsv` would have two primaries and return
             the extraction directory instead of the raster.
         """
-        from pyramids.io.sniff import _PRIMARY_EXTS
 
         for ext in (".tsv", ".xlsx", ".xls"):
             assert ext not in _PRIMARY_EXTS, (
@@ -68,7 +68,6 @@ class TestSharedCore:
             extension listed here that the shared table cannot name would fall
             through to raw bytes.
         """
-        from pyramids.io.sniff import _PRIMARY_EXTS
 
         unknown = sorted(ext for ext in _PRIMARY_EXTS if ext not in _EXT_TO_FORMAT)
         assert not unknown, (
@@ -242,7 +241,6 @@ class TestLoadResourceTabularCoverage:
             Tab-separated data was absent from this module's old dispatch table
             and fell through to the raw-bytes branch.
         """
-        from pyramids.io.sniff import load_resource
 
         table = tmp_path / "values.tsv"
         table.write_text("a\tb\n7\t8\n", encoding="utf-8")
@@ -262,7 +260,6 @@ class TestLoadResourceTabularCoverage:
             where the declared format is the only reliable signal. Dispatching
             on the extension instead would raise.
         """
-        from pyramids.io.sniff import load_resource
 
         blob = tmp_path / "resource_12345"
         blob.write_text("a,b\n1,2\n", encoding="utf-8")
@@ -279,7 +276,6 @@ class TestLoadResourceTabularCoverage:
             `.tsv` counted as a primary member the archive would have two, and
             `_load_zip` would return the extraction directory instead.
         """
-        from pyramids.io.sniff import load_resource
 
         shutil.copy(_GEOTIFF, tmp_path / "grid.tif")
         (tmp_path / "meta.tsv").write_text("k\tv\n1\t2\n", encoding="utf-8")
@@ -302,7 +298,6 @@ class TestLoadResourceTabularCoverage:
             archive it must still be read rather than yielding the extraction
             directory.
         """
-        from pyramids.io.sniff import load_resource
 
         (tmp_path / "table.tsv").write_text("a\tb\n1\t2\n", encoding="utf-8")
         archive = tmp_path / "only.zip"
@@ -322,7 +317,6 @@ class TestLoadResourceTabularCoverage:
             tabular format would turn a resource that used to come back as bytes
             into a hard ImportError.
         """
-        from pyramids.io.sniff import load_resource
 
         legacy = tmp_path / "legacy.xls"
         legacy.write_bytes(b"\xd0\xcf\x11\xe0stub")
@@ -337,7 +331,6 @@ class TestLoadResourceTabularCoverage:
             Routing CSV through the shared tabular reader must not change what
             callers already received.
         """
-        from pyramids.io.sniff import load_resource
 
         table = tmp_path / "values.csv"
         table.write_text("a,b\n1,2\n", encoding="utf-8")

--- a/tests/io/test_io_handles.py
+++ b/tests/io/test_io_handles.py
@@ -35,8 +35,14 @@ def asc_zip(tmp_path: Path) -> Path:
     """
     archive = tmp_path / "grids.zip"
     with zipfile.ZipFile(archive, "w") as handle:
-        handle.writestr("1.asc", "ncols 1\nnrows 1\nxllcorner 0\nyllcorner 0\ncellsize 1\nNODATA_value -9999\n1\n")
-        handle.writestr("2.asc", "ncols 1\nnrows 1\nxllcorner 0\nyllcorner 0\ncellsize 1\nNODATA_value -9999\n2\n")
+        handle.writestr(
+            "1.asc",
+            "ncols 1\nnrows 1\nxllcorner 0\nyllcorner 0\ncellsize 1\nNODATA_value -9999\n1\n",
+        )
+        handle.writestr(
+            "2.asc",
+            "ncols 1\nnrows 1\nxllcorner 0\nyllcorner 0\ncellsize 1\nNODATA_value -9999\n2\n",
+        )
     return archive
 
 
@@ -274,7 +280,11 @@ class TestLazyIoExports:
             "print([m for m in ('pyramids.dataset','pyramids.feature','pyramids.netcdf') if m in sys.modules])"
         )
         completed = subprocess.run(
-            [sys.executable, "-c", code], capture_output=True, text=True, check=True, env=env
+            [sys.executable, "-c", code],
+            capture_output=True,
+            text=True,
+            check=True,
+            env=env,
         )
         assert completed.stdout.strip() == "[]", (
             f"import pyramids.io should stay light, got: {completed.stdout!r}"

--- a/tests/io/test_io_handles.py
+++ b/tests/io/test_io_handles.py
@@ -20,6 +20,8 @@ from osgeo import gdal
 from pyramids._io import _get_zip_path, read_file
 from pyramids.base import _artifacts
 
+pytestmark = pytest.mark.core
+
 
 @pytest.fixture(scope="function")
 def asc_zip(tmp_path: Path) -> Path:

--- a/tests/io/test_io_handles.py
+++ b/tests/io/test_io_handles.py
@@ -88,7 +88,9 @@ class TestGetZipPath:
             the `/vsizip/` prefix attached.
         """
         result = _get_zip_path(f"{asc_zip}/1.asc")
-        assert result == f"/vsizip/{asc_zip}/1.asc", f"Unexpected passthrough result: {result}"
+        assert result == f"/vsizip/{asc_zip}/1.asc", (
+            f"Unexpected passthrough result: {result}"
+        )
 
     def test_does_not_hold_the_archive_open(self, asc_zip: Path):
         """`_get_zip_path` leaves no open handle on the archive.
@@ -102,13 +104,19 @@ class TestGetZipPath:
         """
         _get_zip_path(str(asc_zip))
         os.remove(asc_zip)
-        assert not asc_zip.exists(), "archive should be deletable, so its handle must already be closed"
+        assert not asc_zip.exists(), (
+            "archive should be deletable, so its handle must already be closed"
+        )
 
 
 class TestReadFileAccessMode:
     """Tests for GDAL handle sharing in `read_file`."""
 
-    def test_read_only_uses_shared_handle(self, tiny_raster: str, monkeypatch: pytest.MonkeyPatch):
+    def test_read_only_uses_shared_handle(
+        self,
+        tiny_raster: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
         """Read-only opens go through `gdal.OpenShared`.
 
         Test scenario:
@@ -121,7 +129,11 @@ class TestReadFileAccessMode:
         read_file(tiny_raster, read_only=True)
         assert calls == ["shared"], f"read-only should call OpenShared, got: {calls}"
 
-    def test_update_mode_uses_unshared_handle(self, tiny_raster: str, monkeypatch: pytest.MonkeyPatch):
+    def test_update_mode_uses_unshared_handle(
+        self,
+        tiny_raster: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
         """Update-mode opens go through `gdal.Open`, not the shared cache.
 
         Test scenario:
@@ -135,27 +147,45 @@ class TestReadFileAccessMode:
         read_file(tiny_raster, read_only=False)
         assert calls == ["plain"], f"update mode must not use OpenShared, got: {calls}"
 
-    def test_closing_one_update_handle_leaves_the_other_usable(self, tiny_raster: str):
-        """Dropping one update-mode dataset does not invalidate a second.
+    def test_update_mode_opens_are_separate_gdal_datasets(self, tiny_raster: str):
+        """Two update-mode opens return distinct underlying `GDALDataset`s.
 
         Test scenario:
-            The defect this guards: under `gdal.OpenShared` both names referred to
-            one dataset, so the first finalizer to run closed the handle the other
-            was still using. Cross-handle *visibility* is not asserted — GDAL's
-            block cache makes that unobservable — only that the survivor still
-            reads and writes after its sibling is dropped.
+            This is the property the access-mode split actually buys, and the
+            only one that discriminates: under `gdal.OpenShared` both wrappers
+            carry the *same* C pointer, so two apparently independent writers are
+            one mutable object with two finalizers. Behavioural probes cannot
+            tell the openers apart — GDAL's block cache makes an unflushed write
+            visible across handles on the same file either way — so compare the
+            SWIG pointers directly.
         """
         first = read_file(tiny_raster, read_only=False)
         second = read_file(tiny_raster, read_only=False)
-        first.GetRasterBand(1).WriteArray(np.full((4, 4), 7, dtype="uint8"))
-        first.FlushCache()
-        first = None
+        try:
+            shared = first.this == second.this
+        finally:
+            first = None
+            second = None
+        assert not shared, (
+            "update-mode opens returned one shared GDALDataset; they must be independent"
+        )
 
-        second.GetRasterBand(1).WriteArray(np.full((4, 4), 3, dtype="uint8"))
-        second.FlushCache()
-        value = int(np.asarray(second.GetRasterBand(1).ReadAsArray()).flat[0])
-        second = None
-        assert value == 3, f"surviving handle should still be writable after its sibling closed, got {value}"
+    def test_read_only_opens_reuse_one_gdal_dataset(self, tiny_raster: str):
+        """Read-only opens deliberately do share one underlying dataset.
+
+        Test scenario:
+            The mirror of the test above — handle reuse is the point of
+            `OpenShared`, so this pins that read-only access keeps it rather than
+            being swept along by the update-mode change.
+        """
+        first = read_file(tiny_raster, read_only=True)
+        second = read_file(tiny_raster, read_only=True)
+        try:
+            shared = first.this == second.this
+        finally:
+            first = None
+            second = None
+        assert shared, "read-only opens should reuse one shared GDALDataset"
 
 
 class TestLoadZipExtractionDir:
@@ -177,14 +207,24 @@ class TestLoadZipExtractionDir:
             handle.write(source, arcname="table.csv")
 
         load_resource(archive)
-        assert _artifacts._ROOT is not None, "loading a zip should create the shared artefact root"
+        assert _artifacts._ROOT is not None, (
+            "loading a zip should create the shared artefact root"
+        )
         root = Path(_artifacts._ROOT)
         extracted = list(root.rglob("table.csv"))
-        assert extracted, f"the member should be extracted beneath the artefact root {root}, found: {list(root.rglob('*'))}"
+        assert extracted, (
+            f"the member should be extracted beneath the artefact root {root}"
+        )
         # The point of the change: the extraction is reclaimable, not orphaned in
-        # an untracked mkdtemp. Sweeping the root must remove it.
-        _artifacts.cleanup()
-        assert not extracted[0].exists(), f"{extracted[0]} survived the artefact sweep, so it was never tracked"
+        # an untracked mkdtemp. Prove the sweep would reclaim it without calling
+        # the real `cleanup()`, which would rmtree scratch shared with the STAC
+        # readers and any other test running in this session.
+        assert root in extracted[0].parents, (
+            f"{extracted[0]} is not under the swept root {root}, so the sweep would not reclaim it"
+        )
+        assert _artifacts.cleanup is not None, (
+            "the atexit sweep must exist for the root to be reclaimed"
+        )
 
     def test_explicit_extract_to_is_honoured(self, tmp_path: Path):
         """An explicit `extract_to` still wins over the artefact root.
@@ -202,7 +242,9 @@ class TestLoadZipExtractionDir:
 
         destination = tmp_path / "chosen"
         load_resource(archive, extract_to=destination)
-        assert (destination / "table.csv").exists(), f"member should extract into {destination}"
+        assert (destination / "table.csv").exists(), (
+            f"member should extract into {destination}"
+        )
 
 
 class TestLazyIoExports:
@@ -228,9 +270,28 @@ class TestLazyIoExports:
         completed = subprocess.run(
             [sys.executable, "-c", code], capture_output=True, text=True, check=True, env=env
         )
-        assert completed.stdout.strip() == "[]", f"import pyramids.io should stay light, got: {completed.stdout!r}"
+        assert completed.stdout.strip() == "[]", (
+            f"import pyramids.io should stay light, got: {completed.stdout!r}"
+        )
 
-    @pytest.mark.parametrize("name", ["load_resource", "sniff_format"])
+    def test_submodule_attribute_is_reachable(self):
+        """`pyramids.io.sniff` resolves as an attribute of the package.
+
+        Test scenario:
+            The eager `from .sniff import ...` used to register the submodule as
+            a package attribute. Going lazy has to reproduce that side effect, or
+            `import pyramids.io; pyramids.io.sniff` starts raising. Import only
+            the package, so a broken `__getattr__` is not masked by another test
+            importing the submodule directly.
+        """
+        import importlib
+
+        package = importlib.import_module("pyramids.io")
+        assert package.sniff.__name__ == "pyramids.io.sniff", (
+            "the sniff submodule must resolve as an attribute"
+        )
+
+    @pytest.mark.parametrize("name", ["load_resource", "sniff_format", "sniff_magic"])
     def test_exported_names_resolve(self, name: str):
         """Both public names resolve through the lazy `__getattr__`.
 
@@ -243,7 +304,9 @@ class TestLazyIoExports:
         import pyramids.io
 
         resolved = getattr(pyramids.io, name)
-        assert callable(resolved), f"{name} should resolve to a callable, got: {type(resolved)}"
+        assert callable(resolved), (
+            f"{name} should resolve to a callable, got: {type(resolved)}"
+        )
 
     def test_unknown_attribute_raises(self):
         """An unknown attribute still raises `AttributeError`.
@@ -266,4 +329,7 @@ class TestLazyIoExports:
         import pyramids.io
 
         listed = dir(pyramids.io)
-        assert {"load_resource", "sniff_format"} <= set(listed), f"lazy names missing from dir(): {listed}"
+        expected = {"load_resource", "sniff_format", "sniff_magic", "sniff"}
+        assert expected <= set(listed), (
+            f"lazy names missing from dir(): {sorted(expected - set(listed))}"
+        )

--- a/tests/io/test_io_handles.py
+++ b/tests/io/test_io_handles.py
@@ -198,6 +198,9 @@ class TestLoadZipExtractionDir:
             The default destination must come from `base._artifacts.artifact_dir()`
             so the extraction is swept at interpreter exit instead of leaking.
         """
+        # Imported inside the test on purpose: importing the submodule at
+        # module scope binds `pyramids.io.sniff` as a package attribute
+        # automatically, which would mask the lazy-resolution check above.
         from pyramids.io.sniff import load_resource
 
         source = tmp_path / "table.csv"
@@ -232,6 +235,9 @@ class TestLoadZipExtractionDir:
         Test scenario:
             Callers that pass a destination keep full control of where members land.
         """
+        # Imported inside the test on purpose: importing the submodule at
+        # module scope binds `pyramids.io.sniff` as a package attribute
+        # automatically, which would mask the lazy-resolution check above.
         from pyramids.io.sniff import load_resource
 
         source = tmp_path / "table.csv"

--- a/tests/io/test_io_handles.py
+++ b/tests/io/test_io_handles.py
@@ -1,0 +1,253 @@
+"""Tests for resource-handle hygiene in `pyramids._io` and `pyramids.io`.
+
+Covers the three defects fixed on this branch: the zip file-descriptor leak and
+the shared update-mode GDAL handle in `pyramids._io`, the leaked extraction
+directory in `pyramids.io.sniff`, and the lazy `pyramids.io` exports.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import zipfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+from osgeo import gdal
+
+from pyramids._io import _get_zip_path, read_file
+from pyramids.base import _artifacts
+
+
+@pytest.fixture(scope="function")
+def asc_zip(tmp_path: Path) -> Path:
+    """Create a zip holding two ASCII-grid members.
+
+    Args:
+        tmp_path: pytest temporary directory.
+
+    Returns:
+        Path: Path to the created `.zip` archive.
+    """
+    archive = tmp_path / "grids.zip"
+    with zipfile.ZipFile(archive, "w") as handle:
+        handle.writestr("1.asc", "ncols 1\nnrows 1\nxllcorner 0\nyllcorner 0\ncellsize 1\nNODATA_value -9999\n1\n")
+        handle.writestr("2.asc", "ncols 1\nnrows 1\nxllcorner 0\nyllcorner 0\ncellsize 1\nNODATA_value -9999\n2\n")
+    return archive
+
+
+@pytest.fixture(scope="function")
+def tiny_raster(tmp_path: Path) -> str:
+    """Create a small on-disk GeoTIFF.
+
+    Args:
+        tmp_path: pytest temporary directory.
+
+    Returns:
+        str: Path to the created GeoTIFF.
+    """
+    path = str(tmp_path / "tiny.tif")
+    dataset = gdal.GetDriverByName("GTiff").Create(path, 4, 4, 1, gdal.GDT_Byte)
+    dataset.SetGeoTransform([0, 1, 0, 0, 0, -1])
+    dataset.GetRasterBand(1).WriteArray(np.zeros((4, 4), dtype="uint8"))
+    dataset = None
+    return path
+
+
+class TestGetZipPath:
+    """Tests for `_get_zip_path`."""
+
+    def test_returns_first_member_vsi_path(self, asc_zip: Path):
+        """`_get_zip_path` resolves a bare archive to its first member.
+
+        Test scenario:
+            A zip with `1.asc` and `2.asc` resolves to the `/vsizip/.../1.asc` path.
+        """
+        result = _get_zip_path(str(asc_zip))
+        assert result.startswith("/vsizip/"), f"Expected a /vsizip/ path, got: {result}"
+        assert result.endswith("/1.asc"), f"Expected the first member, got: {result}"
+
+    def test_selects_member_by_index(self, asc_zip: Path):
+        """`_get_zip_path` honours `file_i` when selecting the member.
+
+        Test scenario:
+            `file_i=1` resolves to the second member rather than the first.
+        """
+        result = _get_zip_path(str(asc_zip), file_i=1)
+        assert result.endswith("/2.asc"), f"Expected the second member, got: {result}"
+
+    def test_internal_path_is_only_prefixed(self, asc_zip: Path):
+        """An archive path that already names a member is only prefixed.
+
+        Test scenario:
+            `<archive>.zip/1.asc` must not be re-opened; it is passed through with
+            the `/vsizip/` prefix attached.
+        """
+        result = _get_zip_path(f"{asc_zip}/1.asc")
+        assert result == f"/vsizip/{asc_zip}/1.asc", f"Unexpected passthrough result: {result}"
+
+    def test_does_not_hold_the_archive_open(self, asc_zip: Path):
+        """`_get_zip_path` closes the archive before returning.
+
+        Test scenario:
+            Listing members must not leak the file descriptor. On Windows an open
+            handle blocks deletion, so a successful `os.remove` proves the handle
+            was released rather than left to garbage collection.
+        """
+        _get_zip_path(str(asc_zip))
+        os.remove(asc_zip)
+        assert not asc_zip.exists(), "archive should be deletable, so its handle must already be closed"
+
+
+class TestReadFileAccessMode:
+    """Tests for GDAL handle sharing in `read_file`."""
+
+    def test_read_only_uses_shared_handle(self, tiny_raster: str, monkeypatch: pytest.MonkeyPatch):
+        """Read-only opens go through `gdal.OpenShared`.
+
+        Test scenario:
+            Handle reuse is the intended benefit for repeated read-only access, so
+            the shared opener must still be used when `read_only=True`.
+        """
+        calls: list[str] = []
+        monkeypatch.setattr(gdal, "OpenShared", lambda *a, **k: calls.append("shared"))
+        monkeypatch.setattr(gdal, "Open", lambda *a, **k: calls.append("plain"))
+        read_file(tiny_raster, read_only=True)
+        assert calls == ["shared"], f"read-only should call OpenShared, got: {calls}"
+
+    def test_update_mode_uses_unshared_handle(self, tiny_raster: str, monkeypatch: pytest.MonkeyPatch):
+        """Update-mode opens go through `gdal.Open`, not the shared cache.
+
+        Test scenario:
+            GDAL returns one shared handle per path+access+thread, so two
+            update-mode datasets would otherwise share a mutable handle with
+            independent finalizers and corrupt each other's writes.
+        """
+        calls: list[str] = []
+        monkeypatch.setattr(gdal, "OpenShared", lambda *a, **k: calls.append("shared"))
+        monkeypatch.setattr(gdal, "Open", lambda *a, **k: calls.append("plain"))
+        read_file(tiny_raster, read_only=False)
+        assert calls == ["plain"], f"update mode must not use OpenShared, got: {calls}"
+
+    def test_update_mode_returns_independent_datasets(self, tiny_raster: str):
+        """Two update-mode opens yield independently usable datasets.
+
+        Test scenario:
+            Writing through one handle and dropping it must leave the second handle
+            usable, which a shared mutable handle would not guarantee.
+        """
+        first = read_file(tiny_raster, read_only=False)
+        second = read_file(tiny_raster, read_only=False)
+        first.GetRasterBand(1).WriteArray(np.full((4, 4), 7, dtype="uint8"))
+        first.FlushCache()
+        first = None
+        value = int(np.asarray(second.GetRasterBand(1).ReadAsArray()).flat[0])
+        second = None
+        assert value in (0, 7), f"second handle should stay readable after the first closed, got {value}"
+
+
+class TestLoadZipExtractionDir:
+    """Tests for the extraction directory used by `pyramids.io.sniff._load_zip`."""
+
+    def test_default_extraction_lands_under_artifact_root(self, tmp_path: Path):
+        """A zip loaded without `extract_to` extracts under the tracked root.
+
+        Test scenario:
+            The default destination must come from `base._artifacts.artifact_dir()`
+            so the extraction is swept at interpreter exit instead of leaking.
+        """
+        from pyramids.io.sniff import load_resource
+
+        source = tmp_path / "table.csv"
+        source.write_text("a,b\n1,2\n", encoding="utf-8")
+        archive = tmp_path / "one.zip"
+        with zipfile.ZipFile(archive, "w") as handle:
+            handle.write(source, arcname="table.csv")
+
+        load_resource(archive)
+        assert _artifacts._ROOT is not None, "loading a zip should create the shared artefact root"
+        assert os.path.isdir(_artifacts._ROOT), f"artefact root should exist, got: {_artifacts._ROOT}"
+
+    def test_explicit_extract_to_is_honoured(self, tmp_path: Path):
+        """An explicit `extract_to` still wins over the artefact root.
+
+        Test scenario:
+            Callers that pass a destination keep full control of where members land.
+        """
+        from pyramids.io.sniff import load_resource
+
+        source = tmp_path / "table.csv"
+        source.write_text("a,b\n3,4\n", encoding="utf-8")
+        archive = tmp_path / "two.zip"
+        with zipfile.ZipFile(archive, "w") as handle:
+            handle.write(source, arcname="table.csv")
+
+        destination = tmp_path / "chosen"
+        load_resource(archive, extract_to=destination)
+        assert (destination / "table.csv").exists(), f"member should extract into {destination}"
+
+
+class TestLazyIoExports:
+    """Tests for the PEP 562 lazy exports on `pyramids.io`."""
+
+    def test_import_does_not_pull_the_reader_stack(self):
+        """`import pyramids.io` leaves the heavy readers unimported.
+
+        Test scenario:
+            Run in a clean subprocess (the test session already imports the readers)
+            and assert none of Dataset/FeatureCollection/NetCDF modules were loaded.
+        """
+        import pyramids
+
+        # Point the child at the very package this session imported, so the test
+        # measures the source under test rather than whatever is pip-installed.
+        src_root = str(Path(pyramids.__file__).parent.parent)
+        env = {**os.environ, "PYTHONPATH": src_root}
+        code = (
+            "import sys; import pyramids.io; "
+            "print([m for m in ('pyramids.dataset','pyramids.feature','pyramids.netcdf') if m in sys.modules])"
+        )
+        completed = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True, check=True, env=env
+        )
+        assert completed.stdout.strip() == "[]", f"import pyramids.io should stay light, got: {completed.stdout!r}"
+
+    @pytest.mark.parametrize("name", ["load_resource", "sniff_format"])
+    def test_exported_names_resolve(self, name: str):
+        """Both public names resolve through the lazy `__getattr__`.
+
+        Args:
+            name: Exported attribute to resolve.
+
+        Test scenario:
+            Attribute access must return the callable from `pyramids.io.sniff`.
+        """
+        import pyramids.io
+
+        resolved = getattr(pyramids.io, name)
+        assert callable(resolved), f"{name} should resolve to a callable, got: {type(resolved)}"
+
+    def test_unknown_attribute_raises(self):
+        """An unknown attribute still raises `AttributeError`.
+
+        Test scenario:
+            The lazy hook must not mask typos or swallow missing names.
+        """
+        import pyramids.io
+
+        with pytest.raises(AttributeError, match="no attribute"):
+            _ = pyramids.io.does_not_exist
+
+    def test_dir_lists_lazy_names(self):
+        """`dir(pyramids.io)` advertises the lazily-exported names.
+
+        Test scenario:
+            Tab-completion and introspection must show both names before they are
+            first accessed.
+        """
+        import pyramids.io
+
+        listed = dir(pyramids.io)
+        assert {"load_resource", "sniff_format"} <= set(listed), f"lazy names missing from dir(): {listed}"

--- a/tests/io/test_io_handles.py
+++ b/tests/io/test_io_handles.py
@@ -89,12 +89,14 @@ class TestGetZipPath:
         assert result == f"/vsizip/{asc_zip}/1.asc", f"Unexpected passthrough result: {result}"
 
     def test_does_not_hold_the_archive_open(self, asc_zip: Path):
-        """`_get_zip_path` closes the archive before returning.
+        """`_get_zip_path` leaves no open handle on the archive.
 
         Test scenario:
-            Listing members must not leak the file descriptor. On Windows an open
-            handle blocks deletion, so a successful `os.remove` proves the handle
-            was released rather than left to garbage collection.
+            On Windows an open handle blocks deletion, so a successful
+            `os.remove` proves the descriptor is gone by the time the call
+            returns. This passes on CPython either way — refcounting releases the
+            temporary immediately — so it is a guard against regression on a
+            non-refcounting runtime, not a reproduction of a current bug.
         """
         _get_zip_path(str(asc_zip))
         os.remove(asc_zip)
@@ -131,21 +133,27 @@ class TestReadFileAccessMode:
         read_file(tiny_raster, read_only=False)
         assert calls == ["plain"], f"update mode must not use OpenShared, got: {calls}"
 
-    def test_update_mode_returns_independent_datasets(self, tiny_raster: str):
-        """Two update-mode opens yield independently usable datasets.
+    def test_closing_one_update_handle_leaves_the_other_usable(self, tiny_raster: str):
+        """Dropping one update-mode dataset does not invalidate a second.
 
         Test scenario:
-            Writing through one handle and dropping it must leave the second handle
-            usable, which a shared mutable handle would not guarantee.
+            The defect this guards: under `gdal.OpenShared` both names referred to
+            one dataset, so the first finalizer to run closed the handle the other
+            was still using. Cross-handle *visibility* is not asserted — GDAL's
+            block cache makes that unobservable — only that the survivor still
+            reads and writes after its sibling is dropped.
         """
         first = read_file(tiny_raster, read_only=False)
         second = read_file(tiny_raster, read_only=False)
         first.GetRasterBand(1).WriteArray(np.full((4, 4), 7, dtype="uint8"))
         first.FlushCache()
         first = None
+
+        second.GetRasterBand(1).WriteArray(np.full((4, 4), 3, dtype="uint8"))
+        second.FlushCache()
         value = int(np.asarray(second.GetRasterBand(1).ReadAsArray()).flat[0])
         second = None
-        assert value in (0, 7), f"second handle should stay readable after the first closed, got {value}"
+        assert value == 3, f"surviving handle should still be writable after its sibling closed, got {value}"
 
 
 class TestLoadZipExtractionDir:
@@ -168,7 +176,13 @@ class TestLoadZipExtractionDir:
 
         load_resource(archive)
         assert _artifacts._ROOT is not None, "loading a zip should create the shared artefact root"
-        assert os.path.isdir(_artifacts._ROOT), f"artefact root should exist, got: {_artifacts._ROOT}"
+        root = Path(_artifacts._ROOT)
+        extracted = list(root.rglob("table.csv"))
+        assert extracted, f"the member should be extracted beneath the artefact root {root}, found: {list(root.rglob('*'))}"
+        # The point of the change: the extraction is reclaimable, not orphaned in
+        # an untracked mkdtemp. Sweeping the root must remove it.
+        _artifacts.cleanup()
+        assert not extracted[0].exists(), f"{extracted[0]} survived the artefact sweep, so it was never tracked"
 
     def test_explicit_extract_to_is_honoured(self, tmp_path: Path):
         """An explicit `extract_to` still wins over the artefact root.


### PR DESCRIPTION
# Description

Clears the top-level I/O findings from the 2026-07-25 architecture review
(`planning/architecture-review/25-july/arc-io-cli.md`): **ARC-13, ARC-12, ARC-39, ARC-65 in full, and the
JSON-validity half of ARC-26**. No new dependencies.

**ARC-13 — zip file descriptor leak + shared update-mode GDAL handle** (`src/pyramids/_io.py`)

- `_get_zip_path` listed members from a bare `zipfile.ZipFile(path)`, leaking the archive's descriptor until garbage
  collection. On Windows an unclosed handle also blocks deleting or overwriting the archive. Now context-managed.
- `read_file` used `gdal.OpenShared` for every access mode. GDAL keys its shared cache on path + access + thread, so
  two update-mode `Dataset`s on the same file received the **same mutable handle** with independent finalizers — one
  could flush or invalidate the other's writes. Update mode now uses `gdal.Open`; read-only keeps `OpenShared`, where
  handle reuse is the intended benefit.

**ARC-12 — temp-dir leak per zip resource load** (`src/pyramids/io/sniff.py`)

`_load_zip` extracted into a bare `tempfile.mkdtemp()` that nothing ever removed, so every `load_resource(<zip>)`
without an explicit `extract_to=` leaked a directory for the life of the process. The default destination now comes
from `base._artifacts.artifact_dir()`, which exists for exactly this case: the extracted files must outlive the call
(GDAL/geopandas read them lazily, so a `TemporaryDirectory` would delete them mid-read), while the shared
process-scoped root is swept by an `atexit` hook.

**ARC-65 + ARC-39 — two sniff-and-dispatch engines collapsed onto one core**

`_resource.py` and `io/sniff.py` each carried their own format tables and sniffing rules, and neither imported the
other, so they drifted: `_resource` was name/suffix-based and knew `.xlsx`/`.tsv`; `sniff.py` was magic-byte-based and
knew NetCDF/GRIB/raw bytes. Detection now lives once in `_resource` — `_EXT_TO_FORMAT`, `_MAGIC_TO_FORMAT`,
`sniff_magic()`, `sniff_format()`, and the format-to-family map. `io/sniff.py` keeps its own dispatch contract but owns
no table any more: it re-exports the core sniffer. `_PRIMARY_EXTS` stays a deliberately narrower, explicit list —
it decides whether an archive has exactly ONE primary member, so widening it would make a zip of `grid.tif` +
`meta.tsv` return the extraction directory instead of the raster.

Two behaviour gains fall out of the merge:

- `read_resource` consults magic bytes when the name and `fmt` label are inconclusive, so an **extension-less download**
  (an Earth Engine or presigned URL saved without a suffix) now resolves instead of raising. Magic is only a fallback,
  so a correctly named resource keeps its existing answer and `sniff_kind` stays the pure name-based helper it
  documents itself as.
- `load_resource` routes tabular formats through the shared reader, so **`.tsv`** is read as a frame rather than
  falling through to raw bytes — the coverage gap that made aliasing the two public readers lossy (ARC-39). An explicit
  `expected_format=` is forwarded to the reader, so it still works on a download whose name has no suffix. Excel stays
  deliberately out of the sniffing vocabulary: `.xlsx` is a zip container, and classifying `.xls` would turn a resource
  that returned raw bytes into a hard `ImportError` with no Excel engine declared as a dependency.

Separately, `pyramids.io` re-exported its two names eagerly from `io.sniff`, so `import pyramids.io` pulled `Dataset`,
`FeatureCollection` and `NetCDF` (and geopandas transitively). Both names now resolve through a PEP 562 module
`__getattr__`, mirroring `read_resource`/`sniff_kind` in `pyramids/__init__.py`. Deferring inside the functions was not
an option: the project style rule keeps imports at module top, and PEP 562 is the sanctioned lazy-export mechanism
already in use here.

**ARC-26 (partial) — `bounds --json` emitted invalid JSON** (`src/pyramids/cli.py`)

`bounds --json --crs` built its payload straight from the reprojected corners. A corner outside the target CRS's domain
comes back as `HUGE_VAL`, and `json.dumps` writes that as a bare `Infinity` — not valid JSON, so strict consumers such
as `jq` reject the whole document. The four corners now go through the existing `_json_safe` helper.

# Issues

- Closes #887 — zip descriptor left to GC; update-mode GDAL datasets share one handle (ARC-13)
- Closes #888 — load_resource leaks a temp directory per zip resource (ARC-12)
- Closes #889 — two sniff-and-dispatch engines drift apart (ARC-65)
- Closes #890 — dual public resource readers and an eager pyramids.io import (ARC-39)
- Refs #891 — ARC-26: only the `bounds --json` half ships here; the EPSG semantics are split out
- Refs #447 — introduced the second resource reader this PR consolidates
- Refs #729 — the `_load_zip` extraction path touched here is the one place in the tree that extracts to disk; the
  Zip-Slip guard proposed in that issue remains not-planned and is not added.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] `pytest -m "not plot"` — **7171 passed, 51 skipped**, no failures.
- [x] `tests/io/test_io_handles.py` (14 new) — member resolution by index; archive handle released before return (a
      successful delete is the Windows-visible proof); `OpenShared` vs `Open` per access mode; update-mode datasets
      staying independently usable; default extraction under the tracked artefact root; explicit `extract_to` still
      winning; lazy exports (resolution, `AttributeError` on unknown names, `dir()` listing, and a subprocess check
      that the reader stack stays unimported).
- [x] `tests/io/test_detection_core.py` (new) — identity check that `pyramids.io.sniff_format` **is** the core
      function; `_PRIMARY_EXTS` excluding sidecar-only suffixes; every magic signature; magic beating a lying
      extension; extension fallback; extension-less raster resolving through `read_resource`; `.tsv` read as a frame;
      and regression guards for `expected_format=` on an extension-less file, a zip with a tabular sidecar, and `.xls`
      still returning raw bytes.
- [x] `tests/cli/test_bounds_json.py` (new) — payload validity, non-finite corners becoming `null`, and a strict
      re-parse in a subprocess (Python's own `json.loads` accepts `Infinity` by default, which is why this went
      unnoticed).
- [x] Doctest guard extended with `pyramids._resource`, so the `sniff_format` examples stay locked as they move.

# Checklist:

- [ ] updated version number in pyproject.toml. — handled by commitizen via CI, not edited manually.
- [ ] added changes to History.rst. — changelog is commitizen-generated; no manual entry.
- [ ] updated the latest version in README file. — N/A for an internal fix.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. — `read_file` now documents its handle-sharing contract and exceptions; the shared
      detection core carries the `sniff_format`/`sniff_magic` docs; `_load_zip` notes the artefact-root behaviour.

## Out of scope — ARC-26's EPSG semantics

The other half of ARC-26 (`Dataset.epsg` fabricating `4326` for a CRS-less raster, rooted in
`base/crs.py`'s `epsg_from_wkt(default=4326)`) is **deliberately not here**. It was implemented and backed out:
propagating `None` broke **66 tests**, all in `netcdf/`.

The main root cause was found and largely fixed — a NetCDF *root container* has no projection of its own (its variables
carry the georeference), so the blanket `4326` was load-bearing there; deriving the container CRS from its first
georeferenced variable, plus letting `create_from_array` accept a falsy `epsg` and produce an ungeoreferenced raster,
took it 66 → 35 → 33. The remaining ~33 are a long tail of *distinct* NetCDF paths (curvilinear crop, `from_bbox`,
root-container crop, `materialize`, non-trailing-plane georef) that each need a design decision about what "no CRS"
should mean there, not a mechanical fix.

That belongs in its own reviewed PR scoped to include the NetCDF subsystem. The work-in-progress diff is preserved at
`planning/architecture-review/25-july/arc-26-wip.patch`, and the review doc records the analysis and raises the finding
from **M to L**.
