### PR TITLE
refactor(netcdf): decompose NetCDFPlot._cf_coordinates_pair to clear SonarCloud python:S3776

### DIFF
--- a/src/pyramids/netcdf/_coord_match.py
+++ b/src/pyramids/netcdf/_coord_match.py
@@ -1,0 +1,154 @@
+"""Pure coordinate-matching primitives for NetCDF plot coordinate resolution.
+
+Shape and name predicates shared across :class:`pyramids.netcdf._plot.NetCDFPlot`'s
+coordinate-resolution paths (explicit ``coords=``, stored curvilinear crop coords,
+the CF ``coordinates`` attribute, and well-known model names) and the CF candidate
+value object that pairs them. Pure numpy — no pyramids imports — so every consumer
+can use them without reaching back into the plot engine.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import numpy as np
+
+
+def squeeze_leading_axes(
+    arr: np.ndarray, data_shape: tuple[int, int]
+) -> np.typing.NDArray:
+    """Drop leading singleton/time axes so a coord matches the slice shape.
+
+    WRF stores ``XLAT`` / ``XLONG`` as ``(time, lat, lon)`` even though the same
+    grid is shared across time — taking time-step 0 gives a 2-D view that lines up
+    with the data slice.
+
+    Args:
+        arr: Coord array, typically 2-D or 3-D ``(extra, rows, cols)``.
+        data_shape: Target shape ``(rows, cols)`` of the data slice.
+
+    Returns:
+        np.ndarray: Either ``arr`` unchanged (already 1-D / 2-D matching) or the
+            time-step-0 slice of a 3-D array.
+    """
+    rows, cols = data_shape
+    if arr.ndim == 3 and arr.shape[-2:] == (rows, cols):
+        result = arr[0]
+    else:
+        result = arr
+    return cast("np.typing.NDArray", result)
+
+
+def matches_x_axis(arr: np.ndarray, data_shape: tuple[int, int]) -> bool:
+    """True when ``arr`` can serve as the x axis for ``data_shape`` (1-D cols or 2-D slice)."""
+    _, cols = data_shape
+    return (arr.ndim == 1 and arr.shape[0] == cols) or (
+        arr.ndim == 2 and arr.shape == data_shape
+    )
+
+
+def matches_y_axis(arr: np.ndarray, data_shape: tuple[int, int]) -> bool:
+    """True when ``arr`` can serve as the y axis for ``data_shape`` (1-D rows or 2-D slice)."""
+    rows, _ = data_shape
+    return (arr.ndim == 1 and arr.shape[0] == rows) or (
+        arr.ndim == 2 and arr.shape == data_shape
+    )
+
+
+def coord_shapes_match(
+    x_arr: np.ndarray,
+    y_arr: np.ndarray,
+    data_shape: tuple[int, int] | None,
+) -> bool:
+    """Return True when ``(x_arr, y_arr)`` line up with ``data_shape``.
+
+    Accepts the same shape rules as cleopatra's ``ArrayGlyph(coords=)``:
+
+    * ``x_arr`` is 1-D matching ``cols`` or 2-D matching the slice.
+    * ``y_arr`` is 1-D matching ``rows`` or 2-D matching the slice.
+
+    Args:
+        x_arr: Candidate x coordinate array.
+        y_arr: Candidate y coordinate array.
+        data_shape: ``(rows, cols)`` of the data slice. ``None`` → cannot
+            validate, returns ``False``.
+
+    Returns:
+        bool: ``True`` when both arrays line up with ``data_shape``.
+    """
+    if data_shape is None:
+        return False
+    return matches_x_axis(x_arr, data_shape) and matches_y_axis(y_arr, data_shape)
+
+
+def values_within_latitude(arr: np.ndarray) -> bool:
+    """Return whether every finite value lies in ``[-90, 90]`` — i.e. the array reads as latitude.
+
+    Used to disambiguate the x/y roles of two 2-D coordinate arrays (e.g. rasm's
+    ``xc`` / ``yc``) when neither name matches the lon/lat heuristic: longitudes
+    routinely exceed ±90 (``0..360`` or beyond), latitudes never do. The ±0.5 slack
+    tolerates cell-edge coordinates that graze the pole. An array with no finite
+    values returns ``False`` (it cannot be confirmed as a latitude).
+
+    Args:
+        arr (np.ndarray): Coordinate array to classify. Non-finite entries
+            (``NaN`` / ``inf``) are ignored.
+
+    Returns:
+        bool: ``True`` when at least one value is finite and all finite values fall
+            within ``[-90.5, 90.5]``; ``False`` otherwise.
+
+    Examples:
+        - A latitude array (bounded to ±90) is recognised:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.netcdf._coord_match import values_within_latitude
+            >>> values_within_latitude(np.array([-89.0, 0.0, 89.0]))
+            True
+
+            ```
+        - A ``0..360`` longitude array is rejected (it exceeds ±90):
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.netcdf._coord_match import values_within_latitude
+            >>> values_within_latitude(np.array([0.0, 180.0, 360.0]))
+            False
+
+            ```
+        - An all-``NaN`` array is rejected (nothing finite to confirm):
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.netcdf._coord_match import values_within_latitude
+            >>> values_within_latitude(np.array([np.nan, np.nan]))
+            False
+
+            ```
+    """
+    finite = arr[np.isfinite(arr)]
+    return (
+        bool(finite.size)
+        and float(finite.min()) >= -90.5
+        and float(finite.max()) <= 90.5
+    )
+
+
+def looks_like_x_then_y(x_name: str, y_name: str) -> bool:
+    """Heuristic name check: x looks like a longitude, y like a latitude.
+
+    Used to disambiguate the CF ``coordinates`` attribute when the list has two
+    viable candidates per axis. Returns ``True`` when ``x_name`` contains ``"lon"``
+    / ``"long"`` and ``y_name`` contains ``"lat"`` (case-insensitive). Used purely
+    as a tiebreaker; a failed match falls back to the first viable pair.
+
+    Args:
+        x_name: Candidate x variable name.
+        y_name: Candidate y variable name.
+
+    Returns:
+        bool: ``True`` when the names follow the lon/lat convention.
+    """
+    xl = x_name.lower()
+    yl = y_name.lower()
+    x_is_lon = "lon" in xl or "long" in xl
+    y_is_lat = "lat" in yl
+    return x_is_lon and y_is_lat

--- a/src/pyramids/netcdf/_coord_match.py
+++ b/src/pyramids/netcdf/_coord_match.py
@@ -30,6 +30,24 @@ def squeeze_leading_axes(
     Returns:
         np.ndarray: Either ``arr`` unchanged (already 1-D / 2-D matching) or the
             time-step-0 slice of a 3-D array.
+
+    Examples:
+        - A 3-D ``(time, rows, cols)`` coord collapses to its first plane:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.netcdf._coord_match import squeeze_leading_axes
+            >>> squeeze_leading_axes(np.zeros((2, 4, 5)), (4, 5)).shape
+            (4, 5)
+
+            ```
+        - A 1-D coord passes through unchanged:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.netcdf._coord_match import squeeze_leading_axes
+            >>> squeeze_leading_axes(np.arange(5), (4, 5)).shape
+            (5,)
+
+            ```
     """
     rows, cols = data_shape
     if arr.ndim == 3 and arr.shape[-2:] == (rows, cols):
@@ -40,7 +58,33 @@ def squeeze_leading_axes(
 
 
 def matches_x_axis(arr: np.ndarray, data_shape: tuple[int, int]) -> bool:
-    """True when ``arr`` can serve as the x axis for ``data_shape`` (1-D cols or 2-D slice)."""
+    """True when ``arr`` can serve as the x axis for ``data_shape`` (1-D cols or 2-D slice).
+
+    Args:
+        arr: Candidate coordinate array.
+        data_shape: ``(rows, cols)`` of the data slice.
+
+    Returns:
+        bool: ``True`` when ``arr`` is 1-D of length ``cols`` or 2-D matching the slice.
+
+    Examples:
+        - A 1-D array whose length equals the column count is an x axis:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.netcdf._coord_match import matches_x_axis
+            >>> matches_x_axis(np.arange(5), (4, 5))
+            True
+
+            ```
+        - A 1-D array of a different length is not:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.netcdf._coord_match import matches_x_axis
+            >>> matches_x_axis(np.arange(4), (4, 5))
+            False
+
+            ```
+    """
     _, cols = data_shape
     return (arr.ndim == 1 and arr.shape[0] == cols) or (
         arr.ndim == 2 and arr.shape == data_shape
@@ -48,7 +92,33 @@ def matches_x_axis(arr: np.ndarray, data_shape: tuple[int, int]) -> bool:
 
 
 def matches_y_axis(arr: np.ndarray, data_shape: tuple[int, int]) -> bool:
-    """True when ``arr`` can serve as the y axis for ``data_shape`` (1-D rows or 2-D slice)."""
+    """True when ``arr`` can serve as the y axis for ``data_shape`` (1-D rows or 2-D slice).
+
+    Args:
+        arr: Candidate coordinate array.
+        data_shape: ``(rows, cols)`` of the data slice.
+
+    Returns:
+        bool: ``True`` when ``arr`` is 1-D of length ``rows`` or 2-D matching the slice.
+
+    Examples:
+        - A 1-D array whose length equals the row count is a y axis:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.netcdf._coord_match import matches_y_axis
+            >>> matches_y_axis(np.arange(4), (4, 5))
+            True
+
+            ```
+        - A 1-D array of a different length is not:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.netcdf._coord_match import matches_y_axis
+            >>> matches_y_axis(np.arange(5), (4, 5))
+            False
+
+            ```
+    """
     rows, _ = data_shape
     return (arr.ndim == 1 and arr.shape[0] == rows) or (
         arr.ndim == 2 and arr.shape == data_shape
@@ -75,6 +145,24 @@ def coord_shapes_match(
 
     Returns:
         bool: ``True`` when both arrays line up with ``data_shape``.
+
+    Examples:
+        - A 1-D cols x and 1-D rows y line up with the slice:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.netcdf._coord_match import coord_shapes_match
+            >>> coord_shapes_match(np.arange(5), np.arange(4), (4, 5))
+            True
+
+            ```
+        - A ``None`` slice shape cannot be validated:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.netcdf._coord_match import coord_shapes_match
+            >>> coord_shapes_match(np.arange(5), np.arange(4), None)
+            False
+
+            ```
     """
     if data_shape is None:
         return False
@@ -146,6 +234,22 @@ def looks_like_x_then_y(x_name: str, y_name: str) -> bool:
 
     Returns:
         bool: ``True`` when the names follow the lon/lat convention.
+
+    Examples:
+        - Lon-then-lat names match (case-insensitive):
+            ```python
+            >>> from pyramids.netcdf._coord_match import looks_like_x_then_y
+            >>> looks_like_x_then_y("LONGITUDE", "LATITUDE")
+            True
+
+            ```
+        - The reversed order (lat as x) does not:
+            ```python
+            >>> from pyramids.netcdf._coord_match import looks_like_x_then_y
+            >>> looks_like_x_then_y("lat", "lon")
+            False
+
+            ```
     """
     xl = x_name.lower()
     yl = y_name.lower()

--- a/src/pyramids/netcdf/_coord_match.py
+++ b/src/pyramids/netcdf/_coord_match.py
@@ -164,9 +164,11 @@ def coord_shapes_match(
 
             ```
     """
-    if data_shape is None:
-        return False
-    return matches_x_axis(x_arr, data_shape) and matches_y_axis(y_arr, data_shape)
+    return (
+        data_shape is not None
+        and matches_x_axis(x_arr, data_shape)
+        and matches_y_axis(y_arr, data_shape)
+    )
 
 
 def values_within_latitude(arr: np.ndarray) -> bool:
@@ -179,8 +181,8 @@ def values_within_latitude(arr: np.ndarray) -> bool:
     values returns ``False`` (it cannot be confirmed as a latitude).
 
     Args:
-        arr (np.ndarray): Coordinate array to classify. Non-finite entries
-            (``NaN`` / ``inf``) are ignored.
+        arr: Coordinate array to classify. Non-finite entries (``NaN`` / ``inf``)
+            are ignored.
 
     Returns:
         bool: ``True`` when at least one value is finite and all finite values fall

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -202,7 +202,8 @@ class _CFCoordinateCandidates:
         only when Pass 1 finds nothing: it takes the first shape-matching pair of
         distinct candidates, disambiguating two 2-D curvilinear candidates by
         latitude range (:meth:`_assign_2d_by_latitude`). That assignment is
-        **symmetric** — whichever 2-D array is within-latitude (``[-90, 90]``) becomes
+        **symmetric** — whichever 2-D array is within-latitude (``[-90.5, 90.5]``,
+        the ±0.5 pole slack of :func:`_coord_match.values_within_latitude`) becomes
         the y axis regardless of candidate order, so e.g. rasm's ``xc`` / ``yc`` are
         neither collapsed onto one axis nor swapped. When both or neither 2-D
         candidate looks like a latitude the roles are genuinely ambiguous, so
@@ -265,7 +266,8 @@ class _CFCoordinateCandidates:
     ) -> tuple[np.typing.NDArray, np.typing.NDArray]:
         """Assign x/y roles for two 2-D candidates by latitude range.
 
-        Symmetric: whichever array is within latitude (``[-90, 90]``) becomes the y
+        Symmetric: whichever array is within latitude (``[-90.5, 90.5]``, the ±0.5
+        pole slack of :func:`_coord_match.values_within_latitude`) becomes the y
         axis, regardless of candidate order. When both or neither look like a
         latitude the roles are genuinely ambiguous, so keep candidate order and log
         a debug hint (pass ``x_dim`` / ``y_dim`` or ``coords=`` to override).

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -21,6 +21,8 @@ from pyramids.netcdf import _coord_match
 from pyramids.netcdf.plot_options import CoordinateSpec, FacetSpec, Selectors
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from cleopatra.basemap.geo import Basemap
 
     from pyramids.netcdf.netcdf import NetCDF
@@ -218,18 +220,30 @@ class _CFCoordinateCandidates:
             pair = self._distinct_pair()
         return pair
 
-    def _named_pair(self) -> tuple[np.typing.NDArray, np.typing.NDArray] | None:
-        """First distinct pair whose names match the lon/lat heuristic and shapes line up."""
-        result = None
+    def _candidate_pairs(
+        self,
+    ) -> Iterator[tuple[str, np.ndarray, str, np.ndarray]]:
+        """Yield ``(x_name, x_arr, y_name, y_arr)`` for distinct, shape-matching pairs.
+
+        Walks the x candidates against the y candidates, skipping a pair that names
+        the same variable for both axes (so a 2-D coord present in both lists is never
+        collapsed onto one axis) and any pair whose shapes do not line up with the
+        data slice. Both pairing passes iterate this one shared sequence, in x-then-y
+        candidate order.
+        """
         for x_name, x_arr in self._x:
             for y_name, y_arr in self._y:
                 if x_name == y_name:
                     continue
                 if _coord_match.coord_shapes_match(x_arr, y_arr, self._data_shape):
-                    if _coord_match.looks_like_x_then_y(x_name, y_name):
-                        result = (x_arr, y_arr)
-                        break
-            if result is not None:
+                    yield x_name, x_arr, y_name, y_arr
+
+    def _named_pair(self) -> tuple[np.typing.NDArray, np.typing.NDArray] | None:
+        """First distinct pair whose names match the lon/lat heuristic and shapes line up."""
+        result = None
+        for x_name, x_arr, y_name, y_arr in self._candidate_pairs():
+            if _coord_match.looks_like_x_then_y(x_name, y_name):
+                result = (x_arr, y_arr)
                 break
         return result
 
@@ -237,24 +251,17 @@ class _CFCoordinateCandidates:
         """First viable pair of **distinct** candidates; two 2-D candidates disambiguated by latitude.
 
         A 2-D coord matches both axes, so it lands in both lists — the ``x_name ==
-        y_name`` guard stops it being picked for both axes (which would collapse a
-        curvilinear grid like rasm's ``xc``/``yc`` onto one axis). 1-D candidates are
-        already separated by length.
+        y_name`` guard in :meth:`_candidate_pairs` stops it being picked for both axes
+        (which would collapse a curvilinear grid like rasm's ``xc``/``yc`` onto one
+        axis). 1-D candidates are already separated by length.
         """
         result = None
-        for x_name, x_arr in self._x:
-            for y_name, y_arr in self._y:
-                if x_name == y_name:
-                    continue
-                if not _coord_match.coord_shapes_match(x_arr, y_arr, self._data_shape):
-                    continue
-                if x_arr.ndim == 2 and y_arr.ndim == 2:
-                    result = self._assign_2d_by_latitude(x_name, x_arr, y_name, y_arr)
-                else:
-                    result = (x_arr, y_arr)
-                break
-            if result is not None:
-                break
+        for x_name, x_arr, y_name, y_arr in self._candidate_pairs():
+            if x_arr.ndim == 2 and y_arr.ndim == 2:
+                result = self._assign_2d_by_latitude(x_name, x_arr, y_name, y_arr)
+            else:
+                result = (x_arr, y_arr)
+            break
         return result
 
     @staticmethod

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -186,14 +186,28 @@ class _CFCoordinateCandidates:
         return cls(x_candidates, y_candidates, arrays, data_shape)
 
     def arrays_by_name(self) -> dict[str, np.ndarray]:
-        """Return the resolved candidate arrays by name (for the caller's no-match log)."""
-        return self._arrays
+        """Return the resolved candidate arrays by name (for the caller's no-match log).
+
+        Returns a shallow copy so callers cannot mutate the value object's internal
+        mapping; the arrays themselves are shared (read-only at every call site).
+        """
+        return dict(self._arrays)
 
     def best_pair(self) -> tuple[np.typing.NDArray, np.typing.NDArray] | None:
-        """Return the best ``(x, y)`` pair, or ``None``.
+        """Return the best ``(x, y)`` pair from the candidates, or ``None``.
 
-        The name-heuristic pass runs first; the distinct-pair fallback runs only
-        when the heuristic pass finds nothing.
+        Runs the two passes in order. Pass 1 (:meth:`_named_pair`) picks the first
+        pair of distinct candidates whose shapes line up with the data slice **and**
+        whose names match the lon/lat heuristic. Pass 2 (:meth:`_distinct_pair`) runs
+        only when Pass 1 finds nothing: it takes the first shape-matching pair of
+        distinct candidates, disambiguating two 2-D curvilinear candidates by
+        latitude range (:meth:`_assign_2d_by_latitude`). That assignment is
+        **symmetric** — whichever 2-D array is within-latitude (``[-90, 90]``) becomes
+        the y axis regardless of candidate order, so e.g. rasm's ``xc`` / ``yc`` are
+        neither collapsed onto one axis nor swapped. When both or neither 2-D
+        candidate looks like a latitude the roles are genuinely ambiguous, so
+        candidate order is kept and a debug hint is logged. Returns ``None`` when no
+        distinct pair matches, so the caller falls back to conventional naming.
 
         Returns:
             tuple or None: The chosen x/y arrays, or ``None`` when nothing matched.
@@ -1593,32 +1607,22 @@ class NetCDFPlot:
         nc: NetCDF,
         parent: NetCDF,
     ) -> tuple[np.typing.NDArray, np.typing.NDArray] | None:
-        """Parse the CF `coordinates` attribute into an `(x, y)` array pair.
+        """Parse the CF ``coordinates`` attribute into an ``(x, y)`` array pair.
 
         The CF Conventions allow a data variable to declare auxiliary
         coordinate variables via its ``coordinates`` attribute (a
         space-separated string of variable names). Pyramids reads the
         attribute off ``nc._variable_attrs`` (populated by
-        :meth:`NetCDF.get_variable`), then resolves each name to an
-        array.
-
-        For each pair (n choose 2 from the listed coord vars) the helper
-        picks the first one where one name reads as the x axis (1-D
-        ``cols`` or 2-D matching) and the other as the y axis (1-D
-        ``rows`` or 2-D matching), preferring a pair whose names match
-        the lon/lat heuristic. If none matches the name heuristic, it
-        falls back to the first pair of **distinct** candidates — and
-        because a 2-D coord matches both axes, it disambiguates the x/y
-        roles by range: latitude is bounded to ±90 (via
-        :meth:`_values_within_latitude`). The assignment is **symmetric**
-        — whichever of the two 2-D candidates is within-latitude becomes
-        the y axis regardless of candidate order, so e.g. rasm's ``xc`` /
-        ``yc`` are neither collapsed onto one axis nor swapped. When both
-        or neither candidate looks like a latitude the roles are genuinely
-        ambiguous, so it keeps candidate order and logs a debug message
-        (pass ``coords=`` / ``x_dim`` / ``y_dim`` to override). When the
-        attribute is missing or no valid pair is found returns ``None`` so
-        the caller can fall back to the well-known-naming pass.
+        :meth:`NetCDF.get_variable`), gathers and classifies the named
+        coord arrays, and delegates the ``(x, y)`` pairing to
+        :class:`_CFCoordinateCandidates` — see its class docstring and
+        :meth:`_CFCoordinateCandidates.best_pair` for the two-pass
+        matching algorithm (name heuristic, then a distinct-pair fallback
+        that disambiguates 2-D curvilinear candidates by latitude range).
+        When the attribute is missing or no valid pair is found it returns
+        ``None`` so the caller can fall back to the well-known-naming
+        pass, logging the attempted names and candidate shapes at debug
+        level.
 
         Args:
             nc: The variable subset being plotted — the CF attribute is
@@ -1650,7 +1654,7 @@ class NetCDFPlot:
 
     @staticmethod
     def _cf_coordinate_names(nc: NetCDF) -> list[str]:
-        """Return the CF `coordinates` variable names declared on `nc`, or `[]`.
+        """Return the CF ``coordinates`` variable names declared on ``nc``, or ``[]``.
 
         Reads the space-separated ``coordinates`` attribute off
         ``nc._variable_attrs`` and splits it; a missing / non-string attribute
@@ -1667,11 +1671,6 @@ class NetCDFPlot:
         return (
             [n for n in coord_attr.split() if n] if isinstance(coord_attr, str) else []
         )
-
-    # `values_within_latitude` lives in `_coord_match`; alias it here so the
-    # direct unit test (tests/netcdf/samples/test_curvilinear_crop.py) can keep
-    # calling it as `NetCDFPlot._values_within_latitude`.
-    _values_within_latitude = staticmethod(_coord_match.values_within_latitude)
 
     def _resolve_band_dim_name(
         self,

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, cast
 import numpy as np
 
 from pyramids.dataset._plot_helpers import render_array as _render_array
+from pyramids.netcdf import _coord_match
 from pyramids.netcdf.plot_options import CoordinateSpec, FacetSpec, Selectors
 
 if TYPE_CHECKING:
@@ -116,6 +117,163 @@ _ANIMATE_DROP_KWARGS = frozenset(
         "_extent",
     }
 )
+
+
+class _CFCoordinateCandidates:
+    """The CF auxiliary-coordinate candidates for one data slice.
+
+    Groups the coord arrays that read as an x axis and those that read as a y axis
+    (plus the 2-D data shape they must line up with) and owns the two-pass pairing
+    that turns them into an ``(x, y)`` pair: a name-heuristic pass, then a
+    distinct-pair fallback that disambiguates two 2-D curvilinear candidates by
+    latitude range. A 2-D coord matches both axes, so it appears in both lists; the
+    pairing guards against collapsing it onto one axis.
+    """
+
+    def __init__(
+        self,
+        x_candidates: list[tuple[str, np.ndarray]],
+        y_candidates: list[tuple[str, np.ndarray]],
+        arrays: dict[str, np.ndarray],
+        data_shape: tuple[int, int],
+    ) -> None:
+        """Store the classified candidate lists and the slice shape.
+
+        Args:
+            x_candidates: ``(name, array)`` pairs that read as an x axis.
+            y_candidates: ``(name, array)`` pairs that read as a y axis.
+            arrays: All resolved candidate arrays by name (for the no-match log).
+            data_shape: ``(rows, cols)`` of the data slice the coords must match.
+        """
+        self._x = x_candidates
+        self._y = y_candidates
+        self._arrays = arrays
+        self._data_shape = data_shape
+
+    @classmethod
+    def gather(
+        cls,
+        names: list[str],
+        parent: NetCDF,
+        data_shape: tuple[int, int],
+    ) -> _CFCoordinateCandidates:
+        """Read each named coord var off ``parent``, squeeze it, and classify x / y.
+
+        Args:
+            names: The coordinate variable names from the CF ``coordinates`` attr.
+            parent: NetCDF container the coord vars are read from.
+            data_shape: ``(rows, cols)`` of the data slice.
+
+        Returns:
+            _CFCoordinateCandidates: the classified x / y candidate lists.
+        """
+        arrays: dict[str, np.ndarray] = {}
+        for name in names:
+            if name in parent.variable_names:
+                arr = parent._read_variable(name)
+                if arr is not None:
+                    arrays[name] = _coord_match.squeeze_leading_axes(arr, data_shape)
+        x_candidates = [
+            (n, a)
+            for n, a in arrays.items()
+            if _coord_match.matches_x_axis(a, data_shape)
+        ]
+        y_candidates = [
+            (n, a)
+            for n, a in arrays.items()
+            if _coord_match.matches_y_axis(a, data_shape)
+        ]
+        return cls(x_candidates, y_candidates, arrays, data_shape)
+
+    def arrays_by_name(self) -> dict[str, np.ndarray]:
+        """Return the resolved candidate arrays by name (for the caller's no-match log)."""
+        return self._arrays
+
+    def best_pair(self) -> tuple[np.typing.NDArray, np.typing.NDArray] | None:
+        """Return the best ``(x, y)`` pair, or ``None``.
+
+        The name-heuristic pass runs first; the distinct-pair fallback runs only
+        when the heuristic pass finds nothing.
+
+        Returns:
+            tuple or None: The chosen x/y arrays, or ``None`` when nothing matched.
+        """
+        pair = self._named_pair()
+        if pair is None:
+            pair = self._distinct_pair()
+        return pair
+
+    def _named_pair(self) -> tuple[np.typing.NDArray, np.typing.NDArray] | None:
+        """First distinct pair whose names match the lon/lat heuristic and shapes line up."""
+        result = None
+        for x_name, x_arr in self._x:
+            for y_name, y_arr in self._y:
+                if x_name == y_name:
+                    continue
+                if _coord_match.coord_shapes_match(x_arr, y_arr, self._data_shape):
+                    if _coord_match.looks_like_x_then_y(x_name, y_name):
+                        result = (x_arr, y_arr)
+                        break
+            if result is not None:
+                break
+        return result
+
+    def _distinct_pair(self) -> tuple[np.typing.NDArray, np.typing.NDArray] | None:
+        """First viable pair of **distinct** candidates; two 2-D candidates disambiguated by latitude.
+
+        A 2-D coord matches both axes, so it lands in both lists — the ``x_name ==
+        y_name`` guard stops it being picked for both axes (which would collapse a
+        curvilinear grid like rasm's ``xc``/``yc`` onto one axis). 1-D candidates are
+        already separated by length.
+        """
+        result = None
+        for x_name, x_arr in self._x:
+            for y_name, y_arr in self._y:
+                if x_name == y_name:
+                    continue
+                if not _coord_match.coord_shapes_match(x_arr, y_arr, self._data_shape):
+                    continue
+                if x_arr.ndim == 2 and y_arr.ndim == 2:
+                    result = self._assign_2d_by_latitude(x_name, x_arr, y_name, y_arr)
+                else:
+                    result = (x_arr, y_arr)
+                break
+            if result is not None:
+                break
+        return result
+
+    @staticmethod
+    def _assign_2d_by_latitude(
+        x_name: str,
+        x_arr: np.ndarray,
+        y_name: str,
+        y_arr: np.ndarray,
+    ) -> tuple[np.typing.NDArray, np.typing.NDArray]:
+        """Assign x/y roles for two 2-D candidates by latitude range.
+
+        Symmetric: whichever array is within latitude (``[-90, 90]``) becomes the y
+        axis, regardless of candidate order. When both or neither look like a
+        latitude the roles are genuinely ambiguous, so keep candidate order and log
+        a debug hint (pass ``x_dim`` / ``y_dim`` or ``coords=`` to override).
+        """
+        x_is_lat = _coord_match.values_within_latitude(x_arr)
+        y_is_lat = _coord_match.values_within_latitude(y_arr)
+        if x_is_lat and not y_is_lat:
+            pair = (y_arr, x_arr)
+        elif y_is_lat and not x_is_lat:
+            pair = (x_arr, y_arr)
+        else:
+            logger.debug(
+                "curvilinear x/y roles ambiguous for %r/%r "
+                "(within-latitude: %s/%s); keeping candidate order — pass "
+                "x_dim/y_dim or coords= to override.",
+                x_name,
+                y_name,
+                x_is_lat,
+                y_is_lat,
+            )
+            pair = (x_arr, y_arr)
+        return pair
 
 
 class NetCDFPlot:
@@ -1314,7 +1472,7 @@ class NetCDFPlot:
             x_in, y_in = user_coords
             x_arr = self._coerce_coord_spec(x_in, parent, "x")
             y_arr = self._coerce_coord_spec(y_in, parent, "y")
-            if self._coord_shapes_match(x_arr, y_arr, data_shape):
+            if _coord_match.coord_shapes_match(x_arr, y_arr, data_shape):
                 result = (x_arr, y_arr)
             else:
                 logger.warning(
@@ -1333,14 +1491,14 @@ class NetCDFPlot:
             if stored is not None:
                 x_arr = np.asarray(stored[0])
                 y_arr = np.asarray(stored[1])
-                if self._coord_shapes_match(x_arr, y_arr, data_shape):
+                if _coord_match.coord_shapes_match(x_arr, y_arr, data_shape):
                     result = (x_arr, y_arr)
 
         if result is None and data_shape is not None:
             cf_pair = self._cf_coordinates_pair(nc, parent)
             if cf_pair is not None:
                 x_arr, y_arr = cf_pair
-                if self._coord_shapes_match(x_arr, y_arr, data_shape):
+                if _coord_match.coord_shapes_match(x_arr, y_arr, data_shape):
                     result = (x_arr, y_arr)
 
         if result is None and data_shape is not None:
@@ -1350,8 +1508,8 @@ class NetCDFPlot:
                     yv = parent._read_variable(y_name)
                     if xv is None or yv is None:
                         continue
-                    x_arr = self._squeeze_leading_axes(xv, data_shape)
-                    y_arr = self._squeeze_leading_axes(yv, data_shape)
+                    x_arr = _coord_match.squeeze_leading_axes(xv, data_shape)
+                    y_arr = _coord_match.squeeze_leading_axes(yv, data_shape)
                     if require_2d and (x_arr.ndim != 2 or y_arr.ndim != 2):
                         # A generic name pair (e.g. xc/yc) is trusted only when
                         # BOTH arrays are genuinely 2-D. A 1-D pair (or a 1-D/2-D
@@ -1362,7 +1520,7 @@ class NetCDFPlot:
                         # the CF `coordinates` attribute or explicit `coords=` for
                         # those.
                         continue
-                    if self._coord_shapes_match(x_arr, y_arr, data_shape):
+                    if _coord_match.coord_shapes_match(x_arr, y_arr, data_shape):
                         warnings.warn(
                             "Resolving curvilinear coordinates by hardcoded "
                             f"model-specific names ({x_name!r}, {y_name!r}) is "
@@ -1430,76 +1588,6 @@ class NetCDFPlot:
             result = np.asarray(spec)
         return result
 
-    @staticmethod
-    def _squeeze_leading_axes(
-        arr: np.ndarray,
-        data_shape: tuple[int, int],
-    ) -> np.typing.NDArray:
-        """Drop leading singleton/time axes so a coord matches the slice shape.
-
-        WRF stores `XLAT` / `XLONG` as `(time, lat, lon)` even though the
-        same grid is shared across time — taking time-step 0 gives a 2-D
-        view that lines up with the data slice.
-
-        Args:
-            arr: Coord array, typically 2-D or 3-D ``(extra, rows, cols)``.
-            data_shape: Target shape ``(rows, cols)`` of the data slice.
-
-        Returns:
-            np.ndarray: Either ``arr`` unchanged (already 1-D / 2-D
-                matching) or the time-step-0 slice of a 3-D array.
-        """
-        rows, cols = data_shape
-        if arr.ndim == 3 and arr.shape[-2:] == (rows, cols):
-            result = arr[0]
-        else:
-            result = arr
-        return cast("np.typing.NDArray", result)
-
-    @staticmethod
-    def _matches_x_axis(arr: np.ndarray, data_shape: tuple[int, int]) -> bool:
-        """True when ``arr`` can serve as the x axis for ``data_shape`` (1-D cols or 2-D slice)."""
-        _, cols = data_shape
-        return (arr.ndim == 1 and arr.shape[0] == cols) or (
-            arr.ndim == 2 and arr.shape == data_shape
-        )
-
-    @staticmethod
-    def _matches_y_axis(arr: np.ndarray, data_shape: tuple[int, int]) -> bool:
-        """True when ``arr`` can serve as the y axis for ``data_shape`` (1-D rows or 2-D slice)."""
-        rows, _ = data_shape
-        return (arr.ndim == 1 and arr.shape[0] == rows) or (
-            arr.ndim == 2 and arr.shape == data_shape
-        )
-
-    @staticmethod
-    def _coord_shapes_match(
-        x_arr: np.ndarray,
-        y_arr: np.ndarray,
-        data_shape: tuple[int, int] | None,
-    ) -> bool:
-        """Return True when ``(x_arr, y_arr)`` line up with ``data_shape``.
-
-        Accepts the same shape rules as cleopatra's `ArrayGlyph(coords=)`:
-
-        * ``x_arr`` is 1-D matching ``cols`` or 2-D matching the slice.
-        * ``y_arr`` is 1-D matching ``rows`` or 2-D matching the slice.
-
-        Args:
-            x_arr: Candidate x coordinate array.
-            y_arr: Candidate y coordinate array.
-            data_shape: ``(rows, cols)`` of the data slice. ``None`` →
-                cannot validate, returns ``False``.
-
-        Returns:
-            bool: ``True`` when both arrays line up with ``data_shape``.
-        """
-        if data_shape is None:
-            return False
-        return NetCDFPlot._matches_x_axis(
-            x_arr, data_shape
-        ) and NetCDFPlot._matches_y_axis(y_arr, data_shape)
-
     def _cf_coordinates_pair(
         self,
         nc: NetCDF,
@@ -1543,77 +1631,12 @@ class NetCDFPlot:
                 pair, or ``None`` when nothing matched.
         """
         result = None
-        attrs = getattr(nc, "_variable_attrs", None) or {}
-        coord_attr = attrs.get("coordinates")
+        names = self._cf_coordinate_names(nc)
         data_shape = nc.shape[-2:] if nc.shape else None
-        if isinstance(coord_attr, str) and data_shape is not None:
-            names = [n for n in coord_attr.split() if n]
-            candidate_arrays: dict[str, np.ndarray] = {}
-            for name in names:
-                if name in parent.variable_names:
-                    arr = parent._read_variable(name)
-                    if arr is not None:
-                        candidate_arrays[name] = self._squeeze_leading_axes(
-                            arr,
-                            data_shape,
-                        )
-            x_candidates: list[tuple[str, np.ndarray]] = []
-            y_candidates: list[tuple[str, np.ndarray]] = []
-            for name, arr in candidate_arrays.items():
-                if self._matches_x_axis(arr, data_shape):
-                    x_candidates.append((name, arr))
-                if self._matches_y_axis(arr, data_shape):
-                    y_candidates.append((name, arr))
-            for x_name, x_arr in x_candidates:
-                for y_name, y_arr in y_candidates:
-                    if x_name == y_name:
-                        continue
-                    if self._coord_shapes_match(x_arr, y_arr, data_shape):
-                        if self._looks_like_x_then_y(x_name, y_name):
-                            result = (x_arr, y_arr)
-                            break
-                if result is not None:
-                    break
-            if result is None and x_candidates and y_candidates:
-                # Fallback: first viable pair of **distinct** candidates. A 2-D coord matches both
-                # axes, so it lands in both lists — guard against picking the same array for x and y
-                # (which would collapse a curvilinear grid like rasm's ``xc``/``yc`` onto one axis).
-                # When both are 2-D the x/y roles are ambiguous, so disambiguate by range: latitude
-                # is bounded to [-90, 90]. 1-D candidates are already separated by length.
-                for x_name, x_arr in x_candidates:
-                    for y_name, y_arr in y_candidates:
-                        if x_name == y_name:
-                            continue
-                        if not self._coord_shapes_match(x_arr, y_arr, data_shape):
-                            continue
-                        if x_arr.ndim == 2 and y_arr.ndim == 2:
-                            # Both 2-D: the x/y roles are ambiguous by shape, so assign by range —
-                            # latitude is bounded to [-90, 90]. Symmetric: whichever of the two is
-                            # within-latitude is the y axis, regardless of candidate order. Only when
-                            # both or neither look like latitude do we fall back to candidate order.
-                            x_is_lat = self._values_within_latitude(x_arr)
-                            y_is_lat = self._values_within_latitude(y_arr)
-                            if x_is_lat and not y_is_lat:
-                                result = (y_arr, x_arr)
-                            elif y_is_lat and not x_is_lat:
-                                result = (x_arr, y_arr)
-                            else:
-                                logger.debug(
-                                    "curvilinear x/y roles ambiguous for %r/%r "
-                                    "(within-latitude: %s/%s); keeping candidate order — pass "
-                                    "x_dim/y_dim or coords= to override.",
-                                    x_name,
-                                    y_name,
-                                    x_is_lat,
-                                    y_is_lat,
-                                )
-                                result = (x_arr, y_arr)
-                        else:
-                            result = (x_arr, y_arr)
-                        break
-                    if result is not None:
-                        break
-            if result is None and names:
+        if names and data_shape is not None:
+            candidates = _CFCoordinateCandidates.gather(names, parent, data_shape)
+            result = candidates.best_pair()
+            if result is None:
                 logger.debug(
                     "CF `coordinates` attr %r on variable %r did not yield a "
                     "coord pair matching the data slice shape %s (candidate "
@@ -1621,82 +1644,34 @@ class NetCDFPlot:
                     names,
                     getattr(nc, "_source_var_name", None),
                     data_shape,
-                    {n: a.shape for n, a in candidate_arrays.items()},
+                    {n: a.shape for n, a in candidates.arrays_by_name().items()},
                 )
         return result
 
     @staticmethod
-    def _values_within_latitude(arr: np.ndarray) -> bool:
-        """Return whether every finite value lies in ``[-90, 90]`` — i.e. the array reads as latitude.
+    def _cf_coordinate_names(nc: NetCDF) -> list[str]:
+        """Return the CF `coordinates` variable names declared on `nc`, or `[]`.
 
-        Used to disambiguate the x/y roles of two 2-D coordinate arrays (e.g. rasm's ``xc`` / ``yc``)
-        when neither name matches the lon/lat heuristic: longitudes routinely exceed ±90 (``0..360``
-        or beyond), latitudes never do. The ±0.5 slack tolerates cell-edge coordinates that graze the
-        pole. An array with no finite values returns ``False`` (it cannot be confirmed as a latitude).
+        Reads the space-separated ``coordinates`` attribute off
+        ``nc._variable_attrs`` and splits it; a missing / non-string attribute
+        yields an empty list.
 
         Args:
-            arr (np.ndarray): Coordinate array to classify. Non-finite entries (``NaN`` / ``inf``)
-                are ignored.
+            nc: The variable subset being plotted.
 
         Returns:
-            bool: ``True`` when at least one value is finite and all finite values fall within
-                ``[-90.5, 90.5]``; ``False`` otherwise.
-
-        Examples:
-            - A latitude array (bounded to ±90) is recognised:
-                ```python
-                >>> import numpy as np
-                >>> from pyramids.netcdf._plot import NetCDFPlot
-                >>> NetCDFPlot._values_within_latitude(np.array([-89.0, 0.0, 89.0]))
-                True
-
-                ```
-            - A ``0..360`` longitude array is rejected (it exceeds ±90):
-                ```python
-                >>> import numpy as np
-                >>> from pyramids.netcdf._plot import NetCDFPlot
-                >>> NetCDFPlot._values_within_latitude(np.array([0.0, 180.0, 360.0]))
-                False
-
-                ```
-            - An all-``NaN`` array is rejected (nothing finite to confirm):
-                ```python
-                >>> import numpy as np
-                >>> from pyramids.netcdf._plot import NetCDFPlot
-                >>> NetCDFPlot._values_within_latitude(np.array([np.nan, np.nan]))
-                False
-
-                ```
+            list[str]: The declared coordinate variable names (possibly empty).
         """
-        finite = arr[np.isfinite(arr)]
+        attrs = getattr(nc, "_variable_attrs", None) or {}
+        coord_attr = attrs.get("coordinates")
         return (
-            bool(finite.size)
-            and float(finite.min()) >= -90.5
-            and float(finite.max()) <= 90.5
+            [n for n in coord_attr.split() if n] if isinstance(coord_attr, str) else []
         )
 
-    @staticmethod
-    def _looks_like_x_then_y(x_name: str, y_name: str) -> bool:
-        """Heuristic name check: x looks like a longitude, y like a latitude.
-
-        Used to disambiguate the CF `coordinates` attribute when the
-        list has two viable candidates per axis. Returns ``True`` when
-        ``x_name`` contains ``"lon"`` / ``"long"`` and ``y_name``
-        contains ``"lat"`` (case-insensitive). Used purely as a tiebreaker;
-        a failed match falls back to the first viable pair.
-
-        Args:
-            x_name: Candidate x variable name.
-            y_name: Candidate y variable name.
-
-        Returns:
-            bool: ``True`` when the names follow the lon/lat convention.
-        """
-        xl = x_name.lower()
-        yl = y_name.lower()
-        x_is_lon = "lon" in xl or "long" in xl
-        y_is_lat = "lat" in yl
-        return x_is_lon and y_is_lat
+    # `values_within_latitude` lives in `_coord_match`; alias it here so the
+    # direct unit test (tests/netcdf/samples/test_curvilinear_crop.py) can keep
+    # calling it as `NetCDFPlot._values_within_latitude`.
+    _values_within_latitude = staticmethod(_coord_match.values_within_latitude)
 
     def _resolve_band_dim_name(
         self,

--- a/tests/netcdf/plot/test_cf_coordinate_candidates.py
+++ b/tests/netcdf/plot/test_cf_coordinate_candidates.py
@@ -8,6 +8,8 @@ is covered by ``tests/netcdf/plot/test_plot_coords.py``.
 
 from __future__ import annotations
 
+import logging
+
 import numpy as np
 
 from pyramids.netcdf._plot import _CFCoordinateCandidates
@@ -185,16 +187,26 @@ class TestCFCoordinateCandidates:
             "lon-first still yields (lon, lat)"
         )
 
-    def test_assign_2d_by_latitude_ambiguous_keeps_order(self):
-        """When both or neither array reads as latitude, candidate order is kept.
+    def test_assign_2d_by_latitude_ambiguous_keeps_order(self, caplog):
+        """Ambiguous roles keep candidate order and log a DEBUG hint on the _plot logger.
 
         Test scenario:
-            Two within-latitude arrays (ambiguous) return in the given order.
+            Two within-latitude arrays (ambiguous) return in the given order, and a
+            debug record is emitted on the name-preserved ``pyramids.netcdf._plot``
+            logger so the diagnostic cannot be silently renamed by a later edit.
         """
         a, b = _lat2d(), _lat2d() + 1.0
-        pair = _CFCoordinateCandidates._assign_2d_by_latitude("a", a, "b", b)
+        with caplog.at_level(logging.DEBUG, logger="pyramids.netcdf._plot"):
+            pair = _CFCoordinateCandidates._assign_2d_by_latitude("a", a, "b", b)
         assert pair[0] is a and pair[1] is b, (
             "ambiguous roles must keep candidate order"
+        )
+        hints = [r for r in caplog.records if r.name == "pyramids.netcdf._plot"]
+        assert hints, (
+            "an ambiguous-roles DEBUG record must be emitted on the _plot logger"
+        )
+        assert "ambiguous" in hints[0].getMessage(), (
+            f"unexpected ambiguous-roles log message: {hints[0].getMessage()}"
         )
 
     def test_arrays_by_name_returns_resolved_arrays(self):

--- a/tests/netcdf/plot/test_cf_coordinate_candidates.py
+++ b/tests/netcdf/plot/test_cf_coordinate_candidates.py
@@ -116,7 +116,8 @@ class TestCFCoordinateCandidates:
         )
         pair = candidates.best_pair()
         assert pair is not None, "a lon/lat pair must be found"
-        assert pair[0] is lon and pair[1] is lat, "the lon/lat named pair must win"
+        assert pair[0] is lon, "x must be the lon array"
+        assert pair[1] is lat, "y must be the lat array"
 
     def test_distinct_pair_does_not_collapse_a_single_2d_coord(self):
         """A lone 2-D coord (in both lists) is not paired with itself.
@@ -142,9 +143,9 @@ class TestCFCoordinateCandidates:
         parent = _FakeParent({"a": lon2d, "b": lat2d})
         candidates = _CFCoordinateCandidates.gather(["a", "b"], parent, _SHAPE)
         pair = candidates.best_pair()
-        assert pair is not None and pair[0] is lon2d and pair[1] is lat2d, (
-            "the within-latitude 2-D array must become y"
-        )
+        assert pair is not None, "a 2-D pair must be found"
+        assert pair[0] is lon2d, "the longitude-valued array must be x"
+        assert pair[1] is lat2d, "the within-latitude 2-D array must become y"
 
     def test_distinct_pair_1d_fallback(self):
         """Distinct 1-D candidates with non-lon/lat names still pair (x, y).
@@ -157,9 +158,9 @@ class TestCFCoordinateCandidates:
         parent = _FakeParent({"east": east, "north": north})
         candidates = _CFCoordinateCandidates.gather(["east", "north"], parent, _SHAPE)
         pair = candidates.best_pair()
-        assert pair is not None and pair[0] is east and pair[1] is north, (
-            "distinct 1-D candidates must pair as (x, y)"
-        )
+        assert pair is not None, "a distinct 1-D pair must be found"
+        assert pair[0] is east, "the cols-length array must be x"
+        assert pair[1] is north, "the rows-length array must be y"
 
     def test_best_pair_none_when_no_candidates(self):
         """best_pair returns ``None`` when nothing classifies as a coord.
@@ -181,12 +182,10 @@ class TestCFCoordinateCandidates:
         lon2d, lat2d = _lon2d(), _lat2d()
         forward = _CFCoordinateCandidates._assign_2d_by_latitude("a", lat2d, "b", lon2d)
         reverse = _CFCoordinateCandidates._assign_2d_by_latitude("a", lon2d, "b", lat2d)
-        assert forward[0] is lon2d and forward[1] is lat2d, (
-            "lat-first still yields (lon, lat)"
-        )
-        assert reverse[0] is lon2d and reverse[1] is lat2d, (
-            "lon-first still yields (lon, lat)"
-        )
+        assert forward[0] is lon2d, "lat-first: x must be the longitude array"
+        assert forward[1] is lat2d, "lat-first: y must be the latitude array"
+        assert reverse[0] is lon2d, "lon-first: x must be the longitude array"
+        assert reverse[1] is lat2d, "lon-first: y must be the latitude array"
 
     def test_assign_2d_by_latitude_ambiguous_keeps_order(self, caplog):
         """Ambiguous roles keep candidate order and log a DEBUG hint on the _plot logger.
@@ -199,9 +198,8 @@ class TestCFCoordinateCandidates:
         a, b = _lat2d(), _lat2d() + 1.0
         with caplog.at_level(logging.DEBUG, logger="pyramids.netcdf._plot"):
             pair = _CFCoordinateCandidates._assign_2d_by_latitude("a", a, "b", b)
-        assert pair[0] is a and pair[1] is b, (
-            "ambiguous roles must keep candidate order"
-        )
+        assert pair[0] is a, "ambiguous roles: first candidate stays x"
+        assert pair[1] is b, "ambiguous roles: second candidate stays y"
         hints = [r for r in caplog.records if r.name == "pyramids.netcdf._plot"]
         assert hints, (
             "an ambiguous-roles DEBUG record must be emitted on the _plot logger"

--- a/tests/netcdf/plot/test_cf_coordinate_candidates.py
+++ b/tests/netcdf/plot/test_cf_coordinate_candidates.py
@@ -9,10 +9,11 @@ is covered by ``tests/netcdf/plot/test_plot_coords.py``.
 from __future__ import annotations
 
 import logging
+from types import SimpleNamespace
 
 import numpy as np
 
-from pyramids.netcdf._plot import _CFCoordinateCandidates
+from pyramids.netcdf._plot import NetCDFPlot, _CFCoordinateCandidates
 
 _SHAPE = (4, 5)  # (rows, cols)
 
@@ -221,4 +222,31 @@ class TestCFCoordinateCandidates:
         )
         assert candidates.arrays_by_name()["lon"] is lon, (
             "resolved array must be exposed by name"
+        )
+
+
+class TestCFCoordinatesPairOrchestrator:
+    """Tests for ``NetCDFPlot._cf_coordinates_pair`` (the thin orchestrator)."""
+
+    def test_logs_and_returns_none_on_no_match(self, caplog):
+        """No matching pair returns None and logs the candidate shapes on the _plot logger.
+
+        Test scenario:
+            A CF ``coordinates`` attr whose only named var matches neither axis yields
+            no pair, so the orchestrator returns ``None`` and emits its "did not yield"
+            DEBUG record (formatting the candidate shapes) on ``pyramids.netcdf._plot``.
+        """
+        nc = SimpleNamespace(
+            _variable_attrs={"coordinates": "bad"},
+            shape=_SHAPE,
+            _source_var_name="v",
+        )
+        parent = _FakeParent({"bad": np.zeros((2, 2))})
+        with caplog.at_level(logging.DEBUG, logger="pyramids.netcdf._plot"):
+            result = NetCDFPlot(nc)._cf_coordinates_pair(nc, parent)
+        assert result is None, "an unmatchable coordinates attr must yield None"
+        logs = [r for r in caplog.records if r.name == "pyramids.netcdf._plot"]
+        assert logs, "a no-match DEBUG record must be emitted on the _plot logger"
+        assert "did not yield" in logs[0].getMessage(), (
+            f"unexpected no-match log message: {logs[0].getMessage()}"
         )

--- a/tests/netcdf/plot/test_cf_coordinate_candidates.py
+++ b/tests/netcdf/plot/test_cf_coordinate_candidates.py
@@ -1,0 +1,212 @@
+"""Unit tests for ``_CFCoordinateCandidates`` (CF auxiliary-coordinate pairing).
+
+The value object holds the classified x / y coordinate candidates for a data slice
+and owns the two-pass ``(x, y)`` pairing. These tests drive it in isolation with
+small real numpy arrays and a duck-typed fake ``parent``; the end-to-end plot path
+is covered by ``tests/netcdf/plot/test_plot_coords.py``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from pyramids.netcdf._plot import _CFCoordinateCandidates
+
+_SHAPE = (4, 5)  # (rows, cols)
+
+
+class _FakeParent:
+    """A duck-typed stand-in for a NetCDF container: name -> coord array (or None)."""
+
+    def __init__(self, arrays):
+        """Store the name -> array mapping (``None`` values model unreadable vars)."""
+        self._arrays = arrays
+
+    @property
+    def variable_names(self):
+        """Return the declared variable names."""
+        return list(self._arrays)
+
+    def _read_variable(self, name):
+        """Return the array for ``name`` (``None`` if unreadable)."""
+        return self._arrays.get(name)
+
+
+def _lon1d():
+    """A 1-D x (cols-length) coordinate."""
+    return np.arange(5.0)
+
+
+def _lat1d():
+    """A 1-D y (rows-length) coordinate."""
+    return np.arange(4.0)
+
+
+def _lat2d():
+    """A 2-D coordinate whose values are within latitude bounds."""
+    return np.full(_SHAPE, 45.0)
+
+
+def _lon2d():
+    """A 2-D coordinate whose values exceed latitude bounds (reads as longitude)."""
+    return np.full(_SHAPE, 200.0)
+
+
+class TestCFCoordinateCandidates:
+    """Tests for ``_CFCoordinateCandidates`` gather + pairing."""
+
+    def test_gather_classifies_x_and_y(self):
+        """gather classifies 1-D cols/rows and 2-D coords into the x / y lists.
+
+        Test scenario:
+            A 1-D-cols ``lon`` is x-only, a 1-D-rows ``lat`` is y-only, and a 2-D
+            ``grid`` matches both axes so it appears in both lists.
+        """
+        parent = _FakeParent({"lon": _lon1d(), "lat": _lat1d(), "grid": _lat2d()})
+        candidates = _CFCoordinateCandidates.gather(
+            ["lon", "lat", "grid"], parent, _SHAPE
+        )
+        x_names = {n for n, _ in candidates._x}
+        y_names = {n for n, _ in candidates._y}
+        assert x_names == {"lon", "grid"}, f"x candidates wrong: {x_names}"
+        assert y_names == {"lat", "grid"}, f"y candidates wrong: {y_names}"
+
+    def test_gather_skips_missing_and_unreadable_vars(self):
+        """gather skips names absent from the parent or reading back ``None``.
+
+        Test scenario:
+            ``absent`` is not a variable name; ``bad`` reads ``None`` — neither ends
+            up in the resolved arrays.
+        """
+        parent = _FakeParent({"lon": _lon1d(), "bad": None})
+        candidates = _CFCoordinateCandidates.gather(
+            ["lon", "bad", "absent"], parent, _SHAPE
+        )
+        assert set(candidates.arrays_by_name()) == {"lon"}, (
+            f"only readable, present vars should remain: {set(candidates.arrays_by_name())}"
+        )
+
+    def test_gather_applies_squeeze(self):
+        """gather squeezes a 3-D leading axis to the 2-D slice shape.
+
+        Test scenario:
+            A ``(2, 4, 5)`` coord is reduced to ``(4, 5)`` during gather.
+        """
+        parent = _FakeParent({"c3": np.zeros((2, 4, 5))})
+        candidates = _CFCoordinateCandidates.gather(["c3"], parent, _SHAPE)
+        assert candidates.arrays_by_name()["c3"].shape == _SHAPE, (
+            "3-D coord must be squeezed"
+        )
+
+    def test_best_pair_prefers_lon_lat_names(self):
+        """best_pair uses the lon/lat name heuristic before the distinct fallback.
+
+        Test scenario:
+            With both a lon/lat named pair and other viable candidates, the named
+            pair wins (the distinct fallback is not reached).
+        """
+        east, lon = np.arange(5.0), np.arange(5.0) + 100
+        north, lat = np.arange(4.0), np.arange(4.0) + 100
+        parent = _FakeParent({"east": east, "lon": lon, "north": north, "lat": lat})
+        candidates = _CFCoordinateCandidates.gather(
+            ["east", "lon", "north", "lat"], parent, _SHAPE
+        )
+        pair = candidates.best_pair()
+        assert pair is not None, "a lon/lat pair must be found"
+        assert pair[0] is lon and pair[1] is lat, "the lon/lat named pair must win"
+
+    def test_distinct_pair_does_not_collapse_a_single_2d_coord(self):
+        """A lone 2-D coord (in both lists) is not paired with itself.
+
+        Test scenario:
+            One 2-D coord ``grid`` lands in both x and y lists; the distinct-pair
+            guard rejects ``grid``/``grid``, so best_pair returns ``None``.
+        """
+        parent = _FakeParent({"grid": _lat2d()})
+        candidates = _CFCoordinateCandidates.gather(["grid"], parent, _SHAPE)
+        assert candidates.best_pair() is None, (
+            "a single 2-D coord must not collapse onto both axes"
+        )
+
+    def test_distinct_pair_two_2d_disambiguated_by_latitude(self):
+        """Two 2-D candidates (non-lon/lat names) are assigned by latitude range.
+
+        Test scenario:
+            With ``a`` (longitude-valued) and ``b`` (latitude-valued), the fallback
+            assigns the within-latitude array to y.
+        """
+        lon2d, lat2d = _lon2d(), _lat2d()
+        parent = _FakeParent({"a": lon2d, "b": lat2d})
+        candidates = _CFCoordinateCandidates.gather(["a", "b"], parent, _SHAPE)
+        pair = candidates.best_pair()
+        assert pair is not None and pair[0] is lon2d and pair[1] is lat2d, (
+            "the within-latitude 2-D array must become y"
+        )
+
+    def test_distinct_pair_1d_fallback(self):
+        """Distinct 1-D candidates with non-lon/lat names still pair (x, y).
+
+        Test scenario:
+            ``east`` (1-D cols) and ``north`` (1-D rows) are paired directly (not a
+            2-D disambiguation).
+        """
+        east, north = _lon1d(), _lat1d()
+        parent = _FakeParent({"east": east, "north": north})
+        candidates = _CFCoordinateCandidates.gather(["east", "north"], parent, _SHAPE)
+        pair = candidates.best_pair()
+        assert pair is not None and pair[0] is east and pair[1] is north, (
+            "distinct 1-D candidates must pair as (x, y)"
+        )
+
+    def test_best_pair_none_when_no_candidates(self):
+        """best_pair returns ``None`` when nothing classifies as a coord.
+
+        Test scenario:
+            A wrong-shaped array matches neither axis, so there is no pair.
+        """
+        parent = _FakeParent({"bad": np.zeros((2, 2))})
+        candidates = _CFCoordinateCandidates.gather(["bad"], parent, _SHAPE)
+        assert candidates.best_pair() is None, "no viable candidates must yield None"
+
+    def test_assign_2d_by_latitude_is_symmetric(self):
+        """The 2-D assignment puts the within-latitude array on y regardless of order.
+
+        Test scenario:
+            Whether the latitude array is passed as x or y, the result is
+            ``(longitude, latitude)`` — the assignment is order-independent.
+        """
+        lon2d, lat2d = _lon2d(), _lat2d()
+        forward = _CFCoordinateCandidates._assign_2d_by_latitude("a", lat2d, "b", lon2d)
+        reverse = _CFCoordinateCandidates._assign_2d_by_latitude("a", lon2d, "b", lat2d)
+        assert forward[0] is lon2d and forward[1] is lat2d, (
+            "lat-first still yields (lon, lat)"
+        )
+        assert reverse[0] is lon2d and reverse[1] is lat2d, (
+            "lon-first still yields (lon, lat)"
+        )
+
+    def test_assign_2d_by_latitude_ambiguous_keeps_order(self):
+        """When both or neither array reads as latitude, candidate order is kept.
+
+        Test scenario:
+            Two within-latitude arrays (ambiguous) return in the given order.
+        """
+        a, b = _lat2d(), _lat2d() + 1.0
+        pair = _CFCoordinateCandidates._assign_2d_by_latitude("a", a, "b", b)
+        assert pair[0] is a and pair[1] is b, (
+            "ambiguous roles must keep candidate order"
+        )
+
+    def test_arrays_by_name_returns_resolved_arrays(self):
+        """arrays_by_name exposes the resolved candidate arrays for the no-match log.
+
+        Test scenario:
+            The gathered arrays are returned keyed by name.
+        """
+        lon = _lon1d()
+        candidates = _CFCoordinateCandidates.gather(
+            ["lon"], _FakeParent({"lon": lon}), _SHAPE
+        )
+        assert candidates.arrays_by_name()["lon"] is lon, (
+            "resolved array must be exposed by name"
+        )

--- a/tests/netcdf/samples/test_curvilinear_crop.py
+++ b/tests/netcdf/samples/test_curvilinear_crop.py
@@ -14,7 +14,7 @@ from osgeo import gdal
 from shapely.geometry import MultiPolygon, Polygon
 
 from pyramids.feature import FeatureCollection
-from pyramids.netcdf import GeoReference, NetCDF
+from pyramids.netcdf import GeoReference, NetCDF, _coord_match
 from pyramids.netcdf._plot import NetCDFPlot
 from pyramids.netcdf.engines.selection import _lon_cell_size
 from tests.netcdf.samples.conftest import TOS as RECTILINEAR
@@ -305,10 +305,10 @@ def test_rasm_crop_lazy_matches_eager(sample):
     ],
 )
 def test_values_within_latitude(values, expected):
-    """`_values_within_latitude` flags arrays bounded to [-90, 90] (latitudes) and rejects longitudes."""
-    result = NetCDFPlot._values_within_latitude(np.array(values, dtype=float))
+    """`values_within_latitude` flags arrays bounded to [-90, 90] (latitudes) and rejects longitudes."""
+    result = _coord_match.values_within_latitude(np.array(values, dtype=float))
     assert result == expected, (
-        f"_values_within_latitude({values}) -> {result}, expected {expected}"
+        f"values_within_latitude({values}) -> {result}, expected {expected}"
     )
 
 

--- a/tests/netcdf/test_coord_match.py
+++ b/tests/netcdf/test_coord_match.py
@@ -1,0 +1,198 @@
+"""Unit tests for the shared coordinate-matching predicates in ``_coord_match``.
+
+Pure numpy predicates used across ``NetCDFPlot``'s coordinate-resolution paths and
+the CF candidate value object. End-to-end coverage lives in
+``tests/netcdf/plot/test_plot_coords.py`` and ``tests/netcdf/samples/test_curvilinear_crop.py``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pyramids.netcdf import _coord_match
+
+_SHAPE = (4, 5)  # (rows, cols)
+
+
+class TestSqueezeLeadingAxes:
+    """Tests for ``squeeze_leading_axes``."""
+
+    def test_drops_leading_axis_of_3d_matching_slice(self):
+        """A 3-D ``(extra, rows, cols)`` array is reduced to its first plane.
+
+        Test scenario:
+            ``(2, 4, 5)`` with slice ``(4, 5)`` returns element 0, shape ``(4, 5)``.
+        """
+        arr = np.arange(2 * 4 * 5).reshape(2, 4, 5)
+        result = _coord_match.squeeze_leading_axes(arr, _SHAPE)
+        assert result.shape == _SHAPE, f"expected {_SHAPE}, got {result.shape}"
+        assert np.array_equal(result, arr[0]), "must return the time-step-0 slice"
+
+    def test_passes_2d_through_unchanged(self):
+        """A 2-D array already matching the slice is returned unchanged.
+
+        Test scenario:
+            ``(4, 5)`` is returned as-is (identity).
+        """
+        arr = np.zeros(_SHAPE)
+        assert _coord_match.squeeze_leading_axes(arr, _SHAPE) is arr, (
+            "2-D must pass through"
+        )
+
+    def test_passes_1d_through_unchanged(self):
+        """A 1-D coordinate array is returned unchanged.
+
+        Test scenario:
+            A 1-D array is not 3-D, so it passes through.
+        """
+        arr = np.arange(5)
+        assert _coord_match.squeeze_leading_axes(arr, _SHAPE) is arr, (
+            "1-D must pass through"
+        )
+
+    def test_3d_not_matching_trailing_shape_passes_through(self):
+        """A 3-D array whose trailing 2 axes don't match the slice is not squeezed.
+
+        Test scenario:
+            ``(2, 3, 3)`` with slice ``(4, 5)`` fails the trailing-shape guard, so it
+            is returned unchanged.
+        """
+        arr = np.zeros((2, 3, 3))
+        assert _coord_match.squeeze_leading_axes(arr, _SHAPE) is arr, (
+            "no-match 3-D passes through"
+        )
+
+
+class TestMatchesXAxis:
+    """Tests for ``matches_x_axis`` (1-D cols or 2-D slice)."""
+
+    @pytest.mark.parametrize(
+        "arr, expected",
+        [
+            (np.arange(5), True),
+            (np.arange(4), False),
+            (np.zeros((4, 5)), True),
+            (np.zeros((5, 4)), False),
+        ],
+    )
+    def test_x_axis_shape_rules(self, arr, expected):
+        """1-D length must equal cols, or 2-D shape must equal the slice.
+
+        Args:
+            arr: Candidate array.
+            expected: Whether it can serve as the x axis for ``(4, 5)``.
+        """
+        assert _coord_match.matches_x_axis(arr, _SHAPE) is expected, (
+            f"matches_x_axis({arr.shape}) should be {expected}"
+        )
+
+
+class TestMatchesYAxis:
+    """Tests for ``matches_y_axis`` (1-D rows or 2-D slice)."""
+
+    @pytest.mark.parametrize(
+        "arr, expected",
+        [
+            (np.arange(4), True),
+            (np.arange(5), False),
+            (np.zeros((4, 5)), True),
+            (np.zeros((5, 4)), False),
+        ],
+    )
+    def test_y_axis_shape_rules(self, arr, expected):
+        """1-D length must equal rows, or 2-D shape must equal the slice.
+
+        Args:
+            arr: Candidate array.
+            expected: Whether it can serve as the y axis for ``(4, 5)``.
+        """
+        assert _coord_match.matches_y_axis(arr, _SHAPE) is expected, (
+            f"matches_y_axis({arr.shape}) should be {expected}"
+        )
+
+
+class TestCoordShapesMatch:
+    """Tests for ``coord_shapes_match``."""
+
+    def test_none_data_shape_returns_false(self):
+        """A ``None`` data shape cannot be validated, so returns False.
+
+        Test scenario:
+            ``coord_shapes_match(x, y, None)`` is ``False`` without inspecting arrays.
+        """
+        assert (
+            _coord_match.coord_shapes_match(np.arange(5), np.arange(4), None) is False
+        ), "None data_shape must yield False"
+
+    def test_matching_pair(self):
+        """A 1-D-cols x and 1-D-rows y line up with the slice.
+
+        Test scenario:
+            ``(cols,)`` x and ``(rows,)`` y match ``(4, 5)``.
+        """
+        assert (
+            _coord_match.coord_shapes_match(np.arange(5), np.arange(4), _SHAPE) is True
+        ), "a cols/rows 1-D pair must match"
+
+    def test_x_mismatch(self):
+        """A wrong-length x fails the match.
+
+        Test scenario:
+            An x of length rows (not cols) does not match.
+        """
+        assert (
+            _coord_match.coord_shapes_match(np.arange(4), np.arange(4), _SHAPE) is False
+        ), "x of length rows must not match the x axis"
+
+
+class TestLooksLikeXThenY:
+    """Tests for ``looks_like_x_then_y`` (lon-then-lat name heuristic)."""
+
+    @pytest.mark.parametrize(
+        "x_name, y_name, expected",
+        [
+            ("lon", "lat", True),
+            ("LONGITUDE", "LATITUDE", True),
+            ("lat", "lon", False),
+            ("xc", "yc", False),
+            ("lon", "xc", False),
+        ],
+    )
+    def test_name_heuristic(self, x_name, y_name, expected):
+        """x must read as a longitude and y as a latitude (case-insensitive).
+
+        Args:
+            x_name: Candidate x name.
+            y_name: Candidate y name.
+            expected: Whether the names follow the lon/lat convention.
+        """
+        assert _coord_match.looks_like_x_then_y(x_name, y_name) is expected, (
+            f"looks_like_x_then_y({x_name!r}, {y_name!r}) should be {expected}"
+        )
+
+
+class TestValuesWithinLatitude:
+    """Tests for ``values_within_latitude``."""
+
+    @pytest.mark.parametrize(
+        "values, expected",
+        [
+            ([-89.0, 0.0, 89.0], True),
+            ([0.0, 180.0, 360.0], False),
+            ([np.nan, np.nan], False),
+            ([-90.5, 90.5], True),
+            ([-91.0], False),
+        ],
+    )
+    def test_latitude_bounds(self, values, expected):
+        """All finite values must fall within ``[-90.5, 90.5]`` and at least one be finite.
+
+        Args:
+            values: The coordinate values.
+            expected: Whether the array reads as a latitude.
+        """
+        arr = np.array(values, dtype=float)
+        assert _coord_match.values_within_latitude(arr) is expected, (
+            f"values_within_latitude({values}) should be {expected}"
+        )


### PR DESCRIPTION
# Description

Data-driven refactor of the repository's worst SonarCloud cognitive-complexity offender:
`NetCDFPlot._cf_coordinates_pair` (`src/pyramids/netcdf/_plot.py`) had cognitive complexity **86**
(rule `python:S3776`, threshold 15). It parses a data variable's CF `coordinates` attribute and resolves the listed
auxiliary coordinate variables into an `(x, y)` array pair via a two-pass matching algorithm (lon/lat name
heuristic, then a distinct-pair fallback that disambiguates 2-D curvilinear candidates by latitude range).

The function is decomposed by following the data, not by scattering the nesting into more private methods on the
god-object:

- **(A) Value object** — the two-pass pairing is lifted into a module-level `_CFCoordinateCandidates` (`gather` /
  `best_pair` / `_named_pair` / `_distinct_pair` / `_candidate_pairs` / `_assign_2d_by_latitude` /
  `arrays_by_name`); `_cf_coordinates_pair` is now a thin orchestrator plus a `_cf_coordinate_names` helper.
- **(B) Shared predicate module** — the pure shape/name predicates move off `NetCDFPlot` into a new pure-numpy
  module `src/pyramids/netcdf/_coord_match.py` (`squeeze_leading_axes`, `matches_x_axis`, `matches_y_axis`,
  `coord_shapes_match`, `looks_like_x_then_y`, `values_within_latitude`), each with runnable doctests; every call
  site is rewired.

Behaviour is fully preserved: two-pass name-then-distinct pairing, the distinct-pair guard that never collapses a
2-D coord onto both axes, the symmetric 2-D latitude x/y assignment, the debug logs, and the `None`-return
fallback. This continues the S3776 series (#996, #998). No new dependencies.

# Issues
- Fixes #1001

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Refactor — non-breaking, no public API change (all touched symbols are private); none of the boxes above fit exactly.

# How Has This Been Tested?

- New unit tests: `tests/netcdf/test_coord_match.py` (predicate unit tests with boundary cases) and
  `tests/netcdf/plot/test_cf_coordinate_candidates.py` (value-object `gather` + two-pass pairing, including the
  no-collapse guard, the symmetric latitude assignment, and caplog assertions on both debug logs).
- Runnable doctests added to `_coord_match.py`.
- Full worktree suite green: `pytest -m "not plot"` → **8278 passed, 52 skipped**.
- End-to-end regression (`tests/netcdf/plot/test_plot_coords.py`, `tests/netcdf/samples/test_curvilinear_crop.py`)
  confirms behaviour preservation vs `main`.
- `ruff` + `mypy` clean; SonarCloud clean on the PR (0 unresolved, quality gate OK).

- [x] Test A — predicate + value-object unit tests
- [x] Test B — plot / curvilinear regression suite

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
