### PR TITLE
test(feature): reproduce the #1008 /vsicurl/ GeoJSON segfault in CI

### DIFF
--- a/tests/feature/test_issue_1008_vsicurl_geojson.py
+++ b/tests/feature/test_issue_1008_vsicurl_geojson.py
@@ -1,0 +1,26 @@
+"""Reproduction / regression test for issue #1008.
+
+``FeatureCollection.read_file`` segfaults the interpreter (exit 139) on Linux when
+reading a redirecting remote GeoJSON over ``/vsicurl/``. The geoBoundaries KEN ADM1
+GeoJSON is served from a ``github.com/<org>/<repo>/raw/<sha>/…`` URL that
+302-redirects to ``raw.githubusercontent.com``; GDAL's GeoJSON driver following that
+redirect over ``/vsicurl/`` faults natively. The identical read succeeds on Windows.
+
+This is the exact repro from the issue, added as a plain test so the CI matrix
+(Windows / Linux / macOS) shows the per-OS behaviour: Windows and macOS should read
+the polygons, Linux is expected to crash until #1008 is fixed.
+"""
+
+from pyramids.feature.collection import FeatureCollection
+
+# geoBoundaries KEN ADM1, pinned SHA (resolved from the gbOpen API on 2026-08-19).
+_GEOBOUNDARIES_KEN_ADM1 = (
+    "/vsicurl/https://github.com/wmgeolab/geoBoundaries/raw/9469f09/"
+    "releaseData/gbOpen/KEN/ADM1/geoBoundaries-KEN-ADM1.geojson"
+)
+
+
+def test_read_redirecting_remote_geojson_over_vsicurl():
+    """Read the geoBoundaries KEN ADM1 GeoJSON over ``/vsicurl/`` (issue #1008)."""
+    fc = FeatureCollection.read_file(_GEOBOUNDARIES_KEN_ADM1)
+    assert len(fc) > 0, "geoBoundaries KEN ADM1 should read as non-empty polygons"


### PR DESCRIPTION
# Description

Adds the exact reproduction from #1008 as a plain test, so the CI matrix (Windows / Linux / macOS) demonstrates the
per-OS behaviour of `FeatureCollection.read_file` on a **redirecting remote GeoJSON over `/vsicurl/`**.

The source is geoBoundaries KEN ADM1, served from a `github.com/wmgeolab/geoBoundaries/raw/<sha>/…` URL that
**302-redirects** to `raw.githubusercontent.com`. GDAL's GeoJSON driver following that redirect over `/vsicurl/`
faults natively.

**This PR is a diagnostic, not a fix.** Expected CI result:

- **Windows / macOS**: the test passes (reads the polygons — locally on Windows it's ~2–6 s).
- **Linux**: the read is expected to **segfault the interpreter (exit 139)**, taking the Linux test job down — which
  is the whole point: it reproduces #1008 in CI and shows it is a native crash, not a catchable Python error.

Verified locally on Windows: `1 passed in 2.43s`.

# Issues

- Refs #1008

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) — *reproduction/regression test only; the fix is separate*

# How Has This Been Tested?

- `pixi run -e dev pytest tests/feature/test_issue_1008_vsicurl_geojson.py` on Windows → **1 passed** (read succeeds).
- Pushed to trigger the CI matrix; the Linux leg is expected to crash (exit 139), confirming #1008.

- [x] I have added a test that reproduces the issue.
- [ ] New and existing unit tests pass locally with my changes. *(Linux is expected to fail — that is the repro.)*

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added a test that reproduces the issue.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
