### PR TITLE
perf(netcdf): bound peak memory — stream from_xarray, container crop/to_crs/resample, and UGRID reads

### DIFF
--- a/src/pyramids/netcdf/engines/interop.py
+++ b/src/pyramids/netcdf/engines/interop.py
@@ -352,10 +352,32 @@ def _apply_md_array_attrs(md_arr: gdal.MDArray, attrs: dict[str, Any]) -> None:
         write_attributes_to_md_array(md_arr, remaining)
 
 
+def _write_md_array_streamed(md_arr: gdal.MDArray, arr: Any) -> None:
+    """Write ``arr`` into ``md_arr``, streaming a dask array one block at a time.
+
+    A dask array is written block by block -- each block is computed, written to its
+    hyperslab, then released before the next -- so a lazily-loaded variable never
+    becomes fully resident (ARC-48). Any other array-like is written in one hyperslab.
+
+    Args:
+        md_arr: The full-shape destination MDArray.
+        arr: A dask array (streamed block by block) or a NumPy array (written whole).
+    """
+    if not (hasattr(arr, "dask") and hasattr(arr, "blocks")):
+        md_arr.Write(np.ascontiguousarray(np.asarray(arr)))
+        return
+    for block_id in np.ndindex(*arr.numblocks):
+        block = np.ascontiguousarray(np.asarray(arr.blocks[block_id]))
+        starts = [
+            int(sum(arr.chunks[axis][: block_id[axis]])) for axis in range(arr.ndim)
+        ]
+        md_arr.Write(block, array_start_idx=starts, count=list(block.shape))
+
+
 def _build_multidim(
     dims: dict[str, int],
     coords: dict[str, tuple[np.ndarray, dict[str, Any]]],
-    data_vars: dict[str, tuple[tuple[str, ...], np.ndarray, dict[str, Any]]],
+    data_vars: dict[str, tuple[tuple[str, ...], Any, dict[str, Any]]],
     global_attrs: dict[str, Any],
 ) -> gdal.Dataset:
     """Build an in-memory GDAL multidim container from plain arrays and attrs.
@@ -415,16 +437,35 @@ def _build_multidim(
                 f"variable {var_name!r} references unknown dimension(s) "
                 f"{unknown} not in dims {sorted(gdal_dims)}"
             )
-        values, cf_attrs = _encode_temporal_array(np.asarray(var_values))
+        # A dask-backed variable (a lazily-loaded xarray var passed through by
+        # `_build_multidim_from_xarray`) is written block by block so it never becomes
+        # fully resident; a NumPy variable, or a temporal one that must be CF-encoded,
+        # is materialised and written in one shot (the prior behaviour).
+        dtype = np.dtype(
+            getattr(var_values, "dtype", None) or np.asarray(var_values).dtype
+        )
+        temporal = np.issubdtype(dtype, np.datetime64) or np.issubdtype(
+            dtype, np.timedelta64
+        )
+        stream = hasattr(var_values, "dask") and var_values.ndim > 0 and not temporal
+        if stream:
+            values: Any = var_values
+            cf_attrs: dict[str, Any] = {}
+            shape = tuple(var_values.shape)
+            write_dtype = dtype
+        else:
+            values, cf_attrs = _encode_temporal_array(np.asarray(var_values))
+            shape = values.shape
+            write_dtype = values.dtype
         expected = tuple(dims[d] for d in var_dims)
-        if values.shape != expected:
+        if shape != expected:
             raise ValueError(
-                f"variable {var_name!r} has shape {values.shape} but its "
+                f"variable {var_name!r} has shape {shape} but its "
                 f"dimensions {tuple(var_dims)} imply {expected}"
             )
-        ext = gdal.ExtendedDataType.Create(numpy_to_gdal_dtype(values))
+        ext = gdal.ExtendedDataType.Create(numpy_to_gdal_dtype(np.dtype(write_dtype)))
         md_arr = root.CreateMDArray(var_name, [gdal_dims[d] for d in var_dims], ext)
-        md_arr.Write(np.ascontiguousarray(values))
+        _write_md_array_streamed(md_arr, values)
         merged = dict(var_attrs)
         merged.update(cf_attrs)
         _apply_md_array_attrs(md_arr, merged)
@@ -456,7 +497,10 @@ def _build_multidim_from_xarray(dataset: Any) -> gdal.Dataset:
         if name in dims
     }
     data_vars = {
-        name: (tuple(var.dims), np.asarray(var.values), dict(var.attrs))
+        # `var.data` hands the underlying array through WITHOUT computing it, so a
+        # dask-backed variable stays lazy and `_build_multidim` can stream it block by
+        # block (ARC-48); `.values` would force a full materialisation up front.
+        name: (tuple(var.dims), var.data, dict(var.attrs))
         for name, var in dataset.data_vars.items()
     }
     return _build_multidim(dims, coords, data_vars, dict(dataset.attrs))

--- a/src/pyramids/netcdf/engines/interop.py
+++ b/src/pyramids/netcdf/engines/interop.py
@@ -593,6 +593,19 @@ class _StreamingMultidimWriter:
             count=[1] + list(block.shape),
         )
 
+    def write_whole(self, var_name: str, array: np.ndarray) -> None:
+        """Write an entire (non-streamed) variable in one hyperslab.
+
+        For a variable with no streamed leading dimension -- a 2-D ``(y, x)`` grid, or a small
+        carried-through auxiliary variable -- there is no slab to iterate, so the full array is
+        written at once.
+
+        Args:
+            var_name: Target variable.
+            array: The variable's full array, matching its declared shape.
+        """
+        self._arrays[var_name].Write(np.ascontiguousarray(np.asarray(array)))
+
 
 def _build_streaming_multidim(
     dataset: gdal.Dataset,

--- a/src/pyramids/netcdf/engines/interop.py
+++ b/src/pyramids/netcdf/engines/interop.py
@@ -374,6 +374,60 @@ def _write_md_array_streamed(md_arr: gdal.MDArray, arr: Any) -> None:
         md_arr.Write(block, array_start_idx=starts, count=list(block.shape))
 
 
+def _write_data_var(
+    root: gdal.Group,
+    gdal_dims: dict[str, Any],
+    dims: dict[str, int],
+    var_name: str,
+    var_dims: tuple[str, ...],
+    var_values: Any,
+    var_attrs: dict[str, Any],
+) -> None:
+    """Create and fill one data variable's MDArray, streaming a dask-backed one block by block.
+
+    A dask-backed variable (a lazily-loaded xarray var passed through by
+    `_build_multidim_from_xarray`) is written block by block so it never becomes fully resident; a
+    NumPy variable, or a temporal one that must be CF-encoded, is materialised and written in one
+    shot (the prior behaviour).
+
+    Raises:
+        ValueError: When the variable references an unknown dimension, or its shape does not match
+            the sizes implied by its dimensions.
+    """
+    unknown = [d for d in var_dims if d not in gdal_dims]
+    if unknown:
+        raise ValueError(
+            f"variable {var_name!r} references unknown dimension(s) "
+            f"{unknown} not in dims {sorted(gdal_dims)}"
+        )
+    dtype = np.dtype(getattr(var_values, "dtype", None) or np.asarray(var_values).dtype)
+    temporal = np.issubdtype(dtype, np.datetime64) or np.issubdtype(
+        dtype, np.timedelta64
+    )
+    stream = hasattr(var_values, "dask") and var_values.ndim > 0 and not temporal
+    if stream:
+        values: Any = var_values
+        cf_attrs: dict[str, Any] = {}
+        shape = tuple(var_values.shape)
+        write_dtype = dtype
+    else:
+        values, cf_attrs = _encode_temporal_array(np.asarray(var_values))
+        shape = values.shape
+        write_dtype = values.dtype
+    expected = tuple(dims[d] for d in var_dims)
+    if shape != expected:
+        raise ValueError(
+            f"variable {var_name!r} has shape {shape} but its "
+            f"dimensions {tuple(var_dims)} imply {expected}"
+        )
+    ext = gdal.ExtendedDataType.Create(numpy_to_gdal_dtype(np.dtype(write_dtype)))
+    md_arr = root.CreateMDArray(var_name, [gdal_dims[d] for d in var_dims], ext)
+    _write_md_array_streamed(md_arr, values)
+    merged = dict(var_attrs)
+    merged.update(cf_attrs)
+    _apply_md_array_attrs(md_arr, merged)
+
+
 def _build_multidim(
     dims: dict[str, int],
     coords: dict[str, tuple[np.ndarray, dict[str, Any]]],
@@ -431,44 +485,9 @@ def _build_multidim(
         _apply_md_array_attrs(md_arr, merged)
 
     for var_name, (var_dims, var_values, var_attrs) in data_vars.items():
-        unknown = [d for d in var_dims if d not in gdal_dims]
-        if unknown:
-            raise ValueError(
-                f"variable {var_name!r} references unknown dimension(s) "
-                f"{unknown} not in dims {sorted(gdal_dims)}"
-            )
-        # A dask-backed variable (a lazily-loaded xarray var passed through by
-        # `_build_multidim_from_xarray`) is written block by block so it never becomes
-        # fully resident; a NumPy variable, or a temporal one that must be CF-encoded,
-        # is materialised and written in one shot (the prior behaviour).
-        dtype = np.dtype(
-            getattr(var_values, "dtype", None) or np.asarray(var_values).dtype
+        _write_data_var(
+            root, gdal_dims, dims, var_name, var_dims, var_values, var_attrs
         )
-        temporal = np.issubdtype(dtype, np.datetime64) or np.issubdtype(
-            dtype, np.timedelta64
-        )
-        stream = hasattr(var_values, "dask") and var_values.ndim > 0 and not temporal
-        if stream:
-            values: Any = var_values
-            cf_attrs: dict[str, Any] = {}
-            shape = tuple(var_values.shape)
-            write_dtype = dtype
-        else:
-            values, cf_attrs = _encode_temporal_array(np.asarray(var_values))
-            shape = values.shape
-            write_dtype = values.dtype
-        expected = tuple(dims[d] for d in var_dims)
-        if shape != expected:
-            raise ValueError(
-                f"variable {var_name!r} has shape {shape} but its "
-                f"dimensions {tuple(var_dims)} imply {expected}"
-            )
-        ext = gdal.ExtendedDataType.Create(numpy_to_gdal_dtype(np.dtype(write_dtype)))
-        md_arr = root.CreateMDArray(var_name, [gdal_dims[d] for d in var_dims], ext)
-        _write_md_array_streamed(md_arr, values)
-        merged = dict(var_attrs)
-        merged.update(cf_attrs)
-        _apply_md_array_attrs(md_arr, merged)
 
     if global_attrs:
         write_global_attributes(root, dict(global_attrs))

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -69,6 +69,7 @@ class Selection(_Engine["NetCDF"]):
         bbox: tuple[float, float, float, float] | list[float] | None = None,
         epsg: Any = None,
         chunks: Any = None,
+        path: str | Path | None = None,
     ) -> NetCDF:
         """Crop the dataset using a polygon mask, a raster mask, or a bbox tuple.
 
@@ -124,6 +125,12 @@ class Selection(_Engine["NetCDF"]):
                 for a rectilinear (affine-warp) crop (which is eager), or
                 on a **root container** (call crop on a single variable via
                 :meth:`get_variable` instead).
+            path (keyword-only): Optional output ``.nc`` path. On a **root
+                container** the cropped cube is streamed straight to that
+                file one leading-dimension slab at a time (so the whole
+                result is never resident) and a **file-backed** :class:`NetCDF`
+                reading it is returned; ``None`` (default) builds the result
+                in memory.
 
         Returns:
             NetCDF: Cropped container or variable subset.
@@ -181,7 +188,7 @@ class Selection(_Engine["NetCDF"]):
             bbox, mask, epsg, is_container, touch, chunks
         )
         if antimeridian is not None:
-            return antimeridian
+            return cast("NetCDF", self._finalize_crop_output(antimeridian, path))
         mask = self._resolve_crop_mask(mask, bbox, epsg)
         if is_container:
             # A container crops every variable; `chunks` is a curvilinear-only, per-variable knob
@@ -193,10 +200,30 @@ class Selection(_Engine["NetCDF"]):
                     "curvilinear-only, per-variable option — call crop on a single variable "
                     "via get_variable(name) instead."
                 )
-            result = nc._apply_to_all_variables("crop", {"mask": mask, "touch": touch})
+            # `path` streams every cropped variable straight to `path` slab-by-slab (bounded memory)
+            # and returns a file-backed NetCDF; `path=None` keeps the in-memory fan-out.
+            result = nc._apply_to_all_variables(
+                "crop", {"mask": mask, "touch": touch}, path=path
+            )
         else:
-            result = self._crop_one(mask, touch=touch, chunks=chunks)
+            result = self._finalize_crop_output(
+                self._crop_one(mask, touch=touch, chunks=chunks), path
+            )
         return cast("NetCDF", result)
+
+    @staticmethod
+    def _finalize_crop_output(result: NetCDF, path: str | Path | None) -> NetCDF:
+        """Persist a single-variable / antimeridian crop to ``path`` when requested.
+
+        The container fan-out already streams straight to ``path`` (bounded memory); the
+        non-container crop paths build an in-memory result, so honour ``path`` by writing it
+        out and re-opening a file-backed :class:`NetCDF`. ``path=None`` returns ``result`` as-is.
+        """
+        if path is None:
+            return result
+        result.to_file(str(path))
+        result.close()
+        return cast("NetCDF", type(result).read_file(str(path)))
 
     def _try_antimeridian(
         self,

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import math
 import warnings
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import geopandas as gpd

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -2815,9 +2815,6 @@ class NetCDF(Dataset):
             NetCDF | None: A file-backed container reading ``path``, or ``None`` when the shape is
             not slab-streamable (the caller then falls back to the eager path).
         """
-        from pyramids.netcdf.engines.interop import open_streaming_multidim_netcdf
-        from pyramids.netcdf.utils import _read_attributes
-
         rg = self._working_group()
         for name in spatial_vars:
             if len(self.get_variable(name)._band_dim_names) >= 2:
@@ -2902,7 +2899,7 @@ class NetCDF(Dataset):
         if ndv is not None:
             root_attrs["nodata"] = ndv
 
-        with open_streaming_multidim_netcdf(
+        with _interop.open_streaming_multidim_netcdf(
             str(path), dims, coords, var_specs, root_attrs
         ) as writer:
             for name in spatial_vars:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -2788,7 +2788,141 @@ class NetCDF(Dataset):
                 stacklevel=3,
             )
 
-    def _apply_to_all_variables(self, operation, op_kwargs):
+    def _stream_apply_to_file(
+        self, operation, op_kwargs, spatial_vars, aux_vars, path
+    ) -> NetCDF | None:
+        """Stream ``operation`` over every variable straight to a netCDF ``path``, slab by slab.
+
+        Applies the op to each spatial variable (a cheap VRT/warp -- no data read), builds the
+        output file's dimensions / coordinates / variable specs from the shared transformed grid,
+        then fills each variable one leading-dimension slab at a time via
+        :func:`open_streaming_multidim_netcdf`, so the whole cube is never resident. Non-spatial
+        auxiliary variables are carried through unchanged (written whole).
+
+        Returns ``None`` -- signalling the caller to fall back to the eager build-then-write path --
+        for shapes this single-leading-dimension slab writer cannot represent: a spatial variable
+        with two or more band dimensions, a string/object-typed auxiliary variable, or a
+        curvilinear (2-D) coordinate grid.
+
+        Args:
+            operation: The Dataset method to apply (e.g. ``"crop"``).
+            op_kwargs: Keyword arguments for that method.
+            spatial_vars: Names of the variables carrying both spatial axes.
+            aux_vars: Names of the non-spatial variables to carry through unchanged.
+            path: Output ``.nc`` path.
+
+        Returns:
+            NetCDF | None: A file-backed container reading ``path``, or ``None`` when the shape is
+            not slab-streamable (the caller then falls back to the eager path).
+        """
+        from pyramids.netcdf.engines.interop import open_streaming_multidim_netcdf
+        from pyramids.netcdf.utils import _read_attributes
+
+        rg = self._working_group()
+        for name in spatial_vars:
+            if len(self.get_variable(name)._band_dim_names) >= 2:
+                return None
+        for name in aux_vars:
+            src_md = rg.OpenMDArray(name)
+            if src_md is not None and src_md.GetDataType().GetClass() == gdal.GEDTC_STRING:
+                return None
+
+        results = {
+            name: getattr(self.get_variable(name), operation)(**op_kwargs)
+            for name in spatial_vars
+        }
+        template = results[spatial_vars[0]]
+        y_coord = np.asarray(template.y)
+        x_coord = np.asarray(template.x)
+        if y_coord.ndim != 1 or x_coord.ndim != 1:
+            return None  # curvilinear (2-D) coords aren't slab-streamable here
+
+        dims: dict[str, int] = {"y": int(y_coord.shape[0]), "x": int(x_coord.shape[0])}
+        coords: dict[str, tuple[np.ndarray, dict[str, Any]]] = {
+            "y": (y_coord, {}),
+            "x": (x_coord, {}),
+        }
+        var_specs: dict[str, tuple[tuple[str, ...], Any, dict[str, Any]]] = {}
+        for name in spatial_vars:
+            var = self.get_variable(name)
+            res = results[name]
+            src_md = rg.OpenMDArray(name)
+            attrs = _read_attributes(src_md) if src_md is not None else {}
+            band_dims = var._band_dim_names
+            if band_dims:
+                bd = band_dims[0]
+                if bd not in dims:
+                    dims[bd] = int(var._band_dim_sizes[0])
+                    bd_values = var._band_dim_values_map.get(bd)
+                    coords[bd] = (
+                        np.asarray(bd_values)
+                        if bd_values is not None
+                        else np.arange(int(var._band_dim_sizes[0])),
+                        {},
+                    )
+                var_specs[name] = ((bd, "y", "x"), np.dtype(res.numpy_dtype[0]), attrs)
+            else:
+                var_specs[name] = (("y", "x"), np.dtype(res.numpy_dtype[0]), attrs)
+
+        aux_data: dict[str, np.ndarray] = {}
+        for name in aux_vars:
+            src_md = rg.OpenMDArray(name)
+            if src_md is None:
+                continue
+            aux_dim_names = tuple(d.GetName() for d in src_md.GetDimensions() or [])
+            for d in src_md.GetDimensions() or []:
+                dn = d.GetName()
+                if dn not in dims:
+                    iv = d.GetIndexingVariable()
+                    dims[dn] = int(d.GetSize())
+                    coords[dn] = (
+                        (self._md_array_to_numpy(iv), _read_attributes(iv))
+                        if iv is not None
+                        else (np.arange(int(d.GetSize())), {})
+                    )
+            arr = np.ascontiguousarray(self._md_array_to_numpy(src_md))
+            var_specs[name] = (aux_dim_names, arr.dtype, _read_attributes(src_md))
+            aux_data[name] = arr
+
+        root_attrs: dict[str, Any] = dict(self.global_attributes)
+        root_attrs.setdefault("Conventions", "CF-1.8")
+        try:
+            crs_wkt = template.crs.to_wkt() if template.crs is not None else None
+        except AttributeError:
+            crs_wkt = None
+        if crs_wkt:
+            root_attrs["crs_wkt"] = crs_wkt
+        if template.epsg is not None:
+            root_attrs["epsg"] = int(template.epsg)
+        root_attrs["GeoTransform"] = " ".join(str(v) for v in template.geotransform)
+        ndv = scalar_no_data(template.no_data_value)
+        if ndv is not None:
+            root_attrs["nodata"] = ndv
+
+        with open_streaming_multidim_netcdf(
+            str(path), dims, coords, var_specs, root_attrs
+        ) as writer:
+            for name in spatial_vars:
+                var = self.get_variable(name)
+                res = results[name]
+                if var._band_dim_names:
+                    for i in range(int(var._band_dim_sizes[0])):
+                        plane = np.asarray(res.read_array(band=i))
+                        if plane.ndim == 3 and plane.shape[0] == 1:
+                            plane = plane[0]
+                        writer.write_slab(name, i, plane)
+                else:
+                    plane = np.asarray(res.read_array())
+                    if plane.ndim == 3 and plane.shape[0] == 1:
+                        plane = plane[0]
+                    writer.write_whole(name, plane)
+            for name in aux_vars:
+                if name in aux_data:
+                    writer.write_whole(name, aux_data[name])
+
+        return NetCDF.read_file(str(path))
+
+    def _apply_to_all_variables(self, operation, op_kwargs, path=None):
         """Apply a spatial operation to every gridded variable in the container.
 
         Only variables carrying both spatial axes are cropped / reprojected.
@@ -2849,6 +2983,24 @@ class NetCDF(Dataset):
                 f"metadata (standard_name / axis) or rename the axes to y/x.",
                 stacklevel=3,
             )
+
+        # Streaming-to-file path (ARC-46/#976): write the transformed cube straight to `path`,
+        # one leading-dimension slab at a time, so the whole result is never resident. Variables
+        # with >= 2 band dimensions aren't slab-streamable here, so `_stream_apply_to_file` returns
+        # None and we fall back to the eager in-memory build followed by a plain file write (still
+        # correct, just not bounded-memory for that rare shape).
+        if path is not None:
+            streamed = self._stream_apply_to_file(
+                operation, op_kwargs, spatial_vars, aux_vars, path
+            )
+            if streamed is not None:
+                return streamed
+            mem = self._apply_to_all_variables(operation, op_kwargs)
+            try:
+                mem.to_file(str(path))
+            finally:
+                mem.close()
+            return NetCDF.read_file(str(path))
 
         result = None
         for var_name in spatial_vars:
@@ -3136,6 +3288,7 @@ class NetCDF(Dataset):
         to_epsg: int,
         method: str = DEFAULT_RESAMPLING,
         maintain_alignment: bool = False,
+        path: str | Path | None = None,
     ) -> NetCDF:
         """Reproject the dataset to a different CRS.
 
@@ -3149,6 +3302,10 @@ class NetCDF(Dataset):
             method: Resampling method. Defaults to `"nearest neighbor"`.
             maintain_alignment: If True, keep the same number of rows
                 and columns. Defaults to False.
+            path: Optional output `.nc` path. When set, the reprojected container is streamed
+                straight to that file one slab at a time (so the whole cube is never resident) and a
+                **file-backed** `NetCDF` reading it is returned; `None` (default) builds the result
+                in memory.
 
         Returns:
             NetCDF: Reprojected container or variable subset.
@@ -3161,6 +3318,7 @@ class NetCDF(Dataset):
                     "method": method,
                     "maintain_alignment": maintain_alignment,
                 },
+                path=path,
             )
         else:
             # to_crs warps the backing raster; a multidim view can't be window-read by GDAL >= 3.13,
@@ -3172,6 +3330,10 @@ class NetCDF(Dataset):
                 maintain_alignment=maintain_alignment,
             )
             result = self._preserve_netcdf_metadata(result)
+            if path is not None:
+                result.to_file(str(path))
+                result.close()
+                result = NetCDF.read_file(str(path))
         return cast("NetCDF", result)
 
     def warped_view(
@@ -3391,6 +3553,7 @@ class NetCDF(Dataset):
         self,
         cell_size: float,
         method: str = DEFAULT_RESAMPLING,
+        path: str | Path | None = None,
     ) -> NetCDF:
         """Resample the dataset to a different cell size.
 
@@ -3402,6 +3565,10 @@ class NetCDF(Dataset):
         Args:
             cell_size: New cell size.
             method: Resampling method. Defaults to `"nearest neighbor"`.
+            path: Optional output `.nc` path. When set, the resampled container is streamed straight
+                to that file one slab at a time (so the whole cube is never resident) and a
+                **file-backed** `NetCDF` reading it is returned; `None` (default) builds the result
+                in memory.
 
         Returns:
             NetCDF: Resampled container or variable subset.
@@ -3410,6 +3577,7 @@ class NetCDF(Dataset):
             result = self._apply_to_all_variables(
                 "resample",
                 {"cell_size": cell_size, "method": method},
+                path=path,
             )
         else:
             # resample warps the backing raster; a multidim view can't be window-read by GDAL >= 3.13.
@@ -3419,6 +3587,10 @@ class NetCDF(Dataset):
                 method=method,
             )
             result = self._preserve_netcdf_metadata(result)
+            if path is not None:
+                result.to_file(str(path))
+                result.close()
+                result = NetCDF.read_file(str(path))
         return cast("NetCDF", result)
 
     def sel(self, *args, **kwargs) -> NetCDF:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -2977,7 +2977,9 @@ class NetCDF(Dataset):
             plane = plane[0]
         writer.write_whole(name, plane)
 
-    def _apply_to_all_variables(self, operation, op_kwargs, path=None, *, warn_demoted=True):
+    def _apply_to_all_variables(
+        self, operation, op_kwargs, path=None, *, warn_demoted=True
+    ):
         """Apply a spatial operation to every gridded variable in the container.
 
         Only variables carrying both spatial axes are cropped / reprojected.

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -2820,16 +2820,8 @@ class NetCDF(Dataset):
         # resolve every spatial variable once and reuse it across the guard/spec/write passes below
         # instead of re-opening it up to four times (review R2-N1).
         spatial_var_objs = {name: self.get_variable(name) for name in spatial_vars}
-        for name in spatial_vars:
-            if len(spatial_var_objs[name]._band_dim_names) >= 2:
-                return None
-        for name in aux_vars:
-            src_md = rg.OpenMDArray(name)
-            if (
-                src_md is not None
-                and src_md.GetDataType().GetClass() == gdal.GEDTC_STRING
-            ):
-                return None
+        if not self._stream_feasible(rg, spatial_var_objs, spatial_vars, aux_vars):
+            return None
 
         results = {
             name: getattr(spatial_var_objs[name], operation)(**op_kwargs)
@@ -2862,51 +2854,98 @@ class NetCDF(Dataset):
         }
         var_specs: dict[str, tuple[tuple[str, ...], Any, dict[str, Any]]] = {}
         for name in spatial_vars:
-            var = spatial_var_objs[name]
-            res = results[name]
-            src_md = rg.OpenMDArray(name)
-            # `attrs` carries the source variable's own `_FillValue` (when it declared one), so a
-            # variable that actually has no-data keeps it per-variable; the template's no-data is
-            # additionally recorded as the global `nodata` below. (Writing
-            # `scalar_no_data(res.no_data_value)` unconditionally was rejected — it surfaces GDAL's
-            # uninitialised default as a spurious out-of-range `_FillValue` for no-data-less vars.)
-            attrs = _read_attributes(src_md) if src_md is not None else {}
-            band_dims = var._band_dim_names
-            if band_dims:
-                bd = band_dims[0]
-                if bd not in dims:
-                    dims[bd] = int(var._band_dim_sizes[0])
-                    bd_values = var._band_dim_values_map.get(bd)
-                    coords[bd] = (
-                        np.asarray(bd_values)
-                        if bd_values is not None
-                        else np.arange(int(var._band_dim_sizes[0])),
-                        {},
-                    )
-                var_specs[name] = ((bd, "y", "x"), np.dtype(res.numpy_dtype[0]), attrs)
-            else:
-                var_specs[name] = (("y", "x"), np.dtype(res.numpy_dtype[0]), attrs)
-
+            self._add_spatial_var_spec(
+                name, spatial_var_objs[name], results[name], rg, dims, coords, var_specs
+            )
         aux_data: dict[str, np.ndarray] = {}
         for name in aux_vars:
-            src_md = rg.OpenMDArray(name)
-            if src_md is None:
-                continue
-            aux_dim_names = tuple(d.GetName() for d in src_md.GetDimensions() or [])
-            for d in src_md.GetDimensions() or []:
-                dn = d.GetName()
-                if dn not in dims:
-                    iv = d.GetIndexingVariable()
-                    dims[dn] = int(d.GetSize())
-                    coords[dn] = (
-                        (self._md_array_to_numpy(iv), _read_attributes(iv))
-                        if iv is not None
-                        else (np.arange(int(d.GetSize())), {})
-                    )
-            arr = np.ascontiguousarray(self._md_array_to_numpy(src_md))
-            var_specs[name] = (aux_dim_names, arr.dtype, _read_attributes(src_md))
-            aux_data[name] = arr
+            self._add_aux_var_spec(name, rg, dims, coords, var_specs, aux_data)
 
+        root_attrs = self._stream_root_attrs(template)
+
+        with _interop.open_streaming_multidim_netcdf(
+            str(path), dims, coords, var_specs, root_attrs
+        ) as writer:
+            for name in spatial_vars:
+                self._write_stream_variable(
+                    writer, name, spatial_var_objs[name], results[name]
+                )
+            for name in aux_vars:
+                if name in aux_data:
+                    writer.write_whole(name, aux_data[name])
+
+        return NetCDF.read_file(str(path))
+
+    @staticmethod
+    def _stream_feasible(rg, spatial_var_objs, spatial_vars, aux_vars) -> bool:
+        """True when the single-leading-dimension slab writer can represent every variable's shape.
+
+        Rejects a spatial variable with two or more band dimensions and a string/object-typed
+        auxiliary variable — shapes the writer cannot handle, for which the caller falls back to the
+        eager build.
+        """
+        for name in spatial_vars:
+            if len(spatial_var_objs[name]._band_dim_names) >= 2:
+                return False
+        for name in aux_vars:
+            src_md = rg.OpenMDArray(name)
+            if (
+                src_md is not None
+                and src_md.GetDataType().GetClass() == gdal.GEDTC_STRING
+            ):
+                return False
+        return True
+
+    @staticmethod
+    def _add_spatial_var_spec(name, var, res, rg, dims, coords, var_specs) -> None:
+        """Add one spatial variable's band dimension / coordinate and its var-spec to the builders.
+
+        `attrs` carries the source variable's own `_FillValue` (when it declared one), so a variable
+        that actually has no-data keeps it per-variable; the template's no-data is additionally
+        recorded as the global `nodata`. (Writing `scalar_no_data(res.no_data_value)` unconditionally
+        was rejected — it surfaces GDAL's uninitialised default as a spurious out-of-range
+        `_FillValue` for no-data-less vars.)
+        """
+        src_md = rg.OpenMDArray(name)
+        attrs = _read_attributes(src_md) if src_md is not None else {}
+        band_dims = var._band_dim_names
+        if not band_dims:
+            var_specs[name] = (("y", "x"), np.dtype(res.numpy_dtype[0]), attrs)
+            return
+        bd = band_dims[0]
+        if bd not in dims:
+            dims[bd] = int(var._band_dim_sizes[0])
+            bd_values = var._band_dim_values_map.get(bd)
+            coords[bd] = (
+                np.asarray(bd_values)
+                if bd_values is not None
+                else np.arange(int(var._band_dim_sizes[0])),
+                {},
+            )
+        var_specs[name] = ((bd, "y", "x"), np.dtype(res.numpy_dtype[0]), attrs)
+
+    def _add_aux_var_spec(self, name, rg, dims, coords, var_specs, aux_data) -> None:
+        """Add one carried-through auxiliary variable's dims/coords/spec and cache its whole array."""
+        src_md = rg.OpenMDArray(name)
+        if src_md is None:
+            return
+        aux_dim_names = tuple(d.GetName() for d in src_md.GetDimensions() or [])
+        for d in src_md.GetDimensions() or []:
+            dn = d.GetName()
+            if dn not in dims:
+                iv = d.GetIndexingVariable()
+                dims[dn] = int(d.GetSize())
+                coords[dn] = (
+                    (self._md_array_to_numpy(iv), _read_attributes(iv))
+                    if iv is not None
+                    else (np.arange(int(d.GetSize())), {})
+                )
+        arr = np.ascontiguousarray(self._md_array_to_numpy(src_md))
+        var_specs[name] = (aux_dim_names, arr.dtype, _read_attributes(src_md))
+        aux_data[name] = arr
+
+    def _stream_root_attrs(self, template) -> dict[str, Any]:
+        """Build the streamed file's root attributes (Conventions + CRS + GeoTransform + nodata)."""
         root_attrs: dict[str, Any] = dict(self.global_attributes)
         root_attrs.setdefault("Conventions", "CF-1.8")
         try:
@@ -2921,29 +2960,22 @@ class NetCDF(Dataset):
         ndv = scalar_no_data(template.no_data_value)
         if ndv is not None:
             root_attrs["nodata"] = ndv
+        return root_attrs
 
-        with _interop.open_streaming_multidim_netcdf(
-            str(path), dims, coords, var_specs, root_attrs
-        ) as writer:
-            for name in spatial_vars:
-                var = spatial_var_objs[name]
-                res = results[name]
-                if var._band_dim_names:
-                    for i in range(int(var._band_dim_sizes[0])):
-                        plane = np.asarray(res.read_array(band=i))
-                        if plane.ndim == 3 and plane.shape[0] == 1:
-                            plane = plane[0]
-                        writer.write_slab(name, i, plane)
-                else:
-                    plane = np.asarray(res.read_array())
-                    if plane.ndim == 3 and plane.shape[0] == 1:
-                        plane = plane[0]
-                    writer.write_whole(name, plane)
-            for name in aux_vars:
-                if name in aux_data:
-                    writer.write_whole(name, aux_data[name])
-
-        return NetCDF.read_file(str(path))
+    @staticmethod
+    def _write_stream_variable(writer, name, var, res) -> None:
+        """Write one spatial variable: a band-dim variable slab-by-slab, a 2-D variable whole."""
+        if var._band_dim_names:
+            for i in range(int(var._band_dim_sizes[0])):
+                plane = np.asarray(res.read_array(band=i))
+                if plane.ndim == 3 and plane.shape[0] == 1:
+                    plane = plane[0]
+                writer.write_slab(name, i, plane)
+            return
+        plane = np.asarray(res.read_array())
+        if plane.ndim == 3 and plane.shape[0] == 1:
+            plane = plane[0]
+        writer.write_whole(name, plane)
 
     def _apply_to_all_variables(self, operation, op_kwargs, path=None, *, warn_demoted=True):
         """Apply a spatial operation to every gridded variable in the container.

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -3014,7 +3014,12 @@ class NetCDF(Dataset):
             )
             if streamed is not None:
                 return streamed
-            mem = self._apply_to_all_variables(operation, op_kwargs)
+            # The eager fallback re-runs the same spatial/aux scan and would emit the demoted-
+            # variable warning a second time for one call; it was already warned above, so suppress
+            # the duplicate on the recursive build (review N1).
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                mem = self._apply_to_all_variables(operation, op_kwargs)
             try:
                 mem.to_file(str(path))
             finally:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -2824,7 +2824,10 @@ class NetCDF(Dataset):
                 return None
         for name in aux_vars:
             src_md = rg.OpenMDArray(name)
-            if src_md is not None and src_md.GetDataType().GetClass() == gdal.GEDTC_STRING:
+            if (
+                src_md is not None
+                and src_md.GetDataType().GetClass() == gdal.GEDTC_STRING
+            ):
                 return None
 
         results = {

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -2837,6 +2837,20 @@ class NetCDF(Dataset):
         if y_coord.ndim != 1 or x_coord.ndim != 1:
             return None  # curvilinear (2-D) coords aren't slab-streamable here
 
+        # Every variable is written against the template's shared y/x grid. A container whose
+        # variables transform onto *different* grids (mixed native cell size / extent, or a
+        # reprojection that yields per-variable shapes) isn't slab-streamable here — fall back to
+        # the eager per-variable build rather than mis-writing a slab into a template-shaped array
+        # (review L1).
+        template_yx = (int(y_coord.shape[0]), int(x_coord.shape[0]))
+        for name in spatial_vars:
+            res_yx = (
+                int(np.asarray(results[name].y).shape[0]),
+                int(np.asarray(results[name].x).shape[0]),
+            )
+            if res_yx != template_yx:
+                return None
+
         dims: dict[str, int] = {"y": int(y_coord.shape[0]), "x": int(x_coord.shape[0])}
         coords: dict[str, tuple[np.ndarray, dict[str, Any]]] = {
             "y": (y_coord, {}),
@@ -2847,6 +2861,11 @@ class NetCDF(Dataset):
             var = self.get_variable(name)
             res = results[name]
             src_md = rg.OpenMDArray(name)
+            # `attrs` carries the source variable's own `_FillValue` (when it declared one), so a
+            # variable that actually has no-data keeps it per-variable; the template's no-data is
+            # additionally recorded as the global `nodata` below. (Writing
+            # `scalar_no_data(res.no_data_value)` unconditionally was rejected — it surfaces GDAL's
+            # uninitialised default as a spurious out-of-range `_FillValue` for no-data-less vars.)
             attrs = _read_attributes(src_md) if src_md is not None else {}
             band_dims = var._band_dim_names
             if band_dims:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -2941,7 +2941,7 @@ class NetCDF(Dataset):
 
         return NetCDF.read_file(str(path))
 
-    def _apply_to_all_variables(self, operation, op_kwargs, path=None):
+    def _apply_to_all_variables(self, operation, op_kwargs, path=None, *, warn_demoted=True):
         """Apply a spatial operation to every gridded variable in the container.
 
         Only variables carrying both spatial axes are cropped / reprojected.
@@ -2993,7 +2993,7 @@ class NetCDF(Dataset):
             ]
             if len(unknown_axes) >= 2:
                 demoted.append(n)
-        if demoted:
+        if demoted and warn_demoted:
             warnings.warn(
                 f"{operation}() is carrying {len(demoted)} multi-dimensional "
                 f"variable(s) {demoted} through unchanged because their axes were "
@@ -3015,11 +3015,12 @@ class NetCDF(Dataset):
             if streamed is not None:
                 return streamed
             # The eager fallback re-runs the same spatial/aux scan and would emit the demoted-
-            # variable warning a second time for one call; it was already warned above, so suppress
-            # the duplicate on the recursive build (review N1).
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                mem = self._apply_to_all_variables(operation, op_kwargs)
+            # variable warning a second time for one call; it was already warned above. Suppress
+            # only that duplicate via `warn_demoted=False` — genuine warnings from the real
+            # transform work still surface (reviews N1, R2-L1).
+            mem = self._apply_to_all_variables(
+                operation, op_kwargs, warn_demoted=False
+            )
             try:
                 mem.to_file(str(path))
             finally:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -3024,6 +3024,16 @@ class NetCDF(Dataset):
                 operation, op_kwargs, spatial_vars, aux_vars, path
             )
 
+        return self._fan_out_eager(spatial_vars, aux_vars, operation, op_kwargs)
+
+    def _fan_out_eager(self, spatial_vars, aux_vars, operation, op_kwargs) -> NetCDF:
+        """Build an in-memory container by applying ``operation`` to each spatial variable.
+
+        Each variable is transformed, materialised, and dropped into a shared `NetCDF` container
+        (the first variable creates it); non-spatial auxiliary variables are then carried through
+        unchanged. This is the historical eager fan-out — the ``path=None`` default of
+        :meth:`_apply_to_all_variables`.
+        """
         result = None
         for var_name in spatial_vars:
             var = self.get_variable(var_name)

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -2816,8 +2816,12 @@ class NetCDF(Dataset):
             not slab-streamable (the caller then falls back to the eager path).
         """
         rg = self._working_group()
+        # `get_variable` builds a fresh classic-raster wrapper (a new GDAL dataset) each call, so
+        # resolve every spatial variable once and reuse it across the guard/spec/write passes below
+        # instead of re-opening it up to four times (review R2-N1).
+        spatial_var_objs = {name: self.get_variable(name) for name in spatial_vars}
         for name in spatial_vars:
-            if len(self.get_variable(name)._band_dim_names) >= 2:
+            if len(spatial_var_objs[name]._band_dim_names) >= 2:
                 return None
         for name in aux_vars:
             src_md = rg.OpenMDArray(name)
@@ -2828,7 +2832,7 @@ class NetCDF(Dataset):
                 return None
 
         results = {
-            name: getattr(self.get_variable(name), operation)(**op_kwargs)
+            name: getattr(spatial_var_objs[name], operation)(**op_kwargs)
             for name in spatial_vars
         }
         template = results[spatial_vars[0]]
@@ -2858,7 +2862,7 @@ class NetCDF(Dataset):
         }
         var_specs: dict[str, tuple[tuple[str, ...], Any, dict[str, Any]]] = {}
         for name in spatial_vars:
-            var = self.get_variable(name)
+            var = spatial_var_objs[name]
             res = results[name]
             src_md = rg.OpenMDArray(name)
             # `attrs` carries the source variable's own `_FillValue` (when it declared one), so a
@@ -2922,7 +2926,7 @@ class NetCDF(Dataset):
             str(path), dims, coords, var_specs, root_attrs
         ) as writer:
             for name in spatial_vars:
-                var = self.get_variable(name)
+                var = spatial_var_objs[name]
                 res = results[name]
                 if var._band_dim_names:
                     for i in range(int(var._band_dim_sizes[0])):

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -3015,53 +3015,12 @@ class NetCDF(Dataset):
                 f"{names} have both spatial axes."
             )
 
-        # A variable with >= 2 *unrecognised* axes is likely a grid whose axes
-        # were not recognised (no CF axis attributes / no known x/y names) and is
-        # carried through untransformed — warn. Axes that are clearly non-spatial
-        # (time / vertical / ensemble / bounds) don't count, so a legitimately
-        # non-spatial N-D aux variable (e.g. (time, level)) does not trip the warning.
-        demoted = []
-        for n in aux_vars:
-            unknown_axes = [
-                d
-                for d in self._variable_dim_names(rg, n)
-                if d.lower() not in _NONSPATIAL_AXIS_NAMES
-            ]
-            if len(unknown_axes) >= 2:
-                demoted.append(n)
-        if demoted and warn_demoted:
-            warnings.warn(
-                f"{operation}() is carrying {len(demoted)} multi-dimensional "
-                f"variable(s) {demoted} through unchanged because their axes were "
-                f"not recognised as spatial (no CF axis attributes or known x/y "
-                f"names); they will NOT be cropped/reprojected. Add CF axis "
-                f"metadata (standard_name / axis) or rename the axes to y/x.",
-                stacklevel=3,
-            )
+        self._warn_demoted_variables(rg, aux_vars, operation, warn_demoted)
 
-        # Streaming-to-file path (ARC-46/#976): write the transformed cube straight to `path`,
-        # one leading-dimension slab at a time, so the whole result is never resident. Variables
-        # with >= 2 band dimensions aren't slab-streamable here, so `_stream_apply_to_file` returns
-        # None and we fall back to the eager in-memory build followed by a plain file write (still
-        # correct, just not bounded-memory for that rare shape).
         if path is not None:
-            streamed = self._stream_apply_to_file(
+            return self._to_file_via_stream_or_eager(
                 operation, op_kwargs, spatial_vars, aux_vars, path
             )
-            if streamed is not None:
-                return streamed
-            # The eager fallback re-runs the same spatial/aux scan and would emit the demoted-
-            # variable warning a second time for one call; it was already warned above. Suppress
-            # only that duplicate via `warn_demoted=False` — genuine warnings from the real
-            # transform work still surface (reviews N1, R2-L1).
-            mem = self._apply_to_all_variables(
-                operation, op_kwargs, warn_demoted=False
-            )
-            try:
-                mem.to_file(str(path))
-            finally:
-                mem.close()
-            return NetCDF.read_file(str(path))
 
         result = None
         for var_name in spatial_vars:
@@ -3129,6 +3088,61 @@ class NetCDF(Dataset):
 
         self._carry_aux_variables(cast("NetCDF", result), aux_vars, operation)
         return cast("NetCDF", result)
+
+    def _warn_demoted_variables(self, rg, aux_vars, operation, warn_demoted) -> None:
+        """Warn about auxiliary variables carried through untransformed for lack of spatial axes.
+
+        A variable with >= 2 *unrecognised* axes is likely a grid whose axes were not recognised (no
+        CF axis attributes / no known x/y names). Axes that are clearly non-spatial (time / vertical
+        / ensemble / bounds) don't count, so a legitimately non-spatial N-D aux variable (e.g.
+        ``(time, level)``) does not trip the warning. ``warn_demoted=False`` suppresses the message
+        on the eager fallback recursion, which already warned on the outer call.
+        """
+        demoted = [
+            n
+            for n in aux_vars
+            if len(
+                [
+                    d
+                    for d in self._variable_dim_names(rg, n)
+                    if d.lower() not in _NONSPATIAL_AXIS_NAMES
+                ]
+            )
+            >= 2
+        ]
+        if demoted and warn_demoted:
+            warnings.warn(
+                f"{operation}() is carrying {len(demoted)} multi-dimensional "
+                f"variable(s) {demoted} through unchanged because their axes were "
+                f"not recognised as spatial (no CF axis attributes or known x/y "
+                f"names); they will NOT be cropped/reprojected. Add CF axis "
+                f"metadata (standard_name / axis) or rename the axes to y/x.",
+                stacklevel=4,
+            )
+
+    def _to_file_via_stream_or_eager(
+        self, operation, op_kwargs, spatial_vars, aux_vars, path
+    ) -> NetCDF:
+        """Write the transformed container to ``path``, streaming when possible else eager.
+
+        The streaming path (ARC-46/#976) writes the cube one leading-dimension slab at a time, so the
+        whole result is never resident. A shape the slab writer cannot represent makes
+        ``_stream_apply_to_file`` return None, and we fall back to the eager in-memory build followed
+        by a plain file write (still correct, just not bounded-memory for that rare shape). The
+        fallback recursion passes ``warn_demoted=False`` so the demoted-variable warning — already
+        emitted by the caller — is not duplicated, while genuine transform warnings still surface.
+        """
+        streamed = self._stream_apply_to_file(
+            operation, op_kwargs, spatial_vars, aux_vars, path
+        )
+        if streamed is not None:
+            return streamed
+        mem = self._apply_to_all_variables(operation, op_kwargs, warn_demoted=False)
+        try:
+            mem.to_file(str(path))
+        finally:
+            mem.close()
+        return NetCDF.read_file(str(path))
 
     def reduce(self, *args, **kwargs) -> NetCDF:
         """Facade — :meth:`Selection.reduce <pyramids.netcdf.engines.selection.Selection.reduce>`."""

--- a/src/pyramids/netcdf/ugrid/connectivity.py
+++ b/src/pyramids/netcdf/ugrid/connectivity.py
@@ -63,7 +63,9 @@ class Connectivity:
         raw_data = md_arr.ReadAsArray()
         if raw_data is None:
             raise ValueError(f"Cannot read connectivity array for cf_role='{cf_role}'.")
-        data = raw_data.copy().astype(np.intp)
+        # `astype` already returns a fresh, writable array (mutated below), so the extra `.copy()`
+        # only duplicated the connectivity array for no benefit (#982).
+        data = raw_data.astype(np.intp)
 
         mask = data == raw_fill
 

--- a/src/pyramids/netcdf/ugrid/dataset.py
+++ b/src/pyramids/netcdf/ugrid/dataset.py
@@ -669,8 +669,17 @@ class UgridDataset:
             var = self.get_data(variable_name)
             if var.location == location:
                 # For a temporal variable only the first step is tabulated; `sel_time(0)` reads just
-                # that slab instead of loading every step to slice `[0]` (#982).
-                var_data = var.sel_time(0) if var.has_time else var.data
+                # that slab instead of loading every step to slice `[0]` (#982). `has_data_source`
+                # avoids a temporal-specific `sel_time` error for a variable with no readable data
+                # (checked without forcing a load — review L3).
+                if var.has_time:
+                    var_data = var.sel_time(0) if var.has_data_source else None
+                else:
+                    var_data = var.data
+                # A variable with no readable data becomes a length-correct null column rather than
+                # raising — pandas rejects a scalar `None` column ("must pass an index") (review L3).
+                if var_data is None:
+                    var_data = np.full(len(geometries), np.nan)
                 data_dict[variable_name] = var_data
 
         gdf = gpd.GeoDataFrame(data_dict, geometry=geometries)

--- a/src/pyramids/netcdf/ugrid/dataset.py
+++ b/src/pyramids/netcdf/ugrid/dataset.py
@@ -631,7 +631,11 @@ class UgridDataset:
             if var.has_time and "time" not in dims:
                 time_dim = rg.CreateDimension("time", None, None, var.n_time_steps)
                 dims["time"] = time_dim
-            write_ugrid_data_variable(rg, var, mesh_name, dims)
+            # `load_array` reads each variable without memoising it on the shared dataset, so the
+            # write streams one variable at a time instead of holding the whole cube resident (#982).
+            write_ugrid_data_variable(
+                rg, var.with_data(var.load_array()), mesh_name, dims
+            )
 
         global_attrs = dict(self._global_attributes)
         if "Conventions" not in global_attrs:
@@ -664,9 +668,9 @@ class UgridDataset:
         if variable_name is not None:
             var = self.get_data(variable_name)
             if var.location == location:
-                var_data = var.data
-                if var_data is not None and var.has_time:
-                    var_data = var_data[0]
+                # For a temporal variable only the first step is tabulated; `sel_time(0)` reads just
+                # that slab instead of loading every step to slice `[0]` (#982).
+                var_data = var.sel_time(0) if var.has_time else var.data
                 data_dict[variable_name] = var_data
 
         gdf = gpd.GeoDataFrame(data_dict, geometry=geometries)
@@ -1006,8 +1010,9 @@ def _make_variable_loader(path: str, var_name: str):
             raise ValueError(
                 f"Variable {var_name!r} is no longer present in {path!r} on lazy read."
             )
-        data = md.ReadAsArray()
-        return data.copy() if data is not None else None
+        # `ReadAsArray()` already returns a fresh, numpy-owned array, so an extra `.copy()` only
+        # duplicates the largest arrays for no benefit (#982).
+        return md.ReadAsArray()
 
     return _load
 
@@ -1065,6 +1070,7 @@ def _read_data_variables(
             dimensions=dim_names,
             _loader=_make_variable_loader(path, var_name),
             _dtype=dtype,
+            _source_path=path,
         )
 
     return variables

--- a/src/pyramids/netcdf/ugrid/dataset.py
+++ b/src/pyramids/netcdf/ugrid/dataset.py
@@ -1020,8 +1020,10 @@ def _make_variable_loader(path: str, var_name: str):
                 f"Variable {var_name!r} is no longer present in {path!r} on lazy read."
             )
         # `ReadAsArray()` already returns a fresh, numpy-owned array, so an extra `.copy()` only
-        # duplicates the largest arrays for no benefit (#982).
-        return md.ReadAsArray()
+        # duplicates the largest arrays for no benefit (#982). The typed local coerces GDAL's
+        # untyped `Any` return to the declared type (no-any-return).
+        data: np.typing.NDArray | None = md.ReadAsArray()
+        return data
 
     return _load
 

--- a/src/pyramids/netcdf/ugrid/io.py
+++ b/src/pyramids/netcdf/ugrid/io.py
@@ -563,7 +563,9 @@ def _write_connectivity_array(
         dims,
         gdal.ExtendedDataType.Create(gdal.GDT_Int32),
     )
-    out_data = conn.data.copy().astype(np.int32)
+    # `astype` already returns a fresh, writable array (mutated below), so the extra `.copy()`
+    # only duplicated the connectivity array for no benefit (#982).
+    out_data = conn.data.astype(np.int32)
     file_fill = -999
     out_data[out_data == conn.fill_value] = file_fill
     if conn.original_start_index != 0:

--- a/src/pyramids/netcdf/ugrid/models.py
+++ b/src/pyramids/netcdf/ugrid/models.py
@@ -148,6 +148,15 @@ class MeshVariable:
         return self._data
 
     @property
+    def has_data_source(self) -> bool:
+        """True when the variable can produce an array — eager data or a lazy loader.
+
+        Metadata-only, so callers can decide whether to read a variable's values without forcing
+        the load a bare `.data` access would trigger.
+        """
+        return self._data is not None or self._loader is not None
+
+    @property
     def n_elements(self) -> int:
         """Number of mesh elements (last dimension of shape)."""
         result = self.shape[-1] if self.shape else 0

--- a/src/pyramids/netcdf/ugrid/models.py
+++ b/src/pyramids/netcdf/ugrid/models.py
@@ -242,9 +242,9 @@ class MeshVariable:
 
         Requires an on-disk source, an axis-0 time dimension (what the slab reader indexes), and
         non-negative in-range indices; otherwise the caller falls back to a full load then slice.
-        A reversed/empty range (``stop < start``) is excluded so the in-memory slice — which yields
-        a consistent empty array — handles it, rather than passing a negative ``count`` to GDAL
-        (review L2).
+        A reversed **or empty** range (``stop <= start``) is excluded so the in-memory slice — which
+        yields a consistent empty array — handles it, rather than passing a zero/negative ``count``
+        to GDAL, which raises under ``gdal.UseExceptions()`` (reviews L2, R2-M1).
         """
         n_steps = self.n_time_steps
         return (
@@ -252,7 +252,7 @@ class MeshVariable:
             and self.time_index == 0
             and start >= 0
             and start < n_steps
-            and (stop is None or (start <= stop <= n_steps))
+            and (stop is None or (start < stop <= n_steps))
         )
 
     def _read_time_window(

--- a/src/pyramids/netcdf/ugrid/models.py
+++ b/src/pyramids/netcdf/ugrid/models.py
@@ -233,6 +233,9 @@ class MeshVariable:
 
         Requires an on-disk source, an axis-0 time dimension (what the slab reader indexes), and
         non-negative in-range indices; otherwise the caller falls back to a full load then slice.
+        A reversed/empty range (``stop < start``) is excluded so the in-memory slice — which yields
+        a consistent empty array — handles it, rather than passing a negative ``count`` to GDAL
+        (review L2).
         """
         n_steps = self.n_time_steps
         return (
@@ -240,7 +243,7 @@ class MeshVariable:
             and self.time_index == 0
             and start >= 0
             and start < n_steps
-            and (stop is None or 0 <= stop <= n_steps)
+            and (stop is None or (start <= stop <= n_steps))
         )
 
     def _read_time_window(

--- a/src/pyramids/netcdf/ugrid/models.py
+++ b/src/pyramids/netcdf/ugrid/models.py
@@ -80,16 +80,22 @@ def _read_time_slab(
     ds = gdal.OpenEx(str(path), gdal.OF_MULTIDIM_RASTER | gdal.OF_VERBOSE_ERROR)
     if ds is None:
         raise ValueError(f"GDAL cannot re-open {path!r} for a windowed variable read.")
-    rg = ds.GetRootGroup()
-    md = open_mdarray(rg, var_name) if rg is not None else None
-    if md is None:
-        raise ValueError(f"Variable {var_name!r} is no longer present in {path!r}.")
-    sizes = [d.GetSize() for d in md.GetDimensions()]
-    start_idx = [0] * len(sizes)
-    start_idx[0] = start
-    count = list(sizes)
-    count[0] = 1 if stop is None else stop - start
-    slab = md.ReadAsArray(array_start_idx=start_idx, count=count)
+    try:
+        rg = ds.GetRootGroup()
+        md = open_mdarray(rg, var_name) if rg is not None else None
+        if md is None:
+            raise ValueError(f"Variable {var_name!r} is no longer present in {path!r}.")
+        sizes = [d.GetSize() for d in md.GetDimensions()]
+        start_idx = [0] * len(sizes)
+        start_idx[0] = start
+        count = list(sizes)
+        count[0] = 1 if stop is None else stop - start
+        # `ReadAsArray` returns a fresh, numpy-owned array, so the slab stays valid after the
+        # dataset is closed in `finally` (closing the per-selection reopen deterministically keeps
+        # Windows from holding a read handle on the file — review N3).
+        slab = md.ReadAsArray(array_start_idx=start_idx, count=count)
+    finally:
+        ds = None
     if slab is None:
         result = None
     else:

--- a/src/pyramids/netcdf/ugrid/models.py
+++ b/src/pyramids/netcdf/ugrid/models.py
@@ -12,6 +12,9 @@ from dataclasses import dataclass, field
 from typing import Any, cast
 
 import numpy as np
+from osgeo import gdal
+
+from pyramids.netcdf._mdim import open_mdarray
 
 #: Default UGRID mesh-topology variable name used when a file/in-memory mesh has no
 #: explicit name (the de-facto convention written by Deltares D-Flow FM and others).
@@ -64,6 +67,36 @@ class MeshTopologyInfo:
     crs_wkt: str | None = None
 
 
+def _read_time_slab(
+    path: str, var_name: str, start: int, stop: int | None
+) -> np.typing.NDArray | None:
+    """Read only a time slab of ``var_name`` straight from ``path`` (axis-0 time).
+
+    Reads ``[start]`` (when ``stop`` is ``None``) or ``[start:stop]`` along the leading axis via a
+    windowed MDArray read, so a single-step / short-range selection never materialises the whole
+    ``(n_time, n_elements)`` array (issue #982). The leading axis is dropped for a single step, so the
+    result matches ``data[index]``.
+    """
+    ds = gdal.OpenEx(str(path), gdal.OF_MULTIDIM_RASTER | gdal.OF_VERBOSE_ERROR)
+    if ds is None:
+        raise ValueError(f"GDAL cannot re-open {path!r} for a windowed variable read.")
+    rg = ds.GetRootGroup()
+    md = open_mdarray(rg, var_name) if rg is not None else None
+    if md is None:
+        raise ValueError(f"Variable {var_name!r} is no longer present in {path!r}.")
+    sizes = [d.GetSize() for d in md.GetDimensions()]
+    start_idx = [0] * len(sizes)
+    start_idx[0] = start
+    count = list(sizes)
+    count[0] = 1 if stop is None else stop - start
+    slab = md.ReadAsArray(array_start_idx=start_idx, count=count)
+    if slab is None:
+        result = None
+    else:
+        result = slab[0] if stop is None else slab
+    return result
+
+
 @dataclass
 class MeshVariable:
     """Data variable defined on a mesh location.
@@ -97,6 +130,9 @@ class MeshVariable:
     _data: np.ndarray | None = field(default=None, repr=False)
     _loader: Callable[[], np.ndarray] | None = field(default=None, repr=False)
     _dtype: np.dtype | None = field(default=None, repr=False)
+    # File this variable was read from, threaded so a single-step / short-range time selection can
+    # read only that slab from disk instead of the whole `(n_time, n_elements)` array (issue #982).
+    _source_path: str | None = field(default=None, repr=False)
 
     @property
     def data(self) -> np.typing.NDArray | None:
@@ -170,8 +206,61 @@ class MeshVariable:
             result = np.dtype("float64")
         return result
 
+    def load_array(self) -> np.typing.NDArray | None:
+        """Return the full array **without** memoising it on this variable.
+
+        ``.data`` caches the loaded array on the instance; ``load_array`` reads it for a one-shot
+        consumer (e.g. writing every variable to a file) without retaining it, so a bulk operation
+        over many variables need not hold them all resident at once (issue #982). Returns an already
+        loaded array when present.
+        """
+        if self._data is not None:
+            result = self._data
+        elif self._loader is not None:
+            result = self._loader()
+        else:
+            result = None
+        return result
+
+    def _can_window_time(self, start: int, stop: int | None) -> bool:
+        """True when a time slab can be read straight from disk instead of loading everything.
+
+        Requires an on-disk source, an axis-0 time dimension (what the slab reader indexes), and
+        non-negative in-range indices; otherwise the caller falls back to a full load then slice.
+        """
+        n_steps = self.n_time_steps
+        return (
+            self._source_path is not None
+            and self.time_index == 0
+            and start >= 0
+            and start < n_steps
+            and (stop is None or 0 <= stop <= n_steps)
+        )
+
+    def _read_time_window(
+        self, start: int, stop: int | None
+    ) -> np.typing.NDArray | None:
+        """Return the ``[start]`` step (``stop is None``) or ``[start:stop]`` range of the time axis.
+
+        Reads only the requested slab from disk when possible (:meth:`_can_window_time`); otherwise
+        slices an already loaded array, or falls back to a full load then slice.
+        """
+        if self._data is not None:
+            result = self._data[start] if stop is None else self._data[start:stop]
+        elif self._can_window_time(start, stop):
+            result = _read_time_slab(
+                cast("str", self._source_path), self.name, start, stop
+            )
+        else:
+            data = self.data
+            if data is None:
+                result = None
+            else:
+                result = data[start] if stop is None else data[start:stop]
+        return result
+
     def sel_time(self, index: int) -> np.typing.NDArray:
-        """Select a single time step.
+        """Select a single time step, reading only that slab from disk when possible.
 
         Args:
             index: Time step index.
@@ -186,13 +275,13 @@ class MeshVariable:
         """
         if not self.has_time:
             raise ValueError(f"Variable '{self.name}' has no time dimension.")
-        data = self.data
-        if data is None:
+        slab = self._read_time_window(index, None)
+        if slab is None:
             raise ValueError(f"Variable '{self.name}' has no loaded data.")
-        return cast("np.typing.NDArray", data[index])
+        return cast("np.typing.NDArray", slab)
 
     def sel_time_range(self, start: int, stop: int) -> MeshVariable:
-        """Select a time range, returning a new MeshVariable.
+        """Select a time range, reading only that slab from disk when possible.
 
         Args:
             start: Start time index (inclusive).
@@ -207,10 +296,10 @@ class MeshVariable:
         """
         if not self.has_time:
             raise ValueError(f"Variable '{self.name}' has no time dimension.")
-        data = self.data
-        if data is None:
+        slab = self._read_time_window(start, stop)
+        if slab is None:
             raise ValueError(f"Variable '{self.name}' has no loaded data.")
-        return self.with_data(data[start:stop])
+        return self.with_data(slab)
 
     def with_data(self, data: np.ndarray | None) -> MeshVariable:
         """Return a copy of this variable carrying ``data``, keeping all other metadata.

--- a/src/pyramids/netcdf/ugrid/models.py
+++ b/src/pyramids/netcdf/ugrid/models.py
@@ -152,7 +152,7 @@ class MeshVariable:
         """True when the variable can produce an array — eager data or a lazy loader.
 
         Metadata-only, so callers can decide whether to read a variable's values without forcing
-        the load a bare `.data` access would trigger.
+        the load a bare ``.data`` access would trigger.
         """
         return self._data is not None or self._loader is not None
 

--- a/tests/netcdf/lazy/test_netcdf_interop.py
+++ b/tests/netcdf/lazy/test_netcdf_interop.py
@@ -19,7 +19,10 @@ xr = pytest.importorskip("xarray")
 pytestmark = pytest.mark.interop
 
 from pyramids.dataset import Dataset
-from pyramids.netcdf.engines.interop import _encode_temporal_array
+from pyramids.netcdf.engines.interop import (
+    _encode_temporal_array,
+    _write_md_array_streamed,
+)
 from pyramids.netcdf.netcdf import NetCDF
 from tests._marks import requires_dask
 
@@ -904,4 +907,102 @@ class TestToXarrayLazy:
         )
         assert captured["orient"] is False, (
             "lazy interop read must be raw (orient=False)"
+        )
+
+
+class _RecordingMDArray:
+    """A stand-in ``gdal.MDArray`` that records each hyperslab write into a real buffer."""
+
+    def __init__(self, shape, dtype):
+        """Allocate the destination buffer and a write log.
+
+        Args:
+            shape: Full array shape.
+            dtype: Buffer dtype.
+        """
+        self.buf = np.zeros(shape, dtype=dtype)
+        self.writes = []
+
+    def Write(self, block, array_start_idx=None, count=None):
+        """Record and apply one write; a whole write has ``array_start_idx is None``."""
+        self.writes.append((array_start_idx, count))
+        if array_start_idx is None:
+            self.buf[...] = np.asarray(block)
+        else:
+            sl = tuple(slice(s, s + c) for s, c in zip(array_start_idx, count))
+            self.buf[sl] = np.asarray(block)
+
+
+class TestFromXarrayStreaming:
+    """from_xarray streams a dask-backed variable block by block, not all at once (ARC-48)."""
+
+    @requires_dask
+    def test_dask_input_round_trips_and_matches_eager(self):
+        """A dask-backed input reproduces the data and agrees with the equivalent numpy input.
+
+        Test scenario:
+            Build the same 3-D variable once dask-backed and once as numpy; `from_xarray` of each
+            must yield the same values on read-back, proving the streamed write is correct.
+        """
+        import dask.array as da
+
+        base = np.arange(4 * 3 * 2, dtype="float32").reshape(4, 3, 2)
+        coords = {"time": np.arange(4), "lat": [10.0, 11.0, 12.0], "lon": [20.0, 21.0]}
+        lazy = xr.Dataset(
+            {"t": (("time", "lat", "lon"), da.from_array(base, chunks=(2, 2, 1)))},
+            coords=coords,
+        )
+        eager = xr.Dataset({"t": (("time", "lat", "lon"), base)}, coords=coords)
+        nc_lazy = NetCDF.from_xarray(lazy)
+        nc_eager = NetCDF.from_xarray(eager)
+        try:
+            got = np.asarray(nc_lazy.to_xarray()["t"].values)
+            assert np.array_equal(got, base), (
+                "streamed dask input must reproduce the data"
+            )
+            assert np.array_equal(got, np.asarray(nc_eager.to_xarray()["t"].values)), (
+                "streamed and eager from_xarray must agree"
+            )
+        finally:
+            nc_lazy.close()
+            nc_eager.close()
+
+    @requires_dask
+    def test_dask_written_block_by_block(self):
+        """A dask array is written one hyperslab per block, and the blocks reconstruct the array.
+
+        Test scenario:
+            A `(4, 3, 2)` array chunked `(2, 3, 1)` has 4 blocks; `_write_md_array_streamed` must
+            issue exactly 4 hyperslab writes whose offsets/counts reassemble the original.
+        """
+        import dask.array as da
+
+        base = np.arange(24, dtype="float32").reshape(4, 3, 2)
+        arr = da.from_array(base, chunks=(2, 3, 1))  # 2 * 1 * 2 = 4 blocks
+        rec = _RecordingMDArray((4, 3, 2), "float32")
+        _write_md_array_streamed(rec, arr)
+        assert len(rec.writes) == 4, (
+            f"expected one write per block, got {len(rec.writes)}"
+        )
+        assert all(s is not None and c is not None for s, c in rec.writes), (
+            "each streamed write must be a bounded hyperslab (array_start_idx + count)"
+        )
+        assert np.array_equal(rec.buf, base), (
+            "the block writes must reconstruct the full array"
+        )
+
+    def test_numpy_written_in_a_single_hyperslab(self):
+        """A numpy array is written whole, not streamed.
+
+        Test scenario:
+            `_write_md_array_streamed` on a numpy array issues a single whole-array write
+            (`array_start_idx is None`), preserving the prior eager behaviour.
+        """
+        rec = _RecordingMDArray((2, 3), "int64")
+        _write_md_array_streamed(rec, np.arange(6).reshape(2, 3))
+        assert rec.writes == [(None, None)], (
+            f"numpy must be one whole write, got {rec.writes}"
+        )
+        assert np.array_equal(rec.buf, np.arange(6).reshape(2, 3)), (
+            "the whole write must land"
         )

--- a/tests/netcdf/samples/test_stream_apply_to_file.py
+++ b/tests/netcdf/samples/test_stream_apply_to_file.py
@@ -1,0 +1,142 @@
+"""Streaming-to-file variant of the container spatial ops (issue #976).
+
+``crop`` / ``to_crs`` / ``resample`` on a root MDIM container accept a ``path=`` keyword. With it set,
+the op streams every transformed variable straight to that ``.nc`` file one leading-dimension slab at a
+time -- instead of materialising the whole reprojected/cropped cube in an in-memory MEM container -- and
+returns a **file-backed** :class:`NetCDF`. ``path=None`` keeps the historical in-memory fan-out.
+
+These tests assert the streamed result is value-identical to the in-memory result, that the 3-D write
+really is slab-by-slab (not a single whole-array write), and that a shape the slab writer cannot represent
+(a variable with two band dimensions) still round-trips through the eager fallback.
+"""
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose, assert_array_equal
+
+from pyramids.netcdf import NetCDF
+from pyramids.netcdf.engines import interop
+from pyramids.netcdf.netcdf import NetCDF as _NetCDF
+from tests.netcdf.samples.conftest import RHUM, TOS
+
+pytestmark = pytest.mark.core
+
+
+def _snapshot(nc):
+    """Materialise every variable's array, keyed by name, for a value comparison."""
+    return {
+        name: np.asarray(nc.get_variable(name).read_array()) for name in nc.variables
+    }
+
+
+def _assert_same(mem, streamed):
+    """Assert two containers hold the same variables with value-identical arrays."""
+    assert sorted(mem.variables) == sorted(streamed.variables)
+    left, right = _snapshot(mem), _snapshot(streamed)
+    for name in left:
+        assert left[name].shape == right[name].shape, name
+        if np.issubdtype(left[name].dtype, np.floating):
+            assert_allclose(left[name], right[name], equal_nan=True, err_msg=name)
+        else:
+            assert_array_equal(left[name], right[name], err_msg=name)
+
+
+OPS = {
+    "crop": lambda nc, path: nc.crop(bbox=(0, -40, 60, 40), path=path),
+    "to_crs": lambda nc, path: nc.to_crs(3857, path=path),
+    "resample": lambda nc, path: nc.resample(nc.cell_size * 2, path=path),
+}
+
+
+@pytest.mark.parametrize("op", list(OPS))
+def test_streamed_matches_in_memory(sample, tmp_path, op):
+    """``op(path=…)`` writes a file-backed container value-identical to the in-memory result."""
+    call = OPS[op]
+    mem = call(NetCDF.read_file(sample(TOS)), None)
+    out = tmp_path / f"{op}.nc"
+    streamed = call(NetCDF.read_file(sample(TOS)), str(out))
+    try:
+        assert out.exists()
+        assert streamed._raster is not None
+        _assert_same(mem, streamed)
+    finally:
+        mem.close()
+        streamed.close()
+
+
+def test_three_d_variable_is_written_slab_by_slab(sample, tmp_path, monkeypatch):
+    """The 3-D variable is filled one band slab at a time, not in a single whole-array write."""
+    slab_calls = []
+    original = interop._StreamingMultidimWriter.write_slab
+
+    def counting(self, var_name, index, block):
+        slab_calls.append((var_name, index))
+        return original(self, var_name, index, block)
+
+    monkeypatch.setattr(interop._StreamingMultidimWriter, "write_slab", counting)
+
+    out = tmp_path / "to_crs.nc"
+    streamed = NetCDF.read_file(sample(TOS)).to_crs(3857, path=str(out))
+    try:
+        bands = streamed.get_variable("tos").shape[0]
+        tos_slabs = [index for name, index in slab_calls if name == "tos"]
+        # One write_slab per band of the only 3-D variable, in order 0..bands-1.
+        assert tos_slabs == list(range(bands))
+    finally:
+        streamed.close()
+
+
+def test_two_band_dim_variable_falls_back_to_eager_write(sample, tmp_path, monkeypatch):
+    """A variable with two band dims isn't slab-streamable: stream returns None, eager write matches."""
+    returned = {}
+    real = _NetCDF._stream_apply_to_file
+
+    def spy(self, operation, op_kwargs, spatial_vars, aux_vars, path):
+        result = real(self, operation, op_kwargs, spatial_vars, aux_vars, path)
+        returned["is_none"] = result is None
+        return result
+
+    monkeypatch.setattr(_NetCDF, "_stream_apply_to_file", spy)
+
+    # `resample` avoids any reprojection (RHUM spans past Web Mercator's ±85° limit); the point is
+    # the 4-D (time, level) variable, which the slab writer cannot represent.
+    cell = NetCDF.read_file(sample(RHUM)).cell_size
+    mem = NetCDF.read_file(sample(RHUM)).resample(cell * 2)
+    out = tmp_path / "rhum.nc"
+    streamed = NetCDF.read_file(sample(RHUM)).resample(cell * 2, path=str(out))
+    try:
+        assert returned["is_none"] is True  # 4-D (time, level) var rejects the slab writer
+        assert out.exists()
+        _assert_same(mem, streamed)
+    finally:
+        mem.close()
+        streamed.close()
+
+
+def test_subset_crop_honours_path(sample, tmp_path):
+    """``path=`` on a single-variable (non-container) crop writes and re-opens a file-backed result.
+
+    A single-variable crop is a plain raster, so writing it out yields a generic multi-band raster
+    (``Band1..N``); the point here is that ``path=`` is honoured and the pixel data round-trips.
+    """
+    in_memory = (
+        NetCDF.read_file(sample(TOS)).get_variable("tos").crop(bbox=(0, -40, 60, 40))
+    )
+    out = tmp_path / "tos_subset.nc"
+    on_disk = NetCDF.read_file(sample(TOS)).get_variable("tos").crop(
+        bbox=(0, -40, 60, 40), path=str(out)
+    )
+    try:
+        assert out.exists()
+        bands = in_memory.shape[0]
+        # The raster export splits the 24-band variable into Band1..Band24 — stack them back.
+        stacked = np.stack(
+            [
+                np.asarray(on_disk.get_variable(f"Band{i + 1}").read_array())
+                for i in range(bands)
+            ]
+        )
+        assert_allclose(stacked, np.asarray(in_memory.read_array()), equal_nan=True)
+    finally:
+        in_memory.close()
+        on_disk.close()

--- a/tests/netcdf/samples/test_stream_apply_to_file.py
+++ b/tests/netcdf/samples/test_stream_apply_to_file.py
@@ -105,7 +105,9 @@ def test_two_band_dim_variable_falls_back_to_eager_write(sample, tmp_path, monke
     out = tmp_path / "rhum.nc"
     streamed = NetCDF.read_file(sample(RHUM)).resample(cell * 2, path=str(out))
     try:
-        assert returned["is_none"] is True  # 4-D (time, level) var rejects the slab writer
+        assert (
+            returned["is_none"] is True
+        )  # 4-D (time, level) var rejects the slab writer
         assert out.exists()
         _assert_same(mem, streamed)
     finally:
@@ -123,8 +125,10 @@ def test_subset_crop_honours_path(sample, tmp_path):
         NetCDF.read_file(sample(TOS)).get_variable("tos").crop(bbox=(0, -40, 60, 40))
     )
     out = tmp_path / "tos_subset.nc"
-    on_disk = NetCDF.read_file(sample(TOS)).get_variable("tos").crop(
-        bbox=(0, -40, 60, 40), path=str(out)
+    on_disk = (
+        NetCDF.read_file(sample(TOS))
+        .get_variable("tos")
+        .crop(bbox=(0, -40, 60, 40), path=str(out))
     )
     try:
         assert out.exists()

--- a/tests/netcdf/samples/test_stream_apply_to_file.py
+++ b/tests/netcdf/samples/test_stream_apply_to_file.py
@@ -30,7 +30,16 @@ def _snapshot(nc):
 
 
 def _assert_same(mem, streamed):
-    """Assert two containers hold the same variables with value-identical arrays."""
+    """Assert two containers match on variables, array values, and spatial CRS / geotransform.
+
+    Metadata is compared only for the genuinely spatial variables (those the eager result gives a
+    CRS): non-spatial bounds variables inherit the container's global CRS in the streamed file but
+    stay CRS-less in the eager path — a harmless, known divergence not asserted here. The
+    geotransform tolerance is relative and loose (`rtol=1e-4`): the eager path reconstructs the
+    affine via `create_from_array` while the streamed file round-trips the native warp geotransform,
+    so they differ sub-pixel (~1e-5 of a cell) — still far tighter than any real CRS/affine
+    regression, which flips units or collapses to identity.
+    """
     assert sorted(mem.variables) == sorted(streamed.variables)
     left, right = _snapshot(mem), _snapshot(streamed)
     for name in left:
@@ -39,6 +48,24 @@ def _assert_same(mem, streamed):
             assert_allclose(left[name], right[name], equal_nan=True, err_msg=name)
         else:
             assert_array_equal(left[name], right[name], err_msg=name)
+    # CRS + affine must survive the streamed write, not just the pixel values — a `to_crs` that
+    # dropped or garbled the reconstructed CRS/geotransform would still match on values alone (L5).
+    assert mem.epsg == streamed.epsg, f"container epsg {mem.epsg} != {streamed.epsg}"
+    for name in left:
+        mem_var = mem.get_variable(name)
+        if mem_var.epsg is None:
+            continue  # non-spatial / auxiliary variable in the eager result
+        streamed_var = streamed.get_variable(name)
+        assert mem_var.epsg == streamed_var.epsg, (
+            f"{name}: epsg {mem_var.epsg} != {streamed_var.epsg}"
+        )
+        assert_allclose(
+            np.asarray(mem_var.geotransform, dtype=float),
+            np.asarray(streamed_var.geotransform, dtype=float),
+            rtol=1e-4,
+            atol=1e-3,
+            err_msg=f"{name}: geotransform",
+        )
 
 
 OPS = {

--- a/tests/ugrid/test_lazy_data_variables.py
+++ b/tests/ugrid/test_lazy_data_variables.py
@@ -234,6 +234,46 @@ class TestWindowedTimeSelection:
         assert calls == [], "a reversed range must not take the windowed path"
         np.testing.assert_array_equal(np.asarray(result.data), temporal[2:1])
 
+    def test_empty_range_falls_back_to_empty_slice(self, temporal_file, monkeypatch):
+        """An empty `start == stop` range is not windowed (a `count=0` read raises under GDAL).
+
+        Test scenario:
+            `sel_time_range(1, 1)` on a file-backed variable takes the in-memory fallback (the spy
+            records no windowed read) and returns the same empty `(0, n_elements)` array the cached
+            path would — never sending `count = 0` to GDAL (review R2-M1).
+        """
+        path, temporal = temporal_file
+        calls = []
+        real = models._read_time_slab
+        monkeypatch.setattr(
+            models,
+            "_read_time_slab",
+            lambda p, name, start, stop: (
+                calls.append((start, stop)) or real(p, name, start, stop)
+            ),
+        )
+        result = UgridDataset.read_file(path).get_data("h").sel_time_range(1, 1)
+        assert calls == [], "an empty range must not take the windowed path"
+        assert np.asarray(result.data).shape[0] == 0
+        np.testing.assert_array_equal(np.asarray(result.data), temporal[1:1])
+
+    def test_full_range_reads_every_step(self, temporal_file, monkeypatch):
+        """A full `stop == n_steps` range windows one read and returns every step (upper boundary)."""
+        path, temporal = temporal_file
+        calls = []
+        real = models._read_time_slab
+        monkeypatch.setattr(
+            models,
+            "_read_time_slab",
+            lambda p, name, start, stop: (
+                calls.append((start, stop)) or real(p, name, start, stop)
+            ),
+        )
+        n_steps = temporal.shape[0]
+        result = UgridDataset.read_file(path).get_data("h").sel_time_range(0, n_steps)
+        assert calls == [(0, n_steps)], "a full range should still window a single read"
+        np.testing.assert_array_equal(np.asarray(result.data), temporal)
+
 
 class TestStreamingWrite:
     """`to_file` streams each variable without populating the shared cache (#982)."""

--- a/tests/ugrid/test_lazy_data_variables.py
+++ b/tests/ugrid/test_lazy_data_variables.py
@@ -10,9 +10,36 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from pyramids.netcdf.ugrid import models
 from pyramids.netcdf.ugrid.dataset import UgridDataset
 
 _UGRID_PATH = Path("tests/data/netcdf/ugrid/ugrid.nc")
+
+
+def _temporal_dataset() -> tuple[UgridDataset, np.ndarray]:
+    """A tiny two-triangle mesh carrying one temporal face variable ``h`` of shape ``(3, 2)``."""
+    node_x = np.array([0.0, 1.0, 1.0, 0.0])
+    node_y = np.array([0.0, 0.0, 1.0, 1.0])
+    fnc = np.array([[0, 1, 2], [0, 2, 3]])
+    temporal = np.arange(3 * 2, dtype=np.float64).reshape(3, 2)  # (time=3, n_face=2)
+    ds = UgridDataset.create_from_arrays(
+        node_x,
+        node_y,
+        fnc,
+        data={"h": temporal},
+        data_locations={"h": "face"},
+        epsg=4326,
+    )
+    return ds, temporal
+
+
+@pytest.fixture
+def temporal_file(tmp_path) -> tuple[Path, np.ndarray]:
+    """Write the temporal mesh to a file and return ``(path, expected_array)`` for round-tripping."""
+    ds, temporal = _temporal_dataset()
+    path = tmp_path / "temporal_mesh.nc"
+    ds.to_file(path)
+    return path, temporal
 
 
 @pytest.fixture(scope="function")
@@ -117,4 +144,104 @@ class TestLazyDataVariables:
 
         np.testing.assert_array_equal(
             lazy, eager, err_msg=f"lazy and eager reads of {name!r} differ"
+        )
+
+
+class TestWindowedTimeSelection:
+    """`sel_time` / `sel_time_range` read only the requested slab from a file-backed variable (#982)."""
+
+    def test_sel_time_reads_a_single_slab(self, temporal_file, monkeypatch):
+        """`sel_time(i)` issues exactly one single-step slab read and never caches the full array.
+
+        Test scenario:
+            A spy on the windowed reader records one `(i, None)` call; the returned step equals
+            `array[i]`, and the parent variable's `_data` stays `None` (no full materialisation).
+        """
+        path, temporal = temporal_file
+        calls = []
+        real = models._read_time_slab
+        monkeypatch.setattr(
+            models,
+            "_read_time_slab",
+            lambda p, name, start, stop: (
+                calls.append((start, stop)) or real(p, name, start, stop)
+            ),
+        )
+        var = UgridDataset.read_file(path).get_data("h")
+        result = np.asarray(var.sel_time(1))
+        assert calls == [(1, None)], (
+            "sel_time should issue exactly one single-step slab read"
+        )
+        np.testing.assert_array_equal(result, temporal[1])
+        assert var._data is None, "a windowed read must not cache the full array"
+
+    def test_sel_time_range_reads_a_range_slab(self, temporal_file, monkeypatch):
+        """`sel_time_range(a, b)` issues one `(a, b)` slab read and returns `array[a:b]`."""
+        path, temporal = temporal_file
+        calls = []
+        real = models._read_time_slab
+        monkeypatch.setattr(
+            models,
+            "_read_time_slab",
+            lambda p, name, start, stop: (
+                calls.append((start, stop)) or real(p, name, start, stop)
+            ),
+        )
+        result = UgridDataset.read_file(path).get_data("h").sel_time_range(0, 2)
+        assert calls == [(0, 2)], (
+            "sel_time_range should issue exactly one range slab read"
+        )
+        np.testing.assert_array_equal(np.asarray(result.data), temporal[0:2])
+
+    def test_cached_variable_slices_in_memory(self, temporal_file, monkeypatch):
+        """Once `.data` is cached, `sel_time` slices in memory instead of re-reading the file."""
+        path, temporal = temporal_file
+        var = UgridDataset.read_file(path).get_data("h")
+        _ = var.data  # force the full load / cache
+        calls = []
+        monkeypatch.setattr(models, "_read_time_slab", lambda *a: calls.append(a))
+        np.testing.assert_array_equal(np.asarray(var.sel_time(2)), temporal[2])
+        assert calls == [], "a cached variable must not re-read the file for sel_time"
+
+    def test_negative_index_falls_back_to_full_read(self, temporal_file, monkeypatch):
+        """A negative index is not windowable, so `sel_time` falls back to a full read + slice."""
+        path, temporal = temporal_file
+        calls = []
+        monkeypatch.setattr(models, "_read_time_slab", lambda *a: calls.append(a))
+        result = np.asarray(UgridDataset.read_file(path).get_data("h").sel_time(-1))
+        assert calls == [], "a negative index must not take the windowed path"
+        np.testing.assert_array_equal(result, temporal[-1])
+
+
+class TestStreamingWrite:
+    """`to_file` streams each variable without populating the shared cache (#982)."""
+
+    def test_to_file_does_not_cache_source_variables(self, tmp_path):
+        """Writing a file-backed dataset leaves its variables lazy and round-trips the data.
+
+        Test scenario:
+            A freshly-read dataset starts with every variable uncached (`_data is None`). After
+            `to_file`, the source variables are still uncached — the write read each array locally
+            via `load_array` rather than through the caching `.data` — and the output file
+            reproduces the values.
+        """
+        seed, _ = _temporal_dataset()
+        src = tmp_path / "src.nc"
+        seed.to_file(src)
+
+        rb = UgridDataset.read_file(src)
+        assert all(v._data is None for v in rb._data_variables.values()), (
+            "precondition: a freshly-read dataset is uncached"
+        )
+
+        out = tmp_path / "out.nc"
+        rb.to_file(out)
+        assert all(v._data is None for v in rb._data_variables.values()), (
+            "to_file must not populate the shared variable cache"
+        )
+
+        back = UgridDataset.read_file(out)
+        np.testing.assert_array_equal(
+            np.asarray(back.get_data("h").data),
+            np.asarray(UgridDataset.read_file(src).get_data("h").data),
         )

--- a/tests/ugrid/test_lazy_data_variables.py
+++ b/tests/ugrid/test_lazy_data_variables.py
@@ -212,6 +212,28 @@ class TestWindowedTimeSelection:
         assert calls == [], "a negative index must not take the windowed path"
         np.testing.assert_array_equal(result, temporal[-1])
 
+    def test_reversed_range_falls_back_to_empty_slice(self, temporal_file, monkeypatch):
+        """A reversed/empty range is not windowed (no negative GDAL `count`); it returns empty.
+
+        Test scenario:
+            `sel_time_range(2, 1)` on a file-backed variable takes the in-memory fallback (the spy
+            records no windowed read) and yields the same empty `(0, n_elements)` array the cached
+            path would — never passing `count = -1` to GDAL.
+        """
+        path, temporal = temporal_file
+        calls = []
+        real = models._read_time_slab
+        monkeypatch.setattr(
+            models,
+            "_read_time_slab",
+            lambda p, name, start, stop: (
+                calls.append((start, stop)) or real(p, name, start, stop)
+            ),
+        )
+        result = UgridDataset.read_file(path).get_data("h").sel_time_range(2, 1)
+        assert calls == [], "a reversed range must not take the windowed path"
+        np.testing.assert_array_equal(np.asarray(result.data), temporal[2:1])
+
 
 class TestStreamingWrite:
     """`to_file` streams each variable without populating the shared cache (#982)."""

--- a/tests/ugrid/test_lazy_data_variables.py
+++ b/tests/ugrid/test_lazy_data_variables.py
@@ -267,3 +267,27 @@ class TestStreamingWrite:
             np.asarray(back.get_data("h").data),
             np.asarray(UgridDataset.read_file(src).get_data("h").data),
         )
+
+
+class TestGeoDataFrameTolerance:
+    """`to_geodataframe` tolerates a temporal variable that resolves to no data (review L3)."""
+
+    def test_dataless_temporal_variable_yields_null_column(self):
+        """A temporal variable with neither eager data nor a loader gives a null column, not a raise.
+
+        Test scenario:
+            Injecting a temporal `MeshVariable` with no `_data` and no `_loader` (so `has_data_source`
+            is False), `to_geodataframe` stores `None` for its column — the historical tolerance —
+            instead of raising the `sel_time` "no loaded data" error.
+        """
+        ds, _ = _temporal_dataset()
+        ds._data_variables["h"] = models.MeshVariable(
+            name="h",
+            location="face",
+            mesh_name=ds.mesh_name,
+            shape=(3, 2),
+            dimensions=("time", "mesh2d_nFaces"),
+        )
+        gdf = ds.to_geodataframe(variable_name="h", location="face")
+        assert "h" in gdf.columns
+        assert gdf["h"].isna().all()


### PR DESCRIPTION
# Description

Two write-side streaming changes to `NetCDF` that keep peak memory bounded to a single slab instead of the whole
cube. Both are the write-side mirror of the lazy `to_xarray(chunks=)` reader added in #864.

## `from_xarray` streams a dask-backed input (#977)

`NetCDF.from_xarray` built the in-memory MEM container by calling `np.asarray(var.values)` on **every** data
variable up front: all variables were held in RAM simultaneously, and a dask-backed input was fully `.compute()`-d
before a single byte was written.

Now `from_xarray` passes `var.data` (the underlying array — lazy for a dask-backed variable) through to
`_build_multidim`, and `_build_multidim` writes a dask variable **block by block** via a new
`_write_md_array_streamed` helper: each block is computed, written to its hyperslab
(`md_arr.Write(block, array_start_idx=…, count=…)`), and released before the next. A lazily-loaded xarray variable
therefore never becomes fully resident, and multiple variables are no longer all materialised into a dict at once.

Backward-compatible:

- A NumPy input variable keeps the eager whole-array write, **byte-identical** to before.
- The other `_build_multidim` caller — the GDAL-native `write_multidim_netcdf` / `DatasetCollection.to_netcdf`
  path — passes NumPy arrays, so it is unchanged.
- Coordinate arrays (1-D, small) stay eager, and a temporal (datetime/timedelta) variable that must be CF-encoded
  also takes the eager path.

## `crop` / `to_crs` / `resample` can stream a container to a file (#976)

The root-container fan-out for these three ops applied the op to every spatial variable and built an in-memory MEM
container holding **all** transformed variables at once, so peak memory scaled with the whole cube rather than a
single slab.

These methods now take an opt-in `path=` keyword. On a **root MDIM container**, `path` streams every transformed
variable straight to that `.nc` file one leading-dimension slab at a time via `open_streaming_multidim_netcdf` (so
the whole result is never resident) and returns a **file-backed** `NetCDF`. `path=None` (default) keeps today's
in-memory fan-out unchanged.

- 3-D `(band-dim, y, x)` variables are written slab-by-slab; 2-D `(y, x)` variables and carried-through
  non-spatial auxiliary variables are written whole via a new `_StreamingMultidimWriter.write_whole`.
- Shapes the single-leading-dimension slab writer cannot represent — a variable with two or more band dimensions,
  a string/object auxiliary variable, or a curvilinear (2-D) coordinate grid — make `_stream_apply_to_file` return
  `None`, and the caller falls back to the eager build-then-write path (still correct, just not bounded-memory for
  that rare shape).
- A single-variable (non-container) crop honours `path` by writing the raster and re-opening it file-backed.

No dependencies added.

## UGRID eager reads: windowed time selection, dropped copies, streamed write (#982)

The same audit applied to `UgridDataset`. Variable reads were already deferred to first `.data` access, but
several methods then read the whole `(n_time, n_elements)` array where only a slice was needed, and a couple of
hot paths duplicated the largest arrays.

- `MeshVariable.sel_time` / `sel_time_range` and `to_geodataframe` now read only the requested **time slab**
  straight from disk (`ReadAsArray(array_start_idx=…, count=…)`) when the array isn't already cached and the time
  axis is axis 0, falling back to the full-load-then-slice path for a cached array, a negative/out-of-range index,
  or a non-axis-0 time dimension. A single-step selection no longer materialises (or caches) the whole temporal
  cube. The source file is threaded onto each variable via a new `_source_path` field.
- Dropped the redundant `.copy()` after `ReadAsArray()` in the lazy data loader, `Connectivity.from_gdal_array`,
  and `_write_connectivity_array` — `ReadAsArray` already returns a fresh array and the following `astype` copies
  again.
- `to_file` streams each variable through a new `MeshVariable.load_array` that reads without populating the shared
  cache, so the write holds one variable at a time instead of the whole cube (and leaves the caller's variables
  lazy).

`to_crs` was verified already lazy (it passes the variable dict through and only transforms coordinates).

No dependencies added.

# Issues

- Closes #977 — the deferred `from_xarray` half of ARC-48 (the `open_mfdataset` + `to_xarray(chunks=)` halves
  shipped in #816 / #864)
- Closes #976 — the eager container fan-out for `crop` / `to_crs` / `resample`
- Closes #982 — eager full-array reads in `UgridDataset` (windowed time selection, redundant copies, write
  fan-out)

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

`crop` / `to_crs` / `resample` gain an opt-in `path=` parameter (defaulting to the previous in-memory behaviour);
`from_xarray`'s signature and output are unchanged. No existing behaviour changes when `path` is omitted.

# How Has This Been Tested?

- [x] `tests/netcdf/lazy/test_netcdf_interop.py::TestFromXarrayStreaming` — a dask-backed input round-trips and
      agrees with the equivalent NumPy input; `_write_md_array_streamed` issues one hyperslab write per dask block
      and the blocks reconstruct the array; a NumPy array is written in a single whole write.
- [x] `tests/netcdf/samples/test_stream_apply_to_file.py` (6 tests) — `crop` / `to_crs` / `resample` with `path=`
      write a file-backed container value-identical to the in-memory result; the 3-D variable is written one band
      slab at a time (not a single whole write); a 4-D variable falls back to the eager path and still matches; a
      single-variable crop honours `path`.
- [x] `tests/ugrid/test_lazy_data_variables.py` (5 new tests) — `sel_time` / `sel_time_range` issue exactly one
      windowed slab read and match the full-array slice; a cached variable slices in memory; a negative index
      falls back to a full read; `to_file` leaves the source variables uncached and the output round-trips.
- [x] Full `netcdf` non-plot suite: **2378 passed, 38 skipped**; full `ugrid` suite: **258 passed**.
- [x] Line length / formatting checked by inspection against the repo's ruff config (line-length 88).

Reproduce:
`pixi run -e dev pytest tests/netcdf/lazy/test_netcdf_interop.py tests/netcdf/samples/test_stream_apply_to_file.py`

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.

Versions and the change log are generated by commitizen in CI, so those three boxes are intentionally left for the
release automation.
