### PR TITLE
test: make tracemalloc memory bounds build-agnostic (fix wheel-core failure)

### DIFF
--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -2,7 +2,43 @@
 
 from __future__ import annotations
 
+import tracemalloc
+from collections.abc import Iterator
+from contextlib import contextmanager
+
 from pyramids.dataset import Dataset
+
+
+@contextmanager
+def traced_peak() -> Iterator[list[int]]:
+    """Trace Python-heap allocations in the block and capture their peak.
+
+    Always stops tracing -- even if the block raises -- so a failing measured
+    operation cannot leave `tracemalloc` running and pollute a later test's baseline.
+
+    Yields:
+        list[int]: A one-element list; once the block exits it holds the traced peak
+        (in bytes) of the allocations made inside the block.
+
+    Examples:
+        - Measure the peak of a block:
+
+          ```python
+          >>> import numpy as np
+          >>> with traced_peak() as peak:
+          ...     buf = np.ones(10_000, dtype="int64")
+          >>> peak[0] > 0
+          True
+
+          ```
+    """
+    tracemalloc.start()
+    out: list[int] = []
+    try:
+        yield out
+    finally:
+        out.append(tracemalloc.get_traced_memory()[1])
+        tracemalloc.stop()
 
 
 def write_raster(path, arr, top_left, *, epsg=4326, cell_size=1.0, nodata=-9999.0):

--- a/tests/dataset/io/test_stream_transform.py
+++ b/tests/dataset/io/test_stream_transform.py
@@ -336,7 +336,7 @@ class TestStreamReduce:
         _, stripped_peak = tracemalloc.get_traced_memory()
         tracemalloc.stop()
 
-        assert stripped_result == whole_result, "stripped reduction diverged from the whole"
+        assert stripped_result == whole_result, "stripped reduction diverged"
         assert stripped_peak < whole_peak, (
             f"stream_reduce peaked at {stripped_peak / 1e6:.1f} MB, not below the whole-array "
             f"pass's {whole_peak / 1e6:.1f} MB — the read was not stripped"

--- a/tests/dataset/io/test_stream_transform.py
+++ b/tests/dataset/io/test_stream_transform.py
@@ -481,14 +481,24 @@ class TestStreamedConsumers:
             no_data_value=-9999.0,
             path=str(src_path),
         ).close()
+        # Whole-band baseline: read the full band and count the domain at once.
+        tracemalloc.start()
+        whole = Dataset.read_file(str(src_path)).read_array()
+        whole_count = int((whole != -9999.0).sum())
+        _, whole_peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        del whole
+
+        # Stripped count.
         ds = Dataset.read_file(str(src_path))
-        dense_bytes = rows * cols * 4
         tracemalloc.start()
         count = ds.count_domain_cells()
-        _, peak = tracemalloc.get_traced_memory()
+        _, stripped_peak = tracemalloc.get_traced_memory()
         tracemalloc.stop()
+
         assert count == rows * cols - 2000 * 250, f"wrong domain count {count}"
-        assert peak < dense_bytes // 4, (
-            f"count_domain_cells peaked at {peak / 1e6:.1f} MB; a whole-band pass "
-            f"would need {dense_bytes / 1e6:.1f} MB — the read was not stripped"
+        assert count == whole_count, "stripped count diverged from the whole-band count"
+        assert stripped_peak < whole_peak, (
+            f"count_domain_cells peaked at {stripped_peak / 1e6:.1f} MB, not below the "
+            f"whole-band pass's {whole_peak / 1e6:.1f} MB — the read was not stripped"
         )

--- a/tests/dataset/io/test_stream_transform.py
+++ b/tests/dataset/io/test_stream_transform.py
@@ -341,7 +341,7 @@ class TestStreamReduce:
         assert stripped_result == whole_result, "stripped reduction diverged"
         assert stripped_peak < whole_peak, (
             f"stream_reduce peaked at {stripped_peak / 1e6:.1f} MB, not below the whole-array "
-            f"pass's {whole_peak / 1e6:.1f} MB — the read was not stripped"
+            f"pass's {whole_peak / 1e6:.1f} MB — it did not stay under a full materialisation"
         )
 
 
@@ -502,5 +502,5 @@ class TestStreamedConsumers:
         assert count == rows * cols - 2000 * 250, f"wrong domain count {count}"
         assert stripped_peak < whole_peak, (
             f"count_domain_cells peaked at {stripped_peak / 1e6:.1f} MB, not below the "
-            f"whole-band pass's {whole_peak / 1e6:.1f} MB — the read was not stripped"
+            f"whole-band pass's {whole_peak / 1e6:.1f} MB — it did not stay under a full materialisation"
         )

--- a/tests/dataset/io/test_stream_transform.py
+++ b/tests/dataset/io/test_stream_transform.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 from hpc.indexing import get_pixels2
 
+from pyramids.base._domain import inside_domain
 from pyramids.dataset import Dataset
 from pyramids.dataset.engines.io import IO
 
@@ -486,7 +487,9 @@ class TestStreamedConsumers:
         # Whole-band baseline: read the full band and count the domain at once.
         tracemalloc.start()
         whole = Dataset.read_file(str(src_path)).read_array()
-        whole_count = int((whole != -9999.0).sum())
+        # Mirror count_domain_cells' own domain definition (np.isclose / NaN-aware)
+        # so the baseline and the code under test cannot diverge on tolerance or NaN.
+        whole_count = int(inside_domain(whole, -9999.0).sum())
         _, whole_peak = tracemalloc.get_traced_memory()
         tracemalloc.stop()
         del whole

--- a/tests/dataset/io/test_stream_transform.py
+++ b/tests/dataset/io/test_stream_transform.py
@@ -319,12 +319,14 @@ class TestStreamReduce:
         ).close()
 
         def domain_sum(acc, strip, _w):
-            return acc + int(strip.sum())
+            # int64 accumulation on both sides so the == assertion below is
+            # independent of the platform's default int16.sum() accumulator width.
+            return acc + int(strip.sum(dtype="int64"))
 
         # Whole-array baseline: read the full array and reduce it at once.
         tracemalloc.start()
         whole = Dataset.read_file(str(src_path)).read_array()
-        whole_result = int(whole.sum())
+        whole_result = int(whole.sum(dtype="int64"))
         _, whole_peak = tracemalloc.get_traced_memory()
         tracemalloc.stop()
         del whole

--- a/tests/dataset/io/test_stream_transform.py
+++ b/tests/dataset/io/test_stream_transform.py
@@ -10,6 +10,7 @@ from hpc.indexing import get_pixels2
 
 from pyramids.dataset import Dataset
 from pyramids.dataset.engines.io import IO
+from tests._helpers import traced_peak
 
 pytestmark = pytest.mark.core
 
@@ -324,19 +325,17 @@ class TestStreamReduce:
             return acc + int(strip.sum(dtype="int64"))
 
         # Whole-array baseline: read the full array and reduce it at once.
-        tracemalloc.start()
-        whole = Dataset.read_file(str(src_path)).read_array()
-        whole_result = int(whole.sum(dtype="int64"))
-        _, whole_peak = tracemalloc.get_traced_memory()
-        tracemalloc.stop()
+        with traced_peak() as wp:
+            whole = Dataset.read_file(str(src_path)).read_array()
+            whole_result = int(whole.sum(dtype="int64"))
+        whole_peak = wp[0]
         del whole
 
         # Stripped reduction.
-        ds = Dataset.read_file(str(src_path))
-        tracemalloc.start()
-        stripped_result = ds.io.stream_reduce(value_sum, 0, strip_rows=64)
-        _, stripped_peak = tracemalloc.get_traced_memory()
-        tracemalloc.stop()
+        with traced_peak() as sp:
+            ds = Dataset.read_file(str(src_path))
+            stripped_result = ds.io.stream_reduce(value_sum, 0, strip_rows=64)
+        stripped_peak = sp[0]
 
         assert stripped_result == whole_result, "stripped reduction diverged"
         assert stripped_peak < whole_peak, (
@@ -486,18 +485,16 @@ class TestStreamedConsumers:
         # Whole-band baseline: materialise the full band at once (the non-stripped
         # upper bound). The exact-count assertion below already pins correctness, so
         # the baseline only needs to establish the whole-band memory peak.
-        tracemalloc.start()
-        whole = Dataset.read_file(str(src_path)).read_array()
-        _, whole_peak = tracemalloc.get_traced_memory()
-        tracemalloc.stop()
+        with traced_peak() as wp:
+            whole = Dataset.read_file(str(src_path)).read_array()
+        whole_peak = wp[0]
         del whole
 
         # Stripped count.
-        ds = Dataset.read_file(str(src_path))
-        tracemalloc.start()
-        count = ds.count_domain_cells()
-        _, stripped_peak = tracemalloc.get_traced_memory()
-        tracemalloc.stop()
+        with traced_peak() as sp:
+            ds = Dataset.read_file(str(src_path))
+            count = ds.count_domain_cells()
+        stripped_peak = sp[0]
 
         assert count == rows * cols - 2000 * 250, f"wrong domain count {count}"
         assert stripped_peak < whole_peak, (

--- a/tests/dataset/io/test_stream_transform.py
+++ b/tests/dataset/io/test_stream_transform.py
@@ -298,11 +298,15 @@ class TestStreamReduce:
         assert len(windows) == 3, f"expected 3 strips over 7 rows, got {len(windows)}"
 
     def test_peak_memory_is_bounded_by_the_strip(self, tmp_path):
-        """Reducing a large disk raster peaks near one strip, far below the whole array.
+        """Reducing a disk raster peaks below a whole-array pass, proving the strip read.
 
         Test scenario:
-            Count the domain of a 1000x1000 raster with 64-row strips; the traced peak
-            must be a fraction of the dense-array size.
+            Count the domain of a 1000x1000 raster with 64-row strips, and compare the traced
+            Python peak against a whole-array pass (read the whole array and reduce at once) in
+            the same process. The stripped peak must stay below the whole-array peak. This is a
+            build-agnostic check on purpose: the absolute figures depend on the GDAL build
+            (tracemalloc only sees the Python heap, not GDAL's C buffers), but the same
+            reduction done all-at-once is always an upper bound on the stripped version.
         """
         rows = cols = 1000
         src_path = tmp_path / "big.tif"
@@ -313,17 +317,29 @@ class TestStreamReduce:
             epsg=4326,
             path=str(src_path),
         ).close()
-        ds = Dataset.read_file(str(src_path))
-        dense_bytes = rows * cols * 2
+
+        def domain_sum(acc, strip, _w):
+            return acc + int(strip.sum())
+
+        # Whole-array baseline: read the full array and reduce it at once.
         tracemalloc.start()
-        ds.io.stream_reduce(
-            lambda acc, strip, _w: acc + int(strip.sum()), 0, strip_rows=64
-        )
-        _, peak = tracemalloc.get_traced_memory()
+        whole = Dataset.read_file(str(src_path)).read_array()
+        whole_result = int(whole.sum())
+        _, whole_peak = tracemalloc.get_traced_memory()
         tracemalloc.stop()
-        assert peak < dense_bytes // 4, (
-            f"stream_reduce peaked at {peak / 1e6:.1f} MB; a whole-array pass would "
-            f"need {dense_bytes / 1e6:.1f} MB — the read was not stripped"
+        del whole
+
+        # Stripped reduction.
+        ds = Dataset.read_file(str(src_path))
+        tracemalloc.start()
+        stripped_result = ds.io.stream_reduce(domain_sum, 0, strip_rows=64)
+        _, stripped_peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+
+        assert stripped_result == whole_result, "stripped reduction diverged from the whole"
+        assert stripped_peak < whole_peak, (
+            f"stream_reduce peaked at {stripped_peak / 1e6:.1f} MB, not below the whole-array "
+            f"pass's {whole_peak / 1e6:.1f} MB — the read was not stripped"
         )
 
 

--- a/tests/dataset/io/test_stream_transform.py
+++ b/tests/dataset/io/test_stream_transform.py
@@ -301,9 +301,9 @@ class TestStreamReduce:
         """Reducing a disk raster peaks below a whole-array pass, proving the strip read.
 
         Test scenario:
-            Count the domain of a 1000x1000 raster with 64-row strips, and compare the traced
-            Python peak against a whole-array pass (read the whole array and reduce at once) in
-            the same process. The stripped peak must stay below the whole-array peak. This is a
+            Sum a 1000x1000 raster in 64-row strips, and compare the traced Python peak
+            against a whole-array pass (read the whole array and reduce at once) in the same
+            process. The stripped peak must stay below the whole-array peak. This is a
             build-agnostic check on purpose: the absolute figures depend on the GDAL build
             (tracemalloc only sees the Python heap, not GDAL's C buffers), but the same
             reduction done all-at-once is always an upper bound on the stripped version.
@@ -318,7 +318,7 @@ class TestStreamReduce:
             path=str(src_path),
         ).close()
 
-        def domain_sum(acc, strip, _w):
+        def value_sum(acc, strip, _w):
             # int64 accumulation on both sides so the == assertion below is
             # independent of the platform's default int16.sum() accumulator width.
             return acc + int(strip.sum(dtype="int64"))
@@ -334,7 +334,7 @@ class TestStreamReduce:
         # Stripped reduction.
         ds = Dataset.read_file(str(src_path))
         tracemalloc.start()
-        stripped_result = ds.io.stream_reduce(domain_sum, 0, strip_rows=64)
+        stripped_result = ds.io.stream_reduce(value_sum, 0, strip_rows=64)
         _, stripped_peak = tracemalloc.get_traced_memory()
         tracemalloc.stop()
 

--- a/tests/dataset/io/test_stream_transform.py
+++ b/tests/dataset/io/test_stream_transform.py
@@ -8,7 +8,6 @@ import numpy as np
 import pytest
 from hpc.indexing import get_pixels2
 
-from pyramids.base._domain import inside_domain
 from pyramids.dataset import Dataset
 from pyramids.dataset.engines.io import IO
 
@@ -484,12 +483,11 @@ class TestStreamedConsumers:
             no_data_value=-9999.0,
             path=str(src_path),
         ).close()
-        # Whole-band baseline: read the full band and count the domain at once.
+        # Whole-band baseline: materialise the full band at once (the non-stripped
+        # upper bound). The exact-count assertion below already pins correctness, so
+        # the baseline only needs to establish the whole-band memory peak.
         tracemalloc.start()
         whole = Dataset.read_file(str(src_path)).read_array()
-        # Mirror count_domain_cells' own domain definition (np.isclose / NaN-aware)
-        # so the baseline and the code under test cannot diverge on tolerance or NaN.
-        whole_count = int(inside_domain(whole, -9999.0).sum())
         _, whole_peak = tracemalloc.get_traced_memory()
         tracemalloc.stop()
         del whole
@@ -502,7 +500,6 @@ class TestStreamedConsumers:
         tracemalloc.stop()
 
         assert count == rows * cols - 2000 * 250, f"wrong domain count {count}"
-        assert count == whole_count, "stripped count diverged from the whole-band count"
         assert stripped_peak < whole_peak, (
             f"count_domain_cells peaked at {stripped_peak / 1e6:.1f} MB, not below the "
             f"whole-band pass's {whole_peak / 1e6:.1f} MB — the read was not stripped"

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -201,6 +201,9 @@ class TestMergeMethod:
 
         # Whole-union baseline: read both sources and reduce the full float64 union
         # cube at once (the non-stripped equivalent), holding every array together.
+        # Assumes the two sources are co-registered on the same grid (as the fixture
+        # writes them), so `np.maximum` aligns them directly; a non-overlapping pair
+        # would need the union grid built first.
         tracemalloc.start()
         a = Dataset.read_file(str(pa)).read_array().astype("float64")
         b = Dataset.read_file(str(pb)).read_array().astype("float64")

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -180,12 +180,16 @@ class TestMergeMethod:
         )
 
     def test_reduction_peak_memory_is_bounded_by_the_strip(self, tmp_path, monkeypatch):
-        """The min/max/sum merge peaks near one strip, far below the full union cube.
+        """The min/max/sum merge peaks below a whole-union pass, proving the strip reduction.
 
         Test scenario:
-            Merge two overlapping 4000x250 sources with 128-row strips; the traced
-            Python peak must be a fraction of the dense float64 union, proving the whole
-            output is never accumulated at once.
+            Merge two overlapping 4000x250 sources with 128-row strips, and compare the traced
+            Python peak against a whole-union pass (read both sources and reduce the full union
+            cube at once) in the same process. The stripped peak must stay below the whole-union
+            peak. This is a build-agnostic check on purpose: the absolute figures depend on the
+            GDAL build (tracemalloc only sees the Python heap, not GDAL's C buffers), but the
+            same reduction done all-at-once is always an upper bound on the stripped version,
+            whatever the build.
         """
         rows, cols = 4000, 250
         pa = write_raster(
@@ -194,15 +198,27 @@ class TestMergeMethod:
         pb = write_raster(
             tmp_path / "b.tif", np.full((rows, cols), 2.0, dtype="float32"), (0, rows)
         )
+
+        # Whole-union baseline: read both sources and reduce the full float64 union
+        # cube at once (the non-stripped equivalent), holding every array together.
+        tracemalloc.start()
+        a = Dataset.read_file(str(pa)).read_array().astype("float64")
+        b = Dataset.read_file(str(pb)).read_array().astype("float64")
+        whole = np.maximum(a, b)
+        _, whole_peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        del a, b, whole
+
+        # Stripped merge.
         monkeypatch.setattr(merge_mod, "_MERGE_STRIP_ROWS", 128)
-        union_bytes = rows * cols * 8  # float64 union cube
         tracemalloc.start()
         merge_rasters([pa, pb], tmp_path / "big.tif", no_data_value=-1.0, method="max")
-        _, peak = tracemalloc.get_traced_memory()
+        _, stripped_peak = tracemalloc.get_traced_memory()
         tracemalloc.stop()
-        assert peak < union_bytes // 4, (
-            f"merge peaked at {peak / 1e6:.1f} MB; a whole-union pass would need "
-            f"{union_bytes / 1e6:.1f} MB — the reduction was not stripped"
+
+        assert stripped_peak < whole_peak, (
+            f"merge peaked at {stripped_peak / 1e6:.1f} MB, not below the whole-union "
+            f"pass's {whole_peak / 1e6:.1f} MB — the reduction was not stripped"
         )
 
     def test_default_method_is_last(self, overlapping_pair, tmp_path):

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -11,7 +11,6 @@ covers the reproject-before-composite behaviour and its ``_prepare_sources`` /
 
 from __future__ import annotations
 
-import tracemalloc
 from contextlib import nullcontext
 from pathlib import Path
 
@@ -31,7 +30,7 @@ from pyramids.dataset.merge import (
     merge_rasters,
     stack_bands,
 )
-from tests._helpers import write_raster
+from tests._helpers import traced_peak, write_raster
 
 pytestmark = pytest.mark.core
 
@@ -204,20 +203,20 @@ class TestMergeMethod:
         # Assumes the two sources are co-registered on the same grid (as the fixture
         # writes them), so `np.maximum` aligns them directly; a non-overlapping pair
         # would need the union grid built first.
-        tracemalloc.start()
-        a = Dataset.read_file(str(pa)).read_array().astype("float64")
-        b = Dataset.read_file(str(pb)).read_array().astype("float64")
-        whole = np.maximum(a, b)
-        _, whole_peak = tracemalloc.get_traced_memory()
-        tracemalloc.stop()
+        with traced_peak() as wp:
+            a = Dataset.read_file(str(pa)).read_array().astype("float64")
+            b = Dataset.read_file(str(pb)).read_array().astype("float64")
+            whole = np.maximum(a, b)
+        whole_peak = wp[0]
         del a, b, whole
 
         # Stripped merge.
         monkeypatch.setattr(merge_mod, "_MERGE_STRIP_ROWS", 128)
-        tracemalloc.start()
-        merge_rasters([pa, pb], tmp_path / "big.tif", no_data_value=-1.0, method="max")
-        _, stripped_peak = tracemalloc.get_traced_memory()
-        tracemalloc.stop()
+        with traced_peak() as sp:
+            merge_rasters(
+                [pa, pb], tmp_path / "big.tif", no_data_value=-1.0, method="max"
+            )
+        stripped_peak = sp[0]
 
         assert stripped_peak < whole_peak, (
             f"merge peaked at {stripped_peak / 1e6:.1f} MB, not below the whole-union "

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -221,7 +221,7 @@ class TestMergeMethod:
 
         assert stripped_peak < whole_peak, (
             f"merge peaked at {stripped_peak / 1e6:.1f} MB, not below the whole-union "
-            f"pass's {whole_peak / 1e6:.1f} MB — the reduction was not stripped"
+            f"pass's {whole_peak / 1e6:.1f} MB — it did not stay under a full materialisation"
         )
 
     def test_default_method_is_last(self, overlapping_pair, tmp_path):


### PR DESCRIPTION
# Description

The `test-wheel-core (windows-latest, 3.11)` job on `main` failed at
`tests/dataset/spatial/test_merge.py::TestMergeMethod::test_reduction_peak_memory_is_bounded_by_the_strip`:

```
AssertionError: merge peaked at 4.5 MB; a whole-union pass would need 8.0 MB — the reduction was not stripped
assert 4531642 < (8000000 // 4)
```

The test asserted a **hard-coded `tracemalloc` byte budget** (`union_bytes // 4` = 2 MB). That budget does not hold
across GDAL builds: on the Windows **cibuildwheel** GDAL the stripped merge traces ~4.5 MB even though it strips
correctly, because `tracemalloc` only sees the Python heap (not GDAL's C buffers) and the wheel build's read path
allocates differently from the conda build the budget was tuned against. It is a **test-portability bug, not a
product regression** — the merge streaming is working.

This is the same recurring anti-pattern that already took down `test-wheel-core (macos, 3.12)` earlier (the
`stream_transform` tile test, fixed in #971) — a `tracemalloc` peak compared to a hard-coded `dense_bytes // N`
budget. A sweep found **three** such tests still on `main`, each a latent wheel-build failure hitting a different OS
on each run. This PR fixes all three the same way #971 fixed the tile test: replace the absolute budget with a
**relative, build-agnostic** one — measure a whole-pass equivalent (read everything and reduce at once) in the same
process, and assert the stripped peak stays below it. The baseline shares the read machinery, so any per-build
overhead cancels and only the full-array/union data the streaming avoids remains as the margin (locally the stripped
peaks are 3–13% of the whole-pass peaks, e.g. merge 0.7 MB vs 24 MB).

Fixed:

- `test_merge.py::test_reduction_peak_memory_is_bounded_by_the_strip` (the failing test) — vs a whole-union pass.
- `test_stream_transform.py::TestStreamReduce::test_peak_memory_is_bounded_by_the_strip` — vs a whole-array pass.
- `test_stream_transform.py::test_count_domain_cells_is_byte_identical_and_bounded` — vs a whole-band pass.

Two of the three also now assert the streamed result equals the whole-pass result, pinning correctness as well as the
memory bound.

Deliberately **not** changed: `test_create_empty.py::test_allocation_allocates_no_full_python_buffer`. It asserts a
header-only allocation materialises *nothing* — there is no meaningful "whole-pass baseline" (that baseline would be
the 1.6 GB buffer the test exists to avoid), its `dense_bytes // 10` = 160 MB budget is far too loose to be tripped
by wheel read-path overhead, and it is `@pytest.mark.slow`.

# Issues

- Closes #1005
- Fixes the `test-wheel-core` failure on `main` (run 32065450721).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Note: test-only change; no `src/` behaviour changes.

# How Has This Been Tested?

- [x] `pytest tests/dataset/spatial/test_merge.py tests/dataset/io/test_stream_transform.py
  tests/dataset/io/test_create_empty.py -m "not slow"` → 124 passed locally.
- [x] Margin probes confirm robustness: merge whole-union peak **24 MB** vs stripped **0.7 MB** (the wheel build's
  4.5 MB is still far below 24 MB, since the baseline includes the same per-build read overhead *plus* the full
  float64 cubes); `stream_reduce` **2.1 MB** vs **0.26 MB**.

# Checklist:

- [ ] updated version number in pyproject.toml. (handled by commitizen on release)
- [ ] added changes to History.rst. (changelog is commitizen-generated)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (each test's docstring now explains the build-agnostic rationale)


