### PR TITLE
perf(collection): stream to_netcdf instead of materialising the full cube

### DIFF
--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -1502,6 +1502,10 @@ class DatasetCollection:
             - :meth:`pyramids.netcdf.NetCDF.read_file`: reopen the
               written file as a pyramids NetCDF.
         """
+        if self.time_length == 0:
+            raise ValueError(
+                "to_netcdf: cannot write an empty collection (time_length == 0)."
+            )
         if time_coords is None and self.time is not None:
             # A dated collection (time axis parsed from the file names) exports
             # with its own calendar axis by default; an explicit time_coords

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -434,11 +434,6 @@ def _lazy_timestep(
     )
 
 
-# Above this in-RAM (T, B, Y, X) size, DatasetCollection.to_netcdf warns and points
-# the caller at the streaming to_zarr writer (ARC-46). Default 2 GiB.
-_TO_NETCDF_WARN_BYTES = 2 * 1024**3
-
-
 def _target_epsg(to_epsg: int | str | Any) -> int | None:
     """Return the integer EPSG for ``to_epsg``, or ``None`` for a non-EPSG CRS.
 
@@ -1432,16 +1427,17 @@ class DatasetCollection:
     ) -> None:
         """Write the collection's ``(T, B, Y, X)`` cube to a single NetCDF.
 
-        Materialises every timestep in memory, assembles a GDAL
-        multidimensional container straight from the ``numpy`` arrays,
-        and writes it with pyramids' own GDAL NetCDF writer — and
-        needs no third-party NetCDF engine plug-in. The
-        result is a self-describing NetCDF with one variable per band
-        (``CF-1.8`` ``Conventions`` attr; geobox attached as ``crs_wkt``
-        / ``GeoTransform`` root attrs).
+        Streams the cube one timestep at a time into a GDAL
+        multidimensional NetCDF written by pyramids' own GDAL writer — no
+        third-party NetCDF engine plug-in, and the full T×B×Y×X array is
+        never held in memory (peak is a single timestep plus the
+        coordinate axes). The result is a self-describing NetCDF with one
+        variable per band (``CF-1.8`` ``Conventions`` attr; geobox attached
+        as ``crs_wkt`` / ``GeoTransform`` root attrs).
 
-        For huge cubes prefer :meth:`to_zarr` — this writer is eager (it
-        materialises the full T×B×Y×X array before writing).
+        For very large cubes :meth:`to_zarr` is still preferred (chunked +
+        compressed, resumable), but ``to_netcdf`` no longer materialises
+        the whole cube up front.
 
         No-data values are written as a ``nodata`` attribute on the root
         group and on each data variable. GDAL's multidim NetCDF writer
@@ -1575,31 +1571,9 @@ class DatasetCollection:
             else [f"band_{i + 1}" for i in range(band_count)]
         )
 
-        # ARC-46: this writer stacks the whole (T, B, Y, X) cube in RAM. Warn
-        # (pointing at the streaming to_zarr writer) when that allocation would
-        # be large, rather than OOM without explanation.
-        est_bytes = (
-            self.time_length * int(np.prod(meta.shape)) * np.dtype(meta.dtype).itemsize
-        )
-        if est_bytes > _TO_NETCDF_WARN_BYTES:
-            warnings.warn(
-                f"DatasetCollection.to_netcdf materialises the full (T, B, Y, X) "
-                f"cube in memory (~{est_bytes / 1024**3:.1f} GiB here). For large "
-                f"cubes prefer DatasetCollection.to_zarr, which streams the cube "
-                f"chunk-by-chunk.",
-                stacklevel=2,
-            )
-        # Per-timestep read_array() returns (rows, cols) for a single-band
-        # dataset and (bands, rows, cols) for multi-band, so np.stack gives
-        # (T, rows, cols) or (T, bands, rows, cols). Insert a length-1 band
-        # axis on the single-band path so the rest of this method can treat
-        # the cube uniformly as (T, B, Y, X).
-        cube = np.stack([np.asarray(ds.read_array()) for ds in self.datasets], axis=0)
-        if cube.ndim == 3:
-            cube = cube[:, np.newaxis, :, :]
-
         y_coord = np.asarray(self._base.y)
         x_coord = np.asarray(self._base.x)
+        var_dtype = np.dtype(meta.dtype)
 
         # GDAL's multidim NetCDF writer rejects ``_FillValue`` as an attribute
         # (libnetcdf wants it via the dedicated typed-fill API the writer does
@@ -1609,17 +1583,20 @@ class DatasetCollection:
         var_attrs: dict[str, Any] = {}
         typed_nodata = None
         if nodata is not None:
-            typed_nodata = np.asarray(nodata, dtype=cube.dtype).item()
+            typed_nodata = np.asarray(nodata, dtype=var_dtype).item()
             var_attrs["nodata"] = typed_nodata
 
         dims: dict[str, int] = {time_dim: int(time_values.shape[0])}
         coords: dict[str, tuple[np.ndarray, dict[str, Any]]] = {
             time_dim: (time_values, time_attrs),
         }
-        data_vars: dict[str, tuple[tuple[str, ...], np.ndarray, dict[str, Any]]]
+        # Each data variable is created at full shape but written one timestep
+        # slab at a time below, so the whole (T, B, Y, X) cube is never resident
+        # in memory (ARC-46).
+        var_specs: dict[str, tuple[tuple[str, ...], np.dtype | str, dict[str, Any]]]
         if var_per_band:
-            data_vars = {
-                names[i]: ((time_dim, "y", "x"), cube[:, i, :, :], dict(var_attrs))
+            var_specs = {
+                names[i]: ((time_dim, "y", "x"), var_dtype, dict(var_attrs))
                 for i in range(band_count)
             }
         else:
@@ -1629,8 +1606,8 @@ class DatasetCollection:
             # the labels from that root attribute.
             dims["band"] = band_count
             coords["band"] = (np.arange(band_count), {})
-            data_vars = {
-                "data": ((time_dim, "band", "y", "x"), cube, dict(var_attrs)),
+            var_specs = {
+                "data": ((time_dim, "band", "y", "x"), var_dtype, dict(var_attrs)),
             }
         dims["y"] = int(y_coord.shape[0])
         dims["x"] = int(x_coord.shape[0])
@@ -1656,9 +1633,23 @@ class DatasetCollection:
         # hoisting this to the module top would form a circular import through
         # pyramids.dataset.__init__. Matches the to_kerchunk pattern (see
         # ``to_kerchunk`` above) and CLAUDE.md's circular-import carveout.
-        from pyramids.netcdf.engines.interop import write_multidim_netcdf
+        from pyramids.netcdf.engines.interop import open_streaming_multidim_netcdf
 
-        write_multidim_netcdf(path, dims, coords, data_vars, root_attrs)
+        # Stream one timestep at a time. read_array() returns (rows, cols) for a
+        # single-band dataset and (bands, rows, cols) for multi-band; normalise
+        # each timestep to (B, rows, cols) so the slab write is uniform.
+        with open_streaming_multidim_netcdf(
+            path, dims, coords, var_specs, root_attrs
+        ) as writer:
+            for t, ds in enumerate(self.datasets):
+                block = np.asarray(ds.read_array()).astype(var_dtype, copy=False)
+                if block.ndim == 2:
+                    block = block[np.newaxis, :, :]
+                if var_per_band:
+                    for i in range(band_count):
+                        writer.write_slab(names[i], t, block[i])
+                else:
+                    writer.write_slab("data", t, block)
 
     @classmethod
     def from_stac(

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -1641,10 +1641,18 @@ class DatasetCollection:
         with open_streaming_multidim_netcdf(
             path, dims, coords, var_specs, root_attrs
         ) as writer:
+            expected = (band_count, dims["y"], dims["x"])
             for t, ds in enumerate(self.datasets):
                 block = np.asarray(ds.read_array()).astype(var_dtype, copy=False)
                 if block.ndim == 2:
                     block = block[np.newaxis, :, :]
+                if block.shape != expected:
+                    where = self.files[t] if self.files else f"timestep {t}"
+                    raise AlignmentError(
+                        f"to_netcdf: {where} has shape {block.shape}, but the "
+                        f"collection template is {expected} (band, rows, cols); "
+                        f"every timestep must share the base grid and band count."
+                    )
                 if var_per_band:
                     for i in range(band_count):
                         writer.write_slab(names[i], t, block[i])

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -1469,7 +1469,10 @@ class DatasetCollection:
                 — saner for hyperspectral cubes with hundreds of bands.
 
         Raises:
-            ValueError: When ``len(time_coords) != self.time_length``.
+            ValueError: When ``len(time_coords) != self.time_length``, or the
+                collection is empty (``time_length == 0``).
+            AlignmentError: When a timestep's shape or band count differs from
+                the collection template.
             RuntimeError: When the GDAL NetCDF writer fails to write the
                 file.
 
@@ -1658,7 +1661,11 @@ class DatasetCollection:
                 if block.ndim == 2:
                     block = block[np.newaxis, :, :]
                 if block.shape != expected:
-                    where = self.files[t] if self.files else f"timestep {t}"
+                    where = (
+                        self.files[t]
+                        if self.files and t < len(self.files)
+                        else f"timestep {t}"
+                    )
                     raise AlignmentError(
                         f"to_netcdf: {where} has shape {block.shape}, but the "
                         f"collection template is {expected} (band, rows, cols); "

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -1444,6 +1444,13 @@ class DatasetCollection:
         rejects CF's standard ``_FillValue`` attribute via this code
         path, so the round-trip uses ``nodata`` for compatibility.
 
+        Every variable is written at the collection's own dtype
+        (:attr:`meta.dtype`, the template raster's), and each timestep is
+        cast to it; on a co-registered stack (all timesteps sharing the
+        template's dtype — what :meth:`from_files` with ``validate=True``
+        enforces) this is a no-op. A timestep whose grid or band count
+        differs from the template raises :class:`AlignmentError`.
+
         Args:
             path: Output ``.nc`` path.
             time_dim: Name of the time dimension. Default ``"time"``.

--- a/src/pyramids/netcdf/engines/interop.py
+++ b/src/pyramids/netcdf/engines/interop.py
@@ -13,8 +13,9 @@ from __future__ import annotations
 
 import os
 import tempfile
+import traceback
 import weakref
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -549,51 +550,39 @@ class _StreamingMultidimWriter:
         )
 
 
-@contextmanager
-def open_streaming_multidim_netcdf(
-    path: str | Path,
+def _build_streaming_multidim(
+    dataset: gdal.Dataset,
     dims: dict[str, int],
     coords: dict[str, tuple[np.ndarray, dict[str, Any]]],
     var_specs: dict[str, tuple[tuple[str, ...], np.dtype | str, dict[str, Any]]],
     global_attrs: dict[str, Any],
-):
-    """Create a netCDF multidim file and yield a per-hyperslab writer.
+) -> dict[str, gdal.MDArray]:
+    """Create dims, coord arrays, empty data vars, and global attrs on `dataset`.
 
-    The streaming counterpart of :func:`write_multidim_netcdf`: instead of
-    receiving fully materialised variable arrays, it creates the dimensions,
-    writes the (small, 1-D) coordinate arrays whole, creates each data variable
-    at its full shape with **no data**, then hands back a
-    :class:`_StreamingMultidimWriter` so the caller can fill each variable one
-    leading-dimension slab at a time. The file is flushed and closed on exit, so
-    the whole ``(T, …)`` cube never has to be resident. Used by
-    :meth:`pyramids.dataset.collection.DatasetCollection.to_netcdf`.
+    Split out from :func:`open_streaming_multidim_netcdf` so all the transient
+    GDAL setup handles (the root group, dimensions, and coordinate MDArrays) live
+    in this frame and are released when it returns or raises — leaving the context
+    manager only the data-variable MDArrays to drop before `Close()`, which is
+    what lets the netCDF driver flush and unlock the file.
 
     Args:
-        path: Output ``.nc`` path.
-        dims: Dimension name to length (the full shape, including the streamed
-            leading dimension).
-        coords: Coordinate name (also a dimension) to a ``(values, attrs)`` pair;
-            written whole up front. Entries whose name is not a dimension are
-            skipped.
+        dataset: A freshly created netCDF multidim dataset.
+        dims: Dimension name to length.
+        coords: Coordinate name to a ``(values, attrs)`` pair; entries whose name
+            is not a dimension are skipped.
         var_specs: Variable name to a ``(dimension-name tuple, numpy dtype,
-            attrs)`` triple. The first entry of the dimension tuple is the
-            streamed (leading) dimension.
+            attrs)`` triple.
         global_attrs: Root-group (global) attributes.
 
-    Yields:
-        _StreamingMultidimWriter: Call :meth:`~_StreamingMultidimWriter.write_slab`
-        once per leading-dimension index.
+    Returns:
+        dict[str, gdal.MDArray]: The created (empty, full-shape) data-variable
+        MDArrays, keyed by name, for the caller to fill by slab.
 
     Raises:
-        RuntimeError: When the GDAL netCDF driver fails to create the file.
         ValueError: When a variable references an unknown dimension, or a
             coordinate array shape does not match its dimension size.
     """
-    dataset = gdal.GetDriverByName("netCDF").CreateMultiDimensional(str(path))
-    if dataset is None:
-        raise RuntimeError(f"Failed to create NetCDF at {path}")
     root = dataset.GetRootGroup()
-
     gdal_dims: dict[str, gdal.Dimension] = {
         name: root.CreateDimension(name, "", "", int(size))
         for name, size in dims.items()
@@ -631,12 +620,77 @@ def open_streaming_multidim_netcdf(
     if global_attrs:
         write_global_attributes(root, dict(global_attrs))
 
+    return arrays
+
+
+@contextmanager
+def open_streaming_multidim_netcdf(
+    path: str | Path,
+    dims: dict[str, int],
+    coords: dict[str, tuple[np.ndarray, dict[str, Any]]],
+    var_specs: dict[str, tuple[tuple[str, ...], np.dtype | str, dict[str, Any]]],
+    global_attrs: dict[str, Any],
+):
+    """Create a netCDF multidim file and yield a per-hyperslab writer.
+
+    The streaming counterpart of :func:`write_multidim_netcdf`: instead of
+    receiving fully materialised variable arrays, it creates the dimensions,
+    writes the (small, 1-D) coordinate arrays whole, creates each data variable
+    at its full shape with **no data**, then hands back a
+    :class:`_StreamingMultidimWriter` so the caller can fill each variable one
+    leading-dimension slab at a time. The file is flushed and closed on exit, so
+    the whole ``(T, …)`` cube never has to be resident. The write is
+    all-or-nothing: if setup or any slab write raises, the partially written file
+    is removed, so a surviving file always means a complete write. Used by
+    :meth:`pyramids.dataset.collection.DatasetCollection.to_netcdf`.
+
+    Args:
+        path: Output ``.nc`` path.
+        dims: Dimension name to length (the full shape, including the streamed
+            leading dimension).
+        coords: Coordinate name (also a dimension) to a ``(values, attrs)`` pair;
+            written whole up front. Entries whose name is not a dimension are
+            skipped.
+        var_specs: Variable name to a ``(dimension-name tuple, numpy dtype,
+            attrs)`` triple. The first entry of the dimension tuple is the
+            streamed (leading) dimension.
+        global_attrs: Root-group (global) attributes.
+
+    Yields:
+        _StreamingMultidimWriter: Call :meth:`~_StreamingMultidimWriter.write_slab`
+        once per leading-dimension index.
+
+    Raises:
+        RuntimeError: When the GDAL netCDF driver fails to create the file.
+        ValueError: When a variable references an unknown dimension, or a
+            coordinate array shape does not match its dimension size.
+    """
+    dataset = gdal.GetDriverByName("netCDF").CreateMultiDimensional(str(path))
+    if dataset is None:
+        raise RuntimeError(f"Failed to create NetCDF at {path}")
+    completed = False
+    arrays: dict[str, gdal.MDArray] = {}
     try:
+        arrays = _build_streaming_multidim(
+            dataset, dims, coords, var_specs, global_attrs
+        )
         yield _StreamingMultidimWriter(arrays)
+        completed = True
+    except BaseException as exc:
+        # A raising body leaves its traceback pinning the helper/loop frames that
+        # still hold the transient GDAL dim/coord handles; clear those frames so
+        # Close() can release the file and the partial write can be removed below
+        # (the executing frame this runs in is skipped by clear_frames).
+        traceback.clear_frames(exc.__traceback__)
+        raise
     finally:
-        # Drop the MDArray / root references before closing so the netCDF write
-        # handle is fully released and the on-disk file is recognised by a reader
-        # that reopens the same path (mirrors _create_copy_to_netcdf's note).
+        # Drop the data-variable MDArrays, then Close(): the netCDF driver only
+        # flushes and unlocks the file once every child handle is released.
         arrays.clear()
-        del root
         dataset.Close()
+        if not completed:
+            # Keep the write all-or-nothing: on any setup or mid-stream failure,
+            # drop the partial/stray file so a surviving file always means a
+            # complete write (matching the old eager CreateCopy path).
+            with suppress(OSError):
+                Path(path).unlink()

--- a/src/pyramids/netcdf/engines/interop.py
+++ b/src/pyramids/netcdf/engines/interop.py
@@ -638,11 +638,15 @@ def open_streaming_multidim_netcdf(
     writes the (small, 1-D) coordinate arrays whole, creates each data variable
     at its full shape with **no data**, then hands back a
     :class:`_StreamingMultidimWriter` so the caller can fill each variable one
-    leading-dimension slab at a time. The file is flushed and closed on exit, so
-    the whole ``(T, …)`` cube never has to be resident. The write is
-    all-or-nothing: if setup or any slab write raises, the partially written file
-    is removed, so a surviving file always means a complete write. Used by
-    :meth:`pyramids.dataset.collection.DatasetCollection.to_netcdf`.
+    leading-dimension slab at a time, so the whole ``(T, …)`` cube never has to
+    be resident. The write is atomic: the file is created at a temporary sibling
+    path and only ``os.replace``-d onto ``path`` after a clean close, so ``path``
+    only ever holds a complete file and an existing file there survives a failed
+    write. Variable data is written raw at its declared dtype — unlike
+    :func:`write_multidim_netcdf`, ``datetime64`` / ``timedelta64`` *variable*
+    data is not CF-encoded here (coordinates still are), so variable dtypes must
+    be GDAL-mappable numerics (the sole caller streams numeric raster bands).
+    Used by :meth:`pyramids.dataset.collection.DatasetCollection.to_netcdf`.
 
     Args:
         path: Output ``.nc`` path.
@@ -665,7 +669,11 @@ def open_streaming_multidim_netcdf(
         ValueError: When a variable references an unknown dimension, or a
             coordinate array shape does not match its dimension size.
     """
-    dataset = gdal.GetDriverByName("netCDF").CreateMultiDimensional(str(path))
+    final_path = Path(path)
+    tmp_path = final_path.with_name(f".{final_path.name}.{os.getpid()}.tmp")
+    with suppress(OSError):
+        tmp_path.unlink()  # drop any stale temp left by a crashed prior run
+    dataset = gdal.GetDriverByName("netCDF").CreateMultiDimensional(str(tmp_path))
     if dataset is None:
         raise RuntimeError(f"Failed to create NetCDF at {path}")
     completed = False
@@ -677,20 +685,29 @@ def open_streaming_multidim_netcdf(
         yield _StreamingMultidimWriter(arrays)
         completed = True
     except BaseException as exc:
-        # A raising body leaves its traceback pinning the helper/loop frames that
-        # still hold the transient GDAL dim/coord handles; clear those frames so
-        # Close() can release the file and the partial write can be removed below
-        # (the executing frame this runs in is skipped by clear_frames).
+        # The in-flight exception's traceback also pins the caller's `writer`
+        # (holding the same MDArrays); clear the failure frames so those handles
+        # release and the temp can be removed below (the executing generator
+        # frame is skipped by clear_frames). Deliberate trade-off: this empties
+        # the failure frames' locals, so a post-mortem sees none here — do not
+        # "restore" them or the file lock on Windows returns.
         traceback.clear_frames(exc.__traceback__)
         raise
     finally:
-        # Drop the data-variable MDArrays, then Close(): the netCDF driver only
-        # flushes and unlocks the file once every child handle is released.
+        # `arrays` is the writer's own dict, so clearing it drops the last refs to
+        # the data-variable MDArrays; GDAL only flushes and unlocks the file once
+        # those child handles are gone (needed for os.replace / unlink on Windows).
         arrays.clear()
-        dataset.Close()
-        if not completed:
-            # Keep the write all-or-nothing: on any setup or mid-stream failure,
-            # drop the partial/stray file so a surviving file always means a
-            # complete write (matching the old eager CreateCopy path).
+        if completed:
+            # Close() drives the flush; let a flush error surface (the write did
+            # not truly succeed). Then atomically promote the temp onto `path`.
+            dataset.Close()
+            os.replace(tmp_path, final_path)
+        else:
+            # Best-effort cleanup that never masks the in-flight exception and
+            # never touches an existing file at `path`: release the handle, then
+            # drop the temp.
+            with suppress(Exception):
+                dataset.Close()
             with suppress(OSError):
-                Path(path).unlink()
+                tmp_path.unlink()

--- a/src/pyramids/netcdf/engines/interop.py
+++ b/src/pyramids/netcdf/engines/interop.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import os
 import tempfile
 import weakref
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -510,3 +511,132 @@ def write_multidim_netcdf(
     """
     mem_src = _build_multidim(dims, coords, data_vars, global_attrs)
     _create_copy_to_netcdf(mem_src, str(path))
+
+
+class _StreamingMultidimWriter:
+    """Fills a netCDF multidim file's data variables one hyperslab at a time.
+
+    Created by :func:`open_streaming_multidim_netcdf`. Each data variable is
+    created at its full shape but written incrementally: :meth:`write_slab` writes
+    a single index of the leading (streamed) dimension, so the whole cube is never
+    resident in memory. The owning context manager finalizes the file on exit.
+    """
+
+    def __init__(self, arrays: dict[str, gdal.MDArray]) -> None:
+        """Store the per-variable MDArrays to stream into.
+
+        Args:
+            arrays: Variable name to its (empty, full-shape) MDArray.
+        """
+        self._arrays = arrays
+
+    def write_slab(self, var_name: str, index: int, block: np.ndarray) -> None:
+        """Write one leading-dimension index of a variable.
+
+        Args:
+            var_name: Target data variable.
+            index: Position along the leading (streamed) dimension to write at.
+            block: The array for this index, i.e. the variable's shape with the
+                leading dimension dropped. A length-1 leading axis is prepended
+                before the hyperslab write.
+        """
+        md_arr = self._arrays[var_name]
+        block = np.ascontiguousarray(block)
+        md_arr.Write(
+            block[np.newaxis, ...],
+            array_start_idx=[int(index)] + [0] * block.ndim,
+            count=[1] + list(block.shape),
+        )
+
+
+@contextmanager
+def open_streaming_multidim_netcdf(
+    path: str | Path,
+    dims: dict[str, int],
+    coords: dict[str, tuple[np.ndarray, dict[str, Any]]],
+    var_specs: dict[str, tuple[tuple[str, ...], np.dtype | str, dict[str, Any]]],
+    global_attrs: dict[str, Any],
+):
+    """Create a netCDF multidim file and yield a per-hyperslab writer.
+
+    The streaming counterpart of :func:`write_multidim_netcdf`: instead of
+    receiving fully materialised variable arrays, it creates the dimensions,
+    writes the (small, 1-D) coordinate arrays whole, creates each data variable
+    at its full shape with **no data**, then hands back a
+    :class:`_StreamingMultidimWriter` so the caller can fill each variable one
+    leading-dimension slab at a time. The file is flushed and closed on exit, so
+    the whole ``(T, …)`` cube never has to be resident. Used by
+    :meth:`pyramids.dataset.collection.DatasetCollection.to_netcdf`.
+
+    Args:
+        path: Output ``.nc`` path.
+        dims: Dimension name to length (the full shape, including the streamed
+            leading dimension).
+        coords: Coordinate name (also a dimension) to a ``(values, attrs)`` pair;
+            written whole up front. Entries whose name is not a dimension are
+            skipped.
+        var_specs: Variable name to a ``(dimension-name tuple, numpy dtype,
+            attrs)`` triple. The first entry of the dimension tuple is the
+            streamed (leading) dimension.
+        global_attrs: Root-group (global) attributes.
+
+    Yields:
+        _StreamingMultidimWriter: Call :meth:`~_StreamingMultidimWriter.write_slab`
+        once per leading-dimension index.
+
+    Raises:
+        RuntimeError: When the GDAL netCDF driver fails to create the file.
+        ValueError: When a variable references an unknown dimension, or a
+            coordinate array shape does not match its dimension size.
+    """
+    dataset = gdal.GetDriverByName("netCDF").CreateMultiDimensional(str(path))
+    if dataset is None:
+        raise RuntimeError(f"Failed to create NetCDF at {path}")
+    root = dataset.GetRootGroup()
+
+    gdal_dims: dict[str, gdal.Dimension] = {
+        name: root.CreateDimension(name, "", "", int(size))
+        for name, size in dims.items()
+    }
+
+    for coord_name, (coord_values, coord_attrs) in coords.items():
+        if coord_name not in gdal_dims:
+            continue
+        values, cf_attrs = _encode_temporal_array(np.asarray(coord_values))
+        if values.shape != (dims[coord_name],):
+            raise ValueError(
+                f"coordinate {coord_name!r} has shape {values.shape} but its "
+                f"dimension is length {dims[coord_name]}"
+            )
+        ext = gdal.ExtendedDataType.Create(numpy_to_gdal_dtype(values))
+        coord_arr = root.CreateMDArray(coord_name, [gdal_dims[coord_name]], ext)
+        coord_arr.Write(np.ascontiguousarray(values))
+        merged = dict(coord_attrs)
+        merged.update(cf_attrs)
+        _apply_md_array_attrs(coord_arr, merged)
+
+    arrays: dict[str, gdal.MDArray] = {}
+    for var_name, (var_dims, var_dtype, var_attrs) in var_specs.items():
+        unknown = [d for d in var_dims if d not in gdal_dims]
+        if unknown:
+            raise ValueError(
+                f"variable {var_name!r} references unknown dimension(s) "
+                f"{unknown} not in dims {sorted(gdal_dims)}"
+            )
+        ext = gdal.ExtendedDataType.Create(numpy_to_gdal_dtype(np.dtype(var_dtype)))
+        md_arr = root.CreateMDArray(var_name, [gdal_dims[d] for d in var_dims], ext)
+        _apply_md_array_attrs(md_arr, dict(var_attrs))
+        arrays[var_name] = md_arr
+
+    if global_attrs:
+        write_global_attributes(root, dict(global_attrs))
+
+    try:
+        yield _StreamingMultidimWriter(arrays)
+    finally:
+        # Drop the MDArray / root references before closing so the netCDF write
+        # handle is fully released and the on-disk file is recognised by a reader
+        # that reopens the same path (mirrors _create_copy_to_netcdf's note).
+        arrays.clear()
+        del root
+        dataset.Close()

--- a/tests/dataset/collection/test_to_netcdf.py
+++ b/tests/dataset/collection/test_to_netcdf.py
@@ -830,6 +830,24 @@ class TestToNetcdfStreaming:
         assert out.exists(), "existing file must survive a failed overwrite"
         assert out.read_bytes() == original, "existing file was modified"
 
+    def test_no_temp_file_left_after_success(self, tmp_path):
+        """A successful write leaves no temporary sibling file behind.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            After a normal ``to_netcdf`` the atomic temp has been ``os.replace``-d
+            onto the destination — expected: only the ``.nc`` output remains, no
+            leftover ``.tmp`` file.
+        """
+        col, _ = _make_int16_collection(tmp_path, count=2)
+        out = tmp_path / "clean.nc"
+        col.to_netcdf(str(out))
+        assert out.exists(), "output not written"
+        strays = [p.name for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+        assert not strays, f"stray temp file(s) left: {strays}"
+
     def test_empty_collection_raises_value_error(self, tmp_path):
         """An empty collection (``time_length == 0``) raises a clear ValueError.
 

--- a/tests/dataset/collection/test_to_netcdf.py
+++ b/tests/dataset/collection/test_to_netcdf.py
@@ -21,6 +21,7 @@ import pandas as pd
 import pytest
 from osgeo import gdal
 
+from pyramids.base._errors import AlignmentError
 from pyramids.dataset import Dataset, DatasetCollection
 from pyramids.netcdf import NetCDF
 from tests.dataset.collection._helpers import (
@@ -767,6 +768,34 @@ class TestToNetcdfStreaming:
             np.testing.assert_array_equal(
                 values[t], arrays[t], err_msg=f"timestep {t} mismatch"
             )
+
+    def test_mismatched_timestep_shape_raises_alignment_error(self, tmp_path):
+        """A timestep whose grid differs from the template raises AlignmentError.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            A 4x5 template followed by a 3x3 raster (``from_files`` does not
+            validate headers by default) — expected: a clear AlignmentError
+            naming the offending file, and no partial file left on disk.
+        """
+        paths = []
+        for t, shape in enumerate([(4, 5), (3, 3)]):
+            p = str(tmp_path / f"h_{t}.tif")
+            Dataset.create_from_array(
+                np.zeros(shape, dtype="int16"),
+                top_left_corner=(0, 0),
+                cell_size=0.05,
+                epsg=4326,
+                path=p,
+            ).close()
+            paths.append(p)
+        col = DatasetCollection.from_files(paths)
+        out = tmp_path / "bad.nc"
+        with pytest.raises(AlignmentError, match="must share the base grid"):
+            col.to_netcdf(str(out))
+        assert not out.exists(), "a mismatched timestep must leave no partial file"
 
 
 class TestToNetcdfRoundTrip:

--- a/tests/dataset/collection/test_to_netcdf.py
+++ b/tests/dataset/collection/test_to_netcdf.py
@@ -797,6 +797,29 @@ class TestToNetcdfStreaming:
             col.to_netcdf(str(out))
         assert not out.exists(), "a mismatched timestep must leave no partial file"
 
+    def test_empty_collection_raises_value_error(self, tmp_path):
+        """An empty collection (``time_length == 0``) raises a clear ValueError.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            ``from_dataset(base, 0)`` builds a zero-timestep collection — expected:
+            ``to_netcdf`` raises a ValueError naming the empty collection and
+            writes no file.
+        """
+        base = Dataset.create_from_array(
+            np.zeros((4, 5), dtype="int16"),
+            top_left_corner=(0, 0),
+            cell_size=0.05,
+            epsg=4326,
+        )
+        col = DatasetCollection.from_dataset(base, 0)
+        out = tmp_path / "empty.nc"
+        with pytest.raises(ValueError, match="empty collection"):
+            col.to_netcdf(str(out))
+        assert not out.exists(), "no file should be written for an empty collection"
+
 
 class TestToNetcdfRoundTrip:
     """End-to-end: re-open the written file via :class:`NetCDF` and compare."""

--- a/tests/dataset/collection/test_to_netcdf.py
+++ b/tests/dataset/collection/test_to_netcdf.py
@@ -797,6 +797,39 @@ class TestToNetcdfStreaming:
             col.to_netcdf(str(out))
         assert not out.exists(), "a mismatched timestep must leave no partial file"
 
+    def test_failed_overwrite_preserves_existing_file(self, tmp_path):
+        """A failed overwrite leaves the pre-existing file untouched (atomic).
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            Write a valid cube, then overwrite the same path from a collection
+            whose 2nd timestep mismatches — expected: AlignmentError, and the
+            original file's bytes are unchanged (temp write + os.replace).
+        """
+        out = tmp_path / "cube.nc"
+        good, _ = _make_int16_collection(tmp_path, count=2)
+        good.to_netcdf(str(out))
+        original = out.read_bytes()
+
+        paths = []
+        for i, shape in enumerate([(4, 5), (3, 3)]):
+            p = str(tmp_path / f"ov_{i}.tif")
+            Dataset.create_from_array(
+                np.zeros(shape, dtype="int16"),
+                top_left_corner=(0, 0),
+                cell_size=0.05,
+                epsg=4326,
+                path=p,
+            ).close()
+            paths.append(p)
+        bad = DatasetCollection.from_files(paths)
+        with pytest.raises(AlignmentError):
+            bad.to_netcdf(str(out))
+        assert out.exists(), "existing file must survive a failed overwrite"
+        assert out.read_bytes() == original, "existing file was modified"
+
     def test_empty_collection_raises_value_error(self, tmp_path):
         """An empty collection (``time_length == 0``) raises a clear ValueError.
 

--- a/tests/dataset/collection/test_to_netcdf.py
+++ b/tests/dataset/collection/test_to_netcdf.py
@@ -820,6 +820,45 @@ class TestToNetcdfStreaming:
             col.to_netcdf(str(out))
         assert not out.exists(), "no file should be written for an empty collection"
 
+    def test_var_per_band_true_multi_timestep_streams_each_band(self, tmp_path):
+        """``var_per_band=True`` streams each band into its own variable per step.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            Three 2-band timesteps written with ``var_per_band=True`` — expected:
+            each band becomes a ``(T, y, x)`` variable equal to that band across
+            timesteps, exercising the per-band-per-timestep slab loop.
+        """
+        band0, band1, paths = [], [], []
+        for t in range(3):
+            b0 = np.full((4, 5), t + 1, dtype="int16")
+            b1 = np.full((4, 5), 100 + t, dtype="int16")
+            p = str(tmp_path / f"vb_{t}.tif")
+            Dataset.create_from_array(
+                np.stack([b0, b1], axis=0),
+                top_left_corner=(0, 0),
+                cell_size=0.05,
+                epsg=4326,
+                path=p,
+            ).close()
+            band0.append(b0)
+            band1.append(b1)
+            paths.append(p)
+        col = DatasetCollection.from_files(paths)
+        names = (
+            list(col.meta.band_names) if col.meta.band_names else ["band_1", "band_2"]
+        )
+        out = tmp_path / "vb.nc"
+        col.to_netcdf(str(out), var_per_band=True)
+        v0 = _array_values(str(out), names[0])
+        v1 = _array_values(str(out), names[1])
+        assert v0.shape == (3, 4, 5), f"{names[0]} shape: {v0.shape}"
+        for t in range(3):
+            np.testing.assert_array_equal(v0[t], band0[t], err_msg=f"{names[0]} t={t}")
+            np.testing.assert_array_equal(v1[t], band1[t], err_msg=f"{names[1]} t={t}")
+
 
 class TestToNetcdfRoundTrip:
     """End-to-end: re-open the written file via :class:`NetCDF` and compare."""

--- a/tests/dataset/collection/test_to_netcdf.py
+++ b/tests/dataset/collection/test_to_netcdf.py
@@ -702,42 +702,71 @@ class TestToNetcdfNoFilesPath:
         assert values.shape == (3, 4, 5), f"unexpected shape: {values.shape}"
 
 
-class TestToNetcdfLargeCubeWarning:
-    """ARC-46: ``to_netcdf`` warns (pointing at ``to_zarr``) for an oversized cube."""
+class TestToNetcdfStreaming:
+    """ARC-46: ``to_netcdf`` streams timestep-by-timestep, never the full cube."""
 
-    def test_warns_when_estimate_exceeds_threshold(self, tmp_path, monkeypatch):
-        """A cube above ``_TO_NETCDF_WARN_BYTES`` emits a UserWarning naming to_zarr.
+    def test_does_not_stack_the_full_cube(self, tmp_path, monkeypatch):
+        """``to_netcdf`` must not materialise the whole cube via ``np.stack``.
 
         Args:
             tmp_path: pytest temp directory.
             monkeypatch: pytest monkeypatch fixture.
 
         Test scenario:
-            Shrink the module warn-threshold to 1 byte so the tiny fixture cube
-            trips it — expected: a UserWarning steering the caller at ``to_zarr``.
+            Patch ``np.stack`` in the collection module to raise, then write.
+            The eager implementation stacked every timestep and would trip it;
+            the streaming implementation writes one slab per timestep, so the
+            file is produced correctly with ``np.stack`` disabled.
         """
-        col, _ = _make_int16_collection(tmp_path, count=2)
-        monkeypatch.setattr("pyramids.dataset.collection._TO_NETCDF_WARN_BYTES", 1)
-        with pytest.warns(UserWarning, match="to_zarr"):
-            col.to_netcdf(str(tmp_path / "warn.nc"))
+        col, _ = _make_int16_collection(tmp_path, count=3)
+        import pyramids.dataset.collection as _collection
 
-    def test_no_warning_for_small_cube(self, tmp_path):
-        """A small cube (default 2 GiB threshold) emits no size warning.
+        def _no_stack(*_args, **_kwargs):
+            raise AssertionError("to_netcdf must not materialise the full cube")
+
+        monkeypatch.setattr(_collection.np, "stack", _no_stack)
+        out = tmp_path / "streamed.nc"
+        col.to_netcdf(str(out))
+        assert out.exists(), "streaming write produced no file"
+        values = _array_values(str(out), "Band_1")
+        assert values.shape == (3, 4, 5), f"unexpected shape: {values.shape}"
+
+    def test_multi_band_multi_timestep_streams_var_per_band_false(self, tmp_path):
+        """A multi-band cube streams into the 4-D ``data`` variable correctly.
 
         Args:
             tmp_path: pytest temp directory.
 
         Test scenario:
-            Default threshold, tiny fixture cube — expected: none of the emitted
-            warnings mention the streaming ``to_zarr`` guidance.
+            Three 2-band timesteps written with ``var_per_band=False`` round-trip
+            to a ``(T, band, y, x)`` array equal to the source, exercising the
+            per-timestep ``(B, Y, X)`` slab path.
         """
-        col, _ = _make_int16_collection(tmp_path, count=2)
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            col.to_netcdf(str(tmp_path / "ok.nc"))
-        assert not any("streams the cube" in str(w.message) for w in caught), (
-            f"unexpected size warning: {[str(w.message) for w in caught]}"
-        )
+        arrays = []
+        paths = []
+        for t in range(3):
+            arr = np.stack(
+                [
+                    np.full((4, 5), t + 1, dtype="int16"),
+                    np.full((4, 5), 100 + t, dtype="int16"),
+                ],
+                axis=0,
+            )
+            p = str(tmp_path / f"mb_{t}.tif")
+            Dataset.create_from_array(
+                arr, top_left_corner=(0, 0), cell_size=0.05, epsg=4326, path=p
+            ).close()
+            arrays.append(arr)
+            paths.append(p)
+        col = DatasetCollection.from_files(paths)
+        out = tmp_path / "mb.nc"
+        col.to_netcdf(str(out), var_per_band=False)
+        values = _array_values(str(out), "data")
+        assert values.shape == (3, 2, 4, 5), f"unexpected shape: {values.shape}"
+        for t in range(3):
+            np.testing.assert_array_equal(
+                values[t], arrays[t], err_msg=f"timestep {t} mismatch"
+            )
 
 
 class TestToNetcdfRoundTrip:

--- a/tests/netcdf/test_interop_write_multidim.py
+++ b/tests/netcdf/test_interop_write_multidim.py
@@ -105,6 +105,24 @@ def _root_attrs(path: str) -> dict:
     return {a.GetName(): a.Read() for a in _root(path).GetAttributes()}
 
 
+def _stream_one_slab_then_raise(path, dims, coords, var_specs) -> None:
+    """Enter the streaming writer, write one slab, then raise mid-stream.
+
+    Args:
+        path: Output ``.nc`` path.
+        dims: Dimension name to length.
+        coords: Coordinate spec.
+        var_specs: Variable spec.
+
+    Raises:
+        RuntimeError: Always, after one slab is written, to exercise the
+            mid-stream cleanup path with a single throwing call at the call site.
+    """
+    with open_streaming_multidim_netcdf(path, dims, coords, var_specs, {}) as writer:
+        writer.write_slab("v", 0, np.array([[1]], dtype="int16"))
+        raise RuntimeError("boom")
+
+
 class TestWriteMultidimNetcdf:
     """Tests for :func:`write_multidim_netcdf`."""
 
@@ -524,11 +542,7 @@ class TestOpenStreamingMultidimNetcdf:
         }
         var_specs = {"v": (("time", "y", "x"), np.dtype("int16"), {})}
         with pytest.raises(RuntimeError, match="boom"):
-            with open_streaming_multidim_netcdf(
-                out, dims, coords, var_specs, {}
-            ) as writer:
-                writer.write_slab("v", 0, np.array([[1]], dtype="int16"))
-                raise RuntimeError("boom")
+            _stream_one_slab_then_raise(out, dims, coords, var_specs)
         assert not out.exists(), "a mid-stream error must leave no partial file"
 
 

--- a/tests/netcdf/test_interop_write_multidim.py
+++ b/tests/netcdf/test_interop_write_multidim.py
@@ -22,6 +22,7 @@ from pyramids.netcdf.engines.interop import (
     _apply_md_array_attrs,
     _build_multidim,
     _create_copy_to_netcdf,
+    open_streaming_multidim_netcdf,
     write_multidim_netcdf,
 )
 
@@ -332,6 +333,198 @@ class TestWriteMultidimNetcdf:
         monkeypatch.setattr(interop.gdal, "GetDriverByName", _fake)
         with pytest.raises(RuntimeError, match="Failed to write NetCDF"):
             write_multidim_netcdf(path, dims, coords, data_vars, {})
+
+
+class TestOpenStreamingMultidimNetcdf:
+    """Tests for :func:`open_streaming_multidim_netcdf` (per-slab streaming)."""
+
+    def test_streams_variable_and_coords_round_trip(self, tmp_path):
+        """A ``(time, y, x)`` variable written one slab per timestep round-trips.
+
+        Test scenario:
+            Two timesteps written via ``write_slab`` — expected: the arrays exist,
+            each timestep reads back its own constant block, and the coords are
+            verbatim.
+        """
+        out = tmp_path / "stream.nc"
+        dims = {"time": 2, "y": 2, "x": 3}
+        coords = {
+            "time": (np.array([0, 1], dtype="int64"), {}),
+            "y": (np.array([10.0, 20.0]), {}),
+            "x": (np.array([1.0, 2.0, 3.0]), {}),
+        }
+        var_specs = {"temp": (("time", "y", "x"), np.dtype("int16"), {})}
+        with open_streaming_multidim_netcdf(
+            out, dims, coords, var_specs, {"Conventions": "CF-1.8"}
+        ) as writer:
+            for t in range(2):
+                writer.write_slab("temp", t, np.full((2, 3), t + 1, dtype="int16"))
+        assert {"temp", "time", "y", "x"}.issubset(_array_names(str(out))), (
+            f"missing arrays: {_array_names(str(out))}"
+        )
+        vals = _values(str(out), "temp")
+        assert vals.shape == (2, 2, 3), f"unexpected shape: {vals.shape}"
+        assert np.array_equal(vals[0], np.full((2, 3), 1)), "timestep 0 wrong"
+        assert np.array_equal(vals[1], np.full((2, 3), 2)), "timestep 1 wrong"
+        assert np.array_equal(_values(str(out), "y"), [10.0, 20.0]), "y coord wrong"
+        assert _root_attrs(str(out)).get("Conventions") == "CF-1.8", "root attr wrong"
+
+    def test_multiple_variables_streamed_with_attrs(self, tmp_path):
+        """Two variables stream in parallel and their attributes round-trip.
+
+        Test scenario:
+            Per-timestep ``write_slab`` for ``b1`` (with a ``nodata`` attr) and
+            ``b2`` — expected: both round-trip and ``b1`` carries ``nodata``.
+        """
+        out = tmp_path / "multi.nc"
+        dims = {"time": 2, "y": 2, "x": 2}
+        coords = {
+            "time": (np.array([0, 1], dtype="int64"), {}),
+            "y": (np.array([0.0, 1.0]), {}),
+            "x": (np.array([0.0, 1.0]), {}),
+        }
+        var_specs = {
+            "b1": (("time", "y", "x"), np.dtype("int16"), {"nodata": -1}),
+            "b2": (("time", "y", "x"), np.dtype("int16"), {}),
+        }
+        with open_streaming_multidim_netcdf(out, dims, coords, var_specs, {}) as writer:
+            for t in range(2):
+                writer.write_slab("b1", t, np.full((2, 2), t, dtype="int16"))
+                writer.write_slab("b2", t, np.full((2, 2), 10 + t, dtype="int16"))
+        assert np.array_equal(_values(str(out), "b1")[1], np.full((2, 2), 1)), (
+            "b1 wrong"
+        )
+        assert np.array_equal(_values(str(out), "b2")[0], np.full((2, 2), 10)), (
+            "b2 wrong"
+        )
+        assert _attrs(str(out), "b1").get("nodata") == -1, "nodata attr not written"
+
+    def test_datetime_coord_is_cf_encoded(self, tmp_path):
+        """A raw ``datetime64`` time coordinate is CF-encoded to a numeric axis.
+
+        Test scenario:
+            ``time`` is ``datetime64[ns]`` — expected: a numeric axis whose unit
+            slot carries a CF ``since`` unit.
+        """
+        out = tmp_path / "dt.nc"
+        time = np.array(["2020-01-01", "2020-01-02"], dtype="datetime64[ns]")
+        dims = {"time": 2, "x": 1}
+        coords = {"time": (time, {}), "x": (np.array([0.0]), {})}
+        var_specs = {"v": (("time", "x"), np.dtype("float32"), {})}
+        with open_streaming_multidim_netcdf(out, dims, coords, var_specs, {}) as writer:
+            for t in range(2):
+                writer.write_slab("v", t, np.array([float(t)], dtype="float32"))
+        assert "since" in _unit(str(out), "time"), "time coord not CF-encoded"
+
+    def test_coord_not_in_dims_is_skipped(self, tmp_path):
+        """A coordinate whose name is not a declared dimension is skipped.
+
+        Test scenario:
+            A ``bogus`` coord absent from ``dims`` — expected: it never becomes an
+            MD-array.
+        """
+        out = tmp_path / "skip.nc"
+        dims = {"time": 1, "x": 2}
+        coords = {
+            "x": (np.array([0.0, 1.0]), {}),
+            "bogus": (np.array([5.0, 6.0]), {}),
+        }
+        var_specs = {"v": (("time", "x"), np.dtype("float64"), {})}
+        with open_streaming_multidim_netcdf(out, dims, coords, var_specs, {}):
+            pass
+        assert "bogus" not in _array_names(str(out)), "non-dim coord was written"
+
+    def test_coord_length_mismatch_raises_value_error(self, tmp_path):
+        """A coordinate length that differs from its dimension size raises.
+
+        Test scenario:
+            ``dims={"x": 3}`` but the ``x`` coord has length 2 — expected: a
+            ``ValueError`` naming the length mismatch, raised on context entry.
+        """
+        out = tmp_path / "badcoord.nc"
+        with pytest.raises(ValueError, match="dimension is length"):
+            with open_streaming_multidim_netcdf(
+                out,
+                {"x": 3},
+                {"x": (np.array([0.0, 1.0]), {})},
+                {"v": (("x",), np.dtype("float64"), {})},
+                {},
+            ):
+                pass
+
+    def test_unknown_variable_dimension_raises_value_error(self, tmp_path):
+        """A variable over a dimension absent from ``dims`` raises ``ValueError``.
+
+        Test scenario:
+            A variable references dimension ``z`` not in ``dims`` — expected:
+            ``ValueError`` naming the unknown dimension, raised on context entry.
+        """
+        out = tmp_path / "badvar.nc"
+        with pytest.raises(ValueError, match="unknown dimension"):
+            with open_streaming_multidim_netcdf(
+                out,
+                {"x": 2},
+                {"x": (np.array([0.0, 1.0]), {})},
+                {"v": (("z",), np.dtype("float64"), {})},
+                {},
+            ):
+                pass
+
+    def test_create_failure_raises_runtime_error(self, tmp_path, monkeypatch):
+        """A ``None`` from ``CreateMultiDimensional`` raises ``RuntimeError``.
+
+        Args:
+            tmp_path: pytest temp directory.
+            monkeypatch: pytest monkeypatch fixture.
+
+        Test scenario:
+            Force the netCDF driver's ``CreateMultiDimensional`` to return ``None``
+            — expected: ``RuntimeError`` naming the target path.
+        """
+        real = gdal.GetDriverByName
+
+        class _NullCreateDriver:
+            def CreateMultiDimensional(self, *args, **kwargs):
+                return None
+
+        monkeypatch.setattr(
+            interop.gdal,
+            "GetDriverByName",
+            lambda name: _NullCreateDriver() if name == "netCDF" else real(name),
+        )
+        with pytest.raises(RuntimeError, match="Failed to create NetCDF"):
+            with open_streaming_multidim_netcdf(
+                tmp_path / "boom.nc",
+                {"x": 1},
+                {"x": (np.array([0.0]), {})},
+                {"v": (("x",), np.dtype("float64"), {})},
+                {},
+            ):
+                pass
+
+    def test_context_manager_finalizes_on_exception(self, tmp_path):
+        """An exception raised mid-stream still finalizes (closes) the file.
+
+        Test scenario:
+            Write one slab, then raise inside the ``with`` block — expected: the
+            error propagates and the file is still created (the ``finally`` close
+            ran), not left with an open write handle.
+        """
+        out = tmp_path / "err.nc"
+        dims = {"time": 2, "y": 1, "x": 1}
+        coords = {
+            "time": (np.array([0, 1], dtype="int64"), {}),
+            "y": (np.array([0.0]), {}),
+            "x": (np.array([0.0]), {}),
+        }
+        var_specs = {"v": (("time", "y", "x"), np.dtype("int16"), {})}
+        with pytest.raises(RuntimeError, match="boom"):
+            with open_streaming_multidim_netcdf(
+                out, dims, coords, var_specs, {}
+            ) as writer:
+                writer.write_slab("v", 0, np.array([[1]], dtype="int16"))
+                raise RuntimeError("boom")
+        assert out.exists(), "file should be finalized even when the block raises"
 
 
 class TestApplyMdArrayAttrs:

--- a/tests/netcdf/test_interop_write_multidim.py
+++ b/tests/netcdf/test_interop_write_multidim.py
@@ -451,6 +451,7 @@ class TestOpenStreamingMultidimNetcdf:
                 {},
             ):
                 pass
+        assert not out.exists(), "a setup-phase error must leave no partial file"
 
     def test_unknown_variable_dimension_raises_value_error(self, tmp_path):
         """A variable over a dimension absent from ``dims`` raises ``ValueError``.
@@ -469,6 +470,7 @@ class TestOpenStreamingMultidimNetcdf:
                 {},
             ):
                 pass
+        assert not out.exists(), "a setup-phase error must leave no partial file"
 
     def test_create_failure_raises_runtime_error(self, tmp_path, monkeypatch):
         """A ``None`` from ``CreateMultiDimensional`` raises ``RuntimeError``.
@@ -492,23 +494,26 @@ class TestOpenStreamingMultidimNetcdf:
             "GetDriverByName",
             lambda name: _NullCreateDriver() if name == "netCDF" else real(name),
         )
+        out = tmp_path / "boom.nc"
         with pytest.raises(RuntimeError, match="Failed to create NetCDF"):
             with open_streaming_multidim_netcdf(
-                tmp_path / "boom.nc",
+                out,
                 {"x": 1},
                 {"x": (np.array([0.0]), {})},
                 {"v": (("x",), np.dtype("float64"), {})},
                 {},
             ):
                 pass
+        assert not out.exists(), "no file should exist when creation fails"
 
-    def test_context_manager_finalizes_on_exception(self, tmp_path):
-        """An exception raised mid-stream still finalizes (closes) the file.
+    def test_partial_file_removed_on_mid_stream_exception(self, tmp_path):
+        """A mid-stream exception removes the partial file (atomic write).
 
         Test scenario:
             Write one slab, then raise inside the ``with`` block — expected: the
-            error propagates and the file is still created (the ``finally`` close
-            ran), not left with an open write handle.
+            error propagates and the partially written file is cleaned up, so a
+            surviving file always means a complete write (no silently truncated
+            NetCDF left behind).
         """
         out = tmp_path / "err.nc"
         dims = {"time": 2, "y": 1, "x": 1}
@@ -524,7 +529,7 @@ class TestOpenStreamingMultidimNetcdf:
             ) as writer:
                 writer.write_slab("v", 0, np.array([[1]], dtype="int16"))
                 raise RuntimeError("boom")
-        assert out.exists(), "file should be finalized even when the block raises"
+        assert not out.exists(), "a mid-stream error must leave no partial file"
 
 
 class TestApplyMdArrayAttrs:


### PR DESCRIPTION
# Description

Makes `DatasetCollection.to_netcdf` **streaming** so it no longer holds the whole `(T, B, Y, X)` cube in memory.

Previously `to_netcdf` had two layers of eagerness (~2× the cube in RAM): it `np.stack`-ed every timestep into one
array, then `_build_multidim` wrote that array into an in-memory `MEM` multidim dataset which `CreateCopy`-ied to
netCDF — a second full copy. The docstring/`ARC-46` guard only *warned* above a size threshold.

- New `open_streaming_multidim_netcdf` (context manager, `netcdf/engines/interop.py`): creates the netCDF multidim
  file directly (`netCDF.CreateMultiDimensional`), writes the small 1-D coordinate arrays whole, creates each data
  variable at full shape with **no data**, and yields a writer whose `write_slab(var, index, block)` writes one
  leading-dimension slab via `MDArray.Write(array_start_idx=…, count=…)`. Flushes + closes on exit.
- `to_netcdf` now reads **one raster at a time** from `self.datasets` and writes its `[t]` slab, dropping the
  `np.stack` and the MEM `CreateCopy`. Peak memory falls from ~2×(T·B·Y·X) to **one timestep + the coordinate axes**.
- The obsolete large-cube warning and its `_TO_NETCDF_WARN_BYTES` threshold are removed; the docstring no longer
  describes the writer as eager.
- Output is unchanged (same dims / vars / attrs / nodata / time encodings) — behaviour-preserving.

# Issues

- Closes #960

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Ran against the branch (`MPLBACKEND=Agg`):

```
pytest tests/dataset/collection tests/netcdf/test_interop_write_multidim.py tests/netcdf/selection/test_labeled.py
```

- [x] Full `to_netcdf` suite + `test_to_netcdf_no_engine.py` + interop-writer + labeled-read — **437 passed**
      (output parity: same round-trip, attrs, nodata, time-coord encodings, both `var_per_band` paths)
- [x] New `TestToNetcdfStreaming` — patches `np.stack` to raise and asserts `to_netcdf` still writes correctly
      (proves non-eagerness); plus a multi-band 4-D streaming round-trip
- [x] The runnable `to_netcdf` doctest passes; `mypy` clean on the changed source; pre-commit (ruff/bandit) green
- [x] Empirically confirmed the GDAL netCDF multidim slab-write round-trip (GDAL 3.13.1) before implementing

# Checklist:

- [ ] updated version number in pyproject.toml.  <!-- handled by commitizen on release -->
- [ ] added changes to History.rst.  <!-- generated changelog -->
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.