### PR TITLE
fix(ci): pin build-time setuptools <84 for the GDAL bindings build (macOS clang)

### DIFF
--- a/ci/gdal-build-constraints.txt
+++ b/ci/gdal-build-constraints.txt
@@ -1,0 +1,12 @@
+# Build-time constraints for the GDAL Python-bindings build
+# (ci/install-and-vendor-osgeo.py sets PIP_CONSTRAINT to this file).
+#
+# setuptools 84.0.0 (released 2026-08-08) changed how a build's
+# extra_compile_args are assembled, so GDAL's setup.py `-std=c++11` — which
+# it adds to EVERY extension, including the C module gdalconst_wrap.c — now
+# reaches the C compile. Apple clang (Xcode 16.2 on the macos-14 runners)
+# rejects it with a hard error, `invalid argument '-std=c++11' not allowed
+# with 'C'`, breaking both macOS wheels (arm64 + x86_64). setuptools 83.0.0
+# built fine on the identical toolchain. Cap it until GDAL's setup.py stops
+# passing a C++ std flag to C sources (upstream bug) or setuptools reverts.
+setuptools<84

--- a/ci/install-and-vendor-osgeo.py
+++ b/ci/install-and-vendor-osgeo.py
@@ -146,11 +146,14 @@ def install_gdal_python_bindings() -> None:
     # Cap build-time setuptools (see ci/gdal-build-constraints.txt): 84.0.0
     # lets GDAL's setup.py `-std=c++11` reach the C compile of
     # gdalconst_wrap.c, which Apple clang rejects and breaks the macOS
-    # wheels. PIP_CONSTRAINT is honored for BOTH the isolated build env
-    # (x86_64 / Linux) and the arm64 --no-build-isolation setuptools install.
-    env.setdefault(
-        "PIP_CONSTRAINT", str(REPO_ROOT / "ci" / "gdal-build-constraints.txt")
-    )
+    # wheels. Set BOTH vars: PIP_CONSTRAINT covers the direct install
+    # (arm64 --no-build-isolation), and PIP_BUILD_CONSTRAINT covers the
+    # isolated build env (x86_64 / Linux). pip currently honors
+    # PIP_CONSTRAINT for build deps too but warns it will stop in pip 26.2,
+    # pointing at PIP_BUILD_CONSTRAINT — so we set both to stay durable.
+    _gdal_build_constraints = str(REPO_ROOT / "ci" / "gdal-build-constraints.txt")
+    env.setdefault("PIP_CONSTRAINT", _gdal_build_constraints)
+    env.setdefault("PIP_BUILD_CONSTRAINT", _gdal_build_constraints)
 
     if is_windows:
         bin_dir, _, lib_dir = _data_layout_roots(prefix)

--- a/ci/install-and-vendor-osgeo.py
+++ b/ci/install-and-vendor-osgeo.py
@@ -143,6 +143,13 @@ def install_gdal_python_bindings() -> None:
 
     env = os.environ.copy()
 
+    # Cap build-time setuptools (see ci/gdal-build-constraints.txt): 84.0.0
+    # lets GDAL's setup.py `-std=c++11` reach the C compile of
+    # gdalconst_wrap.c, which Apple clang rejects and breaks the macOS
+    # wheels. PIP_CONSTRAINT is honored for BOTH the isolated build env
+    # (x86_64 / Linux) and the arm64 --no-build-isolation setuptools install.
+    env.setdefault("PIP_CONSTRAINT", str(REPO_ROOT / "ci" / "gdal-build-constraints.txt"))
+
     if is_windows:
         bin_dir, _, lib_dir = _data_layout_roots(prefix)
         include_dir = prefix / "Library" / "include"

--- a/ci/install-and-vendor-osgeo.py
+++ b/ci/install-and-vendor-osgeo.py
@@ -148,7 +148,9 @@ def install_gdal_python_bindings() -> None:
     # gdalconst_wrap.c, which Apple clang rejects and breaks the macOS
     # wheels. PIP_CONSTRAINT is honored for BOTH the isolated build env
     # (x86_64 / Linux) and the arm64 --no-build-isolation setuptools install.
-    env.setdefault("PIP_CONSTRAINT", str(REPO_ROOT / "ci" / "gdal-build-constraints.txt"))
+    env.setdefault(
+        "PIP_CONSTRAINT", str(REPO_ROOT / "ci" / "gdal-build-constraints.txt")
+    )
 
     if is_windows:
         bin_dir, _, lib_dir = _data_layout_roots(prefix)


### PR DESCRIPTION
# Description

The macOS wheel jobs (`build-macos-wheels (arm64)` and `build-macos-wheels (x86_64)`) started failing on
2026-08-09 in `ci/install-and-vendor-osgeo.py` at `pip install GDAL==3.13.1`. GDAL's `setup.py` adds `-std=c++11`
to **every** extension, including the one **C** module `extensions/gdalconst_wrap.c`, and **setuptools 84.0.0**
(released 2026-08-08) changed how a build's `extra_compile_args` are assembled so that C++ std flag now reaches the
C compile. Apple clang (Xcode 16.2 on `macos-14`) then hard-errors:
`invalid argument '-std=c++11' not allowed with 'C'`. The same build on the same image/toolchain passed two days
earlier with setuptools 83.0.0; the run's own change (#945, a netcdf refactor) does not touch the macOS build.

This pins build-time setuptools `<84` for the GDAL bindings build:

- adds `ci/gdal-build-constraints.txt` (`setuptools<84`)
- points `PIP_CONSTRAINT` at it in `install_gdal_python_bindings()` — pip honors it for BOTH the isolated build
  env (x86_64 / Linux) and the arm64 `--no-build-isolation` setuptools install, so both macOS paths are covered.
  It is a build-time-only cap that never ships in the wheel; harmless on Linux/Windows.

Longer term this is a GDAL `setup.py` bug (it should not pass a C++ std flag to a C source); the cap can be
removed once GDAL fixes that or setuptools reverts.

# Issues

- Closes #949 — macOS wheels fail: setuptools 84 makes GDAL's -std=c++11 break the C compile of gdalconst_wrap.c

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Root cause verified by diffing the last green run (2026-08-07, setuptools 83.0.0) against the failing run
  (2026-08-09, setuptools 84.0.0) — identical macOS image, Xcode 16.2, and GDAL 3.13.1; only build-setuptools
  differed. Confirmed setuptools 84.0.0's upload date (2026-08-08) falls in the window.
- A manual `bundle-pypi-wheels` dry-run against this branch validates that `build-macos-wheels` (arm64 + x86_64)
  now builds the GDAL bindings and completes green.

- [x] Constraint file parses; `install-and-vendor-osgeo.py` parses; line lengths OK
- [ ] `build-macos-wheels` (arm64 + x86_64) green on the dispatched dry-run

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen-managed; not applicable)
- [ ] added changes to History.rst. (changelog is commitizen-generated; not applicable)
- [ ] updated the latest version in README file. (not applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works. (CI-build change; validated by
      the dispatched bundle build, no unit-test surface)
- [x] New and existing unit tests pass locally with my changes. (no source touched)
- [ ] documentation are updated. (no user-facing surface)
