### PR TITLE
fix(dataset): don't treat a paletted band as RGB imagery in plot()

### DIFF
--- a/src/pyramids/base/_utils.py
+++ b/src/pyramids/base/_utils.py
@@ -180,11 +180,6 @@ COLOR_NAMES = [
     "YCbCr_CbBand",
     "YCbCr_CrBand",
 ]
-# Human-readable name for GDAL's "no colour interpretation set" sentinel
-# (`gdal.GCI_Undefined` -> `COLOR_NAMES[0]`). Use this constant instead
-# of the bare string literal so a name change can't silently break the
-# "is this band an RGB channel?" checks (e.g. `Dataset._resolve_plot_band`).
-UNDEFINED_COLOR_INTERP = COLOR_NAMES[0]
 
 # The GDAL colour interpretations that mark a band as an RGB channel
 # (`red` / `green` / `blue` -> `COLOR_NAMES[3:6]`). Only these signal that a

--- a/src/pyramids/base/_utils.py
+++ b/src/pyramids/base/_utils.py
@@ -186,11 +186,14 @@ COLOR_NAMES = [
 # "is this band an RGB channel?" checks (e.g. `Dataset._resolve_plot_band`).
 UNDEFINED_COLOR_INTERP = COLOR_NAMES[0]
 
-# Human-readable name for GDAL's palette interpretation
-# (`gdal.GCI_PaletteIndex` -> `COLOR_NAMES[2]`). A paletted band is rendered
-# through its colour table, so it is *not* an RGB channel; the same
-# "is this band an RGB channel?" checks must exclude it as well.
-PALETTE_COLOR_INTERP = COLOR_NAMES[2]
+# The GDAL colour interpretations that mark a band as an RGB channel
+# (`red` / `green` / `blue` -> `COLOR_NAMES[3:6]`). Only these signal that a
+# multi-band raster is RGB imagery. Every other interpretation -- `undefined`,
+# `palette_index`, `gray_index`, alpha, CMYK, HSL, YCbCr -- is single-channel
+# or paletted and must not trigger the RGB plot heuristic (see
+# `Dataset._resolve_plot_band`, issue #910). Kept as an allowlist so a new
+# non-RGB interpretation can never silently re-enable the false-RGB bug.
+RGB_CHANNEL_INTERPS = frozenset(COLOR_NAMES[3:6])
 
 COLOR_TABLE = DataFrame(
     columns=["id", "gdal_constant", "name"],

--- a/src/pyramids/base/_utils.py
+++ b/src/pyramids/base/_utils.py
@@ -186,6 +186,12 @@ COLOR_NAMES = [
 # "is this band an RGB channel?" checks (e.g. `Dataset._resolve_plot_band`).
 UNDEFINED_COLOR_INTERP = COLOR_NAMES[0]
 
+# Human-readable name for GDAL's palette interpretation
+# (`gdal.GCI_PaletteIndex` -> `COLOR_NAMES[2]`). A paletted band is rendered
+# through its colour table, so it is *not* an RGB channel; the same
+# "is this band an RGB channel?" checks must exclude it as well.
+PALETTE_COLOR_INTERP = COLOR_NAMES[2]
+
 COLOR_TABLE = DataFrame(
     columns=["id", "gdal_constant", "name"],
     data=list(zip(range(len(COLOR_NAMES)), COLOR_INTERPRETATIONS, COLOR_NAMES)),

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -722,50 +722,62 @@ class Dataset(RasterBase):
             resolved_band = 0
             resolved_rgb = rgb
         else:
-            band_colors = list(self.band_color.values())
-            # Only a true RGB channel (`red`/`green`/`blue`) signals RGB
-            # imagery. `undefined`, `palette_index`, `gray_index`, and the other
-            # single-channel/paletted interpretations do not -- otherwise a
-            # multi-band raster carrying any of them is mis-resolved as a
-            # false-colour RGB composite (see #910). An allowlist keeps a new
-            # non-RGB interpretation from silently re-enabling that bug.
-            has_rgb_interp = any(c in RGB_CHANNEL_INTERPS for c in band_colors)
-            if not has_rgb_interp:
-                # No RGB channels: render a single band. Honour an explicit
-                # ``rgb`` so ``exclude_value`` downstream keys off the same band
-                # the RGB render uses; otherwise default to band 0 -- a
-                # deliberate placeholder, since the plot path does not (yet)
-                # render a palette through its colour table, so the band index
-                # is not meaningful for paletted data today.
-                resolved_band = int(rgb[0]) if rgb is not None else 0
-                resolved_rgb = rgb
-            else:
-                if rgb is None:
-                    candidate: list[int | None] = [
-                        self.get_band_by_color("red"),
-                        self.get_band_by_color("green"),
-                        self.get_band_by_color("blue"),
-                    ]
-                    if None in candidate:
-                        warnings.warn(
-                            "The implicit Sentinel-2 RGB band order [2, 1, 0] used "
-                            "when colour-interpretation is absent is deprecated and "
-                            "will be removed: it is a remote-sensing sensor "
-                            "assumption, not a generic raster default. Pass an "
-                            "explicit rgb=[...] (e.g. via rgb_options) instead.",
-                            DeprecationWarning,
-                            stacklevel=3,
-                        )
-                        resolved_rgb = [2, 1, 0]
-                    else:
-                        # None NOT in candidate here, so every element is a
-                        # plain int -- mypy does not narrow list contents from
-                        # an `in` check.
-                        resolved_rgb = [int(v) for v in cast("list[int]", candidate)]
-                else:
-                    resolved_rgb = rgb
-                resolved_band = int(resolved_rgb[0])
+            resolved_band, resolved_rgb = self._resolve_multiband_plot(rgb)
         return resolved_band, resolved_rgb
+
+    def _resolve_multiband_plot(
+        self, rgb: list[int] | None
+    ) -> tuple[int, list[int] | None]:
+        """Resolve ``(band, rgb)`` for a raster with ``band_count >= 3``.
+
+        Only a true RGB channel (``red``/``green``/``blue``) marks the raster as
+        RGB imagery; ``undefined``, ``palette_index``, ``gray_index`` and the
+        other single-channel/paletted interpretations do not -- otherwise a
+        multi-band raster carrying any of them is mis-resolved as a false-colour
+        RGB composite (see #910). A non-RGB raster renders a single band: band 0
+        by default, or ``rgb[0]`` when an explicit ``rgb`` is supplied, so the
+        downstream ``exclude_value`` nodata mask keys off the same band the RGB
+        render uses.
+        """
+        band_colors = list(self.band_color.values())
+        has_rgb_interp = any(c in RGB_CHANNEL_INTERPS for c in band_colors)
+        if not has_rgb_interp:
+            resolved_rgb = rgb
+            resolved_band = int(rgb[0]) if rgb is not None else 0
+        else:
+            resolved_rgb = rgb if rgb is not None else self._infer_rgb_band_order()
+            resolved_band = int(resolved_rgb[0])
+        return resolved_band, resolved_rgb
+
+    def _infer_rgb_band_order(self) -> list[int]:
+        """Infer the ``[r, g, b]`` band-index order from the bands' colour tags.
+
+        Resolves red/green/blue via :meth:`get_band_by_color`; falls back to the
+        Sentinel-2 default ``[2, 1, 0]`` (emitting a :class:`DeprecationWarning`)
+        when any channel cannot be identified from the tags.
+        """
+        candidate: list[int | None] = [
+            self.get_band_by_color("red"),
+            self.get_band_by_color("green"),
+            self.get_band_by_color("blue"),
+        ]
+        if None in candidate:
+            warnings.warn(
+                "The implicit Sentinel-2 RGB band order [2, 1, 0] used "
+                "when colour-interpretation is absent is deprecated and "
+                "will be removed: it is a remote-sensing sensor "
+                "assumption, not a generic raster default. Pass an "
+                "explicit rgb=[...] (e.g. via rgb_options) instead.",
+                DeprecationWarning,
+                stacklevel=5,
+            )
+            resolved_rgb = [2, 1, 0]
+        else:
+            # None NOT in candidate here, so every element is a
+            # plain int -- mypy does not narrow list contents from
+            # an `in` check.
+            resolved_rgb = [int(v) for v in cast("list[int]", candidate)]
+        return resolved_rgb
 
     def plot(
         self,

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -23,8 +23,7 @@ from pyramids import _io
 from pyramids.base._errors import AlignmentError, CRSError
 from pyramids.base._utils import (
     DTYPE_CONVERSION_DF,
-    PALETTE_COLOR_INTERP,
-    UNDEFINED_COLOR_INTERP,
+    RGB_CHANNEL_INTERPS,
     numpy_to_gdal_dtype,
 )
 from pyramids.base.crs import (
@@ -627,14 +626,13 @@ class Dataset(RasterBase):
         1. If ``band`` is explicitly provided, it is returned as-is (and ``rgb`` passes
            through untouched).
         2. If the dataset has fewer than 3 bands, return ``(0, rgb)``.
-        3. If the dataset has 3+ bands but **no** band carries an RGB-channel
-           ``ColorInterpretation`` (i.e. every band reports ``undefined`` or
-           ``palette_index``), return ``(0, rgb)``. This is the D-1 fix: ``band_count >= 3``
-           alone is not a sufficient signal that the data is an RGB image — multi-band
-           scalar cubes (e.g. time series stacked into one GeoTIFF) also have
-           ``band_count >= 3`` and must not be misinterpreted as RGB. A ``palette_index``
-           band is rendered through its colour table, not as an RGB channel, so it is
-           excluded here too (see #910).
+        3. If the dataset has 3+ bands but **no** band is tagged as an RGB channel
+           (``red``/``green``/``blue``), return ``(0, rgb)``. This is the D-1 fix:
+           ``band_count >= 3`` alone is not a sufficient signal that the data is an RGB
+           image — multi-band scalar cubes (e.g. time series stacked into one GeoTIFF)
+           also have ``band_count >= 3`` and must not be misinterpreted as RGB. Only the
+           three RGB-channel interpretations count; ``palette_index``, ``gray_index`` and
+           the other single-channel tags are rendered as single bands, not RGB (see #910).
         4. Otherwise, treat the dataset as RGB imagery. If ``rgb`` was supplied, its
            first entry is the red band. If it was not supplied, resolve red/green/blue
            via :meth:`get_band_by_color`; fall back to ``[2, 1, 0]`` (the default
@@ -697,6 +695,16 @@ class Dataset(RasterBase):
               (1, [2, 1, 0])
 
               ```
+
+            - A ``palette_index`` band is not an RGB channel, so it does not trigger
+              the RGB branch — the raster resolves to a single band (rule 3, #910):
+
+              ```python
+              >>> ds.band_color = {0: 'palette_index'}
+              >>> ds._resolve_plot_band(band=None, rgb=None)
+              (0, None)
+
+              ```
         """
         if band is not None:
             # Coerce to a plain ``int`` here too (the RGB branch already
@@ -709,14 +717,18 @@ class Dataset(RasterBase):
             resolved_rgb = rgb
         else:
             band_colors = list(self.band_color.values())
-            # A paletted band (`palette_index`) is rendered through its colour
-            # table, not as an RGB channel, so it must not count as evidence of
-            # RGB imagery any more than `undefined` does -- otherwise a
-            # multi-band raster with a palette on one band is mis-resolved as a
-            # false-colour RGB composite (see #910).
-            non_rgb_interp = {UNDEFINED_COLOR_INTERP, PALETTE_COLOR_INTERP}
-            has_color_interp = any(c not in non_rgb_interp for c in band_colors)
-            if not has_color_interp:
+            # Only a true RGB channel (`red`/`green`/`blue`) signals RGB
+            # imagery. `undefined`, `palette_index`, `gray_index`, and the other
+            # single-channel/paletted interpretations do not -- otherwise a
+            # multi-band raster carrying any of them is mis-resolved as a
+            # false-colour RGB composite (see #910). An allowlist keeps a new
+            # non-RGB interpretation from silently re-enabling that bug.
+            has_rgb_interp = any(c in RGB_CHANNEL_INTERPS for c in band_colors)
+            if not has_rgb_interp:
+                # No RGB channels: render a single band. Band 0 is a deliberate
+                # default -- the plot path does not (yet) render a palette
+                # through its colour table, so the band index is not meaningful
+                # for paletted data today.
                 resolved_band = 0
                 resolved_rgb = rgb
             else:

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -725,11 +725,13 @@ class Dataset(RasterBase):
             # non-RGB interpretation from silently re-enabling that bug.
             has_rgb_interp = any(c in RGB_CHANNEL_INTERPS for c in band_colors)
             if not has_rgb_interp:
-                # No RGB channels: render a single band. Band 0 is a deliberate
-                # default -- the plot path does not (yet) render a palette
-                # through its colour table, so the band index is not meaningful
-                # for paletted data today.
-                resolved_band = 0
+                # No RGB channels: render a single band. Honour an explicit
+                # ``rgb`` so ``exclude_value`` downstream keys off the same band
+                # the RGB render uses; otherwise default to band 0 -- a
+                # deliberate placeholder, since the plot path does not (yet)
+                # render a palette through its colour table, so the band index
+                # is not meaningful for paletted data today.
+                resolved_band = int(rgb[0]) if rgb is not None else 0
                 resolved_rgb = rgb
             else:
                 if rgb is None:

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -697,11 +697,17 @@ class Dataset(RasterBase):
               ```
 
             - A ``palette_index`` band is not an RGB channel, so it does not trigger
-              the RGB branch — the raster resolves to a single band (rule 3, #910):
+              the RGB branch — the raster resolves to a single band (rule 3, #910).
+              A fresh dataset is built here so the example is independent of the
+              tags set above:
 
               ```python
-              >>> ds.band_color = {0: 'palette_index'}
-              >>> ds._resolve_plot_band(band=None, rgb=None)
+              >>> paletted = np.random.rand(3, 8, 8).astype(np.float32)
+              >>> ds_pal = Dataset.create_from_array(
+              ...     paletted, top_left_corner=(0, 0), cell_size=0.1, epsg=4326,
+              ... )
+              >>> ds_pal.band_color = {0: 'palette_index'}
+              >>> ds_pal._resolve_plot_band(band=None, rgb=None)
               (0, None)
 
               ```

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -23,6 +23,7 @@ from pyramids import _io
 from pyramids.base._errors import AlignmentError, CRSError
 from pyramids.base._utils import (
     DTYPE_CONVERSION_DF,
+    PALETTE_COLOR_INTERP,
     UNDEFINED_COLOR_INTERP,
     numpy_to_gdal_dtype,
 )
@@ -626,11 +627,14 @@ class Dataset(RasterBase):
         1. If ``band`` is explicitly provided, it is returned as-is (and ``rgb`` passes
            through untouched).
         2. If the dataset has fewer than 3 bands, return ``(0, rgb)``.
-        3. If the dataset has 3+ bands but **no** band has a GDAL ``ColorInterpretation``
-           set (i.e. every band reports ``undefined``), return ``(0, rgb)``. This is the
-           D-1 fix: ``band_count >= 3`` alone is not a sufficient signal that the data
-           is an RGB image — multi-band scalar cubes (e.g. time series stacked into one
-           GeoTIFF) also have ``band_count >= 3`` and must not be misinterpreted as RGB.
+        3. If the dataset has 3+ bands but **no** band carries an RGB-channel
+           ``ColorInterpretation`` (i.e. every band reports ``undefined`` or
+           ``palette_index``), return ``(0, rgb)``. This is the D-1 fix: ``band_count >= 3``
+           alone is not a sufficient signal that the data is an RGB image — multi-band
+           scalar cubes (e.g. time series stacked into one GeoTIFF) also have
+           ``band_count >= 3`` and must not be misinterpreted as RGB. A ``palette_index``
+           band is rendered through its colour table, not as an RGB channel, so it is
+           excluded here too (see #910).
         4. Otherwise, treat the dataset as RGB imagery. If ``rgb`` was supplied, its
            first entry is the red band. If it was not supplied, resolve red/green/blue
            via :meth:`get_band_by_color`; fall back to ``[2, 1, 0]`` (the default
@@ -705,7 +709,13 @@ class Dataset(RasterBase):
             resolved_rgb = rgb
         else:
             band_colors = list(self.band_color.values())
-            has_color_interp = any(c != UNDEFINED_COLOR_INTERP for c in band_colors)
+            # A paletted band (`palette_index`) is rendered through its colour
+            # table, not as an RGB channel, so it must not count as evidence of
+            # RGB imagery any more than `undefined` does -- otherwise a
+            # multi-band raster with a palette on one band is mis-resolved as a
+            # false-colour RGB composite (see #910).
+            non_rgb_interp = {UNDEFINED_COLOR_INTERP, PALETTE_COLOR_INTERP}
+            has_color_interp = any(c not in non_rgb_interp for c in band_colors)
             if not has_color_interp:
                 resolved_band = 0
                 resolved_rgb = rgb

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -780,10 +780,12 @@ class Dataset(RasterBase):
         forwards the call to the generic rendering engine.
 
         When ``band`` is ``None`` and the dataset looks like an RGB image — i.e. it has
-        at least 3 bands **and** at least one band has a GDAL ``ColorInterpretation`` set —
-        the red band is auto-selected (either from ``rgb[0]`` or by resolving the colour
-        tags). Otherwise the facade defaults to band ``0``. See
-        :meth:`Analysis.plot` for the full kwargs surface.
+        at least 3 bands **and** at least one band is tagged as an RGB channel
+        (``red``/``green``/``blue``) — the red band is auto-selected (either from
+        ``rgb[0]`` or by resolving the colour tags). A ``palette_index``, ``gray_index``
+        or other non-RGB interpretation does **not** count as RGB imagery. Otherwise the
+        facade defaults to band ``0``. See :meth:`Analysis.plot` for the full kwargs
+        surface.
 
         The four satellite-imagery kwargs ``rgb``, ``surface_reflectance``, ``cutoff``,
         and ``percentile`` may be grouped under a single ``rgb_options=`` dict

--- a/tests/dataset/plot/test_plot_resolution.py
+++ b/tests/dataset/plot/test_plot_resolution.py
@@ -257,6 +257,31 @@ class TestResolvePlotBandPolicy:
             f"{[str(w.message) for w in deprecations]}"
         )
 
+    def test_explicit_rgb_on_non_rgb_tagged_raster_keys_band_on_rgb0(self):
+        """Explicit ``rgb`` sets the resolved band to ``rgb[0]`` even off the RGB branch.
+
+        Test scenario:
+            A 3-band raster tagged only ``gray_index`` takes the non-RGB
+            branch, but the user still passed ``rgb=[2, 1, 0]``. The resolved
+            band must be ``rgb[0] == 2`` (not the band-0 default), so the
+            downstream ``exclude_value`` nodata mask keys off the same band the
+            RGB render uses rather than band 0.
+        """
+        rng = np.random.default_rng(913)
+        arr = rng.random((3, 6, 6)).astype("float32")
+        dataset = Dataset.create_from_array(
+            arr, top_left_corner=(0, 0), cell_size=0.05, epsg=4326
+        )
+        dataset.band_color = {0: "gray_index"}
+
+        resolved_band, resolved_rgb = dataset._resolve_plot_band(
+            band=None, rgb=[2, 1, 0]
+        )
+        assert resolved_band == 2, (
+            f"Explicit rgb[0]=2 must set the resolved band, got {resolved_band}"
+        )
+        assert resolved_rgb == [2, 1, 0]
+
     def test_full_rgb_tags_resolves_red_band(self):
         """All three R/G/B tags set → resolved band is red, rgb list filled.
 

--- a/tests/dataset/plot/test_plot_resolution.py
+++ b/tests/dataset/plot/test_plot_resolution.py
@@ -15,6 +15,7 @@ five branches), so we want it covered on every CI run, not only on the
 from __future__ import annotations
 
 import inspect
+import warnings
 from unittest.mock import patch
 
 import numpy as np
@@ -148,6 +149,45 @@ class TestResolvePlotBandPolicy:
             f"got {resolved_band}"
         )
         assert resolved_rgb is None
+
+    @pytest.mark.parametrize("palette_band", [0, 1, 2])
+    def test_paletted_band_not_treated_as_rgb(self, palette_band):
+        """#910: a ``palette_index`` band must not trigger the RGB heuristic.
+
+        Args:
+            palette_band: Which band carries the palette (0, 1, or 2); the
+                others stay ``undefined``.
+
+        Test scenario:
+            A paletted band is rendered through its colour table, not as an
+            RGB channel. A 3-band raster with a palette on one band (others
+            ``undefined``) must resolve to ``(0, None)`` and emit no
+            deprecation warning — not be mis-read as false-colour RGB
+            ``[2, 1, 0]`` with the Sentinel-2 fallback warning.
+        """
+        rng = np.random.default_rng(910)
+        arr = rng.random((3, 6, 6)).astype("float32")
+        dataset = Dataset.create_from_array(
+            arr, top_left_corner=(0, 0), cell_size=0.05, epsg=4326
+        )
+        dataset.band_color = {palette_band: "palette_index"}
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            resolved_band, resolved_rgb = dataset._resolve_plot_band(
+                band=None, rgb=None
+            )
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert resolved_band == 0, (
+            f"Paletted raster must resolve to band 0, got {resolved_band}"
+        )
+        assert resolved_rgb is None, (
+            f"rgb must stay None for a paletted raster, got {resolved_rgb}"
+        )
+        assert not deprecations, (
+            "resolving a paletted raster must not emit the Sentinel-2 RGB "
+            f"deprecation: {[str(w.message) for w in deprecations]}"
+        )
 
     def test_full_rgb_tags_resolves_red_band(self):
         """All three R/G/B tags set → resolved band is red, rgb list filled.

--- a/tests/dataset/plot/test_plot_resolution.py
+++ b/tests/dataset/plot/test_plot_resolution.py
@@ -21,6 +21,7 @@ from unittest.mock import patch
 import numpy as np
 import pytest
 
+from pyramids.base._utils import RGB_CHANNEL_INTERPS
 from pyramids.dataset import Dataset
 from pyramids.dataset.abstract_dataset import RasterBase
 from pyramids.netcdf.netcdf import NetCDF
@@ -164,6 +165,12 @@ class TestResolvePlotBandPolicy:
             ``undefined``) must resolve to ``(0, None)`` and emit no
             deprecation warning — not be mis-read as false-colour RGB
             ``[2, 1, 0]`` with the Sentinel-2 fallback warning.
+
+            Note: ``resolved_band == 0`` is a deliberate placeholder even when
+            the palette sits on band 1 or 2 — the plot path does not yet render
+            a palette through its colour table (see #910), so no specific band
+            is more meaningful today. Revisit this assertion when paletted
+            rendering lands.
         """
         rng = np.random.default_rng(910)
         arr = rng.random((3, 6, 6)).astype("float32")
@@ -282,6 +289,42 @@ class TestResolvePlotBandPolicy:
         )
         assert resolved_rgb == [2, 1, 0]
 
+    def test_palette_beside_partial_rgb_still_falls_back_to_sentinel(self):
+        """A stray palette band does not change the partial-RGB fallback.
+
+        Test scenario:
+            A 3-band raster tagged ``red``/``green`` with a ``palette_index``
+            on the third band still enters the RGB branch (red/green fire the
+            allowlist); ``blue`` is absent, so it falls back to ``[2, 1, 0]``
+            and picks band 2, emitting the Sentinel-2 deprecation — the palette
+            band must not suppress or alter that behaviour.
+        """
+        rng = np.random.default_rng(914)
+        arr = rng.random((3, 6, 6)).astype("float32")
+        dataset = Dataset.create_from_array(
+            arr, top_left_corner=(0, 0), cell_size=0.05, epsg=4326
+        )
+        dataset.band_color = {0: "red", 1: "green", 2: "palette_index"}
+
+        with pytest.warns(DeprecationWarning, match=r"Sentinel-2"):
+            resolved_band, resolved_rgb = dataset._resolve_plot_band(
+                band=None, rgb=None
+            )
+        assert resolved_band == 2, f"Fallback band must be 2, got {resolved_band}"
+        assert resolved_rgb == [2, 1, 0]
+
+    def test_rgb_channel_interps_are_exactly_red_green_blue(self):
+        """The RGB allowlist is exactly ``{red, green, blue}`` (reorder guard).
+
+        Test scenario:
+            ``RGB_CHANNEL_INTERPS`` is built from a positional slice of
+            ``COLOR_NAMES``; pin its contents so a reordering of that list
+            cannot silently widen or narrow the RGB heuristic.
+        """
+        assert RGB_CHANNEL_INTERPS == frozenset({"red", "green", "blue"}), (
+            f"RGB allowlist drifted: {RGB_CHANNEL_INTERPS}"
+        )
+
     def test_full_rgb_tags_resolves_red_band(self):
         """All three R/G/B tags set → resolved band is red, rgb list filled.
 
@@ -353,7 +396,7 @@ class TestResolvePlotBandPolicy:
         """Red+green tagged, blue undefined → fallback ``rgb=[2, 1, 0]``.
 
         Test scenario:
-            ``has_color_interp`` is True (red and green tagged) but
+            ``has_rgb_interp`` is True (red and green tagged) but
             ``get_band_by_color('blue') is None`` because no band has
             the blue tag. The resolver falls back to the Sentinel-2
             default ``[2, 1, 0]`` and picks band 2 as the rendered band.

--- a/tests/dataset/plot/test_plot_resolution.py
+++ b/tests/dataset/plot/test_plot_resolution.py
@@ -189,6 +189,74 @@ class TestResolvePlotBandPolicy:
             f"deprecation: {[str(w.message) for w in deprecations]}"
         )
 
+    @pytest.mark.parametrize(
+        "interp", ["gray_index", "alpha", "hue", "cyan", "YCbCr_YBand"]
+    )
+    def test_non_rgb_interpretation_not_treated_as_rgb(self, interp):
+        """A non-RGB colour interpretation must not trigger the RGB heuristic.
+
+        Args:
+            interp: A single-channel / non-RGB GDAL interpretation name.
+
+        Test scenario:
+            The RGB heuristic is an allowlist of ``red``/``green``/``blue``, so
+            any other interpretation (``gray_index``, ``alpha``, ``hue``,
+            ``cyan``, ``YCbCr_*`` …) on a 3-band raster must resolve to
+            ``(0, None)`` with no Sentinel-2 deprecation — closing the whole
+            non-RGB class, not only ``palette_index`` (see #910).
+        """
+        rng = np.random.default_rng(911)
+        arr = rng.random((3, 6, 6)).astype("float32")
+        dataset = Dataset.create_from_array(
+            arr, top_left_corner=(0, 0), cell_size=0.05, epsg=4326
+        )
+        dataset.band_color = {0: interp}
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            resolved_band, resolved_rgb = dataset._resolve_plot_band(
+                band=None, rgb=None
+            )
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert (resolved_band, resolved_rgb) == (0, None), (
+            f"{interp!r} must resolve to (0, None), got {(resolved_band, resolved_rgb)}"
+        )
+        assert not deprecations, (
+            f"{interp!r} must not emit the Sentinel-2 RGB deprecation: "
+            f"{[str(w.message) for w in deprecations]}"
+        )
+
+    def test_rgb_channels_win_over_a_palette_band(self):
+        """Real ``red``/``green``/``blue`` tags still resolve RGB despite a palette.
+
+        Test scenario:
+            A 4-band raster tagged ``red``/``green``/``blue`` on bands 0-2 and
+            ``palette_index`` on band 3 is genuine RGB imagery. The allowlist
+            still fires on the RGB channels, so it resolves to ``(0, [0, 1, 2])``
+            with no deprecation — the stray palette band does not suppress it.
+        """
+        rng = np.random.default_rng(912)
+        arr = rng.random((4, 6, 6)).astype("float32")
+        dataset = Dataset.create_from_array(
+            arr, top_left_corner=(0, 0), cell_size=0.05, epsg=4326
+        )
+        dataset.band_color = {0: "red", 1: "green", 2: "blue", 3: "palette_index"}
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            resolved_band, resolved_rgb = dataset._resolve_plot_band(
+                band=None, rgb=None
+            )
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert resolved_band == 0, f"Red is band 0, got {resolved_band}"
+        assert resolved_rgb == [0, 1, 2], (
+            f"RGB tags must resolve to [0, 1, 2], got {resolved_rgb}"
+        )
+        assert not deprecations, (
+            "a full RGB tag set must not emit the Sentinel-2 fallback deprecation: "
+            f"{[str(w.message) for w in deprecations]}"
+        )
+
     def test_full_rgb_tags_resolves_red_band(self):
         """All three R/G/B tags set → resolved band is red, rgb list filled.
 


### PR DESCRIPTION
# Description

`Dataset.plot()` mis-rendered a multi-band raster carrying a palette. `_resolve_plot_band` treated a raster with
`band_count >= 3` as RGB imagery whenever *any* band had a colour interpretation other than `undefined` — a
denylist. A `palette_index` band is rendered through its colour table, not as an RGB channel, so a paletted raster
was resolved to a false-colour RGB composite `[2, 1, 0]` and emitted a spurious Sentinel-2 `DeprecationWarning`.

The fix inverts the heuristic to an **allowlist**: only `red`/`green`/`blue` tags signal RGB imagery. This
subsumes the palette case and closes the whole class in one predicate — `palette_index`, `gray_index`, `alpha`,
CMYK, HSL and YCbCr all now resolve to a single-band render, so a new non-RGB interpretation can never silently
re-enable the bug.

```python
# 3-band raster with a palette on one band
ds.plot()          # before: false-colour RGB [2, 1, 0] + Sentinel-2 DeprecationWarning
                   # after:  single-band render, no warning
```

## Changes

- `src/pyramids/base/_utils.py`: add `RGB_CHANNEL_INTERPS = frozenset({red, green, blue})`; remove the now-unused
  `UNDEFINED_COLOR_INTERP` constant (the allowlist rewrite dropped its only consumer).
- `src/pyramids/dataset/dataset.py`: `_resolve_plot_band` gates the RGB heuristic on the allowlist
  (`has_rgb_interp`), and — on the single-band branch — keys the resolved band off `rgb[0]` when an explicit
  `rgb=` is supplied, so the downstream `exclude_value` nodata mask agrees with the RGB render. Rule-3 and
  `plot()` facade docstrings updated; a `palette_index` doctest added.
- `tests/dataset/plot/test_plot_resolution.py`: parametrized regression tests over palette (bands 0/1/2) and the
  other non-RGB interpretations, a mixed 4-band RGB+palette case, a mixed palette+partial-RGB fallback case, an
  explicit-`rgb=` case, and a guard that the allowlist is exactly `{red, green, blue}`. These run in the primary
  `-m "not plot"` suite (they tag interpretations via the `band_color` setter — no cleopatra).

Paletted rasters resolve to band 0 as a deliberate placeholder: the plot path does not yet render a palette
through its GDAL colour table (`Analysis._process_color_table` is unused). That separate gap is tracked in #913.

## Review

Reviewed against `main` over two rounds. The main outcome was widening the fix from a palette-only exclusion to
an **RGB-channel allowlist** — a denylist (exclude only `undefined`/`palette_index`) still mis-triggered the
false-RGB path on `gray_index`, `alpha`, CMYK, HSL and YCbCr tags, so only `red`/`green`/`blue` now count as RGB
imagery. Other resolved points:

- `exclude_value` now keys off `rgb[0]` for an explicit `rgb=` on the single-band branch, so the nodata mask and
  the RGB render agree;
- the orphaned `UNDEFINED_COLOR_INTERP` constant (its last consumer removed by the allowlist) was deleted;
- rule-3 and `plot()` facade docstrings + the `palette_index` doctest were aligned with the allowlist;
- the test matrix was extended to pin the whole non-RGB class, a mixed RGB+palette raster, the partial-RGB
  fallback, an explicit-`rgb=` case, and the exact allowlist contents.

The palette-through-colour-table rendering gap surfaced during review is deliberately out of scope and tracked in
#913.

## Issues

- Closes #910 — `plot()` mis-resolves a multi-band paletted raster as false-colour RGB.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

No public signature changes; the fix is confined to the internal `_resolve_plot_band` heuristic and a constants
module.

# How Has This Been Tested?

- [x] `pytest tests/dataset/plot/ tests/dataset/unit/` + `--doctest-modules` on the touched source against the
      branch → **705 passed, 4 skipped**.
- [x] New resolution tests: every non-RGB interpretation (`palette_index`/`gray_index`/`alpha`/`hue`/`cyan`/
      `YCbCr_*`) resolves to `(0, None)` with no deprecation; real `red`/`green`/`blue` tags still resolve RGB;
      a stray palette beside partial RGB still falls back to `[2, 1, 0]` with the Sentinel-2 warning; explicit
      `rgb=` keys the resolved band off `rgb[0]`.
- [x] The exact #910 reproduction (3-band raster, palette on band 1) now returns `(0, None)` with no warning
      (was `(2, [2, 1, 0])` + warning).

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.

