### PR TITLE
fix(feature): stage remote GeoJSON to a local file instead of /vsicurl/ (#1008)

### DIFF
--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -801,6 +801,10 @@ def _read_remote_geojson_staged(
         FeatureCollection: The features read from the staged local copy.
     """
     url = _strip_vsicurl(str(path))
+    if not url.lower().startswith("https://"):
+        # Self-guard the https invariant so the helper cannot become an
+        # http/file/ftp fetch if the routing in read_file ever changes.
+        raise ValueError(f"remote GeoJSON staging requires an https:// URL, got {url!r}")
     request = urllib.request.Request(url, headers={"User-Agent": "pyramids-gis"})
     with tempfile.TemporaryDirectory(prefix="pyramids_geojson_") as work_dir:
         local = os.path.join(work_dir, "remote.geojson")

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -811,11 +811,16 @@ def _read_remote_geojson_staged(
     request = urllib.request.Request(url, headers={"User-Agent": "pyramids-gis"})
     with tempfile.TemporaryDirectory(prefix="pyramids_geojson_") as work_dir:
         local = os.path.join(work_dir, "remote.geojson")
-        with urllib.request.urlopen(  # nosec B310 - https enforced by _is_remote_geojson
-            request, timeout=_REMOTE_READ_TIMEOUT
-        ) as response:
-            with open(local, "wb") as handle:
-                shutil.copyfileobj(response, handle)
+        try:
+            with urllib.request.urlopen(  # nosec B310 - https enforced above
+                request, timeout=_REMOTE_READ_TIMEOUT
+            ) as response:
+                with open(local, "wb") as handle:
+                    shutil.copyfileobj(response, handle)
+        except urllib.error.URLError as error:
+            # Surface a download failure as the module's error type, mirroring the
+            # GDAL/pyogrio error the /vsicurl/ path would have raised.
+            raise FeatureError(f"failed to download remote GeoJSON {url!r}: {error}") from error
         gdf = _read_file_healing_crs(local, passthrough)
     return fc_cls(gdf)
 

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -729,6 +729,9 @@ _GEOJSON_SUFFIXES = (".geojson",)
 _VSICURL_PREFIXES = ("/vsicurl_streaming/", "/vsicurl/")
 """GDAL virtual-filesystem prefixes for a streamed remote read (:func:`_strip_vsicurl`)."""
 
+_HTTPS_SCHEME = "https://"
+"""The only URL scheme staged locally; a plain ``http://`` read carries no TLS to divert."""
+
 _REMOTE_READ_TIMEOUT = 60.0
 """Per-read socket timeout (seconds) for a staged remote GeoJSON download (issue #1008 review M2);
 it bounds each blocking read, not the whole transfer."""
@@ -779,7 +782,7 @@ def _is_remote_geojson(path: str | Path) -> bool:
     # archive-extension host (the `.zip` TLD) is not mistaken for an archive member.
     archive_member = _ARCHIVE_MARKER_RE.search(urlsplit(without_query).path.lower())
     result = (
-        url.lower().startswith("https://")
+        url.lower().startswith(_HTTPS_SCHEME)
         and stem.endswith(_GEOJSON_SUFFIXES)
         and not archive_member
     )
@@ -808,7 +811,7 @@ def _read_remote_geojson_staged(
         FeatureCollection: The features read from the staged local copy.
     """
     url = _strip_vsicurl(str(path))
-    if not url.lower().startswith("https://"):
+    if not url.lower().startswith(_HTTPS_SCHEME):
         # Self-guard the https invariant so the helper cannot become an
         # http/file/ftp fetch if the routing in read_file ever changes.
         raise ValueError(

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -726,7 +726,8 @@ _VSICURL_PREFIXES = ("/vsicurl_streaming/", "/vsicurl/")
 """GDAL virtual-filesystem prefixes for a streamed remote read (:func:`_strip_vsicurl`)."""
 
 _REMOTE_READ_TIMEOUT = 60.0
-"""Seconds a staged remote GeoJSON download may block before it aborts (issue #1008 review M2)."""
+"""Per-read socket timeout (seconds) for a staged remote GeoJSON download (issue #1008 review M2);
+it bounds each blocking read, not the whole transfer."""
 
 
 def _strip_vsicurl(text: str) -> str:

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -53,7 +53,7 @@ from pyramids.base._errors import FeatureError, VectorTileServerError
 from pyramids.base._ogc_api import http_error_detail, http_get_with_retry
 from pyramids.base._utils import import_pyarrow
 from pyramids.base.crs import _pyproj_crs_via_gdal
-from pyramids.base.remote import is_remote, to_fsspec_url
+from pyramids.base.remote import _ARCHIVE_MARKER_RE, is_remote, to_fsspec_url
 
 if TYPE_CHECKING:
     from pyramids.feature._lazy_collection import LazyFeatureCollection
@@ -762,6 +762,11 @@ def _is_remote_geojson(path: str | Path) -> bool:
     if not url.lower().startswith("https://"):
         return False
     stem = url.split("?", 1)[0].rstrip("/").lower()
+    if _ARCHIVE_MARKER_RE.search(stem):
+        # A GeoJSON *inside* a remote archive (`.zip/inner.geojson`) must keep the
+        # /vsizip//vsicurl/ chain `_parse_path` builds — staging would fetch the
+        # member URL directly and 404. Leave archive members on the normal path.
+        return False
     return stem.endswith(_GEOJSON_SUFFIXES)
 
 

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -722,26 +722,33 @@ _GEOJSON_SUFFIXES = (".geojson",)
 """Extension staged as remote GeoJSON (:func:`_is_remote_geojson`); bare ``.json`` is too broad
 (TopoJSON/ESRIJSON/plain JSON) so it keeps the normal ``/vsicurl/`` reader."""
 
-_VSICURL_PREFIX = "/vsicurl/"
-"""GDAL virtual-filesystem prefix for a streamed remote read (:func:`_strip_vsicurl`)."""
+_VSICURL_PREFIXES = ("/vsicurl_streaming/", "/vsicurl/")
+"""GDAL virtual-filesystem prefixes for a streamed remote read (:func:`_strip_vsicurl`)."""
 
 _REMOTE_READ_TIMEOUT = 60.0
 """Seconds a staged remote GeoJSON download may block before it aborts (issue #1008 review M2)."""
 
 
 def _strip_vsicurl(text: str) -> str:
-    """Return the bare URL behind a leading ``/vsicurl/`` wrapper.
+    """Return the bare URL behind a leading ``/vsicurl/`` or ``/vsicurl_streaming/`` wrapper.
 
     Only a *leading* prefix is removed, so a chained virtual path such as
-    ``/vsizip//vsicurl/…`` is left untouched.
+    ``/vsizip//vsicurl/…`` is left untouched. GDAL's ``/vsicurl?url=`` query form is not
+    decoded here, so a caller who uses that spelling — or reads on the ``dask`` backend —
+    is not diverted to local staging and still reaches GDAL's ``/vsicurl/`` reader.
 
     Args:
-        text: A path or URL, optionally wrapped in ``/vsicurl/``.
+        text: A path or URL, optionally wrapped in a ``/vsicurl*`` prefix.
 
     Returns:
-        str: The URL with a leading ``/vsicurl/`` removed, or ``text`` unchanged.
+        str: The URL with a leading ``/vsicurl*`` prefix removed, or ``text`` unchanged.
     """
-    return text[len(_VSICURL_PREFIX) :] if text.startswith(_VSICURL_PREFIX) else text
+    stripped = text
+    for prefix in _VSICURL_PREFIXES:
+        if text.startswith(prefix):
+            stripped = text[len(prefix) :]
+            break
+    return stripped
 
 
 def _is_remote_geojson(path: str | Path) -> bool:

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -767,15 +767,16 @@ def _is_remote_geojson(path: str | Path) -> bool:
         bool: Whether the path is a remote GeoJSON that should be staged locally.
     """
     url = _strip_vsicurl(str(path))
-    if not url.lower().startswith("https://"):
-        return False
     stem = url.split("?", 1)[0].rstrip("/").lower()
-    if _ARCHIVE_MARKER_RE.search(stem):
-        # A GeoJSON *inside* a remote archive (`.zip/inner.geojson`) must keep the
-        # /vsizip//vsicurl/ chain `_parse_path` builds — staging would fetch the
-        # member URL directly and 404. Leave archive members on the normal path.
-        return False
-    return stem.endswith(_GEOJSON_SUFFIXES)
+    # A GeoJSON *inside* a remote archive (`.zip/inner.geojson`) is excluded: staging
+    # would fetch the member URL directly and 404, so it must keep the /vsizip//vsicurl/
+    # chain `_parse_path` builds.
+    result = (
+        url.lower().startswith("https://")
+        and stem.endswith(_GEOJSON_SUFFIXES)
+        and not _ARCHIVE_MARKER_RE.search(stem)
+    )
+    return result
 
 
 def _read_remote_geojson_staged(

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -26,6 +26,7 @@ import base64
 import json
 import math
 import os
+import shutil
 import tempfile
 import threading
 import urllib.error
@@ -676,6 +677,25 @@ def read_file(
     **kwargs: Any,
 ) -> FeatureCollection | LazyFeatureCollection:
     """Read a vector file into a FeatureCollection (see FeatureCollection.read_file)."""
+    # Only pass kwargs that were actually supplied — passing the unset
+    # defaults (None) confuses some geopandas engines (ARC-72).
+    passthrough = _compact(
+        {
+            "layer": layer,
+            "bbox": bbox,
+            "mask": mask,
+            "rows": rows,
+            "columns": columns,
+            "where": where,
+        }
+    )
+    passthrough.update(kwargs)
+    if backend == "pandas" and _is_remote_geojson(path):
+        # A remote GeoJSON is staged to a local file and read from there (#1008):
+        # streaming a *redirecting* remote GeoJSON over GDAL's /vsicurl/ can segfault
+        # the interpreter in a build whose bundled libcurl/OpenSSL differs from the
+        # interpreter's. GeoJSON has no spatial index, so this loses no read pushdown.
+        return _read_remote_geojson_staged(fc_cls, path, passthrough)
     resolved = _pyramids_io._parse_path(path)
     if backend == "dask":
         return read_file_dask(
@@ -691,20 +711,67 @@ def read_file(
         )
     if backend != "pandas":
         raise ValueError(f"backend must be 'pandas' or 'dask', got {backend!r}")
-    # Only pass kwargs that were actually supplied — passing the unset
-    # defaults (None) confuses some geopandas engines (ARC-72).
-    passthrough = _compact(
-        {
-            "layer": layer,
-            "bbox": bbox,
-            "mask": mask,
-            "rows": rows,
-            "columns": columns,
-            "where": where,
-        }
-    )
-    passthrough.update(kwargs)
     gdf = _read_file_healing_crs(resolved, passthrough)
+    return fc_cls(gdf)
+
+
+_GEOJSON_SUFFIXES = (".geojson", ".json")
+"""File extensions treated as GeoJSON for the remote-staging fallback (:func:`_is_remote_geojson`)."""
+
+
+def _is_remote_geojson(path: str | Path) -> bool:
+    """True for a remote GeoJSON URL, bare or ``/vsicurl/``-wrapped (issue #1008).
+
+    Only ``http(s)://`` GeoJSON qualifies: those are the reads that stream a
+    *redirecting* URL through GDAL's ``/vsicurl/`` and can segfault a build whose
+    bundled libcurl/OpenSSL differs from the interpreter's. A local path, an
+    ``s3://``/``gs://`` object, or any non-GeoJSON remote file returns ``False`` and
+    keeps its normal read path.
+
+    Args:
+        path: The path or URL handed to :func:`read_file`.
+
+    Returns:
+        bool: Whether the path is a remote GeoJSON that should be staged locally.
+    """
+    text = str(path)
+    url = text[len("/vsicurl/") :] if text.startswith("/vsicurl/") else text
+    if not url.lower().startswith(("http://", "https://")):
+        return False
+    stem = url.split("?", 1)[0].rstrip("/").lower()
+    return stem.endswith(_GEOJSON_SUFFIXES)
+
+
+def _read_remote_geojson_staged(
+    fc_cls: type[FeatureCollection],
+    path: str | Path,
+    passthrough: dict[str, Any],
+) -> FeatureCollection:
+    """Download a remote GeoJSON and read the local copy, avoiding a ``/vsicurl/`` read.
+
+    Streaming a redirecting remote GeoJSON over GDAL's ``/vsicurl/`` can segfault the
+    interpreter in a build whose bundled libcurl/OpenSSL differs from the interpreter's
+    (issue #1008 — the manylinux wheel, whose vendored OpenSSL 3 clashes with CPython's).
+    The bytes are fetched with :mod:`urllib` (Python's own TLS, which follows the
+    redirect) and GDAL is handed a plain local file, so GDAL never does the remote read.
+
+    Args:
+        fc_cls: The FeatureCollection class to wrap the result in.
+        path: The remote GeoJSON path (bare ``http(s)://`` or ``/vsicurl/``-wrapped).
+        passthrough: Keyword arguments for :func:`geopandas.read_file`.
+
+    Returns:
+        FeatureCollection: The features read from the staged local copy.
+    """
+    text = str(path)
+    url = text[len("/vsicurl/") :] if text.startswith("/vsicurl/") else text
+    request = urllib.request.Request(url, headers={"User-Agent": "pyramids-gis"})
+    with tempfile.TemporaryDirectory(prefix="pyramids_geojson_") as work_dir:
+        local = os.path.join(work_dir, "remote.geojson")
+        with urllib.request.urlopen(request) as response:  # nosec B310 - http(s) enforced by _is_remote_geojson
+            with open(local, "wb") as handle:
+                shutil.copyfileobj(response, handle)
+        gdf = _read_file_healing_crs(local, passthrough)
     return fc_cls(gdf)
 
 

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -723,7 +723,17 @@ _VSICURL_PREFIX = "/vsicurl/"
 
 
 def _strip_vsicurl(text: str) -> str:
-    """Return the bare URL behind a ``/vsicurl/`` wrapper, else ``text`` unchanged."""
+    """Return the bare URL behind a leading ``/vsicurl/`` wrapper.
+
+    Only a *leading* prefix is removed, so a chained virtual path such as
+    ``/vsizip//vsicurl/…`` is left untouched.
+
+    Args:
+        text: A path or URL, optionally wrapped in ``/vsicurl/``.
+
+    Returns:
+        str: The URL with a leading ``/vsicurl/`` removed, or ``text`` unchanged.
+    """
     return text[len(_VSICURL_PREFIX) :] if text.startswith(_VSICURL_PREFIX) else text
 
 

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -724,6 +724,9 @@ _GEOJSON_SUFFIXES = (".geojson", ".json")
 _VSICURL_PREFIX = "/vsicurl/"
 """GDAL virtual-filesystem prefix for a streamed remote read (:func:`_strip_vsicurl`)."""
 
+_REMOTE_READ_TIMEOUT = 60.0
+"""Seconds a staged remote GeoJSON download may block before it aborts (issue #1008 review M2)."""
+
 
 def _strip_vsicurl(text: str) -> str:
     """Return the bare URL behind a leading ``/vsicurl/`` wrapper.
@@ -787,7 +790,9 @@ def _read_remote_geojson_staged(
     request = urllib.request.Request(url, headers={"User-Agent": "pyramids-gis"})
     with tempfile.TemporaryDirectory(prefix="pyramids_geojson_") as work_dir:
         local = os.path.join(work_dir, "remote.geojson")
-        with urllib.request.urlopen(request) as response:  # nosec B310 - https enforced by _is_remote_geojson
+        with urllib.request.urlopen(  # nosec B310 - https enforced by _is_remote_geojson
+            request, timeout=_REMOTE_READ_TIMEOUT
+        ) as response:
             with open(local, "wb") as handle:
                 shutil.copyfileobj(response, handle)
         gdf = _read_file_healing_crs(local, passthrough)

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -44,6 +44,7 @@ import pandas as pd
 import pyogrio
 import pyproj
 from geopandas import GeoDataFrame
+from osgeo import gdal
 from pyproj.exceptions import CRSError as _PyprojCRSError
 from shapely.geometry import box
 
@@ -690,11 +691,13 @@ def read_file(
         }
     )
     passthrough.update(kwargs)
-    if backend == "pandas" and _is_remote_geojson(path):
+    if backend == "pandas" and _is_remote_geojson(path) and not _gdal_http_options_active():
         # A remote GeoJSON is staged to a local file and read from there (#1008):
         # streaming a *redirecting* remote GeoJSON over GDAL's /vsicurl/ can segfault
         # the interpreter in a build whose bundled libcurl/OpenSSL differs from the
         # interpreter's. GeoJSON has no spatial index, so this loses no read pushdown.
+        # Staging is skipped when a GDAL HTTP option is set so the caller's auth/TLS
+        # tuning still reaches GDAL's /vsicurl/ reader (urllib would drop it).
         return _read_remote_geojson_staged(fc_cls, path, passthrough)
     resolved = _pyramids_io._parse_path(path)
     if backend == "dask":
@@ -789,6 +792,40 @@ def _read_remote_geojson_staged(
                 shutil.copyfileobj(response, handle)
         gdf = _read_file_healing_crs(local, passthrough)
     return fc_cls(gdf)
+
+
+_GDAL_HTTP_OPTION_KEYS = (
+    "GDAL_HTTP_HEADERS",
+    "GDAL_HTTP_HEADER_FILE",
+    "GDAL_HTTP_AUTH",
+    "GDAL_HTTP_USERPWD",
+    "GDAL_HTTP_COOKIE",
+    "GDAL_HTTP_COOKIEFILE",
+    "GDAL_HTTP_PROXY",
+    "GDAL_HTTP_PROXYUSERPWD",
+    "GDAL_HTTP_UNSAFESSL",
+    "GDAL_HTTP_CAPATH",
+    "GDAL_HTTP_CACERT",
+    "GDAL_HTTP_SSLCERT",
+    "GDAL_HTTP_SSLKEY",
+    "CPL_VSIL_CURL_USERPWD",
+)
+"""GDAL HTTP config options a ``/vsicurl/`` read honours (:func:`_gdal_http_options_active`)."""
+
+
+def _gdal_http_options_active() -> bool:
+    """True when a GDAL HTTP auth/TLS config option is set (issue #1008 review M1).
+
+    The staging fallback fetches with :mod:`urllib` and cannot see GDAL config options,
+    so a caller who supplied credentials or TLS tuning through environment variables or
+    :class:`pyramids.base.remote.CloudConfig` must keep the ``/vsicurl/`` path. When any
+    such option is set, :func:`read_file` skips staging and lets GDAL do the read so the
+    caller's options still apply.
+
+    Returns:
+        bool: Whether any GDAL HTTP auth/TLS config option is currently set.
+    """
+    return any(gdal.GetConfigOption(key) for key in _GDAL_HTTP_OPTION_KEYS)
 
 
 _CRS_HEALING_LOCK = threading.Lock()

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -767,14 +767,16 @@ def _is_remote_geojson(path: str | Path) -> bool:
         bool: Whether the path is a remote GeoJSON that should be staged locally.
     """
     url = _strip_vsicurl(str(path))
-    stem = url.split("?", 1)[0].rstrip("/").lower()
-    # A GeoJSON *inside* a remote archive (`.zip/inner.geojson`) is excluded: staging
-    # would fetch the member URL directly and 404, so it must keep the /vsizip//vsicurl/
-    # chain `_parse_path` builds.
+    without_query = url.split("?", 1)[0].rstrip("/")
+    stem = without_query.lower()
+    # A GeoJSON *inside* a remote archive (`.zip/inner.geojson`) is excluded so it keeps
+    # the /vsizip//vsicurl/ chain `_parse_path` builds. Scan only the URL *path* so an
+    # archive-extension host (the `.zip` TLD) is not mistaken for an archive member.
+    archive_member = _ARCHIVE_MARKER_RE.search(urlsplit(without_query).path.lower())
     result = (
         url.lower().startswith("https://")
         and stem.endswith(_GEOJSON_SUFFIXES)
-        and not _ARCHIVE_MARKER_RE.search(stem)
+        and not archive_member
     )
     return result
 

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -718,13 +718,21 @@ def read_file(
 _GEOJSON_SUFFIXES = (".geojson", ".json")
 """File extensions treated as GeoJSON for the remote-staging fallback (:func:`_is_remote_geojson`)."""
 
+_VSICURL_PREFIX = "/vsicurl/"
+"""GDAL virtual-filesystem prefix for a streamed remote read (:func:`_strip_vsicurl`)."""
+
+
+def _strip_vsicurl(text: str) -> str:
+    """Return the bare URL behind a ``/vsicurl/`` wrapper, else ``text`` unchanged."""
+    return text[len(_VSICURL_PREFIX) :] if text.startswith(_VSICURL_PREFIX) else text
+
 
 def _is_remote_geojson(path: str | Path) -> bool:
-    """True for a remote GeoJSON URL, bare or ``/vsicurl/``-wrapped (issue #1008).
+    """True for an ``https://`` GeoJSON URL, bare or ``/vsicurl/``-wrapped (issue #1008).
 
-    Only ``http(s)://`` GeoJSON qualifies: those are the reads that stream a
-    *redirecting* URL through GDAL's ``/vsicurl/`` and can segfault a build whose
-    bundled libcurl/OpenSSL differs from the interpreter's. A local path, an
+    Only an ``https://`` GeoJSON qualifies: the segfault is a TLS/OpenSSL clash while
+    GDAL's ``/vsicurl/`` follows a redirect, so it is the *TLS* read that must be kept
+    away from GDAL. A plain ``http://`` read carries no TLS, and a local path, an
     ``s3://``/``gs://`` object, or any non-GeoJSON remote file returns ``False`` and
     keeps its normal read path.
 
@@ -734,9 +742,8 @@ def _is_remote_geojson(path: str | Path) -> bool:
     Returns:
         bool: Whether the path is a remote GeoJSON that should be staged locally.
     """
-    text = str(path)
-    url = text[len("/vsicurl/") :] if text.startswith("/vsicurl/") else text
-    if not url.lower().startswith(("http://", "https://")):
+    url = _strip_vsicurl(str(path))
+    if not url.lower().startswith("https://"):
         return False
     stem = url.split("?", 1)[0].rstrip("/").lower()
     return stem.endswith(_GEOJSON_SUFFIXES)
@@ -757,18 +764,17 @@ def _read_remote_geojson_staged(
 
     Args:
         fc_cls: The FeatureCollection class to wrap the result in.
-        path: The remote GeoJSON path (bare ``http(s)://`` or ``/vsicurl/``-wrapped).
+        path: The remote GeoJSON path (bare ``https://`` or ``/vsicurl/``-wrapped).
         passthrough: Keyword arguments for :func:`geopandas.read_file`.
 
     Returns:
         FeatureCollection: The features read from the staged local copy.
     """
-    text = str(path)
-    url = text[len("/vsicurl/") :] if text.startswith("/vsicurl/") else text
+    url = _strip_vsicurl(str(path))
     request = urllib.request.Request(url, headers={"User-Agent": "pyramids-gis"})
     with tempfile.TemporaryDirectory(prefix="pyramids_geojson_") as work_dir:
         local = os.path.join(work_dir, "remote.geojson")
-        with urllib.request.urlopen(request) as response:  # nosec B310 - http(s) enforced by _is_remote_geojson
+        with urllib.request.urlopen(request) as response:  # nosec B310 - https enforced by _is_remote_geojson
             with open(local, "wb") as handle:
                 shutil.copyfileobj(response, handle)
         gdf = _read_file_healing_crs(local, passthrough)

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -718,8 +718,9 @@ def read_file(
     return fc_cls(gdf)
 
 
-_GEOJSON_SUFFIXES = (".geojson", ".json")
-"""File extensions treated as GeoJSON for the remote-staging fallback (:func:`_is_remote_geojson`)."""
+_GEOJSON_SUFFIXES = (".geojson",)
+"""Extension staged as remote GeoJSON (:func:`_is_remote_geojson`); bare ``.json`` is too broad
+(TopoJSON/ESRIJSON/plain JSON) so it keeps the normal ``/vsicurl/`` reader."""
 
 _VSICURL_PREFIX = "/vsicurl/"
 """GDAL virtual-filesystem prefix for a streamed remote read (:func:`_strip_vsicurl`)."""

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -823,6 +823,7 @@ _GDAL_HTTP_OPTION_KEYS = (
     "GDAL_HTTP_HEADERS",
     "GDAL_HTTP_HEADER_FILE",
     "GDAL_HTTP_AUTH",
+    "GDAL_HTTP_BEARER",
     "GDAL_HTTP_USERPWD",
     "GDAL_HTTP_COOKIE",
     "GDAL_HTTP_COOKIEFILE",
@@ -833,6 +834,7 @@ _GDAL_HTTP_OPTION_KEYS = (
     "GDAL_HTTP_CACERT",
     "GDAL_HTTP_SSLCERT",
     "GDAL_HTTP_SSLKEY",
+    "GDAL_HTTP_SSLKEYPASSWORD",
     "CPL_VSIL_CURL_USERPWD",
 )
 """GDAL HTTP config options a ``/vsicurl/`` read honours (:func:`_gdal_http_options_active`)."""
@@ -846,6 +848,10 @@ def _gdal_http_options_active() -> bool:
     :class:`pyramids.base.remote.CloudConfig` must keep the ``/vsicurl/`` path. When any
     such option is set, :func:`read_file` skips staging and lets GDAL do the read so the
     caller's options still apply.
+
+    Any non-empty value counts as set — an explicitly falsy value (e.g.
+    ``GDAL_HTTP_UNSAFESSL=NO``) still keeps the ``/vsicurl/`` path, a deliberately
+    conservative choice that never strips a caller's HTTP configuration.
 
     Returns:
         bool: Whether any GDAL HTTP auth/TLS config option is currently set.

--- a/src/pyramids/feature/_read.py
+++ b/src/pyramids/feature/_read.py
@@ -691,7 +691,11 @@ def read_file(
         }
     )
     passthrough.update(kwargs)
-    if backend == "pandas" and _is_remote_geojson(path) and not _gdal_http_options_active():
+    if (
+        backend == "pandas"
+        and _is_remote_geojson(path)
+        and not _gdal_http_options_active()
+    ):
         # A remote GeoJSON is staged to a local file and read from there (#1008):
         # streaming a *redirecting* remote GeoJSON over GDAL's /vsicurl/ can segfault
         # the interpreter in a build whose bundled libcurl/OpenSSL differs from the
@@ -807,7 +811,9 @@ def _read_remote_geojson_staged(
     if not url.lower().startswith("https://"):
         # Self-guard the https invariant so the helper cannot become an
         # http/file/ftp fetch if the routing in read_file ever changes.
-        raise ValueError(f"remote GeoJSON staging requires an https:// URL, got {url!r}")
+        raise ValueError(
+            f"remote GeoJSON staging requires an https:// URL, got {url!r}"
+        )
     request = urllib.request.Request(url, headers={"User-Agent": "pyramids-gis"})
     with tempfile.TemporaryDirectory(prefix="pyramids_geojson_") as work_dir:
         local = os.path.join(work_dir, "remote.geojson")
@@ -820,7 +826,9 @@ def _read_remote_geojson_staged(
         except urllib.error.URLError as error:
             # Surface a download failure as the module's error type, mirroring the
             # GDAL/pyogrio error the /vsicurl/ path would have raised.
-            raise FeatureError(f"failed to download remote GeoJSON {url!r}: {error}") from error
+            raise FeatureError(
+                f"failed to download remote GeoJSON {url!r}: {error}"
+            ) from error
         gdf = _read_file_healing_crs(local, passthrough)
     return fc_cls(gdf)
 

--- a/tests/dataset/io/test_stream_transform.py
+++ b/tests/dataset/io/test_stream_transform.py
@@ -302,14 +302,22 @@ class TestStreamReduce:
         """Reducing a disk raster peaks below a whole-array pass, proving the strip read.
 
         Test scenario:
-            Sum a 1000x1000 raster in 64-row strips, and compare the traced Python peak
+            Sum an 8000x1000 raster in 64-row strips, and compare the traced Python peak
             against a whole-array pass (read the whole array and reduce at once) in the same
             process. The stripped peak must stay below the whole-array peak. This is a
             build-agnostic check on purpose: the absolute figures depend on the GDAL build
             (tracemalloc only sees the Python heap, not GDAL's C buffers), but the same
             reduction done all-at-once is always an upper bound on the stripped version.
+
+            The raster is deliberately tall and narrow. `stream_reduce`'s peak is a *fixed*
+            per-strip overhead that does not grow with the raster but does vary sharply by
+            build (measured ~0.3 MB on conda vs ~4 MB on the pip wheel), while the
+            whole-array peak scales with total size. Sizing the raster so a full
+            materialisation (~16 MB here) dwarfs that overhead keeps the `<` bound true on
+            every build — at 1000x1000 the 2 MB whole-array pass sat *under* the wheel's
+            strip overhead and the bound flipped (#1008 follow-up).
         """
-        rows = cols = 1000
+        rows, cols = 8000, 1000
         src_path = tmp_path / "big.tif"
         Dataset.create_from_array(
             np.arange(rows * cols, dtype="int16").reshape(rows, cols),

--- a/tests/dataset/io/test_stream_transform.py
+++ b/tests/dataset/io/test_stream_transform.py
@@ -298,57 +298,59 @@ class TestStreamReduce:
         )
         assert len(windows) == 3, f"expected 3 strips over 7 rows, got {len(windows)}"
 
-    def test_peak_memory_is_bounded_by_the_strip(self, tmp_path):
-        """Reducing a disk raster peaks below a whole-array pass, proving the strip read.
+    def test_peak_memory_does_not_scale_with_raster_size(self, tmp_path):
+        """stream_reduce's peak stays flat as the raster grows 8x, proving the strip read.
 
         Test scenario:
-            Sum an 8000x1000 raster in 64-row strips, and compare the traced Python peak
-            against a whole-array pass (read the whole array and reduce at once) in the same
-            process. The stripped peak must stay below the whole-array peak. This is a
-            build-agnostic check on purpose: the absolute figures depend on the GDAL build
-            (tracemalloc only sees the Python heap, not GDAL's C buffers), but the same
-            reduction done all-at-once is always an upper bound on the stripped version.
+            Run the same 64-row-strip reduction over a 1000-row raster and an 8000-row
+            raster and compare the two traced Python-heap peaks. A strip read holds one
+            strip at a time, so its peak is a fixed per-strip overhead that does not grow
+            with the raster; an implementation that materialised the whole array would grow
+            ~8x with it.
 
-            The raster is deliberately tall and narrow. `stream_reduce`'s peak is a *fixed*
-            per-strip overhead that does not grow with the raster but does vary sharply by
-            build (measured ~0.3 MB on conda vs ~4 MB on the pip wheel), while the
-            whole-array peak scales with total size. Sizing the raster so a full
-            materialisation (~16 MB here) dwarfs that overhead keeps the `<` bound true on
-            every build — at 1000x1000 the 2 MB whole-array pass sat *under* the wheel's
-            strip overhead and the bound flipped (#1008 follow-up).
+            This is build-agnostic by construction and carries no tight, build-sensitive
+            threshold: whatever the per-strip overhead is (measured ~0.3 MB on conda, ~4 MB
+            on the pip wheel), it cancels because both measurements share it — the assertion
+            only asks that the peak not scale with the raster, with generous headroom for
+            allocator noise. The previous zero-margin `stripped < whole` check on a single
+            1000x1000 raster flaked precisely because the wheel's ~4 MB strip overhead
+            exceeded that raster's 2 MB whole-array pass (#1008 follow-up).
         """
-        rows, cols = 8000, 1000
-        src_path = tmp_path / "big.tif"
-        Dataset.create_from_array(
-            np.arange(rows * cols, dtype="int16").reshape(rows, cols),
-            top_left_corner=(0.0, 0.0),
-            cell_size=0.01,
-            epsg=4326,
-            path=str(src_path),
-        ).close()
+        cols = 1000
 
         def value_sum(acc, strip, _w):
-            # int64 accumulation on both sides so the == assertion below is
-            # independent of the platform's default int16.sum() accumulator width.
+            # int64 accumulation so the result is independent of the platform's default
+            # int16.sum() accumulator width.
             return acc + int(strip.sum(dtype="int64"))
 
-        # Whole-array baseline: read the full array and reduce it at once.
-        with traced_peak() as wp:
-            whole = Dataset.read_file(str(src_path)).read_array()
-            whole_result = int(whole.sum(dtype="int64"))
-        whole_peak = wp[0]
-        del whole
+        def reduce_peak(rows):
+            arr = np.arange(rows * cols, dtype="int16").reshape(rows, cols)
+            src_path = tmp_path / f"strip_{rows}.tif"
+            Dataset.create_from_array(
+                arr,
+                top_left_corner=(0.0, 0.0),
+                cell_size=0.01,
+                epsg=4326,
+                path=str(src_path),
+            ).close()
+            # `arr` is allocated before tracing starts, so it never enters the peak below.
+            expected = int(arr.sum(dtype="int64"))
+            with traced_peak() as peak:
+                ds = Dataset.read_file(str(src_path))
+                result = ds.io.stream_reduce(value_sum, 0, strip_rows=64)
+            assert result == expected, f"stripped reduction diverged at {rows} rows"
+            return peak[0]
 
-        # Stripped reduction.
-        with traced_peak() as sp:
-            ds = Dataset.read_file(str(src_path))
-            stripped_result = ds.io.stream_reduce(value_sum, 0, strip_rows=64)
-        stripped_peak = sp[0]
+        small_peak = reduce_peak(1000)
+        large_peak = reduce_peak(8000)
 
-        assert stripped_result == whole_result, "stripped reduction diverged"
-        assert stripped_peak < whole_peak, (
-            f"stream_reduce peaked at {stripped_peak / 1e6:.1f} MB, not below the whole-array "
-            f"pass's {whole_peak / 1e6:.1f} MB — it did not stay under a full materialisation"
+        # The raster grew 8x; a whole-array reduction's peak would grow with it. The strip
+        # read's peak must stay flat — allow generous headroom (4x) for allocator noise
+        # while still catching an implementation that materialises the whole raster.
+        assert large_peak < small_peak * 4, (
+            f"stream_reduce peak grew from {small_peak / 1e6:.1f} MB at 1000 rows to "
+            f"{large_peak / 1e6:.1f} MB at 8000 rows — it scales with the raster instead "
+            "of reading one strip at a time"
         )
 
 

--- a/tests/feature/test_cloud_reads.py
+++ b/tests/feature/test_cloud_reads.py
@@ -41,7 +41,9 @@ class TestHttpRewrite:
     """Assert that ``http://`` URLs reach ``gpd.read_file`` as ``/vsicurl/...``.
 
     Mocks ``geopandas.read_file`` so no network traffic is issued. The
-    point of the test is the rewrite, not GDAL's curl behavior.
+    point of the test is the rewrite, not GDAL's curl behavior. A GeoPackage
+    URL is used because remote GeoJSON is deliberately staged to a local file
+    instead of streamed over ``/vsicurl/`` (issue #1008).
     """
 
     def _fake_gdf(self) -> gpd.GeoDataFrame:
@@ -62,7 +64,7 @@ class TestHttpRewrite:
 
         monkeypatch.setattr("pyramids.feature.collection.gpd.read_file", fake_read_file)
 
-        url = "http://example.invalid/points.geojson"
+        url = "http://example.invalid/points.gpkg"
         fc = FeatureCollection.read_file(url)
 
         assert captured["path"] == f"/vsicurl/{url}"
@@ -79,7 +81,7 @@ class TestHttpRewrite:
 
         monkeypatch.setattr("pyramids.feature.collection.gpd.read_file", fake_read_file)
 
-        url = "https://example.invalid/points.geojson"
+        url = "https://example.invalid/points.gpkg"
         FeatureCollection.read_file(url)
 
         assert captured["path"] == f"/vsicurl/{url}"
@@ -92,7 +94,7 @@ class TestHttpRewrite:
 
         monkeypatch.setattr("pyramids.feature.collection.gpd.read_file", fake_read_file)
 
-        url = "http://example.invalid/points.geojson"
+        url = "http://example.invalid/points.gpkg"
         with caplog.at_level(logging.DEBUG, logger="pyramids.base.remote"):
             FeatureCollection.read_file(url)
 

--- a/tests/feature/test_cloud_reads.py
+++ b/tests/feature/test_cloud_reads.py
@@ -103,6 +103,23 @@ class TestHttpRewrite:
             f"expected a /vsicurl/ rewrite log; got: {messages}"
         )
 
+    def test_http_geojson_still_rewrites_to_vsicurl(self, monkeypatch):
+        """An `http://…geojson` URL is not staged (staging is https-only) and reaches `/vsicurl/`."""
+        captured: dict[str, object] = {}
+
+        def fake_read_file(path, **kwargs):
+            captured["path"] = path
+            return self._fake_gdf()
+
+        monkeypatch.setattr("pyramids.feature.collection.gpd.read_file", fake_read_file)
+
+        url = "http://example.invalid/points.geojson"
+        FeatureCollection.read_file(url)
+
+        assert captured["path"] == f"/vsicurl/{url}", (
+            f"http GeoJSON should stay on /vsicurl/, got: {captured['path']}"
+        )
+
 
 class TestFileUrlRead:
     """``file://`` URLs are rewritten to plain local paths (no network)."""

--- a/tests/feature/test_issue_1008_remote_geojson.py
+++ b/tests/feature/test_issue_1008_remote_geojson.py
@@ -36,9 +36,9 @@ _POINT_GEOJSON = (
     [
         ("/vsicurl/https://host/x.geojson", True),
         ("https://host/x.geojson", True),
-        ("http://host/x.geojson", True),
         ("https://host/x.json", True),
         ("https://host/data.geojson?token=abc", True),
+        ("http://host/x.geojson", False),
         ("/vsicurl/https://host/x.gpkg", False),
         ("https://host/x.tif", False),
         ("/data/local/x.geojson", False),
@@ -46,7 +46,7 @@ _POINT_GEOJSON = (
     ],
 )
 def test_is_remote_geojson_detection(path: str, expected: bool):
-    """Only ``http(s)://`` GeoJSON (bare or ``/vsicurl/``-wrapped) is staged."""
+    """Only an ``https://`` GeoJSON (bare or ``/vsicurl/``-wrapped) is staged."""
     assert _read._is_remote_geojson(path) is expected
 
 
@@ -67,7 +67,9 @@ def test_remote_geojson_is_staged_not_streamed(monkeypatch: pytest.MonkeyPatch):
     fc = FeatureCollection.read_file(_GEOBOUNDARIES_KEN_ADM1)
 
     assert len(fc) == 1
-    assert "/vsicurl/" not in seen["path"], f"read a local copy, not /vsicurl/: {seen['path']}"
+    assert "/vsicurl/" not in seen["path"], (
+        f"read a local copy, not /vsicurl/: {seen['path']}"
+    )
     assert seen["path"].endswith(".geojson")
 
 

--- a/tests/feature/test_issue_1008_remote_geojson.py
+++ b/tests/feature/test_issue_1008_remote_geojson.py
@@ -7,13 +7,20 @@ with CPython's). The fix fetches the bytes with :mod:`urllib` (Python's own TLS,
 follows the redirect) and hands GDAL a plain local file, so GDAL never does the remote
 read.
 
-The offline tests below assert that routing decision deterministically (they run in the
-normal matrix); the ``live`` test reads the real geoBoundaries source end to end.
+These tests cover the three helpers added for the fix — :func:`_strip_vsicurl`,
+:func:`_is_remote_geojson`, :func:`_read_remote_geojson_staged` — and the routing branch
+they drive in :func:`pyramids.feature._read.read_file`. Every offline test is
+deterministic (mocked download) and runs in the normal matrix; the single ``live`` test
+reads the real geoBoundaries source end to end.
 """
 
 import io
+import urllib.error
+from pathlib import Path
 
+import geopandas as gpd
 import pytest
+from shapely.geometry import Point
 
 from pyramids.feature import _read
 from pyramids.feature.collection import FeatureCollection
@@ -31,50 +38,256 @@ _POINT_GEOJSON = (
 )
 
 
-@pytest.mark.parametrize(
-    "path,expected",
-    [
-        ("/vsicurl/https://host/x.geojson", True),
-        ("https://host/x.geojson", True),
-        ("https://host/x.json", True),
-        ("https://host/data.geojson?token=abc", True),
-        ("http://host/x.geojson", False),
-        ("/vsicurl/https://host/x.gpkg", False),
-        ("https://host/x.tif", False),
-        ("/data/local/x.geojson", False),
-        ("s3://bucket/x.geojson", False),
-    ],
-)
-def test_is_remote_geojson_detection(path: str, expected: bool):
-    """Only an ``https://`` GeoJSON (bare or ``/vsicurl/``-wrapped) is staged."""
-    assert _read._is_remote_geojson(path) is expected
+def _fake_gdf() -> gpd.GeoDataFrame:
+    """Return a one-row GeoDataFrame standing in for a parsed GeoJSON.
+
+    Returns:
+        geopandas.GeoDataFrame: A single WGS84 point feature with an ``n`` column.
+    """
+    return gpd.GeoDataFrame({"n": [1]}, geometry=[Point(0, 0)], crs="EPSG:4326")
 
 
-def test_remote_geojson_is_staged_not_streamed(monkeypatch: pytest.MonkeyPatch):
-    """A remote GeoJSON is downloaded and read from a local file, never over ``/vsicurl/``."""
-    seen: dict[str, str] = {}
-    real_read_file = _read.gpd.read_file
+class TestStripVsicurl:
+    """Tests for :func:`pyramids.feature._read._strip_vsicurl`."""
 
-    def _spy_read_file(target, **kwargs):
-        seen["path"] = str(target)
-        return real_read_file(target, **kwargs)
+    def test_strips_leading_vsicurl_prefix(self):
+        """Strip the ``/vsicurl/`` wrapper to recover the bare URL.
 
-    monkeypatch.setattr(
-        _read.urllib.request, "urlopen", lambda request, **_: io.BytesIO(_POINT_GEOJSON)
+        Test scenario:
+            A ``/vsicurl/https://…`` path returns the ``https://…`` URL behind it.
+        """
+        result = _read._strip_vsicurl("/vsicurl/https://host/x.geojson")
+        assert result == "https://host/x.geojson", f"prefix not stripped: {result}"
+
+    def test_bare_url_is_unchanged(self):
+        """Leave a URL that carries no ``/vsicurl/`` prefix untouched.
+
+        Test scenario:
+            A bare ``https://…`` URL is returned verbatim.
+        """
+        result = _read._strip_vsicurl("https://host/x.geojson")
+        assert result == "https://host/x.geojson", f"bare URL altered: {result}"
+
+    def test_only_leading_prefix_is_stripped(self):
+        """Strip only a *leading* ``/vsicurl/``, never one nested mid-path.
+
+        Test scenario:
+            A chained ``/vsizip//vsicurl/…`` path does not start with the prefix, so it
+            is returned unchanged.
+        """
+        chained = "/vsizip//vsicurl/https://host/x.zip"
+        assert _read._strip_vsicurl(chained) == chained, "nested prefix wrongly stripped"
+
+
+class TestIsRemoteGeojson:
+    """Tests for :func:`pyramids.feature._read._is_remote_geojson`."""
+
+    @pytest.mark.parametrize(
+        "path,expected",
+        [
+            ("/vsicurl/https://host/x.geojson", True),
+            ("https://host/x.geojson", True),
+            ("https://host/x.json", True),
+            ("https://host/data.geojson?token=abc", True),
+            ("https://host/x.geojson/", True),
+            ("HTTPS://host/x.geojson", True),
+            ("https://host/X.GEOJSON", True),
+            ("http://host/x.geojson", False),
+            ("/vsicurl/https://host/x.gpkg", False),
+            ("https://host/x.tif", False),
+            ("https://host/x.json.gz", False),
+            ("/data/local/x.geojson", False),
+            ("s3://bucket/x.geojson", False),
+            ("gs://bucket/x.geojson", False),
+        ],
     )
-    monkeypatch.setattr(_read.gpd, "read_file", _spy_read_file)
+    def test_detection_matrix(self, path: str, expected: bool):
+        """Only an ``https://`` GeoJSON (bare or ``/vsicurl/``-wrapped) is detected.
 
-    fc = FeatureCollection.read_file(_GEOBOUNDARIES_KEN_ADM1)
+        Args:
+            path: The candidate path or URL.
+            expected: Whether it should be routed through local staging.
 
-    assert len(fc) == 1
-    assert "/vsicurl/" not in seen["path"], (
-        f"read a local copy, not /vsicurl/: {seen['path']}"
-    )
-    assert seen["path"].endswith(".geojson")
+        Test scenario:
+            ``https://`` GeoJSON (any case, trailing slash, or query string) is ``True``;
+            plain ``http://``, non-GeoJSON extensions, object-store schemes, and local
+            paths are ``False``.
+        """
+        assert _read._is_remote_geojson(path) is expected, f"misclassified {path!r}"
+
+    def test_accepts_path_object(self):
+        """Accept a :class:`pathlib.Path` and classify a local path as ``False``.
+
+        Test scenario:
+            A local ``Path`` (no ``https://`` scheme) is not staged.
+        """
+        assert _read._is_remote_geojson(Path("/data/local/x.geojson")) is False
 
 
-@pytest.mark.live
-def test_read_geoboundaries_ken_adm1_end_to_end():
-    """The #1008 geoBoundaries KEN ADM1 GeoJSON reads without crashing (real network)."""
-    fc = FeatureCollection.read_file(_GEOBOUNDARIES_KEN_ADM1)
-    assert len(fc) > 0, "geoBoundaries KEN ADM1 should read as non-empty polygons"
+class TestReadRemoteGeojsonStaged:
+    """Tests for :func:`pyramids.feature._read._read_remote_geojson_staged`."""
+
+    def test_downloads_and_reads_local_copy(self, monkeypatch: pytest.MonkeyPatch):
+        """Download the bytes and read them from a local file, never ``/vsicurl/``.
+
+        Test scenario:
+            The mocked download yields a one-point GeoJSON; the resulting collection has
+            one feature and ``gpd.read_file`` is handed a local ``.geojson`` path.
+        """
+        seen: dict[str, str] = {}
+        real_read_file = _read.gpd.read_file
+
+        def _spy_read_file(target, **kwargs):
+            seen["path"] = str(target)
+            return real_read_file(target, **kwargs)
+
+        monkeypatch.setattr(
+            _read.urllib.request, "urlopen", lambda request, **_: io.BytesIO(_POINT_GEOJSON)
+        )
+        monkeypatch.setattr(_read.gpd, "read_file", _spy_read_file)
+
+        fc = _read._read_remote_geojson_staged(FeatureCollection, _GEOBOUNDARIES_KEN_ADM1, {})
+
+        assert isinstance(fc, FeatureCollection), f"wrong return type: {type(fc)}"
+        assert len(fc) == 1, f"expected one feature, got {len(fc)}"
+        assert "/vsicurl/" not in seen["path"], f"read a local copy, not /vsicurl/: {seen['path']}"
+        assert seen["path"].endswith(".geojson"), f"staged file is not .geojson: {seen['path']}"
+
+    def test_request_strips_vsicurl_and_sets_user_agent(self, monkeypatch: pytest.MonkeyPatch):
+        """Fetch the bare URL (``/vsicurl/`` removed) with an explicit User-Agent.
+
+        Test scenario:
+            The :class:`urllib.request.Request` handed to ``urlopen`` targets the
+            redirect-following ``https://`` URL and carries a ``pyramids-gis`` UA header.
+        """
+        captured: dict[str, object] = {}
+
+        def _fake_urlopen(request, **_):
+            captured["url"] = request.full_url
+            captured["ua"] = request.get_header("User-agent")
+            return io.BytesIO(_POINT_GEOJSON)
+
+        monkeypatch.setattr(_read.urllib.request, "urlopen", _fake_urlopen)
+
+        _read._read_remote_geojson_staged(FeatureCollection, _GEOBOUNDARIES_KEN_ADM1, {})
+
+        expected_url = _GEOBOUNDARIES_KEN_ADM1[len("/vsicurl/") :]
+        assert captured["url"] == expected_url, f"unexpected fetch URL: {captured['url']}"
+        assert captured["ua"] == "pyramids-gis", f"missing/incorrect UA header: {captured['ua']}"
+
+    def test_passthrough_kwargs_reach_the_reader(self, monkeypatch: pytest.MonkeyPatch):
+        """Forward filter kwargs to ``gpd.read_file`` on the staged local file.
+
+        Test scenario:
+            ``columns`` and ``where`` passed through ``read_file`` reach the local read
+            unchanged, so pushdown filters still apply after staging.
+        """
+        captured: dict[str, object] = {}
+
+        def _spy_read_file(target, **kwargs):
+            captured["kwargs"] = kwargs
+            return _fake_gdf()
+
+        monkeypatch.setattr(
+            _read.urllib.request, "urlopen", lambda request, **_: io.BytesIO(_POINT_GEOJSON)
+        )
+        monkeypatch.setattr(_read.gpd, "read_file", _spy_read_file)
+
+        passthrough = {"columns": ["n"], "where": "n = 1"}
+        _read._read_remote_geojson_staged(FeatureCollection, _GEOBOUNDARIES_KEN_ADM1, passthrough)
+
+        assert captured["kwargs"] == passthrough, f"kwargs not forwarded: {captured['kwargs']}"
+
+    def test_download_error_propagates(self, monkeypatch: pytest.MonkeyPatch):
+        """Let a download failure surface as the original ``URLError``.
+
+        Test scenario:
+            When ``urlopen`` raises :class:`urllib.error.URLError`, the staging helper
+            does not swallow it — the caller sees the network error.
+        """
+
+        def _boom(request, **_):
+            raise urllib.error.URLError("boom")
+
+        monkeypatch.setattr(_read.urllib.request, "urlopen", _boom)
+
+        with pytest.raises(urllib.error.URLError, match="boom"):
+            _read._read_remote_geojson_staged(FeatureCollection, _GEOBOUNDARIES_KEN_ADM1, {})
+
+
+class TestReadFileRemoteGeojsonRouting:
+    """Tests for the remote-GeoJSON routing branch in :func:`pyramids.feature._read.read_file`."""
+
+    def test_pandas_remote_geojson_is_staged(self, monkeypatch: pytest.MonkeyPatch):
+        """Route a remote GeoJSON to staging on the default (pandas) backend.
+
+        Test scenario:
+            With ``backend='pandas'`` and an ``https://`` GeoJSON URL, ``read_file``
+            delegates to ``_read_remote_geojson_staged`` and returns its result.
+        """
+        sentinel = object()
+        monkeypatch.setattr(
+            _read, "_read_remote_geojson_staged", lambda cls, path, passthrough: sentinel
+        )
+
+        result = _read.read_file(FeatureCollection, _GEOBOUNDARIES_KEN_ADM1)
+
+        assert result is sentinel, "remote GeoJSON was not routed to staging"
+
+    def test_non_geojson_remote_is_not_staged(self, monkeypatch: pytest.MonkeyPatch):
+        """Leave a non-GeoJSON remote read on the ``/vsicurl/`` path.
+
+        Test scenario:
+            A remote ``.gpkg`` URL never enters staging; it flows through the normal
+            ``_read_file_healing_crs`` reader (mocked here to avoid I/O).
+        """
+
+        def _must_not_stage(*_args, **_kwargs):
+            raise AssertionError("non-GeoJSON remote should not be staged")
+
+        monkeypatch.setattr(_read, "_read_remote_geojson_staged", _must_not_stage)
+        monkeypatch.setattr(_read, "_read_file_healing_crs", lambda resolved, passthrough: _fake_gdf())
+
+        result = _read.read_file(FeatureCollection, "https://host/x.gpkg")
+
+        assert isinstance(result, FeatureCollection), f"wrong return type: {type(result)}"
+
+    def test_dask_backend_bypasses_staging(self, monkeypatch: pytest.MonkeyPatch):
+        """Never stage on the dask backend, even for a remote GeoJSON.
+
+        Test scenario:
+            With ``backend='dask'`` and a GeoJSON URL, ``read_file`` skips staging and
+            delegates to ``read_file_dask``.
+        """
+        sentinel = object()
+
+        def _must_not_stage(*_args, **_kwargs):
+            raise AssertionError("dask backend should not stage")
+
+        monkeypatch.setattr(_read, "_read_remote_geojson_staged", _must_not_stage)
+        monkeypatch.setattr(_read, "read_file_dask", lambda *a, **k: sentinel)
+
+        result = _read.read_file(FeatureCollection, _GEOBOUNDARIES_KEN_ADM1, backend="dask")
+
+        assert result is sentinel, "dask backend did not bypass staging"
+
+    def test_invalid_backend_raises(self):
+        """Reject an unknown backend with a clear ``ValueError``.
+
+        Test scenario:
+            A non-GeoJSON local path with ``backend='threads'`` raises ``ValueError``
+            naming the accepted backends.
+        """
+        with pytest.raises(ValueError, match="backend must be 'pandas' or 'dask'"):
+            _read.read_file(FeatureCollection, "local/x.shp", backend="threads")
+
+    @pytest.mark.live
+    def test_read_geoboundaries_ken_adm1_end_to_end(self):
+        """Read the real #1008 geoBoundaries GeoJSON end to end without crashing.
+
+        Test scenario:
+            The redirecting geoBoundaries KEN ADM1 URL reads as non-empty polygons over
+            the staging path (real network).
+        """
+        fc = FeatureCollection.read_file(_GEOBOUNDARIES_KEN_ADM1)
+        assert len(fc) > 0, "geoBoundaries KEN ADM1 should read as non-empty polygons"

--- a/tests/feature/test_issue_1008_remote_geojson.py
+++ b/tests/feature/test_issue_1008_remote_geojson.py
@@ -354,6 +354,19 @@ class TestGdalHttpOptionsGuard:
         )
         assert _read._gdal_http_options_active() is True, "set option should read as active"
 
+    def test_active_for_bearer_only_config(self, monkeypatch: pytest.MonkeyPatch):
+        """A bearer-only config (`GDAL_HTTP_BEARER`) is detected so the token still reaches GDAL.
+
+        Test scenario:
+            A token-gated read authenticated purely with `GDAL_HTTP_BEARER` is not staged.
+        """
+        monkeypatch.setattr(
+            _read.gdal,
+            "GetConfigOption",
+            lambda key: "tok" if key == "GDAL_HTTP_BEARER" else None,
+        )
+        assert _read._gdal_http_options_active() is True, "bearer token should read as active"
+
     def test_inactive_when_no_option_is_set(self, monkeypatch: pytest.MonkeyPatch):
         """`_gdal_http_options_active` is False when no GDAL HTTP option is set.
 

--- a/tests/feature/test_issue_1008_remote_geojson.py
+++ b/tests/feature/test_issue_1008_remote_geojson.py
@@ -226,6 +226,16 @@ class TestReadRemoteGeojsonStaged:
         with pytest.raises(urllib.error.URLError, match="boom"):
             _read._read_remote_geojson_staged(FeatureCollection, _GEOBOUNDARIES_KEN_ADM1, {})
 
+    def test_rejects_non_https_url(self):
+        """Refuse a non-https URL as a self-guard on the https invariant.
+
+        Test scenario:
+            Reaching the helper directly with a plain `http://` URL raises `ValueError`
+            rather than silently fetching over an unintended scheme.
+        """
+        with pytest.raises(ValueError, match="https://"):
+            _read._read_remote_geojson_staged(FeatureCollection, "http://host/x.geojson", {})
+
     def test_download_uses_an_explicit_timeout(self, monkeypatch: pytest.MonkeyPatch):
         """Pass an explicit `timeout` so a stalled TLS server cannot hang the read forever.
 

--- a/tests/feature/test_issue_1008_remote_geojson.py
+++ b/tests/feature/test_issue_1008_remote_geojson.py
@@ -68,6 +68,15 @@ class TestStripVsicurl:
         result = _read._strip_vsicurl("https://host/x.geojson")
         assert result == "https://host/x.geojson", f"bare URL altered: {result}"
 
+    def test_strips_streaming_prefix(self):
+        """Strip a leading `/vsicurl_streaming/` wrapper as well as `/vsicurl/`.
+
+        Test scenario:
+            A `/vsicurl_streaming/https://…` path returns the bare `https://…` URL.
+        """
+        result = _read._strip_vsicurl("/vsicurl_streaming/https://host/x.geojson")
+        assert result == "https://host/x.geojson", f"streaming prefix not stripped: {result}"
+
     def test_only_leading_prefix_is_stripped(self):
         """Strip only a *leading* ``/vsicurl/``, never one nested mid-path.
 
@@ -86,6 +95,7 @@ class TestIsRemoteGeojson:
         "path,expected",
         [
             ("/vsicurl/https://host/x.geojson", True),
+            ("/vsicurl_streaming/https://host/x.geojson", True),
             ("https://host/x.geojson", True),
             ("https://host/data.geojson?token=abc", True),
             ("https://host/x.json", False),

--- a/tests/feature/test_issue_1008_remote_geojson.py
+++ b/tests/feature/test_issue_1008_remote_geojson.py
@@ -99,6 +99,8 @@ class TestIsRemoteGeojson:
             ("/data/local/x.geojson", False),
             ("s3://bucket/x.geojson", False),
             ("gs://bucket/x.geojson", False),
+            ("https://host/data.zip/inner.geojson", False),
+            ("https://host/data.tar.gz/inner.geojson", False),
         ],
     )
     def test_detection_matrix(self, path: str, expected: bool):

--- a/tests/feature/test_issue_1008_remote_geojson.py
+++ b/tests/feature/test_issue_1008_remote_geojson.py
@@ -111,6 +111,8 @@ class TestIsRemoteGeojson:
             ("gs://bucket/x.geojson", False),
             ("https://host/data.zip/inner.geojson", False),
             ("https://host/data.tar.gz/inner.geojson", False),
+            ("https://my.zip/data.geojson", True),
+            ("https://host.gz/data.geojson", True),
         ],
     )
     def test_detection_matrix(self, path: str, expected: bool):

--- a/tests/feature/test_issue_1008_remote_geojson.py
+++ b/tests/feature/test_issue_1008_remote_geojson.py
@@ -1,0 +1,78 @@
+"""Regression tests for issue #1008 — remote GeoJSON is staged, not streamed.
+
+``FeatureCollection.read_file`` on a *redirecting* remote GeoJSON over GDAL's
+``/vsicurl/`` can segfault the interpreter in a build whose bundled libcurl/OpenSSL
+differs from the interpreter's (the manylinux wheel, whose vendored OpenSSL 3 clashes
+with CPython's). The fix fetches the bytes with :mod:`urllib` (Python's own TLS, which
+follows the redirect) and hands GDAL a plain local file, so GDAL never does the remote
+read.
+
+The offline tests below assert that routing decision deterministically (they run in the
+normal matrix); the ``live`` test reads the real geoBoundaries source end to end.
+"""
+
+import io
+
+import pytest
+
+from pyramids.feature import _read
+from pyramids.feature.collection import FeatureCollection
+
+# geoBoundaries KEN ADM1, pinned SHA — a github.com/.../raw/<sha>/… URL that 302-redirects
+# to raw.githubusercontent.com; this is the exact source from issue #1008.
+_GEOBOUNDARIES_KEN_ADM1 = (
+    "/vsicurl/https://github.com/wmgeolab/geoBoundaries/raw/9469f09/"
+    "releaseData/gbOpen/KEN/ADM1/geoBoundaries-KEN-ADM1.geojson"
+)
+
+_POINT_GEOJSON = (
+    b'{"type":"FeatureCollection","features":[{"type":"Feature",'
+    b'"properties":{"n":1},"geometry":{"type":"Point","coordinates":[0,0]}}]}'
+)
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("/vsicurl/https://host/x.geojson", True),
+        ("https://host/x.geojson", True),
+        ("http://host/x.geojson", True),
+        ("https://host/x.json", True),
+        ("https://host/data.geojson?token=abc", True),
+        ("/vsicurl/https://host/x.gpkg", False),
+        ("https://host/x.tif", False),
+        ("/data/local/x.geojson", False),
+        ("s3://bucket/x.geojson", False),
+    ],
+)
+def test_is_remote_geojson_detection(path: str, expected: bool):
+    """Only ``http(s)://`` GeoJSON (bare or ``/vsicurl/``-wrapped) is staged."""
+    assert _read._is_remote_geojson(path) is expected
+
+
+def test_remote_geojson_is_staged_not_streamed(monkeypatch: pytest.MonkeyPatch):
+    """A remote GeoJSON is downloaded and read from a local file, never over ``/vsicurl/``."""
+    seen: dict[str, str] = {}
+    real_read_file = _read.gpd.read_file
+
+    def _spy_read_file(target, **kwargs):
+        seen["path"] = str(target)
+        return real_read_file(target, **kwargs)
+
+    monkeypatch.setattr(
+        _read.urllib.request, "urlopen", lambda request, **_: io.BytesIO(_POINT_GEOJSON)
+    )
+    monkeypatch.setattr(_read.gpd, "read_file", _spy_read_file)
+
+    fc = FeatureCollection.read_file(_GEOBOUNDARIES_KEN_ADM1)
+
+    assert len(fc) == 1
+    assert "/vsicurl/" not in seen["path"], f"read a local copy, not /vsicurl/: {seen['path']}"
+    assert seen["path"].endswith(".geojson")
+
+
+@pytest.mark.live
+def test_read_geoboundaries_ken_adm1_end_to_end():
+    """The #1008 geoBoundaries KEN ADM1 GeoJSON reads without crashing (real network)."""
+    fc = FeatureCollection.read_file(_GEOBOUNDARIES_KEN_ADM1)
+    assert len(fc) > 0, "geoBoundaries KEN ADM1 should read as non-empty polygons"

--- a/tests/feature/test_issue_1008_remote_geojson.py
+++ b/tests/feature/test_issue_1008_remote_geojson.py
@@ -291,3 +291,48 @@ class TestReadFileRemoteGeojsonRouting:
         """
         fc = FeatureCollection.read_file(_GEOBOUNDARIES_KEN_ADM1)
         assert len(fc) > 0, "geoBoundaries KEN ADM1 should read as non-empty polygons"
+
+
+class TestGdalHttpOptionsGuard:
+    """Tests for the GDAL-HTTP-options guard that keeps authed reads on `/vsicurl/` (#1008 M1)."""
+
+    def test_active_when_an_option_is_set(self, monkeypatch: pytest.MonkeyPatch):
+        """`_gdal_http_options_active` is True when any GDAL HTTP option is set.
+
+        Test scenario:
+            A set `GDAL_HTTP_HEADERS` (e.g. a bearer token) makes the guard report active.
+        """
+        monkeypatch.setattr(
+            _read.gdal,
+            "GetConfigOption",
+            lambda key: "Bearer x" if key == "GDAL_HTTP_HEADERS" else None,
+        )
+        assert _read._gdal_http_options_active() is True, "set option should read as active"
+
+    def test_inactive_when_no_option_is_set(self, monkeypatch: pytest.MonkeyPatch):
+        """`_gdal_http_options_active` is False when no GDAL HTTP option is set.
+
+        Test scenario:
+            With every option unset, the guard reports inactive and staging may proceed.
+        """
+        monkeypatch.setattr(_read.gdal, "GetConfigOption", lambda key: None)
+        assert _read._gdal_http_options_active() is False, "unset options should read inactive"
+
+    def test_read_file_skips_staging_when_option_active(self, monkeypatch: pytest.MonkeyPatch):
+        """A set GDAL HTTP option keeps the remote GeoJSON on the `/vsicurl/` reader.
+
+        Test scenario:
+            When the guard is active, `read_file` does not stage — the caller's GDAL auth
+            still reaches GDAL — and the read flows through the normal reader.
+        """
+
+        def _must_not_stage(*_args, **_kwargs):
+            raise AssertionError("staging must be skipped when a GDAL HTTP option is set")
+
+        monkeypatch.setattr(_read, "_gdal_http_options_active", lambda: True)
+        monkeypatch.setattr(_read, "_read_remote_geojson_staged", _must_not_stage)
+        monkeypatch.setattr(_read, "_read_file_healing_crs", lambda resolved, passthrough: _fake_gdf())
+
+        result = _read.read_file(FeatureCollection, _GEOBOUNDARIES_KEN_ADM1)
+
+        assert isinstance(result, FeatureCollection), f"wrong return type: {type(result)}"

--- a/tests/feature/test_issue_1008_remote_geojson.py
+++ b/tests/feature/test_issue_1008_remote_geojson.py
@@ -75,7 +75,9 @@ class TestStripVsicurl:
             A `/vsicurl_streaming/https://…` path returns the bare `https://…` URL.
         """
         result = _read._strip_vsicurl("/vsicurl_streaming/https://host/x.geojson")
-        assert result == "https://host/x.geojson", f"streaming prefix not stripped: {result}"
+        assert result == "https://host/x.geojson", (
+            f"streaming prefix not stripped: {result}"
+        )
 
     def test_only_leading_prefix_is_stripped(self):
         """Strip only a *leading* ``/vsicurl/``, never one nested mid-path.
@@ -85,7 +87,9 @@ class TestStripVsicurl:
             is returned unchanged.
         """
         chained = "/vsizip//vsicurl/https://host/x.zip"
-        assert _read._strip_vsicurl(chained) == chained, "nested prefix wrongly stripped"
+        assert _read._strip_vsicurl(chained) == chained, (
+            "nested prefix wrongly stripped"
+        )
 
 
 class TestIsRemoteGeojson:
@@ -156,18 +160,28 @@ class TestReadRemoteGeojsonStaged:
             return real_read_file(target, **kwargs)
 
         monkeypatch.setattr(
-            _read.urllib.request, "urlopen", lambda request, **_: io.BytesIO(_POINT_GEOJSON)
+            _read.urllib.request,
+            "urlopen",
+            lambda request, **_: io.BytesIO(_POINT_GEOJSON),
         )
         monkeypatch.setattr(_read.gpd, "read_file", _spy_read_file)
 
-        fc = _read._read_remote_geojson_staged(FeatureCollection, _GEOBOUNDARIES_KEN_ADM1, {})
+        fc = _read._read_remote_geojson_staged(
+            FeatureCollection, _GEOBOUNDARIES_KEN_ADM1, {}
+        )
 
         assert isinstance(fc, FeatureCollection), f"wrong return type: {type(fc)}"
         assert len(fc) == 1, f"expected one feature, got {len(fc)}"
-        assert "/vsicurl/" not in seen["path"], f"read a local copy, not /vsicurl/: {seen['path']}"
-        assert seen["path"].endswith(".geojson"), f"staged file is not .geojson: {seen['path']}"
+        assert "/vsicurl/" not in seen["path"], (
+            f"read a local copy, not /vsicurl/: {seen['path']}"
+        )
+        assert seen["path"].endswith(".geojson"), (
+            f"staged file is not .geojson: {seen['path']}"
+        )
 
-    def test_request_strips_vsicurl_and_sets_user_agent(self, monkeypatch: pytest.MonkeyPatch):
+    def test_request_strips_vsicurl_and_sets_user_agent(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
         """Fetch the bare URL (``/vsicurl/`` removed) with an explicit User-Agent.
 
         Test scenario:
@@ -183,11 +197,17 @@ class TestReadRemoteGeojsonStaged:
 
         monkeypatch.setattr(_read.urllib.request, "urlopen", _fake_urlopen)
 
-        _read._read_remote_geojson_staged(FeatureCollection, _GEOBOUNDARIES_KEN_ADM1, {})
+        _read._read_remote_geojson_staged(
+            FeatureCollection, _GEOBOUNDARIES_KEN_ADM1, {}
+        )
 
         expected_url = _GEOBOUNDARIES_KEN_ADM1[len("/vsicurl/") :]
-        assert captured["url"] == expected_url, f"unexpected fetch URL: {captured['url']}"
-        assert captured["ua"] == "pyramids-gis", f"missing/incorrect UA header: {captured['ua']}"
+        assert captured["url"] == expected_url, (
+            f"unexpected fetch URL: {captured['url']}"
+        )
+        assert captured["ua"] == "pyramids-gis", (
+            f"missing/incorrect UA header: {captured['ua']}"
+        )
 
     def test_passthrough_kwargs_reach_the_reader(self, monkeypatch: pytest.MonkeyPatch):
         """Forward filter kwargs to ``gpd.read_file`` on the staged local file.
@@ -203,16 +223,24 @@ class TestReadRemoteGeojsonStaged:
             return _fake_gdf()
 
         monkeypatch.setattr(
-            _read.urllib.request, "urlopen", lambda request, **_: io.BytesIO(_POINT_GEOJSON)
+            _read.urllib.request,
+            "urlopen",
+            lambda request, **_: io.BytesIO(_POINT_GEOJSON),
         )
         monkeypatch.setattr(_read.gpd, "read_file", _spy_read_file)
 
         passthrough = {"columns": ["n"], "where": "n = 1"}
-        _read._read_remote_geojson_staged(FeatureCollection, _GEOBOUNDARIES_KEN_ADM1, passthrough)
+        _read._read_remote_geojson_staged(
+            FeatureCollection, _GEOBOUNDARIES_KEN_ADM1, passthrough
+        )
 
-        assert captured["kwargs"] == passthrough, f"kwargs not forwarded: {captured['kwargs']}"
+        assert captured["kwargs"] == passthrough, (
+            f"kwargs not forwarded: {captured['kwargs']}"
+        )
 
-    def test_download_error_is_wrapped_in_feature_error(self, monkeypatch: pytest.MonkeyPatch):
+    def test_download_error_is_wrapped_in_feature_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
         """A download failure surfaces as `FeatureError`, chaining the original `URLError`.
 
         Test scenario:
@@ -227,7 +255,9 @@ class TestReadRemoteGeojsonStaged:
         monkeypatch.setattr(_read.urllib.request, "urlopen", _boom)
 
         with pytest.raises(_read.FeatureError, match="failed to download") as exc_info:
-            _read._read_remote_geojson_staged(FeatureCollection, _GEOBOUNDARIES_KEN_ADM1, {})
+            _read._read_remote_geojson_staged(
+                FeatureCollection, _GEOBOUNDARIES_KEN_ADM1, {}
+            )
         assert isinstance(exc_info.value.__cause__, urllib.error.URLError), (
             "the original URLError should be chained as the cause"
         )
@@ -240,7 +270,9 @@ class TestReadRemoteGeojsonStaged:
             rather than silently fetching over an unintended scheme.
         """
         with pytest.raises(ValueError, match="https://"):
-            _read._read_remote_geojson_staged(FeatureCollection, "http://host/x.geojson", {})
+            _read._read_remote_geojson_staged(
+                FeatureCollection, "http://host/x.geojson", {}
+            )
 
     def test_download_uses_an_explicit_timeout(self, monkeypatch: pytest.MonkeyPatch):
         """Pass an explicit `timeout` so a stalled TLS server cannot hang the read forever.
@@ -257,7 +289,9 @@ class TestReadRemoteGeojsonStaged:
 
         monkeypatch.setattr(_read.urllib.request, "urlopen", _fake_urlopen)
 
-        _read._read_remote_geojson_staged(FeatureCollection, _GEOBOUNDARIES_KEN_ADM1, {})
+        _read._read_remote_geojson_staged(
+            FeatureCollection, _GEOBOUNDARIES_KEN_ADM1, {}
+        )
 
         assert captured["timeout"] == _read._REMOTE_READ_TIMEOUT, (
             f"expected an explicit timeout, got {captured['timeout']}"
@@ -276,7 +310,9 @@ class TestReadFileRemoteGeojsonRouting:
         """
         sentinel = object()
         monkeypatch.setattr(
-            _read, "_read_remote_geojson_staged", lambda cls, path, passthrough: sentinel
+            _read,
+            "_read_remote_geojson_staged",
+            lambda cls, path, passthrough: sentinel,
         )
 
         result = _read.read_file(FeatureCollection, _GEOBOUNDARIES_KEN_ADM1)
@@ -295,11 +331,15 @@ class TestReadFileRemoteGeojsonRouting:
             raise AssertionError("non-GeoJSON remote should not be staged")
 
         monkeypatch.setattr(_read, "_read_remote_geojson_staged", _must_not_stage)
-        monkeypatch.setattr(_read, "_read_file_healing_crs", lambda resolved, passthrough: _fake_gdf())
+        monkeypatch.setattr(
+            _read, "_read_file_healing_crs", lambda resolved, passthrough: _fake_gdf()
+        )
 
         result = _read.read_file(FeatureCollection, "https://host/x.gpkg")
 
-        assert isinstance(result, FeatureCollection), f"wrong return type: {type(result)}"
+        assert isinstance(result, FeatureCollection), (
+            f"wrong return type: {type(result)}"
+        )
 
     def test_dask_backend_bypasses_staging(self, monkeypatch: pytest.MonkeyPatch):
         """Never stage on the dask backend, even for a remote GeoJSON.
@@ -316,7 +356,9 @@ class TestReadFileRemoteGeojsonRouting:
         monkeypatch.setattr(_read, "_read_remote_geojson_staged", _must_not_stage)
         monkeypatch.setattr(_read, "read_file_dask", lambda *a, **k: sentinel)
 
-        result = _read.read_file(FeatureCollection, _GEOBOUNDARIES_KEN_ADM1, backend="dask")
+        result = _read.read_file(
+            FeatureCollection, _GEOBOUNDARIES_KEN_ADM1, backend="dask"
+        )
 
         assert result is sentinel, "dask backend did not bypass staging"
 
@@ -356,7 +398,9 @@ class TestGdalHttpOptionsGuard:
             "GetConfigOption",
             lambda key: "Bearer x" if key == "GDAL_HTTP_HEADERS" else None,
         )
-        assert _read._gdal_http_options_active() is True, "set option should read as active"
+        assert _read._gdal_http_options_active() is True, (
+            "set option should read as active"
+        )
 
     def test_active_for_bearer_only_config(self, monkeypatch: pytest.MonkeyPatch):
         """A bearer-only config (`GDAL_HTTP_BEARER`) is detected so the token still reaches GDAL.
@@ -369,7 +413,9 @@ class TestGdalHttpOptionsGuard:
             "GetConfigOption",
             lambda key: "tok" if key == "GDAL_HTTP_BEARER" else None,
         )
-        assert _read._gdal_http_options_active() is True, "bearer token should read as active"
+        assert _read._gdal_http_options_active() is True, (
+            "bearer token should read as active"
+        )
 
     def test_inactive_when_no_option_is_set(self, monkeypatch: pytest.MonkeyPatch):
         """`_gdal_http_options_active` is False when no GDAL HTTP option is set.
@@ -378,9 +424,13 @@ class TestGdalHttpOptionsGuard:
             With every option unset, the guard reports inactive and staging may proceed.
         """
         monkeypatch.setattr(_read.gdal, "GetConfigOption", lambda key: None)
-        assert _read._gdal_http_options_active() is False, "unset options should read inactive"
+        assert _read._gdal_http_options_active() is False, (
+            "unset options should read inactive"
+        )
 
-    def test_read_file_skips_staging_when_option_active(self, monkeypatch: pytest.MonkeyPatch):
+    def test_read_file_skips_staging_when_option_active(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
         """A set GDAL HTTP option keeps the remote GeoJSON on the `/vsicurl/` reader.
 
         Test scenario:
@@ -389,12 +439,18 @@ class TestGdalHttpOptionsGuard:
         """
 
         def _must_not_stage(*_args, **_kwargs):
-            raise AssertionError("staging must be skipped when a GDAL HTTP option is set")
+            raise AssertionError(
+                "staging must be skipped when a GDAL HTTP option is set"
+            )
 
         monkeypatch.setattr(_read, "_gdal_http_options_active", lambda: True)
         monkeypatch.setattr(_read, "_read_remote_geojson_staged", _must_not_stage)
-        monkeypatch.setattr(_read, "_read_file_healing_crs", lambda resolved, passthrough: _fake_gdf())
+        monkeypatch.setattr(
+            _read, "_read_file_healing_crs", lambda resolved, passthrough: _fake_gdf()
+        )
 
         result = _read.read_file(FeatureCollection, _GEOBOUNDARIES_KEN_ADM1)
 
-        assert isinstance(result, FeatureCollection), f"wrong return type: {type(result)}"
+        assert isinstance(result, FeatureCollection), (
+            f"wrong return type: {type(result)}"
+        )

--- a/tests/feature/test_issue_1008_remote_geojson.py
+++ b/tests/feature/test_issue_1008_remote_geojson.py
@@ -214,6 +214,27 @@ class TestReadRemoteGeojsonStaged:
         with pytest.raises(urllib.error.URLError, match="boom"):
             _read._read_remote_geojson_staged(FeatureCollection, _GEOBOUNDARIES_KEN_ADM1, {})
 
+    def test_download_uses_an_explicit_timeout(self, monkeypatch: pytest.MonkeyPatch):
+        """Pass an explicit `timeout` so a stalled TLS server cannot hang the read forever.
+
+        Test scenario:
+            `urlopen` receives `timeout=_REMOTE_READ_TIMEOUT` rather than the unbounded
+            process default.
+        """
+        captured: dict[str, object] = {}
+
+        def _fake_urlopen(request, **kwargs):
+            captured["timeout"] = kwargs.get("timeout")
+            return io.BytesIO(_POINT_GEOJSON)
+
+        monkeypatch.setattr(_read.urllib.request, "urlopen", _fake_urlopen)
+
+        _read._read_remote_geojson_staged(FeatureCollection, _GEOBOUNDARIES_KEN_ADM1, {})
+
+        assert captured["timeout"] == _read._REMOTE_READ_TIMEOUT, (
+            f"expected an explicit timeout, got {captured['timeout']}"
+        )
+
 
 class TestReadFileRemoteGeojsonRouting:
     """Tests for the remote-GeoJSON routing branch in :func:`pyramids.feature._read.read_file`."""

--- a/tests/feature/test_issue_1008_remote_geojson.py
+++ b/tests/feature/test_issue_1008_remote_geojson.py
@@ -87,8 +87,8 @@ class TestIsRemoteGeojson:
         [
             ("/vsicurl/https://host/x.geojson", True),
             ("https://host/x.geojson", True),
-            ("https://host/x.json", True),
             ("https://host/data.geojson?token=abc", True),
+            ("https://host/x.json", False),
             ("https://host/x.geojson/", True),
             ("HTTPS://host/x.geojson", True),
             ("https://host/X.GEOJSON", True),

--- a/tests/feature/test_issue_1008_remote_geojson.py
+++ b/tests/feature/test_issue_1008_remote_geojson.py
@@ -212,12 +212,13 @@ class TestReadRemoteGeojsonStaged:
 
         assert captured["kwargs"] == passthrough, f"kwargs not forwarded: {captured['kwargs']}"
 
-    def test_download_error_propagates(self, monkeypatch: pytest.MonkeyPatch):
-        """Let a download failure surface as the original ``URLError``.
+    def test_download_error_is_wrapped_in_feature_error(self, monkeypatch: pytest.MonkeyPatch):
+        """A download failure surfaces as `FeatureError`, chaining the original `URLError`.
 
         Test scenario:
-            When ``urlopen`` raises :class:`urllib.error.URLError`, the staging helper
-            does not swallow it — the caller sees the network error.
+            When `urlopen` raises `URLError`, the helper re-raises the module's
+            `FeatureError` (so remote-read failures share one error type) with the
+            original network error kept as the cause.
         """
 
         def _boom(request, **_):
@@ -225,8 +226,11 @@ class TestReadRemoteGeojsonStaged:
 
         monkeypatch.setattr(_read.urllib.request, "urlopen", _boom)
 
-        with pytest.raises(urllib.error.URLError, match="boom"):
+        with pytest.raises(_read.FeatureError, match="failed to download") as exc_info:
             _read._read_remote_geojson_staged(FeatureCollection, _GEOBOUNDARIES_KEN_ADM1, {})
+        assert isinstance(exc_info.value.__cause__, urllib.error.URLError), (
+            "the original URLError should be chained as the cause"
+        )
 
     def test_rejects_non_https_url(self):
         """Refuse a non-https URL as a self-guard on the https invariant.


### PR DESCRIPTION
# Description

Fixes the native segfault reported in #1008 when reading a **redirecting remote GeoJSON** through
`FeatureCollection.read_file`.

**Root cause (confirmed against the wheel, not memory).** The crash is not a pyramids logic bug and not a
GDAL-version regression. The manylinux wheel and pyramids' conda CI both ship **GDAL 3.13.1** — conda reads the file
cleanly, the wheel crashes. The differentiator is the HTTP/TLS stack: the wheel statically bundles its **own libcurl
4.8.0 + OpenSSL 3** (verified from the SONAMEs in `pyramids_gis.libs/`), and when GDAL's `/vsicurl/` follows the
`github.com/.../raw/<sha>/…` → 302 → `raw.githubusercontent.com` redirect, that vendored OpenSSL clashes with the
OpenSSL CPython's own `_ssl`/`urllib` already loaded — the classic two-OpenSSL-in-one-process segfault. A native
segfault is uncatchable in Python, so the mitigation has to be **proactive**, not a post-crash fallback.

**Fix.** `read_file` now detects a remote `https://` GeoJSON (bare or `/vsicurl/`-wrapped) and stages it: it
fetches the bytes with `urllib` (Python's own TLS, which follows the redirect) and hands GDAL a plain **local**
file, so GDAL never does the remote TLS read that faults. GeoJSON has no spatial index, so this loses no windowed
read pushdown; every other remote format (GPKG, FlatGeobuf, zipped shapefiles, …) keeps its `/vsicurl/` path
unchanged. This mirrors the existing precedent where `read_parquet` hands remote URLs to fsspec instead of
`/vsicurl/`.

# Issues

- Closes #1008 — `FeatureCollection.read_file` segfaults on a redirecting remote GeoJSON over `/vsicurl/`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

New `tests/feature/test_issue_1008_remote_geojson.py`:

- [x] `test_is_remote_geojson_detection` — parametrized routing check: only an `https://` GeoJSON (bare or
  `/vsicurl/`-wrapped) is staged; local paths, `s3://`, and non-GeoJSON remotes keep their normal path.
- [x] `test_remote_geojson_is_staged_not_streamed` — deterministic (mocks the download): asserts the remote GeoJSON
  is read from a **local** file, never `/vsicurl/`. Runs in the normal matrix and guards against a revert.
- [x] `test_read_geoboundaries_ken_adm1_end_to_end` — `live`-marked end-to-end read of the exact #1008 geoBoundaries
  KEN ADM1 source; passes via the staging path.

`tests/feature/test_cloud_reads.py::TestHttpRewrite` updated to use a `.gpkg` URL, since remote GeoJSON is now
staged rather than rewritten to `/vsicurl/` — the general rewrite mechanism it covers still applies to every other
remote format.

Local run (`pixi run -e dev`, Windows, py314): full `tests/feature` suite **728 passed, 1 skipped**; the new
offline tests and the `live` end-to-end all pass.

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
