### PR TITLE
refactor(netcdf): decompose _read_variable to clear SonarCloud python:S3776

### DIFF
--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4212,26 +4212,47 @@ class NetCDF(Dataset):
             np.ndarray or None: The variable data, or None if the
                 variable is not found.
         """
-        result = None
         rg = self._working_group()
         if rg is not None:
-            try:
-                md_arr = rg.OpenMDArray(var)
-                if md_arr is not None:
-                    result = self._read_mdarray(md_arr, window)
-                    # Normalize to the raster convention get_variable produces: row 0 = north,
-                    # col 0 = west. A windowed read is returned in storage order (the window is
-                    # expressed in storage indices), so it is left alone. One probe decides both axes.
-                    if result is not None and result.ndim >= 2 and window is None:
-                        result = self._normalize_mdarray_axes(rg, md_arr, result)
-            except (RuntimeError, ValueError):
-                pass  # nosec B110
-            # Fall back to the dimension indexing variable. This stays OUTSIDE the
-            # guard above so a genuine failure here is not silently swallowed.
-            if result is None:
-                result = self._read_indexing_variable(var, window)
+            result = self._read_mdim_variable(rg, var, window)
         else:
             result = self._read_classic_variable(var)
+        return result
+
+    def _read_mdim_variable(
+        self, rg: gdal.Group, var: str, window: list[tuple[int, int]] | None
+    ) -> np.typing.NDArray | None:
+        """Read ``var`` in MDIM mode: MDArray first, indexing-variable fallback.
+
+        The MDArray open+read+normalize is guarded against GDAL raising for a
+        missing or non-numeric array; the indexing-variable fallback runs
+        *outside* that guard so a genuine failure there is not swallowed. A full
+        (unwindowed) >=2-D read is normalized to raster convention; a windowed
+        read is returned in storage order.
+
+        Args:
+            rg: The working group ``var`` is resolved against (kept alive across
+                the axis-flip probe).
+            var: Variable (or dimension) name to read.
+            window: Per-dimension ``(start, count)`` tuples, or ``None`` for a
+                full read.
+
+        Returns:
+            np.ndarray or None: The variable data, or ``None`` if not found.
+        """
+        result: np.typing.NDArray | None = None
+        try:
+            md_arr = rg.OpenMDArray(var)
+            if md_arr is not None:
+                result = self._read_mdarray(md_arr, window)
+                # A full >=2-D read is normalized to raster convention (row 0 =
+                # north, col 0 = west); a windowed read stays in storage order.
+                if result is not None and result.ndim >= 2 and window is None:
+                    result = self._normalize_mdarray_axes(rg, md_arr, result)
+        except (RuntimeError, ValueError):
+            pass  # nosec B110
+        if result is None:
+            result = self._read_indexing_variable(var, window)
         return result
 
     @staticmethod

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4251,12 +4251,12 @@ class NetCDF(Dataset):
             np.ndarray or None: The variable data, or ``None`` if not found.
 
         Raises:
-            Exception: Any error raised by ``_read_indexing_variable`` propagates
-                unchanged. The MDArray branch is guarded (``RuntimeError`` /
-                ``ValueError`` from ``OpenMDArray`` or the read are swallowed so
-                the fallback can run), but the fallback call sits outside that
-                guard, so a genuine failure there surfaces to the caller instead
-                of being masked as a missing variable.
+            Exception: Propagates unchanged from two places. The MDArray branch
+                only swallows ``RuntimeError`` / ``ValueError`` (from
+                ``OpenMDArray``, the read, or normalization); any other exception
+                type surfaces to the caller. And the indexing-variable fallback
+                runs outside that guard, so any error it raises propagates too,
+                rather than being masked as a missing variable.
         """
         result: np.typing.NDArray | None = None
         try:
@@ -4290,7 +4290,7 @@ class NetCDF(Dataset):
         Returns:
             np.ndarray or None: The read data (``None`` only if GDAL yields it).
         """
-        result: np.typing.NDArray | None = None
+        result: np.typing.NDArray | None
         if window is not None:
             starts = [w[0] for w in window]
             counts = [w[1] for w in window]

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4211,6 +4211,12 @@ class NetCDF(Dataset):
         Returns:
             np.ndarray or None: The variable data, or None if the
                 variable is not found.
+
+        See Also:
+            _read_mdim_variable: The MDIM path (guarded MDArray read plus the
+                dimension indexing-variable fallback).
+            _read_classic_variable: The classic ``NETCDF:file:var`` subdataset
+                path used when no MDIM working group is available.
         """
         rg = self._working_group()
         if rg is not None:
@@ -4239,6 +4245,14 @@ class NetCDF(Dataset):
 
         Returns:
             np.ndarray or None: The variable data, or ``None`` if not found.
+
+        Raises:
+            Exception: Propagates any error raised by the indexing-variable
+                fallback. The MDArray read is guarded (``RuntimeError`` /
+                ``ValueError`` are swallowed so the fallback can run), but the
+                fallback itself is deliberately left unguarded, so a genuine
+                failure there surfaces to the caller instead of being masked as a
+                missing variable.
         """
         result: np.typing.NDArray | None = None
         try:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4226,30 +4226,12 @@ class NetCDF(Dataset):
                         result = self._normalize_mdarray_axes(rg, md_arr, result)
             except (RuntimeError, ValueError):
                 pass  # nosec B110
-            # Fall back to dimension indexing variable
+            # Fall back to the dimension indexing variable. This stays OUTSIDE the
+            # guard above so a genuine failure here is not silently swallowed.
             if result is None:
-                dim = self._get_dimension(var)
-                if dim is not None:
-                    iv = dim.GetIndexingVariable()
-                    if iv is not None:
-                        if window is not None and len(window) == 1:
-                            starts = [window[0][0]]
-                            counts = [window[0][1]]
-                            result = iv.ReadAsArray(
-                                array_start_idx=starts,
-                                count=counts,
-                            )
-                        else:
-                            result = iv.ReadAsArray()
+                result = self._read_indexing_variable(var, window)
         else:
-            # Classic mode: open via subdataset string
-            try:
-                ds = gdal.Open(f"NETCDF:{self.file_name}:{var}")
-                if ds is not None:
-                    result = ds.ReadAsArray()
-                ds = None
-            except (RuntimeError, AttributeError):
-                pass
+            result = self._read_classic_variable(var)
         return result
 
     @staticmethod
@@ -4304,6 +4286,64 @@ class NetCDF(Dataset):
             result = np.flip(result, axis=result.ndim - 2)
         if flip_x:
             result = np.flip(result, axis=result.ndim - 1)
+        return result
+
+    def _read_indexing_variable(
+        self, var: str, window: list[tuple[int, int]] | None
+    ) -> np.typing.NDArray | None:
+        """Read ``var``'s dimension indexing variable (a 1-D coordinate).
+
+        Used as the fallback when ``var`` is not an MDArray but names a
+        dimension whose indexing variable holds the coordinate values. A
+        1-element ``window`` selects a slice of that 1-D coordinate; any other
+        window shape reads the coordinate in full.
+
+        Args:
+            var: The dimension name whose indexing variable to read.
+            window: Per-dimension ``(start, count)`` tuples, or ``None``. Only a
+                length-1 window is applied (the indexing variable is 1-D).
+
+        Returns:
+            np.ndarray or None: The coordinate values, or ``None`` when ``var``
+                has no dimension or indexing variable.
+        """
+        result: np.typing.NDArray | None = None
+        dim = self._get_dimension(var)
+        if dim is not None:
+            iv = dim.GetIndexingVariable()
+            if iv is not None:
+                if window is not None and len(window) == 1:
+                    starts = [window[0][0]]
+                    counts = [window[0][1]]
+                    result = iv.ReadAsArray(
+                        array_start_idx=starts,
+                        count=counts,
+                    )
+                else:
+                    result = iv.ReadAsArray()
+        return result
+
+    def _read_classic_variable(self, var: str) -> np.typing.NDArray | None:
+        """Read ``var`` in classic (non-MDIM) mode via the subdataset string.
+
+        Opens ``NETCDF:<file>:<var>`` and reads it in full. The ``window`` is not
+        supported in classic mode and is intentionally not accepted here.
+
+        Args:
+            var: Variable name to read from the classic subdataset.
+
+        Returns:
+            np.ndarray or None: The variable data, or ``None`` when the
+                subdataset cannot be opened or read.
+        """
+        result: np.typing.NDArray | None = None
+        try:
+            ds = gdal.Open(f"NETCDF:{self.file_name}:{var}")
+            if ds is not None:
+                result = ds.ReadAsArray()
+            ds = None
+        except (RuntimeError, AttributeError):
+            pass
         return result
 
     def _working_group(self) -> gdal.Group | None:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4149,7 +4149,7 @@ class NetCDF(Dataset):
         """
         return self._get_dimension_names()
 
-    def _get_dimension(self, name: str) -> gdal.Dimension:
+    def _get_dimension(self, name: str) -> gdal.Dimension | None:
         dim = None
         for candidate in self._working_group_dimensions():
             if candidate.GetName() == name:
@@ -4217,6 +4217,10 @@ class NetCDF(Dataset):
                 dimension indexing-variable fallback).
             _read_classic_variable: The classic ``NETCDF:file:var`` subdataset
                 path used when no MDIM working group is available.
+            _read_mdarray: The windowed/full MDArray read.
+            _normalize_mdarray_axes: The full-read axis-flip normalization (where
+                the Y/X flip happens).
+            _read_indexing_variable: The dimension indexing-variable fallback read.
         """
         rg = self._working_group()
         if rg is not None:
@@ -4247,12 +4251,12 @@ class NetCDF(Dataset):
             np.ndarray or None: The variable data, or ``None`` if not found.
 
         Raises:
-            Exception: Propagates any error raised by the indexing-variable
-                fallback. The MDArray read is guarded (``RuntimeError`` /
-                ``ValueError`` are swallowed so the fallback can run), but the
-                fallback itself is deliberately left unguarded, so a genuine
-                failure there surfaces to the caller instead of being masked as a
-                missing variable.
+            Exception: Any error raised by ``_read_indexing_variable`` propagates
+                unchanged. The MDArray branch is guarded (``RuntimeError`` /
+                ``ValueError`` from ``OpenMDArray`` or the read are swallowed so
+                the fallback can run), but the fallback call sits outside that
+                guard, so a genuine failure there surfaces to the caller instead
+                of being masked as a missing variable.
         """
         result: np.typing.NDArray | None = None
         try:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4250,13 +4250,13 @@ class NetCDF(Dataset):
         Returns:
             np.ndarray or None: The variable data, or ``None`` if not found.
 
-        Raises:
-            Exception: Propagates unchanged from two places. The MDArray branch
-                only swallows ``RuntimeError`` / ``ValueError`` (from
-                ``OpenMDArray``, the read, or normalization); any other exception
-                type surfaces to the caller. And the indexing-variable fallback
-                runs outside that guard, so any error it raises propagates too,
-                rather than being masked as a missing variable.
+        Note:
+            This method raises nothing of its own but it does not catch
+            everything. The MDArray branch swallows only ``RuntimeError`` /
+            ``ValueError`` (from ``OpenMDArray``, the read, or normalization), so
+            any other exception type propagates unchanged; and the
+            indexing-variable fallback runs outside that guard, so any error it
+            raises propagates too rather than being masked as a missing variable.
         """
         result: np.typing.NDArray | None = None
         try:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4315,7 +4315,8 @@ class NetCDF(Dataset):
         Args:
             rg: The root group, kept alive to prevent SWIG GC.
             md_arr: The MDArray the result was read from.
-            result: The full-read array to normalize in place of storage order.
+            result: The full read (in storage order) to normalize; ``np.flip``
+                returns new views, so this array is not mutated in place.
 
         Returns:
             np.ndarray: The array flipped to raster convention as needed.

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4218,24 +4218,12 @@ class NetCDF(Dataset):
             try:
                 md_arr = rg.OpenMDArray(var)
                 if md_arr is not None:
-                    if window is not None:
-                        starts = [w[0] for w in window]
-                        counts = [w[1] for w in window]
-                        result = md_arr.ReadAsArray(
-                            array_start_idx=starts,
-                            count=counts,
-                        )
-                    else:
-                        result = md_arr.ReadAsArray()
+                    result = self._read_mdarray(md_arr, window)
                     # Normalize to the raster convention get_variable produces: row 0 = north,
                     # col 0 = west. A windowed read is returned in storage order (the window is
                     # expressed in storage indices), so it is left alone. One probe decides both axes.
                     if result is not None and result.ndim >= 2 and window is None:
-                        flip_y, flip_x = axis_flips(rg, md_arr)
-                        if flip_y:
-                            result = np.flip(result, axis=result.ndim - 2)
-                        if flip_x:
-                            result = np.flip(result, axis=result.ndim - 1)
+                        result = self._normalize_mdarray_axes(rg, md_arr, result)
             except (RuntimeError, ValueError):
                 pass  # nosec B110
             # Fall back to dimension indexing variable
@@ -4262,6 +4250,60 @@ class NetCDF(Dataset):
                 ds = None
             except (RuntimeError, AttributeError):
                 pass
+        return result
+
+    @staticmethod
+    def _read_mdarray(
+        md_arr: gdal.MDArray, window: list[tuple[int, int]] | None
+    ) -> np.typing.NDArray | None:
+        """Read an MDArray as a numpy array, windowed or in full.
+
+        A windowed read is expressed in storage indices and returned in storage
+        order (the caller is responsible for any axis normalization).
+
+        Args:
+            md_arr: The GDAL MDArray to read.
+            window: Per-dimension ``(start, count)`` tuples, or ``None`` for a
+                full read.
+
+        Returns:
+            np.ndarray or None: The read data (``None`` only if GDAL yields it).
+        """
+        result: np.typing.NDArray | None = None
+        if window is not None:
+            starts = [w[0] for w in window]
+            counts = [w[1] for w in window]
+            result = md_arr.ReadAsArray(
+                array_start_idx=starts,
+                count=counts,
+            )
+        else:
+            result = md_arr.ReadAsArray()
+        return result
+
+    @staticmethod
+    def _normalize_mdarray_axes(
+        rg: gdal.Group, md_arr: gdal.MDArray, result: np.typing.NDArray
+    ) -> np.typing.NDArray:
+        """Flip a full >=2-D read into raster convention (row 0 = north, col 0 = west).
+
+        One :func:`axis_flips` probe decides both axes. ``rg`` is accepted (not
+        just ``md_arr``) so the root group is held alive across the probe and
+        SWIG cannot garbage-collect it mid-call.
+
+        Args:
+            rg: The root group, kept alive to prevent SWIG GC.
+            md_arr: The MDArray the result was read from.
+            result: The full-read array to normalize in place of storage order.
+
+        Returns:
+            np.ndarray: The array flipped to raster convention as needed.
+        """
+        flip_y, flip_x = axis_flips(rg, md_arr)
+        if flip_y:
+            result = np.flip(result, axis=result.ndim - 2)
+        if flip_x:
+            result = np.flip(result, axis=result.ndim - 1)
         return result
 
     def _working_group(self) -> gdal.Group | None:

--- a/tests/netcdf/io/test_read_variable_helpers.py
+++ b/tests/netcdf/io/test_read_variable_helpers.py
@@ -1,0 +1,482 @@
+"""Unit tests for the ``NetCDF._read_variable`` helper decomposition (ARC-150).
+
+``_read_variable`` was split into a dispatcher plus five private helpers:
+
+- ``_read_mdim_variable`` — MDIM orchestration (guarded MDArray read + fallback),
+- ``_read_mdarray`` — windowed/full MDArray read (static),
+- ``_normalize_mdarray_axes`` — axis-flip normalization (static),
+- ``_read_indexing_variable`` — dimension indexing-variable fallback,
+- ``_read_classic_variable`` — classic ``NETCDF:file:var`` subdataset read.
+
+These tests isolate each helper with mocks so the branch behaviour (windowed vs
+full, flip vs no-flip, MDArray vs fallback vs classic, and — critically — the
+try/except *scoping* that must not swallow fallback failures) is pinned
+independently of any real NetCDF file. The end-to-end behaviour on real fixtures
+is covered by ``test_windowed_reads.py`` and ``unit/test_netcdf_unit_read.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+import numpy as np
+import pytest
+
+from pyramids.netcdf.netcdf import NetCDF
+
+
+class TestReadMdarray:
+    """Tests for the static ``NetCDF._read_mdarray``."""
+
+    def test_full_read_calls_readasarray_without_args(self):
+        """A ``None`` window triggers a bare full ``ReadAsArray()``.
+
+        Test scenario:
+            ``window=None`` must call ``md_arr.ReadAsArray()`` with no index
+            arguments and return its result verbatim.
+        """
+        md_arr = Mock()
+        sentinel = np.arange(6).reshape(2, 3)
+        md_arr.ReadAsArray.return_value = sentinel
+
+        result = NetCDF._read_mdarray(md_arr, None)
+
+        md_arr.ReadAsArray.assert_called_once_with()
+        assert result is sentinel, "full read must return ReadAsArray() verbatim"
+
+    def test_windowed_read_passes_start_and_count(self):
+        """A window becomes ``array_start_idx`` / ``count`` lists in storage order.
+
+        Test scenario:
+            ``window=[(0, 1), (100, 256)]`` must call
+            ``ReadAsArray(array_start_idx=[0, 100], count=[1, 256])`` and return
+            its result (no flipping — that is the caller's job).
+        """
+        md_arr = Mock()
+        sentinel = np.zeros((1, 256))
+        md_arr.ReadAsArray.return_value = sentinel
+
+        result = NetCDF._read_mdarray(md_arr, [(0, 1), (100, 256)])
+
+        md_arr.ReadAsArray.assert_called_once_with(
+            array_start_idx=[0, 100], count=[1, 256]
+        )
+        assert result is sentinel, "windowed read must return ReadAsArray() verbatim"
+
+    def test_returns_none_when_gdal_yields_none(self):
+        """A ``None`` from GDAL propagates as ``None``.
+
+        Test scenario:
+            If ``ReadAsArray`` returns ``None`` the helper returns ``None``.
+        """
+        md_arr = Mock()
+        md_arr.ReadAsArray.return_value = None
+
+        assert NetCDF._read_mdarray(md_arr, None) is None, "None must propagate"
+
+
+class TestNormalizeMdarrayAxes:
+    """Tests for the static ``NetCDF._normalize_mdarray_axes``."""
+
+    @pytest.fixture
+    def arr(self):
+        """Return a distinct 3x4 array so flips are observable.
+
+        Returns:
+            np.ndarray: ``arange(12).reshape(3, 4)``.
+        """
+        return np.arange(12).reshape(3, 4)
+
+    def test_no_flip_returns_array_unchanged(self, arr):
+        """``(False, False)`` leaves the array untouched.
+
+        Args:
+            arr: The 3x4 fixture array.
+
+        Test scenario:
+            When ``axis_flips`` reports neither axis needs flipping, the input is
+            returned unchanged.
+        """
+        with patch(
+            "pyramids.netcdf.netcdf.axis_flips", return_value=(False, False)
+        ) as af:
+            result = NetCDF._normalize_mdarray_axes(Mock(), Mock(), arr)
+        af.assert_called_once()
+        assert np.array_equal(result, arr), "no-flip must return the array unchanged"
+
+    def test_flip_y_only(self, arr):
+        """``(True, False)`` flips the row axis (``ndim - 2``) only.
+
+        Test scenario:
+            Y-flip must equal ``np.flip(arr, axis=0)`` for a 2-D array.
+        """
+        with patch("pyramids.netcdf.netcdf.axis_flips", return_value=(True, False)):
+            result = NetCDF._normalize_mdarray_axes(Mock(), Mock(), arr)
+        assert np.array_equal(result, np.flip(arr, axis=0)), "Y axis must be flipped"
+
+    def test_flip_x_only(self, arr):
+        """``(False, True)`` flips the column axis (``ndim - 1``) only.
+
+        Test scenario:
+            X-flip must equal ``np.flip(arr, axis=1)`` for a 2-D array.
+        """
+        with patch("pyramids.netcdf.netcdf.axis_flips", return_value=(False, True)):
+            result = NetCDF._normalize_mdarray_axes(Mock(), Mock(), arr)
+        assert np.array_equal(result, np.flip(arr, axis=1)), "X axis must be flipped"
+
+    def test_flip_both_axes(self, arr):
+        """``(True, True)`` flips both axes.
+
+        Test scenario:
+            Both-flip must equal ``np.flip(np.flip(arr, axis=0), axis=1)``.
+        """
+        with patch("pyramids.netcdf.netcdf.axis_flips", return_value=(True, True)):
+            result = NetCDF._normalize_mdarray_axes(Mock(), Mock(), arr)
+        expected = np.flip(np.flip(arr, axis=0), axis=1)
+        assert np.array_equal(result, expected), "both axes must be flipped"
+
+    def test_uses_trailing_axes_for_3d(self):
+        """Flips target the trailing two axes for a >2-D array.
+
+        Test scenario:
+            For a 3-D array the Y/X flips must apply to axes ``ndim-2`` / ``ndim-1``
+            (i.e. 1 and 2), leaving the leading band axis intact.
+        """
+        arr3d = np.arange(24).reshape(2, 3, 4)
+        with patch("pyramids.netcdf.netcdf.axis_flips", return_value=(True, True)):
+            result = NetCDF._normalize_mdarray_axes(Mock(), Mock(), arr3d)
+        expected = np.flip(np.flip(arr3d, axis=1), axis=2)
+        assert np.array_equal(result, expected), "3-D flips must target trailing axes"
+
+
+class TestReadIndexingVariable:
+    """Tests for ``NetCDF._read_indexing_variable`` (the fallback)."""
+
+    def test_returns_none_when_no_dimension(self):
+        """A missing dimension yields ``None``.
+
+        Test scenario:
+            ``_get_dimension`` returning ``None`` short-circuits to ``None``.
+        """
+        mock_self = Mock()
+        mock_self._get_dimension.return_value = None
+
+        result = NetCDF._read_indexing_variable(mock_self, "x", None)
+
+        assert result is None, "no dimension must yield None"
+
+    def test_returns_none_when_no_indexing_variable(self):
+        """A dimension without an indexing variable yields ``None``.
+
+        Test scenario:
+            ``dim.GetIndexingVariable()`` returning ``None`` yields ``None``.
+        """
+        mock_self = Mock()
+        dim = Mock()
+        dim.GetIndexingVariable.return_value = None
+        mock_self._get_dimension.return_value = dim
+
+        result = NetCDF._read_indexing_variable(mock_self, "x", None)
+
+        assert result is None, "no indexing variable must yield None"
+
+    def test_full_read_when_window_is_none(self):
+        """``window=None`` reads the whole indexing variable.
+
+        Test scenario:
+            The indexing variable's ``ReadAsArray()`` is called with no args.
+        """
+        mock_self = Mock()
+        iv = Mock()
+        coords = np.array([0.0, 1.0, 2.0])
+        iv.ReadAsArray.return_value = coords
+        dim = Mock()
+        dim.GetIndexingVariable.return_value = iv
+        mock_self._get_dimension.return_value = dim
+
+        result = NetCDF._read_indexing_variable(mock_self, "time", None)
+
+        iv.ReadAsArray.assert_called_once_with()
+        assert result is coords, "full 1-D read must return ReadAsArray() verbatim"
+
+    def test_windowed_read_when_window_length_one(self):
+        """A length-1 window slices the 1-D coordinate.
+
+        Test scenario:
+            ``window=[(5, 3)]`` must call
+            ``ReadAsArray(array_start_idx=[5], count=[3])``.
+        """
+        mock_self = Mock()
+        iv = Mock()
+        iv.ReadAsArray.return_value = np.array([5.0, 6.0, 7.0])
+        dim = Mock()
+        dim.GetIndexingVariable.return_value = iv
+        mock_self._get_dimension.return_value = dim
+
+        NetCDF._read_indexing_variable(mock_self, "time", [(5, 3)])
+
+        iv.ReadAsArray.assert_called_once_with(array_start_idx=[5], count=[3])
+
+    def test_multi_dim_window_falls_back_to_full_read(self):
+        """A window with length != 1 is ignored (full 1-D read).
+
+        Test scenario:
+            The indexing variable is 1-D, so a multi-entry window cannot apply;
+            ``ReadAsArray()`` is called with no args.
+        """
+        mock_self = Mock()
+        iv = Mock()
+        iv.ReadAsArray.return_value = np.array([0.0, 1.0])
+        dim = Mock()
+        dim.GetIndexingVariable.return_value = iv
+        mock_self._get_dimension.return_value = dim
+
+        NetCDF._read_indexing_variable(mock_self, "x", [(0, 1), (2, 3)])
+
+        iv.ReadAsArray.assert_called_once_with()
+
+
+class TestReadClassicVariable:
+    """Tests for ``NetCDF._read_classic_variable`` (classic subdataset read)."""
+
+    def test_reads_full_variable(self):
+        """A successful open reads the subdataset in full.
+
+        Test scenario:
+            ``gdal.Open("NETCDF:<file>:<var>")`` returning a dataset yields its
+            ``ReadAsArray()`` result.
+        """
+        mock_self = Mock()
+        mock_self.file_name = "file.nc"
+        ds = Mock()
+        arr = np.arange(4).reshape(2, 2)
+        ds.ReadAsArray.return_value = arr
+
+        with patch("pyramids.netcdf.netcdf.gdal.Open", return_value=ds) as gopen:
+            result = NetCDF._read_classic_variable(mock_self, "salt")
+
+        gopen.assert_called_once_with("NETCDF:file.nc:salt")
+        assert result is arr, "classic read must return ReadAsArray() verbatim"
+
+    def test_returns_none_when_open_returns_none(self):
+        """A ``None`` from ``gdal.Open`` yields ``None``.
+
+        Test scenario:
+            ``gdal.Open`` returning ``None`` (variable/file not openable) yields
+            ``None`` without calling ``ReadAsArray``.
+        """
+        mock_self = Mock()
+        mock_self.file_name = "file.nc"
+
+        with patch("pyramids.netcdf.netcdf.gdal.Open", return_value=None):
+            result = NetCDF._read_classic_variable(mock_self, "nope")
+
+        assert result is None, "open returning None must yield None"
+
+    @pytest.mark.parametrize("exc", [RuntimeError, AttributeError])
+    def test_swallows_expected_open_errors(self, exc):
+        """RuntimeError/AttributeError from ``gdal.Open`` are swallowed to ``None``.
+
+        Args:
+            exc: The exception type ``gdal.Open`` raises.
+
+        Test scenario:
+            Both guarded exception types must be caught and produce ``None``.
+        """
+        mock_self = Mock()
+        mock_self.file_name = "file.nc"
+
+        with patch("pyramids.netcdf.netcdf.gdal.Open", side_effect=exc("boom")):
+            result = NetCDF._read_classic_variable(mock_self, "salt")
+
+        assert result is None, f"{exc.__name__} must be swallowed to None"
+
+
+class TestReadMdimVariable:
+    """Tests for ``NetCDF._read_mdim_variable`` orchestration and scoping."""
+
+    def _mock_self(self):
+        """Build a mock ``self`` with the leaf read helpers stubbed.
+
+        Returns:
+            Mock: a stand-in ``NetCDF`` whose ``_read_mdarray`` /
+            ``_normalize_mdarray_axes`` / ``_read_indexing_variable`` are Mocks.
+        """
+        mock_self = Mock()
+        return mock_self
+
+    def test_full_2d_read_is_normalized(self):
+        """A full >=2-D MDArray read is passed through normalization.
+
+        Test scenario:
+            ``window=None`` and a 2-D read => ``_normalize_mdarray_axes`` is called
+            and its return value is used; the fallback is not consulted.
+        """
+        mock_self = self._mock_self()
+        rg = Mock()
+        rg.OpenMDArray.return_value = Mock()
+        mock_self._read_mdarray.return_value = np.zeros((3, 4))
+        normalized = np.ones((3, 4))
+        mock_self._normalize_mdarray_axes.return_value = normalized
+
+        result = NetCDF._read_mdim_variable(mock_self, rg, "t2m", None)
+
+        mock_self._normalize_mdarray_axes.assert_called_once()
+        mock_self._read_indexing_variable.assert_not_called()
+        assert result is normalized, "full 2-D read must be normalized"
+
+    def test_1d_read_is_not_normalized(self):
+        """A 1-D read skips normalization (and the fallback).
+
+        Test scenario:
+            ``ndim < 2`` => no ``_normalize_mdarray_axes``, no fallback, result is
+            the raw read.
+        """
+        mock_self = self._mock_self()
+        rg = Mock()
+        rg.OpenMDArray.return_value = Mock()
+        one_d = np.arange(5)
+        mock_self._read_mdarray.return_value = one_d
+
+        result = NetCDF._read_mdim_variable(mock_self, rg, "x", None)
+
+        mock_self._normalize_mdarray_axes.assert_not_called()
+        mock_self._read_indexing_variable.assert_not_called()
+        assert result is one_d, "1-D read must be returned un-normalized"
+
+    def test_windowed_2d_read_is_not_normalized(self):
+        """A windowed read stays in storage order (no flip) even if 2-D.
+
+        Test scenario:
+            ``window`` is not None => ``_normalize_mdarray_axes`` must not be
+            called; the raw windowed read is returned.
+        """
+        mock_self = self._mock_self()
+        rg = Mock()
+        rg.OpenMDArray.return_value = Mock()
+        windowed = np.zeros((2, 2))
+        mock_self._read_mdarray.return_value = windowed
+
+        result = NetCDF._read_mdim_variable(mock_self, rg, "t2m", [(0, 2), (0, 2)])
+
+        mock_self._normalize_mdarray_axes.assert_not_called()
+        assert result is windowed, "windowed read must not be flipped"
+
+    def test_missing_mdarray_falls_back_to_indexing_variable(self):
+        """A ``None`` MDArray triggers the indexing-variable fallback.
+
+        Test scenario:
+            ``OpenMDArray`` returning ``None`` => ``_read_mdarray`` is not called,
+            the fallback runs and its value is returned.
+        """
+        mock_self = self._mock_self()
+        rg = Mock()
+        rg.OpenMDArray.return_value = None
+        coords = np.array([0.0, 1.0])
+        mock_self._read_indexing_variable.return_value = coords
+
+        result = NetCDF._read_mdim_variable(mock_self, rg, "time", None)
+
+        mock_self._read_mdarray.assert_not_called()
+        mock_self._read_indexing_variable.assert_called_once_with("time", None)
+        assert result is coords, "missing MDArray must fall back to indexing var"
+
+    def test_none_mdarray_read_falls_back(self):
+        """A present MDArray whose read yields ``None`` still falls back.
+
+        Test scenario:
+            ``OpenMDArray`` returns an object but ``_read_mdarray`` returns
+            ``None`` (e.g. GDAL yielded nothing) => normalization is skipped and
+            the indexing-variable fallback supplies the result.
+        """
+        mock_self = self._mock_self()
+        rg = Mock()
+        rg.OpenMDArray.return_value = Mock()
+        mock_self._read_mdarray.return_value = None
+        fallback = np.array([9.0])
+        mock_self._read_indexing_variable.return_value = fallback
+
+        result = NetCDF._read_mdim_variable(mock_self, rg, "x", None)
+
+        mock_self._normalize_mdarray_axes.assert_not_called()
+        mock_self._read_indexing_variable.assert_called_once_with("x", None)
+        assert result is fallback, "a None read must fall back to the indexing var"
+
+    @pytest.mark.parametrize("exc", [RuntimeError, ValueError])
+    def test_openmdarray_error_falls_back(self, exc):
+        """A guarded error from ``OpenMDArray`` is swallowed and falls back.
+
+        Args:
+            exc: The guarded exception ``OpenMDArray`` raises.
+
+        Test scenario:
+            RuntimeError/ValueError from the MDArray branch => caught, then the
+            fallback runs and supplies the result.
+        """
+        mock_self = self._mock_self()
+        rg = Mock()
+        rg.OpenMDArray.side_effect = exc("boom")
+        fallback = np.array([1.0])
+        mock_self._read_indexing_variable.return_value = fallback
+
+        result = NetCDF._read_mdim_variable(mock_self, rg, "x", None)
+
+        mock_self._read_indexing_variable.assert_called_once_with("x", None)
+        assert result is fallback, f"{exc.__name__} must be swallowed then fall back"
+
+    def test_fallback_failure_is_not_swallowed(self):
+        """The indexing-variable fallback runs OUTSIDE the guard (R3).
+
+        Test scenario:
+            After the MDArray branch fails, a failure in the fallback itself must
+            propagate (it is deliberately not inside the try/except). This pins the
+            scoping invariant the refactor had to preserve.
+        """
+        mock_self = self._mock_self()
+        rg = Mock()
+        rg.OpenMDArray.side_effect = RuntimeError("mdarray gone")
+        mock_self._read_indexing_variable.side_effect = ValueError("fallback bug")
+
+        with pytest.raises(ValueError, match="fallback bug"):
+            NetCDF._read_mdim_variable(mock_self, rg, "x", None)
+
+
+class TestReadVariableDispatcher:
+    """Tests for the ``NetCDF._read_variable`` dispatcher branch selection."""
+
+    def test_mdim_branch_when_working_group_present(self):
+        """A non-None working group routes to ``_read_mdim_variable``.
+
+        Test scenario:
+            ``_working_group()`` returning a group => MDIM path is taken with the
+            group forwarded; the classic path is not used.
+        """
+        mock_self = Mock()
+        rg = Mock()
+        mock_self._working_group.return_value = rg
+        sentinel = np.zeros((2, 2))
+        mock_self._read_mdim_variable.return_value = sentinel
+
+        result = NetCDF._read_variable(mock_self, "t2m", None)
+
+        mock_self._read_mdim_variable.assert_called_once_with(rg, "t2m", None)
+        mock_self._read_classic_variable.assert_not_called()
+        assert result is sentinel, "present working group must take the MDIM path"
+
+    def test_classic_branch_when_no_working_group(self):
+        """A ``None`` working group routes to ``_read_classic_variable``.
+
+        Test scenario:
+            ``_working_group()`` returning ``None`` => classic path is taken; the
+            MDIM path is not used.
+        """
+        mock_self = Mock()
+        mock_self._working_group.return_value = None
+        sentinel = np.zeros((2, 2))
+        mock_self._read_classic_variable.return_value = sentinel
+
+        result = NetCDF._read_variable(mock_self, "salt", None)
+
+        mock_self._read_classic_variable.assert_called_once_with("salt")
+        mock_self._read_mdim_variable.assert_not_called()
+        assert result is sentinel, "absent working group must take the classic path"

--- a/tests/netcdf/io/test_read_variable_helpers.py
+++ b/tests/netcdf/io/test_read_variable_helpers.py
@@ -308,6 +308,28 @@ class TestReadClassicVariable:
 
         assert result is None, f"{exc.__name__} must be swallowed to None"
 
+    @pytest.mark.parametrize("exc", [RuntimeError, AttributeError])
+    def test_swallows_read_errors_after_successful_open(self, exc):
+        """RuntimeError/AttributeError from ``ReadAsArray`` (post-open) yield ``None``.
+
+        Args:
+            exc: The exception type ``ReadAsArray`` raises.
+
+        Test scenario:
+            ``gdal.Open`` returns a dataset, but its ``ReadAsArray`` then raises a
+            guarded error; the ``except`` must swallow it and produce ``None`` -- a
+            distinct sub-branch from ``gdal.Open`` itself raising.
+        """
+        mock_self = Mock()
+        mock_self.file_name = "file.nc"
+        ds = Mock()
+        ds.ReadAsArray.side_effect = exc("boom")
+
+        with patch("pyramids.netcdf.netcdf.gdal.Open", return_value=ds):
+            result = NetCDF._read_classic_variable(mock_self, "salt")
+
+        assert result is None, f"{exc.__name__} from ReadAsArray must yield None"
+
 
 class TestReadMdimVariable:
     """Tests for ``NetCDF._read_mdim_variable`` orchestration and scoping."""

--- a/tests/netcdf/io/test_read_variable_helpers.py
+++ b/tests/netcdf/io/test_read_variable_helpers.py
@@ -498,6 +498,32 @@ class TestReadMdimVariable:
         mock_self._read_indexing_variable.assert_called_once_with("x", None)
         assert result is fallback, f"{exc.__name__} must be swallowed then fall back"
 
+    @pytest.mark.parametrize("exc", [RuntimeError, ValueError])
+    def test_read_error_after_open_falls_back(self, exc):
+        """A guarded error from ``_read_mdarray`` (post-open) is swallowed → fallback.
+
+        Args:
+            exc: The guarded exception ``_read_mdarray`` raises.
+
+        Test scenario:
+            ``OpenMDArray`` returns a non-None array, but ``_read_mdarray`` then
+            raises a guarded ``RuntimeError`` / ``ValueError``. The ``except``
+            swallows it, ``result`` stays ``None``, and the indexing-variable
+            fallback supplies the result -- a distinct raising call site from
+            ``OpenMDArray`` itself raising.
+        """
+        mock_self = self._mock_self()
+        rg = Mock()
+        rg.OpenMDArray.return_value = Mock()
+        mock_self._read_mdarray.side_effect = exc("read boom")
+        fallback = np.array([2.0])
+        mock_self._read_indexing_variable.return_value = fallback
+
+        result = NetCDF._read_mdim_variable(mock_self, rg, "x", None)
+
+        mock_self._read_indexing_variable.assert_called_once_with("x", None)
+        assert result is fallback, f"{exc.__name__} from the read must fall back"
+
     def test_fallback_failure_is_not_swallowed(self):
         """The indexing-variable fallback runs OUTSIDE the guard (R3).
 

--- a/tests/netcdf/io/test_read_variable_helpers.py
+++ b/tests/netcdf/io/test_read_variable_helpers.py
@@ -104,6 +104,23 @@ class TestNormalizeMdarrayAxes:
         af.assert_called_once()
         assert np.array_equal(result, arr), "no-flip must return the array unchanged"
 
+    def test_forwards_rg_and_mdarray_to_axis_flips(self, arr):
+        """``rg`` and ``md_arr`` are forwarded, in order, to ``axis_flips``.
+
+        Test scenario:
+            The helper takes ``rg`` (not just ``md_arr``) so the root group is held
+            alive across the probe and SWIG cannot GC it. A regression that dropped
+            ``rg`` and called ``axis_flips(md_arr)`` must be caught here, so assert
+            the exact positional forwarding rather than a bare call count.
+        """
+        rg = Mock(name="rg")
+        md_arr = Mock(name="md_arr")
+        with patch(
+            "pyramids.netcdf.netcdf.axis_flips", return_value=(False, False)
+        ) as af:
+            NetCDF._normalize_mdarray_axes(rg, md_arr, arr)
+        af.assert_called_once_with(rg, md_arr)
+
     def test_flip_y_only(self, arr):
         """``(True, False)`` flips the row axis (``ndim - 2``) only.
 
@@ -321,7 +338,15 @@ class TestReadMdimVariable:
 
         result = NetCDF._read_mdim_variable(mock_self, rg, "t2m", None)
 
-        mock_self._normalize_mdarray_axes.assert_called_once()
+        mock_self._read_mdarray.assert_called_once_with(
+            rg.OpenMDArray.return_value, None
+        )
+        norm_args = mock_self._normalize_mdarray_axes.call_args.args
+        assert norm_args[0] is rg, "rg must be forwarded to _normalize_mdarray_axes"
+        assert norm_args[1] is rg.OpenMDArray.return_value, "md_arr must be forwarded"
+        assert norm_args[2] is mock_self._read_mdarray.return_value, (
+            "the read result must be forwarded to _normalize_mdarray_axes"
+        )
         mock_self._read_indexing_variable.assert_not_called()
         assert result is normalized, "full 2-D read must be normalized"
 
@@ -359,6 +384,9 @@ class TestReadMdimVariable:
 
         result = NetCDF._read_mdim_variable(mock_self, rg, "t2m", [(0, 2), (0, 2)])
 
+        mock_self._read_mdarray.assert_called_once_with(
+            rg.OpenMDArray.return_value, [(0, 2), (0, 2)]
+        )
         mock_self._normalize_mdarray_axes.assert_not_called()
         assert result is windowed, "windowed read must not be flipped"
 

--- a/tests/netcdf/io/test_read_variable_helpers.py
+++ b/tests/netcdf/io/test_read_variable_helpers.py
@@ -390,6 +390,30 @@ class TestReadMdimVariable:
         mock_self._normalize_mdarray_axes.assert_not_called()
         assert result is windowed, "windowed read must not be flipped"
 
+    def test_normalization_error_returns_unnormalized_without_fallback(self):
+        """A guarded error DURING normalization returns the raw read, no fallback.
+
+        Test scenario:
+            A non-None 2-D read succeeds, then ``_normalize_mdarray_axes`` raises a
+            guarded ``RuntimeError``. Because ``result`` already holds the raw read
+            (the failed assignment does not rebind it), the ``except`` swallows the
+            error and the ``if result is None`` fallback is skipped -- the
+            un-normalized, storage-order array is returned. This pins the subtle
+            branch the original preserved (the flips lived inside the same ``try``),
+            distinct from the ``OpenMDArray``-raises-before-read path.
+        """
+        mock_self = self._mock_self()
+        rg = Mock()
+        rg.OpenMDArray.return_value = Mock()
+        raw = np.zeros((3, 4))
+        mock_self._read_mdarray.return_value = raw
+        mock_self._normalize_mdarray_axes.side_effect = RuntimeError("flip boom")
+
+        result = NetCDF._read_mdim_variable(mock_self, rg, "t2m", None)
+
+        assert result is raw, "a normalization error must return the raw read"
+        mock_self._read_indexing_variable.assert_not_called()
+
     def test_missing_mdarray_falls_back_to_indexing_variable(self):
         """A ``None`` MDArray triggers the indexing-variable fallback.
 


### PR DESCRIPTION
# Description

Decomposes `NetCDF._read_variable` (`src/pyramids/netcdf/netcdf.py`) — SonarCloud `python:S3776`, cognitive
complexity **42 → < 15** — into a two-branch dispatcher plus five small, single-return private helpers. The
method previously inlined two read strategies (MDIM MDArray read + classic `NETCDF:file:var` subdataset read),
a dimension-indexing-variable fallback, windowed-vs-full branching, and axis-flip normalization, nested up to
five levels deep.

New structure:

- `_read_variable` — dispatcher (MDIM working group vs classic).
- `_read_mdim_variable` — guarded MDArray read + indexing-variable fallback.
- `_read_mdarray` (`@staticmethod`) — windowed/full MDArray read.
- `_normalize_mdarray_axes` (`@staticmethod`) — full-read axis-flip normalization.
- `_read_indexing_variable` — dimension indexing-variable fallback.
- `_read_classic_variable` — classic subdataset read.

The change is **behaviour-preserving**. Invariants preserved exactly: try/except scoping (MDArray read guarded;
the fallback runs outside the guard so a real fallback failure is not swallowed), the full-read-only axis-flip
guard, windowed reads returned in storage order, `rg` kept alive across the `axis_flips` probe (SWIG GC), the
`# nosec B110` asymmetry between the two `except: pass` blocks, and the `ndarray | None` return contract. Also
corrects `_get_dimension`'s annotation to `-> gdal.Dimension | None` (its sole caller guards the `None`).

Design + risk analysis: `planning/cleaning/refactor-plan-read-variable-s3776-2026-08-16.md`. No dependency
changes.

# Issues

- Closes #997

## Type of change

Non-breaking internal refactor (maintainability / SonarCloud) — none of the categories below apply exactly; it
adds no feature, fixes no runtime bug, and needs no user-facing docs update.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Behaviour-preserving, verified against the existing end-to-end read suites plus new isolated unit tests. Run
from the repo root (dev env):

- [x] `pytest tests/netcdf/io/test_windowed_reads.py tests/netcdf/unit/test_netcdf_unit_read.py` — the existing
      end-to-end read suites (MDIM + classic, windowed + full, axis-flip) stay green.
- [x] `pytest tests/netcdf/io/test_read_variable_helpers.py` — **new** file: 33 isolated unit tests covering
      every branch of all six functions (windowed/full, flip matrix incl. 3-D, MDArray/fallback/classic, the
      fallback-not-swallowed scoping invariant, and the normalization-raises branch).
- [x] `pytest tests/netcdf -m "not plot"` — full netcdf suite: 2375 passed.
- [x] `ruff` / `ruff-format` / `mypy` / `bandit` clean on the changed files.
- [x] SonarCloud on this PR: quality gate **OK**, 0 issues (S3776 on `_read_variable` cleared; no new
      `S2325`/`S4144`).

# Checklist:

- [ ] updated version number in pyproject.toml. — handled by commitizen/CI on release.
- [ ] added changes to History.rst. — changelog is commitizen-generated.
- [ ] updated the latest version in README file. — handled on release.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. — helper docstrings (See Also / Note contracts) added; no user-facing docs
      needed for a private method.