### PR TITLE
ci(wheels): cache SHA-verified source distfiles + vcpkg assets on every build

### DIFF
--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -449,7 +449,7 @@ jobs:
         uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: C:\vcpkg\downloads
-          key: vcpkg-arm64-downloads-${{ hashFiles('ci/vcpkg.json') }}
+          key: vcpkg-arm64-downloads-${{ hashFiles('ci/vcpkg.json', 'ci/vcpkg-ports/**') }}
           restore-keys: vcpkg-arm64-downloads-
 
       - name: Build wheels
@@ -468,7 +468,7 @@ jobs:
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: C:\vcpkg\downloads
-          key: vcpkg-arm64-downloads-${{ hashFiles('ci/vcpkg.json') }}
+          key: vcpkg-arm64-downloads-${{ hashFiles('ci/vcpkg.json', 'ci/vcpkg-ports/**') }}
 
       - name: Report wheel sizes
         shell: bash

--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -141,6 +141,19 @@ jobs:
             srcbuild-glibc-${{ matrix.arch }}-${{
             hashFiles('ci/source-build/config.sh', 'ci/source-build/build-gdal-stack.sh') }}
 
+      # NOT gated off workflow_run (unlike the compiled-stack cache above):
+      # config.sh SHA256-verifies every tarball, so a cached distfile cannot
+      # poison a release wheel. Caching them on releases too stops the build
+      # re-downloading ~26 tarballs from ~30 hosts, where one 503/429 fails it.
+      # Arch-independent key: the tarballs are source, identical across arches
+      # and the glibc/musl jobs, so one download seeds all of them.
+      - name: Cache the source distfiles
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .srcbuild-distfiles
+          key: srcbuild-distfiles-${{ hashFiles('ci/source-build/config.sh') }}
+          restore-keys: srcbuild-distfiles-
+
       - name: Build wheels
         uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
         env:
@@ -213,6 +226,15 @@ jobs:
           key: >-
             srcbuild-musl-${{ matrix.arch }}-${{
             hashFiles('ci/source-build/config.sh', 'ci/source-build/build-gdal-stack.sh') }}
+
+      # Same SHA256-verified source-distfile cache as the glibc job, shared
+      # key so either job seeds it. Safe on releases (verified in fetch()).
+      - name: Cache the source distfiles
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .srcbuild-distfiles
+          key: srcbuild-distfiles-${{ hashFiles('ci/source-build/config.sh') }}
+          restore-keys: srcbuild-distfiles-
 
       - name: Build wheels
         uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
@@ -386,6 +408,20 @@ jobs:
           key: >-
             vcpkg-arm64-${{
             hashFiles('ci/vcpkg.json', 'ci/setup-gdal-from-vcpkg.ps1') }}
+
+      # vcpkg asset caching: persist the DOWNLOADED port distfiles (source
+      # tarballs + build tools), which vcpkg SHA512-verifies on every use, so
+      # a cached asset cannot poison a release wheel — unlike the built
+      # `installed` tree above. NOT gated off workflow_run: caching these on
+      # releases too stops the cold build re-fetching every port's source from
+      # its upstream (a 429/503/outage from any one — e.g. the DKRZ libaec host
+      # — fails the whole vcpkg install).
+      - name: Cache the vcpkg downloaded assets
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: C:\vcpkg\downloads
+          key: vcpkg-arm64-downloads-${{ hashFiles('ci/vcpkg.json') }}
+          restore-keys: vcpkg-arm64-downloads-
 
       - name: Build wheels
         uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0

--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -147,7 +147,12 @@ jobs:
       # poison a release wheel. Caching them on releases too stops the build
       # re-downloading ~26 tarballs from ~30 hosts, where one 503/429 fails it.
       # Arch-independent key: the tarballs are source, identical across arches
-      # and the glibc/musl jobs, so one download seeds all of them.
+      # and the glibc/musl jobs, so one download seeds all of them. The key
+      # hashes config.sh only, not build-gdal-stack.sh (where GDAL_VERSION is
+      # defaulted): safe because the GDAL tarball's SHA is pinned inline in
+      # config.sh, so any real bump rotates the key. If GDAL_VERSION ever
+      # becomes a workflow input decoupled from that pin, add build-gdal-stack.sh
+      # to the key.
       # Split restore/save (not the combined cache action): actions/cache saves
       # at post-job even when the build FAILED, and the four Linux jobs share
       # one write-once key — so a job aborting mid-fetch would otherwise seed the

--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -147,8 +147,15 @@ jobs:
       # re-downloading ~26 tarballs from ~30 hosts, where one 503/429 fails it.
       # Arch-independent key: the tarballs are source, identical across arches
       # and the glibc/musl jobs, so one download seeds all of them.
-      - name: Cache the source distfiles
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # Split restore/save (not the combined cache action): actions/cache saves
+      # at post-job even when the build FAILED, and the four Linux jobs share
+      # one write-once key — so a job aborting mid-fetch would otherwise seed the
+      # shared key with a partial tarball set that never self-heals. Restore
+      # before the build; save only on success (below), and only when the exact
+      # key was not already a hit (GHA cache keys are immutable).
+      - name: Restore the source distfiles cache
+        id: distfiles-restore
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .srcbuild-distfiles
           key: srcbuild-distfiles-${{ hashFiles('ci/source-build/config.sh') }}
@@ -163,6 +170,13 @@ jobs:
           # mount) — forward the runner workspace path it needs.
           HOST_WORKSPACE: ${{ github.workspace }}
           CIBW_ENVIRONMENT_PASS_LINUX: HOST_WORKSPACE
+
+      - name: Save the source distfiles cache
+        if: success() && steps.distfiles-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .srcbuild-distfiles
+          key: srcbuild-distfiles-${{ hashFiles('ci/source-build/config.sh') }}
 
       - name: Report wheel sizes
         shell: bash
@@ -227,10 +241,13 @@ jobs:
             srcbuild-musl-${{ matrix.arch }}-${{
             hashFiles('ci/source-build/config.sh', 'ci/source-build/build-gdal-stack.sh') }}
 
-      # Same SHA256-verified source-distfile cache as the glibc job, shared
-      # key so either job seeds it. Safe on releases (verified in fetch()).
-      - name: Cache the source distfiles
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # Same SHA256-verified source-distfile cache as the glibc job, shared key
+      # so either job seeds it. Split restore/save (see the glibc job) so a
+      # mid-fetch failure never locks the write-once shared key with a partial
+      # set. Safe on releases (verified in fetch()).
+      - name: Restore the source distfiles cache
+        id: distfiles-restore
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .srcbuild-distfiles
           key: srcbuild-distfiles-${{ hashFiles('ci/source-build/config.sh') }}
@@ -253,6 +270,13 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND: >-
             LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
             auditwheel repair --plat ${{ matrix.plat }} -w {dest_dir} {wheel}
+
+      - name: Save the source distfiles cache
+        if: success() && steps.distfiles-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .srcbuild-distfiles
+          key: srcbuild-distfiles-${{ hashFiles('ci/source-build/config.sh') }}
 
       - name: Report wheel sizes
         shell: bash
@@ -416,8 +440,13 @@ jobs:
       # releases too stops the cold build re-fetching every port's source from
       # its upstream (a 429/503/outage from any one — e.g. the DKRZ libaec host
       # — fails the whole vcpkg install).
-      - name: Cache the vcpkg downloaded assets
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      # Split restore/save (see the glibc job): actions/cache saves at post-job
+      # even on failure, so a winarm64 build aborting mid-fetch would otherwise
+      # seed the write-once key with a partial downloads set. Restore before the
+      # build; save only on success (below).
+      - name: Restore the vcpkg downloaded assets
+        id: vcpkg-downloads-restore
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: C:\vcpkg\downloads
           key: vcpkg-arm64-downloads-${{ hashFiles('ci/vcpkg.json') }}
@@ -433,6 +462,13 @@ jobs:
           # this list changes (e.g. adding cp315 or dropping cp311).
           CIBW_BUILD: "cp312-win_arm64 cp313-win_arm64 cp314-win_arm64"
           CIBW_BEFORE_ALL_WINDOWS: powershell -File ci/setup-gdal-from-vcpkg.ps1
+
+      - name: Save the vcpkg downloaded assets
+        if: success() && steps.vcpkg-downloads-restore.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: C:\vcpkg\downloads
+          key: vcpkg-arm64-downloads-${{ hashFiles('ci/vcpkg.json') }}
 
       - name: Report wheel sizes
         shell: bash

--- a/.github/workflows/bundle-pypi-wheels.yml
+++ b/.github/workflows/bundle-pypi-wheels.yml
@@ -133,6 +133,7 @@ jobs:
       # costs ~60 min once per release and compiles everything from the
       # SHA256-pinned source tarballs.
       - name: Cache the built GDAL stack
+        id: glibc-stack-cache
         if: github.event_name != 'workflow_run'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -171,8 +172,16 @@ jobs:
           HOST_WORKSPACE: ${{ github.workspace }}
           CIBW_ENVIRONMENT_PASS_LINUX: HOST_WORKSPACE
 
+      # Only save when the source build actually ran fetch() and populated the
+      # dir: on a compiled-stack cache HIT config.sh is skipped and
+      # .srcbuild-distfiles stays empty, so also gate on the stack cache having
+      # missed — else an empty/stale set would seed the immutable key. On the
+      # release path the stack cache step is skipped (its cache-hit output is
+      # '', != 'true'), so the distfile save stays active there as intended.
       - name: Save the source distfiles cache
-        if: success() && steps.distfiles-restore.outputs.cache-hit != 'true'
+        if: >-
+          success() && steps.distfiles-restore.outputs.cache-hit != 'true'
+          && steps.glibc-stack-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .srcbuild-distfiles
@@ -234,6 +243,7 @@ jobs:
       # needs + download pattern), so cache-restored binaries can't reach
       # PyPI from here.
       - name: Cache the built GDAL stack
+        id: musl-stack-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .srcbuild-cache
@@ -271,8 +281,13 @@ jobs:
             LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
             auditwheel repair --plat ${{ matrix.plat }} -w {dest_dir} {wheel}
 
+      # Gate on the stack cache having missed too — see the glibc job: a
+      # compiled-stack HIT skips config.sh, leaving .srcbuild-distfiles empty,
+      # which must not seed the immutable shared key.
       - name: Save the source distfiles cache
-        if: success() && steps.distfiles-restore.outputs.cache-hit != 'true'
+        if: >-
+          success() && steps.distfiles-restore.outputs.cache-hit != 'true'
+          && steps.musl-stack-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .srcbuild-distfiles
@@ -425,6 +440,7 @@ jobs:
       # cold-build from the pinned vcpkg snapshot instead of restoring
       # cache-stored binaries.
       - name: Cache the vcpkg-built GDAL stack
+        id: vcpkg-installed-cache
         if: github.event_name != 'workflow_run'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
@@ -463,8 +479,13 @@ jobs:
           CIBW_BUILD: "cp312-win_arm64 cp313-win_arm64 cp314-win_arm64"
           CIBW_BEFORE_ALL_WINDOWS: powershell -File ci/setup-gdal-from-vcpkg.ps1
 
+      # Gate on the installed cache having missed too — see the glibc job: an
+      # installed-tree HIT makes vcpkg download nothing, leaving
+      # C:\vcpkg\downloads empty, which must not seed the immutable key.
       - name: Save the vcpkg downloaded assets
-        if: success() && steps.vcpkg-downloads-restore.outputs.cache-hit != 'true'
+        if: >-
+          success() && steps.vcpkg-downloads-restore.outputs.cache-hit != 'true'
+          && steps.vcpkg-installed-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: C:\vcpkg\downloads

--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,9 @@ src/pyramids/_data/
 # to themselves); these are generated, not sources. Data lives in examples/data/.
 docs/examples/**/*.tif
 docs/examples/**/*.nc
+
+# Working dirs the from-source GDAL build persists into the runner workspace
+# via cibuildwheel's /host mount: the compiled-stack tar and the SHA-verified
+# source distfiles. Generated build caches, never sources.
+/.srcbuild-cache/
+/.srcbuild-distfiles/

--- a/ci/source-build/build-gdal-stack.sh
+++ b/ci/source-build/build-gdal-stack.sh
@@ -83,6 +83,20 @@ if [[ -d /host && -n "${HOST_WORKSPACE:-}" ]]; then
 else
     CACHE_DIR="${PROJECT_DIR}/.srcbuild-cache"
 fi
+# Source-distfile cache, kept SEPARATE from the compiled-stack cache above.
+# config.sh's fetch() SHA256-verifies every tarball, so a restored distfile
+# cannot poison a wheel (a mismatch aborts the build) — unlike the built
+# binaries. That lets the workflow cache these on the release (workflow_run)
+# path too, so a release stops re-downloading ~26 tarballs from ~30 upstream
+# hosts, where a single 503/429 from any one fails the build. fetch() reads
+# DISTFILES_DIR from the environment; export it for the `bash config.sh` child.
+if [[ -d /host && -n "${HOST_WORKSPACE:-}" ]]; then
+    DISTFILES_DIR="/host${HOST_WORKSPACE}/.srcbuild-distfiles"
+else
+    DISTFILES_DIR="${PROJECT_DIR}/.srcbuild-distfiles"
+fi
+mkdir -p "${DISTFILES_DIR}"
+export DISTFILES_DIR
 # Key on everything that shapes the installed prefix: config.sh (the dep
 # pins + build flags), this script (license collector, prereqs), and the
 # GDAL version, which is injected via the environment rather than

--- a/ci/source-build/config.sh
+++ b/ci/source-build/config.sh
@@ -180,9 +180,13 @@ fetch() {
         echo "       actual   ${actual}" >&2
         exit 1
     fi
-    # Persist a freshly-downloaded, verified tarball so later builds (releases
-    # included) reuse it instead of re-downloading.
-    if [[ -n "${cached}" && ! -f "${cached}" ]]; then
+    # Persist the just-verified tarball so later builds (releases included)
+    # reuse it. Refresh unconditionally, not only when absent: a cached file
+    # whose SHA no longer matches the pin (upstream re-upload, mirror swap,
+    # corrected pin, or a partial write) fell through to the wget branch above
+    # and is now verified here — overwrite the stale copy so it self-heals
+    # instead of re-downloading from a flaky host forever.
+    if [[ -n "${cached}" ]]; then
         cp "${tarball}" "${cached}"
     fi
     case "${tarball}" in

--- a/ci/source-build/config.sh
+++ b/ci/source-build/config.sh
@@ -162,8 +162,9 @@ fetch() {
     # ${DISTFILES_DIR} is set by build-gdal-stack.sh (empty otherwise -> the
     # cache is skipped and this behaves exactly as the old download-only path).
     local cached="${DISTFILES_DIR:+${DISTFILES_DIR}/${tarball}}"
-    if [[ -n "${cached}" && -f "${cached}" \
-        && "$(sha256sum "${cached}" | cut -d ' ' -f1)" == "${SHA256[$dep]}" ]]; then
+    local cached_sha=""
+    [[ -n "${cached}" && -f "${cached}" ]] && cached_sha="$(sha256sum "${cached}" | cut -d ' ' -f1)"
+    if [[ "${cached_sha}" == "${SHA256[$dep]}" ]]; then
         echo "using cached ${tarball} from ${DISTFILES_DIR}"
         cp "${cached}" "${tarball}"
     else

--- a/ci/source-build/config.sh
+++ b/ci/source-build/config.sh
@@ -154,12 +154,23 @@ BUILD_ORDER=(
 #     /download suffix and the explicit local file name.
 
 fetch() {
-    # fetch <dep>: download the pinned tarball, verify its SHA256, extract.
+    # fetch <dep>: reuse a SHA-matching cached tarball if one exists, else
+    # download the pinned tarball; verify its SHA256 either way; persist a
+    # fresh download to the distfile cache; extract.
     local dep="$1"
     local tarball="${TARBALL[$dep]}"
-    wget --retry-connrefused --waitretry=30 --dns-timeout=20 \
-        --connect-timeout=20 --read-timeout=300 --timeout=300 -t 5 \
-        -O "${tarball}" "${URL[$dep]}"
+    # ${DISTFILES_DIR} is set by build-gdal-stack.sh (empty otherwise -> the
+    # cache is skipped and this behaves exactly as the old download-only path).
+    local cached="${DISTFILES_DIR:+${DISTFILES_DIR}/${tarball}}"
+    if [[ -n "${cached}" && -f "${cached}" \
+        && "$(sha256sum "${cached}" | cut -d ' ' -f1)" == "${SHA256[$dep]}" ]]; then
+        echo "using cached ${tarball} from ${DISTFILES_DIR}"
+        cp "${cached}" "${tarball}"
+    else
+        wget --retry-connrefused --waitretry=30 --dns-timeout=20 \
+            --connect-timeout=20 --read-timeout=300 --timeout=300 -t 5 \
+            -O "${tarball}" "${URL[$dep]}"
+    fi
     local actual
     actual="$(sha256sum "${tarball}" | cut -d ' ' -f1)"
     if [[ "${actual}" != "${SHA256[$dep]}" ]]; then
@@ -167,6 +178,11 @@ fetch() {
         echo "       expected ${SHA256[$dep]}" >&2
         echo "       actual   ${actual}" >&2
         exit 1
+    fi
+    # Persist a freshly-downloaded, verified tarball so later builds (releases
+    # included) reuse it instead of re-downloading.
+    if [[ -n "${cached}" && ! -f "${cached}" ]]; then
+        cp "${tarball}" "${cached}"
     fi
     case "${tarball}" in
         *.tar.gz)  tar -xzf "${tarball}" ;;


### PR DESCRIPTION
# Description

Every bundle run — releases included — re-downloads all source tarballs from ~30 upstream hosts, so a single 503/429
from any one fails the whole build (the lcms2 GitHub 503 in run 31621639572; the earlier DKRZ libaec 429). The
existing caches store **compiled binaries** and are (correctly) skipped on the release path to avoid
cache-poisoning-to-release. Source distfiles are a different, safe thing to cache: they are **integrity-verified
before use**, so a tampered/corrupt cache entry is rejected and re-downloaded rather than baked into a wheel.

- **Linux from-source** (`build-gdal-stack.sh` + `config.sh`): exports a `DISTFILES_DIR` (a sibling of the
  compiled-stack cache on the `/host` mount); `fetch()` reuses a cached tarball only when it matches the pinned
  SHA256, else downloads and persists it. A new **un-gated** `actions/cache` (arch-independent key on `config.sh`,
  shared by the glibc + musl jobs) keeps the ~26 tarballs across runs — including releases — so the common path
  makes zero upstream requests.
- **win_arm64 vcpkg**: an **un-gated** `actions/cache` of `C:\vcpkg\downloads` persists vcpkg's SHA512-verified
  port distfiles (vcpkg re-verifies on use).

Both invalidate only when the pins change (`config.sh` / `vcpkg.json` hash). GHA cache is best-effort (branch scope,
eviction), so a first run after a bump still downloads; a persistently-down host still needs a mirror/overlay.

# Issues

- Closes #974

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- `bash -n` clean on both shell scripts; workflow YAML parses; no lines over 120.
- Simulated `fetch()`: cache-hit path taken on a SHA256 match; empty `DISTFILES_DIR` reverts to the exact old
  download-only behavior (safe fallback).
- A `bundle-pypi-wheels` dry-run seeds the caches on this run; a second dry-run confirms the Linux build reuses the
  cached distfiles ("using cached ... from ...") and makes no upstream downloads.

- [x] Shell syntax + YAML + fetch() cache logic validated locally
- [ ] Dry-run seed + hit confirmed in CI

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen-managed; not applicable)
- [ ] added changes to History.rst. (changelog is commitizen-generated; not applicable)
- [ ] updated the latest version in README file. (not applicable)
- [ ] I have added tests that prove my fix is effective. (CI-build change; validated by the dispatched bundle build)
- [x] New and existing unit tests pass locally with my changes. (no source touched)
- [ ] documentation are updated. (no user-facing surface)

