### PR TITLE
fix(ci): only set PIP_BUILD_CONSTRAINT on build-isolation paths (macOS arm64 regression)

### DIFF
--- a/ci/install-and-vendor-osgeo.py
+++ b/ci/install-and-vendor-osgeo.py
@@ -146,14 +146,13 @@ def install_gdal_python_bindings() -> None:
     # Cap build-time setuptools (see ci/gdal-build-constraints.txt): 84.0.0
     # lets GDAL's setup.py `-std=c++11` reach the C compile of
     # gdalconst_wrap.c, which Apple clang rejects and breaks the macOS
-    # wheels. Set BOTH vars: PIP_CONSTRAINT covers the direct install
-    # (arm64 --no-build-isolation), and PIP_BUILD_CONSTRAINT covers the
-    # isolated build env (x86_64 / Linux). pip currently honors
-    # PIP_CONSTRAINT for build deps too but warns it will stop in pip 26.2,
-    # pointing at PIP_BUILD_CONSTRAINT — so we set both to stay durable.
+    # wheels. PIP_CONSTRAINT covers the direct install on every path
+    # (including the arm64 --no-build-isolation setuptools install below).
+    # PIP_BUILD_CONSTRAINT — the build-isolation-specific var pip 26.2 will
+    # require — is set later, ONLY when build isolation is used: pip errors
+    # if it is passed together with --no-build-isolation.
     _gdal_build_constraints = str(REPO_ROOT / "ci" / "gdal-build-constraints.txt")
     env.setdefault("PIP_CONSTRAINT", _gdal_build_constraints)
-    env.setdefault("PIP_BUILD_CONSTRAINT", _gdal_build_constraints)
 
     if is_windows:
         bin_dir, _, lib_dir = _data_layout_roots(prefix)
@@ -270,6 +269,15 @@ def install_gdal_python_bindings() -> None:
             check=True,
         )
         extra_pip_args.append("--no-build-isolation")
+
+    # PIP_BUILD_CONSTRAINT constrains the ISOLATED build env; pip errors out
+    # if it is set together with --no-build-isolation. Set it only when the
+    # GDAL build uses isolation (x86_64 / Linux) — the arm64
+    # --no-build-isolation path pre-installs a PIP_CONSTRAINT-capped
+    # setuptools and is already covered. This future-proofs isolation builds
+    # for pip 26.2, which stops honoring PIP_CONSTRAINT for build deps.
+    if "--no-build-isolation" not in extra_pip_args:
+        env.setdefault("PIP_BUILD_CONSTRAINT", _gdal_build_constraints)
 
     cmd = [
         sys.executable,


### PR DESCRIPTION
# Description

Follow-up fix to #950. That PR added `PIP_BUILD_CONSTRAINT` unconditionally to future-proof the setuptools cap for
pip 26.2, but pip **rejects it together with `--no-build-isolation`**:

```
ERROR: --build-constraint cannot be used with --no-build-isolation.
```

That is exactly the macOS **arm64** path (which pre-installs a pinned setuptools and builds GDAL with
`--no-build-isolation`), so the release build of #950 on `main` broke `build-macos-wheels (arm64)` at
`pip install GDAL==3.13.1` (run 31328453902). It was not caught because the green dry-run predated the
`PIP_BUILD_CONSTRAINT` commit, which merged without re-validation.

This sets `PIP_BUILD_CONSTRAINT` **only** when the GDAL build uses build isolation (x86_64 / Linux / Windows). The
arm64 `--no-build-isolation` path is already covered by `PIP_CONSTRAINT` (which caps the explicit setuptools
pre-install). `PIP_CONSTRAINT` still applies on every path.

# Issues

- Fixes the macOS arm64 regression introduced by #950 (no separate tracking issue).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- Simulated the gating: arm64 (`--no-build-isolation`) -> `PIP_BUILD_CONSTRAINT` NOT set; x86_64 / Linux / Windows
  (isolation) -> set.
- A `bundle-pypi-wheels` dry-run against this branch validates `build-macos-wheels (arm64)` (the path that broke)
  and `(x86_64)` both build the GDAL bindings and complete green.

- [x] Syntax + ruff/ruff-format clean; gating simulated
- [ ] `build-macos-wheels` (arm64 + x86_64) green on the dispatched dry-run

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen-managed; not applicable)
- [ ] added changes to History.rst. (changelog is commitizen-generated; not applicable)
- [ ] updated the latest version in README file. (not applicable)
- [ ] I have added tests that prove my fix is effective. (CI-build change; validated by the dispatched bundle build)
- [x] New and existing unit tests pass locally with my changes. (no source touched)
- [ ] documentation are updated. (no user-facing surface)
