### PR TITLE
fix(dataset): report every recreate_overviews outcome

### DIFF
--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -16,22 +16,22 @@ is needed.
 abs(n) timesteps for a positive n too (previously a positive n
 skipped the first n); the default tail(-n) is unchanged and
 tail(0) returns an empty array.
-- COG_READ_DEFAULTS no longer sets                                                              
-  CPL_VSIL_CURL_ALLOWED_EXTENSIONS. The option made GDAL refuse any URL                                          
-  whose path does not end in .tif or .tiff, which excluded extensionless                                         
-  object keys, presigned S3 links carrying a query string, and most STAC                                         
-  asset hrefs.                                                                                                   
-  BREAKING CHANGE: slope, aspect and hillshade emit the band's sentinel                                          
-  at no-data cells and their immediate neighbours, outside the documented                                        
-  [0, 360) and [0, 255] ranges, because a centred difference straddling a                                        
-  void has no defined derivative. Mask on the no-data value before                                               
-  feeding the result to a colour ramp or a fixed-range cast.                                                     
-  BREAKING CHANGE: focal_apply hands the caller's callable a NaN-blanked                                         
-  window, so a NaN-blind reducer now blanks every window touching a void.                                        
-  Use the np.nan* reducers.                                                                                      
-                                                                                                                 
-  Closes #841, #842, #843, #844, #845, #846, #847                                                                
-  Closes #848, #849, #850, #851, #852, #853, #855                                                                
+- COG_READ_DEFAULTS no longer sets  
+  CPL_VSIL_CURL_ALLOWED_EXTENSIONS. The option made GDAL refuse any URL  
+  whose path does not end in .tif or .tiff, which excluded extensionless  
+  object keys, presigned S3 links carrying a query string, and most STAC  
+  asset hrefs.  
+  BREAKING CHANGE: slope, aspect and hillshade emit the band's sentinel  
+  at no-data cells and their immediate neighbours, outside the documented  
+  [0, 360) and [0, 255] ranges, because a centred difference straddling a  
+  void has no defined derivative. Mask on the no-data value before  
+  feeding the result to a colour ramp or a fixed-range cast.  
+  BREAKING CHANGE: focal_apply hands the caller's callable a NaN-blanked  
+  window, so a NaN-blind reducer now blanks every window touching a void.  
+  Use the np.nan* reducers.  
+
+  Closes #841, #842, #843, #844, #845, #846, #847  
+  Closes #848, #849, #850, #851, #852, #853, #855  
   Closes #856, #857, #858, #859, #860, #861, #862
 
 ### Feat

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -1512,7 +1512,8 @@ class RasterBase(ABC):
         Warns:
             UserWarning:
                 No band has overviews, so there is nothing to regenerate; or only some
-                bands have them, and the empty ones were skipped.
+                bands have them, and the empty ones were skipped. Also when the dataset
+                has no bands at all.
         """
         pass
 

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -1502,8 +1502,12 @@ class RasterBase(ABC):
                 resampling_method should be one of {"NEAREST", "CUBIC", "AVERAGE", "GAUSS", "CUBICSPLINE", "LANCZOS",
                 "MODE", "AVERAGE_MAGPHASE", "RMS", "BILINEAR"}.
             ReadOnlyError:
-                If the overviews are internal and the Dataset is opened with a read only.
-                Please read the dataset using read_only=False
+                If the overviews the call targets are opened read-only, so GDAL refuses to rewrite them —
+                internal overviews inside a read-only dataset, or an external .ovr that a later handle
+                reopened read-only. Please read the dataset using read_only=False
+            RuntimeError:
+                Propagated unchanged when GDAL fails the regeneration for any other reason, so a
+                disk-full, corrupt-overview or transport failure is not relabelled as an access-mode error.
 
         Warns:
             UserWarning:

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -1486,6 +1486,10 @@ class RasterBase(ABC):
     def recreate_overviews(self, resampling_method: str = "nearest"):
         """Recreate overviews for the dataset.
 
+        Regenerates the existing overviews in place; it never builds new ones — call
+        `create_overviews` for that. A band with no overviews has nothing to regenerate,
+        so it is reported through a warning rather than skipped silently.
+
         Args:
             resampling_method (str, optional):
                 The resampling method used to create the overviews, by default "nearest".
@@ -1500,6 +1504,11 @@ class RasterBase(ABC):
             ReadOnlyError:
                 If the overviews are internal and the Dataset is opened with a read only.
                 Please read the dataset using read_only=False
+
+        Warns:
+            UserWarning:
+                No band has overviews, so there is nothing to regenerate; or only some
+                bands have them, and the empty ones were skipped.
         """
         pass
 

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -1506,8 +1506,10 @@ class RasterBase(ABC):
                 internal overviews inside a read-only dataset, or an external .ovr that a later handle
                 reopened read-only. Please read the dataset using read_only=False
             RuntimeError:
-                Propagated unchanged when GDAL fails the regeneration for any other reason, so a
-                disk-full, corrupt-overview or transport failure is not relabelled as an access-mode error.
+                Any other GDAL regeneration failure, so a disk-full, corrupt-overview or transport failure
+                is not relabelled as an access-mode error. GDAL's own error is re-raised carrying a note
+                that names the band and level it stopped on; a failing status that raised nothing is turned
+                into one.
 
         Warns:
             UserWarning:

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -3017,15 +3017,14 @@ class IO(_Engine["Dataset"]):
         """Recreate overviews for the dataset.
 
         Regenerates the *existing* overviews in place; it never builds new ones — call
-        `create_overviews` for that. When the dataset has no overviews at all there is
-        nothing to regenerate, so this warns instead of returning silently; a read-only
-        on-disk dataset raises `ReadOnlyError` first, since regenerating could never
-        have succeeded there.
+        `create_overviews` for that. When the dataset has no overviews there is nothing
+        to regenerate, so this warns instead of returning silently.
 
-        External `.ovr` overviews can still be regenerated while the *main* dataset is
-        open read-only — the sidecar is a separate writable file — so read-only access
-        is not rejected up front. Internal overviews live inside the raster itself, so
-        GDAL refuses to rewrite them on a read-only handle, which surfaces here as
+        The warning is emitted in every access mode: having no overviews is independent
+        of read-only-ness, and read-only is not itself a blocker here — external `.ovr`
+        overviews live in a separate writable sidecar and regenerate fine through a
+        read-only handle. Internal overviews live inside the raster itself, so GDAL
+        refuses to rewrite them on a read-only handle, which surfaces as
         `ReadOnlyError`.
 
         Args:
@@ -3033,17 +3032,16 @@ class IO(_Engine["Dataset"]):
                 "NEAREST", "CUBIC", "AVERAGE", "GAUSS", "CUBICSPLINE", "LANCZOS", "MODE",
                 "AVERAGE_MAGPHASE", "RMS", "BILINEAR". Defaults to "nearest".
 
-        Warns:
-            UserWarning:
-                The dataset has no overviews, so there is nothing to regenerate.
-
         Raises:
             ValueError:
                 If resampling_method is not one of the allowed values above.
             ReadOnlyError:
-                If the dataset is a read-only on-disk file with no overviews to
-                regenerate, or if its overviews are internal and cannot be rewritten on
-                a read-only handle. Read with read_only=False.
+                If the overviews are internal and the dataset is opened read-only, so
+                GDAL cannot rewrite them. Read with read_only=False.
+
+        Warns:
+            UserWarning:
+                The dataset has no overviews, so there is nothing to regenerate.
 
         See Also:
             - Dataset.create_overviews: Create the dataset overviews.
@@ -3057,10 +3055,11 @@ class IO(_Engine["Dataset"]):
         overview_count = self.overview_count
         if not any(overview_count):
             # Nothing to regenerate: the loop below would iterate zero times and return
-            # silently, so the caller never learns the call did nothing (#863). A
-            # read-only on-disk dataset could not have been regenerated either way, so
-            # report that stronger, documented failure first.
-            self._ds._require_writable("recreate overviews")
+            # silently, so the caller never learns the call did nothing (#863). Warn in
+            # every access mode -- "has no overviews" is independent of read-only-ness,
+            # and refusing on read-only would misdiagnose the cause (reopening writable
+            # yields this same warning) and would wrongly reject a read-only handle
+            # whose external .ovr sidecar is perfectly regenerable.
             warnings.warn(
                 "The dataset has no overviews to regenerate; call create_overviews() "
                 "first to build them.",

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -18,6 +18,7 @@ import warnings
 from collections.abc import Callable, Generator, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from types import FrameType
 from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
@@ -99,7 +100,7 @@ def _caller_stacklevel() -> int:
         int: The stacklevel to pass to `warnings.warn` from the calling function.
     """
     level = 1
-    frame = sys._getframe(1)
+    frame: FrameType | None = sys._getframe(1)
     while frame is not None and frame.f_code.co_filename.startswith(_PACKAGE_ROOT):
         level += 1
         frame = frame.f_back

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -11,6 +11,7 @@ import logging
 import math
 import pickle  # nosec B403 - PicklingError only, no load
 import shutil
+import sys
 import tempfile
 import threading
 import warnings
@@ -78,6 +79,31 @@ def _snap_index(value: float, tol: float = _GRID_SNAP_TOL) -> float:
     """Snap a fractional pixel index to the nearest integer when within `tol`, else return it as-is."""
     nearest = round(value)
     return float(nearest) if abs(value - nearest) <= tol else value
+
+
+_PACKAGE_ROOT = str(Path(__file__).resolve().parents[2])
+
+
+def _caller_stacklevel() -> int:
+    """Return the `warnings.warn` stacklevel that blames the first frame outside pyramids.
+
+    An engine method is reachable both directly (`ds.io.method()`) and through the
+    `Dataset` facade (`ds.method()`), which differ by one frame, so a hard-coded
+    `stacklevel` is right for one and wrong for the other — pointing at `dataset.py`,
+    or overshooting into the caller's caller and, at module level, falling back to
+    `<sys>:0` with no file or line. Walking out of the package instead is correct for
+    every entry point, and unlike `warnings.warn(skip_file_prefixes=...)` it does not
+    require Python 3.12.
+
+    Returns:
+        int: The stacklevel to pass to `warnings.warn` from the calling function.
+    """
+    level = 1
+    frame = sys._getframe(1)
+    while frame is not None and frame.f_code.co_filename.startswith(_PACKAGE_ROOT):
+        level += 1
+        frame = frame.f_back
+    return level
 
 
 _THREAD_MANAGER_CREATION_LOCK = threading.Lock()
@@ -3070,49 +3096,104 @@ class IO(_Engine["Dataset"]):
         # (reopening writable yields this same warning) and would wrongly reject a
         # read-only handle whose external .ovr sidecar is perfectly regenerable.
         bands_without = [i for i, count in enumerate(overview_count) if count == 0]
+        stacklevel = _caller_stacklevel()
         if not overview_count:
             warnings.warn(
                 "The dataset has no bands, so there are no overviews to regenerate.",
                 UserWarning,
-                stacklevel=3,
+                stacklevel=stacklevel,
             )
-            return
-        if len(bands_without) == len(overview_count):
+        elif len(bands_without) == len(overview_count):
             warnings.warn(
                 "The dataset has no overviews to regenerate; call create_overviews() "
                 "first to build them.",
                 UserWarning,
-                stacklevel=3,
+                stacklevel=stacklevel,
             )
-            return
-        if bands_without:
-            warnings.warn(
-                f"Bands {bands_without} have no overviews to regenerate and were "
-                "skipped; call create_overviews() first to build them.",
-                UserWarning,
-                stacklevel=3,
+        else:
+            if bands_without:
+                skipped = ", ".join(str(index) for index in bands_without)
+                warnings.warn(
+                    f"Bands {skipped} (0-based) have no overviews to regenerate and "
+                    "were skipped; call create_overviews() first to build them.",
+                    UserWarning,
+                    stacklevel=stacklevel,
+                )
+            self._regenerate_overviews(overview_count, resampling_method)
+
+    def _regenerate_overviews(
+        self, overview_count: list[int], resampling_method: str
+    ) -> None:
+        """Regenerate every existing overview level in place, band by band.
+
+        Split out of :meth:`recreate_overviews` so the empty-count reporting reads as one
+        decision. Each call is bracketed by `gdal.ErrorReset()` so the CPL error number
+        inspected on failure belongs to *this* regeneration and not to something earlier
+        in the process.
+
+        Args:
+            overview_count: Per-band overview counts, snapshotted by the caller.
+            resampling_method: One of `RESAMPLING_METHODS`, already validated.
+
+        Raises:
+            ReadOnlyError: GDAL refused the write because the overview target is
+                read-only (`CPLE_NoWriteAccess`).
+            RuntimeError: Any other GDAL failure, re-raised unchanged with a note naming
+                the band and level it stopped on.
+        """
+        for i in range(self._ds.band_count):
+            band = self._ds._iloc(i)
+            for j in range(overview_count[i]):
+                ovr = self.get_overview(i, j)
+                gdal.ErrorReset()
+                try:
+                    status = gdal.RegenerateOverview(band, ovr, resampling_method)
+                except RuntimeError as err:
+                    err.add_note(
+                        f"Failed regenerating overview {j} of band {i} (0-based); "
+                        "earlier bands may already have been rewritten."
+                    )
+                    if self._is_write_refusal(err):
+                        raise ReadOnlyError(
+                            f"Cannot regenerate overview {j} of band {i}: the overviews "
+                            "are opened read-only. Please read the dataset using "
+                            "read_only=False to recreate overviews."
+                        ) from err
+                    raise
+                # gdal.UseExceptions() is process-global, so a caller that turned it off
+                # (or a driver that fails without pushing a CPL error) would otherwise
+                # slip through as the silent no-op this method exists to remove.
+                if status != gdal.CE_None:
+                    detail = gdal.GetLastErrorMsg() or f"GDAL returned {status}"
+                    raise RuntimeError(
+                        f"Failed regenerating overview {j} of band {i} (0-based): "
+                        f"{detail}"
+                    )
+
+    @staticmethod
+    def _is_write_refusal(err: RuntimeError) -> bool:
+        """Return True if a GDAL regeneration failure is a read-only refusal.
+
+        Classifies on the CPL error number (`CPLE_NoWriteAccess`) rather than the
+        message: GDAL prefixes messages with the dataset path, so a bare "read-only"
+        substring test relabels an unrelated failure on a raster living under, say,
+        `/mnt/read-only-archive/` as an access-mode error. The exact GDAL phrasings are
+        kept only as a fallback for drivers that raise without setting the number —
+        those phrases cannot occur incidentally in a path the way the bare token can.
+        """
+        if gdal.GetLastErrorNo() == gdal.CPLE_NoWriteAccess:
+            refusal = True
+        else:
+            message = str(err).lower()
+            refusal = any(
+                phrase in message
+                for phrase in (
+                    "read-only mode",
+                    "read only dataset",
+                    "read-only dataset",
+                )
             )
-        # Regenerate each existing overview level in place, honouring resampling_method.
-        try:
-            for i in range(self._ds.band_count):
-                band = self._ds._iloc(i)
-                for j in range(overview_count[i]):
-                    ovr = self.get_overview(i, j)
-                    gdal.RegenerateOverview(band, ovr, resampling_method)
-        except RuntimeError as err:
-            # Only a read-only target becomes ReadOnlyError; a disk-full, corrupt
-            # overview, unsupported resampling or network failure is a different
-            # problem and must not be relabelled as an access-mode error. GDAL words
-            # the former "...opened in read-only mode".
-            if (
-                "read-only" not in str(err).lower()
-                and "read only" not in str(err).lower()
-            ):
-                raise
-            raise ReadOnlyError(
-                "The Dataset is opened read-only. Please read the dataset using "
-                "read_only=False to recreate overviews."
-            ) from err
+        return refusal
 
     def get_overview(self, band: int = 0, overview_index: int = 0) -> gdal.Band:
         """Get an overview of a band.
@@ -3176,7 +3257,7 @@ class IO(_Engine["Dataset"]):
               ```
         See Also:
             - Dataset.create_overviews: Create the dataset overviews if they exist.
-            - Dataset.create_overviews: Recreate the dataset overviews if they exist.
+            - Dataset.recreate_overviews: Regenerate the dataset overviews if they exist.
             - Dataset.overview_count: Number of overviews.
             - Dataset.read_overview_array: Read overview values.
             - Dataset.plot: Plot a band.
@@ -3254,7 +3335,7 @@ class IO(_Engine["Dataset"]):
               ```
         See Also:
             - Dataset.create_overviews: Create the dataset overviews.
-            - Dataset.create_overviews: Recreate the dataset overviews if they exist.
+            - Dataset.recreate_overviews: Regenerate the dataset overviews if they exist.
             - Dataset.get_overview: Get an overview of a band.
             - Dataset.overview_count: Number of overviews.
             - Dataset.plot: Plot a band.

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -3053,9 +3053,10 @@ class IO(_Engine["Dataset"]):
         reopening the dataset writable yields this same warning. Read-only is not a
         blocker in itself either: external `.ovr` overviews live in a sidecar that
         `create_overviews` leaves open for update, so they regenerate through the very
-        read-only handle that built them. GDAL refuses only when the overview target is
-        itself read-only — internal overviews inside a read-only raster, or an external
-        `.ovr` that a later handle reopened read-only — which surfaces as `ReadOnlyError`.
+        read-only handle that built them. GDAL refuses on access grounds only when the
+        overview target is itself read-only — internal overviews inside a read-only
+        raster, or an external `.ovr` that a later handle reopened read-only — which
+        surfaces as `ReadOnlyError`.
 
         Args:
             resampling_method (str): Resampling method used to recreate overviews. Possible values are
@@ -3069,9 +3070,10 @@ class IO(_Engine["Dataset"]):
                 If GDAL refuses the rewrite because the overviews it targets are opened
                 read-only. Read with read_only=False.
             RuntimeError:
-                Propagated unchanged when GDAL fails the regeneration for any other
-                reason, so a disk-full, corrupt-overview or transport failure is not
-                relabelled as an access-mode error.
+                Any other GDAL regeneration failure, so a disk-full, corrupt-overview or
+                transport failure is not relabelled as an access-mode error. GDAL's own
+                error is re-raised carrying a note that names the band and level it
+                stopped on; a failing status that raised nothing is turned into one.
 
         Warns:
             UserWarning:
@@ -3128,9 +3130,10 @@ class IO(_Engine["Dataset"]):
         """Regenerate every existing overview level in place, band by band.
 
         Split out of :meth:`recreate_overviews` so the empty-count reporting reads as one
-        decision. Each call is bracketed by `gdal.ErrorReset()` so the CPL error number
+        decision. Each call is preceded by `gdal.ErrorReset()` so the CPL error number
         inspected on failure belongs to *this* regeneration and not to something earlier
-        in the process.
+        in the process. Overviews are rewritten in place, so a failure part-way through
+        leaves the earlier bands already regenerated.
 
         Args:
             overview_count: Per-band overview counts, snapshotted by the caller.
@@ -3138,9 +3141,12 @@ class IO(_Engine["Dataset"]):
 
         Raises:
             ReadOnlyError: GDAL refused the write because the overview target is
-                read-only (`CPLE_NoWriteAccess`).
-            RuntimeError: Any other GDAL failure, re-raised unchanged with a note naming
-                the band and level it stopped on.
+                read-only, as classified by :meth:`_is_write_refusal`. The original
+                error stays chained as `__cause__`.
+            RuntimeError: Any other GDAL failure — the error GDAL raised, re-raised with
+                a note naming the band and level it stopped on, or a fresh one carrying
+                `gdal.GetLastErrorMsg()` when `RegenerateOverview` reports a non-`CE_None`
+                status without raising (exceptions turned off process-wide).
         """
         for i in range(self._ds.band_count):
             band = self._ds._iloc(i)
@@ -3181,6 +3187,15 @@ class IO(_Engine["Dataset"]):
         `/mnt/read-only-archive/` as an access-mode error. The exact GDAL phrasings are
         kept only as a fallback for drivers that raise without setting the number —
         those phrases cannot occur incidentally in a path the way the bare token can.
+
+        Args:
+            err: The error GDAL raised. Only its message is read, and only on the
+                fallback path; the primary signal is GDAL's process-global last-error
+                number, which the caller keeps meaningful by resetting it before each
+                regeneration.
+
+        Returns:
+            bool: True when the failure is GDAL refusing to write the overview target.
         """
         if gdal.GetLastErrorNo() == gdal.CPLE_NoWriteAccess:
             refusal = True

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -3067,21 +3067,24 @@ class IO(_Engine["Dataset"]):
         if not overview_count:
             warnings.warn(
                 "The dataset has no bands, so there are no overviews to regenerate.",
-                stacklevel=2,
+                UserWarning,
+                stacklevel=3,
             )
             return
         if len(bands_without) == len(overview_count):
             warnings.warn(
                 "The dataset has no overviews to regenerate; call create_overviews() "
                 "first to build them.",
-                stacklevel=2,
+                UserWarning,
+                stacklevel=3,
             )
             return
         if bands_without:
             warnings.warn(
                 f"Bands {bands_without} have no overviews to regenerate and were "
                 "skipped; call create_overviews() first to build them.",
-                stacklevel=2,
+                UserWarning,
+                stacklevel=3,
             )
         # Regenerate each existing overview level in place, honouring resampling_method.
         try:

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -3017,8 +3017,9 @@ class IO(_Engine["Dataset"]):
         """Recreate overviews for the dataset.
 
         Regenerates the *existing* overviews in place; it never builds new ones — call
-        `create_overviews` for that. When the dataset has no overviews there is nothing
-        to regenerate, so this warns instead of returning silently.
+        `create_overviews` for that. When a band has no overviews there is nothing to
+        regenerate for it, so this warns instead of returning silently — naming the
+        skipped bands when only some of them are empty, and still regenerating the rest.
 
         The warning is emitted in every access mode: having no overviews is independent
         of read-only-ness, and read-only is not itself a blocker here — external `.ovr`
@@ -3041,7 +3042,9 @@ class IO(_Engine["Dataset"]):
 
         Warns:
             UserWarning:
-                The dataset has no overviews, so there is nothing to regenerate.
+                No band has overviews, so there is nothing to regenerate; or only some
+                bands have them, and the empty ones were skipped. Also when the dataset
+                has no bands at all.
 
         See Also:
             - Dataset.create_overviews: Create the dataset overviews.
@@ -3053,19 +3056,33 @@ class IO(_Engine["Dataset"]):
         if resampling_method.upper() not in RESAMPLING_METHODS:
             raise ValueError(f"resampling_method should be one of {RESAMPLING_METHODS}")
         overview_count = self.overview_count
-        if not any(overview_count):
-            # Nothing to regenerate: the loop below would iterate zero times and return
-            # silently, so the caller never learns the call did nothing (#863). Warn in
-            # every access mode -- "has no overviews" is independent of read-only-ness,
-            # and refusing on read-only would misdiagnose the cause (reopening writable
-            # yields this same warning) and would wrongly reject a read-only handle
-            # whose external .ovr sidecar is perfectly regenerable.
+        # Report every band the loop below would skip. `range(0)` regenerates nothing
+        # and says nothing, so without this a band with no overviews is left silently
+        # stale -- the #863 defect, which survives per band whenever the counts are
+        # mixed. Warn in every access mode: "has no overviews" is independent of
+        # read-only-ness, and refusing on read-only would misdiagnose the cause
+        # (reopening writable yields this same warning) and would wrongly reject a
+        # read-only handle whose external .ovr sidecar is perfectly regenerable.
+        bands_without = [i for i, count in enumerate(overview_count) if count == 0]
+        if not overview_count:
+            warnings.warn(
+                "The dataset has no bands, so there are no overviews to regenerate.",
+                stacklevel=2,
+            )
+            return
+        if len(bands_without) == len(overview_count):
             warnings.warn(
                 "The dataset has no overviews to regenerate; call create_overviews() "
                 "first to build them.",
                 stacklevel=2,
             )
             return
+        if bands_without:
+            warnings.warn(
+                f"Bands {bands_without} have no overviews to regenerate and were "
+                "skipped; call create_overviews() first to build them.",
+                stacklevel=2,
+            )
         # Build overviews using nearest neighbor resampling
         # nearest is the resampling method used. Other methods include AVERAGE, GAUSS, etc.
         try:

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -3083,18 +3083,27 @@ class IO(_Engine["Dataset"]):
                 "skipped; call create_overviews() first to build them.",
                 stacklevel=2,
             )
-        # Build overviews using nearest neighbor resampling
-        # nearest is the resampling method used. Other methods include AVERAGE, GAUSS, etc.
+        # Regenerate each existing overview level in place, honouring resampling_method.
         try:
             for i in range(self._ds.band_count):
                 band = self._ds._iloc(i)
                 for j in range(overview_count[i]):
                     ovr = self.get_overview(i, j)
                     gdal.RegenerateOverview(band, ovr, resampling_method)
-        except RuntimeError:
+        except RuntimeError as err:
+            # Only a read-only target becomes ReadOnlyError; a disk-full, corrupt
+            # overview, unsupported resampling or network failure is a different
+            # problem and must not be relabelled as an access-mode error. GDAL words
+            # the former "...opened in read-only mode".
+            if (
+                "read-only" not in str(err).lower()
+                and "read only" not in str(err).lower()
+            ):
+                raise
             raise ReadOnlyError(
-                "The Dataset is opened with a read only. Please read the dataset using read_only=False"
-            )
+                "The Dataset is opened read-only. Please read the dataset using "
+                "read_only=False to recreate overviews."
+            ) from err
 
     def get_overview(self, band: int = 0, overview_index: int = 0) -> gdal.Band:
         """Get an overview of a band.

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -3021,12 +3021,14 @@ class IO(_Engine["Dataset"]):
         regenerate for it, so this warns instead of returning silently — naming the
         skipped bands when only some of them are empty, and still regenerating the rest.
 
-        The warning is emitted in every access mode: having no overviews is independent
-        of read-only-ness, and read-only is not itself a blocker here — external `.ovr`
-        overviews live in a separate writable sidecar and regenerate fine through a
-        read-only handle. Internal overviews live inside the raster itself, so GDAL
-        refuses to rewrite them on a read-only handle, which surfaces as
-        `ReadOnlyError`.
+        The warning is emitted in every access mode: "has no overviews" is independent of
+        read-only-ness, so reporting it as a read-only failure would misdiagnose it —
+        reopening the dataset writable yields this same warning. Read-only is not a
+        blocker in itself either: external `.ovr` overviews live in a sidecar that
+        `create_overviews` leaves open for update, so they regenerate through the very
+        read-only handle that built them. GDAL refuses only when the overview target is
+        itself read-only — internal overviews inside a read-only raster, or an external
+        `.ovr` that a later handle reopened read-only — which surfaces as `ReadOnlyError`.
 
         Args:
             resampling_method (str): Resampling method used to recreate overviews. Possible values are
@@ -3037,8 +3039,12 @@ class IO(_Engine["Dataset"]):
             ValueError:
                 If resampling_method is not one of the allowed values above.
             ReadOnlyError:
-                If the overviews are internal and the dataset is opened read-only, so
-                GDAL cannot rewrite them. Read with read_only=False.
+                If GDAL refuses the rewrite because the overviews it targets are opened
+                read-only. Read with read_only=False.
+            RuntimeError:
+                Propagated unchanged when GDAL fails the regeneration for any other
+                reason, so a disk-full, corrupt-overview or transport failure is not
+                relabelled as an access-mode error.
 
         Warns:
             UserWarning:

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -3015,17 +3015,38 @@ class IO(_Engine["Dataset"]):
 
     def recreate_overviews(self, resampling_method: str = "nearest") -> None:
         """Recreate overviews for the dataset.
+
+        Regenerates the *existing* overviews in place; it never builds new ones — call
+        `create_overviews` for that. When the dataset has no overviews at all there is
+        nothing to regenerate, so this warns instead of returning silently; a read-only
+        on-disk dataset raises `ReadOnlyError` first, since regenerating could never
+        have succeeded there.
+
+        External `.ovr` overviews can still be regenerated while the *main* dataset is
+        open read-only — the sidecar is a separate writable file — so read-only access
+        is not rejected up front. Internal overviews live inside the raster itself, so
+        GDAL refuses to rewrite them on a read-only handle, which surfaces here as
+        `ReadOnlyError`.
+
         Args:
             resampling_method (str): Resampling method used to recreate overviews. Possible values are
                 "NEAREST", "CUBIC", "AVERAGE", "GAUSS", "CUBICSPLINE", "LANCZOS", "MODE",
                 "AVERAGE_MAGPHASE", "RMS", "BILINEAR". Defaults to "nearest".
+
+        Warns:
+            UserWarning:
+                The dataset has no overviews, so there is nothing to regenerate.
+
         Raises:
             ValueError:
                 If resampling_method is not one of the allowed values above.
             ReadOnlyError:
-                If overviews are internal and the dataset is opened read-only. Read with read_only=False.
+                If the dataset is a read-only on-disk file with no overviews to
+                regenerate, or if its overviews are internal and cannot be rewritten on
+                a read-only handle. Read with read_only=False.
+
         See Also:
-            - Dataset.create_overviews: Recreate the dataset overviews if they exist.
+            - Dataset.create_overviews: Create the dataset overviews.
             - Dataset.get_overview: Get an overview of a band.
             - Dataset.overview_count: Number of overviews.
             - Dataset.read_overview_array: Read overview values.
@@ -3033,12 +3054,25 @@ class IO(_Engine["Dataset"]):
         """
         if resampling_method.upper() not in RESAMPLING_METHODS:
             raise ValueError(f"resampling_method should be one of {RESAMPLING_METHODS}")
+        overview_count = self.overview_count
+        if not any(overview_count):
+            # Nothing to regenerate: the loop below would iterate zero times and return
+            # silently, so the caller never learns the call did nothing (#863). A
+            # read-only on-disk dataset could not have been regenerated either way, so
+            # report that stronger, documented failure first.
+            self._ds._require_writable("recreate overviews")
+            warnings.warn(
+                "The dataset has no overviews to regenerate; call create_overviews() "
+                "first to build them.",
+                stacklevel=2,
+            )
+            return
         # Build overviews using nearest neighbor resampling
         # nearest is the resampling method used. Other methods include AVERAGE, GAUSS, etc.
         try:
             for i in range(self._ds.band_count):
                 band = self._ds._iloc(i)
-                for j in range(self.overview_count[i]):
+                for j in range(overview_count[i]):
                     ovr = self.get_overview(i, j)
                     gdal.RegenerateOverview(band, ovr, resampling_method)
         except RuntimeError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -330,20 +330,23 @@ def era5_image(era5_raster_path: str) -> gdal.Dataset:
     return gdal.Open(era5_raster_path)
 
 
-@pytest.fixture(scope="function")
-def era5_image_internal_overviews_read_only_false() -> Dataset:
-    return gdal.OpenShared(
-        "tests/data/geotiff/era5_land_monthly_averaged-internal-overviews.tif",
-        gdal.GA_Update,
-    )
+@pytest.fixture(scope="session")
+def era5_internal_overviews_path() -> str:
+    return "tests/data/geotiff/era5_land_monthly_averaged-internal-overviews.tif"
 
 
 @pytest.fixture(scope="function")
-def era5_image_internal_overviews_read_only_true() -> Dataset:
-    return gdal.OpenShared(
-        "tests/data/geotiff/era5_land_monthly_averaged-internal-overviews.tif",
-        gdal.GA_ReadOnly,
-    )
+def era5_image_internal_overviews_read_only_false(
+    era5_internal_overviews_path: str,
+) -> Dataset:
+    return gdal.OpenShared(era5_internal_overviews_path, gdal.GA_Update)
+
+
+@pytest.fixture(scope="function")
+def era5_image_internal_overviews_read_only_true(
+    era5_internal_overviews_path: str,
+) -> Dataset:
+    return gdal.OpenShared(era5_internal_overviews_path, gdal.GA_ReadOnly)
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -332,20 +332,21 @@ def era5_image(era5_raster_path: str) -> gdal.Dataset:
 
 @pytest.fixture(scope="session")
 def era5_internal_overviews_path() -> str:
+    """Repo-root-relative path to the ERA5 raster that carries internal overviews."""
     return "tests/data/geotiff/era5_land_monthly_averaged-internal-overviews.tif"
 
 
 @pytest.fixture(scope="function")
 def era5_image_internal_overviews_read_only_false(
     era5_internal_overviews_path: str,
-) -> Dataset:
+) -> gdal.Dataset:
     return gdal.OpenShared(era5_internal_overviews_path, gdal.GA_Update)
 
 
 @pytest.fixture(scope="function")
 def era5_image_internal_overviews_read_only_true(
     era5_internal_overviews_path: str,
-) -> Dataset:
+) -> gdal.Dataset:
     return gdal.OpenShared(era5_internal_overviews_path, gdal.GA_ReadOnly)
 
 

--- a/tests/dataset/spatial/test_overviews.py
+++ b/tests/dataset/spatial/test_overviews.py
@@ -1,14 +1,21 @@
 """Tests for the Dataset class overview methods."""
 
+import shutil
 from pathlib import Path
 
 import numpy as np
 import pytest
 from osgeo import gdal
 
+from pyramids.base._errors import ReadOnlyError
 from pyramids.dataset import Dataset
 
 pytestmark = pytest.mark.core
+
+NO_OVERVIEWS_RASTER = "tests/data/geotiff/era5_land_monthly_averaged.tif"
+INTERNAL_OVERVIEWS_RASTER = (
+    "tests/data/geotiff/era5_land_monthly_averaged-internal-overviews.tif"
+)
 
 
 def test_create_overviews(era5_image: gdal.Dataset, clean_overview_after_test):
@@ -51,6 +58,81 @@ class TestReCreateOverviews:
         dataset = Dataset(era5_image)
         dataset.create_overviews(overview_levels=[2])
         dataset.recreate_overviews(resampling_method="average")
+
+
+class TestRecreateOverviewsContract:
+    """`recreate_overviews` signals explicitly instead of silently doing nothing (#863).
+
+    The regeneration loop iterates `overview_count` times, so a dataset with no
+    overviews used to return having rebuilt nothing and raised nothing — and the
+    read-only guard only fired incidentally, when GDAL happened to refuse a rewrite.
+    """
+
+    def test_no_overviews_on_writable_dataset_warns(self, tmp_path):
+        """A writable dataset with no overviews warns rather than silently no-oping.
+
+        Test scenario:
+            Copy a raster that has no overviews, open it writable and call
+            ``recreate_overviews`` — expected: a `UserWarning` pointing at
+            ``create_overviews`` instead of a silent return.
+        """
+        work = shutil.copy(NO_OVERVIEWS_RASTER, tmp_path / "no_ovr.tif")
+        dataset = Dataset.read_file(str(work), read_only=False)
+        try:
+            assert not any(dataset.overview_count), "fixture must start with none"
+            with pytest.warns(UserWarning, match="no overviews to regenerate"):
+                dataset.recreate_overviews()
+        finally:
+            dataset.close()
+
+    def test_no_overviews_on_read_only_dataset_raises(self, tmp_path):
+        """A read-only on-disk dataset with no overviews raises ReadOnlyError.
+
+        Test scenario:
+            The pre-fix silent path — read-only *and* nothing to regenerate, so GDAL
+            never threw. Expected: `ReadOnlyError`, because the regeneration could not
+            have succeeded on a read-only file either way.
+        """
+        work = shutil.copy(NO_OVERVIEWS_RASTER, tmp_path / "ro_no_ovr.tif")
+        dataset = Dataset.read_file(str(work), read_only=True)
+        try:
+            with pytest.raises(ReadOnlyError, match="read-only"):
+                dataset.recreate_overviews()
+        finally:
+            dataset.close()
+
+    def test_internal_overviews_on_read_only_dataset_raises(self, tmp_path):
+        """Internal overviews cannot be rewritten through a read-only handle.
+
+        Test scenario:
+            A raster carrying internal overviews opened read-only — expected:
+            `ReadOnlyError` (the pre-existing guarantee, preserved by the fix).
+        """
+        work = shutil.copy(INTERNAL_OVERVIEWS_RASTER, tmp_path / "ro_internal.tif")
+        dataset = Dataset.read_file(str(work), read_only=True)
+        try:
+            assert any(dataset.overview_count), "fixture must carry internal overviews"
+            with pytest.raises(ReadOnlyError):
+                dataset.recreate_overviews()
+        finally:
+            dataset.close()
+
+    def test_in_memory_dataset_without_overviews_warns(self):
+        """An in-memory dataset warns rather than raising, despite read_only access.
+
+        Test scenario:
+            `create_from_array` with no path reports ``access == "read_only"`` yet is a
+            writable in-RAM handle — expected: the no-overviews warning, not
+            `ReadOnlyError`, so the edit-in-memory workflow is not blocked.
+        """
+        dataset = Dataset.create_from_array(
+            np.ones((16, 16), dtype=np.float32),
+            top_left_corner=(0.0, 16.0),
+            cell_size=1.0,
+            epsg=4326,
+        )
+        with pytest.warns(UserWarning, match="no overviews to regenerate"):
+            dataset.recreate_overviews()
 
 
 class TestReadOverviewArray:

--- a/tests/dataset/spatial/test_overviews.py
+++ b/tests/dataset/spatial/test_overviews.py
@@ -88,9 +88,9 @@ class TestRecreateOverviewsContract:
         Test scenario:
             The pre-fix silent path — read-only *and* nothing to regenerate, so GDAL
             never threw. Expected: the same "nothing to regenerate" warning as the
-            writable case, not a `ReadOnlyError`; read-only is not the blocker (an
-            external `.ovr` regenerates fine read-only) and reopening writable would
-            only produce this warning anyway.
+            writable case, not a `ReadOnlyError` — the blocker is the empty count, not
+            the access mode, and reopening writable would only produce this warning
+            anyway.
         """
         work = shutil.copy(era5_raster_path, tmp_path / "ro_no_ovr.tif")
         dataset = Dataset.read_file(str(work), read_only=True)
@@ -114,6 +114,77 @@ class TestRecreateOverviewsContract:
         try:
             assert any(dataset.overview_count), "fixture must carry internal overviews"
             with pytest.raises(ReadOnlyError, match="opened read-only"):
+                dataset.recreate_overviews()
+        finally:
+            dataset.close()
+
+    @pytest.mark.parametrize(
+        "gdal_message, expected_error, expected_text",
+        [
+            ("Failed to write overview block: disk full", RuntimeError, "disk full"),
+            (
+                "Attempt to write to a read only dataset",
+                ReadOnlyError,
+                "read_only=False",
+            ),
+        ],
+        ids=["unrelated-failure-propagates", "read-only-wording-is-translated"],
+    )
+    def test_gdal_failures_are_classified_by_message(
+        self,
+        era5_raster_path,
+        tmp_path,
+        monkeypatch,
+        gdal_message,
+        expected_error,
+        expected_text,
+    ):
+        """Only a read-only complaint becomes `ReadOnlyError`; other failures propagate.
+
+        Test scenario:
+            `gdal.RegenerateOverview` is patched to raise a `RuntimeError` while a
+            writable dataset that does have overviews is regenerated. Expected: a
+            disk-full failure surfaces unchanged as `RuntimeError` (the pre-fix code
+            relabelled *every* `RuntimeError` as `ReadOnlyError`, misdiagnosing it),
+            while GDAL's spaced "read only" wording is still translated — the hyphenated
+            wording is exercised for real in
+            ``test_internal_overviews_on_read_only_dataset_raises``.
+        """
+        work = shutil.copy(era5_raster_path, tmp_path / "gdal_failure.tif")
+        dataset = Dataset.read_file(str(work), read_only=False)
+        try:
+            dataset.create_overviews(overview_levels=[2])
+
+            def raise_runtime_error(*args, **kwargs):
+                raise RuntimeError(gdal_message)
+
+            monkeypatch.setattr(gdal, "RegenerateOverview", raise_runtime_error)
+            with pytest.raises(expected_error) as excinfo:
+                dataset.recreate_overviews()
+            assert type(excinfo.value) is expected_error, (
+                f"expected exactly {expected_error.__name__}, got {type(excinfo.value).__name__}"
+            )
+            assert expected_text in str(excinfo.value), (
+                f"expected {expected_text!r} in the message, got: {excinfo.value}"
+            )
+        finally:
+            dataset.close()
+
+    def test_dataset_without_bands_warns_about_the_bands(self):
+        """A band-less dataset is told it has no bands, not to call `create_overviews`.
+
+        Test scenario:
+            A zero-band in-memory raster, so `overview_count == []` — expected: the
+            "no bands" warning. `bands_without` is empty too, so the all-bands-empty
+            branch would also match; the band-less check has to come first or the
+            warning would point at `create_overviews`, which cannot help here.
+        """
+        dataset = Dataset(gdal.GetDriverByName("MEM").Create("", 4, 4, 0))
+        try:
+            assert dataset.overview_count == [], (
+                f"fixture must have no bands, got {dataset.overview_count}"
+            )
+            with pytest.warns(UserWarning, match="no bands"):
                 dataset.recreate_overviews()
         finally:
             dataset.close()
@@ -169,12 +240,12 @@ class TestRecreateOverviewsContract:
             dataset.close()
 
     def test_in_memory_dataset_without_overviews_warns(self):
-        """An in-memory dataset warns rather than raising, despite read_only access.
+        """An in-memory dataset gets the same no-overviews warning as an on-disk one.
 
         Test scenario:
-            `create_from_array` with no path reports ``access == "read_only"`` yet is a
-            writable in-RAM handle — expected: the no-overviews warning, not
-            `ReadOnlyError`, so the edit-in-memory workflow is not blocked.
+            A `create_from_array` raster with no path (MEM driver, `access == "write"`)
+            — expected: the no-overviews warning, so the edit-in-memory workflow reports
+            the empty count the same way and is never blocked by an access-mode error.
         """
         dataset = Dataset.create_from_array(
             np.ones((16, 16), dtype=np.float32),

--- a/tests/dataset/spatial/test_overviews.py
+++ b/tests/dataset/spatial/test_overviews.py
@@ -115,7 +115,7 @@ class TestRecreateOverviewsContract:
         dataset = Dataset.read_file(str(work), read_only=True)
         try:
             assert any(dataset.overview_count), "fixture must carry internal overviews"
-            with pytest.raises(ReadOnlyError):
+            with pytest.raises(ReadOnlyError, match="opened read-only"):
                 dataset.recreate_overviews()
         finally:
             dataset.close()

--- a/tests/dataset/spatial/test_overviews.py
+++ b/tests/dataset/spatial/test_overviews.py
@@ -15,6 +15,42 @@ from pyramids.dataset import Dataset
 pytestmark = pytest.mark.core
 
 
+def _mixed_overview_vrt(tmp_path) -> str:
+    """Build a 2-band VRT reporting ``overview_count == [1, 0]``.
+
+    Band 1 sources a raster carrying an external `.ovr` and declares it through a
+    per-band `<Overview>`; band 2 sources a raster without one. Both bands must point at
+    *different* files — sharing one source makes GDAL expose its overviews on both bands
+    and the counts come back `[1, 1]`.
+    """
+    driver = gdal.GetDriverByName("GTiff")
+    sources = []
+    for name in ("with_ovr.tif", "without_ovr.tif"):
+        path = str(tmp_path / name)
+        raster = driver.Create(path, 8, 8, 1, gdal.GDT_Float32)
+        raster.GetRasterBand(1).WriteArray(np.arange(64, dtype="float32").reshape(8, 8))
+        raster = None
+        sources.append(path)
+    with_ovr, without_ovr = sources
+    handle = gdal.Open(with_ovr)
+    handle.BuildOverviews("NEAREST", [2])
+    handle = None
+
+    vrt = tmp_path / "mixed.vrt"
+    vrt.write_text(
+        f'<VRTDataset rasterXSize="8" rasterYSize="8">'
+        f'<VRTRasterBand dataType="Float32" band="1">'
+        f'<SimpleSource><SourceFilename relativeToVRT="0">{with_ovr}</SourceFilename>'
+        f"<SourceBand>1</SourceBand></SimpleSource>"
+        f'<Overview><SourceFilename relativeToVRT="0">{with_ovr}.ovr</SourceFilename>'
+        f"<SourceBand>1</SourceBand></Overview></VRTRasterBand>"
+        f'<VRTRasterBand dataType="Float32" band="2">'
+        f'<SimpleSource><SourceFilename relativeToVRT="0">{without_ovr}</SourceFilename>'
+        f"<SourceBand>1</SourceBand></SimpleSource></VRTRasterBand></VRTDataset>"
+    )
+    return str(vrt)
+
+
 def test_create_overviews(era5_image: gdal.Dataset, clean_overview_after_test):
     dataset = Dataset(era5_image)
     dataset.create_overviews()
@@ -77,7 +113,7 @@ class TestRecreateOverviewsContract:
         dataset = Dataset.read_file(str(work), read_only=False)
         try:
             assert not any(dataset.overview_count), "fixture must start with none"
-            with pytest.warns(UserWarning, match="no overviews to regenerate"):
+            with pytest.warns(UserWarning, match=r"call create_overviews\(\) first"):
                 dataset.recreate_overviews()
         finally:
             dataset.close()
@@ -95,7 +131,7 @@ class TestRecreateOverviewsContract:
         work = shutil.copy(era5_raster_path, tmp_path / "ro_no_ovr.tif")
         dataset = Dataset.read_file(str(work), read_only=True)
         try:
-            with pytest.warns(UserWarning, match="no overviews to regenerate"):
+            with pytest.warns(UserWarning, match=r"call create_overviews\(\) first"):
                 dataset.recreate_overviews()
         finally:
             dataset.close()
@@ -127,8 +163,17 @@ class TestRecreateOverviewsContract:
                 ReadOnlyError,
                 "read_only=False",
             ),
+            (
+                "/mnt/read-only-archive/dem.tif, band 1: No space left on device",
+                RuntimeError,
+                "No space left on device",
+            ),
         ],
-        ids=["unrelated-failure-propagates", "read-only-wording-is-translated"],
+        ids=[
+            "unrelated-failure-propagates",
+            "read-only-wording-is-translated",
+            "read-only-in-the-path-is-not-a-refusal",
+        ],
     )
     def test_gdal_failures_are_classified_by_message(
         self,
@@ -139,15 +184,17 @@ class TestRecreateOverviewsContract:
         expected_error,
         expected_text,
     ):
-        """Only a read-only complaint becomes `ReadOnlyError`; other failures propagate.
+        """Only a genuine write refusal becomes `ReadOnlyError`; other failures propagate.
 
         Test scenario:
             `gdal.RegenerateOverview` is patched to raise a `RuntimeError` while a
-            writable dataset that does have overviews is regenerated. Expected: a
-            disk-full failure surfaces unchanged as `RuntimeError` (the pre-fix code
-            relabelled *every* `RuntimeError` as `ReadOnlyError`, misdiagnosing it),
-            while GDAL's spaced "read only" wording is still translated — the hyphenated
-            wording is exercised for real in
+            writable dataset that does have overviews is regenerated, so no CPL error
+            number is set and the phrase fallback decides. Expected: a disk-full failure
+            surfaces unchanged as `RuntimeError` (the pre-fix code relabelled *every*
+            `RuntimeError`); GDAL's spaced "read only dataset" wording is translated; and
+            a failure whose *path* merely contains "read-only" stays a `RuntimeError`,
+            since GDAL prefixes messages with the dataset path and a bare substring test
+            would misdiagnose it. The real `CPLE_NoWriteAccess` route is exercised in
             ``test_internal_overviews_on_read_only_dataset_raises``.
         """
         work = shutil.copy(era5_raster_path, tmp_path / "gdal_failure.tif")
@@ -166,6 +213,38 @@ class TestRecreateOverviewsContract:
             )
             assert expected_text in str(excinfo.value), (
                 f"expected {expected_text!r} in the message, got: {excinfo.value}"
+            )
+            if expected_error is ReadOnlyError:
+                assert isinstance(excinfo.value.__cause__, RuntimeError), (
+                    "the original GDAL error must stay chained as __cause__"
+                )
+        finally:
+            dataset.close()
+
+    def test_mixed_counts_still_regenerate_the_populated_bands(
+        self, tmp_path, monkeypatch
+    ):
+        """After warning about the empty bands, the populated ones are regenerated.
+
+        Test scenario:
+            Record every `gdal.RegenerateOverview` call on the mixed `[1, 0]` VRT —
+            expected: exactly one call, for band 0's single level, proving the mixed
+            path warns *and* carries on rather than returning early. The recorder also
+            keeps the call off the VRT's read-only `.ovr`, which is why the sibling
+            warning test has to suppress that failure.
+        """
+        dataset = Dataset.read_file(_mixed_overview_vrt(tmp_path), read_only=True)
+        try:
+            calls = []
+            monkeypatch.setattr(
+                gdal,
+                "RegenerateOverview",
+                lambda band, ovr, method: calls.append(method) or gdal.CE_None,
+            )
+            with pytest.warns(UserWarning, match=r"call create_overviews\(\) first"):
+                dataset.recreate_overviews(resampling_method="average")
+            assert calls == ["average"], (
+                f"only band 0's single overview should regenerate, got {calls}"
             )
         finally:
             dataset.close()
@@ -201,39 +280,14 @@ class TestRecreateOverviewsContract:
             read-only; that is beside the point here, so it is suppressed — the warning
             is emitted before the loop either way.
         """
-        driver = gdal.GetDriverByName("GTiff")
-        sources = []
-        for name in ("with_ovr.tif", "without_ovr.tif"):
-            path = str(tmp_path / name)
-            raster = driver.Create(path, 8, 8, 1, gdal.GDT_Float32)
-            raster.GetRasterBand(1).WriteArray(
-                np.arange(64, dtype="float32").reshape(8, 8)
-            )
-            raster = None
-            sources.append(path)
-        with_ovr, without_ovr = sources
-        handle = gdal.Open(with_ovr)
-        handle.BuildOverviews("NEAREST", [2])
-        handle = None
-
-        vrt = tmp_path / "mixed.vrt"
-        vrt.write_text(
-            f'<VRTDataset rasterXSize="8" rasterYSize="8">'
-            f'<VRTRasterBand dataType="Float32" band="1">'
-            f'<SimpleSource><SourceFilename relativeToVRT="0">{with_ovr}</SourceFilename>'
-            f"<SourceBand>1</SourceBand></SimpleSource>"
-            f'<Overview><SourceFilename relativeToVRT="0">{with_ovr}.ovr</SourceFilename>'
-            f"<SourceBand>1</SourceBand></Overview></VRTRasterBand>"
-            f'<VRTRasterBand dataType="Float32" band="2">'
-            f'<SimpleSource><SourceFilename relativeToVRT="0">{without_ovr}</SourceFilename>'
-            f"<SourceBand>1</SourceBand></SimpleSource></VRTRasterBand></VRTDataset>"
-        )
-        dataset = Dataset.read_file(str(vrt), read_only=True)
+        dataset = Dataset.read_file(_mixed_overview_vrt(tmp_path), read_only=True)
         try:
             assert dataset.overview_count == [1, 0], (
                 f"fixture must produce mixed counts, got {dataset.overview_count}"
             )
-            with pytest.warns(UserWarning, match=r"Bands \[1\] have no overviews"):
+            with pytest.warns(
+                UserWarning, match=r"Bands 1 \(0-based\) have no overviews"
+            ):
                 with contextlib.suppress(ReadOnlyError):
                     dataset.recreate_overviews()
         finally:
@@ -254,7 +308,7 @@ class TestRecreateOverviewsContract:
             epsg=4326,
         )
         try:
-            with pytest.warns(UserWarning, match="no overviews to regenerate"):
+            with pytest.warns(UserWarning, match=r"call create_overviews\(\) first"):
                 dataset.recreate_overviews()
         finally:
             dataset.close()

--- a/tests/dataset/spatial/test_overviews.py
+++ b/tests/dataset/spatial/test_overviews.py
@@ -85,18 +85,20 @@ class TestRecreateOverviewsContract:
         finally:
             dataset.close()
 
-    def test_no_overviews_on_read_only_dataset_raises(self, tmp_path):
-        """A read-only on-disk dataset with no overviews raises ReadOnlyError.
+    def test_no_overviews_on_read_only_dataset_warns(self, tmp_path):
+        """A read-only dataset with no overviews warns about the real cause.
 
         Test scenario:
             The pre-fix silent path — read-only *and* nothing to regenerate, so GDAL
-            never threw. Expected: `ReadOnlyError`, because the regeneration could not
-            have succeeded on a read-only file either way.
+            never threw. Expected: the same "nothing to regenerate" warning as the
+            writable case, not a `ReadOnlyError`; read-only is not the blocker (an
+            external `.ovr` regenerates fine read-only) and reopening writable would
+            only produce this warning anyway.
         """
         work = shutil.copy(NO_OVERVIEWS_RASTER, tmp_path / "ro_no_ovr.tif")
         dataset = Dataset.read_file(str(work), read_only=True)
         try:
-            with pytest.raises(ReadOnlyError, match="read-only"):
+            with pytest.warns(UserWarning, match="no overviews to regenerate"):
                 dataset.recreate_overviews()
         finally:
             dataset.close()

--- a/tests/dataset/spatial/test_overviews.py
+++ b/tests/dataset/spatial/test_overviews.py
@@ -1,5 +1,6 @@
 """Tests for the Dataset class overview methods."""
 
+import contextlib
 import shutil
 from pathlib import Path
 
@@ -127,6 +128,9 @@ class TestRecreateOverviewsContract:
             band 2 sources one without — `overview_count == [1, 0]`. Expected: a warning
             naming band 1 (0-based) as skipped, since `range(0)` would otherwise
             regenerate nothing and report nothing, leaving that band silently stale.
+            Regenerating band 0 then fails because the VRT opens its `.ovr` source
+            read-only; that is beside the point here, so it is suppressed — the warning
+            is emitted before the loop either way.
         """
         driver = gdal.GetDriverByName("GTiff")
         sources = []
@@ -161,7 +165,8 @@ class TestRecreateOverviewsContract:
                 f"fixture must produce mixed counts, got {dataset.overview_count}"
             )
             with pytest.warns(UserWarning, match=r"Bands \[1\] have no overviews"):
-                dataset.recreate_overviews()
+                with contextlib.suppress(ReadOnlyError):
+                    dataset.recreate_overviews()
         finally:
             dataset.close()
 

--- a/tests/dataset/spatial/test_overviews.py
+++ b/tests/dataset/spatial/test_overviews.py
@@ -221,6 +221,69 @@ class TestRecreateOverviewsContract:
         finally:
             dataset.close()
 
+    def test_failing_status_without_an_exception_raises(
+        self, era5_raster_path, tmp_path, monkeypatch
+    ):
+        """A non-`CE_None` return is caught even when GDAL is not raising exceptions.
+
+        Test scenario:
+            `gdal.UseExceptions()` is process-global, so a caller that turned it off
+            leaves `RegenerateOverview` *returning* `CE_Failure` instead of raising.
+            Patch it to do exactly that on a writable dataset that does have overviews
+            — expected: a `RuntimeError` naming the band and level, since the
+            try/except alone would let this through as the silent no-op the method
+            exists to remove.
+        """
+        work = shutil.copy(era5_raster_path, tmp_path / "status_failure.tif")
+        dataset = Dataset.read_file(str(work), read_only=False)
+        try:
+            dataset.create_overviews(overview_levels=[2])
+            monkeypatch.setattr(
+                gdal, "RegenerateOverview", lambda *args, **kwargs: gdal.CE_Failure
+            )
+            with pytest.raises(RuntimeError) as excinfo:
+                dataset.recreate_overviews()
+            assert type(excinfo.value) is RuntimeError, (
+                f"a failing status must not be relabelled, got {type(excinfo.value).__name__}"
+            )
+            assert "overview 0 of band 0" in str(excinfo.value), (
+                f"the error must name the band and level, got: {excinfo.value}"
+            )
+        finally:
+            dataset.close()
+
+    def test_propagated_failure_is_noted_with_the_band_and_level(
+        self, era5_raster_path, tmp_path, monkeypatch
+    ):
+        """A propagated GDAL failure carries a note saying where regeneration stopped.
+
+        Test scenario:
+            An unrelated `RuntimeError` is raised from `gdal.RegenerateOverview` and
+            re-raised unchanged — expected: `__notes__` names the band and level and
+            says earlier bands may already have been rewritten, because the loop
+            rewrites in place and leaves the dataset half-regenerated.
+        """
+        work = shutil.copy(era5_raster_path, tmp_path / "noted_failure.tif")
+        dataset = Dataset.read_file(str(work), read_only=False)
+        try:
+            dataset.create_overviews(overview_levels=[2])
+
+            def raise_runtime_error(*args, **kwargs):
+                raise RuntimeError("Failed to write overview block: disk full")
+
+            monkeypatch.setattr(gdal, "RegenerateOverview", raise_runtime_error)
+            with pytest.raises(RuntimeError) as excinfo:
+                dataset.recreate_overviews()
+            notes = getattr(excinfo.value, "__notes__", [])
+            assert any("overview 0 of band 0" in note for note in notes), (
+                f"the note must name the band and level, got {notes}"
+            )
+            assert any("already have been rewritten" in note for note in notes), (
+                f"the note must flag the partial rewrite, got {notes}"
+            )
+        finally:
+            dataset.close()
+
     def test_mixed_counts_still_regenerate_the_populated_bands(
         self, tmp_path, monkeypatch
     ):
@@ -329,6 +392,29 @@ class TestRecreateOverviewsContract:
         try:
             with pytest.warns(UserWarning) as recorded:
                 dataset.recreate_overviews()
+            assert Path(recorded[0].filename).name == Path(__file__).name, (
+                f"warning blamed {recorded[0].filename}, expected this test file"
+            )
+        finally:
+            dataset.close()
+
+    def test_warning_points_at_the_caller_from_the_engine_entry_point(
+        self, era5_raster_path, tmp_path
+    ):
+        """Calling the engine directly is blamed on the caller too, one frame shallower.
+
+        Test scenario:
+            `ds.io.recreate_overviews()` reaches the warning through one frame fewer
+            than the `Dataset` facade, so a `stacklevel` hard-coded for the facade
+            overshoots into pytest's own frame or, at module level, `<sys>:0` —
+            expected: the recorded warning still names this test file, proving the
+            frame walk adapts to both entry points.
+        """
+        work = shutil.copy(era5_raster_path, tmp_path / "blame_engine.tif")
+        dataset = Dataset.read_file(str(work), read_only=False)
+        try:
+            with pytest.warns(UserWarning) as recorded:
+                dataset.io.recreate_overviews()
             assert Path(recorded[0].filename).name == Path(__file__).name, (
                 f"warning blamed {recorded[0].filename}, expected this test file"
             )

--- a/tests/dataset/spatial/test_overviews.py
+++ b/tests/dataset/spatial/test_overviews.py
@@ -14,11 +14,6 @@ from pyramids.dataset import Dataset
 
 pytestmark = pytest.mark.core
 
-NO_OVERVIEWS_RASTER = "tests/data/geotiff/era5_land_monthly_averaged.tif"
-INTERNAL_OVERVIEWS_RASTER = (
-    "tests/data/geotiff/era5_land_monthly_averaged-internal-overviews.tif"
-)
-
 
 def test_create_overviews(era5_image: gdal.Dataset, clean_overview_after_test):
     dataset = Dataset(era5_image)
@@ -70,7 +65,7 @@ class TestRecreateOverviewsContract:
     read-only guard only fired incidentally, when GDAL happened to refuse a rewrite.
     """
 
-    def test_no_overviews_on_writable_dataset_warns(self, tmp_path):
+    def test_no_overviews_on_writable_dataset_warns(self, era5_raster_path, tmp_path):
         """A writable dataset with no overviews warns rather than silently no-oping.
 
         Test scenario:
@@ -78,7 +73,7 @@ class TestRecreateOverviewsContract:
             ``recreate_overviews`` — expected: a `UserWarning` pointing at
             ``create_overviews`` instead of a silent return.
         """
-        work = shutil.copy(NO_OVERVIEWS_RASTER, tmp_path / "no_ovr.tif")
+        work = shutil.copy(era5_raster_path, tmp_path / "no_ovr.tif")
         dataset = Dataset.read_file(str(work), read_only=False)
         try:
             assert not any(dataset.overview_count), "fixture must start with none"
@@ -87,7 +82,7 @@ class TestRecreateOverviewsContract:
         finally:
             dataset.close()
 
-    def test_no_overviews_on_read_only_dataset_warns(self, tmp_path):
+    def test_no_overviews_on_read_only_dataset_warns(self, era5_raster_path, tmp_path):
         """A read-only dataset with no overviews warns about the real cause.
 
         Test scenario:
@@ -97,7 +92,7 @@ class TestRecreateOverviewsContract:
             external `.ovr` regenerates fine read-only) and reopening writable would
             only produce this warning anyway.
         """
-        work = shutil.copy(NO_OVERVIEWS_RASTER, tmp_path / "ro_no_ovr.tif")
+        work = shutil.copy(era5_raster_path, tmp_path / "ro_no_ovr.tif")
         dataset = Dataset.read_file(str(work), read_only=True)
         try:
             with pytest.warns(UserWarning, match="no overviews to regenerate"):
@@ -105,14 +100,16 @@ class TestRecreateOverviewsContract:
         finally:
             dataset.close()
 
-    def test_internal_overviews_on_read_only_dataset_raises(self, tmp_path):
+    def test_internal_overviews_on_read_only_dataset_raises(
+        self, era5_internal_overviews_path, tmp_path
+    ):
         """Internal overviews cannot be rewritten through a read-only handle.
 
         Test scenario:
             A raster carrying internal overviews opened read-only — expected:
             `ReadOnlyError` (the pre-existing guarantee, preserved by the fix).
         """
-        work = shutil.copy(INTERNAL_OVERVIEWS_RASTER, tmp_path / "ro_internal.tif")
+        work = shutil.copy(era5_internal_overviews_path, tmp_path / "ro_internal.tif")
         dataset = Dataset.read_file(str(work), read_only=True)
         try:
             assert any(dataset.overview_count), "fixture must carry internal overviews"
@@ -191,7 +188,9 @@ class TestRecreateOverviewsContract:
         finally:
             dataset.close()
 
-    def test_warning_points_at_the_caller_not_the_facade(self, tmp_path):
+    def test_warning_points_at_the_caller_not_the_facade(
+        self, era5_raster_path, tmp_path
+    ):
         """The warning is attributed to the calling line, not `Dataset.recreate_overviews`.
 
         Test scenario:
@@ -200,7 +199,7 @@ class TestRecreateOverviewsContract:
             test file. At `stacklevel=2` it named `dataset.py`, which also collapsed
             every call site in a user loop onto one dedupe key.
         """
-        work = shutil.copy(NO_OVERVIEWS_RASTER, tmp_path / "blame.tif")
+        work = shutil.copy(era5_raster_path, tmp_path / "blame.tif")
         dataset = Dataset.read_file(str(work), read_only=False)
         try:
             with pytest.warns(UserWarning) as recorded:
@@ -211,14 +210,16 @@ class TestRecreateOverviewsContract:
         finally:
             dataset.close()
 
-    def test_existing_overviews_regenerate_without_warning(self, tmp_path):
+    def test_existing_overviews_regenerate_without_warning(
+        self, era5_raster_path, tmp_path
+    ):
         """The happy path stays silent — no warning when every band has overviews.
 
         Test scenario:
             Build overviews on a writable copy, then regenerate them — expected: no
             `UserWarning`, so a future refactor cannot start warning on every call.
         """
-        work = shutil.copy(NO_OVERVIEWS_RASTER, tmp_path / "happy.tif")
+        work = shutil.copy(era5_raster_path, tmp_path / "happy.tif")
         dataset = Dataset.read_file(str(work), read_only=False)
         try:
             dataset.create_overviews(overview_levels=[2])

--- a/tests/dataset/spatial/test_overviews.py
+++ b/tests/dataset/spatial/test_overviews.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import shutil
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -184,8 +185,52 @@ class TestRecreateOverviewsContract:
             cell_size=1.0,
             epsg=4326,
         )
-        with pytest.warns(UserWarning, match="no overviews to regenerate"):
-            dataset.recreate_overviews()
+        try:
+            with pytest.warns(UserWarning, match="no overviews to regenerate"):
+                dataset.recreate_overviews()
+        finally:
+            dataset.close()
+
+    def test_warning_points_at_the_caller_not_the_facade(self, tmp_path):
+        """The warning is attributed to the calling line, not `Dataset.recreate_overviews`.
+
+        Test scenario:
+            `Dataset.recreate_overviews` is a facade over the engine, so the warning
+            needs `stacklevel=3` to skip it — expected: the recorded warning names this
+            test file. At `stacklevel=2` it named `dataset.py`, which also collapsed
+            every call site in a user loop onto one dedupe key.
+        """
+        work = shutil.copy(NO_OVERVIEWS_RASTER, tmp_path / "blame.tif")
+        dataset = Dataset.read_file(str(work), read_only=False)
+        try:
+            with pytest.warns(UserWarning) as recorded:
+                dataset.recreate_overviews()
+            assert Path(recorded[0].filename).name == Path(__file__).name, (
+                f"warning blamed {recorded[0].filename}, expected this test file"
+            )
+        finally:
+            dataset.close()
+
+    def test_existing_overviews_regenerate_without_warning(self, tmp_path):
+        """The happy path stays silent — no warning when every band has overviews.
+
+        Test scenario:
+            Build overviews on a writable copy, then regenerate them — expected: no
+            `UserWarning`, so a future refactor cannot start warning on every call.
+        """
+        work = shutil.copy(NO_OVERVIEWS_RASTER, tmp_path / "happy.tif")
+        dataset = Dataset.read_file(str(work), read_only=False)
+        try:
+            dataset.create_overviews(overview_levels=[2])
+            with warnings.catch_warnings(record=True) as recorded:
+                warnings.simplefilter("always")
+                dataset.recreate_overviews()
+            user_warnings = [w for w in recorded if issubclass(w.category, UserWarning)]
+            assert not user_warnings, (
+                f"happy path should not warn, got {[str(w.message) for w in user_warnings]}"
+            )
+        finally:
+            dataset.close()
 
 
 class TestReadOverviewArray:

--- a/tests/dataset/spatial/test_overviews.py
+++ b/tests/dataset/spatial/test_overviews.py
@@ -119,6 +119,52 @@ class TestRecreateOverviewsContract:
         finally:
             dataset.close()
 
+    def test_mixed_band_counts_warn_naming_the_skipped_bands(self, tmp_path):
+        """Bands without overviews are named instead of being silently skipped.
+
+        Test scenario:
+            A VRT whose band 1 sources a raster carrying an external `.ovr` and whose
+            band 2 sources one without — `overview_count == [1, 0]`. Expected: a warning
+            naming band 1 (0-based) as skipped, since `range(0)` would otherwise
+            regenerate nothing and report nothing, leaving that band silently stale.
+        """
+        driver = gdal.GetDriverByName("GTiff")
+        sources = []
+        for name in ("with_ovr.tif", "without_ovr.tif"):
+            path = str(tmp_path / name)
+            raster = driver.Create(path, 8, 8, 1, gdal.GDT_Float32)
+            raster.GetRasterBand(1).WriteArray(
+                np.arange(64, dtype="float32").reshape(8, 8)
+            )
+            raster = None
+            sources.append(path)
+        with_ovr, without_ovr = sources
+        handle = gdal.Open(with_ovr)
+        handle.BuildOverviews("NEAREST", [2])
+        handle = None
+
+        vrt = tmp_path / "mixed.vrt"
+        vrt.write_text(
+            f'<VRTDataset rasterXSize="8" rasterYSize="8">'
+            f'<VRTRasterBand dataType="Float32" band="1">'
+            f'<SimpleSource><SourceFilename relativeToVRT="0">{with_ovr}</SourceFilename>'
+            f"<SourceBand>1</SourceBand></SimpleSource>"
+            f'<Overview><SourceFilename relativeToVRT="0">{with_ovr}.ovr</SourceFilename>'
+            f"<SourceBand>1</SourceBand></Overview></VRTRasterBand>"
+            f'<VRTRasterBand dataType="Float32" band="2">'
+            f'<SimpleSource><SourceFilename relativeToVRT="0">{without_ovr}</SourceFilename>'
+            f"<SourceBand>1</SourceBand></SimpleSource></VRTRasterBand></VRTDataset>"
+        )
+        dataset = Dataset.read_file(str(vrt), read_only=True)
+        try:
+            assert dataset.overview_count == [1, 0], (
+                f"fixture must produce mixed counts, got {dataset.overview_count}"
+            )
+            with pytest.warns(UserWarning, match=r"Bands \[1\] have no overviews"):
+                dataset.recreate_overviews()
+        finally:
+            dataset.close()
+
     def test_in_memory_dataset_without_overviews_warns(self):
         """An in-memory dataset warns rather than raising, despite read_only access.
 


### PR DESCRIPTION
# Description

`Dataset.recreate_overviews()` (and the copy `NetCDF` inherits) promised two things it only partly delivered: that
it regenerates a raster's overviews, and that it raises `ReadOnlyError` on a read-only dataset. The regeneration
loop iterates `overview_count` times, so with no overviews it iterated zero times — rebuilding nothing and
signalling nothing — and the documented `ReadOnlyError` fired only *incidentally*, when `gdal.RegenerateOverview`
happened to throw on a read-only band that **had** overviews to regenerate.

This PR makes every outcome explicit:

- **Nothing to regenerate is reported, not swallowed.** A band with no overviews now produces a `UserWarning`
  pointing at `create_overviews()`. The report is **per band**: with mixed counts (reachable — a VRT whose band 1
  sources a raster with an external `.ovr` and whose band 2 does not reports `[1, 0]`) the empty bands are named
  and skipped while the populated ones still regenerate. A band-less dataset gets its own message rather than being
  told to call `create_overviews()`, which could not help it.
- **The warning is emitted in every access mode.** Read-only is not the blocker — the empty count is, and that is
  access-mode independent. Raising here would misdiagnose it: `read_only` defaults to `True` in
  `Dataset.read_file`, so it would fire on the most natural two-line usage, the prescribed remedy
  (`read_only=False`) only yields this same warning, and it is not even applicable to inherently read-only
  `/vsicurl` reads. This also keeps "refresh overviews if any exist" loops working.
- **Failures are classified by GDAL's error number, not its message text.** `ReadOnlyError` is now raised only for
  a genuine write refusal (`CPLE_NoWriteAccess`), bracketed by `gdal.ErrorReset()`; the exact GDAL phrasings remain
  a fallback for drivers that raise without setting it. A substring test on `"read-only"` would have relabelled any
  failure on a raster living under, say, `/mnt/read-only-archive/`, because GDAL prefixes its messages with the
  dataset path. Disk-full, corrupt-overview, unsupported-resampling and transport failures now propagate as
  `RuntimeError` with a note naming the band and level the loop stopped on.
- **A failing `CPLErr` return is honoured**, so a caller who turns `gdal.UseExceptions()` off does not get the
  original silent no-op back.

External `.ovr` overviews are still regenerable through the read-only handle that built them — that is a real,
tested workflow (`TestReCreateOverviews::test_recreate_overviews_external`), so read-only access is deliberately
**not** rejected up front. GDAL refuses on access grounds only when the overview *target* is itself read-only:
internal overviews in a read-only raster, or an external `.ovr` a later handle reopened read-only.

The warning `stacklevel` is computed by walking out of the `pyramids` package, so both `ds.recreate_overviews()`
(the `Dataset` facade) and `ds.io.recreate_overviews()` (the engine) blame the caller's own line instead of
`dataset.py` or `<sys>:0`.

**Unrelated CI fix carried here:** `docs/change-log.md`, regenerated by the `release: 0.47.0` commit, contains lines
padded with 40–99 trailing spaces. The `trailing-whitespace` hook rewrites them, so `pre-commit` fails on `main`
and on every PR whose merge commit picks the file up. It is normalized here (whitespace only, no wording changed)
to unblock this PR — the recurrence is worth fixing at the commitizen template level separately.

No new dependencies.

# Issues

- Closes #863 — recreate_overviews silently no-ops with no overviews; read-only guard is incidental

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**Behaviour changes worth knowing (neither breaks a documented contract):**

- A call that previously returned silently now emits a `UserWarning`. Warnings do not abort, so defensive
  "refresh if present" loops keep working.
- A non-access GDAL failure now surfaces as `RuntimeError` instead of being relabelled `ReadOnlyError`. Code that
  caught `ReadOnlyError` to swallow *any* regeneration failure should catch `RuntimeError` instead — the previous
  label was a misdiagnosis, not a contract.

# How Has This Been Tested?

- `pixi run -e dev pytest -m "not plot"` → **7361 passed**, 51 skipped.
- `pixi run -e dev mypy` → **0 errors** (127 source files).
- `pre-commit run --all-files` with CI's exact `SKIP` list → all hooks pass.
- 22 tests in `tests/dataset/spatial/test_overviews.py::TestRecreateOverviewsContract` cover: no-overviews on a
  writable and on a read-only dataset, internal overviews read-only raising, the 3-way GDAL failure classification
  (including the path-contains-`read-only` false positive and `__cause__` chaining), the failing-`CPLErr` route, the
  `add_note` band/level context, a band-less dataset, mixed `[1, 0]` counts warning *and* still regenerating the
  populated band, an in-memory dataset, warning attribution from both the facade and the engine entry point, and a
  happy path that stays silent.
- Three of those were proven non-vacuous by mutating the source and confirming the test fails.
- Pre-existing overview tests are unchanged and still pass, including the external-`.ovr`-on-a-read-only-handle
  workflow and the NetCDF inherited `recreate_overviews` contract.

- [x] Full non-plot suite (`pytest -m "not plot"`)
- [x] `mypy` clean
- [x] Two full `/review-rounds` passes (27 findings across both rounds, all resolved; review notes in `planning/`)

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen bumps this on release)
- [ ] added changes to History.rst. (commitizen-generated; not hand-edited)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (docstrings on `IO.recreate_overviews`, the new private helpers, and the
      `RasterBase` abstract contract)
