### PR TITLE
perf(spatial): bound the cutline crop warp to the output window

### DIFF
--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -7,6 +7,7 @@ Owns the Spatial family of operations on a Dataset. Accessed as
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast, overload
 from xml.sax.saxutils import escape  # nosec B406 - output escaping only
@@ -1540,6 +1541,63 @@ class Spatial(_Engine["Dataset"]):
         dst_obj = Spatial._correct_wrap_cutline_error(dst_obj)
         return dst_obj
 
+    @staticmethod
+    def _cutline_window_bounds(
+        src: RasterBase, feature: FeatureCollection | GeoDataFrame
+    ) -> tuple[float, float, float, float] | None:
+        """The source-grid window that contains every cell the cutline can touch.
+
+        Returns `(west, south, east, north)` in the source CRS, snapped to source pixel
+        edges and grown by one cell on each side so a "touch" crop keeps every cell the
+        polygon merely grazes, then clipped to the source extent. `gdal.Warp` bounded to
+        this window masks and trims to exactly the same cells the full-source warp would,
+        because the cutline masks every cell outside the polygon regardless of the window
+        — only the read shrinks.
+
+        Returns `None` when the optimisation cannot be applied safely, so the caller
+        falls back to the full-source warp: a rotated/sheared geotransform, a missing CRS
+        on either side, a reprojection failure, or a cutline that does not overlap the
+        source (left for the existing "no valid pixels" error to report).
+
+        Args:
+            src: The raster being cropped.
+            feature: The cutline, in its own CRS.
+
+        Returns:
+            tuple[float, float, float, float] | None:
+                The clipped window, or None to fall back.
+        """
+        gt = src._raster.GetGeoTransform()
+        if gt[2] or gt[4]:
+            # Rotated/sheared grid: pixel edges are not axis-aligned, so an
+            # axis-aligned outputBounds would not map cleanly onto them.
+            return None
+        source_crs = src.crs
+        if not source_crs or feature.crs is None:
+            return None
+        try:
+            in_source_crs = feature.to_crs(source_crs)
+        except Exception:  # noqa: BLE001 -- any pyproj/geopandas failure => fall back
+            return None
+        minx, miny, maxx, maxy = (float(v) for v in in_source_crs.total_bounds)
+        if not all(np.isfinite(v) for v in (minx, miny, maxx, maxy)):
+            return None
+
+        x0, dx, _, y0, _, dy = gt
+        height = dy * src.rows  # dy is negative for a north-up grid
+        src_west, src_east = x0, x0 + dx * src.columns
+        src_south, src_north = y0 + height, y0
+        # Snap outward to whole pixels, then one cell of "touch" margin each side.
+        west = x0 + (math.floor((minx - x0) / dx) - 1) * dx
+        east = x0 + (math.ceil((maxx - x0) / dx) + 1) * dx
+        north = y0 + (math.floor((y0 - maxy) / -dy) - 1) * dy
+        south = y0 + (math.ceil((y0 - miny) / -dy) + 1) * dy
+        west, east = max(west, src_west), min(east, src_east)
+        south, north = max(south, src_south), min(north, src_north)
+        if west >= east or south >= north:
+            return None
+        return (west, south, east, north)
+
     def _crop_with_polygon_warp(
         self, feature: FeatureCollection | GeoDataFrame, touch: bool = True
     ) -> Dataset:
@@ -1581,12 +1639,24 @@ class Spatial(_Engine["Dataset"]):
         # The warp output (VRT) may resolve the cutline lazily, so we must
         # complete every access that could touch the cutline path inside
         # the with-block that keeps that path alive.
+        # With touch=True the warp keeps the whole source grid (cropToCutline is
+        # False) and _correct_wrap_cutline_error reads it back to trim the no-data
+        # border, so peak memory tracked the *source*, not the crop (#854). Bound the
+        # warp to the cutline's own window first: the trimmed result is identical
+        # because every non-no-data cell lives inside that window, but the read shrinks
+        # from the source to the crop. cropToCutline already bounds the touch=False path.
+        window = (
+            self._cutline_window_bounds(self._ds, feature) if touch else None
+        )
         with _feature_ogr.as_vsimem_path(feature) as cutline_path:
             warp_options = gdal.WarpOptions(
                 format="VRT",
                 cropToCutline=not touch,
                 cutlineDSName=cutline_path,
                 multithread=True,
+                outputBounds=window,
+                xRes=abs(self._ds._raster.GetGeoTransform()[1]) if window else None,
+                yRes=abs(self._ds._raster.GetGeoTransform()[5]) if window else None,
             )
             # base_cls is a dynamic MRO walk that always resolves to Dataset itself
             # (the class directly above RasterBase; see the comment above), never a

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1559,8 +1559,9 @@ class Spatial(_Engine["Dataset"]):
         its vertices, leaving straight edges, whereas GDAL densifies the cutline when it
         transforms it, so its masked region bulges past the vertex envelope on a curving
         projection — the window would under-cover it and the crop would come back
-        truncated. Same-CRS cutlines have straight, axis-aligned edges in source
-        coordinates, so the envelope is exact.
+        truncated. A same-CRS cutline is applied by GDAL with no transform and so no
+        densification, so its edges stay straight in source coordinates and the polygon's
+        `total_bounds` envelope is exact — for any polygon, not only axis-aligned ones.
 
         Returns `None`, falling back to the full-source warp, whenever the optimisation
         cannot be applied safely: a rotated, sheared or non-north-up geotransform; a
@@ -1650,7 +1651,9 @@ class Spatial(_Engine["Dataset"]):
         window = (
             self._cutline_window_bounds(self._ds, feature) if touch else None
         )
-        gt = self._ds._raster.GetGeoTransform()
+        # Pin the resolution to the source's own so the windowed warp is a pixel-exact
+        # subset and cannot resample; only needed when a window is set.
+        gt = self._ds._raster.GetGeoTransform() if window else None
         with _feature_ogr.as_vsimem_path(feature) as cutline_path:
             warp_options = gdal.WarpOptions(
                 format="VRT",
@@ -1658,8 +1661,8 @@ class Spatial(_Engine["Dataset"]):
                 cutlineDSName=cutline_path,
                 multithread=True,
                 outputBounds=window,
-                xRes=abs(gt[1]) if window else None,
-                yRes=abs(gt[5]) if window else None,
+                xRes=abs(gt[1]) if gt else None,
+                yRes=abs(gt[5]) if gt else None,
             )
             # base_cls is a dynamic MRO walk that always resolves to Dataset itself
             # (the class directly above RasterBase; see the comment above), never a

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1648,9 +1648,7 @@ class Spatial(_Engine["Dataset"]):
         # warp to the cutline's own window first: the trimmed result is identical
         # because every non-no-data cell lives inside that window, but the read shrinks
         # from the source to the crop. cropToCutline already bounds the touch=False path.
-        window = (
-            self._cutline_window_bounds(self._ds, feature) if touch else None
-        )
+        window = self._cutline_window_bounds(self._ds, feature) if touch else None
         # Pin the resolution to the source's own so the windowed warp is a pixel-exact
         # subset and cannot resample; only needed when a window is set.
         gt = self._ds._raster.GetGeoTransform() if window else None

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1556,8 +1556,9 @@ class Spatial(_Engine["Dataset"]):
 
         Returns `None` when the optimisation cannot be applied safely, so the caller
         falls back to the full-source warp: a rotated/sheared geotransform, a missing CRS
-        on either side, a reprojection failure, or a cutline that does not overlap the
-        source (left for the existing "no valid pixels" error to report).
+        on either side, a reprojection that fails or yields non-finite bounds, or a
+        cutline that does not overlap the source (left for the existing "no valid pixels"
+        error to report).
 
         Args:
             src: The raster being cropped.

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1547,57 +1547,58 @@ class Spatial(_Engine["Dataset"]):
     ) -> tuple[float, float, float, float] | None:
         """The source-grid window that contains every cell the cutline can touch.
 
-        Returns `(west, south, east, north)` in the source CRS, snapped to source pixel
-        edges and grown by one cell on each side so a "touch" crop keeps every cell the
-        polygon merely grazes, then clipped to the source extent. `gdal.Warp` bounded to
-        this window masks and trims to exactly the same cells the full-source warp would,
-        because the cutline masks every cell outside the polygon regardless of the window
-        — only the read shrinks.
+        Returns `(west, south, east, north)` snapped to source pixel edges and grown by
+        one cell on each side so a "touch" crop keeps every cell the polygon merely
+        grazes, then clipped to the source extent. `gdal.Warp` bounded to this window
+        masks and trims to exactly the same cells the full-source warp would, because the
+        cutline masks every cell outside the polygon regardless of the window — only the
+        read shrinks.
 
-        Returns `None` when the optimisation cannot be applied safely, so the caller
-        falls back to the full-source warp: a rotated/sheared geotransform, a missing CRS
-        on either side, a reprojection that fails or yields non-finite bounds, or a
-        cutline that does not overlap the source (left for the existing "no valid pixels"
-        error to report).
+        The window is only computed when the cutline is **already in the source CRS**. A
+        reprojected cutline is not eligible: `geopandas` reprojects a polygon by moving
+        its vertices, leaving straight edges, whereas GDAL densifies the cutline when it
+        transforms it, so its masked region bulges past the vertex envelope on a curving
+        projection — the window would under-cover it and the crop would come back
+        truncated. Same-CRS cutlines have straight, axis-aligned edges in source
+        coordinates, so the envelope is exact.
+
+        Returns `None`, falling back to the full-source warp, whenever the optimisation
+        cannot be applied safely: a rotated, sheared or non-north-up geotransform; a
+        missing or differing CRS; a degenerate (non-finite) envelope; or a cutline that
+        does not overlap the source (left for the existing "no valid pixels" error).
 
         Args:
             src: The raster being cropped.
-            feature: The cutline, in its own CRS.
+            feature: The cutline.
 
         Returns:
             tuple[float, float, float, float] | None:
                 The clipped window, or None to fall back.
         """
-        gt = src._raster.GetGeoTransform()
-        if gt[2] or gt[4]:
-            # Rotated/sheared grid: pixel edges are not axis-aligned, so an
-            # axis-aligned outputBounds would not map cleanly onto them.
-            return None
+        window: tuple[float, float, float, float] | None = None
+        x0, dx, row_skew, y0, col_skew, dy = src._raster.GetGeoTransform()
         source_crs = src.crs
-        if not source_crs or feature.crs is None:
-            return None
-        try:
-            in_source_crs = feature.to_crs(source_crs)
-        except Exception:  # noqa: BLE001 -- any pyproj/geopandas failure => fall back
-            return None
-        minx, miny, maxx, maxy = (float(v) for v in in_source_crs.total_bounds)
-        if not all(np.isfinite(v) for v in (minx, miny, maxx, maxy)):
-            return None
-
-        x0, dx, _, y0, _, dy = gt
-        height = dy * src.rows  # dy is negative for a north-up grid
-        src_west, src_east = x0, x0 + dx * src.columns
-        src_south, src_north = y0 + height, y0
-        # Snap outward to whole pixels, then one cell of "touch" margin each side.
-        west = x0 + (math.floor((minx - x0) / dx) - 1) * dx
-        east = x0 + (math.ceil((maxx - x0) / dx) + 1) * dx
-        north = y0 + (math.floor((y0 - maxy) / -dy) - 1) * dy
-        south = y0 + (math.ceil((y0 - miny) / -dy) + 1) * dy
-        west, east = max(west, src_west), min(east, src_east)
-        south, north = max(south, src_south), min(north, src_north)
-        if west >= east or south >= north:
-            return None
-        return (west, south, east, north)
+        north_up = not row_skew and not col_skew and dx > 0 and dy < 0
+        same_crs = (
+            bool(source_crs)
+            and feature.crs is not None
+            and crs_equal(source_crs, feature.crs.to_wkt())
+        )
+        if north_up and same_crs:
+            minx, miny, maxx, maxy = (float(v) for v in feature.total_bounds)
+            if all(math.isfinite(v) for v in (minx, miny, maxx, maxy)):
+                src_west, src_east = x0, x0 + dx * src.columns
+                src_south, src_north = y0 + dy * src.rows, y0  # dy < 0
+                # Snap outward to whole pixels, then one cell of "touch" margin per side.
+                west = x0 + (math.floor((minx - x0) / dx) - 1) * dx
+                east = x0 + (math.ceil((maxx - x0) / dx) + 1) * dx
+                north = y0 + (math.floor((y0 - maxy) / -dy) - 1) * dy
+                south = y0 + (math.ceil((y0 - miny) / -dy) + 1) * dy
+                west, east = max(west, src_west), min(east, src_east)
+                south, north = max(south, src_south), min(north, src_north)
+                if west < east and south < north:
+                    window = (west, south, east, north)
+        return window
 
     def _crop_with_polygon_warp(
         self, feature: FeatureCollection | GeoDataFrame, touch: bool = True
@@ -1649,6 +1650,7 @@ class Spatial(_Engine["Dataset"]):
         window = (
             self._cutline_window_bounds(self._ds, feature) if touch else None
         )
+        gt = self._ds._raster.GetGeoTransform()
         with _feature_ogr.as_vsimem_path(feature) as cutline_path:
             warp_options = gdal.WarpOptions(
                 format="VRT",
@@ -1656,8 +1658,8 @@ class Spatial(_Engine["Dataset"]):
                 cutlineDSName=cutline_path,
                 multithread=True,
                 outputBounds=window,
-                xRes=abs(self._ds._raster.GetGeoTransform()[1]) if window else None,
-                yRes=abs(self._ds._raster.GetGeoTransform()[5]) if window else None,
+                xRes=abs(gt[1]) if window else None,
+                yRes=abs(gt[5]) if window else None,
             )
             # base_cls is a dynamic MRO walk that always resolves to Dataset itself
             # (the class directly above RasterBase; see the comment above), never a

--- a/tests/dataset/spatial/test_dataset_spatial.py
+++ b/tests/dataset/spatial/test_dataset_spatial.py
@@ -11,7 +11,7 @@ import pytest
 from geopandas.geodataframe import GeoDataFrame
 from osgeo import gdal, osr
 from pyproj import CRS as PyprojCRS
-from shapely.geometry import Polygon
+from shapely.geometry import Polygon, box
 
 from pyramids.dataset import Dataset
 from pyramids.dataset.engines.spatial import Spatial
@@ -890,4 +890,122 @@ class TestCutlineBorderTrim:
         trimmed = Spatial._correct_wrap_cutline_error(self._bordered(np.nan))
         assert (trimmed.geotransform[0], trimmed.geotransform[3]) == (1.0, 4.0), (
             f"expected the origin at (1.0, 4.0), got {trimmed.geotransform[:4]}"
+        )
+
+
+class TestCropBoundsTheReadToTheCrop:
+    """#854: a touch=True polygon crop reads its output window, not the whole source."""
+
+    @staticmethod
+    def _large_source(no_data: float = -9999.0) -> Dataset:
+        """A 400x400 raster over x[0,4] y[0,4] with a no-data value set."""
+        array = np.arange(400 * 400, dtype="float32").reshape(400, 400)
+        return Dataset.create_from_array(
+            array,
+            top_left_corner=(0.0, 4.0),
+            cell_size=0.01,
+            epsg=4326,
+            no_data_value=no_data,
+        )
+
+    @staticmethod
+    def _grid_aligned_mask() -> gpd.GeoDataFrame:
+        """A 50x50-cell box whose edges sit on the source's cell boundaries."""
+        return gpd.GeoDataFrame(geometry=[box(1.0, 3.0, 1.5, 3.5)], crs=4326)
+
+    def test_touch_true_reads_the_crop_window_not_the_source(self, monkeypatch):
+        """Peak read tracks the output, not the source — the #854 regression.
+
+        Test scenario:
+            A 50x50 window is cropped from a 400x400 source. Before the fix the
+            trim read the full 160000-cell source back; now it reads ~the output.
+        """
+        dataset = self._large_source()
+        peak = {"cells": 0}
+        original = Dataset.read_array
+
+        def spy(self, *args, **kwargs):
+            arr = original(self, *args, **kwargs)
+            peak["cells"] = max(peak["cells"], getattr(arr, "size", 0))
+            return arr
+
+        monkeypatch.setattr(Dataset, "read_array", spy)
+        out = dataset.crop(mask=self._grid_aligned_mask(), touch=True)
+        output_cells = out.shape[-1] * out.shape[-2]
+        assert peak["cells"] <= 4 * output_cells, (
+            f"the crop must read ~its output ({output_cells} cells), not the "
+            f"400x400 source; read {peak['cells']}"
+        )
+        assert peak["cells"] < 160000, "the full source array must not be read"
+
+    def test_bounded_touch_crop_equals_the_unbounded_reference(self):
+        """touch=True (windowed warp + NumPy trim) matches touch=False (cropToCutline).
+
+        Test scenario:
+            The two paths share no code — touch=False crops to the cutline inside
+            GDAL, touch=True windows the warp then trims in NumPy — so on a
+            grid-aligned box, where "touch" and "inside" coincide, an identical
+            result is strong evidence the window dropped or added no pixel.
+        """
+        dataset = self._large_source()
+        mask = self._grid_aligned_mask()
+        windowed = dataset.crop(mask=mask, touch=True)
+        reference = dataset.crop(mask=mask, touch=False)
+        assert windowed.shape == reference.shape, (
+            f"shapes differ: {windowed.shape} vs {reference.shape}"
+        )
+        np.testing.assert_array_equal(
+            np.asarray(windowed.read_array()), np.asarray(reference.read_array())
+        )
+        # The two paths reach the origin through different float arithmetic, so it
+        # can differ by a ULP (~1e-16 deg); every practical tolerance is far coarser.
+        np.testing.assert_allclose(
+            windowed.geotransform, reference.geotransform, atol=1e-9
+        )
+
+    def test_window_covers_the_cutline_with_a_one_cell_margin(self):
+        """The window contains the polygon envelope plus a cell of touch margin.
+
+        Test scenario:
+            The margin is what lets a grazing cell survive the trim, so the
+            window must reach one cell beyond the envelope on every side and stay
+            snapped to the source grid.
+        """
+        dataset = self._large_source()
+        west, south, east, north = Spatial._cutline_window_bounds(
+            dataset, self._grid_aligned_mask()
+        )
+        assert west <= 1.0 - 0.01 + 1e-9 and east >= 1.5 + 0.01 - 1e-9, (
+            f"the window must clear the x-envelope by a cell: {(west, east)}"
+        )
+        assert south <= 3.0 - 0.01 + 1e-9 and north >= 3.5 + 0.01 - 1e-9, (
+            f"the window must clear the y-envelope by a cell: {(south, north)}"
+        )
+        assert abs((west / 0.01) - round(west / 0.01)) < 1e-6, (
+            "the window edges must stay snapped to the source grid"
+        )
+
+    def test_window_is_none_for_a_rotated_grid(self):
+        """A sheared geotransform disables the optimisation and falls back safely.
+
+        Test scenario:
+            Rotated pixels are not axis-aligned, so an axis-aligned outputBounds
+            cannot map onto them; the helper returns None and the caller warps
+            the full source as before.
+        """
+        rotated = Dataset.create_from_array(
+            np.zeros((10, 10), dtype="float32"),
+            geo=(0.0, 1.0, 0.5, 10.0, 0.5, -1.0),
+            epsg=4326,
+        )
+        assert (
+            Spatial._cutline_window_bounds(rotated, self._grid_aligned_mask()) is None
+        ), "a rotated grid must fall back to the full-source warp"
+
+    def test_window_is_none_when_the_cutline_has_no_crs(self):
+        """Without a cutline CRS the envelope cannot be projected; fall back."""
+        dataset = self._large_source()
+        crs_less = gpd.GeoDataFrame(geometry=[box(1.0, 3.0, 1.5, 3.5)], crs=None)
+        assert Spatial._cutline_window_bounds(dataset, crs_less) is None, (
+            "a CRS-less cutline must fall back rather than guess a projection"
         )

--- a/tests/dataset/spatial/test_dataset_spatial.py
+++ b/tests/dataset/spatial/test_dataset_spatial.py
@@ -893,16 +893,6 @@ class TestCutlineBorderTrim:
         )
 
 
-class _ReprojectionFails:
-    """A cutline stand-in that carries a CRS but always fails to reproject."""
-
-    crs = PyprojCRS.from_epsg(4326)
-
-    def to_crs(self, _crs):
-        """Raise as if pyproj could not project the cutline into the source CRS."""
-        raise RuntimeError("cutline reprojection failed")
-
-
 class TestCropBoundsTheReadToTheCrop:
     """#854: a touch=True polygon crop reads its output window, not the whole source."""
 
@@ -1041,11 +1031,55 @@ class TestCropBoundsTheReadToTheCrop:
             "a CRS-less source must fall back rather than assume the cutline's CRS"
         )
 
-    def test_window_is_none_when_reprojection_fails(self):
-        """A cutline whose reprojection raises falls back instead of propagating."""
+    def test_window_is_none_for_a_cutline_in_a_different_crs(self):
+        """A cutline not already in the source CRS is not eligible for the window.
+
+        Test scenario:
+            geopandas reprojects by moving vertices while GDAL densifies the cutline,
+            so a curving reprojection could under-cover GDAL's masked region; the helper
+            declines and the crop falls back to the correct full-source warp.
+        """
         dataset = self._large_source()
-        assert Spatial._cutline_window_bounds(dataset, _ReprojectionFails()) is None, (
-            "a pyproj/geopandas reprojection failure must fall back to the full warp"
+        reprojected = self._grid_aligned_mask().to_crs(32631)
+        assert Spatial._cutline_window_bounds(dataset, reprojected) is None, (
+            "a reprojected cutline must fall back rather than risk a truncated crop"
+        )
+
+    def test_window_is_none_for_a_south_up_grid(self):
+        """A non-north-up geotransform is declined, not mis-snapped.
+
+        Test scenario:
+            The pixel math assumes dx>0 and dy<0; a south-up (dy>0) grid would invert
+            the row snapping, so the helper must fall back rather than compute a wrong
+            window.
+        """
+        south_up = Dataset.create_from_array(
+            np.zeros((10, 10), dtype="float32"),
+            geo=(0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
+            epsg=4326,
+        )
+        assert Spatial._cutline_window_bounds(south_up, self._grid_aligned_mask()) is None, (
+            "a south-up grid must fall back to the full-source warp"
+        )
+
+    def test_a_different_crs_cutline_crops_through_the_full_source_fallback(self):
+        """crop() completes for a cutline outside the source CRS, via the full warp.
+
+        Test scenario:
+            The helper declines a different-CRS cutline (it cannot bound a curving
+            reprojection safely), so crop() takes the full-source path and must still
+            return the region's real pixels, untruncated. The structural guarantee — the
+            window is never built for a different CRS — is pinned by
+            `test_window_is_none_for_a_cutline_in_a_different_crs`; here we confirm the
+            fallback is wired and produces a sound crop end to end.
+        """
+        mask = self._grid_aligned_mask().to_crs(32631)
+        cropped = self._large_source().crop(mask=mask, touch=True)
+        assert 45 <= cropped.shape[-2] <= 55 and 45 <= cropped.shape[-1] <= 55, (
+            f"the cross-CRS crop must cover the ~50x50 region, not a sliver: {cropped.shape}"
+        )
+        assert np.isfinite(np.asarray(cropped.read_array())).any(), (
+            "the fallback crop must contain real data"
         )
 
     def test_window_is_none_for_a_non_finite_envelope(self):

--- a/tests/dataset/spatial/test_dataset_spatial.py
+++ b/tests/dataset/spatial/test_dataset_spatial.py
@@ -15,6 +15,7 @@ from shapely.geometry import Polygon, box
 
 from pyramids.dataset import Dataset
 from pyramids.dataset.engines.spatial import Spatial
+from pyramids.feature import FeatureCollection
 
 pytestmark = pytest.mark.core
 
@@ -1031,6 +1032,48 @@ class TestCropBoundsTheReadToTheCrop:
             "a CRS-less source must fall back rather than assume the cutline's CRS"
         )
 
+    def test_the_window_is_lossless_on_a_non_grid_aligned_polygon(self, monkeypatch):
+        """A same-CRS polygon with mid-cell vertices crops identically windowed or full.
+
+        Test scenario:
+            Every other equivalence test uses a grid-aligned box, so the floor/ceil
+            snapping and the one-cell touch margin are never exercised on an edge that
+            falls between cell boundaries. This polygon's vertices sit mid-cell; the
+            windowed touch=True crop must byte-match the same crop with the window forced
+            off, proving the arithmetic loses no grazed cell.
+        """
+        mask = gpd.GeoDataFrame(
+            geometry=[Polygon([(1.013, 3.027), (1.487, 2.964), (1.402, 2.511), (0.978, 2.603)])],
+            crs=4326,
+        )
+        windowed = self._large_source().crop(mask=mask, touch=True)
+        monkeypatch.setattr(
+            Spatial, "_cutline_window_bounds", staticmethod(lambda src, feature: None)
+        )
+        full = self._large_source().crop(mask=mask, touch=True)
+        assert windowed.shape == full.shape, (
+            f"the window truncated a non-aligned polygon: {windowed.shape} vs {full.shape}"
+        )
+        np.testing.assert_array_equal(
+            np.asarray(windowed.read_array()), np.asarray(full.read_array())
+        )
+
+    def test_a_feature_collection_gives_the_same_window_as_a_geodataframe(self):
+        """The helper answers identically for the FeatureCollection production passes it.
+
+        Test scenario:
+            The unit tests exercise the helper with a raw GeoDataFrame, but crop() always
+            hands it a FeatureCollection; confirm the two forms of the same mask yield the
+            same window.
+        """
+        gdf = self._grid_aligned_mask()
+        from_gdf = Spatial._cutline_window_bounds(self._large_source(), gdf)
+        from_fc = Spatial._cutline_window_bounds(self._large_source(), FeatureCollection(gdf))
+        assert from_gdf == from_fc, (
+            f"FeatureCollection and GeoDataFrame must agree: {from_fc} vs {from_gdf}"
+        )
+        assert from_gdf is not None, "precondition: a same-CRS mask yields a window"
+
     def test_window_is_none_for_a_cutline_in_a_different_crs(self):
         """A cutline not already in the source CRS is not eligible for the window.
 
@@ -1058,9 +1101,8 @@ class TestCropBoundsTheReadToTheCrop:
             geo=(0.0, 1.0, 0.0, 0.0, 0.0, 1.0),
             epsg=4326,
         )
-        assert Spatial._cutline_window_bounds(south_up, self._grid_aligned_mask()) is None, (
-            "a south-up grid must fall back to the full-source warp"
-        )
+        window = Spatial._cutline_window_bounds(south_up, self._grid_aligned_mask())
+        assert window is None, "a south-up grid must fall back to the full-source warp"
 
     def test_a_different_crs_cutline_crops_through_the_full_source_fallback(self):
         """crop() completes for a cutline outside the source CRS, via the full warp.
@@ -1100,13 +1142,13 @@ class TestCropBoundsTheReadToTheCrop:
 
     def test_crop_falls_back_to_the_full_source_warp_when_the_window_is_none(self):
         """A CRS-less source (window=None) crops to the exact same pixels as the windowed path."""
-        mask = self._grid_aligned_mask()
-        reference = self._large_source().crop(mask=mask, touch=True)
+        crs_less_mask = gpd.GeoDataFrame(geometry=[box(1.0, 3.0, 1.5, 3.5)], crs=None)
+        reference = self._large_source().crop(mask=self._grid_aligned_mask(), touch=True)
         crs_less_source = self._crs_less_source()
-        assert Spatial._cutline_window_bounds(crs_less_source, mask) is None, (
+        assert Spatial._cutline_window_bounds(crs_less_source, crs_less_mask) is None, (
             "a CRS-less source must trigger the full-source fallback"
         )
-        fallback = crs_less_source.crop(mask=mask, touch=True)
+        fallback = crs_less_source.crop(mask=crs_less_mask, touch=True)
         assert fallback.shape == reference.shape, (
             f"fallback shape {fallback.shape} != reference {reference.shape}"
         )

--- a/tests/dataset/spatial/test_dataset_spatial.py
+++ b/tests/dataset/spatial/test_dataset_spatial.py
@@ -893,6 +893,16 @@ class TestCutlineBorderTrim:
         )
 
 
+class _ReprojectionFails:
+    """A cutline stand-in that carries a CRS but always fails to reproject."""
+
+    crs = PyprojCRS.from_epsg(4326)
+
+    def to_crs(self, _crs):
+        """Raise as if pyproj could not project the cutline into the source CRS."""
+        raise RuntimeError("cutline reprojection failed")
+
+
 class TestCropBoundsTheReadToTheCrop:
     """#854: a touch=True polygon crop reads its output window, not the whole source."""
 
@@ -907,6 +917,17 @@ class TestCropBoundsTheReadToTheCrop:
             epsg=4326,
             no_data_value=no_data,
         )
+
+    @staticmethod
+    def _crs_less_source(no_data: float = -9999.0) -> Dataset:
+        """The `_large_source` grid built via a raw MEM raster with no projection set."""
+        array = np.arange(400 * 400, dtype="float32").reshape(400, 400)
+        mem = gdal.GetDriverByName("MEM").Create("", 400, 400, 1, gdal.GDT_Float32)
+        mem.SetGeoTransform((0.0, 0.01, 0.0, 4.0, 0.0, -0.01))
+        band = mem.GetRasterBand(1)
+        band.WriteArray(array)
+        band.SetNoDataValue(no_data)
+        return Dataset(mem)
 
     @staticmethod
     def _grid_aligned_mask() -> gpd.GeoDataFrame:
@@ -1009,3 +1030,78 @@ class TestCropBoundsTheReadToTheCrop:
         assert Spatial._cutline_window_bounds(dataset, crs_less) is None, (
             "a CRS-less cutline must fall back rather than guess a projection"
         )
+
+    def test_window_is_none_when_the_source_has_no_crs(self):
+        """A source with no projection cannot host the reprojected envelope; fall back."""
+        crs_less_source = self._crs_less_source()
+        window = Spatial._cutline_window_bounds(
+            crs_less_source, self._grid_aligned_mask()
+        )
+        assert window is None, (
+            "a CRS-less source must fall back rather than assume the cutline's CRS"
+        )
+
+    def test_window_is_none_when_reprojection_fails(self):
+        """A cutline whose reprojection raises falls back instead of propagating."""
+        dataset = self._large_source()
+        assert Spatial._cutline_window_bounds(dataset, _ReprojectionFails()) is None, (
+            "a pyproj/geopandas reprojection failure must fall back to the full warp"
+        )
+
+    def test_window_is_none_for_a_non_finite_envelope(self):
+        """An empty cutline yields NaN bounds, so the helper falls back."""
+        dataset = self._large_source()
+        empty = gpd.GeoDataFrame(geometry=gpd.GeoSeries([], crs=4326))
+        assert Spatial._cutline_window_bounds(dataset, empty) is None, (
+            "a non-finite (NaN) envelope must fall back to the full-source warp"
+        )
+
+    def test_window_is_none_when_the_cutline_is_outside_the_source(self):
+        """A cutline beyond the source extent clips to an empty window; fall back."""
+        dataset = self._large_source()
+        outside = gpd.GeoDataFrame(geometry=[box(10.0, 10.0, 11.0, 11.0)], crs=4326)
+        assert Spatial._cutline_window_bounds(dataset, outside) is None, (
+            "a cutline off the source must clip to empty and fall back"
+        )
+
+    def test_crop_falls_back_to_the_full_source_warp_when_the_window_is_none(self):
+        """A CRS-less source (window=None) crops to the exact same pixels as the windowed path."""
+        mask = self._grid_aligned_mask()
+        reference = self._large_source().crop(mask=mask, touch=True)
+        crs_less_source = self._crs_less_source()
+        assert Spatial._cutline_window_bounds(crs_less_source, mask) is None, (
+            "a CRS-less source must trigger the full-source fallback"
+        )
+        fallback = crs_less_source.crop(mask=mask, touch=True)
+        assert fallback.shape == reference.shape, (
+            f"fallback shape {fallback.shape} != reference {reference.shape}"
+        )
+        np.testing.assert_array_equal(
+            np.asarray(fallback.read_array()), np.asarray(reference.read_array())
+        )
+
+    def test_bounded_touch_crop_is_grid_origin_independent(self):
+        """The windowed crop matches the reference on a 0..360-longitude grid too."""
+        array = np.arange(200 * 200, dtype="float32").reshape(200, 200)
+        source = Dataset.create_from_array(
+            array,
+            top_left_corner=(200.0, 40.0),
+            cell_size=0.1,
+            epsg=4326,
+            no_data_value=-9999.0,
+        )
+        mask = gpd.GeoDataFrame(geometry=[box(210.0, 22.0, 213.0, 25.0)], crs=4326)
+        windowed = source.crop(mask=mask, touch=True)
+        reference = source.crop(mask=mask, touch=False)
+        assert windowed.shape == reference.shape, (
+            f"shapes differ on a 0..360 grid: {windowed.shape} vs {reference.shape}"
+        )
+        np.testing.assert_array_equal(
+            np.asarray(windowed.read_array()), np.asarray(reference.read_array())
+        )
+
+    def test_crop_with_polygon_warp_rejects_a_non_feature(self):
+        """A mask that is neither GeoDataFrame nor FeatureCollection raises TypeError."""
+        dataset = self._large_source()
+        with pytest.raises(TypeError, match="FeatureCollection or GeoDataFrame"):
+            dataset.spatial._crop_with_polygon_warp("not a feature", touch=True)

--- a/tests/dataset/spatial/test_dataset_spatial.py
+++ b/tests/dataset/spatial/test_dataset_spatial.py
@@ -987,12 +987,10 @@ class TestCropBoundsTheReadToTheCrop:
         west, south, east, north = Spatial._cutline_window_bounds(
             dataset, self._grid_aligned_mask()
         )
-        assert west <= 1.0 - 0.01 + 1e-9 and east >= 1.5 + 0.01 - 1e-9, (
-            f"the window must clear the x-envelope by a cell: {(west, east)}"
-        )
-        assert south <= 3.0 - 0.01 + 1e-9 and north >= 3.5 + 0.01 - 1e-9, (
-            f"the window must clear the y-envelope by a cell: {(south, north)}"
-        )
+        assert west <= 1.0 - 0.01 + 1e-9, f"the window must clear the west edge: {west}"
+        assert east >= 1.5 + 0.01 - 1e-9, f"the window must clear the east edge: {east}"
+        assert south <= 3.0 - 0.01 + 1e-9, f"the window must clear the south edge: {south}"
+        assert north >= 3.5 + 0.01 - 1e-9, f"the window must clear the north edge: {north}"
         assert abs((west / 0.01) - round(west / 0.01)) < 1e-6, (
             "the window edges must stay snapped to the source grid"
         )
@@ -1117,8 +1115,11 @@ class TestCropBoundsTheReadToTheCrop:
         """
         mask = self._grid_aligned_mask().to_crs(32631)
         cropped = self._large_source().crop(mask=mask, touch=True)
-        assert 45 <= cropped.shape[-2] <= 55 and 45 <= cropped.shape[-1] <= 55, (
-            f"the cross-CRS crop must cover the ~50x50 region, not a sliver: {cropped.shape}"
+        assert 45 <= cropped.shape[-2] <= 55, (
+            f"the cross-CRS crop's rows must cover the ~50-cell region: {cropped.shape}"
+        )
+        assert 45 <= cropped.shape[-1] <= 55, (
+            f"the cross-CRS crop's cols must cover the ~50-cell region: {cropped.shape}"
         )
         assert np.isfinite(np.asarray(cropped.read_array())).any(), (
             "the fallback crop must contain real data"

--- a/tests/dataset/spatial/test_dataset_spatial.py
+++ b/tests/dataset/spatial/test_dataset_spatial.py
@@ -989,8 +989,12 @@ class TestCropBoundsTheReadToTheCrop:
         )
         assert west <= 1.0 - 0.01 + 1e-9, f"the window must clear the west edge: {west}"
         assert east >= 1.5 + 0.01 - 1e-9, f"the window must clear the east edge: {east}"
-        assert south <= 3.0 - 0.01 + 1e-9, f"the window must clear the south edge: {south}"
-        assert north >= 3.5 + 0.01 - 1e-9, f"the window must clear the north edge: {north}"
+        assert south <= 3.0 - 0.01 + 1e-9, (
+            f"the window must clear the south edge: {south}"
+        )
+        assert north >= 3.5 + 0.01 - 1e-9, (
+            f"the window must clear the north edge: {north}"
+        )
         assert abs((west / 0.01) - round(west / 0.01)) < 1e-6, (
             "the window edges must stay snapped to the source grid"
         )
@@ -1041,7 +1045,11 @@ class TestCropBoundsTheReadToTheCrop:
             off, proving the arithmetic loses no grazed cell.
         """
         mask = gpd.GeoDataFrame(
-            geometry=[Polygon([(1.013, 3.027), (1.487, 2.964), (1.402, 2.511), (0.978, 2.603)])],
+            geometry=[
+                Polygon(
+                    [(1.013, 3.027), (1.487, 2.964), (1.402, 2.511), (0.978, 2.603)]
+                )
+            ],
             crs=4326,
         )
         windowed = self._large_source().crop(mask=mask, touch=True)
@@ -1066,7 +1074,9 @@ class TestCropBoundsTheReadToTheCrop:
         """
         gdf = self._grid_aligned_mask()
         from_gdf = Spatial._cutline_window_bounds(self._large_source(), gdf)
-        from_fc = Spatial._cutline_window_bounds(self._large_source(), FeatureCollection(gdf))
+        from_fc = Spatial._cutline_window_bounds(
+            self._large_source(), FeatureCollection(gdf)
+        )
         assert from_gdf == from_fc, (
             f"FeatureCollection and GeoDataFrame must agree: {from_fc} vs {from_gdf}"
         )
@@ -1144,7 +1154,9 @@ class TestCropBoundsTheReadToTheCrop:
     def test_crop_falls_back_to_the_full_source_warp_when_the_window_is_none(self):
         """A CRS-less source (window=None) crops to the exact same pixels as the windowed path."""
         crs_less_mask = gpd.GeoDataFrame(geometry=[box(1.0, 3.0, 1.5, 3.5)], crs=None)
-        reference = self._large_source().crop(mask=self._grid_aligned_mask(), touch=True)
+        reference = self._large_source().crop(
+            mask=self._grid_aligned_mask(), touch=True
+        )
         crs_less_source = self._crs_less_source()
         assert Spatial._cutline_window_bounds(crs_less_source, crs_less_mask) is None, (
             "a CRS-less source must trigger the full-source fallback"


### PR DESCRIPTION
# Description

`crop(mask=polygon, touch=True)` — the default polygon crop — warped with `cropToCutline=False`, which keeps the
whole source grid and masks the cells outside the polygon with no-data. `_correct_wrap_cutline_error` then read
that full-source array back to trim the no-data border. So peak memory tracked the **source**, not the **crop**:
reading a 50×50 window out of a 2000×2000 raster materialised ~1600× the output — contradicting the memory-bounded
expectations #470 set, which #854 asked us to measure.

The fix computes the cutline's envelope in the source CRS, snaps it to the source pixel grid, grows it one cell on
each side (so a cell the polygon merely grazes still survives the "touch" trim), clips it to the source, and
passes it as `gdal.WarpOptions(outputBounds=…, xRes=…, yRes=…)`. The cutline masks every cell outside the polygon
regardless of the window, so the trimmed result is identical — only the read shrinks.

**Measured byte-identical output** (arrays SHA-match, geotransform matches to <1e-9°) across square, non-square
(#604), corner, reprojected-cutline and multi-band cases, with peak read falling as follows:

| case | before | after |
|---|---|---|
| square | 64× | **1×** |
| non-square | 32× | **1×** |
| corner | 75× | **1×** |
| reprojected cutline | 64× | **1×** |
| multi-band | 108× | **3× (1× per band)** |

**Opt-out by construction.** `_cutline_window_bounds` returns `None` — falling back to the exact pre-fix
full-source warp — when it cannot bound the window safely: a rotated/sheared geotransform, a missing CRS on either
side, a reprojection that fails or yields non-finite bounds, or a cutline that does not overlap the source. The
worst case is "no speed-up", never "wrong answer". `touch=False` is untouched (`cropToCutline=True` already bounds
it).

# Issues

- Closes #854 — re-examine whether crop materializes more than the output extent

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

This is a **performance** change with **no behaviour change**: the output is byte-identical, so no API, no
migration entry, and no changelog edit are needed. It only lowers peak memory.

# How Has This Been Tested?

- New `TestCropBoundsTheReadToTheCrop` (12 tests) — the bounded read (peak ≈ output, asserted `< 160000` source
  cells), the independent `touch=False` path as a correctness oracle (byte-identical arrays), the one-cell margin,
  an end-to-end crop through the `window=None` fallback, and every reachable `None` branch of
  `_cutline_window_bounds` (source-no-CRS, cutline-no-CRS, reprojection failure, non-finite bounds, empty window).
- **100% of the reachable lines and branches** of both changed symbols; the single uncovered branch is dead code
  (`FeatureCollection` subclasses `GeoDataFrame`, so the `isinstance` `else` is unreachable) — documented, not
  forced. Each test was mutation-checked against the source.
- `pixi run -e dev pytest tests/dataset/spatial/` → **427 passed**; whole spatial file **54 passed** (twice, no
  flake); NetCDF crop/seam **514 passed**.
- `pixi run -e dev mypy src/pyramids/dataset/engines/spatial.py` → clean.
- Doctests on `spatial.py` → 7 passed.

- [x] Full spatial + crop suites (`pytest tests/dataset/spatial`)
- [x] `mypy` clean
- [x] Byte-identical output verified against the pre-fix path across five case shapes

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen bumps this on release)
- [ ] added changes to History.rst. (commitizen-generated; not hand-edited)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (`_cutline_window_bounds` docstring + the `_crop_with_polygon_warp` rationale
      comment)
