### PR TITLE
refactor(netcdf): decompose NetCDFPlot._resolve_curvilinear_coords to clear SonarCloud python:S3776

### DIFF
--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -1587,7 +1587,9 @@ class NetCDFPlot:
         against the rendered slice. Shapes that do not match silently
         skip — the next candidate gets a chance. When nothing resolves
         to a valid pair the helper returns ``None`` so the caller falls
-        back to the geotransform-derived ``extent``.
+        back to the geotransform-derived ``extent``. The per-source logic
+        lives in :class:`CurvilinearCoordResolver`; this method is a thin
+        facade delegating to it.
 
         Args:
             nc: The variable subset being plotted.

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -468,17 +468,17 @@ class CurvilinearCoordResolver:
     ) -> tuple[np.typing.NDArray, np.typing.NDArray] | None:
         """Read and squeeze a conventional name-pair to its 2-D arrays, or ``None`` if unusable.
 
-        Returns ``None`` when either name is absent from the parent, either variable reads
-        back ``None``, or the ``require_2d`` gate rejects a non-2-D generic pair (e.g. 1-D
-        ``xc``/``yc`` projected axes). Shape validation against the slice is left to the
-        caller.
+        Returns ``None`` when the slice shape is unknown (``data_shape`` is ``None``), either
+        name is absent from the parent, either variable reads back ``None``, or the
+        ``require_2d`` gate rejects a non-2-D generic pair (e.g. 1-D ``xc``/``yc`` projected
+        axes). Shape validation against the slice is left to the caller.
         """
         result = None
         present = (
             x_name in self.parent.variable_names
             and y_name in self.parent.variable_names
         )
-        if present:
+        if present and self.data_shape is not None:
             xv = self.parent._read_variable(x_name)
             yv = self.parent._read_variable(y_name)
             if xv is not None and yv is not None:

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -299,19 +299,16 @@ class CFCoordinateCandidates:
         return pair
 
 
-class NetCDFPlot:
-    """Owns the plotting pipeline for a :class:`~pyramids.netcdf.netcdf.NetCDF`.
+class CurvilinearCoordResolver:
+    """Resolve the curvilinear ``(x, y)`` coordinate arrays for one rendered slice.
 
-    Constructed per :meth:`NetCDF.plot` call. Holds a strong reference to the
-    NetCDF (or variable subset) being rendered — unlike the long-lived weakref
-    engines on :class:`~pyramids.dataset.Dataset`, this object is created fresh
-    each call and discarded once :meth:`run` returns, so there is no
-    GDAL-handle-leak concern.
-
-    The methods mirror what used to be private methods on ``NetCDF`` itself —
-    the bodies are copied verbatim, with ``self`` (the NetCDF) replaced by
-    ``self.nc`` (or by an explicit ``nc`` argument where the old code operated
-    on a pinned subset rather than the original instance).
+    Tries an ordered list of sources — explicit ``coords=`` → stored crop coords → the CF
+    ``coordinates`` attribute → conventional model name-pairs — and returns the first pair
+    whose shapes line up with the data slice, else ``None`` so the caller falls back to the
+    geotransform-derived extent. Holds the resolution context ``(nc, parent, data_shape)``
+    shared by every source, and reuses :mod:`pyramids.netcdf._coord_match` for shape
+    validation and :class:`CFCoordinateCandidates` (via
+    :meth:`NetCDFPlot._cf_coordinates_pair`) for the CF pairing.
     """
 
     # Conventional curvilinear coordinate-variable name triples, each
@@ -327,6 +324,222 @@ class NetCDFPlot:
         ("nav_lon", "nav_lat", False),
         ("xc", "yc", True),
     )
+
+    def __init__(self, nc: NetCDF) -> None:
+        """Derive and hold the resolution context from the rendered slice ``nc``.
+
+        Args:
+            nc: The variable subset being plotted; ``parent`` (where coord variables are
+                read) and ``data_shape`` (the ``(rows, cols)`` the coords must match) are
+                derived from it.
+        """
+        self.nc = nc
+        self.parent = nc._parent_nc if nc._parent_nc is not None else nc
+        self.data_shape = nc.shape[-2:] if nc.shape else None
+
+    def resolve(
+        self, coords: tuple | list | None
+    ) -> tuple[np.typing.NDArray, np.typing.NDArray] | None:
+        """Return the first shape-valid ``(x, y)`` pair across the sources, or ``None``.
+
+        Source priority: explicit ``coords=`` first (it may raise on a malformed spec);
+        then, only when ``data_shape`` is known, the stored-crop, CF-attribute, and
+        conventional-names sources in that order. Returns ``None`` when nothing resolves,
+        so the caller falls back to the geotransform-derived extent.
+
+        Args:
+            coords: Explicit ``(x, y)`` spec (two names or two arrays), or ``None``.
+
+        Returns:
+            tuple[np.ndarray, np.ndarray] or None: The resolved curvilinear pair, or
+                ``None``.
+        """
+        result = self._from_explicit(coords)
+        if result is None and self.data_shape is not None:
+            for source in (self._from_stored, self._from_cf, self._from_conventional):
+                result = source()
+                if result is not None:
+                    break
+        return result
+
+    def _validated(
+        self, x_arr: np.ndarray, y_arr: np.ndarray
+    ) -> tuple[np.typing.NDArray, np.typing.NDArray] | None:
+        """Return ``(x_arr, y_arr)`` when they line up with ``data_shape``, else ``None``."""
+        return (
+            (x_arr, y_arr)
+            if _coord_match.coord_shapes_match(x_arr, y_arr, self.data_shape)
+            else None
+        )
+
+    def _from_explicit(
+        self, coords: tuple | list | None
+    ) -> tuple[np.typing.NDArray, np.typing.NDArray] | None:
+        """Source 1: an explicit user ``coords=`` spec (two names or two arrays).
+
+        Raises on a spec that is not a length-2 sequence; a shape-mismatching pair is
+        rejected (logging a warning) so the resolver falls through to auto-detection.
+        """
+        result = None
+        if coords is not None:
+            if not isinstance(coords, (tuple, list)) or len(coords) != 2:
+                raise ValueError(
+                    "`coords=` must be a length-2 sequence (x, y). Got "
+                    f"{type(coords).__name__} of length "
+                    f"{len(coords) if hasattr(coords, '__len__') else '?'}."
+                )
+            x_arr = self._coerce(coords[0], "x")
+            y_arr = self._coerce(coords[1], "y")
+            result = self._validated(x_arr, y_arr)
+            if result is None:
+                logger.warning(
+                    "Explicit `coords=` shapes %s / %s don't match the data "
+                    "slice shape %s; ignoring the supplied coords and falling "
+                    "back to auto-detection / the geotransform extent.",
+                    x_arr.shape,
+                    y_arr.shape,
+                    self.data_shape,
+                )
+        return result
+
+    def _from_stored(self) -> tuple[np.typing.NDArray, np.typing.NDArray] | None:
+        """Source 2: the ``_curvilinear_coords`` stashed on a curvilinear-crop result.
+
+        :meth:`NetCDF.crop` stores the windowed 2-D lon/lat arrays on a cropped
+        2-D-coordinate grid so the subset still replots on its real curvilinear geometry.
+        """
+        result = None
+        stored = getattr(self.nc, "_curvilinear_coords", None)
+        if stored is not None:
+            result = self._validated(np.asarray(stored[0]), np.asarray(stored[1]))
+        return result
+
+    def _from_cf(self) -> tuple[np.typing.NDArray, np.typing.NDArray] | None:
+        """Source 3: the CF ``coordinates`` attribute, via :meth:`NetCDFPlot._cf_coordinates_pair`.
+
+        Delegates the two-pass pairing to :class:`CFCoordinateCandidates` (no logic
+        duplicated) and re-checks the resolved pair against the slice shape.
+        """
+        result = None
+        cf_pair = NetCDFPlot._cf_coordinates_pair(self.nc, self.parent)
+        if cf_pair is not None:
+            result = self._validated(cf_pair[0], cf_pair[1])
+        return result
+
+    def _from_conventional(self) -> tuple[np.typing.NDArray, np.typing.NDArray] | None:
+        """Source 4: well-known model name-pairs (WRF/ROMS/NEMO/RASM), first shape-valid wins.
+
+        Emits a :class:`DeprecationWarning` on a hit — these model-specific name heuristics
+        are domain knowledge, not a generic GIS convention. A present-but-wrong-shape pair
+        logs a debug hint and the search moves on to the next pair.
+        """
+        result = None
+        for x_name, y_name, require_2d in self._CURVILINEAR_NAME_PAIRS:
+            arrays = self._conventional_pair_arrays(x_name, y_name, require_2d)
+            if arrays is not None:
+                pair = self._validated(arrays[0], arrays[1])
+                if pair is not None:
+                    warnings.warn(
+                        "Resolving curvilinear coordinates by hardcoded "
+                        f"model-specific names ({x_name!r}, {y_name!r}) is "
+                        "deprecated and will be removed: model-specific name "
+                        "heuristics (WRF, ROMS, NEMO, RASM) are domain "
+                        "knowledge, not a generic GIS convention. Set the CF "
+                        "`coordinates` attribute, or pass `coords=` explicitly.",
+                        DeprecationWarning,
+                        stacklevel=5,
+                    )
+                    result = pair
+                    break
+                logger.debug(
+                    "Conventional curvilinear coord pair (%r, %r) is "
+                    "present on the NetCDF but shapes %s / %s don't match "
+                    "the data slice shape %s; skipping this pair.",
+                    x_name,
+                    y_name,
+                    arrays[0].shape,
+                    arrays[1].shape,
+                    self.data_shape,
+                )
+        return result
+
+    def _conventional_pair_arrays(
+        self, x_name: str, y_name: str, require_2d: bool
+    ) -> tuple[np.typing.NDArray, np.typing.NDArray] | None:
+        """Read and squeeze a conventional name-pair to its 2-D arrays, or ``None`` if unusable.
+
+        Returns ``None`` when either name is absent from the parent, either variable reads
+        back ``None``, or the ``require_2d`` gate rejects a non-2-D generic pair (e.g. 1-D
+        ``xc``/``yc`` projected axes). Shape validation against the slice is left to the
+        caller.
+        """
+        result = None
+        present = (
+            x_name in self.parent.variable_names
+            and y_name in self.parent.variable_names
+        )
+        if present:
+            xv = self.parent._read_variable(x_name)
+            yv = self.parent._read_variable(y_name)
+            if xv is not None and yv is not None:
+                x_arr = _coord_match.squeeze_leading_axes(xv, self.data_shape)
+                y_arr = _coord_match.squeeze_leading_axes(yv, self.data_shape)
+                # A generic name pair (e.g. xc/yc) is trusted only when BOTH arrays are
+                # genuinely 2-D. A 1-D pair (or a 1-D/2-D mix) means projected/rectilinear
+                # axes, not curvilinear coords, so skip it. The gate is ndim-only: 2-D
+                # xc/yc in projected metres cannot be told apart from 2-D lon/lat here — use
+                # the CF `coordinates` attribute or explicit `coords=` for those.
+                if not (require_2d and (x_arr.ndim != 2 or y_arr.ndim != 2)):
+                    result = (x_arr, y_arr)
+        return result
+
+    def _coerce(self, spec: Any, axis_label: str) -> np.typing.NDArray:
+        """Convert one coord spec (variable name ``str`` or array-like) to a numpy array.
+
+        Args:
+            spec: A variable name looked up on the parent container, or an array-like
+                converted via :func:`numpy.asarray`.
+            axis_label: ``"x"`` or ``"y"``, used in the error messages.
+
+        Returns:
+            np.ndarray: The resolved coordinate array.
+
+        Raises:
+            ValueError: If a string name is absent from the parent's ``variable_names`` or
+                :meth:`NetCDF._read_variable` returns ``None``.
+        """
+        if isinstance(spec, str):
+            if spec not in self.parent.variable_names:
+                raise ValueError(
+                    f"coords {axis_label}={spec!r} is not a variable of "
+                    f"the parent NetCDF. Available: {self.parent.variable_names}."
+                )
+            arr = self.parent._read_variable(spec)
+            if arr is None:
+                raise ValueError(
+                    f"coords {axis_label}={spec!r} could not be read via "
+                    "`_read_variable`."
+                )
+            result = arr
+        else:
+            result = np.asarray(spec)
+        return result
+
+
+class NetCDFPlot:
+    """Owns the plotting pipeline for a :class:`~pyramids.netcdf.netcdf.NetCDF`.
+
+    Constructed per :meth:`NetCDF.plot` call. Holds a strong reference to the
+    NetCDF (or variable subset) being rendered — unlike the long-lived weakref
+    engines on :class:`~pyramids.dataset.Dataset`, this object is created fresh
+    each call and discarded once :meth:`run` returns, so there is no
+    GDAL-handle-leak concern.
+
+    The methods mirror what used to be private methods on ``NetCDF`` itself —
+    the bodies are copied verbatim, with ``self`` (the NetCDF) replaced by
+    ``self.nc`` (or by an explicit ``nc`` argument where the old code operated
+    on a pinned subset rather than the original instance).
+    """
 
     def __init__(self, nc: NetCDF) -> None:
         self.nc = nc
@@ -1475,144 +1688,10 @@ class NetCDFPlot:
 
                 ```
         """
-        result: tuple[np.ndarray, np.ndarray] | None = None
-
-        parent = nc._parent_nc if nc._parent_nc is not None else nc
-        data_shape = nc.shape[-2:] if nc.shape else None
-
-        if coords is not None:
-            if not isinstance(coords, (tuple, list)) or len(coords) != 2:
-                raise ValueError(
-                    "`coords=` must be a length-2 sequence (x, y). Got "
-                    f"{type(coords).__name__} of length "
-                    f"{len(coords) if hasattr(coords, '__len__') else '?'}."
-                )
-            user_coords: tuple | None = tuple(coords)
-        else:
-            user_coords = None
-
-        if user_coords is not None:
-            x_in, y_in = user_coords
-            x_arr = self._coerce_coord_spec(x_in, parent, "x")
-            y_arr = self._coerce_coord_spec(y_in, parent, "y")
-            if _coord_match.coord_shapes_match(x_arr, y_arr, data_shape):
-                result = (x_arr, y_arr)
-            else:
-                logger.warning(
-                    "Explicit `coords=` shapes %s / %s don't match the data "
-                    "slice shape %s; ignoring the supplied coords and falling "
-                    "back to auto-detection / the geotransform extent.",
-                    x_arr.shape,
-                    y_arr.shape,
-                    data_shape,
-                )
-
-        if result is None and data_shape is not None:
-            # A curvilinear crop result (NetCDF.crop on a 2-D-coordinate grid) carries its windowed
-            # lon/lat arrays here so the cropped subset still plots on its real curvilinear geometry.
-            stored = getattr(nc, "_curvilinear_coords", None)
-            if stored is not None:
-                x_arr = np.asarray(stored[0])
-                y_arr = np.asarray(stored[1])
-                if _coord_match.coord_shapes_match(x_arr, y_arr, data_shape):
-                    result = (x_arr, y_arr)
-
-        if result is None and data_shape is not None:
-            cf_pair = self._cf_coordinates_pair(nc, parent)
-            if cf_pair is not None:
-                x_arr, y_arr = cf_pair
-                if _coord_match.coord_shapes_match(x_arr, y_arr, data_shape):
-                    result = (x_arr, y_arr)
-
-        if result is None and data_shape is not None:
-            for x_name, y_name, require_2d in self._CURVILINEAR_NAME_PAIRS:
-                if x_name in parent.variable_names and y_name in parent.variable_names:
-                    xv = parent._read_variable(x_name)
-                    yv = parent._read_variable(y_name)
-                    if xv is None or yv is None:
-                        continue
-                    x_arr = _coord_match.squeeze_leading_axes(xv, data_shape)
-                    y_arr = _coord_match.squeeze_leading_axes(yv, data_shape)
-                    if require_2d and (x_arr.ndim != 2 or y_arr.ndim != 2):
-                        # A generic name pair (e.g. xc/yc) is trusted only when
-                        # BOTH arrays are genuinely 2-D. A 1-D pair (or a 1-D/2-D
-                        # mix) means projected/rectilinear axes, not curvilinear
-                        # coords, so skip it and fall back to the geotransform
-                        # extent. The gate is ndim-only: 2-D xc/yc in projected
-                        # metres cannot be told apart from 2-D lon/lat here — use
-                        # the CF `coordinates` attribute or explicit `coords=` for
-                        # those.
-                        continue
-                    if _coord_match.coord_shapes_match(x_arr, y_arr, data_shape):
-                        warnings.warn(
-                            "Resolving curvilinear coordinates by hardcoded "
-                            f"model-specific names ({x_name!r}, {y_name!r}) is "
-                            "deprecated and will be removed: model-specific name "
-                            "heuristics (WRF, ROMS, NEMO, RASM) are domain "
-                            "knowledge, not a generic GIS convention. Set the CF "
-                            "`coordinates` attribute, or pass `coords=` explicitly.",
-                            DeprecationWarning,
-                            stacklevel=3,
-                        )
-                        result = (x_arr, y_arr)
-                        break
-                    logger.debug(
-                        "Conventional curvilinear coord pair (%r, %r) is "
-                        "present on the NetCDF but shapes %s / %s don't match "
-                        "the data slice shape %s; skipping this pair.",
-                        x_name,
-                        y_name,
-                        x_arr.shape,
-                        y_arr.shape,
-                        data_shape,
-                    )
-
-        return result
+        return CurvilinearCoordResolver(nc).resolve(coords)
 
     @staticmethod
-    def _coerce_coord_spec(
-        spec: Any,
-        parent: NetCDF,
-        axis_label: str,
-    ) -> np.typing.NDArray:
-        """Convert a single coord spec (str or array) to a numpy array.
-
-        Args:
-            spec: Either a variable name (str) to look up on the parent
-                container, or an array-like that is converted via
-                :func:`numpy.asarray`.
-            parent: NetCDF container used to resolve string names via
-                :meth:`NetCDF._read_variable`.
-            axis_label: ``"x"`` or ``"y"``; used in error messages so the
-                caller can spot which axis failed.
-
-        Returns:
-            np.ndarray: The resolved coordinate array.
-
-        Raises:
-            ValueError: If a string name is not in the parent's
-                ``variable_names`` or :meth:`NetCDF._read_variable`
-                returns ``None``.
-        """
-        if isinstance(spec, str):
-            if spec not in parent.variable_names:
-                raise ValueError(
-                    f"coords {axis_label}={spec!r} is not a variable of "
-                    f"the parent NetCDF. Available: {parent.variable_names}."
-                )
-            arr = parent._read_variable(spec)
-            if arr is None:
-                raise ValueError(
-                    f"coords {axis_label}={spec!r} could not be read via "
-                    "`_read_variable`."
-                )
-            result = arr
-        else:
-            result = np.asarray(spec)
-        return result
-
     def _cf_coordinates_pair(
-        self,
         nc: NetCDF,
         parent: NetCDF,
     ) -> tuple[np.typing.NDArray, np.typing.NDArray] | None:
@@ -1644,7 +1723,7 @@ class NetCDFPlot:
                 pair, or ``None`` when nothing matched.
         """
         result = None
-        names = self._cf_coordinate_names(nc)
+        names = NetCDFPlot._cf_coordinate_names(nc)
         data_shape = nc.shape[-2:] if nc.shape else None
         if names and data_shape is not None:
             candidates = CFCoordinateCandidates.gather(names, parent, data_shape)

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -121,7 +121,7 @@ _ANIMATE_DROP_KWARGS = frozenset(
 )
 
 
-class _CFCoordinateCandidates:
+class CFCoordinateCandidates:
     """The CF auxiliary-coordinate candidates for one data slice.
 
     Groups the coord arrays that read as an x axis and those that read as a y axis
@@ -158,7 +158,7 @@ class _CFCoordinateCandidates:
         names: list[str],
         parent: NetCDF,
         data_shape: tuple[int, int],
-    ) -> _CFCoordinateCandidates:
+    ) -> CFCoordinateCandidates:
         """Read each named coord var off ``parent``, squeeze it, and classify x / y.
 
         Args:
@@ -167,7 +167,7 @@ class _CFCoordinateCandidates:
             data_shape: ``(rows, cols)`` of the data slice.
 
         Returns:
-            _CFCoordinateCandidates: the classified x / y candidate lists.
+            CFCoordinateCandidates: the classified x / y candidate lists.
         """
         arrays: dict[str, np.ndarray] = {}
         for name in names:
@@ -1624,8 +1624,8 @@ class NetCDFPlot:
         attribute off ``nc._variable_attrs`` (populated by
         :meth:`NetCDF.get_variable`), gathers and classifies the named
         coord arrays, and delegates the ``(x, y)`` pairing to
-        :class:`_CFCoordinateCandidates` — see its class docstring and
-        :meth:`_CFCoordinateCandidates.best_pair` for the two-pass
+        :class:`CFCoordinateCandidates` — see its class docstring and
+        :meth:`CFCoordinateCandidates.best_pair` for the two-pass
         matching algorithm (name heuristic, then a distinct-pair fallback
         that disambiguates 2-D curvilinear candidates by latitude range).
         When the attribute is missing or no valid pair is found it returns
@@ -1647,7 +1647,7 @@ class NetCDFPlot:
         names = self._cf_coordinate_names(nc)
         data_shape = nc.shape[-2:] if nc.shape else None
         if names and data_shape is not None:
-            candidates = _CFCoordinateCandidates.gather(names, parent, data_shape)
+            candidates = CFCoordinateCandidates.gather(names, parent, data_shape)
             result = candidates.best_pair()
             if result is None:
                 logger.debug(

--- a/tests/netcdf/plot/test_cf_coordinate_candidates.py
+++ b/tests/netcdf/plot/test_cf_coordinate_candidates.py
@@ -1,4 +1,4 @@
-"""Unit tests for ``_CFCoordinateCandidates`` (CF auxiliary-coordinate pairing).
+"""Unit tests for ``CFCoordinateCandidates`` (CF auxiliary-coordinate pairing).
 
 The value object holds the classified x / y coordinate candidates for a data slice
 and owns the two-pass ``(x, y)`` pairing. These tests drive it in isolation with
@@ -13,7 +13,7 @@ from types import SimpleNamespace
 
 import numpy as np
 
-from pyramids.netcdf._plot import NetCDFPlot, _CFCoordinateCandidates
+from pyramids.netcdf._plot import CFCoordinateCandidates, NetCDFPlot
 
 _SHAPE = (4, 5)  # (rows, cols)
 
@@ -56,7 +56,7 @@ def _lon2d():
 
 
 class TestCFCoordinateCandidates:
-    """Tests for ``_CFCoordinateCandidates`` gather + pairing."""
+    """Tests for ``CFCoordinateCandidates`` gather + pairing."""
 
     def test_gather_classifies_x_and_y(self):
         """gather classifies 1-D cols/rows and 2-D coords into the x / y lists.
@@ -66,7 +66,7 @@ class TestCFCoordinateCandidates:
             ``grid`` matches both axes so it appears in both lists.
         """
         parent = _FakeParent({"lon": _lon1d(), "lat": _lat1d(), "grid": _lat2d()})
-        candidates = _CFCoordinateCandidates.gather(
+        candidates = CFCoordinateCandidates.gather(
             ["lon", "lat", "grid"], parent, _SHAPE
         )
         x_names = {n for n, _ in candidates._x}
@@ -82,7 +82,7 @@ class TestCFCoordinateCandidates:
             up in the resolved arrays.
         """
         parent = _FakeParent({"lon": _lon1d(), "bad": None})
-        candidates = _CFCoordinateCandidates.gather(
+        candidates = CFCoordinateCandidates.gather(
             ["lon", "bad", "absent"], parent, _SHAPE
         )
         assert set(candidates.arrays_by_name()) == {"lon"}, (
@@ -96,7 +96,7 @@ class TestCFCoordinateCandidates:
             A ``(2, 4, 5)`` coord is reduced to ``(4, 5)`` during gather.
         """
         parent = _FakeParent({"c3": np.zeros((2, 4, 5))})
-        candidates = _CFCoordinateCandidates.gather(["c3"], parent, _SHAPE)
+        candidates = CFCoordinateCandidates.gather(["c3"], parent, _SHAPE)
         assert candidates.arrays_by_name()["c3"].shape == _SHAPE, (
             "3-D coord must be squeezed"
         )
@@ -111,7 +111,7 @@ class TestCFCoordinateCandidates:
         east, lon = np.arange(5.0), np.arange(5.0) + 100
         north, lat = np.arange(4.0), np.arange(4.0) + 100
         parent = _FakeParent({"east": east, "lon": lon, "north": north, "lat": lat})
-        candidates = _CFCoordinateCandidates.gather(
+        candidates = CFCoordinateCandidates.gather(
             ["east", "lon", "north", "lat"], parent, _SHAPE
         )
         pair = candidates.best_pair()
@@ -127,7 +127,7 @@ class TestCFCoordinateCandidates:
             guard rejects ``grid``/``grid``, so best_pair returns ``None``.
         """
         parent = _FakeParent({"grid": _lat2d()})
-        candidates = _CFCoordinateCandidates.gather(["grid"], parent, _SHAPE)
+        candidates = CFCoordinateCandidates.gather(["grid"], parent, _SHAPE)
         assert candidates.best_pair() is None, (
             "a single 2-D coord must not collapse onto both axes"
         )
@@ -141,7 +141,7 @@ class TestCFCoordinateCandidates:
         """
         lon2d, lat2d = _lon2d(), _lat2d()
         parent = _FakeParent({"a": lon2d, "b": lat2d})
-        candidates = _CFCoordinateCandidates.gather(["a", "b"], parent, _SHAPE)
+        candidates = CFCoordinateCandidates.gather(["a", "b"], parent, _SHAPE)
         pair = candidates.best_pair()
         assert pair is not None, "a 2-D pair must be found"
         assert pair[0] is lon2d, "the longitude-valued array must be x"
@@ -156,7 +156,7 @@ class TestCFCoordinateCandidates:
         """
         east, north = _lon1d(), _lat1d()
         parent = _FakeParent({"east": east, "north": north})
-        candidates = _CFCoordinateCandidates.gather(["east", "north"], parent, _SHAPE)
+        candidates = CFCoordinateCandidates.gather(["east", "north"], parent, _SHAPE)
         pair = candidates.best_pair()
         assert pair is not None, "a distinct 1-D pair must be found"
         assert pair[0] is east, "the cols-length array must be x"
@@ -169,7 +169,7 @@ class TestCFCoordinateCandidates:
             A wrong-shaped array matches neither axis, so there is no pair.
         """
         parent = _FakeParent({"bad": np.zeros((2, 2))})
-        candidates = _CFCoordinateCandidates.gather(["bad"], parent, _SHAPE)
+        candidates = CFCoordinateCandidates.gather(["bad"], parent, _SHAPE)
         assert candidates.best_pair() is None, "no viable candidates must yield None"
 
     def test_assign_2d_by_latitude_is_symmetric(self):
@@ -180,8 +180,8 @@ class TestCFCoordinateCandidates:
             ``(longitude, latitude)`` — the assignment is order-independent.
         """
         lon2d, lat2d = _lon2d(), _lat2d()
-        forward = _CFCoordinateCandidates._assign_2d_by_latitude("a", lat2d, "b", lon2d)
-        reverse = _CFCoordinateCandidates._assign_2d_by_latitude("a", lon2d, "b", lat2d)
+        forward = CFCoordinateCandidates._assign_2d_by_latitude("a", lat2d, "b", lon2d)
+        reverse = CFCoordinateCandidates._assign_2d_by_latitude("a", lon2d, "b", lat2d)
         assert forward[0] is lon2d, "lat-first: x must be the longitude array"
         assert forward[1] is lat2d, "lat-first: y must be the latitude array"
         assert reverse[0] is lon2d, "lon-first: x must be the longitude array"
@@ -197,7 +197,7 @@ class TestCFCoordinateCandidates:
         """
         a, b = _lat2d(), _lat2d() + 1.0
         with caplog.at_level(logging.DEBUG, logger="pyramids.netcdf._plot"):
-            pair = _CFCoordinateCandidates._assign_2d_by_latitude("a", a, "b", b)
+            pair = CFCoordinateCandidates._assign_2d_by_latitude("a", a, "b", b)
         assert pair[0] is a, "ambiguous roles: first candidate stays x"
         assert pair[1] is b, "ambiguous roles: second candidate stays y"
         hints = [r for r in caplog.records if r.name == "pyramids.netcdf._plot"]
@@ -215,7 +215,7 @@ class TestCFCoordinateCandidates:
             The gathered arrays are returned keyed by name.
         """
         lon = _lon1d()
-        candidates = _CFCoordinateCandidates.gather(
+        candidates = CFCoordinateCandidates.gather(
             ["lon"], _FakeParent({"lon": lon}), _SHAPE
         )
         assert candidates.arrays_by_name()["lon"] is lon, (

--- a/tests/netcdf/plot/test_curvilinear_coord_resolver.py
+++ b/tests/netcdf/plot/test_curvilinear_coord_resolver.py
@@ -446,3 +446,13 @@ class TestCurvilinearCoordResolver:
         assert debugs, (
             "the early wrong-shape pair must log a debug skip before the later pair resolves"
         )
+
+    def test_conventional_pair_arrays_none_data_shape_returns_none(self):
+        """A direct call with ``data_shape=None`` returns ``None`` (not TypeError), like the siblings."""
+        fake = _FakeNC({"xc": _grid_2d(200.0), "yc": _grid_2d(45.0)}, shape=())
+        result = CurvilinearCoordResolver(fake)._conventional_pair_arrays(
+            "xc", "yc", True
+        )
+        assert result is None, (
+            "a None data_shape must yield None, consistent with the other sources"
+        )

--- a/tests/netcdf/plot/test_curvilinear_coord_resolver.py
+++ b/tests/netcdf/plot/test_curvilinear_coord_resolver.py
@@ -8,20 +8,44 @@ curvilinear crops by ``tests/netcdf/samples/test_curvilinear_crop.py``.
 
 from __future__ import annotations
 
+import logging
 import warnings
 from pathlib import Path
 
 import numpy as np
+import pytest
 
-from pyramids.netcdf._plot import NetCDFPlot
+from pyramids.netcdf._plot import CurvilinearCoordResolver, NetCDFPlot
 
 _SHAPE = (5, 6)  # (rows, cols)
+
+
+def _cols_1d():
+    """A 1-D coordinate whose length equals the column count (matches the x axis)."""
+    return np.arange(6.0)
+
+
+def _rows_1d():
+    """A 1-D coordinate whose length equals the row count (matches the y axis)."""
+    return np.arange(5.0)
+
+
+def _grid_2d(value=1.0):
+    """A 2-D coordinate matching the slice shape ``(5, 6)``."""
+    return np.full(_SHAPE, value)
+
+
+def _bad_2d():
+    """A 2-D coordinate whose shape does not match the slice ``(5, 6)``."""
+    return np.full((3, 3), 0.0)
 
 
 class _FakeNC:
     """Minimal duck-typed NetCDF slice exposing only what ``_resolve_curvilinear_coords`` reads."""
 
-    def __init__(self, arrays, shape=_SHAPE, variable_attrs=None, curvilinear_coords=None):
+    def __init__(
+        self, arrays, shape=_SHAPE, variable_attrs=None, curvilinear_coords=None
+    ):
         """Store the name -> coord-array map plus the slice shape and optional CF / crop state."""
         self._arrays = arrays
         self.shape = shape
@@ -73,15 +97,293 @@ class TestConventionalNamesWarningFrame:
         depr = [
             w
             for w in caught
-            if issubclass(w.category, DeprecationWarning) and "model-specific" in str(w.message)
+            if issubclass(w.category, DeprecationWarning)
+            and "model-specific" in str(w.message)
         ]
         assert depr, "the conventional-names source must emit a DeprecationWarning"
         rec = depr[0]
         assert rec.filename.endswith("test_curvilinear_coord_resolver.py"), (
             f"warning attributed to {rec.filename}, expected this test module (stacklevel drift)"
         )
-        src_line = Path(rec.filename).read_text(encoding="utf-8").splitlines()[rec.lineno - 1]
+        src_line = (
+            Path(rec.filename).read_text(encoding="utf-8").splitlines()[rec.lineno - 1]
+        )
         assert "_mimic_build_render_kwargs" in src_line, (
             f"stacklevel drift: warning attributed to {rec.filename}:{rec.lineno} -> "
             f"{src_line.strip()!r}; expected the `_mimic_run` frame two frames above the resolver"
         )
+
+
+class TestCurvilinearCoordResolver:
+    """Unit tests for the four-source ``CurvilinearCoordResolver`` and its helpers."""
+
+    def test_init_derives_context_from_slice(self):
+        """The ctor stores nc and derives parent (self when no parent) and data_shape."""
+        fake = _FakeNC({"lon": _cols_1d()})
+        resolver = CurvilinearCoordResolver(fake)
+        assert resolver.nc is fake, "nc must be stored"
+        assert resolver.parent is fake, (
+            "parent falls back to nc when _parent_nc is None"
+        )
+        assert resolver.data_shape == _SHAPE, (
+            f"data_shape should be {_SHAPE}, got {resolver.data_shape}"
+        )
+
+    def test_init_uses_parent_nc_when_present(self):
+        """When the slice has a parent container, coord variables are read off the parent."""
+        parent = _FakeNC({"xc": _grid_2d(200.0), "yc": _grid_2d(45.0)})
+        child = _FakeNC({})
+        child._parent_nc = parent
+        resolver = CurvilinearCoordResolver(child)
+        assert resolver.parent is parent, "parent must be _parent_nc when it is set"
+
+    def test_init_none_shape_yields_none_data_shape(self):
+        """An empty ``nc.shape`` yields ``data_shape=None`` (the guard for sources 2-4)."""
+        resolver = CurvilinearCoordResolver(_FakeNC({}, shape=()))
+        assert resolver.data_shape is None, "empty shape must map to None data_shape"
+
+    def test_resolve_explicit_wins_over_other_sources(self):
+        """An explicit shape-valid ``coords=`` short-circuits the auto-detection sources.
+
+        Test scenario:
+            The slice also has stored coords and conventional xc/yc, but explicit coords
+            win, so the returned pair is the explicit arrays and no DeprecationWarning fires.
+        """
+        lon, lat = _cols_1d(), _rows_1d()
+        fake = _FakeNC(
+            {"xc": _grid_2d(200.0), "yc": _grid_2d(45.0)},
+            curvilinear_coords=(_grid_2d(1.0), _grid_2d(2.0)),
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            pair = CurvilinearCoordResolver(fake).resolve((lon, lat))
+        assert pair is not None, "explicit coords must resolve"
+        assert pair[0] is lon, "x must be the explicit lon array"
+        assert pair[1] is lat, "y must be the explicit lat array"
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert not deprecations, (
+            "the conventional source must not be reached when explicit wins"
+        )
+
+    def test_resolve_none_data_shape_skips_fallback_sources(self):
+        """With ``data_shape=None`` only source 1 runs; sources 2-4 are skipped.
+
+        Test scenario:
+            A slice with empty shape but conventional xc/yc present resolves to ``None`` and
+            emits no DeprecationWarning, proving the conventional source was never reached.
+        """
+        fake = _FakeNC({"xc": _grid_2d(200.0), "yc": _grid_2d(45.0)}, shape=())
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = CurvilinearCoordResolver(fake).resolve(None)
+        assert result is None, "no source can resolve without a data shape"
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert not deprecations, "sources 2-4 must be skipped when data_shape is None"
+
+    def test_resolve_falls_through_to_conventional(self):
+        """With no explicit/stored/CF coords, resolve reaches the conventional source."""
+        xc, yc = _grid_2d(200.0), _grid_2d(45.0)
+        fake = _FakeNC({"xc": xc, "yc": yc})
+        with pytest.warns(DeprecationWarning, match="model-specific"):
+            pair = CurvilinearCoordResolver(fake).resolve(None)
+        assert pair is not None, "xc/yc must resolve via the conventional source"
+        assert pair[0] is xc, "x must be xc"
+        assert pair[1] is yc, "y must be yc"
+
+    def test_from_explicit_none_returns_none(self):
+        """A ``None`` explicit spec yields ``None`` without raising."""
+        assert CurvilinearCoordResolver(_FakeNC({}))._from_explicit(None) is None, (
+            "None coords must yield None"
+        )
+
+    @pytest.mark.parametrize("coords", [("only-one",), ("a", "b", "c"), "ab", 5])
+    def test_from_explicit_non_length_2_raises(self, coords):
+        """A spec that is not a length-2 tuple/list raises ``ValueError``.
+
+        Args:
+            coords: A malformed ``coords=`` value (wrong length or wrong type).
+        """
+        with pytest.raises(ValueError, match="length-2 sequence") as exc:
+            CurvilinearCoordResolver(_FakeNC({}))._from_explicit(coords)
+        assert "length-2 sequence" in str(exc.value), f"unexpected message: {exc.value}"
+
+    def test_from_explicit_two_names_resolves(self):
+        """Two coord-variable names are looked up and validated into a pair."""
+        lon, lat = _cols_1d(), _rows_1d()
+        resolver = CurvilinearCoordResolver(_FakeNC({"lon": lon, "lat": lat}))
+        pair = resolver._from_explicit(("lon", "lat"))
+        assert pair is not None, "named coords must resolve"
+        assert pair[0] is lon, "x must be the looked-up lon array"
+        assert pair[1] is lat, "y must be the looked-up lat array"
+
+    def test_from_explicit_two_arrays_resolves(self):
+        """Two array-likes are passed through and validated into a pair."""
+        x2d, y2d = _grid_2d(1.0), _grid_2d(2.0)
+        pair = CurvilinearCoordResolver(_FakeNC({}))._from_explicit((x2d, y2d))
+        assert pair is not None, "array coords must resolve"
+        assert pair[0] is x2d, "x array passes through unchanged"
+        assert pair[1] is y2d, "y array passes through unchanged"
+
+    def test_from_explicit_shape_mismatch_warns_and_returns_none(self, caplog):
+        """A shape-mismatching explicit pair returns ``None`` and logs a warning."""
+        with caplog.at_level(logging.WARNING, logger="pyramids.netcdf._plot"):
+            result = CurvilinearCoordResolver(_FakeNC({}))._from_explicit(
+                (_bad_2d(), _bad_2d())
+            )
+        assert result is None, "a shape-mismatching explicit pair must be rejected"
+        warns = [r for r in caplog.records if r.name == "pyramids.netcdf._plot"]
+        assert warns, "a mismatch warning must be logged on the _plot logger"
+        assert "don't match" in warns[0].getMessage(), (
+            f"unexpected message: {warns[0].getMessage()}"
+        )
+
+    def test_from_stored_present_and_matching(self):
+        """Stored ``_curvilinear_coords`` that match the slice shape resolve to a pair."""
+        x2d, y2d = _grid_2d(1.0), _grid_2d(2.0)
+        resolver = CurvilinearCoordResolver(_FakeNC({}, curvilinear_coords=(x2d, y2d)))
+        pair = resolver._from_stored()
+        assert pair is not None, "stored matching coords must resolve"
+        assert np.array_equal(pair[0], x2d), "x must be the stored array"
+        assert np.array_equal(pair[1], y2d), "y must be the stored array"
+
+    def test_from_stored_present_but_mismatching(self):
+        """Stored coords that do not match the slice shape yield ``None``."""
+        resolver = CurvilinearCoordResolver(
+            _FakeNC({}, curvilinear_coords=(_bad_2d(), _bad_2d()))
+        )
+        assert resolver._from_stored() is None, (
+            "shape-mismatching stored coords must be rejected"
+        )
+
+    def test_from_stored_absent(self):
+        """No ``_curvilinear_coords`` attribute yields ``None``."""
+        assert CurvilinearCoordResolver(_FakeNC({}))._from_stored() is None, (
+            "absent stored coords must yield None"
+        )
+
+    def test_from_cf_resolves_via_cf_candidates(self):
+        """A CF ``coordinates`` attribute resolves through CFCoordinateCandidates."""
+        lon, lat = _cols_1d(), _rows_1d()
+        fake = _FakeNC(
+            {"lon": lon, "lat": lat}, variable_attrs={"coordinates": "lon lat"}
+        )
+        pair = CurvilinearCoordResolver(fake)._from_cf()
+        assert pair is not None, "a CF coordinates attr must resolve"
+        assert pair[0] is lon, "x must be the CF lon candidate"
+        assert pair[1] is lat, "y must be the CF lat candidate"
+
+    def test_from_cf_no_valid_pair_returns_none(self):
+        """A CF attribute whose vars don't form a valid pair yields ``None``."""
+        fake = _FakeNC({"bad": _bad_2d()}, variable_attrs={"coordinates": "bad"})
+        assert CurvilinearCoordResolver(fake)._from_cf() is None, (
+            "an unmatchable CF attr must yield None"
+        )
+
+    def test_from_conventional_matching_pair_warns(self):
+        """A matching conventional pair resolves and emits the deprecation warning."""
+        xc, yc = _grid_2d(200.0), _grid_2d(45.0)
+        resolver = CurvilinearCoordResolver(_FakeNC({"xc": xc, "yc": yc}))
+        with pytest.warns(DeprecationWarning, match="model-specific"):
+            pair = resolver._from_conventional()
+        assert pair is not None, "a matching conventional pair must resolve"
+        assert pair[0] is xc, "x must be xc"
+        assert pair[1] is yc, "y must be yc"
+
+    def test_from_conventional_require_2d_gate_rejects_1d(self):
+        """A generic ``require_2d`` pair (xc/yc) with 1-D arrays is rejected (no warning)."""
+        fake = _FakeNC({"xc": _cols_1d(), "yc": _rows_1d()})
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = CurvilinearCoordResolver(fake)._from_conventional()
+        assert result is None, "1-D xc/yc must fail the require_2d gate"
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert not deprecations, "a rejected pair must not emit the deprecation warning"
+
+    def test_from_conventional_present_wrong_shape_logs_debug(self, caplog):
+        """A present-but-wrong-shape conventional pair logs a debug skip and returns ``None``."""
+        fake = _FakeNC({"XLONG": _bad_2d(), "XLAT": _bad_2d()})
+        with caplog.at_level(logging.DEBUG, logger="pyramids.netcdf._plot"):
+            result = CurvilinearCoordResolver(fake)._from_conventional()
+        assert result is None, "a wrong-shape conventional pair must not resolve"
+        debugs = [
+            r
+            for r in caplog.records
+            if "don't match the data slice shape" in r.getMessage()
+        ]
+        assert debugs, (
+            "a debug skip message must be logged for the present-but-wrong-shape pair"
+        )
+
+    def test_from_conventional_absent_names_returns_none(self):
+        """No conventional names present yields ``None``."""
+        assert (
+            CurvilinearCoordResolver(
+                _FakeNC({"other": _grid_2d()})
+            )._from_conventional()
+            is None
+        ), "absent conventional names must yield None"
+
+    def test_conventional_pair_arrays_unreadable_variable(self):
+        """A conventional name that reads back ``None`` is treated as unusable."""
+        fake = _FakeNC({"XLONG": _grid_2d(1.0), "XLAT": None})
+        result = CurvilinearCoordResolver(fake)._conventional_pair_arrays(
+            "XLONG", "XLAT", False
+        )
+        assert result is None, "an unreadable variable must yield None"
+
+    @pytest.mark.parametrize(
+        "x_arr, y_arr, expected_pair",
+        [
+            (_grid_2d(1.0), _grid_2d(2.0), True),
+            (_bad_2d(), _bad_2d(), False),
+            (_cols_1d(), _rows_1d(), True),
+        ],
+    )
+    def test_validated(self, x_arr, y_arr, expected_pair):
+        """``_validated`` returns the pair when shapes line up with the slice, else ``None``.
+
+        Args:
+            x_arr: Candidate x array.
+            y_arr: Candidate y array.
+            expected_pair: Whether the arrays should validate against ``(5, 6)``.
+        """
+        result = CurvilinearCoordResolver(_FakeNC({}))._validated(x_arr, y_arr)
+        assert (result is not None) is expected_pair, (
+            f"unexpected _validated result: {result}"
+        )
+
+    def test_validated_none_data_shape_returns_none(self):
+        """With ``data_shape=None`` no pair can be validated."""
+        resolver = CurvilinearCoordResolver(_FakeNC({}, shape=()))
+        assert resolver._validated(_grid_2d(), _grid_2d()) is None, (
+            "None data_shape must reject any pair"
+        )
+
+    def test_coerce_name_lookup_success(self):
+        """A known variable name is resolved to its array."""
+        lon = _cols_1d()
+        resolver = CurvilinearCoordResolver(_FakeNC({"lon": lon}))
+        assert resolver._coerce("lon", "x") is lon, (
+            "a known name must resolve to its array"
+        )
+
+    def test_coerce_unknown_name_raises(self):
+        """An unknown coord name raises ``ValueError``."""
+        with pytest.raises(ValueError, match="is not a variable") as exc:
+            CurvilinearCoordResolver(_FakeNC({"lon": _cols_1d()}))._coerce("nope", "x")
+        assert "nope" in str(exc.value), f"error must echo the bad name: {exc.value}"
+
+    def test_coerce_unreadable_name_raises(self):
+        """A name present but reading back ``None`` raises ``ValueError``."""
+        with pytest.raises(ValueError, match="could not be read"):
+            CurvilinearCoordResolver(_FakeNC({"lon": None}))._coerce("lon", "y")
+
+    def test_coerce_array_like_passthrough(self):
+        """An array-like spec is converted via ``numpy.asarray``."""
+        result = CurvilinearCoordResolver(_FakeNC({}))._coerce(
+            [[1.0, 2.0], [3.0, 4.0]], "x"
+        )
+        assert isinstance(result, np.ndarray), (
+            f"expected ndarray, got {type(result).__name__}"
+        )
+        assert result.shape == (2, 2), f"expected (2, 2), got {result.shape}"

--- a/tests/netcdf/plot/test_curvilinear_coord_resolver.py
+++ b/tests/netcdf/plot/test_curvilinear_coord_resolver.py
@@ -183,9 +183,9 @@ class TestCurvilinearCoordResolver:
     def test_resolve_falls_through_to_conventional(self):
         """With no explicit/stored/CF coords, resolve reaches the conventional source."""
         xc, yc = _grid_2d(200.0), _grid_2d(45.0)
-        fake = _FakeNC({"xc": xc, "yc": yc})
+        resolver = CurvilinearCoordResolver(_FakeNC({"xc": xc, "yc": yc}))
         with pytest.warns(DeprecationWarning, match="model-specific"):
-            pair = CurvilinearCoordResolver(fake).resolve(None)
+            pair = resolver.resolve(None)
         assert pair is not None, "xc/yc must resolve via the conventional source"
         assert pair[0] is xc, "x must be xc"
         assert pair[1] is yc, "y must be yc"
@@ -203,8 +203,9 @@ class TestCurvilinearCoordResolver:
         Args:
             coords: A malformed ``coords=`` value (wrong length or wrong type).
         """
+        resolver = CurvilinearCoordResolver(_FakeNC({}))
         with pytest.raises(ValueError, match="length-2 sequence") as exc:
-            CurvilinearCoordResolver(_FakeNC({}))._from_explicit(coords)
+            resolver._from_explicit(coords)
         assert "length-2 sequence" in str(exc.value), f"unexpected message: {exc.value}"
 
     def test_from_explicit_two_names_resolves(self):
@@ -369,14 +370,16 @@ class TestCurvilinearCoordResolver:
 
     def test_coerce_unknown_name_raises(self):
         """An unknown coord name raises ``ValueError``."""
+        resolver = CurvilinearCoordResolver(_FakeNC({"lon": _cols_1d()}))
         with pytest.raises(ValueError, match="is not a variable") as exc:
-            CurvilinearCoordResolver(_FakeNC({"lon": _cols_1d()}))._coerce("nope", "x")
+            resolver._coerce("nope", "x")
         assert "nope" in str(exc.value), f"error must echo the bad name: {exc.value}"
 
     def test_coerce_unreadable_name_raises(self):
         """A name present but reading back ``None`` raises ``ValueError``."""
+        resolver = CurvilinearCoordResolver(_FakeNC({"lon": None}))
         with pytest.raises(ValueError, match="could not be read"):
-            CurvilinearCoordResolver(_FakeNC({"lon": None}))._coerce("lon", "y")
+            resolver._coerce("lon", "y")
 
     def test_coerce_array_like_passthrough(self):
         """An array-like spec is converted via ``numpy.asarray``."""
@@ -431,10 +434,12 @@ class TestCurvilinearCoordResolver:
             resolves + warns, proving the loop does not stop at the debug-skip.
         """
         xc, yc = _grid_2d(200.0), _grid_2d(45.0)
-        fake = _FakeNC({"XLONG": _bad_2d(), "XLAT": _bad_2d(), "xc": xc, "yc": yc})
+        resolver = CurvilinearCoordResolver(
+            _FakeNC({"XLONG": _bad_2d(), "XLAT": _bad_2d(), "xc": xc, "yc": yc})
+        )
         with caplog.at_level(logging.DEBUG, logger="pyramids.netcdf._plot"):
             with pytest.warns(DeprecationWarning, match="model-specific"):
-                pair = CurvilinearCoordResolver(fake)._from_conventional()
+                pair = resolver._from_conventional()
         assert pair is not None, "the valid later pair must resolve"
         assert pair[0] is xc, "x must be xc from the later pair"
         assert pair[1] is yc, "y must be yc from the later pair"

--- a/tests/netcdf/plot/test_curvilinear_coord_resolver.py
+++ b/tests/netcdf/plot/test_curvilinear_coord_resolver.py
@@ -387,3 +387,62 @@ class TestCurvilinearCoordResolver:
             f"expected ndarray, got {type(result).__name__}"
         )
         assert result.shape == (2, 2), f"expected (2, 2), got {result.shape}"
+
+    def test_resolve_stored_wins_over_cf_and_conventional(self):
+        """Stored crop coords (source 2) take precedence over CF (3) and conventional (4).
+
+        Test scenario:
+            The slice has stored coords AND a resolvable CF ``coordinates`` attr AND
+            conventional xc/yc all present; the stored pair wins and no DeprecationWarning
+            fires, proving sources 3-4 are not reached.
+        """
+        stored_x, stored_y = _grid_2d(1.0), _grid_2d(2.0)
+        fake = _FakeNC(
+            {
+                "xc": _grid_2d(200.0),
+                "yc": _grid_2d(45.0),
+                "lon": _cols_1d(),
+                "lat": _rows_1d(),
+            },
+            variable_attrs={"coordinates": "lon lat"},
+            curvilinear_coords=(stored_x, stored_y),
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            pair = CurvilinearCoordResolver(fake).resolve(None)
+        assert pair is not None, "stored coords must resolve"
+        assert np.array_equal(pair[0], stored_x), (
+            "x must be the stored array (source 2 wins)"
+        )
+        assert np.array_equal(pair[1], stored_y), (
+            "y must be the stored array (source 2 wins)"
+        )
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert not deprecations, (
+            "conventional source must not run when stored coords win"
+        )
+
+    def test_from_conventional_skips_wrong_shape_then_matches_later_pair(self, caplog):
+        """A present-but-wrong-shape early pair is skipped (debug) and a valid later pair resolves.
+
+        Test scenario:
+            XLONG/XLAT (first name-pair) are present but wrong-shape -> one debug skip; xc/yc
+            (last name-pair) are present and valid -> the loop continues past the skip and
+            resolves + warns, proving the loop does not stop at the debug-skip.
+        """
+        xc, yc = _grid_2d(200.0), _grid_2d(45.0)
+        fake = _FakeNC({"XLONG": _bad_2d(), "XLAT": _bad_2d(), "xc": xc, "yc": yc})
+        with caplog.at_level(logging.DEBUG, logger="pyramids.netcdf._plot"):
+            with pytest.warns(DeprecationWarning, match="model-specific"):
+                pair = CurvilinearCoordResolver(fake)._from_conventional()
+        assert pair is not None, "the valid later pair must resolve"
+        assert pair[0] is xc, "x must be xc from the later pair"
+        assert pair[1] is yc, "y must be yc from the later pair"
+        debugs = [
+            r
+            for r in caplog.records
+            if "don't match the data slice shape" in r.getMessage()
+        ]
+        assert debugs, (
+            "the early wrong-shape pair must log a debug skip before the later pair resolves"
+        )

--- a/tests/netcdf/plot/test_curvilinear_coord_resolver.py
+++ b/tests/netcdf/plot/test_curvilinear_coord_resolver.py
@@ -1,0 +1,87 @@
+"""Unit tests for curvilinear coordinate resolution in ``NetCDFPlot``.
+
+Drives ``_resolve_curvilinear_coords`` in isolation with a duck-typed fake NetCDF slice — no
+cleopatra, no sample files — so these run in the main (``not plot``) suite. The end-to-end
+render path is covered by ``tests/netcdf/plot/test_plot_coords.py`` and the real-sample
+curvilinear crops by ``tests/netcdf/samples/test_curvilinear_crop.py``.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+
+from pyramids.netcdf._plot import NetCDFPlot
+
+_SHAPE = (5, 6)  # (rows, cols)
+
+
+class _FakeNC:
+    """Minimal duck-typed NetCDF slice exposing only what ``_resolve_curvilinear_coords`` reads."""
+
+    def __init__(self, arrays, shape=_SHAPE, variable_attrs=None, curvilinear_coords=None):
+        """Store the name -> coord-array map plus the slice shape and optional CF / crop state."""
+        self._arrays = arrays
+        self.shape = shape
+        self._parent_nc = None
+        self._variable_attrs = variable_attrs if variable_attrs is not None else {}
+        self._source_var_name = "v"
+        if curvilinear_coords is not None:
+            self._curvilinear_coords = curvilinear_coords
+
+    @property
+    def variable_names(self):
+        """Return the declared variable names."""
+        return list(self._arrays)
+
+    def _read_variable(self, name):
+        """Return the array for ``name`` (``None`` if unreadable)."""
+        return self._arrays.get(name)
+
+
+def _mimic_build_render_kwargs(engine, nc):
+    """Stand in for ``NetCDFPlot._build_render_kwargs`` — the direct caller of the resolver."""
+    return engine._resolve_curvilinear_coords(nc, coords=None)
+
+
+def _mimic_run(engine, nc):
+    """Stand in for ``NetCDFPlot.run`` — the frame the deprecation warning must be attributed to."""
+    return _mimic_build_render_kwargs(engine, nc)
+
+
+class TestConventionalNamesWarningFrame:
+    """Characterization of the model-specific-names ``DeprecationWarning`` attribution frame."""
+
+    def test_warning_attributed_two_frames_above_resolver(self):
+        """The deprecation warning is attributed to the caller two real frames above the resolver.
+
+        Test scenario:
+            RASM-style ``xc``/``yc`` auto-detection fires the model-specific-names
+            ``DeprecationWarning``. Its ``stacklevel`` must attribute it to ``_mimic_run``
+            (mirroring the production ``run`` frame, two frames above
+            ``_resolve_curvilinear_coords``), so a refactor that moves ``warn()`` across
+            function boundaries without updating ``stacklevel`` is caught by this test.
+        """
+        fake = _FakeNC({"xc": np.full(_SHAPE, 200.0), "yc": np.full(_SHAPE, 45.0)})
+        engine = NetCDFPlot(fake)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            pair = _mimic_run(engine, fake)
+        assert pair is not None, "xc/yc must resolve via the conventional-names source"
+        depr = [
+            w
+            for w in caught
+            if issubclass(w.category, DeprecationWarning) and "model-specific" in str(w.message)
+        ]
+        assert depr, "the conventional-names source must emit a DeprecationWarning"
+        rec = depr[0]
+        assert rec.filename.endswith("test_curvilinear_coord_resolver.py"), (
+            f"warning attributed to {rec.filename}, expected this test module (stacklevel drift)"
+        )
+        src_line = Path(rec.filename).read_text(encoding="utf-8").splitlines()[rec.lineno - 1]
+        assert "_mimic_build_render_kwargs" in src_line, (
+            f"stacklevel drift: warning attributed to {rec.filename}:{rec.lineno} -> "
+            f"{src_line.strip()!r}; expected the `_mimic_run` frame two frames above the resolver"
+        )

--- a/tests/netcdf/plot/test_plot_coords.py
+++ b/tests/netcdf/plot/test_plot_coords.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 import types
+import warnings
+from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
@@ -305,6 +307,39 @@ class TestCurvilinearCoords:
         # The two arrays live in disjoint ranges, so a swap would fail here.
         np.testing.assert_allclose(cleo.coords[0], x_2d)
         np.testing.assert_allclose(cleo.coords[1], y_2d)
+
+    def test_conventional_deprecation_warning_attributed_to_run_frame(self):
+        """The model-specific-names DeprecationWarning lands on run()'s _build_render_kwargs call.
+
+        Test scenario:
+            A real ``nc.plot()`` on an xc/yc grid fires the deprecation warning; via its
+            ``stacklevel`` it must be attributed to the ``run`` frame's
+            ``self._build_render_kwargs(...)`` call site in ``_plot.py``, pinning the real
+            production chain (the mimic-frame characterization test in
+            ``test_curvilinear_coord_resolver.py`` guards only the resolver-internal depth).
+        """
+        nc = _make_curvilinear_nc(rows=5, cols=6, x_name="xc", y_name="yc")[0]
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            nc.plot(variable="CANWAT")
+        depr = [
+            w
+            for w in caught
+            if issubclass(w.category, DeprecationWarning)
+            and "model-specific" in str(w.message)
+        ]
+        assert depr, "the conventional-names path must emit a DeprecationWarning"
+        rec = depr[0]
+        assert rec.filename.endswith("_plot.py"), (
+            f"warning not attributed to _plot.py: {rec.filename}"
+        )
+        src_line = (
+            Path(rec.filename).read_text(encoding="utf-8").splitlines()[rec.lineno - 1]
+        )
+        assert "_build_render_kwargs" in src_line, (
+            f"production stacklevel drift: warning at {rec.filename}:{rec.lineno} -> "
+            f"{src_line.strip()!r}; expected run()'s _build_render_kwargs call site"
+        )
 
     def test_1d_xc_yc_not_auto_detected(self):
         """1-D `xc`/`yc` (projected axes) are not treated as curvilinear (#633).

--- a/tests/netcdf/plot/test_plot_coords.py
+++ b/tests/netcdf/plot/test_plot_coords.py
@@ -55,7 +55,7 @@ class TestNetCDFPlotCoordAxes:
             On this in-memory NetCDF the only variable name is the
             data variable itself. Passing the same name on both axes
             exercises the variable-name lookup branch of
-            ``_coerce_coord_spec`` without needing a separate coord
+            ``CurvilinearCoordResolver._coerce`` without needing a separate coord
             variable; shape validation falls through to the
             geotransform-derived extent because the data variable's
             shape does not match the slice's 2-D shape.
@@ -85,7 +85,7 @@ class TestNetCDFPlotCoordAxesExtra:
 
         Test scenario:
             Pass the data variable's own name on both axes. The lookup
-            via ``_coerce_coord_spec`` succeeds for both; shape
+            via ``CurvilinearCoordResolver._coerce`` succeeds for both; shape
             validation then falls back through the auto-detection
             ladder, and the final render returns an ArrayGlyph.
         """


### PR DESCRIPTION
# Description

Data-driven refactor of the largest remaining SonarCloud cognitive-complexity offender in the NetCDF plot engine:
`NetCDFPlot._resolve_curvilinear_coords` (`src/pyramids/netcdf/_plot.py`) had cognitive complexity **51** (rule
`python:S3776`, threshold 15). It resolves the curvilinear `(x, y)` coordinate arrays for a rendered slice via a
four-strategy priority ladder (explicit `coords=` → stored crop coords → CF `coordinates` attribute → conventional
model name-pairs; first shape-valid pair wins, else `None` → geotransform-extent fallback).

The method is decomposed by following the data — the `(nc, parent, data_shape)` context is one clump read by every
strategy, and every strategy ends with the same shape validation:

- **Value object** — the ladder + its context are lifted into a new module-level `CurvilinearCoordResolver`
  (`resolve`, `_from_explicit` / `_from_stored` / `_from_cf` / `_from_conventional`, `_conventional_pair_arrays`,
  `_validated`, `_coerce`), placed next to `CFCoordinateCandidates`. `_resolve_curvilinear_coords` collapses to a
  one-line facade `return CurvilinearCoordResolver(nc).resolve(coords)` (keeping its docstring + 3 runnable
  doctests). Every method is now well under the S3776 threshold.
- **Reuse, not reinvention** — `_coord_match` stays the shape-validation backbone, and the CF source delegates to
  `_cf_coordinates_pair` (made a `@staticmethod`) which orchestrates `CFCoordinateCandidates`; no pairing logic is
  duplicated.
- **Consistency rename** — the ARC-152 value object `_CFCoordinateCandidates` is renamed `CFCoordinateCandidates`
  (drop the leading underscore) to match the new resolver. Both stay internal to the private `_plot.py`.

Behaviour is preserved exactly: source priority 1→2→3→4, the `data_shape`-is-`None` guard, the length-2 `coords=`
`ValueError`, the `require_2d` ndim gate, both the explicit-`coords=` shape-mismatch `logger.warning` and the
conventional-pair skip `logger.debug` on the `pyramids.netcdf._plot` logger, and the `None`-return fallback. The
model-specific-names `DeprecationWarning` moved two frames deeper into the resolver, so its `stacklevel` was bumped
`3 → 5` to keep attributing it to the caller (`run`'s `_build_render_kwargs` call site) — pinned by both a
mimic-frame characterization test and a real-`nc.plot()` test. No new dependencies.

# Issues
- Fixes #1002

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Refactor — non-breaking, no public API change (all touched symbols are private); none of the boxes above fit exactly.

# How Has This Been Tested?

- New unit tests: `tests/netcdf/plot/test_curvilinear_coord_resolver.py` — a `stacklevel` characterization test
  (mimic-frame wrappers + a duck-typed `_FakeNC`, no cleopatra/sample files) plus `TestCurvilinearCoordResolver`
  branch-covering the four sources and every helper (source priority, the `data_shape`-`None` short-circuit, the
  `require_2d` gate, the present-but-wrong-shape debug path, `_validated` / `_coerce` edge cases).
- New `tests/netcdf/plot/test_plot_coords.py` case pinning the real production `DeprecationWarning` frame to
  `run`'s `_build_render_kwargs` call site.
- Full worktree suite green: `pytest -m "not plot"` → **8315 passed, 52 skipped**; plot suite → **66 passed**.
- `ruff` + `mypy` clean; the `_plot.py` doctests pass.
- Two rounds of adversarial review (`/review-rounds`) — all findings resolved.

- [x] Test A — resolver branch-coverage + stacklevel characterization unit tests
- [x] Test B — plot / curvilinear end-to-end render + real-chain stacklevel test

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
