### PR TITLE
fix(remote)!: recognise ADLS Gen2 and complete the VSI handler tables

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -37,7 +37,12 @@ Azure Blob *File System* driver, which is Gen2.
   now get the right one, with directory semantics.
 - If you used `abfs://` against a **flat Blob** account, switch to `az://`, which is unchanged and still names
   Blob. Credentials are the same `AZURE_STORAGE_*` family either way.
-- `abfss://` and `adls://` are new spellings of the Gen2 scheme, if you prefer to be explicit.
+- `abfss://` is accepted too, if you prefer to be explicit about TLS. There is no `adls://` scheme: the
+  registered Azure Data Lake name is `adl://` (Gen1), which GDAL does not handle.
+- The canonical `abfss://<filesystem>@<account>.dfs.core.windows.net/<path>` form is understood, but GDAL
+  takes the storage account from configuration rather than from the URL. If the URL names an account,
+  `AZURE_STORAGE_ACCOUNT` must be set to match it — a mismatch, or naming an account with none configured,
+  raises instead of silently reading a different account.
 
 **`/vsiadls/` is now recognised as a remote, network-backed path.** Previously `is_remote()` and
 `is_network_backed()` both returned `False` for a Gen2 path, so it was classified as a local file — opening still
@@ -47,7 +52,6 @@ worked, but anything reasoning about the path (credential handling, archive chai
 `/vsizip/<handler>/...` for `/vsiadls/`, `/vsioss/` (Alibaba), `/vsiswift/` (OpenStack), `/vsihdfs/` and
 `/vsiwebhdfs/`, not only for S3, Google Cloud, Azure Blob and `/vsicurl/`. If you were chaining these by hand,
 the manual prefix is no longer needed — and a hand-built `/vsizip//vsioss/...` still works unchanged.
-
 
 **`Dataset.epsg` no longer reports EPSG:4326 for a raster that has no CRS.** It previously substituted WGS 84
 whenever the projection was empty, so an ungeoreferenced grid claimed a georeference it did not have — and that

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -29,6 +29,26 @@ This catches the deprecations; the hard behavior changes do **not** warn — sea
 
 ### unreleased
 
+**`abfs://` now means Azure Data Lake Storage Gen2, not Blob.** It mapped to GDAL's `/vsiaz/` (Blob) and now maps
+to `/vsiadls/` (Gen2), matching what `abfs` means everywhere else in the Azure and Hadoop ecosystems — it is the
+Azure Blob *File System* driver, which is Gen2.
+
+- If you used `abfs://` against a **Gen2** account, this is the fix: you were being routed to the Blob handler and
+  now get the right one, with directory semantics.
+- If you used `abfs://` against a **flat Blob** account, switch to `az://`, which is unchanged and still names
+  Blob. Credentials are the same `AZURE_STORAGE_*` family either way.
+- `abfss://` and `adls://` are new spellings of the Gen2 scheme, if you prefer to be explicit.
+
+**`/vsiadls/` is now recognised as a remote, network-backed path.** Previously `is_remote()` and
+`is_network_backed()` both returned `False` for a Gen2 path, so it was classified as a local file — opening still
+worked, but anything reasoning about the path (credential handling, archive chaining) got the wrong answer.
+
+**Archive chaining now covers every network handler.** A raster inside a zip or tar is rewritten to
+`/vsizip/<handler>/...` for `/vsiadls/`, `/vsioss/` (Alibaba), `/vsiswift/` (OpenStack), `/vsihdfs/` and
+`/vsiwebhdfs/`, not only for S3, Google Cloud, Azure Blob and `/vsicurl/`. If you were chaining these by hand,
+the manual prefix is no longer needed — and a hand-built `/vsizip//vsioss/...` still works unchanged.
+
+
 **`Dataset.epsg` no longer reports EPSG:4326 for a raster that has no CRS.** It previously substituted WGS 84
 whenever the projection was empty, so an ungeoreferenced grid claimed a georeference it did not have — and that
 claim propagated into `to_file`, `to_crs`, `bounds` and alignment checks. It now returns `None`, matching GDAL,

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -39,10 +39,12 @@ Azure Blob *File System* driver, which is Gen2.
   Blob. Credentials are the same `AZURE_STORAGE_*` family either way.
 - `abfss://` is accepted too, if you prefer to be explicit about TLS. There is no `adls://` scheme: the
   registered Azure Data Lake name is `adl://` (Gen1), which GDAL does not handle.
-- The canonical `abfss://<filesystem>@<account>.dfs.core.windows.net/<path>` form is understood, but GDAL
-  takes the storage account from configuration rather than from the URL. If the URL names an account,
-  `AZURE_STORAGE_ACCOUNT` must be set to match it — a mismatch, or naming an account with none configured,
-  raises instead of silently reading a different account.
+- The canonical `abfss://<filesystem>@<account>.dfs.core.windows.net/<path>` form is understood: the filesystem
+  becomes the container and the account is dropped from the path, because GDAL takes it from configuration. The
+  rewrite is deterministic — the same URL always yields the same `/vsi*` path — and if the URL names an account
+  that disagrees with the configured one, a `UserWarning` says which account will actually be read. Set
+  `AZURE_STORAGE_ACCOUNT` (or `AccountName=` inside `AZURE_STORAGE_CONNECTION_STRING`) to match, or use the bare
+  `abfs://<filesystem>/<path>` form.
 
 **`/vsiadls/` is now recognised as a remote, network-backed path.** Previously `is_remote()` and
 `is_network_backed()` both returned `False` for a Gen2 path, so it was classified as a local file — opening still
@@ -55,9 +57,11 @@ URL scheme at all, so the raw `/vsi*` spelling is the only way to name them — 
 go through the chaining too, where before they were returned untouched. If you were chaining by hand, the manual
 prefix is no longer needed, and a hand-built `/vsizip//vsioss/...` still works unchanged.
 
-**Credentials for `abfs://` are the same `AZURE_STORAGE_*` family**, with one exception: GDAL's anonymous-access
-switch is per-handler, so a workflow relying on `AZURE_NO_SIGN_REQUEST` against `/vsiaz/` needs the `/vsiadls/`
-equivalent once `abfs://` routes there.
+**Credentials are unchanged.** `/vsiadls/` reads the same `AZURE_STORAGE_ACCOUNT` / `AZURE_STORAGE_ACCESS_KEY` /
+`AZURE_STORAGE_SAS_TOKEN` / `AZURE_STORAGE_CONNECTION_STRING` family as `/vsiaz/`, and honours
+`AZURE_NO_SIGN_REQUEST` identically (verified: with it set both handlers skip the instance-metadata credential
+lookup). `CloudConfig` gains an `azure_no_sign_request=True` flag so anonymous Azure reads have the same knob the
+S3 side already had.
 
 **`Dataset.epsg` no longer reports EPSG:4326 for a raster that has no CRS.** It previously substituted WGS 84
 whenever the projection was empty, so an ungeoreferenced grid claimed a georeference it did not have — and that

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -48,10 +48,16 @@ Azure Blob *File System* driver, which is Gen2.
 `is_network_backed()` both returned `False` for a Gen2 path, so it was classified as a local file — opening still
 worked, but anything reasoning about the path (credential handling, archive chaining) got the wrong answer.
 
-**Archive chaining now covers every network handler.** A raster inside a zip or tar is rewritten to
-`/vsizip/<handler>/...` for `/vsiadls/`, `/vsioss/` (Alibaba), `/vsiswift/` (OpenStack), `/vsihdfs/` and
-`/vsiwebhdfs/`, not only for S3, Google Cloud, Azure Blob and `/vsicurl/`. If you were chaining these by hand,
-the manual prefix is no longer needed — and a hand-built `/vsizip//vsioss/...` still works unchanged.
+**Archive chaining now covers every network handler, including for raw `/vsi*` paths.** A raster inside a zip
+or tar is rewritten to `/vsizip/<handler>/...` for `/vsiadls/`, `/vsioss/` (Alibaba), `/vsiswift/` (OpenStack),
+`/vsihdfs/` and `/vsiwebhdfs/`, not only for S3, Google Cloud, Azure Blob and `/vsicurl/`. Four of those have no
+URL scheme at all, so the raw `/vsi*` spelling is the only way to name them — paths already in `/vsi*` form now
+go through the chaining too, where before they were returned untouched. If you were chaining by hand, the manual
+prefix is no longer needed, and a hand-built `/vsizip//vsioss/...` still works unchanged.
+
+**Credentials for `abfs://` are the same `AZURE_STORAGE_*` family**, with one exception: GDAL's anonymous-access
+switch is per-handler, so a workflow relying on `AZURE_NO_SIGN_REQUEST` against `/vsiaz/` needs the `/vsiadls/`
+equivalent once `abfs://` routes there.
 
 **`Dataset.epsg` no longer reports EPSG:4326 for a raster that has no CRS.** It previously substituted WGS 84
 whenever the projection was empty, so an ungeoreferenced grid claimed a georeference it did not have — and that

--- a/docs/reference/dataset/io.md
+++ b/docs/reference/dataset/io.md
@@ -15,7 +15,7 @@ flowchart LR
 ## Open a raster — paths, URLs, archives, and bytes
 
 `Dataset.read_file(path)` accepts plain paths, `/vsi*` paths, and URL
-schemes (`http(s)://`, `s3://`, `gs://`, `az://`, `abfs://` / `adls://`,
+schemes (`http(s)://`, `s3://`, `gs://`, `az://`, `abfs://` / `abfss://`,
 `file://`) — URLs are transparently rewritten to GDAL's virtual
 filesystem so cloud objects open with HTTP range requests, no extra
 boilerplate.

--- a/docs/reference/dataset/io.md
+++ b/docs/reference/dataset/io.md
@@ -15,7 +15,7 @@ flowchart LR
 ## Open a raster — paths, URLs, archives, and bytes
 
 `Dataset.read_file(path)` accepts plain paths, `/vsi*` paths, and URL
-schemes (`http(s)://`, `s3://`, `gs://`, `az://` / `abfs://`,
+schemes (`http(s)://`, `s3://`, `gs://`, `az://`, `abfs://` / `adls://`,
 `file://`) — URLs are transparently rewritten to GDAL's virtual
 filesystem so cloud objects open with HTTP range requests, no extra
 boilerplate.

--- a/docs/tutorials/cog.md
+++ b/docs/tutorials/cog.md
@@ -148,7 +148,7 @@ pyramids rewrites URL-scheme paths to GDAL's `/vsi*` form automatically:
 | `gs://bucket/key.tif` | `/vsigs/bucket/key.tif` |
 | `az://container/blob.tif` | `/vsiaz/container/blob.tif` |
 | `abfs://container/blob.tif` | `/vsiadls/container/blob.tif` |
-| `adls://container/blob.tif` | `/vsiadls/container/blob.tif` |
+| `abfss://container/blob.tif` | `/vsiadls/container/blob.tif` |
 | `https://foo/x.tif` | `/vsicurl/https://foo/x.tif` |
 | `file:///C:/path/x.tif` | `C:/path/x.tif` |
 

--- a/docs/tutorials/cog.md
+++ b/docs/tutorials/cog.md
@@ -147,7 +147,8 @@ pyramids rewrites URL-scheme paths to GDAL's `/vsi*` form automatically:
 | `s3://bucket/key.tif` | `/vsis3/bucket/key.tif` |
 | `gs://bucket/key.tif` | `/vsigs/bucket/key.tif` |
 | `az://container/blob.tif` | `/vsiaz/container/blob.tif` |
-| `abfs://container/blob.tif` | `/vsiaz/container/blob.tif` |
+| `abfs://container/blob.tif` | `/vsiadls/container/blob.tif` |
+| `adls://container/blob.tif` | `/vsiadls/container/blob.tif` |
 | `https://foo/x.tif` | `/vsicurl/https://foo/x.tif` |
 | `file:///C:/path/x.tif` | `C:/path/x.tif` |
 

--- a/docs/tutorials/feature.md
+++ b/docs/tutorials/feature.md
@@ -22,7 +22,7 @@ pip install 'pyramids-gis[parquet]'  # optional GeoParquet
 
 `read_file` handles Shapefile, GeoJSON, GeoPackage, KML, FlatGeobuf —
 anything pyogrio / fiona supports — plus zip/tar/gz archives and
-cloud URLs (`s3://`, `gs://`, `az://`, `abfs://`, `http(s)://`).
+cloud URLs (`s3://`, `gs://`, `az://`, `abfs://`, `adls://`, `http(s)://`).
 
 ```python
 from pyramids.feature import FeatureCollection

--- a/docs/tutorials/feature.md
+++ b/docs/tutorials/feature.md
@@ -22,7 +22,7 @@ pip install 'pyramids-gis[parquet]'  # optional GeoParquet
 
 `read_file` handles Shapefile, GeoJSON, GeoPackage, KML, FlatGeobuf —
 anything pyogrio / fiona supports — plus zip/tar/gz archives and
-cloud URLs (`s3://`, `gs://`, `az://`, `abfs://`, `adls://`, `http(s)://`).
+cloud URLs (`s3://`, `gs://`, `az://`, `abfs://`, `abfss://`, `http(s)://`).
 
 ```python
 from pyramids.feature import FeatureCollection

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -13,9 +13,11 @@ Two concerns live in this module:
    tables classify a path, and they answer different questions — they
    are not copies of one list:
 
-   * :data:`_VSI_PREFIXES` — "is this a VSI path at all?" Every handler
-     GDAL exposes that pyramids recognises, including the in-memory and
-     archive ones. Drives :func:`is_remote`.
+   * :data:`_VSI_PREFIXES` — "is this a VSI path at all?" The handlers
+     pyramids recognises, including the in-memory and archive ones. GDAL
+     ships more (`/vsisparse/`, `/vsicrypt/`, …); a path using one of
+     those is not rewritten and is treated as local. Drives
+     :func:`is_remote`.
    * :data:`_NETWORK_VSI_PREFIXES` — "does reading this touch the
      network?" A strict subset of the above: archives and `/vsimem/`
      are local. Drives :func:`is_network_backed`, and therefore the
@@ -93,11 +95,12 @@ _URL_EMBEDDING_VSI_PREFIXES: tuple[str, ...] = (
     "/vsiwebhdfs/",
 )
 
-# "May this path chain an archive?" — equal to _NETWORK_VSI_PREFIXES by the
-# invariant in the module docstring: anything read over the network can hold a
-# zip or tar. The two curl variants that carry options in the path itself
-# (`/vsicurl?...`, `/vsicurl_streaming/`) are deliberately absent: their query
-# strings are not path structure, so archive detection cannot be trusted there.
+# "May this path chain an archive?" — the network handlers whose path component
+# is trustworthy structure, since anything read over the network can hold a zip
+# or tar. The variants that carry options or stream (`/vsicurl?...`, and the
+# `_streaming` twins) are deliberately absent: their remainder is a query string
+# or an option list rather than a path, so an archive marker found there cannot
+# be trusted. So this is a strict subset of _NETWORK_VSI_PREFIXES, not its equal.
 _CLOUD_VSI_PREFIXES: tuple[str, ...] = (
     _OBJECT_STORE_VSI_PREFIXES + _URL_EMBEDDING_VSI_PREFIXES
 )
@@ -129,18 +132,22 @@ URL_SCHEMES: dict[str, str] = {
     "az": _VSIAZ,
     "abfs": _VSIADLS,
     "abfss": _VSIADLS,
-    "adls": _VSIADLS,
     "http": _VSICURL,
     "https": _VSICURL,
     "file": "",
 }
 """Map URL scheme to GDAL VSI prefix. Empty string means strip-and-use.
 
-`az://` is Azure Blob (`/vsiaz/`). `abfs://`, `abfss://` and `adls://` are Data
-Lake Storage Gen2 (`/vsiadls/`), matching what those schemes mean everywhere
-else in the Azure and Hadoop ecosystems — `abfs` is the Azure Blob **File
-System** driver, which is Gen2, not Blob. Reach a flat Blob account with
-`az://`.
+`az://` is Azure Blob (`/vsiaz/`). `abfs://` and `abfss://` are Data Lake
+Storage Gen2 (`/vsiadls/`), matching what those schemes mean everywhere else in
+the Azure and Hadoop ecosystems — `abfs` is the Azure Blob **File System**
+driver, which is Gen2, not Blob. Reach a flat Blob account with `az://`.
+
+Only spellings that exist in the wider ecosystem are listed. There is no
+`adls://` scheme: the registered Azure Data Lake name is `adl://` (Gen1, which
+GDAL does not handle), and inventing a near-identical `adls://` would both
+collide visually with it and fail in the fsspec-backed readers, which resolve
+the scheme themselves rather than going through this map.
 """
 
 # Schemes addressed as `<scheme>://<bucket>/<key>`; the rest of URL_SCHEMES is
@@ -153,9 +160,29 @@ _BUCKET_URL_SCHEMES: frozenset[str] = frozenset(
     if prefix in _OBJECT_STORE_VSI_PREFIXES
 )
 
+# The Gen2 schemes take a `<filesystem>@<account>.dfs.core.windows.net` authority
+# rather than a bare container, so they are rewritten by `_gen2_filesystem`.
+_GEN2_URL_SCHEMES: frozenset[str] = frozenset(
+    scheme for scheme, prefix in URL_SCHEMES.items() if prefix == _VSIADLS
+)
+
 # OPeNDAP / THREDDS scheme. Not in URL_SCHEMES because it maps to a NETCDF:
 # connection string (GDAL's DAP-capable netCDF driver), not a /vsi* prefix.
 _DODS_SCHEME = "dods"
+
+
+# The `_streaming` twin GDAL registers for each object store. They read the same
+# services over the same credentials, so every classification that applies to the
+# non-streaming form applies here too; only archive chaining stays out, for the
+# reason given on _CLOUD_VSI_PREFIXES.
+_STREAMING_VSI_PREFIXES: tuple[str, ...] = (
+    "/vsis3_streaming/",
+    "/vsigs_streaming/",
+    "/vsiaz_streaming/",
+    "/vsioss_streaming/",
+    "/vsiswift_streaming/",
+    "/vsicurl_streaming/",
+)
 
 
 _VSI_PREFIXES: tuple[str, ...] = (
@@ -168,15 +195,14 @@ _VSI_PREFIXES: tuple[str, ...] = (
     # carries per-source options (headers, retry, empty_dir) in the path itself.
     # It has no trailing slash, so the `/vsicurl/` entry above does not match it.
     "/vsicurl?",
-    "/vsicurl_streaming/",
     "/vsimem/",
     _VSIZIP,
     _VSIGZIP,
     _VSITAR,
-    "/vsioss/",
-    "/vsiswift/",
     "/vsihdfs/",
     "/vsiwebhdfs/",
+    *_OBJECT_STORE_VSI_PREFIXES,
+    *_STREAMING_VSI_PREFIXES,
 )
 
 
@@ -239,18 +265,13 @@ def is_remote(path: str) -> bool:
     return result
 
 
-_NETWORK_VSI_PREFIXES: tuple[str, ...] = (
-    _VSIS3,
-    _VSIGS,
-    _VSIAZ,
-    _VSIADLS,
-    _VSICURL,
-    "/vsicurl?",
-    "/vsicurl_streaming/",
-    "/vsioss/",
-    "/vsiswift/",
-    "/vsihdfs/",
-    "/vsiwebhdfs/",
+# Everything in _VSI_PREFIXES except the handlers that read no network: the
+# archives and the in-memory filesystem. Derived rather than repeated, so a new
+# handler cannot be remote but not network-backed by omission (#918).
+_LOCAL_VSI_PREFIXES: tuple[str, ...] = ("/vsimem/", _VSIZIP, _VSIGZIP, _VSITAR)
+
+_NETWORK_VSI_PREFIXES: tuple[str, ...] = tuple(
+    prefix for prefix in _VSI_PREFIXES if prefix not in _LOCAL_VSI_PREFIXES
 )
 
 
@@ -513,6 +534,8 @@ def _scheme_to_vsi(parsed: ParseResult, scheme: str, path: str) -> str:
         return f'NETCDF:"https://{remainder}"'
     if scheme not in URL_SCHEMES or len(scheme) <= 1:
         return path
+    if scheme in _GEN2_URL_SCHEMES:
+        return f"{URL_SCHEMES[scheme]}{_gen2_filesystem(parsed, path)}/{parsed.path.lstrip('/')}"
     if scheme in _BUCKET_URL_SCHEMES:
         bucket = parsed.netloc
         key = parsed.path.lstrip("/")
@@ -528,6 +551,55 @@ def _scheme_to_vsi(parsed: ParseResult, scheme: str, path: str) -> str:
     return path  # pragma: no cover — all schemes above covered
 
 
+def _gen2_filesystem(parsed: ParseResult, path: str) -> str:
+    """Filesystem (container) name from an ABFS(S) authority.
+
+    The canonical ABFS URI in the Azure, Hadoop, Spark and Databricks world is
+    `abfss://<filesystem>@<account>.dfs.core.windows.net/<path>`, so the
+    authority is not a bare container name. Taking it verbatim yields a
+    URL-encoded nonsense container on whatever account `AZURE_STORAGE_ACCOUNT`
+    happens to hold — a silent read of the wrong storage account.
+
+    The account cannot simply be adopted here: `_to_vsi` rewrites a string and
+    GDAL takes the account from configuration, so a URL naming a different
+    account than the one configured is a conflict the caller has to resolve.
+    Rather than pick one silently, that case raises.
+
+    Args:
+        parsed: The parsed URL.
+        path: The original path, for the error message.
+
+    Returns:
+        str: The filesystem name to use as the `/vsiadls/` container.
+
+    Raises:
+        ValueError: The URI names a storage account that does not match the
+            configured `AZURE_STORAGE_ACCOUNT`.
+    """
+    authority = parsed.netloc
+    if "@" not in authority:
+        return authority
+    filesystem, _, host = authority.partition("@")
+    account = host.split(".", 1)[0]
+    configured = gdal.GetConfigOption("AZURE_STORAGE_ACCOUNT") or os.environ.get(
+        "AZURE_STORAGE_ACCOUNT", ""
+    )
+    if configured and configured != account:
+        raise ValueError(
+            f"{path!r} names storage account {account!r}, but AZURE_STORAGE_ACCOUNT "
+            f"is set to {configured!r}. GDAL takes the account from configuration, "
+            "so set it to match the URL (or drop the `@account` part of the URL)."
+        )
+    if not configured:
+        raise ValueError(
+            f"{path!r} names storage account {account!r}, but AZURE_STORAGE_ACCOUNT "
+            "is not set. GDAL reads the account from configuration, not from the "
+            "URL: set it (e.g. `CloudConfig(azure_storage_account=...)`) before "
+            "opening, or use the bare `abfs://<filesystem>/<path>` form."
+        )
+    return filesystem
+
+
 def _extract_archive_search_region(path: str) -> str | None:
     """Return the portion of `path` to scan for archive markers.
 
@@ -536,9 +608,11 @@ def _extract_archive_search_region(path: str) -> str | None:
     that a hostname like `host.gz` or a query value like
     `?key=archive.tar/...` cannot false-trigger archive detection.
 
-    For `/vsis3/`, `/vsigs/`, `/vsiaz/` paths, returns everything
-    after the prefix — these VSI schemes have no hostname/query
-    structure, only `<bucket>/<key>`.
+    For the object-store handlers (`/vsis3/`, `/vsigs/`, `/vsiaz/`,
+    `/vsiadls/`, `/vsioss/`, `/vsiswift/`) it returns everything after
+    the prefix — those have no hostname/query structure, only
+    `<bucket>/<key>`. `/vsihdfs/` and `/vsiwebhdfs/` embed a full URL
+    like `/vsicurl/` does, so they take the URL-parsing branch.
 
     Args:
         path: A VSI path that has already been rewritten by
@@ -554,7 +628,9 @@ def _extract_archive_search_region(path: str) -> str | None:
     )
     if embedding is not None:
         url = path[len(embedding) :]
-        parsed = urlparse(url)
+        # `//` guards against `urlparse` reading a colon in the first path
+        # segment as a scheme (`bucket:tag/a.zip/x` would lose `bucket:tag`).
+        parsed = urlparse(url) if "://" in url else urlparse(f"//{url}")
         # Only the path component — excludes scheme, hostname, and query. A
         # handler that embeds a URL (`/vsihdfs/hdfs://host/x`) is scanned the
         # same way as `/vsicurl/`, so a host named `data.gz` cannot trigger
@@ -572,6 +648,10 @@ def _extract_archive_search_region(path: str) -> str | None:
 
 def _chain_archive_vsi(path: str) -> str:
     """Prepend archive VSI prefix to a cloud/VSI path that points inside an archive.
+
+    Applies to every network handler whose path component is real path
+    structure — the object stores plus the URL-embedding handlers — not
+    only to `/vsicurl/`.
 
     Handles the case where a user passes a URL like
     `https://host/archive.tar/inner.tif` — after the initial

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -129,6 +129,7 @@ _ARCHIVE_MARKER_RE = re.compile(r"\.(tar\.gz|tgz|zip|tar|gz)(?=/)", re.IGNORECAS
 URL_SCHEMES: dict[str, str] = {
     "s3": _VSIS3,
     "gs": _VSIGS,
+    "gcs": _VSIGS,
     "az": _VSIAZ,
     "abfs": _VSIADLS,
     "abfss": _VSIADLS,
@@ -549,6 +550,48 @@ def _scheme_to_vsi(parsed: ParseResult, scheme: str, path: str) -> str:
             local = local[1:]
         return local
     return path  # pragma: no cover — all schemes above covered
+
+
+# GDAL-only spellings mapped to the equivalent fsspec protocol. The Parquet
+# readers hand a remote URL straight to geopandas/fsspec, which resolves the
+# scheme itself -- and fsspec registers `abfs` but not `abfss`, so the TLS
+# spelling would die as an unknown protocol there while working for GDAL.
+_FSSPEC_SCHEME_ALIASES: dict[str, str] = {"abfss": "abfs"}
+
+
+def to_fsspec_url(path: str) -> str:
+    """Rewrite a URL to a scheme fsspec recognises, leaving others untouched.
+
+    GDAL and fsspec accept overlapping but not identical scheme spellings. A path
+    handed to the Parquet readers goes to fsspec, not GDAL, so a GDAL-only
+    spelling has to be normalised first.
+
+    Args:
+        path: A URL or local path.
+
+    Returns:
+        str: The same path with a GDAL-only scheme swapped for its fsspec
+        equivalent; unchanged when the scheme is already known or absent.
+
+    Examples:
+        - The TLS spelling of ABFS becomes the one fsspec registers:
+            ```python
+            >>> from pyramids.base.remote import to_fsspec_url
+            >>> to_fsspec_url("abfss://fs/part.parquet")
+            'abfs://fs/part.parquet'
+
+            ```
+        - Anything else is returned as-is:
+            ```python
+            >>> from pyramids.base.remote import to_fsspec_url
+            >>> to_fsspec_url("s3://bucket/part.parquet")
+            's3://bucket/part.parquet'
+
+            ```
+    """
+    scheme, separator, remainder = path.partition("://")
+    alias = _FSSPEC_SCHEME_ALIASES.get(scheme.lower())
+    return f"{alias}{separator}{remainder}" if separator and alias else path
 
 
 def _gen2_filesystem(parsed: ParseResult, path: str) -> str:

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -4,7 +4,7 @@ Two concerns live in this module:
 
 1. :func:`_to_vsi` and :func:`is_remote` — transparently rewrite
    user-facing URLs (`s3://`, `gs://`, `az://`, `abfs://`, `abfss://`,
-   `adls://`, `http`, `https`, `file`) into GDAL's virtual filesystem
+   `http`, `https`, `file`) into GDAL's virtual filesystem
    syntax (`/vsis3/`, `/vsigs/`, `/vsiaz/`, `/vsiadls/`, `/vsicurl/`).
    Called from :func:`pyramids._io._parse_path` so every file-open
    path in the package benefits without explicit wiring.
@@ -24,10 +24,10 @@ Two concerns live in this module:
      credential reasoning.
    * :data:`_CLOUD_VSI_PREFIXES` — "may this chain an archive?" Anything
      fetched over the network can hold a zip or tar worth reading into,
-     so this is the network set minus the two `/vsicurl` variants that
-     carry options in the path itself (`/vsicurl?`,
-     `/vsicurl_streaming/`): their query strings are not path structure,
-     so an archive marker found there cannot be trusted.
+     so this is the network set minus the variants whose remainder is an
+     option list or a stream rather than path structure (`/vsicurl?` and
+     the `_streaming` twins): an archive marker found there cannot be
+     trusted.
    * :data:`URL_SCHEMES` — "can a user name this with a URL?" Only the
      handlers with an established scheme; a handler may be readable
      through its `/vsi*` form without appearing here.
@@ -186,24 +186,25 @@ _STREAMING_VSI_PREFIXES: tuple[str, ...] = (
 )
 
 
-_VSI_PREFIXES: tuple[str, ...] = (
-    _VSIS3,
-    _VSIGS,
-    _VSIAZ,
-    _VSIADLS,
-    _VSICURL,
-    # GDAL's query-string form, `/vsicurl?[option=value&]*url=<encoded>`, which
-    # carries per-source options (headers, retry, empty_dir) in the path itself.
-    # It has no trailing slash, so the `/vsicurl/` entry above does not match it.
-    "/vsicurl?",
-    "/vsimem/",
-    _VSIZIP,
-    _VSIGZIP,
-    _VSITAR,
-    "/vsihdfs/",
-    "/vsiwebhdfs/",
-    *_OBJECT_STORE_VSI_PREFIXES,
-    *_STREAMING_VSI_PREFIXES,
+# Deduplicated while preserving order: the object-store, URL-embedding and
+# streaming groups already name most of these, and repeating one made
+# `_VSI_PREFIXES` -- and every table derived from it -- carry it twice.
+_VSI_PREFIXES: tuple[str, ...] = tuple(
+    dict.fromkeys(
+        (
+            *_OBJECT_STORE_VSI_PREFIXES,
+            *_URL_EMBEDDING_VSI_PREFIXES,
+            *_STREAMING_VSI_PREFIXES,
+            # GDAL's query-string form, `/vsicurl?[option=value&]*url=<encoded>`,
+            # carrying per-source options in the path itself. It has no trailing
+            # slash, so the `/vsicurl/` entry does not match it.
+            "/vsicurl?",
+            "/vsimem/",
+            _VSIZIP,
+            _VSIGZIP,
+            _VSITAR,
+        )
+    )
 )
 
 
@@ -218,7 +219,7 @@ def is_remote(path: str) -> bool:
         path: A string path or URL.
 
     Returns:
-        `True` for `s3://`, `gs://`, `az://`, `abfs://`, `abfss://`, `adls://`,
+        `True` for `s3://`, `gs://`, `gcs://`, `az://`, `abfs://`, `abfss://`,
         `http(s)://`, `file://`, and any `/vsi*` path. `False`
         for local POSIX or Windows paths (including drive-letter form)
         and for compressed-archive paths that don't start with `/vsi`.
@@ -269,7 +270,8 @@ def is_remote(path: str) -> bool:
 # Everything in _VSI_PREFIXES except the handlers that read no network: the
 # archives and the in-memory filesystem. Derived rather than repeated, so a new
 # handler cannot be remote but not network-backed by omission (#918).
-_LOCAL_VSI_PREFIXES: tuple[str, ...] = ("/vsimem/", _VSIZIP, _VSIGZIP, _VSITAR)
+_ARCHIVE_VSI_PREFIXES: tuple[str, ...] = (_VSIZIP, _VSIGZIP, _VSITAR)
+_LOCAL_VSI_PREFIXES: tuple[str, ...] = ("/vsimem/", *_ARCHIVE_VSI_PREFIXES)
 
 _NETWORK_VSI_PREFIXES: tuple[str, ...] = tuple(
     prefix for prefix in _VSI_PREFIXES if prefix not in _LOCAL_VSI_PREFIXES
@@ -290,7 +292,7 @@ def is_network_backed(path: str) -> bool:
 
     Returns:
         `True` for the cloud URL schemes — `s3://`, `gs://`, `az://`, `abfs://`,
-        `abfss://`, `adls://`,
+        `abfss://`,
         `http(s)://`, `dods://` — and for the network `/vsi*` handlers: `/vsis3/`,
         `/vsigs/`, `/vsiaz/`, `/vsicurl/` and its query-string form,
         `/vsicurl_streaming/`, `/vsioss/`, `/vsiswift/`, `/vsihdfs/`,
@@ -319,8 +321,18 @@ def is_network_backed(path: str) -> bool:
 
             ```
     """
+    # An archive chain wraps the real handler: `/vsizip//vsicurl/https://...`
+    # is read over the network, and `_to_vsi` builds exactly that shape from a
+    # `https://host/a.zip/x.tif` URL. Look past the archive prefixes first, or
+    # every chained remote path classifies as local.
+    unwrapped = path
+    while unwrapped.startswith(_ARCHIVE_VSI_PREFIXES):
+        for prefix in _ARCHIVE_VSI_PREFIXES:
+            if unwrapped.startswith(prefix):
+                unwrapped = unwrapped[len(prefix) :]
+                break
     network: bool
-    if path.startswith(_NETWORK_VSI_PREFIXES):
+    if unwrapped.startswith(_NETWORK_VSI_PREFIXES):
         network = True
     else:
         scheme = urlparse(path).scheme.lower()
@@ -452,7 +464,6 @@ def _to_vsi(path: str) -> str:
     `az://container/blob`       `/vsiaz/container/blob`
     `abfs://container/blob`     `/vsiadls/container/blob`
     `abfss://container/blob`    `/vsiadls/container/blob`
-    `adls://container/blob`     `/vsiadls/container/blob`
     `https://host/path.tif`     `/vsicurl/https://host/path.tif`
     `http://host/path.tif`      `/vsicurl/http://host/path.tif`
     `file:///C:/path/x.tif`     `C:/path/x.tif` (Windows)
@@ -472,6 +483,12 @@ def _to_vsi(path: str) -> str:
     Returns:
         The VSI-rewritten path if a rewrite applies; otherwise
         `path` unchanged.
+
+    Raises:
+        ValueError: An ABFS(S) URL names a storage account that does not match
+            the configured one, or names one with nothing configured. GDAL takes
+            the account from configuration, so continuing would read a different
+            storage account than the URL asks for.
 
     Examples:
         - Cloud-object-store URLs get the matching /vsi prefix:
@@ -505,7 +522,13 @@ def _to_vsi(path: str) -> str:
             ```
     """
     if path.startswith(_VSI_PREFIXES):
-        return path
+        # Already VSI, so there is no scheme to rewrite -- but archive chaining
+        # still applies. `/vsioss/`, `/vsiswift/`, `/vsihdfs/` and `/vsiwebhdfs/`
+        # have no URL scheme at all, so the raw form is the ONLY way to name
+        # them; returning here made their chaining unreachable. Idempotent: an
+        # already-chained path starts with an archive prefix, which
+        # `_chain_archive_vsi` does not act on.
+        return _chain_archive_vsi(path)
     parsed = urlparse(path)
     scheme = parsed.scheme.lower()
     new_path = _chain_archive_vsi(_scheme_to_vsi(parsed, scheme, path))
@@ -594,6 +617,27 @@ def to_fsspec_url(path: str) -> str:
     return f"{alias}{separator}{remainder}" if separator and alias else path
 
 
+def _configured_azure_account() -> str:
+    """The Azure storage account GDAL will use, or ``""`` when none is set.
+
+    GDAL accepts the account either directly as `AZURE_STORAGE_ACCOUNT` or
+    embedded in `AZURE_STORAGE_CONNECTION_STRING` as `AccountName=`. Reading only
+    the first refuses a setup that is perfectly valid for `/vsiadls/`.
+
+    Returns:
+        str: The configured account name, lower-cased, or ``""`` when unset.
+    """
+    account = gdal.GetConfigOption("AZURE_STORAGE_ACCOUNT") or ""
+    if not account:
+        connection = gdal.GetConfigOption("AZURE_STORAGE_CONNECTION_STRING") or ""
+        for part in connection.split(";"):
+            key, separator, value = part.partition("=")
+            if separator and key.strip().lower() == "accountname":
+                account = value.strip()
+                break
+    return account.lower()
+
+
 def _gen2_filesystem(parsed: ParseResult, path: str) -> str:
     """Filesystem (container) name from an ABFS(S) authority.
 
@@ -623,10 +667,8 @@ def _gen2_filesystem(parsed: ParseResult, path: str) -> str:
     if "@" not in authority:
         return authority
     filesystem, _, host = authority.partition("@")
-    account = host.split(".", 1)[0]
-    configured = gdal.GetConfigOption("AZURE_STORAGE_ACCOUNT") or os.environ.get(
-        "AZURE_STORAGE_ACCOUNT", ""
-    )
+    account = host.split(".", 1)[0].lower()
+    configured = _configured_azure_account()
     if configured and configured != account:
         raise ValueError(
             f"{path!r} names storage account {account!r}, but AZURE_STORAGE_ACCOUNT "
@@ -673,7 +715,7 @@ def _extract_archive_search_region(path: str) -> str | None:
         url = path[len(embedding) :]
         # `//` guards against `urlparse` reading a colon in the first path
         # segment as a scheme (`bucket:tag/a.zip/x` would lose `bucket:tag`).
-        parsed = urlparse(url) if "://" in url else urlparse(f"//{url}")
+        parsed = urlparse(url if "://" in url else f"//{url}")
         # Only the path component — excludes scheme, hostname, and query. A
         # handler that embeds a URL (`/vsihdfs/hdfs://host/x`) is scanned the
         # same way as `/vsicurl/`, so a host named `data.gz` cannot trigger
@@ -871,7 +913,7 @@ class CloudConfig:
     ================================ ==================================
 
     The HTTP knobs apply to GDAL's `/vsicurl/` family (so `s3://`,
-    `gs://`, `az://`, `abfs://`, `adls://`, `http(s)://` all benefit). `vsi_cache`
+    `gs://`, `az://`, `abfs://`, `abfss://`, `http(s)://` all benefit). `vsi_cache`
     toggles GDAL's in-memory range cache for `/vsicurl/`-style readers
     — useful when re-reading the same remote chunks (e.g. iterating over
     blocks of a single COG). Set `vsi_cache=None` (default) to leave

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -484,11 +484,6 @@ def _to_vsi(path: str) -> str:
         The VSI-rewritten path if a rewrite applies; otherwise
         `path` unchanged.
 
-    Raises:
-        ValueError: An ABFS(S) URL names a storage account that does not match
-            the configured one, or names one with nothing configured. GDAL takes
-            the account from configuration, so continuing would read a different
-            storage account than the URL asks for.
 
     Examples:
         - Cloud-object-store URLs get the matching /vsi prefix:
@@ -644,24 +639,29 @@ def _gen2_filesystem(parsed: ParseResult, path: str) -> str:
     The canonical ABFS URI in the Azure, Hadoop, Spark and Databricks world is
     `abfss://<filesystem>@<account>.dfs.core.windows.net/<path>`, so the
     authority is not a bare container name. Taking it verbatim yields a
-    URL-encoded nonsense container on whatever account `AZURE_STORAGE_ACCOUNT`
-    happens to hold — a silent read of the wrong storage account.
+    URL-encoded nonsense container on whatever account GDAL is configured with.
 
-    The account cannot simply be adopted here: `_to_vsi` rewrites a string and
-    GDAL takes the account from configuration, so a URL naming a different
-    account than the one configured is a conflict the caller has to resolve.
-    Rather than pick one silently, that case raises.
+    The rewrite is deterministic: the same URL always produces the same `/vsi*`
+    path, whether or not credentials are configured and whether or not a
+    :class:`CloudConfig` block is active. The account cannot be carried in the
+    path — GDAL reads it from configuration — so when the URL names one that
+    disagrees with the configured account, that is a genuine conflict and warns.
+    It does not raise: this runs on every open, and a warning surfaces the
+    problem (including as an error under `-W error`) without turning a
+    path-rewriting helper into a failure point.
 
     Args:
         parsed: The parsed URL.
-        path: The original path, for the error message.
+        path: The original path, for the warning message.
 
     Returns:
         str: The filesystem name to use as the `/vsiadls/` container.
 
-    Raises:
-        ValueError: The URI names a storage account that does not match the
-            configured `AZURE_STORAGE_ACCOUNT`.
+    Warns:
+        UserWarning: The URI names a storage account that differs from the
+            configured `AZURE_STORAGE_ACCOUNT` (or the `AccountName=` inside
+            `AZURE_STORAGE_CONNECTION_STRING`), so the read would silently go to
+            a different account than the URL asks for.
     """
     authority = parsed.netloc
     if "@" not in authority:
@@ -669,18 +669,15 @@ def _gen2_filesystem(parsed: ParseResult, path: str) -> str:
     filesystem, _, host = authority.partition("@")
     account = host.split(".", 1)[0].lower()
     configured = _configured_azure_account()
-    if configured and configured != account:
-        raise ValueError(
-            f"{path!r} names storage account {account!r}, but AZURE_STORAGE_ACCOUNT "
-            f"is set to {configured!r}. GDAL takes the account from configuration, "
-            "so set it to match the URL (or drop the `@account` part of the URL)."
-        )
-    if not configured:
-        raise ValueError(
-            f"{path!r} names storage account {account!r}, but AZURE_STORAGE_ACCOUNT "
-            "is not set. GDAL reads the account from configuration, not from the "
-            "URL: set it (e.g. `CloudConfig(azure_storage_account=...)`) before "
-            "opening, or use the bare `abfs://<filesystem>/<path>` form."
+    if configured and account and configured != account:
+        warnings.warn(
+            f"{path!r} names storage account {account!r}, but GDAL is configured "
+            f"for {configured!r} and takes the account from configuration rather "
+            "than from the URL, so the read will go to "
+            f"{configured!r}. Set AZURE_STORAGE_ACCOUNT to match the URL (or use "
+            "the bare `abfs://<filesystem>/<path>` form) to remove the ambiguity.",
+            UserWarning,
+            stacklevel=4,
         )
     return filesystem
 
@@ -902,7 +899,8 @@ class CloudConfig:
     `gs_secret_access_key`           `GS_SECRET_ACCESS_KEY`
     `azure_storage_account`          `AZURE_STORAGE_ACCOUNT`
     `azure_storage_access_key`       `AZURE_STORAGE_ACCESS_KEY`
-    `azure_storage_sas_token`        `AZURE_STORAGE_SAS_TOKEN`
+    `azure_storage_sas_token`         `AZURE_STORAGE_SAS_TOKEN`
+    `azure_no_sign_request=True`      `AZURE_NO_SIGN_REQUEST=YES`
     `http_max_retry`                 `GDAL_HTTP_MAX_RETRY`
     `http_retry_delay`               `GDAL_HTTP_RETRY_DELAY` (seconds)
     `http_timeout`                   `GDAL_HTTP_TIMEOUT` (seconds)
@@ -1000,6 +998,7 @@ class CloudConfig:
     azure_storage_account: str | None = None
     azure_storage_access_key: str | None = None
     azure_storage_sas_token: str | None = None
+    azure_no_sign_request: bool = False
     http_max_retry: int | None = None
     http_retry_delay: float | None = None
     http_timeout: int | None = None
@@ -1134,6 +1133,9 @@ class CloudConfig:
             "AZURE_STORAGE_ACCOUNT": self.azure_storage_account,
             "AZURE_STORAGE_ACCESS_KEY": self.azure_storage_access_key,
             "AZURE_STORAGE_SAS_TOKEN": self.azure_storage_sas_token,
+            # Measured to apply to `/vsiaz/` and `/vsiadls/` alike: with it set,
+            # both skip the instance-metadata credential lookup.
+            "AZURE_NO_SIGN_REQUEST": "YES" if self.azure_no_sign_request else None,
             "GDAL_HTTP_MAX_RETRY": self.http_max_retry,
             "GDAL_HTTP_RETRY_DELAY": self.http_retry_delay,
             "GDAL_HTTP_TIMEOUT": self.http_timeout,

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -3,11 +3,36 @@
 Two concerns live in this module:
 
 1. :func:`_to_vsi` and :func:`is_remote` — transparently rewrite
-   user-facing URLs (`s3://`, `gs://`, `az://`, `abfs://`,
-   `http`, `https`, `file`) into GDAL's virtual filesystem
-   syntax (`/vsis3/`, `/vsigs/`, `/vsiaz/`, `/vsicurl/`).
+   user-facing URLs (`s3://`, `gs://`, `az://`, `abfs://`, `abfss://`,
+   `adls://`, `http`, `https`, `file`) into GDAL's virtual filesystem
+   syntax (`/vsis3/`, `/vsigs/`, `/vsiaz/`, `/vsiadls/`, `/vsicurl/`).
    Called from :func:`pyramids._io._parse_path` so every file-open
    path in the package benefits without explicit wiring.
+
+   **The handler tables and the invariant that relates them.** Four
+   tables classify a path, and they answer different questions — they
+   are not copies of one list:
+
+   * :data:`_VSI_PREFIXES` — "is this a VSI path at all?" Every handler
+     GDAL exposes that pyramids recognises, including the in-memory and
+     archive ones. Drives :func:`is_remote`.
+   * :data:`_NETWORK_VSI_PREFIXES` — "does reading this touch the
+     network?" A strict subset of the above: archives and `/vsimem/`
+     are local. Drives :func:`is_network_backed`, and therefore the
+     credential reasoning.
+   * :data:`_CLOUD_VSI_PREFIXES` — "may this chain an archive?" Anything
+     fetched over the network can hold a zip or tar worth reading into,
+     so this is the network set minus the two `/vsicurl` variants that
+     carry options in the path itself (`/vsicurl?`,
+     `/vsicurl_streaming/`): their query strings are not path structure,
+     so an archive marker found there cannot be trusted.
+   * :data:`URL_SCHEMES` — "can a user name this with a URL?" Only the
+     handlers with an established scheme; a handler may be readable
+     through its `/vsi*` form without appearing here.
+
+   Adding a handler means deciding its place in all four. The invariant
+   the tests enforce is `cloud ⊆ network ⊆ vsi`, with the network set
+   never containing a purely local handler (`/vsimem/`, the archives).
 
 2. :class:`CloudConfig` — a context manager wrapping
    :func:`gdal.config_options` that sets AWS / GS / Azure credential
@@ -41,19 +66,40 @@ _VSICURL = "/vsicurl/"
 _VSIS3 = "/vsis3/"
 _VSIGS = "/vsigs/"
 _VSIAZ = "/vsiaz/"
+_VSIADLS = "/vsiadls/"
 _VSIZIP = "/vsizip/"
 _VSITAR = "/vsitar/"
 _VSIGZIP = "/vsigzip/"
 
 
-# Module-scope tuple of cloud VSI prefixes; referenced by _chain_archive_vsi
-# to decide whether a path is eligible for archive-chaining. Keep in sync
-# with URL_SCHEMES below.
-_CLOUD_VSI_PREFIXES: tuple[str, ...] = (
-    _VSICURL,
+# Handlers addressed as `<prefix><bucket>/<key>`. Everything after the prefix
+# is path-like, so an archive marker can be searched for directly.
+_OBJECT_STORE_VSI_PREFIXES: tuple[str, ...] = (
     _VSIS3,
     _VSIGS,
     _VSIAZ,
+    _VSIADLS,
+    "/vsioss/",
+    "/vsiswift/",
+)
+
+# Handlers that embed a full URL after the prefix (`/vsihdfs/hdfs://host/path`,
+# `/vsiwebhdfs/http://host:port/webhdfs/v1/path`, `/vsicurl/https://host/path`).
+# Their hostname and query string must be stripped before an archive marker is
+# searched for, or a host like `data.gz` false-triggers the chaining.
+_URL_EMBEDDING_VSI_PREFIXES: tuple[str, ...] = (
+    _VSICURL,
+    "/vsihdfs/",
+    "/vsiwebhdfs/",
+)
+
+# "May this path chain an archive?" — equal to _NETWORK_VSI_PREFIXES by the
+# invariant in the module docstring: anything read over the network can hold a
+# zip or tar. The two curl variants that carry options in the path itself
+# (`/vsicurl?...`, `/vsicurl_streaming/`) are deliberately absent: their query
+# strings are not path structure, so archive detection cannot be trusted there.
+_CLOUD_VSI_PREFIXES: tuple[str, ...] = (
+    _OBJECT_STORE_VSI_PREFIXES + _URL_EMBEDDING_VSI_PREFIXES
 )
 
 # Map archive extensions to GDAL's matching VSI prefix. Ordered longest-
@@ -81,12 +127,31 @@ URL_SCHEMES: dict[str, str] = {
     "s3": _VSIS3,
     "gs": _VSIGS,
     "az": _VSIAZ,
-    "abfs": _VSIAZ,
+    "abfs": _VSIADLS,
+    "abfss": _VSIADLS,
+    "adls": _VSIADLS,
     "http": _VSICURL,
     "https": _VSICURL,
     "file": "",
 }
-"""Map URL scheme to GDAL VSI prefix. Empty string means strip-and-use."""
+"""Map URL scheme to GDAL VSI prefix. Empty string means strip-and-use.
+
+`az://` is Azure Blob (`/vsiaz/`). `abfs://`, `abfss://` and `adls://` are Data
+Lake Storage Gen2 (`/vsiadls/`), matching what those schemes mean everywhere
+else in the Azure and Hadoop ecosystems — `abfs` is the Azure Blob **File
+System** driver, which is Gen2, not Blob. Reach a flat Blob account with
+`az://`.
+"""
+
+# Schemes addressed as `<scheme>://<bucket>/<key>`; the rest of URL_SCHEMES is
+# handled by dedicated branches in `_to_vsi` (`http(s)` keeps its full URL,
+# `file` strips to a local path). Derived rather than repeated so a new scheme
+# cannot be added to the map and silently fall through to "unrecognised".
+_BUCKET_URL_SCHEMES: frozenset[str] = frozenset(
+    scheme
+    for scheme, prefix in URL_SCHEMES.items()
+    if prefix in _OBJECT_STORE_VSI_PREFIXES
+)
 
 # OPeNDAP / THREDDS scheme. Not in URL_SCHEMES because it maps to a NETCDF:
 # connection string (GDAL's DAP-capable netCDF driver), not a /vsi* prefix.
@@ -97,6 +162,7 @@ _VSI_PREFIXES: tuple[str, ...] = (
     _VSIS3,
     _VSIGS,
     _VSIAZ,
+    _VSIADLS,
     _VSICURL,
     # GDAL's query-string form, `/vsicurl?[option=value&]*url=<encoded>`, which
     # carries per-source options (headers, retry, empty_dir) in the path itself.
@@ -125,7 +191,7 @@ def is_remote(path: str) -> bool:
         path: A string path or URL.
 
     Returns:
-        `True` for `s3://`, `gs://`, `az://`, `abfs://`,
+        `True` for `s3://`, `gs://`, `az://`, `abfs://`, `abfss://`, `adls://`,
         `http(s)://`, `file://`, and any `/vsi*` path. `False`
         for local POSIX or Windows paths (including drive-letter form)
         and for compressed-archive paths that don't start with `/vsi`.
@@ -177,6 +243,7 @@ _NETWORK_VSI_PREFIXES: tuple[str, ...] = (
     _VSIS3,
     _VSIGS,
     _VSIAZ,
+    _VSIADLS,
     _VSICURL,
     "/vsicurl?",
     "/vsicurl_streaming/",
@@ -201,6 +268,7 @@ def is_network_backed(path: str) -> bool:
 
     Returns:
         `True` for the cloud URL schemes — `s3://`, `gs://`, `az://`, `abfs://`,
+        `abfss://`, `adls://`,
         `http(s)://`, `dods://` — and for the network `/vsi*` handlers: `/vsis3/`,
         `/vsigs/`, `/vsiaz/`, `/vsicurl/` and its query-string form,
         `/vsicurl_streaming/`, `/vsioss/`, `/vsiswift/`, `/vsihdfs/`,
@@ -360,7 +428,9 @@ def _to_vsi(path: str) -> str:
     `s3://bucket/key`           `/vsis3/bucket/key`
     `gs://bucket/key`           `/vsigs/bucket/key`
     `az://container/blob`       `/vsiaz/container/blob`
-    `abfs://container/blob`     `/vsiaz/container/blob`
+    `abfs://container/blob`     `/vsiadls/container/blob`
+    `abfss://container/blob`    `/vsiadls/container/blob`
+    `adls://container/blob`     `/vsiadls/container/blob`
     `https://host/path.tif`     `/vsicurl/https://host/path.tif`
     `http://host/path.tif`      `/vsicurl/http://host/path.tif`
     `file:///C:/path/x.tif`     `C:/path/x.tif` (Windows)
@@ -443,7 +513,7 @@ def _scheme_to_vsi(parsed: ParseResult, scheme: str, path: str) -> str:
         return f'NETCDF:"https://{remainder}"'
     if scheme not in URL_SCHEMES or len(scheme) <= 1:
         return path
-    if scheme in {"s3", "gs", "az", "abfs"}:
+    if scheme in _BUCKET_URL_SCHEMES:
         bucket = parsed.netloc
         key = parsed.path.lstrip("/")
         return f"{URL_SCHEMES[scheme]}{bucket}/{key}"
@@ -478,20 +548,25 @@ def _extract_archive_search_region(path: str) -> str | None:
         The search region (string) or `None` when `path` is not a
         cloud VSI path eligible for archive chaining.
     """
-    result: str | None
-    if path.startswith(_VSICURL):
-        url = path[len(_VSICURL) :]
+    result: str | None = None
+    embedding = next(
+        (p for p in _URL_EMBEDDING_VSI_PREFIXES if path.startswith(p)), None
+    )
+    if embedding is not None:
+        url = path[len(embedding) :]
         parsed = urlparse(url)
-        # Only the path component — excludes scheme, hostname, and query.
-        result = parsed.path if parsed.scheme in {"http", "https"} else url
-    elif path.startswith(_VSIS3):
-        result = path[len(_VSIS3) :]
-    elif path.startswith(_VSIGS):
-        result = path[len(_VSIGS) :]
-    elif path.startswith(_VSIAZ):
-        result = path[len(_VSIAZ) :]
+        # Only the path component — excludes scheme, hostname, and query. A
+        # handler that embeds a URL (`/vsihdfs/hdfs://host/x`) is scanned the
+        # same way as `/vsicurl/`, so a host named `data.gz` cannot trigger
+        # chaining; an unrecognised inner scheme falls back to the whole
+        # remainder, which has no hostname to confuse the search.
+        result = parsed.path if parsed.scheme else url
     else:
-        result = None
+        store = next(
+            (p for p in _OBJECT_STORE_VSI_PREFIXES if path.startswith(p)), None
+        )
+        if store is not None:
+            result = path[len(store) :]
     return result
 
 
@@ -673,7 +748,7 @@ class CloudConfig:
     ================================ ==================================
 
     The HTTP knobs apply to GDAL's `/vsicurl/` family (so `s3://`,
-    `gs://`, `az://`, `abfs://`, `http(s)://` all benefit). `vsi_cache`
+    `gs://`, `az://`, `abfs://`, `adls://`, `http(s)://` all benefit). `vsi_cache`
     toggles GDAL's in-memory range cache for `/vsicurl/`-style readers
     — useful when re-reading the same remote chunks (e.g. iterating over
     blocks of a single COG). Set `vsi_cache=None` (default) to leave

--- a/src/pyramids/dataset/cog/validate.py
+++ b/src/pyramids/dataset/cog/validate.py
@@ -22,6 +22,7 @@ from typing import Any
 
 from osgeo import gdal
 
+from pyramids.base.remote import is_network_backed
 from pyramids.dataset.cog.options import COG_READ_DEFAULTS
 
 
@@ -58,28 +59,21 @@ def config_context(config: dict[str, str] | None) -> Iterator[None]:
             gdal.SetConfigOption(key, old)
 
 
-_REMOTE_PREFIXES: tuple[str, ...] = (
-    "/vsicurl",
-    "/vsis3",
-    "/vsigs",
-    "/vsiaz",
-    "/vsioss",
-    "/vsiswift",
-    "http://",
-    "https://",
-)
-
-
 def _is_remote(path: str) -> bool:
     """Return ``True`` for a remote / network-backed path.
+
+    Delegates to :func:`pyramids.base.remote.is_network_backed` rather than
+    keeping a prefix table of its own. The local copy listed six handlers and
+    went stale: `/vsiadls/` was absent, so the COG read defaults were skipped for
+    an ADLS Gen2 path while the identical `/vsiaz/` path got them (#918).
 
     Args:
         path: A local path or ``/vsi*`` path.
 
     Returns:
-        bool: ``True`` for ``/vsicurl``/cloud-VSI/HTTP(S) paths.
+        bool: ``True`` for a path GDAL reads over the network.
     """
-    return path.startswith(_REMOTE_PREFIXES) or "://" in path
+    return is_network_backed(path)
 
 
 def _resolve_read_config(

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2421,7 +2421,7 @@ class Dataset(RasterBase):
         """Open a raster from a path, URL, or archive member.
 
         Plain local paths, ``/vsi*`` paths, and URL schemes
-        (``http(s)://``, ``s3://``, ``gs://``, ``az://`` / ``abfs://``,
+        (``http(s)://``, ``s3://``, ``gs://``, ``az://``, ``abfs://`` / ``adls://``,
         ``file://``) are all accepted — URLs are transparently rewritten to
         GDAL's virtual filesystem (GDAL fetches via HTTP range requests for
         ``http(s)``). Compressed archives are detected from the extension; pass
@@ -2496,7 +2496,7 @@ class Dataset(RasterBase):
 
         This is **not** a URL helper. Reading from a URL is already
         supported by :meth:`read_file`, which rewrites ``http(s)://``,
-        ``s3://``, ``gs://``, ``az://`` / ``abfs://`` and ``file://``
+        ``s3://``, ``gs://``, ``az://``, ``abfs://`` / ``adls://`` and ``file://``
         to GDAL ``/vsi*`` paths. Use ``from_bytes`` only when you
         already hold the bytes.
 

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2421,7 +2421,7 @@ class Dataset(RasterBase):
         """Open a raster from a path, URL, or archive member.
 
         Plain local paths, ``/vsi*`` paths, and URL schemes
-        (``http(s)://``, ``s3://``, ``gs://``, ``az://``, ``abfs://`` / ``adls://``,
+        (``http(s)://``, ``s3://``, ``gs://``, ``az://``, ``abfs://`` / ``abfss://``,
         ``file://``) are all accepted — URLs are transparently rewritten to
         GDAL's virtual filesystem (GDAL fetches via HTTP range requests for
         ``http(s)``). Compressed archives are detected from the extension; pass
@@ -2496,7 +2496,7 @@ class Dataset(RasterBase):
 
         This is **not** a URL helper. Reading from a URL is already
         supported by :meth:`read_file`, which rewrites ``http(s)://``,
-        ``s3://``, ``gs://``, ``az://``, ``abfs://`` / ``adls://`` and ``file://``
+        ``s3://``, ``gs://``, ``az://``, ``abfs://`` / ``abfss://`` and ``file://``
         to GDAL ``/vsi*`` paths. Use ``from_bytes`` only when you
         already hold the bytes.
 

--- a/src/pyramids/feature/_lazy_collection.py
+++ b/src/pyramids/feature/_lazy_collection.py
@@ -20,6 +20,8 @@ from typing import TYPE_CHECKING, Any, cast
 import dask_geopandas
 import geopandas
 
+from pyramids.base.remote import to_fsspec_url
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -604,7 +606,9 @@ class LazyFeatureCollection(dask_geopandas.GeoDataFrame):
                 "Delayed."
             )
         kwargs["compute"] = True
-        super().to_parquet(path, *args, **kwargs)
+        # dask_geopandas writes through fsspec, which resolves the scheme itself
+        # and does not register every spelling GDAL accepts (#918).
+        super().to_parquet(to_fsspec_url(str(path)), *args, **kwargs)
 
     def __repr__(self) -> str:
         """Pyramids-branded repr; avoids the generic Dask DataFrame one."""

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -38,7 +38,7 @@ from shapely.geometry import box
 from pyramids import _io as _pyramids_io
 from pyramids.base._errors import FeatureError
 from pyramids.base._utils import import_pyarrow
-from pyramids.base.remote import is_remote
+from pyramids.base.remote import is_remote, to_fsspec_url
 
 if TYPE_CHECKING:
     from pyramids.feature._lazy_collection import LazyFeatureCollection
@@ -553,7 +553,11 @@ def read_parquet(
     # resolves against the drive root, so the read dies with FileNotFoundError.
     # Hand fsspec the URL untouched; local paths still go through _parse_path.
     path_str = str(path)
-    resolved = path_str if is_remote(path_str) else _pyramids_io._parse_path(path)
+    resolved = (
+        to_fsspec_url(path_str)
+        if is_remote(path_str)
+        else _pyramids_io._parse_path(path)
+    )
     if backend == "dask":
         return read_parquet_dask(
             resolved,

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -741,7 +741,7 @@ class FeatureCollection(GeoDataFrame):
         :func:`pyramids._io._parse_path`, which handles:
 
         * Cloud-URL rewriting (`s3://`, `gs://`, `az://`,
-          `abfs://`, `adls://`, `http(s)://`, `file://` → GDAL `/vsi*/`
+          `abfs://`, `abfss://`, `http(s)://`, `file://` → GDAL `/vsi*/`
           form). verified end-to-end through an HTTP test.
           For AWS / GCS / Azure credentials either set the standard
           environment variables (`AWS_ACCESS_KEY_ID`,

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -741,7 +741,7 @@ class FeatureCollection(GeoDataFrame):
         :func:`pyramids._io._parse_path`, which handles:
 
         * Cloud-URL rewriting (`s3://`, `gs://`, `az://`,
-          `abfs://`, `http(s)://`, `file://` → GDAL `/vsi*/`
+          `abfs://`, `adls://`, `http(s)://`, `file://` → GDAL `/vsi*/`
           form). verified end-to-end through an HTTP test.
           For AWS / GCS / Azure credentials either set the standard
           environment variables (`AWS_ACCESS_KEY_ID`,

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -29,7 +29,12 @@ import pandas as pd
 from osgeo import gdal
 
 from pyramids.base._utils import import_pyarrow
-from pyramids.base.remote import CloudConfig, _to_vsi, resolve_s3_region
+from pyramids.base.remote import (
+    URL_SCHEMES,
+    CloudConfig,
+    _to_vsi,
+    resolve_s3_region,
+)
 from pyramids.netcdf.utils import decode_cf_time, encode_cf_time
 
 # Soft guard: realising a store this large into a DataFrame loads it all into
@@ -45,8 +50,11 @@ _PARQUET_INSTALL_HINT = (
 )
 
 # Remote object-store / http URL schemes (the part before "://"). A store opened
-# from one of these is read through GDAL's /vsi* virtual filesystem.
-_REMOTE_SCHEMES = ("s3", "gs", "gcs", "az", "abfs", "http", "https")
+# from one of these is read through GDAL's /vsi* virtual filesystem. Derived from
+# `URL_SCHEMES` rather than repeated, so a handler added there (ADLS Gen2, #918)
+# cannot be remote for `Dataset` and local here. `file` names a local path and is
+# excluded; `gcs` is an alias GDAL accepts that `URL_SCHEMES` does not list.
+_REMOTE_SCHEMES = tuple(sorted({*URL_SCHEMES, "gcs"} - {"file"}))
 
 
 def _get_attr(obj: Any, name: str) -> Any:

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -30,6 +30,7 @@ from osgeo import gdal
 
 from pyramids.base._utils import import_pyarrow
 from pyramids.base.remote import (
+    _DODS_SCHEME,
     URL_SCHEMES,
     CloudConfig,
     _to_vsi,
@@ -49,12 +50,16 @@ _PARQUET_INSTALL_HINT = (
     "  - conda: conda install -c conda-forge pyarrow"
 )
 
-# Remote object-store / http URL schemes (the part before "://"). A store opened
-# from one of these is read through GDAL's /vsi* virtual filesystem. Derived from
-# `URL_SCHEMES` rather than repeated, so a handler added there (ADLS Gen2, #918)
-# cannot be remote for `Dataset` and local here. `file` names a local path and is
-# excluded; `gcs` is an alias GDAL accepts that `URL_SCHEMES` does not list.
-_REMOTE_SCHEMES = tuple(sorted({*URL_SCHEMES, "gcs"} - {"file"}))
+# URL schemes whose paths must go through `_to_vsi` before GDAL sees them.
+# Derived from the rewriter's own table rather than repeated, so a handler added
+# there (ADLS Gen2, #918) cannot be understood by `Dataset` and not here.
+#
+# `_DODS_SCHEME` is included because it lives outside `URL_SCHEMES` (it rewrites
+# to a `NETCDF:` connection string, not a `/vsi*` prefix) yet still needs the
+# rewrite. `file` is included too: it names a *local* path but GDAL cannot open
+# the `file://` form, so it must be stripped — "remote" and "needs rewriting"
+# are different questions and this list answers the second.
+_REWRITABLE_SCHEMES = tuple(sorted({*URL_SCHEMES, _DODS_SCHEME}))
 
 
 def _get_attr(obj: Any, name: str) -> Any:
@@ -111,9 +116,14 @@ def _contiguous_runs(sorted_idx: np.typing.NDArray) -> list[tuple[int, int]]:
 
 
 def _is_remote_url(source: str) -> bool:
-    """True for a remote object-store / http URL (not a local filesystem path)."""
+    """True when `source` is a URL GDAL needs rewritten before it can open it.
+
+    Named for the common case, but the question it answers is "does this need
+    `_to_vsi`?" — `file://` is local and still needs rewriting, because GDAL
+    rejects the URI form.
+    """
     scheme = source.split("://", 1)[0].lower() if "://" in source else ""
-    return scheme in _REMOTE_SCHEMES
+    return scheme in _REWRITABLE_SCHEMES
 
 
 # Recognised store engines. ``"zarr"`` selects the Zarr path; the NetCDF / HDF5 family

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -3378,7 +3378,7 @@ class NetCDF(Dataset):
         """Open a NetCDF file from a path, URL, or archive member.
 
         Plain local paths, ``/vsi*`` paths, and URL schemes
-        (``http(s)://``, ``s3://``, ``gs://``, ``az://`` / ``abfs://``,
+        (``http(s)://``, ``s3://``, ``gs://``, ``az://``, ``abfs://`` / ``adls://``,
         ``file://``) are all accepted — URLs are transparently rewritten
         to GDAL's virtual filesystem. Compressed archives (``.zip`` /
         ``.tar`` / ``.tar.gz`` / ``.gz``) are detected from the

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -3378,7 +3378,7 @@ class NetCDF(Dataset):
         """Open a NetCDF file from a path, URL, or archive member.
 
         Plain local paths, ``/vsi*`` paths, and URL schemes
-        (``http(s)://``, ``s3://``, ``gs://``, ``az://``, ``abfs://`` / ``adls://``,
+        (``http(s)://``, ``s3://``, ``gs://``, ``az://``, ``abfs://`` / ``abfss://``,
         ``file://``) are all accepted — URLs are transparently rewritten
         to GDAL's virtual filesystem. Compressed archives (``.zip`` /
         ``.tar`` / ``.tar.gz`` / ``.gz``) are detected from the

--- a/tests/base/test_remote.py
+++ b/tests/base/test_remote.py
@@ -119,11 +119,9 @@ class TestToVsi:
         assert "adls" not in URL_SCHEMES, "adls:// is not an ecosystem scheme"
         assert _to_vsi("adls://container/blob.tif") == "adls://container/blob.tif"
 
-    def test_gen2_account_authority_resolves_when_configured(self, monkeypatch):
+    def test_gen2_account_authority_resolves_when_configured(self):
         """The canonical `filesystem@account` authority uses only the filesystem.
 
-        Args:
-            monkeypatch: pytest monkeypatch fixture.
 
         Test scenario:
             `abfss://<fs>@<account>.dfs.core.windows.net/<path>` is how ABFS URIs
@@ -131,50 +129,31 @@ class TestToVsi:
             authority verbatim as the container yields a URL-encoded nonsense
             container on whatever account is configured.
         """
-        monkeypatch.setenv("AZURE_STORAGE_ACCOUNT", "prodlake")
-        gdal.SetConfigOption("AZURE_STORAGE_ACCOUNT", "prodlake")
-        try:
+        with gdal.config_option("AZURE_STORAGE_ACCOUNT", "prodlake"):
             resolved = _to_vsi("abfss://raw@prodlake.dfs.core.windows.net/2026/x.tif")
-        finally:
-            gdal.SetConfigOption("AZURE_STORAGE_ACCOUNT", None)
         assert resolved == "/vsiadls/raw/2026/x.tif", resolved
 
-    def test_gen2_account_authority_refuses_when_unconfigured(self, monkeypatch):
-        """Naming an account in the URL with none configured is an error, not a guess.
+    def test_gen2_account_authority_refuses_when_unconfigured(self):
+        """Naming an account in the URL with none configured is an error, not a guess."""
+        with gdal.config_option("AZURE_STORAGE_ACCOUNT", None):
+            with pytest.raises(ValueError, match="AZURE_STORAGE_ACCOUNT"):
+                _to_vsi("abfss://raw@prodlake.dfs.core.windows.net/x.tif")
 
-        Args:
-            monkeypatch: pytest monkeypatch fixture.
-        """
-        monkeypatch.delenv("AZURE_STORAGE_ACCOUNT", raising=False)
-        gdal.SetConfigOption("AZURE_STORAGE_ACCOUNT", None)
-        with pytest.raises(ValueError, match="AZURE_STORAGE_ACCOUNT"):
-            _to_vsi("abfss://raw@prodlake.dfs.core.windows.net/x.tif")
-
-    def test_gen2_account_authority_refuses_a_mismatch(self, monkeypatch):
+    def test_gen2_account_authority_refuses_a_mismatch(self):
         """A URL naming a different account than the configured one refuses.
 
-        Args:
-            monkeypatch: pytest monkeypatch fixture.
 
         Test scenario:
             GDAL reads the account from configuration, so silently proceeding
             would read a different storage account than the URL names.
         """
-        monkeypatch.setenv("AZURE_STORAGE_ACCOUNT", "otheracct")
-        gdal.SetConfigOption("AZURE_STORAGE_ACCOUNT", "otheracct")
-        try:
+        with gdal.config_option("AZURE_STORAGE_ACCOUNT", "otheracct"):
             with pytest.raises(ValueError, match="otheracct"):
                 _to_vsi("abfss://raw@prodlake.dfs.core.windows.net/x.tif")
-        finally:
-            gdal.SetConfigOption("AZURE_STORAGE_ACCOUNT", None)
 
     def test_bare_gen2_authority_is_still_a_plain_container(self):
         """Without an `@`, the authority is the filesystem name as before."""
         assert _to_vsi("abfs://fs/2026/x.tif") == "/vsiadls/fs/2026/x.tif"
-
-    def test_az_still_maps_to_blob(self):
-        """`az://` keeps naming Blob, so the two Azure handlers stay reachable."""
-        assert _to_vsi("az://container/blob.tif") == "/vsiaz/container/blob.tif"
 
     def test_https_simple(self):
         assert _to_vsi("https://foo.com/x.tif") == "/vsicurl/https://foo.com/x.tif"
@@ -933,7 +912,7 @@ class TestHandlerTableInvariant:
     def test_streaming_handlers_do_not_chain_archives(self):
         """Their remainder is an option list, so an archive marker is untrustworthy."""
         path = "/vsis3_streaming/b/a.zip/x.tif"
-        assert _chain_archive_vsi(path) == path, "streaming handlers must not chain"
+        assert _to_vsi(path) == path, "streaming handlers must not chain"
 
 
 class TestAdlsHandler:
@@ -951,7 +930,7 @@ class TestAdlsHandler:
 
     def test_chains_an_archive(self):
         """A zipped raster on Gen2 is rewritten the way the S3 equivalent is."""
-        chained = _chain_archive_vsi("/vsiadls/c/a.zip/x.tif")
+        chained = _to_vsi("/vsiadls/c/a.zip/x.tif")
         assert chained == "/vsizip//vsiadls/c/a.zip/x.tif", chained
 
 
@@ -988,7 +967,9 @@ class TestNetworkHandlersChainArchives:
             path: A VSI path pointing inside an archive.
             expected: The chained form GDAL needs to read the inner file.
         """
-        assert _chain_archive_vsi(path) == expected
+        assert _to_vsi(path) == expected, (
+            "chaining must be reachable through the public rewrite"
+        )
 
     @pytest.mark.parametrize(
         "path",
@@ -1008,4 +989,4 @@ class TestNetworkHandlersChainArchives:
             scanning the raw remainder would let a host named `data.gz` trigger
             chaining — the same trap `/vsicurl/` already guarded against.
         """
-        assert _chain_archive_vsi(path) == path, "a hostname must not trigger chaining"
+        assert _to_vsi(path) == path, "a hostname must not trigger chaining"

--- a/tests/base/test_remote.py
+++ b/tests/base/test_remote.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import warnings
 from contextlib import nullcontext
 
 import numpy as np  # noqa: E402
@@ -119,37 +120,63 @@ class TestToVsi:
         assert "adls" not in URL_SCHEMES, "adls:// is not an ecosystem scheme"
         assert _to_vsi("adls://container/blob.tif") == "adls://container/blob.tif"
 
-    def test_gen2_account_authority_resolves_when_configured(self):
-        """The canonical `filesystem@account` authority uses only the filesystem.
+    @pytest.mark.parametrize("configured", [None, "prodlake", "otheracct"])
+    def test_gen2_account_authority_rewrites_deterministically(self, configured):
+        """The rewrite does not depend on ambient credentials.
 
+        Args:
+            configured: The `AZURE_STORAGE_ACCOUNT` in force, or `None`.
 
         Test scenario:
-            `abfss://<fs>@<account>.dfs.core.windows.net/<path>` is how ABFS URIs
-            are written everywhere in the Azure and Hadoop world. Taking the
-            authority verbatim as the container yields a URL-encoded nonsense
-            container on whatever account is configured.
+            `_to_vsi` runs on essentially every open, so the same URL must
+            produce the same path whether or not credentials are configured and
+            whether or not a `CloudConfig` block is active.
         """
-        with gdal.config_option("AZURE_STORAGE_ACCOUNT", "prodlake"):
-            resolved = _to_vsi("abfss://raw@prodlake.dfs.core.windows.net/2026/x.tif")
+        with gdal.config_option("AZURE_STORAGE_ACCOUNT", configured):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                resolved = _to_vsi(
+                    "abfss://raw@prodlake.dfs.core.windows.net/2026/x.tif"
+                )
         assert resolved == "/vsiadls/raw/2026/x.tif", resolved
 
-    def test_gen2_account_authority_refuses_when_unconfigured(self):
-        """Naming an account in the URL with none configured is an error, not a guess."""
-        with gdal.config_option("AZURE_STORAGE_ACCOUNT", None):
-            with pytest.raises(ValueError, match="AZURE_STORAGE_ACCOUNT"):
-                _to_vsi("abfss://raw@prodlake.dfs.core.windows.net/x.tif")
-
-    def test_gen2_account_authority_refuses_a_mismatch(self):
-        """A URL naming a different account than the configured one refuses.
-
+    def test_a_conflicting_account_warns_rather_than_raising(self):
+        """A URL account that disagrees with the configured one is surfaced.
 
         Test scenario:
-            GDAL reads the account from configuration, so silently proceeding
-            would read a different storage account than the URL names.
+            GDAL takes the account from configuration, so the read would go
+            somewhere other than the URL names. That is worth flagging — but not
+            by raising from a path-rewriting helper on the open path.
         """
         with gdal.config_option("AZURE_STORAGE_ACCOUNT", "otheracct"):
-            with pytest.raises(ValueError, match="otheracct"):
+            with pytest.warns(UserWarning, match="otheracct"):
                 _to_vsi("abfss://raw@prodlake.dfs.core.windows.net/x.tif")
+
+    def test_a_matching_account_is_silent(self):
+        """No warning when the URL and the configuration agree."""
+        with gdal.config_option("AZURE_STORAGE_ACCOUNT", "prodlake"):
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                assert (
+                    _to_vsi("abfss://raw@prodlake.dfs.core.windows.net/x.tif")
+                    == "/vsiadls/raw/x.tif"
+                )
+
+    def test_the_account_may_come_from_the_connection_string(self):
+        """GDAL accepts the account embedded in the connection string.
+
+        Test scenario:
+            Reading only `AZURE_STORAGE_ACCOUNT` warned about a conflict on a
+            setup that is perfectly valid for `/vsiadls/`.
+        """
+        connection = "DefaultEndpointsProtocol=https;AccountName=prodlake;AccountKey=k"
+        with gdal.config_option("AZURE_STORAGE_CONNECTION_STRING", connection):
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                assert (
+                    _to_vsi("abfss://raw@prodlake.dfs.core.windows.net/x.tif")
+                    == "/vsiadls/raw/x.tif"
+                )
 
     def test_bare_gen2_authority_is_still_a_plain_container(self):
         """Without an `@`, the authority is the filesystem name as before."""

--- a/tests/base/test_remote.py
+++ b/tests/base/test_remote.py
@@ -109,9 +109,68 @@ class TestToVsi:
         """The TLS spelling of the Gen2 scheme resolves the same way."""
         assert _to_vsi("abfss://container/blob.tif") == "/vsiadls/container/blob.tif"
 
-    def test_adls_maps_to_vsiadls(self):
-        """`adls://` names the Gen2 handler explicitly."""
-        assert _to_vsi("adls://container/blob.tif") == "/vsiadls/container/blob.tif"
+    def test_there_is_no_adls_scheme(self):
+        """`adls://` is not a real scheme, so it is not accepted.
+
+        The registered Azure Data Lake name is `adl://` (Gen1, which GDAL does
+        not handle). Inventing `adls://` would collide with it visually and fail
+        in the fsspec-backed readers, which resolve the scheme themselves.
+        """
+        assert "adls" not in URL_SCHEMES, "adls:// is not an ecosystem scheme"
+        assert _to_vsi("adls://container/blob.tif") == "adls://container/blob.tif"
+
+    def test_gen2_account_authority_resolves_when_configured(self, monkeypatch):
+        """The canonical `filesystem@account` authority uses only the filesystem.
+
+        Args:
+            monkeypatch: pytest monkeypatch fixture.
+
+        Test scenario:
+            `abfss://<fs>@<account>.dfs.core.windows.net/<path>` is how ABFS URIs
+            are written everywhere in the Azure and Hadoop world. Taking the
+            authority verbatim as the container yields a URL-encoded nonsense
+            container on whatever account is configured.
+        """
+        monkeypatch.setenv("AZURE_STORAGE_ACCOUNT", "prodlake")
+        gdal.SetConfigOption("AZURE_STORAGE_ACCOUNT", "prodlake")
+        try:
+            resolved = _to_vsi("abfss://raw@prodlake.dfs.core.windows.net/2026/x.tif")
+        finally:
+            gdal.SetConfigOption("AZURE_STORAGE_ACCOUNT", None)
+        assert resolved == "/vsiadls/raw/2026/x.tif", resolved
+
+    def test_gen2_account_authority_refuses_when_unconfigured(self, monkeypatch):
+        """Naming an account in the URL with none configured is an error, not a guess.
+
+        Args:
+            monkeypatch: pytest monkeypatch fixture.
+        """
+        monkeypatch.delenv("AZURE_STORAGE_ACCOUNT", raising=False)
+        gdal.SetConfigOption("AZURE_STORAGE_ACCOUNT", None)
+        with pytest.raises(ValueError, match="AZURE_STORAGE_ACCOUNT"):
+            _to_vsi("abfss://raw@prodlake.dfs.core.windows.net/x.tif")
+
+    def test_gen2_account_authority_refuses_a_mismatch(self, monkeypatch):
+        """A URL naming a different account than the configured one refuses.
+
+        Args:
+            monkeypatch: pytest monkeypatch fixture.
+
+        Test scenario:
+            GDAL reads the account from configuration, so silently proceeding
+            would read a different storage account than the URL names.
+        """
+        monkeypatch.setenv("AZURE_STORAGE_ACCOUNT", "otheracct")
+        gdal.SetConfigOption("AZURE_STORAGE_ACCOUNT", "otheracct")
+        try:
+            with pytest.raises(ValueError, match="otheracct"):
+                _to_vsi("abfss://raw@prodlake.dfs.core.windows.net/x.tif")
+        finally:
+            gdal.SetConfigOption("AZURE_STORAGE_ACCOUNT", None)
+
+    def test_bare_gen2_authority_is_still_a_plain_container(self):
+        """Without an `@`, the authority is the filesystem name as before."""
+        assert _to_vsi("abfs://fs/2026/x.tif") == "/vsiadls/fs/2026/x.tif"
 
     def test_az_still_maps_to_blob(self):
         """`az://` keeps naming Blob, so the two Azure handlers stay reachable."""
@@ -832,15 +891,49 @@ class TestHandlerTableInvariant:
         assert prefix in _VSI_PREFIXES, f"{prefix} should be a known VSI prefix"
         assert prefix not in _NETWORK_VSI_PREFIXES, f"{prefix} is not network-backed"
 
-    def test_every_bucket_scheme_maps_to_an_object_store(self):
-        """A URL scheme in the bucket form must name a `<bucket>/<key>` handler.
+    def test_every_url_scheme_is_actually_rewritten(self):
+        """No scheme in the map may fall through `_to_vsi` unchanged.
 
-        Guards the derivation in `_to_vsi`: a scheme added to `URL_SCHEMES`
-        whose prefix is not an object store would silently fall through to
-        "unrecognised" instead of being rewritten.
+        The real risk the derivation guards against: a scheme added to
+        `URL_SCHEMES` whose prefix no branch of `_to_vsi` handles would be
+        returned as-is and handed to GDAL raw. Asserting on the rewrite is what
+        catches that; asserting that the derived set matches its own derivation
+        cannot fail.
         """
-        for scheme in _BUCKET_URL_SCHEMES:
-            assert URL_SCHEMES[scheme] in _OBJECT_STORE_VSI_PREFIXES, scheme
+        for scheme in URL_SCHEMES:
+            rewritten = _to_vsi(f"{scheme}://container/key.tif")
+            assert rewritten != f"{scheme}://container/key.tif", (
+                f"{scheme}:// is in URL_SCHEMES but _to_vsi leaves it unchanged"
+            )
+
+    @pytest.mark.parametrize(
+        "prefix",
+        [
+            "/vsis3_streaming/",
+            "/vsigs_streaming/",
+            "/vsiaz_streaming/",
+            "/vsioss_streaming/",
+            "/vsiswift_streaming/",
+        ],
+    )
+    def test_streaming_handlers_are_network_backed(self, prefix: str):
+        """GDAL's `_streaming` twins read the same services over the network.
+
+        Args:
+            prefix: A streaming VSI prefix.
+
+        Test scenario:
+            Only `/vsicurl_streaming/` was listed, so the five object-store
+            streaming handlers classified as local files.
+        """
+        path = f"{prefix}bucket/key.tif"
+        assert is_remote(path), f"{prefix} must be remote"
+        assert is_network_backed(path), f"{prefix} must be network-backed"
+
+    def test_streaming_handlers_do_not_chain_archives(self):
+        """Their remainder is an option list, so an archive marker is untrustworthy."""
+        path = "/vsis3_streaming/b/a.zip/x.tif"
+        assert _chain_archive_vsi(path) == path, "streaming handlers must not chain"
 
 
 class TestAdlsHandler:
@@ -867,6 +960,10 @@ class TestNetworkHandlersChainArchives:
 
     `_CLOUD_VSI_PREFIXES` used to be s3/gs/az/curl only, so a zipped raster on
     Alibaba OSS, OpenStack Swift or HDFS was never rewritten.
+
+    These assert the path *rewrite* only. `/vsihdfs/` and `/vsiwebhdfs/` need a
+    GDAL built with HDFS support and are not registered in every build (the
+    project's own is one that lacks them), so nothing here opens a dataset.
     """
 
     @pytest.mark.parametrize(

--- a/tests/base/test_remote.py
+++ b/tests/base/test_remote.py
@@ -11,7 +11,14 @@ from osgeo import gdal
 
 from pyramids import _io
 from pyramids.base.remote import (
+    _BUCKET_URL_SCHEMES,
+    _CLOUD_VSI_PREFIXES,
+    _NETWORK_VSI_PREFIXES,
+    _OBJECT_STORE_VSI_PREFIXES,
+    _VSI_PREFIXES,
+    URL_SCHEMES,
     CloudConfig,
+    _chain_archive_vsi,
     _to_vsi,
     is_network_backed,
     is_remote,
@@ -88,8 +95,27 @@ class TestToVsi:
     def test_az(self):
         assert _to_vsi("az://container/blob.tif") == "/vsiaz/container/blob.tif"
 
-    def test_abfs_maps_to_vsiaz(self):
-        assert _to_vsi("abfs://container/blob.tif") == "/vsiaz/container/blob.tif"
+    def test_abfs_maps_to_vsiadls(self):
+        """`abfs://` is the Gen2 scheme, so it routes to the Gen2 handler.
+
+        It mapped to `/vsiaz/` (Blob) until #918. `abfs` is the Azure Blob
+        *File System* driver, which is Data Lake Gen2 everywhere else in the
+        Azure and Hadoop ecosystems; a flat Blob account is reached with
+        `az://`.
+        """
+        assert _to_vsi("abfs://container/blob.tif") == "/vsiadls/container/blob.tif"
+
+    def test_abfss_maps_to_vsiadls(self):
+        """The TLS spelling of the Gen2 scheme resolves the same way."""
+        assert _to_vsi("abfss://container/blob.tif") == "/vsiadls/container/blob.tif"
+
+    def test_adls_maps_to_vsiadls(self):
+        """`adls://` names the Gen2 handler explicitly."""
+        assert _to_vsi("adls://container/blob.tif") == "/vsiadls/container/blob.tif"
+
+    def test_az_still_maps_to_blob(self):
+        """`az://` keeps naming Blob, so the two Azure handlers stay reachable."""
+        assert _to_vsi("az://container/blob.tif") == "/vsiaz/container/blob.tif"
 
     def test_https_simple(self):
         assert _to_vsi("https://foo.com/x.tif") == "/vsicurl/https://foo.com/x.tif"
@@ -774,3 +800,115 @@ class TestRedactCredentials:
         assert is_remote("/vsicurl?empty_dir=yes&url=https%3A%2F%2Fh%2Fa.tif"), (
             "the query form must be recognised as remote"
         )
+
+
+class TestHandlerTableInvariant:
+    """Tests for the relationship between the four handler tables (#918).
+
+    The tables answer different questions and are not copies of one list, so
+    the thing worth pinning is how they relate: `cloud` subset of `network`
+    subset of `vsi`, and no purely local handler in the network set.
+    """
+
+    def test_network_is_a_subset_of_vsi(self):
+        """Every network handler is recognised as a VSI path at all."""
+        missing = set(_NETWORK_VSI_PREFIXES) - set(_VSI_PREFIXES)
+        assert not missing, f"network handlers absent from _VSI_PREFIXES: {missing}"
+
+    def test_cloud_is_a_subset_of_network(self):
+        """Archive chaining is only offered for handlers that touch the network."""
+        missing = set(_CLOUD_VSI_PREFIXES) - set(_NETWORK_VSI_PREFIXES)
+        assert not missing, f"chaining handlers that are not network-backed: {missing}"
+
+    @pytest.mark.parametrize(
+        "prefix", ["/vsimem/", "/vsizip/", "/vsitar/", "/vsigzip/"]
+    )
+    def test_local_handlers_are_not_network_backed(self, prefix: str):
+        """An in-memory or archive handler reads no network.
+
+        Args:
+            prefix: A purely local VSI prefix.
+        """
+        assert prefix in _VSI_PREFIXES, f"{prefix} should be a known VSI prefix"
+        assert prefix not in _NETWORK_VSI_PREFIXES, f"{prefix} is not network-backed"
+
+    def test_every_bucket_scheme_maps_to_an_object_store(self):
+        """A URL scheme in the bucket form must name a `<bucket>/<key>` handler.
+
+        Guards the derivation in `_to_vsi`: a scheme added to `URL_SCHEMES`
+        whose prefix is not an object store would silently fall through to
+        "unrecognised" instead of being rewritten.
+        """
+        for scheme in _BUCKET_URL_SCHEMES:
+            assert URL_SCHEMES[scheme] in _OBJECT_STORE_VSI_PREFIXES, scheme
+
+
+class TestAdlsHandler:
+    """Tests for the ADLS Gen2 handler recognised in #918."""
+
+    ADLS_PATH = "/vsiadls/container/x.tif"
+
+    def test_is_remote(self):
+        """A Gen2 path is remote, where it used to read as a local file."""
+        assert is_remote(self.ADLS_PATH), "an ADLS path must be recognised as remote"
+
+    def test_is_network_backed(self):
+        """It is network-backed too, so credential reasoning applies."""
+        assert is_network_backed(self.ADLS_PATH), "an ADLS path is network-backed"
+
+    def test_chains_an_archive(self):
+        """A zipped raster on Gen2 is rewritten the way the S3 equivalent is."""
+        chained = _chain_archive_vsi("/vsiadls/c/a.zip/x.tif")
+        assert chained == "/vsizip//vsiadls/c/a.zip/x.tif", chained
+
+
+class TestNetworkHandlersChainArchives:
+    """Tests that every network handler may chain an archive (#918).
+
+    `_CLOUD_VSI_PREFIXES` used to be s3/gs/az/curl only, so a zipped raster on
+    Alibaba OSS, OpenStack Swift or HDFS was never rewritten.
+    """
+
+    @pytest.mark.parametrize(
+        ("path", "expected"),
+        [
+            ("/vsioss/c/a.zip/x.tif", "/vsizip//vsioss/c/a.zip/x.tif"),
+            ("/vsiswift/c/a.zip/x.tif", "/vsizip//vsiswift/c/a.zip/x.tif"),
+            (
+                "/vsihdfs/hdfs://nn:8020/d/a.zip/x.tif",
+                "/vsizip//vsihdfs/hdfs://nn:8020/d/a.zip/x.tif",
+            ),
+            (
+                "/vsiwebhdfs/http://h:50070/webhdfs/v1/a.tar/x.tif",
+                "/vsitar//vsiwebhdfs/http://h:50070/webhdfs/v1/a.tar/x.tif",
+            ),
+        ],
+    )
+    def test_chains(self, path: str, expected: str):
+        """Each network handler gets the archive prefix it needs.
+
+        Args:
+            path: A VSI path pointing inside an archive.
+            expected: The chained form GDAL needs to read the inner file.
+        """
+        assert _chain_archive_vsi(path) == expected
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/vsihdfs/hdfs://data.gz/x.tif",
+            "/vsiwebhdfs/http://data.zip/webhdfs/v1/x.tif",
+        ],
+    )
+    def test_a_hostname_that_looks_like_an_archive_does_not_chain(self, path: str):
+        """The URL-embedding handlers strip the hostname before searching.
+
+        Args:
+            path: A path whose *hostname* ends in an archive extension.
+
+        Test scenario:
+            `/vsihdfs/` and `/vsiwebhdfs/` embed a full URL after the prefix, so
+            scanning the raw remainder would let a host named `data.gz` trigger
+            chaining — the same trap `/vsicurl/` already guarded against.
+        """
+        assert _chain_archive_vsi(path) == path, "a hostname must not trigger chaining"

--- a/tests/netcdf/selection/test_labeled.py
+++ b/tests/netcdf/selection/test_labeled.py
@@ -595,10 +595,20 @@ class TestIsRemoteUrl:
         """Every supported object-store / web scheme is classified remote."""
         assert _is_remote_url(f"{scheme}://host/store") is True
 
-    @pytest.mark.parametrize("scheme", ["ftp", "sftp", "file", "mailto"])
+    @pytest.mark.parametrize("scheme", ["ftp", "sftp", "mailto"])
     def test_unknown_schemes_are_not_remote(self, scheme: str):
         """A scheme outside the known set is not classified remote."""
         assert _is_remote_url(f"{scheme}://host/store") is False
+
+    def test_file_uris_are_claimed_because_they_need_rewriting(self):
+        """`file://` is known and local, but GDAL cannot open the URI form.
+
+        It sat in the unknown-scheme group above, which conflated "is it remote?"
+        with "does it need rewriting?" — the second is what this predicate
+        answers, and `file://` must be stripped to a plain path before GDAL sees
+        it (#918).
+        """
+        assert _is_remote_url("file:///data/store.zarr") is True
 
     @pytest.mark.parametrize(
         "source",

--- a/tests/netcdf/selection/test_labeled_remote_schemes.py
+++ b/tests/netcdf/selection/test_labeled_remote_schemes.py
@@ -1,58 +1,86 @@
-"""Tests that LabeledDataset recognises the same remote URL schemes as Dataset (#918).
+"""Tests that LabeledDataset rewrites the same URL schemes as Dataset (#918).
 
 ``labeled.py`` kept its own scheme tuple, so a handler added to ``URL_SCHEMES`` was
-remote for ``Dataset`` and local here — an ADLS Gen2 store would have been opened as
-if it were a path on disk. The list is now derived from the one source.
+understood by ``Dataset`` and not here — an ADLS Gen2 store would have been opened as
+if it were a path on disk. The list is now derived from the rewriter's own table.
 """
 
 from __future__ import annotations
 
 import pytest
 
-from pyramids.base.remote import URL_SCHEMES
+from pyramids.base.remote import _DODS_SCHEME, URL_SCHEMES
 from pyramids.netcdf.labeled import _is_remote_url
 
 pytestmark = pytest.mark.core
 
 
-class TestRemoteSchemeRecognition:
+class TestSchemeRewriteRecognition:
     """Tests for `_is_remote_url` against the shared scheme table."""
 
-    @pytest.mark.parametrize(
-        "scheme", sorted(set(URL_SCHEMES) - {"file"})
-    )
-    def test_every_url_scheme_is_remote(self, scheme: str):
-        """A scheme the rewriter understands is remote to the labeled reader too.
+    @pytest.mark.parametrize("scheme", sorted(URL_SCHEMES))
+    def test_every_url_scheme_needs_rewriting(self, scheme: str):
+        """A scheme the rewriter understands must reach the rewriter here too.
 
         Args:
             scheme: A scheme from the shared `URL_SCHEMES` table.
         """
         assert _is_remote_url(f"{scheme}://container/store.zarr"), (
-            f"{scheme}:// is rewritten to a /vsi* path, so it must read as remote"
+            f"{scheme}:// is rewritten by _to_vsi, so it must not be passed to GDAL raw"
         )
 
-    @pytest.mark.parametrize("scheme", ["adls", "abfss", "abfs"])
-    def test_gen2_schemes_are_remote(self, scheme: str):
+    @pytest.mark.parametrize("scheme", ["abfs", "abfss"])
+    def test_gen2_schemes_are_recognised(self, scheme: str):
         """The Gen2 schemes specifically, which #918 added.
 
         Args:
             scheme: An ADLS Gen2 URL scheme.
         """
         assert _is_remote_url(f"{scheme}://container/store.zarr"), (
-            f"{scheme}:// names ADLS Gen2 and must not read as a local path"
+            f"{scheme}:// names ADLS Gen2 and must not be read as a local path"
         )
 
-    @pytest.mark.parametrize(
-        "source", ["/tmp/store.zarr", "C:/data/store.zarr", "file:///tmp/store.zarr"]
-    )
-    def test_local_paths_are_not_remote(self, source: str):
-        """A local path — including `file://` — is not remote.
+    def test_dods_is_recognised(self):
+        """`dods://` lives outside `URL_SCHEMES` but still needs rewriting.
+
+        Test scenario:
+            It rewrites to a `NETCDF:` connection string rather than a `/vsi*`
+            prefix, so deriving from `URL_SCHEMES` alone would miss it and hand
+            GDAL a raw `dods://` URI.
+        """
+        assert _is_remote_url("dods://test.opendap.org/data.nc"), (
+            "dods:// must be rewritten to a NETCDF: connection string"
+        )
+        assert _DODS_SCHEME == "dods", "the constant this relies on"
+
+    def test_file_uris_need_rewriting_even_though_they_are_local(self):
+        """`file://` names a local path, but GDAL cannot open the URI form.
+
+        Test scenario:
+            "Is it remote?" and "does it need rewriting?" are different
+            questions. Treating `file://` as local skipped the rewrite and
+            handed GDAL a URI it rejects.
+        """
+        assert _is_remote_url("file:///data/store.zarr"), (
+            "file:// must be stripped to a plain path before GDAL sees it"
+        )
+
+    @pytest.mark.parametrize("source", ["/tmp/store.zarr", "C:/data/store.zarr"])
+    def test_plain_paths_need_no_rewriting(self, source: str):
+        """A path with no scheme is passed through untouched.
 
         Args:
-            source: A local filesystem path or URI.
+            source: A local filesystem path.
         """
-        assert not _is_remote_url(source), f"{source} is local"
+        assert not _is_remote_url(source), f"{source} needs no rewrite"
 
-    def test_the_gcs_alias_is_kept(self):
-        """`gcs://` is not in `URL_SCHEMES` but GDAL accepts it, so it stays."""
-        assert _is_remote_url("gcs://bucket/store.zarr"), "gcs:// must stay recognised"
+    def test_an_unhandled_scheme_is_not_claimed(self):
+        """`gcs://` has no GDAL handler, so claiming it would hand GDAL a raw URI.
+
+        Test scenario:
+            It was kept as an alias on the claim that GDAL accepts it; `_to_vsi`
+            returns it unchanged, so the alias was never functional.
+        """
+        assert not _is_remote_url("gcs://bucket/store.zarr"), (
+            "gcs:// is not rewritten by _to_vsi, so it must not be claimed here"
+        )

--- a/tests/netcdf/selection/test_labeled_remote_schemes.py
+++ b/tests/netcdf/selection/test_labeled_remote_schemes.py
@@ -1,0 +1,58 @@
+"""Tests that LabeledDataset recognises the same remote URL schemes as Dataset (#918).
+
+``labeled.py`` kept its own scheme tuple, so a handler added to ``URL_SCHEMES`` was
+remote for ``Dataset`` and local here — an ADLS Gen2 store would have been opened as
+if it were a path on disk. The list is now derived from the one source.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from pyramids.base.remote import URL_SCHEMES
+from pyramids.netcdf.labeled import _is_remote_url
+
+pytestmark = pytest.mark.core
+
+
+class TestRemoteSchemeRecognition:
+    """Tests for `_is_remote_url` against the shared scheme table."""
+
+    @pytest.mark.parametrize(
+        "scheme", sorted(set(URL_SCHEMES) - {"file"})
+    )
+    def test_every_url_scheme_is_remote(self, scheme: str):
+        """A scheme the rewriter understands is remote to the labeled reader too.
+
+        Args:
+            scheme: A scheme from the shared `URL_SCHEMES` table.
+        """
+        assert _is_remote_url(f"{scheme}://container/store.zarr"), (
+            f"{scheme}:// is rewritten to a /vsi* path, so it must read as remote"
+        )
+
+    @pytest.mark.parametrize("scheme", ["adls", "abfss", "abfs"])
+    def test_gen2_schemes_are_remote(self, scheme: str):
+        """The Gen2 schemes specifically, which #918 added.
+
+        Args:
+            scheme: An ADLS Gen2 URL scheme.
+        """
+        assert _is_remote_url(f"{scheme}://container/store.zarr"), (
+            f"{scheme}:// names ADLS Gen2 and must not read as a local path"
+        )
+
+    @pytest.mark.parametrize(
+        "source", ["/tmp/store.zarr", "C:/data/store.zarr", "file:///tmp/store.zarr"]
+    )
+    def test_local_paths_are_not_remote(self, source: str):
+        """A local path — including `file://` — is not remote.
+
+        Args:
+            source: A local filesystem path or URI.
+        """
+        assert not _is_remote_url(source), f"{source} is local"
+
+    def test_the_gcs_alias_is_kept(self):
+        """`gcs://` is not in `URL_SCHEMES` but GDAL accepts it, so it stays."""
+        assert _is_remote_url("gcs://bucket/store.zarr"), "gcs:// must stay recognised"

--- a/tests/netcdf/selection/test_labeled_remote_schemes.py
+++ b/tests/netcdf/selection/test_labeled_remote_schemes.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import pytest
 
-from pyramids.base.remote import _DODS_SCHEME, URL_SCHEMES
+from pyramids.base.remote import _DODS_SCHEME, URL_SCHEMES, _to_vsi
 from pyramids.netcdf.labeled import _is_remote_url
 
 pytestmark = pytest.mark.core
@@ -74,13 +74,25 @@ class TestSchemeRewriteRecognition:
         """
         assert not _is_remote_url(source), f"{source} needs no rewrite"
 
-    def test_an_unhandled_scheme_is_not_claimed(self):
-        """`gcs://` has no GDAL handler, so claiming it would hand GDAL a raw URI.
+    def test_the_gcs_alias_is_functional(self):
+        """`gcs://` is claimed here because it is now actually rewritten.
 
         Test scenario:
-            It was kept as an alias on the claim that GDAL accepts it; `_to_vsi`
-            returns it unchanged, so the alias was never functional.
+            It used to be claimed on the false premise that GDAL accepts it, so
+            the raw URI reached GDAL and failed. It is a real, fsspec-registered
+            alias for Google Cloud Storage, so the fix was to map it to
+            `/vsigs/` rather than to stop claiming it.
         """
-        assert not _is_remote_url("gcs://bucket/store.zarr"), (
-            "gcs:// is not rewritten by _to_vsi, so it must not be claimed here"
+        assert _is_remote_url("gcs://bucket/store.zarr"), "gcs:// is handled"
+        assert _to_vsi("gcs://bucket/store.zarr") == "/vsigs/bucket/store.zarr"
+
+    @pytest.mark.parametrize("scheme", ["ftp", "sftp", "mailto"])
+    def test_a_genuinely_unhandled_scheme_is_not_claimed(self, scheme: str):
+        """A scheme no handler covers is left for the caller to fail on.
+
+        Args:
+            scheme: A URL scheme pyramids does not rewrite.
+        """
+        assert not _is_remote_url(f"{scheme}://host/store.zarr"), (
+            f"{scheme}:// is not rewritten, so it must not be claimed"
         )


### PR DESCRIPTION
# Description

GDAL has shipped `/vsiadls/` — the Azure Data Lake Storage Gen2 handler, distinct from `/vsiaz/` (Blob) — since
3.4. pyramids listed it nowhere, so a Gen2 path was classified as a **local file**: `is_remote()` and
`is_network_backed()` both returned `False`. Opening still worked, because `_to_vsi` passes an unrecognised
`/vsi*` path straight through — what broke was everything that *reasons* about the path: the
stranded-credentials warning added in #915, archive chaining, and any caller asking `is_remote`.

The fix completes the handler tables under a stated invariant rather than bolting on one handler. Four tables
classify a path and they answer **different** questions; reading them as copies of one list is what let this
drift. The module docstring now records that, and the tests enforce `cloud ⊆ network ⊆ vsi`.

## What changed

**Recognition.** `/vsiadls/` joins `_VSI_PREFIXES` and `_NETWORK_VSI_PREFIXES`, along with GDAL's five
`_streaming` object-store twins, which were classifying as local for the same reason.

**Archive chaining reaches every network handler — including raw `/vsi*` paths.** Previously only S3, Google
Cloud, Azure Blob and `/vsicurl/` chained. Now `/vsiadls/`, `/vsioss/` (Alibaba), `/vsiswift/` (OpenStack),
`/vsihdfs/` and `/vsiwebhdfs/` do too. Four of those have **no URL scheme at all**, so the raw `/vsi*` spelling is
the only way to name them — and `_to_vsi` used to short-circuit on it, which made the feature unreachable for
them. Already-VSI paths now go through the chaining; it stays idempotent, because an already-chained path starts
with an archive prefix the chainer does not act on.

Handlers are split by *shape* so the search region is correct: `<bucket>/<key>` stores are scanned directly,
while handlers that embed a URL (`/vsicurl/`, `/vsihdfs/hdfs://host/x`, `/vsiwebhdfs/…`) have their hostname and
query stripped first, so a host named `data.gz` cannot trigger chaining.

**`abfs://` now means Gen2.** It resolved to `/vsiaz/` (Blob). `abfs` is the Azure Blob *File System* driver,
which is Gen2 everywhere else in the Azure and Hadoop ecosystems, so pyramids was quietly handing Gen2 users the
wrong handler. `abfss://` is accepted too. `az://` still names Blob.

**The canonical `filesystem@account` authority is handled.** `abfss://<fs>@<account>.dfs.core.windows.net/<path>`
is how ABFS URIs are normally written; taking the authority verbatim as the container produced a URL-encoded
nonsense container on whatever account was configured — a silent read of the wrong storage account. The
filesystem is now used as the container. The rewrite stays **deterministic** — the same URL yields the same
`/vsi*` path in every credential state, inside or outside a `CloudConfig` block — because a path-rewriting helper
that runs on every open should not change behaviour with ambient configuration. GDAL takes the account from
configuration (`AZURE_STORAGE_ACCOUNT`, or `AccountName=` inside `AZURE_STORAGE_CONNECTION_STRING`), so a URL
naming an account that disagrees with it emits a `UserWarning` identifying the account that will actually be
read — visible in CI under `-W error`, without turning `_to_vsi` into a failure point.

**`gcs://` was claimed but never worked** — it is not in `URL_SCHEMES`, so it was reported remote and then handed
to GDAL raw. It is a real fsspec-registered alias, so it now maps to `/vsigs/`.

**Three private copies of these tables are gone.** `dataset/cog/validate.py` kept its own prefix list (so ADLS
silently skipped the COG read presets) and `netcdf/labeled.py` kept its own scheme tuple (so a Gen2 store would
have been opened as a path on disk). Both now call the shared functions. `_to_vsi`'s bucket-scheme set and
`_NETWORK_VSI_PREFIXES` are derived rather than repeated.

**fsspec vs GDAL spellings.** The Parquet read and lazy-write paths hand a URL to fsspec, which resolves the
scheme itself and does not register `abfss`. `to_fsspec_url` normalises on those paths only.

## Issues

- Closes #918

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**Breaking, in two ways.** `abfs://` routes to Gen2 — if you used it against a Gen2 account this is the fix; if
you used it against a flat Blob account, switch to `az://`, which is unchanged. Credentials are otherwise
identical: `/vsiadls/` reads the same `AZURE_STORAGE_*` family as `/vsiaz/` and honours `AZURE_NO_SIGN_REQUEST`
the same way (measured — with it set both handlers skip the instance-metadata lookup). `CloudConfig` gains an
`azure_no_sign_request` flag, the Azure counterpart of the existing S3 one, which was missing entirely.

There is **no `adls://` scheme**: the registered Azure Data Lake name is `adl://` (Gen1, which GDAL does not
handle), so inventing a near-identical spelling was rejected.

# How Has This Been Tested?

- [x] `pytest tests/base/test_remote.py tests/netcdf/selection/test_labeled_remote_schemes.py` → **159 passed,
      1 skipped**
- [x] Full suite `pytest tests -m "not plot"` → **7604 passed, 51 skipped, 0 failed**
- [x] **Mutation-checked (7/7)** on the initial implementation: every change reverted in turn to confirm a named
      test fails without it. That caught one gap — the `labeled.py` unification was pinned by nothing until a
      test module was added for it.
- [x] Two adversarial review rounds, 33 findings, all resolved. Round 2 caught that the chaining tests were
      calling the *private* `_chain_archive_vsi`, so six of them passed over a path no user could reach; they now
      go through `_to_vsi`.
- [x] `mypy` clean; doctests pass; `pre-commit run --all-files` clean (skipping only pytest/doctest/notebooks)
- [x] SonarCloud: **0 issues**, quality gate OK

Original report, before and after:

```text
                                              before        after
is_remote("/vsiadls/c/x.tif")                 False         True
is_network_backed("/vsiadls/c/x.tif")         False         True
_to_vsi("/vsiadls/c/a.zip/x.tif")             unchanged     /vsizip//vsiadls/c/a.zip/x.tif
_to_vsi("/vsioss/b/a.zip/x.tif")              unchanged     /vsizip//vsioss/b/a.zip/x.tif
_to_vsi("abfs://c/x.tif")                     /vsiaz/…      /vsiadls/c/x.tif
```

Guards that must keep holding, and do:

```text
_to_vsi("/vsicurl/https://host.gz/x.tif")          -> unchanged
_to_vsi("/vsihdfs/hdfs://data.gz/x.tif")           -> unchanged
_to_vsi("/vsicurl/https://h/f.tif?key=a.zip/x")    -> unchanged
_to_vsi("/vsizip//vsis3/b/a.zip/x.tif")            -> unchanged (idempotent)
```

# Checklist:

- [ ] updated version number in pyproject.toml. — handled by commitizen on release
- [ ] added changes to History.rst. — generated by commitizen
- [ ] updated the latest version in README file. — handled on release
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. — `docs/migration.md` (both breaking changes, the account rule, the credential
      caveat), the `_to_vsi` rewrite table, and the four tutorial/reference pages

