### PR TITLE
docs(dataset): correct the stale _iloc migration note on RasterBase

### DIFF
--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -772,11 +772,11 @@ class RasterBase(ABC):
     def _iloc(self, i: int) -> gdal.Band:
         """Access a GDAL Band by 0-based index.
 
-        Hosted on `RasterBase` so every collaborator can resolve
-        `self._ds._iloc(i)` without depending on `BandMetadata` being
-        in the MRO. The duplicate body on `BandMetadata` is kept during
-        Stage 1 of the L-2 migration (both bodies are identical) and is
-        removed in Stage 2 PR2.7 when the bands collaborator lands.
+        Hosted on `RasterBase` so any collaborator can resolve
+        `self._ds._iloc(i)` through its back-reference to the dataset,
+        without `RasterBase` having to know about the collaborators. The
+        `Bands` collaborator keeps an identical `_iloc` of its own for its
+        internal calls (`engines/bands.py`); the two bodies are equivalent.
 
         The returned band object is only valid while the parent dataset
         is open. Do not store the band reference — use it immediately


### PR DESCRIPTION
# Description

`RasterBase._iloc`'s docstring carried a migration note that has gone stale on all three of its claims. Verified
against the code:

- it says the duplicate `_iloc` body lives on **`BandMetadata`** — that class no longer exists; the band methods
  live on the `Bands` collaborator (`engines/bands.py`);
- it says the duplicate is kept "during **Stage 1** of the L-2 migration" — the L-2 mixin→collaborator migration is
  complete (`Dataset.__mro__` is `Dataset → RasterBase → ABC → object`, and the op-families are `_Engine`
  collaborators, not mixins);
- it says the duplicate "is **removed in Stage 2 PR2.7** when the bands collaborator lands" — that never happened.
  `RasterBase._iloc` and `Bands._iloc` both exist and are both live (`RasterBase._iloc` reached by collaborators
  via `self._ds._iloc(...)`, `Bands._iloc` called by four `Bands` methods via `self._iloc(...)`).

The note now describes the actual arrangement: `_iloc` is hosted on `RasterBase` so any collaborator can reach it
through its back-reference to the dataset, and `Bands` keeps an identical copy for its own internal calls.

Docstring only — no code, no behaviour change. Surfaced while re-checking #814.

# Issues

- Refs #814 — the ABC-split tracker whose stale L-2 migration references this corrects

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- `pixi run -e dev pytest --doctest-modules src/pyramids/dataset/abstract_dataset.py` → 11 passed.
- Docstring-only change; no line exceeds 120 characters.

- [x] Doctests on `abstract_dataset.py` pass
- [x] No behaviour change (docstring text only)

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen bumps this on release)
- [ ] added changes to History.rst. (commitizen-generated; not hand-edited)
- [ ] updated the latest version in README file.
- [ ] I have added tests that prove my fix is effective or that my feature works. (docstring-only; nothing to test)
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (`RasterBase._iloc` docstring)
