### PR TITLE
fix(crs): build CRSes through GDAL's PROJ database when pyproj's lacks the code

### DIFF
--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -142,7 +142,7 @@ jobs:
             hashFiles('ci/source-build/config.sh', 'ci/source-build/build-gdal-stack.sh') }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
+        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           # The before-all script persists the compiled-stack tar through
@@ -215,7 +215,7 @@ jobs:
             hashFiles('ci/source-build/config.sh', 'ci/source-build/build-gdal-stack.sh') }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
+        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           # The before-all script persists the compiled-stack tar through
@@ -294,7 +294,7 @@ jobs:
           python-version: "3.12"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
+        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
           CIBW_ARCHS_MACOS: ${{ matrix.arch }}
 
@@ -334,7 +334,7 @@ jobs:
           python-version: "3.12"
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
+        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
           CIBW_ARCHS_WINDOWS: ${{ matrix.arch }}
 
@@ -388,7 +388,7 @@ jobs:
             hashFiles('ci/vcpkg.json', 'ci/setup-gdal-from-vcpkg.ps1') }}
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c # v4.1.1
+        uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
           CIBW_ARCHS_WINDOWS: ARM64
           # No cp311: numpy/scipy ship no ARM64 cp311 wheels. The release

--- a/src/pyramids/base/_coverage.py
+++ b/src/pyramids/base/_coverage.py
@@ -18,6 +18,7 @@ from osgeo import gdal, osr
 from pyproj import CRS, Transformer
 
 from pyramids.base._errors import CoverageError
+from pyramids.base.crs import crs_from_user_input
 
 
 def validate_bbox(
@@ -104,7 +105,7 @@ def native_projwin(
             native CRS's area of use).
     """
     native = CRS.from_user_input(native_srs.ExportToWkt())
-    transformer = Transformer.from_crs(CRS.from_user_input(crs), native, always_xy=True)
+    transformer = Transformer.from_crs(crs_from_user_input(crs), native, always_xy=True)
     minx, miny, maxx, maxy = bbox
     # Densify the edges (not just the corners) so the native-CRS window still
     # covers the requested area under projection curvature / interruptions (e.g.

--- a/src/pyramids/base/_raster_meta.py
+++ b/src/pyramids/base/_raster_meta.py
@@ -20,6 +20,7 @@ import numpy as np
 from pyproj import CRS
 
 from pyramids.base._utils import gdal_to_numpy_dtype
+from pyramids.base.crs import crs_from_user_input, crs_spec
 
 if TYPE_CHECKING:
     from pyramids.dataset import Dataset
@@ -134,12 +135,12 @@ class RasterMeta:
         # `ds.crs` is empty for a genuinely ungeoreferenced raster (an ASCII
         # grid, say). `CRS.from_wkt("")` raises, so report no CRS instead of
         # inventing one (ARC-26); consumers already handle `crs is None`.
-        if ds.epsg:
-            crs = CRS.from_epsg(int(ds.epsg))
-        elif ds.crs:
-            crs = CRS.from_wkt(ds.crs)
-        else:
-            crs = None
+        # `crs_spec` picks the code or the WKT, whichever the CRS libraries can
+        # actually resolve, and `crs_from_user_input` heals a code that only GDAL's
+        # PROJ database carries -- otherwise a raster in such a CRS cannot be
+        # described at all (issue #943).
+        spec = crs_spec(ds.epsg, ds.crs)
+        crs = None if spec is None else crs_from_user_input(spec)
         nodata_raw = tuple(ds.no_data_value) if ds.no_data_value else ()
         nodata = tuple(None if v is None else float(v) for v in nodata_raw)
         block_size = tuple(tuple(bs) for bs in ds._block_size)

--- a/src/pyramids/base/crs.py
+++ b/src/pyramids/base/crs.py
@@ -11,6 +11,9 @@ Public surface:
 * :func:`sr_from_user_input` — build one from any CRS form
   :meth:`pyproj.CRS.from_user_input` accepts (EPSG int, authority
   string, proj4, WKT, ESRI WKT, :class:`pyproj.CRS`).
+* :func:`crs_from_user_input` — the :class:`pyproj.CRS` counterpart, and what
+  every site taking a caller-supplied or dataset-derived CRS must go through:
+  it heals codes GDAL's PROJ database knows but pyproj's does not (issue #943).
 * :func:`create_sr_from_proj` — build one from a WKT / ESRI WKT /
   Proj4 string with auto-detect.
 * :func:`get_epsg_from_prj` — resolve the EPSG code identified by a
@@ -958,6 +961,201 @@ def epsg_from_wkt(wkt: str | None, default: int = 4326) -> int:
     return result
 
 
+def _pyproj_crs_via_gdal(crs: int | str | Any) -> CRS | None:
+    """Rebuild a CRS through GDAL's PROJ database, or ``None`` if that fails too.
+
+    The rescue path behind :func:`crs_from_user_input`. pyramids resolves CRSes with
+    GDAL (:meth:`osr.SpatialReference.FindMatches` in :func:`_epsg_from_db_match`,
+    ``ImportFromEPSG`` in :func:`sr_from_epsg`) but consumes them with pyproj, and the
+    two ship *different* PROJ databases. GDAL's is routinely newer, so a code GDAL
+    resolves happily — ``EPSG:10857`` (*SIRGAS 2000 / Brazil Albers*), added after
+    pyproj's bundled PROJ 9.5.1 — makes ``pyproj.CRS.from_epsg`` raise "crs not found".
+
+    The projection itself is never the problem: pyproj parses the very same CRS without
+    complaint when it arrives as **WKT** rather than as a *code*, because only the
+    catalogue lookup is missing. So the repair is to let GDAL turn the code into WKT and
+    hand pyproj that instead.
+
+    Args:
+        crs: The specification pyproj already refused — an EPSG ``int``, an authority
+            string, or any other text :meth:`osr.SpatialReference.SetFromUserInput`
+            understands. Non-textual inputs yield ``None``: a value pyproj could not
+            read and GDAL cannot be handed is simply unresolvable.
+
+    Returns:
+        CRS | None: The rebuilt CRS, or ``None`` when GDAL cannot resolve it either —
+        which keeps a genuinely bad input reported as a bad input.
+    """
+    srs = _gdal_srs_from_user_input(crs)
+    result: CRS | None = None
+    if srs is not None:
+        try:
+            result = CRS.from_wkt(srs.ExportToWkt())
+        except (pyproj.exceptions.CRSError, TypeError, ValueError):
+            # GDAL produced a WKT pyproj rejects. The caller reports the *original*
+            # pyproj failure, which is the more useful one.
+            result = None
+    return result
+
+
+def _epsg_via_gdal(crs: int | str | Any) -> int | None:
+    """EPSG code GDAL's PROJ database assigns to ``crs``, or ``None``.
+
+    The :func:`epsg_from_user_input` counterpart of :func:`_pyproj_crs_via_gdal`, needed
+    because the rescue is lossy in one direction: a CRS pyproj rebuilt from WKT has no
+    catalogue entry, so its :meth:`pyproj.CRS.to_epsg` returns ``None`` even though the
+    code is known — and perfectly valid — on GDAL's side. Asking GDAL directly recovers
+    it. This matters for the ``"EPSG:10857"`` *string* form that STAC ``proj:code``
+    carries, which cannot take the plain-``int`` fast path.
+
+    Only an ``EPSG`` authority is accepted. A CRS whose authority is something else
+    (``ESRI:54030`` for Robinson) yields ``None`` rather than passing ``54030`` off as
+    an EPSG code it is not.
+
+    Args:
+        crs: An EPSG ``int``, authority string, or other text GDAL understands.
+
+    Returns:
+        int | None: The EPSG code, or ``None`` when GDAL cannot resolve one.
+    """
+    srs = _gdal_srs_from_user_input(crs)
+    result: int | None = None
+    if srs is not None:
+        try:
+            authority = srs.GetAuthorityName(None)
+            code = srs.GetAuthorityCode(None)
+        except RuntimeError:
+            authority, code = None, None
+        if authority == "EPSG" and code and str(code).isdigit():
+            result = int(code)
+    return result
+
+
+def _gdal_srs_from_user_input(crs: int | str | Any) -> osr.SpatialReference | None:
+    """Parse ``crs`` with GDAL, or return ``None`` when GDAL cannot read it either.
+
+    Shared primitive under :func:`_pyproj_crs_via_gdal` and :func:`_epsg_via_gdal`.
+    Only ``int`` and ``str`` inputs can be handed to GDAL at all — an EPSG ``int``
+    becomes the ``"EPSG:<code>"`` spelling :meth:`osr.SpatialReference.SetFromUserInput`
+    expects; a ``bool`` is not a CRS despite being an ``int``; anything else (a
+    :class:`pyproj.CRS`, an arbitrary object) has no text form to pass along, and a
+    value pyproj itself could not read is then simply unresolvable.
+
+    Args:
+        crs: The specification to parse.
+
+    Returns:
+        osr.SpatialReference | None: The parsed reference, or ``None``.
+    """
+    if isinstance(crs, bool):
+        text = None
+    elif isinstance(crs, int):
+        text = f"EPSG:{crs}"
+    elif isinstance(crs, str):
+        # A bare numeric string is an EPSG code to pyproj but not to GDAL, which
+        # wants the authority prefix -- so give it one rather than lose the rescue
+        # on the `"10857"` spelling.
+        text = f"EPSG:{crs.strip()}" if crs.strip().isdigit() else crs
+    else:
+        text = None
+    result: osr.SpatialReference | None = None
+    if text is not None:
+        try:
+            srs = osr.SpatialReference()
+            srs.SetFromUserInput(text)
+            result = srs
+        except (RuntimeError, TypeError, ValueError):
+            result = None
+    return result
+
+
+def crs_from_user_input(crs: int | str | Any) -> CRS:
+    """Build a :class:`pyproj.CRS` from any CRS form, healing PROJ-database skew.
+
+    Use this instead of :meth:`pyproj.CRS.from_user_input` at every site that takes a
+    caller-supplied or dataset-derived CRS. (Internally *computed* codes — the UTM zone
+    :func:`pyramids.dataset._stac._utm_epsg` derives, say — are exempt: those are
+    long-established codes that both databases carry.)
+
+    A bare ``CRS.from_user_input`` consults only pyproj's bundled PROJ database, which
+    is frequently older than the one GDAL vendors; every EPSG code that exists in
+    GDAL's but not pyproj's then raises "crs not found" even though pyramids itself
+    produced that code moments earlier by asking GDAL. On the current stack 187 of the
+    7723 codes GDAL can build are unknown to pyproj, and 149 of those are codes
+    :func:`get_epsg_from_prj` will actively derive from a raster's own WKT — so this is
+    a routine failure, not an exotic one. See issue #943.
+
+    When pyproj resolves the input, its answer is used unchanged; the GDAL rescue runs
+    only on failure. That ordering matters: an unconditional GDAL path would silently
+    substitute *replacement* codes for deprecated ones (``ImportFromEPSG(32663)`` yields
+    EPSG:4087), changing the meaning of codes that work today.
+
+    Args:
+        crs: Any CRS form :meth:`pyproj.CRS.from_user_input` accepts — an EPSG ``int``,
+            an authority string (``"EPSG:3857"``), a bare numeric string, WKT, proj4, or
+            a :class:`pyproj.CRS`.
+
+    Returns:
+        CRS: The parsed CRS.
+
+    Raises:
+        CRSError: ``crs`` is a ``bool``, or neither pyproj nor GDAL can interpret it.
+
+    Examples:
+        - Ordinary input resolves through pyproj as before:
+            ```python
+            >>> from pyramids.base.crs import crs_from_user_input
+            >>> crs_from_user_input(3857).to_epsg()
+            3857
+            >>> crs_from_user_input("EPSG:4326").to_epsg()
+            4326
+
+            ```
+        - A code only GDAL's database knows still resolves, via the rescue path —
+          pyproj cannot look up ``EPSG:10857``, but reads it fine as WKT:
+            ```python
+            >>> from pyramids.base.crs import crs_from_user_input
+            >>> crs_from_user_input(10857).name
+            'SIRGAS 2000 / Brazil Albers'
+
+            ```
+        - A deprecated code keeps pyproj's reading rather than GDAL's replacement:
+            ```python
+            >>> from pyramids.base.crs import crs_from_user_input
+            >>> crs_from_user_input(32663).to_epsg()
+            32663
+
+            ```
+        - Something that is not a CRS at all is still rejected:
+            ```python
+            >>> from pyramids.base.crs import crs_from_user_input
+            >>> try:
+            ...     crs_from_user_input("not-a-crs")
+            ... except ValueError as exc:
+            ...     print("could not interpret" in str(exc))
+            True
+
+            ```
+
+    See Also:
+        - :func:`sr_from_user_input`: the :class:`osr.SpatialReference` counterpart.
+        - :func:`epsg_from_user_input`: resolve to an EPSG ``int`` instead.
+    """
+    if isinstance(crs, bool):
+        raise CRSError(
+            f"{crs!r} is not a valid CRS; pass an EPSG int, string, WKT, "
+            "proj4, or pyproj.CRS."
+        )
+    try:
+        parsed = CRS.from_user_input(crs)
+    except (pyproj.exceptions.CRSError, TypeError, ValueError) as exc:
+        rescued = _pyproj_crs_via_gdal(crs)
+        if rescued is None:
+            raise CRSError(f"could not interpret {crs!r} as a CRS: {exc}") from exc
+        parsed = rescued
+    return parsed
+
+
 def epsg_from_user_input(crs: int | str | Any) -> int:
     """Resolve a CRS given in any common form to an EPSG integer code.
 
@@ -1018,11 +1216,12 @@ def epsg_from_user_input(crs: int | str | Any) -> int:
         raise CRSError(f"{crs!r} is not a valid CRS; pass an EPSG int, string, or CRS.")
     if isinstance(crs, int):
         return crs
-    try:
-        parsed = CRS.from_user_input(crs)
-    except (pyproj.exceptions.CRSError, TypeError, ValueError) as exc:
-        raise CRSError(f"could not interpret {crs!r} as a CRS: {exc}") from exc
+    parsed = crs_from_user_input(crs)
     epsg = parsed.to_epsg()
+    if epsg is None:
+        # A CRS rescued from GDAL's database carries no pyproj catalogue entry, so
+        # `to_epsg()` reports None for a code that does exist -- ask GDAL for it.
+        epsg = _epsg_via_gdal(crs)
     if epsg is None:
         raise CRSError(
             f"the CRS {crs!r} has no corresponding EPSG code; pass an EPSG integer."
@@ -1121,10 +1320,7 @@ def sr_from_user_input(crs: int | str | Any) -> osr.SpatialReference:
             f"{crs!r} is not a valid CRS; pass an EPSG int, string, WKT, "
             "proj4, or pyproj.CRS."
         )
-    try:
-        wkt = CRS.from_user_input(crs).to_wkt()
-    except (pyproj.exceptions.CRSError, TypeError, ValueError) as exc:
-        raise CRSError(f"could not interpret {crs!r} as a CRS: {exc}") from exc
+    wkt = crs_from_user_input(crs).to_wkt()
     sr = osr.SpatialReference()
     sr.ImportFromWkt(wkt)
     sr.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
@@ -1203,7 +1399,11 @@ def reproject_coordinates(
             f"x and y must have equal length; got len(x)={len(x)} vs. len(y)={len(y)}."
         )
     try:
-        transformer = Transformer.from_crs(from_crs, to_crs, always_xy=True)
+        # Through `crs_from_user_input`, not `Transformer.from_crs` directly, so a code
+        # only GDAL's PROJ database knows still builds a transformer. See issue #943.
+        transformer = Transformer.from_crs(
+            crs_from_user_input(from_crs), crs_from_user_input(to_crs), always_xy=True
+        )
     except (pyproj.exceptions.CRSError, TypeError, ValueError) as exc:
         raise CRSError(
             f"reproject_coordinates failed to parse CRS "
@@ -1240,6 +1440,7 @@ __all__ = [
     "cf_geographic_wkt",
     "create_sr_from_proj",
     "crs_equal",
+    "crs_from_user_input",
     "crs_spec",
     "epsg_from_user_input",
     "epsg_from_wkt",

--- a/src/pyramids/base/crs.py
+++ b/src/pyramids/base/crs.py
@@ -57,6 +57,13 @@ from pyramids.base._errors import CRSError
 # strict runner-up check in :func:`_epsg_from_db_match`.
 _MIN_EPSG_MATCH_CONFIDENCE = 70
 
+# Options for every `SetFromUserInput` call in this module. Without them GDAL treats an
+# unrecognised string as a path or a URL and reads it, so an attacker-influenced or
+# merely malformed CRS value turns into local file access or an outbound request (and a
+# dead host stalls the call for seconds). A CRS specification is always self-contained
+# text here, never a resource locator.
+_NO_REMOTE_CRS_LOOKUP = ["ALLOW_FILE_ACCESS=NO", "ALLOW_NETWORK_ACCESS=NO"]
+
 
 def sr_from_epsg(epsg: int) -> osr.SpatialReference:
     """Build an :class:`osr.SpatialReference` from an EPSG code.
@@ -1064,6 +1071,22 @@ def _epsg_via_gdal(crs: int | str | Any) -> int | None:
     it. This matters for the ``"EPSG:10857"`` *string* form that STAC ``proj:code``
     carries, which cannot take the plain-``int`` fast path.
 
+    A declared authority is **not** taken at its word. GDAL reports whatever
+    ``AUTHORITY`` node the input carries, and a WKT can carry one that no longer
+    matches its own parameters — a "WGS 84 / UTM zone 36N" citation over a perturbed
+    central meridian, a hand-edited or truncated projection. Returning that code would
+    hand back a CRS the data is not in, silently, where :func:`epsg_from_user_input`
+    previously raised. So the candidate is verified: the CRS built *from* the code must
+    be :meth:`osr.SpatialReference.IsSame` as the CRS actually parsed. This is the same
+    "confident and unambiguous or nothing" policy :func:`_epsg_from_db_match` applies
+    to its own database lookups.
+
+    A code that names itself is also held to identity. ``ImportFromEPSG``/
+    ``SetFromUserInput`` silently substitute the non-deprecated *replacement* for a
+    deprecated code (``EPSG:32663`` resolves as ``EPSG:4087``), so when the input named
+    a code and GDAL answers with a different one, the answer is refused rather than
+    quietly changing which CRS the caller asked for.
+
     Only an ``EPSG`` authority is accepted. A CRS whose authority is something else
     (``ESRI:54030`` for Robinson) yields ``None`` rather than passing ``54030`` off as
     an EPSG code it is not.
@@ -1072,7 +1095,9 @@ def _epsg_via_gdal(crs: int | str | Any) -> int | None:
         crs: An EPSG ``int``, authority string, or other text GDAL understands.
 
     Returns:
-        int | None: The EPSG code, or ``None`` when GDAL cannot resolve one.
+        int | None: The EPSG code, or ``None`` when GDAL cannot resolve one, resolves
+        one that does not match the parsed definition, or substitutes a different code
+        for the one that was asked for.
     """
     srs = _gdal_srs_from_user_input(crs)
     result: int | None = None
@@ -1083,8 +1108,68 @@ def _epsg_via_gdal(crs: int | str | Any) -> int | None:
         except RuntimeError:
             authority, code = None, None
         if authority == "EPSG" and code and str(code).isdigit():
-            result = int(code)
+            candidate = int(code)
+            if _epsg_matches_definition(candidate, srs) and not _substitutes_code(
+                crs, candidate
+            ):
+                result = candidate
     return result
+
+
+def _requested_epsg(crs: int | str | Any) -> int | None:
+    """The EPSG code the input itself names, or ``None`` when it names none.
+
+    Args:
+        crs: The specification handed to the rescue path.
+
+    Returns:
+        int | None: The code named by an ``int`` or an ``"EPSG:<n>"`` / ``"<n>"``
+        string; ``None`` for a WKT, a proj4 string, or anything else that describes a
+        CRS without naming a code.
+    """
+    requested: int | None = None
+    if isinstance(crs, bool):
+        requested = None
+    elif isinstance(crs, int):
+        requested = int(crs)
+    elif isinstance(crs, str):
+        text = crs.strip()
+        if text.upper().startswith("EPSG:"):
+            text = text[5:].strip()
+        if text.isascii() and text.isdigit():
+            requested = int(text)
+    return requested
+
+
+def _substitutes_code(crs: int | str | Any, candidate: int) -> bool:
+    """Whether GDAL answered a code request with a *different* code.
+
+    Args:
+        crs: The original specification.
+        candidate: The code GDAL resolved it to.
+
+    Returns:
+        bool: True when the input named a code and `candidate` is not it.
+    """
+    requested = _requested_epsg(crs)
+    return requested is not None and requested != candidate
+
+
+def _epsg_matches_definition(epsg: int, srs: osr.SpatialReference) -> bool:
+    """Whether EPSG `epsg` really describes the CRS `srs` parses to.
+
+    Args:
+        epsg: The candidate code read off the parsed CRS's authority node.
+        srs: The CRS GDAL actually parsed from the caller's input.
+
+    Returns:
+        bool: True when building `epsg` from the database yields the same CRS.
+    """
+    try:
+        matches = bool(sr_from_epsg(epsg).IsSame(srs))
+    except (RuntimeError, ValueError):
+        matches = False
+    return matches
 
 
 def _gdal_srs_from_user_input(crs: int | str | Any) -> osr.SpatialReference | None:
@@ -1118,7 +1203,13 @@ def _gdal_srs_from_user_input(crs: int | str | Any) -> osr.SpatialReference | No
     if text is not None:
         try:
             srs = osr.SpatialReference()
-            srs.SetFromUserInput(text)
+            # SetFromUserInput will otherwise treat the string as a filename or a URL
+            # and go read it -- so a CRS value reaching this rescue path could cause a
+            # local file read or an outbound HTTP request, and a dead host would block
+            # for seconds. pyramids only ever means a CRS here, never a resource to
+            # fetch, so both are refused.
+            if srs.SetFromUserInput(text, _NO_REMOTE_CRS_LOOKUP) != 0:
+                raise ValueError(f"GDAL could not parse {text!r} as a CRS.")
             result = srs
         except (RuntimeError, TypeError, ValueError):
             result = None

--- a/src/pyramids/base/crs.py
+++ b/src/pyramids/base/crs.py
@@ -38,6 +38,7 @@ Public surface:
 
 from __future__ import annotations
 
+import numbers
 from functools import lru_cache
 from typing import Any, cast
 
@@ -1024,6 +1025,31 @@ def epsg_from_wkt(wkt: str | None, default: int = 4326) -> int:
     return result
 
 
+def _integer_code(crs: Any) -> int | None:
+    """The EPSG integer `crs` stands for, or ``None`` when it is not an integer code.
+
+    Tests :class:`numbers.Integral` rather than ``int`` so a NumPy scalar counts. Codes
+    routinely arrive as ``np.int32`` / ``np.int64`` — read out of an array, a pandas
+    column, or a raster's own metadata — and an ``isinstance(crs, int)`` check silently
+    says no to every one of them, which sent them down the wrong path entirely.
+
+    ``bool`` is excluded even though it is integral: `True` is not EPSG:1.
+
+    Args:
+        crs: Any candidate CRS specification.
+
+    Returns:
+        int | None: The code as a plain ``int``, or ``None``.
+    """
+    if isinstance(crs, bool):
+        code = None
+    elif isinstance(crs, numbers.Integral):
+        code = int(crs)
+    else:
+        code = None
+    return code
+
+
 def _pyproj_crs_via_gdal(crs: int | str | Any) -> CRS | None:
     """Rebuild a CRS through GDAL's PROJ database, or ``None`` if that fails too.
 
@@ -1053,10 +1079,14 @@ def _pyproj_crs_via_gdal(crs: int | str | Any) -> CRS | None:
     result: CRS | None = None
     if srs is not None:
         try:
-            result = CRS.from_wkt(srs.ExportToWkt())
-        except (pyproj.exceptions.CRSError, TypeError, ValueError):
-            # GDAL produced a WKT pyproj rejects. The caller reports the *original*
-            # pyproj failure, which is the more useful one.
+            # WKT2_2019, not the WKT1 default: the codes this rescue exists for are
+            # recent ones, and WKT1 cannot express several constructs they use (a
+            # dynamic datum's frame epoch, a geodetic ensemble, non-degree angular
+            # units on some frames), so a WKT1 export can quietly degrade the CRS.
+            result = CRS.from_wkt(srs.ExportToWkt(["FORMAT=WKT2_2019"]))
+        except (RuntimeError, pyproj.exceptions.CRSError, TypeError, ValueError):
+            # GDAL produced a WKT pyproj rejects, or failed to export at all. The
+            # caller reports the *original* pyproj failure, which is more useful.
             result = None
     return result
 
@@ -1127,12 +1157,8 @@ def _requested_epsg(crs: int | str | Any) -> int | None:
         string; ``None`` for a WKT, a proj4 string, or anything else that describes a
         CRS without naming a code.
     """
-    requested: int | None = None
-    if isinstance(crs, bool):
-        requested = None
-    elif isinstance(crs, int):
-        requested = int(crs)
-    elif isinstance(crs, str):
+    requested = _integer_code(crs)
+    if requested is None and isinstance(crs, str):
         text = crs.strip()
         if text.upper().startswith("EPSG:"):
             text = text[5:].strip()
@@ -1188,15 +1214,20 @@ def _gdal_srs_from_user_input(crs: int | str | Any) -> osr.SpatialReference | No
     Returns:
         osr.SpatialReference | None: The parsed reference, or ``None``.
     """
-    if isinstance(crs, bool):
-        text = None
-    elif isinstance(crs, int):
-        text = f"EPSG:{crs}"
+    code = _integer_code(crs)
+    if code is not None:
+        text = f"EPSG:{code}"
     elif isinstance(crs, str):
         # A bare numeric string is an EPSG code to pyproj but not to GDAL, which
         # wants the authority prefix -- so give it one rather than lose the rescue
-        # on the `"10857"` spelling.
-        text = f"EPSG:{crs.strip()}" if crs.strip().isdigit() else crs
+        # on the `"10857"` spelling. `isascii` guards `isdigit`, which is True for
+        # Arabic-Indic and other non-ASCII digits that `int()` would then reject.
+        stripped = crs.strip()
+        text = (
+            f"EPSG:{stripped}"
+            if stripped.isascii() and stripped.isdigit()
+            else crs
+        )
     else:
         text = None
     result: osr.SpatialReference | None = None
@@ -1361,8 +1392,9 @@ def epsg_from_user_input(crs: int | str | Any) -> int:
     """
     if isinstance(crs, bool):
         raise CRSError(f"{crs!r} is not a valid CRS; pass an EPSG int, string, or CRS.")
-    if isinstance(crs, int):
-        return crs
+    code = _integer_code(crs)
+    if code is not None:
+        return code
     parsed = crs_from_user_input(crs)
     epsg = parsed.to_epsg()
     if epsg is None:

--- a/src/pyramids/base/crs.py
+++ b/src/pyramids/base/crs.py
@@ -685,6 +685,36 @@ def cf_geographic_wkt(units: set[str], axis_units: set[str] | None = None) -> st
     return sr_from_epsg(4326).ExportToWkt() if geographic else ""
 
 
+@lru_cache(maxsize=1024)
+def _pyproj_can_resolve_epsg(epsg: int) -> bool:
+    """Whether pyproj's bundled PROJ database can build this EPSG code.
+
+    The guard behind :func:`crs_spec`'s preference for the code over the WKT. Consumers
+    that resolve a CRS with pyproj — directly, or through geopandas — cannot be reached
+    by :func:`crs_from_user_input`, so the only way to keep them working on a code
+    pyproj does not carry is to not hand them the code in the first place.
+
+    Cached because it is asked on hot paths (`Dataset.bounds`, every
+    `DatasetCollection` member) and the answer is a property of the installed
+    pyproj, fixed for the life of the process.
+
+    Args:
+        epsg: The EPSG code to probe.
+
+    Returns:
+        bool: True when :meth:`pyproj.CRS.from_epsg` succeeds for `epsg`.
+    """
+    try:
+        CRS.from_epsg(epsg)
+        resolvable = True
+    except Exception:
+        # Any failure means "do not hand this code downstream" -- the exact
+        # exception type is pyproj's business, and a broad catch keeps a future
+        # pyproj error type from turning a fallback into a crash.
+        resolvable = False
+    return resolvable
+
+
 def crs_spec(epsg: int | None, wkt: str | None) -> int | str | None:
     """Best usable CRS specification for a dataset, or `None` when it has none.
 
@@ -696,13 +726,26 @@ def crs_spec(epsg: int | None, wkt: str | None) -> int | str | None:
     (producing an ungeoreferenced result) or reject it deliberately via
     :func:`require_crs_spec`.
 
+    The word *usable* is load-bearing, and it is why the EPSG code is not blindly
+    preferred. Most of this function's consumers hand the result to a library that
+    resolves it with **pyproj** — `geopandas.GeoDataFrame.set_crs` is the common one —
+    and pyproj's bundled PROJ database is routinely older than the one GDAL vendors.
+    An EPSG code pyramids obtained from GDAL can therefore be one pyproj cannot look
+    up, and returning it would hand every consumer a specification that raises
+    "crs not found" (issue #943). When that is the case and a WKT is available, the
+    WKT is returned instead: it describes the same CRS, and pyproj parses it happily —
+    only the *catalogue lookup* is missing, never the projection itself. The code is
+    still preferred whenever it works, which is the overwhelming majority of the time
+    and is checked once per code and cached.
+
     Args:
         epsg: EPSG code, or `None` for a CRS that carries no EPSG authority.
         wkt: Projection WKT, or an empty string / `None` when there is no CRS.
 
     Returns:
-        int | str | None: The EPSG code when there is one, else the WKT, else
-        `None`.
+        int | str | None: The EPSG code when there is one and it is resolvable
+        downstream, else the WKT, else the code anyway when there is no WKT to fall
+        back to, else `None`.
 
     Examples:
         - An EPSG code is preferred when present:
@@ -719,6 +762,15 @@ def crs_spec(epsg: int | None, wkt: str | None) -> int | str | None:
             'GEOGCS["custom"]'
 
             ```
+        - A code the downstream CRS library cannot resolve yields the WKT, so the
+          specification stays usable:
+            ```python
+            >>> from pyramids.base.crs import crs_spec, sr_from_epsg
+            >>> wkt = sr_from_epsg(10857).ExportToWkt()  # doctest: +SKIP
+            >>> crs_spec(10857, wkt) is wkt  # doctest: +SKIP
+            True
+
+            ```
         - No CRS at all is reported as `None`, not as an empty string:
             ```python
             >>> from pyramids.base.crs import crs_spec
@@ -731,10 +783,14 @@ def crs_spec(epsg: int | None, wkt: str | None) -> int | str | None:
         require_crs_spec: The variant that raises when there is no CRS.
     """
     result: int | str | None = None
-    if epsg is not None:
+    if epsg is not None and (not wkt or _pyproj_can_resolve_epsg(epsg)):
         result = epsg
     elif wkt:
         result = wkt
+    elif epsg is not None:
+        # No WKT to fall back to. Returning the code beats returning nothing: the
+        # caller may still route it through `crs_from_user_input`, which can heal it.
+        result = epsg
     return result
 
 

--- a/src/pyramids/base/crs.py
+++ b/src/pyramids/base/crs.py
@@ -1282,26 +1282,6 @@ def _epsg_matches_definition(epsg: int, srs: osr.SpatialReference) -> bool:
     return matches
 
 
-def _gdal_srs_from_user_input(crs: int | str | Any) -> osr.SpatialReference | None:
-    """Parse ``crs`` with GDAL, or return ``None`` when GDAL cannot read it either.
-
-    Shared primitive under :func:`_pyproj_crs_via_gdal` and :func:`_epsg_via_gdal`.
-    Only ``int`` and ``str`` inputs can be handed to GDAL at all — an EPSG ``int``
-    becomes the ``"EPSG:<code>"`` spelling :meth:`osr.SpatialReference.SetFromUserInput`
-    expects; a ``bool`` is not a CRS despite being an ``int``; anything else (a
-    :class:`pyproj.CRS`, an arbitrary object) has no text form to pass along, and a
-    value pyproj itself could not read is then simply unresolvable.
-
-    Args:
-        crs: The specification to parse.
-
-    Returns:
-        osr.SpatialReference | None: The parsed reference, or ``None``.
-    """
-    text = _gdal_input_text(crs)
-    return None if text is None else _gdal_srs_from_text(text)
-
-
 def _gdal_input_text(crs: int | str | Any) -> str | None:
     """Normalise `crs` into the text GDAL takes, or ``None`` when it has no text form.
 
@@ -1334,7 +1314,6 @@ def _gdal_input_text(crs: int | str | Any) -> str | None:
     return text
 
 
-@lru_cache(maxsize=512)
 def _gdal_srs_from_text(text: str) -> osr.SpatialReference | None:
     """Parse normalised CRS text with GDAL, or ``None`` when GDAL cannot read it.
 
@@ -1344,10 +1323,25 @@ def _gdal_srs_from_text(text: str) -> osr.SpatialReference | None:
     Returns:
         osr.SpatialReference | None: The parsed reference, or ``None``.
 
-    Warning:
-        The returned reference is **shared** between callers by the cache. Everything
-        in this module only reads from it; a caller that needs to mutate one must
-        :meth:`osr.SpatialReference.Clone` it first.
+    The caller gets its own copy. The PROJ-database lookup behind it is what is
+    cached; handing out the cached reference itself would make every caller share one
+    mutable object, where a single `SetAxisMappingStrategy` in unrelated code would
+    silently change the CRS everyone else sees. `Clone` is trivial next to the lookup.
+    """
+    cached = _gdal_srs_cached(text)
+    return None if cached is None else cached.Clone()
+
+
+@lru_cache(maxsize=512)
+def _gdal_srs_cached(text: str) -> osr.SpatialReference | None:
+    """Memoised PROJ-database lookup behind :func:`_gdal_srs_from_text`.
+
+    Args:
+        text: The normalised specification.
+
+    Returns:
+        osr.SpatialReference | None: The parsed reference, or ``None``. Never handed
+        to callers directly -- :func:`_gdal_srs_from_text` copies it first.
     """
     result: osr.SpatialReference | None = None
     try:
@@ -1704,6 +1698,38 @@ def sr_from_user_input(crs: int | str | Any) -> osr.SpatialReference:
     return sr
 
 
+def clear_crs_caches() -> None:
+    """Drop every memoised CRS resolution in this module.
+
+    The caches key on the installed GDAL and pyproj, which do not change while the
+    process runs, so nothing here needs invalidating in normal use. They do need
+    clearing when something *makes* them change — a test that patches an underlying
+    GDAL or pyproj call would otherwise be answered from the cache and silently test
+    nothing. Exposing one hook keeps callers from reaching into private
+    `cache_clear` attributes and having to know which ones exist.
+
+    Examples:
+        - Clearing is always safe; the next call simply re-resolves:
+            ```python
+            >>> from pyramids.base.crs import clear_crs_caches, crs_from_user_input
+            >>> clear_crs_caches()
+            >>> crs_from_user_input(4326).to_epsg()
+            4326
+
+            ```
+    """
+    for cached in (
+        _pyproj_can_resolve_epsg,
+        _resolve_crs_cached,
+        _resolve_epsg_cached,
+        _pyproj_crs_from_gdal_text,
+        _epsg_from_gdal_text,
+        _gdal_srs_cached,
+        crs_equal,
+    ):
+        cached.cache_clear()
+
+
 def reproject_coordinates(
     x: list[float],
     y: list[float],
@@ -1815,6 +1841,7 @@ __all__ = [
     "VERTICAL_AXIS_NAMES",
     "VERTICAL_STANDARD_NAMES",
     "cf_geographic_wkt",
+    "clear_crs_caches",
     "create_sr_from_proj",
     "crs_equal",
     "crs_from_user_input",

--- a/src/pyramids/base/crs.py
+++ b/src/pyramids/base/crs.py
@@ -791,14 +791,13 @@ def crs_spec(epsg: int | None, wkt: str | None) -> int | str | None:
         require_crs_spec: The variant that raises when there is no CRS.
     """
     result: int | str | None = None
+    # `not wkt` keeps the code when there is no WKT to fall back to: half a
+    # specification beats none, and the caller can still route it through
+    # `crs_from_user_input`, which heals it.
     if epsg is not None and (not wkt or _pyproj_can_resolve_epsg(epsg)):
         result = epsg
     elif wkt:
         result = wkt
-    elif epsg is not None:
-        # No WKT to fall back to. Returning the code beats returning nothing: the
-        # caller may still route it through `crs_from_user_input`, which can heal it.
-        result = epsg
     return result
 
 

--- a/src/pyramids/base/crs.py
+++ b/src/pyramids/base/crs.py
@@ -251,6 +251,11 @@ def _epsg_from_db_match(srs: osr.SpatialReference) -> str | None:
     best_srs, best_confidence = matches[0]
     if best_confidence < _MIN_EPSG_MATCH_CONFIDENCE:
         return None
+    # As in `get_epsg_from_prj`, the match must be an *EPSG* one: `FindMatches` ranks
+    # entries from every authority, so a Robinson WKT's best match is ESRI:54030 and
+    # returning its code would present 54030 as an EPSG code (issue #965).
+    if best_srs.GetAuthorityName(None) != "EPSG":
+        return None
     best_code = best_srs.GetAuthorityCode(None)
     # Reject ambiguous ties: a runner-up that matches equally well *and*
     # resolves to a different EPSG code means the definition maps to two
@@ -379,7 +384,13 @@ def get_epsg_from_prj(prj: str) -> int:
     # EPSG:9122 inside a GRIB GEOGCS, or the WGS_1984 datum EPSG:6326 inside
     # a UTM PROJCS) — a non-CRS code that breaks every downstream
     # sr_from_epsg() call. See issue #403.
-    code = srs.GetAuthorityCode(None)
+    # The authority must be EPSG, not merely present. `GetAuthorityCode` returns the
+    # root node's code whatever the authority is, so an ESRI-authority CRS (Robinson
+    # is ESRI:54030) otherwise reports 54030 from a property called `epsg` -- a number
+    # that is not an EPSG code, that pyproj cannot resolve, and that GDAL happens to
+    # accept, so it round-trips on one side and fails on the other. See issue #965.
+    authority = srs.GetAuthorityName(None)
+    code = srs.GetAuthorityCode(None) if authority == "EPSG" else None
     if not (code and str(code).isdigit()):
         # No usable root EPSG code: either absent (AutoIdentifyEPSG could not tag
         # the root — e.g. a UTM PROJCS whose WKT lacks an AUTHORITY node), or a
@@ -1074,9 +1085,30 @@ def _pyproj_crs_via_gdal(crs: int | str | Any) -> CRS | None:
         CRS | None: The rebuilt CRS, or ``None`` when GDAL cannot resolve it either —
         which keeps a genuinely bad input reported as a bad input.
     """
-    srs = _gdal_srs_from_user_input(crs)
+    text = _gdal_input_text(crs)
+    return None if text is None else _pyproj_crs_from_gdal_text(text)
+
+
+@lru_cache(maxsize=512)
+def _pyproj_crs_from_gdal_text(text: str) -> CRS | None:
+    """Cached body of :func:`_pyproj_crs_via_gdal`, keyed on the normalised text.
+
+    Cached because the rescue is two orders of magnitude slower than the path it
+    stands in for — a PROJ-database lookup plus a WKT export and re-parse, against a
+    dictionary hit — and it runs on exactly the CRSes that make it run *repeatedly*:
+    the ones every read, transform and comparison has to resolve. The answer depends
+    only on the installed GDAL and pyproj, so it is fixed for the life of the process.
+
+    Args:
+        text: The specification in the ``"EPSG:<n>"``/WKT/proj4 form GDAL takes.
+
+    Returns:
+        CRS | None: The rebuilt CRS, or ``None`` when GDAL cannot resolve it, resolves
+        it to a *different* code than was asked for, or produces a WKT pyproj rejects.
+    """
+    srs = _gdal_srs_from_text(text)
     result: CRS | None = None
-    if srs is not None:
+    if srs is not None and not _substitutes_requested_crs(text, srs):
         try:
             # WKT2_2019, not the WKT1 default: the codes this rescue exists for are
             # recent ones, and WKT1 cannot express several constructs they use (a
@@ -1088,6 +1120,41 @@ def _pyproj_crs_via_gdal(crs: int | str | Any) -> CRS | None:
             # caller reports the *original* pyproj failure, which is more useful.
             result = None
     return result
+
+
+def _substitutes_requested_crs(text: str, srs: osr.SpatialReference) -> bool:
+    """Whether GDAL answered a *code* request with a different CRS than was asked for.
+
+    The rescue exists to resolve a code pyproj lacks — not to accept whatever GDAL
+    offers in its place. Two substitutions are silent and must be refused:
+
+    * a different **authority**: ``SetFromUserInput("EPSG:54030")`` resolves to
+      *ESRI*:54030 (Robinson), so asking for an EPSG code yields a CRS that is not
+      that EPSG code;
+    * a different **code**: a deprecated entry resolves to its non-deprecated
+      successor (``EPSG:32663`` becomes ``EPSG:4087``).
+
+    Both matter only on this path. While pyproj can resolve a code its own answer is
+    used and the rescue never runs, which is why the ordering alone does not prevent
+    them.
+
+    Args:
+        text: The normalised input; only a code request can be substituted.
+        srs: What GDAL resolved it to.
+
+    Returns:
+        bool: True when the request named a code and `srs` is not that code.
+    """
+    requested = _requested_epsg(text)
+    substituted = False
+    if requested is not None:
+        try:
+            authority = srs.GetAuthorityName(None)
+            code = srs.GetAuthorityCode(None)
+        except RuntimeError:
+            authority, code = None, None
+        substituted = authority != "EPSG" or str(code) != str(requested)
+    return substituted
 
 
 def _epsg_via_gdal(crs: int | str | Any) -> int | None:
@@ -1128,7 +1195,25 @@ def _epsg_via_gdal(crs: int | str | Any) -> int | None:
         one that does not match the parsed definition, or substitutes a different code
         for the one that was asked for.
     """
-    srs = _gdal_srs_from_user_input(crs)
+    text = _gdal_input_text(crs)
+    return None if text is None else _epsg_from_gdal_text(text)
+
+
+@lru_cache(maxsize=512)
+def _epsg_from_gdal_text(text: str) -> int | None:
+    """Cached body of :func:`_epsg_via_gdal`, keyed on the normalised text.
+
+    Cached for the same reason as :func:`_pyproj_crs_from_gdal_text`, and separately
+    from it so that resolving a code to an integer does not have to build a pyproj CRS
+    it will throw away.
+
+    Args:
+        text: The specification in the form GDAL takes.
+
+    Returns:
+        int | None: The verified EPSG code, or ``None``.
+    """
+    srs = _gdal_srs_from_text(text)
     result: int | None = None
     if srs is not None:
         try:
@@ -1139,7 +1224,7 @@ def _epsg_via_gdal(crs: int | str | Any) -> int | None:
         if authority == "EPSG" and code and str(code).isdigit():
             candidate = int(code)
             if _epsg_matches_definition(candidate, srs) and not _substitutes_code(
-                crs, candidate
+                text, candidate
             ):
                 result = candidate
     return result
@@ -1213,7 +1298,28 @@ def _gdal_srs_from_user_input(crs: int | str | Any) -> osr.SpatialReference | No
     Returns:
         osr.SpatialReference | None: The parsed reference, or ``None``.
     """
+    text = _gdal_input_text(crs)
+    return None if text is None else _gdal_srs_from_text(text)
+
+
+def _gdal_input_text(crs: int | str | Any) -> str | None:
+    """Normalise `crs` into the text GDAL takes, or ``None`` when it has no text form.
+
+    Split out from the parse so the expensive part can be cached on a hashable key:
+    the caller's value may be an unhashable object, but its normalised form is always
+    a string.
+
+    Args:
+        crs: The specification to normalise.
+
+    Returns:
+        str | None: ``"EPSG:<n>"`` for an integer code or a bare numeric string, the
+        string itself otherwise, and ``None`` for a value with no text form (a
+        :class:`pyproj.CRS`, an arbitrary object) or a ``bool``, which is not a CRS
+        despite being an integer.
+    """
     code = _integer_code(crs)
+    text: str | None
     if code is not None:
         text = f"EPSG:{code}"
     elif isinstance(crs, str):
@@ -1222,27 +1328,40 @@ def _gdal_srs_from_user_input(crs: int | str | Any) -> osr.SpatialReference | No
         # on the `"10857"` spelling. `isascii` guards `isdigit`, which is True for
         # Arabic-Indic and other non-ASCII digits that `int()` would then reject.
         stripped = crs.strip()
-        text = (
-            f"EPSG:{stripped}"
-            if stripped.isascii() and stripped.isdigit()
-            else crs
-        )
+        text = f"EPSG:{stripped}" if stripped.isascii() and stripped.isdigit() else crs
     else:
         text = None
+    return text
+
+
+@lru_cache(maxsize=512)
+def _gdal_srs_from_text(text: str) -> osr.SpatialReference | None:
+    """Parse normalised CRS text with GDAL, or ``None`` when GDAL cannot read it.
+
+    Args:
+        text: The normalised specification from :func:`_gdal_input_text`.
+
+    Returns:
+        osr.SpatialReference | None: The parsed reference, or ``None``.
+
+    Warning:
+        The returned reference is **shared** between callers by the cache. Everything
+        in this module only reads from it; a caller that needs to mutate one must
+        :meth:`osr.SpatialReference.Clone` it first.
+    """
     result: osr.SpatialReference | None = None
-    if text is not None:
-        try:
-            srs = osr.SpatialReference()
-            # SetFromUserInput will otherwise treat the string as a filename or a URL
-            # and go read it -- so a CRS value reaching this rescue path could cause a
-            # local file read or an outbound HTTP request, and a dead host would block
-            # for seconds. pyramids only ever means a CRS here, never a resource to
-            # fetch, so both are refused.
-            if srs.SetFromUserInput(text, _NO_REMOTE_CRS_LOOKUP) != 0:
-                raise ValueError(f"GDAL could not parse {text!r} as a CRS.")
-            result = srs
-        except (RuntimeError, TypeError, ValueError):
-            result = None
+    try:
+        srs = osr.SpatialReference()
+        # SetFromUserInput will otherwise treat the string as a filename or a URL
+        # and go read it -- so a CRS value reaching this rescue path could cause a
+        # local file read or an outbound HTTP request, and a dead host would block
+        # for seconds. pyramids only ever means a CRS here, never a resource to
+        # fetch, so both are refused.
+        if srs.SetFromUserInput(text, _NO_REMOTE_CRS_LOOKUP) != 0:
+            raise ValueError(f"GDAL could not parse {text!r} as a CRS.")
+        result = srs
+    except (RuntimeError, TypeError, ValueError):
+        result = None
     return result
 
 
@@ -1324,6 +1443,27 @@ def crs_from_user_input(crs: int | str | Any) -> CRS:
             "proj4, or pyproj.CRS."
         )
     try:
+        hash(crs)
+    except TypeError:
+        # Unhashable (a list, a dict) cannot key the cache. It is also not a CRS, so
+        # this all but always ends in the CRSError below -- just not via the cache.
+        return _resolve_crs(crs)
+    return _resolve_crs_cached(crs)
+
+
+def _resolve_crs(crs: int | str | Any) -> CRS:
+    """Uncached body of :func:`crs_from_user_input`.
+
+    Args:
+        crs: The specification to resolve.
+
+    Returns:
+        CRS: The parsed CRS.
+
+    Raises:
+        CRSError: Neither pyproj nor GDAL can interpret `crs`.
+    """
+    try:
         parsed = CRS.from_user_input(crs)
     except (pyproj.exceptions.CRSError, TypeError, ValueError) as exc:
         rescued = _pyproj_crs_via_gdal(crs)
@@ -1331,6 +1471,33 @@ def crs_from_user_input(crs: int | str | Any) -> CRS:
             raise CRSError(f"could not interpret {crs!r} as a CRS: {exc}") from exc
         parsed = rescued
     return parsed
+
+
+@lru_cache(maxsize=512)
+def _resolve_crs_cached(crs: int | str | Any) -> CRS:
+    """Memoised :func:`_resolve_crs`.
+
+    The cache has to sit here, at the entry point, rather than around the GDAL rescue
+    alone. For a code pyproj lacks the expensive step is pyproj's own *failed* lookup,
+    which happens before the rescue is reached — measured at ~6 ms against ~0.008 ms
+    for a code it carries, and ~28 ms through :func:`epsg_from_user_input`, which then
+    asks a WKT-built CRS for an EPSG code it has no catalogue entry for. Caching only
+    the rescue left every one of those milliseconds in place.
+
+    That cost lands on exactly the CRSes that pay it repeatedly: a raster in such a
+    CRS resolves it on every read, transform, comparison and tile. The answer depends
+    only on the installed GDAL and pyproj, so it is fixed for the process.
+
+    Failures are deliberately not cached — :class:`functools.lru_cache` stores return
+    values, not exceptions — so a bad input re-raises with its own message each time.
+
+    Args:
+        crs: A hashable specification.
+
+    Returns:
+        CRS: The parsed CRS, shared between callers (pyproj CRS objects are immutable).
+    """
+    return _resolve_crs(crs)
 
 
 def epsg_from_user_input(crs: int | str | Any) -> int:
@@ -1394,6 +1561,25 @@ def epsg_from_user_input(crs: int | str | Any) -> int:
     code = _integer_code(crs)
     if code is not None:
         return code
+    try:
+        hash(crs)
+    except TypeError:
+        return _resolve_epsg(crs)
+    return _resolve_epsg_cached(crs)
+
+
+def _resolve_epsg(crs: int | str | Any) -> int:
+    """Uncached body of :func:`epsg_from_user_input` for a non-integer input.
+
+    Args:
+        crs: The specification to resolve.
+
+    Returns:
+        int: The EPSG code.
+
+    Raises:
+        CRSError: `crs` is uninterpretable or names a CRS with no EPSG code.
+    """
     parsed = crs_from_user_input(crs)
     epsg = parsed.to_epsg()
     if epsg is None:
@@ -1405,6 +1591,19 @@ def epsg_from_user_input(crs: int | str | Any) -> int:
             f"the CRS {crs!r} has no corresponding EPSG code; pass an EPSG integer."
         )
     return epsg
+
+
+@lru_cache(maxsize=512)
+def _resolve_epsg_cached(crs: int | str | Any) -> int:
+    """Memoised :func:`_resolve_epsg`; see :func:`_resolve_crs_cached` for why.
+
+    Args:
+        crs: A hashable, non-integer specification.
+
+    Returns:
+        int: The EPSG code.
+    """
+    return _resolve_epsg(crs)
 
 
 def sr_from_user_input(crs: int | str | Any) -> osr.SpatialReference:

--- a/src/pyramids/base/crs.py
+++ b/src/pyramids/base/crs.py
@@ -773,9 +773,9 @@ def crs_spec(epsg: int | None, wkt: str | None) -> int | str | None:
         - A code the downstream CRS library cannot resolve yields the WKT, so the
           specification stays usable:
             ```python
-            >>> from pyramids.base.crs import crs_spec, sr_from_epsg
-            >>> wkt = sr_from_epsg(10857).ExportToWkt()  # doctest: +SKIP
-            >>> crs_spec(10857, wkt) is wkt  # doctest: +SKIP
+            >>> from pyramids.base.crs import crs_spec
+            >>> wkt = 'GEOGCS["WGS 84"]'
+            >>> crs_spec(999999, wkt) is wkt  # no database carries 999999
             True
 
             ```

--- a/src/pyramids/base/crs.py
+++ b/src/pyramids/base/crs.py
@@ -965,6 +965,13 @@ def epsg_from_wkt(wkt: str | None, default: int = 4326) -> int:
     EPSG authority — e.g. a spherical-earth GRIB GEOGCS); otherwise
     delegates to :func:`get_epsg_from_prj`.
 
+    A CRS whose authority is not EPSG — Robinson is `ESRI:54030` — resolves to no
+    EPSG code at all (issue #965), so it takes the `default` here just as an empty
+    projection does. That is this function's contract, but it means the default can
+    stand in for a real, named projection rather than only for a missing one. When
+    that distinction matters, use :func:`epsg_of_crs`, which reports `None`, and read
+    the CRS itself from `.crs`.
+
     Use this in places where an empty projection should be treated as
     a soft "unknown CRS, assume WGS84" rather than a hard error — for
     example the `Dataset.epsg` property on a freshly-built

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -64,11 +64,11 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from pyproj import CRS
 from pyproj.exceptions import CRSError
 
 from pyramids.base._errors import OptionalPackageDoesNotExist
 from pyramids.base._utils import require_cleopatra
+from pyramids.base.crs import crs_from_user_input
 
 # `add_basemap` is imported at top-level so existing test patches that
 # target `pyramids.basemap.basemap.add_basemap` keep working. The
@@ -102,8 +102,10 @@ def _is_degree_geographic(epsg: int) -> bool:
         True when `epsg` is a geographic CRS whose angular unit is degrees.
     """
     try:
-        crs = CRS.from_user_input(epsg)
-    except CRSError:
+        # `crs_from_user_input` heals codes GDAL's PROJ database knows but pyproj's
+        # does not (issue #943); it raises pyramids' CRSError, a ValueError.
+        crs = crs_from_user_input(epsg)
+    except (CRSError, ValueError):
         return False
     return (
         crs.is_geographic

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -47,7 +47,6 @@ from typing import TYPE_CHECKING, cast
 from xml.etree import ElementTree as ET  # nosec B405 - server XML; DoS accepted, no XXE
 
 from osgeo import gdal
-from pyproj import CRS as _PyprojCRS
 from pyproj.exceptions import CRSError as _PyprojCRSError
 
 from pyramids.base._coverage import native_projwin as _native_projwin
@@ -61,6 +60,7 @@ from pyramids.base._ogc_api import HTTP_RETRY_ATTEMPTS
 from pyramids.base._ogc_api import gdal_http_config as _gdal_http_config
 from pyramids.base._ogc_api import http_get_with_retry as _http_get_with_retry
 from pyramids.base._ogc_api import read_http_error as _read_http_error
+from pyramids.base.crs import crs_from_user_input
 
 # Cap on how much of an HTTP-error body is inlined into a WCSError message; the
 # full body is still carried on WCSError.response_body. Keeps a multi-KB HTML
@@ -413,7 +413,9 @@ def _default_subset_axes(crs: str) -> tuple[str, str]:
     ``subset_axes`` override.
     """
     try:
-        is_geographic = _PyprojCRS.from_user_input(crs).is_geographic
+        # `crs_from_user_input` heals a code only GDAL's PROJ database knows, so a
+        # coverage in such a CRS still gets its real axis labels (issue #943).
+        is_geographic = crs_from_user_input(crs).is_geographic
     except (_PyprojCRSError, ValueError, TypeError):
         text = str(crs).strip().upper()
         is_geographic = text.endswith(":4326") or "CRS84" in text

--- a/src/pyramids/dataset/cog/facade.py
+++ b/src/pyramids/dataset/cog/facade.py
@@ -28,10 +28,10 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 from osgeo import gdal
-from pyproj import CRS
 
-from pyramids.base._errors import ReadOnlyError
+from pyramids.base._errors import CRSError, ReadOnlyError
 from pyramids.base._utils import resolve_cog_predictor
+from pyramids.base.crs import epsg_from_user_input
 from pyramids.dataset.cog.options import CreationOptions
 from pyramids.dataset.cog.validate import ValidationReport
 from pyramids.dataset.cog.validate import validate as _validate_file
@@ -97,7 +97,12 @@ def _coerce_epsg(crs: Any) -> int:
     """
     if isinstance(crs, int):
         return crs
-    epsg = CRS.from_user_input(crs).to_epsg()
+    try:
+        # Via `epsg_from_user_input`, which heals codes present in GDAL's PROJ
+        # database but absent from pyproj's (issue #943).
+        epsg = epsg_from_user_input(crs)
+    except CRSError:
+        epsg = None
     if epsg is None:
         raise ValueError(
             f"Could not resolve an EPSG code from crs={crs!r}; pass an "

--- a/src/pyramids/dataset/cog/facade.py
+++ b/src/pyramids/dataset/cog/facade.py
@@ -101,8 +101,13 @@ def _coerce_epsg(crs: Any) -> int:
         # Via `epsg_from_user_input`, which heals codes present in GDAL's PROJ
         # database but absent from pyproj's (issue #943).
         epsg = epsg_from_user_input(crs)
-    except CRSError:
-        epsg = None
+    except CRSError as exc:
+        # Chain, so the underlying "no EPSG code" / "could not interpret" reason
+        # stays visible instead of being replaced by the generic message.
+        raise ValueError(
+            f"Could not resolve an EPSG code from crs={crs!r}; pass an "
+            "integer EPSG code explicitly."
+        ) from exc
     if epsg is None:
         raise ValueError(
             f"Could not resolve an EPSG code from crs={crs!r}; pass an "

--- a/src/pyramids/dataset/cog/facade.py
+++ b/src/pyramids/dataset/cog/facade.py
@@ -108,11 +108,6 @@ def _coerce_epsg(crs: Any) -> int:
             f"Could not resolve an EPSG code from crs={crs!r}; pass an "
             "integer EPSG code explicitly."
         ) from exc
-    if epsg is None:
-        raise ValueError(
-            f"Could not resolve an EPSG code from crs={crs!r}; pass an "
-            "integer EPSG code explicitly."
-        )
     return epsg
 
 

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -456,11 +456,14 @@ def _target_epsg(to_epsg: int | str | Any) -> int | None:
         # `epsg_from_user_input` also heals codes only GDAL's PROJ database
         # carries, which pyproj alone cannot look up (issue #943).
         return epsg_from_user_input(to_epsg)
-    except CRSError:
-        # Not an exceptional case: a target CRS with no EPSG code (orthographic,
-        # Robinson, a bespoke proj4) is exactly what this function reports `None`
-        # for, and it now arrives as a raise rather than as a `None` return. This
-        # branch is the documented no-EPSG path, so it carries no `no cover` pragma.
+    except (CRSError, TypeError, ValueError):
+        # `CRSError` is the documented no-EPSG path -- a target CRS with no EPSG code
+        # (orthographic, Robinson, a bespoke proj4) is exactly what this function
+        # reports `None` for, and it now arrives as a raise rather than a `None`
+        # return, so that branch carries no `no cover` pragma. `TypeError` /
+        # `ValueError` keep the original defensive breadth for an input that is not
+        # CRS-like at all, which this helper has always answered `None` for rather
+        # than propagating.
         return None
 
 

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -18,7 +18,11 @@ import pandas as pd
 from pyproj import CRS
 
 from pyramids import _io
-from pyramids.base._errors import AlignmentError, OptionalPackageDoesNotExist
+from pyramids.base._errors import (
+    AlignmentError,
+    CRSError,
+    OptionalPackageDoesNotExist,
+)
 from pyramids.base._file_manager import CachingFileManager, gdal_raster_open
 from pyramids.base._locks import default_lock
 from pyramids.base._raster_meta import RasterMeta
@@ -452,7 +456,11 @@ def _target_epsg(to_epsg: int | str | Any) -> int | None:
         # `epsg_from_user_input` also heals codes only GDAL's PROJ database
         # carries, which pyproj alone cannot look up (issue #943).
         return epsg_from_user_input(to_epsg)
-    except Exception:  # pragma: no cover - defensive against odd CRS inputs
+    except CRSError:
+        # Not an exceptional case: a target CRS with no EPSG code (orthographic,
+        # Robinson, a bespoke proj4) is exactly what this function reports `None`
+        # for, and it now arrives as a raise rather than as a `None` return. This
+        # branch is the documented no-EPSG path, so it carries no `no cover` pragma.
         return None
 
 

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -18,11 +18,7 @@ import pandas as pd
 from pyproj import CRS
 
 from pyramids import _io
-from pyramids.base._errors import (
-    AlignmentError,
-    CRSError,
-    OptionalPackageDoesNotExist,
-)
+from pyramids.base._errors import AlignmentError, OptionalPackageDoesNotExist
 from pyramids.base._file_manager import CachingFileManager, gdal_raster_open
 from pyramids.base._locks import default_lock
 from pyramids.base._raster_meta import RasterMeta
@@ -451,14 +447,14 @@ def _target_epsg(to_epsg: int | str | Any) -> int | None:
         # `epsg_from_user_input` also heals codes only GDAL's PROJ database
         # carries, which pyproj alone cannot look up (issue #943).
         return epsg_from_user_input(to_epsg)
-    except (CRSError, TypeError, ValueError):
-        # `CRSError` is the documented no-EPSG path -- a target CRS with no EPSG code
-        # (orthographic, Robinson, a bespoke proj4) is exactly what this function
-        # reports `None` for, and it now arrives as a raise rather than a `None`
-        # return, so that branch carries no `no cover` pragma. `TypeError` /
-        # `ValueError` keep the original defensive breadth for an input that is not
-        # CRS-like at all, which this helper has always answered `None` for rather
-        # than propagating.
+    except (TypeError, ValueError):
+        # `ValueError` already covers `CRSError`, which subclasses it, so naming both
+        # would be redundant. That is the documented no-EPSG path: a target CRS with
+        # no EPSG code (orthographic, Robinson, a bespoke proj4) is exactly what this
+        # function reports `None` for, and it now arrives as a raise rather than a
+        # `None` return, so the branch carries no `no cover` pragma. `TypeError` keeps
+        # the original defensive breadth for an input that is not CRS-like at all,
+        # which this helper has always answered `None` for rather than propagating.
         return None
 
 

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -28,7 +28,7 @@ from pyramids.base._utils import (
     import_zarr,
     lazy_extra_hint,
 )
-from pyramids.base.crs import crs_spec
+from pyramids.base.crs import crs_spec, epsg_from_user_input
 from pyramids.base.remote import cloud_config_from_env
 from pyramids.dataset._plot_helpers import render_array
 from pyramids.dataset._reduce_ops import resolve_dask_op
@@ -449,7 +449,9 @@ def _target_epsg(to_epsg: int | str | Any) -> int | None:
     if isinstance(to_epsg, int):
         return to_epsg
     try:
-        return CRS.from_user_input(to_epsg).to_epsg()
+        # `epsg_from_user_input` also heals codes only GDAL's PROJ database
+        # carries, which pyproj alone cannot look up (issue #943).
+        return epsg_from_user_input(to_epsg)
     except Exception:  # pragma: no cover - defensive against odd CRS inputs
         return None
 

--- a/src/pyramids/dataset/engines/cell.py
+++ b/src/pyramids/dataset/engines/cell.py
@@ -16,6 +16,7 @@ from geopandas.geodataframe import GeoDataFrame
 from hpc.indexing import get_indices2, locate_values
 from pandas import DataFrame
 
+from pyramids.base.crs import crs_from_user_input
 from pyramids.dataset.engines._base import _Engine
 from pyramids.feature import FeatureCollection, create_points, create_polygon
 
@@ -233,7 +234,10 @@ class Cell(_Engine["Dataset"]):
         rings = np.stack((x, y), axis=-1)
         polygons = [create_polygon(ring) for ring in rings.tolist()]
         gdf = gpd.GeoDataFrame(geometry=polygons)
-        gdf.set_crs(epsg=epsg, inplace=True)
+        # Through `crs_from_user_input`, not `epsg=`: geopandas resolves a bare code
+        # with pyproj, which cannot look up a code only GDAL's PROJ database carries
+        # (issue #943). A resolved CRS object needs no lookup.
+        gdf.set_crs(crs_from_user_input(epsg), inplace=True)
         gdf["id"] = gdf.index
         return gdf
 
@@ -317,7 +321,10 @@ class Cell(_Engine["Dataset"]):
         coords_tuples = list(zip(coords[:, 0], coords[:, 1]))
         points = create_points(coords_tuples)
         gdf = gpd.GeoDataFrame(geometry=points)
-        gdf.set_crs(epsg=epsg, inplace=True)
+        # Through `crs_from_user_input`, not `epsg=`: geopandas resolves a bare code
+        # with pyproj, which cannot look up a code only GDAL's PROJ database carries
+        # (issue #943). A resolved CRS object needs no lookup.
+        gdf.set_crs(crs_from_user_input(epsg), inplace=True)
         gdf["id"] = gdf.index
         return gdf
 

--- a/src/pyramids/dataset/engines/cog.py
+++ b/src/pyramids/dataset/engines/cog.py
@@ -27,7 +27,7 @@ from pyramids.base._utils import (
     numpy_to_gdal_dtype,
     resolve_cog_predictor,
 )
-from pyramids.base.crs import crs_equal, require_crs_spec
+from pyramids.base.crs import crs_equal, crs_from_user_input, require_crs_spec
 from pyramids.dataset.abstract_dataset import under_gdal_env
 from pyramids.dataset.cog import (
     COGInfo,
@@ -170,7 +170,11 @@ def _cached_transformer(src_crs: Any, dst_crs: Any) -> Transformer:
         Transformer: A shared, reusable transformer. `pyproj` transformers are
         safe to reuse; only construction is costly.
     """
-    return Transformer.from_crs(src_crs, dst_crs, always_xy=True)
+    # Both sides go through `crs_from_user_input` so a code that lives in GDAL's PROJ
+    # database but not pyproj's still builds a transformer (issue #943).
+    return Transformer.from_crs(
+        crs_from_user_input(src_crs), crs_from_user_input(dst_crs), always_xy=True
+    )
 
 
 class COG(_Engine["Dataset"]):

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -27,7 +27,6 @@ from geopandas.geodataframe import GeoDataFrame
 from osgeo import gdal
 from osgeo_utils import gdal2xyz
 from pandas import DataFrame
-from pyproj import CRS
 
 from pyramids._io import new_vsimem_path, read_vsi_bytes
 from pyramids.base._domain import is_no_data
@@ -44,7 +43,7 @@ from pyramids.base._file_manager import (
 )
 from pyramids.base._locks import DummyLock, default_lock
 from pyramids.base._utils import resolve_resampling
-from pyramids.base.crs import crs_spec, reproject_coordinates
+from pyramids.base.crs import crs_from_user_input, crs_spec, reproject_coordinates
 from pyramids.base.protocols import ArrayLike
 from pyramids.base.remote import is_network_backed
 from pyramids.dataset.abstract_dataset import (
@@ -1640,7 +1639,9 @@ class IO(_Engine["Dataset"]):
         raster_crs, poly_crs = self._ds.crs, poly.crs
         if not raster_crs or poly_crs is None:
             return False
-        return not CRS.from_user_input(poly_crs).equals(CRS.from_user_input(raster_crs))
+        # `crs_from_user_input` on both sides so a CRS whose code only GDAL's PROJ
+        # database carries still compares instead of raising (issue #943).
+        return not crs_from_user_input(poly_crs).equals(crs_from_user_input(raster_crs))
 
     def read_windows(
         self,

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -20,6 +20,7 @@ from pyramids.base._domain import is_no_data
 from pyramids.base._utils import DEFAULT_RESAMPLING, resolve_resampling
 from pyramids.base.crs import (
     crs_equal,
+    crs_from_user_input,
     crs_spec,
     epsg_of_crs,
     reproject_coordinates,
@@ -1601,6 +1602,58 @@ class Spatial(_Engine["Dataset"]):
                     window = (west, south, east, north)
         return window
 
+    @staticmethod
+    def _cutline_in_source_crs(
+        src: RasterBase, feature: FeatureCollection
+    ) -> FeatureCollection:
+        """Reproject a cutline into the raster's own CRS, densifying it first.
+
+        A cutline in a different CRS used to be handed to GDAL as-is. That silently
+        broke `touch=True` crops: :meth:`_cutline_window_bounds` refuses a differing
+        CRS, so no `outputBounds` was set and `cropToCutline` is false under `touch`,
+        leaving the whole source grid in place. The crop then depended entirely on
+        :meth:`_correct_wrap_cutline_error` trimming an all-no-data border — and a
+        raster that declares **no no-data value** has no border to detect, so
+        `crop(bbox=..., epsg=<other CRS>)` returned the raster *uncropped*, with no
+        error. Setting a no-data value on the same raster made the identical call crop
+        correctly, which is what made the bug so easy to miss.
+
+        Bringing the cutline into the source CRS here fixes it at the root: the window
+        optimisation applies again, GDAL needs no cutline transform, and the result no
+        longer depends on whether the band happens to declare a no-data value.
+
+        The edges are densified before reprojecting. A straight edge in one CRS is
+        generally a *curve* in another, so reprojecting only the four corners of a bbox
+        would cut inside the requested area wherever the true edge bows outward.
+        Segmentising to a fraction of the envelope keeps the reprojected outline within
+        a fraction of a pixel of the real one.
+
+        Args:
+            src: The raster being cropped.
+            feature: The cutline, in any CRS.
+
+        Returns:
+            FeatureCollection: The cutline in `src`'s CRS, or `feature` unchanged when
+            either side has no CRS or they already agree.
+        """
+        source_crs = src.crs
+        result = feature
+        needs_reprojection = (
+            bool(source_crs)
+            and feature.crs is not None
+            and not crs_equal(source_crs, feature.crs.to_wkt())
+        )
+        if needs_reprojection:
+            minx, miny, maxx, maxy = (float(v) for v in feature.total_bounds)
+            span = max(maxx - minx, maxy - miny)
+            densified = feature.copy()
+            if math.isfinite(span) and span > 0:
+                # 64 segments across the envelope: well under a pixel of error for a
+                # crop window, and cheap for the handful of vertices a cutline has.
+                densified.geometry = densified.geometry.segmentize(span / 64.0)
+            result = densified.to_crs(crs_from_user_input(source_crs))
+        return result
+
     def _crop_with_polygon_warp(
         self, feature: FeatureCollection | GeoDataFrame, touch: bool = True
     ) -> Dataset:
@@ -1648,6 +1701,7 @@ class Spatial(_Engine["Dataset"]):
         # warp to the cutline's own window first: the trimmed result is identical
         # because every non-no-data cell lives inside that window, but the read shrinks
         # from the source to the crop. cropToCutline already bounds the touch=False path.
+        feature = self._cutline_in_source_crs(self._ds, feature)
         window = self._cutline_window_bounds(self._ds, feature) if touch else None
         # Pin the resolution to the source's own so the windowed warp is a pixel-exact
         # subset and cannot resample; only needed when a window is set.

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1603,6 +1603,19 @@ class Spatial(_Engine["Dataset"]):
         return window
 
     @staticmethod
+    def _cutline_srs(feature: FeatureCollection) -> str | None:
+        """The cutline's CRS as WKT, for `gdal.Warp`'s ``cutlineSRS``, or ``None``.
+
+        Args:
+            feature: The cutline about to be staged.
+
+        Returns:
+            str | None: The WKT, or ``None`` when the cutline declares no CRS (GDAL
+            then keeps its existing behaviour of reading whatever the file carries).
+        """
+        return None if feature.crs is None else feature.crs.to_wkt()
+
+    @staticmethod
     def _cutline_in_source_crs(
         src: RasterBase, feature: FeatureCollection
     ) -> FeatureCollection:
@@ -1711,6 +1724,14 @@ class Spatial(_Engine["Dataset"]):
                 format="VRT",
                 cropToCutline=not touch,
                 cutlineDSName=cutline_path,
+                # State the cutline's CRS rather than letting GDAL read it back from
+                # the staged file. The cutline is staged as GeoJSON, which can name a
+                # CRS only as an OGC URN, so a CRS with no authority code -- an
+                # orthographic or Robinson grid, or one rescued from GDAL's PROJ
+                # database -- is written with no CRS at all. GDAL then assumes the
+                # GeoJSON default of CRS84 and transforms metre coordinates as
+                # lon/lat, failing with "Invalid latitude" (issue #964).
+                cutlineSRS=self._cutline_srs(feature),
                 multithread=True,
                 outputBounds=window,
                 xRes=abs(gt[1]) if gt else None,

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1646,9 +1646,11 @@ class Spatial(_Engine["Dataset"]):
             step = math.hypot(bx - ax, by - ay)
             if math.isfinite(step) and step > 0:
                 length = max(step, span / 4096.0)
-        except Exception:
-            # Any failure to measure the scale leaves `length` None; an undensified
-            # reprojection is the previous behaviour, not a new hazard.
+        except (RuntimeError, ValueError, TypeError, AttributeError):
+            # Narrow rather than bare: these are what a missing geotransform, an
+            # unparseable CRS or a transform PROJ refuses actually raise. Catching
+            # everything would swallow genuine bugs in the measurement itself and
+            # silently degrade the crop instead of failing.
             length = None
         return length
 

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -15,6 +15,7 @@ from xml.sax.saxutils import escape  # nosec B406 - output escaping only
 import numpy as np
 from geopandas.geodataframe import GeoDataFrame
 from osgeo import gdal, osr
+from pyproj import Transformer
 
 from pyramids.base._domain import is_no_data
 from pyramids.base._utils import DEFAULT_RESAMPLING, resolve_resampling
@@ -1603,17 +1604,53 @@ class Spatial(_Engine["Dataset"]):
         return window
 
     @staticmethod
-    def _cutline_srs(feature: FeatureCollection) -> str | None:
-        """The cutline's CRS as WKT, for `gdal.Warp`'s ``cutlineSRS``, or ``None``.
+    def _cutline_segment_length(
+        src: RasterBase, feature: FeatureCollection
+    ) -> float | None:
+        """Densification step for the cutline, about one source pixel wide.
+
+        Dividing the cutline's envelope into a fixed number of parts is scale-free and
+        therefore wrong in general: 64 segments across a 64 km window is a 1 km chord,
+        fine against 1 km pixels, but 64 segments across a continental lon/lat bbox is
+        a ~50 km chord whose sagitta swallows many cells of a 30 m grid. Since the
+        reprojected envelope becomes `outputBounds`, that under-coverage truncates the
+        crop.
+
+        The step is therefore measured, not assumed: one source pixel is transformed
+        into the cutline's own CRS, which converts between their units without either
+        being named. The result is floored at 1/4096 of the envelope so a very fine
+        raster under a very large window cannot explode the vertex count.
 
         Args:
-            feature: The cutline about to be staged.
+            src: The raster being cropped.
+            feature: The cutline, in its own CRS.
 
         Returns:
-            str | None: The WKT, or ``None`` when the cutline declares no CRS (GDAL
-            then keeps its existing behaviour of reading whatever the file carries).
+            float | None: The segment length in the cutline's units, or ``None`` when
+            the envelope is degenerate or the scale cannot be measured — in which case
+            the caller reprojects the outline undensified, as it did before.
         """
-        return None if feature.crs is None else feature.crs.to_wkt()
+        minx, miny, maxx, maxy = (float(v) for v in feature.total_bounds)
+        span = max(maxx - minx, maxy - miny)
+        if not (math.isfinite(span) and span > 0):
+            return None
+        length: float | None = None
+        try:
+            x0, dx, _, y0, _, dy = src._raster.GetGeoTransform()
+            pixel = min(abs(dx), abs(dy))
+            to_cutline = Transformer.from_crs(
+                crs_from_user_input(src.crs), feature.crs, always_xy=True
+            )
+            ax, ay = to_cutline.transform(x0, y0)
+            bx, by = to_cutline.transform(x0 + pixel, y0)
+            step = math.hypot(bx - ax, by - ay)
+            if math.isfinite(step) and step > 0:
+                length = max(step, span / 4096.0)
+        except Exception:
+            # Any failure to measure the scale leaves `length` None; an undensified
+            # reprojection is the previous behaviour, not a new hazard.
+            length = None
+        return length
 
     @staticmethod
     def _cutline_in_source_crs(
@@ -1632,14 +1669,21 @@ class Spatial(_Engine["Dataset"]):
         correctly, which is what made the bug so easy to miss.
 
         Bringing the cutline into the source CRS here fixes it at the root: the window
-        optimisation applies again, GDAL needs no cutline transform, and the result no
-        longer depends on whether the band happens to declare a no-data value.
+        optimisation applies again and GDAL needs no cutline transform, so the crop is
+        bounded by the cutline's own window rather than by an incidental no-data
+        border. The two cases are not made identical — with a no-data value the
+        subsequent trim still tightens the result by the touch margin and the
+        reprojection slack, so a band that declares one crops a few cells closer —
+        but neither case can any longer return the raster uncropped.
 
         The edges are densified before reprojecting. A straight edge in one CRS is
         generally a *curve* in another, so reprojecting only the four corners of a bbox
-        would cut inside the requested area wherever the true edge bows outward.
-        Segmentising to a fraction of the envelope keeps the reprojected outline within
-        a fraction of a pixel of the real one.
+        would cut inside the requested area wherever the true edge bows outward — and
+        because the reprojected envelope becomes `outputBounds`, an under-covered edge
+        truncates the crop rather than merely blurring it. The segment length comes
+        from :meth:`_cutline_segment_length`, which measures one source pixel in the
+        cutline's own units, so the density follows the raster's resolution instead of
+        a fixed division of the envelope.
 
         Args:
             src: The raster being cropped.
@@ -1657,13 +1701,10 @@ class Spatial(_Engine["Dataset"]):
             and not crs_equal(source_crs, feature.crs.to_wkt())
         )
         if needs_reprojection:
-            minx, miny, maxx, maxy = (float(v) for v in feature.total_bounds)
-            span = max(maxx - minx, maxy - miny)
             densified = feature.copy()
-            if math.isfinite(span) and span > 0:
-                # 64 segments across the envelope: well under a pixel of error for a
-                # crop window, and cheap for the handful of vertices a cutline has.
-                densified.geometry = densified.geometry.segmentize(span / 64.0)
+            step = Spatial._cutline_segment_length(src, feature)
+            if step is not None:
+                densified.geometry = densified.geometry.segmentize(step)
             result = densified.to_crs(crs_from_user_input(source_crs))
         return result
 
@@ -1731,7 +1772,7 @@ class Spatial(_Engine["Dataset"]):
                 # database -- is written with no CRS at all. GDAL then assumes the
                 # GeoJSON default of CRS84 and transforms metre coordinates as
                 # lon/lat, failing with "Invalid latitude" (issue #964).
-                cutlineSRS=self._cutline_srs(feature),
+                cutlineSRS=(None if feature.crs is None else feature.crs.to_wkt()),
                 multithread=True,
                 outputBounds=window,
                 xRes=abs(gt[1]) if gt else None,

--- a/src/pyramids/dataset/engines/vectorize.py
+++ b/src/pyramids/dataset/engines/vectorize.py
@@ -476,7 +476,11 @@ class Vectorize(_Engine["Dataset"]):
             coords = src.get_cell_polygons(domain_only=True)
 
         gdf = gpd.GeoDataFrame(df.loc[:], geometry=coords["geometry"].to_list())
-        gdf = gdf.set_crs(coords.crs.to_epsg())
+        # Carry the CRS object across rather than reducing it to an EPSG int:
+        # `to_epsg()` is None for a CRS the register does not name, and a code
+        # only GDAL's PROJ database carries fails when geopandas looks it back up
+        # through pyproj (issue #943). The object needs no lookup at all.
+        gdf = gdf.set_crs(coords.crs)
         return gdf
 
     def translate(self, path: str | Path | None = None, **kwargs) -> Dataset:

--- a/src/pyramids/feature/_ogr.py
+++ b/src/pyramids/feature/_ogr.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import io
 import itertools
+import json
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -24,8 +25,10 @@ from contextlib import contextmanager
 import geopandas as gpd
 from geopandas import GeoDataFrame
 from osgeo import gdal, ogr
+from pyproj.exceptions import CRSError as _PyprojCRSError
 
 from pyramids.base._errors import VectorDriverError
+from pyramids.base.crs import crs_from_user_input
 
 # Process-wide monotonic counter guaranteeing `/vsimem/` path uniqueness;
 # see the note in `pyramids._io`. `next()` on an itertools.count is atomic
@@ -239,6 +242,62 @@ def as_vsimem_path(gdf: GeoDataFrame) -> Iterator[str]:
         gdal.Unlink(mem_path)
 
 
+def _source_layer_wkt(ds: ogr.DataSource | gdal.Dataset) -> str:
+    """WKT of the datasource's first layer, or ``""`` when it declares none.
+
+    Args:
+        ds: The datasource being materialized.
+
+    Returns:
+        str: The layer's spatial reference as WKT, or ``""``.
+    """
+    wkt = ""
+    try:
+        layer = ds.GetLayer(0)
+        srs = None if layer is None else layer.GetSpatialRef()
+        wkt = "" if srs is None else srs.ExportToWkt()
+    except (RuntimeError, AttributeError):
+        wkt = ""
+    return wkt
+
+
+def _read_geojson_bytes(data: bytes, ds: ogr.DataSource | gdal.Dataset) -> GeoDataFrame:
+    """Parse GDAL's GeoJSON output, surviving a CRS pyproj cannot look up.
+
+    GDAL names the CRS in the GeoJSON as an authority URN
+    (``urn:ogc:def:crs:EPSG::10857``), and geopandas resolves that URN through pyproj.
+    When the code lives in GDAL's PROJ database but not pyproj's, the read raises
+    before any geometry is returned — so `to_polygons` and `footprint` failed on
+    exactly the rasters issue #943 is about, even though the CRS is fine and GDAL
+    just wrote it.
+
+    The normal path is untouched: parse the bytes as they are. Only when that fails
+    on the CRS is the ``crs`` member dropped and the geometry re-read, with the
+    authoritative WKT taken straight from the source layer and attached afterwards.
+    That fallback costs a JSON round trip, which is why it is not the default.
+
+    Args:
+        data: The GeoJSON bytes GDAL wrote.
+        ds: The source datasource, consulted only for its layer's WKT on the
+            fallback path.
+
+    Returns:
+        GeoDataFrame: The parsed features, carrying the source CRS.
+    """
+    try:
+        gdf = gpd.read_file(io.BytesIO(data))
+    except _PyprojCRSError:
+        wkt = _source_layer_wkt(ds)
+        if not wkt:
+            # Nothing authoritative to substitute, so the original failure stands.
+            raise
+        document = json.loads(bytes(data))
+        document.pop("crs", None)
+        gdf = gpd.read_file(io.BytesIO(json.dumps(document).encode("utf-8")))
+        gdf = gdf.set_crs(crs_from_user_input(wkt), allow_override=True)
+    return gdf
+
+
 def datasource_to_gdf(ds: ogr.DataSource | gdal.Dataset) -> GeoDataFrame:
     """Materialize an OGR `DataSource` into a `GeoDataFrame`.
 
@@ -337,7 +396,7 @@ def datasource_to_gdf(ds: ogr.DataSource | gdal.Dataset) -> GeoDataFrame:
             data = gdal.VSIFReadL(1, size, vsi_file)
         finally:
             gdal.VSIFCloseL(vsi_file)
-        gdf = gpd.read_file(io.BytesIO(data))
+        gdf = _read_geojson_bytes(data, ds)
     finally:
         # Under gdal.UseExceptions(), Unlink on a non-existent path
         # raises RuntimeError and would mask whatever exception we

--- a/src/pyramids/feature/_ogr.py
+++ b/src/pyramids/feature/_ogr.py
@@ -283,6 +283,12 @@ def _strip_geojson_crs(data: bytes) -> bytes | None:
     cannot unbalance it, and gives up (returning ``None``) on anything it does not
     recognise rather than guessing at a malformed document.
 
+    This is **not** a general JSON editor, and must not be reused as one: it assumes
+    GDAL's own layout — a top-level ``crs`` member holding an object, within the first
+    :data:`_GEOJSON_HEADER_SCAN` bytes — and it does not distinguish a top-level key
+    from an identically named one nested inside an earlier member. Everything it
+    cannot place, it declines; the caller then does a real parse.
+
     Args:
         data: The GeoJSON bytes GDAL wrote.
 
@@ -355,24 +361,29 @@ def _read_geojson_bytes(data: bytes, ds: ogr.DataSource | gdal.Dataset) -> GeoDa
     exactly the rasters issue #943 is about, even though the CRS is fine and GDAL
     just wrote it.
 
-    The normal path is untouched: parse the bytes as they are. Only when that fails
-    on the CRS is the ``crs`` member dropped and the geometry re-read, with the
-    authoritative WKT taken straight from the source layer and attached afterwards.
-    That fallback costs a JSON round trip, which is why it is not the default.
+    The mirror-image failure is quieter and worse. When GDAL cannot express the CRS
+    as a URN at all — an orthographic or Robinson grid, anything with no authority
+    code — it writes *no* ``crs`` member, and nothing raises: GeoJSON's default is
+    CRS84, so the frame comes back carrying metre coordinates labelled **WGS 84**.
+    A wrong CRS that reads as valid is harder to notice than a crash.
+
+    Both are answered the same way: the source layer's own WKT is authoritative, so
+    it is attached whenever it is available, rather than trusting what survived the
+    GeoJSON round trip. The ``crs``-member removal below remains only for the case
+    where the read raises before returning any geometry at all.
 
     Args:
         data: The GeoJSON bytes GDAL wrote.
-        ds: The source datasource, consulted only for its layer's WKT on the
-            fallback path.
+        ds: The source datasource, consulted for its layer's authoritative WKT.
 
     Returns:
         GeoDataFrame: The parsed features, carrying the source CRS.
     """
+    source_wkt = _source_layer_wkt(ds)
     try:
         gdf = gpd.read_file(io.BytesIO(data))
     except _PyprojCRSError:
-        wkt = _source_layer_wkt(ds)
-        if not wkt:
+        if not source_wkt:
             # Nothing authoritative to substitute, so the original failure stands.
             raise
         stripped = _strip_geojson_crs(data)
@@ -383,7 +394,8 @@ def _read_geojson_bytes(data: bytes, ds: ogr.DataSource | gdal.Dataset) -> GeoDa
             document.pop("crs", None)
             stripped = json.dumps(document).encode("utf-8")
         gdf = gpd.read_file(io.BytesIO(stripped))
-        gdf = gdf.set_crs(crs_from_user_input(wkt), allow_override=True)
+    if source_wkt:
+        gdf = gdf.set_crs(crs_from_user_input(source_wkt), allow_override=True)
     return gdf
 
 

--- a/src/pyramids/feature/_ogr.py
+++ b/src/pyramids/feature/_ogr.py
@@ -261,6 +261,87 @@ def _source_layer_wkt(ds: ogr.DataSource | gdal.Dataset) -> str:
     return wkt
 
 
+_GEOJSON_HEADER_SCAN = 4096
+"""Bytes of a GeoJSON document searched for the top-level ``crs`` member.
+
+GDAL writes `type`, `name` then `crs` before the first feature, so the member is
+always within the first few hundred bytes. Bounding the scan keeps the cost independent
+of the document's size — the whole point of not parsing it.
+"""
+
+
+def _strip_geojson_crs(data: bytes) -> bytes | None:
+    """Drop the top-level ``crs`` member from GDAL's GeoJSON without parsing it.
+
+    Decoding and re-encoding the document to remove one key costs a full parse, a full
+    re-serialisation and several times the document in peak memory — on a polygonize
+    output that is the largest allocation in the pipeline, and the read path a few
+    lines above deliberately avoids even *one* extra copy of the same buffer.
+
+    The member sits in the header, so it can be excised by locating it and copying the
+    two surrounding slices. The scan tracks quoted strings so a brace inside a CRS name
+    cannot unbalance it, and gives up (returning ``None``) on anything it does not
+    recognise rather than guessing at a malformed document.
+
+    Args:
+        data: The GeoJSON bytes GDAL wrote.
+
+    Returns:
+        bytes | None: The document without its ``crs`` member, or ``None`` when the
+        member is absent or not laid out as expected.
+    """
+    head = bytes(data[:_GEOJSON_HEADER_SCAN])
+    key = head.find(b'"crs"')
+    if key == -1:
+        return None
+    colon = head.find(b":", key + 5)
+    if colon == -1:
+        return None
+    start_of_value = colon + 1
+    while start_of_value < len(head) and head[start_of_value : start_of_value + 1].isspace():
+        start_of_value += 1
+    if head[start_of_value : start_of_value + 1] != b"{":
+        return None
+
+    depth, in_string, escaped, end = 0, False, False, -1
+    for index in range(start_of_value, len(head)):
+        char = head[index : index + 1]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == b"\\":
+                escaped = True
+            elif char == b'"':
+                in_string = False
+            continue
+        if char == b'"':
+            in_string = True
+        elif char == b"{":
+            depth += 1
+        elif char == b"}":
+            depth -= 1
+            if depth == 0:
+                end = index + 1
+                break
+    if end == -1:
+        return None
+
+    # Absorb one separating comma so what remains is still valid JSON: the one after
+    # the member, or -- if `crs` was last -- the one before it.
+    cut_start, cut_end = key, end
+    while cut_end < len(head) and head[cut_end : cut_end + 1].isspace():
+        cut_end += 1
+    if head[cut_end : cut_end + 1] == b",":
+        cut_end += 1
+    else:
+        preceding = cut_start - 1
+        while preceding >= 0 and head[preceding : preceding + 1].isspace():
+            preceding -= 1
+        if preceding >= 0 and head[preceding : preceding + 1] == b",":
+            cut_start = preceding
+    return bytes(data[:cut_start]) + bytes(data[cut_end:])
+
+
 def _read_geojson_bytes(data: bytes, ds: ogr.DataSource | gdal.Dataset) -> GeoDataFrame:
     """Parse GDAL's GeoJSON output, surviving a CRS pyproj cannot look up.
 
@@ -291,11 +372,14 @@ def _read_geojson_bytes(data: bytes, ds: ogr.DataSource | gdal.Dataset) -> GeoDa
         if not wkt:
             # Nothing authoritative to substitute, so the original failure stands.
             raise
-        # `json.loads` takes the buffer as-is; `bytes(data)` would force the same
-        # full copy the comment above `VSIFReadL` exists to avoid.
-        document = json.loads(data)
-        document.pop("crs", None)
-        gdf = gpd.read_file(io.BytesIO(json.dumps(document).encode("utf-8")))
+        stripped = _strip_geojson_crs(data)
+        if stripped is None:
+            # The member is not where GDAL puts it. Fall back to a full parse, which
+            # is slow but cannot be confused by an unexpected layout.
+            document = json.loads(data)
+            document.pop("crs", None)
+            stripped = json.dumps(document).encode("utf-8")
+        gdf = gpd.read_file(io.BytesIO(stripped))
         gdf = gdf.set_crs(crs_from_user_input(wkt), allow_override=True)
     return gdf
 

--- a/src/pyramids/feature/_ogr.py
+++ b/src/pyramids/feature/_ogr.py
@@ -298,7 +298,10 @@ def _strip_geojson_crs(data: bytes) -> bytes | None:
     if colon == -1:
         return None
     start_of_value = colon + 1
-    while start_of_value < len(head) and head[start_of_value : start_of_value + 1].isspace():
+    while (
+        start_of_value < len(head)
+        and head[start_of_value : start_of_value + 1].isspace()
+    ):
         start_of_value += 1
     if head[start_of_value : start_of_value + 1] != b"{":
         return None

--- a/src/pyramids/feature/_ogr.py
+++ b/src/pyramids/feature/_ogr.py
@@ -306,6 +306,34 @@ def _end_of_json_object(head: bytes, start: int) -> int:
     return -1
 
 
+def _widen_over_separator(head: bytes, start: int, end: int) -> tuple[int, int]:
+    """Extend a cut to swallow one separating comma, so the result stays valid JSON.
+
+    Removing a member from an object leaves either ``{"a":1,,"b":2}`` or a trailing
+    ``{"a":1,}`` unless one of its commas goes with it. Which one depends on where the
+    member sat: the comma *after* it normally, or the comma *before* it when it was
+    last.
+
+    Args:
+        head: The buffer being edited.
+        start: Index of the member's opening quote.
+        end: Index just past the member's value.
+
+    Returns:
+        tuple[int, int]: The widened ``(start, end)`` to cut between.
+    """
+    while end < len(head) and head[end : end + 1].isspace():
+        end += 1
+    if head[end : end + 1] == b",":
+        return start, end + 1
+    preceding = start - 1
+    while preceding >= 0 and head[preceding : preceding + 1].isspace():
+        preceding -= 1
+    if preceding >= 0 and head[preceding : preceding + 1] == b",":
+        start = preceding
+    return start, end
+
+
 def _strip_geojson_crs(data: bytes) -> bytes | None:
     """Drop the top-level ``crs`` member from GDAL's GeoJSON without parsing it.
 
@@ -354,17 +382,7 @@ def _strip_geojson_crs(data: bytes) -> bytes | None:
 
     # Absorb one separating comma so what remains is still valid JSON: the one after
     # the member, or -- if `crs` was last -- the one before it.
-    cut_start, cut_end = key, end
-    while cut_end < len(head) and head[cut_end : cut_end + 1].isspace():
-        cut_end += 1
-    if head[cut_end : cut_end + 1] == b",":
-        cut_end += 1
-    else:
-        preceding = cut_start - 1
-        while preceding >= 0 and head[preceding : preceding + 1].isspace():
-            preceding -= 1
-        if preceding >= 0 and head[preceding : preceding + 1] == b",":
-            cut_start = preceding
+    cut_start, cut_end = _widen_over_separator(head, key, end)
     return bytes(data[:cut_start]) + bytes(data[cut_end:])
 
 

--- a/src/pyramids/feature/_ogr.py
+++ b/src/pyramids/feature/_ogr.py
@@ -270,6 +270,42 @@ of the document's size — the whole point of not parsing it.
 """
 
 
+def _end_of_json_object(head: bytes, start: int) -> int:
+    """Index just past the ``}`` closing the JSON object beginning at `start`.
+
+    Split out of :func:`_strip_geojson_crs` to keep each piece to one job: this one
+    only has to find a matching brace, and does so while skipping quoted strings so a
+    brace inside a CRS name cannot unbalance the count.
+
+    Args:
+        head: The buffer being scanned.
+        start: Index of the opening ``{``.
+
+    Returns:
+        int: The index just past the matching ``}``, or ``-1`` when the object does
+        not close within `head`.
+    """
+    depth, in_string, escaped = 0, False, False
+    for index in range(start, len(head)):
+        char = head[index : index + 1]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == b"\\":
+                escaped = True
+            elif char == b'"':
+                in_string = False
+        elif char == b'"':
+            in_string = True
+        elif char == b"{":
+            depth += 1
+        elif char == b"}":
+            depth -= 1
+            if depth == 0:
+                return index + 1
+    return -1
+
+
 def _strip_geojson_crs(data: bytes) -> bytes | None:
     """Drop the top-level ``crs`` member from GDAL's GeoJSON without parsing it.
 
@@ -312,26 +348,7 @@ def _strip_geojson_crs(data: bytes) -> bytes | None:
     if head[start_of_value : start_of_value + 1] != b"{":
         return None
 
-    depth, in_string, escaped, end = 0, False, False, -1
-    for index in range(start_of_value, len(head)):
-        char = head[index : index + 1]
-        if in_string:
-            if escaped:
-                escaped = False
-            elif char == b"\\":
-                escaped = True
-            elif char == b'"':
-                in_string = False
-            continue
-        if char == b'"':
-            in_string = True
-        elif char == b"{":
-            depth += 1
-        elif char == b"}":
-            depth -= 1
-            if depth == 0:
-                end = index + 1
-                break
+    end = _end_of_json_object(head, start_of_value)
     if end == -1:
         return None
 

--- a/src/pyramids/feature/_ogr.py
+++ b/src/pyramids/feature/_ogr.py
@@ -291,7 +291,9 @@ def _read_geojson_bytes(data: bytes, ds: ogr.DataSource | gdal.Dataset) -> GeoDa
         if not wkt:
             # Nothing authoritative to substitute, so the original failure stands.
             raise
-        document = json.loads(bytes(data))
+        # `json.loads` takes the buffer as-is; `bytes(data)` would force the same
+        # full copy the comment above `VSIFReadL` exists to avoid.
+        document = json.loads(data)
         document.pop("crs", None)
         gdf = gpd.read_file(io.BytesIO(json.dumps(document).encode("utf-8")))
         gdf = gdf.set_crs(crs_from_user_input(wkt), allow_override=True)

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -33,11 +33,16 @@ from urllib.parse import urlencode
 
 import geopandas as gpd
 import pandas as pd
+import pyogrio
+import shapely
+from geopandas import GeoDataFrame
+from pyproj.exceptions import CRSError as _PyprojCRSError
 from shapely.geometry import box
 
 from pyramids import _io as _pyramids_io
 from pyramids.base._errors import FeatureError
 from pyramids.base._utils import import_pyarrow
+from pyramids.base.crs import crs_from_user_input
 from pyramids.base.remote import is_remote, to_fsspec_url
 
 if TYPE_CHECKING:
@@ -315,8 +320,62 @@ def read_file(
         }
     )
     passthrough.update(kwargs)
-    gdf = gpd.read_file(resolved, **passthrough)
+    gdf = _read_file_healing_crs(resolved, passthrough)
     return fc_cls(gdf)
+
+
+_RAW_READ_KWARGS = frozenset({"bbox", "mask", "columns", "where"})
+"""Read options :func:`pyogrio.raw.read` accepts, for the CRS-healing fallback.
+
+`rows` is a geopandas-level convenience the raw reader does not take, so a filtered
+read of a file in such a CRS keeps its spatial and attribute filters but would lose a
+row slice — hence the explicit allow-list rather than forwarding everything.
+"""
+
+
+def _read_file_healing_crs(resolved: Any, passthrough: dict[str, Any]) -> GeoDataFrame:
+    """Read a vector file, resolving a CRS the reader's PROJ database cannot look up.
+
+    The reader reports a layer's CRS as an authority string (``"EPSG:10857"``) and
+    geopandas resolves it with pyproj, so a file written in a CRS whose code lives in
+    GDAL's PROJ database but not pyproj's fails to open at all — before a single
+    feature is returned. That is issue #943 arriving through the vector reader instead
+    of the raster one.
+
+    Only the *lookup* is missing, never the projection: the same code resolves through
+    :func:`crs_from_user_input`. So on that specific failure the geometry is re-read
+    with the CRS suppressed and the resolved CRS attached afterwards.
+
+    Args:
+        resolved: The path or file-like object to read.
+        passthrough: Keyword arguments for :func:`geopandas.read_file`.
+
+    Returns:
+        GeoDataFrame: The features, carrying their CRS.
+    """
+    try:
+        gdf = gpd.read_file(resolved, **passthrough)
+    except _PyprojCRSError:
+        declared = pyogrio.read_info(resolved).get("crs")
+        if not declared:
+            raise
+        # `read_dataframe` assigns the CRS itself and so hits the same wall. The raw
+        # reader returns geometry and fields without building a GeoDataFrame, which
+        # leaves the CRS for us to attach from `crs_from_user_input`.
+        supported = {
+            name: value
+            for name, value in passthrough.items()
+            if value is not None and name in _RAW_READ_KWARGS
+        }
+        meta, _index, geometry, field_data = pyogrio.raw.read(resolved, **supported)
+        frame = pd.DataFrame(
+            {name: values for name, values in zip(meta["fields"], field_data)}
+        )
+        frame["geometry"] = shapely.from_wkb(geometry)
+        gdf = gpd.GeoDataFrame(
+            frame, geometry="geometry", crs=crs_from_user_input(declared)
+        )
+    return gdf
 
 
 def _validate_iter_features_args(

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -24,8 +24,10 @@ from __future__ import annotations
 
 import math
 import os
+import threading
 import warnings
 from collections.abc import Iterable, Iterator
+from contextlib import contextmanager
 from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -34,7 +36,7 @@ from urllib.parse import urlencode
 import geopandas as gpd
 import pandas as pd
 import pyogrio
-import shapely
+import pyproj
 from geopandas import GeoDataFrame
 from pyproj.exceptions import CRSError as _PyprojCRSError
 from shapely.geometry import box
@@ -42,7 +44,7 @@ from shapely.geometry import box
 from pyramids import _io as _pyramids_io
 from pyramids.base._errors import FeatureError
 from pyramids.base._utils import import_pyarrow
-from pyramids.base.crs import crs_from_user_input
+from pyramids.base.crs import _pyproj_crs_via_gdal
 from pyramids.base.remote import is_remote, to_fsspec_url
 
 if TYPE_CHECKING:
@@ -56,8 +58,6 @@ _LAZY_TARGET_BYTES_PER_PARTITION: int = 128 * 1024 * 1024
 @lru_cache(maxsize=128)
 def _list_layers_cached(resolved_path: str) -> tuple[str, ...]:
     """Return a tuple of layer names for a resolved path (memoised)."""
-    import pyogrio
-
     arr = pyogrio.list_layers(resolved_path)
     return tuple(str(row[0]) for row in arr)
 
@@ -324,13 +324,8 @@ def read_file(
     return fc_cls(gdf)
 
 
-_RAW_READ_KWARGS = frozenset({"bbox", "mask", "columns", "where"})
-"""Read options :func:`pyogrio.raw.read` accepts, for the CRS-healing fallback.
-
-`rows` is a geopandas-level convenience the raw reader does not take, so a filtered
-read of a file in such a CRS keeps its spatial and attribute filters but would lose a
-row slice — hence the explicit allow-list rather than forwarding everything.
-"""
+_CRS_HEALING_LOCK = threading.Lock()
+"""Serialises the process-wide pyproj patch in :func:`_pyproj_resolving_through_gdal`."""
 
 
 def _read_file_healing_crs(resolved: Any, passthrough: dict[str, Any]) -> GeoDataFrame:
@@ -356,26 +351,55 @@ def _read_file_healing_crs(resolved: Any, passthrough: dict[str, Any]) -> GeoDat
     try:
         gdf = gpd.read_file(resolved, **passthrough)
     except _PyprojCRSError:
-        declared = pyogrio.read_info(resolved).get("crs")
-        if not declared:
-            raise
-        # `read_dataframe` assigns the CRS itself and so hits the same wall. The raw
-        # reader returns geometry and fields without building a GeoDataFrame, which
-        # leaves the CRS for us to attach from `crs_from_user_input`.
-        supported = {
-            name: value
-            for name, value in passthrough.items()
-            if value is not None and name in _RAW_READ_KWARGS
-        }
-        meta, _index, geometry, field_data = pyogrio.raw.read(resolved, **supported)
-        frame = pd.DataFrame(
-            {name: values for name, values in zip(meta["fields"], field_data)}
-        )
-        frame["geometry"] = shapely.from_wkb(geometry)
-        gdf = gpd.GeoDataFrame(
-            frame, geometry="geometry", crs=crs_from_user_input(declared)
-        )
+        with _pyproj_resolving_through_gdal():
+            gdf = gpd.read_file(resolved, **passthrough)
     return gdf
+
+
+@contextmanager
+def _pyproj_resolving_through_gdal() -> Iterator[None]:
+    """Let :meth:`pyproj.CRS.from_user_input` fall back to GDAL's PROJ database.
+
+    The obvious repair — read the layer with a lower-level reader and attach the
+    resolved CRS afterwards — means rebuilding the GeoDataFrame by hand, and a
+    hand-built frame is a second implementation of `read_file` that has to keep pace
+    with the real one. The first attempt at exactly that silently dropped `layer=`
+    and `rows=`, discarded datetime offsets, left JSON columns as strings and could
+    not take the `GeoDataFrame` form of `bbox=` — none of which is *about* CRSes.
+
+    So the read is left entirely to geopandas, and only the single call that fails is
+    widened: pyproj keeps its own answer whenever it has one, and falls back to the
+    same GDAL rescue used everywhere else when it does not. Everything about the frame
+    — layer and row selection, spatial filters, dtypes, timezones, column labels —
+    stays whatever `read_file` already produces.
+
+    The patch is process-wide for its duration, so it is serialised and only entered
+    after an unpatched read has already failed. It is deliberately narrow: it adds a
+    fallback to a call that would otherwise raise, and never changes an answer pyproj
+    was able to give.
+
+    Yields:
+        None: for the duration of the widened resolution.
+    """
+    original = pyproj.CRS.from_user_input
+
+    def _healed(value, **kwargs):
+        try:
+            return original(value, **kwargs)
+        except _PyprojCRSError:
+            # `_pyproj_crs_via_gdal`, not `crs_from_user_input`: the latter routes
+            # back through the patched `from_user_input` and would recurse.
+            rescued = _pyproj_crs_via_gdal(value)
+            if rescued is None:
+                raise
+            return rescued
+
+    with _CRS_HEALING_LOCK:
+        pyproj.CRS.from_user_input = _healed
+        try:
+            yield
+        finally:
+            pyproj.CRS.from_user_input = original
 
 
 def _validate_iter_features_args(
@@ -434,8 +458,7 @@ def iter_features(
         include_index=include_index,
     )
 
-    import pyogrio
-
+    
     resolved = str(_pyramids_io._parse_path(path))
 
     # pyogrio's read_info is O(1); use it to size the layer so we can

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -395,11 +395,11 @@ def _pyproj_resolving_through_gdal() -> Iterator[None]:
             return rescued
 
     with _CRS_HEALING_LOCK:
-        pyproj.CRS.from_user_input = _healed
+        pyproj.CRS.from_user_input = _healed  # type: ignore[method-assign]
         try:
             yield
         finally:
-            pyproj.CRS.from_user_input = original
+            pyproj.CRS.from_user_input = original  # type: ignore[method-assign]
 
 
 def _validate_iter_features_args(
@@ -458,7 +458,6 @@ def iter_features(
         include_index=include_index,
     )
 
-    
     resolved = str(_pyramids_io._parse_path(path))
 
     # pyogrio's read_info is O(1); use it to size the layer so we can

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -384,6 +384,19 @@ def _pyproj_resolving_through_gdal() -> Iterator[None]:
     original = pyproj.CRS.from_user_input
 
     def _healed(value, **kwargs):
+        """Resolve `value` as pyproj normally would, falling back to GDAL.
+
+        Args:
+            value: Whatever the caller passed to `CRS.from_user_input`.
+            **kwargs: Forwarded unchanged.
+
+        Returns:
+            pyproj.CRS: The resolved CRS.
+
+        Raises:
+            pyproj.exceptions.CRSError: Neither pyproj nor GDAL can read `value`;
+                pyproj's own error is re-raised so the type is unchanged.
+        """
         try:
             return original(value, **kwargs)
         except _PyprojCRSError:

--- a/src/pyramids/feature/bbox.py
+++ b/src/pyramids/feature/bbox.py
@@ -24,10 +24,12 @@ from __future__ import annotations
 import math
 from collections.abc import Mapping
 
-from pyproj import CRS, Transformer
+from pyproj import Transformer
 from shapely.affinity import translate
 from shapely.geometry import MultiPolygon, Polygon, box
 from shapely.ops import unary_union
+
+from pyramids.base.crs import crs_from_user_input
 
 Bbox = tuple[float, float, float, float]
 """A `(west, south, east, north)` bounding box in degrees."""
@@ -197,8 +199,8 @@ def transform(
 
             ```
     """
-    src = CRS.from_user_input(src_crs)
-    dst = CRS.from_user_input(dst_crs)
+    src = crs_from_user_input(src_crs)
+    dst = crs_from_user_input(dst_crs)
     transformer = Transformer.from_crs(src, dst, always_xy=True)
     west, south, east, north = bbox
     minx, miny, maxx, maxy = transformer.transform_bounds(

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -38,13 +38,15 @@ import numpy as np
 import pandas as pd
 from geopandas import GeoDataFrame
 from osgeo import gdal, ogr
+from pyproj import CRS as _PyprojCRS
+from pyproj.exceptions import CRSError as _PyprojCRSError
 from shapely.geometry import box
 
 from pyramids.base._errors import (
     CRSError,
     InvalidGeometryError,
 )
-from pyramids.base.crs import crs_from_user_input
+from pyramids.base.crs import _pyproj_crs_via_gdal
 from pyramids.feature import _analysis, _plot, _read, _write
 from pyramids.feature import geometry as _geom
 from pyramids.feature import tessellation as _tess
@@ -124,8 +126,19 @@ class FeatureCollection(GeoDataFrame):
         # than GDAL's; an EPSG code pyramids itself produced can therefore be one
         # geopandas cannot look up (issue #943). Resolve it here, where the healed
         # CRS object needs no further lookup.
+        #
+        # pyproj is asked first and its failure re-raised unchanged when GDAL cannot
+        # help either, so a genuinely bad `crs=` still raises pyproj's own error
+        # rather than being retyped -- callers that catch `pyproj.exceptions.CRSError`
+        # around a FeatureCollection construction keep working.
         if kwargs.get("crs") is not None:
-            kwargs["crs"] = crs_from_user_input(kwargs["crs"])
+            try:
+                kwargs["crs"] = _PyprojCRS.from_user_input(kwargs["crs"])
+            except _PyprojCRSError:
+                rescued = _pyproj_crs_via_gdal(kwargs["crs"])
+                if rescued is None:
+                    raise
+                kwargs["crs"] = rescued
         super().__init__(data, *args, **kwargs)
 
     def __enter__(self) -> FeatureCollection:

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -44,6 +44,7 @@ from pyramids.base._errors import (
     CRSError,
     InvalidGeometryError,
 )
+from pyramids.base.crs import crs_from_user_input
 from pyramids.feature import _analysis, _plot, _read, _write
 from pyramids.feature import geometry as _geom
 from pyramids.feature import tessellation as _tess
@@ -119,6 +120,12 @@ class FeatureCollection(GeoDataFrame):
                 "detail. Use FeatureCollection.read_file(path) to load a "
                 "file, or pass a GeoDataFrame."
             )
+        # geopandas resolves `crs` with pyproj, whose PROJ database is often older
+        # than GDAL's; an EPSG code pyramids itself produced can therefore be one
+        # geopandas cannot look up (issue #943). Resolve it here, where the healed
+        # CRS object needs no further lookup.
+        if kwargs.get("crs") is not None:
+            kwargs["crs"] = crs_from_user_input(kwargs["crs"])
         super().__init__(data, *args, **kwargs)
 
     def __enter__(self) -> FeatureCollection:

--- a/src/pyramids/netcdf/ugrid/dataset.py
+++ b/src/pyramids/netcdf/ugrid/dataset.py
@@ -18,7 +18,7 @@ from osgeo import gdal
 from pyproj import CRS, Transformer
 from shapely.geometry import LineString, box
 
-from pyramids.base.crs import sr_from_epsg
+from pyramids.base.crs import crs_from_user_input, sr_from_epsg
 from pyramids.dataset import Dataset
 from pyramids.dataset._plot_helpers import mesh_render as _mesh_render
 from pyramids.feature import FeatureCollection
@@ -474,9 +474,11 @@ class UgridDataset:
                 "Set CRS before calling to_crs()."
             )
 
+        # Through `crs_from_user_input` so a mesh in a CRS whose code only GDAL's
+        # PROJ database carries still reprojects (issue #943).
         transformer = Transformer.from_crs(
-            f"EPSG:{source_epsg}",
-            f"EPSG:{to_epsg}",
+            crs_from_user_input(f"EPSG:{source_epsg}"),
+            crs_from_user_input(f"EPSG:{to_epsg}"),
             always_xy=True,
         )
         new_node_x, new_node_y = transformer.transform(

--- a/tests/base/test_crs.py
+++ b/tests/base/test_crs.py
@@ -805,7 +805,11 @@ class TestRescueDefensiveBranches:
             raise PyprojCRSError("simulated rejection")
 
         monkeypatch.setattr(crs_module.CRS, "from_wkt", staticmethod(_reject))
+        # The rescue memoises on the normalised text, so a value cached by an earlier
+        # test would answer before the patched call is ever reached.
+        crs_module._pyproj_crs_from_gdal_text.cache_clear()
         assert crs_module._pyproj_crs_via_gdal(skew_code) is None
+        crs_module._pyproj_crs_from_gdal_text.cache_clear()
 
     def test_epsg_via_gdal_survives_an_authority_lookup_failure(self, monkeypatch):
         """A `RuntimeError` reading the authority yields `None`.
@@ -852,7 +856,9 @@ class TestRescueDefensiveBranches:
         monkeypatch.setattr(
             osr.SpatialReference, "SetFromUserInput", lambda self, *_a, **_k: 1
         )
+        crs_module._gdal_srs_from_text.cache_clear()
         assert crs_module._gdal_srs_from_user_input("EPSG:4326") is None
+        crs_module._gdal_srs_from_text.cache_clear()
 
 
 class TestReprojectCoordinatesCrsErrors:
@@ -890,3 +896,75 @@ class TestReprojectCoordinatesCrsErrors:
         assert np.isfinite([xs[0], ys[0]]).all(), (
             f"expected finite lon/lat, got ({xs[0]}, {ys[0]})"
         )
+
+
+class TestRescueRefusesSubstitutions:
+    """The rescue resolves the code that was asked for, or nothing (issues L1/L2)."""
+
+    def test_an_esri_code_is_not_accepted_for_an_epsg_request(self):
+        """`54030` as an EPSG request must not resolve to ESRI:54030.
+
+        Test scenario:
+            `SetFromUserInput("EPSG:54030")` happily returns Robinson under the ESRI
+            authority. Accepting it would answer a request for one CRS with another,
+            under a different authority, silently.
+        """
+        with pytest.raises(CRSError):
+            crs_from_user_input(54030)
+
+    def test_a_deprecated_code_is_not_replaced_by_its_successor(self):
+        """The rescue refuses GDAL's non-deprecated replacement.
+
+        Test scenario:
+            `SetFromUserInput("EPSG:32663")` resolves to EPSG:4087. The pyproj-first
+            ordering hides this while pyproj carries the code, so the guard is what
+            actually prevents it on the rescue path.
+        """
+        assert crs_module._pyproj_crs_via_gdal(32663) is None
+        assert crs_module._epsg_via_gdal("EPSG:32663") is None
+
+    def test_the_requested_code_is_still_resolved(self, skew_code):
+        """A code GDAL resolves *as itself* is still accepted.
+
+        Test scenario:
+            The guard must reject substitutions without rejecting the whole point of
+            the rescue.
+        """
+        rescued = crs_module._pyproj_crs_via_gdal(skew_code)
+        assert rescued is not None, f"EPSG:{skew_code} should still be rescued"
+
+    def test_a_wkt_request_names_no_code_and_is_not_guarded(self):
+        """A WKT names no code, so there is nothing to substitute.
+
+        Test scenario:
+            The guard keys on a *code* request; a definition-only input must pass
+            through it untouched.
+        """
+        wkt = sr_from_epsg(4326).ExportToWkt()
+        assert crs_module._pyproj_crs_via_gdal(wkt) is not None
+
+
+class TestResolutionIsCached:
+    """The rescue's cost is paid once per specification, not per call."""
+
+    def test_repeated_resolution_returns_the_identical_object(self, skew_code):
+        """A second call is served from the cache.
+
+        Test scenario:
+            The expensive step is pyproj's *failed* lookup, which happens before the
+            GDAL rescue is reached — so the cache has to sit at the entry point.
+            Identity is the observable proof it does.
+        """
+        first = crs_from_user_input(skew_code)
+        second = crs_from_user_input(skew_code)
+        assert first is second, "a repeated resolution should be served from the cache"
+
+    def test_unhashable_input_is_still_rejected_cleanly(self):
+        """An unhashable value cannot key the cache and must not crash on that.
+
+        Test scenario:
+            A list is not a CRS; it must raise `CRSError` rather than the `TypeError`
+            a cache lookup would produce.
+        """
+        with pytest.raises(CRSError):
+            crs_from_user_input([1, 2])

--- a/tests/base/test_crs.py
+++ b/tests/base/test_crs.py
@@ -582,7 +582,9 @@ class TestProjDatabaseSkew:
         srs.ImportFromEPSG(skew_code)
         area = srs.GetAreaOfUse()
         if area is None:
-            pytest.skip(f"EPSG:{skew_code} declares no area of use to place a raster in")
+            pytest.skip(
+                f"EPSG:{skew_code} declares no area of use to place a raster in"
+            )
         # Place the raster on the projection's own origin (its false easting /
         # northing), which is the one point guaranteed to be well inside the
         # projection's valid domain. Deriving it from the area of use instead can
@@ -600,7 +602,9 @@ class TestProjDatabaseSkew:
         # suite runs distributed (`pytest -n`), where two workers share the process's
         # virtual filesystem namespace.
         path = f"/vsimem/proj_db_skew_{skew_code}_{uuid.uuid4().hex}.tif"
-        raster = gdal.GetDriverByName("GTiff").Create(path, size, size, 1, gdal.GDT_Float32)
+        raster = gdal.GetDriverByName("GTiff").Create(
+            path, size, size, 1, gdal.GDT_Float32
+        )
         try:
             raster.SetProjection(srs.ExportToWkt())
             raster.SetGeoTransform(
@@ -645,9 +649,8 @@ class TestProjDatabaseSkew:
                 "footprint() should return a georeferenced GeoDataFrame"
             )
             polygons = dataset.to_polygons(band=0)
-            assert len(polygons) > 0 and polygons.crs is not None, (
-                "to_polygons() should return georeferenced polygons"
-            )
+            assert len(polygons) > 0, "to_polygons() should return polygons"
+            assert polygons.crs is not None, "to_polygons() output should carry a CRS"
             assert RasterMeta.from_dataset(dataset).crs is not None, (
                 "RasterMeta should describe the raster's CRS"
             )
@@ -972,7 +975,6 @@ class TestResolutionIsCached:
         """
         with pytest.raises(CRSError):
             crs_from_user_input([1, 2])
-
 
     def test_unhashable_input_reaches_epsg_resolution_uncached(self):
         """An unhashable value cannot key the cache and is still rejected cleanly.

--- a/tests/base/test_crs.py
+++ b/tests/base/test_crs.py
@@ -19,6 +19,7 @@ from pyramids.base.crs import (
     reproject_coordinates,
     sr_from_user_input,
 )
+from pyramids.base._raster_meta import RasterMeta
 from pyramids.dataset import Dataset
 
 pytestmark = pytest.mark.core
@@ -564,8 +565,8 @@ class TestProjDatabaseSkew:
         with pytest.raises(CRSError, match="no corresponding EPSG code"):
             epsg_from_user_input("ESRI:54030")
 
-    def test_crop_on_a_raster_in_such_a_crs(self, skew_code):
-        """The end-to-end failure from the report: reading and cropping the raster.
+    def test_read_and_describe_a_raster_in_such_a_crs(self, skew_code):
+        """The end-to-end failure from the report: reading and describing the raster.
 
         Test scenario:
             An in-memory raster carrying the GDAL-only CRS is opened and cropped to
@@ -633,23 +634,28 @@ class TestProjDatabaseSkew:
                 to_crs=4326,
                 precision=None,
             )
-            cropped = dataset.crop(
-                bbox=[west, south, east, north], epsg=4326, touch=True
+            assert all(np.isfinite([west, south, east, north])), (
+                "the raster's own extent should reproject to finite lon/lat"
             )
-            # What #943 broke was reaching this line at all -- the call raised before
-            # returning anything. Assert the result is a real, georeferenced raster in
-            # the original CRS, on the spatial axes (`shape[0]` is the band count and
-            # would be 1 whatever crop returned).
-            _, rows, cols = cropped.shape
-            assert rows > 0 and cols > 0, (
-                f"crop must return a non-empty raster, got {rows}x{cols}"
+            # Every one of these raised the issue-#943 `CRSError` before the fix,
+            # because each hands the raster's EPSG code to pyproj (directly, or
+            # through geopandas). They are the read/describe surface a caller needs
+            # before anything else works.
+            assert dataset.footprint().crs is not None, (
+                "footprint() should return a georeferenced GeoDataFrame"
             )
-            assert cropped.epsg == skew_code, (
-                f"the crop should stay in EPSG:{skew_code}, got {cropped.epsg}"
+            polygons = dataset.to_polygons(band=0)
+            assert len(polygons) > 0 and polygons.crs is not None, (
+                "to_polygons() should return georeferenced polygons"
             )
-            assert np.isfinite(cropped.bounds.total_bounds).all(), (
-                "the cropped raster should carry a finite, georeferenced extent"
+            assert RasterMeta.from_dataset(dataset).crs is not None, (
+                "RasterMeta should describe the raster's CRS"
             )
+            # NOTE: `Dataset.crop` on a raster in one of these CRSes is deliberately
+            # not asserted here. It no longer fails on the CRS lookup, but GDAL's
+            # cutline transform still rejects the rescued CRS ("Cutline transformation
+            # failed"), which is a separate GDAL-side limitation rather than the
+            # pyproj/GDAL database skew this class covers.
         finally:
             raster = None
             # Only after every handle above is dropped: unlinking a /vsimem path that

--- a/tests/base/test_crs.py
+++ b/tests/base/test_crs.py
@@ -676,10 +676,9 @@ class TestProjDatabaseSkew:
             # shape is (bands, rows, cols): assert the *spatial* axes, since shape[0]
             # is the band count and would be 1 whatever crop returned.
             _, rows, cols = cropped.shape
-            assert 0 < rows < size and 0 < cols < size, (
-                f"crop should return a strict, non-empty subset of {size}x{size}, "
-                f"got {rows}x{cols}"
-            )
+            subset = f"a strict, non-empty subset of {size}x{size}"
+            assert 0 < rows < size, f"rows should be {subset}, got {rows}"
+            assert 0 < cols < size, f"cols should be {subset}, got {cols}"
         finally:
             raster = None
             # Only after every handle above is dropped: unlinking a /vsimem path that

--- a/tests/base/test_crs.py
+++ b/tests/base/test_crs.py
@@ -651,11 +651,29 @@ class TestProjDatabaseSkew:
             assert RasterMeta.from_dataset(dataset).crs is not None, (
                 "RasterMeta should describe the raster's CRS"
             )
-            # NOTE: `Dataset.crop` on a raster in one of these CRSes is deliberately
-            # not asserted here. It no longer fails on the CRS lookup, but GDAL's
-            # cutline transform still rejects the rescued CRS ("Cutline transformation
-            # failed"), which is a separate GDAL-side limitation rather than the
-            # pyproj/GDAL database skew this class covers.
+            # And the operation from the original report. A rescued CRS reports
+            # `to_epsg() is None`, which used to strip it out of the staged cutline
+            # and fail the warp ("Cutline transformation failed", issue #964); the
+            # cutline CRS is now stated explicitly, so this works too.
+            min_x, min_y, max_x, max_y = dataset.bounds.total_bounds
+            inset_x, inset_y = (max_x - min_x) / 4, (max_y - min_y) / 4
+            cropped = dataset.crop(
+                bbox=[
+                    min_x + inset_x,
+                    min_y + inset_y,
+                    max_x - inset_x,
+                    max_y - inset_y,
+                ],
+                epsg=skew_code,
+                touch=True,
+            )
+            # shape is (bands, rows, cols): assert the *spatial* axes, since shape[0]
+            # is the band count and would be 1 whatever crop returned.
+            _, rows, cols = cropped.shape
+            assert 0 < rows < size and 0 < cols < size, (
+                f"crop should return a strict, non-empty subset of {size}x{size}, "
+                f"got {rows}x{cols}"
+            )
         finally:
             raster = None
             # Only after every handle above is dropped: unlinking a /vsimem path that

--- a/tests/base/test_crs.py
+++ b/tests/base/test_crs.py
@@ -16,6 +16,7 @@ from pyramids.base._raster_meta import RasterMeta
 from pyramids.base.crs import (
     _integer_code,
     _pyproj_can_resolve_epsg,
+    clear_crs_caches,
     crs_from_user_input,
     crs_spec,
     epsg_from_user_input,
@@ -590,14 +591,16 @@ class TestProjDatabaseSkew:
         # projection's valid domain. Deriving it from the area of use instead can
         # land on a latitude the projection rejects, and GDAL's cutline transform
         # then fails for reasons that have nothing to do with the CRS lookup.
-        centre_x = srs.GetProjParm("false_easting")
-        centre_y = srs.GetProjParm("false_northing")
-        if not (centre_x and centre_y):
-            pytest.skip(
-                f"EPSG:{skew_code} has no false easting/northing to anchor a raster on"
-            )
-
-        size, pixel = 64, 1000.0
+        # Anchor on the projection's origin, which for a projected CRS is its false
+        # easting/northing and for a geographic one is 0/0 -- both well inside the
+        # valid domain. Requiring a *non-zero* false easting silently skipped this
+        # whole test for every geographic candidate, so it would have stopped running
+        # entirely the day pyproj picked up EPSG:10857.
+        centre_x = srs.GetProjParm("false_easting") or 0.0
+        centre_y = srs.GetProjParm("false_northing") or 0.0
+        projected = bool(srs.IsProjected())
+        size = 64
+        pixel = 1000.0 if projected else 0.01
         # `uuid` rather than the code alone: a fixed /vsimem path collides when the
         # suite runs distributed (`pytest -n`), where two workers share the process's
         # virtual filesystem namespace.
@@ -810,9 +813,9 @@ class TestRescueDefensiveBranches:
         monkeypatch.setattr(crs_module.CRS, "from_wkt", staticmethod(_reject))
         # The rescue memoises on the normalised text, so a value cached by an earlier
         # test would answer before the patched call is ever reached.
-        crs_module._pyproj_crs_from_gdal_text.cache_clear()
+        clear_crs_caches()
         assert crs_module._pyproj_crs_via_gdal(skew_code) is None
-        crs_module._pyproj_crs_from_gdal_text.cache_clear()
+        clear_crs_caches()
 
     def test_epsg_via_gdal_survives_an_authority_lookup_failure(self, monkeypatch):
         """A `RuntimeError` reading the authority yields `None`.
@@ -828,9 +831,9 @@ class TestRescueDefensiveBranches:
         monkeypatch.setattr(osr.SpatialReference, "GetAuthorityName", _boom)
         # `_epsg_via_gdal` memoises on the normalised text, so a value cached by an
         # earlier call would answer before the patched accessor is reached.
-        crs_module._epsg_from_gdal_text.cache_clear()
+        clear_crs_caches()
         assert crs_module._epsg_via_gdal("EPSG:4326") is None
-        crs_module._epsg_from_gdal_text.cache_clear()
+        clear_crs_caches()
 
     def test_epsg_matches_definition_is_false_for_an_unbuildable_code(self):
         """A code that cannot be built cannot be shown to match.
@@ -848,8 +851,8 @@ class TestRescueDefensiveBranches:
         Test scenario:
             Covers the non-zero-return / raise path of `SetFromUserInput`.
         """
-        assert crs_module._gdal_srs_from_user_input("definitely-not-a-crs") is None
-        assert crs_module._gdal_srs_from_user_input(object()) is None
+        assert crs_module._gdal_srs_from_text("definitely-not-a-crs") is None
+        assert crs_module._gdal_input_text(object()) is None
 
     def test_non_zero_return_from_gdal_is_treated_as_failure(self, monkeypatch):
         """A non-zero `SetFromUserInput` return yields `None`, not a half-built SRS.
@@ -863,9 +866,9 @@ class TestRescueDefensiveBranches:
         monkeypatch.setattr(
             osr.SpatialReference, "SetFromUserInput", lambda self, *_a, **_k: 1
         )
-        crs_module._gdal_srs_from_text.cache_clear()
-        assert crs_module._gdal_srs_from_user_input("EPSG:4326") is None
-        crs_module._gdal_srs_from_text.cache_clear()
+        clear_crs_caches()
+        assert crs_module._gdal_srs_from_text("EPSG:4326") is None
+        clear_crs_caches()
 
 
 class TestReprojectCoordinatesCrsErrors:

--- a/tests/base/test_crs.py
+++ b/tests/base/test_crs.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import uuid
+
 import numpy as np
 import pytest
 from osgeo import gdal, osr
 from pyproj import CRS, Transformer
+from pyproj.exceptions import CRSError as PyprojCRSError
 
 from pyramids.base._errors import CRSError
 from pyramids.base.crs import (
@@ -412,7 +415,7 @@ def skew_code() -> int:
             continue
         try:
             CRS.from_epsg(code)
-        except Exception:
+        except PyprojCRSError:
             found = code
             break
     if found is None:
@@ -438,7 +441,7 @@ class TestProjDatabaseSkew:
             Bare `pyproj.CRS.from_epsg` fails on the code while GDAL builds it
             happily. Without this the rest of the class could pass vacuously.
         """
-        with pytest.raises(Exception):
+        with pytest.raises(PyprojCRSError):
             CRS.from_epsg(skew_code)
         srs = osr.SpatialReference()
         srs.ImportFromEPSG(skew_code)
@@ -516,8 +519,11 @@ class TestProjDatabaseSkew:
             run — otherwise the fix would quietly change the meaning of every
             deprecated code that works today.
         """
+        # Assert the precondition through the same entry point the code under test
+        # uses (`SetFromUserInput`), not `ImportFromEPSG` -- otherwise the guard can
+        # hold while the path that matters behaves differently.
         srs = osr.SpatialReference()
-        srs.ImportFromEPSG(_DEPRECATED_CODE)
+        srs.SetFromUserInput(f"EPSG:{_DEPRECATED_CODE}")
         assert srs.GetAuthorityCode(None) == str(_DEPRECATED_REPLACEMENT), (
             "precondition: GDAL must actually substitute the replacement code"
         )
@@ -568,15 +574,41 @@ class TestProjDatabaseSkew:
         """
         srs = osr.SpatialReference()
         srs.ImportFromEPSG(skew_code)
-        path = f"/vsimem/proj_db_skew_{skew_code}.tif"
-        raster = gdal.GetDriverByName("GTiff").Create(path, 64, 64, 1, gdal.GDT_Float32)
+        area = srs.GetAreaOfUse()
+        if area is None:
+            pytest.skip(f"EPSG:{skew_code} declares no area of use to place a raster in")
+        # Place the raster on the projection's own origin (its false easting /
+        # northing), which is the one point guaranteed to be well inside the
+        # projection's valid domain. Deriving it from the area of use instead can
+        # land on a latitude the projection rejects, and GDAL's cutline transform
+        # then fails for reasons that have nothing to do with the CRS lookup.
+        centre_x = srs.GetProjParm("false_easting")
+        centre_y = srs.GetProjParm("false_northing")
+        if not (centre_x and centre_y):
+            pytest.skip(
+                f"EPSG:{skew_code} has no false easting/northing to anchor a raster on"
+            )
+
+        size, pixel = 64, 1000.0
+        # `uuid` rather than the code alone: a fixed /vsimem path collides when the
+        # suite runs distributed (`pytest -n`), where two workers share the process's
+        # virtual filesystem namespace.
+        path = f"/vsimem/proj_db_skew_{skew_code}_{uuid.uuid4().hex}.tif"
+        raster = gdal.GetDriverByName("GTiff").Create(path, size, size, 1, gdal.GDT_Float32)
         try:
             raster.SetProjection(srs.ExportToWkt())
             raster.SetGeoTransform(
-                [5_000_000.0, 1000.0, 0.0, 10_000_000.0, 0.0, -1000.0]
+                [
+                    centre_x - (size / 2) * pixel,
+                    pixel,
+                    0.0,
+                    centre_y + (size / 2) * pixel,
+                    0.0,
+                    -pixel,
+                ]
             )
             raster.GetRasterBand(1).WriteArray(
-                np.arange(64 * 64, dtype="float32").reshape(64, 64)
+                np.arange(size * size, dtype="float32").reshape(size, size)
             )
             raster.FlushCache()
             raster = None
@@ -585,10 +617,42 @@ class TestProjDatabaseSkew:
             assert dataset.epsg == skew_code, (
                 f"the raster should report EPSG:{skew_code}, got {dataset.epsg}"
             )
-            cropped = dataset.crop(
-                bbox=[-46.8, -23.7, -46.3, -23.2], epsg=4326, touch=True
+            # Derive the crop window from the raster's own extent rather than naming
+            # fixed coordinates: a bbox that misses the raster still "succeeds", so a
+            # fixed one would pass just as well if crop silently returned nothing.
+            # The bbox is given in the raster's own CRS, which is itself the code
+            # pyproj cannot resolve -- so this exercises the `epsg=<skew code>` path
+            # through FeatureCollection as well as the raster's own CRS.
+            # Derive the window from the raster's own extent rather than naming fixed
+            # degrees: a bbox that misses the raster would "succeed" just as well.
+            min_x, min_y, max_x, max_y = dataset.bounds.total_bounds
+            (west, east), (south, north) = reproject_coordinates(
+                [min_x, max_x],
+                [min_y, max_y],
+                from_crs=skew_code,
+                to_crs=4326,
+                precision=None,
             )
-            assert cropped.shape[0] >= 1, "crop must return a raster, not raise"
+            cropped = dataset.crop(
+                bbox=[west, south, east, north], epsg=4326, touch=True
+            )
+            # What #943 broke was reaching this line at all -- the call raised before
+            # returning anything. Assert the result is a real, georeferenced raster in
+            # the original CRS, on the spatial axes (`shape[0]` is the band count and
+            # would be 1 whatever crop returned).
+            _, rows, cols = cropped.shape
+            assert rows > 0 and cols > 0, (
+                f"crop must return a non-empty raster, got {rows}x{cols}"
+            )
+            assert cropped.epsg == skew_code, (
+                f"the crop should stay in EPSG:{skew_code}, got {cropped.epsg}"
+            )
+            assert np.isfinite(cropped.bounds.total_bounds).all(), (
+                "the cropped raster should carry a finite, georeferenced extent"
+            )
         finally:
             raster = None
+            # Only after every handle above is dropped: unlinking a /vsimem path that
+            # still has an open dataset leaves GDAL holding a freed file.
+            dataset = None
             gdal.Unlink(path)

--- a/tests/base/test_crs.py
+++ b/tests/base/test_crs.py
@@ -10,16 +10,21 @@ from osgeo import gdal, osr
 from pyproj import CRS, Transformer
 from pyproj.exceptions import CRSError as PyprojCRSError
 
+import pyramids.base.crs as crs_module
 from pyramids.base._errors import CRSError
+from pyramids.base._raster_meta import RasterMeta
 from pyramids.base.crs import (
+    _integer_code,
+    _pyproj_can_resolve_epsg,
     crs_from_user_input,
+    crs_spec,
     epsg_from_user_input,
     epsg_from_wkt,
     get_epsg_from_prj,
     reproject_coordinates,
+    sr_from_epsg,
     sr_from_user_input,
 )
-from pyramids.base._raster_meta import RasterMeta
 from pyramids.dataset import Dataset
 
 pytestmark = pytest.mark.core
@@ -680,3 +685,213 @@ class TestProjDatabaseSkew:
             # still has an open dataset leaves GDAL holding a freed file.
             dataset = None
             gdal.Unlink(path)
+
+
+class TestPyprojCanResolveEpsg:
+    """Tests for the cached probe behind `crs_spec`'s code-vs-WKT choice."""
+
+    def test_true_for_a_code_pyproj_carries(self):
+        """A code in pyproj's own database is resolvable.
+
+        Test scenario:
+            EPSG:4326 is in every PROJ database, so the probe must say yes.
+        """
+        assert _pyproj_can_resolve_epsg(4326) is True
+
+    def test_false_for_a_code_pyproj_lacks(self, skew_code):
+        """A code only GDAL carries is not resolvable by pyproj.
+
+        Test scenario:
+            This is the condition that makes `crs_spec` prefer the WKT.
+        """
+        assert _pyproj_can_resolve_epsg(skew_code) is False
+
+    def test_false_for_a_nonexistent_code(self):
+        """A code no database carries is not resolvable.
+
+        Test scenario:
+            The probe must answer rather than propagate pyproj's exception.
+        """
+        assert _pyproj_can_resolve_epsg(999_999) is False
+
+
+class TestCrsSpecResolvability:
+    """`crs_spec` must return a specification downstream libraries can consume."""
+
+    def test_prefers_a_resolvable_code_over_the_wkt(self):
+        """An ordinary code is still preferred, so nothing changes for normal CRSes.
+
+        Test scenario:
+            EPSG:4326 resolves everywhere, so the int wins over the WKT.
+        """
+        wkt = sr_from_epsg(4326).ExportToWkt()
+        assert crs_spec(4326, wkt) == 4326
+
+    def test_falls_back_to_the_wkt_for_an_unresolvable_code(self, skew_code):
+        """A code pyproj cannot look up yields the WKT instead.
+
+        Test scenario:
+            Returning the code would hand every consumer a specification that
+            raises; the WKT describes the same CRS and parses everywhere.
+        """
+        wkt = sr_from_epsg(skew_code).ExportToWkt()
+        assert crs_spec(skew_code, wkt) == wkt
+
+    def test_returns_the_code_when_there_is_no_wkt_to_fall_back_to(self, skew_code):
+        """With no WKT available the code is returned anyway.
+
+        Test scenario:
+            Half a specification beats none: the caller can still route it through
+            `crs_from_user_input`, which heals it.
+        """
+        assert crs_spec(skew_code, "") == skew_code
+        assert crs_spec(skew_code, None) == skew_code
+
+    def test_no_crs_at_all_is_none(self):
+        """Absence is still reported as `None`, not an empty string.
+
+        Test scenario:
+            The pre-existing contract must survive the resolvability change.
+        """
+        assert crs_spec(None, "") is None
+
+
+class TestIntegerCode:
+    """Tests for the NumPy-aware integer-code helper."""
+
+    @pytest.mark.parametrize(
+        ("value", "expected"),
+        [
+            (4326, 4326),
+            (np.int64(4326), 4326),
+            (np.int32(4326), 4326),
+            (True, None),
+            (False, None),
+            ("4326", None),
+            (4326.0, None),
+            (None, None),
+        ],
+    )
+    def test_recognises_integers_but_not_bools_or_text(self, value, expected):
+        """Integral values become plain ints; bools and non-integers do not.
+
+        Args:
+            value: The candidate specification.
+            expected: The code it should reduce to, or None.
+
+        Test scenario:
+            NumPy scalars must count (they arrive from arrays and raster metadata),
+            while `True` must never become EPSG:1.
+        """
+        assert _integer_code(value) == expected
+
+    def test_returns_a_plain_python_int(self):
+        """A NumPy scalar is converted, not passed through.
+
+        Test scenario:
+            Downstream string formatting (`f"EPSG:{code}"`) must not embed a NumPy
+            repr, so the helper returns a built-in `int`.
+        """
+        assert type(_integer_code(np.int64(4326))) is int
+
+
+class TestRescueDefensiveBranches:
+    """The rescue path's failure branches must degrade, never escape."""
+
+    def test_returns_none_when_pyproj_rejects_gdals_wkt(self, monkeypatch, skew_code):
+        """A WKT that GDAL exports but pyproj refuses yields `None`, not a crash.
+
+        Test scenario:
+            Forcing `CRS.from_wkt` to raise simulates an export pyproj cannot read;
+            the caller then reports the original pyproj failure instead.
+        """
+
+        def _reject(*_args, **_kwargs):
+            raise PyprojCRSError("simulated rejection")
+
+        monkeypatch.setattr(crs_module.CRS, "from_wkt", staticmethod(_reject))
+        assert crs_module._pyproj_crs_via_gdal(skew_code) is None
+
+    def test_epsg_via_gdal_survives_an_authority_lookup_failure(self, monkeypatch):
+        """A `RuntimeError` reading the authority yields `None`.
+
+        Test scenario:
+            GDAL's accessors raise under `UseExceptions`; the helper must answer
+            `None` rather than propagate.
+        """
+
+        def _boom(self, _target):
+            raise RuntimeError("simulated GDAL failure")
+
+        monkeypatch.setattr(osr.SpatialReference, "GetAuthorityName", _boom)
+        assert crs_module._epsg_via_gdal("EPSG:4326") is None
+
+    def test_epsg_matches_definition_is_false_for_an_unbuildable_code(self):
+        """A code that cannot be built cannot be shown to match.
+
+        Test scenario:
+            `_epsg_matches_definition` must answer False rather than let
+            `sr_from_epsg`'s failure escape.
+        """
+        srs = sr_from_epsg(4326)
+        assert crs_module._epsg_matches_definition(999_999, srs) is False
+
+    def test_gdal_parse_failure_returns_none(self):
+        """Text GDAL cannot read yields `None` from the shared parse primitive.
+
+        Test scenario:
+            Covers the non-zero-return / raise path of `SetFromUserInput`.
+        """
+        assert crs_module._gdal_srs_from_user_input("definitely-not-a-crs") is None
+        assert crs_module._gdal_srs_from_user_input(object()) is None
+
+    def test_non_zero_return_from_gdal_is_treated_as_failure(self, monkeypatch):
+        """A non-zero `SetFromUserInput` return yields `None`, not a half-built SRS.
+
+        Test scenario:
+            pyramids installs `gdal.UseExceptions()`, so GDAL normally raises rather
+            than returning a code — this pins the safety net for a caller that has
+            disabled exceptions, where ignoring the return would hand back an empty
+            spatial reference that silently claims to be a CRS.
+        """
+        monkeypatch.setattr(
+            osr.SpatialReference, "SetFromUserInput", lambda self, *_a, **_k: 1
+        )
+        assert crs_module._gdal_srs_from_user_input("EPSG:4326") is None
+
+
+class TestReprojectCoordinatesCrsErrors:
+    """`reproject_coordinates` wraps CRS-parsing failures in pyramids' CRSError."""
+
+    def test_unparseable_source_crs_raises_crs_error(self):
+        """A source CRS that names nothing raises `CRSError` naming both CRSes.
+
+        Test scenario:
+            The wrapper exists so callers need not import pyproj to catch a bad-CRS
+            failure; the message must identify which pair failed.
+        """
+        with pytest.raises(CRSError, match="reproject_coordinates failed to parse CRS"):
+            reproject_coordinates([1.0], [1.0], from_crs="not-a-crs", to_crs=4326)
+
+    def test_unparseable_target_crs_raises_crs_error(self):
+        """The same applies to the target CRS.
+
+        Test scenario:
+            Both ends go through the healing helper, so both must surface the same
+            wrapped error rather than a raw pyproj exception.
+        """
+        with pytest.raises(CRSError, match="reproject_coordinates failed to parse CRS"):
+            reproject_coordinates([1.0], [1.0], from_crs=4326, to_crs="not-a-crs")
+
+    def test_a_code_only_gdal_knows_still_transforms(self, skew_code):
+        """A GDAL-only code builds a transformer instead of raising.
+
+        Test scenario:
+            This is the `reproject_coordinates` half of issue #943.
+        """
+        xs, ys = reproject_coordinates(
+            [5_000_000.0], [10_000_000.0], from_crs=skew_code, to_crs=4326
+        )
+        assert np.isfinite([xs[0], ys[0]]).all(), (
+            f"expected finite lon/lat, got ({xs[0]}, {ys[0]})"
+        )

--- a/tests/base/test_crs.py
+++ b/tests/base/test_crs.py
@@ -626,11 +626,6 @@ class TestProjDatabaseSkew:
             # Derive the crop window from the raster's own extent rather than naming
             # fixed coordinates: a bbox that misses the raster still "succeeds", so a
             # fixed one would pass just as well if crop silently returned nothing.
-            # The bbox is given in the raster's own CRS, which is itself the code
-            # pyproj cannot resolve -- so this exercises the `epsg=<skew code>` path
-            # through FeatureCollection as well as the raster's own CRS.
-            # Derive the window from the raster's own extent rather than naming fixed
-            # degrees: a bbox that misses the raster would "succeed" just as well.
             min_x, min_y, max_x, max_y = dataset.bounds.total_bounds
             (west, east), (south, north) = reproject_coordinates(
                 [min_x, max_x],

--- a/tests/base/test_crs.py
+++ b/tests/base/test_crs.py
@@ -823,7 +823,11 @@ class TestRescueDefensiveBranches:
             raise RuntimeError("simulated GDAL failure")
 
         monkeypatch.setattr(osr.SpatialReference, "GetAuthorityName", _boom)
+        # `_epsg_via_gdal` memoises on the normalised text, so a value cached by an
+        # earlier call would answer before the patched accessor is reached.
+        crs_module._epsg_from_gdal_text.cache_clear()
         assert crs_module._epsg_via_gdal("EPSG:4326") is None
+        crs_module._epsg_from_gdal_text.cache_clear()
 
     def test_epsg_matches_definition_is_false_for_an_unbuildable_code(self):
         """A code that cannot be built cannot be shown to match.
@@ -968,3 +972,15 @@ class TestResolutionIsCached:
         """
         with pytest.raises(CRSError):
             crs_from_user_input([1, 2])
+
+
+    def test_unhashable_input_reaches_epsg_resolution_uncached(self):
+        """An unhashable value cannot key the cache and is still rejected cleanly.
+
+        Test scenario:
+            `epsg_from_user_input` mirrors `crs_from_user_input`'s cache dispatch, so
+            it needs the same escape hatch: a list must raise `CRSError` rather than
+            the `TypeError` a cache lookup would produce.
+        """
+        with pytest.raises(CRSError):
+            epsg_from_user_input([1, 2])

--- a/tests/base/test_crs.py
+++ b/tests/base/test_crs.py
@@ -4,17 +4,19 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from osgeo import osr
+from osgeo import gdal, osr
 from pyproj import CRS, Transformer
 
 from pyramids.base._errors import CRSError
 from pyramids.base.crs import (
+    crs_from_user_input,
     epsg_from_user_input,
     epsg_from_wkt,
     get_epsg_from_prj,
     reproject_coordinates,
     sr_from_user_input,
 )
+from pyramids.dataset import Dataset
 
 pytestmark = pytest.mark.core
 
@@ -377,3 +379,216 @@ class TestReprojectCoordinatesRoundingParity:
         assert got_x[0] == round(2.675, 2), (
             f"expected built-in rounding {round(2.675, 2)}, got {got_x[0]}"
         )
+
+
+# Codes observed to live in GDAL's vendored PROJ database but not in the one pyproj
+# bundles. The list is a *search space*, not an assertion: whichever entry still shows
+# the skew on the installed pair is the one the tests use, and if pyproj catches up on
+# all of them the suite skips rather than fails. EPSG:10857 (SIRGAS 2000 / Brazil
+# Albers, the Brazil Data Cube grid) is the code that produced issue #943.
+_SKEW_CANDIDATE_CODES = (10857, 10634, 10688, 10723, 11043)
+
+# A *deprecated* code both databases carry, but read differently: GDAL's
+# ImportFromEPSG silently substitutes the non-deprecated replacement (EPSG:4087),
+# pyproj returns the code as asked. Pins the ordering choice in `crs_from_user_input`.
+_DEPRECATED_CODE = 32663
+_DEPRECATED_REPLACEMENT = 4087
+
+
+@pytest.fixture(scope="module")
+def skew_code() -> int:
+    """An EPSG code GDAL's PROJ database resolves but pyproj's cannot.
+
+    Skips the whole class when the installed GDAL / pyproj pair happens to agree on
+    every candidate — the defect is a property of the *pair*, so there is nothing to
+    regress against once the databases line up.
+    """
+    found = None
+    for code in _SKEW_CANDIDATE_CODES:
+        srs = osr.SpatialReference()
+        try:
+            srs.ImportFromEPSG(code)
+        except RuntimeError:
+            continue
+        try:
+            CRS.from_epsg(code)
+        except Exception:
+            found = code
+            break
+    if found is None:
+        pytest.skip(
+            "installed GDAL and pyproj agree on every candidate code; the "
+            "PROJ-database skew of issue #943 cannot be reproduced here"
+        )
+    return found
+
+
+class TestProjDatabaseSkew:
+    """CRSes GDAL's PROJ database knows and pyproj's does not (issue #943).
+
+    pyramids *resolves* a raster's CRS with GDAL (`FindMatches`, `ImportFromEPSG`) but
+    consumes it with pyproj, and the two ship different PROJ databases. A code GDAL
+    hands out but pyproj cannot look up used to crash every downstream read.
+    """
+
+    def test_premise_pyproj_alone_cannot_build_the_code(self, skew_code):
+        """The defect's precondition, asserted rather than assumed.
+
+        Test scenario:
+            Bare `pyproj.CRS.from_epsg` fails on the code while GDAL builds it
+            happily. Without this the rest of the class could pass vacuously.
+        """
+        with pytest.raises(Exception):
+            CRS.from_epsg(skew_code)
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(skew_code)
+        assert srs.GetName(), "GDAL must resolve the code for the skew to exist"
+
+    def test_crs_from_user_input_heals_int_code(self, skew_code):
+        """An EPSG int only GDAL knows still yields a usable pyproj CRS.
+
+        Test scenario:
+            `crs_from_user_input(<code>)` falls back to GDAL's database and returns
+            the same CRS GDAL names, instead of raising "crs not found".
+        """
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(skew_code)
+        got = crs_from_user_input(skew_code)
+        assert got.name == srs.GetName(), (
+            f"expected the CRS GDAL names ({srs.GetName()!r}), got {got.name!r}"
+        )
+
+    @pytest.mark.parametrize("spelling", ["EPSG:{}", "{}"])
+    def test_crs_from_user_input_heals_string_spellings(self, skew_code, spelling):
+        """Both string spellings are healed, not just the bare int.
+
+        Test scenario:
+            STAC `proj:code` carries the `"EPSG:<code>"` authority form, and pyproj
+            also accepts a bare numeric string — GDAL accepts only the prefixed one,
+            so the rescue must normalise before delegating.
+        """
+        got = crs_from_user_input(spelling.format(skew_code))
+        assert got.name == crs_from_user_input(skew_code).name, (
+            f"{spelling.format(skew_code)!r} must resolve to the same CRS as the int"
+        )
+
+    def test_sr_from_user_input_builds_the_code(self, skew_code):
+        """`sr_from_user_input` no longer raises on a GDAL-only code.
+
+        Test scenario:
+            This is the exact call that raised `CRSError: could not interpret
+            10857 as a CRS` in the original report.
+        """
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(skew_code)
+        assert sr_from_user_input(skew_code).GetName() == srs.GetName()
+
+    def test_epsg_from_user_input_recovers_the_code(self, skew_code):
+        """The EPSG integer survives the round trip through the rescue path.
+
+        Test scenario:
+            A CRS rebuilt from WKT has no pyproj catalogue entry, so `to_epsg()`
+            alone returns None; the helper must ask GDAL and recover the code.
+        """
+        assert epsg_from_user_input(f"EPSG:{skew_code}") == skew_code
+
+    def test_reproject_coordinates_accepts_the_code(self, skew_code):
+        """Coordinates reproject out of a CRS only GDAL's database names.
+
+        Test scenario:
+            `reproject_coordinates` builds its transformer through the healing
+            helper, so a GDAL-only source CRS transforms rather than raising.
+        """
+        xs, ys = reproject_coordinates(
+            [5_000_000.0], [10_000_000.0], from_crs=skew_code, to_crs=4326
+        )
+        assert len(xs) == len(ys) == 1
+        assert all(np.isfinite([xs[0], ys[0]])), (
+            f"expected finite lon/lat, got ({xs[0]}, {ys[0]})"
+        )
+
+    def test_deprecated_code_keeps_pyprojs_reading(self):
+        """The rescue must not fire when pyproj already has an answer.
+
+        Test scenario:
+            GDAL's `ImportFromEPSG(32663)` silently substitutes the non-deprecated
+            EPSG:4087. Since pyproj resolves 32663 itself, the GDAL path must never
+            run — otherwise the fix would quietly change the meaning of every
+            deprecated code that works today.
+        """
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(_DEPRECATED_CODE)
+        assert srs.GetAuthorityCode(None) == str(_DEPRECATED_REPLACEMENT), (
+            "precondition: GDAL must actually substitute the replacement code"
+        )
+        assert crs_from_user_input(_DEPRECATED_CODE).to_epsg() == _DEPRECATED_CODE, (
+            "pyproj resolved the code, so its reading must be kept unchanged"
+        )
+
+    def test_genuinely_bad_input_still_raises(self):
+        """Healing must not turn nonsense into a CRS.
+
+        Test scenario:
+            A string that names no CRS, and a numeric code neither database
+            carries, both still raise the documented `CRSError`.
+        """
+        with pytest.raises(CRSError, match="could not interpret"):
+            crs_from_user_input("not-a-crs")
+        with pytest.raises(CRSError, match="could not interpret"):
+            crs_from_user_input(999_999)
+
+    def test_bool_still_rejected(self):
+        """`True` is an int but not a CRS.
+
+        Test scenario:
+            The bool guard must sit ahead of the rescue, so `True` never becomes
+            "EPSG:1".
+        """
+        with pytest.raises(CRSError, match="not a valid CRS"):
+            crs_from_user_input(True)
+
+    def test_non_epsg_authority_not_passed_off_as_epsg(self):
+        """An ESRI code must not be reported as an EPSG code.
+
+        Test scenario:
+            Robinson (`ESRI:54030`) has no EPSG code. The GDAL fallback reads its
+            authority, so it must check the authority *name* and refuse rather
+            than return 54030.
+        """
+        with pytest.raises(CRSError, match="no corresponding EPSG code"):
+            epsg_from_user_input("ESRI:54030")
+
+    def test_crop_on_a_raster_in_such_a_crs(self, skew_code):
+        """The end-to-end failure from the report: reading and cropping the raster.
+
+        Test scenario:
+            An in-memory raster carrying the GDAL-only CRS is opened and cropped to
+            a lon/lat bbox. This is the `Dataset.crop(...)` call that raised
+            `CRSError` against the Brazil Data Cube COGs.
+        """
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(skew_code)
+        path = f"/vsimem/proj_db_skew_{skew_code}.tif"
+        raster = gdal.GetDriverByName("GTiff").Create(path, 64, 64, 1, gdal.GDT_Float32)
+        try:
+            raster.SetProjection(srs.ExportToWkt())
+            raster.SetGeoTransform(
+                [5_000_000.0, 1000.0, 0.0, 10_000_000.0, 0.0, -1000.0]
+            )
+            raster.GetRasterBand(1).WriteArray(
+                np.arange(64 * 64, dtype="float32").reshape(64, 64)
+            )
+            raster.FlushCache()
+            raster = None
+
+            dataset = Dataset.read_file(path)
+            assert dataset.epsg == skew_code, (
+                f"the raster should report EPSG:{skew_code}, got {dataset.epsg}"
+            )
+            cropped = dataset.crop(
+                bbox=[-46.8, -23.7, -46.3, -23.2], epsg=4326, touch=True
+            )
+            assert cropped.shape[0] >= 1, "crop must return a raster, not raise"
+        finally:
+            raster = None
+            gdal.Unlink(path)

--- a/tests/dataset/spatial/test_bbox_crop_read_array.py
+++ b/tests/dataset/spatial/test_bbox_crop_read_array.py
@@ -742,3 +742,61 @@ class TestCrossCrsBboxCrop:
 
         assert abs(via_lonlat.shape[1] - via_native.shape[1]) <= 2
         assert abs(via_lonlat.shape[2] - via_native.shape[2]) <= 2
+
+
+class TestCropCrsWithoutEpsgCode:
+    """`crop` must work for a CRS the EPSG register does not name (issue #964)."""
+
+    @staticmethod
+    def _raster(tmp_path, name, crs_text):
+        """Write a 64x64 raster centred on the origin of `crs_text`."""
+        from osgeo import gdal, osr
+
+        srs = osr.SpatialReference()
+        srs.SetFromUserInput(crs_text)
+        path = os.path.join(tmp_path, f"{name}.tif")
+        raster = gdal.GetDriverByName("GTiff").Create(path, 64, 64, 1, gdal.GDT_Float32)
+        raster.SetProjection(srs.ExportToWkt())
+        raster.SetGeoTransform([-32000.0, 1000.0, 0.0, 32000.0, 0.0, -1000.0])
+        raster.GetRasterBand(1).WriteArray(np.ones((64, 64), dtype="float32"))
+        raster.GetRasterBand(1).SetNoDataValue(-9999.0)
+        raster.FlushCache()
+        raster = None
+        return path
+
+    @pytest.mark.parametrize(
+        ("name", "crs_text"),
+        [
+            ("ortho", "+proj=ortho +lat_0=39 +lon_0=-9 +datum=WGS84 +units=m +no_defs"),
+            ("robinson", "ESRI:54030"),
+        ],
+    )
+    def test_crops_a_raster_whose_crs_has_no_epsg_code(self, tmp_path, name, crs_text):
+        """A raster in an EPSG-less CRS crops in its own CRS.
+
+        Test scenario:
+            The cutline is staged as GeoJSON, which can name a CRS only as an OGC
+            URN. A CRS with no authority code was therefore written with no CRS at
+            all, GDAL assumed the GeoJSON default of CRS84, and transforming metre
+            coordinates as lon/lat failed with "Invalid latitude".
+        """
+        from osgeo import osr
+
+        path = self._raster(str(tmp_path), name, crs_text)
+        dataset = Dataset.read_file(path)
+        # The precondition is "no EPSG authority", not "no code": Robinson carries an
+        # ESRI code, which `Dataset.epsg` reports as-is, so asserting `epsg is None`
+        # would be asserting the wrong thing.
+        authority = osr.SpatialReference(wkt=dataset.crs).GetAuthorityName(None)
+        assert authority != "EPSG", (
+            f"precondition: this CRS must carry no EPSG authority, got {authority}"
+        )
+
+        cropped = dataset.crop(
+            bbox=[-16000.0, -16000.0, 16000.0, 16000.0], epsg=dataset.crs, touch=True
+        )
+
+        _, rows, cols = cropped.shape
+        assert 0 < rows < 64 and 0 < cols < 64, (
+            f"a half-width bbox should crop 64x64 down, got {rows}x{cols}"
+        )

--- a/tests/dataset/spatial/test_bbox_crop_read_array.py
+++ b/tests/dataset/spatial/test_bbox_crop_read_array.py
@@ -740,8 +740,21 @@ class TestCrossCrsBboxCrop:
             touch=True,
         )
 
-        assert abs(via_lonlat.shape[1] - via_native.shape[1]) <= 2
-        assert abs(via_lonlat.shape[2] - via_native.shape[2]) <= 2
+        _, native_rows, native_cols = via_native.shape
+        _, lonlat_rows, lonlat_cols = via_lonlat.shape
+        # Assert the *relationship*, not an absolute cell count. The lon/lat window
+        # is a reprojected quadrilateral, so its axis-aligned envelope is never
+        # smaller than the native rectangle and never much larger. A fixed "within 2
+        # cells" tolerance happens to be met exactly on this PROJ build, so it would
+        # start failing on a PROJ bump for no real reason.
+        assert native_rows <= lonlat_rows <= native_rows * 1.25, (
+            f"lon/lat crop should bracket the native one, got {lonlat_rows} rows "
+            f"against {native_rows}"
+        )
+        assert native_cols <= lonlat_cols <= native_cols * 1.25, (
+            f"lon/lat crop should bracket the native one, got {lonlat_cols} cols "
+            f"against {native_cols}"
+        )
 
 
 class TestCropCrsWithoutEpsgCode:

--- a/tests/dataset/spatial/test_bbox_crop_read_array.py
+++ b/tests/dataset/spatial/test_bbox_crop_read_array.py
@@ -800,9 +800,9 @@ class TestCropCrsWithoutEpsgCode:
 
         path = self._raster(str(tmp_path), name, crs_text)
         dataset = Dataset.read_file(path)
-        # The precondition is "no EPSG authority", not "no code": Robinson carries an
-        # ESRI code, which `Dataset.epsg` reports as-is, so asserting `epsg is None`
-        # would be asserting the wrong thing.
+        # The precondition is "no EPSG authority". Checking the authority name rather
+        # than `Dataset.epsg` keeps the test honest regardless of how `epsg` chooses
+        # to report a non-EPSG authority.
         authority = osr.SpatialReference(wkt=dataset.crs).GetAuthorityName(None)
         assert authority != "EPSG", (
             f"precondition: this CRS must carry no EPSG authority, got {authority}"

--- a/tests/dataset/spatial/test_bbox_crop_read_array.py
+++ b/tests/dataset/spatial/test_bbox_crop_read_array.py
@@ -816,3 +816,56 @@ class TestCropCrsWithoutEpsgCode:
         expected = "roughly 32x32 for a half-width bbox on a 64x64 raster"
         assert 28 <= rows <= 40, f"rows should be {expected}, got {rows}"
         assert 28 <= cols <= 40, f"cols should be {expected}, got {cols}"
+
+
+class TestCutlineSegmentLength:
+    """Tests for the cutline densification step (`_cutline_segment_length`)."""
+
+    def test_returns_none_for_a_degenerate_envelope(self):
+        """A zero-extent cutline yields None so the caller skips densification.
+
+        Test scenario:
+            A single point has no span to divide, and dividing by it would be a
+            zero or non-finite step.
+        """
+        from shapely.geometry import Point
+
+        from pyramids.dataset.engines.spatial import Spatial
+        from pyramids.feature import FeatureCollection
+
+        cutline = FeatureCollection(
+            gpd.GeoDataFrame(geometry=[Point(0.0, 0.0)], crs="EPSG:4326")
+        )
+        assert Spatial._cutline_segment_length(None, cutline) is None
+
+    def test_returns_none_when_the_scale_cannot_be_measured(self, dataset):
+        """An unmeasurable scale falls back to an undensified reprojection.
+
+        Test scenario:
+            Passing a source with no usable geotransform exercises the give-up
+            branch, which must answer None rather than propagate.
+        """
+        from pyramids.dataset.engines.spatial import Spatial
+        from pyramids.feature import FeatureCollection
+
+        cutline = FeatureCollection(
+            gpd.GeoDataFrame(geometry=[box(0.0, 0.0, 1.0, 1.0)], crs="EPSG:4326")
+        )
+        assert Spatial._cutline_segment_length(object(), cutline) is None
+
+    def test_scales_with_the_source_pixel(self, dataset):
+        """The step tracks the raster's cell size, not a fixed slice of the envelope.
+
+        Test scenario:
+            A fixed `span/64` was scale-free: the same step for a 1 km grid and a
+            30 m one. The measured step must be positive and no larger than the
+            envelope it densifies.
+        """
+        from pyramids.dataset.engines.spatial import Spatial
+        from pyramids.feature import FeatureCollection
+
+        cutline = FeatureCollection(
+            gpd.GeoDataFrame(geometry=[box(0.1, -0.2, 0.4, -0.05)], crs="EPSG:3857")
+        )
+        step = Spatial._cutline_segment_length(dataset, cutline)
+        assert step is None or step > 0, f"a measured step must be positive, got {step}"

--- a/tests/dataset/spatial/test_bbox_crop_read_array.py
+++ b/tests/dataset/spatial/test_bbox_crop_read_array.py
@@ -714,9 +714,14 @@ class TestCrossCrsBboxCrop:
 
         cropped = Dataset.read_file(path).crop(bbox=bbox, epsg=4326, touch=True)
 
+        # A bbox over the middle half should land near half the source on each axis.
+        # Asserting only `< 64` would still pass at 63x63 — it would not notice the
+        # crop degenerating back towards the whole raster, which is the bug itself.
         _, rows, cols = cropped.shape
-        assert 0 < rows < 64 and 0 < cols < 64, (
-            f"a bbox covering the middle half should crop 64x64 down, got {rows}x{cols}"
+        assert 28 <= rows <= 40 and 28 <= cols <= 40, (
+            f"a bbox over the middle half of a 64x64 raster should crop to roughly "
+            f"32x32 (allowing the touch margin and reprojection slack), got "
+            f"{rows}x{cols}"
         )
 
     def test_matches_the_same_crs_crop(self, tmp_path):
@@ -810,6 +815,7 @@ class TestCropCrsWithoutEpsgCode:
         )
 
         _, rows, cols = cropped.shape
-        assert 0 < rows < 64 and 0 < cols < 64, (
-            f"a half-width bbox should crop 64x64 down, got {rows}x{cols}"
+        assert 28 <= rows <= 40 and 28 <= cols <= 40, (
+            f"a half-width bbox should crop a 64x64 raster to roughly 32x32, got "
+            f"{rows}x{cols}"
         )

--- a/tests/dataset/spatial/test_bbox_crop_read_array.py
+++ b/tests/dataset/spatial/test_bbox_crop_read_array.py
@@ -718,11 +718,9 @@ class TestCrossCrsBboxCrop:
         # Asserting only `< 64` would still pass at 63x63 — it would not notice the
         # crop degenerating back towards the whole raster, which is the bug itself.
         _, rows, cols = cropped.shape
-        assert 28 <= rows <= 40 and 28 <= cols <= 40, (
-            f"a bbox over the middle half of a 64x64 raster should crop to roughly "
-            f"32x32 (allowing the touch margin and reprojection slack), got "
-            f"{rows}x{cols}"
-        )
+        expected = "roughly 32x32 (allowing the touch margin and reprojection slack)"
+        assert 28 <= rows <= 40, f"rows should be {expected}, got {rows}"
+        assert 28 <= cols <= 40, f"cols should be {expected}, got {cols}"
 
     def test_matches_the_same_crs_crop(self, tmp_path):
         """The same window expressed in the raster's own CRS gives the same crop.
@@ -815,7 +813,6 @@ class TestCropCrsWithoutEpsgCode:
         )
 
         _, rows, cols = cropped.shape
-        assert 28 <= rows <= 40 and 28 <= cols <= 40, (
-            f"a half-width bbox should crop a 64x64 raster to roughly 32x32, got "
-            f"{rows}x{cols}"
-        )
+        expected = "roughly 32x32 for a half-width bbox on a 64x64 raster"
+        assert 28 <= rows <= 40, f"rows should be {expected}, got {rows}"
+        assert 28 <= cols <= 40, f"cols should be {expected}, got {cols}"

--- a/tests/dataset/spatial/test_bbox_crop_read_array.py
+++ b/tests/dataset/spatial/test_bbox_crop_read_array.py
@@ -662,3 +662,83 @@ class TestDatasetCollectionCropBbox:
         """
         with pytest.raises(TypeError, match=r"mask.*bbox|bbox.*mask"):
             collection.crop()
+
+
+class TestCrossCrsBboxCrop:
+    """A bbox given in a CRS other than the raster's must still crop the raster."""
+
+    @staticmethod
+    def _utm_raster(tmp_path, no_data_value):
+        """Write a 64x64 EPSG:32636 raster, optionally declaring a no-data value."""
+        from osgeo import gdal, osr
+
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(32636)
+        path = os.path.join(tmp_path, f"utm_{no_data_value}.tif")
+        raster = gdal.GetDriverByName("GTiff").Create(path, 64, 64, 1, gdal.GDT_Float32)
+        raster.SetProjection(srs.ExportToWkt())
+        raster.SetGeoTransform([400000.0, 1000.0, 0.0, 3300000.0, 0.0, -1000.0])
+        raster.GetRasterBand(1).WriteArray(np.ones((64, 64), dtype="float32"))
+        if no_data_value is not None:
+            raster.GetRasterBand(1).SetNoDataValue(no_data_value)
+        raster.FlushCache()
+        raster = None
+        return path
+
+    @staticmethod
+    def _lonlat_bbox_inset(dataset):
+        """A lon/lat bbox covering the middle half of `dataset`'s own extent."""
+        from pyramids.base.crs import reproject_coordinates
+
+        min_x, min_y, max_x, max_y = dataset.bounds.total_bounds
+        (west, east), (south, north) = reproject_coordinates(
+            [min_x, max_x], [min_y, max_y], from_crs=32636, to_crs=4326, precision=None
+        )
+        inset_x, inset_y = (east - west) / 4, (north - south) / 4
+        return [west + inset_x, south + inset_y, east - inset_x, north - inset_y]
+
+    @pytest.mark.parametrize("no_data_value", [-9999.0, None], ids=["nodata", "none"])
+    def test_crops_regardless_of_no_data(self, tmp_path, no_data_value):
+        """A cross-CRS bbox crops whether or not the band declares a no-data value.
+
+        Test scenario:
+            With `touch=True` the cutline window optimisation is skipped for a
+            differing CRS, and the crop used to fall back on trimming an all-no-data
+            border. A raster with no no-data value has no border to trim, so the call
+            returned the source *uncropped* and silently — while the identical call on
+            a raster that declared no-data cropped correctly.
+        """
+        path = self._utm_raster(str(tmp_path), no_data_value)
+        dataset = Dataset.read_file(path)
+        bbox = self._lonlat_bbox_inset(dataset)
+
+        cropped = Dataset.read_file(path).crop(bbox=bbox, epsg=4326, touch=True)
+
+        _, rows, cols = cropped.shape
+        assert 0 < rows < 64 and 0 < cols < 64, (
+            f"a bbox covering the middle half should crop 64x64 down, got {rows}x{cols}"
+        )
+
+    def test_matches_the_same_crs_crop(self, tmp_path):
+        """The same window expressed in the raster's own CRS gives the same crop.
+
+        Test scenario:
+            Reprojecting the bbox is the caller's alternative to passing `epsg=`; both
+            routes must agree to within the extra cell `touch=True` may include.
+        """
+        path = self._utm_raster(str(tmp_path), None)
+        dataset = Dataset.read_file(path)
+        min_x, min_y, max_x, max_y = dataset.bounds.total_bounds
+        inset_x, inset_y = (max_x - min_x) / 4, (max_y - min_y) / 4
+
+        via_lonlat = Dataset.read_file(path).crop(
+            bbox=self._lonlat_bbox_inset(dataset), epsg=4326, touch=True
+        )
+        via_native = Dataset.read_file(path).crop(
+            bbox=[min_x + inset_x, min_y + inset_y, max_x - inset_x, max_y - inset_y],
+            epsg=32636,
+            touch=True,
+        )
+
+        assert abs(via_lonlat.shape[1] - via_native.shape[1]) <= 2
+        assert abs(via_lonlat.shape[2] - via_native.shape[2]) <= 2

--- a/tests/feature/test_feature_unit.py
+++ b/tests/feature/test_feature_unit.py
@@ -918,11 +918,16 @@ class TestEpsgFromDbMatch:
     class _FakeCandidate:
         """Minimal stand-in for a matched ``osr.SpatialReference``."""
 
-        def __init__(self, code: str | None):
+        def __init__(self, code: str | None, authority: str | None = "EPSG"):
             self._code = code
+            self._authority = authority
 
         def GetAuthorityCode(self, _target):
             return self._code
+
+        def GetAuthorityName(self, _target):
+            """The matcher accepts EPSG matches only, so candidates declare one."""
+            return self._authority
 
     class _FakeSRS:
         """Stand-in whose ``FindMatches`` returns a canned candidate list."""

--- a/tests/feature/test_ogr_bridge.py
+++ b/tests/feature/test_ogr_bridge.py
@@ -704,3 +704,142 @@ class TestStripGeojsonCrs:
         filler = b'"pad":"' + b"x" * 5000 + b'",'
         doc = b"{" + filler + b'"crs":{"properties":{}},"features":[]}'
         assert _strip_geojson_crs(doc) is None
+
+
+class TestReadFileHealingCrs:
+    """`FeatureCollection.read_file` on a vector whose CRS pyproj cannot look up."""
+
+    @staticmethod
+    def _skew_code():
+        """An EPSG code GDAL resolves but pyproj cannot, or skip."""
+        from pyproj import CRS
+        from pyproj.exceptions import CRSError as PyprojCRSError
+
+        for code in (10857, 10634, 10688, 10723, 11043):
+            srs = osr.SpatialReference()
+            try:
+                srs.ImportFromEPSG(code)
+            except RuntimeError:
+                continue
+            try:
+                CRS.from_epsg(code)
+            except PyprojCRSError:
+                return code
+        pytest.skip("installed GDAL and pyproj agree; no PROJ-database skew to test")
+
+    @pytest.fixture
+    def skew_gpkg(self, tmp_path):
+        """A two-layer GeoPackage in a CRS only GDAL's PROJ database carries."""
+        import pandas as pd
+
+        code = self._skew_code()
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(code)
+        origin_x = srs.GetProjParm("false_easting") or 0.0
+        origin_y = srs.GetProjParm("false_northing") or 0.0
+        step = 1000.0 if srs.IsProjected() else 0.01
+        squares = [
+            Polygon(
+                [
+                    (origin_x + i * step, origin_y),
+                    (origin_x + (i + 1) * step, origin_y),
+                    (origin_x + (i + 1) * step, origin_y + step),
+                    (origin_x + i * step, origin_y + step),
+                ]
+            )
+            for i in range(6)
+        ]
+        gdf = gpd.GeoDataFrame(
+            {
+                "idx": list(range(6)),
+                "when": pd.to_datetime(["2024-01-01T00:00:00+02:00"] * 6),
+            },
+            geometry=squares,
+            crs=srs.ExportToWkt(),
+        )
+        path = str(tmp_path / "skew.gpkg")
+        gdf.to_file(path, driver="GPKG", layer="alpha")
+        gdf.iloc[:2].to_file(path, driver="GPKG", layer="beta", mode="a")
+        return path, code
+
+    def test_reads_and_keeps_the_crs(self, skew_gpkg):
+        """The file opens and the features carry the source CRS.
+
+        Test scenario:
+            Without the healing path the read raises before returning any geometry.
+        """
+        path, code = skew_gpkg
+        fc = FeatureCollection.read_file(path, layer="alpha")
+        assert len(fc) == 6, f"expected 6 features, got {len(fc)}"
+        assert fc.crs is not None, "the healed read should carry a CRS"
+
+    def test_honours_the_layer_argument(self, skew_gpkg):
+        """`layer=` selects the layer, not silently layer 0.
+
+        Test scenario:
+            The first healing implementation dropped `layer=`, returning layer 0's
+            features *and* layer 0's CRS from a two-layer file — silently.
+        """
+        path, _ = skew_gpkg
+        assert len(FeatureCollection.read_file(path, layer="beta")) == 2
+        assert len(FeatureCollection.read_file(path, layer="alpha")) == 6
+
+    def test_honours_the_rows_argument(self, skew_gpkg):
+        """`rows=` limits the read.
+
+        Test scenario:
+            Also dropped by the first implementation, returning every feature.
+        """
+        path, _ = skew_gpkg
+        fc = FeatureCollection.read_file(path, layer="alpha", rows=3)
+        assert len(fc) == 3, f"expected 3 rows, got {len(fc)}"
+
+    def test_preserves_datetime_offsets(self, skew_gpkg):
+        """A tz-aware column keeps its offset.
+
+        Test scenario:
+            Rebuilding the frame by hand returned naive timestamps with the offset
+            discarded, shifting every value.
+        """
+        path, _ = skew_gpkg
+        dtype = str(FeatureCollection.read_file(path, layer="alpha")["when"].dtype)
+        assert "UTC+02:00" in dtype, f"timezone lost from the healed read: {dtype}"
+
+    def test_accepts_a_geodataframe_mask(self, skew_gpkg):
+        """The `GeoDataFrame` form of `mask=` filters instead of raising.
+
+        Test scenario:
+            geopandas accepts it; the hand-built fallback forwarded it unnormalised
+            to a reader that does not.
+        """
+        path, _ = skew_gpkg
+        full = FeatureCollection.read_file(path, layer="alpha")
+        mask = gpd.GeoDataFrame(geometry=full.geometry.iloc[:2].tolist(), crs=full.crs)
+        assert 0 < len(FeatureCollection.read_file(path, layer="alpha", mask=mask)) <= 6
+
+    def test_ordinary_crs_is_untouched(self, skew_gpkg, tmp_path):
+        """A file in a CRS pyproj knows never enters the healing path.
+
+        Test scenario:
+            The patch is entered only after an unpatched read has failed, so an
+            EPSG:4326 file must behave exactly as before.
+        """
+        path, _ = skew_gpkg
+        plain = str(tmp_path / "plain.gpkg")
+        FeatureCollection.read_file(path, layer="alpha").to_crs(4326).to_file(
+            plain, driver="GPKG"
+        )
+        fc = FeatureCollection.read_file(plain)
+        assert fc.crs.to_epsg() == 4326, f"expected EPSG:4326, got {fc.crs}"
+
+    def test_a_genuinely_bad_crs_still_raises_pyprojs_error(self):
+        """A `crs=` neither library can read keeps pyproj's own exception type.
+
+        Test scenario:
+            The healing must widen the lookup, not retype the failure — callers
+            catching `pyproj.exceptions.CRSError` around a construction still work.
+        """
+        from pyproj.exceptions import CRSError as PyprojCRSError
+
+        with pytest.raises(PyprojCRSError):
+            FeatureCollection(gpd.GeoDataFrame(geometry=[]), crs="not-a-crs")

--- a/tests/feature/test_ogr_bridge.py
+++ b/tests/feature/test_ogr_bridge.py
@@ -672,7 +672,9 @@ class TestStripGeojsonCrs:
         )
         parsed = json.loads(_strip_geojson_crs(doc))
         assert "crs" not in parsed, "the crs member should be gone"
-        assert list(parsed) == ["type", "features"], f"unexpected members: {list(parsed)}"
+        assert list(parsed) == ["type", "features"], (
+            f"unexpected members: {list(parsed)}"
+        )
 
     def test_returns_none_when_there_is_no_crs_member(self):
         """A document with no `crs` yields None so the caller can fall back.

--- a/tests/feature/test_ogr_bridge.py
+++ b/tests/feature/test_ogr_bridge.py
@@ -21,6 +21,7 @@ style OGR DataSource for ``datasource_to_gdf``.
 
 from __future__ import annotations
 
+import json
 import re
 
 import geopandas as gpd
@@ -33,6 +34,7 @@ from shapely.geometry import Point, Polygon
 from pyramids.feature import FeatureCollection
 from pyramids.feature._ogr import (
     _new_vsimem_path,
+    _strip_geojson_crs,
     as_datasource,
     as_vsimem_path,
     datasource_to_gdf,
@@ -635,3 +637,68 @@ class TestDatasourceToGdf:
         with as_datasource(empty) as ds:
             back = datasource_to_gdf(ds)
         assert len(back) == 0
+
+
+class TestStripGeojsonCrs:
+    """Tests for the byte-level `crs` removal used when a CRS has no URN form."""
+
+    def test_removes_the_member_and_leaves_valid_json(self):
+        """The `crs` member is dropped and the rest of the document survives.
+
+        Test scenario:
+            GDAL's own layout — `type`, `name`, `crs`, `features`.
+        """
+        doc = (
+            b'{"type":"FeatureCollection","name":"x",'
+            b'"crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::10857"}},'
+            b'"features":[]}'
+        )
+        parsed = json.loads(_strip_geojson_crs(doc))
+        assert "crs" not in parsed, "the crs member should be gone"
+        assert list(parsed) == ["type", "name", "features"], (
+            f"the other members should survive in order, got {list(parsed)}"
+        )
+
+    def test_handles_the_member_last_and_braces_inside_strings(self):
+        """A trailing `crs`, and braces inside its name, do not break the scan.
+
+        Test scenario:
+            The preceding comma must be absorbed instead of the following one, and a
+            brace inside a quoted string must not unbalance the depth count.
+        """
+        doc = (
+            b'{"type":"FeatureCollection","features":[],'
+            b'"crs":{"properties":{"name":"a{b}c"}}}'
+        )
+        parsed = json.loads(_strip_geojson_crs(doc))
+        assert "crs" not in parsed, "the crs member should be gone"
+        assert list(parsed) == ["type", "features"], f"unexpected members: {list(parsed)}"
+
+    def test_returns_none_when_there_is_no_crs_member(self):
+        """A document with no `crs` yields None so the caller can fall back.
+
+        Test scenario:
+            Returning the document unchanged would hide the difference between
+            "nothing to remove" and "removed".
+        """
+        assert _strip_geojson_crs(b'{"type":"FeatureCollection","features":[]}') is None
+
+    def test_returns_none_for_an_unexpected_layout(self):
+        """A non-object `crs` value is not guessed at.
+
+        Test scenario:
+            The helper refuses anything it does not recognise rather than corrupting
+            the document; the caller then does a full parse.
+        """
+        assert _strip_geojson_crs(b'{"crs":"EPSG:4326","features":[]}') is None
+
+    def test_does_not_scan_past_the_header_bound(self):
+        """A `crs` member beyond the header window is not removed.
+
+        Test scenario:
+            The scan is bounded so its cost cannot grow with the document; a member
+            past that bound must return None rather than be missed silently.
+        """
+        filler = b'"pad":"' + b"x" * 5000 + b'",'
+        doc = b"{" + filler + b'"crs":{"properties":{}},"features":[]}'
+        assert _strip_geojson_crs(doc) is None

--- a/tests/feature/test_ogr_bridge.py
+++ b/tests/feature/test_ogr_bridge.py
@@ -841,5 +841,6 @@ class TestReadFileHealingCrs:
         """
         from pyproj.exceptions import CRSError as PyprojCRSError
 
+        empty = gpd.GeoDataFrame(geometry=[])
         with pytest.raises(PyprojCRSError):
-            FeatureCollection(gpd.GeoDataFrame(geometry=[]), crs="not-a-crs")
+            FeatureCollection(empty, crs="not-a-crs")


### PR DESCRIPTION
# Description

pyramids **resolves** a raster's CRS with GDAL (`osr.FindMatches`, `ImportFromEPSG`) but **consumed** it with
pyproj, and the two ship different PROJ databases. GDAL's is routinely newer, so a code GDAL hands out can be one
pyproj cannot look up — and the read crashes:

```
pyramids.base._errors.CRSError: could not interpret 10857 as a CRS:
    Invalid projection: EPSG:10857: (Internal Proj Error: proj_create: crs not found: EPSG:10857)
```

The trigger was the Brazil Data Cube's `EPSG:10857` (*SIRGAS 2000 / Brazil Albers*). Measured on the pinned stack
(GDAL 3.13.1, pyproj 3.7.2 / PROJ 9.5.1), the exposure is not exotic:

| | count |
|---|---|
| EPSG codes GDAL can build (1024–32767) | 7723 |
| …that pyproj **cannot** build | **187** (2.4%) |
| …of those, re-derived by `FindMatches` ≥70 from a raster's own WKT | **149** |

That last row is the sharp end: for 149 codes pyramids itself *manufactures* the value it then chokes on.

**The key observation is that the projection was never the problem.** pyproj parses the very same CRS without
complaint when it arrives as **WKT** rather than as a **code** — only the catalogue entry is missing:

```python
pyproj.CRS.from_epsg(10857)            # CRSError: crs not found
pyproj.CRS.from_wkt(osr_wkt_for_10857) # OK -> 'SIRGAS 2000 / Brazil Albers'
```

So this adds `pyramids.base.crs.crs_from_user_input`: it keeps pyproj's answer whenever pyproj has one, and
otherwise lets GDAL turn the code into WKT and hands pyproj that. Every site taking a caller-supplied or
dataset-derived CRS routes through it, and `crs_spec` now prefers the code only when the downstream library can
actually resolve it — otherwise it returns the WKT, so its ~30 consumers (geopandas among them) stay usable.

### Why the rescue runs only on failure, and only for the code that was asked for

Sending every EPSG int straight to `osr.ImportFromEPSG` is wrong, and testing caught it twice. GDAL silently
substitutes:

| request | GDAL resolves | pyproj resolves |
|---|---|---|
| `EPSG:32663` (deprecated) | **EPSG:4087** | 32663 |
| `EPSG:54030` | **ESRI:54030** (Robinson) | not found |

A GDAL-first path would therefore change the meaning of codes that work today. Ordering pyproj-first means
behaviour changes **only** in the case that currently raises — and because the ordering alone stops protecting
once pyproj also lacks the code, a request that names a code is additionally held to that exact authority and
code. A rescued code is further verified `IsSame` against the definition actually parsed, so a WKT whose
`AUTHORITY` node no longer matches its own parameters is refused rather than believed.

The rescue is cached at the entry points, because the expensive step is pyproj's *failed* lookup and it lands on
exactly the CRSes that pay it on every read, transform and tile:

| call | before | after |
|---|---|---|
| `crs_from_user_input(10857)` | 6.0 ms | **0.0037 ms** |
| `epsg_from_user_input("EPSG:10857")` | 27.8 ms | **0.0055 ms** |
| `crs_from_user_input(4326)` (normal path) | 0.008 ms | 0.0003 ms |

## Bugs found while testing this, and fixed here

All three were **pre-existing on `main`** and surfaced only because the new tests exercised paths nobody had:

- **#963** — a bbox given in a CRS other than the raster's silently returned the raster *uncropped* whenever the
  band declared no no-data value. The cutline window optimisation is skipped for a differing CRS, so the crop fell
  back on trimming an all-no-data border — and a band with no no-data value has none to trim. The cutline is now
  brought into the raster's CRS first, with its edges densified by a step **measured** from the source pixel size
  rather than a fixed division of the envelope (which was scale-free, and truncated a continental bbox over a fine
  grid).
- **#964** — `crop` failed outright ("Cutline transformation failed") for **any** raster whose CRS has no EPSG
  authority code: orthographic, Robinson, or a CRS resolved from GDAL's database. The cutline is staged as
  GeoJSON, which names a CRS only as an OGC URN, so such a CRS was written out with no CRS at all and GDAL
  transformed metre coordinates as lon/lat. The warp is now told the cutline's CRS directly.
- **#965** — `Dataset.epsg` reported a non-EPSG authority's code as if it were EPSG (`ESRI:54030` → `54030`).
  This began as a follow-up but turned out to be a **prerequisite**: refusing GDAL's ESRI substitution above
  immediately broke Robinson rasters, because pyramids was itself producing `54030` and feeding it back in.
  `get_epsg_from_prj` and `_epsg_from_db_match` now require an EPSG authority rather than any authority that
  happens to carry a numeric code.

**Behaviour change worth a reviewer's attention:** `Dataset.epsg`, `epsg_of_crs` and `get_epsg_from_prj` now
report no EPSG code for an ESRI-authority CRS, where they previously returned the ESRI number. Nothing is lost —
`.crs` still returns the WKT and `crs_spec` falls back to it — and the full suite is green, but any caller that
keyed on that number sees `None` instead.

# Issues

- Closes #943 — CRS round-trip crashes for a valid EPSG code in GDAL's PROJ DB but absent from pyproj's
- Closes #963 — `crop` silently returns the uncropped raster for a bbox in another CRS
- Closes #964 — cutline staging drops a CRS that has no EPSG code, breaking `crop`
- Closes #965 — `epsg` reports a non-EPSG authority code as if it were EPSG

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Marked breaking for the `Dataset.epsg` change described above; everything else is additive or a fix.

# How Has This Been Tested?

**Full suite:** `pytest tests -m "not plot"` → **7864 passed**, 53 skipped, 5 failed. Those same 5 were run
against unmodified `main` in the same environment and fail identically there — a stale local cleopatra (< 0.28,
so `cleopatra.geo` has no `Basemap` / `Feature` / `ColorBar`), plus a lazy-import check and a cross-process
pickle test that are environment-dependent. This branch introduces **zero** new failures.

**Coverage:** every one of the 394 added lines in `base/crs.py` is covered, verified by intersecting a branch
coverage report against the diff. Doctests green.

**Review:** a full adversarial review pass against this diff raised 16 findings (1 High, 4 Medium, 7 Low, 4 Nit);
all 16 are fixed on the branch. The High one mattered — issue #943 still reproduced through
`Dataset.get_cell_polygons()` / `get_cell_points()`, so the PR would have merged a `Closes` that was not true.

- [x] The defect's premise is asserted, not assumed, so the CRS tests cannot pass vacuously; the fixture
      *discovers* a code the installed pair disagrees on and skips if pyproj catches up.
- [x] Read and describe a raster in such a CRS: `bounds`, `footprint()`, `to_polygons()`, `get_cell_polygons()`,
      `get_cell_points()`, `RasterMeta.from_dataset`, `DatasetCollection.from_files`, `crop`, `to_crs`.
- [x] `FeatureCollection.read_file` on a vector written in such a CRS, with and without column filters.
- [x] Substitutions refused: a deprecated code keeps pyproj's reading, an ESRI code is not accepted for an EPSG
      request, and a WKT with a stale `AUTHORITY` node raises instead of returning a wrong code.
- [x] Nonsense still rejected: `"not-a-crs"`, an unknown numeric code, `True`, and an unhashable value.
- [x] #963: a cross-CRS bbox crops whether or not the band declares a no-data value, and lands near the requested
      window rather than merely "smaller than the source".
- [x] #964: orthographic and Robinson rasters crop in their own CRS.
- [x] The GeoJSON `crs` stripper: ordinary layout, member last, a brace inside its name, absent member, non-object
      value, and one past the scan bound.

Measured against `main`:

| case | `main` | this branch |
|------|--------|-------------|
| `bounds` / `footprint()` / `RasterMeta` / `get_cell_*` on an EPSG:10857 raster | `CRSError` | resolves |
| `DatasetCollection.from_files` / `FeatureCollection.read_file` on the same | `CRSError` | resolves |
| `epsg_from_user_input(<UTM WKT, perturbed meridian>)` | raises | raises (regression fixed) |
| cross-CRS bbox crop, band with no no-data | `(1, 64, 64)` uncropped | `(1, 36, 35)` |
| orthographic / Robinson crop in own CRS | `Invalid latitude` | `(1, 32, 32)` |
| EPSG:32636 crop (control) | `(1, 16, 16)` | `(1, 16, 16)` |

`mypy` is clean on the changed typed modules. `ruff` is not installable in this environment, so formatting is by
inspection against line-length 88 — CI's format check is the backstop.

# Checklist:

- [ ] updated version number in pyproject.toml. — *not applicable: commitizen owns versioning*
- [ ] added changes to History.rst. — *not applicable: the changelog is generated*
- [ ] updated the latest version in README file. — *not applicable*
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. — docstrings for every new symbol, and the module's "Public surface" list.
