### PR TITLE
feat(plot): finish the typed plot-spec migration on .plot/.animate

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,14 +20,18 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # Fast, environment-free hooks: ruff (lint + format), the file/format/security
-  # checks, beautysh, shellcheck. Formatting and linting are identical on every OS and
-  # Python version, so this runs ONCE (no matrix) on a plain runner in ~1-2 min.
+  # Runs the pre-commit hooks in CI: ruff (lint + format), the file/format/security
+  # checks, beautysh, shellcheck, bandit, checkov — plus mypy, which needs the pixi `dev`
+  # env (typed deps + an importable package), so this job installs that env and the mypy
+  # hook runs here. One runner, no matrix (formatting/linting/typing are identical on every
+  # OS and Python version).
   #
-  # SKIP drops the hooks that need the pixi dev env: pytest-check and notebook-check are
-  # already the tests.yml matrix's job (running them here would duplicate it and pin to
-  # one Python), while mypy and doctest run in the `static` job below. no-commit-to-branch
-  # is a local commit guard that would misfire in CI, which legitimately runs on main.
+  # SKIP drops the hooks CI runs elsewhere or that can't run here: pytest-check and
+  # notebook-check are the tests.yml matrix's job (running them here would duplicate it and
+  # pin to one Python); doctest runs in the `static` job below; no-commit-to-branch is a
+  # local commit guard that would misfire in CI, which legitimately runs on main; gitleaks
+  # scans only staged changes (empty after a CI checkout), so it is inert in --all-files —
+  # the dedicated `gitleaks` job scans the whole tree.
   #
   # pixi-lock-check is deliberately out of CI scope: `pixi lock --check` re-solves against
   # live conda/PyPI channels, so it fails on *upstream* churn (a new build of an unrelated
@@ -37,10 +41,21 @@ jobs:
   # against the resolved env, so tests.yml exercises real code either way.
   pre-commit:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 20
     steps:
       # No fetch-depth: `pre-commit run --all-files` scans the working tree, not history.
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      # The mypy hook shells out to `pixi run --frozen -e dev mypy`, so the dev env must
+      # exist here. Installs pixi + the cached dev env (not activated — the hook selects
+      # the env explicitly with `-e dev`, and leaving it unactivated keeps the system
+      # Python below as the one that runs pre-commit itself).
+      - name: Set up pixi dev env
+        uses: serapeum-org/github-actions/actions/python-setup/pixi@38c111084f99d5ff5f4a1e63bedce48fe33a10c0  # pixi/v1.2.1
+        with:
+          environments: dev
+          cache: true
+          version: v0.73.0
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
         with:
@@ -61,16 +76,13 @@ jobs:
       - name: Run pre-commit hooks
         # --show-diff-on-failure prints exactly what the auto-fixers (ruff-format,
         # end-of-file-fixer, ...) would change, so a contributor sees the fix to apply.
-        # gitleaks is skipped here: its hook scans only staged changes (empty after a CI
-        # checkout), so it is inert in --all-files; the dedicated `gitleaks` job below
-        # scans the whole tree and is the real CI secret gate.
         run: pre-commit run --all-files --show-diff-on-failure --color=always
         env:
-          SKIP: no-commit-to-branch,gitleaks,mypy,pytest-check,doctest,notebook-check,pixi-lock-check
+          SKIP: no-commit-to-branch,gitleaks,pytest-check,doctest,notebook-check,pixi-lock-check
 
-  # Type check and doctests. Both need the full `dev` pixi env (typed deps and an
-  # importable package) but neither is platform- or Python-version-sensitive, so one
-  # runner covers them. Neither runs anywhere else in CI today.
+  # Src doctests. Need the full `dev` pixi env (typed deps and an importable package) but
+  # are not platform- or Python-version-sensitive, so one runner covers them. (mypy now
+  # runs in the `pre-commit` job above, via its hook.)
   static:
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -86,9 +98,6 @@ jobs:
           activate-environment: dev
           cache: true
           version: v0.73.0
-
-      - name: Type check with mypy
-        run: pixi run -e dev mypy
 
       - name: Doctests (src)
         # The same check as the `doctest` pre-commit hook: run the shipped `>>>` examples

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -123,6 +123,11 @@ repos:
         name: "[cred -  check] gitleaks"
         args: ["--config", "ci/gitleaks.toml"]
 
+  - repo: https://github.com/bridgecrewio/checkov
+    rev: 3.3.8
+    hooks:
+      - id: checkov
+
   # The local hooks below run inside the pixi `dev` environment. `--frozen` uses
   # pixi.lock as-is — without it pixi re-solves every platform on each hook run,
   # which is slow and can hang. `-p no:cacheprovider` stops pytest writing to

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,12 @@
+# pre-commit.ci-only settings. Skip checkov there: its hook repo
+# (bridgecrewio/checkov) is 101.6 MiB, past pre-commit.ci's 100 MiB tier cache
+# cap, so cloning it fails the whole run at the build stage before any hook
+# executes. checkov still runs in the GitHub Actions lint.yml `pre-commit` job
+# (no such cap, and it finds no IaC files there), so coverage is unchanged —
+# this only unblocks pre-commit.ci.
+ci:
+  skip: [checkov]
+
 fail_fast: true
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,3 @@
-# pre-commit.ci-only settings. Skip checkov there: its hook repo
-# (bridgecrewio/checkov) is 101.6 MiB, past pre-commit.ci's 100 MiB tier cache
-# cap, so cloning it fails the whole run at the build stage before any hook
-# executes. checkov still runs in the GitHub Actions lint.yml `pre-commit` job
-# (no such cap, and it finds no IaC files there), so coverage is unchanged —
-# this only unblocks pre-commit.ci.
-ci:
-  skip: [checkov]
-
 fail_fast: true
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -131,11 +122,6 @@ repos:
       - id: gitleaks
         name: "[cred -  check] gitleaks"
         args: ["--config", "ci/gitleaks.toml"]
-
-  - repo: https://github.com/bridgecrewio/checkov
-    rev: 3.3.8
-    hooks:
-      - id: checkov
 
   # The local hooks below run inside the pixi `dev` environment. `--frozen` uses
   # pixi.lock as-is — without it pixi re-solves every platform on each hook run,

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -532,7 +532,28 @@ def render_array(
     # render method only overwrites ``default_options["title"]`` when its
     # ``title`` arg is not ``None``, so a constructor-set title survives and
     # routing it to the constructor (via ``option_keys()``) is correct.
-    RENDER_ONLY_OVERRIDES = {"kind"}
+    # cleopatra 0.28 deprecated these loose colour-bar kwargs in favour of
+    # ``ColorBar`` fields, and emits the ``DeprecationWarning`` only inside
+    # ``.plot`` / ``.animate`` — never the constructor. Because they are in
+    # ``option_keys()``, routing them to the constructor (like every other
+    # option) would *suppress* that warning on the single-frame plot/facet path,
+    # while the animate path — which merges every kwarg into the render call —
+    # still warned. The same ``cbar_label=`` then warned on an animation but not
+    # on a plain plot. Force them to the render call so cleopatra's deprecation
+    # fires uniformly; they still render (cleopatra folds them into
+    # ``default_options`` there). Prefer ``colorbar=ColorBar(...)`` instead.
+    _DEPRECATED_CBAR_KWARGS = frozenset(
+        {
+            "cbar_label",
+            "cbar_length",
+            "cbar_label_size",
+            "cbar_label_rotation",
+            "cbar_label_location",
+            "cbar_orientation",
+            "ticks_spacing",
+        }
+    )
+    RENDER_ONLY_OVERRIDES = {"kind"} | _DEPRECATED_CBAR_KWARGS
     # Reuse the option set resolved for the style/hillshade guard above — it is
     # cleopatra's declared constructor options and does not change within a call.
     ctor_option_keys = option_keys

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -529,6 +529,9 @@ def render_array(
     # cleopatra's ``ArrayGlyph.facet`` does not accept ``colorbar=ColorBar`` /
     # ``PointOverlay`` (only the loose ``cbar_*`` kwargs, like the mesh glyph), so
     # faceting keeps the loose forms — there is no typed alternative there.
+    # TODO(cleopatra#256): once ``ArrayGlyph.facet`` accepts ``colorbar=ColorBar``,
+    # drop this facet exception (and the ``cbar_*`` in ``RENDER_ONLY_OVERRIDES``
+    # below) so facet folds the loose kwargs like plot/animate. Tracked in #934.
     if mode != "facet":
         _migrate_deprecated_plot_specs(kwargs, ColorBar, PointOverlay)
     if isinstance(basemap, dict) and basemap:

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -230,10 +230,13 @@ _CBAR_TO_COLORBAR = {
 _POINT_TO_OVERLAY = {
     "point_color": "color",
     "point_size": "size",
-    "point_label_color": "label_color",
-    "point_label_size": "label_size",
+    # Legacy ``pid_*`` aliases first, then the modern ``point_label_*`` names — the
+    # fold below is last-write-wins, so passing both makes ``point_label_*`` win,
+    # matching cleopatra's ``_resolve_point_overlay`` precedence.
     "pid_color": "label_color",
     "pid_size": "label_size",
+    "point_label_color": "label_color",
+    "point_label_size": "label_size",
 }
 
 
@@ -242,13 +245,14 @@ def _migrate_deprecated_plot_specs(
 ) -> None:
     """Fold deprecated loose ``cbar_*`` / ``point_*`` kwargs into the typed specs.
 
-    Mutates ``kwargs`` in place: the loose keys are popped and, when no explicit
-    ``colorbar=`` / ``points=`` was given, folded into a ``ColorBar`` /
-    ``PointOverlay``. Emits a pyramids ``DeprecationWarning`` naming the typed
-    replacement. When an explicit ``colorbar=`` (any value) or a ``PointOverlay``
-    was also passed, the loose keys are dropped and the explicit value wins (the
-    warning says so). Cleopatra therefore never sees the loose kwargs, so its own
-    deprecation never fires — no double warning.
+    Mutates ``kwargs`` in place: the loose keys are popped and folded into a
+    ``ColorBar`` / ``PointOverlay`` unless an explicit typed spec was already given.
+    A typed ``colorbar=ColorBar`` (or ``colorbar=False``, which hides the bar) and a
+    ``points=PointOverlay`` win — the loose keys are dropped with the warning.
+    ``colorbar=True`` / ``None`` still fold (they carry no styling of their own, so
+    dropping the loose kwargs would silently lose the caption). Emits a pyramids
+    ``DeprecationWarning`` naming the typed replacement. Cleopatra therefore never
+    sees the loose kwargs, so its own deprecation never fires — no double warning.
     """
     cbar = {
         _CBAR_TO_COLORBAR[k]: kwargs.pop(k)
@@ -256,11 +260,16 @@ def _migrate_deprecated_plot_specs(
         if k in kwargs
     }
     if cbar:
-        if "colorbar" in kwargs:
+        existing = kwargs.get("colorbar")
+        # Only a typed ColorBar (carries its own styling) or colorbar=False (bar
+        # hidden) can't be augmented by the loose kwargs. colorbar=True / None /
+        # absent carry no caption of their own, so fold the loose form in — else
+        # the caption that rendered before this migration would silently vanish.
+        if isinstance(existing, colorbar_cls) or existing is False:
             warnings.warn(
                 "The loose cbar_* / ticks_spacing kwargs are deprecated and were "
-                "ignored because colorbar= was also given; set them on the "
-                "pyramids.plot.ColorBar instead.",
+                "ignored because an explicit colorbar= was given; set the styling "
+                "on the pyramids.plot.ColorBar instead.",
                 DeprecationWarning,
                 stacklevel=3,
             )
@@ -376,11 +385,12 @@ def render_array(
             non-empty contextily provider string adds a pyramids web-tile
             basemap underneath the rendered plot (tile mode is applied on
             ``"plot"`` and per-panel on ``"facet"``). A
-            :class:`cleopatra.geo.Basemap` (or an equivalent ``dict``) is
-            cleopatra's relief/features reference layer, forwarded to the
-            glyph's own ``basemap=`` on the ``"plot"``/``"animate"`` render
-            call; it is **not** supported on ``"facet"`` (raises). An empty
-            string is treated as no basemap.
+            :class:`cleopatra.geo.Basemap` is cleopatra's relief/features
+            reference layer, forwarded to the glyph's own ``basemap=`` on the
+            ``"plot"``/``"animate"`` render call; it is **not** supported on
+            ``"facet"`` (raises). A ``dict`` is a deprecated alias translated to
+            ``Basemap`` up front (emits a ``DeprecationWarning``). An empty string
+            or empty ``dict`` is treated as no basemap.
         basemap_epsg: CRS code passed to
             :func:`pyramids.basemap.basemap.add_basemap` (and stamped on the
             glyph so cleopatra's own reference layers default to it). When
@@ -704,9 +714,10 @@ def render_array(
     # with pyramids' pre-existing web-tile ``basemap=``, so dispatch on the type:
     #   - a ``str`` provider name (or ``True``) is a pyramids web-tile basemap
     #     drawn under the raster -- pyramids owns this via ``add_basemap``;
-    #   - a ``cleopatra.geo.Basemap`` (or an equivalent ``dict``) is cleopatra's
-    #     relief/features reference layer, forwarded to the glyph's own
-    #     ``basemap=`` on the render call.
+    #   - a ``cleopatra.geo.Basemap`` is cleopatra's relief/features reference
+    #     layer, forwarded to the glyph's own ``basemap=`` on the render call.
+    #     (A non-empty ``dict`` was already deprecated + translated to a
+    #     ``Basemap`` up front, so only an empty ``{}`` reaches here — no basemap.)
     # ``basemap and basemap_epsg is None`` was already rejected at the top of
     # this function, so when ``basemap`` is truthy ``basemap_epsg`` is set.
     # A non-empty provider string, or ``True``, is a pyramids web-tile basemap.

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -542,7 +542,7 @@ def render_array(
     # cleopatra's ``ArrayGlyph.facet`` does not accept ``colorbar=ColorBar`` /
     # ``PointOverlay`` (only the loose ``cbar_*`` kwargs, like the mesh glyph), so
     # faceting keeps the loose forms — there is no typed alternative there.
-    # TODO(cleopatra#256): once ``ArrayGlyph.facet`` accepts ``colorbar=ColorBar``,
+    # Once cleopatra#256 lands (``ArrayGlyph.facet`` accepts ``colorbar=ColorBar``),
     # drop this facet exception (and the ``cbar_*`` in ``RENDER_ONLY_OVERRIDES``
     # below) so facet folds the loose kwargs like plot/animate. Tracked in #934.
     if mode != "facet":

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -265,11 +265,18 @@ def _migrate_deprecated_plot_specs(
         # hidden) can't be augmented by the loose kwargs. colorbar=True / None /
         # absent carry no caption of their own, so fold the loose form in — else
         # the caption that rendered before this migration would silently vanish.
-        if isinstance(existing, colorbar_cls) or existing is False:
+        if existing is False:
             warnings.warn(
                 "The loose cbar_* / ticks_spacing kwargs are deprecated and were "
-                "ignored because an explicit colorbar= was given; set the styling "
-                "on the pyramids.plot.ColorBar instead.",
+                "ignored because colorbar=False hides the colour bar.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+        elif isinstance(existing, colorbar_cls):
+            warnings.warn(
+                "The loose cbar_* / ticks_spacing kwargs are deprecated and were "
+                "ignored because an explicit colorbar=ColorBar was given; set the "
+                "styling on it instead.",
                 DeprecationWarning,
                 stacklevel=3,
             )

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -211,6 +211,22 @@ def _guard_style_hillshade(kwargs: dict[str, Any], option_keys: Any) -> None:
         )
 
 
+# cleopatra 0.28 deprecated these loose colour-bar kwargs in favour of ``ColorBar``
+# fields (see the routing rationale in ``render_array``). Module-level so the frozen
+# set is built once, not rebuilt on every plot call.
+_DEPRECATED_CBAR_KWARGS = frozenset(
+    {
+        "cbar_label",
+        "cbar_length",
+        "cbar_label_size",
+        "cbar_label_rotation",
+        "cbar_label_location",
+        "cbar_orientation",
+        "ticks_spacing",
+    }
+)
+
+
 def render_array(
     *,
     arr: np.ndarray | None,
@@ -536,23 +552,15 @@ def render_array(
     # ``ColorBar`` fields, and emits the ``DeprecationWarning`` only inside
     # ``.plot`` / ``.animate`` — never the constructor. Because they are in
     # ``option_keys()``, routing them to the constructor (like every other
-    # option) would *suppress* that warning on the single-frame plot/facet path,
-    # while the animate path — which merges every kwarg into the render call —
-    # still warned. The same ``cbar_label=`` then warned on an animation but not
-    # on a plain plot. Force them to the render call so cleopatra's deprecation
-    # fires uniformly; they still render (cleopatra folds them into
+    # option) suppressed that warning on the single-frame ``plot`` path, while the
+    # animate path — which merges every kwarg into the render call — still warned.
+    # The same ``cbar_label=`` then warned on an animation but not on a plain plot.
+    # Force them to the render call so cleopatra's deprecation fires on both the
+    # ``plot`` and ``animate`` paths; they still render (cleopatra folds them into
     # ``default_options`` there). Prefer ``colorbar=ColorBar(...)`` instead.
-    _DEPRECATED_CBAR_KWARGS = frozenset(
-        {
-            "cbar_label",
-            "cbar_length",
-            "cbar_label_size",
-            "cbar_label_rotation",
-            "cbar_label_location",
-            "cbar_orientation",
-            "ticks_spacing",
-        }
-    )
+    # NOTE: the ``facet`` path stays silent — cleopatra's ``ArrayGlyph.facet``
+    # forwards these to each per-panel *constructor* (not ``.plot``), which does
+    # not emit the deprecation; they still render on every panel's shared bar.
     RENDER_ONLY_OVERRIDES = {"kind"} | _DEPRECATED_CBAR_KWARGS
     # Reuse the option set resolved for the style/hillshade guard above — it is
     # cleopatra's declared constructor options and does not change within a call.

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -255,9 +255,7 @@ def _migrate_deprecated_plot_specs(
     sees the loose kwargs, so its own deprecation never fires — no double warning.
     """
     cbar = {
-        _CBAR_TO_COLORBAR[k]: kwargs.pop(k)
-        for k in list(_CBAR_TO_COLORBAR)
-        if k in kwargs
+        _CBAR_TO_COLORBAR[k]: kwargs.pop(k) for k in _CBAR_TO_COLORBAR if k in kwargs
     }
     if cbar:
         existing = kwargs.get("colorbar")
@@ -290,9 +288,7 @@ def _migrate_deprecated_plot_specs(
             kwargs["colorbar"] = colorbar_cls(**cbar)
 
     style = {
-        _POINT_TO_OVERLAY[k]: kwargs.pop(k)
-        for k in list(_POINT_TO_OVERLAY)
-        if k in kwargs
+        _POINT_TO_OVERLAY[k]: kwargs.pop(k) for k in _POINT_TO_OVERLAY if k in kwargs
     }
     if style:
         points = kwargs.get("points")

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -59,6 +59,7 @@ and pass nothing to the constructor.
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
@@ -211,20 +212,96 @@ def _guard_style_hillshade(kwargs: dict[str, Any], option_keys: Any) -> None:
         )
 
 
-# cleopatra 0.28 deprecated these loose colour-bar kwargs in favour of ``ColorBar``
-# fields (see the routing rationale in ``render_array``). Module-level so the frozen
-# set is built once, not rebuilt on every plot call.
-_DEPRECATED_CBAR_KWARGS = frozenset(
-    {
-        "cbar_label",
-        "cbar_length",
-        "cbar_label_size",
-        "cbar_label_rotation",
-        "cbar_label_location",
-        "cbar_orientation",
-        "ticks_spacing",
+# Loose plot kwargs cleopatra 0.28 deprecated in favour of the typed specs
+# (ColorBar / PointOverlay). ``render_array`` translates them to the spec at the
+# render boundary (see ``_migrate_deprecated_plot_specs``) so cleopatra only ever
+# sees the typed form — no double DeprecationWarning — and the loose forms are
+# steered off in one place for every raster plot / animate path. The maps mirror
+# cleopatra's own loose-kwarg -> spec-field mapping.
+_CBAR_TO_COLORBAR = {
+    "cbar_label": "label",
+    "cbar_length": "length",
+    "cbar_label_size": "label_size",
+    "cbar_label_rotation": "label_rotation",
+    "cbar_label_location": "label_location",
+    "cbar_orientation": "orientation",
+    "ticks_spacing": "ticks_spacing",
+}
+_POINT_TO_OVERLAY = {
+    "point_color": "color",
+    "point_size": "size",
+    "point_label_color": "label_color",
+    "point_label_size": "label_size",
+    "pid_color": "label_color",
+    "pid_size": "label_size",
+}
+
+
+def _migrate_deprecated_plot_specs(
+    kwargs: dict[str, Any], colorbar_cls: Any, point_overlay_cls: Any
+) -> None:
+    """Fold deprecated loose ``cbar_*`` / ``point_*`` kwargs into the typed specs.
+
+    Mutates ``kwargs`` in place: the loose keys are popped and, when no explicit
+    ``colorbar=`` / ``points=`` was given, folded into a ``ColorBar`` /
+    ``PointOverlay``. Emits a pyramids ``DeprecationWarning`` naming the typed
+    replacement. When an explicit ``colorbar=`` (any value) or a ``PointOverlay``
+    was also passed, the loose keys are dropped and the explicit value wins (the
+    warning says so). Cleopatra therefore never sees the loose kwargs, so its own
+    deprecation never fires — no double warning.
+    """
+    cbar = {
+        _CBAR_TO_COLORBAR[k]: kwargs.pop(k)
+        for k in list(_CBAR_TO_COLORBAR)
+        if k in kwargs
     }
-)
+    if cbar:
+        if "colorbar" in kwargs:
+            warnings.warn(
+                "The loose cbar_* / ticks_spacing kwargs are deprecated and were "
+                "ignored because colorbar= was also given; set them on the "
+                "pyramids.plot.ColorBar instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+        else:
+            warnings.warn(
+                "The loose cbar_* / ticks_spacing kwargs are deprecated; pass "
+                "colorbar=pyramids.plot.ColorBar(...) instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            kwargs["colorbar"] = colorbar_cls(**cbar)
+
+    style = {
+        _POINT_TO_OVERLAY[k]: kwargs.pop(k)
+        for k in list(_POINT_TO_OVERLAY)
+        if k in kwargs
+    }
+    if style:
+        points = kwargs.get("points")
+        if isinstance(points, point_overlay_cls):
+            warnings.warn(
+                "The loose point_* / pid_* kwargs are deprecated and were ignored "
+                "because points= is already a PointOverlay; set them on it instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+        elif points is None:
+            warnings.warn(
+                "The loose point_* / pid_* kwargs are deprecated and have no effect "
+                "without points=; pass points=pyramids.plot.PointOverlay(points, ...).",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+        else:
+            warnings.warn(
+                "The loose point_* / pid_* kwargs are deprecated; pass "
+                "points=pyramids.plot.PointOverlay(points, ...) instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            kwargs["points"] = point_overlay_cls(points, **style)
 
 
 def render_array(
@@ -441,8 +518,27 @@ def render_array(
             ```
     """
     require_cleopatra()
-    from cleopatra.array_glyph import ArrayGlyph
+    from cleopatra.array_glyph import ArrayGlyph, ColorBar, PointOverlay
+    from cleopatra.geo import Basemap
     from cleopatra.styles import ColorScale
+
+    # Deprecate + translate the loose plot kwargs to the typed specs (cbar_* ->
+    # ColorBar, point_*/pid_* -> PointOverlay, dict basemap -> Basemap) so every
+    # raster plot/animate call is steered onto the typed API in one place and
+    # cleopatra only ever sees the typed form. The facet path is skipped:
+    # cleopatra's ``ArrayGlyph.facet`` does not accept ``colorbar=ColorBar`` /
+    # ``PointOverlay`` (only the loose ``cbar_*`` kwargs, like the mesh glyph), so
+    # faceting keeps the loose forms — there is no typed alternative there.
+    if mode != "facet":
+        _migrate_deprecated_plot_specs(kwargs, ColorBar, PointOverlay)
+    if isinstance(basemap, dict) and basemap:
+        warnings.warn(
+            "Passing a dict as basemap= is deprecated; pass "
+            "basemap=pyramids.plot.Basemap(...) instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        basemap = Basemap(**basemap)
 
     valid_modes = ("plot", "animate", "facet")
     if mode not in valid_modes:
@@ -548,20 +644,13 @@ def render_array(
     # render method only overwrites ``default_options["title"]`` when its
     # ``title`` arg is not ``None``, so a constructor-set title survives and
     # routing it to the constructor (via ``option_keys()``) is correct.
-    # cleopatra 0.28 deprecated these loose colour-bar kwargs in favour of
-    # ``ColorBar`` fields, and emits the ``DeprecationWarning`` only inside
-    # ``.plot`` / ``.animate`` — never the constructor. Because they are in
-    # ``option_keys()``, routing them to the constructor (like every other
-    # option) suppressed that warning on the single-frame ``plot`` path, while the
-    # animate path — which merges every kwarg into the render call — still warned.
-    # The same ``cbar_label=`` then warned on an animation but not on a plain plot.
-    # Force them to the render call so cleopatra's deprecation fires on both the
-    # ``plot`` and ``animate`` paths; they still render (cleopatra folds them into
-    # ``default_options`` there). Prefer ``colorbar=ColorBar(...)`` instead.
-    # NOTE: the ``facet`` path stays silent — cleopatra's ``ArrayGlyph.facet``
-    # forwards these to each per-panel *constructor* (not ``.plot``), which does
-    # not emit the deprecation; they still render on every panel's shared bar.
-    RENDER_ONLY_OVERRIDES = {"kind"} | _DEPRECATED_CBAR_KWARGS
+    # ``kind`` is force-routed to the render call. The deprecated loose cbar_*
+    # kwargs are too — but only the ``facet`` path still carries them here (plot /
+    # animate already folded them into ``colorbar=ColorBar(...)`` above, so this is
+    # a no-op there). cleopatra's ``facet`` renders them only when they reach the
+    # facet *call* (its per-panel constructors), so force-routing keeps the loose
+    # cbar_* rendering on facet instead of being dropped on the parent constructor.
+    RENDER_ONLY_OVERRIDES = {"kind", *_CBAR_TO_COLORBAR}
     # Reuse the option set resolved for the style/hillshade guard above — it is
     # cleopatra's declared constructor options and does not change within a call.
     ctor_option_keys = option_keys

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -1111,20 +1111,8 @@ class RasterBase(ABC):
                     Colour-bar spec ``pyramids.plot.ColorBar(label=..., length=..., orientation=...,
                     label_size=..., label_rotation=..., label_location=..., ticks_spacing=...)``
                     (cleopatra >= 0.28) — the complete, preferred replacement for the loose ``cbar_*`` /
-                    ``orientation`` / ``rotation`` / ``ticks_spacing`` kwargs below. ``False`` hides the
-                    bar, ``None`` uses the default.
-                orientation (str, optional):
-                    Orientation of the color bar horizontal/vertical. The default is 'vertical'.
-                rotation (number, optional):
-                    Rotation of the color bar label. The default is -90.
-                cbar_length (float, optional):
-                    Ratio to control the height of the color bar. The default is 0.75.
-                ticks_spacing (int, optional):
-                    Spacing in the color bar ticks. The default is 2.
-                cbar_label_size (int, optional):
-                    Size of the color bar label. The default is 12.
-                cbar_label (str, optional):
-                    Label of the color bar. The default is 'Discharge m3/s'.
+                    ``ticks_spacing`` kwargs, which are deprecated (still accepted, but they emit a
+                    ``DeprecationWarning``). ``False`` hides the bar, ``None`` uses the default.
                 color_scale (str, optional):
                     Color-scale mode. One of "linear", "power", "sym-lognorm", "boundary-norm", "midpoint"
                     (case-insensitive), or a ``cleopatra.styles.ColorScale`` member. Integer codes are no

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -1097,10 +1097,11 @@ class RasterBase(ABC):
                     the point, the second is the rows index of the point in the array, and the third column as
                     the column index in the array. The second and third columns tell the location of the point
                     in the array. To style the points, pass a
-                    ``cleopatra.array_glyph.PointOverlay(points, color=..., size=..., label_color=...,
-                    label_size=...)`` instead — on cleopatra >= 0.26 the loose ``point_color`` /
-                    ``point_size`` / ``pid_color`` / ``pid_size`` kwargs are deprecated; set the styling on
-                    the ``PointOverlay`` instead.
+                    ``pyramids.plot.PointOverlay(points, color=..., size=..., label_color=...,
+                    label_size=...)`` instead — pyramids folds the loose ``point_color`` / ``point_size`` /
+                    ``point_label_color`` / ``point_label_size`` / ``pid_color`` / ``pid_size`` kwargs into a
+                    ``PointOverlay`` and emits a ``DeprecationWarning``; set the styling on the
+                    ``PointOverlay`` instead.
                 figsize (tuple, optional):
                     Figure size. The default is (8, 8).
                 title (str, optional):

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -46,7 +46,8 @@ from pyramids.dataset.ops.io import _read_chunk
 from pyramids.feature import FeatureCollection
 
 if TYPE_CHECKING:
-    from cleopatra.array_glyph import ArrayGlyph
+    from cleopatra.array_glyph import ArrayGlyph, FrameLabel
+    from cleopatra.geo import Basemap
     from dask.delayed import Delayed
 
 
@@ -2425,6 +2426,8 @@ class DatasetCollection:
         cutoff: list | None = None,
         percentile: int | None = None,
         rgb_options: dict | None = None,
+        basemap: bool | str | dict[str, Any] | Basemap | None = None,
+        frame_label: FrameLabel | None = None,
         **kwargs: Any,
     ) -> ArrayGlyph:
         r"""Render the collection as an animated stack of band slices.
@@ -2491,6 +2494,20 @@ class DatasetCollection:
                 ``"cutoff"``, ``"percentile"``. Mirrors
                 :meth:`Dataset.plot`. On collision with a loose kwarg the
                 ``rgb_options`` value wins. Default ``None``.
+            basemap (bool, str, or Basemap, optional):
+                Reference layer under the animation, dispatched by type. ``True``
+                or a tile-provider string (e.g. ``"CartoDB.Positron"``) overlays a
+                pyramids web-tile basemap; a ``pyramids.plot.Basemap(relief=...,
+                features=...)`` (cleopatra >= 0.28) draws a shaded-relief /
+                coastline layer instead. The base raster's CRS is supplied
+                automatically. Default ``None`` (no basemap). Requires the
+                ``[viz]`` extra.
+            frame_label (FrameLabel, optional):
+                Typed per-frame label spec ``pyramids.plot.FrameLabel(...)``
+                (cleopatra >= 0.28) that styles the animation's frame caption
+                (colour, size, placement). ``animation_axis_values`` sets the
+                label *text* per frame; ``frame_label`` styles it. Default
+                ``None`` (cleopatra's default frame label).
             **kwargs:
                 | Parameter                  | Type                  | Description |
                 |----------------------------|-----------------------|-------------|
@@ -2603,6 +2620,17 @@ class DatasetCollection:
                 f"animation_axis_values has {len(axis_values)} labels but the "
                 f"collection has {self.time_length} timesteps."
             )
+        # Forward the basemap + typed animate spec once to both render paths.
+        # ``basemap`` type-dispatches in render_array (str/True -> web tiles,
+        # ``Basemap`` -> relief); ``basemap_epsg`` comes from the base raster so a
+        # collection basemap always has a CRS. ``frame_label`` is only forwarded when
+        # set, so cleopatra keeps its default per-frame label otherwise.
+        animate_extras: dict[str, Any] = {
+            "basemap": basemap,
+            "basemap_epsg": self.base.epsg,
+        }
+        if frame_label is not None:
+            animate_extras["frame_label"] = frame_label
         # Materialise the cube on demand for plotting. The render helper
         # expects a single (time, rows, cols) numpy array; reading each
         # Dataset's band into one stacked array is fine for a plot call
@@ -2644,7 +2672,7 @@ class DatasetCollection:
                 percentile=percentile,
                 mode="animate",
                 animation_axis_values=axis_values,
-                basemap_epsg=self.base.epsg,
+                **animate_extras,
                 **kwargs,
             )
         data = np.stack([ds.read_array(band=band) for ds in self.datasets], axis=0)
@@ -2665,7 +2693,7 @@ class DatasetCollection:
             exclude_value=exclude_value,
             mode="animate",
             animation_axis_values=axis_values,
-            basemap_epsg=self.base.epsg,
+            **animate_extras,
             **kwargs,
         )
 

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -2499,13 +2499,7 @@ class DatasetCollection:
                 | figsize                    | tuple, optional       | Figure size. Default is `(8, 8)`. |
                 | title                      | str, optional         | Title of the plot. Default is `'Total Discharge'`. |
                 | title_size                 | int, optional         | Title size. Default is `15`. |
-                | orientation                | str, optional         | Orientation of the color bar (`horizontal` or `vertical`). Default is `'vertical'`. |
-                | rotation                   | number, optional      | Rotation of the color bar label. Default is `-90`. |
-                | colorbar                   | bool \| ColorBar, optional | Colour-bar spec `pyramids.plot.ColorBar(label=…, length=…, orientation=…, label_size=…, label_rotation=…, label_location=…, ticks_spacing=…)` (cleopatra >= 0.28) — the complete, preferred replacement for the loose `cbar_*` / `orientation` / `rotation` / `ticks_spacing` kwargs. `False` hides it, `None` uses the default. |
-                | cbar_length                | float, optional       | Ratio to control the height of the color bar. Default is `0.75`. |
-                | ticks_spacing              | int, optional         | Spacing in the color bar ticks. Default is `2`. |
-                | cbar_label_size            | int, optional         | Size of the color bar label. Default is `12`. |
-                | cbar_label                 | str, optional         | Label of the color bar. Default is `'Discharge m³/s'`. |
+                | colorbar                   | bool \| ColorBar, optional | Colour-bar spec `pyramids.plot.ColorBar(label=…, length=…, orientation=…, label_size=…, label_rotation=…, label_location=…, ticks_spacing=…)` (cleopatra >= 0.28). The loose `cbar_*` / `ticks_spacing` kwargs it replaces are deprecated — still accepted, but they emit a `DeprecationWarning`. `False` hides it, `None` uses the default. |
                 | color_scale                | str, optional         | Color-scale mode (default `"linear"`): one of `"linear"`, `"power"`, `"sym-lognorm"`, `"boundary-norm"`, `"midpoint"` (case-insensitive), or a `cleopatra.styles.ColorScale` member. Integer codes are no longer accepted. |
                 | gamma                      | float, optional       | Exponent for `color_scale="power"`. Default is `1/2`. |
                 | line_threshold             | float, optional       | `linthresh` for `color_scale="sym-lognorm"`. Default is `0.0001`. |

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -855,8 +855,9 @@ class Dataset(RasterBase):
                 Reference layer, dispatched by type. ``True`` or a tile-provider string
                 (e.g. ``"CartoDB.Positron"``) overlays a pyramids web-tile basemap. A
                 ``pyramids.plot.Basemap(relief=..., features=...)`` (cleopatra >= 0.28)
-                draws a shaded-relief / coastline layer instead. Default is ``None``.
-                Requires the ``[viz]`` extra.
+                draws a shaded-relief / coastline layer instead. Passing a ``dict`` here is
+                a deprecated alias for ``Basemap`` (emits a ``DeprecationWarning``). Default
+                is ``None``. Requires the ``[viz]`` extra.
             rgb_options (dict, optional):
                 Grouped Sentinel-imagery kwargs. Accepted keys:
                 ``"rgb"``, ``"surface_reflectance"``, ``"cutoff"``,

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -2009,9 +2009,10 @@ class Analysis(_Engine["Dataset"]):
                 Configure the colour bar through ``colorbar=ColorBar(label=..., length=...,
                 orientation=..., label_size=..., label_rotation=..., label_location=...,
                 ticks_spacing=...)``. The loose ``cbar_*`` / ``ticks_spacing`` kwargs it replaces
-                are deprecated (cleopatra >= 0.28): still accepted for now — and emit a
-                ``DeprecationWarning`` on the ``plot`` / ``animate`` render paths — but are no
-                longer listed below. Migrate to ``ColorBar``.
+                are deprecated: pyramids still accepts them but folds them into a ``ColorBar``
+                and emits a ``DeprecationWarning``, so they are no longer listed below. The
+                same applies to ``point_*`` -> ``PointOverlay`` and a ``dict`` basemap ->
+                ``Basemap``. Migrate to the typed specs.
                 | Parameter                   | Type                | Description |
                 |-----------------------------|---------------------|-------------|
                 | `points`                    | array \\| PointOverlay | Point overlay. A 3-column array (value to display, row index, column index) draws unstyled points. To style them, pass a `cleopatra.array_glyph.PointOverlay(points, color=..., size=..., label_color=..., label_size=...)` instead — on cleopatra >= 0.26 the loose `point_color` / `point_size` / `pid_color` / `pid_size` kwargs are deprecated; set the styling on the `PointOverlay` instead. |

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -2015,7 +2015,7 @@ class Analysis(_Engine["Dataset"]):
                 ``Basemap``. Migrate to the typed specs.
                 | Parameter                   | Type                | Description |
                 |-----------------------------|---------------------|-------------|
-                | `points`                    | array \\| PointOverlay | Point overlay. A 3-column array (value to display, row index, column index) draws unstyled points. To style them, pass a `cleopatra.array_glyph.PointOverlay(points, color=..., size=..., label_color=..., label_size=...)` instead — on cleopatra >= 0.26 the loose `point_color` / `point_size` / `pid_color` / `pid_size` kwargs are deprecated; set the styling on the `PointOverlay` instead. |
+                | `points`                    | array \\| PointOverlay | Point overlay. A 3-column array (value to display, row index, column index) draws unstyled points. To style them, pass a `pyramids.plot.PointOverlay(points, color=..., size=..., label_color=..., label_size=...)` instead — pyramids folds the loose `point_color` / `point_size` / `point_label_color` / `point_label_size` / `pid_color` / `pid_size` kwargs into a `PointOverlay` and emits a `DeprecationWarning`; set the styling on the `PointOverlay` instead. |
                 | `figsize`                   | tuple, optional     | Figure size. Default is `(8, 8)`. |
                 | `title`                     | str, optional       | Title of the plot. Default is `'Total Discharge'`. |
                 | `title_size`                | int, optional       | Title size. Default is `15`. |

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -2009,8 +2009,9 @@ class Analysis(_Engine["Dataset"]):
                 Configure the colour bar through ``colorbar=ColorBar(label=..., length=...,
                 orientation=..., label_size=..., label_rotation=..., label_location=...,
                 ticks_spacing=...)``. The loose ``cbar_*`` / ``ticks_spacing`` kwargs it replaces
-                are deprecated (cleopatra >= 0.28): still accepted for now, but they emit a
-                ``DeprecationWarning`` and are no longer listed below — migrate to ``ColorBar``.
+                are deprecated (cleopatra >= 0.28): still accepted for now — and emit a
+                ``DeprecationWarning`` on the ``plot`` / ``animate`` render paths — but are no
+                longer listed below. Migrate to ``ColorBar``.
                 | Parameter                   | Type                | Description |
                 |-----------------------------|---------------------|-------------|
                 | `points`                    | array \\| PointOverlay | Point overlay. A 3-column array (value to display, row index, column index) draws unstyled points. To style them, pass a `cleopatra.array_glyph.PointOverlay(points, color=..., size=..., label_color=..., label_size=...)` instead — on cleopatra >= 0.26 the loose `point_color` / `point_size` / `pid_color` / `pid_size` kwargs are deprecated; set the styling on the `PointOverlay` instead. |
@@ -2028,7 +2029,7 @@ class Analysis(_Engine["Dataset"]):
                 | `num_size`                  | int, optional       | Size of numbers plotted on top of each cell. Default is `8`. |
                 | `background_color_threshold`| float or int, optional | Threshold for deciding text color over cells: if value > threshold -> black text; else white text. If `None`, max value / 2 is used. Default is `None`. |
                 | `add_colorbar`              | bool, optional      | Whether to draw the colour bar. Default is `True`. When `False`, no colorbar is created and the returned glyph's `cbar` is `None`. |
-                | `colorbar`                  | bool \\| ColorBar, optional | Colour-bar spec `pyramids.plot.ColorBar(label=…, length=…, orientation=…, label_size=…, label_rotation=…, label_location=…, ticks_spacing=…)` (cleopatra >= 0.28) — the complete, preferred replacement for the loose `cbar_*` kwargs. `False` hides it, `None` uses the default. |
+                | `colorbar`                  | bool \\| ColorBar, optional | Colour-bar spec `pyramids.plot.ColorBar(label=…, length=…, orientation=…, label_size=…, label_rotation=…, label_location=…, ticks_spacing=…)` (cleopatra >= 0.28) — the complete, preferred replacement for the loose `cbar_*` / `ticks_spacing` kwargs. `False` hides it, `None` uses the default. |
                 | `full_bleed`                | bool \\| str, optional | cleopatra >= 0.28 chrome-free layout: drop axes/margins so the array fills the figure. Default `False`. |
         Returns:
             ArrayGlyph:

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -2008,20 +2008,15 @@ class Analysis(_Engine["Dataset"]):
                 re-exported from ``pyramids.plot`` — import them from there rather than cleopatra.
                 Configure the colour bar through ``colorbar=ColorBar(label=..., length=...,
                 orientation=..., label_size=..., label_rotation=..., label_location=...,
-                ticks_spacing=...)`` (cleopatra >= 0.28); the loose ``cbar_*`` / ``orientation`` /
-                ``rotation`` / ``ticks_spacing`` rows below are the deprecated aliases it replaces.
+                ticks_spacing=...)``. The loose ``cbar_*`` / ``ticks_spacing`` kwargs it replaces
+                are deprecated (cleopatra >= 0.28): still accepted for now, but they emit a
+                ``DeprecationWarning`` and are no longer listed below — migrate to ``ColorBar``.
                 | Parameter                   | Type                | Description |
                 |-----------------------------|---------------------|-------------|
                 | `points`                    | array \\| PointOverlay | Point overlay. A 3-column array (value to display, row index, column index) draws unstyled points. To style them, pass a `cleopatra.array_glyph.PointOverlay(points, color=..., size=..., label_color=..., label_size=...)` instead — on cleopatra >= 0.26 the loose `point_color` / `point_size` / `pid_color` / `pid_size` kwargs are deprecated; set the styling on the `PointOverlay` instead. |
                 | `figsize`                   | tuple, optional     | Figure size. Default is `(8, 8)`. |
                 | `title`                     | str, optional       | Title of the plot. Default is `'Total Discharge'`. |
                 | `title_size`                | int, optional       | Title size. Default is `15`. |
-                | `orientation`               | str, optional       | Orientation of the color bar (`horizontal` or `vertical`). Default is `'vertical'`. |
-                | `rotation`                  | number, optional    | Rotation of the color bar label. Default is `-90`. |
-                | `cbar_length`               | float, optional     | Ratio to control the height of the color bar. Default is `0.75`. |
-                | `ticks_spacing`             | int, optional       | Spacing between color bar ticks. Default is `2`. |
-                | `cbar_label_size`           | int, optional       | Size of the color bar label. Default is `12`. |
-                | `cbar_label`                | str, optional       | Label of the color bar. Default is `'Discharge m\u00b3/s'`. |
                 | `color_scale`               | str, optional       | Color-scale mode. One of `"linear"`, `"power"`, `"sym-lognorm"`, `"boundary-norm"`, `"midpoint"` (case-insensitive), or a `cleopatra.styles.ColorScale` member. Integer codes are no longer accepted. Default is `"linear"`. |
                 | `gamma`                     | float, optional     | Exponent for the `"power"` color scale. Default is `1/2`. |
                 | `line_threshold`            | float, optional     | `linthresh` for the `"sym-lognorm"` color scale. Default is `0.0001`. |

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1735,7 +1735,11 @@ class NetCDF(Dataset):
                 the dim to animate along. ``None`` (default) returns a
                 static plot. Mutually exclusive with faceting and with
                 any selector that pins the animated dim. Defaults to
-                None.
+                None. On this animate path a
+                ``frame_label=pyramids.plot.FrameLabel(...)`` (cleopatra
+                >= 0.28) kwarg styles the per-frame caption — colour,
+                size and placement — and is forwarded to cleopatra's
+                animate call.
             chunks (Any, optional):
                 Chunking spec forwarded to :meth:`read_array` for the
                 static-plot path. ``None`` (default) preserves the eager

--- a/tests/dataset/collection/test_plot_labels.py
+++ b/tests/dataset/collection/test_plot_labels.py
@@ -67,6 +67,37 @@ class TestPlotAnimationAxisValues:
             cube.plot(band=0, basemap="CartoDB.Positron")
         assert render.call_args.kwargs["basemap_epsg"] == cube.base.epsg
 
+    def test_forwards_named_basemap_and_frame_label(self):
+        """`plot` forwards the named `basemap` and `frame_label` to `render_array`."""
+        cube = _collection(3)
+        marker = object()
+        with patch("pyramids.dataset.collection.render_array") as render:
+            cube.plot(band=0, basemap="CartoDB.Positron", frame_label=marker)
+        kwargs = render.call_args.kwargs
+        assert kwargs["basemap"] == "CartoDB.Positron"
+        assert kwargs["frame_label"] is marker
+
+    def test_forwards_named_basemap_and_frame_label_rgb(self):
+        """The named `basemap` / `frame_label` reach `render_array` on the RGB path too."""
+        cube = _collection(2, bands=3)
+        marker = object()
+        with patch("pyramids.dataset.collection.render_array") as render:
+            cube.plot(
+                rgb_options={"rgb": [0, 1, 2], "surface_reflectance": 255},
+                basemap="CartoDB.Positron",
+                frame_label=marker,
+            )
+        kwargs = render.call_args.kwargs
+        assert kwargs["basemap"] == "CartoDB.Positron"
+        assert kwargs["frame_label"] is marker
+
+    def test_frame_label_omitted_when_none(self):
+        """`frame_label=None` (default) is not forwarded, so cleopatra keeps its default."""
+        cube = _collection(3)
+        with patch("pyramids.dataset.collection.render_array") as render:
+            cube.plot(band=0)
+        assert "frame_label" not in render.call_args.kwargs
+
     def test_defaults_to_time_axis_when_present(self):
         """When the collection carries a time axis, plot labels frames by it."""
         cube = _collection(3)

--- a/tests/dataset/plot/test_basemap_dispatch.py
+++ b/tests/dataset/plot/test_basemap_dispatch.py
@@ -61,14 +61,14 @@ class TestBasemapDispatch:
         assert not mock_add.called, "a Basemap must not go through the tile path"
         assert glyph is not None
 
-    def test_dict_basemap_is_forwarded_not_tiled(self):
-        """A dict (the equivalent of a Basemap spec) also forwards, not tiled."""
+    def test_dict_basemap_is_translated_to_basemap_not_tiled(self):
+        """A dict basemap is deprecated, translated to a Basemap, and forwarded (not tiled)."""
         captured, spy = self._spy_on("plot")
-        basemap = {"relief": False}
         with patch.object(ArrayGlyph, "plot", spy):
             with patch("pyramids.basemap.basemap.add_basemap") as mock_add:
-                self._dataset().plot(band=0, basemap=basemap)
-        assert captured.get("basemap") == basemap
+                with pytest.warns(DeprecationWarning, match="dict as basemap"):
+                    self._dataset().plot(band=0, basemap={"relief": False})
+        assert isinstance(captured.get("basemap"), Basemap)
         assert not mock_add.called
 
     def test_no_basemap_draws_no_tiles(self):
@@ -168,22 +168,22 @@ class TestBasemapDispatch:
             )
         assert captured.get("basemap") is basemap
 
-    def test_dict_basemap_reaches_the_animate_render_call(self):
-        """A dict basemap on the animate path forwards to `cleo.animate(basemap=)`."""
+    def test_dict_basemap_translated_to_basemap_on_animate(self):
+        """A dict basemap on animate is translated to a Basemap and forwarded to cleo.animate."""
         captured, spy = self._spy_on("animate")
-        basemap = {"relief": False}
         stack = np.random.default_rng(4).random((3, 6, 6)).astype("float32")
         with patch.object(ArrayGlyph, "animate", spy):
             with patch("pyramids.basemap.basemap.add_basemap") as mock_add:
-                render_array(
-                    arr=stack,
-                    mode="animate",
-                    animation_axis_values=[0, 1, 2],
-                    basemap=basemap,
-                    basemap_epsg=4326,
-                    extent=[0.0, 0.0, 1.0, 1.0],
-                )
-        assert captured.get("basemap") == basemap
+                with pytest.warns(DeprecationWarning, match="dict as basemap"):
+                    render_array(
+                        arr=stack,
+                        mode="animate",
+                        animation_axis_values=[0, 1, 2],
+                        basemap={"relief": False},
+                        basemap_epsg=4326,
+                        extent=[0.0, 0.0, 1.0, 1.0],
+                    )
+        assert isinstance(captured.get("basemap"), Basemap)
         assert not mock_add.called
 
     def test_tile_basemap_on_facet_draws_per_visible_panel(self):

--- a/tests/dataset/plot/test_new_render_params.py
+++ b/tests/dataset/plot/test_new_render_params.py
@@ -87,14 +87,12 @@ class TestNewRenderParams:
         )
         assert isinstance(result, ArrayGlyph)
 
-    def test_deprecated_cbar_kwarg_routes_to_the_render_call(self):
-        """A loose `cbar_*` kwarg reaches `ArrayGlyph.plot`, not the constructor.
+    def test_deprecated_cbar_kwarg_folds_into_colorbar_and_renders(self):
+        """A loose `cbar_*` kwarg is folded into `colorbar=ColorBar(...)` and still renders.
 
-        The loose colour-bar kwargs are in `option_keys()`, so the default split would
-        route them to the constructor — where cleopatra's own `cbar_*` deprecation never
-        fires (it warns only from the render method). `render_array` forces them to the
-        render call so the deprecation surfaces uniformly; assert they get there and the
-        label still renders (behaviour preserved). Prefer `colorbar=ColorBar(...)`.
+        `render_array` translates the deprecated loose colour-bar kwargs into a typed
+        ColorBar before the cleopatra call (so cleopatra never sees the loose form); the
+        folded spec still renders the label.
         """
         captured: dict = {}
         original = ArrayGlyph.plot
@@ -104,17 +102,32 @@ class TestNewRenderParams:
             return original(self, *args, **kwargs)
 
         with patch.object(ArrayGlyph, "plot", spy):
-            glyph = self._dataset().plot(band=0, cbar_label="mm")
-        assert "cbar_label" in captured, "loose cbar_label must reach the render call"
+            with pytest.warns(DeprecationWarning, match="cbar_"):
+                glyph = self._dataset().plot(band=0, cbar_label="mm", cbar_length=0.85)
+        assert "cbar_label" not in captured, (
+            "loose cbar_label must be folded away, not passed loose"
+        )
+        assert isinstance(captured.get("colorbar"), ColorBar), (
+            "cbar_* must fold into a ColorBar"
+        )
         label = glyph.cbar.ax.get_ylabel() or glyph.cbar.ax.get_xlabel()
-        assert label == "mm", f"colour-bar label should still render, got {label!r}"
+        assert label == "mm", f"folded ColorBar label should render, got {label!r}"
+
+    def test_explicit_colorbar_wins_over_loose_cbar(self):
+        """An explicit `colorbar=ColorBar` wins; the loose `cbar_*` are dropped (deprecated)."""
+        with pytest.warns(DeprecationWarning, match="ignored because colorbar"):
+            glyph = self._dataset().plot(
+                band=0, colorbar=ColorBar(label="TYPED"), cbar_label="LOOSE"
+            )
+        label = glyph.cbar.ax.get_ylabel() or glyph.cbar.ax.get_xlabel()
+        assert label == "TYPED", f"explicit ColorBar should win, got {label!r}"
 
     def test_deprecated_cbar_kwarg_renders_on_the_facet_path(self):
         """A loose `cbar_*` kwarg still renders the shared colour-bar label on the facet path.
 
-        cleopatra's `facet` forwards these to each per-panel constructor (not `.plot`), so the
-        deprecation does not fire there — but the label must still render: `cbar_label` reaches
-        `cleo.facet(...)`, and the returned grid's shared colour bar carries it.
+        cleopatra's `facet` does not accept `colorbar=ColorBar` (only the loose `cbar_*`
+        kwargs), so the translation is skipped on the facet path — the loose form is kept,
+        and the returned grid's shared colour bar still carries the label.
         """
         stack = np.random.default_rng(3).random((3, 6, 6)).astype("float32")
         result = render_array(

--- a/tests/dataset/plot/test_new_render_params.py
+++ b/tests/dataset/plot/test_new_render_params.py
@@ -108,3 +108,22 @@ class TestNewRenderParams:
         assert "cbar_label" in captured, "loose cbar_label must reach the render call"
         label = glyph.cbar.ax.get_ylabel() or glyph.cbar.ax.get_xlabel()
         assert label == "mm", f"colour-bar label should still render, got {label!r}"
+
+    def test_deprecated_cbar_kwarg_renders_on_the_facet_path(self):
+        """A loose `cbar_*` kwarg still renders the shared colour-bar label on the facet path.
+
+        cleopatra's `facet` forwards these to each per-panel constructor (not `.plot`), so the
+        deprecation does not fire there — but the label must still render. This routing fixed a
+        latent drop where a facet `cbar_label` was previously routed to the parent constructor
+        and never forwarded into `cleo.facet`.
+        """
+        stack = np.random.default_rng(3).random((3, 6, 6)).astype("float32")
+        result = render_array(
+            arr=stack,
+            mode="facet",
+            facet_kwargs={"col": "time", "col_coords": [0, 1, 2]},
+            cbar_label="mm",
+            extent=[0.0, 0.0, 1.0, 1.0],
+        )
+        label = result.cbar.ax.get_ylabel() or result.cbar.ax.get_xlabel()
+        assert label == "mm", f"facet colour-bar label should render, got {label!r}"

--- a/tests/dataset/plot/test_new_render_params.py
+++ b/tests/dataset/plot/test_new_render_params.py
@@ -5,6 +5,8 @@ its `**kwargs` pass-through; cleopatra rejects an unknown kwarg, so a clean rend
 proves the param reached the glyph rather than being dropped.
 """
 
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 
@@ -84,3 +86,25 @@ class TestNewRenderParams:
             extent=[0.0, 0.0, 1.0, 1.0],
         )
         assert isinstance(result, ArrayGlyph)
+
+    def test_deprecated_cbar_kwarg_routes_to_the_render_call(self):
+        """A loose `cbar_*` kwarg reaches `ArrayGlyph.plot`, not the constructor.
+
+        The loose colour-bar kwargs are in `option_keys()`, so the default split would
+        route them to the constructor — where cleopatra's own `cbar_*` deprecation never
+        fires (it warns only from the render method). `render_array` forces them to the
+        render call so the deprecation surfaces uniformly; assert they get there and the
+        label still renders (behaviour preserved). Prefer `colorbar=ColorBar(...)`.
+        """
+        captured: dict = {}
+        original = ArrayGlyph.plot
+
+        def spy(self, *args, **kwargs):
+            captured.update(kwargs)
+            return original(self, *args, **kwargs)
+
+        with patch.object(ArrayGlyph, "plot", spy):
+            glyph = self._dataset().plot(band=0, cbar_label="mm")
+        assert "cbar_label" in captured, "loose cbar_label must reach the render call"
+        label = glyph.cbar.ax.get_ylabel() or glyph.cbar.ax.get_xlabel()
+        assert label == "mm", f"colour-bar label should still render, got {label!r}"

--- a/tests/dataset/plot/test_new_render_params.py
+++ b/tests/dataset/plot/test_new_render_params.py
@@ -113,9 +113,8 @@ class TestNewRenderParams:
         """A loose `cbar_*` kwarg still renders the shared colour-bar label on the facet path.
 
         cleopatra's `facet` forwards these to each per-panel constructor (not `.plot`), so the
-        deprecation does not fire there — but the label must still render. This routing fixed a
-        latent drop where a facet `cbar_label` was previously routed to the parent constructor
-        and never forwarded into `cleo.facet`.
+        deprecation does not fire there — but the label must still render: `cbar_label` reaches
+        `cleo.facet(...)`, and the returned grid's shared colour bar carries it.
         """
         stack = np.random.default_rng(3).random((3, 6, 6)).astype("float32")
         result = render_array(

--- a/tests/dataset/plot/test_new_render_params.py
+++ b/tests/dataset/plot/test_new_render_params.py
@@ -115,12 +115,27 @@ class TestNewRenderParams:
 
     def test_explicit_colorbar_wins_over_loose_cbar(self):
         """An explicit `colorbar=ColorBar` wins; the loose `cbar_*` are dropped (deprecated)."""
-        with pytest.warns(DeprecationWarning, match="ignored because colorbar"):
+        with pytest.warns(
+            DeprecationWarning, match="ignored because an explicit colorbar"
+        ):
             glyph = self._dataset().plot(
                 band=0, colorbar=ColorBar(label="TYPED"), cbar_label="LOOSE"
             )
         label = glyph.cbar.ax.get_ylabel() or glyph.cbar.ax.get_xlabel()
         assert label == "TYPED", f"explicit ColorBar should win, got {label!r}"
+
+    def test_colorbar_true_still_folds_loose_cbar(self):
+        """`colorbar=True` + a loose `cbar_*` folds the styling in (not dropped).
+
+        `True` / `None` carry no caption of their own, so the loose kwargs must still
+        render — only a typed `ColorBar` (or `colorbar=False`) suppresses them.
+        """
+        with pytest.warns(DeprecationWarning, match="cbar_"):
+            glyph = self._dataset().plot(band=0, colorbar=True, cbar_label="DEPTH")
+        label = glyph.cbar.ax.get_ylabel() or glyph.cbar.ax.get_xlabel()
+        assert label == "DEPTH", (
+            f"colorbar=True must keep the loose label, got {label!r}"
+        )
 
     def test_deprecated_cbar_kwarg_renders_on_the_facet_path(self):
         """A loose `cbar_*` kwarg still renders the shared colour-bar label on the facet path.

--- a/tests/dataset/plot/test_new_render_params.py
+++ b/tests/dataset/plot/test_new_render_params.py
@@ -124,6 +124,18 @@ class TestNewRenderParams:
         label = glyph.cbar.ax.get_ylabel() or glyph.cbar.ax.get_xlabel()
         assert label == "TYPED", f"explicit ColorBar should win, got {label!r}"
 
+    def test_colorbar_false_drops_loose_cbar_and_hides_bar(self):
+        """`colorbar=False` hides the bar and drops the loose `cbar_*` (not folded).
+
+        The suppress half of the conflict contract: an explicit `colorbar=False` wins,
+        so the loose kwarg is dropped with a warning naming the `False` case and no
+        colour bar is drawn.
+        """
+        with pytest.warns(DeprecationWarning, match="ignored because colorbar=False"):
+            glyph = self._dataset().plot(band=0, colorbar=False, cbar_label="x")
+        assert isinstance(glyph, ArrayGlyph)
+        assert getattr(glyph, "cbar", None) is None, "colorbar=False must hide the bar"
+
     def test_colorbar_true_still_folds_loose_cbar(self):
         """`colorbar=True` + a loose `cbar_*` folds the styling in (not dropped).
 

--- a/tests/dataset/plot/test_plot_engine.py
+++ b/tests/dataset/plot/test_plot_engine.py
@@ -397,8 +397,12 @@ class TestRenderArrayKwargRouting:
                     pid_size=7,
                 )
         seen = {**ctor, **plot}
-        assert "pid_color" not in seen, f"legacy pid_color must fold away; seen={sorted(seen)}"
-        assert "pid_size" not in seen, f"legacy pid_size must fold away; seen={sorted(seen)}"
+        assert "pid_color" not in seen, (
+            f"legacy pid_color must fold away; seen={sorted(seen)}"
+        )
+        assert "pid_size" not in seen, (
+            f"legacy pid_size must fold away; seen={sorted(seen)}"
+        )
         overlay = plot.get("points", ctor.get("points"))
         assert isinstance(overlay, PointOverlay), (
             f"pid_* must fold into a PointOverlay; got {overlay!r}"

--- a/tests/dataset/plot/test_plot_engine.py
+++ b/tests/dataset/plot/test_plot_engine.py
@@ -397,9 +397,8 @@ class TestRenderArrayKwargRouting:
                     pid_size=7,
                 )
         seen = {**ctor, **plot}
-        assert "pid_color" not in seen and "pid_size" not in seen, (
-            f"legacy pid_* must be folded away; seen={sorted(seen)}"
-        )
+        assert "pid_color" not in seen, f"legacy pid_color must fold away; seen={sorted(seen)}"
+        assert "pid_size" not in seen, f"legacy pid_size must fold away; seen={sorted(seen)}"
         overlay = plot.get("points", ctor.get("points"))
         assert isinstance(overlay, PointOverlay), (
             f"pid_* must fold into a PointOverlay; got {overlay!r}"

--- a/tests/dataset/plot/test_plot_engine.py
+++ b/tests/dataset/plot/test_plot_engine.py
@@ -308,6 +308,37 @@ class TestRenderArrayKwargRouting:
             f"`kind` must be force-routed to the render call; plot={plot}"
         )
 
+    def test_deprecated_cbar_kwargs_are_force_routed_to_the_render_call(self):
+        """Deprecated loose ``cbar_*`` kwargs route to the render call, not the ctor.
+
+        Test scenario:
+            The loose colour-bar kwargs are in ``option_keys()``, so the default
+            split would send them to ``__init__`` (where cleopatra's 0.28
+            deprecation never fires). They are force-routed to the render call
+            instead so the ``DeprecationWarning`` is not suppressed on the plot
+            path. Uses the ``_capture_calls`` fake, so it locks the routing
+            contract on any installed cleopatra, independent of the render.
+        """
+        assert "cbar_label" in ArrayGlyph.option_keys()
+        assert "ticks_spacing" in ArrayGlyph.option_keys()
+        fake_cls, ctor, plot, _, _, _ = self._capture_calls()
+        rng = np.random.default_rng(506)
+        arr = rng.random((4, 4)).astype("float32")
+        with patch("cleopatra.array_glyph.ArrayGlyph", new=fake_cls):
+            render_array(
+                arr=arr,
+                extent=[0.0, 0.0, 1.0, 1.0],
+                mode="plot",
+                cbar_label="mm",
+                ticks_spacing=2,
+            )
+        assert "cbar_label" in plot and "cbar_label" not in ctor, (
+            f"loose `cbar_label` must be force-routed to the render call; ctor={ctor}"
+        )
+        assert "ticks_spacing" in plot and "ticks_spacing" not in ctor, (
+            f"loose `ticks_spacing` must be force-routed to the render call; plot={plot}"
+        )
+
     @pytest.mark.plot
     def test_kind_contourf_reaches_plot_not_clobbered(self):
         """Regression: ``kind="contourf"`` renders as contourf, not ``"auto"``.

--- a/tests/dataset/plot/test_plot_engine.py
+++ b/tests/dataset/plot/test_plot_engine.py
@@ -332,12 +332,10 @@ class TestRenderArrayKwargRouting:
                 cbar_label="mm",
                 ticks_spacing=2,
             )
-        assert "cbar_label" in plot and "cbar_label" not in ctor, (
-            f"loose `cbar_label` must be force-routed to the render call; ctor={ctor}"
-        )
-        assert "ticks_spacing" in plot and "ticks_spacing" not in ctor, (
-            f"loose `ticks_spacing` must be force-routed to the render call; plot={plot}"
-        )
+        assert "cbar_label" in plot, f"loose `cbar_label` must reach the render call; plot={plot}"
+        assert "cbar_label" not in ctor, f"loose `cbar_label` must not reach the ctor; ctor={ctor}"
+        assert "ticks_spacing" in plot, f"loose `ticks_spacing` must reach the render call; plot={plot}"
+        assert "ticks_spacing" not in ctor, f"loose `ticks_spacing` must not reach the ctor; ctor={ctor}"
 
     @pytest.mark.plot
     def test_kind_contourf_reaches_plot_not_clobbered(self):

--- a/tests/dataset/plot/test_plot_engine.py
+++ b/tests/dataset/plot/test_plot_engine.py
@@ -20,6 +20,7 @@ ArrayGlyph = _cleo_array.ArrayGlyph
 # and the animate frame-label pair into FrameLabel.
 PointOverlay = getattr(_cleo_array, "PointOverlay", None)
 FrameLabel = getattr(_cleo_array, "FrameLabel", None)
+ColorBar = getattr(_cleo_array, "ColorBar", None)
 _cleo_config = pytest.importorskip("cleopatra.config", reason="cleopatra not installed")
 Config = _cleo_config.Config
 Config.set_matplotlib_backend("agg")
@@ -183,20 +184,17 @@ class TestRenderArrayKwargRouting:
             ``plot_call_only`` set in ``_plot_helpers.render_array``; a
             regression here would resurrect the double-forward bug.
 
-            The loose point-styling names below are superseded upstream in
-            cleopatra 0.26 (``PointOverlay`` replaces them) and survive here only
-            as vehicles for the routing invariant — they are still accepted, and
-            pyramids must route them like any other non-option kwarg.
+            ``points`` (a render-call-only overlay) and ``full_bleed`` stand in
+            for non-option kwargs; ``kind`` is the option that is force-routed to
+            the render call. (The loose ``point_*`` style names are no longer used
+            here — ``render_array`` now folds them into a ``PointOverlay``.)
         """
         fake_cls, ctor, plot, _, _, _ = self._capture_calls()
         rng = np.random.default_rng(202)
         arr = rng.random((4, 4)).astype("float32")
         render_only_kwargs = {
-            "points": None,
-            "point_color": "red",
-            "point_size": 5,
-            "pid_color": "blue",
-            "pid_size": 7,
+            "points": np.array([[1.0, 2, 3]]),
+            "full_bleed": True,
             "kind": "imshow",
         }
         with patch("cleopatra.array_glyph.ArrayGlyph", new=fake_cls):
@@ -308,34 +306,73 @@ class TestRenderArrayKwargRouting:
             f"`kind` must be force-routed to the render call; plot={plot}"
         )
 
-    def test_deprecated_cbar_kwargs_are_force_routed_to_the_render_call(self):
-        """Deprecated loose ``cbar_*`` kwargs route to the render call, not the ctor.
+    def test_deprecated_cbar_kwargs_fold_into_colorbar(self):
+        """Deprecated loose ``cbar_*`` kwargs are folded into a ColorBar, not passed loose.
 
         Test scenario:
-            The loose colour-bar kwargs are in ``option_keys()``, so the default
-            split would send them to ``__init__`` (where cleopatra's 0.28
-            deprecation never fires). They are force-routed to the render call
-            instead so the ``DeprecationWarning`` is not suppressed on the plot
-            path. Uses the ``_capture_calls`` fake, so it locks the routing
-            contract on any installed cleopatra, independent of the render.
+            ``render_array`` translates the loose colour-bar kwargs into a
+            ``colorbar=ColorBar(...)`` before the cleopatra call, so neither the
+            constructor nor the render call ever sees a raw ``cbar_*``; the folded
+            ColorBar carries the mapped fields. Uses the ``_capture_calls`` fake.
         """
-        assert "cbar_label" in ArrayGlyph.option_keys()
-        assert "ticks_spacing" in ArrayGlyph.option_keys()
         fake_cls, ctor, plot, _, _, _ = self._capture_calls()
         rng = np.random.default_rng(506)
         arr = rng.random((4, 4)).astype("float32")
         with patch("cleopatra.array_glyph.ArrayGlyph", new=fake_cls):
-            render_array(
-                arr=arr,
-                extent=[0.0, 0.0, 1.0, 1.0],
-                mode="plot",
-                cbar_label="mm",
-                ticks_spacing=2,
-            )
-        assert "cbar_label" in plot, f"loose `cbar_label` must reach the render call; plot={plot}"
-        assert "cbar_label" not in ctor, f"loose `cbar_label` must not reach the ctor; ctor={ctor}"
-        assert "ticks_spacing" in plot, f"loose `ticks_spacing` must reach the render call; plot={plot}"
-        assert "ticks_spacing" not in ctor, f"loose `ticks_spacing` must not reach the ctor; ctor={ctor}"
+            with pytest.warns(DeprecationWarning, match="cbar_"):
+                render_array(
+                    arr=arr,
+                    extent=[0.0, 0.0, 1.0, 1.0],
+                    mode="plot",
+                    cbar_label="mm",
+                    ticks_spacing=2,
+                )
+        seen = {**ctor, **plot}
+        assert "cbar_label" not in seen, (
+            f"loose cbar_label must be folded away; seen={sorted(seen)}"
+        )
+        assert "ticks_spacing" not in seen, (
+            f"loose ticks_spacing must be folded away; seen={sorted(seen)}"
+        )
+        colorbar = plot.get("colorbar", ctor.get("colorbar"))
+        assert isinstance(colorbar, ColorBar), (
+            f"cbar_* must fold into a ColorBar; got {colorbar!r}"
+        )
+        assert colorbar.label == "mm"
+        assert colorbar.ticks_spacing == 2
+
+    def test_deprecated_point_kwargs_fold_into_pointoverlay(self):
+        """Deprecated loose point_* kwargs are folded into a PointOverlay carrying the array.
+
+        Test scenario:
+            ``render_array`` translates the loose point-style kwargs into a
+            ``points=PointOverlay(points, ...)`` before the cleopatra call, so the
+            raw ``point_*`` never reach cleopatra; the overlay carries the styling.
+        """
+        fake_cls, ctor, plot, _, _, _ = self._capture_calls()
+        rng = np.random.default_rng(507)
+        arr = rng.random((4, 4)).astype("float32")
+        pts = np.array([[1.0, 2, 3]])
+        with patch("cleopatra.array_glyph.ArrayGlyph", new=fake_cls):
+            with pytest.warns(DeprecationWarning, match="point_"):
+                render_array(
+                    arr=arr,
+                    extent=[0.0, 0.0, 1.0, 1.0],
+                    mode="plot",
+                    points=pts,
+                    point_color="red",
+                    point_size=9,
+                )
+        seen = {**ctor, **plot}
+        assert "point_color" not in seen, (
+            f"loose point_color must be folded away; seen={sorted(seen)}"
+        )
+        overlay = plot.get("points", ctor.get("points"))
+        assert isinstance(overlay, PointOverlay), (
+            f"point_* must fold into a PointOverlay; got {overlay!r}"
+        )
+        assert overlay.color == "red"
+        assert overlay.size == 9
 
     @pytest.mark.plot
     def test_kind_contourf_reaches_plot_not_clobbered(self):

--- a/tests/dataset/plot/test_plot_engine.py
+++ b/tests/dataset/plot/test_plot_engine.py
@@ -374,6 +374,118 @@ class TestRenderArrayKwargRouting:
         assert overlay.color == "red"
         assert overlay.size == 9
 
+    def test_deprecated_pid_kwargs_fold_into_pointoverlay_labels(self):
+        """Legacy ``pid_*`` label kwargs fold into ``PointOverlay.label_*``.
+
+        Test scenario:
+            The oldest loose aliases ``pid_color`` / ``pid_size`` map to the
+            overlay's ``label_color`` / ``label_size`` — the least-obvious mapping,
+            so pin it explicitly rather than trusting the map by inspection.
+        """
+        fake_cls, ctor, plot, _, _, _ = self._capture_calls()
+        rng = np.random.default_rng(508)
+        arr = rng.random((4, 4)).astype("float32")
+        pts = np.array([[1.0, 2, 3]])
+        with patch("cleopatra.array_glyph.ArrayGlyph", new=fake_cls):
+            with pytest.warns(DeprecationWarning, match="pid_"):
+                render_array(
+                    arr=arr,
+                    extent=[0.0, 0.0, 1.0, 1.0],
+                    mode="plot",
+                    points=pts,
+                    pid_color="green",
+                    pid_size=7,
+                )
+        seen = {**ctor, **plot}
+        assert "pid_color" not in seen and "pid_size" not in seen, (
+            f"legacy pid_* must be folded away; seen={sorted(seen)}"
+        )
+        overlay = plot.get("points", ctor.get("points"))
+        assert isinstance(overlay, PointOverlay), (
+            f"pid_* must fold into a PointOverlay; got {overlay!r}"
+        )
+        assert overlay.label_color == "green"
+        assert overlay.label_size == 7
+
+    def test_point_label_alias_wins_over_legacy_pid(self):
+        """When both ``point_label_*`` and ``pid_*`` are passed, the modern name wins.
+
+        Test scenario:
+            The fold is last-write-wins over ``_POINT_TO_OVERLAY`` insertion order
+            (``pid_*`` before ``point_label_*``), so passing both must land the
+            ``point_label_*`` value on the overlay — matching cleopatra's
+            ``_resolve_point_overlay`` precedence. Locks the fragile dict-order
+            invariant against a silent reorder.
+        """
+        fake_cls, ctor, plot, _, _, _ = self._capture_calls()
+        rng = np.random.default_rng(509)
+        arr = rng.random((4, 4)).astype("float32")
+        pts = np.array([[1.0, 2, 3]])
+        with patch("cleopatra.array_glyph.ArrayGlyph", new=fake_cls):
+            with pytest.warns(DeprecationWarning, match="point_"):
+                render_array(
+                    arr=arr,
+                    extent=[0.0, 0.0, 1.0, 1.0],
+                    mode="plot",
+                    points=pts,
+                    pid_color="green",
+                    point_label_color="purple",
+                )
+        overlay = plot.get("points", ctor.get("points"))
+        assert overlay.label_color == "purple", (
+            f"point_label_color must win over pid_color; got {overlay.label_color!r}"
+        )
+
+    def test_loose_point_kwargs_ignored_when_points_is_pointoverlay(self):
+        """A loose ``point_*`` is dropped (with a warning) when ``points`` is already typed.
+
+        Test scenario:
+            An explicit ``PointOverlay`` wins — the loose ``point_color`` is popped
+            and warned as "ignored", and the overlay reaches the render call
+            untouched (its own styling preserved, not overwritten by the loose kwarg).
+        """
+        fake_cls, ctor, plot, _, _, _ = self._capture_calls()
+        rng = np.random.default_rng(510)
+        arr = rng.random((4, 4)).astype("float32")
+        overlay_in = PointOverlay(np.array([[1.0, 2, 3]]), color="black")
+        with patch("cleopatra.array_glyph.ArrayGlyph", new=fake_cls):
+            with pytest.warns(DeprecationWarning, match="ignored because points="):
+                render_array(
+                    arr=arr,
+                    extent=[0.0, 0.0, 1.0, 1.0],
+                    mode="plot",
+                    points=overlay_in,
+                    point_color="red",
+                )
+        seen = {**ctor, **plot}
+        assert "point_color" not in seen, "loose point_color must be dropped"
+        assert plot.get("points") is overlay_in, (
+            "the explicit PointOverlay must reach the render call untouched"
+        )
+
+    def test_loose_point_kwargs_dropped_when_no_points(self):
+        """A loose ``point_*`` with no ``points`` is a no-op (warned and dropped).
+
+        Test scenario:
+            Without a ``points`` array there is nothing to style, so the loose
+            ``point_color`` warns "no effect" and is dropped — never reaching
+            cleopatra, and no ``points`` kwarg is invented.
+        """
+        fake_cls, ctor, plot, _, _, _ = self._capture_calls()
+        rng = np.random.default_rng(511)
+        arr = rng.random((4, 4)).astype("float32")
+        with patch("cleopatra.array_glyph.ArrayGlyph", new=fake_cls):
+            with pytest.warns(DeprecationWarning, match="no effect"):
+                render_array(
+                    arr=arr,
+                    extent=[0.0, 0.0, 1.0, 1.0],
+                    mode="plot",
+                    point_color="red",
+                )
+        seen = {**ctor, **plot}
+        assert "point_color" not in seen, "loose point_color must be dropped"
+        assert "points" not in seen, "no points= may be invented from a loose kwarg"
+
     @pytest.mark.plot
     def test_kind_contourf_reaches_plot_not_clobbered(self):
         """Regression: ``kind="contourf"`` renders as contourf, not ``"auto"``.

--- a/tests/netcdf/plot/test_plot_animate.py
+++ b/tests/netcdf/plot/test_plot_animate.py
@@ -19,6 +19,8 @@ _cleo_array = pytest.importorskip(
     "cleopatra.array_glyph", reason="cleopatra not installed"
 )
 ArrayGlyph = _cleo_array.ArrayGlyph
+# cleopatra >= 0.26 bundles the animate frame-label pair into FrameLabel.
+FrameLabel = getattr(_cleo_array, "FrameLabel", None)
 _cleo_config = pytest.importorskip("cleopatra.config", reason="cleopatra not installed")
 Config = _cleo_config.Config
 Config.set_matplotlib_backend("Agg")
@@ -138,6 +140,30 @@ class TestNetCDFPlotAnimate:
                 nc.plot(variable="t2m", animate=True)
         assert captured["kw"]["mode"] == "animate"
         assert captured["kw"]["animation_axis_values"] == labels
+
+    @pytest.mark.skipif(FrameLabel is None, reason="cleopatra < 0.26 has no FrameLabel")
+    def test_animate_forwards_frame_label_to_render_array(self):
+        """``frame_label=FrameLabel(...)`` forwards through NetCDF.plot to the animate render.
+
+        Test scenario:
+            ``NetCDF.plot`` carries ``frame_label`` only via ``**kwargs`` (it is not a
+            named param, since the multi-mode facade rejects it on the static/facet
+            paths), so this pins that hop: with ``animate=True`` the typed spec must
+            reach :func:`pyramids.dataset._plot_helpers.render_array` on the
+            ``mode="animate"`` call, unchanged.
+        """
+        nc = make_plot_3d_nc(n_times=3)
+        spec = FrameLabel(location=(1, 3))
+        captured: dict = {}
+        with patch(
+            "pyramids.netcdf._plot._render_array",
+            side_effect=_make_fake_render(captured),
+        ):
+            nc.plot(variable="t2m", animate=True, frame_label=spec)
+        assert captured["kw"]["mode"] == "animate"
+        assert captured["kw"]["frame_label"] is spec, (
+            "frame_label must forward through NetCDF.plot's **kwargs to the animate render"
+        )
 
     def test_animate_data_getter_called_once_per_frame(self):
         """The lazy ``data_getter`` invokes ``sel().read_array`` per frame.


### PR DESCRIPTION
# Description

Completes the cleopatra typed plot-spec migration on the raster `.plot` / `.animate` facades, and moves mypy into
the `lint.yml` pre-commit job. Three parts:

## 1. Deprecate the loose plot kwargs — translate them to the typed specs

cleopatra 0.28 groups the loose kwargs into typed dataclasses (`ColorBar`, `PointOverlay`, …). pyramids now emits
its own `DeprecationWarning` and **folds each loose form into the typed spec at the `render_array` boundary**, so
cleopatra only ever sees the typed object (no double warning) and every raster plot/animate path is steered onto
the typed API in one place:

- `cbar_*` / `ticks_spacing` → `colorbar=pyramids.plot.ColorBar(...)`
- `point_*` / `pid_*` → `points=pyramids.plot.PointOverlay(points, ...)`
- a `dict` basemap → `basemap=pyramids.plot.Basemap(...)`

An explicit typed spec (a `ColorBar` / `PointOverlay`) wins over the loose kwargs, which are then dropped with a
warning. The loose forms still *work* (soft deprecation, deprecation window) — they warn and translate. The plot
docstrings drop the loose rows and document only the typed specs.

**Two paths deliberately keep the loose form** (no typed alternative there — cleopatra limitations, not choices):

- **facet** — cleopatra's `ArrayGlyph.facet` doesn't accept `colorbar=ColorBar` (only the loose `cbar_*`). The fold
  is skipped there and the loose kwargs are force-routed to the facet call so they still render. Filed upstream as
  `serapeum-org/cleopatra#256`; the pyramids follow-up to remove the special-case is tracked in #934.
- **mesh / UGRID** — `MeshGlyph` has no `ColorBar` on the 0.28 floor (fixed upstream in cleopatra 0.29 via
  `#239`/`#244`); the pyramids adopt-0.29 follow-up is #933.

## 2. Name `basemap` and wire `FrameLabel` on the animate methods

`FrameLabel` was re-exported from `pyramids.plot` but never surfaced on any `.plot`/`.animate` method, and
`DatasetCollection.plot` took `basemap` only via `**kwargs`.

- `DatasetCollection.plot` now names `basemap` (`bool | str | Basemap`) and `frame_label` (`FrameLabel`) as
  first-class, documented params, forwarded on both the single-band and RGB animate paths.
- `NetCDF.plot` already names `basemap`; its docstring now documents `frame_label=FrameLabel(...)` on the animate
  path (forwarded via `**kwargs` — not a named param, since the multi-mode facade rejects it on the static/facet
  paths).

## 3. CI: run mypy through the `lint.yml` pre-commit job

`lint.yml`'s `pre-commit` job previously skipped mypy (`SKIP=…,mypy,…`), and mypy ran only in the separate
`static` job. This PR installs the pixi `dev` env in the `pre-commit` job and drops `mypy` from its `SKIP`, so the
mypy hook runs alongside the other pre-commit hooks; the now-duplicate mypy step is removed from the `static` job
(which keeps the src doctests). `.pre-commit-config.yaml` itself is unchanged from `main`.

# Issues

- Refs #926 — completes the typed plot-spec migration it began (cleopatra 0.28 adoption).
- Refs #933 — the mesh/UGRID half (adopt cleopatra 0.29) is tracked separately.
- Refs #934 — the facet fold, once `serapeum-org/cleopatra#256` lands.

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] Full plot-marker suite across the tree (`pytest -m plot`) and the core collection tests.
- [x] netcdf plot tests (animate/facet `render_array` paths) — 175 passed.
- [x] Doctests on the changed modules (`--doctest-modules`).
- [x] Behaviour validated end to end: each loose family warns once + folds to the typed spec and still renders;
      the typed spec alone is warning-free; an explicit spec wins; facet keeps the loose form and renders;
      `DatasetCollection.plot(basemap=..., frame_label=FrameLabel(...))` and `NetCDF.plot(animate=True,
      frame_label=...)` forward to cleopatra's animate call.
- [x] `lint.yml` change validated: the workflow YAML parses, the `pre-commit` job installs the pixi `dev` env and
      runs the mypy hook, and the `static` job runs the src doctests.

# Checklist:

- [ ] updated version number in pyproject.toml. (release version is bumped by commitizen in CI, not by hand)
- [ ] added changes to History.rst. (change log is commitizen-generated)
- [ ] updated the latest version in README file. (n/a)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.
