### PR TITLE
refactor(plot): decompose render_array to clear python:S107 and python:S3776

### DIFF
--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -61,6 +61,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Callable, Collection
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -229,6 +230,118 @@ def nonnull_group_kwargs(**groups: Any) -> dict[str, Any]:
         A dict of only the groups whose value is not ``None``.
     """
     return {name: value for name, value in groups.items() if value is not None}
+
+
+@dataclass(frozen=True)
+class BasemapPlan:
+    """Resolved basemap dispatch for a single :func:`render_array` call.
+
+    cleopatra 0.27 added its own ``basemap=`` for shaded-relief / feature
+    reference layers, which collides with pyramids' pre-existing web-tile
+    ``basemap=``. This value object classifies the caller's ``basemap`` argument
+    by type once, so the render dispatch just asks the plan what to do:
+
+    - a ``str`` provider name (or ``True``) is a pyramids web-tile basemap drawn
+      under the raster (``tile`` / ``source``);
+    - a :class:`cleopatra.basemap.geo.Basemap` is cleopatra's relief/features
+      layer, forwarded to the glyph's own ``basemap=`` on the render call
+      (``cleo_kwarg`` / ``forwards_cleo_basemap``);
+    - falsy inputs (``None`` / ``False`` / ``""`` / empty ``dict``) mean no
+      basemap.
+
+    Attributes:
+        tile: Draw a pyramids web-tile basemap under the raster.
+        source: Tile provider name, or ``None`` for the default provider.
+        epsg: CRS code for the tile fetch. Set whenever ``tile`` is True — the
+            caller rejects a truthy ``basemap`` with no CRS up front.
+        cleo_basemap: A cleopatra ``Basemap`` to forward on the render call, or
+            ``None``.
+
+    Examples:
+        - A provider string resolves to a web-tile plan:
+
+            ```python
+            >>> from pyramids.dataset._plot_helpers import BasemapPlan
+            >>> plan = BasemapPlan.resolve("OpenStreetMap", 4326)
+            >>> plan.tile, plan.source, plan.forwards_cleo_basemap
+            (True, 'OpenStreetMap', False)
+            >>> plan.cleo_kwarg
+            {}
+
+            ```
+
+        - A falsy basemap resolves to a no-op plan:
+
+            ```python
+            >>> plan = BasemapPlan.resolve("", None)
+            >>> plan.tile, plan.forwards_cleo_basemap, plan.cleo_kwarg
+            (False, False, {})
+
+            ```
+    """
+
+    tile: bool
+    source: str | None
+    epsg: int | None
+    cleo_basemap: Any
+
+    @classmethod
+    def resolve(cls, basemap: Any, basemap_epsg: int | None) -> BasemapPlan:
+        """Classify a (already dict-coerced) ``basemap`` argument into a plan.
+
+        ``basemap`` must already have had the deprecated ``dict`` alias
+        translated to a ``Basemap`` (``render_array`` does that up front), so
+        only ``str`` / ``bool`` / ``Basemap`` / empty-``dict`` / ``None`` reach
+        here. Truthiness is used throughout, so every falsy input means "no
+        basemap": an empty ``dict`` must not be forwarded to cleopatra without a
+        CRS any more than an empty string is tiled.
+        """
+        tile = (isinstance(basemap, str) and basemap != "") or basemap is True
+        source = basemap if tile and isinstance(basemap, str) else None
+        forward = bool(basemap) and not isinstance(basemap, (str, bool))
+        return cls(
+            tile=tile,
+            source=source,
+            epsg=basemap_epsg,
+            cleo_basemap=basemap if forward else None,
+        )
+
+    @property
+    def cleo_kwarg(self) -> dict[str, Any]:
+        """The ``basemap=`` kwarg for cleopatra's render call (empty if none)."""
+        if self.cleo_basemap is None:
+            return {}
+        return {"basemap": self.cleo_basemap}
+
+    @property
+    def forwards_cleo_basemap(self) -> bool:
+        """True when a cleopatra relief/features ``Basemap`` must be forwarded."""
+        return self.cleo_basemap is not None
+
+    def apply_to(self, target_ax: Any) -> None:
+        """Draw the pyramids web-tile basemap under ``target_ax``.
+
+        Resolves ``add_basemap`` via the module attribute at call time so a
+        test ``patch("pyramids.basemap.basemap.add_basemap")`` is honoured (the
+        patch swaps the module attribute, not any pre-bound reference). Only
+        called when ``tile`` is True, which implies ``epsg`` is set — mypy does
+        not track that implication, hence the assert.
+        """
+        assert self.epsg is not None
+        _basemap_module.add_basemap(target_ax, crs=self.epsg, source=self.source)
+
+    def apply_to_facets(self, grid: Any) -> None:
+        """Draw the tile basemap under every visible panel of a facet grid.
+
+        Every panel renders the same spatial domain, so each visible panel gets
+        the same tile layer underneath (one tile fetch per panel); hidden
+        trailing slots (``set_visible(False)``) are skipped.
+        """
+        panel_axes = getattr(grid, "axes", None)
+        if panel_axes is not None:
+            for panel_ax in np.asarray(panel_axes).ravel():
+                if panel_ax is not None and panel_ax.get_visible():
+                    self.apply_to(panel_ax)
 
 
 def _split_render_kwargs(
@@ -684,65 +797,36 @@ def render_array(
     if basemap_epsg is not None:
         cleo.crs = basemap_epsg
 
-    # Split the ``basemap`` argument by type. cleopatra 0.27 added its own
-    # ``basemap=`` for shaded-relief / feature reference layers, which collides
-    # with pyramids' pre-existing web-tile ``basemap=``, so dispatch on the type:
-    #   - a ``str`` provider name (or ``True``) is a pyramids web-tile basemap
-    #     drawn under the raster -- pyramids owns this via ``add_basemap``;
-    #   - a ``cleopatra.basemap.geo.Basemap`` is cleopatra's relief/features reference
-    #     layer, forwarded to the glyph's own ``basemap=`` on the render call.
-    #     (A non-empty ``dict`` was already deprecated + translated to a
-    #     ``Basemap`` up front, so only an empty ``{}`` reaches here — no basemap.)
-    # ``basemap and basemap_epsg is None`` was already rejected at the top of
-    # this function, so when ``basemap`` is truthy ``basemap_epsg`` is set.
-    # A non-empty provider string, or ``True``, is a pyramids web-tile basemap.
-    # An empty string is treated as "no basemap" so it stays consistent with the
-    # falsy top guard (``if basemap ...``) rather than reaching ``_apply_basemap``
-    # with no source / no CRS.
-    # Use truthiness throughout so falsy inputs (None, False, "", {}) all mean
-    # "no basemap" and agree with the top guard -- an empty dict must not be
-    # forwarded to cleopatra without a CRS any more than an empty string is tiled.
-    tile_basemap = (isinstance(basemap, str) and basemap != "") or basemap is True
-    basemap_source = basemap if tile_basemap and isinstance(basemap, str) else None
-    forward_cleo_basemap = bool(basemap) and not isinstance(basemap, (str, bool))
-    cleo_basemap_kwarg = {"basemap": basemap} if forward_cleo_basemap else {}
-
-    def _apply_basemap(target_ax: Any) -> None:
-        # Resolve ``add_basemap`` via the module attribute at call time so
-        # test-time ``patch("pyramids.basemap.basemap.add_basemap")`` is
-        # honoured (the patch swaps the module attribute, not any
-        # pre-bound reference this helper might hold).
-        # Only called when a tile basemap is requested, and the guard above
-        # already proved basemap_epsg is set in that case; mypy does not track
-        # that implication into this closure.
-        assert basemap_epsg is not None
-        _basemap_module.add_basemap(
-            target_ax,
-            crs=basemap_epsg,
-            source=basemap_source,
-        )
+    # Resolve the ``basemap`` argument by type — pyramids web-tile vs cleopatra
+    # relief/features layer vs none — into a plan the dispatch below consults.
+    # (A non-empty ``dict`` was already deprecated + translated to a ``Basemap``
+    # up front; ``basemap and basemap_epsg is None`` was already rejected, so a
+    # truthy basemap always has a CRS here.)
+    basemap_plan = BasemapPlan.resolve(basemap, basemap_epsg)
 
     if mode == "plot":
         # Only render-call-only kwargs reach ``cleo.plot`` — the constructor
         # already absorbed every option meaningful to cleopatra's
         # ``default_options`` machinery. A cleopatra relief basemap rides along
         # on the render call; a pyramids tile basemap is drawn afterwards.
-        cleo.plot(**render_kwargs, **cleo_basemap_kwarg)
+        cleo.plot(**render_kwargs, **basemap_plan.cleo_kwarg)
         result: Any = cleo
-        if tile_basemap:
-            _apply_basemap(cleo.ax)
+        if basemap_plan.tile:
+            basemap_plan.apply_to(cleo.ax)
     elif mode == "animate":
         if data_getter is not None:
             cleo.animate(
                 animation_axis_values,
                 data_getter=data_getter,
                 **animate_kwargs,
-                **cleo_basemap_kwarg,
+                **basemap_plan.cleo_kwarg,
             )
         else:
-            cleo.animate(animation_axis_values, **animate_kwargs, **cleo_basemap_kwarg)
+            cleo.animate(
+                animation_axis_values, **animate_kwargs, **basemap_plan.cleo_kwarg
+            )
         result = cleo
-        if tile_basemap:
+        if basemap_plan.tile:
             # A pyramids web-tile basemap draws on the animation's single
             # persistent Axes, mirroring the plot path — so ``basemap=`` behaves
             # the same whether the caller renders a single frame or an animation
@@ -750,7 +834,7 @@ def render_array(
             # cleopatra's ``animate`` only updates the raster via ``im.set_data``
             # (blit=True) and never clears the Axes, so the underlay drawn now is
             # captured in the blit background and persists across frames.
-            _apply_basemap(cleo.ax)
+            basemap_plan.apply_to(cleo.ax)
     else:
         # Facet path: cleopatra's ``ArrayGlyph.facet`` accepts every
         # option that ``ArrayGlyph.plot`` does (it allocates one Axes
@@ -759,7 +843,7 @@ def render_array(
         # the constructor. The guard at the top of this function already
         # proved facet_kwargs is set for mode == "facet".
         assert facet_kwargs is not None
-        if forward_cleo_basemap:
+        if basemap_plan.forwards_cleo_basemap:
             # cleopatra's ``ArrayGlyph.facet`` has no ``basemap=`` param, so a
             # relief/features reference layer cannot be drawn per panel. Fail
             # loudly rather than forward an unsupported kwarg.
@@ -781,17 +865,10 @@ def render_array(
         if "figsize" in facet_call:
             facet_call["figure_size"] = facet_call.pop("figsize")
         result = cleo.facet(**facet_call, **render_kwargs)
-        if tile_basemap:
-            # Every facet panel renders the same spatial domain (cleopatra
-            # reuses the parent extent / curvilinear coords across panels),
-            # so each visible panel gets the same tile layer underneath —
-            # at the cost of one tile fetch per panel. Hidden trailing
-            # slots (``set_visible(False)``) are skipped.
-            panel_axes = getattr(result, "axes", None)
-            if panel_axes is not None:
-                for panel_ax in np.asarray(panel_axes).ravel():
-                    if panel_ax is not None and panel_ax.get_visible():
-                        _apply_basemap(panel_ax)
+        if basemap_plan.tile:
+            # Every facet panel renders the same spatial domain, so each visible
+            # panel gets the same tile layer underneath (one fetch per panel).
+            basemap_plan.apply_to_facets(result)
     return result
 
 

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -693,6 +693,110 @@ class RenderRequest:
             raise ValueError("Dataset must have a CRS (epsg) to use basemap.")
 
 
+def _translate_facet_kwargs(
+    facet_kwargs: dict[str, Any], panel_labels_cls: Any
+) -> dict[str, Any]:
+    """Translate the loose NetCDF facet kwargs to cleopatra 0.30's facet names.
+
+    cleopatra 0.30 renamed facet's ``figsize`` to ``figure_size`` and moved the
+    per-panel coordinate labels onto a ``PanelLabels`` group (``col`` / ``row``);
+    the NetCDF facet builder still emits the historical ``col_coords`` /
+    ``row_coords`` / ``figsize`` spelling, so translate it here.
+
+    Args:
+        facet_kwargs: The loose facet kwargs from the NetCDF facet path.
+        panel_labels_cls: cleopatra's ``PanelLabels`` (injected).
+
+    Returns:
+        A new dict suitable for ``ArrayGlyph.facet(**...)``.
+    """
+    facet_call = dict(facet_kwargs)
+    col_coords = facet_call.pop("col_coords", None)
+    row_coords = facet_call.pop("row_coords", None)
+    if col_coords is not None or row_coords is not None:
+        facet_call["labels"] = panel_labels_cls(col=col_coords, row=row_coords)
+    if "figsize" in facet_call:
+        facet_call["figure_size"] = facet_call.pop("figsize")
+    return facet_call
+
+
+def _dispatch_render(
+    cleo: Any,
+    mode: ModeSpec,
+    render_kwargs: dict[str, Any],
+    animate_kwargs: dict[str, Any],
+    basemap_plan: BasemapPlan,
+    panel_labels_cls: Any,
+) -> Any:
+    """Run the ``plot`` / ``animate`` / ``facet`` render call for a built glyph.
+
+    Only the render-call-only kwargs reach the render method — the constructor
+    already absorbed every ``default_options`` key. A cleopatra relief basemap
+    rides along on the render call (``basemap_plan.cleo_kwarg``); a pyramids
+    web-tile basemap is drawn afterwards on the plot/animate Axes or under every
+    visible facet panel. A cleopatra ``Basemap`` is unsupported on the facet path
+    and raises.
+
+    Args:
+        cleo: The built cleopatra ``ArrayGlyph``.
+        mode: The render mode + its mode-specific inputs.
+        render_kwargs: Render-call-only kwargs (plot / facet).
+        animate_kwargs: The merged kwargs for the animate call.
+        basemap_plan: The resolved basemap dispatch.
+        panel_labels_cls: cleopatra's ``PanelLabels`` (injected for the facet path).
+
+    Returns:
+        cleopatra's return for that mode — an ``ArrayGlyph`` (plot / animate) or a
+        ``FacetGrid`` (facet).
+
+    Raises:
+        ValueError: If a cleopatra ``Basemap`` reference layer is passed on the
+            facet path.
+    """
+    if mode.mode == "plot":
+        cleo.plot(**render_kwargs, **basemap_plan.cleo_kwarg)
+        result: Any = cleo
+        if basemap_plan.tile:
+            basemap_plan.apply_to(cleo.ax)
+    elif mode.mode == "animate":
+        if mode.data_getter is not None:
+            cleo.animate(
+                mode.animation_axis_values,
+                data_getter=mode.data_getter,
+                **animate_kwargs,
+                **basemap_plan.cleo_kwarg,
+            )
+        else:
+            cleo.animate(
+                mode.animation_axis_values, **animate_kwargs, **basemap_plan.cleo_kwarg
+            )
+        result = cleo
+        if basemap_plan.tile:
+            # cleopatra's ``animate`` only updates the raster via ``im.set_data``
+            # (blit=True) and never clears the Axes, so a tile underlay drawn now is
+            # captured in the blit background and persists across every frame.
+            basemap_plan.apply_to(cleo.ax)
+    else:
+        # The guard at the top of ``render_array`` already proved facet_kwargs is set.
+        assert mode.facet_kwargs is not None
+        if basemap_plan.forwards_cleo_basemap:
+            # cleopatra's ``ArrayGlyph.facet`` has no ``basemap=`` param, so a
+            # relief/features reference layer cannot be drawn per panel.
+            raise ValueError(
+                "A cleopatra `Basemap` (or equivalent dict) reference layer is not "
+                "supported on the faceted plot path. Use a web-tile basemap "
+                "(basemap='<provider>') for per-panel tiles, or plot without faceting "
+                "for a relief/features basemap."
+            )
+        facet_call = _translate_facet_kwargs(mode.facet_kwargs, panel_labels_cls)
+        result = cleo.facet(**facet_call, **render_kwargs)
+        if basemap_plan.tile:
+            # Every facet panel renders the same spatial domain, so each visible
+            # panel gets the same tile layer underneath (one fetch per panel).
+            basemap_plan.apply_to_facets(result)
+    return result
+
+
 def render_array(request: RenderRequest, **kwargs: Any) -> ArrayGlyph:
     """Build an ArrayGlyph from a :class:`RenderRequest` and dispatch by mode.
 
@@ -824,9 +928,6 @@ def render_array(request: RenderRequest, **kwargs: Any) -> ArrayGlyph:
     # Unpack the grouped request into the working locals the dispatch uses.
     arr = request.arr
     mode = request.mode.mode
-    animation_axis_values = request.mode.animation_axis_values
-    data_getter = request.mode.data_getter
-    facet_kwargs = request.mode.facet_kwargs
     rgb_spec = request.rgb
     coords = request.coords
     extent = request.extent
@@ -937,72 +1038,10 @@ def render_array(request: RenderRequest, **kwargs: Any) -> ArrayGlyph:
     # truthy basemap always has a CRS here.)
     basemap_plan = BasemapPlan.resolve(basemap, basemap_epsg)
 
-    if mode == "plot":
-        # Only render-call-only kwargs reach ``cleo.plot`` — the constructor
-        # already absorbed every option meaningful to cleopatra's
-        # ``default_options`` machinery. A cleopatra relief basemap rides along
-        # on the render call; a pyramids tile basemap is drawn afterwards.
-        cleo.plot(**render_kwargs, **basemap_plan.cleo_kwarg)
-        result: Any = cleo
-        if basemap_plan.tile:
-            basemap_plan.apply_to(cleo.ax)
-    elif mode == "animate":
-        if data_getter is not None:
-            cleo.animate(
-                animation_axis_values,
-                data_getter=data_getter,
-                **animate_kwargs,
-                **basemap_plan.cleo_kwarg,
-            )
-        else:
-            cleo.animate(
-                animation_axis_values, **animate_kwargs, **basemap_plan.cleo_kwarg
-            )
-        result = cleo
-        if basemap_plan.tile:
-            # A pyramids web-tile basemap draws on the animation's single
-            # persistent Axes, mirroring the plot path — so ``basemap=`` behaves
-            # the same whether the caller renders a single frame or an animation
-            # (e.g. ``DatasetCollection.plot`` / ``NetCDF.plot`` on a time stack).
-            # cleopatra's ``animate`` only updates the raster via ``im.set_data``
-            # (blit=True) and never clears the Axes, so the underlay drawn now is
-            # captured in the blit background and persists across frames.
-            basemap_plan.apply_to(cleo.ax)
-    else:
-        # Facet path: cleopatra's ``ArrayGlyph.facet`` accepts every
-        # option that ``ArrayGlyph.plot`` does (it allocates one Axes
-        # per panel and calls ``imshow``/``pcolormesh`` under the hood).
-        # Forward only the render-call-only set; the rest is already on
-        # the constructor. The guard at the top of this function already
-        # proved facet_kwargs is set for mode == "facet".
-        assert facet_kwargs is not None
-        if basemap_plan.forwards_cleo_basemap:
-            # cleopatra's ``ArrayGlyph.facet`` has no ``basemap=`` param, so a
-            # relief/features reference layer cannot be drawn per panel. Fail
-            # loudly rather than forward an unsupported kwarg.
-            raise ValueError(
-                "A cleopatra `Basemap` (or equivalent dict) reference layer is not "
-                "supported on the faceted plot path. Use a web-tile basemap "
-                "(basemap='<provider>') for per-panel tiles, or plot without faceting "
-                "for a relief/features basemap."
-            )
-        # cleopatra 0.30 renamed facet's ``figsize`` to ``figure_size`` and moved the
-        # per-panel coordinate labels onto a ``PanelLabels`` group (``col`` / ``row``).
-        # Translate the loose facet_kwargs (built by the NetCDF facet path) into the new
-        # names so the NetCDF facet builder can keep emitting the historical spelling.
-        facet_call = dict(facet_kwargs)
-        col_coords = facet_call.pop("col_coords", None)
-        row_coords = facet_call.pop("row_coords", None)
-        if col_coords is not None or row_coords is not None:
-            facet_call["labels"] = PanelLabels(col=col_coords, row=row_coords)
-        if "figsize" in facet_call:
-            facet_call["figure_size"] = facet_call.pop("figsize")
-        result = cleo.facet(**facet_call, **render_kwargs)
-        if basemap_plan.tile:
-            # Every facet panel renders the same spatial domain, so each visible
-            # panel gets the same tile layer underneath (one fetch per panel).
-            basemap_plan.apply_to_facets(result)
-    return result
+    # Run the plot / animate / facet render call and draw any tile basemap.
+    return _dispatch_render(
+        cleo, request.mode, render_kwargs, animate_kwargs, basemap_plan, PanelLabels
+    )
 
 
 def mesh_render(

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -12,8 +12,10 @@ The mesh counterpart lives in :mod:`pyramids.netcdf.ugrid.plot` as
 ``plot_mesh_data`` / ``plot_mesh_outline`` (N-6) — same contract,
 different cleopatra glyph (``MeshGlyph`` vs ``ArrayGlyph``).
 
-The helper takes an explicit ``mode`` argument so callers can pick
-between three render shapes:
+:func:`render_array` takes a single :class:`RenderRequest` — composing an
+:class:`RgbSpec` band spec and a :class:`ModeSpec` that carries the render mode
+plus its mode-specific inputs — so callers hand over one grouped object rather
+than a long parameter list. ``ModeSpec.mode`` picks between three render shapes:
 
 * ``"plot"`` — `ArrayGlyph(...).plot(**kwargs)` for a single 2-D slice.
 * ``"animate"`` — `ArrayGlyph(...).animate(animation_axis_values,
@@ -31,8 +33,9 @@ Cleopatra's ``ArrayGlyph`` validates every kwarg twice: the constructor
 stores style/colour options into ``self.default_options``, and
 ``ArrayGlyph.plot`` writes the same dict again. Forwarding the *same*
 kwargs dict to both call sites was the original D-4 smell — harmless
-(values were just re-assigned) but confusing. PR-6 splits the
-incoming ``**kwargs`` into two buckets, and the split is sourced from
+(values were just re-assigned) but confusing. :func:`_split_render_kwargs`
+splits the incoming ``**kwargs`` into constructor / render / animate buckets,
+and the split is sourced from
 ``ArrayGlyph.option_keys()`` (cleopatra's own declared set of
 constructor options, resolvable without building an instance) rather
 than a hand-maintained enumeration — so the routing tracks cleopatra
@@ -79,6 +82,7 @@ from pyramids.base.crs import crs_from_user_input
 from pyramids.basemap import basemap as _basemap_module
 
 if TYPE_CHECKING:
+    from cleopatra.basemap.geo import Basemap
     from cleopatra.glyphs.gridded.array_glyph import ArrayGlyph
 
 # N-6 — Mesh rendering shares this module's "data in, glyph out"
@@ -324,14 +328,15 @@ class RgbSpec:
         Returns:
             An ``RgbBands`` instance, or None for the single-band path.
         """
-        if not self.is_set:
-            return None
-        return rgb_bands_cls(
-            self.rgb,
-            surface_reflectance=self.surface_reflectance,
-            cutoff=self.cutoff,
-            percentile=self.percentile,
-        )
+        bands = None
+        if self.is_set:
+            bands = rgb_bands_cls(
+                self.rgb,
+                surface_reflectance=self.surface_reflectance,
+                cutoff=self.cutoff,
+                percentile=self.percentile,
+            )
+        return bands
 
 
 @dataclass(frozen=True)
@@ -411,9 +416,10 @@ class BasemapPlan:
     @property
     def cleo_kwarg(self) -> dict[str, Any]:
         """The ``basemap=`` kwarg for cleopatra's render call (empty if none)."""
-        if self.cleo_basemap is None:
-            return {}
-        return {"basemap": self.cleo_basemap}
+        kwarg: dict[str, Any] = {}
+        if self.cleo_basemap is not None:
+            kwarg = {"basemap": self.cleo_basemap}
+        return kwarg
 
     @property
     def forwards_cleo_basemap(self) -> bool:
@@ -621,7 +627,7 @@ class RenderRequest:
     exclude_value: list | None = None
     ax: Any = None
     fig: Any = None
-    basemap: bool | str | dict[str, Any] | Any = None
+    basemap: bool | str | dict[str, Any] | Basemap | None = None
     basemap_epsg: int | None = None
 
     def validate(self) -> None:
@@ -835,6 +841,11 @@ def render_array(request: RenderRequest, **kwargs: Any) -> ArrayGlyph:
     # forms — which cleopatra still tolerates — are rejected here so pyramids exposes a
     # single typed colour-bar surface (``colorbar=ColorBar``).
     _reject_replaced_cbar_kwargs(kwargs)
+    # Validate the request as given (the user's raw intent) before translating the
+    # deprecated dict-basemap alias below. A truthy basemap of any form needs a CRS,
+    # so validating first keeps the coercion — which only rewrites the local
+    # ``basemap`` that ``BasemapPlan.resolve`` consumes — out of the guard's reasoning.
+    request.validate()
     # Translate the deprecated ``dict`` basemap alias to a ``Basemap``.
     if isinstance(basemap, dict) and basemap:
         warnings.warn(
@@ -844,8 +855,6 @@ def render_array(request: RenderRequest, **kwargs: Any) -> ArrayGlyph:
             stacklevel=2,
         )
         basemap = Basemap(**basemap)
-
-    request.validate()
 
     if mode == "animate" and rgb_spec.is_set:
         # cleopatra's ``ArrayGlyph.animate`` renders a 4-D ``(time, rows, cols,

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -60,7 +60,7 @@ and pass nothing to the constructor.
 from __future__ import annotations
 
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Collection
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -229,6 +229,88 @@ def nonnull_group_kwargs(**groups: Any) -> dict[str, Any]:
         A dict of only the groups whose value is not ``None``.
     """
     return {name: value for name, value in groups.items() if value is not None}
+
+
+def _split_render_kwargs(
+    kwargs: dict[str, Any], mode: str, option_keys: Collection[str]
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Route render kwargs into constructor / render-call / animate buckets.
+
+    cleopatra's ``ArrayGlyph`` validates every kwarg twice — once on the
+    constructor (against ``DEFAULT_OPTIONS``) and again on the render call — so
+    pyramids sends each kwarg to exactly one place. The split is driven by
+    ``option_keys`` (``ArrayGlyph.option_keys()``, cleopatra's declared
+    constructor-option set): a key in that set lands on the constructor; any
+    other key (a render-only param such as ``points``, or an unknown key the
+    render method should reject) lands on the render call.
+
+    ``kind`` is the one override: it is a ``DEFAULT_OPTIONS`` key *and* an
+    explicit ``ArrayGlyph.plot`` / ``.facet`` parameter that the render method
+    unconditionally rewrites, so a constructor-set ``kind`` would be clobbered
+    back to ``"auto"`` — it must reach the render call instead.
+
+    On the ``"animate"`` path cleopatra's ``ArrayGlyph.animate`` re-validates
+    every kwarg, so the two buckets are merged and the constructor bucket is
+    emptied (animate flows everything through ``animate(...)``, and keys like
+    ``interval`` are valid for animate but not in ``DEFAULT_OPTIONS``).
+
+    Args:
+        kwargs: The caller's render kwargs — already stripped of the rejected
+            loose ``cbar_*`` forms, with any bare points array wrapped in a
+            ``PointOverlay``.
+        mode: One of ``"plot"`` / ``"animate"`` / ``"facet"``.
+        option_keys: cleopatra's declared constructor-option names.
+
+    Returns:
+        ``(ctor_kwargs, render_kwargs, animate_kwargs)``. For ``"plot"`` /
+        ``"facet"`` the animate bucket is empty; for ``"animate"`` the
+        constructor bucket is empty and the animate bucket carries the merge.
+
+    Examples:
+        - A constructor option and a render-only key split apart:
+
+            ```python
+            >>> from pyramids.dataset._plot_helpers import _split_render_kwargs
+            >>> ctor, render, animate = _split_render_kwargs(
+            ...     {"cmap": "viridis", "points": [[1, 2, 3]]},
+            ...     "plot",
+            ...     {"cmap", "vmin"},
+            ... )
+            >>> ctor, render, animate
+            ({'cmap': 'viridis'}, {'points': [[1, 2, 3]]}, {})
+
+            ```
+
+        - ``kind`` is force-routed to the render call even though it is an
+          option key, and ``"animate"`` empties the constructor bucket:
+
+            ```python
+            >>> ctor, render, animate = _split_render_kwargs(
+            ...     {"cmap": "viridis", "kind": "contourf"},
+            ...     "animate",
+            ...     {"cmap", "kind"},
+            ... )
+            >>> ctor
+            {}
+            >>> animate == {"cmap": "viridis", "kind": "contourf"}
+            True
+
+            ```
+    """
+    render_only_overrides = {"kind"}
+    ctor_kwargs: dict[str, Any] = {}
+    render_kwargs: dict[str, Any] = {}
+    for key, value in kwargs.items():
+        if key in option_keys and key not in render_only_overrides:
+            ctor_kwargs[key] = value
+        else:
+            render_kwargs[key] = value
+    result: tuple[dict[str, Any], dict[str, Any], dict[str, Any]]
+    if mode == "animate":
+        result = ({}, render_kwargs, {**ctor_kwargs, **render_kwargs})
+    else:
+        result = (ctor_kwargs, render_kwargs, {})
+    return result
 
 
 def render_array(
@@ -557,60 +639,13 @@ def render_array(
     # `extent` when curvilinear coords are present.
     effective_extent = None if coords is not None else extent
 
-    # D-4 split: keep figure/colour/scale options on the constructor
-    # (they land in cleopatra's ``default_options`` once) and route the
-    # render-call-only kwargs (``points``, ``kind``) to
-    # ``cleo.plot``/``cleo.animate``/``cleo.facet``. Before
-    # PR-6 the same ``kwargs`` dict was passed to both call sites; that
-    # double-forward was harmless (cleopatra re-assigned the same values
-    # into ``default_options``) but obscured which kwargs belonged where.
-    # The split is driven by ``ArrayGlyph.option_keys()`` — cleopatra's
-    # own declared set of constructor options, resolvable without building
-    # an instance — so pyramids tracks cleopatra automatically instead of
-    # hand-maintaining the render-only list. The render-only method params
-    # (``points`` — an array or a ``PointOverlay``) are not in that set,
-    # so they fall to ``render_kwargs`` on their own; an invalid key does
-    # too, so the render method rejects it instead of being silently dropped.
-    #
-    # ``kind`` is the one exception that needs an override: it lives in BOTH
-    # places — a ``default_options`` key *and* an explicit
-    # ``ArrayGlyph.plot``/``.facet`` parameter (default ``"auto"``) — and the
-    # render method *unconditionally* writes its own ``kind`` arg into
-    # ``default_options`` (``array_glyph.py``: ``default_options["kind"] =
-    # kind``). So routing a constructor ``kind`` would be clobbered back to
-    # ``"auto"``; it must reach the render call instead.
-    #
-    # ``title`` is also dual-membership, but it does NOT need an override: the
-    # render method only overwrites ``default_options["title"]`` when its
-    # ``title`` arg is not ``None``, so a constructor-set title survives and
-    # routing it to the constructor (via ``option_keys()``) is correct.
-    # ``kind`` is force-routed to the render call. The loose cbar_* kwargs no longer
-    # need force-routing: they are rejected up front by ``_reject_replaced_cbar_kwargs``
-    # (``colorbar=ColorBar`` is the only colour-bar surface), so they never reach the split.
-    RENDER_ONLY_OVERRIDES = {"kind"}
-    # Reuse the option set resolved for the style/hillshade guard above — it is
-    # cleopatra's declared constructor options and does not change within a call.
-    ctor_option_keys = option_keys
-    ctor_kwargs: dict[str, Any] = {}
-    render_kwargs: dict[str, Any] = {}
-    for key, value in kwargs.items():
-        if key in ctor_option_keys and key not in RENDER_ONLY_OVERRIDES:
-            ctor_kwargs[key] = value
-        else:
-            render_kwargs[key] = value
-    # The cleopatra render groups (``color`` / ``contour`` / ``cells`` / ``data_style``) the
-    # facades pass are not constructor options, so the split above already routed them to
-    # ``render_kwargs`` — they ride on the plot / animate / facet call as-is.
-    # The ``"animate"`` path only flows kwargs into ``cleo.animate(...)``,
-    # not the constructor — keys like ``interval`` are valid for animate
-    # but not in cleopatra's ``DEFAULT_OPTIONS`` and would trigger an
-    # "Unknown option" ValueError on the constructor pass. Merge the two
-    # buckets back together for the animate call.
-    if mode == "animate":
-        animate_kwargs = {**ctor_kwargs, **render_kwargs}
-        ctor_kwargs = {}
-    else:
-        animate_kwargs = {}
+    # D-4 split: route each render kwarg to exactly one cleopatra call site
+    # (constructor options vs the render call), driven by cleopatra's own
+    # declared option set. ``_split_render_kwargs`` owns the ``kind`` override
+    # and the animate-path merge (see its docstring).
+    ctor_kwargs, render_kwargs, animate_kwargs = _split_render_kwargs(
+        kwargs, mode, option_keys
+    )
 
     # cleopatra 0.31 (serapeum-org/cleopatra#291) grouped the four loose RGB
     # band-prep keywords (``rgb`` / ``surface_reflectance`` / ``cutoff`` /

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -468,7 +468,10 @@ def _split_render_kwargs(
     ``kind`` is the one override: it is a ``DEFAULT_OPTIONS`` key *and* an
     explicit ``ArrayGlyph.plot`` / ``.facet`` parameter that the render method
     unconditionally rewrites, so a constructor-set ``kind`` would be clobbered
-    back to ``"auto"`` — it must reach the render call instead.
+    back to ``"auto"`` — it must reach the render call instead. Other
+    dual-membership keys (notably ``title``) need no override: the render method
+    only overwrites ``default_options[key]`` when its own arg is non-``None``, so
+    a constructor-routed value survives and staying on the constructor is correct.
 
     On the ``"animate"`` path cleopatra's ``ArrayGlyph.animate`` re-validates
     every kwarg, so the two buckets are merged and the constructor bucket is
@@ -845,6 +848,10 @@ def render_array(request: RenderRequest, **kwargs: Any) -> ArrayGlyph:
     # deprecated dict-basemap alias below. A truthy basemap of any form needs a CRS,
     # so validating first keeps the coercion — which only rewrites the local
     # ``basemap`` that ``BasemapPlan.resolve`` consumes — out of the guard's reasoning.
+    # This intentionally reorders only invalid-input paths vs the old
+    # coerce-then-validate flow: a malformed dict or a missing CRS raises a clear
+    # ValueError here before the deprecation warning fires, instead of warning (or
+    # raising a coercion TypeError) first. Every such case was — and stays — an error.
     request.validate()
     # Translate the deprecated ``dict`` basemap alias to a ``Basemap``.
     if isinstance(basemap, dict) and basemap:

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -631,6 +631,45 @@ class RenderRequest:
             ValueError: If ``mode.mode`` is not one of the accepted values, if a
                 required mode-specific argument is missing, or if ``basemap`` is
                 truthy while ``basemap_epsg`` is ``None``.
+
+        Examples:
+            - A default plot request validates silently (returns ``None``):
+
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset._plot_helpers import RenderRequest
+                >>> RenderRequest(arr=np.zeros((4, 4))).validate() is None
+                True
+
+                ```
+
+            - An unknown mode is rejected:
+
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset._plot_helpers import ModeSpec, RenderRequest
+                >>> RenderRequest(  # doctest: +IGNORE_EXCEPTION_DETAIL
+                ...     arr=np.zeros((4, 4)), mode=ModeSpec(mode="bogus")
+                ... ).validate()
+                Traceback (most recent call last):
+                    ...
+                ValueError: Invalid mode='bogus'...
+
+                ```
+
+            - A truthy basemap without a CRS is rejected:
+
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset._plot_helpers import RenderRequest
+                >>> RenderRequest(  # doctest: +IGNORE_EXCEPTION_DETAIL
+                ...     arr=np.zeros((4, 4)), basemap="OpenStreetMap"
+                ... ).validate()
+                Traceback (most recent call last):
+                    ...
+                ValueError: Dataset must have a CRS (epsg) to use basemap.
+
+                ```
         """
         valid_modes = ("plot", "animate", "facet")
         if self.mode.mode not in valid_modes:

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -61,7 +61,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Callable, Collection
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -79,7 +79,6 @@ from pyramids.base.crs import crs_from_user_input
 from pyramids.basemap import basemap as _basemap_module
 
 if TYPE_CHECKING:
-    from cleopatra.basemap.geo import Basemap
     from cleopatra.glyphs.gridded.array_glyph import ArrayGlyph
 
 # N-6 — Mesh rendering shares this module's "data in, glyph out"
@@ -529,179 +528,202 @@ def _split_render_kwargs(
     return result
 
 
-def render_array(
-    *,
-    arr: np.ndarray | None,
-    extent: list | None = None,
-    coords: tuple | list | None = None,
-    exclude_value: list | None = None,
-    rgb: list[int] | None = None,
-    surface_reflectance: int | None = None,
-    cutoff: list | None = None,
-    percentile: int | None = None,
-    mode: str = "plot",
-    animation_axis_values: list[Any] | None = None,
-    data_getter: Callable[[int], np.ndarray] | None = None,
-    facet_kwargs: dict[str, Any] | None = None,
-    ax: Any | None = None,
-    fig: Any | None = None,
-    basemap: bool | str | dict[str, Any] | Basemap | None = None,
-    basemap_epsg: int | None = None,
-    **kwargs: Any,
-) -> ArrayGlyph:
-    """Build an ArrayGlyph and dispatch to the right cleopatra render path.
+@dataclass(frozen=True)
+class ModeSpec:
+    """Render mode plus its mode-specific inputs for :func:`render_array`.
 
-    Args:
-        arr: Data array. Shape rules depend on ``mode``:
+    Groups the ``mode`` selector with the parameters only one mode consumes, so
+    the render request carries a single ``mode`` field instead of four loose
+    ones.
 
-            * ``"plot"`` — 2-D ``(rows, cols)``; or 3-D
-              ``(bands, rows, cols)`` when ``rgb`` is set so cleopatra
-              can pick the colour channels.
-            * ``"animate"`` — 3-D ``(time, rows, cols)`` for a
-              single-band colormapped time-lapse; or 4-D
-              ``(time, bands, rows, cols)`` when ``rgb`` is set, which
-              this helper composites into display-ready true-colour
-              frames before handing cleopatra a
-              ``(time, rows, cols, 3|4)`` stack.
-            * ``"facet"`` — 3-D ``(N, rows, cols)`` or 4-D
-              ``(Ncol, Nrow, rows, cols)``.
-        extent: Optional ``[xmin, ymin, xmax, ymax]`` extent. Mutually
-            exclusive with ``coords`` (cleopatra's contract). Suppressed
-            automatically when ``coords`` is supplied.
-        coords: Optional ``(x, y)`` curvilinear coordinate pair. When
-            set the renderer routes via pcolormesh.
-        exclude_value: Per-band no-data values to mask before rendering.
-        rgb: Three- or four-element list of band indices for RGB
-            compositing. Sentinel-only; meaningful for ``"plot"`` (a
-            single true-colour still) and ``"animate"`` (a true-colour
-            time-lapse, which requires a 4-D ``(time, bands, rows,
-            cols)`` ``arr``).
-        surface_reflectance: Sentinel surface-reflectance scale factor.
-        cutoff: Sentinel per-band clip values.
-        percentile: Sentinel percentile-stretch value.
+    Attributes:
         mode: One of ``"plot"`` / ``"animate"`` / ``"facet"``.
-        animation_axis_values: Frame labels for the animation path.
-            Required when ``mode == "animate"``.
-        data_getter: Optional callable ``f(i) -> ndarray`` forwarded to
-            :meth:`cleopatra.glyphs.gridded.array_glyph.ArrayGlyph.animate` as the
-            ``data_getter`` kwarg. When set the animation streams each
-            frame lazily through this callback instead of slicing the
-            pre-materialised ``arr`` stack — used by
-            :meth:`pyramids.netcdf.NetCDF.plot` to avoid building a 3-D
-            stack up front. The callable must return a 2-D array
-            matching ``arr.shape[-2:]``. Only meaningful when
-            ``mode == "animate"``.
-        facet_kwargs: Keyword args forwarded to ``ArrayGlyph.facet``
-            (``col``, ``row``, ``col_wrap``, ``col_coords``,
-            ``row_coords``, ``kind``). Required when
-            ``mode == "facet"``.
-        ax: Optional pre-existing matplotlib Axes.
-        fig: Optional pre-existing matplotlib Figure.
-        basemap: Reference layer, dispatched by type. ``True`` or a
-            non-empty web-tile / basemap provider string adds a pyramids web-tile
-            basemap underneath the rendered plot (tile mode is applied on
-            ``"plot"`` and per-panel on ``"facet"``). A
-            :class:`cleopatra.basemap.geo.Basemap` is cleopatra's relief/features
-            reference layer, forwarded to the glyph's own ``basemap=`` on the
-            ``"plot"``/``"animate"`` render call; it is **not** supported on
-            ``"facet"`` (raises). A ``dict`` is a deprecated alias translated to
-            ``Basemap`` up front (emits a ``DeprecationWarning``). An empty string
-            or empty ``dict`` is treated as no basemap.
-        basemap_epsg: CRS code passed to
-            :func:`pyramids.basemap.basemap.add_basemap` (and stamped on the
-            glyph so cleopatra's own reference layers default to it). When
-            ``basemap`` is truthy and this is ``None`` the helper
-            raises :class:`ValueError`.
-        **kwargs: Forwarded to the cleopatra entry point selected by
-            ``mode`` (including render params such as ``colorbar=`` /
-            ``full_bleed=``).
-
-    Returns:
-        The result object cleopatra returns for that mode — typically a
-        :class:`cleopatra.glyphs.gridded.array_glyph.ArrayGlyph` for ``"plot"`` and
-        ``"animate"``, and a :class:`cleopatra.glyphs.gridded.array_glyph.FacetGrid`
-        for ``"facet"``.
-
-    Raises:
-        ValueError: If ``mode`` is not one of the accepted values, if a
-            required mode-specific argument is missing, if ``basemap`` is
-            truthy and ``basemap_epsg`` is ``None``, if a cleopatra
-            ``Basemap`` (or equivalent dict) is passed on the ``"facet"``
-            path, or if a removed loose colour-bar kwarg (``cbar_*`` /
-            ``ticks_spacing``) is passed. A removed loose styling kwarg
-            (``color_scale`` / ``style`` / ``levels`` / ``point_*`` / ...)
-            surfaces cleopatra's own "moved onto a grouped parameter object"
-            ``ValueError`` from the render call.
+        animation_axis_values: Frame labels for the animation path — required
+            when ``mode == "animate"``.
+        data_getter: Optional ``f(i) -> ndarray`` streamed frame-by-frame into
+            cleopatra's ``ArrayGlyph.animate`` (used by ``NetCDF.plot`` to avoid
+            materialising a 3-D stack). Only meaningful when
+            ``mode == "animate"``; the callable must return a 2-D array matching
+            ``arr.shape[-2:]``.
+        facet_kwargs: Keyword args forwarded to ``ArrayGlyph.facet`` (``col`` /
+            ``row`` / ``col_wrap`` / ``col_coords`` / ``row_coords`` / ``kind``)
+            — required when ``mode == "facet"``.
 
     Examples:
-        - Single-slice plot path. Tagged ``+SKIP`` because the call
-          touches cleopatra / matplotlib (the helper short-circuits
-          on ``mode`` validation before that, but rendering itself
-          requires the optional ``[viz]`` extra):
+        - The default is a bare ``"plot"`` request:
+
+            ```python
+            >>> from pyramids.dataset._plot_helpers import ModeSpec
+            >>> ModeSpec().mode
+            'plot'
+
+            ```
+    """
+
+    mode: str = "plot"
+    animation_axis_values: list[Any] | None = None
+    data_getter: Callable[[int], np.ndarray] | None = None
+    facet_kwargs: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class RenderRequest:
+    """The full input to :func:`render_array`, grouped from its loose parameters.
+
+    Introducing this parameter object (composing :class:`RgbSpec` and
+    :class:`ModeSpec`) collapses ``render_array``'s signature to
+    ``render_array(request, **kwargs)`` — the styling ``**kwargs`` still ride
+    separately because they are forwarded verbatim to cleopatra.
+
+    Attributes:
+        arr: Data array. Shape rules depend on ``mode.mode``: ``"plot"`` — 2-D
+            ``(rows, cols)`` (or 3-D ``(bands, rows, cols)`` with an RGB spec);
+            ``"animate"`` — 3-D ``(time, rows, cols)`` (or 4-D
+            ``(time, bands, rows, cols)`` with an RGB spec, composited into
+            true-colour frames); ``"facet"`` — 3-D ``(N, rows, cols)`` or 4-D
+            ``(Ncol, Nrow, rows, cols)``.
+        rgb: RGB band selection + stretch (see :class:`RgbSpec`); the default
+            empty spec is the single-band colormapped path.
+        mode: Render mode + its mode-specific inputs (see :class:`ModeSpec`).
+        extent: Optional ``[xmin, ymin, xmax, ymax]`` — mutually exclusive with
+            ``coords`` (suppressed automatically when ``coords`` is supplied).
+        coords: Optional ``(x, y)`` curvilinear coordinate pair (routes via
+            pcolormesh).
+        exclude_value: Per-band no-data values to mask before rendering.
+        ax: Optional pre-existing matplotlib Axes.
+        fig: Optional pre-existing matplotlib Figure.
+        basemap: Reference layer dispatched by type — ``True`` / a provider
+            string adds a pyramids web-tile basemap; a
+            :class:`cleopatra.basemap.geo.Basemap` is forwarded to the glyph's
+            own ``basemap=``; a ``dict`` is the deprecated alias for ``Basemap``;
+            an empty string / dict means none.
+        basemap_epsg: CRS code for the tile fetch and stamped on the glyph.
+            Required (raises) when ``basemap`` is truthy.
+
+    Examples:
+        - A minimal single-band plot request:
 
             ```python
             >>> import numpy as np
-            >>> from pyramids.dataset._plot_helpers import render_array
-            >>> arr = np.random.rand(8, 8).astype(np.float32)
-            >>> cleo = render_array(  # doctest: +SKIP
-            ...     arr=arr,
-            ...     extent=[0, 0, 8, 8],
-            ...     mode="plot",
+            >>> from pyramids.dataset._plot_helpers import RenderRequest
+            >>> req = RenderRequest(arr=np.zeros((4, 4)), extent=[0, 0, 4, 4])
+            >>> req.mode.mode, req.rgb.is_set
+            ('plot', False)
+
+            ```
+    """
+
+    arr: np.ndarray | None
+    rgb: RgbSpec = field(default_factory=RgbSpec)
+    mode: ModeSpec = field(default_factory=ModeSpec)
+    extent: list | None = None
+    coords: tuple | list | None = None
+    exclude_value: list | None = None
+    ax: Any = None
+    fig: Any = None
+    basemap: bool | str | dict[str, Any] | Any = None
+    basemap_epsg: int | None = None
+
+    def validate(self) -> None:
+        """Reject an invalid mode, a missing mode-specific arg, or basemap-without-CRS.
+
+        Raises:
+            ValueError: If ``mode.mode`` is not one of the accepted values, if a
+                required mode-specific argument is missing, or if ``basemap`` is
+                truthy while ``basemap_epsg`` is ``None``.
+        """
+        valid_modes = ("plot", "animate", "facet")
+        if self.mode.mode not in valid_modes:
+            raise ValueError(
+                f"Invalid mode={self.mode.mode!r}; expected one of {valid_modes}."
+            )
+        if self.mode.mode == "animate" and self.mode.animation_axis_values is None:
+            raise ValueError("`animation_axis_values` is required when mode='animate'.")
+        if self.mode.mode == "facet" and not self.mode.facet_kwargs:
+            raise ValueError("`facet_kwargs` is required when mode='facet'.")
+        if self.basemap and self.basemap_epsg is None:
+            raise ValueError("Dataset must have a CRS (epsg) to use basemap.")
+
+
+def render_array(request: RenderRequest, **kwargs: Any) -> ArrayGlyph:
+    """Build an ArrayGlyph from a :class:`RenderRequest` and dispatch by mode.
+
+    Thin orchestrator: validate the request, composite RGB animate frames, route
+    the styling ``**kwargs`` to the right cleopatra call site, build the glyph,
+    resolve the basemap, and run the ``plot`` / ``animate`` / ``facet`` dispatch.
+    The per-field contract lives on :class:`RenderRequest`, :class:`RgbSpec`, and
+    :class:`ModeSpec`.
+
+    Args:
+        request: The grouped render input (see :class:`RenderRequest`).
+        **kwargs: Styling forwarded to the cleopatra entry point selected by
+            ``request.mode.mode`` — constructor options (``cmap`` / ``vmin`` /
+            ``colorbar=`` / ...) and render-call params (``points`` / ``kind`` /
+            ``full_bleed`` / the typed render groups). The removed loose
+            ``cbar_*`` / ``ticks_spacing`` forms are rejected here (use
+            ``colorbar=ColorBar``); a form cleopatra dropped (``color_scale`` /
+            ``style`` / ``levels`` / ``point_*`` / ...) surfaces cleopatra's own
+            "moved onto a grouped parameter object" error from the render call.
+
+    Returns:
+        The object cleopatra returns for that mode — an
+        :class:`cleopatra.glyphs.gridded.array_glyph.ArrayGlyph` for ``"plot"``
+        and ``"animate"``, a
+        :class:`cleopatra.glyphs.gridded.array_glyph.FacetGrid` for ``"facet"``.
+
+    Raises:
+        ValueError: If the request is invalid (see
+            :meth:`RenderRequest.validate`), if RGB animate gets a non-4-D
+            stack, if a cleopatra ``Basemap`` is passed on the ``"facet"`` path,
+            or if a removed loose colour-bar kwarg is passed.
+        OptionalPackageDoesNotExist: If the installed cleopatra is too old to
+            provide ``RgbBands``.
+
+    Examples:
+        - Single-slice plot request (``+SKIP`` — rendering needs the ``[viz]``
+          extra):
+
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.dataset._plot_helpers import RenderRequest, render_array
+            >>> req = RenderRequest(
+            ...     arr=np.random.rand(8, 8).astype(np.float32), extent=[0, 0, 8, 8]
             ... )
-            >>> cleo.fig  # doctest: +SKIP
-            <Figure size 800x800 with 2 Axes>
+            >>> cleo = render_array(req)  # doctest: +SKIP
 
             ```
 
-        - Animation path used by
-          :meth:`pyramids.dataset.collection.DatasetCollection.plot`.
-          The 3-D stack is ``(time, rows, cols)`` and the frame
-          labels are passed via ``animation_axis_values``:
+        - RGB animation request — a 4-D ``(time, bands, rows, cols)`` stack with
+          an :class:`RgbSpec` selecting the channels:
 
             ```python
             >>> import numpy as np
-            >>> from pyramids.dataset._plot_helpers import render_array
-            >>> stack = np.random.rand(4, 8, 8).astype(np.float32)
-            >>> cleo = render_array(  # doctest: +SKIP
-            ...     arr=stack,
-            ...     mode="animate",
-            ...     animation_axis_values=[0, 1, 2, 3],
+            >>> from pyramids.dataset._plot_helpers import (
+            ...     ModeSpec, RenderRequest, RgbSpec, render_array,
             ... )
+            >>> req = RenderRequest(
+            ...     arr=np.random.rand(4, 3, 8, 8).astype(np.float32),
+            ...     rgb=RgbSpec(rgb=[0, 1, 2], percentile=2),
+            ...     mode=ModeSpec(mode="animate", animation_axis_values=[0, 1, 2, 3]),
+            ... )
+            >>> cleo = render_array(req)  # doctest: +SKIP
 
             ```
 
-        - RGB animation path. The stack is 4-D
-          ``(time, bands, rows, cols)`` and ``rgb`` selects the colour
-          channels; the helper composites each timestep into a
-          display-ready true-colour frame before cleopatra renders it:
+        - Passing an RGB spec with a single-band 3-D stack is rejected before
+          any compositing (guards the #538 frame loss):
 
             ```python
             >>> import numpy as np
-            >>> from pyramids.dataset._plot_helpers import render_array
-            >>> stack = np.random.rand(4, 3, 8, 8).astype(np.float32)
-            >>> cleo = render_array(  # doctest: +SKIP
-            ...     arr=stack,
-            ...     rgb=[0, 1, 2],
-            ...     percentile=2,
-            ...     mode="animate",
-            ...     animation_axis_values=[0, 1, 2, 3],
+            >>> from pyramids.dataset._plot_helpers import (
+            ...     ModeSpec, RenderRequest, RgbSpec, render_array,
             ... )
-
-            ```
-
-        - Passing ``rgb`` with a single-band 3-D stack is rejected
-          before any compositing, so the time axis is never silently
-          read as the colour channels (guards the #538 frame loss):
-
-            ```python
-            >>> import numpy as np
-            >>> from pyramids.dataset._plot_helpers import render_array
-            >>> bad = np.random.rand(4, 8, 8).astype(np.float32)
             >>> render_array(  # doctest: +IGNORE_EXCEPTION_DETAIL
-            ...     arr=bad,
-            ...     rgb=[0, 1, 2],
-            ...     mode="animate",
-            ...     animation_axis_values=[0, 1, 2, 3],
+            ...     RenderRequest(
+            ...         arr=np.random.rand(4, 8, 8).astype(np.float32),
+            ...         rgb=RgbSpec(rgb=[0, 1, 2]),
+            ...         mode=ModeSpec(mode="animate", animation_axis_values=[0, 1, 2, 3]),
+            ...     )
             ... )
             Traceback (most recent call last):
                 ...
@@ -709,36 +731,18 @@ def render_array(
 
             ```
 
-        - Facet path used by :meth:`pyramids.netcdf.NetCDF.plot`. The
-          caller pre-builds the stack with ``_build_facet_stack`` and
-          passes the matching ``facet_kwargs`` dict (containing
-          ``col``, ``col_coords``, optionally ``row`` / ``row_coords``
-          / ``col_wrap``):
+        - Invalid ``mode`` values are rejected up-front:
 
             ```python
             >>> import numpy as np
-            >>> from pyramids.dataset._plot_helpers import render_array
-            >>> stack = np.random.rand(3, 8, 8).astype(np.float32)
-            >>> grid = render_array(  # doctest: +SKIP
-            ...     arr=stack,
-            ...     mode="facet",
-            ...     facet_kwargs={
-            ...         "col": "time",
-            ...         "col_coords": [0, 1, 2],
-            ...     },
+            >>> from pyramids.dataset._plot_helpers import (
+            ...     ModeSpec, RenderRequest, render_array,
             ... )
-
-            ```
-
-        - Invalid ``mode`` values are rejected up-front so caller
-          mistakes surface without touching cleopatra:
-
-            ```python
-            >>> import numpy as np
-            >>> from pyramids.dataset._plot_helpers import render_array
-            >>> arr = np.random.rand(4, 4).astype(np.float32)
             >>> render_array(  # doctest: +IGNORE_EXCEPTION_DETAIL
-            ...     arr=arr, mode="bogus",
+            ...     RenderRequest(
+            ...         arr=np.random.rand(4, 4).astype(np.float32),
+            ...         mode=ModeSpec(mode="bogus"),
+            ...     )
             ... )
             Traceback (most recent call last):
                 ...
@@ -769,6 +773,21 @@ def render_array(
             "to satisfy the version pinned in pyproject.toml."
         ) from exc
 
+    # Unpack the grouped request into the working locals the dispatch uses.
+    arr = request.arr
+    mode = request.mode.mode
+    animation_axis_values = request.mode.animation_axis_values
+    data_getter = request.mode.data_getter
+    facet_kwargs = request.mode.facet_kwargs
+    rgb_spec = request.rgb
+    coords = request.coords
+    extent = request.extent
+    exclude_value = request.exclude_value
+    ax = request.ax
+    fig = request.fig
+    basemap = request.basemap
+    basemap_epsg = request.basemap_epsg
+
     # The loose styling kwargs are no longer translated here: they moved onto the typed
     # render groups (color=ColorScaling / contour=Contour / cells=CellValues /
     # data_style=DataStyle / points=PointOverlay / colorbar=ColorBar). Passing a form
@@ -787,18 +806,8 @@ def render_array(
         )
         basemap = Basemap(**basemap)
 
-    valid_modes = ("plot", "animate", "facet")
-    if mode not in valid_modes:
-        raise ValueError(f"Invalid mode={mode!r}; expected one of {valid_modes}.")
-    if mode == "animate" and animation_axis_values is None:
-        raise ValueError("`animation_axis_values` is required when mode='animate'.")
-    if mode == "facet" and not facet_kwargs:
-        raise ValueError("`facet_kwargs` is required when mode='facet'.")
-    if basemap and basemap_epsg is None:
-        raise ValueError("Dataset must have a CRS (epsg) to use basemap.")
+    request.validate()
 
-    # RGB band selection + stretch, grouped as one value object.
-    rgb_spec = RgbSpec(rgb, surface_reflectance, cutoff, percentile)
     if mode == "animate" and rgb_spec.is_set:
         # cleopatra's ``ArrayGlyph.animate`` renders a 4-D ``(time, rows, cols,
         # 3|4)`` stack as true colour only when each frame is already

--- a/src/pyramids/dataset/_plot_helpers.py
+++ b/src/pyramids/dataset/_plot_helpers.py
@@ -233,6 +233,109 @@ def nonnull_group_kwargs(**groups: Any) -> dict[str, Any]:
 
 
 @dataclass(frozen=True)
+class RgbSpec:
+    """RGB band selection + stretch for a :func:`render_array` call.
+
+    Groups the four Sentinel RGB band-prep values — the ``[r, g, b]`` band
+    indices and the stretch controls — that select colour channels and stretch
+    them. ``is_set`` is False when no ``rgb`` list was given (the single-band
+    colormapped path); the two operations are meaningful only when ``is_set``.
+
+    The cleopatra classes the operations need (``ArrayGlyph`` for compositing,
+    ``RgbBands`` for the constructor) are passed in rather than imported, so this
+    value object stays independent of the optional ``[viz]`` extra — the caller
+    has already imported them after ``require_cleopatra()``.
+
+    Attributes:
+        rgb: Three- or four-element list of band indices, or None.
+        surface_reflectance: Sentinel surface-reflectance scale factor, or None.
+        cutoff: Sentinel per-band clip values, or None.
+        percentile: Sentinel percentile-stretch value, or None.
+
+    Examples:
+        - An empty spec is the single-band (non-RGB) case:
+
+            ```python
+            >>> from pyramids.dataset._plot_helpers import RgbSpec
+            >>> RgbSpec().is_set
+            False
+            >>> RgbSpec(rgb=[0, 1, 2]).is_set
+            True
+
+            ```
+    """
+
+    rgb: list[int] | None = None
+    surface_reflectance: int | None = None
+    cutoff: list | None = None
+    percentile: int | None = None
+
+    @property
+    def is_set(self) -> bool:
+        """True when an ``rgb`` band list was provided."""
+        return self.rgb is not None
+
+    def composite_animate_frames(
+        self, arr: np.ndarray | None, array_glyph_cls: Any
+    ) -> np.ndarray:
+        """Composite a 4-D ``(time, bands, rows, cols)`` stack into true-colour frames.
+
+        cleopatra's ``ArrayGlyph.animate`` renders a 4-D ``(time, rows, cols,
+        3|4)`` stack as true colour only when each frame is already
+        display-ready, so pyramids composites each timestep with the same
+        ``prepare_array`` cleopatra uses for the single-frame plot RGB path.
+        Requires a 4-D stack — a single-band 3-D stack is rejected up front so
+        the time axis is never read as the colour channels (guards the #538
+        frame loss).
+
+        Args:
+            arr: The ``(time, bands, rows, cols)`` stack to composite.
+            array_glyph_cls: cleopatra's ``ArrayGlyph`` (injected).
+
+        Returns:
+            A ``(time, rows, cols, 3|4)`` display-ready stack.
+        """
+        if arr is None or arr.ndim != 4:
+            raise ValueError(
+                "RGB animate requires a 4-D (time, bands, rows, cols) array; "
+                f"got {None if arr is None else arr.ndim}-D. Pass rgb only with "
+                "a multi-band temporal stack."
+            )
+        compositor = array_glyph_cls(np.zeros((1, 1)))
+        return np.stack(
+            [
+                compositor.prepare_array(
+                    arr[frame],
+                    rgb=self.rgb,
+                    surface_reflectance=self.surface_reflectance,
+                    cutoff=self.cutoff,
+                    percentile=self.percentile,
+                )
+                for frame in range(arr.shape[0])
+            ],
+            axis=0,
+        )
+
+    def to_cleo_bands(self, rgb_bands_cls: Any) -> Any:
+        """Build cleopatra's ``RgbBands`` from this spec, or None when not set.
+
+        Args:
+            rgb_bands_cls: cleopatra's ``RgbBands`` (injected).
+
+        Returns:
+            An ``RgbBands`` instance, or None for the single-band path.
+        """
+        if not self.is_set:
+            return None
+        return rgb_bands_cls(
+            self.rgb,
+            surface_reflectance=self.surface_reflectance,
+            cutoff=self.cutoff,
+            percentile=self.percentile,
+        )
+
+
+@dataclass(frozen=True)
 class BasemapPlan:
     """Resolved basemap dispatch for a single :func:`render_array` call.
 
@@ -694,39 +797,17 @@ def render_array(
     if basemap and basemap_epsg is None:
         raise ValueError("Dataset must have a CRS (epsg) to use basemap.")
 
-    # RGB animate: cleopatra's ``ArrayGlyph.animate`` renders a 4-D
-    # ``(time, rows, cols, 3|4)`` stack as true colour only when each frame is
-    # already display-ready (floats in ``[0, 1]`` / ``uint8``). We own that
-    # compositing here — the single backend abstraction — so the constructor
-    # receives a finished stack and must NOT re-run its own ``rgb`` preparation
-    # (which would re-collapse the first axis). We composite each timestep's
-    # ``(bands, rows, cols)`` slice with the same ``prepare_array`` cleopatra
-    # uses for the single-frame ``plot`` RGB path, then drop ``rgb`` so the
-    # 4-D stack flows straight through.
-    if mode == "animate" and rgb is not None:
-        if arr is None or arr.ndim != 4:
-            raise ValueError(
-                "RGB animate requires a 4-D (time, bands, rows, cols) array; "
-                f"got {None if arr is None else arr.ndim}-D. Pass rgb only with "
-                "a multi-band temporal stack."
-            )
-        compositor = ArrayGlyph(np.zeros((1, 1)))
-        arr = np.stack(
-            [
-                compositor.prepare_array(
-                    arr[frame],
-                    rgb=rgb,
-                    surface_reflectance=surface_reflectance,
-                    cutoff=cutoff,
-                    percentile=percentile,
-                )
-                for frame in range(arr.shape[0])
-            ],
-            axis=0,
-        )
-        # The stretch parameters have been consumed by ``prepare_array`` above;
-        # null them so the constructor call below cannot re-read inert values.
-        rgb = surface_reflectance = cutoff = percentile = None
+    # RGB band selection + stretch, grouped as one value object.
+    rgb_spec = RgbSpec(rgb, surface_reflectance, cutoff, percentile)
+    if mode == "animate" and rgb_spec.is_set:
+        # cleopatra's ``ArrayGlyph.animate`` renders a 4-D ``(time, rows, cols,
+        # 3|4)`` stack as true colour only when each frame is already
+        # display-ready, so composite here. After compositing, the constructor
+        # must NOT re-run RGB preparation — clear the spec so ``to_cleo_bands``
+        # yields ``rgb_bands=None`` and the finished 4-D stack flows straight
+        # through (mirrors the old "null the stretch params" step).
+        arr = rgb_spec.composite_animate_frames(arr, ArrayGlyph)
+        rgb_spec = RgbSpec()
     # A bare ``(N, 3)`` points array is no longer auto-wrapped by cleopatra (it raises on
     # the overlay-drawing kinds, and is silently ignored on contour); wrap it in a
     # ``PointOverlay`` so pyramids callers can keep passing a plain array (the ``points``
@@ -760,22 +841,10 @@ def render_array(
         kwargs, mode, option_keys
     )
 
-    # cleopatra 0.31 (serapeum-org/cleopatra#291) grouped the four loose RGB
-    # band-prep keywords (``rgb`` / ``surface_reflectance`` / ``cutoff`` /
-    # ``percentile``) into an ``RgbBands`` object; the constructor takes only
-    # ``rgb_bands=``. ``rgb`` is ``None`` on the single-band path (and on the
-    # animate path, where ``prepare_array`` already consumed the stretch above),
-    # so pass ``rgb_bands=None`` there.
-    rgb_bands = (
-        RgbBands(
-            rgb,
-            surface_reflectance=surface_reflectance,
-            cutoff=cutoff,
-            percentile=percentile,
-        )
-        if rgb is not None
-        else None
-    )
+    # cleopatra 0.31 (serapeum-org/cleopatra#291) takes the grouped
+    # ``rgb_bands=`` on the constructor; the empty spec (single-band, or the
+    # already-composited animate stack) yields ``None``.
+    rgb_bands = rgb_spec.to_cleo_bands(RgbBands)
     cleo = ArrayGlyph(
         arr,
         exclude_value=exclude_value if exclude_value is not None else np.nan,

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -30,7 +30,13 @@ from pyramids.base._utils import (
 )
 from pyramids.base.crs import crs_spec, epsg_from_user_input
 from pyramids.base.remote import cloud_config_from_env
-from pyramids.dataset._plot_helpers import nonnull_group_kwargs, render_array
+from pyramids.dataset._plot_helpers import (
+    ModeSpec,
+    RenderRequest,
+    RgbSpec,
+    nonnull_group_kwargs,
+    render_array,
+)
 from pyramids.dataset._reduce_ops import resolve_dask_op
 from pyramids.dataset._stac import from_point as _from_point
 from pyramids.dataset._stac import from_stac as _from_stac
@@ -2667,14 +2673,12 @@ class DatasetCollection:
                 f"animation_axis_values has {len(axis_values)} labels but the "
                 f"collection has {self.time_length} timesteps."
             )
-        # Forward the basemap + typed animate spec once to both render paths.
-        # ``basemap`` type-dispatches in render_array (str/True -> web tiles,
-        # ``Basemap`` -> relief); ``basemap_epsg`` comes from the base raster so a
-        # collection basemap always has a CRS. ``frame_label`` is only forwarded when
-        # set, so cleopatra keeps its default per-frame label otherwise.
+        # Styling kwargs forwarded once to both render paths as render_array's
+        # ``**kwargs``. ``basemap`` / ``basemap_epsg`` are RenderRequest fields
+        # (set on the request below), not styling kwargs. ``frame_label`` is only
+        # forwarded when set, so cleopatra keeps its default per-frame label
+        # otherwise.
         animate_extras: dict[str, Any] = {
-            "basemap": basemap,
-            "basemap_epsg": self.base.epsg,
             "colorbar": colorbar,
             "points": points,
         }
@@ -2701,13 +2705,13 @@ class DatasetCollection:
             self._validate_rgb_animation(rgb, exclude_value)
             data = np.stack([ds.read_array(band=None) for ds in self.datasets], axis=0)
             return render_array(
-                arr=data,
-                rgb=rgb,
-                surface_reflectance=surface_reflectance,
-                cutoff=cutoff,
-                percentile=percentile,
-                mode="animate",
-                animation_axis_values=axis_values,
+                RenderRequest(
+                    arr=data,
+                    rgb=RgbSpec(rgb, surface_reflectance, cutoff, percentile),
+                    mode=ModeSpec(mode="animate", animation_axis_values=axis_values),
+                    basemap=basemap,
+                    basemap_epsg=self.base.epsg,
+                ),
                 **animate_extras,
                 **kwargs,
             )
@@ -2725,10 +2729,13 @@ class DatasetCollection:
             else [no_data_value[band]]
         )
         return render_array(
-            arr=data,
-            exclude_value=exclude_value,
-            mode="animate",
-            animation_axis_values=axis_values,
+            RenderRequest(
+                arr=data,
+                exclude_value=exclude_value,
+                mode=ModeSpec(mode="animate", animation_axis_values=axis_values),
+                basemap=basemap,
+                basemap_epsg=self.base.epsg,
+            ),
             **animate_extras,
             **kwargs,
         )

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -2707,7 +2707,12 @@ class DatasetCollection:
             return render_array(
                 RenderRequest(
                     arr=data,
-                    rgb=RgbSpec(rgb, surface_reflectance, cutoff, percentile),
+                    rgb=RgbSpec(
+                        rgb=rgb,
+                        surface_reflectance=surface_reflectance,
+                        cutoff=cutoff,
+                        percentile=percentile,
+                    ),
                     mode=ModeSpec(mode="animate", animation_axis_values=axis_values),
                     basemap=basemap,
                     basemap_epsg=self.base.epsg,

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -23,7 +23,12 @@ from pyramids.base._domain import inside_domain, is_no_data
 from pyramids.base._errors import AlignmentError, OutOfBoundsError, ReadOnlyError
 from pyramids.base._utils import gdal_to_numpy_dtype, require_cleopatra
 from pyramids.dataset._mask import MaskFlags
-from pyramids.dataset._plot_helpers import render_array
+from pyramids.dataset._plot_helpers import (
+    ModeSpec,
+    RenderRequest,
+    RgbSpec,
+    render_array,
+)
 from pyramids.dataset.window import Window
 from pyramids.feature import FeatureCollection
 
@@ -2347,20 +2352,18 @@ class Analysis(_Engine["Dataset"]):
                 kwargs["cmap"] = cmap
                 kwargs["color"] = ColorScaling.boundary(bounds=bounds)
         return render_array(
-            arr=arr,
-            extent=effective_extent,
-            coords=coords,
-            exclude_value=exclude_value,
-            rgb=rgb,
-            surface_reflectance=surface_reflectance,
-            cutoff=cutoff,
-            percentile=percentile,
-            mode=mode,
-            facet_kwargs=facet_kwargs,
-            ax=ax,
-            fig=fig,
-            basemap=basemap,
-            basemap_epsg=self._ds.epsg,
+            RenderRequest(
+                arr=arr,
+                extent=effective_extent,
+                coords=coords,
+                exclude_value=exclude_value,
+                rgb=RgbSpec(rgb, surface_reflectance, cutoff, percentile),
+                mode=ModeSpec(mode=mode, facet_kwargs=facet_kwargs),
+                ax=ax,
+                fig=fig,
+                basemap=basemap,
+                basemap_epsg=self._ds.epsg,
+            ),
             **kwargs,
         )
 

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -2357,7 +2357,12 @@ class Analysis(_Engine["Dataset"]):
                 extent=effective_extent,
                 coords=coords,
                 exclude_value=exclude_value,
-                rgb=RgbSpec(rgb, surface_reflectance, cutoff, percentile),
+                rgb=RgbSpec(
+                    rgb=rgb,
+                    surface_reflectance=surface_reflectance,
+                    cutoff=cutoff,
+                    percentile=percentile,
+                ),
                 mode=ModeSpec(mode=mode, facet_kwargs=facet_kwargs),
                 ax=ax,
                 fig=fig,

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 import numpy as np
 
+from pyramids.dataset._plot_helpers import ModeSpec, RenderRequest
 from pyramids.dataset._plot_helpers import render_array as _render_array
 from pyramids.netcdf import _coord_match
 from pyramids.netcdf.plot_options import CoordinateSpec, FacetSpec, Selectors
@@ -1442,16 +1443,20 @@ class NetCDFPlot:
         ax = animate_kwargs.pop("ax", None)
         fig = animate_kwargs.pop("fig", None)
         return _render_array(
-            arr=template,
-            extent=nc.bbox,
-            exclude_value=resolved_exclude,
-            mode="animate",
-            animation_axis_values=frame_labels,
-            data_getter=_data_getter,
-            ax=ax,
-            fig=fig,
-            basemap=basemap,
-            basemap_epsg=nc.epsg,
+            RenderRequest(
+                arr=template,
+                extent=nc.bbox,
+                exclude_value=resolved_exclude,
+                mode=ModeSpec(
+                    mode="animate",
+                    animation_axis_values=frame_labels,
+                    data_getter=_data_getter,
+                ),
+                ax=ax,
+                fig=fig,
+                basemap=basemap,
+                basemap_epsg=nc.epsg,
+            ),
             **animate_kwargs,
         )
 

--- a/tests/dataset/collection/test_plot_labels.py
+++ b/tests/dataset/collection/test_plot_labels.py
@@ -57,7 +57,7 @@ class TestPlotAnimationAxisValues:
         assert cube.time is None
         with patch("pyramids.dataset.collection.render_array") as render:
             cube.plot(band=0)
-        assert render.call_args.kwargs["animation_axis_values"] == [0, 1, 2]
+        assert render.call_args.args[0].mode.animation_axis_values == [0, 1, 2]
 
     def test_forwards_basemap_epsg_from_the_base_raster(self):
         """`plot` forwards the base raster's EPSG so a basemap does not falsely
@@ -65,7 +65,7 @@ class TestPlotAnimationAxisValues:
         cube = _collection(3)
         with patch("pyramids.dataset.collection.render_array") as render:
             cube.plot(band=0, basemap="CartoDB.Positron")
-        assert render.call_args.kwargs["basemap_epsg"] == cube.base.epsg
+        assert render.call_args.args[0].basemap_epsg == cube.base.epsg
 
     def test_forwards_named_basemap_and_frame_label(self):
         """`plot` forwards the named `basemap` and `frame_label` to `render_array`."""
@@ -74,7 +74,7 @@ class TestPlotAnimationAxisValues:
         with patch("pyramids.dataset.collection.render_array") as render:
             cube.plot(band=0, basemap="CartoDB.Positron", frame_label=marker)
         kwargs = render.call_args.kwargs
-        assert kwargs["basemap"] == "CartoDB.Positron"
+        assert render.call_args.args[0].basemap == "CartoDB.Positron"
         assert kwargs["frame_label"] is marker
 
     def test_forwards_named_basemap_and_frame_label_rgb(self):
@@ -88,7 +88,7 @@ class TestPlotAnimationAxisValues:
                 frame_label=marker,
             )
         kwargs = render.call_args.kwargs
-        assert kwargs["basemap"] == "CartoDB.Positron"
+        assert render.call_args.args[0].basemap == "CartoDB.Positron"
         assert kwargs["frame_label"] is marker
 
     def test_frame_label_omitted_when_none(self):
@@ -104,7 +104,7 @@ class TestPlotAnimationAxisValues:
         cube.time = [2000, 2001, 2002]
         with patch("pyramids.dataset.collection.render_array") as render:
             cube.plot(band=0)
-        assert render.call_args.kwargs["animation_axis_values"] == [2000, 2001, 2002]
+        assert render.call_args.args[0].mode.animation_axis_values == [2000, 2001, 2002]
 
     def test_explicit_axis_values_respected(self):
         """An explicit ``animation_axis_values`` wins over the default.
@@ -117,7 +117,7 @@ class TestPlotAnimationAxisValues:
         cube.time = [2000, 2001, 2002]  # override must beat the time axis too
         with patch("pyramids.dataset.collection.render_array") as render:
             cube.plot(band=0, animation_axis_values=[7, 8, 9])
-        assert render.call_args.kwargs["animation_axis_values"] == [7, 8, 9]
+        assert render.call_args.args[0].mode.animation_axis_values == [7, 8, 9]
 
     def test_explicit_axis_values_respected_rgb(self):
         """The override also reaches the RGB (true-colour) animation branch."""
@@ -128,7 +128,7 @@ class TestPlotAnimationAxisValues:
                 rgb_options={"rgb": [0, 1, 2], "surface_reflectance": 255},
                 animation_axis_values=labels,
             )
-        assert render.call_args.kwargs["animation_axis_values"] == labels
+        assert render.call_args.args[0].mode.animation_axis_values == labels
 
     def test_wrong_length_axis_values_raises(self):
         """An explicit override whose length != frame count raises a clear error."""
@@ -160,7 +160,7 @@ class TestPlotAnimationAxisValues:
         )
         with patch("pyramids.dataset.collection.render_array") as render:
             cube.plot(band=0)
-        assert render.call_args.kwargs["animation_axis_values"] == [
+        assert render.call_args.args[0].mode.animation_axis_values == [
             dt.datetime(2000, 1, 1),
             dt.datetime(2001, 1, 1),
             dt.datetime(2002, 1, 1),

--- a/tests/dataset/plot/_render_helpers.py
+++ b/tests/dataset/plot/_render_helpers.py
@@ -8,6 +8,7 @@ internal kwarg routing and predate that change, so this thin adapter rebuilds a
 New tests should construct :class:`RenderRequest` directly.
 """
 
+from dataclasses import fields
 from typing import Any
 
 from pyramids.dataset._plot_helpers import (
@@ -17,13 +18,12 @@ from pyramids.dataset._plot_helpers import (
 )
 from pyramids.dataset._plot_helpers import render_array as _render_array
 
-_REQUEST_FIELDS = frozenset(
-    {"arr", "extent", "coords", "exclude_value", "ax", "fig", "basemap", "basemap_epsg"}
-)
-_RGB_FIELDS = frozenset({"rgb", "surface_reflectance", "cutoff", "percentile"})
-_MODE_FIELDS = frozenset(
-    {"mode", "animation_axis_values", "data_getter", "facet_kwargs"}
-)
+# Derive the field-name sets from the dataclasses so the loose-kwarg split can never
+# drift from RenderRequest / RgbSpec / ModeSpec when a field is added or renamed.
+_RGB_FIELDS = frozenset(f.name for f in fields(RgbSpec))
+_MODE_FIELDS = frozenset(f.name for f in fields(ModeSpec))
+# The RenderRequest-level fields, minus the two sub-object fields built separately.
+_REQUEST_FIELDS = frozenset(f.name for f in fields(RenderRequest)) - {"rgb", "mode"}
 
 
 def render_array(**kwargs: Any) -> Any:

--- a/tests/dataset/plot/_render_helpers.py
+++ b/tests/dataset/plot/_render_helpers.py
@@ -1,0 +1,40 @@
+"""Test adapter for calling ``render_array`` with the pre-RenderRequest kwarg style.
+
+``render_array``'s 17 loose parameters were grouped into a :class:`RenderRequest`
+(composing :class:`RgbSpec` and :class:`ModeSpec`) to clear SonarCloud
+``python:S107`` — see issue #1006. These plot tests exercise ``render_array``'s
+internal kwarg routing and predate that change, so this thin adapter rebuilds a
+``RenderRequest`` from loose kwargs and forwards the styling kwargs verbatim.
+New tests should construct :class:`RenderRequest` directly.
+"""
+
+from typing import Any
+
+from pyramids.dataset._plot_helpers import (
+    ModeSpec,
+    RenderRequest,
+    RgbSpec,
+)
+from pyramids.dataset._plot_helpers import render_array as _render_array
+
+_REQUEST_FIELDS = frozenset(
+    {"arr", "extent", "coords", "exclude_value", "ax", "fig", "basemap", "basemap_epsg"}
+)
+_RGB_FIELDS = frozenset({"rgb", "surface_reflectance", "cutoff", "percentile"})
+_MODE_FIELDS = frozenset(
+    {"mode", "animation_axis_values", "data_getter", "facet_kwargs"}
+)
+
+
+def render_array(**kwargs: Any) -> Any:
+    """Build a ``RenderRequest`` from loose kwargs and forward styling as ``**kwargs``.
+
+    Splits the caller's kwargs into the :class:`RenderRequest` fields, the
+    :class:`RgbSpec` fields, and the :class:`ModeSpec` fields; everything left
+    over is a styling kwarg forwarded verbatim to ``render_array``.
+    """
+    fields = {k: kwargs.pop(k) for k in list(kwargs) if k in _REQUEST_FIELDS}
+    rgb = {k: kwargs.pop(k) for k in list(kwargs) if k in _RGB_FIELDS}
+    mode = {k: kwargs.pop(k) for k in list(kwargs) if k in _MODE_FIELDS}
+    request = RenderRequest(rgb=RgbSpec(**rgb), mode=ModeSpec(**mode), **fields)
+    return _render_array(request, **kwargs)

--- a/tests/dataset/plot/test_basemap_dispatch.py
+++ b/tests/dataset/plot/test_basemap_dispatch.py
@@ -11,7 +11,7 @@ import numpy as np
 import pytest
 
 from pyramids.dataset import Dataset, DatasetCollection
-from pyramids.dataset._plot_helpers import render_array
+from ._render_helpers import render_array
 
 pytestmark = pytest.mark.plot
 

--- a/tests/dataset/plot/test_basemap_dispatch.py
+++ b/tests/dataset/plot/test_basemap_dispatch.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 
 from pyramids.dataset import Dataset, DatasetCollection
+
 from ._render_helpers import render_array
 
 pytestmark = pytest.mark.plot

--- a/tests/dataset/plot/test_new_render_params.py
+++ b/tests/dataset/plot/test_new_render_params.py
@@ -9,6 +9,7 @@ import numpy as np
 import pytest
 
 from pyramids.dataset import Dataset
+
 from ._render_helpers import render_array
 
 pytestmark = pytest.mark.plot

--- a/tests/dataset/plot/test_new_render_params.py
+++ b/tests/dataset/plot/test_new_render_params.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 from pyramids.dataset import Dataset
-from pyramids.dataset._plot_helpers import render_array
+from ._render_helpers import render_array
 
 pytestmark = pytest.mark.plot
 

--- a/tests/dataset/plot/test_plot_cleanups.py
+++ b/tests/dataset/plot/test_plot_cleanups.py
@@ -6,9 +6,10 @@ import numpy as np
 import pytest
 
 from pyramids.dataset import Dataset, DatasetCollection
-from ._render_helpers import render_array
 from pyramids.dataset.engines import Analysis
 from pyramids.netcdf.netcdf import NetCDF
+
+from ._render_helpers import render_array
 
 pytestmark = pytest.mark.plot
 

--- a/tests/dataset/plot/test_plot_cleanups.py
+++ b/tests/dataset/plot/test_plot_cleanups.py
@@ -6,7 +6,7 @@ import numpy as np
 import pytest
 
 from pyramids.dataset import Dataset, DatasetCollection
-from pyramids.dataset._plot_helpers import render_array
+from ._render_helpers import render_array
 from pyramids.dataset.engines import Analysis
 from pyramids.netcdf.netcdf import NetCDF
 
@@ -298,7 +298,7 @@ class TestPlotPR6Cleanups:
         """
         from unittest.mock import patch as _patch
 
-        from pyramids.dataset._plot_helpers import render_array as _rarr
+        from ._render_helpers import render_array as _rarr
 
         rng = np.random.default_rng(7)
         arr = rng.random((4, 4)).astype("float32")

--- a/tests/dataset/plot/test_plot_engine.py
+++ b/tests/dataset/plot/test_plot_engine.py
@@ -7,7 +7,7 @@ import pytest
 
 from pyramids.base._errors import OptionalPackageDoesNotExist
 from pyramids.dataset import Dataset
-from pyramids.dataset._plot_helpers import render_array
+from ._render_helpers import render_array
 from pyramids.dataset.engines import Analysis
 
 pytestmark = pytest.mark.plot

--- a/tests/dataset/plot/test_plot_engine.py
+++ b/tests/dataset/plot/test_plot_engine.py
@@ -7,8 +7,9 @@ import pytest
 
 from pyramids.base._errors import OptionalPackageDoesNotExist
 from pyramids.dataset import Dataset
-from ._render_helpers import render_array
 from pyramids.dataset.engines import Analysis
+
+from ._render_helpers import render_array
 
 pytestmark = pytest.mark.plot
 

--- a/tests/dataset/plot/test_render_array_units.py
+++ b/tests/dataset/plot/test_render_array_units.py
@@ -185,8 +185,9 @@ class TestRgbSpec:
             Guards the #538 frame loss by refusing a single-band 3-D stack (or None).
         """
         fake_cls, _ = _fake_array_glyph()
+        spec = RgbSpec(rgb=[0, 1, 2])
         with pytest.raises(ValueError, match="4-D"):
-            RgbSpec(rgb=[0, 1, 2]).composite_animate_frames(arr, fake_cls)
+            spec.composite_animate_frames(arr, fake_cls)
 
 
 class TestModeSpec:
@@ -233,8 +234,9 @@ class TestRenderRequest:
         Test scenario:
             ``mode.mode`` outside plot/animate/facet raises naming the bad value.
         """
+        request = RenderRequest(arr=np.zeros((4, 4)), mode=ModeSpec(mode="bogus"))
         with pytest.raises(ValueError, match="Invalid mode='bogus'"):
-            RenderRequest(arr=np.zeros((4, 4)), mode=ModeSpec(mode="bogus")).validate()
+            request.validate()
 
     def test_validate_requires_animation_axis_values(self):
         """Animate mode requires animation_axis_values.
@@ -242,8 +244,9 @@ class TestRenderRequest:
         Test scenario:
             ``mode='animate'`` without axis values raises.
         """
+        request = RenderRequest(arr=np.zeros((4, 4)), mode=ModeSpec(mode="animate"))
         with pytest.raises(ValueError, match="animation_axis_values"):
-            RenderRequest(arr=np.zeros((4, 4)), mode=ModeSpec(mode="animate")).validate()
+            request.validate()
 
     def test_validate_requires_facet_kwargs(self):
         """Facet mode requires facet_kwargs.
@@ -251,8 +254,9 @@ class TestRenderRequest:
         Test scenario:
             ``mode='facet'`` with no facet_kwargs raises.
         """
+        request = RenderRequest(arr=np.zeros((4, 4)), mode=ModeSpec(mode="facet"))
         with pytest.raises(ValueError, match="facet_kwargs"):
-            RenderRequest(arr=np.zeros((4, 4)), mode=ModeSpec(mode="facet")).validate()
+            request.validate()
 
     def test_validate_requires_epsg_for_basemap(self):
         """A truthy basemap without a CRS is rejected.
@@ -260,8 +264,9 @@ class TestRenderRequest:
         Test scenario:
             ``basemap`` set while ``basemap_epsg`` is None raises the CRS error.
         """
+        request = RenderRequest(arr=np.zeros((4, 4)), basemap="OpenStreetMap")
         with pytest.raises(ValueError, match="CRS"):
-            RenderRequest(arr=np.zeros((4, 4)), basemap="OpenStreetMap").validate()
+            request.validate()
 
 
 class _FakePanel:
@@ -306,7 +311,8 @@ class TestBasemapPlan:
             ``basemap=True`` means tile mode with ``source=None`` (default provider).
         """
         plan = BasemapPlan.resolve(True, 3857)
-        assert plan.tile is True and plan.source is None, f"unexpected plan: {plan}"
+        assert plan.tile is True, f"True must resolve to a tile plan: {plan}"
+        assert plan.source is None, f"True must use the default provider: {plan}"
 
     @pytest.mark.parametrize("value", ["", None, False, {}])
     def test_resolve_falsy_is_no_basemap(self, value):

--- a/tests/dataset/plot/test_render_array_units.py
+++ b/tests/dataset/plot/test_render_array_units.py
@@ -50,7 +50,9 @@ def _fake_array_glyph():
 class _FakeRgbBands:
     """Stand-in for cleopatra's RgbBands recording the constructor arguments."""
 
-    def __init__(self, indices, *, surface_reflectance=None, cutoff=None, percentile=None):
+    def __init__(
+        self, indices, *, surface_reflectance=None, cutoff=None, percentile=None
+    ):
         """Store the band indices and stretch controls verbatim."""
         self.indices = indices
         self.surface_reflectance = surface_reflectance
@@ -142,7 +144,9 @@ class TestRgbSpec:
             ``to_cleo_bands`` returns None for the single-band path so the ctor gets
             ``rgb_bands=None``.
         """
-        assert RgbSpec().to_cleo_bands(_FakeRgbBands) is None, "unset spec must give None"
+        assert RgbSpec().to_cleo_bands(_FakeRgbBands) is None, (
+            "unset spec must give None"
+        )
 
     def test_to_cleo_bands_builds_populated_bands(self):
         """A set spec builds bands echoing indices and stretch controls.
@@ -152,7 +156,10 @@ class TestRgbSpec:
             by keyword.
         """
         bands = RgbSpec(
-            rgb=[2, 1, 0], surface_reflectance=10000, cutoff=[0.1, 0.2, 0.3], percentile=2
+            rgb=[2, 1, 0],
+            surface_reflectance=10000,
+            cutoff=[0.1, 0.2, 0.3],
+            percentile=2,
         ).to_cleo_bands(_FakeRgbBands)
         assert bands.indices == [2, 1, 0], f"indices wrong: {bands.indices}"
         assert bands.surface_reflectance == 10000, "surface_reflectance not forwarded"
@@ -301,7 +308,9 @@ class TestBasemapPlan:
         plan = BasemapPlan.resolve("OpenStreetMap", 4326)
         assert plan.tile is True, "string basemap must be a tile plan"
         assert plan.source == "OpenStreetMap", f"source wrong: {plan.source}"
-        assert plan.forwards_cleo_basemap is False, "string must not forward a cleo basemap"
+        assert plan.forwards_cleo_basemap is False, (
+            "string must not forward a cleo basemap"
+        )
         assert plan.cleo_kwarg == {}, "no cleo basemap -> empty kwarg"
 
     def test_resolve_true_is_default_provider_tile(self):
@@ -338,7 +347,9 @@ class TestBasemapPlan:
         plan = BasemapPlan.resolve(marker, 4326)
         assert plan.tile is False, "an object basemap must not tile"
         assert plan.forwards_cleo_basemap is True, "an object basemap must forward"
-        assert plan.cleo_kwarg == {"basemap": marker}, f"cleo_kwarg wrong: {plan.cleo_kwarg}"
+        assert plan.cleo_kwarg == {"basemap": marker}, (
+            f"cleo_kwarg wrong: {plan.cleo_kwarg}"
+        )
 
     def test_apply_to_calls_add_basemap(self, monkeypatch):
         """``apply_to`` draws the tile basemap on the given axes via add_basemap.
@@ -373,7 +384,9 @@ class TestBasemapPlan:
             lambda ax, *, crs, source: drawn.append(ax),
             raising=True,
         )
-        grid = _FakeGrid(np.array([_FakePanel(True), _FakePanel(False), None], dtype=object))
+        grid = _FakeGrid(
+            np.array([_FakePanel(True), _FakePanel(False), None], dtype=object)
+        )
         BasemapPlan.resolve("OpenStreetMap", 4326).apply_to_facets(grid)
         assert len(drawn) == 1, f"only the visible panel must be drawn: {len(drawn)}"
 

--- a/tests/dataset/plot/test_render_array_units.py
+++ b/tests/dataset/plot/test_render_array_units.py
@@ -19,27 +19,32 @@ from pyramids.dataset._plot_helpers import (
 )
 
 
-class _FakeArrayGlyph:
-    """Stand-in for cleopatra's ArrayGlyph used by RgbSpec.composite_animate_frames."""
+def _fake_array_glyph():
+    """Return a (fake ArrayGlyph class, calls list) for RgbSpec.composite_animate_frames.
 
+    The compositor instantiates the class internally, so the per-frame stretch kwargs
+    are recorded into a closed-over ``calls`` list rather than shared class state — a
+    fresh list per factory call keeps tests isolated.
+    """
     calls: list = []
 
-    def __init__(self, array):
-        """Record construction; the compositor builds one with a dummy array."""
-        self.array = array
+    class _Fake:
+        def __init__(self, array):
+            self.array = array
 
-    def prepare_array(self, frame, *, rgb, surface_reflectance, cutoff, percentile):
-        """Record the per-frame stretch kwargs and return a display-ready RGB frame."""
-        _FakeArrayGlyph.calls.append(
-            {
-                "rgb": rgb,
-                "surface_reflectance": surface_reflectance,
-                "cutoff": cutoff,
-                "percentile": percentile,
-            }
-        )
-        rows, cols = frame.shape[-2:]
-        return np.zeros((rows, cols, 3), dtype="float32")
+        def prepare_array(self, frame, *, rgb, surface_reflectance, cutoff, percentile):
+            calls.append(
+                {
+                    "rgb": rgb,
+                    "surface_reflectance": surface_reflectance,
+                    "cutoff": cutoff,
+                    "percentile": percentile,
+                }
+            )
+            rows, cols = frame.shape[-2:]
+            return np.zeros((rows, cols, 3), dtype="float32")
+
+    return _Fake, calls
 
 
 class _FakeRgbBands:
@@ -55,11 +60,6 @@ class _FakeRgbBands:
 
 class TestSplitRenderKwargs:
     """Tests for _split_render_kwargs."""
-
-    @pytest.fixture(autouse=True)
-    def _reset(self):
-        """No shared state; present for symmetry with other fixtures."""
-        yield
 
     def test_plot_routes_options_to_ctor_and_rest_to_render(self):
         """Option keys land on the ctor bucket; non-option keys on the render bucket.
@@ -126,10 +126,6 @@ class TestSplitRenderKwargs:
 class TestRgbSpec:
     """Tests for the RgbSpec value object."""
 
-    def setup_method(self):
-        """Reset the fake glyph's recorded calls before each test."""
-        _FakeArrayGlyph.calls = []
-
     def test_is_set_false_by_default_true_with_rgb(self):
         """``is_set`` reflects whether an rgb band list was supplied.
 
@@ -170,12 +166,13 @@ class TestRgbSpec:
             Each timestep is prepared via the injected glyph and stacked on axis 0;
             the stretch kwargs reach ``prepare_array`` for every frame.
         """
+        fake_cls, calls = _fake_array_glyph()
         spec = RgbSpec(rgb=[0, 1, 2], percentile=2)
         arr = np.zeros((4, 3, 5, 6), dtype="float32")
-        out = spec.composite_animate_frames(arr, _FakeArrayGlyph)
+        out = spec.composite_animate_frames(arr, fake_cls)
         assert out.shape == (4, 5, 6, 3), f"composited shape wrong: {out.shape}"
-        assert len(_FakeArrayGlyph.calls) == 4, "prepare_array must run once per frame"
-        assert _FakeArrayGlyph.calls[0]["percentile"] == 2, "stretch kwargs not forwarded"
+        assert len(calls) == 4, "prepare_array must run once per frame"
+        assert calls[0]["percentile"] == 2, "stretch kwargs not forwarded"
 
     @pytest.mark.parametrize("arr", [None, np.zeros((4, 5, 6), dtype="float32")])
     def test_composite_animate_frames_rejects_non_4d(self, arr):
@@ -187,8 +184,9 @@ class TestRgbSpec:
         Test scenario:
             Guards the #538 frame loss by refusing a single-band 3-D stack (or None).
         """
+        fake_cls, _ = _fake_array_glyph()
         with pytest.raises(ValueError, match="4-D"):
-            RgbSpec(rgb=[0, 1, 2]).composite_animate_frames(arr, _FakeArrayGlyph)
+            RgbSpec(rgb=[0, 1, 2]).composite_animate_frames(arr, fake_cls)
 
 
 class TestModeSpec:

--- a/tests/dataset/plot/test_render_array_units.py
+++ b/tests/dataset/plot/test_render_array_units.py
@@ -1,0 +1,389 @@
+"""Fast unit tests for the render_array decomposition value objects (#1006).
+
+These target the cleopatra-free logic of the components extracted from
+``render_array`` — ``_split_render_kwargs``, ``RgbSpec``, ``ModeSpec``,
+``RenderRequest``, and ``BasemapPlan``. The cleopatra classes the RGB methods
+need are injected as fakes and ``add_basemap`` is mocked, so this module runs in
+the default (non-``plot``) suite without the ``[viz]`` extra.
+"""
+
+import numpy as np
+import pytest
+
+from pyramids.dataset._plot_helpers import (
+    BasemapPlan,
+    ModeSpec,
+    RenderRequest,
+    RgbSpec,
+    _split_render_kwargs,
+)
+
+
+class _FakeArrayGlyph:
+    """Stand-in for cleopatra's ArrayGlyph used by RgbSpec.composite_animate_frames."""
+
+    calls: list = []
+
+    def __init__(self, array):
+        """Record construction; the compositor builds one with a dummy array."""
+        self.array = array
+
+    def prepare_array(self, frame, *, rgb, surface_reflectance, cutoff, percentile):
+        """Record the per-frame stretch kwargs and return a display-ready RGB frame."""
+        _FakeArrayGlyph.calls.append(
+            {
+                "rgb": rgb,
+                "surface_reflectance": surface_reflectance,
+                "cutoff": cutoff,
+                "percentile": percentile,
+            }
+        )
+        rows, cols = frame.shape[-2:]
+        return np.zeros((rows, cols, 3), dtype="float32")
+
+
+class _FakeRgbBands:
+    """Stand-in for cleopatra's RgbBands recording the constructor arguments."""
+
+    def __init__(self, indices, *, surface_reflectance=None, cutoff=None, percentile=None):
+        """Store the band indices and stretch controls verbatim."""
+        self.indices = indices
+        self.surface_reflectance = surface_reflectance
+        self.cutoff = cutoff
+        self.percentile = percentile
+
+
+class TestSplitRenderKwargs:
+    """Tests for _split_render_kwargs."""
+
+    @pytest.fixture(autouse=True)
+    def _reset(self):
+        """No shared state; present for symmetry with other fixtures."""
+        yield
+
+    def test_plot_routes_options_to_ctor_and_rest_to_render(self):
+        """Option keys land on the ctor bucket; non-option keys on the render bucket.
+
+        Test scenario:
+            In ``plot`` mode a key in ``option_keys`` goes to ctor and a render-only
+            key goes to render; the animate bucket is empty.
+        """
+        ctor, render, animate = _split_render_kwargs(
+            {"cmap": "viridis", "points": [[1, 2, 3]]}, "plot", {"cmap", "vmin"}
+        )
+        assert ctor == {"cmap": "viridis"}, f"ctor bucket wrong: {ctor}"
+        assert render == {"points": [[1, 2, 3]]}, f"render bucket wrong: {render}"
+        assert animate == {}, f"animate bucket must be empty in plot mode: {animate}"
+
+    def test_kind_is_force_routed_to_render_even_when_an_option(self):
+        """``kind`` reaches the render call even though it is an option key.
+
+        Test scenario:
+            ``kind`` is in ``option_keys`` but must be routed to the render call so
+            cleopatra does not clobber it back to ``"auto"``.
+        """
+        ctor, render, _ = _split_render_kwargs(
+            {"cmap": "viridis", "kind": "contourf"}, "plot", {"cmap", "kind"}
+        )
+        assert "kind" not in ctor, f"kind must not stay on the ctor: {ctor}"
+        assert render["kind"] == "contourf", f"kind must reach render: {render}"
+
+    def test_animate_empties_ctor_and_merges_into_animate(self):
+        """Animate mode empties the ctor bucket and merges both into the animate bucket.
+
+        Test scenario:
+            cleopatra's ``animate`` re-validates every kwarg, so nothing rides on the
+            constructor and the animate bucket carries the union.
+        """
+        ctor, render, animate = _split_render_kwargs(
+            {"cmap": "viridis", "kind": "contourf"}, "animate", {"cmap", "kind"}
+        )
+        assert ctor == {}, f"ctor must be empty in animate mode: {ctor}"
+        assert animate == {"cmap": "viridis", "kind": "contourf"}, (
+            f"animate bucket must be the merge: {animate}"
+        )
+
+    def test_unknown_key_falls_to_render(self):
+        """A key outside ``option_keys`` is routed to the render call, not dropped.
+
+        Test scenario:
+            An unknown key must reach the render method (which rejects it) rather
+            than being silently swallowed.
+        """
+        ctor, render, _ = _split_render_kwargs({"bogus": 1}, "plot", {"cmap"})
+        assert render == {"bogus": 1}, f"unknown key must fall to render: {render}"
+        assert ctor == {}, f"ctor must be empty: {ctor}"
+
+    def test_empty_kwargs_yields_empty_buckets(self):
+        """No kwargs produces three empty buckets.
+
+        Test scenario:
+            An empty kwargs dict returns empty ctor / render / animate buckets.
+        """
+        assert _split_render_kwargs({}, "plot", {"cmap"}) == ({}, {}, {})
+
+
+class TestRgbSpec:
+    """Tests for the RgbSpec value object."""
+
+    def setup_method(self):
+        """Reset the fake glyph's recorded calls before each test."""
+        _FakeArrayGlyph.calls = []
+
+    def test_is_set_false_by_default_true_with_rgb(self):
+        """``is_set`` reflects whether an rgb band list was supplied.
+
+        Test scenario:
+            Empty spec is the single-band path; a spec with ``rgb`` is RGB.
+        """
+        assert RgbSpec().is_set is False, "empty spec must report is_set False"
+        assert RgbSpec(rgb=[0, 1, 2]).is_set is True, "rgb spec must report is_set True"
+
+    def test_to_cleo_bands_none_when_unset(self):
+        """An unset spec yields no cleopatra bands.
+
+        Test scenario:
+            ``to_cleo_bands`` returns None for the single-band path so the ctor gets
+            ``rgb_bands=None``.
+        """
+        assert RgbSpec().to_cleo_bands(_FakeRgbBands) is None, "unset spec must give None"
+
+    def test_to_cleo_bands_builds_populated_bands(self):
+        """A set spec builds bands echoing indices and stretch controls.
+
+        Test scenario:
+            ``to_cleo_bands`` forwards indices positionally and each stretch control
+            by keyword.
+        """
+        bands = RgbSpec(
+            rgb=[2, 1, 0], surface_reflectance=10000, cutoff=[0.1, 0.2, 0.3], percentile=2
+        ).to_cleo_bands(_FakeRgbBands)
+        assert bands.indices == [2, 1, 0], f"indices wrong: {bands.indices}"
+        assert bands.surface_reflectance == 10000, "surface_reflectance not forwarded"
+        assert bands.cutoff == [0.1, 0.2, 0.3], "cutoff not forwarded"
+        assert bands.percentile == 2, "percentile not forwarded"
+
+    def test_composite_animate_frames_stacks_display_ready_frames(self):
+        """Compositing a 4-D stack returns a (time, rows, cols, 3) stack.
+
+        Test scenario:
+            Each timestep is prepared via the injected glyph and stacked on axis 0;
+            the stretch kwargs reach ``prepare_array`` for every frame.
+        """
+        spec = RgbSpec(rgb=[0, 1, 2], percentile=2)
+        arr = np.zeros((4, 3, 5, 6), dtype="float32")
+        out = spec.composite_animate_frames(arr, _FakeArrayGlyph)
+        assert out.shape == (4, 5, 6, 3), f"composited shape wrong: {out.shape}"
+        assert len(_FakeArrayGlyph.calls) == 4, "prepare_array must run once per frame"
+        assert _FakeArrayGlyph.calls[0]["percentile"] == 2, "stretch kwargs not forwarded"
+
+    @pytest.mark.parametrize("arr", [None, np.zeros((4, 5, 6), dtype="float32")])
+    def test_composite_animate_frames_rejects_non_4d(self, arr):
+        """A missing or non-4-D array is rejected before any compositing.
+
+        Args:
+            arr: A None array or a 3-D stack — both invalid for RGB animate.
+
+        Test scenario:
+            Guards the #538 frame loss by refusing a single-band 3-D stack (or None).
+        """
+        with pytest.raises(ValueError, match="4-D"):
+            RgbSpec(rgb=[0, 1, 2]).composite_animate_frames(arr, _FakeArrayGlyph)
+
+
+class TestModeSpec:
+    """Tests for the ModeSpec value object."""
+
+    def test_defaults(self):
+        """The default ModeSpec is a bare plot request.
+
+        Test scenario:
+            Unset fields default to plot mode with no animate/facet inputs.
+        """
+        spec = ModeSpec()
+        assert spec.mode == "plot", f"default mode must be plot: {spec.mode}"
+        assert spec.animation_axis_values is None, "animation axis default must be None"
+        assert spec.data_getter is None, "data_getter default must be None"
+        assert spec.facet_kwargs is None, "facet_kwargs default must be None"
+
+
+class TestRenderRequest:
+    """Tests for the RenderRequest parameter object."""
+
+    def test_defaults_compose_empty_specs(self):
+        """The request defaults to an empty RgbSpec and a plot ModeSpec.
+
+        Test scenario:
+            Only ``arr`` is required; ``rgb`` / ``mode`` default via factories.
+        """
+        req = RenderRequest(arr=np.zeros((4, 4)))
+        assert req.rgb.is_set is False, "default rgb must be an unset RgbSpec"
+        assert req.mode.mode == "plot", "default mode must be a plot ModeSpec"
+        assert req.basemap is None, "default basemap must be None"
+
+    def test_validate_accepts_valid_plot(self):
+        """A plain plot request validates without error.
+
+        Test scenario:
+            A default request has a valid mode and no basemap, so validate passes.
+        """
+        RenderRequest(arr=np.zeros((4, 4))).validate()
+
+    def test_validate_rejects_unknown_mode(self):
+        """An unknown mode is rejected.
+
+        Test scenario:
+            ``mode.mode`` outside plot/animate/facet raises naming the bad value.
+        """
+        with pytest.raises(ValueError, match="Invalid mode='bogus'"):
+            RenderRequest(arr=np.zeros((4, 4)), mode=ModeSpec(mode="bogus")).validate()
+
+    def test_validate_requires_animation_axis_values(self):
+        """Animate mode requires animation_axis_values.
+
+        Test scenario:
+            ``mode='animate'`` without axis values raises.
+        """
+        with pytest.raises(ValueError, match="animation_axis_values"):
+            RenderRequest(arr=np.zeros((4, 4)), mode=ModeSpec(mode="animate")).validate()
+
+    def test_validate_requires_facet_kwargs(self):
+        """Facet mode requires facet_kwargs.
+
+        Test scenario:
+            ``mode='facet'`` with no facet_kwargs raises.
+        """
+        with pytest.raises(ValueError, match="facet_kwargs"):
+            RenderRequest(arr=np.zeros((4, 4)), mode=ModeSpec(mode="facet")).validate()
+
+    def test_validate_requires_epsg_for_basemap(self):
+        """A truthy basemap without a CRS is rejected.
+
+        Test scenario:
+            ``basemap`` set while ``basemap_epsg`` is None raises the CRS error.
+        """
+        with pytest.raises(ValueError, match="CRS"):
+            RenderRequest(arr=np.zeros((4, 4)), basemap="OpenStreetMap").validate()
+
+
+class _FakePanel:
+    """A minimal facet panel exposing get_visible for apply_to_facets tests."""
+
+    def __init__(self, visible):
+        """Store the panel's visibility flag."""
+        self._visible = visible
+
+    def get_visible(self):
+        """Return whether this panel is visible."""
+        return self._visible
+
+
+class _FakeGrid:
+    """A minimal facet grid exposing an ``axes`` array."""
+
+    def __init__(self, axes):
+        """Store the panel axes array."""
+        self.axes = axes
+
+
+class TestBasemapPlan:
+    """Tests for the BasemapPlan value object."""
+
+    def test_resolve_provider_string_is_a_tile_plan(self):
+        """A provider string resolves to a web-tile plan.
+
+        Test scenario:
+            A non-empty string means tile mode with that source and no cleo basemap.
+        """
+        plan = BasemapPlan.resolve("OpenStreetMap", 4326)
+        assert plan.tile is True, "string basemap must be a tile plan"
+        assert plan.source == "OpenStreetMap", f"source wrong: {plan.source}"
+        assert plan.forwards_cleo_basemap is False, "string must not forward a cleo basemap"
+        assert plan.cleo_kwarg == {}, "no cleo basemap -> empty kwarg"
+
+    def test_resolve_true_is_default_provider_tile(self):
+        """``True`` resolves to a tile plan with the default provider.
+
+        Test scenario:
+            ``basemap=True`` means tile mode with ``source=None`` (default provider).
+        """
+        plan = BasemapPlan.resolve(True, 3857)
+        assert plan.tile is True and plan.source is None, f"unexpected plan: {plan}"
+
+    @pytest.mark.parametrize("value", ["", None, False, {}])
+    def test_resolve_falsy_is_no_basemap(self, value):
+        """Falsy inputs resolve to a no-op plan.
+
+        Args:
+            value: An empty string / None / False / empty dict.
+
+        Test scenario:
+            Every falsy basemap means no tile and no forwarded cleo basemap.
+        """
+        plan = BasemapPlan.resolve(value, 4326)
+        assert plan.tile is False, f"falsy basemap must not tile: {value!r}"
+        assert plan.forwards_cleo_basemap is False, f"falsy must not forward: {value!r}"
+
+    def test_resolve_object_forwards_cleo_basemap(self):
+        """A non-str/bool object resolves to a forwarded cleopatra basemap.
+
+        Test scenario:
+            A ``Basemap``-like object is not a tile; it is forwarded on the render call.
+        """
+        marker = object()
+        plan = BasemapPlan.resolve(marker, 4326)
+        assert plan.tile is False, "an object basemap must not tile"
+        assert plan.forwards_cleo_basemap is True, "an object basemap must forward"
+        assert plan.cleo_kwarg == {"basemap": marker}, f"cleo_kwarg wrong: {plan.cleo_kwarg}"
+
+    def test_apply_to_calls_add_basemap(self, monkeypatch):
+        """``apply_to`` draws the tile basemap on the given axes via add_basemap.
+
+        Test scenario:
+            ``apply_to`` resolves ``add_basemap`` at call time and passes the axes,
+            the CRS, and the provider source.
+        """
+        seen = {}
+
+        def _fake_add_basemap(ax, *, crs, source):
+            seen.update(ax=ax, crs=crs, source=source)
+
+        monkeypatch.setattr(
+            "pyramids.basemap.basemap.add_basemap", _fake_add_basemap, raising=True
+        )
+        BasemapPlan.resolve("CartoDB.Positron", 4326).apply_to("AX")
+        assert seen == {"ax": "AX", "crs": 4326, "source": "CartoDB.Positron"}, (
+            f"add_basemap called with wrong args: {seen}"
+        )
+
+    def test_apply_to_facets_only_visible_panels(self, monkeypatch):
+        """``apply_to_facets`` draws under visible panels only, skipping hidden/None.
+
+        Test scenario:
+            A grid with a visible panel, a hidden panel, and a None slot draws the
+            basemap exactly once (under the visible panel).
+        """
+        drawn = []
+        monkeypatch.setattr(
+            "pyramids.basemap.basemap.add_basemap",
+            lambda ax, *, crs, source: drawn.append(ax),
+            raising=True,
+        )
+        grid = _FakeGrid(np.array([_FakePanel(True), _FakePanel(False), None], dtype=object))
+        BasemapPlan.resolve("OpenStreetMap", 4326).apply_to_facets(grid)
+        assert len(drawn) == 1, f"only the visible panel must be drawn: {len(drawn)}"
+
+    def test_apply_to_facets_no_axes_is_noop(self, monkeypatch):
+        """A grid without an ``axes`` attribute is a no-op.
+
+        Test scenario:
+            When ``grid.axes`` is None nothing is drawn.
+        """
+        drawn = []
+        monkeypatch.setattr(
+            "pyramids.basemap.basemap.add_basemap",
+            lambda ax, *, crs, source: drawn.append(ax),
+            raising=True,
+        )
+        BasemapPlan.resolve("OpenStreetMap", 4326).apply_to_facets(_FakeGrid(None))
+        assert drawn == [], "a grid with no axes must draw nothing"

--- a/tests/netcdf/plot/_plot_helpers.py
+++ b/tests/netcdf/plot/_plot_helpers.py
@@ -21,9 +21,10 @@ def _make_capture(captured: dict):
 
 
 def _make_fake_render(captured: dict):
-    """Return a side-effect for patching _render_array that stores the call kwargs."""
+    """Return a side-effect for patching _render_array; stores the RenderRequest + kwargs."""
 
-    def _inner(**kw):
+    def _inner(request=None, **kw):
+        captured["request"] = request
         captured["kw"] = kw
         return "ok"
 

--- a/tests/netcdf/plot/test_plot_animate.py
+++ b/tests/netcdf/plot/test_plot_animate.py
@@ -138,8 +138,8 @@ class TestNetCDFPlotAnimate:
                 side_effect=_make_fake_render(captured),
             ):
                 nc.plot(variable="t2m", animate=True)
-        assert captured["kw"]["mode"] == "animate"
-        assert captured["kw"]["animation_axis_values"] == labels
+        assert captured["request"].mode.mode == "animate"
+        assert captured["request"].mode.animation_axis_values == labels
 
     @pytest.mark.skipif(FrameLabel is None, reason="cleopatra < 0.26 has no FrameLabel")
     def test_animate_forwards_frame_label_to_render_array(self):
@@ -160,7 +160,7 @@ class TestNetCDFPlotAnimate:
             side_effect=_make_fake_render(captured),
         ):
             nc.plot(variable="t2m", animate=True, frame_label=spec)
-        assert captured["kw"]["mode"] == "animate"
+        assert captured["request"].mode.mode == "animate"
         assert captured["kw"]["frame_label"] is spec, (
             "frame_label must forward through NetCDF.plot's **kwargs to the animate render"
         )
@@ -184,7 +184,7 @@ class TestNetCDFPlotAnimate:
             side_effect=_make_fake_render(captured),
         ):
             nc.plot(variable="t2m", animate=True)
-        getter = captured["kw"]["data_getter"]
+        getter = captured["request"].mode.data_getter
         var = nc.get_variable("t2m")
         full = var.read_array()
         for i in range(4):
@@ -214,7 +214,7 @@ class TestNetCDFPlotAnimate:
             side_effect=_make_fake_render(captured),
         ):
             nc.plot(variable="t2m", animate=True)
-        template = captured["kw"]["arr"]
+        template = captured["request"].arr
         assert template.ndim == 2, (
             f"Template handed to render_array must be 2-D, got {template.shape}"
         )
@@ -249,11 +249,11 @@ class TestNetCDFPlotAnimateEdges:
                 selectors=Selectors(sel={"pressure_level": 500}),
                 animate=True,
             )
-        assert captured["kw"]["mode"] == "animate", (
+        assert captured["request"].mode.mode == "animate", (
             f"Pinning level via sel must still resolve animate, got "
-            f"mode={captured['kw'].get('mode')!r}"
+            f"mode={captured['request'].mode.mode!r}"
         )
-        labels = captured["kw"]["animation_axis_values"]
+        labels = captured["request"].mode.animation_axis_values
         assert list(labels) == [
             0,
             6,
@@ -294,7 +294,7 @@ class TestNetCDFPlotAnimateEdges:
                 selectors=Selectors(time=0),
                 animate="pressure_level",
             )
-        labels = captured["kw"]["animation_axis_values"]
+        labels = captured["request"].mode.animation_axis_values
         assert list(labels) == [
             1000,
             500,
@@ -339,7 +339,7 @@ class TestNetCDFPlotAnimateEdges:
             side_effect=_make_fake_render(captured),
         ):
             nc.plot(variable="t2m", animate=True)
-        getter = captured["kw"]["data_getter"]
+        getter = captured["request"].mode.data_getter
         var_cls = type(nc.get_variable("t2m"))
         orig_read = var_cls.read_array
 
@@ -379,7 +379,7 @@ class TestNetCDFPlotAnimateEdges:
                 "animate path must not allocate per-frame sel() subsets; "
                 f"sel was called {sel_mock.call_count} time(s)"
             )
-        getter = captured["kw"]["data_getter"]
+        getter = captured["request"].mode.data_getter
         var = nc.get_variable("t2m")
         for i in range(4):
             assert_array_equal(

--- a/tests/netcdf/plot/test_plot_facet.py
+++ b/tests/netcdf/plot/test_plot_facet.py
@@ -463,12 +463,12 @@ class TestNetCDFPlotFacetingEdges:
         with patch("pyramids.dataset.engines.analysis.render_array") as mock_render:
             mock_render.return_value = "ok"
             nc.plot(variable="t2m", facet=FacetSpec(col="time"))
-        extent = mock_render.call_args.kwargs.get("extent")
+        extent = mock_render.call_args.args[0].extent
         assert extent == var.bbox, (
             f"facet render extent must be the pinned subset's bbox "
             f"{var.bbox}, got {extent}"
         )
-        assert mock_render.call_args.kwargs.get("mode") == "facet", (
+        assert mock_render.call_args.args[0].mode.mode == "facet", (
             "this should have gone through the facet render path"
         )
 
@@ -486,8 +486,8 @@ class TestNetCDFPlotFacetingEdges:
         with patch("pyramids.dataset.engines.analysis.render_array") as mock_render:
             mock_render.return_value = "ok"
             nc.plot(variable="t2m")
-        extent = mock_render.call_args.kwargs.get("extent")
+        extent = mock_render.call_args.args[0].extent
         assert extent == var.bbox, (
             f"static render extent should be self._ds.bbox {var.bbox}, got {extent}"
         )
-        assert mock_render.call_args.kwargs.get("mode") == "plot"
+        assert mock_render.call_args.args[0].mode.mode == "plot"

--- a/tests/netcdf/plot/test_plot_options.py
+++ b/tests/netcdf/plot/test_plot_options.py
@@ -266,6 +266,6 @@ class TestPlotConsumesOptionDataclasses:
                 animate=True,
                 data_style=DataStyle(style="topography", hillshade=True),
             )
-        assert captured["kw"]["mode"] == "animate"
+        assert captured["request"].mode.mode == "animate"
         assert captured["kw"]["data_style"].style == "topography"
         assert captured["kw"]["data_style"].hillshade is True


### PR DESCRIPTION
# Description

Decomposes `render_array` (`src/pyramids/dataset/_plot_helpers.py`) to clear the two SonarCloud findings that both
sat on it: **`python:S107`** (17 parameters — the only remaining S107 in the codebase) and **`python:S3776`**
(cognitive complexity 69 — the highest S3776). The decomposition is data-driven: each new component was chosen by
tracing how the function's variables are born, transform, travel, and die together — not by cutting the function at
blank lines. `render_array` becomes a thin orchestrator.

**S3776 — extract cohesive clumps into named components:**

- **`_split_render_kwargs(kwargs, mode, option_keys)`** — the constructor/render/animate kwarg-routing split (the
  D-4 split, the `kind` override, the animate merge) as a stateless module-level function.
- **`BasemapPlan`** — a frozen value object that resolves the `basemap` argument by type once and owns
  `cleo_kwarg` / `forwards_cleo_basemap` / `apply_to(ax)` / `apply_to_facets(grid)`. This lifts the deeply-nested
  per-panel facet basemap loop out of `render_array` — it was the single biggest cx contributor.
- **`RgbSpec`** — a frozen value object grouping the four RGB band-prep values and owning
  `composite_animate_frames()` (the 4-D true-colour compositing + the #538 4-D guard) and `to_cleo_bands()` (the
  `RgbBands` construction). The cleopatra classes are injected so the object stays independent of the `[viz]` extra.
- **`_dispatch_render` + `_translate_facet_kwargs`** — the `plot` / `animate` / `facet` mode dispatch (and the
  facet-kwargs name translation) as module functions. The first round of extractions dropped `render_array` from
  cognitive complexity **69 → 29**, still over SonarCloud's 15 limit; lifting the mode dispatch out is what takes
  it **under 15**. `render_array` ends as a thin orchestrator: unpack → validate → composite → split → build glyph
  → resolve basemap → dispatch.

**S107 — group the parameters into cohesive sub-objects:**

- **`RenderRequest`** (frozen) composes `RgbSpec` + a new **`ModeSpec`** (`mode` + `animation_axis_values` /
  `data_getter` / `facet_kwargs`) and carries the remaining fields, collapsing the signature to
  `render_array(request, **kwargs)`. Grouping into cohesive sub-objects — rather than one flat 17-field dataclass,
  which would just relocate S107 to that dataclass's `__init__` — keeps every constructor under the 13-param limit:
  `RgbSpec` (4), `ModeSpec` (4), `BasemapPlan` (4), `RenderRequest` (10), `render_array` (2). Validation moves onto
  `RenderRequest.validate()`.

The four internal callers (`Analysis.plot`, the NetCDF animate path, and `DatasetCollection`'s RGB + non-RGB
animate paths) build a `RenderRequest`. `render_array` is a **private** helper (`_plot_helpers`), so there is **no
public API change** — `Dataset.plot` / `NetCDF.plot` / `DatasetCollection.plot` and their `rgb_options` surface are
untouched.

The plot tests that drive `render_array` directly go through a small
`tests/dataset/plot/_render_helpers.render_array` adapter (loose kwargs → `RenderRequest`), so their ~45 call sites
are unchanged; the patch/capture tests read the `RenderRequest` off the call's positional argument.

# Issues

- Closes #1006 — refactor `render_array` for `python:S107` and `python:S3776`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Each step was gated (plot lane + doctests + mypy) before the next; final state:

- [x] Full plot surface against cleopatra 0.31.0: `tests/dataset/plot tests/netcdf/plot tests/dataset/collection
      tests/basemap` → **854 passed** (incl. the 28 new unit tests); `tests/ugrid
      tests/feature/test_plot_cleopatra.py` → **291 passed**.
- [x] New fast, cleopatra-free unit file `tests/dataset/plot/test_render_array_units.py` (**28 tests**) covering
      `_split_render_kwargs`, `RgbSpec`, `ModeSpec`, `RenderRequest.validate`, and `BasemapPlan` via injected fakes
      / mocked `add_basemap` — runs in the default (non-`plot`) lane.
- [x] Behaviour-preserving: the kwarg-routing (`_FakeGlyph` capture), basemap dispatch, RGB still/animate, and
      facet per-panel paths all keep their existing assertions.
- [x] Doctests on `_plot_helpers.py` → **8 passed** (new `RgbSpec` / `BasemapPlan` / `ModeSpec` / `RenderRequest`
      examples + the rewritten `render_array` examples).
- [x] `mypy` clean on `_plot_helpers.py`, `engines/analysis.py`, `netcdf/_plot.py`, `collection.py`.
- [x] Final metrics (both confirmed by SonarCloud on this PR — 0 open issues, quality gate OK): `render_array`
      **17 → 2** params (S107 cleared) and cognitive complexity **69 → under 15** (S3776 cleared, after also
      extracting the mode dispatch); every new constructor ≤ 10 params.

# Checklist:

- [ ] updated version number in pyproject.toml. (release version is bumped by commitizen in CI, not by hand)
- [ ] added changes to History.rst. (change log is commitizen-generated)
- [ ] updated the latest version in README file. (n/a)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (Google-style docstrings + doctests on every new component)

