### PR TITLE
feat(dataset): expose an overview level as a Dataset

### DIFF
--- a/docs/reference/dataset/index.md
+++ b/docs/reference/dataset/index.md
@@ -209,6 +209,7 @@ classDiagram
         +create_overviews()
         +recreate_overviews()
         +get_overview()
+        +get_overview_dataset()
     }
     Dataset --> Visualization : «visualisation»
 

--- a/docs/reference/dataset/io.md
+++ b/docs/reference/dataset/io.md
@@ -7,7 +7,9 @@ flowchart LR
     IO(("IO<br/>ds.io"))
     IO --> R["<b>read</b><br/>read_array · read_windows<br/>get_block_arrangement<br/>get_tile · map_blocks"]
     IO --> W["<b>write / export</b><br/>write_array · to_file · to_bytes<br/>to_raster · to_xyz · to_terrain_rgb"]
-    IO --> O["<b>overviews</b><br/>overview_count · create_overviews<br/>recreate_overviews · get_overview<br/>get_overview_dataset · read_overview_array"]
+    IO --> O["<b>overviews</b><br/>overview_count · create_overviews<br/>
+        recreate_overviews · get_overview<br/>
+        get_overview_dataset · read_overview_array"]
 ```
 
 ## Open a raster — paths, URLs, archives, and bytes

--- a/docs/reference/dataset/io.md
+++ b/docs/reference/dataset/io.md
@@ -7,7 +7,7 @@ flowchart LR
     IO(("IO<br/>ds.io"))
     IO --> R["<b>read</b><br/>read_array · read_windows<br/>get_block_arrangement<br/>get_tile · map_blocks"]
     IO --> W["<b>write / export</b><br/>write_array · to_file · to_bytes<br/>to_raster · to_xyz · to_terrain_rgb"]
-    IO --> O["<b>overviews</b><br/>overview_count · create_overviews<br/>recreate_overviews · get_overview<br/>read_overview_array"]
+    IO --> O["<b>overviews</b><br/>overview_count · create_overviews<br/>recreate_overviews · get_overview<br/>get_overview_dataset · read_overview_array"]
 ```
 
 ## Open a raster — paths, URLs, archives, and bytes

--- a/src/pyramids/base/protocols.py
+++ b/src/pyramids/base/protocols.py
@@ -255,6 +255,12 @@ class RasterLike(SpatialObject, Protocol):
         """Return an overview level (protocol stub; see concrete impls)."""
         ...
 
+    def get_overview_dataset(
+        self, *args: Any, **kwargs: Any
+    ) -> Any:  # pragma: no cover - protocol stub
+        """Return an overview level as a Dataset (protocol stub; see concrete impls)."""
+        ...
+
     def read_overview_array(  # pragma: no cover - protocol stub
         self, *args: Any, **kwargs: Any
     ) -> ArrayLike:

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -180,7 +180,6 @@ _NETWORK_VSI_PREFIXES: tuple[str, ...] = (
     _VSICURL,
     "/vsicurl?",
     "/vsicurl_streaming/",
-    "/vsiadls/",
     "/vsioss/",
     "/vsiswift/",
     "/vsihdfs/",
@@ -228,7 +227,13 @@ def is_network_backed(path: str) -> bool:
         network = True
     else:
         scheme = urlparse(path).scheme.lower()
-        network = (scheme in URL_SCHEMES or scheme == _DODS_SCHEME) and len(scheme) > 1
+        # `file://` is in URL_SCHEMES but names a local path, so it never needs
+        # credentials -- the one scheme in that map that does not cross the network.
+        network = (
+            (scheme in URL_SCHEMES or scheme == _DODS_SCHEME)
+            and scheme != "file"
+            and len(scheme) > 1
+        )
     return network
 
 

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -190,17 +190,22 @@ _NETWORK_VSI_PREFIXES: tuple[str, ...] = (
 def is_network_backed(path: str) -> bool:
     """True if reading `path` crosses the network, so credentials may matter.
 
-    Narrower than :func:`is_remote`, which answers "is this a URL or any `/vsi*`
-    path" and therefore also covers the purely local virtual filesystems —
-    `/vsimem/`, `/vsizip/`, `/vsigzip/`, `/vsitar/`. Those never authenticate, so
-    a caller reasoning about credentials wants this predicate instead.
+    Narrower than :func:`is_remote`, which answers "is this a URL or one of the
+    `/vsi*` prefixes it lists" and therefore also covers the purely local virtual
+    filesystems — `/vsimem/`, `/vsizip/`, `/vsigzip/`, `/vsitar/` — and `file://`,
+    a URL that names a local path. None of those ever authenticate, so a caller
+    reasoning about credentials wants this predicate instead.
 
     Args:
         path: A string path or URL.
 
     Returns:
-        `True` for cloud URL schemes and for the `/vsi*` handlers that fetch over
-        the network; `False` for local paths and for local virtual filesystems.
+        `True` for the cloud URL schemes — `s3://`, `gs://`, `az://`, `abfs://`,
+        `http(s)://`, `dods://` — and for the network `/vsi*` handlers: `/vsis3/`,
+        `/vsigs/`, `/vsiaz/`, `/vsicurl/` and its query-string form,
+        `/vsicurl_streaming/`, `/vsioss/`, `/vsiswift/`, `/vsihdfs/`,
+        `/vsiwebhdfs/`. `False` for local paths, for `file://`, and for the local
+        virtual filesystems.
 
     Examples:
         - Network-backed sources:
@@ -211,11 +216,13 @@ def is_network_backed(path: str) -> bool:
             True
 
             ```
-        - Local virtual filesystems are not network-backed:
+        - Local virtual filesystems and `file://` are not network-backed:
             ```python
             >>> is_network_backed("/vsimem/temp.tif")
             False
             >>> is_network_backed("/vsizip/local.zip/x.tif")
+            False
+            >>> is_network_backed("file:///data/x.tif")
             False
             >>> is_network_backed("/data/x.tif")
             False

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -173,6 +173,65 @@ def is_remote(path: str) -> bool:
     return result
 
 
+_NETWORK_VSI_PREFIXES: tuple[str, ...] = (
+    _VSIS3,
+    _VSIGS,
+    _VSIAZ,
+    _VSICURL,
+    "/vsicurl?",
+    "/vsicurl_streaming/",
+    "/vsiadls/",
+    "/vsioss/",
+    "/vsiswift/",
+    "/vsihdfs/",
+    "/vsiwebhdfs/",
+)
+
+
+def is_network_backed(path: str) -> bool:
+    """True if reading `path` crosses the network, so credentials may matter.
+
+    Narrower than :func:`is_remote`, which answers "is this a URL or any `/vsi*`
+    path" and therefore also covers the purely local virtual filesystems —
+    `/vsimem/`, `/vsizip/`, `/vsigzip/`, `/vsitar/`. Those never authenticate, so
+    a caller reasoning about credentials wants this predicate instead.
+
+    Args:
+        path: A string path or URL.
+
+    Returns:
+        `True` for cloud URL schemes and for the `/vsi*` handlers that fetch over
+        the network; `False` for local paths and for local virtual filesystems.
+
+    Examples:
+        - Network-backed sources:
+            ```python
+            >>> is_network_backed("/vsicurl/https://foo/x.tif")
+            True
+            >>> is_network_backed("s3://bucket/key.tif")
+            True
+
+            ```
+        - Local virtual filesystems are not network-backed:
+            ```python
+            >>> is_network_backed("/vsimem/temp.tif")
+            False
+            >>> is_network_backed("/vsizip/local.zip/x.tif")
+            False
+            >>> is_network_backed("/data/x.tif")
+            False
+
+            ```
+    """
+    network: bool
+    if path.startswith(_NETWORK_VSI_PREFIXES):
+        network = True
+    else:
+        scheme = urlparse(path).scheme.lower()
+        network = (scheme in URL_SCHEMES or scheme == _DODS_SCHEME) and len(scheme) > 1
+    return network
+
+
 # Per-process cache of resolved S3 bucket regions (None caches a failed probe so
 # a single offline/blocked attempt is not retried on every open of the bucket).
 # Intentionally lock-free: two threads racing the first probe of the same bucket

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -1539,9 +1539,9 @@ class RasterBase(ABC):
     def get_overview_dataset(self, band: int | None = None, overview_index: int = 0):
         """Get an overview level as a standalone Dataset.
 
-        The `gdal.Band` from `get_overview` carries no geotransform, CRS or no-data
-        value; this returns the same pixels as a read-only `Dataset` view whose cell
-        size is scaled by the decimation factor. The caller owns the returned handle.
+        The `gdal.Band` from `get_overview` carries no geotransform and no CRS; this
+        returns the same pixels as a read-only `Dataset` view whose cell size is scaled
+        by the decimation factor. The caller owns the returned handle.
 
         Args:
             band (int | None, optional):

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -1536,6 +1536,27 @@ class RasterBase(ABC):
         pass
 
     @abstractmethod
+    def get_overview_dataset(self, band: int | None = None, overview_index: int = 0):
+        """Get an overview level as a standalone Dataset.
+
+        The `gdal.Band` from `get_overview` carries no geotransform, CRS or no-data
+        value; this returns the same pixels as a read-only `Dataset` view whose cell
+        size is scaled by the decimation factor. The caller owns the returned handle.
+
+        Args:
+            band (int | None, optional):
+                The band to take; None (the default) keeps every band.
+            overview_index (int):
+                Index of the overview. Default is 0.
+
+        Returns:
+            Dataset:
+                The overview level, carrying the parent's CRS, no-data value and band
+                metadata.
+        """
+        pass
+
+    @abstractmethod
     def read_overview_array(
         self, band: int | None = None, overview_index: int = 0
     ) -> np.typing.NDArray:

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -1228,6 +1228,10 @@ class Dataset(RasterBase):
         """Facade — delegates to :meth:`IO.get_overview <pyramids.dataset.engines.IO.get_overview>`."""
         return self.io.get_overview(*args, **kwargs)
 
+    def get_overview_dataset(self, *args, **kwargs):
+        """Facade — delegates to :meth:`IO.get_overview_dataset <pyramids.dataset.engines.IO.get_overview_dataset>`."""
+        return self.io.get_overview_dataset(*args, **kwargs)
+
     def read_overview_array(self, *args, **kwargs):
         """Facade — delegates to :meth:`IO.read_overview_array <pyramids.dataset.engines.IO.read_overview_array>`."""
         return self.io.read_overview_array(*args, **kwargs)

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -39,7 +39,7 @@ from pyramids.base._file_manager import (
 )
 from pyramids.base._locks import DummyLock, default_lock
 from pyramids.base._utils import resolve_resampling
-from pyramids.base.crs import reproject_coordinates
+from pyramids.base.crs import crs_spec, reproject_coordinates
 from pyramids.base.protocols import ArrayLike
 from pyramids.dataset.abstract_dataset import (
     OVERVIEW_LEVELS,
@@ -3339,48 +3339,54 @@ class IO(_Engine["Dataset"]):
             - Dataset.create_overviews: Create the dataset overviews.
             - Dataset.overview_count: Number of overviews.
         """
-        # Circular import: `pyramids.dataset.dataset` imports this engine module while it
-        # is still initialising, so `Dataset` is only reachable from inside a call. Same
-        # carve-out as `engines/analysis.py`.
-        from pyramids.dataset.dataset import Dataset as _Dataset
-
+        # get_overview resolves the band through _iloc, which raises IndexError; this
+        # accessor documents ValueError, and its read_overview_array sibling already
+        # rejects the same inputs that way.
+        validate_band_index(band, self._ds.band_count)
+        if overview_index < 0:
+            # GDAL reads a negative OVERVIEW_LEVEL as "no overview" and hands back the
+            # full-resolution raster, so a caller reaching for the Python "last element"
+            # idiom would silently load the parent instead of the coarsest level.
+            raise ValueError(
+                f"overview_index must not be negative; got {overview_index}"
+            )
+        if self._ds.band_count == 0:
+            raise ValueError(
+                "The dataset has no bands, so it has no overviews to return."
+            )
         selection = [band] if band is not None else list(range(self._ds.band_count))
         for index in selection:
             # Reuse get_overview's "no overviews" / "index out of range" guards, so this
             # accessor rejects exactly what its gdal.Band sibling rejects.
             self.get_overview(index, overview_index)
         file_name = self._ds.file_name
-        # Mirrors RasterBase._require_writable's rule: a MEM/vsimem/path-less handle has
-        # nothing to reopen, so OVERVIEW_LEVEL cannot reach it.
-        in_memory = (
-            not file_name
-            or file_name.startswith(_VSIMEM_PREFIX)
-            or self._ds.driver_type == "memory"
-        )
-        if in_memory:
-            overview = self._overview_dataset_from_array(
-                _Dataset, selection, band, overview_index
-            )
+        # Only a handle GDAL can reopen by name can be described by a VRT. A `MEM`
+        # dataset has no name; `/vsimem/` does, and reopens fine, so it takes the file
+        # path rather than being copied into a second RAM buffer.
+        reopenable = bool(file_name) and self._ds.driver_type != "memory"
+        if reopenable:
+            overview = self._overview_dataset_from_file(file_name, band, overview_index)
         else:
-            overview = self._overview_dataset_from_file(
-                _Dataset, file_name, band, overview_index
+            overview = self._overview_dataset_from_array(
+                selection, band, overview_index
             )
         return overview
 
     def _overview_dataset_from_file(
-        self,
-        dataset_cls: type[Dataset],
-        file_name: str,
-        band: int | None,
-        overview_index: int,
+        self, file_name: str, band: int | None, overview_index: int
     ) -> Dataset:
-        """Open one overview level of an on-disk raster without reading its pixels.
+        """Describe one overview level of a re-openable raster, without reading pixels.
 
         GDAL's `OVERVIEW_LEVEL` open option exposes the level as a full dataset and
-        scales the geotransform itself, so nothing has to be recomputed here.
+        scales the geotransform itself. That dataset is then wrapped in a VRT, which is
+        what makes the result **self-describing**: `OpenEx` alone returns a handle whose
+        description is still the *parent's* path, so every pyramids path that reopens by
+        name — `read_array(threadsafe=True)`, `read_array(chunks=...)`, `__reduce__` —
+        would silently read the full-resolution raster while the object reported the
+        level's shape. The VRT records `<OpenOptions><OOI key="OVERVIEW_LEVEL">` and
+        carries no path of its own, so those shortcuts are structurally unavailable.
 
         Args:
-            dataset_cls: The `Dataset` class, passed in to keep the import call-local.
             file_name: Path or VSI URL of the parent raster.
             band: A single 0-based band to keep, or `None` for every band.
             overview_index: Index of the overview level to open.
@@ -3388,31 +3394,33 @@ class IO(_Engine["Dataset"]):
         Returns:
             Dataset: The overview level, wrapping a lazily opened GDAL handle.
         """
+        # Circular import: `pyramids.dataset.dataset` imports this engine module while it
+        # is still initialising, so `Dataset` is only reachable from inside a call. Same
+        # carve-out as `engines/analysis.py`.
+        from pyramids.dataset.dataset import Dataset as _Dataset
+
+        # The level is reopened from disk, so anything still sitting in the parent
+        # handle's write cache would otherwise be invisible to it.
+        self._ds.raster.FlushCache()
+        band_list = None if band is None else [band + 1]
         with self._ds._cloud_config():
             level = gdal.OpenEx(
                 file_name, open_options=[f"OVERVIEW_LEVEL={overview_index}"]
             )
-            if band is not None:
-                # A VRT keeps the band subset lazy; MEM would copy the level into RAM,
-                # which on a large raster is exactly what the overview avoids.
-                level = gdal.Translate("", level, format="VRT", bandList=[band + 1])
-        return dataset_cls(level, gdal_env=self._ds.gdal_env)
+            level = gdal.Translate("", level, format="VRT", bandList=band_list)
+        return _Dataset(level, gdal_env=self._ds.gdal_env)
 
     def _overview_dataset_from_array(
-        self,
-        dataset_cls: type[Dataset],
-        selection: list[int],
-        band: int | None,
-        overview_index: int,
+        self, selection: list[int], band: int | None, overview_index: int
     ) -> Dataset:
-        """Materialise one overview level of a path-less raster into a new `Dataset`.
+        """Materialise one overview level of a nameless raster into a new `Dataset`.
 
-        Reads each selected band's overview directly rather than through
-        `read_overview_array`, whose all-bands branch sizes its buffer from overview 0
-        and so cannot serve a higher `overview_index`.
+        Only a `MEM` handle reaches this path — it has no name for GDAL to reopen, so it
+        cannot be described by a VRT. Reads each selected band's overview directly rather
+        than through `read_overview_array`, whose all-bands branch sizes its buffer from
+        overview 0 and so cannot serve a higher `overview_index`.
 
         Args:
-            dataset_cls: The `Dataset` class, passed in to keep the import call-local.
             selection: The 0-based band indices to read.
             band: The single band requested, or `None` when every band was requested.
             overview_index: Index of the overview level to read.
@@ -3421,6 +3429,9 @@ class IO(_Engine["Dataset"]):
             Dataset: An in-memory dataset holding the overview pixels, with the parent's
             CRS and no-data value and a geotransform scaled by the decimation factor.
         """
+        # Circular import: see _overview_dataset_from_file.
+        from pyramids.dataset.dataset import Dataset as _Dataset
+
         planes = [
             np.asarray(self.get_overview(index, overview_index).ReadAsArray())
             for index in selection
@@ -3428,23 +3439,36 @@ class IO(_Engine["Dataset"]):
         arr = planes[0] if band is not None else np.stack(planes, axis=0)
         rows, columns = planes[0].shape
         geo = self._ds.geotransform
+        # Scale all four resolution/rotation terms, as GDALOverviewDataset does: leaving
+        # the rotation terms unscaled shears every pixel but the origin on a skewed grid.
+        x_ratio = self._ds.columns / columns
+        y_ratio = self._ds.rows / rows
         scaled_geo = (
             geo[0],
-            geo[1] * (self._ds.columns / columns),
-            geo[2],
+            geo[1] * x_ratio,
+            geo[2] * y_ratio,
             geo[3],
-            geo[4],
-            geo[5] * (self._ds.rows / rows),
+            geo[4] * x_ratio,
+            geo[5] * y_ratio,
         )
-        no_data_value = (
-            self._ds.no_data_value[band]
+        parent_no_data = (
+            [self._ds.no_data_value[band]]
             if band is not None
             else list(self._ds.no_data_value)
         )
-        return dataset_cls.create_from_array(
+        # A parent that declares no no-data must not gain one: passing a list of Nones
+        # makes the builder coerce them into a real sentinel (nan).
+        no_data_value = (
+            None
+            if all(value is None for value in parent_no_data)
+            else (parent_no_data[0] if band is not None else parent_no_data)
+        )
+        return _Dataset.create_from_array(
             arr,
             geo=scaled_geo,
-            epsg=self._ds.epsg,
+            # `epsg` alone is None for a CRS with no authority code (a geostationary
+            # grid, say), which would clear the projection outright.
+            epsg=crs_spec(self._ds.epsg, self._ds.crs),
             no_data_value=no_data_value,
         )
 

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -3288,6 +3288,166 @@ class IO(_Engine["Dataset"]):
             raise ValueError(f"overview_level should be less than {n_views}")
         return band_obj.GetOverview(overview_index)
 
+    def get_overview_dataset(
+        self, band: int | None = None, overview_index: int = 0
+    ) -> Dataset:
+        """Get an overview level as a standalone `Dataset`.
+
+        `get_overview` hands back a raw `gdal.Band`, which carries no geotransform, CRS
+        or no-data value, so an overview cannot be plotted, written, cropped or
+        reprojected without dropping to GDAL. This returns the same pixels as a
+        first-class `Dataset` whose cell size is scaled by the decimation factor.
+
+        A raster backed by a file is reopened lazily through GDAL's `OVERVIEW_LEVEL`
+        open option, so no pixels are read and GDAL derives the scaled geotransform
+        itself. A raster with no path to reopen — an in-memory `MEM` dataset, a
+        `/vsimem/` raster, or a `NetCDF` variable view — is materialised into a new
+        in-memory `Dataset` instead, with the geotransform scaled here.
+
+        Args:
+            band (int | None):
+                The band to take. `None` (the default) keeps every band, matching
+                `read_overview_array`; an `int` returns a single-band `Dataset`.
+            overview_index (int):
+                Index of the overview level. Defaults to 0, the largest (least
+                decimated) overview.
+
+        Returns:
+            Dataset:
+                The requested overview level, carrying the parent's CRS and no-data
+                value and a cell size scaled by the decimation factor.
+
+        Raises:
+            ValueError:
+                A selected band has no overviews, or `overview_index` is out of range.
+
+        Examples:
+            - Build overviews on a raster, then take level 1 as a `Dataset`:
+              ```python
+              >>> from pyramids.dataset import Dataset
+              >>> dataset = Dataset.read_file("dem.tif", read_only=False)  # doctest: +SKIP
+              >>> dataset.create_overviews()  # doctest: +SKIP
+              >>> overview = dataset.get_overview_dataset(overview_index=1)  # doctest: +SKIP
+              >>> overview.cell_size, overview.epsg  # doctest: +SKIP
+              (0.2, 4326)
+              >>> overview.to_file("dem_ov1.tif")  # doctest: +SKIP
+
+              ```
+        See Also:
+            - Dataset.get_overview: The same level as a raw `gdal.Band`.
+            - Dataset.read_overview_array: The same level as a numpy array.
+            - Dataset.create_overviews: Create the dataset overviews.
+            - Dataset.overview_count: Number of overviews.
+        """
+        # Circular import: `pyramids.dataset.dataset` imports this engine module while it
+        # is still initialising, so `Dataset` is only reachable from inside a call. Same
+        # carve-out as `engines/analysis.py`.
+        from pyramids.dataset.dataset import Dataset as _Dataset
+
+        selection = [band] if band is not None else list(range(self._ds.band_count))
+        for index in selection:
+            # Reuse get_overview's "no overviews" / "index out of range" guards, so this
+            # accessor rejects exactly what its gdal.Band sibling rejects.
+            self.get_overview(index, overview_index)
+        file_name = self._ds.file_name
+        # Mirrors RasterBase._require_writable's rule: a MEM/vsimem/path-less handle has
+        # nothing to reopen, so OVERVIEW_LEVEL cannot reach it.
+        in_memory = (
+            not file_name
+            or file_name.startswith(_VSIMEM_PREFIX)
+            or self._ds.driver_type == "memory"
+        )
+        if in_memory:
+            overview = self._overview_dataset_from_array(
+                _Dataset, selection, band, overview_index
+            )
+        else:
+            overview = self._overview_dataset_from_file(
+                _Dataset, file_name, band, overview_index
+            )
+        return overview
+
+    def _overview_dataset_from_file(
+        self,
+        dataset_cls: type[Dataset],
+        file_name: str,
+        band: int | None,
+        overview_index: int,
+    ) -> Dataset:
+        """Open one overview level of an on-disk raster without reading its pixels.
+
+        GDAL's `OVERVIEW_LEVEL` open option exposes the level as a full dataset and
+        scales the geotransform itself, so nothing has to be recomputed here.
+
+        Args:
+            dataset_cls: The `Dataset` class, passed in to keep the import call-local.
+            file_name: Path or VSI URL of the parent raster.
+            band: A single 0-based band to keep, or `None` for every band.
+            overview_index: Index of the overview level to open.
+
+        Returns:
+            Dataset: The overview level, wrapping a lazily opened GDAL handle.
+        """
+        with self._ds._cloud_config():
+            level = gdal.OpenEx(
+                file_name, open_options=[f"OVERVIEW_LEVEL={overview_index}"]
+            )
+            if band is not None:
+                # A VRT keeps the band subset lazy; MEM would copy the level into RAM,
+                # which on a large raster is exactly what the overview avoids.
+                level = gdal.Translate("", level, format="VRT", bandList=[band + 1])
+        return dataset_cls(level, gdal_env=self._ds.gdal_env)
+
+    def _overview_dataset_from_array(
+        self,
+        dataset_cls: type[Dataset],
+        selection: list[int],
+        band: int | None,
+        overview_index: int,
+    ) -> Dataset:
+        """Materialise one overview level of a path-less raster into a new `Dataset`.
+
+        Reads each selected band's overview directly rather than through
+        `read_overview_array`, whose all-bands branch sizes its buffer from overview 0
+        and so cannot serve a higher `overview_index`.
+
+        Args:
+            dataset_cls: The `Dataset` class, passed in to keep the import call-local.
+            selection: The 0-based band indices to read.
+            band: The single band requested, or `None` when every band was requested.
+            overview_index: Index of the overview level to read.
+
+        Returns:
+            Dataset: An in-memory dataset holding the overview pixels, with the parent's
+            CRS and no-data value and a geotransform scaled by the decimation factor.
+        """
+        planes = [
+            np.asarray(self.get_overview(index, overview_index).ReadAsArray())
+            for index in selection
+        ]
+        arr = planes[0] if band is not None else np.stack(planes, axis=0)
+        rows, columns = planes[0].shape
+        geo = self._ds.geotransform
+        scaled_geo = (
+            geo[0],
+            geo[1] * (self._ds.columns / columns),
+            geo[2],
+            geo[3],
+            geo[4],
+            geo[5] * (self._ds.rows / rows),
+        )
+        no_data_value = (
+            self._ds.no_data_value[band]
+            if band is not None
+            else list(self._ds.no_data_value)
+        )
+        return dataset_cls.create_from_array(
+            arr,
+            geo=scaled_geo,
+            epsg=self._ds.epsg,
+            no_data_value=no_data_value,
+        )
+
     def read_overview_array(
         self, band: int | None = None, overview_index: int = 0
     ) -> np.typing.NDArray:

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -3299,11 +3299,21 @@ class IO(_Engine["Dataset"]):
         reprojected without dropping to GDAL. This returns the same pixels as a
         first-class `Dataset` whose cell size is scaled by the decimation factor.
 
-        A raster backed by a file is reopened lazily through GDAL's `OVERVIEW_LEVEL`
-        open option, so no pixels are read and GDAL derives the scaled geotransform
-        itself. A raster with no path to reopen — an in-memory `MEM` dataset, a
-        `/vsimem/` raster, or a `NetCDF` variable view — is materialised into a new
-        in-memory `Dataset` instead, with the geotransform scaled here.
+        A raster GDAL can reopen by name — an on-disk file, a `/vsimem/` raster, any
+        `/vsi*` URL — is described lazily through the `OVERVIEW_LEVEL` open option and
+        wrapped in a VRT, so no pixels are read and GDAL derives the scaled geotransform
+        itself. Only a nameless `MEM` handle (a `create_from_array` raster with no path,
+        a `NetCDF` variable view) is materialised into an in-memory `Dataset`, with the
+        geotransform scaled here.
+
+        The result is a **read-only view** of the parent's pixels: it is detached from
+        the parent handle and carries its own GDAL handle, which the caller owns and
+        should `close()` — until it is closed it keeps the parent file open, so on
+        Windows the file cannot be deleted. Because the lazy form has no path of its
+        own, `read_array(threadsafe=True)`, `read_array(chunks=...)` and pickling it are
+        unavailable and fail loudly; call `to_file()` first if you need any of those.
+        A `NetCDF` variable view returns a plain `Dataset` — an overview level is an
+        ordinary raster, not a NetCDF container.
 
         Args:
             band (int | None):
@@ -3311,27 +3321,37 @@ class IO(_Engine["Dataset"]):
                 `read_overview_array`; an `int` returns a single-band `Dataset`.
             overview_index (int):
                 Index of the overview level. Defaults to 0, the largest (least
-                decimated) overview.
+                decimated) overview. Negative values are rejected rather than counting
+                from the end.
 
         Returns:
             Dataset:
-                The requested overview level, carrying the parent's CRS and no-data
-                value and a cell size scaled by the decimation factor.
+                The requested overview level, carrying the parent's CRS, no-data value,
+                band names/units/scale/offset and dataset metadata, with a cell size
+                scaled by the decimation factor. The caller owns its handle.
 
         Raises:
             ValueError:
-                A selected band has no overviews, or `overview_index` is out of range.
+                `band` is out of range, `overview_index` is negative or past the built
+                levels, a selected band has no overviews, or the dataset has no bands.
+
+        Warns:
+            UserWarning:
+                The parent is remote and carries cloud credentials, which GDAL will not
+                replay when the VRT reopens its source.
 
         Examples:
-            - Build overviews on a raster, then take level 1 as a `Dataset`:
+            - Build overviews on a 0.1-degree raster, then take level 1 (a 4x
+              decimation) as a `Dataset`:
               ```python
               >>> from pyramids.dataset import Dataset
               >>> dataset = Dataset.read_file("dem.tif", read_only=False)  # doctest: +SKIP
               >>> dataset.create_overviews()  # doctest: +SKIP
               >>> overview = dataset.get_overview_dataset(overview_index=1)  # doctest: +SKIP
-              >>> overview.cell_size, overview.epsg  # doctest: +SKIP
-              (0.2, 4326)
+              >>> overview.cell_size  # doctest: +SKIP
+              0.4
               >>> overview.to_file("dem_ov1.tif")  # doctest: +SKIP
+              >>> overview.close()  # doctest: +SKIP
 
               ```
         See Also:

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -3312,8 +3312,13 @@ class IO(_Engine["Dataset"]):
         Windows the file cannot be deleted. Neither form carries a path of its own, so
         `read_array(threadsafe=True)` and pickling it raise, and `read_array(chunks=...)`
         returns a graph that raises when it is computed; call `to_file()` first if you
-        need any of those. A `NetCDF` variable view returns a plain `Dataset` — an
-        overview level is an ordinary raster, not a NetCDF container.
+        need any of those, and note that `create_overviews()` on the level would drop a
+        stray `.ovr` into the process's working directory. The `read_only` label stops
+        pixel writes; metadata setters still work, since a pathless handle cannot spill
+        a PAM sidecar. A `NetCDF` variable view returns a plain `Dataset` — an overview
+        level is an ordinary raster, not a NetCDF container — and only a real mapping of
+        dataset metadata is carried, so a container's structured attributes stay behind.
+        The materialised form holds the level's pixels twice while it is being built.
 
         Args:
             band (int | None):
@@ -3334,6 +3339,9 @@ class IO(_Engine["Dataset"]):
             ValueError:
                 `band` is out of range, `overview_index` is negative or past the built
                 levels, a selected band has no overviews, or the dataset has no bands.
+            RuntimeError:
+                GDAL failed to describe the level — a source that disappeared between
+                the identity check and the open, or a driver that cannot express it.
 
         Warns:
             UserWarning:
@@ -3381,9 +3389,19 @@ class IO(_Engine["Dataset"]):
             # accessor rejects exactly what its gdal.Band sibling rejects.
             self.get_overview(index, overview_index)
         file_name = self._reopenable_source()
+        overview = None
         if file_name is not None:
-            overview = self._overview_dataset_from_file(file_name, band, overview_index)
-        else:
+            try:
+                overview = self._overview_dataset_from_file(
+                    file_name, band, overview_index
+                )
+            except RuntimeError:
+                # GDAL refuses OVERVIEW_LEVEL on some shapes it can still read band by
+                # band -- a VRT whose bands carry different overview counts, say. The
+                # materialised path handles those, so fall back rather than letting a
+                # raw GDAL error escape a method documented to raise ValueError.
+                overview = None
+        if overview is None:
             overview = self._overview_dataset_from_array(
                 selection, band, overview_index
             )

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -3299,12 +3299,14 @@ class IO(_Engine["Dataset"]):
         without dropping to GDAL. This returns the same pixels as a first-class
         `Dataset` whose cell size is scaled by the decimation factor.
 
-        A raster GDAL can reopen by name — an on-disk file, a `/vsimem/` raster, any
-        `/vsi*` URL — is described lazily through the `OVERVIEW_LEVEL` open option and
-        wrapped in a VRT, so no pixels are read and GDAL derives the scaled geotransform
-        itself. Only a handle GDAL cannot reopen by name (a `create_from_array` raster
-        with no path, a `NetCDF` variable view) is materialised into an in-memory
-        `Dataset`, with the geotransform scaled here.
+        A raster whose own GDAL description reopens to this same grid — an on-disk file,
+        a `/vsimem/` raster, any `/vsi*` URL — is described lazily through the
+        `OVERVIEW_LEVEL` open option and wrapped in a VRT, so no pixels are read and
+        GDAL derives the scaled geotransform itself. Everything else is materialised
+        into an in-memory `Dataset`, with the geotransform scaled here: a handle GDAL
+        cannot reopen by name (a `create_from_array` raster with no path, a `NetCDF`
+        variable view), a name that no longer reopens to this grid, and any level GDAL
+        refuses to describe.
 
         The result is a **read-only view** of the parent's pixels: it is detached from
         the parent handle and carries its own GDAL handle, which the caller owns and
@@ -3312,13 +3314,17 @@ class IO(_Engine["Dataset"]):
         Windows the file cannot be deleted. Neither form carries a path of its own, so
         `read_array(threadsafe=True)` and pickling it raise, and `read_array(chunks=...)`
         returns a graph that raises when it is computed; call `to_file()` first if you
-        need any of those, and note that `create_overviews()` on the level would drop a
-        stray `.ovr` into the process's working directory. The `read_only` label stops
-        pixel writes; metadata setters still work, since a pathless handle cannot spill
-        a PAM sidecar. A `NetCDF` variable view returns a plain `Dataset` — an overview
-        level is an ordinary raster, not a NetCDF container — and only a real mapping of
-        dataset metadata is carried, so a container's structured attributes stay behind.
-        The materialised form holds the level's pixels twice while it is being built.
+        need any of those. `create_overviews()` on the lazily described form has nowhere
+        to put the external sidecar it needs either, so it drops a stray `.ovr` into the
+        process's working directory — the materialised form builds its levels in RAM and
+        writes nothing. The `read_only` label stops pixel writes; metadata setters still
+        work, since a pathless handle cannot spill a PAM sidecar. A `NetCDF` variable
+        view returns a plain `Dataset` — an overview level is an ordinary raster, not a
+        NetCDF container — and only a real mapping of dataset metadata is carried, so a
+        container's structured attributes stay behind. While the materialised form is
+        being built it holds the level's pixels three times over: the per-band reads,
+        the array stacked from them, and the in-memory raster written from that (twice
+        when `band` selects one, which skips the stack).
 
         Args:
             band (int | None):
@@ -3331,22 +3337,25 @@ class IO(_Engine["Dataset"]):
 
         Returns:
             Dataset:
-                The requested overview level, carrying the parent's CRS, no-data value,
-                band names/units/scale/offset and dataset metadata, with a cell size
-                scaled by the decimation factor. The caller owns its handle.
+                The requested overview level, carrying the parent's CRS, its per-band
+                no-data values, band names/units/scale/offset, colour table and colour
+                interpretation, and its dataset metadata, with a cell size scaled by the
+                decimation factor. The caller owns its handle.
 
         Raises:
             ValueError:
                 `band` is out of range, `overview_index` is negative or past the built
                 levels, a selected band has no overviews, or the dataset has no bands.
             RuntimeError:
-                GDAL failed to describe the level — a source that disappeared between
-                the identity check and the open, or a driver that cannot express it.
+                GDAL failed while materialising the level — reading the parent's
+                overview pixels, or building the in-memory copy from them. A failure to
+                *describe* the level does not surface here; it is retried through that
+                same materialised path.
 
         Warns:
             UserWarning:
-                The parent is remote and carries cloud credentials, which GDAL will not
-                replay when the VRT reopens its source.
+                The parent is network-backed and carries cloud credentials, which GDAL
+                will not replay when the VRT reopens its source.
 
         Examples:
             - Build overviews on a 0.1-degree raster, then take level 1 (a 4x
@@ -3447,13 +3456,18 @@ class IO(_Engine["Dataset"]):
         return source
 
     def _carry_overview_metadata(self, overview: Dataset, selection: list[int]) -> None:
-        """Copy the parent's band and dataset metadata onto an overview level.
+        """Copy the parent's per-band properties and dataset metadata onto a level.
 
-        Neither backing path carries this on its own: GDAL's overview dataset does not
-        propagate band metadata and `create_from_array` never sets it. Without it a
-        packed raster — a `scale`/`offset` pair, the norm for Sentinel, Landsat and CF
+        Neither backing path carries the band metadata on its own: GDAL's overview
+        dataset does not propagate it and `create_from_array` never sets it. Without it
+        a packed raster — a `scale`/`offset` pair, the norm for Sentinel, Landsat and CF
         NetCDF — silently stops decoding to physical units the moment the overview is
         written out, and every band loses its name and units.
+
+        The colour table and colour interpretation ride along too. The VRT path inherits
+        those from its source, so re-setting them there is a no-op, but a materialised
+        level comes back with neither and would render a paletted raster as raw grey
+        indices.
 
         Args:
             overview: The freshly built overview dataset, mutated in place.
@@ -3558,7 +3572,8 @@ class IO(_Engine["Dataset"]):
 
         Returns:
             Dataset: An in-memory dataset holding the overview pixels, with the parent's
-            CRS and no-data value and a geotransform scaled by the decimation factor.
+            CRS, its per-band no-data values — a band the parent left without one keeps
+            none — and a geotransform scaled by the decimation factor.
         """
         # Circular import: see _overview_dataset_from_file.
         from pyramids.dataset.dataset import Dataset as _Dataset

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -41,7 +41,7 @@ from pyramids.base._locks import DummyLock, default_lock
 from pyramids.base._utils import resolve_resampling
 from pyramids.base.crs import crs_spec, reproject_coordinates
 from pyramids.base.protocols import ArrayLike
-from pyramids.base.remote import is_remote
+from pyramids.base.remote import is_network_backed
 from pyramids.dataset.abstract_dataset import (
     OVERVIEW_LEVELS,
     RESAMPLING_METHODS,
@@ -3380,12 +3380,8 @@ class IO(_Engine["Dataset"]):
             # Reuse get_overview's "no overviews" / "index out of range" guards, so this
             # accessor rejects exactly what its gdal.Band sibling rejects.
             self.get_overview(index, overview_index)
-        file_name = self._ds.file_name
-        # Only a handle GDAL can reopen by name can be described by a VRT. A `MEM`
-        # dataset has no name; `/vsimem/` does, and reopens fine, so it takes the file
-        # path rather than being copied into a second RAM buffer.
-        reopenable = bool(file_name) and self._ds.driver_type != "memory"
-        if reopenable:
+        file_name = self._reopenable_source()
+        if file_name is not None:
             overview = self._overview_dataset_from_file(file_name, band, overview_index)
         else:
             overview = self._overview_dataset_from_array(
@@ -3393,6 +3389,44 @@ class IO(_Engine["Dataset"]):
             )
         self._carry_overview_metadata(overview, selection)
         return overview
+
+    def _reopenable_source(self) -> str | None:
+        """Return a name that provably reopens *this* raster, or `None`.
+
+        The lazy path describes the level by name, so the name has to be an identity,
+        not a label. `Dataset.file_name` is not: `from_bytes(data, name="dem.tif")`
+        stamps a cosmetic label, so trusting it hands back the overview of whatever
+        `dem.tif` happens to sit in the process's working directory — silently, with no
+        error. A classic `NETCDF:"/data/x.nc":tos` subdataset string mangles the same
+        way. GDAL's own description survives both, so start there, then prove it by
+        reopening and comparing the grid; anything that fails falls back to being
+        materialised, which is always correct.
+
+        Returns:
+            str | None: A name that reopens to the same grid, or `None` to materialise.
+        """
+        description = self._ds.raster.GetDescription()
+        source = None
+        if description and self._ds.driver_type != "memory":
+            try:
+                with self._ds._cloud_config():
+                    candidate = gdal.OpenEx(description)
+            except RuntimeError:
+                candidate = None
+            if candidate is not None:
+                same_grid = (
+                    candidate.RasterXSize == self._ds.columns
+                    and candidate.RasterYSize == self._ds.rows
+                    and candidate.RasterCount == self._ds.band_count
+                    and np.allclose(
+                        candidate.GetGeoTransform(),
+                        tuple(self._ds.geotransform),
+                        rtol=0,
+                        atol=1e-9,
+                    )
+                )
+                source = description if same_grid else None
+        return source
 
     def _carry_overview_metadata(self, overview: Dataset, selection: list[int]) -> None:
         """Copy the parent's band and dataset metadata onto an overview level.
@@ -3407,10 +3441,27 @@ class IO(_Engine["Dataset"]):
             overview: The freshly built overview dataset, mutated in place.
             selection: The parent's 0-based band indices the overview holds, in order.
         """
-        overview.band_names = [self._ds.band_names[index] for index in selection]
-        overview.band_units = [self._ds.band_units[index] for index in selection]
-        overview.scale = [self._ds.scale[index] for index in selection]
-        overview.offset = [self._ds.offset[index] for index in selection]
+        # Each of these walks every band on access, so read them once instead of
+        # indexing them inside the comprehension: at 400 bands -- an ordinary NetCDF
+        # time series, and the branch that gets here -- that difference measured in
+        # seconds, not milliseconds.
+        band_names = self._ds.band_names
+        band_units = self._ds.band_units
+        scale = self._ds.scale
+        offset = self._ds.offset
+        overview.band_names = [band_names[index] for index in selection]
+        overview.band_units = [band_units[index] for index in selection]
+        overview.scale = [scale[index] for index in selection]
+        overview.offset = [offset[index] for index in selection]
+        for position, index in enumerate(selection):
+            source_band = self._ds._iloc(index)
+            target_band = overview._iloc(position)
+            colour_table = source_band.GetRasterColorTable()
+            if colour_table is not None:
+                target_band.SetRasterColorTable(colour_table)
+            target_band.SetRasterColorInterpretation(
+                source_band.GetRasterColorInterpretation()
+            )
         meta_data = self._ds.meta_data
         # A NetCDF exposes meta_data as a NetCDFMetadata, not a mapping, and the Dataset
         # setter iterates .items(). An overview level is a plain raster, so carry only a
@@ -3448,7 +3499,7 @@ class IO(_Engine["Dataset"]):
         # The level is reopened from disk, so anything still sitting in the parent
         # handle's write cache would otherwise be invisible to it.
         self._ds.raster.FlushCache()
-        if self._ds.gdal_env and is_remote(file_name):
+        if self._ds.gdal_env and is_network_backed(file_name):
             # A VRT opens its sources on the first pixel read, and GDAL does not consult
             # the thread-local config CloudConfig installs when it does -- see
             # pyramids/stac/_vrt.py, which measured every source request going out
@@ -3513,26 +3564,22 @@ class IO(_Engine["Dataset"]):
             geo[4] * x_ratio,
             geo[5] * y_ratio,
         )
-        parent_no_data = (
-            [self._ds.no_data_value[band]]
-            if band is not None
-            else list(self._ds.no_data_value)
-        )
-        # A parent that declares no no-data must not gain one: passing a list of Nones
-        # makes the builder coerce them into a real sentinel (nan).
-        no_data_value = (
-            None
-            if all(value is None for value in parent_no_data)
-            else (parent_no_data[0] if band is not None else parent_no_data)
-        )
+        parent_no_data = [self._ds.no_data_value[index] for index in selection]
+        # Build with no no-data at all, then declare it only for the bands that actually
+        # had one. Handing the builder a list containing Nones coerces each None into a
+        # real sentinel (nan), which invents a no-data the parent never had -- and a
+        # parent may well declare it on some bands and not others.
         overview = _Dataset.create_from_array(
             arr,
             geo=scaled_geo,
             # `epsg` alone is None for a CRS with no authority code (a geostationary
             # grid, say), which would clear the projection outright.
             epsg=crs_spec(self._ds.epsg, self._ds.crs),
-            no_data_value=no_data_value,
+            no_data_value=None,
         )
+        for position, value in enumerate(parent_no_data):
+            if value is not None:
+                overview.bands._change_no_data_value_attr(position, value)
         # create_from_array hands back a "write" handle; label it like the VRT branch so
         # one public method does not report two different access modes.
         overview._access = "read_only"

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -3370,7 +3370,29 @@ class IO(_Engine["Dataset"]):
             overview = self._overview_dataset_from_array(
                 selection, band, overview_index
             )
+        self._carry_overview_metadata(overview, selection)
         return overview
+
+    def _carry_overview_metadata(self, overview: Dataset, selection: list[int]) -> None:
+        """Copy the parent's band and dataset metadata onto an overview level.
+
+        Neither backing path carries this on its own: GDAL's overview dataset does not
+        propagate band metadata and `create_from_array` never sets it. Without it a
+        packed raster — a `scale`/`offset` pair, the norm for Sentinel, Landsat and CF
+        NetCDF — silently stops decoding to physical units the moment the overview is
+        written out, and every band loses its name and units.
+
+        Args:
+            overview: The freshly built overview dataset, mutated in place.
+            selection: The parent's 0-based band indices the overview holds, in order.
+        """
+        overview.band_names = [self._ds.band_names[index] for index in selection]
+        overview.band_units = [self._ds.band_units[index] for index in selection]
+        overview.scale = [self._ds.scale[index] for index in selection]
+        overview.offset = [self._ds.offset[index] for index in selection]
+        meta_data = self._ds.meta_data
+        if meta_data:
+            overview.meta_data = meta_data
 
     def _overview_dataset_from_file(
         self, file_name: str, band: int | None, overview_index: int

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -3294,26 +3294,26 @@ class IO(_Engine["Dataset"]):
     ) -> Dataset:
         """Get an overview level as a standalone `Dataset`.
 
-        `get_overview` hands back a raw `gdal.Band`, which carries no geotransform, CRS
-        or no-data value, so an overview cannot be plotted, written, cropped or
-        reprojected without dropping to GDAL. This returns the same pixels as a
-        first-class `Dataset` whose cell size is scaled by the decimation factor.
+        `get_overview` hands back a raw `gdal.Band`, which carries no geotransform and
+        no CRS, so an overview cannot be plotted, written, cropped or reprojected
+        without dropping to GDAL. This returns the same pixels as a first-class
+        `Dataset` whose cell size is scaled by the decimation factor.
 
         A raster GDAL can reopen by name — an on-disk file, a `/vsimem/` raster, any
         `/vsi*` URL — is described lazily through the `OVERVIEW_LEVEL` open option and
         wrapped in a VRT, so no pixels are read and GDAL derives the scaled geotransform
-        itself. Only a nameless `MEM` handle (a `create_from_array` raster with no path,
-        a `NetCDF` variable view) is materialised into an in-memory `Dataset`, with the
-        geotransform scaled here.
+        itself. Only a handle GDAL cannot reopen by name (a `create_from_array` raster
+        with no path, a `NetCDF` variable view) is materialised into an in-memory
+        `Dataset`, with the geotransform scaled here.
 
         The result is a **read-only view** of the parent's pixels: it is detached from
         the parent handle and carries its own GDAL handle, which the caller owns and
         should `close()` — until it is closed it keeps the parent file open, so on
-        Windows the file cannot be deleted. Because the lazy form has no path of its
-        own, `read_array(threadsafe=True)`, `read_array(chunks=...)` and pickling it are
-        unavailable and fail loudly; call `to_file()` first if you need any of those.
-        A `NetCDF` variable view returns a plain `Dataset` — an overview level is an
-        ordinary raster, not a NetCDF container.
+        Windows the file cannot be deleted. Neither form carries a path of its own, so
+        `read_array(threadsafe=True)` and pickling it raise, and `read_array(chunks=...)`
+        returns a graph that raises when it is computed; call `to_file()` first if you
+        need any of those. A `NetCDF` variable view returns a plain `Dataset` — an
+        overview level is an ordinary raster, not a NetCDF container.
 
         Args:
             band (int | None):
@@ -3412,7 +3412,10 @@ class IO(_Engine["Dataset"]):
         overview.scale = [self._ds.scale[index] for index in selection]
         overview.offset = [self._ds.offset[index] for index in selection]
         meta_data = self._ds.meta_data
-        if meta_data:
+        # A NetCDF exposes meta_data as a NetCDFMetadata, not a mapping, and the Dataset
+        # setter iterates .items(). An overview level is a plain raster, so carry only a
+        # real mapping and leave a container's structured attributes behind.
+        if isinstance(meta_data, dict) and meta_data:
             overview.meta_data = meta_data
 
     def _overview_dataset_from_file(
@@ -3473,10 +3476,11 @@ class IO(_Engine["Dataset"]):
     ) -> Dataset:
         """Materialise one overview level of a nameless raster into a new `Dataset`.
 
-        Only a `MEM` handle reaches this path — it has no name for GDAL to reopen, so it
-        cannot be described by a VRT. Reads each selected band's overview directly rather
-        than through `read_overview_array`, whose all-bands branch sizes its buffer from
-        overview 0 and so cannot serve a higher `overview_index`.
+        Only a handle GDAL cannot reopen by name reaches this path — a nameless `MEM`
+        raster, or a NetCDF variable view — so it cannot be described by a VRT. Reads
+        each selected band's overview directly rather than through
+        `read_overview_array`, whose all-bands branch sizes its buffer from overview 0
+        and so cannot serve a higher `overview_index`.
 
         Args:
             selection: The 0-based band indices to read.

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -41,6 +41,7 @@ from pyramids.base._locks import DummyLock, default_lock
 from pyramids.base._utils import resolve_resampling
 from pyramids.base.crs import crs_spec, reproject_coordinates
 from pyramids.base.protocols import ArrayLike
+from pyramids.base.remote import is_remote
 from pyramids.dataset.abstract_dataset import (
     OVERVIEW_LEVELS,
     RESAMPLING_METHODS,
@@ -3424,6 +3425,21 @@ class IO(_Engine["Dataset"]):
         # The level is reopened from disk, so anything still sitting in the parent
         # handle's write cache would otherwise be invisible to it.
         self._ds.raster.FlushCache()
+        if self._ds.gdal_env and is_remote(file_name):
+            # A VRT opens its sources on the first pixel read, and GDAL does not consult
+            # the thread-local config CloudConfig installs when it does -- see
+            # pyramids/stac/_vrt.py, which measured every source request going out
+            # unauthenticated. The overview reads fine while the source stays in GDAL's
+            # dataset pool, then starts failing once it is evicted.
+            warnings.warn(
+                f"{file_name} is remote and this dataset carries cloud credentials, but "
+                "the overview is described by a VRT whose sources GDAL reopens without "
+                "the thread-local config. Later reads may go out unauthenticated; call "
+                "to_file() on the overview while the credentials are active to "
+                "materialise it.",
+                UserWarning,
+                stacklevel=_caller_stacklevel(),
+            )
         band_list = None if band is None else [band + 1]
         with self._ds._cloud_config():
             level = gdal.OpenEx(
@@ -3485,7 +3501,7 @@ class IO(_Engine["Dataset"]):
             if all(value is None for value in parent_no_data)
             else (parent_no_data[0] if band is not None else parent_no_data)
         )
-        return _Dataset.create_from_array(
+        overview = _Dataset.create_from_array(
             arr,
             geo=scaled_geo,
             # `epsg` alone is None for a CRS with no authority code (a geostationary
@@ -3493,6 +3509,10 @@ class IO(_Engine["Dataset"]):
             epsg=crs_spec(self._ds.epsg, self._ds.crs),
             no_data_value=no_data_value,
         )
+        # create_from_array hands back a "write" handle; label it like the VRT branch so
+        # one public method does not report two different access modes.
+        overview._access = "read_only"
+        return overview
 
     def read_overview_array(
         self, band: int | None = None, overview_index: int = 0

--- a/tests/base/test_remote.py
+++ b/tests/base/test_remote.py
@@ -13,6 +13,7 @@ from pyramids import _io
 from pyramids.base.remote import (
     CloudConfig,
     _to_vsi,
+    is_network_backed,
     is_remote,
     redact_credentials,
     signer_cloud_config,
@@ -184,6 +185,43 @@ class TestIsRemote:
     )
     def test_false_cases(self, path):
         assert is_remote(path) is False
+
+
+class TestIsNetworkBacked:
+    """`is_network_backed` narrows `is_remote` to the sources that cross the network."""
+
+    @pytest.mark.parametrize(
+        "path, network",
+        [
+            ("/vsis3/bucket/key.tif", True),
+            ("/vsigs/bucket/key.tif", True),
+            ("/vsiaz/container/blob.tif", True),
+            ("/vsicurl/https://foo/x.tif", True),
+            ("/vsicurl?empty_dir=yes&url=https%3A%2F%2Fh%2Fa.tif", True),
+            ("/vsicurl_streaming/https://foo/x.tif", True),
+            ("/vsiswift/container/x.tif", True),
+            ("s3://bucket/key.tif", True),
+            ("abfs://container/blob.tif", True),
+            ("dods://test.opendap.org/opendap/data/nc/coads.nc", True),
+            ("/vsimem/x.tif", False),
+            ("/vsizip/a.zip/b.tif", False),
+            ("/vsigzip/a.gz", False),
+            ("/vsitar/a.tar/b.tif", False),
+        ],
+    )
+    def test_only_the_network_handlers_are_network_backed(self, path, network):
+        """Every path here is remote; only the network-fetching ones are credentialed.
+
+        Test scenario:
+            The local virtual filesystems (`/vsimem/`, `/vsizip/`, `/vsigzip/`,
+            `/vsitar/`) never authenticate, so a caller reasoning about credentials must
+            not treat them like a cloud source — expected: `is_remote` is `True` for the
+            whole table while `is_network_backed` splits it.
+        """
+        assert is_remote(path) is True, f"{path} should be remote"
+        assert is_network_backed(path) is network, (
+            f"is_network_backed({path!r}) should be {network}"
+        )
 
 
 class TestCloudConfigAsGdalConfig:

--- a/tests/dataset/spatial/test_overviews.py
+++ b/tests/dataset/spatial/test_overviews.py
@@ -485,6 +485,7 @@ class TestGetOverviewDataset:
             same origin, EPSG and no-data, and all three bands carried over.
         """
         dataset = Dataset.read_file(_overviewed_raster(tmp_path))
+        overview = None
         try:
             overview = dataset.get_overview_dataset(overview_index=0)
             assert (overview.rows, overview.columns) == (32, 32), (
@@ -500,6 +501,8 @@ class TestGetOverviewDataset:
                 "the origin must not move when decimating"
             )
         finally:
+            if overview is not None:
+                overview.close()
             dataset.close()
 
     def test_higher_level_scales_further(self, tmp_path):
@@ -510,6 +513,7 @@ class TestGetOverviewDataset:
             the scaling follows the requested level rather than always level 0.
         """
         dataset = Dataset.read_file(_overviewed_raster(tmp_path))
+        overview = None
         try:
             overview = dataset.get_overview_dataset(overview_index=1)
             assert (overview.rows, overview.columns) == (16, 16), (
@@ -517,6 +521,8 @@ class TestGetOverviewDataset:
             )
             assert overview.cell_size == 2.0, f"cell size {overview.cell_size} != 2.0"
         finally:
+            if overview is not None:
+                overview.close()
             dataset.close()
 
     def test_band_selection_returns_that_band(self, tmp_path):
@@ -528,6 +534,7 @@ class TestGetOverviewDataset:
             rather than defaulting to band 0.
         """
         dataset = Dataset.read_file(_overviewed_raster(tmp_path))
+        overview = None
         try:
             overview = dataset.get_overview_dataset(band=1, overview_index=0)
             assert overview.band_count == 1, (
@@ -538,6 +545,8 @@ class TestGetOverviewDataset:
                 f"expected band 1's constant 2.0, got {values[0, 0]}"
             )
         finally:
+            if overview is not None:
+                overview.close()
             dataset.close()
 
     def test_file_backed_level_is_not_materialised(self, tmp_path):
@@ -614,7 +623,7 @@ class TestGetOverviewDataset:
             assert lazy.shape == (32, 32), (
                 f"the graph must be shaped from the level, got {lazy.shape}"
             )
-            with pytest.raises(RuntimeError):
+            with pytest.raises(RuntimeError, match="No such file or directory"):
                 lazy.compute()
         finally:
             if overview is not None:
@@ -935,6 +944,9 @@ class TestGetOverviewDataset:
             assert dataset.epsg is None, "precondition: this CRS has no EPSG code"
             overview = dataset.get_overview_dataset()
             assert overview.crs, "the level lost its CRS entirely"
+            assert "geos" in overview.crs.lower(), (
+                f"expected the parent's geostationary projection, got {overview.crs[:60]}"
+            )
         finally:
             if overview is not None:
                 overview.close()
@@ -957,6 +969,30 @@ class TestGetOverviewDataset:
             with pytest.raises(ValueError, match="must not be negative"):
                 dataset.get_overview_dataset(overview_index=-1)
         finally:
+            dataset.close()
+
+    def test_all_bands_rejected_when_one_lacks_overviews(self, tmp_path):
+        """An all-bands request is rejected if any single band has no overviews.
+
+        Test scenario:
+            The mixed ``[1, 0]`` VRT — expected: ``band=None`` raises, since the level
+            cannot be assembled from a band that has none, while ``band=0`` still
+            succeeds. The guard loop runs per selected band, so only the all-bands path
+            reaches the empty one.
+        """
+        dataset = Dataset.read_file(_mixed_overview_vrt(tmp_path))
+        overview = None
+        try:
+            assert dataset.overview_count == [1, 0], (
+                f"fixture must produce mixed counts, got {dataset.overview_count}"
+            )
+            with pytest.raises(ValueError, match="no overviews"):
+                dataset.get_overview_dataset()
+            overview = dataset.get_overview_dataset(band=0)
+            assert overview.band_count == 1, "the populated band should still work"
+        finally:
+            if overview is not None:
+                overview.close()
             dataset.close()
 
     def test_band_less_dataset_raises(self):
@@ -987,6 +1023,7 @@ class TestGetOverviewDataset:
         dataset = Dataset.create_from_array(
             arr, top_left_corner=(10.0, 80.0), cell_size=0.5, epsg=4326
         )
+        overview = None
         try:
             dataset.create_overviews(overview_levels=[2, 4])
             overview = dataset.get_overview_dataset(band=1, overview_index=1)
@@ -999,6 +1036,8 @@ class TestGetOverviewDataset:
                 "the fallback must read the requested band, not band 0"
             )
         finally:
+            if overview is not None:
+                overview.close()
             dataset.close()
 
     def test_written_level_round_trips(self, tmp_path):
@@ -1012,7 +1051,9 @@ class TestGetOverviewDataset:
         dataset = Dataset.read_file(_overviewed_raster(tmp_path))
         out = str(tmp_path / "level0.tif")
         try:
-            dataset.get_overview_dataset(overview_index=0).to_file(out)
+            level = dataset.get_overview_dataset(overview_index=0)
+            level.to_file(out)
+            level.close()
         finally:
             dataset.close()
         saved = Dataset.read_file(out)

--- a/tests/dataset/spatial/test_overviews.py
+++ b/tests/dataset/spatial/test_overviews.py
@@ -7,12 +7,36 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from osgeo import gdal
+from osgeo import gdal, osr
 
 from pyramids.base._errors import ReadOnlyError
 from pyramids.dataset import Dataset
 
 pytestmark = pytest.mark.core
+
+
+def _overviewed_raster(tmp_path, name: str = "ovr_src.tif") -> str:
+    """Write a georeferenced 3-band raster and build two overview levels on it.
+
+    Band ``i`` is filled with the constant ``i + 1`` so a caller can tell the bands
+    apart after decimation, and the cell size (0.5) halves per level.
+    """
+    path = str(tmp_path / name)
+    raster = gdal.GetDriverByName("GTiff").Create(path, 64, 64, 3, gdal.GDT_Float32)
+    raster.SetGeoTransform((10.0, 0.5, 0.0, 80.0, 0.0, -0.5))
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(4326)
+    raster.SetProjection(srs.ExportToWkt())
+    for index in range(3):
+        band = raster.GetRasterBand(index + 1)
+        band.SetNoDataValue(-9999.0)
+        band.WriteArray(np.full((64, 64), float(index + 1), dtype="float32"))
+    raster = None
+
+    handle = gdal.Open(path, gdal.GA_Update)
+    handle.BuildOverviews("AVERAGE", [2, 4])
+    handle = None
+    return path
 
 
 def _mixed_overview_vrt(tmp_path) -> str:
@@ -441,6 +465,177 @@ class TestRecreateOverviewsContract:
             assert not user_warnings, (
                 f"happy path should not warn, got {[str(w.message) for w in user_warnings]}"
             )
+        finally:
+            dataset.close()
+
+
+class TestGetOverviewDataset:
+    """`get_overview_dataset` returns an overview level as a first-class Dataset (#784).
+
+    `get_overview` yields a raw `gdal.Band` with no geotransform, CRS or no-data, so an
+    overview could not be plotted, written or reprojected without dropping to GDAL.
+    """
+
+    def test_file_backed_level_scales_the_grid(self, tmp_path):
+        """A file-backed level keeps the CRS and no-data and halves the resolution.
+
+        Test scenario:
+            Level 0 of a 64x64 raster at cell 0.5 — expected: 32x32 at cell 1.0, the
+            same origin, EPSG and no-data, and all three bands carried over.
+        """
+        dataset = Dataset.read_file(_overviewed_raster(tmp_path))
+        try:
+            overview = dataset.get_overview_dataset(overview_index=0)
+            assert (overview.rows, overview.columns) == (32, 32), (
+                f"expected 32x32, got {(overview.rows, overview.columns)}"
+            )
+            assert overview.cell_size == 1.0, f"cell size {overview.cell_size} != 1.0"
+            assert overview.epsg == dataset.epsg, "EPSG should carry over"
+            assert overview.band_count == 3, (
+                f"expected 3 bands, got {overview.band_count}"
+            )
+            assert overview.no_data_value[0] == -9999.0, "no-data should carry over"
+            assert overview.top_left_corner == dataset.top_left_corner, (
+                "the origin must not move when decimating"
+            )
+        finally:
+            dataset.close()
+
+    def test_higher_level_scales_further(self, tmp_path):
+        """Level 1 decimates twice as far as level 0.
+
+        Test scenario:
+            ``overview_index=1`` on the same raster — expected: 16x16 at cell 2.0, so
+            the scaling follows the requested level rather than always level 0.
+        """
+        dataset = Dataset.read_file(_overviewed_raster(tmp_path))
+        try:
+            overview = dataset.get_overview_dataset(overview_index=1)
+            assert (overview.rows, overview.columns) == (16, 16), (
+                f"expected 16x16, got {(overview.rows, overview.columns)}"
+            )
+            assert overview.cell_size == 2.0, f"cell size {overview.cell_size} != 2.0"
+        finally:
+            dataset.close()
+
+    def test_band_selection_returns_that_band(self, tmp_path):
+        """Passing `band` returns a single-band Dataset holding that band's pixels.
+
+        Test scenario:
+            Each band is filled with a distinct constant, so ``band=1`` must come back
+            as one band whose values are 2.0 — proving the subset picks the right band
+            rather than defaulting to band 0.
+        """
+        dataset = Dataset.read_file(_overviewed_raster(tmp_path))
+        try:
+            overview = dataset.get_overview_dataset(band=1, overview_index=0)
+            assert overview.band_count == 1, (
+                f"expected 1 band, got {overview.band_count}"
+            )
+            values = np.asarray(overview.read_array(band=0))
+            assert np.allclose(values, 2.0), (
+                f"expected band 1's constant 2.0, got {values[0, 0]}"
+            )
+        finally:
+            dataset.close()
+
+    def test_file_backed_level_is_not_materialised(self, tmp_path):
+        """A file-backed level is opened lazily rather than copied into memory.
+
+        Test scenario:
+            Inspect the returned dataset's driver — expected: not the MEM driver, i.e.
+            it came through GDAL's ``OVERVIEW_LEVEL`` open option, so a large raster's
+            overview is not read into RAM just to be described.
+        """
+        dataset = Dataset.read_file(_overviewed_raster(tmp_path))
+        try:
+            overview = dataset.get_overview_dataset(overview_index=0)
+            assert overview.driver_type != "memory", (
+                f"file-backed level should stay lazy, got driver {overview.driver_type}"
+            )
+        finally:
+            dataset.close()
+
+    def test_path_less_dataset_falls_back_to_the_array(self):
+        """An in-memory raster has no path to reopen, so its level is materialised.
+
+        Test scenario:
+            A `create_from_array` raster (MEM driver, empty `file_name`) — expected: the
+            level still comes back with the scaled cell size and the right values, via
+            the array fallback rather than ``OVERVIEW_LEVEL``.
+        """
+        arr = np.stack(
+            [np.full((64, 64), float(index + 1), dtype="float32") for index in range(3)]
+        )
+        dataset = Dataset.create_from_array(
+            arr, top_left_corner=(10.0, 80.0), cell_size=0.5, epsg=4326
+        )
+        try:
+            dataset.create_overviews(overview_levels=[2, 4])
+            overview = dataset.get_overview_dataset(band=1, overview_index=1)
+            assert (overview.rows, overview.columns) == (16, 16), (
+                f"expected 16x16, got {(overview.rows, overview.columns)}"
+            )
+            assert overview.cell_size == 2.0, f"cell size {overview.cell_size} != 2.0"
+            assert overview.epsg == 4326, f"epsg {overview.epsg} != 4326"
+            assert np.allclose(np.asarray(overview.read_array(band=0)), 2.0), (
+                "the fallback must read the requested band, not band 0"
+            )
+        finally:
+            dataset.close()
+
+    def test_written_level_round_trips(self, tmp_path):
+        """The returned Dataset is writable like any other, with the scaled grid.
+
+        Test scenario:
+            ``to_file`` the level and reopen it — expected: the saved raster keeps the
+            decimated shape and scaled cell size, which is the motivating use case
+            (`get_overview` could not do this at all).
+        """
+        dataset = Dataset.read_file(_overviewed_raster(tmp_path))
+        out = str(tmp_path / "level0.tif")
+        try:
+            dataset.get_overview_dataset(overview_index=0).to_file(out)
+        finally:
+            dataset.close()
+        saved = Dataset.read_file(out)
+        try:
+            assert (saved.rows, saved.columns) == (32, 32), (
+                f"expected 32x32 on disk, got {(saved.rows, saved.columns)}"
+            )
+            assert saved.cell_size == 1.0, f"cell size {saved.cell_size} != 1.0"
+        finally:
+            saved.close()
+
+    def test_missing_overviews_raise(self):
+        """A raster with no overviews raises, matching `get_overview`.
+
+        Test scenario:
+            Call the accessor before `create_overviews` — expected: the same
+            `ValueError` its `gdal.Band` sibling raises, not an empty Dataset.
+        """
+        dataset = Dataset.create_from_array(
+            np.zeros((8, 8), dtype="float32"),
+            top_left_corner=(0.0, 8.0),
+            cell_size=1.0,
+            epsg=4326,
+        )
+        try:
+            with pytest.raises(ValueError, match="no overviews"):
+                dataset.get_overview_dataset()
+        finally:
+            dataset.close()
+
+    def test_out_of_range_level_raises(self, tmp_path):
+        """An overview_index past the built levels raises, matching `get_overview`.
+
+        Test scenario:
+            Two levels exist; ask for index 9 — expected: `ValueError` naming the bound.
+        """
+        dataset = Dataset.read_file(_overviewed_raster(tmp_path))
+        try:
+            with pytest.raises(ValueError, match="should be less than"):
+                dataset.get_overview_dataset(overview_index=9)
         finally:
             dataset.close()
 

--- a/tests/dataset/spatial/test_overviews.py
+++ b/tests/dataset/spatial/test_overviews.py
@@ -715,6 +715,55 @@ class TestGetOverviewDataset:
                 overview.close()
             dataset.close()
 
+    def test_a_source_that_now_holds_another_grid_is_not_trusted(self):
+        """A description that reopens to a different grid is refused, not described.
+
+        Test scenario:
+            The `from_bytes` sibling covers a label naming another file; this covers the
+            name itself going stale — the `/vsimem/` raster is unlinked and recreated at
+            16x16 under the open handle. Expected: `_reopenable_source` returns `None`
+            and the level is materialised from the parent's own 64x64 pixels (7.0),
+            rather than described from the 16x16 impostor now sitting at that name.
+        """
+        path = "/vsimem/overview_swapped.tif"
+        raster = gdal.GetDriverByName("GTiff").Create(path, 64, 64, 1, gdal.GDT_Float32)
+        raster.SetGeoTransform((10.0, 0.5, 0.0, 80.0, 0.0, -0.5))
+        raster.GetRasterBand(1).WriteArray(np.full((64, 64), 7.0, dtype="float32"))
+        raster = None
+        dataset = Dataset.read_file(path, read_only=False)
+        overview = None
+        try:
+            dataset.create_overviews(overview_levels=[2])
+            gdal.Unlink(path)
+            swap = gdal.GetDriverByName("GTiff").Create(
+                path, 16, 16, 1, gdal.GDT_Float32
+            )
+            swap.SetGeoTransform((0.0, 2.0, 0.0, 0.0, 0.0, -2.0))
+            swap.GetRasterBand(1).WriteArray(np.full((16, 16), 99.0, dtype="float32"))
+            swap = None
+
+            assert dataset.io._reopenable_source() is None, (
+                "a name that reopens to another grid is not an identity"
+            )
+            overview = dataset.get_overview_dataset()
+            assert overview.driver_type == "memory", (
+                f"the level should be materialised, got driver {overview.driver_type}"
+            )
+            assert (overview.rows, overview.columns) == (32, 32), (
+                f"expected the parent's own level, got "
+                f"{(overview.rows, overview.columns)}"
+            )
+            value = float(np.asarray(overview.read_array(band=0))[0, 0])
+            assert value == pytest.approx(7.0), (
+                f"expected the parent's own value 7.0, got {value} "
+                "(99.0 means the impostor at the same /vsimem/ name was described)"
+            )
+        finally:
+            if overview is not None:
+                overview.close()
+            dataset.close()
+            gdal.Unlink(path)
+
     def test_partly_declared_no_data_is_not_completed(self):
         """A band without a no-data value does not gain one from its neighbours.
 
@@ -878,6 +927,57 @@ class TestGetOverviewDataset:
                 if handle is not None:
                     handle.close()
             dataset.close()
+
+    def test_colour_table_and_interpretation_are_carried(self, tmp_path):
+        """A palette-indexed band keeps its colour table and its interpretation.
+
+        Test scenario:
+            The same paletted band on disk (described by a VRT) and in memory
+            (materialised) — expected: both levels come back `palette_index` carrying
+            the parent's two entries. `create_from_array` sets neither, so a
+            materialised level rendered as a plain grey band and wrote out a raster
+            whose class colours were gone.
+        """
+        table = gdal.ColorTable()
+        table.SetColorEntry(0, (10, 20, 30, 255))
+        table.SetColorEntry(1, (200, 100, 50, 255))
+        path = str(tmp_path / "palette.tif")
+        on_disk = gdal.GetDriverByName("GTiff").Create(path, 32, 32, 1, gdal.GDT_Byte)
+        in_memory = gdal.GetDriverByName("MEM").Create("", 32, 32, 1, gdal.GDT_Byte)
+        for target in (on_disk, in_memory):
+            target.SetGeoTransform((0.0, 1.0, 0.0, 32.0, 0.0, -1.0))
+            band = target.GetRasterBand(1)
+            band.SetRasterColorTable(table)
+            band.SetRasterColorInterpretation(gdal.GCI_PaletteIndex)
+            band.WriteArray(np.zeros((32, 32), dtype="uint8"))
+        on_disk = None
+        handle = gdal.Open(path)
+        handle.BuildOverviews("NEAREST", [2])
+        handle = None
+        in_memory.BuildOverviews("NEAREST", [2])
+
+        lazy_parent = Dataset.read_file(path)
+        memory_parent = Dataset(in_memory)
+        levels = {}
+        try:
+            levels["lazy"] = lazy_parent.get_overview_dataset()
+            levels["materialised"] = memory_parent.get_overview_dataset()
+            for tag, level in levels.items():
+                assert level.band_color == {0: "palette_index"}, (
+                    f"{tag} level lost its colour interpretation: {level.band_color}"
+                )
+                # GTiff pads its palette out to 256 entries and MEM does not, so compare
+                # the two the parent actually declared.
+                entries = level.color_table[["red", "green", "blue", "alpha"]]
+                assert entries.values.tolist()[:2] == [
+                    [10, 20, 30, 255],
+                    [200, 100, 50, 255],
+                ], f"{tag} level lost its colour table:\n{level.color_table.head()}"
+        finally:
+            for level in levels.values():
+                level.close()
+            lazy_parent.close()
+            memory_parent.close()
 
     def test_dataset_metadata_is_carried_but_never_invented(self):
         """The parent's dataset metadata is copied over, and absence stays absence.

--- a/tests/dataset/spatial/test_overviews.py
+++ b/tests/dataset/spatial/test_overviews.py
@@ -1,6 +1,7 @@
 """Tests for the Dataset class overview methods."""
 
 import contextlib
+import pickle
 import shutil
 import warnings
 from pathlib import Path
@@ -540,19 +541,249 @@ class TestGetOverviewDataset:
             dataset.close()
 
     def test_file_backed_level_is_not_materialised(self, tmp_path):
-        """A file-backed level is opened lazily rather than copied into memory.
+        """A file-backed level is described by a VRT rather than copied into memory.
 
         Test scenario:
-            Inspect the returned dataset's driver — expected: not the MEM driver, i.e.
-            it came through GDAL's ``OVERVIEW_LEVEL`` open option, so a large raster's
-            overview is not read into RAM just to be described.
+            Inspect the returned dataset's driver and handle — expected: the ``vrt``
+            driver (not merely "not memory", which an unrecognised driver would also
+            satisfy) and a handle distinct from the parent's, i.e. it came through
+            ``OVERVIEW_LEVEL`` without reading the level into RAM.
+        """
+        dataset = Dataset.read_file(_overviewed_raster(tmp_path))
+        overview = None
+        try:
+            overview = dataset.get_overview_dataset(overview_index=0)
+            assert overview.driver_type == "vrt", (
+                f"file-backed level should be a lazy VRT, got {overview.driver_type}"
+            )
+            assert overview.raster is not dataset.raster, "must be its own handle"
+        finally:
+            if overview is not None:
+                overview.close()
+            dataset.close()
+
+    def test_lazy_level_refuses_the_reopen_by_path_reads(self, tmp_path):
+        """The lazy level fails loudly on reads that would reopen it by path.
+
+        Test scenario:
+            `OpenEx(OVERVIEW_LEVEL=...)` alone yields a handle described by the
+            *parent's* path, so `threadsafe=`/`chunks=`/pickle would silently read the
+            full-resolution raster while the object reported the level's shape. The VRT
+            wrapper leaves it pathless — expected: a plain read is correct, and each
+            reopen-by-path route raises instead of returning parent pixels.
+        """
+        dataset = Dataset.read_file(_overviewed_raster(tmp_path, "gradient.tif"))
+        overview = None
+        try:
+            overview = dataset.get_overview_dataset(band=0, overview_index=1)
+            expected = dataset.read_overview_array(band=0, overview_index=1)
+            np.testing.assert_array_equal(
+                np.asarray(overview.read_array(band=0)),
+                expected,
+                err_msg="the plain read must return the level's own pixels",
+            )
+            assert overview.file_name == "", (
+                f"the lazy level must carry no path, got {overview.file_name!r}"
+            )
+            with pytest.raises(ValueError, match="reopenable path"):
+                overview.read_array(band=0, threadsafe=True)
+            with pytest.raises(TypeError, match="no on-disk path"):
+                pickle.dumps(overview)
+        finally:
+            if overview is not None:
+                overview.close()
+            dataset.close()
+
+    def test_vsimem_parent_stays_lazy(self):
+        """A /vsimem/ raster reopens under OVERVIEW_LEVEL, so it is not materialised.
+
+        Test scenario:
+            `/vsimem/` has a name GDAL can reopen, unlike a bare MEM handle — expected:
+            the VRT path, not a second RAM copy of the level.
+        """
+        path = "/vsimem/overview_lazy.tif"
+        raster = gdal.GetDriverByName("GTiff").Create(path, 64, 64, 1, gdal.GDT_Float32)
+        raster.SetGeoTransform((10.0, 0.5, 0.0, 80.0, 0.0, -0.5))
+        raster.GetRasterBand(1).WriteArray(
+            np.arange(4096, dtype="float32").reshape(64, 64)
+        )
+        raster = None
+        dataset = Dataset.read_file(path, read_only=False)
+        overview = None
+        try:
+            dataset.create_overviews(overview_levels=[2])
+            overview = dataset.get_overview_dataset(overview_index=0)
+            assert overview.driver_type == "vrt", (
+                f"/vsimem/ should stay lazy, got driver {overview.driver_type}"
+            )
+        finally:
+            if overview is not None:
+                overview.close()
+            dataset.close()
+            gdal.Unlink(path)
+
+    def test_rotated_grid_scales_the_same_on_both_paths(self, tmp_path):
+        """The rotation terms are scaled, so a skewed grid is not sheared.
+
+        Test scenario:
+            The same skewed geotransform on disk and in memory — expected: identical
+            geotransforms. Scaling only gt[1]/gt[5] left the rotation terms at half
+            their correct value, displacing every pixel but the origin.
+        """
+        geo = (10.0, 0.5, 0.1, 80.0, 0.2, -0.5)
+        arr = np.arange(4096, dtype="float32").reshape(64, 64)
+        path = str(tmp_path / "skewed.tif")
+        raster = gdal.GetDriverByName("GTiff").Create(path, 64, 64, 1, gdal.GDT_Float32)
+        raster.SetGeoTransform(geo)
+        raster.GetRasterBand(1).WriteArray(arr)
+        raster = None
+        handle = gdal.Open(path, gdal.GA_Update)
+        handle.BuildOverviews("AVERAGE", [2])
+        handle = None
+
+        on_disk = Dataset.read_file(path)
+        in_memory = Dataset.create_from_array(arr, geo=geo, epsg=4326)
+        in_memory.create_overviews(overview_levels=[2])
+        lazy_level = memory_level = None
+        try:
+            lazy_level = on_disk.get_overview_dataset(overview_index=0)
+            memory_level = in_memory.get_overview_dataset(overview_index=0)
+            np.testing.assert_allclose(
+                np.asarray(memory_level.geotransform),
+                np.asarray(lazy_level.geotransform),
+                err_msg="the two paths must agree on the scaled geotransform",
+            )
+            assert lazy_level.geotransform[2] == pytest.approx(0.2), (
+                f"gt[2] should scale to 0.2, got {lazy_level.geotransform[2]}"
+            )
+        finally:
+            for handle in (lazy_level, memory_level):
+                if handle is not None:
+                    handle.close()
+            on_disk.close()
+            in_memory.close()
+
+    def test_absent_no_data_is_not_fabricated(self):
+        """A parent with no no-data value does not gain one.
+
+        Test scenario:
+            A MEM parent created with `no_data_value=None` — expected: the level's
+            no-data stays `None`, rather than a list of `None`s being coerced into a
+            `nan` sentinel that masking and statistics would then honour.
+        """
+        dataset = Dataset.create_from_array(
+            np.stack([np.zeros((32, 32), dtype="float32")] * 2),
+            top_left_corner=(0.0, 32.0),
+            cell_size=1.0,
+            epsg=4326,
+            no_data_value=None,
+        )
+        overview = None
+        try:
+            dataset.create_overviews(overview_levels=[2])
+            overview = dataset.get_overview_dataset()
+            assert all(value is None for value in overview.no_data_value), (
+                f"no-data should stay absent, got {overview.no_data_value}"
+            )
+        finally:
+            if overview is not None:
+                overview.close()
+            dataset.close()
+
+    def test_band_metadata_is_carried(self, tmp_path):
+        """Band names, units, scale and offset survive, so packed data still decodes.
+
+        Test scenario:
+            A raster whose bands carry a scale/offset pair and names — expected: the
+            level keeps them, since `to_file` on a level that lost its scale writes
+            values that no longer decode to physical units.
+        """
+        path = _overviewed_raster(tmp_path, "packed.tif")
+        writable = gdal.Open(path, gdal.GA_Update)
+        for index in range(3):
+            band = writable.GetRasterBand(index + 1)
+            band.SetDescription(["red", "green", "nir"][index])
+            band.SetScale(0.5)
+            band.SetOffset(3.0)
+        writable = None
+
+        dataset = Dataset.read_file(path)
+        overview = single = None
+        try:
+            overview = dataset.get_overview_dataset()
+            assert overview.band_names == ["red", "green", "nir"], (
+                f"band names lost: {overview.band_names}"
+            )
+            assert overview.scale == [0.5, 0.5, 0.5], f"scale lost: {overview.scale}"
+            assert overview.offset == [3.0, 3.0, 3.0], f"offset lost: {overview.offset}"
+            single = dataset.get_overview_dataset(band=2)
+            assert single.band_names == ["nir"], (
+                f"a band subset should keep that band's name, got {single.band_names}"
+            )
+        finally:
+            for handle in (overview, single):
+                if handle is not None:
+                    handle.close()
+            dataset.close()
+
+    def test_crs_without_an_epsg_code_survives(self):
+        """A CRS with no EPSG authority code is not silently cleared.
+
+        Test scenario:
+            A MEM parent in a geostationary projection, which has no EPSG code, so
+            `epsg` alone is `None` — expected: the level still carries a projection,
+            rather than `create_from_array` clearing it.
+        """
+        geostationary = (
+            "+proj=geos +h=35785831 +lon_0=0 +sweep=y +ellps=GRS80 +units=m +no_defs"
+        )
+        dataset = Dataset.create_from_array(
+            np.zeros((32, 32), dtype="float32"),
+            top_left_corner=(0.0, 32.0),
+            cell_size=1000.0,
+            epsg=geostationary,
+        )
+        overview = None
+        try:
+            dataset.create_overviews(overview_levels=[2])
+            assert dataset.epsg is None, "precondition: this CRS has no EPSG code"
+            overview = dataset.get_overview_dataset()
+            assert overview.crs, "the level lost its CRS entirely"
+        finally:
+            if overview is not None:
+                overview.close()
+            dataset.close()
+
+    def test_invalid_band_and_negative_level_raise(self, tmp_path):
+        """Bad `band` and negative `overview_index` raise the documented ValueError.
+
+        Test scenario:
+            `band` out of range previously raised `IndexError` from `_iloc`, and a
+            negative `overview_index` made GDAL hand back the *full-resolution* parent
+            labelled as an overview — expected: `ValueError` for both.
         """
         dataset = Dataset.read_file(_overviewed_raster(tmp_path))
         try:
-            overview = dataset.get_overview_dataset(overview_index=0)
-            assert overview.driver_type != "memory", (
-                f"file-backed level should stay lazy, got driver {overview.driver_type}"
-            )
+            with pytest.raises(ValueError, match="out of range"):
+                dataset.get_overview_dataset(band=9)
+            with pytest.raises(ValueError, match="out of range"):
+                dataset.get_overview_dataset(band=-1)
+            with pytest.raises(ValueError, match="must not be negative"):
+                dataset.get_overview_dataset(overview_index=-1)
+        finally:
+            dataset.close()
+
+    def test_band_less_dataset_raises(self):
+        """A dataset with no bands says so instead of failing inside numpy.
+
+        Test scenario:
+            A zero-band MEM raster — expected: the same clear message
+            `recreate_overviews` gives, not `need at least one array to stack`.
+        """
+        dataset = Dataset(gdal.GetDriverByName("MEM").Create("", 4, 4, 0))
+        try:
+            with pytest.raises(ValueError, match="no bands"):
+                dataset.get_overview_dataset()
         finally:
             dataset.close()
 

--- a/tests/dataset/spatial/test_overviews.py
+++ b/tests/dataset/spatial/test_overviews.py
@@ -594,6 +594,73 @@ class TestGetOverviewDataset:
                 overview.close()
             dataset.close()
 
+    def test_lazy_level_refuses_a_chunked_read(self, tmp_path):
+        """A chunked read of the lazy level never hands back full-resolution pixels.
+
+        Test scenario:
+            `chunks=` reopens the dataset by path inside each dask task and the VRT
+            carries no path, making it the third reopen-by-path route beside
+            `threadsafe=` and pickle — expected: the graph is shaped from the level
+            (32x32, not the parent's 64x64) and computing it raises, rather than quietly
+            filling the blocks from the parent raster. The refusal surfaces on compute
+            rather than at the call, unlike its two siblings.
+        """
+        pytest.importorskip("dask")
+        dataset = Dataset.read_file(_overviewed_raster(tmp_path, "chunked.tif"))
+        overview = None
+        try:
+            overview = dataset.get_overview_dataset(band=0, overview_index=0)
+            lazy = overview.read_array(band=0, chunks=16)
+            assert lazy.shape == (32, 32), (
+                f"the graph must be shaped from the level, got {lazy.shape}"
+            )
+            with pytest.raises(RuntimeError):
+                lazy.compute()
+        finally:
+            if overview is not None:
+                overview.close()
+            dataset.close()
+
+    def test_remote_parent_with_credentials_warns(self, tmp_path):
+        """A remote parent carrying cloud credentials warns that the VRT strands them.
+
+        Test scenario:
+            A `/vsimem/` path reads as remote, so attaching a `gdal_env` reproduces the
+            stranded-credentials case without a network — expected: a `UserWarning`
+            naming the credentials, and none at all for a local parent carrying the same
+            env, whose sources GDAL reopens without needing them.
+        """
+        path = "/vsimem/overview_credentials.tif"
+        raster = gdal.GetDriverByName("GTiff").Create(path, 64, 64, 1, gdal.GDT_Float32)
+        raster.SetGeoTransform((10.0, 0.5, 0.0, 80.0, 0.0, -0.5))
+        raster.GetRasterBand(1).WriteArray(
+            np.arange(4096, dtype="float32").reshape(64, 64)
+        )
+        raster = None
+        remote = Dataset.read_file(path, read_only=False)
+        local = Dataset.read_file(_overviewed_raster(tmp_path, "credentialed.tif"))
+        remote_level = local_level = None
+        try:
+            remote.create_overviews(overview_levels=[2])
+            remote.attach_gdal_env({"AWS_REQUEST_PAYER": "requester"})
+            with pytest.warns(UserWarning, match="cloud credentials"):
+                remote_level = remote.get_overview_dataset()
+            local.attach_gdal_env({"AWS_REQUEST_PAYER": "requester"})
+            with warnings.catch_warnings(record=True) as recorded:
+                warnings.simplefilter("always")
+                local_level = local.get_overview_dataset()
+            stranded = [w for w in recorded if "cloud credentials" in str(w.message)]
+            assert not stranded, (
+                f"a local parent must not warn about credentials: {stranded}"
+            )
+        finally:
+            for handle in (remote_level, local_level):
+                if handle is not None:
+                    handle.close()
+            remote.close()
+            local.close()
+            gdal.Unlink(path)
+
     def test_vsimem_parent_stays_lazy(self):
         """A /vsimem/ raster reopens under OVERVIEW_LEVEL, so it is not materialised.
 
@@ -725,6 +792,48 @@ class TestGetOverviewDataset:
                 if handle is not None:
                     handle.close()
             dataset.close()
+
+    def test_dataset_metadata_is_carried_but_never_invented(self):
+        """The parent's dataset metadata is copied over, and absence stays absence.
+
+        Test scenario:
+            The materialised path builds the level with `create_from_array`, which
+            starts with an empty metadata dictionary — expected: a parent describing
+            itself with `units`/`source` passes both on, while a parent with no metadata
+            leaves the level's dictionary empty instead of gaining keys of its own.
+        """
+        described = Dataset.create_from_array(
+            np.zeros((32, 32), dtype="float32"),
+            top_left_corner=(0.0, 32.0),
+            cell_size=1.0,
+            epsg=4326,
+        )
+        described.meta_data = {"units": "K", "source": "reanalysis"}
+        bare = Dataset.create_from_array(
+            np.zeros((32, 32), dtype="float32"),
+            top_left_corner=(0.0, 32.0),
+            cell_size=1.0,
+            epsg=4326,
+        )
+        described_level = bare_level = None
+        try:
+            described.create_overviews(overview_levels=[2])
+            bare.create_overviews(overview_levels=[2])
+            described_level = described.get_overview_dataset()
+            expected = {"units": "K", "source": "reanalysis"}
+            assert described_level.meta_data == expected, (
+                f"dataset metadata lost: {described_level.meta_data}"
+            )
+            bare_level = bare.get_overview_dataset()
+            assert bare_level.meta_data == {}, (
+                f"a metadata-less parent must not gain any: {bare_level.meta_data}"
+            )
+        finally:
+            for handle in (described_level, bare_level):
+                if handle is not None:
+                    handle.close()
+            described.close()
+            bare.close()
 
     def test_crs_without_an_epsg_code_survives(self):
         """A CRS with no EPSG authority code is not silently cleared.

--- a/tests/dataset/spatial/test_overviews.py
+++ b/tests/dataset/spatial/test_overviews.py
@@ -621,45 +621,122 @@ class TestGetOverviewDataset:
                 overview.close()
             dataset.close()
 
-    def test_remote_parent_with_credentials_warns(self, tmp_path):
-        """A remote parent carrying cloud credentials warns that the VRT strands them.
+    def test_network_parent_with_credentials_warns(self, tmp_path, monkeypatch):
+        """A network-backed parent carrying credentials warns that the VRT strands them.
 
         Test scenario:
-            A `/vsimem/` path reads as remote, so attaching a `gdal_env` reproduces the
-            stranded-credentials case without a network — expected: a `UserWarning`
-            naming the credentials, and none at all for a local parent carrying the same
-            env, whose sources GDAL reopens without needing them.
+            The warning must key on *network* backing, not on `is_remote`, which is also
+            true for purely local `/vsimem/` and `/vsizip/`. Force the predicate true for
+            a local file so the branch is reachable offline — expected: a `UserWarning`
+            naming the credentials. The same parent without credentials, and a genuinely
+            local one, must stay silent.
         """
-        path = "/vsimem/overview_credentials.tif"
-        raster = gdal.GetDriverByName("GTiff").Create(path, 64, 64, 1, gdal.GDT_Float32)
-        raster.SetGeoTransform((10.0, 0.5, 0.0, 80.0, 0.0, -0.5))
-        raster.GetRasterBand(1).WriteArray(
-            np.arange(4096, dtype="float32").reshape(64, 64)
-        )
-        raster = None
-        remote = Dataset.read_file(path, read_only=False)
-        local = Dataset.read_file(_overviewed_raster(tmp_path, "credentialed.tif"))
-        remote_level = local_level = None
+        from pyramids.dataset.engines import io as io_module
+
+        dataset = Dataset.read_file(_overviewed_raster(tmp_path, "credentialed.tif"))
+        with_env = without_env = local_level = None
         try:
-            remote.create_overviews(overview_levels=[2])
-            remote.attach_gdal_env({"AWS_REQUEST_PAYER": "requester"})
-            with pytest.warns(UserWarning, match="cloud credentials"):
-                remote_level = remote.get_overview_dataset()
-            local.attach_gdal_env({"AWS_REQUEST_PAYER": "requester"})
+            dataset.attach_gdal_env({"AWS_REQUEST_PAYER": "requester"})
             with warnings.catch_warnings(record=True) as recorded:
                 warnings.simplefilter("always")
-                local_level = local.get_overview_dataset()
-            stranded = [w for w in recorded if "cloud credentials" in str(w.message)]
-            assert not stranded, (
-                f"a local parent must not warn about credentials: {stranded}"
+                local_level = dataset.get_overview_dataset()
+            assert not [w for w in recorded if "cloud credentials" in str(w.message)], (
+                "a local parent must not warn, even carrying an env"
+            )
+
+            monkeypatch.setattr(io_module, "is_network_backed", lambda path: True)
+            with pytest.warns(UserWarning, match="cloud credentials"):
+                with_env = dataset.get_overview_dataset()
+
+            dataset.attach_gdal_env(None)
+            with warnings.catch_warnings(record=True) as recorded:
+                warnings.simplefilter("always")
+                without_env = dataset.get_overview_dataset()
+            assert not [w for w in recorded if "cloud credentials" in str(w.message)], (
+                "no credentials means nothing can be stranded"
             )
         finally:
-            for handle in (remote_level, local_level):
+            for handle in (with_env, without_env, local_level):
                 if handle is not None:
                     handle.close()
-            remote.close()
-            local.close()
-            gdal.Unlink(path)
+            dataset.close()
+
+    def test_from_bytes_label_does_not_reopen_a_same_named_file(
+        self, tmp_path, monkeypatch
+    ):
+        """A cosmetic `from_bytes` name never reopens an unrelated file of that name.
+
+        Test scenario:
+            `from_bytes(payload, name="dem.tif")` stamps a label, not an identity. With
+            a *different* `dem.tif` in the working directory, keying the lazy path off
+            `file_name` returned that decoy's overview — silently, with no error.
+            Expected: the level holds the payload's own value.
+        """
+        monkeypatch.chdir(tmp_path)
+        decoy = gdal.GetDriverByName("GTiff").Create(
+            "dem.tif", 32, 32, 1, gdal.GDT_Float32
+        )
+        decoy.SetGeoTransform((0.0, 1.0, 0.0, 32.0, 0.0, -1.0))
+        decoy.GetRasterBand(1).WriteArray(np.full((32, 32), 999.0, dtype="float32"))
+        decoy = None
+        handle = gdal.Open("dem.tif", gdal.GA_Update)
+        handle.BuildOverviews("AVERAGE", [2])
+        handle = None
+
+        real = str(tmp_path / "real.tif")
+        raster = gdal.GetDriverByName("GTiff").Create(real, 32, 32, 1, gdal.GDT_Float32)
+        raster.SetGeoTransform((0.0, 1.0, 0.0, 32.0, 0.0, -1.0))
+        raster.GetRasterBand(1).WriteArray(np.full((32, 32), 111.0, dtype="float32"))
+        raster = None
+        handle = gdal.Open(real, gdal.GA_Update)
+        handle.BuildOverviews("AVERAGE", [2])
+        handle = None
+
+        dataset = Dataset.from_bytes(Path(real).read_bytes(), name="dem.tif")
+        overview = None
+        try:
+            overview = dataset.get_overview_dataset()
+            value = float(np.asarray(overview.read_array(band=0))[0, 0])
+            assert value == pytest.approx(111.0), (
+                f"expected the payload's own value 111.0, got {value} "
+                "(999.0 means the decoy dem.tif in the CWD was read)"
+            )
+        finally:
+            if overview is not None:
+                overview.close()
+            dataset.close()
+
+    def test_partly_declared_no_data_is_not_completed(self):
+        """A band without a no-data value does not gain one from its neighbours.
+
+        Test scenario:
+            A parent declaring no-data on band 0 only — expected: band 1 stays `None`.
+            Passing the builder a list containing `None` coerced it into a `nan`
+            sentinel that masking and statistics would then honour.
+        """
+        raster = gdal.GetDriverByName("MEM").Create("", 32, 32, 2, gdal.GDT_Float32)
+        raster.SetGeoTransform((0.0, 1.0, 0.0, 32.0, 0.0, -1.0))
+        raster.GetRasterBand(1).SetNoDataValue(-9999.0)
+        for index in range(2):
+            raster.GetRasterBand(index + 1).WriteArray(
+                np.zeros((32, 32), dtype="float32")
+            )
+        raster.BuildOverviews("AVERAGE", [2])
+        dataset = Dataset(raster)
+        overview = None
+        try:
+            assert dataset.no_data_value[1] is None, "precondition: band 1 has none"
+            overview = dataset.get_overview_dataset()
+            assert overview.no_data_value[0] == pytest.approx(-9999.0), (
+                f"band 0 should keep its no-data, got {overview.no_data_value[0]}"
+            )
+            assert overview.no_data_value[1] is None, (
+                f"band 1 must stay unset, got {overview.no_data_value[1]}"
+            )
+        finally:
+            if overview is not None:
+                overview.close()
+            dataset.close()
 
     def test_vsimem_parent_stays_lazy(self):
         """A /vsimem/ raster reopens under OVERVIEW_LEVEL, so it is not materialised.

--- a/tests/dataset/unit/test_engines.py
+++ b/tests/dataset/unit/test_engines.py
@@ -257,6 +257,7 @@ FACADE_METHODS = [
     ("io", "create_overviews"),
     ("io", "recreate_overviews"),
     ("io", "get_overview"),
+    ("io", "get_overview_dataset"),
     ("io", "read_overview_array"),
     ("spatial", "crop"),
     ("spatial", "to_crs"),

--- a/tests/netcdf/samples/test_inherited_ops.py
+++ b/tests/netcdf/samples/test_inherited_ops.py
@@ -14,6 +14,7 @@ import pytest
 from osgeo import gdal
 
 from pyramids.base._errors import ReadOnlyError
+from pyramids.dataset import Dataset
 from pyramids.netcdf import NetCDF
 
 pytestmark = pytest.mark.core
@@ -223,6 +224,37 @@ def test_overview_ops_isolated_to_temp_copy(sample, tmp_path):
     assert set(data_dir.glob("*.ovr")) == before, (
         "overview ops must not write a sidecar into the committed tests/data tree"
     )
+
+
+def test_overview_dataset_from_a_variable_view(sample, tmp_path):
+    """A variable view's overview level comes back as a usable plain `Dataset`.
+
+    Test scenario:
+        `NetCDF.meta_data` is a `NetCDFMetadata`, not a mapping, so carrying it onto
+        the level crashed the `Dataset.meta_data` setter — expected: the level builds,
+        halves the grid, and is a plain `Dataset` (an overview is an ordinary raster,
+        not a NetCDF container).
+    """
+    work = shutil.copy(sample("cf__7v__1d3-2d3-3d1__y-asc.nc"), tmp_path / "tos.nc")
+    nc = NetCDF.read_file(str(work))
+    overview = None
+    try:
+        view = nc.get_variable("tos")
+        view.create_overviews(overview_levels=[2])
+        overview = view.get_overview_dataset(band=0)
+        assert type(overview) is Dataset, (
+            f"expected a plain Dataset, got {type(overview).__name__}"
+        )
+        assert overview.columns == view.columns // 2, (
+            f"expected half the columns, got {overview.columns} of {view.columns}"
+        )
+        assert overview.cell_size == view.cell_size * 2, (
+            f"cell size should double, got {overview.cell_size}"
+        )
+    finally:
+        if overview is not None:
+            overview.close()
+        nc.close()
 
 
 def test_inherited_to_cog_writes_file(tos_view, tmp_path):


### PR DESCRIPTION
# Description

`get_overview()` returns a raw `gdal.Band`, which carries no geotransform and no CRS, so an overview level could
not be plotted, written, cropped or reprojected without dropping to GDAL — inconsistent with the rest of the API,
where operations return `Dataset` objects.

Adds **`Dataset.get_overview_dataset(band=None, overview_index=0)`**, which returns the level as a read-only
`Dataset` view carrying the parent's CRS, per-band no-data, band names/units/scale/offset, colour table and
interpretation, with the cell size scaled by the decimation factor. `band` defaults to `None` (every band),
matching `read_overview_array`; an `int` returns a single-band `Dataset`. `get_overview`'s `gdal.Band` contract is
unchanged, and the new accessor reuses its "no overviews" / "index out of range" guards.

**Two backing paths.** A raster whose own GDAL description reopens to *this same grid* is described lazily through
the `OVERVIEW_LEVEL` open option and wrapped in a VRT, so no pixels are read and GDAL derives the scaled
geotransform itself. Anything else — a nameless `MEM` handle, a `NetCDF` variable view, a name that no longer
resolves to the same raster, or a shape GDAL refuses to describe — is materialised into an in-memory `Dataset`,
which is always correct.

**Why the VRT wrapper.** `gdal.OpenEx(path, OVERVIEW_LEVEL=i)` alone returns a handle whose *description is the
parent's path*, so every pyramids route that reopens by name silently read the full-resolution raster while the
object reported the level's shape — `read_array(threadsafe=True)` returned a 64x64 array from an object reporting
`(1, 16, 16)`, `read_array(chunks=...)` returned the right shape with the parent's pixels, and pickling
reconstructed the parent, breaking the `dask.distributed` path. The VRT records
`<OpenOptions><OOI key="OVERVIEW_LEVEL">` and carries no path, so those routes are structurally unavailable and
fail loudly instead.

**Why the identity check.** `Dataset.file_name` is a display label, not an identity:
`from_bytes(payload, name="dem.tif")` stamps a cosmetic name, so keying the lazy path off it returned the overview
of whatever `dem.tif` happened to sit in the working directory — silently, with no error (verified: a payload
holding `111.0` came back as an unrelated file's `999.0`). A classic `NETCDF:"/data/x.nc":tos` subdataset string
mangles the same way. The source now comes from GDAL's own description and is proved by reopening and comparing
size, band count and geotransform before it is trusted.

Also adds **`is_network_backed()`** to `base/remote.py`. The stranded-credentials warning has to key on *network*
backing, not `is_remote`, which is also true for the purely local `/vsimem/`, `/vsizip/` and `/vsigzip/`. It is
documented, doctested, and a strict subset of `is_remote`.

No new dependencies.

# Issues

- Closes #784 — feat(dataset): expose overviews as Dataset objects (get_overview returns a raw gdal.Band)

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

Purely additive: `get_overview`, `read_overview_array` and `recreate_overviews` are untouched, and the new
accessor is declared alongside them on `RasterBase`, the protocol and both docs class diagrams.

**Known limitations, all documented on the method:** the caller owns the returned handle and should `close()` it
(until then it pins the parent file on Windows); neither form carries a path, so `threadsafe=`/pickle raise and
`chunks=` returns a graph that raises at compute — call `to_file()` first; `create_overviews()` on a lazily
described level would drop a stray `.ovr` in the working directory; the materialised form holds the level's pixels
up to three times while building; a `NetCDF` variable view returns a plain `Dataset` and its structured container
metadata is left behind.

# How Has This Been Tested?

- `pixi run -e dev pytest -m "not plot"` → **7401 passed**, 51 skipped.
- `pixi run -e dev mypy` → **0 errors** (127 source files).
- `pre-commit run --all-files` (CI's `SKIP` set) → all hooks pass.
- **26 new tests.** `TestGetOverviewDataset` covers grid scaling at two levels, band selection proven by
  per-band constants, VRT laziness and a distinct handle, the reopen-by-path refusals against a *gradient* fixture
  (so wrong pixels cannot look right), `/vsimem/` staying lazy, rotated-grid parity between the two paths, absent
  and partly-declared no-data, band + dataset metadata carry, colour table/interpretation carry, non-EPSG CRS
  survival, the `from_bytes` identity regression, a source that no longer holds the same grid, all-bands rejection
  on mixed counts, the network-credential warning plus its two silence cases, validation errors and a `to_file`
  round-trip. Plus a NetCDF variable-view test and `is_network_backed` beside `is_remote`'s tests.
- Several were mutation-verified: the source was temporarily broken to confirm the test fails.

- [x] Full non-plot suite (`pytest -m "not plot"`)
- [x] `mypy` clean
- [x] Two full `/review-rounds` passes — 40 findings across both rounds, all resolved; review notes in `planning/`

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen bumps this on release)
- [ ] added changes to History.rst. (commitizen-generated; not hand-edited)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (docstrings on every new symbol, plus `RasterBase`, the protocol stub and both
      `docs/reference/dataset/` class diagrams)
