### PR TITLE
test(netcdf): gate external-overview assertions on GDAL >= 3.13 (win_…

### DIFF
--- a/tests/netcdf/samples/test_inherited_ops.py
+++ b/tests/netcdf/samples/test_inherited_ops.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
+from osgeo import gdal
 
 from pyramids.base._errors import ReadOnlyError
 from pyramids.netcdf import NetCDF
@@ -167,6 +168,13 @@ def test_recreate_overviews_requires_write(sample, tmp_path):
         nc.close()
 
 
+# The win_arm64 wheel ships GDAL 3.12.4 (the vcpkg port ceiling), where `create_overviews()` on a
+# read-only NetCDF variable view does not emit an external `.ovr` sidecar; GDAL >= 3.13 (every other
+# platform's wheel) does. Gate the external-sidecar assertions on that floor so the overview family is
+# still exercised everywhere and the "no sidecar leaks into tests/data" invariant is always checked.
+_EXTERNAL_NETCDF_OVERVIEWS = int(gdal.VersionInfo("VERSION_NUM")) >= 3130000
+
+
 def test_overview_ops_isolated_to_temp_copy(sample, tmp_path):
     """The overview ops run on a tmp_path copy so their external `.ovr` never touches tests/data.
 
@@ -174,7 +182,9 @@ def test_overview_ops_isolated_to_temp_copy(sample, tmp_path):
         `create_overviews` on a read-only variable view writes an external `<source>.0.ovr` next to
         the *source file*. Copy the fixture into `tmp_path` first, so the sidecar lands there (and is
         auto-cleaned); assert the overview family runs, the sidecar is written beside the copy, and no
-        new `.ovr` appears in the committed data dir.
+        new `.ovr` appears in the committed data dir. GDAL 3.12.4 (the win_arm64 wheel) does not emit
+        the external NetCDF sidecar, so those assertions are gated on `_EXTERNAL_NETCDF_OVERVIEWS`
+        while the no-leak invariant is checked on every platform.
     """
     src = sample("cf__7v__1d3-2d3-3d1__y-asc.nc")
     data_dir = Path(src).parent
@@ -185,15 +195,16 @@ def test_overview_ops_isolated_to_temp_copy(sample, tmp_path):
     try:
         view = nc.get_variable("tos")
         view.create_overviews()
-        assert (tmp_path / "tos.nc.0.ovr").exists(), (
-            "external overview should land beside the tmp copy"
-        )
-        assert view.get_overview() is not None, (
-            "get_overview should return a band after building"
-        )
-        assert view.read_overview_array() is not None, (
-            "read_overview_array should return data"
-        )
+        if _EXTERNAL_NETCDF_OVERVIEWS:
+            assert (tmp_path / "tos.nc.0.ovr").exists(), (
+                "external overview should land beside the tmp copy"
+            )
+            assert view.get_overview() is not None, (
+                "get_overview should return a band after building"
+            )
+            assert view.read_overview_array() is not None, (
+                "read_overview_array should return data"
+            )
     finally:
         nc.close()
 

--- a/tests/netcdf/samples/test_inherited_ops.py
+++ b/tests/netcdf/samples/test_inherited_ops.py
@@ -169,10 +169,11 @@ def test_recreate_overviews_requires_write(sample, tmp_path):
 
 
 # The win_arm64 wheel ships GDAL 3.12.4 (the vcpkg port ceiling), where `create_overviews()` on a
-# read-only NetCDF variable view does not emit an external `.ovr` sidecar; GDAL >= 3.13 (every other
-# platform's wheel) does. Gate the external-sidecar assertions on that floor so the overview family is
-# still exercised everywhere and the "no sidecar leaks into tests/data" invariant is always checked.
-_EXTERNAL_NETCDF_OVERVIEWS = int(gdal.VersionInfo("VERSION_NUM")) >= 3130000
+# read-only NetCDF variable view does not write the external `tos.nc.0.ovr` sidecar file; GDAL >= 3.13
+# (every other platform's wheel) does. Only the external-sidecar *file* assertion is version-gated;
+# whether the built overviews are queryable is a weaker, platform-independent capability probed via
+# `overview_count`, so win_arm64 keeps that coverage if 3.12.4 builds the overviews internally.
+_GDAL_WRITES_EXTERNAL_NETCDF_OVR = int(gdal.VersionInfo("VERSION_NUM")) >= 3130000
 
 
 def test_overview_ops_isolated_to_temp_copy(sample, tmp_path):
@@ -182,9 +183,9 @@ def test_overview_ops_isolated_to_temp_copy(sample, tmp_path):
         `create_overviews` on a read-only variable view writes an external `<source>.0.ovr` next to
         the *source file*. Copy the fixture into `tmp_path` first, so the sidecar lands there (and is
         auto-cleaned); assert the overview family runs, the sidecar is written beside the copy, and no
-        new `.ovr` appears in the committed data dir. GDAL 3.12.4 (the win_arm64 wheel) does not emit
-        the external NetCDF sidecar, so those assertions are gated on `_EXTERNAL_NETCDF_OVERVIEWS`
-        while the no-leak invariant is checked on every platform.
+        new `.ovr` appears in the committed data dir. GDAL 3.12.4 (the win_arm64 wheel) does not write
+        the external NetCDF sidecar file, so that assertion is version-gated; overview queryability is
+        probed via `overview_count`, and the no-leak invariant is checked on every platform.
     """
     src = sample("cf__7v__1d3-2d3-3d1__y-asc.nc")
     data_dir = Path(src).parent
@@ -195,10 +196,15 @@ def test_overview_ops_isolated_to_temp_copy(sample, tmp_path):
     try:
         view = nc.get_variable("tos")
         view.create_overviews()
-        if _EXTERNAL_NETCDF_OVERVIEWS:
+        # The external `.ovr` file only lands on GDAL >= 3.13; require it there so a real regression on
+        # a capable build is caught, and skip only the file check on win_arm64's 3.12.4.
+        if _GDAL_WRITES_EXTERNAL_NETCDF_OVR:
             assert (tmp_path / "tos.nc.0.ovr").exists(), (
                 "external overview should land beside the tmp copy"
             )
+        # Queryability is platform-independent: assert it wherever create_overviews actually built the
+        # overviews (probe the count, not the GDAL version), so win_arm64 keeps this coverage too.
+        if view.overview_count[0] > 0:
             assert view.get_overview() is not None, (
                 "get_overview should return a band after building"
             )

--- a/tests/netcdf/samples/test_inherited_ops.py
+++ b/tests/netcdf/samples/test_inherited_ops.py
@@ -184,8 +184,9 @@ def test_overview_ops_isolated_to_temp_copy(sample, tmp_path):
         the *source file*. Copy the fixture into `tmp_path` first, so the sidecar lands there (and is
         auto-cleaned); assert the overview family runs, the sidecar is written beside the copy, and no
         new `.ovr` appears in the committed data dir. GDAL 3.12.4 (the win_arm64 wheel) does not write
-        the external NetCDF sidecar file, so that assertion is version-gated; overview queryability is
-        probed via `overview_count`, and the no-leak invariant is checked on every platform.
+        the external NetCDF sidecar file, so that assertion is version-gated; the get/read assertions
+        run wherever overviews were built (probed via `overview_count`, which holds on 3.12.4 too, per
+        `test_recreate_overviews_requires_write`), and the no-leak invariant is checked on every platform.
     """
     src = sample("cf__7v__1d3-2d3-3d1__y-asc.nc")
     data_dir = Path(src).parent
@@ -196,15 +197,20 @@ def test_overview_ops_isolated_to_temp_copy(sample, tmp_path):
     try:
         view = nc.get_variable("tos")
         view.create_overviews()
-        # The external `.ovr` file only lands on GDAL >= 3.13; require it there so a real regression on
-        # a capable build is caught, and skip only the file check on win_arm64's 3.12.4.
+        # The external `.ovr` file only lands on GDAL >= 3.13; win_arm64's 3.12.4 builds the overviews
+        # without that sidecar file. This assertion is intentionally version-gated, NOT capability-gated
+        # (`overview_count > 0`), so a total no-op regression on a capable build -- nothing built and no
+        # file -- is still caught here rather than silently skipped (do not collapse it onto the probe
+        # below).
         if _GDAL_WRITES_EXTERNAL_NETCDF_OVR:
             assert (tmp_path / "tos.nc.0.ovr").exists(), (
                 "external overview should land beside the tmp copy"
             )
-        # Queryability is platform-independent: assert it wherever create_overviews actually built the
-        # overviews (probe the count, not the GDAL version), so win_arm64 keeps this coverage too.
-        if view.overview_count[0] > 0:
+        # Queryability is platform-independent, and 3.12.4 does build queryable overviews on win_arm64
+        # (`test_recreate_overviews_requires_write` passes there, which requires `overview_count > 0`),
+        # so these run on every platform. Probe every band -- matching `read_overview_array(band=None)`'s
+        # all-bands precondition and guarding a hypothetical zero-band view.
+        if view.overview_count and all(c > 0 for c in view.overview_count):
             assert view.get_overview() is not None, (
                 "get_overview should return a band after building"
             )


### PR DESCRIPTION
…arm64)

test_overview_ops_isolated_to_temp_copy asserted an external .ovr sidecar is written beside a NetCDF copy after create_overviews(). The win_arm64 wheel ships GDAL 3.12.4 (the vcpkg port ceiling), which does not emit the external NetCDF sidecar, so the test failed only in the Bundle PyPI Wheels verify-winarm64 job. Gate the sidecar/get/read assertions on int(gdal.VersionInfo("VERSION_NUM")) >= 3130000 (mirroring test_windowed_read_705), keeping create_overviews() and the no-leak-into-tests/data invariant exercised on every platform.

# Description

- Please include a summary of the change and which issue is fixed.
- Please also include relevant motivation and context.
- List any dependencies that are required for this change.


# Issues
- Fixes # (issue)

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Please describe the tests that you ran to verify your changes.
- Provide instructions so we can reproduce.
- Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
