### PR TITLE
feat(dataset): generate a color table from a color ramp

### DIFF
--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -1348,7 +1348,16 @@ class Dataset(RasterBase):
         self._require_writable("set band colors")
         self.bands.band_color = values
 
-    def set_color_ramp(self, *args, **kwargs):
+    def set_color_ramp(
+        self,
+        band: int = 1,
+        *,
+        start_value: int,
+        end_value: int,
+        start_color: str | None = None,
+        end_color: str | None = None,
+        colormap: str | None = None,
+    ) -> None:
         """Facade — delegates to :meth:`Bands.set_color_ramp <pyramids.dataset.engines.Bands.set_color_ramp>`.
 
         Raises:
@@ -1356,7 +1365,14 @@ class Dataset(RasterBase):
                 would otherwise silently spill a PAM sidecar).
         """
         self._require_writable("set a color ramp")
-        return self.bands.set_color_ramp(*args, **kwargs)
+        return self.bands.set_color_ramp(
+            band,
+            start_value=start_value,
+            end_value=end_value,
+            start_color=start_color,
+            end_color=end_color,
+            colormap=colormap,
+        )
 
     @property
     def color_table(self):

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -1348,6 +1348,16 @@ class Dataset(RasterBase):
         self._require_writable("set band colors")
         self.bands.band_color = values
 
+    def set_color_ramp(self, *args, **kwargs):
+        """Facade — delegates to :meth:`Bands.set_color_ramp <pyramids.dataset.engines.Bands.set_color_ramp>`.
+
+        Raises:
+            ReadOnlyError: The dataset is opened read-only on-disk (writing the palette
+                would otherwise silently spill a PAM sidecar).
+        """
+        self._require_writable("set a color ramp")
+        return self.bands.set_color_ramp(*args, **kwargs)
+
     @property
     def color_table(self):
         """Facade — delegates to :attr:`Bands.color_table <pyramids.dataset.engines.Bands.color_table>`."""

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -895,6 +895,28 @@ class Bands(_Engine["Dataset"]):
               5    1      5  242   206  133   255
 
               ```
+
+            - A named matplotlib colormap is sampled evenly across the range instead of a
+              two-colour pair; value 1 is viridis' dark-purple start:
+
+              ```python
+              >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
+              >>> arr = np.random.randint(1, 6, size=(10, 10))
+              >>> ds = Dataset.create_from_array(
+              ...     arr, top_left_corner=(0, 0), cell_size=0.05, epsg=4326
+              ... )
+              >>> ds.set_color_ramp(band=1, start_value=1, end_value=5, colormap="viridis")
+              >>> row = ds.color_table.set_index("values").loc[1, ["red", "green", "blue"]]
+              >>> [int(component) for component in row]
+              [68, 1, 84]
+
+              ```
+
+        See Also:
+            color_table: The lower-level setter that takes an explicit per-value colour
+                table; `set_color_ramp` generates that table from a ramp and forwards it
+                through the same path.
         """
         if not 1 <= band <= self._ds.band_count:
             raise ValueError(

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -848,7 +848,10 @@ class Bands(_Engine["Dataset"]):
                 colour entry is written per integer in `[start_value, end_value]`, so a
                 very wide range (e.g. every UInt16 value, 0..65535) builds a
                 correspondingly large table — keep the range to the classes you actually
-                need.
+                need. The GDAL palette is dense from index 0, so the table always spans
+                `0..end_value`: a narrow ramp at a high `start_value` still allocates every
+                lower index, and values below `start_value` are left transparent
+                `(0, 0, 0, 0)`. Cost therefore scales with `end_value`, not the range width.
             start_color (str, optional):
                 Hex colour at `start_value`. Give together with `end_color`, and not with
                 `colormap`.
@@ -898,8 +901,17 @@ class Bands(_Engine["Dataset"]):
                 f"band {band} is out of range for a {self._ds.band_count}-band "
                 "dataset (bands are 1-based)"
             )
-        if int(start_value) != start_value or int(end_value) != end_value:
-            raise TypeError("start_value and end_value must be integers")
+        for name, value in (("start_value", start_value), ("end_value", end_value)):
+            # bool is an int subclass but not a meaningful colour index; reject it
+            # (and any non-numeric type) with the documented TypeError rather than a
+            # cryptic downstream one. float('inf').is_integer() is False, so a
+            # non-finite float lands here too instead of raising OverflowError.
+            if isinstance(value, bool) or not isinstance(
+                value, (int, np.integer, float, np.floating)
+            ):
+                raise TypeError(f"{name} must be an integer, not {type(value).__name__}")
+            if not float(value).is_integer():
+                raise TypeError(f"{name} must be a whole number, got {value!r}")
         start_value, end_value = int(start_value), int(end_value)
         if start_value < 0:
             raise ValueError(
@@ -952,15 +964,17 @@ class Bands(_Engine["Dataset"]):
                 start_value, (*start_rgb, 255), end_value, (*end_rgb, 255)
             )
 
-        rows = [
-            {
-                "band": band,
-                "values": value,
-                "color": "#{:02x}{:02x}{:02x}".format(*ramp.GetColorEntry(value)[:3]),
-                "alpha": ramp.GetColorEntry(value)[3],
-            }
-            for value in range(start_value, end_value + 1)
-        ]
+        rows = []
+        for value in range(start_value, end_value + 1):
+            entry = ramp.GetColorEntry(value)
+            rows.append(
+                {
+                    "band": band,
+                    "values": value,
+                    "color": "#{:02x}{:02x}{:02x}".format(*entry[:3]),
+                    "alpha": entry[3],
+                }
+            )
         self._set_color_table(DataFrame(rows), overwrite=True)
 
     def _set_color_table(self, color_df: DataFrame, overwrite: bool = False) -> None:

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -931,7 +931,9 @@ class Bands(_Engine["Dataset"]):
             if isinstance(value, bool) or not isinstance(
                 value, (int, np.integer, float, np.floating)
             ):
-                raise TypeError(f"{name} must be an integer, not {type(value).__name__}")
+                raise TypeError(
+                    f"{name} must be an integer, not {type(value).__name__}"
+                )
             if not float(value).is_integer():
                 raise TypeError(f"{name} must be a whole number, got {value!r}")
         start_value, end_value = int(start_value), int(end_value)

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -812,6 +812,126 @@ class Bands(_Engine["Dataset"]):
 
         self._set_color_table(df, overwrite=True)
 
+    def set_color_ramp(
+        self,
+        band: int = 1,
+        *,
+        start_value: int,
+        end_value: int,
+        start_color: str | None = None,
+        end_color: str | None = None,
+        colormap: str | None = None,
+    ) -> None:
+        """Attach a colour table interpolated across a value range.
+
+        Fills every integer value in `[start_value, end_value]` with a colour, so a
+        continuous raster does not need every stop enumerated by hand the way the plain
+        `color_table` setter demands. Exactly one of two modes must be given:
+
+        - a **two-colour linear ramp** between `start_color` and `end_color`, built with
+          `gdal.ColorTable.CreateColorRamp`;
+        - a named matplotlib **`colormap`** (e.g. `"viridis"`), sampled evenly across the
+          range.
+
+        The generated entries flow through the same `_set_color_table` path the enumerated
+        setter uses, so the attached palette matches it in form. Needs the `[viz]` extra
+        (the `colormap` mode also uses its matplotlib).
+
+        Args:
+            band (int):
+                1-based band to colour. Defaults to 1.
+            start_value (int):
+                First value in the ramp (keyword-only).
+            end_value (int):
+                Last value in the ramp; must exceed `start_value` (keyword-only).
+            start_color (str, optional):
+                Hex colour at `start_value`. Give together with `end_color`, and not with
+                `colormap`.
+            end_color (str, optional):
+                Hex colour at `end_value`. Give together with `start_color`.
+            colormap (str, optional):
+                Named matplotlib colormap sampled across the range. Give instead of the
+                `start_color` / `end_color` pair.
+
+        Raises:
+            ValueError:
+                `end_value` is not greater than `start_value`; only one of
+                `start_color` / `end_color` is given; or the mode is ambiguous (neither a
+                colour pair nor a colormap, or both).
+
+        Examples:
+            - A two-colour ramp green -> tan across values 1..5 fills the three
+              intermediate stops for you:
+
+              ```python
+              >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
+              >>> arr = np.random.randint(1, 6, size=(10, 10))
+              >>> ds = Dataset.create_from_array(
+              ...     arr, top_left_corner=(0, 0), cell_size=0.05, epsg=4326
+              ... )
+              >>> ds.set_color_ramp(
+              ...     band=1, start_value=1, end_value=5,
+              ...     start_color="#709959", end_color="#F2CE85",
+              ... )
+              >>> print(ds.color_table)
+                band values  red green blue alpha
+              0    1      0    0     0    0     0
+              1    1      1  112   153   89   255
+              2    1      2  144   166  100   255
+              3    1      3  177   179  111   255
+              4    1      4  209   192  122   255
+              5    1      5  242   206  133   255
+
+              ```
+        """
+        if end_value <= start_value:
+            raise ValueError(
+                f"end_value ({end_value}) must be greater than start_value "
+                f"({start_value})"
+            )
+        if (start_color is None) != (end_color is None):
+            raise ValueError("start_color and end_color must be given together")
+        pair_given = start_color is not None
+        if pair_given == (colormap is not None):
+            raise ValueError(
+                "provide exactly one of a (start_color, end_color) pair or a colormap="
+            )
+
+        require_cleopatra()
+        from cleopatra.colors import Colors
+
+        ramp = gdal.ColorTable()
+        if colormap is not None:
+            from matplotlib import colormaps
+
+            cmap = colormaps[colormap]
+            span = end_value - start_value
+            for offset in range(span + 1):
+                red, green, blue, _ = cmap(offset / span)
+                ramp.SetColorEntry(
+                    start_value + offset,
+                    (round(red * 255), round(green * 255), round(blue * 255), 255),
+                )
+        else:
+            start_rgb, end_rgb = Colors([start_color, end_color]).to_rgb(
+                normalized=False
+            )
+            ramp.CreateColorRamp(
+                start_value, (*start_rgb, 255), end_value, (*end_rgb, 255)
+            )
+
+        rows = [
+            {
+                "band": band,
+                "values": value,
+                "color": "#{:02x}{:02x}{:02x}".format(*ramp.GetColorEntry(value)[:3]),
+                "alpha": ramp.GetColorEntry(value)[3],
+            }
+            for value in range(start_value, end_value + 1)
+        ]
+        self._set_color_table(DataFrame(rows), overwrite=True)
+
     def _set_color_table(self, color_df: DataFrame, overwrite: bool = False) -> None:
         """_set_color_table.
 

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -841,9 +841,14 @@ class Bands(_Engine["Dataset"]):
             band (int):
                 1-based band to colour. Defaults to 1.
             start_value (int):
-                First value in the ramp (keyword-only).
+                First value in the ramp; must be `>= 0` (GDAL colour indices are
+                non-negative). Keyword-only.
             end_value (int):
-                Last value in the ramp; must exceed `start_value` (keyword-only).
+                Last value in the ramp; must exceed `start_value` (keyword-only). One
+                colour entry is written per integer in `[start_value, end_value]`, so a
+                very wide range (e.g. every UInt16 value, 0..65535) builds a
+                correspondingly large table — keep the range to the classes you actually
+                need.
             start_color (str, optional):
                 Hex colour at `start_value`. Give together with `end_color`, and not with
                 `colormap`.
@@ -854,10 +859,13 @@ class Bands(_Engine["Dataset"]):
                 `start_color` / `end_color` pair.
 
         Raises:
+            TypeError:
+                `start_value` or `end_value` is not an integer.
             ValueError:
-                `end_value` is not greater than `start_value`; only one of
-                `start_color` / `end_color` is given; or the mode is ambiguous (neither a
-                colour pair nor a colormap, or both).
+                `band` is outside `1..band_count`; `start_value` is negative; `end_value`
+                is not greater than `start_value`; only one of `start_color` / `end_color`
+                is given (or one is blank); the mode is ambiguous (neither a colour pair
+                nor a colormap, or both); or `colormap` is not a known matplotlib name.
 
         Examples:
             - A two-colour ramp green -> tan across values 1..5 fills the three
@@ -885,15 +893,30 @@ class Bands(_Engine["Dataset"]):
 
               ```
         """
+        if not 1 <= band <= self._ds.band_count:
+            raise ValueError(
+                f"band {band} is out of range for a {self._ds.band_count}-band "
+                "dataset (bands are 1-based)"
+            )
+        if int(start_value) != start_value or int(end_value) != end_value:
+            raise TypeError("start_value and end_value must be integers")
+        start_value, end_value = int(start_value), int(end_value)
+        if start_value < 0:
+            raise ValueError(
+                f"start_value ({start_value}) must be >= 0: GDAL colour indices are "
+                "non-negative"
+            )
         if end_value <= start_value:
             raise ValueError(
                 f"end_value ({end_value}) must be greater than start_value "
                 f"({start_value})"
             )
-        if (start_color is None) != (end_color is None):
-            raise ValueError("start_color and end_color must be given together")
-        pair_given = start_color is not None
-        if pair_given == (colormap is not None):
+        # Treat an empty/blank string as "not given", so the mode guards reject it with a
+        # clear message instead of letting it reach cleopatra/matplotlib as a cryptic one.
+        has_pair = bool(start_color) and bool(end_color)
+        if bool(start_color) != bool(end_color):
+            raise ValueError("start_color and end_color must both be given")
+        if has_pair == bool(colormap):
             raise ValueError(
                 "provide exactly one of a (start_color, end_color) pair or a colormap="
             )
@@ -902,9 +925,17 @@ class Bands(_Engine["Dataset"]):
         from cleopatra.colors import Colors
 
         ramp = gdal.ColorTable()
-        if colormap is not None:
+        if colormap:
+            # matplotlib is a hard cleopatra dependency, so it is importable once
+            # require_cleopatra() has passed; imported here for the same reason
+            # _set_color_table imports cleopatra lazily (optional viz extra).
             from matplotlib import colormaps
 
+            if colormap not in colormaps:
+                raise ValueError(
+                    f"unknown colormap {colormap!r}; pass a name from matplotlib's "
+                    "registry (e.g. 'viridis', 'terrain')"
+                )
             cmap = colormaps[colormap]
             span = end_value - start_value
             for offset in range(span + 1):

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -918,6 +918,69 @@ class Bands(_Engine["Dataset"]):
                 table; `set_color_ramp` generates that table from a ramp and forwards it
                 through the same path.
         """
+        start_value, end_value = self._validate_color_ramp_args(
+            band, start_value, end_value, start_color, end_color, colormap
+        )
+
+        require_cleopatra()
+        from cleopatra.colors import Colors
+
+        if colormap:
+            ramp = self._ramp_from_colormap(colormap, start_value, end_value)
+        else:
+            start_rgb, end_rgb = Colors([start_color, end_color]).to_rgb(
+                normalized=False
+            )
+            ramp = gdal.ColorTable()
+            ramp.CreateColorRamp(
+                start_value, (*start_rgb, 255), end_value, (*end_rgb, 255)
+            )
+
+        rows = []
+        for value in range(start_value, end_value + 1):
+            entry = ramp.GetColorEntry(value)
+            rows.append(
+                {
+                    "band": band,
+                    "values": value,
+                    "color": "#{:02x}{:02x}{:02x}".format(*entry[:3]),
+                    "alpha": entry[3],
+                }
+            )
+        self._set_color_table(DataFrame(rows), overwrite=True)
+
+    def _validate_color_ramp_args(
+        self,
+        band: int,
+        start_value: int,
+        end_value: int,
+        start_color: str | None,
+        end_color: str | None,
+        colormap: str | None,
+    ) -> tuple[int, int]:
+        """Validate `set_color_ramp` inputs and return the coerced integer range.
+
+        Raises the same `TypeError` / `ValueError` documented on `set_color_ramp`.
+        Extracted to keep the public method's cognitive complexity low.
+
+        Args:
+            band (int):
+                1-based band index to colour.
+            start_value (int):
+                First value in the ramp.
+            end_value (int):
+                Last value in the ramp.
+            start_color (str, optional):
+                Hex colour at `start_value`, paired with `end_color`.
+            end_color (str, optional):
+                Hex colour at `end_value`, paired with `start_color`.
+            colormap (str, optional):
+                Named matplotlib colormap, given instead of the colour pair.
+
+        Returns:
+            tuple[int, int]:
+                The coerced `(start_value, end_value)` integers.
+        """
         if not 1 <= band <= self._ds.band_count:
             raise ValueError(
                 f"band {band} is out of range for a {self._ds.band_count}-band "
@@ -956,50 +1019,46 @@ class Bands(_Engine["Dataset"]):
             raise ValueError(
                 "provide exactly one of a (start_color, end_color) pair or a colormap="
             )
+        return start_value, end_value
 
-        require_cleopatra()
-        from cleopatra.colors import Colors
+    @staticmethod
+    def _ramp_from_colormap(
+        colormap: str, start_value: int, end_value: int
+    ) -> gdal.ColorTable:
+        """Sample a named matplotlib colormap evenly across `[start_value, end_value]`.
 
+        Args:
+            colormap (str):
+                Named matplotlib colormap (e.g. `"viridis"`).
+            start_value (int):
+                First value in the ramp.
+            end_value (int):
+                Last value in the ramp.
+
+        Returns:
+            gdal.ColorTable:
+                A colour table with one opaque entry per value in the range.
+        """
+        # matplotlib is a hard cleopatra dependency, so it is importable once
+        # require_cleopatra() has passed (the caller enforces that); imported here for
+        # the same reason _set_color_table imports cleopatra lazily (optional viz extra).
+        from matplotlib import colormaps
+
+        if colormap not in colormaps:
+            raise ValueError(
+                f"unknown colormap {colormap!r}; pass a name from matplotlib's "
+                "registry (e.g. 'viridis', 'terrain')"
+            )
+        cmap = colormaps[colormap]
+        span = end_value - start_value
         ramp = gdal.ColorTable()
-        if colormap:
-            # matplotlib is a hard cleopatra dependency, so it is importable once
-            # require_cleopatra() has passed; imported here for the same reason
-            # _set_color_table imports cleopatra lazily (optional viz extra).
-            from matplotlib import colormaps
-
-            if colormap not in colormaps:
-                raise ValueError(
-                    f"unknown colormap {colormap!r}; pass a name from matplotlib's "
-                    "registry (e.g. 'viridis', 'terrain')"
-                )
-            cmap = colormaps[colormap]
-            span = end_value - start_value
-            for offset in range(span + 1):
-                red, green, blue, _ = cmap(offset / span)
-                ramp.SetColorEntry(
-                    start_value + offset,
-                    (round(red * 255), round(green * 255), round(blue * 255), 255),
-                )
-        else:
-            start_rgb, end_rgb = Colors([start_color, end_color]).to_rgb(
-                normalized=False
+        for offset in range(span + 1):
+            red, green, blue, _ = cmap(offset / span)
+            ramp.SetColorEntry(
+                start_value + offset,
+                (round(red * 255), round(green * 255), round(blue * 255), 255),
             )
-            ramp.CreateColorRamp(
-                start_value, (*start_rgb, 255), end_value, (*end_rgb, 255)
-            )
-
-        rows = []
-        for value in range(start_value, end_value + 1):
-            entry = ramp.GetColorEntry(value)
-            rows.append(
-                {
-                    "band": band,
-                    "values": value,
-                    "color": "#{:02x}{:02x}{:02x}".format(*entry[:3]),
-                    "alpha": entry[3],
-                }
-            )
-        self._set_color_table(DataFrame(rows), overwrite=True)
+        return ramp
 
     def _set_color_table(self, color_df: DataFrame, overwrite: bool = False) -> None:
         """_set_color_table.

--- a/tests/dataset/plot/test_plot_color.py
+++ b/tests/dataset/plot/test_plot_color.py
@@ -350,3 +350,110 @@ class TestPalettePlot:
         assert got[:3] == (1.0, 0.0, 0.0), (
             f"band-1 value 1 should be red, got {got[:3]}"
         )
+
+
+class TestColorRamp:
+    """`set_color_ramp` (#911): generate a palette from a continuous ramp."""
+
+    @staticmethod
+    def _dataset() -> Dataset:
+        """A single-band 10x10 raster with values 1..5."""
+        rng = np.random.default_rng(0)
+        arr = rng.integers(1, 6, size=(10, 10))
+        return Dataset.create_from_array(
+            arr, top_left_corner=(0, 0), cell_size=0.05, epsg=4326
+        )
+
+    def test_two_color_ramp_interpolates_the_intermediate_stops(self):
+        """A two-colour ramp fills the values between the endpoints via CreateColorRamp.
+
+        Test scenario:
+            Ramp #709959 -> #F2CE85 across 1..5 -> the midpoint value 3 is GDAL's
+            interpolated (177, 179, 111, 255), the endpoints are exact, and the band ends
+            up paletted.
+        """
+        dataset = self._dataset()
+        dataset.set_color_ramp(
+            band=1, start_value=1, end_value=5,
+            start_color="#709959", end_color="#F2CE85",
+        )
+        table = dataset.color_table.set_index("values")
+        assert tuple(table.loc[1, ["red", "green", "blue", "alpha"]]) == (112, 153, 89, 255), (
+            "value 1 must be the start colour"
+        )
+        assert tuple(table.loc[3, ["red", "green", "blue", "alpha"]]) == (177, 179, 111, 255), (
+            "value 3 must be the interpolated midpoint"
+        )
+        assert tuple(table.loc[5, ["red", "green", "blue", "alpha"]]) == (242, 206, 133, 255), (
+            "value 5 must be the end colour"
+        )
+        assert dataset.raster.GetRasterBand(1).GetColorTable() is not None, (
+            "the band must end up paletted"
+        )
+
+    def test_named_colormap_ramp_samples_the_endpoints(self):
+        """A named colormap is sampled across the range through the same path.
+
+        Test scenario:
+            colormap='viridis' across 1..5 -> value 1 is viridis' dark-purple start and
+            value 5 its yellow end, and the band is paletted.
+        """
+        dataset = self._dataset()
+        dataset.set_color_ramp(band=1, start_value=1, end_value=5, colormap="viridis")
+        table = dataset.color_table.set_index("values")
+        assert tuple(table.loc[1, ["red", "green", "blue"]]) == (68, 1, 84), (
+            "value 1 must be viridis' start"
+        )
+        assert tuple(table.loc[5, ["red", "green", "blue"]]) == (253, 231, 37), (
+            "value 5 must be viridis' end"
+        )
+        assert dataset.raster.GetRasterBand(1).GetColorTable() is not None, (
+            "the band must end up paletted"
+        )
+
+    def test_ramp_matches_the_enumerated_setter_for_the_same_stops(self):
+        """The ramp path produces the same palette as enumerating those stops by hand.
+
+        Test scenario:
+            Build the identical five stops through the plain `color_table` setter and
+            through `set_color_ramp`; the retrieved tables must be equal.
+        """
+        stops = ["#709959", "#90a664", "#b1b36f", "#d1c07a", "#f2ce85"]
+        enumerated = self._dataset()
+        enumerated.color_table = pd.DataFrame(
+            {"band": [1] * 5, "values": [1, 2, 3, 4, 5], "color": stops}
+        )
+        ramped = self._dataset()
+        ramped.set_color_ramp(
+            band=1, start_value=1, end_value=5,
+            start_color="#709959", end_color="#f2ce85",
+        )
+        pd.testing.assert_frame_equal(enumerated.color_table, ramped.color_table)
+
+    def test_end_not_greater_than_start_raises(self):
+        """A non-increasing range is rejected before any GDAL call."""
+        with pytest.raises(ValueError, match="must be greater than start_value"):
+            self._dataset().set_color_ramp(
+                band=1, start_value=5, end_value=5,
+                start_color="#000000", end_color="#ffffff",
+            )
+
+    def test_a_partial_colour_pair_raises(self):
+        """Giving only one of start_color / end_color is rejected."""
+        with pytest.raises(ValueError, match="given together"):
+            self._dataset().set_color_ramp(
+                band=1, start_value=1, end_value=5, start_color="#000000"
+            )
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"start_color": "#000000", "end_color": "#ffffff", "colormap": "viridis"},
+            {},
+        ],
+        ids=["both-modes", "neither-mode"],
+    )
+    def test_ambiguous_mode_raises(self, kwargs):
+        """Supplying both a colour pair and a colormap, or neither, is rejected."""
+        with pytest.raises(ValueError, match="exactly one"):
+            self._dataset().set_color_ramp(band=1, start_value=1, end_value=5, **kwargs)

--- a/tests/dataset/plot/test_plot_color.py
+++ b/tests/dataset/plot/test_plot_color.py
@@ -511,7 +511,8 @@ class TestColorRamp:
 
     def test_an_unknown_colormap_raises(self):
         """A colormap name absent from matplotlib's registry is rejected clearly."""
+        dataset = self._dataset()
         with pytest.raises(ValueError, match="unknown colormap"):
-            self._dataset().set_color_ramp(
+            dataset.set_color_ramp(
                 band=1, start_value=1, end_value=5, colormap="not-a-real-cmap"
             )

--- a/tests/dataset/plot/test_plot_color.py
+++ b/tests/dataset/plot/test_plot_color.py
@@ -415,10 +415,19 @@ class TestColorRamp:
         """The ramp path produces the same palette as enumerating those stops by hand.
 
         Test scenario:
-            Build the identical five stops through the plain `color_table` setter and
-            through `set_color_ramp`; the retrieved tables must be equal.
+            Compute the five expected stops independently from the interpolation formula
+            (GDAL truncates towards zero), feed them through the plain `color_table` setter,
+            and assert `set_color_ramp` over the same endpoints yields an equal table. The
+            oracle is derived from the formula, not copied from the ramp's own output.
         """
-        stops = ["#709959", "#90a664", "#b1b36f", "#d1c07a", "#f2ce85"]
+        start_rgb, end_rgb = (112, 153, 89), (242, 206, 133)
+        span = 4
+        stops = [
+            "#{:02x}{:02x}{:02x}".format(
+                *(int(s + (e - s) * i / span) for s, e in zip(start_rgb, end_rgb))
+            )
+            for i in range(span + 1)
+        ]
         enumerated = self._dataset()
         enumerated.color_table = pd.DataFrame(
             {"band": [1] * 5, "values": [1, 2, 3, 4, 5], "color": stops}
@@ -430,30 +439,18 @@ class TestColorRamp:
         )
         pd.testing.assert_frame_equal(enumerated.color_table, ramped.color_table)
 
-    def test_end_not_greater_than_start_raises(self):
-        """A non-increasing range is rejected before any GDAL call."""
-        with pytest.raises(ValueError, match="must be greater than start_value"):
-            self._dataset().set_color_ramp(
-                band=1, start_value=5, end_value=5,
-                start_color="#000000", end_color="#ffffff",
-            )
+    def test_an_integral_float_value_is_accepted(self):
+        """An integer-valued float (5.0) is coerced and builds the full range."""
+        dataset = self._dataset()
+        dataset.set_color_ramp(
+            band=1, start_value=1, end_value=5.0,
+            start_color="#000000", end_color="#ffffff",
+        )
+        assert {1, 2, 3, 4, 5}.issubset(set(dataset.color_table["values"]))
 
-    def test_a_partial_colour_pair_raises(self):
-        """Giving only one of start_color / end_color is rejected."""
-        with pytest.raises(ValueError, match="given together"):
+    def test_an_unknown_colormap_raises(self):
+        """A colormap name absent from matplotlib's registry is rejected clearly."""
+        with pytest.raises(ValueError, match="unknown colormap"):
             self._dataset().set_color_ramp(
-                band=1, start_value=1, end_value=5, start_color="#000000"
+                band=1, start_value=1, end_value=5, colormap="not-a-real-cmap"
             )
-
-    @pytest.mark.parametrize(
-        "kwargs",
-        [
-            {"start_color": "#000000", "end_color": "#ffffff", "colormap": "viridis"},
-            {},
-        ],
-        ids=["both-modes", "neither-mode"],
-    )
-    def test_ambiguous_mode_raises(self, kwargs):
-        """Supplying both a colour pair and a colormap, or neither, is rejected."""
-        with pytest.raises(ValueError, match="exactly one"):
-            self._dataset().set_color_ramp(band=1, start_value=1, end_value=5, **kwargs)

--- a/tests/dataset/plot/test_plot_color.py
+++ b/tests/dataset/plot/test_plot_color.py
@@ -411,6 +411,38 @@ class TestColorRamp:
             "the band must end up paletted"
         )
 
+    def test_named_colormap_samples_the_midpoint_evenly(self):
+        """The intermediate value is `cmap(0.5)`, pinning the even-spacing contract.
+
+        Test scenario:
+            colormap='viridis' across 1..5 -> value 3 is the exact midpoint sample
+            `round(viridis(0.5) * 255)`, computed independently from matplotlib.
+        """
+        from matplotlib import colormaps
+
+        dataset = self._dataset()
+        dataset.set_color_ramp(band=1, start_value=1, end_value=5, colormap="viridis")
+        table = dataset.color_table.set_index("values")
+        red, green, blue, _ = colormaps["viridis"](0.5)
+        assert tuple(table.loc[3, ["red", "green", "blue"]]) == (
+            round(red * 255), round(green * 255), round(blue * 255)
+        ), "value 3 must be the evenly-sampled midpoint of the colormap"
+
+    def test_start_value_zero_is_the_ramp_start_not_a_spurious_entry(self):
+        """`start_value=0` is accepted and value 0 becomes the ramp start colour."""
+        dataset = self._dataset()
+        dataset.set_color_ramp(
+            band=1, start_value=0, end_value=4,
+            start_color="#000000", end_color="#ffffff",
+        )
+        table = dataset.color_table.set_index("values")
+        assert tuple(table.loc[0, ["red", "green", "blue", "alpha"]]) == (0, 0, 0, 255), (
+            "value 0 must be the black ramp start, not a transparent (0,0,0,0) fill"
+        )
+        assert tuple(table.loc[4, ["red", "green", "blue", "alpha"]]) == (
+            255, 255, 255, 255
+        ), "value 4 must be the white ramp end"
+
     def test_ramp_matches_the_enumerated_setter_for_the_same_stops(self):
         """The ramp path produces the same palette as enumerating those stops by hand.
 

--- a/tests/dataset/plot/test_plot_color.py
+++ b/tests/dataset/plot/test_plot_color.py
@@ -374,19 +374,31 @@ class TestColorRamp:
         """
         dataset = self._dataset()
         dataset.set_color_ramp(
-            band=1, start_value=1, end_value=5,
-            start_color="#709959", end_color="#F2CE85",
+            band=1,
+            start_value=1,
+            end_value=5,
+            start_color="#709959",
+            end_color="#F2CE85",
         )
         table = dataset.color_table.set_index("values")
-        assert tuple(table.loc[1, ["red", "green", "blue", "alpha"]]) == (112, 153, 89, 255), (
-            "value 1 must be the start colour"
-        )
-        assert tuple(table.loc[3, ["red", "green", "blue", "alpha"]]) == (177, 179, 111, 255), (
-            "value 3 must be the interpolated midpoint"
-        )
-        assert tuple(table.loc[5, ["red", "green", "blue", "alpha"]]) == (242, 206, 133, 255), (
-            "value 5 must be the end colour"
-        )
+        assert tuple(table.loc[1, ["red", "green", "blue", "alpha"]]) == (
+            112,
+            153,
+            89,
+            255,
+        ), "value 1 must be the start colour"
+        assert tuple(table.loc[3, ["red", "green", "blue", "alpha"]]) == (
+            177,
+            179,
+            111,
+            255,
+        ), "value 3 must be the interpolated midpoint"
+        assert tuple(table.loc[5, ["red", "green", "blue", "alpha"]]) == (
+            242,
+            206,
+            133,
+            255,
+        ), "value 5 must be the end colour"
         assert dataset.raster.GetRasterBand(1).GetColorTable() is not None, (
             "the band must end up paletted"
         )
@@ -425,22 +437,33 @@ class TestColorRamp:
         table = dataset.color_table.set_index("values")
         red, green, blue, _ = colormaps["viridis"](0.5)
         assert tuple(table.loc[3, ["red", "green", "blue"]]) == (
-            round(red * 255), round(green * 255), round(blue * 255)
+            round(red * 255),
+            round(green * 255),
+            round(blue * 255),
         ), "value 3 must be the evenly-sampled midpoint of the colormap"
 
     def test_start_value_zero_is_the_ramp_start_not_a_spurious_entry(self):
         """`start_value=0` is accepted and value 0 becomes the ramp start colour."""
         dataset = self._dataset()
         dataset.set_color_ramp(
-            band=1, start_value=0, end_value=4,
-            start_color="#000000", end_color="#ffffff",
+            band=1,
+            start_value=0,
+            end_value=4,
+            start_color="#000000",
+            end_color="#ffffff",
         )
         table = dataset.color_table.set_index("values")
-        assert tuple(table.loc[0, ["red", "green", "blue", "alpha"]]) == (0, 0, 0, 255), (
-            "value 0 must be the black ramp start, not a transparent (0,0,0,0) fill"
-        )
+        assert tuple(table.loc[0, ["red", "green", "blue", "alpha"]]) == (
+            0,
+            0,
+            0,
+            255,
+        ), "value 0 must be the black ramp start, not a transparent (0,0,0,0) fill"
         assert tuple(table.loc[4, ["red", "green", "blue", "alpha"]]) == (
-            255, 255, 255, 255
+            255,
+            255,
+            255,
+            255,
         ), "value 4 must be the white ramp end"
 
     def test_ramp_matches_the_enumerated_setter_for_the_same_stops(self):
@@ -466,8 +489,11 @@ class TestColorRamp:
         )
         ramped = self._dataset()
         ramped.set_color_ramp(
-            band=1, start_value=1, end_value=5,
-            start_color="#709959", end_color="#f2ce85",
+            band=1,
+            start_value=1,
+            end_value=5,
+            start_color="#709959",
+            end_color="#f2ce85",
         )
         pd.testing.assert_frame_equal(enumerated.color_table, ramped.color_table)
 
@@ -475,8 +501,11 @@ class TestColorRamp:
         """An integer-valued float (5.0) is coerced and builds the full range."""
         dataset = self._dataset()
         dataset.set_color_ramp(
-            band=1, start_value=1, end_value=5.0,
-            start_color="#000000", end_color="#ffffff",
+            band=1,
+            start_value=1,
+            end_value=5.0,
+            start_color="#000000",
+            end_color="#ffffff",
         )
         assert {1, 2, 3, 4, 5}.issubset(set(dataset.color_table["values"]))
 

--- a/tests/dataset/unit/test_color_ramp_validation.py
+++ b/tests/dataset/unit/test_color_ramp_validation.py
@@ -1,0 +1,92 @@
+"""Validation guards for `set_color_ramp` (#911) — viz-free, so they run in the main lane.
+
+Every case here raises before `require_cleopatra()`, so these need neither cleopatra nor
+matplotlib; the palette-building tests that do live in `tests/dataset/plot/test_plot_color.py`.
+"""
+
+import numpy as np
+import pytest
+
+from pyramids.dataset import Dataset
+
+pytestmark = pytest.mark.core
+
+
+def _dataset(bands: int = 1) -> Dataset:
+    """A writable in-memory raster with `bands` bands and values 1..5."""
+    arr = np.random.default_rng(0).integers(1, 6, size=(bands, 10, 10))
+    return Dataset.create_from_array(
+        arr, top_left_corner=(0, 0), cell_size=0.05, epsg=4326
+    )
+
+
+class TestSetColorRampValidation:
+    """`set_color_ramp` rejects bad inputs with a clear message before touching GDAL."""
+
+    def test_band_out_of_range_raises(self):
+        """A 1-based band beyond the count is a clear ValueError, not a raw GDAL error."""
+        with pytest.raises(ValueError, match="band 99 is out of range"):
+            _dataset().set_color_ramp(
+                band=99, start_value=1, end_value=5,
+                start_color="#000000", end_color="#ffffff",
+            )
+
+    def test_band_zero_raises(self):
+        """Band 0 is rejected because bands are 1-based."""
+        with pytest.raises(ValueError, match="out of range"):
+            _dataset().set_color_ramp(
+                band=0, start_value=1, end_value=5,
+                start_color="#000000", end_color="#ffffff",
+            )
+
+    def test_negative_start_value_raises(self):
+        """A negative start_value is rejected — GDAL colour indices are non-negative."""
+        with pytest.raises(ValueError, match="must be >= 0"):
+            _dataset().set_color_ramp(
+                band=1, start_value=-1, end_value=5,
+                start_color="#000000", end_color="#ffffff",
+            )
+
+    def test_non_integer_value_raises(self):
+        """A fractional value is a TypeError before any range is built."""
+        with pytest.raises(TypeError, match="must be integers"):
+            _dataset().set_color_ramp(
+                band=1, start_value=1.5, end_value=5,
+                start_color="#000000", end_color="#ffffff",
+            )
+
+    def test_end_not_greater_than_start_raises(self):
+        """A non-increasing range is rejected."""
+        with pytest.raises(ValueError, match="must be greater than start_value"):
+            _dataset().set_color_ramp(
+                band=1, start_value=5, end_value=5,
+                start_color="#000000", end_color="#ffffff",
+            )
+
+    def test_a_partial_colour_pair_raises(self):
+        """Only one of start_color / end_color is rejected."""
+        with pytest.raises(ValueError, match="both be given"):
+            _dataset().set_color_ramp(
+                band=1, start_value=1, end_value=5, start_color="#000000"
+            )
+
+    def test_a_blank_colour_raises(self):
+        """A blank colour string is treated as missing, not passed to cleopatra."""
+        with pytest.raises(ValueError, match="both be given"):
+            _dataset().set_color_ramp(
+                band=1, start_value=1, end_value=5, start_color="", end_color="#ffffff"
+            )
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"start_color": "#000000", "end_color": "#ffffff", "colormap": "viridis"},
+            {"colormap": ""},
+            {},
+        ],
+        ids=["both-modes", "blank-colormap", "neither-mode"],
+    )
+    def test_ambiguous_mode_raises(self, kwargs):
+        """Both a colour pair and a colormap, a blank colormap, or neither, is rejected."""
+        with pytest.raises(ValueError, match="exactly one"):
+            _dataset().set_color_ramp(band=1, start_value=1, end_value=5, **kwargs)

--- a/tests/dataset/unit/test_color_ramp_validation.py
+++ b/tests/dataset/unit/test_color_ramp_validation.py
@@ -28,56 +28,77 @@ class TestSetColorRampValidation:
         """A 1-based band beyond the count is a clear ValueError, not a raw GDAL error."""
         with pytest.raises(ValueError, match="band 99 is out of range"):
             _dataset().set_color_ramp(
-                band=99, start_value=1, end_value=5,
-                start_color="#000000", end_color="#ffffff",
+                band=99,
+                start_value=1,
+                end_value=5,
+                start_color="#000000",
+                end_color="#ffffff",
             )
 
     def test_band_zero_raises(self):
         """Band 0 is rejected because bands are 1-based."""
         with pytest.raises(ValueError, match="out of range"):
             _dataset().set_color_ramp(
-                band=0, start_value=1, end_value=5,
-                start_color="#000000", end_color="#ffffff",
+                band=0,
+                start_value=1,
+                end_value=5,
+                start_color="#000000",
+                end_color="#ffffff",
             )
 
     def test_negative_start_value_raises(self):
         """A negative start_value is rejected — GDAL colour indices are non-negative."""
         with pytest.raises(ValueError, match="must be >= 0"):
             _dataset().set_color_ramp(
-                band=1, start_value=-1, end_value=5,
-                start_color="#000000", end_color="#ffffff",
+                band=1,
+                start_value=-1,
+                end_value=5,
+                start_color="#000000",
+                end_color="#ffffff",
             )
 
     def test_non_integer_value_raises(self):
         """A fractional value is a TypeError before any range is built."""
         with pytest.raises(TypeError, match="whole number"):
             _dataset().set_color_ramp(
-                band=1, start_value=1.5, end_value=5,
-                start_color="#000000", end_color="#ffffff",
+                band=1,
+                start_value=1.5,
+                end_value=5,
+                start_color="#000000",
+                end_color="#ffffff",
             )
 
     def test_non_numeric_value_raises_type_error(self):
         """A non-numeric value gets the documented TypeError, not a cryptic int() error."""
         with pytest.raises(TypeError, match="must be an integer"):
             _dataset().set_color_ramp(
-                band=1, start_value="1", end_value=5,
-                start_color="#000000", end_color="#ffffff",
+                band=1,
+                start_value="1",
+                end_value=5,
+                start_color="#000000",
+                end_color="#ffffff",
             )
 
     def test_boolean_value_raises_type_error(self):
         """A bool is not a meaningful colour index and is rejected."""
         with pytest.raises(TypeError, match="must be an integer"):
             _dataset().set_color_ramp(
-                band=1, start_value=True, end_value=5,
-                start_color="#000000", end_color="#ffffff",
+                band=1,
+                start_value=True,
+                end_value=5,
+                start_color="#000000",
+                end_color="#ffffff",
             )
 
     def test_end_not_greater_than_start_raises(self):
         """A non-increasing range is rejected."""
         with pytest.raises(ValueError, match="must be greater than start_value"):
             _dataset().set_color_ramp(
-                band=1, start_value=5, end_value=5,
-                start_color="#000000", end_color="#ffffff",
+                band=1,
+                start_value=5,
+                end_value=5,
+                start_color="#000000",
+                end_color="#ffffff",
             )
 
     def test_a_partial_colour_pair_raises(self):
@@ -113,11 +134,17 @@ class TestSetColorRampValidation:
         path = tmp_path / "ro.tif"
         Dataset.create_from_array(
             np.ones((3, 3), dtype="float32"),
-            top_left_corner=(0.0, 3.0), cell_size=1.0, epsg=4326, path=str(path),
+            top_left_corner=(0.0, 3.0),
+            cell_size=1.0,
+            epsg=4326,
+            path=str(path),
         )
         ro_ds = Dataset.read_file(str(path), read_only=True)
         with pytest.raises(ReadOnlyError, match="read-only"):
             ro_ds.set_color_ramp(
-                band=1, start_value=1, end_value=5,
-                start_color="#000000", end_color="#ffffff",
+                band=1,
+                start_value=1,
+                end_value=5,
+                start_color="#000000",
+                end_color="#ffffff",
             )

--- a/tests/dataset/unit/test_color_ramp_validation.py
+++ b/tests/dataset/unit/test_color_ramp_validation.py
@@ -26,8 +26,9 @@ class TestSetColorRampValidation:
 
     def test_band_out_of_range_raises(self):
         """A 1-based band beyond the count is a clear ValueError, not a raw GDAL error."""
+        dataset = _dataset()
         with pytest.raises(ValueError, match="band 99 is out of range"):
-            _dataset().set_color_ramp(
+            dataset.set_color_ramp(
                 band=99,
                 start_value=1,
                 end_value=5,
@@ -37,8 +38,9 @@ class TestSetColorRampValidation:
 
     def test_band_zero_raises(self):
         """Band 0 is rejected because bands are 1-based."""
+        dataset = _dataset()
         with pytest.raises(ValueError, match="out of range"):
-            _dataset().set_color_ramp(
+            dataset.set_color_ramp(
                 band=0,
                 start_value=1,
                 end_value=5,
@@ -48,8 +50,9 @@ class TestSetColorRampValidation:
 
     def test_negative_start_value_raises(self):
         """A negative start_value is rejected — GDAL colour indices are non-negative."""
+        dataset = _dataset()
         with pytest.raises(ValueError, match="must be >= 0"):
-            _dataset().set_color_ramp(
+            dataset.set_color_ramp(
                 band=1,
                 start_value=-1,
                 end_value=5,
@@ -59,8 +62,9 @@ class TestSetColorRampValidation:
 
     def test_non_integer_value_raises(self):
         """A fractional value is a TypeError before any range is built."""
+        dataset = _dataset()
         with pytest.raises(TypeError, match="whole number"):
-            _dataset().set_color_ramp(
+            dataset.set_color_ramp(
                 band=1,
                 start_value=1.5,
                 end_value=5,
@@ -70,8 +74,9 @@ class TestSetColorRampValidation:
 
     def test_non_numeric_value_raises_type_error(self):
         """A non-numeric value gets the documented TypeError, not a cryptic int() error."""
+        dataset = _dataset()
         with pytest.raises(TypeError, match="must be an integer"):
-            _dataset().set_color_ramp(
+            dataset.set_color_ramp(
                 band=1,
                 start_value="1",
                 end_value=5,
@@ -81,8 +86,9 @@ class TestSetColorRampValidation:
 
     def test_boolean_value_raises_type_error(self):
         """A bool is not a meaningful colour index and is rejected."""
+        dataset = _dataset()
         with pytest.raises(TypeError, match="must be an integer"):
-            _dataset().set_color_ramp(
+            dataset.set_color_ramp(
                 band=1,
                 start_value=True,
                 end_value=5,
@@ -92,8 +98,9 @@ class TestSetColorRampValidation:
 
     def test_end_not_greater_than_start_raises(self):
         """A non-increasing range is rejected."""
+        dataset = _dataset()
         with pytest.raises(ValueError, match="must be greater than start_value"):
-            _dataset().set_color_ramp(
+            dataset.set_color_ramp(
                 band=1,
                 start_value=5,
                 end_value=5,
@@ -103,15 +110,17 @@ class TestSetColorRampValidation:
 
     def test_a_partial_colour_pair_raises(self):
         """Only one of start_color / end_color is rejected."""
+        dataset = _dataset()
         with pytest.raises(ValueError, match="both be given"):
-            _dataset().set_color_ramp(
+            dataset.set_color_ramp(
                 band=1, start_value=1, end_value=5, start_color="#000000"
             )
 
     def test_a_blank_colour_raises(self):
         """A blank colour string is treated as missing, not passed to cleopatra."""
+        dataset = _dataset()
         with pytest.raises(ValueError, match="both be given"):
-            _dataset().set_color_ramp(
+            dataset.set_color_ramp(
                 band=1, start_value=1, end_value=5, start_color="", end_color="#ffffff"
             )
 
@@ -126,8 +135,9 @@ class TestSetColorRampValidation:
     )
     def test_ambiguous_mode_raises(self, kwargs):
         """Both a colour pair and a colormap, a blank colormap, or neither, is rejected."""
+        dataset = _dataset()
         with pytest.raises(ValueError, match="exactly one"):
-            _dataset().set_color_ramp(band=1, start_value=1, end_value=5, **kwargs)
+            dataset.set_color_ramp(band=1, start_value=1, end_value=5, **kwargs)
 
     def test_read_only_on_disk_dataset_raises(self, tmp_path):
         """The facade guard rejects a read-only on-disk raster before spilling a sidecar."""

--- a/tests/dataset/unit/test_color_ramp_validation.py
+++ b/tests/dataset/unit/test_color_ramp_validation.py
@@ -7,6 +7,7 @@ matplotlib; the palette-building tests that do live in `tests/dataset/plot/test_
 import numpy as np
 import pytest
 
+from pyramids.base._errors import ReadOnlyError
 from pyramids.dataset import Dataset
 
 pytestmark = pytest.mark.core
@@ -49,9 +50,25 @@ class TestSetColorRampValidation:
 
     def test_non_integer_value_raises(self):
         """A fractional value is a TypeError before any range is built."""
-        with pytest.raises(TypeError, match="must be integers"):
+        with pytest.raises(TypeError, match="whole number"):
             _dataset().set_color_ramp(
                 band=1, start_value=1.5, end_value=5,
+                start_color="#000000", end_color="#ffffff",
+            )
+
+    def test_non_numeric_value_raises_type_error(self):
+        """A non-numeric value gets the documented TypeError, not a cryptic int() error."""
+        with pytest.raises(TypeError, match="must be an integer"):
+            _dataset().set_color_ramp(
+                band=1, start_value="1", end_value=5,
+                start_color="#000000", end_color="#ffffff",
+            )
+
+    def test_boolean_value_raises_type_error(self):
+        """A bool is not a meaningful colour index and is rejected."""
+        with pytest.raises(TypeError, match="must be an integer"):
+            _dataset().set_color_ramp(
+                band=1, start_value=True, end_value=5,
                 start_color="#000000", end_color="#ffffff",
             )
 
@@ -90,3 +107,17 @@ class TestSetColorRampValidation:
         """Both a colour pair and a colormap, a blank colormap, or neither, is rejected."""
         with pytest.raises(ValueError, match="exactly one"):
             _dataset().set_color_ramp(band=1, start_value=1, end_value=5, **kwargs)
+
+    def test_read_only_on_disk_dataset_raises(self, tmp_path):
+        """The facade guard rejects a read-only on-disk raster before spilling a sidecar."""
+        path = tmp_path / "ro.tif"
+        Dataset.create_from_array(
+            np.ones((3, 3), dtype="float32"),
+            top_left_corner=(0.0, 3.0), cell_size=1.0, epsg=4326, path=str(path),
+        )
+        ro_ds = Dataset.read_file(str(path), read_only=True)
+        with pytest.raises(ReadOnlyError, match="read-only"):
+            ro_ds.set_color_ramp(
+                band=1, start_value=1, end_value=5,
+                start_color="#000000", end_color="#ffffff",
+            )


### PR DESCRIPTION
# Description

Adds `set_color_ramp`, so a colour table can be generated from a continuous ramp instead of forcing callers
to enumerate every colour stop by hand. Two mutually-exclusive modes:

- a **two-colour linear ramp** between `start_color` and `end_color`, built with
  `gdal.ColorTable.CreateColorRamp`;
- a **named matplotlib colormap** (e.g. `"viridis"`), sampled evenly across `[start_value, end_value]`.

Every integer value in the range gets an entry, which is formatted to the existing `band/values/color/alpha`
DataFrame shape and pushed through the same `_set_color_table` path the enumerated `color_table` setter uses,
so the attached palette is identical in form. The feature lives on the `Bands` engine
(`Bands.set_color_ramp`) with a typed keyword-only facade on `Dataset` (`Dataset.set_color_ramp`) that also
carries the read-only-write guard to avoid spilling a PAM sidecar.

Input is validated up front with clear errors: 1-based `band` range, non-negative and whole-number
`start`/`end` (bools and non-numerics rejected), `end_value > start_value`, exactly one of the colour-pair or
`colormap` modes (blank strings treated as missing), and an unknown colormap name. Needs the existing `[viz]`
extra (cleopatra + its matplotlib); no new dependency.

# Issues

- Closes #911 — add a `set_color_ramp` that generates a GDAL colour table from a colour ramp

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Two test modules, split by dependency so the default CI lane exercises the validation:

- `tests/dataset/unit/test_color_ramp_validation.py` (`pytest.mark.core`, runs in the main `-m 'not plot'`
  lane; needs no viz): band out of range / band 0, negative / non-integer / non-numeric / boolean values,
  non-increasing range, partial and blank colour pairs, the three ambiguous-mode variants, and the facade
  `ReadOnlyError` path on a read-only on-disk raster.
- `tests/dataset/plot/test_plot_color.py::TestColorRamp` (`pytest.mark.plot`; needs cleopatra + matplotlib):
  two-colour interpolation (start / interpolated midpoint / end + band paletted), viridis endpoints and the
  evenly-sampled midpoint, an integral-float value, an unknown colormap, `start_value == 0`, and equivalence
  with the enumerated setter using a formula-derived (non-circular) oracle.

Commands run locally (`dev` env):

- [x] `pytest tests/dataset/unit/test_color_ramp_validation.py tests/dataset/plot/test_plot_color.py::TestColorRamp` — 21 passed
- [x] `pytest --doctest-modules src/pyramids/dataset/engines/bands.py -k set_color_ramp` (Agg backend) — passed
- [x] `mypy src/pyramids/dataset/engines/bands.py src/pyramids/dataset/dataset.py` — no issues

# Checklist:

- [ ] updated version number in pyproject.toml. (handled by commitizen on release)
- [ ] added changes to History.rst. (changelog is commitizen-generated)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (docstrings with executable examples on both the engine method and facade)
