### PR TITLE
feat(plot): render paletted rasters through their GDAL colour table

### DIFF
--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -916,7 +916,7 @@ jobs:
 
       - name: Publish to PyPI
         if: github.event_name == 'workflow_run'
-        uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           password: ${{ secrets.PYPI_PUBLISH }}
           packages-dir: dist/

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -63,7 +63,7 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -707,9 +707,9 @@ class Dataset(RasterBase):
               ```
 
             - A ``palette_index`` band is not an RGB channel, so it does not trigger
-              the RGB branch — the raster resolves to a single band (rule 3, #910).
-              A fresh dataset is built here so the example is independent of the
-              tags set above:
+              the RGB branch — the raster resolves to the paletted band so its GDAL
+              colour table renders (#913; band ``0`` here). A fresh dataset is built
+              here so the example is independent of the tags set above:
 
               ```python
               >>> paletted = np.random.rand(3, 8, 8).astype(np.float32)
@@ -744,16 +744,25 @@ class Dataset(RasterBase):
         RGB imagery; ``undefined``, ``palette_index``, ``gray_index`` and the
         other single-channel/paletted interpretations do not -- otherwise a
         multi-band raster carrying any of them is mis-resolved as a false-colour
-        RGB composite (see #910). A non-RGB raster renders a single band: band 0
-        by default, or ``rgb[0]`` when an explicit ``rgb`` is supplied, so the
-        downstream ``exclude_value`` nodata mask keys off the same band the RGB
-        render uses.
+        RGB composite (see #910). A non-RGB raster renders a single band:
+        ``rgb[0]`` when an explicit ``rgb`` is supplied, else the first
+        ``palette_index`` band so its GDAL colour table renders (#913), else
+        band 0. The downstream ``exclude_value`` nodata mask keys off the same
+        band the render uses.
         """
         band_colors = list(self.band_color.values())
         has_rgb_interp = any(c in RGB_CHANNEL_INTERPS for c in band_colors)
         if not has_rgb_interp:
             resolved_rgb = rgb
-            resolved_band = int(rgb[0]) if rgb is not None else 0
+            if rgb is not None:
+                resolved_band = int(rgb[0])
+            else:
+                # Prefer a paletted band so its colour table renders (#913),
+                # otherwise fall back to band 0.
+                palette_bands = [
+                    i for i, c in enumerate(band_colors) if c == "palette_index"
+                ]
+                resolved_band = palette_bands[0] if palette_bands else 0
         else:
             resolved_rgb = rgb if rgb is not None else self._infer_rgb_band_order()
             resolved_band = int(resolved_rgb[0])

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -2132,12 +2132,13 @@ class Analysis(_Engine["Dataset"]):
         # discrete colormap from the palette and hand it to cleopatra as an
         # explicit ``cmap`` + ``color_scale="boundary-norm"``. Only the single-band
         # static path (no ``rgb``, no facet) carries a palette, and an explicit
-        # ``cmap`` / ``color_scale`` from the caller wins over it.
+        # ``cmap`` / ``color_scale`` / ``bounds`` from the caller wins over it.
         if (
             mode == "plot"
             and rgb is None
             and kwargs.get("cmap") is None
             and kwargs.get("color_scale") is None
+            and kwargs.get("bounds") is None
         ):
             # Read only the resolved band's colour table, not every band's — the
             # full-dataset ``color_table`` rebuilds a row per entry for all bands.

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -2259,13 +2259,15 @@ class Analysis(_Engine["Dataset"]):
         renders through its own colours — pyramids only builds the mapping; cleopatra
         draws it.
 
-        cleopatra's ``boundary-norm`` builds its ``BoundaryNorm`` with a fixed
-        ``ncolors=256``, so the palette is resampled to a **256-entry step lookup**
-        (nearest colour, no interpolation): each class then indexes its own exact,
-        opaque colour. A ``LinearSegmentedColormap`` would instead interpolate between
-        stops, blending the hue and bleeding alpha toward GDAL's transparent
-        ``(0, 0, 0, 0)`` gap-filler entries (GDAL densifies a colour table to
-        ``0..maxvalue``), so real classes would render translucent. An exact
+        cleopatra renders with ``BoundaryNorm(bounds, ncolors=256)``, so the palette is
+        turned into a **256-entry step lookup** whose slots are filled by asking that
+        exact norm which slot each class maps to and placing the class's colour there.
+        Each class then indexes its own exact, opaque colour regardless of the
+        palette's value range. (A fixed round-trip formula mis-indexes once the
+        densified entry count exceeds ~131, because the norm stretches regions to slots
+        by truncation; a ``LinearSegmentedColormap`` would instead interpolate between
+        stops, bleeding alpha toward GDAL's transparent ``(0, 0, 0, 0)`` gap-filler
+        entries — GDAL densifies a colour table to ``0..maxvalue``.) An exact
         one-swatch-per-class rendering with a discrete legend would need a first-class
         categorical colour-table API on cleopatra's ``ArrayGlyph``; see the follow-up
         tracked for #913.
@@ -2273,7 +2275,8 @@ class Analysis(_Engine["Dataset"]):
         Args:
             color_table (DataFrame):
                 The band's colour table — ``values`` plus ``red``/``green``/``blue``
-                (and optional ``alpha``), or a hex ``color`` column.
+                (and optional ``alpha``), or a hex ``color`` column. Must be non-empty
+                (the plot path only calls this once a colour table is present).
 
         Returns:
             tuple[matplotlib.colors.ListedColormap, list[float]]:
@@ -2282,13 +2285,15 @@ class Analysis(_Engine["Dataset"]):
         """
         require_cleopatra()
         from cleopatra.colors import category_boundaries
-        from matplotlib.colors import ListedColormap
+        from matplotlib.colors import BoundaryNorm, ListedColormap
 
         processed = Analysis._process_color_table(color_table).sort_values("values")
         rgba = processed[["red", "green", "blue", "alpha"]].to_numpy(dtype=float) / 255.0
         values = [float(v) for v in processed["values"].to_list()]
-        last = len(rgba) - 1
-        lut = [tuple(rgba[min(round(slot * last / 255), last)]) for slot in range(256)]
-        cmap = ListedColormap(lut)
         bounds = category_boundaries(values)
+        norm = BoundaryNorm(bounds, 256)
+        slots = np.asarray(norm(np.asarray(values))).astype(int)
+        lut = np.tile(rgba[0], (256, 1))
+        lut[slots] = rgba
+        cmap = ListedColormap(lut)
         return cmap, bounds

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -1958,6 +1958,12 @@ class Analysis(_Engine["Dataset"]):
         heuristic, no `ColorInterpretation` lookup, no default-to-zero fallback) \u2014 those
         are dataset-type-specific decisions that belong on the facades.
 
+        When the resolved band carries a GDAL colour table and the caller passes neither
+        ``cmap`` nor ``color_scale``, the raster renders through that palette: the colour
+        table is turned into a colormap and handed to cleopatra with
+        ``color_scale="boundary-norm"`` so each pixel value shows its own colour (#913).
+        An explicit ``cmap`` / ``color_scale`` opts out.
+
         The plot function uses the `cleopatra` as a backend to plot the raster data, for more information check
         [ArrayGlyph](https://serapeum-org.github.io/cleopatra/latest/api/array-glyph-class/#cleopatra.array_glyph.ArrayGlyph.plot).
 
@@ -2122,6 +2128,30 @@ class Analysis(_Engine["Dataset"]):
         effective_extent = (
             injected_extent if injected_extent is not None else self._ds.bbox
         )
+        # Render a paletted band through its GDAL colour table (#913): build a
+        # discrete colormap from the palette and hand it to cleopatra as an
+        # explicit ``cmap`` + ``color_scale="boundary-norm"``. Only the single-band
+        # static path (no ``rgb``, no facet) carries a palette, and an explicit
+        # ``cmap`` / ``color_scale`` from the caller wins over it.
+        if (
+            mode == "plot"
+            and rgb is None
+            and kwargs.get("cmap") is None
+            and kwargs.get("color_scale") is None
+        ):
+            full_color_table = self._ds.color_table
+            # ``_get_color_table`` numbers its ``band`` column 1-indexed (GDAL
+            # band number), while ``band`` here is the 0-indexed plot band.
+            band_color_table = (
+                full_color_table[full_color_table["band"] == band + 1]
+                if not full_color_table.empty
+                else full_color_table
+            )
+            if not band_color_table.empty:
+                cmap, bounds = self._palette_colormap(band_color_table)
+                kwargs["cmap"] = cmap
+                kwargs["color_scale"] = "boundary-norm"
+                kwargs["bounds"] = bounds
         return render_array(
             arr=arr,
             extent=effective_extent,
@@ -2220,3 +2250,46 @@ class Analysis(_Engine["Dataset"]):
         else:
             color_df.loc[:, "alpha"] = color_table["alpha"]
         return color_df
+
+    @staticmethod
+    def _palette_colormap(color_table: DataFrame) -> tuple[Any, list[float]]:
+        """Build a colormap + boundary edges from a GDAL colour table.
+
+        Normalises the ``[values, red, green, blue, alpha]`` colour table (via
+        :meth:`_process_color_table`) into a matplotlib ``LinearSegmentedColormap``
+        whose stops are the palette's colours, and derives the ``BoundaryNorm`` bin
+        edges from cleopatra's ``category_boundaries``. The colormap is handed to
+        cleopatra as an explicit ``cmap`` with ``color_scale="boundary-norm"`` so a
+        paletted raster renders through its own colours — pyramids only builds the
+        mapping; cleopatra draws it.
+
+        A segmented (not listed) colormap is used deliberately: cleopatra's
+        ``boundary-norm`` builds its ``BoundaryNorm`` with a fixed ``ncolors=256``, so
+        a small ``ListedColormap`` would be over-indexed and every class would clamp
+        to the last colour. Sampling the segmented ramp at each class's bin centre
+        lands on the palette stop instead. (An exact one-swatch-per-class rendering
+        with a discrete legend would need a first-class categorical colour-table API
+        on cleopatra's ``ArrayGlyph``; see the follow-up tracked for #913.)
+
+        Args:
+            color_table (DataFrame):
+                The band's colour table — ``values`` plus ``red``/``green``/``blue``
+                (and optional ``alpha``), or a hex ``color`` column.
+
+        Returns:
+            tuple[matplotlib.colors.LinearSegmentedColormap, list[float]]:
+                The colormap and its ``len(values) + 1`` ascending boundary edges,
+                sorted by colour-table value.
+        """
+        require_cleopatra()
+        from cleopatra.colors import category_boundaries
+        from matplotlib.colors import LinearSegmentedColormap
+
+        processed = Analysis._process_color_table(color_table).sort_values("values")
+        rgba = processed[["red", "green", "blue", "alpha"]].to_numpy(dtype=float) / 255.0
+        values = [float(v) for v in processed["values"].to_list()]
+        cmap = LinearSegmentedColormap.from_list(
+            "gdal_color_table", [tuple(channel) for channel in rgba]
+        )
+        bounds = category_boundaries(values)
+        return cmap, bounds

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -2139,14 +2139,9 @@ class Analysis(_Engine["Dataset"]):
             and kwargs.get("cmap") is None
             and kwargs.get("color_scale") is None
         ):
-            full_color_table = self._ds.color_table
-            # ``_get_color_table`` numbers its ``band`` column 1-indexed (GDAL
-            # band number), while ``band`` here is the 0-indexed plot band.
-            band_color_table = (
-                full_color_table[full_color_table["band"] == band + 1]
-                if not full_color_table.empty
-                else full_color_table
-            )
+            # Read only the resolved band's colour table, not every band's — the
+            # full-dataset ``color_table`` rebuilds a row per entry for all bands.
+            band_color_table = self._ds.bands._get_color_table(band=band)
             if not band_color_table.empty:
                 cmap, bounds = self._palette_colormap(band_color_table)
                 kwargs["cmap"] = cmap

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -2256,20 +2256,23 @@ class Analysis(_Engine["Dataset"]):
         """Build a colormap + boundary edges from a GDAL colour table.
 
         Normalises the ``[values, red, green, blue, alpha]`` colour table (via
-        :meth:`_process_color_table`) into a matplotlib ``LinearSegmentedColormap``
-        whose stops are the palette's colours, and derives the ``BoundaryNorm`` bin
-        edges from cleopatra's ``category_boundaries``. The colormap is handed to
-        cleopatra as an explicit ``cmap`` with ``color_scale="boundary-norm"`` so a
-        paletted raster renders through its own colours — pyramids only builds the
-        mapping; cleopatra draws it.
+        :meth:`_process_color_table`) into a matplotlib ``ListedColormap`` carrying the
+        palette's exact colours, and derives the ``BoundaryNorm`` bin edges from
+        cleopatra's ``category_boundaries``. The colormap is handed to cleopatra as an
+        explicit ``cmap`` with ``color_scale="boundary-norm"`` so a paletted raster
+        renders through its own colours — pyramids only builds the mapping; cleopatra
+        draws it.
 
-        A segmented (not listed) colormap is used deliberately: cleopatra's
-        ``boundary-norm`` builds its ``BoundaryNorm`` with a fixed ``ncolors=256``, so
-        a small ``ListedColormap`` would be over-indexed and every class would clamp
-        to the last colour. Sampling the segmented ramp at each class's bin centre
-        lands on the palette stop instead. (An exact one-swatch-per-class rendering
-        with a discrete legend would need a first-class categorical colour-table API
-        on cleopatra's ``ArrayGlyph``; see the follow-up tracked for #913.)
+        cleopatra's ``boundary-norm`` builds its ``BoundaryNorm`` with a fixed
+        ``ncolors=256``, so the palette is resampled to a **256-entry step lookup**
+        (nearest colour, no interpolation): each class then indexes its own exact,
+        opaque colour. A ``LinearSegmentedColormap`` would instead interpolate between
+        stops, blending the hue and bleeding alpha toward GDAL's transparent
+        ``(0, 0, 0, 0)`` gap-filler entries (GDAL densifies a colour table to
+        ``0..maxvalue``), so real classes would render translucent. An exact
+        one-swatch-per-class rendering with a discrete legend would need a first-class
+        categorical colour-table API on cleopatra's ``ArrayGlyph``; see the follow-up
+        tracked for #913.
 
         Args:
             color_table (DataFrame):
@@ -2277,19 +2280,19 @@ class Analysis(_Engine["Dataset"]):
                 (and optional ``alpha``), or a hex ``color`` column.
 
         Returns:
-            tuple[matplotlib.colors.LinearSegmentedColormap, list[float]]:
-                The colormap and its ``len(values) + 1`` ascending boundary edges,
-                sorted by colour-table value.
+            tuple[matplotlib.colors.ListedColormap, list[float]]:
+                The 256-entry step colormap and the ``len(values) + 1`` ascending
+                boundary edges, sorted by colour-table value.
         """
         require_cleopatra()
         from cleopatra.colors import category_boundaries
-        from matplotlib.colors import LinearSegmentedColormap
+        from matplotlib.colors import ListedColormap
 
         processed = Analysis._process_color_table(color_table).sort_values("values")
         rgba = processed[["red", "green", "blue", "alpha"]].to_numpy(dtype=float) / 255.0
         values = [float(v) for v in processed["values"].to_list()]
-        cmap = LinearSegmentedColormap.from_list(
-            "gdal_color_table", [tuple(channel) for channel in rgba]
-        )
+        last = len(rgba) - 1
+        lut = [tuple(rgba[min(round(slot * last / 255), last)]) for slot in range(256)]
+        cmap = ListedColormap(lut)
         bounds = category_boundaries(values)
         return cmap, bounds

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -2288,7 +2288,9 @@ class Analysis(_Engine["Dataset"]):
         from matplotlib.colors import BoundaryNorm, ListedColormap
 
         processed = Analysis._process_color_table(color_table).sort_values("values")
-        rgba = processed[["red", "green", "blue", "alpha"]].to_numpy(dtype=float) / 255.0
+        rgba = (
+            processed[["red", "green", "blue", "alpha"]].to_numpy(dtype=float) / 255.0
+        )
         values = [float(v) for v in processed["values"].to_list()]
         bounds = category_boundaries(values)
         norm = BoundaryNorm(bounds, 256)

--- a/tests/dataset/plot/test_plot_color.py
+++ b/tests/dataset/plot/test_plot_color.py
@@ -169,12 +169,59 @@ class TestPalettePlot:
             returns the palette colour, not a default matplotlib colormap.
         """
         glyph = self._paletted_dataset().plot(band=0)
-        assert type(glyph.im.cmap).__name__ == "LinearSegmentedColormap"
+        assert type(glyph.im.cmap).__name__ == "ListedColormap"
         assert type(glyph.im.norm).__name__ == "BoundaryNorm"
-        expected = {1: (1.0, 0.0, 0.0), 2: (0.0, 1.0, 0.0), 3: (0.0, 0.0, 1.0)}
-        for value, rgb in expected.items():
+        expected = {1: (1.0, 0.0, 0.0, 1.0), 2: (0.0, 1.0, 0.0, 1.0), 3: (0.0, 0.0, 1.0, 1.0)}
+        for value, rgba in expected.items():
             got = tuple(round(c, 3) for c in glyph.im.cmap(glyph.im.norm(value)))
-            assert got[:3] == rgb, f"value {value} should render {rgb}, got {got[:3]}"
+            assert got == rgba, f"value {value} should render {rgba} (opaque), got {got}"
+
+    @pytest.mark.plot
+    def test_sparse_land_cover_palette_renders_exact_and_opaque(self):
+        """A sparse land-cover palette renders each class exactly, fully opaque.
+
+        Test scenario:
+            GDAL densifies a colour table to ``0..maxvalue`` with transparent
+            ``(0, 0, 0, 0)`` gap-fillers, so classes such as 11/21/31 land far apart.
+            The 256-entry step colormap must still map each class to its own opaque
+            colour — no interpolation blend and no alpha bleed toward the phantom
+            transparent stops.
+        """
+        arr = np.array([[11, 21, 31, 11]], dtype=np.int32)
+        dataset = Dataset.create_from_array(
+            arr, top_left_corner=(0, 0), cell_size=0.05, epsg=4326
+        )
+        dataset.color_table = pd.DataFrame(
+            {
+                "band": [1, 1, 1],
+                "values": [11, 21, 31],
+                "color": ["#00ff00", "#ff0000", "#0000ff"],
+            }
+        )
+        glyph = dataset.plot(band=0)
+        expected = {11: (0.0, 1.0, 0.0, 1.0), 21: (1.0, 0.0, 0.0, 1.0), 31: (0.0, 0.0, 1.0, 1.0)}
+        for value, rgba in expected.items():
+            got = tuple(round(c, 3) for c in glyph.im.cmap(glyph.im.norm(value)))
+            assert got == rgba, f"class {value} should render {rgba} (opaque), got {got}"
+
+    @pytest.mark.plot
+    def test_single_entry_palette_renders_without_crash(self):
+        """A one-entry colour table renders instead of crashing the colormap build.
+
+        Test scenario:
+            A palette with a single value must not raise from the colormap
+            construction; the class renders in its one colour.
+        """
+        arr = np.zeros((1, 3), dtype=np.int32)
+        dataset = Dataset.create_from_array(
+            arr, top_left_corner=(0, 0), cell_size=0.05, epsg=4326
+        )
+        dataset.color_table = pd.DataFrame(
+            {"band": [1], "values": [0], "color": ["#ff0000"]}
+        )
+        glyph = dataset.plot(band=0)
+        got = tuple(round(c, 3) for c in glyph.im.cmap(glyph.im.norm(0)))
+        assert got == (1.0, 0.0, 0.0, 1.0), f"single-entry palette should render red, got {got}"
 
     @pytest.mark.plot
     def test_explicit_cmap_overrides_palette(self):
@@ -199,13 +246,13 @@ class TestPalettePlot:
         assert glyph.im.cmap.name == "coolwarm_r"
 
     @pytest.mark.plot
-    def test_palette_colormap_returns_ramp_and_sorted_edges(self):
-        """``_palette_colormap`` returns a segmented ramp + ``N+1`` ascending edges.
+    def test_palette_colormap_returns_step_cmap_and_sorted_edges(self):
+        """``_palette_colormap`` returns a 256-entry step colormap + ``N+1`` edges.
 
         Test scenario:
             Given an unsorted three-value colour table, the helper sorts by value
-            and returns a ``LinearSegmentedColormap`` plus four ascending boundary
-            edges (one per gap, bracketing each class).
+            and returns a ``ListedColormap`` plus four ascending boundary edges (one
+            per gap, bracketing each class).
         """
         color_table = pd.DataFrame(
             {
@@ -216,7 +263,8 @@ class TestPalettePlot:
             }
         )
         cmap, bounds = Analysis._palette_colormap(color_table)
-        assert type(cmap).__name__ == "LinearSegmentedColormap"
+        assert type(cmap).__name__ == "ListedColormap"
+        assert cmap.N == 256
         assert len(bounds) == 4
         assert bounds == sorted(bounds)
 

--- a/tests/dataset/plot/test_plot_color.py
+++ b/tests/dataset/plot/test_plot_color.py
@@ -236,6 +236,12 @@ class TestPalettePlot:
         assert type(glyph.im.norm).__name__ != "BoundaryNorm"
 
     @pytest.mark.plot
+    def test_explicit_bounds_overrides_palette(self):
+        """A lone ``bounds=`` opts out of the palette rather than being overwritten."""
+        glyph = self._paletted_dataset().plot(band=0, bounds=[0, 1, 2, 3])
+        assert glyph.im.cmap.name == "coolwarm_r"
+
+    @pytest.mark.plot
     def test_non_paletted_raster_keeps_default_cmap(self):
         """A raster with no colour table renders with cleopatra's default colormap."""
         arr = np.random.default_rng(0).random((5, 5)).astype("float32")

--- a/tests/dataset/plot/test_plot_color.py
+++ b/tests/dataset/plot/test_plot_color.py
@@ -121,3 +121,129 @@ class TestColorRelief:
         color_table = Analysis._process_color_table(self.df)
         assert isinstance(color_table, DataFrame)
         assert all(color_table.columns == ["values", "red", "green", "blue", "alpha"])
+
+    @pytest.mark.plot
+    def test_process_color_table_without_rgb_or_color_raises(self):
+        """A colour table lacking both RGB and hex ``color`` columns is rejected.
+
+        Test scenario:
+            ``_process_color_table`` needs either ``red``/``green``/``blue`` or a
+            single hex ``color`` column; a table with only ``values`` raises
+            ``ValueError`` naming the columns it did receive.
+        """
+        bad = pd.DataFrame({"values": [1, 2, 3]})
+        with pytest.raises(ValueError, match="red, green, blue, or color") as exc_info:
+            Analysis._process_color_table(bad)
+        assert "values" in str(exc_info.value), (
+            f"error should list the given columns, got: {exc_info.value}"
+        )
+
+
+class TestPalettePlot:
+    """#913: a paletted raster renders through its GDAL colour table on ``plot()``."""
+
+    @staticmethod
+    def _paletted_dataset():
+        """A single-band raster (values 1..3) tagged with a red/green/blue palette."""
+        arr = np.array([[1, 2, 3], [3, 2, 1], [1, 2, 3]], dtype=np.int32)
+        dataset = Dataset.create_from_array(
+            arr, top_left_corner=(0, 0), cell_size=0.05, epsg=4326
+        )
+        dataset.color_table = pd.DataFrame(
+            {
+                "band": [1, 1, 1],
+                "values": [1, 2, 3],
+                "color": ["#ff0000", "#00ff00", "#0000ff"],
+            }
+        )
+        return dataset
+
+    @pytest.mark.plot
+    def test_paletted_raster_renders_through_color_table(self):
+        """Each pixel value maps to its exact palette colour via a boundary norm.
+
+        Test scenario:
+            A single-band raster carrying a red/green/blue colour table on values
+            1/2/3 must plot through that table — the mappable's colormap is the
+            palette ramp under a ``BoundaryNorm``, and sampling it at each value
+            returns the palette colour, not a default matplotlib colormap.
+        """
+        glyph = self._paletted_dataset().plot(band=0)
+        assert type(glyph.im.cmap).__name__ == "LinearSegmentedColormap"
+        assert type(glyph.im.norm).__name__ == "BoundaryNorm"
+        expected = {1: (1.0, 0.0, 0.0), 2: (0.0, 1.0, 0.0), 3: (0.0, 0.0, 1.0)}
+        for value, rgb in expected.items():
+            got = tuple(round(c, 3) for c in glyph.im.cmap(glyph.im.norm(value)))
+            assert got[:3] == rgb, f"value {value} should render {rgb}, got {got[:3]}"
+
+    @pytest.mark.plot
+    def test_explicit_cmap_overrides_palette(self):
+        """An explicit ``cmap=`` wins over the colour table — palette wiring skipped."""
+        glyph = self._paletted_dataset().plot(band=0, cmap="viridis")
+        assert glyph.im.cmap.name == "viridis"
+
+    @pytest.mark.plot
+    def test_explicit_color_scale_overrides_palette(self):
+        """An explicit ``color_scale=`` opts out of the palette's boundary norm."""
+        glyph = self._paletted_dataset().plot(band=0, color_scale="linear")
+        assert type(glyph.im.norm).__name__ != "BoundaryNorm"
+
+    @pytest.mark.plot
+    def test_non_paletted_raster_keeps_default_cmap(self):
+        """A raster with no colour table renders with cleopatra's default colormap."""
+        arr = np.random.default_rng(0).random((5, 5)).astype("float32")
+        dataset = Dataset.create_from_array(
+            arr, top_left_corner=(0, 0), cell_size=0.05, epsg=4326
+        )
+        glyph = dataset.plot(band=0)
+        assert glyph.im.cmap.name == "coolwarm_r"
+
+    @pytest.mark.plot
+    def test_palette_colormap_returns_ramp_and_sorted_edges(self):
+        """``_palette_colormap`` returns a segmented ramp + ``N+1`` ascending edges.
+
+        Test scenario:
+            Given an unsorted three-value colour table, the helper sorts by value
+            and returns a ``LinearSegmentedColormap`` plus four ascending boundary
+            edges (one per gap, bracketing each class).
+        """
+        color_table = pd.DataFrame(
+            {
+                "values": [3, 1, 2],
+                "red": [0, 255, 0],
+                "green": [0, 0, 255],
+                "blue": [255, 0, 0],
+            }
+        )
+        cmap, bounds = Analysis._palette_colormap(color_table)
+        assert type(cmap).__name__ == "LinearSegmentedColormap"
+        assert len(bounds) == 4
+        assert bounds == sorted(bounds)
+
+    @pytest.mark.plot
+    def test_multiband_palette_band_renders_its_table(self):
+        """A 3-band raster with a palette on band 1 plots band 1's colour table.
+
+        Test scenario:
+            ``plot()`` with no explicit band resolves the ``palette_index`` band
+            (band 1, GDAL band 2), then renders that band's red/green table so
+            value 1 comes back red. Values ``1``/``3`` (an even entry count once
+            gap-filled) keep the boundary-norm sampling exact.
+        """
+        mid = np.array([[1, 3, 1, 3]] * 4, dtype=np.int32)
+        other = np.full((4, 4), 9, dtype=np.int32)
+        dataset = Dataset.create_from_array(
+            np.stack([other, mid, other]),
+            top_left_corner=(0, 0),
+            cell_size=0.05,
+            epsg=4326,
+        )
+        dataset.color_table = pd.DataFrame(
+            {"band": [2, 2], "values": [1, 3], "color": ["#ff0000", "#00ff00"]}
+        )
+        dataset.band_color = {1: "palette_index"}
+
+        glyph = dataset.plot()
+        assert type(glyph.im.norm).__name__ == "BoundaryNorm"
+        got = tuple(round(c, 3) for c in glyph.im.cmap(glyph.im.norm(1)))
+        assert got[:3] == (1.0, 0.0, 0.0), f"band-1 value 1 should be red, got {got[:3]}"

--- a/tests/dataset/plot/test_plot_color.py
+++ b/tests/dataset/plot/test_plot_color.py
@@ -205,6 +205,33 @@ class TestPalettePlot:
             assert got == rgba, f"class {value} should render {rgba} (opaque), got {got}"
 
     @pytest.mark.plot
+    def test_high_code_land_cover_palette_renders_exact_and_opaque(self):
+        """High class codes (densified count > 131) still render exact + opaque.
+
+        Test scenario:
+            Land-cover products use codes up to ~200-220, so GDAL densifies the table
+            to that many entries. Each class must land on the slot cleopatra's
+            ``BoundaryNorm`` actually maps it to — a fixed round-trip index mis-maps
+            past ~131 and renders some classes transparent.
+        """
+        arr = np.array([[10, 132, 200, 10]], dtype=np.int32)
+        dataset = Dataset.create_from_array(
+            arr, top_left_corner=(0, 0), cell_size=0.05, epsg=4326
+        )
+        dataset.color_table = pd.DataFrame(
+            {
+                "band": [1, 1, 1],
+                "values": [10, 132, 200],
+                "color": ["#00ff00", "#ff0000", "#0000ff"],
+            }
+        )
+        glyph = dataset.plot(band=0)
+        expected = {10: (0.0, 1.0, 0.0, 1.0), 132: (1.0, 0.0, 0.0, 1.0), 200: (0.0, 0.0, 1.0, 1.0)}
+        for value, rgba in expected.items():
+            got = tuple(round(c, 3) for c in glyph.im.cmap(glyph.im.norm(value)))
+            assert got == rgba, f"class {value} should render {rgba} (opaque), got {got}"
+
+    @pytest.mark.plot
     def test_single_entry_palette_renders_without_crash(self):
         """A one-entry colour table renders instead of crashing the colormap build.
 

--- a/tests/dataset/plot/test_plot_color.py
+++ b/tests/dataset/plot/test_plot_color.py
@@ -171,10 +171,16 @@ class TestPalettePlot:
         glyph = self._paletted_dataset().plot(band=0)
         assert type(glyph.im.cmap).__name__ == "ListedColormap"
         assert type(glyph.im.norm).__name__ == "BoundaryNorm"
-        expected = {1: (1.0, 0.0, 0.0, 1.0), 2: (0.0, 1.0, 0.0, 1.0), 3: (0.0, 0.0, 1.0, 1.0)}
+        expected = {
+            1: (1.0, 0.0, 0.0, 1.0),
+            2: (0.0, 1.0, 0.0, 1.0),
+            3: (0.0, 0.0, 1.0, 1.0),
+        }
         for value, rgba in expected.items():
             got = tuple(round(c, 3) for c in glyph.im.cmap(glyph.im.norm(value)))
-            assert got == rgba, f"value {value} should render {rgba} (opaque), got {got}"
+            assert got == rgba, (
+                f"value {value} should render {rgba} (opaque), got {got}"
+            )
 
     @pytest.mark.plot
     def test_sparse_land_cover_palette_renders_exact_and_opaque(self):
@@ -199,10 +205,16 @@ class TestPalettePlot:
             }
         )
         glyph = dataset.plot(band=0)
-        expected = {11: (0.0, 1.0, 0.0, 1.0), 21: (1.0, 0.0, 0.0, 1.0), 31: (0.0, 0.0, 1.0, 1.0)}
+        expected = {
+            11: (0.0, 1.0, 0.0, 1.0),
+            21: (1.0, 0.0, 0.0, 1.0),
+            31: (0.0, 0.0, 1.0, 1.0),
+        }
         for value, rgba in expected.items():
             got = tuple(round(c, 3) for c in glyph.im.cmap(glyph.im.norm(value)))
-            assert got == rgba, f"class {value} should render {rgba} (opaque), got {got}"
+            assert got == rgba, (
+                f"class {value} should render {rgba} (opaque), got {got}"
+            )
 
     @pytest.mark.plot
     def test_high_code_land_cover_palette_renders_exact_and_opaque(self):
@@ -226,10 +238,16 @@ class TestPalettePlot:
             }
         )
         glyph = dataset.plot(band=0)
-        expected = {10: (0.0, 1.0, 0.0, 1.0), 132: (1.0, 0.0, 0.0, 1.0), 200: (0.0, 0.0, 1.0, 1.0)}
+        expected = {
+            10: (0.0, 1.0, 0.0, 1.0),
+            132: (1.0, 0.0, 0.0, 1.0),
+            200: (0.0, 0.0, 1.0, 1.0),
+        }
         for value, rgba in expected.items():
             got = tuple(round(c, 3) for c in glyph.im.cmap(glyph.im.norm(value)))
-            assert got == rgba, f"class {value} should render {rgba} (opaque), got {got}"
+            assert got == rgba, (
+                f"class {value} should render {rgba} (opaque), got {got}"
+            )
 
     @pytest.mark.plot
     def test_single_entry_palette_renders_without_crash(self):
@@ -248,7 +266,9 @@ class TestPalettePlot:
         )
         glyph = dataset.plot(band=0)
         got = tuple(round(c, 3) for c in glyph.im.cmap(glyph.im.norm(0)))
-        assert got == (1.0, 0.0, 0.0, 1.0), f"single-entry palette should render red, got {got}"
+        assert got == (1.0, 0.0, 0.0, 1.0), (
+            f"single-entry palette should render red, got {got}"
+        )
 
     @pytest.mark.plot
     def test_explicit_cmap_overrides_palette(self):
@@ -327,4 +347,6 @@ class TestPalettePlot:
         glyph = dataset.plot()
         assert type(glyph.im.norm).__name__ == "BoundaryNorm"
         got = tuple(round(c, 3) for c in glyph.im.cmap(glyph.im.norm(1)))
-        assert got[:3] == (1.0, 0.0, 0.0), f"band-1 value 1 should be red, got {got[:3]}"
+        assert got[:3] == (1.0, 0.0, 0.0), (
+            f"band-1 value 1 should be red, got {got[:3]}"
+        )

--- a/tests/dataset/plot/test_plot_resolution.py
+++ b/tests/dataset/plot/test_plot_resolution.py
@@ -152,8 +152,8 @@ class TestResolvePlotBandPolicy:
         assert resolved_rgb is None
 
     @pytest.mark.parametrize("palette_band", [0, 1, 2])
-    def test_paletted_band_not_treated_as_rgb(self, palette_band):
-        """#910: a ``palette_index`` band must not trigger the RGB heuristic.
+    def test_paletted_band_resolves_to_its_band(self, palette_band):
+        """#910/#913: a ``palette_index`` band resolves to itself, never RGB.
 
         Args:
             palette_band: Which band carries the palette (0, 1, or 2); the
@@ -162,15 +162,10 @@ class TestResolvePlotBandPolicy:
         Test scenario:
             A paletted band is rendered through its colour table, not as an
             RGB channel. A 3-band raster with a palette on one band (others
-            ``undefined``) must resolve to ``(0, None)`` and emit no
-            deprecation warning — not be mis-read as false-colour RGB
-            ``[2, 1, 0]`` with the Sentinel-2 fallback warning.
-
-            Note: ``resolved_band == 0`` is a deliberate placeholder even when
-            the palette sits on band 1 or 2 — the plot path does not yet render
-            a palette through its colour table (see #910), so no specific band
-            is more meaningful today. Revisit this assertion when paletted
-            rendering lands.
+            ``undefined``) must resolve to ``(palette_band, None)`` — so its
+            GDAL colour table renders (#913) — and emit no deprecation warning,
+            not be mis-read as false-colour RGB ``[2, 1, 0]`` with the
+            Sentinel-2 fallback warning.
         """
         rng = np.random.default_rng(910)
         arr = rng.random((3, 6, 6)).astype("float32")
@@ -185,8 +180,8 @@ class TestResolvePlotBandPolicy:
                 band=None, rgb=None
             )
         deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
-        assert resolved_band == 0, (
-            f"Paletted raster must resolve to band 0, got {resolved_band}"
+        assert resolved_band == palette_band, (
+            f"paletted raster must resolve to band {palette_band}, got {resolved_band}"
         )
         assert resolved_rgb is None, (
             f"rgb must stay None for a paletted raster, got {resolved_rgb}"


### PR DESCRIPTION
# Description

Renders paletted (single-band, colour-table) rasters through their **GDAL colour table** on `Dataset.plot()`,
instead of silently dropping the palette and applying a default matplotlib colormap.

What changed:

- **Wires in the previously-dead `Analysis._process_color_table`.** It had no `src/` caller; the plot path now
  uses it.
- **New `Analysis._palette_colormap`.** Turns the `[values, red, green, blue, alpha]` colour table into a
  256-entry **step `ListedColormap`** plus `BoundaryNorm` bin edges (via cleopatra's `category_boundaries`). The LUT
  slots are filled by asking the exact `BoundaryNorm(bounds, ncolors=256)` cleopatra will render with which slot
  each class maps to, and placing the class's colour there — so every class shows its own exact, opaque colour
  regardless of the palette's value range.
- **`Analysis.plot` palette branch.** On the single-band static path, when the resolved band carries a colour
  table and the caller passed none of `cmap` / `color_scale` / `bounds`, it hands cleopatra `cmap` +
  `color_scale="boundary-norm"` + `bounds`. Reads only the resolved band's table (`_get_color_table(band=band)`).
  An explicit `cmap` / `color_scale` / `bounds` opts out.
- **`Dataset._resolve_multiband_plot`** now resolves to the `palette_index` band (so its table is the one that
  renders), instead of always band 0 — retiring the #910 placeholder.

**Why a 256-entry step colormap keyed to cleopatra's norm.** cleopatra's public `color_scale="boundary-norm"`
builds its `BoundaryNorm` with a fixed `ncolors=256`. A small `ListedColormap` would be over-indexed (every class
clamps to the last colour); a `LinearSegmentedColormap` would interpolate between stops, blending the hue and
bleeding alpha toward GDAL's transparent `(0, 0, 0, 0)` gap-filler entries (GDAL densifies a colour table to
`0..maxvalue`), so real thematic classes would render translucent; and a fixed round-trip index mis-maps once the
densified entry count exceeds ~131 (the norm stretches regions to slots by truncation), so land-cover codes
(ESA CCI-LC ≤ 220, Copernicus ≤ 200) would land on a neighbour's transparent slot. Building the 256-entry LUT from
the same norm avoids all three and is exact for any code range. Plotting still goes entirely through cleopatra —
pyramids only builds the colour mapping. An exact one-swatch-per-class rendering with a discrete legend would need
a first-class categorical colour-table API on cleopatra's `ArrayGlyph`; that is a tracked follow-up
(breadcrumbed in `_palette_colormap`).

# Issues

- Closes #913 — render paletted rasters through their GDAL colour table (wire in `_process_color_table`).

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] `TestPalettePlot` — value→palette-colour render; a **sparse land-cover** palette (codes 11/21/31) and a
      **high-code** palette (10/132/200) both render each class exact + fully opaque; single-entry (N=1) palette
      renders without crashing; explicit `cmap` / `color_scale` / `bounds` each opt out; non-paletted rasters keep
      the default colormap; plus `_palette_colormap` (step cmap + edges) and the `_process_color_table` error
      branch, and the updated palette-aware resolution test.
- [x] Full plot suite for regressions (`pytest -m "plot or core" tests/dataset/plot tests/guards`) → 494 passed.
- [x] Doctests on both changed modules (`--doctest-modules`).
- [x] Branch coverage on the changed code is 100%.
- [x] Empirical render check across value ranges: exact + opaque for codes `{10, 132, 200}`, the full `0..220`
      ESA CCI-LC range, and a `0..255` sweep.
- [x] `mypy` clean; `ruff-format` / `ruff-check` clean; SonarCloud quality gate OK (0 bugs / 0 vulns / 0 smells).

# Checklist:

- [ ] updated version number in pyproject.toml. (release version is bumped by commitizen in CI, not by hand)
- [ ] added changes to History.rst. (change log is commitizen-generated)
- [ ] updated the latest version in README file. (n/a)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.
