### PR TITLE
fix(cell): label cell polygons/points with the CRS spec, not the EPSG code

### DIFF
--- a/src/pyramids/dataset/engines/cell.py
+++ b/src/pyramids/dataset/engines/cell.py
@@ -16,7 +16,7 @@ from geopandas.geodataframe import GeoDataFrame
 from hpc.indexing import get_indices2, locate_values
 from pandas import DataFrame
 
-from pyramids.base.crs import crs_from_user_input
+from pyramids.base.crs import crs_from_user_input, crs_spec
 from pyramids.dataset.engines._base import _Engine
 from pyramids.feature import FeatureCollection, create_points, create_polygon
 
@@ -215,7 +215,7 @@ class Cell(_Engine["Dataset"]):
         # Expressed as vector steps it also carries the rotation terms, so a skewed
         # raster yields the right parallelogram instead of an axis-aligned box.
         _, col_dx, row_dx, _, col_dy, row_dy = self._ds.geotransform
-        epsg = self._ds._get_epsg()
+        crs = crs_spec(self._ds.epsg, self._ds.crs)
         x = np.zeros((coords.shape[0], 4))
         y = np.zeros((coords.shape[0], 4))
         x[:, 0] = coords[:, 0]
@@ -234,10 +234,16 @@ class Cell(_Engine["Dataset"]):
         rings = np.stack((x, y), axis=-1)
         polygons = [create_polygon(ring) for ring in rings.tolist()]
         gdf = gpd.GeoDataFrame(geometry=polygons)
-        # Through `crs_from_user_input`, not `epsg=`: geopandas resolves a bare code
-        # with pyproj, which cannot look up a code only GDAL's PROJ database carries
-        # (issue #943). A resolved CRS object needs no lookup.
-        gdf.set_crs(crs_from_user_input(epsg), inplace=True)
+        # Label with the resolved CRS *spec* (the EPSG code when the CRS has one,
+        # else its WKT), routed through `crs_from_user_input` rather than a bare
+        # `epsg=`: geopandas resolves a code with pyproj, which cannot look up a code
+        # only GDAL's PROJ database carries (issue #943). Using `_get_epsg()` alone
+        # passed `None` for a valid CRS with no EPSG authority (a custom projection or
+        # a proj4/WKT reprojection), which crashed `set_crs` and, before #893, silently
+        # mislabelled such cells as EPSG:4326 (issue #979). `crs_spec` is `None` only
+        # when the raster truly has no CRS -- then leave the frame unprojected.
+        if crs is not None:
+            gdf.set_crs(crs_from_user_input(crs), inplace=True)
         gdf["id"] = gdf.index
         return gdf
 
@@ -316,15 +322,21 @@ class Cell(_Engine["Dataset"]):
             ![get_cell_points-corner](./../../_images/dataset/get_cell_points-corner.png)
         """
         coords = self.get_cell_coords(location=location, domain_only=domain_only)
-        epsg = self._ds._get_epsg()
+        crs = crs_spec(self._ds.epsg, self._ds.crs)
 
         coords_tuples = list(zip(coords[:, 0], coords[:, 1]))
         points = create_points(coords_tuples)
         gdf = gpd.GeoDataFrame(geometry=points)
-        # Through `crs_from_user_input`, not `epsg=`: geopandas resolves a bare code
-        # with pyproj, which cannot look up a code only GDAL's PROJ database carries
-        # (issue #943). A resolved CRS object needs no lookup.
-        gdf.set_crs(crs_from_user_input(epsg), inplace=True)
+        # Label with the resolved CRS *spec* (the EPSG code when the CRS has one,
+        # else its WKT), routed through `crs_from_user_input` rather than a bare
+        # `epsg=`: geopandas resolves a code with pyproj, which cannot look up a code
+        # only GDAL's PROJ database carries (issue #943). Using `_get_epsg()` alone
+        # passed `None` for a valid CRS with no EPSG authority (a custom projection or
+        # a proj4/WKT reprojection), which crashed `set_crs` and, before #893, silently
+        # mislabelled such cells as EPSG:4326 (issue #979). `crs_spec` is `None` only
+        # when the raster truly has no CRS -- then leave the frame unprojected.
+        if crs is not None:
+            gdf.set_crs(crs_from_user_input(crs), inplace=True)
         gdf["id"] = gdf.index
         return gdf
 

--- a/src/pyramids/dataset/engines/cell.py
+++ b/src/pyramids/dataset/engines/cell.py
@@ -161,6 +161,25 @@ class Cell(_Engine["Dataset"]):
 
         return coords
 
+    def _attach_crs(self, gdf: GeoDataFrame) -> None:
+        """Label `gdf` in place with the raster's CRS, or leave it unprojected.
+
+        Uses the resolved CRS *spec* (the EPSG code when it is resolvable downstream,
+        else the WKT), routed through `crs_from_user_input` rather than a bare `epsg=`:
+        geopandas resolves a code with pyproj, which cannot look up a code only GDAL's
+        PROJ database carries (issue #943). Passing the bare `_get_epsg()` code alone was
+        `None` for a valid CRS with no EPSG authority (a custom projection or a proj4/WKT
+        reprojection), which crashed `set_crs` and, before #893, silently mislabelled such
+        cells as EPSG:4326 (issue #979). `crs_spec` is `None` only when the raster truly
+        has no CRS -- then the frame is left unprojected.
+
+        Args:
+            gdf (GeoDataFrame): The frame to label in place.
+        """
+        crs = crs_spec(self._ds.epsg, self._ds.crs)
+        if crs is not None:
+            gdf.set_crs(crs_from_user_input(crs), inplace=True)
+
     def get_cell_polygons(self, domain_only: bool = False) -> GeoDataFrame:
         """Get a polygon shapely geometry for the raster cells.
 
@@ -220,7 +239,6 @@ class Cell(_Engine["Dataset"]):
         # Expressed as vector steps it also carries the rotation terms, so a skewed
         # raster yields the right parallelogram instead of an axis-aligned box.
         _, col_dx, row_dx, _, col_dy, row_dy = self._ds.geotransform
-        crs = crs_spec(self._ds.epsg, self._ds.crs)
         x = np.zeros((coords.shape[0], 4))
         y = np.zeros((coords.shape[0], 4))
         x[:, 0] = coords[:, 0]
@@ -239,16 +257,7 @@ class Cell(_Engine["Dataset"]):
         rings = np.stack((x, y), axis=-1)
         polygons = [create_polygon(ring) for ring in rings.tolist()]
         gdf = gpd.GeoDataFrame(geometry=polygons)
-        # Label with the resolved CRS *spec* (the EPSG code when the CRS has one,
-        # else its WKT), routed through `crs_from_user_input` rather than a bare
-        # `epsg=`: geopandas resolves a code with pyproj, which cannot look up a code
-        # only GDAL's PROJ database carries (issue #943). Using `_get_epsg()` alone
-        # passed `None` for a valid CRS with no EPSG authority (a custom projection or
-        # a proj4/WKT reprojection), which crashed `set_crs` and, before #893, silently
-        # mislabelled such cells as EPSG:4326 (issue #979). `crs_spec` is `None` only
-        # when the raster truly has no CRS -- then leave the frame unprojected.
-        if crs is not None:
-            gdf.set_crs(crs_from_user_input(crs), inplace=True)
+        self._attach_crs(gdf)
         gdf["id"] = gdf.index
         return gdf
 
@@ -332,21 +341,10 @@ class Cell(_Engine["Dataset"]):
             ![get_cell_points-corner](./../../_images/dataset/get_cell_points-corner.png)
         """
         coords = self.get_cell_coords(location=location, domain_only=domain_only)
-        crs = crs_spec(self._ds.epsg, self._ds.crs)
-
         coords_tuples = list(zip(coords[:, 0], coords[:, 1]))
         points = create_points(coords_tuples)
         gdf = gpd.GeoDataFrame(geometry=points)
-        # Label with the resolved CRS *spec* (the EPSG code when the CRS has one,
-        # else its WKT), routed through `crs_from_user_input` rather than a bare
-        # `epsg=`: geopandas resolves a code with pyproj, which cannot look up a code
-        # only GDAL's PROJ database carries (issue #943). Using `_get_epsg()` alone
-        # passed `None` for a valid CRS with no EPSG authority (a custom projection or
-        # a proj4/WKT reprojection), which crashed `set_crs` and, before #893, silently
-        # mislabelled such cells as EPSG:4326 (issue #979). `crs_spec` is `None` only
-        # when the raster truly has no CRS -- then leave the frame unprojected.
-        if crs is not None:
-            gdf.set_crs(crs_from_user_input(crs), inplace=True)
+        self._attach_crs(gdf)
         gdf["id"] = gdf.index
         return gdf
 

--- a/src/pyramids/dataset/engines/cell.py
+++ b/src/pyramids/dataset/engines/cell.py
@@ -170,7 +170,10 @@ class Cell(_Engine["Dataset"]):
 
         Returns:
             GeoDataFrame:
-                With two columns, geometry, and id.
+                With two columns, geometry, and id. The frame is labelled with the
+                raster's own CRS -- the EPSG code when it has one, otherwise its WKT
+                (so a custom, authority-less projection is preserved, not fabricated as
+                EPSG:4326) -- or left unprojected (`crs=None`) when the raster has no CRS.
 
         Examples:
             - Create `Dataset` consists of 1 band, 3 rows, 3 columns, at the point lon/lat (0, 0).
@@ -260,7 +263,10 @@ class Cell(_Engine["Dataset"]):
 
         Returns:
             GeoDataFrame:
-                With two columns, geometry, and id.
+                With two columns, geometry, and id. The frame is labelled with the
+                raster's own CRS -- the EPSG code when it has one, otherwise its WKT
+                (so a custom, authority-less projection is preserved, not fabricated as
+                EPSG:4326) -- or left unprojected (`crs=None`) when the raster has no CRS.
 
         Examples:
             - Create `Dataset` consists of 1 band, 3 rows, 3 columns, at the point lon/lat (0, 0).

--- a/src/pyramids/dataset/engines/cell.py
+++ b/src/pyramids/dataset/engines/cell.py
@@ -171,9 +171,11 @@ class Cell(_Engine["Dataset"]):
         Returns:
             GeoDataFrame:
                 With two columns, geometry, and id. The frame is labelled with the
-                raster's own CRS -- the EPSG code when it has one, otherwise its WKT
-                (so a custom, authority-less projection is preserved, not fabricated as
-                EPSG:4326) -- or left unprojected (`crs=None`) when the raster has no CRS.
+                raster's own CRS -- its EPSG code when that code is resolvable
+                downstream, otherwise its WKT (so a custom authority-less projection, or
+                a code only GDAL's PROJ database carries, is preserved rather than
+                fabricated as EPSG:4326) -- or left unprojected (`crs=None`) when the
+                raster has no CRS.
 
         Examples:
             - Create `Dataset` consists of 1 band, 3 rows, 3 columns, at the point lon/lat (0, 0).
@@ -264,9 +266,11 @@ class Cell(_Engine["Dataset"]):
         Returns:
             GeoDataFrame:
                 With two columns, geometry, and id. The frame is labelled with the
-                raster's own CRS -- the EPSG code when it has one, otherwise its WKT
-                (so a custom, authority-less projection is preserved, not fabricated as
-                EPSG:4326) -- or left unprojected (`crs=None`) when the raster has no CRS.
+                raster's own CRS -- its EPSG code when that code is resolvable
+                downstream, otherwise its WKT (so a custom authority-less projection, or
+                a code only GDAL's PROJ database carries, is preserved rather than
+                fabricated as EPSG:4326) -- or left unprojected (`crs=None`) when the
+                raster has no CRS.
 
         Examples:
             - Create `Dataset` consists of 1 band, 3 rows, 3 columns, at the point lon/lat (0, 0).

--- a/tests/dataset/unit/test_unit_properties.py
+++ b/tests/dataset/unit/test_unit_properties.py
@@ -774,6 +774,43 @@ class TestCellGeometryMethods:
             "cell polygons must carry the CRS the GDAL-only code resolves to"
         )
 
+    def test_get_cell_points_domain_only_authority_less_crs(self):
+        """The domain_only point path also labels an authority-less CRS correctly (#979).
+
+        Test scenario:
+            get_cell_points(domain_only=True) on the authority-less raster carries the source
+            orthographic CRS, mirroring the polygon masked-path check.
+        """
+        r = self._authority_less_raster()
+        gdf = r.get_cell_points(domain_only=True)
+        assert gdf.crs is not None, "domain_only path must still label the frame"
+        assert gdf.crs.to_epsg() is None, "authority-less CRS has no EPSG code"
+        assert gdf.crs.equals(crs_from_user_input(self._ORTHO_PROJ4)), (
+            "domain_only points must carry the source orthographic CRS"
+        )
+
+    def test_get_cell_points_gdal_only_epsg_code(self):
+        """A GDAL-only EPSG code is labelled from its WKT on the point path (#943 / #979).
+
+        Test scenario:
+            EPSG:10857 (which pyproj cannot look up) yields cell points whose crs is the CRS
+            crs_from_user_input heals the code to, mirroring the polygon GDAL-only check.
+        """
+        arr = np.arange(9, dtype="float32").reshape(3, 3)
+        ds = Dataset.create_from_array(
+            arr, geo=(0.0, 1.0, 0.0, 3.0, 0.0, -1.0), epsg=10857
+        )
+        if not isinstance(crs_spec(ds.epsg, ds.crs), str):
+            pytest.skip(
+                "pyproj resolves EPSG:10857 on this stack; the WKT-fallback branch "
+                "is not exercised here"
+            )
+        gdf = ds.get_cell_points()
+        assert gdf.crs is not None, "a GDAL-only code must still label the frame"
+        assert gdf.crs.equals(crs_from_user_input(10857)), (
+            "cell points must carry the CRS the GDAL-only code resolves to"
+        )
+
 
 class TestGetBandByColor:
     """Tests for get_band_by_color method."""

--- a/tests/dataset/unit/test_unit_properties.py
+++ b/tests/dataset/unit/test_unit_properties.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 from osgeo import gdal, osr
 
-from pyramids.base.crs import crs_from_user_input, sr_from_epsg
+from pyramids.base.crs import crs_from_user_input, crs_spec, sr_from_epsg
 from pyramids.dataset import Dataset
 from pyramids.dataset.abstract_dataset import RasterBase
 
@@ -763,6 +763,11 @@ class TestCellGeometryMethods:
         ds = Dataset.create_from_array(
             arr, geo=(0.0, 1.0, 0.0, 3.0, 0.0, -1.0), epsg=10857
         )
+        if not isinstance(crs_spec(ds.epsg, ds.crs), str):
+            pytest.skip(
+                "pyproj resolves EPSG:10857 on this stack; the WKT-fallback branch "
+                "is not exercised here"
+            )
         gdf = ds.get_cell_polygons()
         assert gdf.crs is not None, "a GDAL-only code must still label the frame"
         assert gdf.crs.equals(crs_from_user_input(10857)), (

--- a/tests/dataset/unit/test_unit_properties.py
+++ b/tests/dataset/unit/test_unit_properties.py
@@ -736,6 +736,39 @@ class TestCellGeometryMethods:
         assert gdf.crs is None, "a CRS-less raster must yield an unprojected frame"
         assert len(gdf) == 9, f"expected 9 points, got {len(gdf)}"
 
+    def test_get_cell_polygons_domain_only_authority_less_crs(self):
+        """The domain_only path also labels an authority-less CRS correctly (#979).
+
+        Test scenario:
+            get_cell_polygons(domain_only=True) on the authority-less raster (all cells valid)
+            still carries the source orthographic CRS, proving the masked path shares the fix.
+        """
+        r = self._authority_less_raster()
+        gdf = r.get_cell_polygons(domain_only=True)
+        assert gdf.crs is not None, "domain_only path must still label the frame"
+        assert gdf.crs.to_epsg() is None, "authority-less CRS has no EPSG code"
+        assert gdf.crs.equals(crs_from_user_input(self._ORTHO_PROJ4)), (
+            "domain_only polygons must carry the source orthographic CRS"
+        )
+
+    def test_get_cell_polygons_gdal_only_epsg_code(self):
+        """A code GDAL resolves but pyproj cannot is labelled from its WKT (#943 / #979).
+
+        Test scenario:
+            A raster on EPSG:10857 (which pyproj's bundled database cannot look up) yields cell
+            polygons whose crs is the same CRS crs_from_user_input heals the code to -- proving
+            crs_spec's WKT fallback labels these methods correctly rather than crashing.
+        """
+        arr = np.arange(9, dtype="float32").reshape(3, 3)
+        ds = Dataset.create_from_array(
+            arr, geo=(0.0, 1.0, 0.0, 3.0, 0.0, -1.0), epsg=10857
+        )
+        gdf = ds.get_cell_polygons()
+        assert gdf.crs is not None, "a GDAL-only code must still label the frame"
+        assert gdf.crs.equals(crs_from_user_input(10857)), (
+            "cell polygons must carry the CRS the GDAL-only code resolves to"
+        )
+
 
 class TestGetBandByColor:
     """Tests for get_band_by_color method."""

--- a/tests/dataset/unit/test_unit_properties.py
+++ b/tests/dataset/unit/test_unit_properties.py
@@ -658,21 +658,22 @@ class TestCellGeometryMethods:
         assert isinstance(gdf, gpd.GeoDataFrame), "Should return GeoDataFrame"
         assert len(gdf) == 4, f"Expected 4 polygons for domain cells, got {len(gdf)}"
 
-    @staticmethod
-    def _authority_less_raster() -> Dataset:
+    _ORTHO_PROJ4 = "+proj=ortho +lat_0=50 +lon_0=10 +datum=WGS84 +units=m +no_defs"
+
+    @classmethod
+    def _authority_less_raster(cls) -> Dataset:
         """A raster on a valid CRS that carries no EPSG authority code.
 
         Returns:
-            Dataset: a 10x10 raster reprojected to a local orthographic (proj4/WKT
-            only), so `_get_epsg()` is None while the full CRS spec is present.
+            Dataset: a 10x10 raster reprojected to the local orthographic (proj4/WKT
+            only) `_ORTHO_PROJ4`, so `_get_epsg()` is None while the full CRS spec is
+            present.
         """
         arr = np.arange(100, dtype="float32").reshape(10, 10)
         ds = Dataset.create_from_array(
             arr, geo=(10.0, 0.1, 0.0, 50.0, 0.0, -0.1), epsg=4326
         )
-        return ds.to_crs(
-            "+proj=ortho +lat_0=50 +lon_0=10 +datum=WGS84 +units=m +no_defs"
-        )
+        return ds.to_crs(cls._ORTHO_PROJ4)
 
     def test_get_cell_polygons_authority_less_crs(self):
         """get_cell_polygons labels the frame with an authority-less CRS, not a crash (#979).
@@ -686,8 +687,8 @@ class TestCellGeometryMethods:
         gdf = r.get_cell_polygons()
         assert gdf.crs is not None, "authority-less CRS must still label the frame"
         assert gdf.crs.to_epsg() is None, "authority-less CRS has no EPSG code"
-        assert gdf.crs.equals(crs_from_user_input(r.crs)), (
-            "cell polygons must carry the raster's own CRS, not a fabricated one"
+        assert gdf.crs.equals(crs_from_user_input(self._ORTHO_PROJ4)), (
+            "cell polygons must carry the source orthographic CRS, not a fabricated one"
         )
 
     def test_get_cell_points_authority_less_crs(self):
@@ -701,8 +702,8 @@ class TestCellGeometryMethods:
         gdf = r.get_cell_points()
         assert gdf.crs is not None, "authority-less CRS must still label the frame"
         assert gdf.crs.to_epsg() is None, "authority-less CRS has no EPSG code"
-        assert gdf.crs.equals(crs_from_user_input(r.crs)), (
-            "cell points must carry the raster's own CRS, not a fabricated one"
+        assert gdf.crs.equals(crs_from_user_input(self._ORTHO_PROJ4)), (
+            "cell points must carry the source orthographic CRS, not a fabricated one"
         )
 
     def test_get_cell_polygons_no_crs_is_unprojected(self):

--- a/tests/dataset/unit/test_unit_properties.py
+++ b/tests/dataset/unit/test_unit_properties.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pytest
 from osgeo import gdal, osr
 
-from pyramids.base.crs import sr_from_epsg
+from pyramids.base.crs import crs_from_user_input, sr_from_epsg
 from pyramids.dataset import Dataset
 from pyramids.dataset.abstract_dataset import RasterBase
 
@@ -682,8 +682,6 @@ class TestCellGeometryMethods:
             crs equals the source CRS -- not None, not a fabricated EPSG:4326 -- and to_epsg()
             is None.
         """
-        from pyramids.base.crs import crs_from_user_input
-
         r = self._authority_less_raster()
         gdf = r.get_cell_polygons()
         assert gdf.crs is not None, "authority-less CRS must still label the frame"
@@ -699,8 +697,6 @@ class TestCellGeometryMethods:
             The point variant of the raster above carries the same source CRS with no EPSG
             code, instead of raising CRSError.
         """
-        from pyramids.base.crs import crs_from_user_input
-
         r = self._authority_less_raster()
         gdf = r.get_cell_points()
         assert gdf.crs is not None, "authority-less CRS must still label the frame"

--- a/tests/dataset/unit/test_unit_properties.py
+++ b/tests/dataset/unit/test_unit_properties.py
@@ -593,6 +593,8 @@ class TestDatasetLike:
 class TestCellGeometryMethods:
     """Tests for get_cell_coords, get_cell_points, get_cell_polygons."""
 
+    _ORTHO_PROJ4 = "+proj=ortho +lat_0=50 +lon_0=10 +datum=WGS84 +units=m +no_defs"
+
     def test_get_cell_coords_center(self, single_band_dataset):
         """Center coords should be at half-cell offsets from corners."""
         coords = single_band_dataset.get_cell_coords(location="center")
@@ -657,8 +659,6 @@ class TestCellGeometryMethods:
         gdf = dataset_with_nodata.get_cell_polygons(domain_only=True)
         assert isinstance(gdf, gpd.GeoDataFrame), "Should return GeoDataFrame"
         assert len(gdf) == 4, f"Expected 4 polygons for domain cells, got {len(gdf)}"
-
-    _ORTHO_PROJ4 = "+proj=ortho +lat_0=50 +lon_0=10 +datum=WGS84 +units=m +no_defs"
 
     @classmethod
     def _authority_less_raster(cls) -> Dataset:

--- a/tests/dataset/unit/test_unit_properties.py
+++ b/tests/dataset/unit/test_unit_properties.py
@@ -658,6 +658,72 @@ class TestCellGeometryMethods:
         assert isinstance(gdf, gpd.GeoDataFrame), "Should return GeoDataFrame"
         assert len(gdf) == 4, f"Expected 4 polygons for domain cells, got {len(gdf)}"
 
+    @staticmethod
+    def _authority_less_raster() -> Dataset:
+        """A raster on a valid CRS that carries no EPSG authority code.
+
+        Returns:
+            Dataset: a 10x10 raster reprojected to a local orthographic (proj4/WKT
+            only), so `_get_epsg()` is None while the full CRS spec is present.
+        """
+        arr = np.arange(100, dtype="float32").reshape(10, 10)
+        ds = Dataset.create_from_array(
+            arr, geo=(10.0, 0.1, 0.0, 50.0, 0.0, -0.1), epsg=4326
+        )
+        return ds.to_crs(
+            "+proj=ortho +lat_0=50 +lon_0=10 +datum=WGS84 +units=m +no_defs"
+        )
+
+    def test_get_cell_polygons_authority_less_crs(self):
+        """get_cell_polygons labels the frame with an authority-less CRS, not a crash (#979).
+
+        Test scenario:
+            A raster on a custom orthographic CRS (no EPSG code) yields cell polygons whose
+            crs equals the source CRS -- not None, not a fabricated EPSG:4326 -- and to_epsg()
+            is None.
+        """
+        from pyramids.base.crs import crs_from_user_input
+
+        r = self._authority_less_raster()
+        gdf = r.get_cell_polygons()
+        assert gdf.crs is not None, "authority-less CRS must still label the frame"
+        assert gdf.crs.to_epsg() is None, "authority-less CRS has no EPSG code"
+        assert gdf.crs.equals(crs_from_user_input(r.crs)), (
+            "cell polygons must carry the raster's own CRS, not a fabricated one"
+        )
+
+    def test_get_cell_points_authority_less_crs(self):
+        """get_cell_points labels the frame with an authority-less CRS, not a crash (#979).
+
+        Test scenario:
+            The point variant of the raster above carries the same source CRS with no EPSG
+            code, instead of raising CRSError.
+        """
+        from pyramids.base.crs import crs_from_user_input
+
+        r = self._authority_less_raster()
+        gdf = r.get_cell_points()
+        assert gdf.crs is not None, "authority-less CRS must still label the frame"
+        assert gdf.crs.to_epsg() is None, "authority-less CRS has no EPSG code"
+        assert gdf.crs.equals(crs_from_user_input(r.crs)), (
+            "cell points must carry the raster's own CRS, not a fabricated one"
+        )
+
+    def test_get_cell_polygons_no_crs_is_unprojected(self):
+        """A raster with no CRS at all yields an unprojected frame, not a crash (#979).
+
+        Test scenario:
+            When the raster carries no CRS, the cell polygons come back with crs=None rather
+            than raising on `crs_from_user_input(None)`.
+        """
+        arr = np.arange(9, dtype="float32").reshape(3, 3)
+        ds = Dataset.create_from_array(
+            arr, geo=(0.0, 1.0, 0.0, 3.0, 0.0, -1.0), epsg=None
+        )
+        gdf = ds.get_cell_polygons()
+        assert gdf.crs is None, "a CRS-less raster must yield an unprojected frame"
+        assert len(gdf) == 9, f"expected 9 polygons, got {len(gdf)}"
+
 
 class TestGetBandByColor:
     """Tests for get_band_by_color method."""

--- a/tests/dataset/unit/test_unit_properties.py
+++ b/tests/dataset/unit/test_unit_properties.py
@@ -724,6 +724,21 @@ class TestCellGeometryMethods:
         assert gdf.crs is None, "a CRS-less raster must yield an unprojected frame"
         assert len(gdf) == 9, f"expected 9 polygons, got {len(gdf)}"
 
+    def test_get_cell_points_no_crs_is_unprojected(self):
+        """A raster with no CRS at all yields unprojected points, not a crash (#979).
+
+        Test scenario:
+            When the raster carries no CRS, get_cell_points comes back with crs=None rather
+            than raising on `crs_from_user_input(None)`, mirroring the polygon path.
+        """
+        arr = np.arange(9, dtype="float32").reshape(3, 3)
+        ds = Dataset.create_from_array(
+            arr, geo=(0.0, 1.0, 0.0, 3.0, 0.0, -1.0), epsg=None
+        )
+        gdf = ds.get_cell_points()
+        assert gdf.crs is None, "a CRS-less raster must yield an unprojected frame"
+        assert len(gdf) == 9, f"expected 9 points, got {len(gdf)}"
+
 
 class TestGetBandByColor:
     """Tests for get_band_by_color method."""


### PR DESCRIPTION
# Description

`Dataset.get_cell_polygons()` and `Dataset.get_cell_points()` raised `CRSError: could not interpret None as a CRS`
for any raster whose CRS has **no EPSG authority code** — a valid but "unknown"-authority CRS such as a custom
orthographic / Albers / Lambert, or the output of a reprojection to a proj4 / WKT string. Both methods labelled the
returned `GeoDataFrame` by passing the raster's EPSG *code* (`_get_epsg()`, which is `None` for such a CRS) to
`crs_from_user_input`, discarding the fully valid CRS spec the dataset actually carries.

This was a pre-existing latent defect that #893 ("stop fabricating EPSG:4326 for rasters that have no CRS") exposed:
before #893, `_get_epsg()` returned `4326` for an authority-less CRS, so `set_crs` did not crash — but it **silently
mislabelled** the cell polygons of every custom-projection raster as EPSG:4326. So the fix both stops the crash and
corrects that mislabelling.

The fix resolves the CRS through the existing `crs_spec(epsg, wkt)` helper — which returns the EPSG code when the CRS
has one, else its WKT, else `None` when the raster has no CRS at all — and only calls `set_crs` when a CRS is present:

```python
crs = crs_spec(self._ds.epsg, self._ds.crs)
...
if crs is not None:
    gdf.set_crs(crs_from_user_input(crs), inplace=True)
```

`crs_spec` is the same helper `footprint` already uses; it also heals codes GDAL's PROJ database carries but pyproj's
does not (#943). Applied to both `get_cell_polygons` and `get_cell_points`. The `is not None` guard additionally fixes
a second latent crash for free: a truly CRS-less raster (`_get_epsg()` and `_get_crs()` both empty) hit the same
`crs_from_user_input(None)` path — it now yields an unprojected `GeoDataFrame` instead.

# Issues

- Closes #979

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Note: the common EPSG-authority path is unchanged (still labelled with the code). The only behaviour changes are for
CRSes that previously **crashed** — an authority-less CRS is now labelled with its own CRS, and a CRS-less raster now
yields an unprojected frame — so nothing that worked before changes.

# How Has This Been Tested?

- [x] `tests/dataset/unit/test_unit_properties.py::TestCellGeometryMethods` — added: `get_cell_polygons` and
  `get_cell_points` on a raster reprojected to a local orthographic (authority-less) CRS return a frame whose `crs`
  equals the source CRS (not `None`, not a fabricated `4326`) with `to_epsg() is None`; and a CRS-less raster yields
  `crs is None` instead of crashing.
- [x] Existing `TestCellGeometryMethods` + `test_dataset_create.py` cell tests (EPSG-authority rasters, still labelled
  with the code) and the `cell.py` doctests all pass.
- [x] Broad regression: `tests/dataset/unit/test_unit_properties.py`, `test_engines.py`, `test_dataset_create.py`
  (247 passed). `mypy` clean (136 source files).

Reproduce:

```bash
pixi run -e dev pytest tests/dataset/unit/test_unit_properties.py::TestCellGeometryMethods -q
```

# Checklist:

- [ ] updated version number in pyproject.toml. (handled by commitizen on release)
- [ ] added changes to History.rst. (changelog is commitizen-generated)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (method comments explain the CRS-spec routing and the #979 / #943 rationale)
