### PR TITLE
feat(spatial): windowed crop(bbox=) that avoids full reads of huge/remote rasters

### DIFF
--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1982,6 +1982,16 @@ class Spatial(_Engine["Dataset"]):
         Hint:
             - If the mask is a dataset with multi-bands, the `crop` method will use the first band as the mask.
 
+        Note:
+            A ``bbox`` that is axis-aligned in the dataset's own CRS (no ``epsg``
+            reprojection, no antimeridian split, a north-up grid, ``touch=True``) is
+            cropped by reading only that pixel window straight from the source, rather
+            than warping a cutline over the whole raster. A small crop out of a very
+            large or ``/vsicurl`` raster therefore reads only the AOI instead of the
+            full source; the result is identical to the cutline path. Any case that is
+            not eligible (a reprojecting bbox, a rotated grid, ``touch=False``) falls
+            back to the cutline warp unchanged.
+
         Examples:
             - Crop the raster using a polygon mask.
 

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1951,6 +1951,69 @@ class Spatial(_Engine["Dataset"]):
         """
         return _stitch_lon_halves(self._ds, west_part, east_part)
 
+    def _crop_from_bbox(
+        self,
+        bbox: tuple[float, float, float, float] | list[float],
+        mask: GeoDataFrame | FeatureCollection | None,
+        epsg: Any,
+        touch: bool,
+    ) -> Dataset | FeatureCollection:
+        """Resolve a `crop(bbox=...)` request to a finished crop or a cutline mask.
+
+        Handles the three bbox outcomes so :meth:`crop` stays flat: an
+        antimeridian-crossing geographic box is split and cropped, an eligible
+        axis-aligned box is cropped by the windowed fast path, and anything else is
+        wrapped in a one-row :class:`FeatureCollection` for the cutline warp.
+
+        Args:
+            bbox (tuple[float, float, float, float] | list[float]):
+                ``(west, south, east, north)`` in the CRS named by ``epsg``.
+            mask (GeoDataFrame | FeatureCollection | None):
+                The caller's ``mask`` argument, rejected here if also supplied.
+            epsg (Any):
+                CRS for ``bbox``; defaults to the dataset's own CRS when ``None``.
+            touch (bool):
+                Forwarded to the fast path / warp (``True`` enables the fast path).
+
+        Returns:
+            Dataset | FeatureCollection:
+                A finished :class:`Dataset` crop (antimeridian or fast path), or a
+                :class:`FeatureCollection` for the caller to warp.
+
+        Raises:
+            ValueError: Both ``mask`` and ``bbox`` were supplied.
+        """
+        if mask is not None:
+            raise ValueError("crop accepts either `mask` or `bbox`, not both")
+        # `.epsg` is None for a no-EPSG CRS (e.g. geostationary); fall back to the WKT
+        # so a bbox in the grid's own CRS is still honoured (#706).
+        crs = (
+            epsg
+            if epsg is not None
+            else require_crs_spec(
+                self._ds.epsg, self._ds.crs, "crop by a bbox without an explicit epsg="
+            )
+        )
+        west, _, east, _ = bbox
+        crs_geo = bool(crs) and sr_from_user_input(crs).IsGeographic()
+        ds_epsg = self._ds.epsg
+        ds_geo = ds_epsg is not None and sr_from_user_input(ds_epsg).IsGeographic()
+        if west > east and crs_geo and ds_geo:
+            # bbox is validated 4-long above; tuple(bbox) loses that fixed arity
+            # statically (it may start as a list), so restore it.
+            bbox_4 = cast(tuple[float, float, float, float], tuple(bbox))
+            _require_antimeridian_seam(self._ds, bbox_4)
+            return self._crop_antimeridian(bbox_4, crs, touch)
+        # Fast path: an axis-aligned box in the source CRS is just a window, so read
+        # only that window instead of warping a cutline over the whole source (#957).
+        # Falls through to the warp path when it does not apply (reprojection, a rotated
+        # grid, or a degenerate/off-grid box).
+        if touch:
+            windowed = self._crop_bbox_windowed(bbox, crs)
+            if windowed is not None:
+                return windowed
+        return FeatureCollection.from_bbox(bbox, epsg=crs)
+
     def crop(
         self,
         mask: GeoDataFrame | FeatureCollection | None = None,
@@ -2161,38 +2224,12 @@ class Spatial(_Engine["Dataset"]):
         """
         bbox_mask = False
         if bbox is not None:
-            if mask is not None:
-                raise ValueError("crop accepts either `mask` or `bbox`, not both")
-            # `.epsg` is None for a no-EPSG CRS (e.g. geostationary); fall back to
-            # the WKT so a bbox in the grid's own CRS is still honoured (#706).
-            crs = (
-                epsg
-                if epsg is not None
-                else require_crs_spec(
-                    self._ds.epsg,
-                    self._ds.crs,
-                    "crop by a bbox without an explicit epsg=",
-                )
-            )
-            west, _, east, _ = bbox
-            crs_geo = bool(crs) and sr_from_user_input(crs).IsGeographic()
-            ds_epsg = self._ds.epsg
-            ds_geo = ds_epsg is not None and sr_from_user_input(ds_epsg).IsGeographic()
-            if west > east and crs_geo and ds_geo:
-                # bbox is validated 4-long above; tuple(bbox) loses that fixed
-                # arity statically (it may start as a list), so restore it.
-                bbox_4 = cast(tuple[float, float, float, float], tuple(bbox))
-                _require_antimeridian_seam(self._ds, bbox_4)
-                return self._crop_antimeridian(bbox_4, crs, touch)
-            # Fast path: an axis-aligned box in the source CRS is just a window, so
-            # read only that window instead of warping a cutline over the whole
-            # source (#957). Falls through to the warp path when it does not apply
-            # (reprojection, a rotated grid, or a degenerate/off-grid box).
-            if touch:
-                windowed = self._crop_bbox_windowed(bbox, crs)
-                if windowed is not None:
-                    return windowed
-            mask = FeatureCollection.from_bbox(bbox, epsg=crs)
+            # Resolve the bbox: a completed crop (antimeridian split or windowed fast
+            # path) is returned as-is; otherwise it yields a FeatureCollection to warp.
+            resolved = self._crop_from_bbox(bbox, mask, epsg, touch)
+            if isinstance(resolved, RasterBase):
+                return cast("Dataset", resolved)
+            mask = resolved
             bbox_mask = True
         if mask is None:
             raise TypeError(

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1615,10 +1615,13 @@ class Spatial(_Engine["Dataset"]):
         source and rebuilds the geotransform, so a small crop out of a very large
         remote raster never triggers a full read.
 
-        The result is byte-identical to the cutline-warp path: for an axis-aligned
-        box in the source CRS the cells the box touches are exactly
-        ``floor``/``ceil`` of the box edges in pixel space — the same window the
-        warp keeps — and the windowed read is passed through the identical
+        Semantics: the crop keeps **every pixel the box overlaps** — the cells from
+        ``floor`` of the west/north edges to ``ceil`` of the east/south edges in
+        pixel space — the same all-touched convention :meth:`Dataset.read_array`
+        uses for its ``bbox=`` argument. The ``bbox=`` crop's warp fallback
+        (reprojection / rotated grids) is run with an all-touched cutline so it
+        keeps the same cells; only a user-supplied polygon ``mask=`` keeps GDAL's
+        centre-containment default. The windowed read is passed through the same
         :meth:`_correct_wrap_cutline_error` trim, so an all-no-data crop raises the
         same "no valid pixels" error and interior all-no-data rows/cols drop the
         same way.
@@ -1690,7 +1693,10 @@ class Spatial(_Engine["Dataset"]):
         return Spatial._correct_wrap_cutline_error(dst)
 
     def _crop_with_polygon_warp(
-        self, feature: FeatureCollection | GeoDataFrame, touch: bool = True
+        self,
+        feature: FeatureCollection | GeoDataFrame,
+        touch: bool = True,
+        cutline_all_touched: bool = False,
     ) -> Dataset:
         """Crop raster with polygon.
 
@@ -1702,6 +1708,11 @@ class Spatial(_Engine["Dataset"]):
                 Vector mask.
             touch (bool):
                 Include cells that touch the polygon, not only those entirely inside the polygon mask. Defaults to True.
+            cutline_all_touched (bool):
+                Rasterize the cutline with `CUTLINE_ALL_TOUCHED=TRUE`, keeping every cell the cutline overlaps
+                rather than only cells whose centre it contains. Set by the `bbox=` crop so its reprojection /
+                rotated-grid fallback matches the windowed fast path's overlap semantics. Defaults to False (the
+                GDAL centre-containment default) for a user-supplied polygon mask. Ignored when `touch` is False.
 
         Returns:
             Dataset:
@@ -1749,6 +1760,9 @@ class Spatial(_Engine["Dataset"]):
                 outputBounds=window,
                 xRes=abs(gt[1]) if gt else None,
                 yRes=abs(gt[5]) if gt else None,
+                warpOptions=(
+                    ["CUTLINE_ALL_TOUCHED=TRUE"] if touch and cutline_all_touched else None
+                ),
             )
             # base_cls is a dynamic MRO walk that always resolves to Dataset itself
             # (the class directly above RasterBase; see the comment above), never a
@@ -1983,14 +1997,17 @@ class Spatial(_Engine["Dataset"]):
             - If the mask is a dataset with multi-bands, the `crop` method will use the first band as the mask.
 
         Note:
-            A ``bbox`` that is axis-aligned in the dataset's own CRS (no ``epsg``
-            reprojection, no antimeridian split, a north-up grid, ``touch=True``) is
-            cropped by reading only that pixel window straight from the source, rather
-            than warping a cutline over the whole raster. A small crop out of a very
-            large or ``/vsicurl`` raster therefore reads only the AOI instead of the
-            full source; the result is identical to the cutline path. Any case that is
-            not eligible (a reprojecting bbox, a rotated grid, ``touch=False``) falls
-            back to the cutline warp unchanged.
+            A ``bbox`` crop keeps **every pixel the box overlaps** (the all-touched
+            convention :meth:`read_array` uses for ``bbox=``), which for a box not
+            aligned to pixel edges can be up to one pixel wider per side than a
+            polygon ``mask=`` crop (GDAL's centre-containment default). When the box
+            is axis-aligned in the dataset's own CRS (no ``epsg`` reprojection, no
+            antimeridian split, a north-up grid, ``touch=True``) it is cropped by
+            reading only that pixel window straight from the source, so a small crop
+            out of a very large or ``/vsicurl`` raster reads only the AOI instead of
+            the full source. Ineligible cases (a reprojecting bbox, a rotated grid)
+            fall back to the cutline warp, run all-touched so the result matches the
+            windowed path; ``touch=False`` keeps the entirely-inside cutline crop.
 
         Examples:
             - Crop the raster using a polygon mask.
@@ -2130,6 +2147,7 @@ class Spatial(_Engine["Dataset"]):
               ```
 
         """
+        bbox_mask = False
         if bbox is not None:
             if mask is not None:
                 raise ValueError("crop accepts either `mask` or `bbox`, not both")
@@ -2163,13 +2181,19 @@ class Spatial(_Engine["Dataset"]):
                 if windowed is not None:
                     return windowed
             mask = FeatureCollection.from_bbox(bbox, epsg=crs)
+            bbox_mask = True
         if mask is None:
             raise TypeError(
                 "crop requires a `mask` (GeoDataFrame / FeatureCollection / "
                 "Dataset) or a `bbox` (west, south, east, north) tuple"
             )
         if isinstance(mask, GeoDataFrame):
-            dst = self._crop_with_polygon_warp(mask, touch=touch)
+            # A bbox that fell through the fast path (reprojection / rotated grid) still
+            # crops by overlap, so its warp uses the all-touched cutline to match the fast
+            # path; a user-supplied polygon mask keeps GDAL's centre-containment default.
+            dst = self._crop_with_polygon_warp(
+                mask, touch=touch, cutline_all_touched=bbox_mask
+            )
         elif isinstance(mask, RasterBase):
             dst = self._crop_with_raster(mask)
         else:

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1664,7 +1664,8 @@ class Spatial(_Engine["Dataset"]):
             # (in pixel units) absorbs binary-float noise so an edge that is
             # mathematically on a pixel boundary does not flip floor/ceil by one pixel;
             # it is applied in the snap direction (floor edges up, ceil edges down) so
-            # it only removes noise, never a genuine fractional-pixel overlap.
+            # it drops nothing but noise-scale (< ~1e-9 px) overlaps, which are
+            # sub-nanometre at any realistic cell size.
             eps = 1e-9
             xoff = min(max(math.floor((west - x0) / dx + eps), 0), columns)
             x_far = min(max(math.ceil((east - x0) / dx - eps), 0), columns)

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1601,6 +1601,94 @@ class Spatial(_Engine["Dataset"]):
                     window = (west, south, east, north)
         return window
 
+    def _crop_bbox_windowed(
+        self,
+        bbox: tuple[float, float, float, float] | list[float],
+        crs: Any,
+    ) -> Dataset | None:
+        """Crop an axis-aligned bbox by reading only its pixel window.
+
+        The default bbox crop wraps the box in a one-row cutline and runs
+        ``gdal.Warp``; over a huge or ``/vsicurl`` source that is far heavier than
+        a plain windowed read (#957). When the crop needs neither reprojection nor
+        antimeridian handling, this reads just the AOI window straight from the
+        source and rebuilds the geotransform, so a small crop out of a very large
+        remote raster never triggers a full read.
+
+        The result is byte-identical to the cutline-warp path: for an axis-aligned
+        box in the source CRS the cells the box touches are exactly
+        ``floor``/``ceil`` of the box edges in pixel space — the same window the
+        warp keeps — and the windowed read is passed through the identical
+        :meth:`_correct_wrap_cutline_error` trim, so an all-no-data crop raises the
+        same "no valid pixels" error and interior all-no-data rows/cols drop the
+        same way.
+
+        Eligibility (returns ``None`` to fall back to the warp path otherwise):
+
+        - the source is north-up (no rotation/shear, ``dx > 0``, ``dy < 0``);
+        - the bbox CRS equals the source CRS, so no reprojection is needed;
+        - the box is a normal ``west < east``, ``south < north`` quadruple that
+          overlaps the source (a transposed or non-overlapping box is left to the
+          warp path, which reports it with a clear error).
+
+        Args:
+            bbox (tuple[float, float, float, float] | list[float]):
+                ``(west, south, east, north)`` in the CRS named by ``crs``.
+            crs (Any):
+                CRS of ``bbox`` — anything :func:`crs_equal` accepts (EPSG code,
+                WKT/authority string).
+
+        Returns:
+            Dataset | None:
+                The windowed crop, or ``None`` when the fast path does not apply.
+        """
+        x0, dx, row_skew, y0, col_skew, dy = self._ds._raster.GetGeoTransform()
+        if row_skew or col_skew or dx <= 0 or dy >= 0:
+            return None
+        source_crs = self._ds.crs
+        if not source_crs or not crs_equal(source_crs, crs):
+            return None
+        west, south, east, north = (float(v) for v in bbox)
+        if not (west < east and south < north):
+            return None
+        columns, rows = self._ds.columns, self._ds.rows
+        # Cells whose extent intersects the box (touch semantics), snapped outward
+        # to whole pixels, then clipped to the source grid.
+        xoff = min(max(math.floor((west - x0) / dx), 0), columns)
+        x_far = min(max(math.ceil((east - x0) / dx), 0), columns)
+        yoff = min(max(math.floor((y0 - north) / -dy), 0), rows)
+        y_far = min(max(math.ceil((y0 - south) / -dy), 0), rows)
+        x_size, y_size = x_far - xoff, y_far - yoff
+        if x_size <= 0 or y_size <= 0:
+            return None
+        array = self._ds.read_array(window=[xoff, yoff, x_size, y_size])
+        new_gt = (x0 + xoff * dx, dx, 0.0, y0 + yoff * dy, 0.0, dy)
+        # Rebuild on the base Dataset class (never a subclass like NetCDF), whose
+        # create_from_array has the plain array->raster behaviour this path needs;
+        # mirrors _crop_with_polygon_warp's base-class walk.
+        base_cls = cast(
+            "type[Dataset]",
+            next(
+                c
+                for c in self._ds.__class__.__mro__
+                if RasterBase in getattr(c, "__bases__", ())
+            ),
+        )
+        dst = cast(
+            "Dataset",
+            base_cls.create_from_array(
+                array, geo=new_gt, no_data_value=self._ds.no_data_value
+            ),
+        )
+        # Preserve the source CRS from its WKT so _correct_wrap_cutline_error carries
+        # it onto the trimmed result (and a custom CRS with no EPSG code survives).
+        if source_crs:
+            dst.crs = source_crs
+        # Same trim the warp path applies with touch=True: drop all-no-data rows/cols
+        # and raise "no valid pixels" when the whole window is no-data. The read above
+        # already covered only the AOI window, so this stays off the full source.
+        return Spatial._correct_wrap_cutline_error(dst)
+
     def _crop_with_polygon_warp(
         self, feature: FeatureCollection | GeoDataFrame, touch: bool = True
     ) -> Dataset:
@@ -2056,6 +2144,14 @@ class Spatial(_Engine["Dataset"]):
                 bbox_4 = cast(tuple[float, float, float, float], tuple(bbox))
                 _require_antimeridian_seam(self._ds, bbox_4)
                 return self._crop_antimeridian(bbox_4, crs, touch)
+            # Fast path: an axis-aligned box in the source CRS is just a window, so
+            # read only that window instead of warping a cutline over the whole
+            # source (#957). Falls through to the warp path when it does not apply
+            # (reprojection, a rotated grid, or a degenerate/off-grid box).
+            if touch:
+                windowed = self._crop_bbox_windowed(bbox, crs)
+                if windowed is not None:
+                    return windowed
             mask = FeatureCollection.from_bbox(bbox, epsg=crs)
         if mask is None:
             raise TypeError(

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1645,52 +1645,61 @@ class Spatial(_Engine["Dataset"]):
             Dataset | None:
                 The windowed crop, or ``None`` when the fast path does not apply.
         """
+        result: Dataset | None = None
         x0, dx, row_skew, y0, col_skew, dy = self._ds._raster.GetGeoTransform()
-        if row_skew or col_skew or dx <= 0 or dy >= 0:
-            return None
+        north_up = not row_skew and not col_skew and dx > 0 and dy < 0
         source_crs = self._ds.crs
-        if not source_crs or not crs_equal(source_crs, crs):
-            return None
         west, south, east, north = (float(v) for v in bbox)
-        if not (west < east and south < north):
-            return None
-        columns, rows = self._ds.columns, self._ds.rows
-        # Cells whose extent intersects the box (touch semantics), snapped outward
-        # to whole pixels, then clipped to the source grid.
-        xoff = min(max(math.floor((west - x0) / dx), 0), columns)
-        x_far = min(max(math.ceil((east - x0) / dx), 0), columns)
-        yoff = min(max(math.floor((y0 - north) / -dy), 0), rows)
-        y_far = min(max(math.ceil((y0 - south) / -dy), 0), rows)
-        x_size, y_size = x_far - xoff, y_far - yoff
-        if x_size <= 0 or y_size <= 0:
-            return None
-        array = self._ds.read_array(window=[xoff, yoff, x_size, y_size])
-        new_gt = (x0 + xoff * dx, dx, 0.0, y0 + yoff * dy, 0.0, dy)
-        # Rebuild on the base Dataset class (never a subclass like NetCDF), whose
-        # create_from_array has the plain array->raster behaviour this path needs;
-        # mirrors _crop_with_polygon_warp's base-class walk.
-        base_cls = cast(
-            "type[Dataset]",
-            next(
-                c
-                for c in self._ds.__class__.__mro__
-                if RasterBase in getattr(c, "__bases__", ())
-            ),
+        eligible = (
+            north_up
+            and bool(source_crs)
+            and crs_equal(source_crs, crs)
+            and west < east
+            and south < north
         )
-        dst = cast(
-            "Dataset",
-            base_cls.create_from_array(
-                array, geo=new_gt, no_data_value=self._ds.no_data_value
-            ),
-        )
-        # Preserve the source CRS from its WKT so _correct_wrap_cutline_error carries
-        # it onto the trimmed result (and a custom CRS with no EPSG code survives).
-        if source_crs:
-            dst.crs = source_crs
-        # Same trim the warp path applies with touch=True: drop all-no-data rows/cols
-        # and raise "no valid pixels" when the whole window is no-data. The read above
-        # already covered only the AOI window, so this stays off the full source.
-        return Spatial._correct_wrap_cutline_error(dst)
+        if eligible:
+            columns, rows = self._ds.columns, self._ds.rows
+            # Cells whose extent intersects the box (overlap / all-touched), snapped
+            # outward to whole pixels, then clipped to the source grid. A tiny epsilon
+            # (in pixel units) absorbs binary-float noise so an edge that is
+            # mathematically on a pixel boundary does not flip floor/ceil by one pixel;
+            # it is applied in the snap direction (floor edges up, ceil edges down) so
+            # it only removes noise, never a genuine fractional-pixel overlap.
+            eps = 1e-9
+            xoff = min(max(math.floor((west - x0) / dx + eps), 0), columns)
+            x_far = min(max(math.ceil((east - x0) / dx - eps), 0), columns)
+            yoff = min(max(math.floor((y0 - north) / -dy + eps), 0), rows)
+            y_far = min(max(math.ceil((y0 - south) / -dy - eps), 0), rows)
+            x_size, y_size = x_far - xoff, y_far - yoff
+            if x_size > 0 and y_size > 0:
+                array = self._ds.read_array(window=[xoff, yoff, x_size, y_size])
+                new_gt = (x0 + xoff * dx, dx, 0.0, y0 + yoff * dy, 0.0, dy)
+                # Rebuild on the base Dataset class (never a subclass like NetCDF),
+                # whose create_from_array has the plain array->raster behaviour this
+                # path needs; mirrors _crop_with_polygon_warp's base-class walk.
+                base_cls = cast(
+                    "type[Dataset]",
+                    next(
+                        c
+                        for c in self._ds.__class__.__mro__
+                        if RasterBase in getattr(c, "__bases__", ())
+                    ),
+                )
+                dst = cast(
+                    "Dataset",
+                    base_cls.create_from_array(
+                        array, geo=new_gt, no_data_value=self._ds.no_data_value
+                    ),
+                )
+                # Preserve the source CRS from its WKT so _correct_wrap_cutline_error
+                # carries it onto the trimmed result (a custom CRS with no EPSG survives).
+                dst.crs = source_crs
+                # Same trim the warp path applies with touch=True: drop all-no-data
+                # rows/cols and raise "no valid pixels" when the whole window is
+                # no-data. The read above covered only the AOI, so this stays off the
+                # full source.
+                result = Spatial._correct_wrap_cutline_error(dst)
+        return result
 
     def _crop_with_polygon_warp(
         self,

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1771,7 +1771,9 @@ class Spatial(_Engine["Dataset"]):
                 xRes=abs(gt[1]) if gt else None,
                 yRes=abs(gt[5]) if gt else None,
                 warpOptions=(
-                    ["CUTLINE_ALL_TOUCHED=TRUE"] if touch and cutline_all_touched else None
+                    ["CUTLINE_ALL_TOUCHED=TRUE"]
+                    if touch and cutline_all_touched
+                    else None
                 ),
             )
             # base_cls is a dynamic MRO walk that always resolves to Dataset itself

--- a/tests/base/test_remote.py
+++ b/tests/base/test_remote.py
@@ -522,7 +522,12 @@ class TestHttpCogRead:
         """
         from pyramids.dataset import Dataset
 
-        bbox = (0.1, -0.11, 0.15, -0.06)  # cols 100:150, rows 60:110 -> window [100,60,50,50]
+        bbox = (
+            0.1,
+            -0.11,
+            0.15,
+            -0.06,
+        )  # cols 100:150, rows 60:110 -> window [100,60,50,50]
         remote_ds = Dataset.read_file(f"{http_server}/valid.tif")
         spy = mocker.spy(Dataset, "read_array")
         remote = remote_ds.crop(bbox=bbox)

--- a/tests/base/test_remote.py
+++ b/tests/base/test_remote.py
@@ -509,6 +509,29 @@ class TestHttpCogRead:
         expected = np.arange(256 * 256, dtype=np.float32).reshape(256, 256)
         assert np.array_equal(arr, expected)
 
+    def test_windowed_bbox_crop_over_http_matches_local(self, http_server, http_cog_dir):
+        """#957: a windowed bbox crop over /vsicurl equals the same crop of the local file.
+
+        The 256x256 COG spans x in [0, 0.256], y in [-0.256, 0] at 0.001 deg cells.
+        Cropping a small sub-bbox straight from the /vsicurl URL must return the same
+        shape, geotransform and pixels as cropping the local file — proving the
+        windowed crop reads the AOI correctly over a range-read URL, not just locally.
+        """
+        from pyramids.dataset import Dataset
+
+        bbox = (0.1, -0.11, 0.15, -0.06)  # cols 100:150, rows 60:110
+        remote = Dataset.read_file(f"{http_server}/valid.tif").crop(bbox=bbox)
+        local = Dataset.read_file(str(http_cog_dir / "valid.tif")).crop(bbox=bbox)
+        assert remote.shape == local.shape, (
+            f"remote crop shape {remote.shape} != local {local.shape}"
+        )
+        assert remote.geotransform == local.geotransform, (
+            "remote crop geotransform differs from the local crop"
+        )
+        assert np.array_equal(remote.read_array(), local.read_array()), (
+            "remote crop pixels differ from the local crop"
+        )
+
     def test_read_plain_gtiff_over_http_may_require_range(self, http_server):
         """Plain (stripped) GTiff needs byte-range requests.
 

--- a/tests/base/test_remote.py
+++ b/tests/base/test_remote.py
@@ -509,18 +509,32 @@ class TestHttpCogRead:
         expected = np.arange(256 * 256, dtype=np.float32).reshape(256, 256)
         assert np.array_equal(arr, expected)
 
-    def test_windowed_bbox_crop_over_http_matches_local(self, http_server, http_cog_dir):
-        """#957: a windowed bbox crop over /vsicurl equals the same crop of the local file.
+    def test_windowed_bbox_crop_over_http_matches_local(
+        self, http_server, http_cog_dir, mocker
+    ):
+        """#957: a windowed bbox crop over /vsicurl reads only the AOI and equals the local crop.
 
         The 256x256 COG spans x in [0, 0.256], y in [-0.256, 0] at 0.001 deg cells.
-        Cropping a small sub-bbox straight from the /vsicurl URL must return the same
-        shape, geotransform and pixels as cropping the local file — proving the
-        windowed crop reads the AOI correctly over a range-read URL, not just locally.
+        Cropping a small sub-bbox straight from the /vsicurl URL must (a) read the remote
+        source with just the AOI pixel window (never a full-source read — that is what makes
+        a range-read URL fetch only the AOI) and (b) return the same shape, geotransform and
+        pixels as cropping the local file.
         """
         from pyramids.dataset import Dataset
 
-        bbox = (0.1, -0.11, 0.15, -0.06)  # cols 100:150, rows 60:110
-        remote = Dataset.read_file(f"{http_server}/valid.tif").crop(bbox=bbox)
+        bbox = (0.1, -0.11, 0.15, -0.06)  # cols 100:150, rows 60:110 -> window [100,60,50,50]
+        remote_ds = Dataset.read_file(f"{http_server}/valid.tif")
+        spy = mocker.spy(Dataset, "read_array")
+        remote = remote_ds.crop(bbox=bbox)
+        source_windows = [
+            kw.get("window", (a[1] if len(a) > 1 else None))
+            for a, kw in spy.call_args_list
+            if a and a[0] is remote_ds
+        ]
+        assert source_windows == [[100, 60, 50, 50]], (
+            f"remote source must be read once, windowed to the AOI; saw {source_windows}"
+        )
+
         local = Dataset.read_file(str(http_cog_dir / "valid.tif")).crop(bbox=bbox)
         assert remote.shape == local.shape, (
             f"remote crop shape {remote.shape} != local {local.shape}"

--- a/tests/dataset/spatial/test_bbox_crop_read_array.py
+++ b/tests/dataset/spatial/test_bbox_crop_read_array.py
@@ -105,6 +105,31 @@ def _bbox_in_3857(
     return (w3, s3, e3, n3)
 
 
+def _ds_multiband() -> Dataset:
+    """A 3-band 10x10 square-pixel EPSG:4326 raster."""
+    return Dataset.create_from_array(
+        np.arange(3 * 10 * 10, dtype="int16").reshape(3, 10, 10),
+        top_left_corner=(0.0, 0.0), cell_size=0.05, epsg=4326,
+    )
+
+
+def _ds_non_square() -> Dataset:
+    """A 10x10 raster with 0.1 deg columns and 0.05 deg rows (dx != -dy)."""
+    return Dataset.create_from_array(
+        np.arange(100, dtype="int16").reshape(10, 10),
+        geo=(0.0, 0.1, 0.0, 0.0, 0.0, -0.05), epsg=4326,
+    )
+
+
+def _ds_nodata_edge() -> Dataset:
+    """A raster with a full no-data row at index 3 (an all-no-data edge to trim)."""
+    arr = np.arange(100, dtype="float32").reshape(10, 10)
+    arr[3, :] = -9999.0
+    return Dataset.create_from_array(
+        arr, top_left_corner=(0.0, 0.0), cell_size=0.05, epsg=4326, no_data_value=-9999.0
+    )
+
+
 class TestDatasetCropBbox:
     """Tests for ``Dataset.crop(bbox=..., epsg=...)``."""
 
@@ -436,6 +461,38 @@ class TestWindowedBboxCropFastPath:
         assert np.array_equal(fast.read_array(), warp.read_array()), (
             f"pixels differ for {bbox}"
         )
+
+    @pytest.mark.parametrize(
+        "make_ds, bbox",
+        [
+            (_ds_multiband, (0.11, -0.19, 0.19, -0.11)),  # multi-band, non-aligned
+            (_ds_non_square, (0.15, -0.28, 0.63, -0.07)),  # non-square pixels, non-aligned
+            (_ds_multiband, (0.1, -0.2, 0.2, -0.1)),  # boundary-aligned
+            (_ds_nodata_edge, (0.1, -0.35, 0.3, -0.1)),  # AOI spans the all-no-data row 3
+        ],
+        ids=["multi-band", "non-square", "boundary-aligned", "no-data-edge"],
+    )
+    def test_fast_path_matches_warp_across_dataset_shapes(self, make_ds, bbox, mocker):
+        """Fast path == all-touched warp fallback for multi-band, non-square, aligned and no-data-edge crops.
+
+        Test scenario:
+            Beyond the single-band square case, the fast path and the all-touched warp
+            fallback must still agree in shape, geotransform and pixels for a multi-band
+            raster, a non-square-pixel grid, a pixel-boundary-aligned box, and a box whose
+            AOI contains an all-no-data row that both paths trim identically.
+        """
+        ds = make_ds()
+        fast = ds.crop(bbox=bbox)
+        mocker.patch(
+            "pyramids.dataset.engines.spatial.Spatial._crop_bbox_windowed",
+            return_value=None,
+        )
+        warp = make_ds().crop(bbox=bbox)
+        assert fast.shape == warp.shape, (
+            f"shape differs: fast={fast.shape}, warp={warp.shape}"
+        )
+        assert fast.geotransform == warp.geotransform, "geotransform differs"
+        assert np.array_equal(fast.read_array(), warp.read_array()), "pixels differ"
 
     def test_overlap_semantics_keep_every_touched_pixel(self, dataset):
         """A box straddling pixel boundaries keeps every pixel it overlaps (floor/ceil).

--- a/tests/dataset/spatial/test_bbox_crop_read_array.py
+++ b/tests/dataset/spatial/test_bbox_crop_read_array.py
@@ -381,6 +381,93 @@ class TestWindowedBboxCropFastPath:
             "a rotated grid must fall back to the warp path"
         )
 
+    @pytest.mark.parametrize(
+        "geo",
+        [
+            (0.0, 0.05, 0.0, -0.5, 0.0, 0.05),  # south-up: dy > 0
+            (0.5, -0.05, 0.0, 0.0, 0.0, -0.05),  # flipped x: dx < 0
+        ],
+        ids=["south-up", "negative-dx"],
+    )
+    def test_flipped_grid_skips_the_fast_path(self, geo):
+        """A south-up (`dy > 0`) or negative-`dx` grid is not eligible for the fast path.
+
+        Test scenario:
+            ``_crop_bbox_windowed`` must return ``None`` for a non-north-up grid so the
+            crop falls back to the warp path, which orients the axes correctly.
+        """
+        ds = Dataset.create_from_array(
+            np.arange(100, dtype="int16").reshape(10, 10), geo=geo, epsg=4326
+        )
+        assert ds.spatial._crop_bbox_windowed((0.1, -0.2, 0.2, -0.1), 4326) is None, (
+            "a flipped/non-north-up grid must fall back to the warp path"
+        )
+
+    @pytest.mark.parametrize(
+        "bbox",
+        [
+            (0.125, -0.375, 0.375, -0.125),  # edges on pixel centres, not boundaries
+            (0.11, -0.19, 0.19, -0.11),  # arbitrary sub-pixel edges
+            (0.13, -0.14, 0.14, -0.13),  # tiny box covering no pixel centre
+            (0.07, -0.33, 0.28, -0.02),  # wider, off-grid on every side
+        ],
+    )
+    def test_fast_path_matches_the_all_touched_warp_fallback(self, dataset, bbox, mocker):
+        """The windowed fast path returns the same crop as the all-touched warp fallback.
+
+        Test scenario:
+            For non-pixel-aligned boxes, compute the crop via the fast path, then patch
+            ``_crop_bbox_windowed`` to ``None`` so the same bbox crop takes the
+            (all-touched) warp fallback; the two must agree in shape, geotransform and
+            pixels. This pins the overlap-semantics equivalence the fast path relies on.
+        """
+        fast = dataset.crop(bbox=bbox)
+        mocker.patch(
+            "pyramids.dataset.engines.spatial.Spatial._crop_bbox_windowed",
+            return_value=None,
+        )
+        warp = dataset.crop(bbox=bbox)
+        assert fast.shape == warp.shape, (
+            f"shape differs for {bbox}: fast={fast.shape}, warp={warp.shape}"
+        )
+        assert fast.geotransform == warp.geotransform, (
+            f"geotransform differs for {bbox}"
+        )
+        assert np.array_equal(fast.read_array(), warp.read_array()), (
+            f"pixels differ for {bbox}"
+        )
+
+    def test_overlap_semantics_keep_every_touched_pixel(self, dataset):
+        """A box straddling pixel boundaries keeps every pixel it overlaps (floor/ceil).
+
+        Test scenario:
+            ``bbox=(0.125,-0.375,0.375,-0.125)`` on the 0.05 deg grid spans cols 2..7 and
+            rows 2..7, so the crop is 6x6 with its origin at the box's floored top-left —
+            the documented all-touched overlap result, wider than a centre-containment crop.
+        """
+        out = dataset.crop(bbox=(0.125, -0.375, 0.375, -0.125))
+        assert out.shape == (1, 6, 6), f"expected 6x6 overlap crop, got {out.shape}"
+        assert out.geotransform[0] == pytest.approx(0.10), "origin x must be the floored west edge"
+        assert out.geotransform[3] == pytest.approx(-0.10), "origin y must be the floored north edge"
+
+    def test_no_nodata_raster_crops_to_the_tight_overlap_window(self):
+        """A raster with no no-data marker crops to the tight AOI, not an untrimmable border.
+
+        Test scenario:
+            With ``no_data_value=None`` the warp path leaves a border it cannot trim, but
+            the fast path reads exactly the overlap window; an aligned 2x2 bbox must return
+            a 2x2 crop.
+        """
+        ds = Dataset.create_from_array(
+            np.arange(100, dtype="int16").reshape(10, 10),
+            top_left_corner=(0.0, 0.0),
+            cell_size=0.05,
+            epsg=4326,
+            no_data_value=None,
+        )
+        out = ds.crop(bbox=(0.1, -0.2, 0.2, -0.1))
+        assert out.shape == (1, 2, 2), f"expected tight 2x2 crop, got {out.shape}"
+
 
 class TestAntimeridianCrop:
     """Tests for crop with a geographic ``west > east`` (antimeridian) bbox."""

--- a/tests/dataset/spatial/test_bbox_crop_read_array.py
+++ b/tests/dataset/spatial/test_bbox_crop_read_array.py
@@ -109,7 +109,9 @@ def _ds_multiband() -> Dataset:
     """A 3-band 10x10 square-pixel EPSG:4326 raster."""
     return Dataset.create_from_array(
         np.arange(3 * 10 * 10, dtype="int16").reshape(3, 10, 10),
-        top_left_corner=(0.0, 0.0), cell_size=0.05, epsg=4326,
+        top_left_corner=(0.0, 0.0),
+        cell_size=0.05,
+        epsg=4326,
     )
 
 
@@ -117,7 +119,8 @@ def _ds_non_square() -> Dataset:
     """A 10x10 raster with 0.1 deg columns and 0.05 deg rows (dx != -dy)."""
     return Dataset.create_from_array(
         np.arange(100, dtype="int16").reshape(10, 10),
-        geo=(0.0, 0.1, 0.0, 0.0, 0.0, -0.05), epsg=4326,
+        geo=(0.0, 0.1, 0.0, 0.0, 0.0, -0.05),
+        epsg=4326,
     )
 
 
@@ -126,7 +129,11 @@ def _ds_nodata_edge() -> Dataset:
     arr = np.arange(100, dtype="float32").reshape(10, 10)
     arr[3, :] = -9999.0
     return Dataset.create_from_array(
-        arr, top_left_corner=(0.0, 0.0), cell_size=0.05, epsg=4326, no_data_value=-9999.0
+        arr,
+        top_left_corner=(0.0, 0.0),
+        cell_size=0.05,
+        epsg=4326,
+        no_data_value=-9999.0,
     )
 
 
@@ -293,7 +300,9 @@ class TestDatasetCropBbox:
 class TestWindowedBboxCropFastPath:
     """#957: an axis-aligned same-CRS bbox crop reads only its window, not the whole source."""
 
-    def test_windowed_crop_avoids_the_full_source_warp(self, dataset, small_bbox, mocker):
+    def test_windowed_crop_avoids_the_full_source_warp(
+        self, dataset, small_bbox, mocker
+    ):
         """A same-CRS bbox crop never calls the cutline warp.
 
         Test scenario:
@@ -373,9 +382,9 @@ class TestWindowedBboxCropFastPath:
             :meth:`FeatureCollection.from_bbox`, which raises the clear
             ``west < east`` validation error rather than reading a negative window.
         """
-        assert dataset.spatial._crop_bbox_windowed((0.2, -0.1, 0.1, -0.2), 4326) is None, (
-            "a transposed bbox must fall back to the warp/validation path"
-        )
+        assert (
+            dataset.spatial._crop_bbox_windowed((0.2, -0.1, 0.1, -0.2), 4326) is None
+        ), "a transposed bbox must fall back to the warp/validation path"
 
     def test_bbox_outside_source_skips_the_fast_path(self, dataset):
         """A box that does not overlap the source is not eligible for the fast path.
@@ -385,9 +394,9 @@ class TestWindowedBboxCropFastPath:
             ``_crop_bbox_windowed`` must return ``None`` so the warp path reports the
             non-overlap with its usual error instead of building an empty array.
         """
-        assert dataset.spatial._crop_bbox_windowed((1.0, -0.2, 1.1, -0.1), 4326) is None, (
-            "a non-overlapping bbox must fall back to the warp path"
-        )
+        assert (
+            dataset.spatial._crop_bbox_windowed((1.0, -0.2, 1.1, -0.1), 4326) is None
+        ), "a non-overlapping bbox must fall back to the warp path"
 
     def test_rotated_grid_skips_the_fast_path(self, tmp_path):
         """A rotated (non-north-up) geotransform is not eligible for the fast path.
@@ -437,7 +446,9 @@ class TestWindowedBboxCropFastPath:
             (0.07, -0.33, 0.28, -0.02),  # wider, off-grid on every side
         ],
     )
-    def test_fast_path_matches_the_all_touched_warp_fallback(self, dataset, bbox, mocker):
+    def test_fast_path_matches_the_all_touched_warp_fallback(
+        self, dataset, bbox, mocker
+    ):
         """The windowed fast path returns the same crop as the all-touched warp fallback.
 
         Test scenario:
@@ -466,9 +477,15 @@ class TestWindowedBboxCropFastPath:
         "make_ds, bbox",
         [
             (_ds_multiband, (0.11, -0.19, 0.19, -0.11)),  # multi-band, non-aligned
-            (_ds_non_square, (0.15, -0.28, 0.63, -0.07)),  # non-square pixels, non-aligned
+            (
+                _ds_non_square,
+                (0.15, -0.28, 0.63, -0.07),
+            ),  # non-square pixels, non-aligned
             (_ds_multiband, (0.1, -0.2, 0.2, -0.1)),  # boundary-aligned
-            (_ds_nodata_edge, (0.1, -0.35, 0.3, -0.1)),  # AOI spans the all-no-data row 3
+            (
+                _ds_nodata_edge,
+                (0.1, -0.35, 0.3, -0.1),
+            ),  # AOI spans the all-no-data row 3
         ],
         ids=["multi-band", "non-square", "boundary-aligned", "no-data-edge"],
     )
@@ -504,8 +521,12 @@ class TestWindowedBboxCropFastPath:
         """
         out = dataset.crop(bbox=(0.125, -0.375, 0.375, -0.125))
         assert out.shape == (1, 6, 6), f"expected 6x6 overlap crop, got {out.shape}"
-        assert out.geotransform[0] == pytest.approx(0.10), "origin x must be the floored west edge"
-        assert out.geotransform[3] == pytest.approx(-0.10), "origin y must be the floored north edge"
+        assert out.geotransform[0] == pytest.approx(0.10), (
+            "origin x must be the floored west edge"
+        )
+        assert out.geotransform[3] == pytest.approx(-0.10), (
+            "origin y must be the floored north edge"
+        )
 
     def test_no_nodata_raster_crops_to_the_tight_overlap_window(self):
         """A raster with no no-data marker crops to the tight AOI, not an untrimmable border.

--- a/tests/dataset/spatial/test_bbox_crop_read_array.py
+++ b/tests/dataset/spatial/test_bbox_crop_read_array.py
@@ -339,6 +339,31 @@ class TestWindowedBboxCropFastPath:
             "a different-CRS bbox must fall back to the warp path"
         )
 
+    def test_transposed_same_crs_bbox_skips_the_fast_path(self, dataset):
+        """A transposed (west >= east) box in the source CRS is not eligible.
+
+        Test scenario:
+            ``_crop_bbox_windowed`` must return ``None`` for a ``west > east``,
+            ``south > north`` box so ``crop`` falls through to
+            :meth:`FeatureCollection.from_bbox`, which raises the clear
+            ``west < east`` validation error rather than reading a negative window.
+        """
+        assert dataset.spatial._crop_bbox_windowed((0.2, -0.1, 0.1, -0.2), 4326) is None, (
+            "a transposed bbox must fall back to the warp/validation path"
+        )
+
+    def test_bbox_outside_source_skips_the_fast_path(self, dataset):
+        """A box that does not overlap the source is not eligible for the fast path.
+
+        Test scenario:
+            A bbox entirely east of the 10×10 fixture clips to a zero-width window;
+            ``_crop_bbox_windowed`` must return ``None`` so the warp path reports the
+            non-overlap with its usual error instead of building an empty array.
+        """
+        assert dataset.spatial._crop_bbox_windowed((1.0, -0.2, 1.1, -0.1), 4326) is None, (
+            "a non-overlapping bbox must fall back to the warp path"
+        )
+
     def test_rotated_grid_skips_the_fast_path(self, tmp_path):
         """A rotated (non-north-up) geotransform is not eligible for the fast path.
 

--- a/tests/dataset/spatial/test_bbox_crop_read_array.py
+++ b/tests/dataset/spatial/test_bbox_crop_read_array.py
@@ -265,6 +265,98 @@ class TestDatasetCropBbox:
             ds.crop(bbox=(6.0, 0.0, 9.0, 4.0))  # bottom-right: all no-data
 
 
+class TestWindowedBboxCropFastPath:
+    """#957: an axis-aligned same-CRS bbox crop reads only its window, not the whole source."""
+
+    def test_windowed_crop_avoids_the_full_source_warp(self, dataset, small_bbox, mocker):
+        """A same-CRS bbox crop never calls the cutline warp.
+
+        Test scenario:
+            Patch ``warp_to_dataset`` to blow up if reached, then crop a bbox in the
+            dataset's own CRS — the windowed fast path must satisfy it without the
+            warp, proving no full-source warp is issued.
+        """
+        boom = mocker.patch(
+            "pyramids.dataset.engines.spatial.warp_to_dataset",
+            side_effect=AssertionError("warp path should not run for a same-CRS bbox"),
+        )
+        out = dataset.crop(bbox=small_bbox)
+        assert out.shape == (1, 2, 2), f"unexpected crop shape {out.shape}"
+        assert boom.call_count == 0, "the cutline warp was invoked for a same-CRS bbox"
+
+    def test_windowed_crop_reads_only_the_aoi_window(self, dataset, small_bbox, mocker):
+        """The crop issues a bounded windowed read of just the AOI, never a full read.
+
+        Test scenario:
+            Spy on ``Dataset.read_array``; the crop of a 2×2 bbox must read with the
+            resolved ``[xoff, yoff, xsize, ysize]`` window (here ``[2, 2, 2, 2]``) and
+            never a windowless (full-source) read. This bounded read is what makes a
+            ``/vsicurl`` crop range-read only the AOI.
+        """
+        spy = mocker.spy(Dataset, "read_array")
+        dataset.crop(bbox=small_bbox)
+        # Spying the unbound method, a[0] is the receiver: keep only reads of the
+        # source raster (later windowless reads land on the tiny derived crop, which
+        # is fine — the point is the *source* is never read in full).
+        source_windows = [
+            kw.get("window", (a[1] if len(a) > 1 else None))
+            for a, kw in spy.call_args_list
+            if a and a[0] is dataset
+        ]
+        assert source_windows == [[2, 2, 2, 2]], (
+            f"source must be read once, windowed to the AOI; saw {source_windows}"
+        )
+
+    def test_windowed_crop_matches_a_direct_windowed_read(self, dataset, small_bbox):
+        """The crop equals a hand-rolled ``read_array(window=)`` + geotransform.
+
+        Test scenario:
+            The old hand-rolled recipe (``read_array(window=[2, 2, 2, 2])`` plus origin
+            math) must equal ``crop(bbox=...)`` in both pixels and geotransform — the
+            exact consolidation #957 asks for.
+        """
+        cropped = dataset.crop(bbox=small_bbox)
+        gt = dataset.geotransform
+        window_array = dataset.read_array(window=[2, 2, 2, 2])
+        assert np.array_equal(cropped.read_array(), window_array), (
+            "crop pixels differ from the direct windowed read"
+        )
+        expected_gt = (gt[0] + 2 * gt[1], gt[1], 0.0, gt[3] + 2 * gt[5], 0.0, gt[5])
+        assert cropped.geotransform == expected_gt, (
+            f"crop geotransform {cropped.geotransform} != expected {expected_gt}"
+        )
+
+    def test_reprojecting_bbox_skips_the_fast_path(self, dataset, small_bbox):
+        """A bbox in a different CRS is not eligible for the windowed fast path.
+
+        Test scenario:
+            ``_crop_bbox_windowed`` must return ``None`` for a bbox declared in
+            EPSG:3857 on a 4326 dataset, so ``crop`` falls back to the reprojecting
+            warp path instead of reading a mis-projected window.
+        """
+        bbox_3857 = _bbox_in_3857(small_bbox)
+        assert dataset.spatial._crop_bbox_windowed(bbox_3857, 3857) is None, (
+            "a different-CRS bbox must fall back to the warp path"
+        )
+
+    def test_rotated_grid_skips_the_fast_path(self, tmp_path):
+        """A rotated (non-north-up) geotransform is not eligible for the fast path.
+
+        Test scenario:
+            Build a dataset whose geotransform carries a rotation term;
+            ``_crop_bbox_windowed`` must return ``None`` so the crop uses the warp
+            path, which handles the rotation correctly.
+        """
+        ds = Dataset.create_from_array(
+            np.arange(100, dtype="int16").reshape(10, 10),
+            geo=(0.0, 0.05, 0.01, 0.0, 0.0, -0.05),  # non-zero row-skew -> rotated
+            epsg=4326,
+        )
+        assert ds.spatial._crop_bbox_windowed((0.1, -0.2, 0.2, -0.1), 4326) is None, (
+            "a rotated grid must fall back to the warp path"
+        )
+
+
 class TestAntimeridianCrop:
     """Tests for crop with a geographic ``west > east`` (antimeridian) bbox."""
 


### PR DESCRIPTION
# Description

`Dataset.crop(bbox=...)` wrapped the box in a one-row cutline and ran `gdal.Warp` over the whole source. For a
very large or `/vsicurl`-backed raster that reads far more than the area of interest — or hangs over the
network — so every consumer wanting a small AOI out of a big remote raster had to hand-roll
`read_array(window=)` + origin math + a GeoTIFF write.

This adds a **windowed fast path** to `crop(bbox=)`. When the box is axis-aligned in the dataset's own CRS
(north-up grid, `touch=True`, no reprojection, no antimeridian split), the crop resolves the box to a pixel
window and reads **only that window** straight from the source (`read_array(window=...)`), rebuilds the
geotransform, and routes the result through the existing `_correct_wrap_cutline_error` trim. A small crop out
of a huge or remote raster therefore reads only the AOI instead of the full source. No new public API and no
new dependency.

### Semantics (behaviour note)

`crop(bbox=)` now consistently keeps **every pixel the box overlaps** (the same all-touched convention
`read_array(bbox=)` already uses), rather than GDAL's pixel-centre containment. For a box not aligned to pixel
edges this can be up to one pixel wider per side than before. To keep the two implementations consistent, the
bbox warp **fallback** (used for a reprojecting bbox or a rotated grid) now runs with `CUTLINE_ALL_TOUCHED`, so
it returns the same cells as the fast path; a user-supplied polygon `mask=` keeps GDAL's centre-containment
default. For pixel-aligned boxes (the common case) the result is unchanged.

# Issues

- Closes #957 — windowed crop-from-path/URL to avoid full reads of huge `/vsicurl` rasters

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Note: additive feature; the only behaviour change is the documented overlap-vs-centre-containment difference
for **non-pixel-aligned** bbox crops (pixel-aligned crops are unchanged).

# How Has This Been Tested?

- [x] `tests/dataset/spatial/test_bbox_crop_read_array.py::TestWindowedBboxCropFastPath` — fast path avoids the
  warp, reads only the AOI window, equals a hand-rolled `read_array(window=)`, and is byte-for-byte equal to the
  all-touched warp fallback across non-aligned / sub-pixel / tiny / multi-band / non-square-pixel /
  boundary-aligned / no-data-edge boxes; plus the reprojection / transposed / off-grid / rotated / south-up /
  negative-dx eligibility guards.
- [x] `tests/base/test_remote.py::TestHttpCogRead::test_windowed_bbox_crop_over_http_matches_local` — a real
  `/vsicurl` crop over a loopback HTTP COG reads only the AOI window (`[100, 60, 50, 50]`) and matches the local
  crop in shape / geotransform / pixels.
- [x] Broad regression sweep of the shared crop path: `tests/dataset/spatial/`, `tests/netcdf/spatial/`,
  `tests/netcdf/samples/`, `tests/ugrid/test_spatial.py`, `tests/base/test_remote.py` — all green
  (`-m "not e2e"`).
- [x] `mypy src/pyramids/dataset/engines/spatial.py` clean; `pytest --doctest-modules
  src/pyramids/dataset/engines/spatial.py` green.

Reproduce:

```bash
pixi run -e dev pytest tests/dataset/spatial/test_bbox_crop_read_array.py tests/netcdf/spatial -q
pixi run -e dev pytest tests/base/test_remote.py -q
```

# Checklist:

- [ ] updated version number in pyproject.toml. (handled by commitizen on release)
- [ ] added changes to History.rst. (changelog is commitizen-generated)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (crop `Note` + `_crop_bbox_windowed` / `_crop_with_polygon_warp` docstrings)
