### PR TITLE
fix(dataset): tag paletted bands with GCI_PaletteIndex

### DIFF
--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -719,7 +719,7 @@ class Bands(_Engine["Dataset"]):
 
     @color_table.setter
     def color_table(self, df: DataFrame):
-        """Get color table.
+        """Set the color table for one or more bands.
 
         Args:
             df (DataFrame):

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -857,7 +857,9 @@ class Bands(_Engine["Dataset"]):
                 )
 
             band.SetColorTable(color_table)
-            # band.SetRasterColorInterpretation(gdal.GCI_PaletteIndex)
+            # tag the band as paletted so GDAL and downstream readers treat the
+            # values as palette indices, matching the COG writer (see cog.py).
+            band.SetColorInterpretation(gdal.GCI_PaletteIndex)
 
     def _get_color_table(self, band: int | None = None) -> DataFrame:
         """Get color table.

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -735,6 +735,11 @@ class Bands(_Engine["Dataset"]):
 
                     ```
 
+        Note:
+            Each band that receives a palette is also tagged with the
+            `palette_index` colour interpretation, so its reported `band_color`
+            changes from `undefined` to `palette_index`.
+
         Examples:
             - Create `Dataset` consisting of 4 bands, 10 rows, 10 columns, at lon/lat
               (0, 0):
@@ -857,8 +862,9 @@ class Bands(_Engine["Dataset"]):
                 )
 
             band.SetColorTable(color_table)
-            # tag the band as paletted so GDAL and downstream readers treat the
-            # values as palette indices, matching the COG writer (see cog.py).
+            # tag the band as paletted so GDAL and downstream readers read the
+            # values as palette indices rather than raw data (the COG writer sets
+            # the same interpretation on its paletted band, see cog.py).
             band.SetColorInterpretation(gdal.GCI_PaletteIndex)
 
     def _get_color_table(self, band: int | None = None) -> DataFrame:

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -853,7 +853,11 @@ class Bands(_Engine["Dataset"]):
             if overwrite:
                 color_table = gdal.ColorTable()
             else:
+                # a band with no existing palette returns None here; start a fresh
+                # table so appending entries does not raise on the None.
                 color_table = band.GetColorTable()
+                if color_table is None:
+                    color_table = gdal.ColorTable()
 
             for i, row in df_band.iterrows():
                 color_table.SetColorEntry(

--- a/tests/dataset/plot/test_plot_color.py
+++ b/tests/dataset/plot/test_plot_color.py
@@ -131,6 +131,27 @@ class TestColorTable:
             == gdal.GCI_PaletteIndex
         )
 
+    @pytest.mark.plot
+    def test_set_color_table_overwrite_false_starts_fresh_table(self):
+        rng = np.random.default_rng(2)
+        arr = rng.integers(1, 4, size=(1, 5, 5))
+        dataset = Dataset.create_from_array(
+            arr, top_left_corner=(0, 0), cell_size=0.05, epsg=4326
+        )
+        df = pd.DataFrame(
+            {
+                "band": [1, 1, 1],
+                "values": [1, 2, 3],
+                "color": ["#709959", "#F2EEA2", "#F2CE85"],
+            }
+        )
+        # the band has no existing palette, so overwrite=False must start a fresh
+        # table rather than raising on the None returned by GetColorTable.
+        dataset.bands._set_color_table(df, overwrite=False)
+        band = dataset.raster.GetRasterBand(1)
+        assert band.GetColorTable() is not None
+        assert band.GetColorInterpretation() == gdal.GCI_PaletteIndex
+
 
 class TestColorRelief:
     color_hex = ["#709959", "#F2EEA2", "#F2CE85", "#C28C7C", "#D6C19C"]

--- a/tests/dataset/plot/test_plot_color.py
+++ b/tests/dataset/plot/test_plot_color.py
@@ -152,6 +152,48 @@ class TestColorTable:
         assert band.GetColorTable() is not None
         assert band.GetColorInterpretation() == gdal.GCI_PaletteIndex
 
+    @pytest.mark.plot
+    def test_set_color_table_tags_only_targeted_bands(self):
+        rng = np.random.default_rng(3)
+        arr = rng.integers(1, 4, size=(3, 5, 5))
+        dataset = Dataset.create_from_array(
+            arr, top_left_corner=(0, 0), cell_size=0.05, epsg=4326
+        )
+        dataset.color_table = pd.DataFrame(
+            {
+                "band": [1, 1, 1],
+                "values": [1, 2, 3],
+                "color": ["#709959", "#F2EEA2", "#F2CE85"],
+            }
+        )
+        assert dataset.band_color == {
+            0: "palette_index",
+            1: "undefined",
+            2: "undefined",
+        }
+
+    @pytest.mark.plot
+    def test_palette_interpretation_survives_gtiff_roundtrip(self, tmp_path):
+        rng = np.random.default_rng(4)
+        arr = rng.integers(1, 4, size=(1, 5, 5)).astype("uint8")
+        dataset = Dataset.create_from_array(
+            arr, top_left_corner=(0, 0), cell_size=0.05, epsg=4326, no_data_value=255
+        )
+        dataset.color_table = pd.DataFrame(
+            {
+                "band": [1, 1, 1],
+                "values": [1, 2, 3],
+                "color": ["#709959", "#F2EEA2", "#F2CE85"],
+            }
+        )
+        path = tmp_path / "paletted.tif"
+        dataset.to_file(str(path))
+
+        reopened = Dataset.read_file(str(path))
+        band = reopened.raster.GetRasterBand(1)
+        assert band.GetColorInterpretation() == gdal.GCI_PaletteIndex
+        assert not reopened.color_table.empty
+
 
 class TestColorRelief:
     color_hex = ["#709959", "#F2EEA2", "#F2CE85", "#C28C7C", "#D6C19C"]

--- a/tests/dataset/plot/test_plot_color.py
+++ b/tests/dataset/plot/test_plot_color.py
@@ -3,6 +3,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from osgeo import gdal
 from pandas import DataFrame
 
 from pyramids.dataset import Dataset
@@ -106,6 +107,29 @@ class TestColorTable:
         ]
         # test the color_table property
         dataset.color_table = df
+
+    @pytest.mark.plot
+    def test_set_color_table_tags_palette_interpretation(self):
+        rng = np.random.default_rng(1)
+        arr = rng.integers(1, 4, size=(1, 5, 5))
+        dataset = Dataset.create_from_array(
+            arr, top_left_corner=(0, 0), cell_size=0.05, epsg=4326
+        )
+        assert (
+            dataset.raster.GetRasterBand(1).GetColorInterpretation()
+            == gdal.GCI_Undefined
+        )
+        dataset.color_table = pd.DataFrame(
+            {
+                "band": [1, 1, 1],
+                "values": [1, 2, 3],
+                "color": ["#709959", "#F2EEA2", "#F2CE85"],
+            }
+        )
+        assert (
+            dataset.raster.GetRasterBand(1).GetColorInterpretation()
+            == gdal.GCI_PaletteIndex
+        )
 
 
 class TestColorRelief:


### PR DESCRIPTION
# Description

`Bands._set_color_table` attaches a palette to a band but left the band's **colour interpretation** unset — the
`SetColorInterpretation` call was commented out. As a result a raster written through `Dataset.color_table` was
tagged differently from one written through the COG path, which already sets `GCI_PaletteIndex`
(`dataset/engines/cog.py`). GDAL and downstream readers use the interpretation to know the pixel values are
palette indices rather than raw data, so the two write paths produced inconsistently-tagged paletted rasters.

This sets `band.SetColorInterpretation(gdal.GCI_PaletteIndex)` after the palette is attached, matching the COG
writer. `gdal` is already imported at the top of the module; no new dependency.

This is the "bonus" cleanup identified in #782. The other item flagged there — removing a stale `TODO` — is a
no-op on `main`: that `TODO` only exists on the unmerged `docs/improve-netcdf-docs` branch, and `main`'s
`bands.py` already has no such comment. The genuinely open parts of #782 (reconciling `color_table` with the
raster attribute table, and adding a colour-ramp → colour-table path) are out of scope here and stay tracked in
the issue.

# Issues

- Refs #782 — implements the palette-interpretation consistency fix (the "bonus" item); does not close it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

The change adds a tag that was intended but disabled; it does not alter the palette itself or any public
signature.

# How Has This Been Tested?

- [x] New `test_set_color_table_tags_palette_interpretation` — asserts a band's interpretation flips from
      `Undefined` to `Palette` when a colour table is assigned.
- [x] `pytest tests/dataset/plot/test_plot_color.py tests/dataset/unit/test_unit_properties.py
      tests/dataset/cog/test_unified_write_policy.py tests/dataset/create/test_dataset_create.py` against the
      branch → **194 passed**. Includes the existing `test_dataset_create.py` assertion that a freshly-created
      band stays `Undefined` (unaffected — only colour-table assignment now tags the band).

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
