### PR TITLE
refactor(cog): move grouped-option logic onto the option dataclasses

### DIFF
--- a/src/pyramids/dataset/cog/options.py
+++ b/src/pyramids/dataset/cog/options.py
@@ -18,6 +18,11 @@ resolved). ``BandSelection`` and ``Tags`` instead *transform* the source raster
 — ``_translate`` runs the in-memory band-subset/cast/NoData ``gdal.Translate``
 and ``_stamp`` applies the colour table / metadata — so the write call site is a
 thin orchestrator over these methods rather than the home of the mapping logic.
+
+These ``_``-prefixed methods are private by convention, but they are the COG
+engine's internal contract: :class:`pyramids.dataset.engines.cog.COG` is their
+only intended caller (a sibling module in this subpackage), and they are *not*
+part of the public API. Rename or re-signature them in lockstep with that engine.
 """
 
 from __future__ import annotations

--- a/src/pyramids/dataset/cog/options.py
+++ b/src/pyramids/dataset/cog/options.py
@@ -1,8 +1,8 @@
 """COG creation-option types, serialization, and validation.
 
 Provides the :data:`CreationOptions` alias (a `Mapping[str, Any]`), the named
-:data:`PROFILES`, and pure-Python helpers used by
-:mod:`pyramids.dataset.cog.write` and :class:`pyramids.dataset.engines.cog.COG`:
+:data:`PROFILES`, and helpers used by :mod:`pyramids.dataset.cog.write` and
+:class:`pyramids.dataset.engines.cog.COG`:
 
 - :func:`to_gdal_options` — serialize a mapping into GDAL's `['KEY=VALUE',...]` list form.
 - :func:`merge_options` — merge defaults with user-supplied extras (dict or legacy `list[str]`).
@@ -10,15 +10,31 @@ Provides the :data:`CreationOptions` alias (a `Mapping[str, Any]`), the named
 - :func:`validate_option_keys` — gate unknown keys against :data:`COG_DRIVER_OPTIONS`.
 - :func:`profile_options` / :func:`validate_profile` — named compression presets.
 
-The module has no GDAL dependency — all helpers operate on plain Python
-values. GDAL is invoked only at the write call site.
+Each grouped option dataclass owns the logic that turns *its own* fields into
+the effective GDAL options via a ``_to_options`` method (``Layout``/``Tiling``
+serialize from their fields alone; ``Compression``/``Overviews`` also take the
+source band so the dtype-aware predictor / overview-resampling default can be
+resolved). ``BandSelection`` and ``Tags`` instead *transform* the source raster
+— ``_translate`` runs the in-memory band-subset/cast/NoData ``gdal.Translate``
+and ``_stamp`` applies the colour table / metadata — so the write call site is a
+thin orchestrator over these methods rather than the home of the mapping logic.
 """
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
+
+from osgeo import gdal
+
+from pyramids.base._errors import FailedToSaveError
+from pyramids.base._utils import (
+    default_cog_overview_resampling,
+    numpy_to_gdal_dtype,
+    resolve_cog_predictor,
+)
 
 CreationOptions = Mapping[str, Any]
 """Alias for a mapping of GDAL creation-option names to Python values.
@@ -66,6 +82,19 @@ COG_DRIVER_OPTIONS: frozenset[str] = frozenset(
 
 
 _VALID_BLOCKSIZES: frozenset[int] = frozenset({64, 128, 256, 512, 1024, 2048, 4096})
+
+
+_PREDICTOR_COMPRESSORS: frozenset[str] = frozenset({"DEFLATE", "LZW", "LZMA", "ZSTD"})
+"""Compression methods for which the GDAL ``PREDICTOR`` option is meaningful.
+
+The COG driver ignores ``PREDICTOR`` (and emits a ``RuntimeWarning``) for every
+other method — LERC, NONE, JPEG, WEBP, PACKBITS — so :meth:`Compression._to_options`
+omits it there.
+"""
+
+
+_PALETTE_GDAL_DTYPES: frozenset[int] = frozenset({gdal.GDT_Byte, gdal.GDT_UInt16})
+"""GDAL dtypes for which a colour table (palette) is meaningful."""
 
 
 COG_READ_DEFAULTS: dict[str, str] = {
@@ -329,6 +358,40 @@ class Compression:
             max_z_error=opts.get("MAX_Z_ERROR"),
         )
 
+    def _to_options(self, source_band: Any) -> dict[str, Any]:
+        """Map the compression fields to their GDAL COG creation options.
+
+        The compression method falls back to the house ``DEFLATE`` default; the
+        predictor is resolved per the source dtype when unset (``2`` for
+        integer, ``3`` for float) and is emitted only for methods that honour it
+        (:data:`_PREDICTOR_COMPRESSORS`) — GDAL ignores and warns on ``PREDICTOR``
+        for LERC/NONE/JPEG/WEBP. ``max_z_error`` (LERC family) rides along as
+        ``MAX_Z_ERROR``. ``None`` values are kept and dropped later by
+        :func:`merge_options` / :func:`to_gdal_options`.
+
+        Args:
+            source_band: Band 0 of the effective source, whose ``DataType``
+                drives the predictor default.
+
+        Returns:
+            The compression slice of the GDAL creation-option dict
+            (``COMPRESS``/``LEVEL``/``QUALITY``/``MAX_Z_ERROR``/``PREDICTOR``).
+        """
+        compress = self.compress if self.compress is not None else "DEFLATE"
+        predictor = self.predictor
+        if predictor is None:
+            predictor = resolve_cog_predictor(source_band.DataType)
+        options: dict[str, Any] = {
+            "COMPRESS": compress,
+            "LEVEL": self.level,
+            "QUALITY": self.quality,
+            "MAX_Z_ERROR": self.max_z_error,
+            "PREDICTOR": (
+                predictor if compress.upper() in _PREDICTOR_COMPRESSORS else None
+            ),
+        }
+        return options
+
 
 @dataclass(frozen=True)
 class Overviews:
@@ -374,6 +437,34 @@ class Overviews:
         """Validate the overview count."""
         if self.count is not None and self.count < 0:
             raise ValueError(f"overview count must be >= 0; got {self.count}.")
+
+    def _to_options(self, source_band: Any) -> dict[str, Any]:
+        """Map the overview fields to their GDAL COG creation options.
+
+        When ``resampling`` is unset it resolves to a category-safe default from
+        the source dtype / colour table (``mode`` for categorical, ``average``
+        for continuous) so the default never corrupts a categorical raster. The
+        caller (:meth:`pyramids.dataset.engines.cog.COG.to_cog`) still owns the
+        guardrail warning for an *explicit* averaging choice on categorical data.
+
+        Args:
+            source_band: Band 0 of the effective source, whose ``DataType`` and
+                colour table drive the resampling default.
+
+        Returns:
+            The overview slice of the GDAL creation-option dict
+            (``OVERVIEW_RESAMPLING``/``OVERVIEW_COUNT``/``OVERVIEW_COMPRESS``).
+        """
+        resampling = self.resampling
+        if resampling is None:
+            resampling = default_cog_overview_resampling(
+                source_band.DataType, source_band.GetColorTable() is not None
+            )
+        return {
+            "OVERVIEW_RESAMPLING": resampling,
+            "OVERVIEW_COUNT": self.count,
+            "OVERVIEW_COMPRESS": self.compress,
+        }
 
 
 @dataclass(frozen=True)
@@ -431,6 +522,64 @@ class Tiling:
                 f"got {self.zoom_level_strategy!r}."
             )
 
+    def _to_options(self) -> dict[str, Any]:
+        """Map the tiling / reprojection fields to their GDAL COG options.
+
+        ``scheme`` and ``target_srs`` are mutually exclusive: when both are set,
+        ``scheme`` wins, ``target_srs`` is dropped, and a ``UserWarning`` is
+        emitted. ``WARP_RESAMPLING`` is only emitted when actually reprojecting
+        (a scheme or a surviving ``target_srs``); an integer ``target_srs``
+        becomes ``EPSG:<n>``, a string is forwarded verbatim.
+
+        Returns:
+            The tiling slice of the GDAL creation-option dict.
+
+        Examples:
+            - A tiling scheme drives the scheme keys and warp resampling:
+                ```python
+                >>> from pyramids.dataset.cog import Tiling
+                >>> Tiling(scheme="GoogleMapsCompatible")._to_options()["TILING_SCHEME"]
+                'GoogleMapsCompatible'
+
+                ```
+            - An integer target SRS is formatted as an EPSG string:
+                ```python
+                >>> Tiling(target_srs=3857)._to_options()["TARGET_SRS"]
+                'EPSG:3857'
+
+                ```
+            - With neither scheme nor target SRS, warp resampling is dropped:
+                ```python
+                >>> Tiling()._to_options()["WARP_RESAMPLING"] is None
+                True
+
+                ```
+        """
+        eff_target_srs = self.target_srs
+        if self.scheme is not None and eff_target_srs is not None:
+            warnings.warn(
+                "Both tiling.scheme and tiling.target_srs provided; "
+                "scheme wins and target_srs is ignored.",
+                UserWarning,
+                stacklevel=3,
+            )
+            eff_target_srs = None
+        reprojecting = bool(self.scheme or eff_target_srs)
+        options: dict[str, Any] = {
+            "TILING_SCHEME": self.scheme,
+            "ZOOM_LEVEL": self.zoom_level,
+            "ZOOM_LEVEL_STRATEGY": self.zoom_level_strategy,
+            "ALIGNED_LEVELS": self.aligned_levels,
+            "WARP_RESAMPLING": self.resampling if reprojecting else None,
+        }
+        if eff_target_srs is not None:
+            options["TARGET_SRS"] = (
+                f"EPSG:{eff_target_srs}"
+                if isinstance(eff_target_srs, int)
+                else eff_target_srs
+            )
+        return options
+
 
 @dataclass(frozen=True)
 class BandSelection:
@@ -485,6 +634,53 @@ class BandSelection:
                 f"band indexes must be >= 0 (0-based); got {self.indexes}."
             )
 
+    def _needs_translate(self) -> bool:
+        """Return ``True`` when any field requires an in-memory pre-process.
+
+        A band subset, a dtype cast, or a NoData override all route the source
+        through :meth:`_translate`; with none of them set the backing raster is
+        used unchanged.
+        """
+        return (
+            self.indexes is not None
+            or self.out_dtype is not None
+            or self.nodata is not None
+        )
+
+    def _translate(self, source: gdal.Dataset) -> gdal.Dataset:
+        """Run the in-memory ``gdal.Translate`` for the selected fields.
+
+        Applies band selection/reordering (0-based indices mapped to GDAL's
+        1-based ``bandList``), the output dtype cast, and the NoData override,
+        producing a MEM dataset so the predictor / overview policy and the COG
+        write see the *output* bands rather than the original source.
+
+        Args:
+            source: The backing :class:`gdal.Dataset` to pre-process.
+
+        Returns:
+            A new in-memory :class:`gdal.Dataset`.
+
+        Raises:
+            FailedToSaveError: When ``gdal.Translate`` returns no dataset.
+        """
+        translate_kwargs: dict[str, Any] = {}
+        if self.indexes is not None:
+            # pyramids band indices are 0-based; GDAL bandList is 1-based.
+            translate_kwargs["bandList"] = [i + 1 for i in self.indexes]
+        if self.out_dtype is not None:
+            translate_kwargs["outputType"] = numpy_to_gdal_dtype(self.out_dtype)
+        if self.nodata is not None:
+            translate_kwargs["noData"] = self.nodata
+        mem = gdal.Translate("", source, format="MEM", **translate_kwargs)
+        if mem is None:
+            raise FailedToSaveError(
+                "failed to build the pre-processed COG source "
+                f"(indexes={self.indexes}, out_dtype={self.out_dtype}, "
+                f"nodata={self.nodata})"
+            )
+        return mem
+
 
 @dataclass(frozen=True)
 class Tags:
@@ -527,6 +723,49 @@ class Tags:
     band_tags: dict[int, dict[str, Any]] | None = None
     colormap: dict[int, tuple[int, int, int, int]] | None = None
     metadata: dict[str, Any] | None = None
+
+    def _has_any(self) -> bool:
+        """Return ``True`` when any tag / colourmap / metadata is set to stamp."""
+        return bool(self.band_tags or self.colormap or self.metadata)
+
+    def _stamp(self, ds: gdal.Dataset) -> None:
+        """Stamp band tags / colourmap / dataset metadata onto a dataset.
+
+        Mutates ``ds`` in place — the caller passes a MEM copy so the user's open
+        dataset is never touched. Dataset metadata and per-band tags are written
+        as strings; the colourmap builds a palette on band 1 and flips its colour
+        interpretation to ``PaletteIndex``.
+
+        Args:
+            ds: The (copied) :class:`gdal.Dataset` to mutate.
+
+        Raises:
+            ValueError: When ``colormap`` targets a band whose dtype is not
+                ``Byte`` / ``UInt16`` (GeoTIFF only supports a colour table
+                there; GDAL would otherwise fail deep in ``CreateCopy``).
+        """
+        if self.metadata:
+            ds.SetMetadata({str(k): str(v) for k, v in self.metadata.items()})
+        if self.colormap:
+            band = ds.GetRasterBand(1)
+            if band.DataType not in _PALETTE_GDAL_DTYPES:
+                raise ValueError(
+                    f"colormap is only supported on Byte/UInt16 rasters; got "
+                    f"{gdal.GetDataTypeName(band.DataType)}. Cast first with "
+                    f"to_cog(..., bands=cog.BandSelection(out_dtype='uint8')), "
+                    f"or drop the colormap."
+                )
+            color_table = gdal.ColorTable()
+            for value, rgba in self.colormap.items():
+                color_table.SetColorEntry(int(value), tuple(rgba))
+            band.SetColorTable(color_table)
+            band.SetColorInterpretation(gdal.GCI_PaletteIndex)
+        if self.band_tags:
+            for index, tags in self.band_tags.items():
+                # 0-based index -> GDAL 1-based band number.
+                ds.GetRasterBand(index + 1).SetMetadata(
+                    {str(k): str(v) for k, v in tags.items()}
+                )
 
 
 @dataclass(frozen=True)
@@ -579,6 +818,48 @@ class Layout:
                 f"bigtiff must be 'IF_SAFER'/'YES'/'NO'/'IF_NEEDED'; "
                 f"got {self.bigtiff!r}."
             )
+
+    def _to_options(self) -> dict[str, Any]:
+        """Map the physical-layout fields to their GDAL COG creation options.
+
+        ``num_threads`` is stringified (``"ALL_CPUS"`` or an int becomes its
+        decimal string); the boolean toggles map to ``YES``/dropped — an unset
+        toggle is left as ``None`` so :func:`merge_options` /
+        :func:`to_gdal_options` omit it rather than forcing ``NO``.
+
+        Returns:
+            The layout slice of the GDAL creation-option dict.
+
+        Examples:
+            - Defaults keep the house tile size and enable statistics:
+                ```python
+                >>> from pyramids.dataset.cog import Layout
+                >>> opts = Layout()._to_options()
+                >>> opts["BLOCKSIZE"], opts["STATISTICS"]
+                (512, 'YES')
+
+                ```
+            - An integer thread count is stringified; unset toggles drop out:
+                ```python
+                >>> opts = Layout(num_threads=4)._to_options()
+                >>> opts["NUM_THREADS"], opts["ADD_ALPHA"], opts["SPARSE_OK"]
+                ('4', None, None)
+
+                ```
+        """
+        num_threads = (
+            self.num_threads
+            if isinstance(self.num_threads, str)
+            else str(self.num_threads)
+        )
+        return {
+            "BLOCKSIZE": self.blocksize,
+            "BIGTIFF": self.bigtiff,
+            "NUM_THREADS": num_threads,
+            "ADD_ALPHA": True if self.add_mask else None,
+            "SPARSE_OK": True if self.sparse_ok else None,
+            "STATISTICS": "YES" if self.statistics else None,
+        }
 
 
 def _stringify(value: Any) -> str:

--- a/src/pyramids/dataset/cog/options.py
+++ b/src/pyramids/dataset/cog/options.py
@@ -640,6 +640,25 @@ class BandSelection:
         A band subset, a dtype cast, or a NoData override all route the source
         through :meth:`_translate`; with none of them set the backing raster is
         used unchanged.
+
+        Returns:
+            ``True`` if ``indexes``, ``out_dtype``, or ``nodata`` is set.
+
+        Examples:
+            - A bare selection needs no pre-process:
+                ```python
+                >>> from pyramids.dataset.cog import BandSelection
+                >>> BandSelection()._needs_translate()
+                False
+
+                ```
+            - Any populated field flips it on (here a dtype cast):
+                ```python
+                >>> from pyramids.dataset.cog import BandSelection
+                >>> BandSelection(out_dtype="uint8")._needs_translate()
+                True
+
+                ```
         """
         return (
             self.indexes is not None
@@ -725,7 +744,27 @@ class Tags:
     metadata: dict[str, Any] | None = None
 
     def _has_any(self) -> bool:
-        """Return ``True`` when any tag / colourmap / metadata is set to stamp."""
+        """Return ``True`` when any tag / colourmap / metadata is set to stamp.
+
+        Returns:
+            ``True`` if ``band_tags``, ``colormap``, or ``metadata`` is non-empty.
+
+        Examples:
+            - A bare instance carries nothing to stamp:
+                ```python
+                >>> from pyramids.dataset.cog import Tags
+                >>> Tags()._has_any()
+                False
+
+                ```
+            - Any populated field makes it true (here dataset metadata):
+                ```python
+                >>> from pyramids.dataset.cog import Tags
+                >>> Tags(metadata={"source": "s2"})._has_any()
+                True
+
+                ```
+        """
         return bool(self.band_tags or self.colormap or self.metadata)
 
     def _stamp(self, ds: gdal.Dataset) -> None:

--- a/src/pyramids/dataset/engines/cog.py
+++ b/src/pyramids/dataset/engines/cog.py
@@ -21,12 +21,7 @@ from pyproj import Transformer
 
 from pyramids._io import read_vsi_bytes, silent_unlink
 from pyramids.base._errors import FailedToSaveError, OutOfBoundsError
-from pyramids.base._utils import (
-    default_cog_overview_resampling,
-    is_integer_gdal_dtype,
-    numpy_to_gdal_dtype,
-    resolve_cog_predictor,
-)
+from pyramids.base._utils import is_integer_gdal_dtype
 from pyramids.base.crs import crs_equal, crs_from_user_input, require_crs_spec
 from pyramids.dataset.abstract_dataset import under_gdal_env
 from pyramids.dataset.cog import (
@@ -56,14 +51,6 @@ if TYPE_CHECKING:
 _AVERAGING_RESAMPLERS: frozenset[str] = frozenset(
     {"average", "bilinear", "cubic", "cubicspline", "lanczos"}
 )
-
-
-_PREDICTOR_COMPRESSORS: frozenset[str] = frozenset({"DEFLATE", "LZW", "LZMA", "ZSTD"})
-"""Compression methods for which the GDAL ``PREDICTOR`` option is meaningful.
-
-The COG driver ignores ``PREDICTOR`` (and emits a ``RuntimeWarning``) for every
-other method — LERC, NONE, JPEG, WEBP, PACKBITS — so it is omitted there.
-"""
 
 
 _RESAMPLING_ALG: dict[str, int] = {
@@ -115,10 +102,6 @@ def _resolve_read_resampling(resampling: str) -> int:
             f"unknown resampling {resampling!r}; choose from {sorted(_RESAMPLING_ALG)}"
         )
     return _RESAMPLING_ALG[key]
-
-
-_PALETTE_GDAL_DTYPES: frozenset[int] = frozenset({gdal.GDT_Byte, gdal.GDT_UInt16})
-"""GDAL dtypes for which a colour table (palette) is meaningful."""
 
 
 _WEB_MERCATOR_HALF_EXTENT: float = 20037508.342789244
@@ -331,320 +314,100 @@ class COG(_Engine["Dataset"]):
         # GDAL, matching the pre-refactor flat `compress="JPEG"` path (which GDAL
         # accepts for e.g. 4-band Byte).
         compression_from_profile = isinstance(compression, str)
-        compression = Compression.coerce(compression)
+        compression = Compression.coerce(compression) or Compression()
         overviews = overviews or Overviews()
         tiling = tiling or Tiling()
         bands = bands or BandSelection()
         tags = tags or Tags()
         layout = layout or Layout()
 
-        eff_target_srs = tiling.target_srs
-        if tiling.scheme is not None and eff_target_srs is not None:
-            warnings.warn(
-                "Both tiling.scheme and tiling.target_srs provided; "
-                "scheme wins and target_srs is ignored.",
-                UserWarning,
-                stacklevel=2,
+        # Build the effective source (PB-4): band-subset/cast/NoData routes through
+        # `BandSelection._translate` and tag/colourmap/metadata through
+        # `Tags._stamp`, so the predictor/overview policy below — and the COG write
+        # itself — see the *output* bands, and the user's dataset is never mutated.
+        source_ds, source_band0 = self._effective_source(bands, tags)
+
+        # The jpeg/webp dtype/band constraints (PB-5) mirror the named-profile
+        # presets, so they are enforced against the *effective* source only for the
+        # profile-string path; a direct `Compression(compress="JPEG")` goes straight
+        # to GDAL, matching the pre-refactor flat `compress="JPEG"` behaviour.
+        if compression_from_profile and compression.compress is not None:
+            validate_profile(
+                compression.compress.lower(),
+                gdal.GetDataTypeName(source_band0.DataType),
+                source_ds.RasterCount,
             )
-            eff_target_srs = None
 
-        # Build the effective source (PB-4): when band-subsetting, casting the
-        # dtype, or (re)setting NoData, pre-process through an in-memory
-        # gdal.Translate so the predictor/overview policy below — and the COG
-        # write itself — see the *output* bands, not the original source.
-        source_ds, source_band0 = self._effective_source(
-            bands.indexes,
-            bands.out_dtype,
-            bands.nodata,
-            tags.band_tags,
-            tags.colormap,
-            tags.metadata,
-        )
-
-        # Resolve the compression (PB-5): the profile string is already expanded
-        # by Compression.coerce; jpeg/webp enforce dtype/band constraints against
-        # the *effective* source only for the named-profile path.
-        eff_compress, eff_level, eff_quality, compress_extra = (
-            self._resolve_compression(
-                compression, source_ds, source_band0, compression_from_profile
+        # Guardrail (ARC-3): warn only when the *caller* explicitly asked for an
+        # averaging resampler on categorical data — never for a default resolved
+        # inside `Overviews._to_options`.
+        if overviews.resampling is not None:
+            self._warn_if_categorical_with_averaging(
+                overviews.resampling, band=source_band0
             )
-        )
 
-        # Single house policy lives here (ARC-1): `_build_cog_defaults` resolves
-        # the dtype-dependent defaults so a direct `ds.to_cog(...)` and the
-        # `write_cog(...)` facade — which now just delegates here — produce
-        # identical output for identical input.
-        defaults = self._build_cog_defaults(
-            compression,
-            overviews,
-            tiling,
-            layout,
-            eff_target_srs,
-            eff_compress,
-            eff_level,
-            eff_quality,
-            compress_extra,
-            source_band0,
-        )
+        # Single house policy (ARC-1): each option group serializes its own fields
+        # — `Compression`/`Overviews` resolve the dtype-aware predictor and overview
+        # resampling from the source band — so a direct `ds.to_cog(...)` and the
+        # `write_cog(...)` facade produce identical output for identical input.
+        defaults = {
+            **compression._to_options(source_band0),
+            **overviews._to_options(source_band0),
+            **tiling._to_options(),
+            **layout._to_options(),
+        }
 
         options = merge_options(defaults, extra)
         with config_context(config):
             self._translate_with_statistics_retry(path, options, src=source_ds)
         return Path(path)
 
-    @staticmethod
-    def _resolve_compression(
-        compression: Compression | None,
-        source_ds: gdal.Dataset,
-        source_band0: Any,
-        from_profile: bool = False,
-    ) -> tuple[str, int | None, int | None, dict[str, Any]]:
-        """Resolve effective compression options from a `Compression` group.
-
-        The profile-string form is already expanded into `compression` by
-        :meth:`Compression.coerce`, so this only reads its fields. `None` yields
-        the house `DEFLATE` default.
-
-        Args:
-            compression: The coerced compression group, or `None`.
-            source_ds: Effective source dataset (for band-count validation).
-            source_band0: Band 0 of the effective source (for dtype validation).
-            from_profile: `True` when the method was selected via a profile-name
-                string. Only then are the `jpeg`/`webp` dtype/band constraints
-                enforced (they mirror the profile presets); a direct
-                `Compression(compress=...)` is passed straight to GDAL, matching
-                the pre-refactor flat-`compress=` behaviour.
-
-        Returns:
-            `(eff_compress, eff_level, eff_quality, compress_extra)` where
-            `compress_extra` holds any non-COMPRESS/LEVEL/QUALITY options
-            (currently `MAX_Z_ERROR` for the LERC family).
-        """
-        eff_compress = (
-            compression.compress
-            if compression is not None and compression.compress is not None
-            else "DEFLATE"
-        )
-        eff_level = compression.level if compression is not None else None
-        eff_quality = compression.quality if compression is not None else None
-        if from_profile:
-            # profile name == method name for the constrained profiles (jpeg/webp);
-            # unconstrained profiles pass silently.
-            validate_profile(
-                eff_compress.lower(),
-                gdal.GetDataTypeName(source_band0.DataType),
-                source_ds.RasterCount,
-            )
-        compress_extra: dict[str, Any] = {}
-        if compression is not None and compression.max_z_error is not None:
-            compress_extra["MAX_Z_ERROR"] = compression.max_z_error
-        return eff_compress, eff_level, eff_quality, compress_extra
-
-    def _build_cog_defaults(
-        self,
-        compression: Compression | None,
-        overviews: Overviews,
-        tiling: Tiling,
-        layout: Layout,
-        eff_target_srs: int | str | None,
-        eff_compress: str,
-        eff_level: int | None,
-        eff_quality: int | None,
-        compress_extra: dict[str, Any],
-        source_band0: Any,
-    ) -> dict[str, Any]:
-        """Assemble the GDAL COG creation-option dict from the resolved groups.
-
-        Resolves the dtype-dependent defaults (predictor and overview
-        resampling), emits the categorical-averaging guardrail when the caller
-        chose an averaging resampler, and maps every group field to its GDAL
-        option key.
-
-        Args:
-            compression: The coerced compression group, or `None`.
-            overviews: The overview group.
-            tiling: The tiling/reprojection group.
-            layout: The physical-layout group.
-            eff_target_srs: The effective target SRS (after the scheme conflict
-                resolution), or `None`.
-            eff_compress: Resolved compression method.
-            eff_level: Resolved compression level, or `None`.
-            eff_quality: Resolved lossy quality, or `None`.
-            compress_extra: Extra compression options (e.g. `MAX_Z_ERROR`).
-            source_band0: Band 0 of the effective source (for dtype-aware
-                predictor / overview resolution).
-
-        Returns:
-            The GDAL COG creation-option dict (before merging `extra`).
-        """
-        # Per-dtype predictor (ARC-2): 2 for integer, 3 for float. GeoTIFF bands
-        # share a dtype, so band 0 decides for the whole file. Set
-        # `Compression(predictor=...)` to override for a mixed source.
-        predictor = compression.predictor if compression is not None else None
-        if predictor is None:
-            predictor = resolve_cog_predictor(source_band0.DataType)
-        # Category-safe default (ARC-3): `mode` for integer/colour-table sources,
-        # `average` for continuous — the default never corrupts categorical
-        # rasters and never trips the guardrail below.
-        caller_chose_resampling = overviews.resampling is not None
-        overview_resampling = overviews.resampling
-        if overview_resampling is None:
-            overview_resampling = default_cog_overview_resampling(
-                source_band0.DataType, source_band0.GetColorTable() is not None
-            )
-        if caller_chose_resampling:
-            # Only warn when the *caller* explicitly asked for an averaging
-            # resampler on categorical data — never for a default we picked.
-            self._warn_if_categorical_with_averaging(
-                overview_resampling, band=source_band0
-            )
-
-        num_threads_str = (
-            layout.num_threads
-            if isinstance(layout.num_threads, str)
-            else str(layout.num_threads)
-        )
-        reprojecting = bool(tiling.scheme or eff_target_srs)
-        defaults: dict[str, Any] = {
-            "COMPRESS": eff_compress,
-            "LEVEL": eff_level,
-            "QUALITY": eff_quality,
-            **compress_extra,
-            "BLOCKSIZE": layout.blocksize,
-            # PREDICTOR is only honoured by DEFLATE/LZW/LZMA/ZSTD; omit it for the
-            # others (LERC/NONE/JPEG/WEBP/...) which ignore it and warn.
-            "PREDICTOR": (
-                predictor if eff_compress.upper() in _PREDICTOR_COMPRESSORS else None
-            ),
-            "BIGTIFF": layout.bigtiff,
-            "NUM_THREADS": num_threads_str,
-            "OVERVIEW_RESAMPLING": overview_resampling,
-            "OVERVIEW_COUNT": overviews.count,
-            "OVERVIEW_COMPRESS": overviews.compress,
-            "TILING_SCHEME": tiling.scheme,
-            "ZOOM_LEVEL": tiling.zoom_level,
-            "ZOOM_LEVEL_STRATEGY": tiling.zoom_level_strategy,
-            "ALIGNED_LEVELS": tiling.aligned_levels,
-            "WARP_RESAMPLING": tiling.resampling if reprojecting else None,
-            "ADD_ALPHA": True if layout.add_mask else None,
-            "SPARSE_OK": True if layout.sparse_ok else None,
-            "STATISTICS": "YES" if layout.statistics else None,
-        }
-        if eff_target_srs is not None:
-            defaults["TARGET_SRS"] = (
-                f"EPSG:{eff_target_srs}"
-                if isinstance(eff_target_srs, int)
-                else eff_target_srs
-            )
-        return defaults
-
     def _effective_source(
-        self,
-        indexes: list[int] | None,
-        out_dtype: str | None,
-        nodata: float | int | None,
-        band_tags: dict[int, dict[str, Any]] | None = None,
-        colormap: dict[int, tuple[int, int, int, int]] | None = None,
-        metadata: dict[str, Any] | None = None,
+        self, bands: BandSelection, tags: Tags
     ) -> tuple[gdal.Dataset, Any]:
         """Return the source dataset (optionally pre-processed) and its band 0.
 
-        When band-subsetting / dtype-casting / setting NoData (PB-4) the backing
-        raster is run through an in-memory ``gdal.Translate``; when stamping
-        band tags / colourmap / metadata (PC-2) it is copied to a MEM dataset
-        first so the user's open dataset is **never mutated**. With neither, the
-        backing raster is returned unchanged.
+        Orchestrates the two per-group transforms: a band subset / dtype cast /
+        NoData override (PB-4) runs the source through
+        :meth:`~pyramids.dataset.cog.BandSelection._translate`; band tags /
+        colourmap / metadata (PC-2) are applied by
+        :meth:`~pyramids.dataset.cog.Tags._stamp` onto a MEM copy so the user's
+        open dataset is **never mutated**. With neither, the backing raster is
+        returned unchanged.
 
         Args:
-            indexes: 0-based band indices to keep/reorder, or ``None``.
-            out_dtype: Output NumPy dtype name to cast to, or ``None``.
-            nodata: NoData value to set, or ``None``.
-            band_tags: Per-band metadata keyed by 0-based band index, or ``None``.
-            colormap: Palette for band 1 (value -> RGBA), or ``None``.
-            metadata: Dataset-level metadata, or ``None``.
+            bands: The band-selection group deciding the ``gdal.Translate``.
+            tags: The tag/colourmap/metadata group to stamp.
 
         Returns:
             A ``(dataset, band1)`` tuple where ``band1`` is GDAL band 1 of the
             returned dataset (used for predictor/resampling resolution).
+
+        Raises:
+            FailedToSaveError: When the stamp-only MEM copy fails.
         """
-        # The COG write (and the gdal.Translate pre-process below) do tiled reads of the source; a
+        # The COG write (and the gdal.Translate pre-process) do tiled reads of the source; a
         # NetCDF multidim view can't be window-read by GDAL >= 3.13, so materialise it first (no-op
         # for an ordinary raster).
         self._ds._materialize_md_view()
-        needs_translate = (
-            indexes is not None or out_dtype is not None or nodata is not None
-        )
-        needs_stamp = bool(band_tags or colormap or metadata)
+        needs_translate = bands._needs_translate()
+        needs_stamp = tags._has_any()
         if not needs_translate and not needs_stamp:
             ds = self._ds._raster
             return ds, ds.GetRasterBand(1)
 
         if needs_translate:
-            translate_kwargs: dict[str, Any] = {}
-            if indexes is not None:
-                # pyramids band indices are 0-based; GDAL bandList is 1-based.
-                translate_kwargs["bandList"] = [i + 1 for i in indexes]
-            if out_dtype is not None:
-                translate_kwargs["outputType"] = numpy_to_gdal_dtype(out_dtype)
-            if nodata is not None:
-                translate_kwargs["noData"] = nodata
-            mem = gdal.Translate("", self._ds._raster, format="MEM", **translate_kwargs)
+            mem = bands._translate(self._ds._raster)
         else:
             # Stamp-only: copy so the user's dataset is not mutated.
             mem = gdal.GetDriverByName("MEM").CreateCopy("", self._ds._raster)
-        if mem is None:
-            raise FailedToSaveError(
-                "failed to build the pre-processed COG source "
-                f"(indexes={indexes}, out_dtype={out_dtype}, nodata={nodata})"
-            )
+            if mem is None:
+                raise FailedToSaveError(
+                    "failed to copy the source dataset for COG metadata stamping"
+                )
         if needs_stamp:
-            self._stamp_metadata(mem, band_tags, colormap, metadata)
+            tags._stamp(mem)
         return mem, mem.GetRasterBand(1)
-
-    @staticmethod
-    def _stamp_metadata(
-        ds: gdal.Dataset,
-        band_tags: dict[int, dict[str, Any]] | None,
-        colormap: dict[int, tuple[int, int, int, int]] | None,
-        metadata: dict[str, Any] | None,
-    ) -> None:
-        """Stamp band tags / colourmap / dataset metadata onto a MEM dataset.
-
-        Args:
-            ds: The (copied) dataset to mutate.
-            band_tags: Per-band metadata keyed by 0-based band index.
-            colormap: Palette for band 1 (value -> RGBA tuple). GeoTIFF only
-                supports a colour table on a single-band `Byte` / `UInt16`
-                raster; a `ValueError` is raised up-front for other dtypes
-                (GDAL would otherwise fail deep in `CreateCopy`).
-            metadata: Dataset-level metadata items.
-
-        Raises:
-            ValueError: When `colormap` is applied to a band whose dtype is
-                not `Byte`/`UInt16`.
-        """
-        if metadata:
-            ds.SetMetadata({str(k): str(v) for k, v in metadata.items()})
-        if colormap:
-            band = ds.GetRasterBand(1)
-            if band.DataType not in _PALETTE_GDAL_DTYPES:
-                raise ValueError(
-                    f"colormap is only supported on Byte/UInt16 rasters; got "
-                    f"{gdal.GetDataTypeName(band.DataType)}. Cast first with "
-                    f"to_cog(..., bands=cog.BandSelection(out_dtype='uint8')), "
-                    f"or drop the colormap."
-                )
-            color_table = gdal.ColorTable()
-            for value, rgba in colormap.items():
-                color_table.SetColorEntry(int(value), tuple(rgba))
-            band.SetColorTable(color_table)
-            band.SetColorInterpretation(gdal.GCI_PaletteIndex)
-        if band_tags:
-            for index, tags in band_tags.items():
-                # 0-based index -> GDAL 1-based band number.
-                ds.GetRasterBand(index + 1).SetMetadata(
-                    {str(k): str(v) for k, v in tags.items()}
-                )
 
     def to_cog_bytes(self, **kwargs: Any) -> bytes:
         """Encode the dataset as a COG and return the file contents as bytes.

--- a/src/pyramids/dataset/engines/cog.py
+++ b/src/pyramids/dataset/engines/cog.py
@@ -314,7 +314,9 @@ class COG(_Engine["Dataset"]):
         # GDAL, matching the pre-refactor flat `compress="JPEG"` path (which GDAL
         # accepts for e.g. 4-band Byte).
         compression_from_profile = isinstance(compression, str)
-        compression = Compression.coerce(compression) or Compression()
+        compression = Compression.coerce(compression)
+        if compression is None:
+            compression = Compression()
         overviews = overviews or Overviews()
         tiling = tiling or Tiling()
         bands = bands or BandSelection()
@@ -326,6 +328,20 @@ class COG(_Engine["Dataset"]):
         # `Tags._stamp`, so the predictor/overview policy below — and the COG write
         # itself — see the *output* bands, and the user's dataset is never mutated.
         source_ds, source_band0 = self._effective_source(bands, tags)
+
+        # Single house policy (ARC-1): each option group serializes its own fields
+        # — `Compression`/`Overviews` resolve the dtype-aware predictor and overview
+        # resampling from the source band — so a direct `ds.to_cog(...)` and the
+        # `write_cog(...)` facade produce identical output for identical input.
+        # Assembled before the checks below so `Tiling._to_options`'
+        # scheme-vs-target_srs conflict warning keeps firing ahead of them (and is
+        # not swallowed by a `validate_profile` raise), matching pre-refactor order.
+        defaults = {
+            **compression._to_options(source_band0),
+            **overviews._to_options(source_band0),
+            **tiling._to_options(),
+            **layout._to_options(),
+        }
 
         # The jpeg/webp dtype/band constraints (PB-5) mirror the named-profile
         # presets, so they are enforced against the *effective* source only for the
@@ -345,17 +361,6 @@ class COG(_Engine["Dataset"]):
             self._warn_if_categorical_with_averaging(
                 overviews.resampling, band=source_band0
             )
-
-        # Single house policy (ARC-1): each option group serializes its own fields
-        # — `Compression`/`Overviews` resolve the dtype-aware predictor and overview
-        # resampling from the source band — so a direct `ds.to_cog(...)` and the
-        # `write_cog(...)` facade produce identical output for identical input.
-        defaults = {
-            **compression._to_options(source_band0),
-            **overviews._to_options(source_band0),
-            **tiling._to_options(),
-            **layout._to_options(),
-        }
 
         options = merge_options(defaults, extra)
         with config_context(config):

--- a/tests/dataset/cog/test_dataset_cog_api.py
+++ b/tests/dataset/cog/test_dataset_cog_api.py
@@ -221,7 +221,7 @@ class TestToCogCategoricalWarning:
 
 
 class TestToCogOptionMapping:
-    """Cover the option-mapping branches of the engine's _build_cog_defaults."""
+    """Cover the option-mapping branches of the group dataclasses' _to_options."""
 
     def test_max_z_error_from_compression_field(self, small_float_dataset, tmp_path):
         """`Compression(max_z_error=...)` forwards MAX_Z_ERROR (not just via extra).

--- a/tests/dataset/cog/test_option_dataclasses.py
+++ b/tests/dataset/cog/test_option_dataclasses.py
@@ -159,10 +159,16 @@ class TestCompression:
         ds = _mem_dataset(gdal.GDT_Float32)
         band = ds.GetRasterBand(1)
         opts = Compression()._to_options(band)
-        assert opts["COMPRESS"] == "DEFLATE", f"expected DEFLATE, got {opts['COMPRESS']}"
-        assert opts["PREDICTOR"] == 3, f"float predictor should be 3, got {opts['PREDICTOR']}"
+        assert opts["COMPRESS"] == "DEFLATE", (
+            f"expected DEFLATE, got {opts['COMPRESS']}"
+        )
+        assert opts["PREDICTOR"] == 3, (
+            f"float predictor should be 3, got {opts['PREDICTOR']}"
+        )
         assert opts["LEVEL"] is None and opts["QUALITY"] is None, f"unexpected: {opts}"
-        assert opts["MAX_Z_ERROR"] is None, f"MAX_Z_ERROR should be None, got {opts['MAX_Z_ERROR']}"
+        assert opts["MAX_Z_ERROR"] is None, (
+            f"MAX_Z_ERROR should be None, got {opts['MAX_Z_ERROR']}"
+        )
 
     def test_to_options_integer_source_gets_predictor_2(self):
         """An integer source resolves PREDICTOR to 2.
@@ -173,7 +179,9 @@ class TestCompression:
         """
         ds = _mem_dataset(gdal.GDT_Byte)
         band = ds.GetRasterBand(1)
-        assert Compression()._to_options(band)["PREDICTOR"] == 2, "integer predictor should be 2"
+        assert Compression()._to_options(band)["PREDICTOR"] == 2, (
+            "integer predictor should be 2"
+        )
 
     def test_to_options_explicit_fields_passthrough(self):
         """Explicit compression fields are forwarded verbatim.
@@ -186,7 +194,9 @@ class TestCompression:
         band = ds.GetRasterBand(1)
         opts = Compression(compress="ZSTD", level=18, predictor=1)._to_options(band)
         assert (opts["COMPRESS"], opts["LEVEL"]) == ("ZSTD", 18), f"unexpected: {opts}"
-        assert opts["PREDICTOR"] == 1, f"explicit predictor should win, got {opts['PREDICTOR']}"
+        assert opts["PREDICTOR"] == 1, (
+            f"explicit predictor should win, got {opts['PREDICTOR']}"
+        )
 
     @pytest.mark.parametrize("compress", ["LERC", "NONE", "JPEG", "WEBP", "PACKBITS"])
     def test_to_options_predictor_dropped_for_non_predictor_compressor(self, compress):
@@ -202,7 +212,9 @@ class TestCompression:
         ds = _mem_dataset(gdal.GDT_Byte)
         band = ds.GetRasterBand(1)
         opts = Compression(compress=compress, predictor=2)._to_options(band)
-        assert opts["PREDICTOR"] is None, f"{compress} should drop PREDICTOR, got {opts['PREDICTOR']}"
+        assert opts["PREDICTOR"] is None, (
+            f"{compress} should drop PREDICTOR, got {opts['PREDICTOR']}"
+        )
 
     def test_to_options_max_z_error_carried(self):
         """`max_z_error` rides along as MAX_Z_ERROR.
@@ -239,8 +251,12 @@ class TestOverviews:
         ds = _mem_dataset(gdal.GDT_Float32)
         band = ds.GetRasterBand(1)
         opts = Overviews()._to_options(band)
-        assert opts["OVERVIEW_RESAMPLING"] == "average", f"got {opts['OVERVIEW_RESAMPLING']}"
-        assert opts["OVERVIEW_COUNT"] is None and opts["OVERVIEW_COMPRESS"] is None, f"unexpected: {opts}"
+        assert opts["OVERVIEW_RESAMPLING"] == "average", (
+            f"got {opts['OVERVIEW_RESAMPLING']}"
+        )
+        assert opts["OVERVIEW_COUNT"] is None and opts["OVERVIEW_COMPRESS"] is None, (
+            f"unexpected: {opts}"
+        )
 
     def test_to_options_default_resampling_integer_is_mode(self):
         """An integer source defaults to the category-safe `mode` resampler.
@@ -250,7 +266,9 @@ class TestOverviews:
         """
         ds = _mem_dataset(gdal.GDT_Byte)
         band = ds.GetRasterBand(1)
-        assert Overviews()._to_options(band)["OVERVIEW_RESAMPLING"] == "mode", "integer should use mode"
+        assert Overviews()._to_options(band)["OVERVIEW_RESAMPLING"] == "mode", (
+            "integer should use mode"
+        )
 
     def test_to_options_default_resampling_color_table_is_mode(self):
         """A palette source (float + colour table) still defaults to `mode`.
@@ -260,7 +278,9 @@ class TestOverviews:
         """
         ds = _mem_dataset(gdal.GDT_Float32, color_table=True)
         band = ds.GetRasterBand(1)
-        assert Overviews()._to_options(band)["OVERVIEW_RESAMPLING"] == "mode", "palette should use mode"
+        assert Overviews()._to_options(band)["OVERVIEW_RESAMPLING"] == "mode", (
+            "palette should use mode"
+        )
 
     def test_to_options_explicit_fields_passthrough(self):
         """Explicit resampling / count / compress are forwarded verbatim.
@@ -271,7 +291,9 @@ class TestOverviews:
         """
         ds = _mem_dataset(gdal.GDT_Byte)
         band = ds.GetRasterBand(1)
-        opts = Overviews(resampling="lanczos", count=4, compress="ZSTD")._to_options(band)
+        opts = Overviews(resampling="lanczos", count=4, compress="ZSTD")._to_options(
+            band
+        )
         assert opts == {
             "OVERVIEW_RESAMPLING": "lanczos",
             "OVERVIEW_COUNT": 4,
@@ -304,8 +326,12 @@ class TestTiling:
             WARP_RESAMPLING (not reprojecting), and omits the TARGET_SRS key.
         """
         opts = Tiling()._to_options()
-        assert opts["TILING_SCHEME"] is None, f"expected no scheme, got {opts['TILING_SCHEME']}"
-        assert opts["WARP_RESAMPLING"] is None, f"warp should be dropped, got {opts['WARP_RESAMPLING']}"
+        assert opts["TILING_SCHEME"] is None, (
+            f"expected no scheme, got {opts['TILING_SCHEME']}"
+        )
+        assert opts["WARP_RESAMPLING"] is None, (
+            f"warp should be dropped, got {opts['WARP_RESAMPLING']}"
+        )
         assert "TARGET_SRS" not in opts, f"TARGET_SRS should be absent, got {opts}"
 
     def test_to_options_target_srs_int_formats_epsg(self):
@@ -335,7 +361,9 @@ class TestTiling:
             the scheme and WARP_RESAMPLING; TARGET_SRS stays absent.
         """
         opts = Tiling(scheme="GoogleMapsCompatible", resampling="cubic")._to_options()
-        assert opts["TILING_SCHEME"] == "GoogleMapsCompatible", f"got {opts['TILING_SCHEME']}"
+        assert opts["TILING_SCHEME"] == "GoogleMapsCompatible", (
+            f"got {opts['TILING_SCHEME']}"
+        )
         assert opts["WARP_RESAMPLING"] == "cubic", f"got {opts['WARP_RESAMPLING']}"
         assert "TARGET_SRS" not in opts, f"TARGET_SRS should be absent, got {opts}"
 
@@ -350,7 +378,9 @@ class TestTiling:
         with pytest.warns(UserWarning, match="scheme wins and target_srs is ignored"):
             opts = til._to_options()
         assert "TARGET_SRS" not in opts, f"target_srs should be dropped, got {opts}"
-        assert opts["TILING_SCHEME"] == "GoogleMapsCompatible", f"scheme should win, got {opts}"
+        assert opts["TILING_SCHEME"] == "GoogleMapsCompatible", (
+            f"scheme should win, got {opts}"
+        )
 
     def test_to_options_zoom_and_aligned_fields_passthrough(self):
         """Zoom / aligned-level knobs are forwarded verbatim.
@@ -359,8 +389,14 @@ class TestTiling:
             `zoom_level`, `zoom_level_strategy`, and `aligned_levels` map straight
             to their GDAL keys.
         """
-        opts = Tiling(zoom_level=5, zoom_level_strategy="upper", aligned_levels=2)._to_options()
-        assert (opts["ZOOM_LEVEL"], opts["ZOOM_LEVEL_STRATEGY"], opts["ALIGNED_LEVELS"]) == (
+        opts = Tiling(
+            zoom_level=5, zoom_level_strategy="upper", aligned_levels=2
+        )._to_options()
+        assert (
+            opts["ZOOM_LEVEL"],
+            opts["ZOOM_LEVEL_STRATEGY"],
+            opts["ALIGNED_LEVELS"],
+        ) == (
             5,
             "upper",
             2,
@@ -381,7 +417,9 @@ class TestBandSelection:
 
     def test_needs_translate_false_when_empty(self):
         """A bare `BandSelection` needs no pre-process."""
-        assert BandSelection()._needs_translate() is False, "empty selection should not translate"
+        assert BandSelection()._needs_translate() is False, (
+            "empty selection should not translate"
+        )
 
     @pytest.mark.parametrize(
         "kwargs",
@@ -397,7 +435,9 @@ class TestBandSelection:
         Args:
             kwargs: A single populated `BandSelection` field.
         """
-        assert BandSelection(**kwargs)._needs_translate() is True, f"{kwargs} should translate"
+        assert BandSelection(**kwargs)._needs_translate() is True, (
+            f"{kwargs} should translate"
+        )
 
     def test_translate_subsets_and_reorders_bands(self):
         """`_translate` keeps and reorders the requested bands.
@@ -417,7 +457,9 @@ class TestBandSelection:
         """
         src = _mem_dataset(gdal.GDT_Float32)
         mem = BandSelection(out_dtype="uint8")._translate(src)
-        assert mem.GetRasterBand(1).DataType == gdal.GDT_Byte, "output should be cast to Byte"
+        assert mem.GetRasterBand(1).DataType == gdal.GDT_Byte, (
+            "output should be cast to Byte"
+        )
 
     def test_translate_sets_nodata(self):
         """`_translate` stamps the requested NoData value.
@@ -445,7 +487,9 @@ class TestBandSelection:
         )
         with pytest.raises(FailedToSaveError, match="pre-processed COG source") as exc:
             BandSelection(out_dtype="uint8")._translate(src)
-        assert "out_dtype" in str(exc.value), f"message should name the fields, got: {exc.value}"
+        assert "out_dtype" in str(exc.value), (
+            f"message should name the fields, got: {exc.value}"
+        )
 
 
 class TestLayout:
@@ -498,7 +542,9 @@ class TestLayout:
         Test scenario:
             `Layout(num_threads=4)._to_options()` forwards NUM_THREADS "4".
         """
-        assert Layout(num_threads=4)._to_options()["NUM_THREADS"] == "4", "int threads should stringify"
+        assert Layout(num_threads=4)._to_options()["NUM_THREADS"] == "4", (
+            "int threads should stringify"
+        )
 
     def test_to_options_toggles_map_to_yes_or_dropped(self):
         """The boolean toggles map to `True`/`None` (kept/dropped downstream).
@@ -508,8 +554,12 @@ class TestLayout:
             ADD_ALPHA / SPARSE_OK truthy and drops STATISTICS (`None`).
         """
         opts = Layout(add_mask=True, sparse_ok=True, statistics=False)._to_options()
-        assert opts["ADD_ALPHA"] is True and opts["SPARSE_OK"] is True, f"toggles should be on: {opts}"
-        assert opts["STATISTICS"] is None, f"statistics=False should drop, got {opts['STATISTICS']}"
+        assert opts["ADD_ALPHA"] is True and opts["SPARSE_OK"] is True, (
+            f"toggles should be on: {opts}"
+        )
+        assert opts["STATISTICS"] is None, (
+            f"statistics=False should drop, got {opts['STATISTICS']}"
+        )
 
 
 class TestTags:
@@ -550,7 +600,9 @@ class TestTags:
         """
         ds = _mem_dataset(gdal.GDT_Byte)
         Tags(metadata={"source": "s2"})._stamp(ds)
-        assert ds.GetMetadata().get("source") == "s2", f"metadata not stamped: {ds.GetMetadata()}"
+        assert ds.GetMetadata().get("source") == "s2", (
+            f"metadata not stamped: {ds.GetMetadata()}"
+        )
 
     def test_stamp_band_tags_set_per_band(self):
         """`_stamp` writes per-band tags at the 1-based band number.
@@ -574,7 +626,9 @@ class TestTags:
         Tags(colormap={0: (1, 2, 3, 4)})._stamp(ds)
         band = ds.GetRasterBand(1)
         assert band.GetColorTable() is not None, "colour table should be attached"
-        assert band.GetColorInterpretation() == gdal.GCI_PaletteIndex, "should be palette-interpreted"
+        assert band.GetColorInterpretation() == gdal.GCI_PaletteIndex, (
+            "should be palette-interpreted"
+        )
 
     def test_stamp_colormap_rejects_non_byte_dtype(self):
         """`_stamp` rejects a colourmap on a non-Byte/UInt16 band.

--- a/tests/dataset/cog/test_option_dataclasses.py
+++ b/tests/dataset/cog/test_option_dataclasses.py
@@ -165,7 +165,8 @@ class TestCompression:
         assert opts["PREDICTOR"] == 3, (
             f"float predictor should be 3, got {opts['PREDICTOR']}"
         )
-        assert opts["LEVEL"] is None and opts["QUALITY"] is None, f"unexpected: {opts}"
+        assert opts["LEVEL"] is None, f"LEVEL should be None, got {opts['LEVEL']}"
+        assert opts["QUALITY"] is None, f"QUALITY should be None, got {opts['QUALITY']}"
         assert opts["MAX_Z_ERROR"] is None, (
             f"MAX_Z_ERROR should be None, got {opts['MAX_Z_ERROR']}"
         )
@@ -254,8 +255,11 @@ class TestOverviews:
         assert opts["OVERVIEW_RESAMPLING"] == "average", (
             f"got {opts['OVERVIEW_RESAMPLING']}"
         )
-        assert opts["OVERVIEW_COUNT"] is None and opts["OVERVIEW_COMPRESS"] is None, (
-            f"unexpected: {opts}"
+        assert opts["OVERVIEW_COUNT"] is None, (
+            f"OVERVIEW_COUNT should be None, got {opts['OVERVIEW_COUNT']}"
+        )
+        assert opts["OVERVIEW_COMPRESS"] is None, (
+            f"OVERVIEW_COMPRESS should be None, got {opts['OVERVIEW_COMPRESS']}"
         )
 
     def test_to_options_default_resampling_integer_is_mode(self):
@@ -554,8 +558,11 @@ class TestLayout:
             ADD_ALPHA / SPARSE_OK truthy and drops STATISTICS (`None`).
         """
         opts = Layout(add_mask=True, sparse_ok=True, statistics=False)._to_options()
-        assert opts["ADD_ALPHA"] is True and opts["SPARSE_OK"] is True, (
-            f"toggles should be on: {opts}"
+        assert opts["ADD_ALPHA"] is True, (
+            f"ADD_ALPHA should be True, got {opts['ADD_ALPHA']}"
+        )
+        assert opts["SPARSE_OK"] is True, (
+            f"SPARSE_OK should be True, got {opts['SPARSE_OK']}"
         )
         assert opts["STATISTICS"] is None, (
             f"statistics=False should drop, got {opts['STATISTICS']}"

--- a/tests/dataset/cog/test_option_dataclasses.py
+++ b/tests/dataset/cog/test_option_dataclasses.py
@@ -641,3 +641,54 @@ class TestTags:
         with pytest.raises(ValueError, match="only supported on Byte/UInt16") as exc:
             Tags(colormap={0: (1, 2, 3, 4)})._stamp(ds)
         assert "Byte/UInt16" in str(exc.value), f"unexpected message: {exc.value}"
+
+
+class TestOptionComposition:
+    """The four `_to_options` slices compose into the GDAL creation-option dict."""
+
+    def test_slices_merge_without_key_collision(self):
+        """The group slices union to the full COG key set with no collision.
+
+        Test scenario:
+            Merging Compression/Overviews/Tiling/Layout `_to_options` for a plain
+            float source must not have one slice clobber another (a dict-merge
+            collision would silently drop keys), and must yield exactly the keys
+            the engine's old flat `_build_cog_defaults` produced.
+        """
+        ds = _mem_dataset(gdal.GDT_Float32)
+        band = ds.GetRasterBand(1)
+        slices = [
+            Compression()._to_options(band),
+            Overviews()._to_options(band),
+            Tiling()._to_options(),
+            Layout()._to_options(),
+        ]
+        merged: dict = {}
+        for group_slice in slices:
+            merged.update(group_slice)
+        total_keys = sum(len(group_slice) for group_slice in slices)
+        assert len(merged) == total_keys, (
+            f"key collision across slices: {total_keys} keys collapsed to {len(merged)}"
+        )
+        expected = {
+            "COMPRESS",
+            "LEVEL",
+            "QUALITY",
+            "MAX_Z_ERROR",
+            "PREDICTOR",
+            "OVERVIEW_RESAMPLING",
+            "OVERVIEW_COUNT",
+            "OVERVIEW_COMPRESS",
+            "TILING_SCHEME",
+            "ZOOM_LEVEL",
+            "ZOOM_LEVEL_STRATEGY",
+            "ALIGNED_LEVELS",
+            "WARP_RESAMPLING",
+            "BLOCKSIZE",
+            "BIGTIFF",
+            "NUM_THREADS",
+            "ADD_ALPHA",
+            "SPARSE_OK",
+            "STATISTICS",
+        }
+        assert set(merged) == expected, f"unexpected key set: {set(merged) ^ expected}"

--- a/tests/dataset/cog/test_option_dataclasses.py
+++ b/tests/dataset/cog/test_option_dataclasses.py
@@ -489,8 +489,9 @@ class TestBandSelection:
         monkeypatch.setattr(
             "pyramids.dataset.cog.options.gdal.Translate", lambda *a, **k: None
         )
+        selection = BandSelection(out_dtype="uint8")
         with pytest.raises(FailedToSaveError, match="pre-processed COG source") as exc:
-            BandSelection(out_dtype="uint8")._translate(src)
+            selection._translate(src)
         assert "out_dtype" in str(exc.value), (
             f"message should name the fields, got: {exc.value}"
         )
@@ -645,8 +646,9 @@ class TestTags:
             Byte/UInt16 constraint.
         """
         ds = _mem_dataset(gdal.GDT_Float32)
+        tags = Tags(colormap={0: (1, 2, 3, 4)})
         with pytest.raises(ValueError, match="only supported on Byte/UInt16") as exc:
-            Tags(colormap={0: (1, 2, 3, 4)})._stamp(ds)
+            tags._stamp(ds)
         assert "Byte/UInt16" in str(exc.value), f"unexpected message: {exc.value}"
 
 

--- a/tests/dataset/cog/test_option_dataclasses.py
+++ b/tests/dataset/cog/test_option_dataclasses.py
@@ -1,13 +1,18 @@
 """Unit tests for the grouped COG option dataclasses and their validators.
 
-Covers each ``__post_init__`` validation branch and ``Compression.coerce`` for
-`Compression`, `Overviews`, `Tiling`, `BandSelection`, `Tags`, and `Layout`.
+Covers each ``__post_init__`` validation branch, ``Compression.coerce``, and the
+per-group logic methods — ``_to_options`` (``Compression``/``Overviews``/
+``Tiling``/``Layout``), ``BandSelection._needs_translate`` / ``_translate``, and
+``Tags._has_any`` / ``_stamp`` — for `Compression`, `Overviews`, `Tiling`,
+`BandSelection`, `Tags`, and `Layout`.
 """
 
 from __future__ import annotations
 
 import pytest
+from osgeo import gdal
 
+from pyramids.base._errors import FailedToSaveError
 from pyramids.dataset.cog import (
     PROFILES,
     BandSelection,
@@ -21,6 +26,30 @@ from pyramids.dataset.cog import (
 pytestmark = pytest.mark.core
 
 _COERCED_PROFILE_KEYS = {"COMPRESS", "LEVEL", "QUALITY", "MAX_Z_ERROR"}
+
+
+def _mem_dataset(
+    gdal_dtype: int = gdal.GDT_Float32,
+    n_bands: int = 1,
+    color_table: bool = False,
+) -> gdal.Dataset:
+    """Build a tiny in-memory GDAL dataset for the method tests.
+
+    Args:
+        gdal_dtype: Band data type (drives the predictor / resampling defaults).
+        n_bands: Number of bands to create.
+        color_table: When ``True``, attach a 1-entry colour table to band 1 so
+            the source reads as categorical.
+
+    Returns:
+        gdal.Dataset: A 4x4 MEM dataset the caller owns for the test's duration.
+    """
+    ds = gdal.GetDriverByName("MEM").Create("", 4, 4, n_bands, gdal_dtype)
+    if color_table:
+        ct = gdal.ColorTable()
+        ct.SetColorEntry(0, (0, 0, 0, 255))
+        ds.GetRasterBand(1).SetColorTable(ct)
+    return ds
 
 
 def test_all_profiles_use_only_coerced_keys():
@@ -119,6 +148,74 @@ class TestCompression:
         with pytest.raises(ValueError, match="unknown COG profile"):
             Compression.coerce("nope")
 
+    def test_to_options_defaults_deflate_with_float_predictor(self):
+        """A bare `Compression` yields DEFLATE with the float predictor.
+
+        Test scenario:
+            `Compression()._to_options(float_band)` defaults COMPRESS to DEFLATE,
+            resolves PREDICTOR to 3 for a float source, and leaves LEVEL / QUALITY
+            / MAX_Z_ERROR as `None`.
+        """
+        ds = _mem_dataset(gdal.GDT_Float32)
+        band = ds.GetRasterBand(1)
+        opts = Compression()._to_options(band)
+        assert opts["COMPRESS"] == "DEFLATE", f"expected DEFLATE, got {opts['COMPRESS']}"
+        assert opts["PREDICTOR"] == 3, f"float predictor should be 3, got {opts['PREDICTOR']}"
+        assert opts["LEVEL"] is None and opts["QUALITY"] is None, f"unexpected: {opts}"
+        assert opts["MAX_Z_ERROR"] is None, f"MAX_Z_ERROR should be None, got {opts['MAX_Z_ERROR']}"
+
+    def test_to_options_integer_source_gets_predictor_2(self):
+        """An integer source resolves PREDICTOR to 2.
+
+        Test scenario:
+            `Compression()._to_options(byte_band)` picks the horizontal-differencing
+            predictor (2) suited to integer data.
+        """
+        ds = _mem_dataset(gdal.GDT_Byte)
+        band = ds.GetRasterBand(1)
+        assert Compression()._to_options(band)["PREDICTOR"] == 2, "integer predictor should be 2"
+
+    def test_to_options_explicit_fields_passthrough(self):
+        """Explicit compression fields are forwarded verbatim.
+
+        Test scenario:
+            `Compression(compress="ZSTD", level=18, predictor=1)` forwards
+            COMPRESS/LEVEL and the explicit predictor (ZSTD honours PREDICTOR).
+        """
+        ds = _mem_dataset(gdal.GDT_Float32)
+        band = ds.GetRasterBand(1)
+        opts = Compression(compress="ZSTD", level=18, predictor=1)._to_options(band)
+        assert (opts["COMPRESS"], opts["LEVEL"]) == ("ZSTD", 18), f"unexpected: {opts}"
+        assert opts["PREDICTOR"] == 1, f"explicit predictor should win, got {opts['PREDICTOR']}"
+
+    @pytest.mark.parametrize("compress", ["LERC", "NONE", "JPEG", "WEBP", "PACKBITS"])
+    def test_to_options_predictor_dropped_for_non_predictor_compressor(self, compress):
+        """PREDICTOR is omitted for methods that ignore it.
+
+        Args:
+            compress: A compression method outside the predictor-honouring set.
+
+        Test scenario:
+            Even with an explicit predictor, `_to_options` drops PREDICTOR (`None`)
+            for LERC/NONE/JPEG/WEBP/PACKBITS, which GDAL would warn on.
+        """
+        ds = _mem_dataset(gdal.GDT_Byte)
+        band = ds.GetRasterBand(1)
+        opts = Compression(compress=compress, predictor=2)._to_options(band)
+        assert opts["PREDICTOR"] is None, f"{compress} should drop PREDICTOR, got {opts['PREDICTOR']}"
+
+    def test_to_options_max_z_error_carried(self):
+        """`max_z_error` rides along as MAX_Z_ERROR.
+
+        Test scenario:
+            `Compression(compress="LERC", max_z_error=0.5)._to_options(band)`
+            forwards the LERC tolerance.
+        """
+        ds = _mem_dataset(gdal.GDT_Float32)
+        band = ds.GetRasterBand(1)
+        opts = Compression(compress="LERC", max_z_error=0.5)._to_options(band)
+        assert opts["MAX_Z_ERROR"] == 0.5, f"expected 0.5, got {opts['MAX_Z_ERROR']}"
+
 
 class TestOverviews:
     """Validation for `Overviews`."""
@@ -131,6 +228,55 @@ class TestOverviews:
     def test_zero_count_accepted(self):
         """A zero overview count is accepted."""
         assert Overviews(count=0).count == 0
+
+    def test_to_options_default_resampling_continuous(self):
+        """A continuous (float, no palette) source defaults to averaging.
+
+        Test scenario:
+            `Overviews()._to_options(float_band)` resolves OVERVIEW_RESAMPLING to
+            `average` and leaves count / compress as `None`.
+        """
+        ds = _mem_dataset(gdal.GDT_Float32)
+        band = ds.GetRasterBand(1)
+        opts = Overviews()._to_options(band)
+        assert opts["OVERVIEW_RESAMPLING"] == "average", f"got {opts['OVERVIEW_RESAMPLING']}"
+        assert opts["OVERVIEW_COUNT"] is None and opts["OVERVIEW_COMPRESS"] is None, f"unexpected: {opts}"
+
+    def test_to_options_default_resampling_integer_is_mode(self):
+        """An integer source defaults to the category-safe `mode` resampler.
+
+        Test scenario:
+            `Overviews()._to_options(byte_band)` never averages categorical data.
+        """
+        ds = _mem_dataset(gdal.GDT_Byte)
+        band = ds.GetRasterBand(1)
+        assert Overviews()._to_options(band)["OVERVIEW_RESAMPLING"] == "mode", "integer should use mode"
+
+    def test_to_options_default_resampling_color_table_is_mode(self):
+        """A palette source (float + colour table) still defaults to `mode`.
+
+        Test scenario:
+            A colour table marks the source categorical regardless of dtype.
+        """
+        ds = _mem_dataset(gdal.GDT_Float32, color_table=True)
+        band = ds.GetRasterBand(1)
+        assert Overviews()._to_options(band)["OVERVIEW_RESAMPLING"] == "mode", "palette should use mode"
+
+    def test_to_options_explicit_fields_passthrough(self):
+        """Explicit resampling / count / compress are forwarded verbatim.
+
+        Test scenario:
+            `Overviews(resampling="lanczos", count=4, compress="ZSTD")` maps each
+            field to its OVERVIEW_* key without touching the source band.
+        """
+        ds = _mem_dataset(gdal.GDT_Byte)
+        band = ds.GetRasterBand(1)
+        opts = Overviews(resampling="lanczos", count=4, compress="ZSTD")._to_options(band)
+        assert opts == {
+            "OVERVIEW_RESAMPLING": "lanczos",
+            "OVERVIEW_COUNT": 4,
+            "OVERVIEW_COMPRESS": "ZSTD",
+        }, f"unexpected: {opts}"
 
 
 class TestTiling:
@@ -150,6 +296,76 @@ class TestTiling:
         with pytest.raises(ValueError, match="zoom_level_strategy must be"):
             Tiling(zoom_level_strategy="sideways")
 
+    def test_to_options_plain_has_no_reprojection(self):
+        """A bare `Tiling` emits no scheme, no target SRS, no warp resampling.
+
+        Test scenario:
+            `Tiling()._to_options()` leaves TILING_SCHEME `None`, drops
+            WARP_RESAMPLING (not reprojecting), and omits the TARGET_SRS key.
+        """
+        opts = Tiling()._to_options()
+        assert opts["TILING_SCHEME"] is None, f"expected no scheme, got {opts['TILING_SCHEME']}"
+        assert opts["WARP_RESAMPLING"] is None, f"warp should be dropped, got {opts['WARP_RESAMPLING']}"
+        assert "TARGET_SRS" not in opts, f"TARGET_SRS should be absent, got {opts}"
+
+    def test_to_options_target_srs_int_formats_epsg(self):
+        """An integer `target_srs` becomes `EPSG:<n>` and enables warp resampling.
+
+        Test scenario:
+            `Tiling(target_srs=3857, resampling="bilinear")._to_options()` formats
+            the SRS and, because it reprojects, forwards WARP_RESAMPLING.
+        """
+        opts = Tiling(target_srs=3857, resampling="bilinear")._to_options()
+        assert opts["TARGET_SRS"] == "EPSG:3857", f"got {opts['TARGET_SRS']}"
+        assert opts["WARP_RESAMPLING"] == "bilinear", f"got {opts['WARP_RESAMPLING']}"
+
+    def test_to_options_target_srs_string_verbatim(self):
+        """A string `target_srs` is forwarded unchanged.
+
+        Test scenario:
+            `Tiling(target_srs="EPSG:3857")` is not re-formatted (already a string).
+        """
+        assert Tiling(target_srs="EPSG:3857")._to_options()["TARGET_SRS"] == "EPSG:3857"
+
+    def test_to_options_scheme_sets_warp_no_target_srs(self):
+        """A tiling scheme reprojects (warp on) but sets no TARGET_SRS.
+
+        Test scenario:
+            `Tiling(scheme="GoogleMapsCompatible", resampling="cubic")` forwards
+            the scheme and WARP_RESAMPLING; TARGET_SRS stays absent.
+        """
+        opts = Tiling(scheme="GoogleMapsCompatible", resampling="cubic")._to_options()
+        assert opts["TILING_SCHEME"] == "GoogleMapsCompatible", f"got {opts['TILING_SCHEME']}"
+        assert opts["WARP_RESAMPLING"] == "cubic", f"got {opts['WARP_RESAMPLING']}"
+        assert "TARGET_SRS" not in opts, f"TARGET_SRS should be absent, got {opts}"
+
+    def test_to_options_scheme_and_target_srs_conflict_warns_scheme_wins(self):
+        """When both scheme and target_srs are set, scheme wins with a warning.
+
+        Test scenario:
+            `Tiling(scheme=..., target_srs=3857)._to_options()` emits a
+            `UserWarning`, drops TARGET_SRS, and keeps the scheme.
+        """
+        til = Tiling(scheme="GoogleMapsCompatible", target_srs=3857)
+        with pytest.warns(UserWarning, match="scheme wins and target_srs is ignored"):
+            opts = til._to_options()
+        assert "TARGET_SRS" not in opts, f"target_srs should be dropped, got {opts}"
+        assert opts["TILING_SCHEME"] == "GoogleMapsCompatible", f"scheme should win, got {opts}"
+
+    def test_to_options_zoom_and_aligned_fields_passthrough(self):
+        """Zoom / aligned-level knobs are forwarded verbatim.
+
+        Test scenario:
+            `zoom_level`, `zoom_level_strategy`, and `aligned_levels` map straight
+            to their GDAL keys.
+        """
+        opts = Tiling(zoom_level=5, zoom_level_strategy="upper", aligned_levels=2)._to_options()
+        assert (opts["ZOOM_LEVEL"], opts["ZOOM_LEVEL_STRATEGY"], opts["ALIGNED_LEVELS"]) == (
+            5,
+            "upper",
+            2,
+        ), f"unexpected: {opts}"
+
 
 class TestBandSelection:
     """Validation for `BandSelection`."""
@@ -162,6 +378,74 @@ class TestBandSelection:
     def test_zero_based_indexes_accepted(self):
         """Non-negative 0-based indices are accepted in order."""
         assert BandSelection(indexes=[2, 0, 1]).indexes == [2, 0, 1]
+
+    def test_needs_translate_false_when_empty(self):
+        """A bare `BandSelection` needs no pre-process."""
+        assert BandSelection()._needs_translate() is False, "empty selection should not translate"
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"indexes": [0]},
+            {"out_dtype": "uint8"},
+            {"nodata": 0},
+        ],
+    )
+    def test_needs_translate_true_when_any_field_set(self, kwargs):
+        """Any of indexes / out_dtype / nodata requires a translate.
+
+        Args:
+            kwargs: A single populated `BandSelection` field.
+        """
+        assert BandSelection(**kwargs)._needs_translate() is True, f"{kwargs} should translate"
+
+    def test_translate_subsets_and_reorders_bands(self):
+        """`_translate` keeps and reorders the requested bands.
+
+        Test scenario:
+            A 3-band source with `indexes=[2, 0]` yields a 2-band MEM dataset.
+        """
+        src = _mem_dataset(gdal.GDT_Byte, n_bands=3)
+        mem = BandSelection(indexes=[2, 0])._translate(src)
+        assert mem.RasterCount == 2, f"expected 2 bands, got {mem.RasterCount}"
+
+    def test_translate_casts_output_dtype(self):
+        """`_translate` casts to the requested output dtype.
+
+        Test scenario:
+            A float source with `out_dtype="uint8"` yields a Byte MEM band.
+        """
+        src = _mem_dataset(gdal.GDT_Float32)
+        mem = BandSelection(out_dtype="uint8")._translate(src)
+        assert mem.GetRasterBand(1).DataType == gdal.GDT_Byte, "output should be cast to Byte"
+
+    def test_translate_sets_nodata(self):
+        """`_translate` stamps the requested NoData value.
+
+        Test scenario:
+            `BandSelection(nodata=0)._translate(src)` sets NoData 0 on band 1.
+        """
+        src = _mem_dataset(gdal.GDT_Float32)
+        mem = BandSelection(nodata=0)._translate(src)
+        assert mem.GetRasterBand(1).GetNoDataValue() == 0, "NoData should be set to 0"
+
+    def test_translate_raises_when_gdal_returns_none(self, monkeypatch):
+        """`_translate` raises `FailedToSaveError` when GDAL yields no dataset.
+
+        Args:
+            monkeypatch: pytest fixture used to force `gdal.Translate` to `None`.
+
+        Test scenario:
+            A `None` return from `gdal.Translate` surfaces as a descriptive
+            `FailedToSaveError` naming the requested fields.
+        """
+        src = _mem_dataset(gdal.GDT_Float32)
+        monkeypatch.setattr(
+            "pyramids.dataset.cog.options.gdal.Translate", lambda *a, **k: None
+        )
+        with pytest.raises(FailedToSaveError, match="pre-processed COG source") as exc:
+            BandSelection(out_dtype="uint8")._translate(src)
+        assert "out_dtype" in str(exc.value), f"message should name the fields, got: {exc.value}"
 
 
 class TestLayout:
@@ -190,12 +474,116 @@ class TestLayout:
         with pytest.raises(ValueError, match="bigtiff must be"):
             Layout(bigtiff="MAYBE")
 
+    def test_to_options_defaults(self):
+        """The default `Layout` serializes the house defaults.
+
+        Test scenario:
+            `Layout()._to_options()` emits BLOCKSIZE 512, BIGTIFF IF_SAFER,
+            NUM_THREADS "ALL_CPUS", STATISTICS "YES", and drops the two unset
+            toggles (`None`).
+        """
+        opts = Layout()._to_options()
+        assert opts == {
+            "BLOCKSIZE": 512,
+            "BIGTIFF": "IF_SAFER",
+            "NUM_THREADS": "ALL_CPUS",
+            "ADD_ALPHA": None,
+            "SPARSE_OK": None,
+            "STATISTICS": "YES",
+        }, f"unexpected defaults: {opts}"
+
+    def test_to_options_num_threads_int_stringified(self):
+        """An integer `num_threads` is stringified.
+
+        Test scenario:
+            `Layout(num_threads=4)._to_options()` forwards NUM_THREADS "4".
+        """
+        assert Layout(num_threads=4)._to_options()["NUM_THREADS"] == "4", "int threads should stringify"
+
+    def test_to_options_toggles_map_to_yes_or_dropped(self):
+        """The boolean toggles map to `True`/`None` (kept/dropped downstream).
+
+        Test scenario:
+            `Layout(add_mask=True, sparse_ok=True, statistics=False)` sets
+            ADD_ALPHA / SPARSE_OK truthy and drops STATISTICS (`None`).
+        """
+        opts = Layout(add_mask=True, sparse_ok=True, statistics=False)._to_options()
+        assert opts["ADD_ALPHA"] is True and opts["SPARSE_OK"] is True, f"toggles should be on: {opts}"
+        assert opts["STATISTICS"] is None, f"statistics=False should drop, got {opts['STATISTICS']}"
+
 
 class TestTags:
-    """`Tags` is a plain carrier with no validation."""
+    """`Tags` is a plain carrier; `_has_any` / `_stamp` apply its contents."""
 
     def test_fields_round_trip(self):
         """The three fields are stored verbatim."""
         t = Tags(band_tags={0: {"name": "x"}}, metadata={"a": "b"})
         assert t.band_tags == {0: {"name": "x"}}
         assert t.metadata == {"a": "b"}
+
+    def test_has_any_false_when_empty(self):
+        """A bare `Tags` carries nothing to stamp."""
+        assert Tags()._has_any() is False, "empty tags should have nothing to stamp"
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"band_tags": {0: {"name": "x"}}},
+            {"colormap": {0: (1, 2, 3, 4)}},
+            {"metadata": {"a": "b"}},
+        ],
+    )
+    def test_has_any_true_when_any_field_set(self, kwargs):
+        """Any populated field makes `_has_any` true.
+
+        Args:
+            kwargs: A single populated `Tags` field.
+        """
+        assert Tags(**kwargs)._has_any() is True, f"{kwargs} should stamp"
+
+    def test_stamp_metadata_sets_dataset_items(self):
+        """`_stamp` writes dataset-level metadata as strings.
+
+        Test scenario:
+            `Tags(metadata={"source": "s2"})._stamp(ds)` sets the item on the MEM
+            dataset.
+        """
+        ds = _mem_dataset(gdal.GDT_Byte)
+        Tags(metadata={"source": "s2"})._stamp(ds)
+        assert ds.GetMetadata().get("source") == "s2", f"metadata not stamped: {ds.GetMetadata()}"
+
+    def test_stamp_band_tags_set_per_band(self):
+        """`_stamp` writes per-band tags at the 1-based band number.
+
+        Test scenario:
+            `Tags(band_tags={0: {"name": "NDVI"}})._stamp(ds)` stamps band 1.
+        """
+        ds = _mem_dataset(gdal.GDT_Byte)
+        Tags(band_tags={0: {"name": "NDVI"}})._stamp(ds)
+        got = ds.GetRasterBand(1).GetMetadata().get("name")
+        assert got == "NDVI", f"band tag not stamped, got {got!r}"
+
+    def test_stamp_colormap_on_byte_builds_palette(self):
+        """`_stamp` attaches a colour table to a Byte band.
+
+        Test scenario:
+            `Tags(colormap={0: (1, 2, 3, 4)})._stamp(byte_ds)` sets a colour table
+            and flips the colour interpretation to palette.
+        """
+        ds = _mem_dataset(gdal.GDT_Byte)
+        Tags(colormap={0: (1, 2, 3, 4)})._stamp(ds)
+        band = ds.GetRasterBand(1)
+        assert band.GetColorTable() is not None, "colour table should be attached"
+        assert band.GetColorInterpretation() == gdal.GCI_PaletteIndex, "should be palette-interpreted"
+
+    def test_stamp_colormap_rejects_non_byte_dtype(self):
+        """`_stamp` rejects a colourmap on a non-Byte/UInt16 band.
+
+        Test scenario:
+            A float band with a colourmap raises `ValueError` naming the
+            Byte/UInt16 constraint.
+        """
+        ds = _mem_dataset(gdal.GDT_Float32)
+        with pytest.raises(ValueError, match="only supported on Byte/UInt16") as exc:
+            Tags(colormap={0: (1, 2, 3, 4)})._stamp(ds)
+        assert "Byte/UInt16" in str(exc.value), f"unexpected message: {exc.value}"

--- a/tests/dataset/cog/test_options.py
+++ b/tests/dataset/cog/test_options.py
@@ -156,9 +156,13 @@ class TestValidateProfile:
         Test scenario:
             Profiles without a dtype/band constraint return `None` silently.
         """
-        assert validate_profile(name, dtype, bands) is None, f"{name} should pass silently"
+        assert validate_profile(name, dtype, bands) is None, (
+            f"{name} should pass silently"
+        )
 
-    @pytest.mark.parametrize("name, bands", [("jpeg", 1), ("jpeg", 3), ("webp", 3), ("webp", 4)])
+    @pytest.mark.parametrize(
+        "name, bands", [("jpeg", 1), ("jpeg", 3), ("webp", 3), ("webp", 4)]
+    )
     def test_constrained_profile_accepts_valid_source(self, name, bands):
         """JPEG/WEBP accept a Byte source within their band range.
 
@@ -169,7 +173,9 @@ class TestValidateProfile:
         Test scenario:
             JPEG (1-3) and WEBP (3-4) pass for a Byte source in range.
         """
-        assert validate_profile(name, "Byte", bands) is None, f"{name}/{bands} should pass"
+        assert validate_profile(name, "Byte", bands) is None, (
+            f"{name}/{bands} should pass"
+        )
 
     @pytest.mark.parametrize("name", ["jpeg", "webp"])
     def test_constrained_profile_rejects_non_byte_dtype(self, name):
@@ -183,7 +189,9 @@ class TestValidateProfile:
         """
         with pytest.raises(ValueError, match="requires dtype in") as exc:
             validate_profile(name, "Float32", 3)
-        assert name in str(exc.value), f"message should name the profile, got: {exc.value}"
+        assert name in str(exc.value), (
+            f"message should name the profile, got: {exc.value}"
+        )
 
     @pytest.mark.parametrize("name, bands", [("jpeg", 4), ("webp", 1), ("webp", 5)])
     def test_constrained_profile_rejects_bad_band_count(self, name, bands):
@@ -198,4 +206,6 @@ class TestValidateProfile:
         """
         with pytest.raises(ValueError, match="bands; got") as exc:
             validate_profile(name, "Byte", bands)
-        assert str(bands) in str(exc.value), f"message should name the band count, got: {exc.value}"
+        assert str(bands) in str(exc.value), (
+            f"message should name the band count, got: {exc.value}"
+        )

--- a/tests/dataset/cog/test_options.py
+++ b/tests/dataset/cog/test_options.py
@@ -12,6 +12,7 @@ from pyramids.dataset.cog.options import (
     to_gdal_options,
     validate_blocksize,
     validate_option_keys,
+    validate_profile,
 )
 
 
@@ -131,3 +132,70 @@ class TestCogDriverOptions:
 
     def test_is_frozenset(self):
         assert isinstance(COG_DRIVER_OPTIONS, frozenset)
+
+
+class TestValidateProfile:
+    """Per-profile dtype / band-count constraints in `validate_profile`."""
+
+    @pytest.mark.parametrize(
+        "name, dtype, bands",
+        [
+            ("deflate", "Float32", 4),
+            ("zstd", "Byte", 1),
+            ("lerc", "Float64", 10),
+        ],
+    )
+    def test_unconstrained_profile_passes(self, name, dtype, bands):
+        """An unconstrained profile accepts any dtype / band count.
+
+        Args:
+            name: An unconstrained profile name.
+            dtype: Any GDAL dtype name.
+            bands: Any band count.
+
+        Test scenario:
+            Profiles without a dtype/band constraint return `None` silently.
+        """
+        assert validate_profile(name, dtype, bands) is None, f"{name} should pass silently"
+
+    @pytest.mark.parametrize("name, bands", [("jpeg", 1), ("jpeg", 3), ("webp", 3), ("webp", 4)])
+    def test_constrained_profile_accepts_valid_source(self, name, bands):
+        """JPEG/WEBP accept a Byte source within their band range.
+
+        Args:
+            name: A constrained profile name.
+            bands: A band count inside the allowed range.
+
+        Test scenario:
+            JPEG (1-3) and WEBP (3-4) pass for a Byte source in range.
+        """
+        assert validate_profile(name, "Byte", bands) is None, f"{name}/{bands} should pass"
+
+    @pytest.mark.parametrize("name", ["jpeg", "webp"])
+    def test_constrained_profile_rejects_non_byte_dtype(self, name):
+        """JPEG/WEBP reject a non-Byte source dtype.
+
+        Args:
+            name: A constrained profile name.
+
+        Test scenario:
+            A Float32 source raises `ValueError` naming the dtype constraint.
+        """
+        with pytest.raises(ValueError, match="requires dtype in") as exc:
+            validate_profile(name, "Float32", 3)
+        assert name in str(exc.value), f"message should name the profile, got: {exc.value}"
+
+    @pytest.mark.parametrize("name, bands", [("jpeg", 4), ("webp", 1), ("webp", 5)])
+    def test_constrained_profile_rejects_bad_band_count(self, name, bands):
+        """JPEG/WEBP reject a Byte source outside their band range.
+
+        Args:
+            name: A constrained profile name.
+            bands: A band count outside the allowed range.
+
+        Test scenario:
+            An out-of-range band count raises `ValueError` naming the band range.
+        """
+        with pytest.raises(ValueError, match="bands; got") as exc:
+            validate_profile(name, "Byte", bands)
+        assert str(bands) in str(exc.value), f"message should name the band count, got: {exc.value}"


### PR DESCRIPTION
# Description

Follow-up cohesion refactor to #986 (which grouped `to_cog`'s parameters into typed option dataclasses). This
moves the logic that acts on each group's field values out of the COG engine and onto the dataclass that owns
those fields, so each option group is responsible for both validating **and** serializing/applying itself. No
behaviour change — pure relocation.

In `src/pyramids/dataset/cog/options.py`:

- `Layout._to_options()` / `Tiling._to_options()` — serialize from their own fields alone (`Tiling` also owns the
  `scheme` vs `target_srs` conflict warning, the reprojecting gate, and `EPSG:<n>` formatting).
- `Compression._to_options(source_band)` / `Overviews._to_options(source_band)` — take the source band so the
  dtype-aware predictor and overview-resampling defaults resolve on the group (the only external input they need).
- `BandSelection._needs_translate()` / `BandSelection._translate(source)` — the in-memory band-subset / dtype-cast
  / NoData `gdal.Translate`.
- `Tags._has_any()` / `Tags._stamp(ds)` — the colour-table / band-tag / dataset-metadata stamping and the
  Byte/UInt16 guard.

In `src/pyramids/dataset/engines/cog.py`: removed `_resolve_compression`, `_build_cog_defaults`, and
`_stamp_metadata`; `_effective_source` is now a thin orchestrator over `BandSelection`/`Tags`; `to_cog` assembles
the creation options from the four groups' `_to_options()`. The `_PREDICTOR_COMPRESSORS` / `_PALETTE_GDAL_DTYPES`
constants moved into `options.py` alongside the classes that use them.

The new methods are single-underscore (private-by-convention, not exported), so this adds no public API surface.
As a consequence `options.py` now imports `osgeo.gdal` and the base dtype helpers — the module's former
"no GDAL dependency" note was updated to match; GDAL is a hard dependency of the package regardless.

Net: the engine sheds ~297 lines of mapping/transform logic; `options.py` gains the six methods next to the
fields they operate on.

# Issues

- Closes #991 — move the COG grouped-option mapping and source-transform logic onto the option dataclasses.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)  <!-- refactor, non-breaking -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran locally against the branch's `src` on the `dev` pixi environment:

- [x] `pytest tests/dataset/cog` — 454 passed.
- [x] `pytest --doctest-modules src/pyramids/dataset/cog/options.py` — 20 passed (incl. the new
  `Layout`/`Tiling`/`BandSelection`/`Tags` doctests).
- [x] Full non-plot suite `pytest tests -m "not plot"` — 8138 passed, 51 skipped, 396 deselected, 0 failures.
- [x] Two review-round passes applied: preserved `to_cog`'s warning-emission order, added the slice-composition
  invariant test, and cleared every SonarCloud finding (S9073/S5778). All CI checks green on the head commit.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.

