### PR TITLE
perf(dataset)!: regenerate a band's overviews in one GDAL pass

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -129,6 +129,24 @@ that leaked out of an empty table lookup. Only affects code catching the old typ
 
 ### unreleased
 
+**`recreate_overviews` now rebuilds a band's levels in one cascading pass.** Each deeper level is decimated from
+the level above rather than from the full-resolution band, matching what `create_overviews` (`BuildOverviews`)
+has always done — previously `recreate_overviews` rebuilt every level directly from the source. Nothing warns;
+the call still succeeds.
+
+Level 0 is unaffected. A level >= 1 keeps its previous values only where the resampling survives being applied
+twice:
+
+- `nearest` — unchanged everywhere; GDAL does not cascade it.
+- `average`, `rms` — unchanged on a floating-point band with no no-data value. An integer band picks up per-level
+  rounding of up to 1 DN, and a no-data gap changes the result regardless of dtype.
+- `cubic`, `cubicspline`, `bilinear`, `lanczos`, `gauss`, `mode` — changed on ordinary data. `mode` can move by
+  whole classes, because the mode of modes is not the mode.
+
+There is no way to get the old per-level values back: no API rebuilds a deep level directly from the source any
+more. If your pipeline depends on them, rebuild the levels you need yourself from
+`Dataset.read_array()` and write them out.
+
 **Operations that need a CRS now refuse instead of assuming one.** Each raises `CRSError` naming the operation
 and how to fix it, where previously the missing CRS was silently filled in with WGS 84:
 

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -1490,6 +1490,12 @@ class RasterBase(ABC):
         `create_overviews` for that. A band with no overviews has nothing to regenerate,
         so it is reported through a warning rather than skipped silently.
 
+        A band's levels are rebuilt in a single GDAL pass, which cascades: each deeper
+        level is decimated from the level above rather than from the full-resolution
+        band, matching what `create_overviews` does. A level >= 1 therefore holds what a
+        per-level rebuild wrote only where the resampling is idempotent under composition
+        (`nearest` always, `average` and `rms` while no no-data is present).
+
         Args:
             resampling_method (str, optional):
                 The resampling method used to create the overviews, by default "nearest".

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -1493,8 +1493,9 @@ class RasterBase(ABC):
         A band's levels are rebuilt in a single GDAL pass, which cascades: each deeper
         level is decimated from the level above rather than from the full-resolution
         band, matching what `create_overviews` does. A level >= 1 therefore holds what a
-        per-level rebuild wrote only where the resampling is idempotent under composition
-        (`nearest` always, `average` and `rms` while no no-data is present).
+        per-level rebuild wrote only where the resampling survives being applied twice --
+        `nearest` always, and `average`/`rms` on a floating-point band with no no-data.
+        See `docs/migration.md`.
 
         Args:
             resampling_method (str, optional):

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -1508,8 +1508,8 @@ class RasterBase(ABC):
             RuntimeError:
                 Any other GDAL regeneration failure, so a disk-full, corrupt-overview or transport failure
                 is not relabelled as an access-mode error. GDAL's own error is re-raised carrying a note
-                that names the band and level it stopped on; a failing status that raised nothing is turned
-                into one.
+                that names the band it stopped on — a band's levels regenerate in one call, so no level is
+                named; a failing status that raised nothing is turned into one.
 
         Warns:
             UserWarning:

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -3049,6 +3049,14 @@ class IO(_Engine["Dataset"]):
         regenerate for it, so this warns instead of returning silently — naming the
         skipped bands when only some of them are empty, and still regenerating the rest.
 
+        A band's levels are rebuilt in a single GDAL pass, which **cascades**: each
+        deeper level is decimated from the level above rather than from the
+        full-resolution band. That is what `create_overviews` already does, so the two
+        now agree — but it means a level ≥ 1 matches a per-level rebuild only where the
+        resampling is idempotent under composition (`nearest` always, `average` and `rms`
+        while no no-data is present). With any other method, or across a no-data gap, the
+        values differ. Use `create_overviews` if you need the levels rebuilt from scratch.
+
         The warning is emitted in every access mode: "has no overviews" is independent of
         read-only-ness, so reporting it as a read-only failure would misdiagnose it —
         reopening the dataset writable yields this same warning. Read-only is not a
@@ -3136,12 +3144,20 @@ class IO(_Engine["Dataset"]):
         `gdal.RegenerateOverviews` call, which reads the full-resolution band **once** for
         the whole batch; regenerating them one at a time re-read the source per level.
         GDAL then fills each deeper level by decimating the level above rather than the
-        source, so wherever those two disagree — a no-data gap, or a kernel wider than the
-        decimation window such as `cubic` — a deep level ends up holding different values
-        than the per-level loop wrote. Each call is preceded by `gdal.ErrorReset()` so the
-        CPL error number inspected on failure belongs to *this* regeneration and not to
-        something earlier in the process. Overviews are rewritten in place, so a failure
-        part-way through leaves the earlier bands already regenerated.
+        source, so a level ≥ 1 holds what the per-level loop wrote only where the
+        resampling is idempotent under composition — `nearest` always, `average` and
+        `rms` while no no-data is present. Every other method diverges on ordinary data:
+        measured at level 1 on a clean 16x16, `cubic` by 0.006, `bilinear` by 0.012,
+        `gauss` by 0.086, and `mode` by 2 whole classes, because the mode of modes is not
+        the mode. This is the same cascade `create_overviews` (`BuildOverviews`) already
+        uses, so the two now agree; the per-level loop was the odd one out. Non-power-of-
+        two chains compound it, since each step decimates an already-decimated grid.
+
+        Each call is preceded by `gdal.ErrorReset()` so the CPL error number inspected on
+        failure belongs to *this* regeneration and not to something earlier in the
+        process. Overviews are rewritten in place, so a failure part-way through leaves
+        the earlier bands already regenerated — and, within the failing band, GDAL may
+        have written some of its levels before giving up.
 
         Args:
             overview_count: Per-band overview counts, snapshotted by the caller.
@@ -3165,7 +3181,10 @@ class IO(_Engine["Dataset"]):
                 # the #863 defect, narrowed to a band.
                 continue
             band = self._ds._iloc(i)
-            overviews = [self.get_overview(i, j) for j in range(overview_count[i])]
+            # Take the levels off the band that is already resolved: get_overview would
+            # re-resolve it and re-read GetOverviewCount once per level, and the caller
+            # has already validated the count it snapshotted.
+            overviews = [band.GetOverview(j) for j in range(overview_count[i])]
             gdal.ErrorReset()
             try:
                 status = gdal.RegenerateOverviews(band, overviews, resampling_method)

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -3073,8 +3073,9 @@ class IO(_Engine["Dataset"]):
             RuntimeError:
                 Any other GDAL regeneration failure, so a disk-full, corrupt-overview or
                 transport failure is not relabelled as an access-mode error. GDAL's own
-                error is re-raised carrying a note that names the band and level it
-                stopped on; a failing status that raised nothing is turned into one.
+                error is re-raised carrying a note that names the band it stopped on — a
+                band's levels regenerate in one call, so no level is named; a failing
+                status that raised nothing is turned into one.
 
         Warns:
             UserWarning:
@@ -3132,12 +3133,15 @@ class IO(_Engine["Dataset"]):
 
         Split out of :meth:`recreate_overviews` so the empty-count reporting reads as one
         decision. All of a band's levels go to GDAL in a single
-        `gdal.RegenerateOverviews` call, which reads the full-resolution band **once**
-        and fills every level from that pass; regenerating them one at a time re-read the
-        source per level. Each call is preceded by `gdal.ErrorReset()` so the CPL error
-        number inspected on failure belongs to *this* regeneration and not to something
-        earlier in the process. Overviews are rewritten in place, so a failure part-way
-        through leaves the earlier bands already regenerated.
+        `gdal.RegenerateOverviews` call, which reads the full-resolution band **once** for
+        the whole batch; regenerating them one at a time re-read the source per level.
+        GDAL then fills each deeper level by decimating the level above rather than the
+        source, so wherever those two disagree — a no-data gap, or a kernel wider than the
+        decimation window such as `cubic` — a deep level ends up holding different values
+        than the per-level loop wrote. Each call is preceded by `gdal.ErrorReset()` so the
+        CPL error number inspected on failure belongs to *this* regeneration and not to
+        something earlier in the process. Overviews are rewritten in place, so a failure
+        part-way through leaves the earlier bands already regenerated.
 
         Args:
             overview_count: Per-band overview counts, snapshotted by the caller.

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -3128,13 +3128,16 @@ class IO(_Engine["Dataset"]):
     def _regenerate_overviews(
         self, overview_count: list[int], resampling_method: str
     ) -> None:
-        """Regenerate every existing overview level in place, band by band.
+        """Regenerate every existing overview level in place, one pass per band.
 
         Split out of :meth:`recreate_overviews` so the empty-count reporting reads as one
-        decision. Each call is preceded by `gdal.ErrorReset()` so the CPL error number
-        inspected on failure belongs to *this* regeneration and not to something earlier
-        in the process. Overviews are rewritten in place, so a failure part-way through
-        leaves the earlier bands already regenerated.
+        decision. All of a band's levels go to GDAL in a single
+        `gdal.RegenerateOverviews` call, which reads the full-resolution band **once**
+        and fills every level from that pass; regenerating them one at a time re-read the
+        source per level. Each call is preceded by `gdal.ErrorReset()` so the CPL error
+        number inspected on failure belongs to *this* regeneration and not to something
+        earlier in the process. Overviews are rewritten in place, so a failure part-way
+        through leaves the earlier bands already regenerated.
 
         Args:
             overview_count: Per-band overview counts, snapshotted by the caller.
@@ -3145,38 +3148,43 @@ class IO(_Engine["Dataset"]):
                 read-only, as classified by :meth:`_is_write_refusal`. The original
                 error stays chained as `__cause__`.
             RuntimeError: Any other GDAL failure — the error GDAL raised, re-raised with
-                a note naming the band and level it stopped on, or a fresh one carrying
-                `gdal.GetLastErrorMsg()` when `RegenerateOverview` reports a non-`CE_None`
-                status without raising (exceptions turned off process-wide).
+                a note naming the band it stopped on, or a fresh one carrying
+                `gdal.GetLastErrorMsg()` when `RegenerateOverviews` reports a
+                non-`CE_None` status without raising (exceptions turned off
+                process-wide). Batching costs the level granularity the per-level loop
+                had: a failure names the band, not which of its levels failed.
         """
         for i in range(self._ds.band_count):
+            if overview_count[i] == 0:
+                # Already reported by recreate_overviews, which names the skipped bands.
+                # Passing GDAL an empty list would regenerate nothing and say nothing --
+                # the #863 defect, narrowed to a band.
+                continue
             band = self._ds._iloc(i)
-            for j in range(overview_count[i]):
-                ovr = self.get_overview(i, j)
-                gdal.ErrorReset()
-                try:
-                    status = gdal.RegenerateOverview(band, ovr, resampling_method)
-                except RuntimeError as err:
-                    err.add_note(
-                        f"Failed regenerating overview {j} of band {i} (0-based); "
-                        "earlier bands may already have been rewritten."
-                    )
-                    if self._is_write_refusal(err):
-                        raise ReadOnlyError(
-                            f"Cannot regenerate overview {j} of band {i}: the overviews "
-                            "are opened read-only. Please read the dataset using "
-                            "read_only=False to recreate overviews."
-                        ) from err
-                    raise
-                # gdal.UseExceptions() is process-global, so a caller that turned it off
-                # (or a driver that fails without pushing a CPL error) would otherwise
-                # slip through as the silent no-op this method exists to remove.
-                if status != gdal.CE_None:
-                    detail = gdal.GetLastErrorMsg() or f"GDAL returned {status}"
-                    raise RuntimeError(
-                        f"Failed regenerating overview {j} of band {i} (0-based): "
-                        f"{detail}"
-                    )
+            overviews = [self.get_overview(i, j) for j in range(overview_count[i])]
+            gdal.ErrorReset()
+            try:
+                status = gdal.RegenerateOverviews(band, overviews, resampling_method)
+            except RuntimeError as err:
+                err.add_note(
+                    f"Failed regenerating the overviews of band {i} (0-based); "
+                    "earlier bands may already have been rewritten."
+                )
+                if self._is_write_refusal(err):
+                    raise ReadOnlyError(
+                        f"Cannot regenerate the overviews of band {i}: the overviews "
+                        "are opened read-only. Please read the dataset using "
+                        "read_only=False to recreate overviews."
+                    ) from err
+                raise
+            # gdal.UseExceptions() is process-global, so a caller that turned it off
+            # (or a driver that fails without pushing a CPL error) would otherwise
+            # slip through as the silent no-op this method exists to remove.
+            if status != gdal.CE_None:
+                detail = gdal.GetLastErrorMsg() or f"GDAL returned {status}"
+                raise RuntimeError(
+                    f"Failed regenerating the overviews of band {i} (0-based): {detail}"
+                )
 
     @staticmethod
     def _is_write_refusal(err: RuntimeError) -> bool:

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -3051,11 +3051,14 @@ class IO(_Engine["Dataset"]):
 
         A band's levels are rebuilt in a single GDAL pass, which **cascades**: each
         deeper level is decimated from the level above rather than from the
-        full-resolution band. That is what `create_overviews` already does, so the two
-        now agree — but it means a level ≥ 1 matches a per-level rebuild only where the
-        resampling is idempotent under composition (`nearest` always, `average` and `rms`
-        while no no-data is present). With any other method, or across a no-data gap, the
-        values differ. Use `create_overviews` if you need the levels rebuilt from scratch.
+        full-resolution band. That is what `create_overviews` (`BuildOverviews`) already
+        does, so the two now agree. A level ≥ 1 keeps the values a per-level rebuild
+        wrote only where the resampling survives being applied twice: `nearest` always
+        (GDAL does not cascade it), and `average`/`rms` on a floating-point band with no
+        no-data — an integer band picks up per-level rounding of up to 1 DN, and a
+        no-data gap changes the result at any dtype. Every other method differs on
+        ordinary data. No API rebuilds a deep level directly from the source any more;
+        see `docs/migration.md`.
 
         The warning is emitted in every access mode: "has no overviews" is independent of
         read-only-ness, so reporting it as a read-only failure would misdiagnose it —
@@ -3144,14 +3147,11 @@ class IO(_Engine["Dataset"]):
         `gdal.RegenerateOverviews` call, which reads the full-resolution band **once** for
         the whole batch; regenerating them one at a time re-read the source per level.
         GDAL then fills each deeper level by decimating the level above rather than the
-        source, so a level ≥ 1 holds what the per-level loop wrote only where the
-        resampling is idempotent under composition — `nearest` always, `average` and
-        `rms` while no no-data is present. Every other method diverges on ordinary data:
-        measured at level 1 on a clean 16x16, `cubic` by 0.006, `bilinear` by 0.012,
-        `gauss` by 0.086, and `mode` by 2 whole classes, because the mode of modes is not
-        the mode. This is the same cascade `create_overviews` (`BuildOverviews`) already
-        uses, so the two now agree; the per-level loop was the odd one out. Non-power-of-
-        two chains compound it, since each step decimates an already-decimated grid.
+        source — the cascade :meth:`recreate_overviews` documents, and the same one
+        `BuildOverviews` uses, so the two now agree; the per-level loop was the odd one
+        out. For the cascading methods a non-power-of-two chain compounds it, since each
+        step decimates an already-decimated grid; `nearest` is exempt because GDAL never
+        cascades it.
 
         Each call is preceded by `gdal.ErrorReset()` so the CPL error number inspected on
         failure belongs to *this* regeneration and not to something earlier in the
@@ -3181,17 +3181,23 @@ class IO(_Engine["Dataset"]):
                 # the #863 defect, narrowed to a band.
                 continue
             band = self._ds._iloc(i)
-            # Take the levels off the band that is already resolved: get_overview would
-            # re-resolve it and re-read GetOverviewCount once per level, and the caller
-            # has already validated the count it snapshotted.
-            overviews = [band.GetOverview(j) for j in range(overview_count[i])]
             gdal.ErrorReset()
             try:
+                # Resolve inside the try so a level that has gone missing since the
+                # caller snapshotted the counts is reported against its band like any
+                # other failure, rather than escaping bare. Taken off the already
+                # resolved band: get_overview would re-resolve it and re-read
+                # GetOverviewCount once per level.
+                # Holding every level's handle at once (the singular loop held one) is
+                # safe: GetOverview registers a child reference on the owning dataset,
+                # so the parent outlives the list.
+                overviews = [band.GetOverview(j) for j in range(overview_count[i])]
                 status = gdal.RegenerateOverviews(band, overviews, resampling_method)
             except RuntimeError as err:
                 err.add_note(
                     f"Failed regenerating the overviews of band {i} (0-based); "
-                    "earlier bands may already have been rewritten."
+                    "earlier bands, and this band's earlier levels, may already have "
+                    "been rewritten."
                 )
                 if self._is_write_refusal(err):
                     raise ReadOnlyError(

--- a/tests/dataset/spatial/test_overviews.py
+++ b/tests/dataset/spatial/test_overviews.py
@@ -46,11 +46,13 @@ def _raster_with_overviews(
     bands: list[np.ndarray],
     levels: list[int],
     resampling: str = "AVERAGE",
+    no_data_value: float | None = None,
 ) -> str:
     """Write a georeferenced raster holding ``bands`` and build ``levels`` overviews on it.
 
     Complements :func:`_overviewed_raster` for the cases that need the band values, the
-    number of levels or the resampling method picked per test rather than fixed.
+    number of levels, the resampling method or a declared no-data value picked per test
+    rather than fixed.
     """
     path = str(tmp_path / name)
     rows, columns = bands[0].shape
@@ -62,7 +64,10 @@ def _raster_with_overviews(
     srs.ImportFromEPSG(4326)
     raster.SetProjection(srs.ExportToWkt())
     for index, values in enumerate(bands):
-        raster.GetRasterBand(index + 1).WriteArray(values)
+        band = raster.GetRasterBand(index + 1)
+        if no_data_value is not None:
+            band.SetNoDataValue(no_data_value)
+        band.WriteArray(values)
     raster = None
 
     handle = gdal.Open(path, gdal.GA_Update)
@@ -72,7 +77,11 @@ def _raster_with_overviews(
 
 
 def _block_mean(values: np.ndarray, factor: int) -> np.ndarray:
-    """Average ``values`` over non-overlapping ``factor`` by ``factor`` blocks."""
+    """Average ``values`` over non-overlapping ``factor`` by ``factor`` blocks.
+
+    Both dimensions of ``values`` must divide by ``factor``; the reshape below silently
+    misaligns the blocks otherwise, so callers pick power-of-two shapes.
+    """
     rows, columns = values.shape
     averaged = (
         values.astype("float64")
@@ -593,7 +602,68 @@ class TestRecreateOverviewsBatching:
         finally:
             dataset.close()
 
-    def test_deeper_levels_cascade_from_the_level_above(self, tmp_path):
+    def test_each_band_is_batched_with_its_own_level_count(self, tmp_path, monkeypatch):
+        """A band with fewer levels than its neighbour is batched with its own count.
+
+        Test scenario:
+            Two bands whose non-zero level counts differ — band 0 carries two levels and
+            band 1 one, via a per-band `<Overview>` VRT — expected: calls of 2 and 1
+            overviews respectively. Every other fixture gives both bands the same count,
+            so indexing the snapshot by the wrong band survives them unnoticed.
+        """
+        sources = []
+        for name, levels in (("two.tif", [2, 4]), ("one.tif", [2])):
+            path = str(tmp_path / name)
+            raster = gdal.GetDriverByName("GTiff").Create(
+                path, 16, 16, 1, gdal.GDT_Float32
+            )
+            raster.GetRasterBand(1).WriteArray(
+                np.arange(256, dtype="float32").reshape(16, 16)
+            )
+            raster = None
+            handle = gdal.Open(path, gdal.GA_Update)
+            handle.BuildOverviews("AVERAGE", levels)
+            handle = None
+            sources.append(path)
+
+        vrt = tmp_path / "uneven.vrt"
+        vrt.write_text(
+            f'<VRTDataset rasterXSize="16" rasterYSize="16">'
+            + "".join(
+                f'<VRTRasterBand dataType="Float32" band="{position + 1}">'
+                f'<SimpleSource><SourceFilename relativeToVRT="0">{source}'
+                f"</SourceFilename><SourceBand>1</SourceBand></SimpleSource>"
+                + "".join(
+                    f'<Overview><SourceFilename relativeToVRT="0">{source}'
+                    f"</SourceFilename><SourceBand>1</SourceBand></Overview>"
+                    for _ in range(count)
+                )
+                + "</VRTRasterBand>"
+                for position, (source, count) in enumerate(zip(sources, (2, 1)))
+            )
+            + "</VRTDataset>"
+        )
+        dataset = Dataset.read_file(str(vrt), read_only=True)
+        try:
+            assert dataset.overview_count == [2, 1], (
+                f"fixture must give the bands different counts, got {dataset.overview_count}"
+            )
+            batches = []
+            monkeypatch.setattr(
+                gdal,
+                "RegenerateOverviews",
+                lambda band, overviews, method: (
+                    batches.append(len(overviews)) or gdal.CE_None
+                ),
+            )
+            dataset.recreate_overviews(resampling_method="average")
+            assert batches == [2, 1], (
+                f"each band must be batched with its own level count, got {batches}"
+            )
+        finally:
+            dataset.close()
+
+    def test_a_deep_level_holds_the_cascaded_values(self, tmp_path):
         """A deeper level is decimated from the level above, not from the source.
 
         Test scenario:

--- a/tests/dataset/spatial/test_overviews.py
+++ b/tests/dataset/spatial/test_overviews.py
@@ -212,7 +212,7 @@ class TestRecreateOverviewsContract:
         """Only a genuine write refusal becomes `ReadOnlyError`; other failures propagate.
 
         Test scenario:
-            `gdal.RegenerateOverview` is patched to raise a `RuntimeError` while a
+            `gdal.RegenerateOverviews` is patched to raise a `RuntimeError` while a
             writable dataset that does have overviews is regenerated, so no CPL error
             number is set and the phrase fallback decides. Expected: a disk-full failure
             surfaces unchanged as `RuntimeError` (the pre-fix code relabelled *every*
@@ -230,7 +230,7 @@ class TestRecreateOverviewsContract:
             def raise_runtime_error(*args, **kwargs):
                 raise RuntimeError(gdal_message)
 
-            monkeypatch.setattr(gdal, "RegenerateOverview", raise_runtime_error)
+            monkeypatch.setattr(gdal, "RegenerateOverviews", raise_runtime_error)
             with pytest.raises(expected_error) as excinfo:
                 dataset.recreate_overviews()
             assert type(excinfo.value) is expected_error, (
@@ -253,7 +253,7 @@ class TestRecreateOverviewsContract:
 
         Test scenario:
             `gdal.UseExceptions()` is process-global, so a caller that turned it off
-            leaves `RegenerateOverview` *returning* `CE_Failure` instead of raising.
+            leaves `RegenerateOverviews` *returning* `CE_Failure` instead of raising.
             Patch it to do exactly that on a writable dataset that does have overviews
             — expected: a `RuntimeError` naming the band and level, since the
             try/except alone would let this through as the silent no-op the method
@@ -264,15 +264,15 @@ class TestRecreateOverviewsContract:
         try:
             dataset.create_overviews(overview_levels=[2])
             monkeypatch.setattr(
-                gdal, "RegenerateOverview", lambda *args, **kwargs: gdal.CE_Failure
+                gdal, "RegenerateOverviews", lambda *args, **kwargs: gdal.CE_Failure
             )
             with pytest.raises(RuntimeError) as excinfo:
                 dataset.recreate_overviews()
             assert type(excinfo.value) is RuntimeError, (
                 f"a failing status must not be relabelled, got {type(excinfo.value).__name__}"
             )
-            assert "overview 0 of band 0" in str(excinfo.value), (
-                f"the error must name the band and level, got: {excinfo.value}"
+            assert "overviews of band 0" in str(excinfo.value), (
+                f"the error must name the band, got: {excinfo.value}"
             )
         finally:
             dataset.close()
@@ -283,7 +283,7 @@ class TestRecreateOverviewsContract:
         """A propagated GDAL failure carries a note saying where regeneration stopped.
 
         Test scenario:
-            An unrelated `RuntimeError` is raised from `gdal.RegenerateOverview` and
+            An unrelated `RuntimeError` is raised from `gdal.RegenerateOverviews` and
             re-raised unchanged — expected: `__notes__` names the band and level and
             says earlier bands may already have been rewritten, because the loop
             rewrites in place and leaves the dataset half-regenerated.
@@ -296,12 +296,12 @@ class TestRecreateOverviewsContract:
             def raise_runtime_error(*args, **kwargs):
                 raise RuntimeError("Failed to write overview block: disk full")
 
-            monkeypatch.setattr(gdal, "RegenerateOverview", raise_runtime_error)
+            monkeypatch.setattr(gdal, "RegenerateOverviews", raise_runtime_error)
             with pytest.raises(RuntimeError) as excinfo:
                 dataset.recreate_overviews()
             notes = getattr(excinfo.value, "__notes__", [])
-            assert any("overview 0 of band 0" in note for note in notes), (
-                f"the note must name the band and level, got {notes}"
+            assert any("overviews of band 0" in note for note in notes), (
+                f"the note must name the band, got {notes}"
             )
             assert any("already have been rewritten" in note for note in notes), (
                 f"the note must flag the partial rewrite, got {notes}"
@@ -315,24 +315,27 @@ class TestRecreateOverviewsContract:
         """After warning about the empty bands, the populated ones are regenerated.
 
         Test scenario:
-            Record every `gdal.RegenerateOverview` call on the mixed `[1, 0]` VRT —
-            expected: exactly one call, for band 0's single level, proving the mixed
-            path warns *and* carries on rather than returning early. The recorder also
-            keeps the call off the VRT's read-only `.ovr`, which is why the sibling
+            Record every `gdal.RegenerateOverviews` call on the mixed `[1, 0]` VRT —
+            expected: exactly one call, carrying band 0's levels as a batch, proving the
+            mixed path warns *and* carries on rather than returning early, and that the
+            empty band is skipped instead of being handed an empty list. The recorder
+            also keeps the call off the VRT's read-only `.ovr`, which is why the sibling
             warning test has to suppress that failure.
         """
         dataset = Dataset.read_file(_mixed_overview_vrt(tmp_path), read_only=True)
         try:
             calls = []
-            monkeypatch.setattr(
-                gdal,
-                "RegenerateOverview",
-                lambda band, ovr, method: calls.append(method) or gdal.CE_None,
-            )
+
+            def record(band, overviews, method):
+                calls.append((len(overviews), method))
+                return gdal.CE_None
+
+            monkeypatch.setattr(gdal, "RegenerateOverviews", record)
             with pytest.warns(UserWarning, match=r"call create_overviews\(\) first"):
                 dataset.recreate_overviews(resampling_method="average")
-            assert calls == ["average"], (
-                f"only band 0's single overview should regenerate, got {calls}"
+            assert calls == [(1, "average")], (
+                "band 0's levels should regenerate in one batched call and the empty "
+                f"band be skipped, got {calls}"
             )
         finally:
             dataset.close()

--- a/tests/dataset/spatial/test_overviews.py
+++ b/tests/dataset/spatial/test_overviews.py
@@ -306,7 +306,7 @@ class TestRecreateOverviewsContract:
             `gdal.UseExceptions()` is process-global, so a caller that turned it off
             leaves `RegenerateOverviews` *returning* `CE_Failure` instead of raising.
             Patch it to do exactly that on a writable dataset that does have overviews
-            — expected: a `RuntimeError` naming the band and level, since the
+            — expected: a `RuntimeError` naming the band, since the
             try/except alone would let this through as the silent no-op the method
             exists to remove.
         """
@@ -335,7 +335,7 @@ class TestRecreateOverviewsContract:
 
         Test scenario:
             An unrelated `RuntimeError` is raised from `gdal.RegenerateOverviews` and
-            re-raised unchanged — expected: `__notes__` names the band and level and
+            re-raised unchanged — expected: `__notes__` names the band and warns that
             says earlier bands may already have been rewritten, because the loop
             rewrites in place and leaves the dataset half-regenerated.
         """
@@ -611,6 +611,9 @@ class TestRecreateOverviewsBatching:
             overviews respectively. Every other fixture gives both bands the same count,
             so indexing the snapshot by the wrong band survives them unnoticed.
         """
+        # The <Overview> entries below alias the full-resolution band: this test
+        # monkeypatches RegenerateOverviews, so nothing ever reads their pixels -- only
+        # the per-band *count* the engine snapshots matters here.
         sources = []
         for name, levels in (("two.tif", [2, 4]), ("one.tif", [2])):
             path = str(tmp_path / name)
@@ -663,6 +666,67 @@ class TestRecreateOverviewsBatching:
         finally:
             dataset.close()
 
+    def test_read_only_refusal_on_a_multi_level_batch(self, tmp_path):
+        """A read-only refusal is still classified when the batch carries many levels.
+
+        Test scenario:
+            The unmocked read-only path is otherwise only exercised on a single-level
+            fixture, so nothing showed that the wider single call still yields a
+            `CPLE_NoWriteAccess` GDAL can be asked about — expected: `ReadOnlyError`
+            naming the band, with the original chained.
+        """
+        values = np.arange(4096, dtype="float32").reshape(64, 64)
+        path = _raster_with_overviews(tmp_path, "ro_batch.tif", [values], [2, 4, 8])
+        dataset = Dataset.read_file(path, read_only=True)
+        try:
+            assert dataset.overview_count == [3], (
+                f"fixture must carry three levels, got {dataset.overview_count}"
+            )
+            with pytest.raises(ReadOnlyError, match="overviews of band 0") as excinfo:
+                dataset.recreate_overviews(resampling_method="average")
+            assert isinstance(excinfo.value.__cause__, RuntimeError), (
+                "the original GDAL error must stay chained"
+            )
+        finally:
+            dataset.close()
+
+    def test_create_overviews_cascades_the_same_way(self, tmp_path):
+        """`create_overviews` produces the same deep level, which is what makes the
+        cascade defensible.
+
+        Test scenario:
+            Build the levels from scratch and regenerate them on a copy of the same
+            raster — expected: identical level 1. The justification for accepting the
+            behaviour change is that `BuildOverviews` already cascades, so
+            `recreate_overviews` now agrees with how the levels were built; nothing
+            asserted that, leaving the argument resting on prose.
+        """
+        values = np.arange(64, dtype="float32").reshape(8, 8)
+        values[0, 0] = -9999.0
+        built = _raster_with_overviews(
+            tmp_path, "built.tif", [values], [2, 4], no_data_value=-9999.0
+        )
+        regenerated = _raster_with_overviews(
+            tmp_path, "regenerated.tif", [values], [2, 4], no_data_value=-9999.0
+        )
+
+        dataset = Dataset.read_file(regenerated, read_only=False)
+        try:
+            dataset.recreate_overviews(resampling_method="average")
+            after = np.asarray(dataset.get_overview(0, 1).ReadAsArray())
+        finally:
+            dataset.close()
+        reference = Dataset.read_file(built)
+        try:
+            expected = np.asarray(reference.get_overview(0, 1).ReadAsArray())
+        finally:
+            reference.close()
+        np.testing.assert_allclose(
+            after,
+            expected,
+            err_msg="regenerating must land where create_overviews already builds",
+        )
+
     def test_a_deep_level_holds_the_cascaded_values(self, tmp_path):
         """A deeper level is decimated from the level above, not from the source.
 
@@ -675,17 +739,15 @@ class TestRecreateOverviewsBatching:
             it also makes recreate_overviews agree with how create_overviews built the
             levels in the first place.
         """
-        path = str(tmp_path / "cascade.tif")
-        raster = gdal.GetDriverByName("GTiff").Create(path, 8, 8, 1, gdal.GDT_Float32)
-        band = raster.GetRasterBand(1)
-        band.SetNoDataValue(-9999.0)
         values = np.arange(64, dtype="float32").reshape(8, 8)
         values[0, 0] = -9999.0
-        band.WriteArray(values)
-        raster = None
-        handle = gdal.Open(path, gdal.GA_Update)
-        handle.BuildOverviews("AVERAGE", [2, 4])
-        handle = None
+        path = _raster_with_overviews(
+            tmp_path,
+            "cascade.tif",
+            [values],
+            [2, 4],
+            no_data_value=-9999.0,
+        )
 
         dataset = Dataset.read_file(path, read_only=False)
         try:

--- a/tests/dataset/spatial/test_overviews.py
+++ b/tests/dataset/spatial/test_overviews.py
@@ -40,6 +40,48 @@ def _overviewed_raster(tmp_path, name: str = "ovr_src.tif") -> str:
     return path
 
 
+def _raster_with_overviews(
+    tmp_path,
+    name: str,
+    bands: list[np.ndarray],
+    levels: list[int],
+    resampling: str = "AVERAGE",
+) -> str:
+    """Write a georeferenced raster holding ``bands`` and build ``levels`` overviews on it.
+
+    Complements :func:`_overviewed_raster` for the cases that need the band values, the
+    number of levels or the resampling method picked per test rather than fixed.
+    """
+    path = str(tmp_path / name)
+    rows, columns = bands[0].shape
+    raster = gdal.GetDriverByName("GTiff").Create(
+        path, columns, rows, len(bands), gdal.GDT_Float32
+    )
+    raster.SetGeoTransform((10.0, 0.5, 0.0, 80.0, 0.0, -0.5))
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(4326)
+    raster.SetProjection(srs.ExportToWkt())
+    for index, values in enumerate(bands):
+        raster.GetRasterBand(index + 1).WriteArray(values)
+    raster = None
+
+    handle = gdal.Open(path, gdal.GA_Update)
+    handle.BuildOverviews(resampling, levels)
+    handle = None
+    return path
+
+
+def _block_mean(values: np.ndarray, factor: int) -> np.ndarray:
+    """Average ``values`` over non-overlapping ``factor`` by ``factor`` blocks."""
+    rows, columns = values.shape
+    averaged = (
+        values.astype("float64")
+        .reshape(rows // factor, factor, columns // factor, factor)
+        .mean(axis=(1, 3))
+    )
+    return averaged
+
+
 def _mixed_overview_vrt(tmp_path) -> str:
     """Build a 2-band VRT reporting ``overview_count == [1, 0]``.
 
@@ -468,6 +510,126 @@ class TestRecreateOverviewsContract:
             user_warnings = [w for w in recorded if issubclass(w.category, UserWarning)]
             assert not user_warnings, (
                 f"happy path should not warn, got {[str(w.message) for w in user_warnings]}"
+            )
+        finally:
+            dataset.close()
+
+
+class TestRecreateOverviewsBatching:
+    """A band's levels are regenerated in one GDAL pass, not one pass per level (#783).
+
+    `gdal.RegenerateOverviews` reads the full-resolution band once and fills every level
+    from that single pass; the singular call it replaced re-read the source per level.
+    """
+
+    def test_a_bands_levels_go_out_in_a_single_call(self, tmp_path, monkeypatch):
+        """Three bands carrying three levels produce three calls of three overviews each.
+
+        Test scenario:
+            Record every `gdal.RegenerateOverviews` call on a 3-band raster with levels
+            `[2, 4, 8]` — expected: one call per band, in band order, each handed all
+            three of that band's overviews. The per-level loop this replaced would make
+            nine one-overview calls, and batching every band together would make one.
+            Bands are told apart by their constant fill (band `i` holds `i + 1`), so a
+            call landing on the wrong band is caught as well.
+        """
+        constants = [np.full((64, 64), i + 1, dtype="float32") for i in range(3)]
+        path = _raster_with_overviews(tmp_path, "batched.tif", constants, [2, 4, 8])
+        dataset = Dataset.read_file(path, read_only=False)
+        try:
+            calls = []
+
+            def record(band, overviews, method):
+                fill = int(band.ReadAsArray(0, 0, 1, 1).item())
+                calls.append((fill, len(overviews), method))
+                return gdal.CE_None
+
+            monkeypatch.setattr(gdal, "RegenerateOverviews", record)
+            dataset.recreate_overviews(resampling_method="average")
+            expected = [(1, 3, "average"), (2, 3, "average"), (3, 3, "average")]
+            assert calls == expected, (
+                f"each band's three levels should go out in one call per band, got {calls}"
+            )
+        finally:
+            dataset.close()
+
+    def test_every_level_is_rewritten_from_its_own_band(self, tmp_path):
+        """Batched regeneration fills each level with that band's own averaged values.
+
+        Test scenario:
+            Build the levels with NEAREST over three different random grids, then
+            regenerate with AVERAGE — expected: levels 0 and 1 of every band become the
+            2x2 and 4x4 block means of *that* band's grid, which the nearest-neighbour
+            picks they started from are not. A batch that filled only the first level, or
+            crossed one band's source into another's overviews, would satisfy the
+            call-shape assertions above but not these values.
+        """
+        rng = np.random.default_rng(1337)
+        grids = [rng.random((64, 64)).astype("float32") for _ in range(3)]
+        path = _raster_with_overviews(tmp_path, "values.tif", grids, [2, 4], "NEAREST")
+        dataset = Dataset.read_file(path, read_only=False)
+        try:
+            before = dataset.read_overview_array(band=0, overview_index=0)
+            assert not np.allclose(before, _block_mean(grids[0], 2)), (
+                "the NEAREST-built level must start out different from the average, "
+                "otherwise regenerating it would prove nothing"
+            )
+            dataset.recreate_overviews(resampling_method="average")
+            for index, grid in enumerate(grids):
+                for level, factor in enumerate((2, 4)):
+                    actual = dataset.read_overview_array(
+                        band=index, overview_index=level
+                    )
+                    np.testing.assert_allclose(
+                        actual,
+                        _block_mean(grid, factor),
+                        rtol=1e-5,
+                        atol=1e-6,
+                        err_msg=(
+                            f"level {level} of band {index} should hold the "
+                            f"{factor}x{factor} block means of that band"
+                        ),
+                    )
+        finally:
+            dataset.close()
+
+    def test_deeper_levels_cascade_from_the_level_above(self, tmp_path):
+        """A deeper level is decimated from the level above, not from the source.
+
+        Test scenario:
+            `gdal.RegenerateOverviews` cascades: level 1 is built from level 0, whereas
+            the per-level call it replaced built every level from the full-resolution
+            band. On a raster carrying a no-data gap the two disagree — expected: level
+            1 matches the mean of level 0's cells, not the mean of the source window it
+            covers. This is the behaviour change #783 trades for the single read pass;
+            it also makes recreate_overviews agree with how create_overviews built the
+            levels in the first place.
+        """
+        path = str(tmp_path / "cascade.tif")
+        raster = gdal.GetDriverByName("GTiff").Create(path, 8, 8, 1, gdal.GDT_Float32)
+        band = raster.GetRasterBand(1)
+        band.SetNoDataValue(-9999.0)
+        values = np.arange(64, dtype="float32").reshape(8, 8)
+        values[0, 0] = -9999.0
+        band.WriteArray(values)
+        raster = None
+        handle = gdal.Open(path, gdal.GA_Update)
+        handle.BuildOverviews("AVERAGE", [2, 4])
+        handle = None
+
+        dataset = Dataset.read_file(path, read_only=False)
+        try:
+            dataset.recreate_overviews(resampling_method="average")
+            level_0 = np.asarray(dataset.get_overview(0, 0).ReadAsArray())
+            level_1 = np.asarray(dataset.get_overview(0, 1).ReadAsArray())
+            cascaded = float(level_0[:2, :2].mean())
+            assert float(level_1.ravel()[0]) == pytest.approx(cascaded, rel=1e-6), (
+                f"level 1 should decimate level 0 ({cascaded}), got {level_1.ravel()[0]}"
+            )
+            from_source = float(values[:4, :4][values[:4, :4] != -9999.0].mean())
+            assert float(level_1.ravel()[0]) != pytest.approx(from_source, rel=1e-6), (
+                "level 1 must no longer be computed from the source window; the "
+                "fixture's no-data gap is what makes the two differ"
             )
         finally:
             dataset.close()


### PR DESCRIPTION
# Description

`recreate_overviews` rebuilt each level with the singular `gdal.RegenerateOverview`, so a band with N levels
re-read the full-resolution source N times. The plural `gdal.RegenerateOverviews` reads the band once per batch.
The long-standing TODO avoided it on the grounds that it could not take a resampling method — that is no longer
true: on the GDAL we ship it accepts one and returns `0` for every method in `RESAMPLING_METHODS`.

Measured on 3 bands × 3 levels @ 2048², best of 5 on identical data: **0.169s → 0.132s (~22%)**, and one source
read pass instead of three (counted directly: 1 RasterIO request at 1.00× full resolution, against 3 at 3.00×).

Everything #863 added is preserved: bands with no overviews are skipped with `continue` rather than handed an
empty list (GDAL accepts one silently, so the guard is load-bearing), `gdal.ErrorReset()` precedes each call,
`_is_write_refusal` still classifies read-only refusals into `ReadOnlyError` with the original chained, and a
non-`CE_None` status still raises instead of passing as a silent no-op.

# Issues

- Closes #783 — perf(dataset): batch overview regeneration in recreate_overviews via gdal.RegenerateOverviews

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**BREAKING CHANGE — overview values change for levels ≥ 1.** `gdal.RegenerateOverviews` **cascades**: it fills
each deeper level by decimating the level above rather than the full-resolution band. Level 0 is unaffected. A
level ≥ 1 keeps its previous values only where the resampling survives being applied twice:

| resampling | level ≥ 1 |
|---|---|
| `nearest` | unchanged — GDAL does not cascade it |
| `average`, `rms` | unchanged on a **float** band with no no-data; an integer band picks up per-level rounding of up to 1 DN, and a no-data gap changes it at any dtype |
| `cubic`, `cubicspline`, `bilinear`, `lanczos`, `gauss`, `mode` | changed on ordinary data; `mode` can move by whole classes, since the mode of modes is not the mode |

Nothing warns — the call still succeeds. There is no way back to the old per-level values: `create_overviews`
(`BuildOverviews`) cascades too, so **no API rebuilds a deep level directly from the source any more**.

Note this makes the two consistent. `create_overviews` has always cascaded, so `recreate_overviews` now agrees
with how the levels were built in the first place; the per-level loop was the odd one out. That is asserted, not
just argued — `test_create_overviews_cascades_the_same_way` builds levels from scratch and regenerates them on an
identical raster and compares.

Recorded in `docs/migration.md` under `dataset → unreleased`, the repo's declared discovery mechanism for changes
that do not warn.

# How Has This Been Tested?

- `pixi run -e dev pytest -m "not plot"` → **7419 passed**, 51 skipped, 0 failures. (An earlier run tripped
  `tests/io/test_archives.py::TestHttpsrequest::test_read_from_aws`, a live-AWS `vfs` test; it passes in isolation
  on both this branch and `main`, and the clean run above confirms it was a network flake unrelated to the diff.)
- `pixi run -e dev mypy` → **0 errors** (127 source files).
- 6 tests in the new `TestRecreateOverviewsBatching`: a band's levels go out in one call (3 bands × 3 levels →
  three calls of three, in band order); each band batched with **its own** level count (a VRT carrying 2 and 1 —
  mutation-verified, `overview_count[i]` → `overview_count[0]` fails it); every level rewritten from its own band's
  data; the cascade pinned with a no-data fixture; `create_overviews` shown to cascade identically; and the
  unmocked read-only refusal on a three-level batch with the original chained.
- The existing `TestRecreateOverviewsContract` suite is unchanged in intent and still passes, now patching the
  plural entry point.

- [x] Full non-plot suite (`pytest -m "not plot"`)
- [x] `mypy` clean
- [x] Two full `/review-rounds` passes — 24 findings across both rounds, all resolved; notes in `planning/`

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen bumps this on release)
- [ ] added changes to History.rst. (commitizen-generated; not hand-edited)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (`docs/migration.md`, plus `IO.recreate_overviews`,
      `RasterBase.recreate_overviews` and the private helper)

