### PR TITLE
perf(collection): skip GDAL's per-open directory scan in from_files for sidecar-free folders

### DIFF
--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -71,6 +71,10 @@ if TYPE_CHECKING:
 
 _DEFAULT_GLOB = "*.tif"
 _EMPTY_RANGE_MSG = "no files fall within the given start/end range"
+# GDAL raster sidecar suffixes. When a folder holds any of these, ``from_files``
+# keeps GDAL's per-open directory scan on so the sidecar is still discovered;
+# a folder with none lets it default ``GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR``.
+_SIDECAR_SUFFIXES = (".aux.xml", ".ovr", ".msk", ".prj", ".tfw", ".wld", ".rrd")
 
 
 class _GroupedCollection:
@@ -1733,6 +1737,16 @@ class DatasetCollection:
         sequence of paths. Only the first file is opened eagerly (to derive
         :class:`RasterMeta`); the rest are opened lazily on demand.
 
+        For a folder with no GDAL sidecars (``.aux.xml`` / ``.ovr`` / ..., see
+        :data:`_SIDECAR_SUFFIXES`), the reader defaults
+        ``GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR`` so each raster open skips GDAL's
+        per-open directory rescan. On high-latency network storage (SMB / NFS) that
+        rescan is a remote listing per file and otherwise dominates the read — the cost
+        scales with the folder size, not the file size. The default is applied only when
+        the single directory listing this method already performs confirms there is no
+        sidecar to discover; a folder that has any, an explicit file / sequence, or an
+        explicit ``gdal_env`` value, leaves the rescan on.
+
         When ``date_format`` is given, a date is parsed out of each file *name* and
         the timesteps are sorted by it, and those dates become the collection's
         :attr:`time` axis (used by :meth:`plot` as the frame labels). ``start`` /
@@ -1758,7 +1772,9 @@ class DatasetCollection:
                 file when omitted.
             gdal_env: Optional GDAL config (e.g. a signer's ``gdal_env()``) installed
                 around every open of the backing files, including the eager template
-                open, and persisted on the collection for the lazy reads.
+                open, and persisted on the collection for the lazy reads. Any key here
+                overrides the sidecar-scan default described above (e.g. pass
+                ``{"GDAL_DISABLE_READDIR_ON_OPEN": "FALSE"}`` to force the rescan on).
             validate: When ``True``, check every file's header shape/dtype against the
                 template and raise :class:`AlignmentError` on a mismatch instead of
                 lazily corrupting the cube. Default ``False``.
@@ -1792,7 +1808,14 @@ class DatasetCollection:
 
               ```
         """
-        resolved = cls._resolve_files(files, glob)
+        resolved, scan_safe = cls._resolve_files_and_scan_safe(files, glob)
+        # On high-latency network storage GDAL's per-open directory rescan (for
+        # sidecar discovery) dominates the read; skip it when the folder has none.
+        # A caller's gdal_env value always wins over this auto-default.
+        effective_env: dict[str, str] = (
+            {"GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR"} if scan_safe else {}
+        )
+        effective_env.update(gdal_env or {})
         time_axis: list[datetime] | None = None
         if date_format is not None:
             dates = [
@@ -1817,7 +1840,11 @@ class DatasetCollection:
                 "start/end filtering needs date_format to parse the file-name dates"
             )
         return cls._build(
-            resolved, time_axis, meta=meta, gdal_env=gdal_env, validate=validate
+            resolved,
+            time_axis,
+            meta=meta,
+            gdal_env=effective_env or None,
+            validate=validate,
         )
 
     @classmethod
@@ -1866,24 +1893,45 @@ class DatasetCollection:
         returned as-is — order preserved, so callers such as ``from_stac`` keep their
         temporally-ordered list.
         """
+        return DatasetCollection._resolve_files_and_scan_safe(files, glob)[0]
+
+    @staticmethod
+    def _resolve_files_and_scan_safe(
+        files: str | Path | Sequence[str | Path], glob: str
+    ) -> tuple[list[str], bool]:
+        """Resolve ``files`` and report whether GDAL's per-open directory scan is skippable.
+
+        Returns ``(resolved, scan_safe)``. ``resolved`` is the path list documented on
+        :meth:`_resolve_files`. ``scan_safe`` is ``True`` **only** when ``files`` is a
+        folder that a single :meth:`~pathlib.Path.iterdir` listing shows holds no GDAL
+        sidecars (:data:`_SIDECAR_SUFFIXES` — ``.aux.xml`` / ``.ovr`` / ...); then
+        :meth:`from_files` may safely default ``GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR``
+        so each raster open skips the (remote-latency-bound) directory rescan. For a
+        single explicit file or a sequence there is no listing to trust, so ``scan_safe``
+        is ``False`` — leave the rescan on, so any real sidecar is still discovered.
+        """
         if isinstance(files, (str, Path)):
             folder = Path(files)
             if not folder.exists():
                 raise FileNotFoundError(f"The path does not exist: {folder}")
             if folder.is_file():
-                return [str(folder)]
+                return [str(folder)], False
+            entries = list(folder.iterdir())
             matched = sorted(
                 str(folder / entry.name)
-                for entry in folder.iterdir()
+                for entry in entries
                 if fnmatch.fnmatch(entry.name, glob)
             )
             if not matched:
                 raise FileNotFoundError(f"No file in {folder} matched glob {glob!r}")
-            return matched
+            scan_safe = not any(
+                entry.name.endswith(_SIDECAR_SUFFIXES) for entry in entries
+            )
+            return matched, scan_safe
         resolved = [str(p) for p in files]
         if not resolved:
             raise ValueError("files must contain at least one path")
-        return resolved
+        return resolved, False
 
     @staticmethod
     def _parse_date(name: str, regex: str, fmt: str) -> datetime:

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -77,9 +77,10 @@ _EMPTY_RANGE_MSG = "no files fall within the given start/end range"
 # ``GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR``. Covers PAM stats (.aux.xml / legacy
 # .aux), overviews (.ovr), masks (.msk), reduced-resolution (.rrd), projection
 # (.prj), the generic (.wld) and per-format world files (TIFF/JPEG/PNG/GIF/JP2),
-# the ENVI header (.hdr), statistics sidecars (.stx / .sta) and the ESRI raster
-# attribute table (.vat.dbf). An exotic format whose companion is not listed should
-# pass ``gdal_env`` explicitly to keep the rescan on.
+# the ENVI header (.hdr), statistics sidecars (.stx / .sta), the ESRI raster attribute
+# table (.vat.dbf) and satellite RPC / IMD metadata (.rpb / .rpc / .imd / .pvl /
+# _rpc.txt). An exotic format whose companion is not listed should pass ``gdal_env``
+# explicitly to keep the rescan on.
 _SIDECAR_SUFFIXES = (
     ".aux.xml",
     ".aux",
@@ -102,6 +103,11 @@ _SIDECAR_SUFFIXES = (
     ".stx",
     ".sta",
     ".vat.dbf",
+    ".rpb",
+    ".rpc",
+    ".imd",
+    ".pvl",
+    "_rpc.txt",
 )
 
 

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -77,8 +77,9 @@ _EMPTY_RANGE_MSG = "no files fall within the given start/end range"
 # ``GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR``. Covers PAM stats (.aux.xml / legacy
 # .aux), overviews (.ovr), masks (.msk), reduced-resolution (.rrd), projection
 # (.prj), the generic (.wld) and per-format world files (TIFF/JPEG/PNG/GIF/JP2),
-# and the ENVI header (.hdr). An exotic format whose companion is not listed should
-# pass ``gdal_env`` explicitly to keep the rescan on.
+# the ENVI header (.hdr), and the ESRI raster attribute table (.vat.dbf). An exotic
+# format whose companion is not listed should pass ``gdal_env`` explicitly to keep
+# the rescan on.
 _SIDECAR_SUFFIXES = (
     ".aux.xml",
     ".aux",
@@ -96,6 +97,7 @@ _SIDECAR_SUFFIXES = (
     ".j2w",
     ".jp2w",
     ".jpw",
+    ".vat.dbf",
 )
 
 

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -1834,6 +1834,17 @@ class DatasetCollection:
               ... )
 
               ```
+            - Override the sidecar-scan default — force GDAL's per-open rescan back
+              on for a folder whose companions are not in the recognised set:
+
+              ```python
+              >>> from pyramids.dataset import DatasetCollection
+              >>> cube = DatasetCollection.from_files(  # doctest: +SKIP
+              ...     "rasters",
+              ...     gdal_env={"GDAL_DISABLE_READDIR_ON_OPEN": "FALSE"},
+              ... )
+
+              ```
         """
         resolved, scan_safe = cls._resolve_files_and_scan_safe(files, glob)
         # On high-latency network storage GDAL's per-open directory rescan (for

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -77,9 +77,9 @@ _EMPTY_RANGE_MSG = "no files fall within the given start/end range"
 # ``GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR``. Covers PAM stats (.aux.xml / legacy
 # .aux), overviews (.ovr), masks (.msk), reduced-resolution (.rrd), projection
 # (.prj), the generic (.wld) and per-format world files (TIFF/JPEG/PNG/GIF/JP2),
-# the ENVI header (.hdr), and the ESRI raster attribute table (.vat.dbf). An exotic
-# format whose companion is not listed should pass ``gdal_env`` explicitly to keep
-# the rescan on.
+# the ENVI header (.hdr), statistics sidecars (.stx / .sta) and the ESRI raster
+# attribute table (.vat.dbf). An exotic format whose companion is not listed should
+# pass ``gdal_env`` explicitly to keep the rescan on.
 _SIDECAR_SUFFIXES = (
     ".aux.xml",
     ".aux",
@@ -97,6 +97,10 @@ _SIDECAR_SUFFIXES = (
     ".j2w",
     ".jp2w",
     ".jpw",
+    ".jpgw",
+    ".jpegw",
+    ".stx",
+    ".sta",
     ".vat.dbf",
 )
 

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -71,10 +71,32 @@ if TYPE_CHECKING:
 
 _DEFAULT_GLOB = "*.tif"
 _EMPTY_RANGE_MSG = "no files fall within the given start/end range"
-# GDAL raster sidecar suffixes. When a folder holds any of these, ``from_files``
-# keeps GDAL's per-open directory scan on so the sidecar is still discovered;
-# a folder with none lets it default ``GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR``.
-_SIDECAR_SUFFIXES = (".aux.xml", ".ovr", ".msk", ".prj", ".tfw", ".wld", ".rrd")
+# GDAL raster sidecar / companion suffixes, matched case-insensitively. When a
+# folder holds any of these, ``from_files`` keeps GDAL's per-open directory scan on
+# so the companion is still discovered; a folder with none lets it default
+# ``GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR``. Covers PAM stats (.aux.xml / legacy
+# .aux), overviews (.ovr), masks (.msk), reduced-resolution (.rrd), projection
+# (.prj), the generic (.wld) and per-format world files (TIFF/JPEG/PNG/GIF/JP2),
+# and the ENVI header (.hdr). An exotic format whose companion is not listed should
+# pass ``gdal_env`` explicitly to keep the rescan on.
+_SIDECAR_SUFFIXES = (
+    ".aux.xml",
+    ".aux",
+    ".ovr",
+    ".msk",
+    ".rrd",
+    ".prj",
+    ".wld",
+    ".hdr",
+    ".tfw",
+    ".tifw",
+    ".jgw",
+    ".pgw",
+    ".gfw",
+    ".j2w",
+    ".jp2w",
+    ".jpw",
+)
 
 
 class _GroupedCollection:
@@ -1745,7 +1767,10 @@ class DatasetCollection:
         scales with the folder size, not the file size. The default is applied only when
         the single directory listing this method already performs confirms there is no
         sidecar to discover; a folder that has any, an explicit file / sequence, or an
-        explicit ``gdal_env`` value, leaves the rescan on.
+        explicit ``gdal_env`` value, leaves the rescan on. The sidecar set
+        (:data:`_SIDECAR_SUFFIXES`, matched case-insensitively) covers the common
+        raster companions; for an exotic format whose companion is not listed, pass
+        ``gdal_env`` explicitly to keep the rescan on.
 
         When ``date_format`` is given, a date is parsed out of each file *name* and
         the timesteps are sorted by it, and those dates become the collection's
@@ -1915,23 +1940,31 @@ class DatasetCollection:
             if not folder.exists():
                 raise FileNotFoundError(f"The path does not exist: {folder}")
             if folder.is_file():
-                return [str(folder)], False
-            entries = list(folder.iterdir())
-            matched = sorted(
-                str(folder / entry.name)
-                for entry in entries
-                if fnmatch.fnmatch(entry.name, glob)
-            )
-            if not matched:
-                raise FileNotFoundError(f"No file in {folder} matched glob {glob!r}")
-            scan_safe = not any(
-                entry.name.endswith(_SIDECAR_SUFFIXES) for entry in entries
-            )
-            return matched, scan_safe
-        resolved = [str(p) for p in files]
-        if not resolved:
-            raise ValueError("files must contain at least one path")
-        return resolved, False
+                resolved, scan_safe = [str(folder)], False
+            else:
+                entries = list(folder.iterdir())
+                resolved = sorted(
+                    str(folder / entry.name)
+                    for entry in entries
+                    if fnmatch.fnmatch(entry.name, glob)
+                )
+                if not resolved:
+                    raise FileNotFoundError(
+                        f"No file in {folder} matched glob {glob!r}"
+                    )
+                # Match case-insensitively: the target filesystems (Windows / macOS)
+                # are case-insensitive and GDAL discovers a sidecar regardless of its
+                # extension case, so an uppercase ``DATA.TIF.OVR`` must still block the
+                # scan-skip. ``_SIDECAR_SUFFIXES`` is lower-case.
+                scan_safe = not any(
+                    entry.name.lower().endswith(_SIDECAR_SUFFIXES) for entry in entries
+                )
+        else:
+            resolved = [str(p) for p in files]
+            if not resolved:
+                raise ValueError("files must contain at least one path")
+            scan_safe = False
+        return resolved, scan_safe
 
     @staticmethod
     def _parse_date(name: str, regex: str, fmt: str) -> datetime:

--- a/tests/dataset/io/test_gdal_env.py
+++ b/tests/dataset/io/test_gdal_env.py
@@ -422,10 +422,9 @@ class TestFromFilesDirScanDefault:
             "<PAMDataset></PAMDataset>", encoding="utf-8"
         )
         col = DatasetCollection.from_files(str(tmp_path))
-        assert _READDIR not in col._gdal_env, (
-            f"a folder with a sidecar must not disable the scan: {col._gdal_env}"
+        assert col._gdal_env == {}, (
+            f"a sidecar folder must install no env (no EMPTY_DIR): {col._gdal_env}"
         )
-        assert col._gdal_env == {}, f"no env should be installed, got {col._gdal_env}"
 
     def test_explicit_gdal_env_overrides_default(self, tmp_path):
         """A caller's GDAL_DISABLE_READDIR_ON_OPEN wins over the sidecar-free default."""

--- a/tests/dataset/io/test_gdal_env.py
+++ b/tests/dataset/io/test_gdal_env.py
@@ -401,6 +401,19 @@ class TestFromFilesDirScanDefault:
             "timesteps must inherit the directory-scan default"
         )
 
+    def test_lazy_index_open_carries_the_env(self, tmp_path):
+        """The single-index lazy path (iloc -> _dataset_at) also carries EMPTY_DIR.
+
+        Test scenario:
+            iloc opens one timestep without materialising the bulk ``datasets`` list,
+            so its handle must still inherit the directory-scan default.
+        """
+        _write_folder_of_tifs(tmp_path)
+        col = DatasetCollection.from_files(str(tmp_path))
+        assert col.iloc(0).gdal_env.get(_READDIR) == "EMPTY_DIR", (
+            "the single-index lazy open must inherit the directory-scan default"
+        )
+
     def test_folder_with_aux_xml_leaves_scan_on(self, tmp_path):
         """A folder holding a .aux.xml sidecar keeps the per-open rescan on (no EMPTY_DIR)."""
         _write_folder_of_tifs(tmp_path)
@@ -458,7 +471,25 @@ class TestResolveFilesAndScanSafe:
         assert scan_safe is True, "no sidecars -> scan is safe to skip"
 
     @pytest.mark.parametrize(
-        "sidecar", ["d.aux.xml", "d.ovr", "d.msk", "d.prj", "d.tfw", "d.wld", "d.rrd"]
+        "sidecar",
+        [
+            "d.aux.xml",
+            "d.aux",
+            "d.ovr",
+            "d.msk",
+            "d.rrd",
+            "d.prj",
+            "d.wld",
+            "d.hdr",
+            "d.tfw",
+            "d.tifw",
+            "d.jgw",
+            "d.pgw",
+            "d.gfw",
+            "d.j2w",
+            "d.jp2w",
+            "d.jpw",
+        ],
     )
     def test_each_sidecar_suffix_is_detected(self, tmp_path, sidecar):
         """Any recognised sidecar suffix in the folder flips scan_safe to False.
@@ -472,6 +503,35 @@ class TestResolveFilesAndScanSafe:
             str(tmp_path), "*.tif"
         )
         assert scan_safe is False, f"{sidecar!r} must keep the directory scan on"
+
+    def test_uppercase_sidecar_is_detected(self, tmp_path):
+        """An uppercase sidecar is detected (case-insensitive match, #1010 M1).
+
+        Test scenario:
+            On case-insensitive filesystems GDAL discovers ``T0.TIF.OVR`` regardless
+            of case, so the scan must stay on even though the suffix is upper-case.
+        """
+        _write_folder_of_tifs(tmp_path)
+        (tmp_path / "T0.TIF.OVR").write_text("", encoding="utf-8")
+        _, scan_safe = DatasetCollection._resolve_files_and_scan_safe(
+            str(tmp_path), "*.tif"
+        )
+        assert scan_safe is False, (
+            "an uppercase sidecar must keep the directory scan on"
+        )
+
+    def test_non_tiff_world_file_is_detected(self, tmp_path):
+        """A format-specific world file (.pgw for PNG) blocks the scan-skip (#1010 M2)."""
+        (tmp_path / "a.png").write_text("", encoding="utf-8")
+        (tmp_path / "b.png").write_text("", encoding="utf-8")
+        (tmp_path / "a.pgw").write_text("", encoding="utf-8")
+        resolved, scan_safe = DatasetCollection._resolve_files_and_scan_safe(
+            str(tmp_path), "*.png"
+        )
+        assert [Path(p).name for p in resolved] == ["a.png", "b.png"], (
+            f"only the .png rasters should resolve: {resolved}"
+        )
+        assert scan_safe is False, "a .pgw world file must keep the directory scan on"
 
     def test_sidecar_not_matching_glob_still_counts(self, tmp_path):
         """A sidecar is detected even though it does not match the raster glob."""

--- a/tests/dataset/io/test_gdal_env.py
+++ b/tests/dataset/io/test_gdal_env.py
@@ -18,6 +18,7 @@ import pytest
 from osgeo import gdal
 
 from pyramids.dataset import Dataset, DatasetCollection
+from pyramids.dataset.collection import _SIDECAR_SUFFIXES
 from pyramids.dataset.engines import io as io_engine
 from tests._helpers import write_raster
 
@@ -470,39 +471,22 @@ class TestResolveFilesAndScanSafe:
         )
         assert scan_safe is True, "no sidecars -> scan is safe to skip"
 
-    @pytest.mark.parametrize(
-        "sidecar",
-        [
-            "d.aux.xml",
-            "d.aux",
-            "d.ovr",
-            "d.msk",
-            "d.rrd",
-            "d.prj",
-            "d.wld",
-            "d.hdr",
-            "d.tfw",
-            "d.tifw",
-            "d.jgw",
-            "d.pgw",
-            "d.gfw",
-            "d.j2w",
-            "d.jp2w",
-            "d.jpw",
-        ],
-    )
-    def test_each_sidecar_suffix_is_detected(self, tmp_path, sidecar):
-        """Any recognised sidecar suffix in the folder flips scan_safe to False.
+    @pytest.mark.parametrize("suffix", _SIDECAR_SUFFIXES)
+    def test_each_sidecar_suffix_is_detected(self, tmp_path, suffix):
+        """Every companion suffix in _SIDECAR_SUFFIXES flips scan_safe to False.
 
         Args:
-            sidecar: A sidecar file name written alongside the rasters.
+            suffix: A recognised companion suffix, derived from the constant so a new
+                suffix added to _SIDECAR_SUFFIXES is covered automatically.
         """
         _write_folder_of_tifs(tmp_path)
-        (tmp_path / sidecar).write_text("", encoding="utf-8")
+        (tmp_path / f"d{suffix}").write_text("", encoding="utf-8")
         _, scan_safe = DatasetCollection._resolve_files_and_scan_safe(
             str(tmp_path), "*.tif"
         )
-        assert scan_safe is False, f"{sidecar!r} must keep the directory scan on"
+        assert scan_safe is False, (
+            f"a {suffix!r} companion must keep the directory scan on"
+        )
 
     def test_uppercase_sidecar_is_detected(self, tmp_path):
         """An uppercase sidecar is detected (case-insensitive match, #1010 M1).

--- a/tests/dataset/io/test_gdal_env.py
+++ b/tests/dataset/io/test_gdal_env.py
@@ -518,3 +518,21 @@ class TestResolveFilesAndScanSafe:
         assert DatasetCollection._resolve_files(str(tmp_path), "*.tif") == expected, (
             "_resolve_files must still return the plain resolved list"
         )
+
+    def test_missing_folder_raises(self, tmp_path):
+        """A folder that does not exist raises ``FileNotFoundError``."""
+        with pytest.raises(FileNotFoundError, match="does not exist"):
+            DatasetCollection._resolve_files_and_scan_safe(
+                str(tmp_path / "nope"), "*.tif"
+            )
+
+    def test_no_glob_match_raises(self, tmp_path):
+        """A folder with no file matching ``glob`` raises ``FileNotFoundError``."""
+        (tmp_path / "note.txt").write_text("", encoding="utf-8")
+        with pytest.raises(FileNotFoundError, match="matched glob"):
+            DatasetCollection._resolve_files_and_scan_safe(str(tmp_path), "*.tif")
+
+    def test_empty_sequence_raises(self):
+        """An empty sequence raises ``ValueError``."""
+        with pytest.raises(ValueError, match="at least one path"):
+            DatasetCollection._resolve_files_and_scan_safe([], "*.tif")

--- a/tests/dataset/io/test_gdal_env.py
+++ b/tests/dataset/io/test_gdal_env.py
@@ -456,6 +456,27 @@ class TestFromFilesDirScanDefault:
             f"a file sequence must not default EMPTY_DIR, got {col._gdal_env}"
         )
 
+    def test_sidecar_folder_still_takes_the_caller_env(self, tmp_path):
+        """A sidecar folder suppresses EMPTY_DIR but still persists the caller's gdal_env.
+
+        Test scenario:
+            The auto-default and the caller's env compose independently: the sidecar
+            withholds EMPTY_DIR, yet an explicit caller key is still installed.
+        """
+        _write_folder_of_tifs(tmp_path)
+        (tmp_path / "t0.tif.aux.xml").write_text(
+            "<PAMDataset></PAMDataset>", encoding="utf-8"
+        )
+        col = DatasetCollection.from_files(
+            str(tmp_path), gdal_env={"AWS_REQUEST_PAYER": "requester"}
+        )
+        assert _READDIR not in col._gdal_env, (
+            f"a sidecar folder must not add EMPTY_DIR: {col._gdal_env}"
+        )
+        assert col._gdal_env.get("AWS_REQUEST_PAYER") == "requester", (
+            "the caller's env must still be persisted"
+        )
+
 
 class TestResolveFilesAndScanSafe:
     """Unit tests for `_resolve_files_and_scan_safe` and the `_resolve_files` delegate."""
@@ -470,6 +491,17 @@ class TestResolveFilesAndScanSafe:
             f"resolved list wrong: {resolved}"
         )
         assert scan_safe is True, "no sidecars -> scan is safe to skip"
+
+    def test_accepts_a_path_object(self, tmp_path):
+        """A ``pathlib.Path`` folder (not a str) resolves the same as its str form."""
+        _write_folder_of_tifs(tmp_path)
+        resolved, scan_safe = DatasetCollection._resolve_files_and_scan_safe(
+            tmp_path, "*.tif"
+        )
+        assert [Path(p).name for p in resolved] == ["t0.tif", "t1.tif"], (
+            f"a Path folder should resolve like its str form: {resolved}"
+        )
+        assert scan_safe is True, "a sidecar-free Path folder is scan-safe"
 
     @pytest.mark.parametrize("suffix", _SIDECAR_SUFFIXES)
     def test_each_sidecar_suffix_is_detected(self, tmp_path, suffix):

--- a/tests/dataset/io/test_gdal_env.py
+++ b/tests/dataset/io/test_gdal_env.py
@@ -11,6 +11,7 @@ those re-opens installs it again.
 from __future__ import annotations
 
 import pickle
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -366,3 +367,154 @@ class TestGdalEnvOnEveryReadPath:
         ds = Dataset.read_file(cog_path, gdal_env=ENV)
         payer = self._payer_during(lambda: ds.cog.preview(max_size=8))
         assert payer == "requester", f"COG preview ran without the config: {payer}"
+
+
+_READDIR = "GDAL_DISABLE_READDIR_ON_OPEN"
+
+
+def _write_folder_of_tifs(folder, count=2):
+    """Write ``count`` tiny 3x3 GeoTIFFs into ``folder`` and return their paths."""
+    return [
+        write_raster(
+            folder / f"t{i}.tif", np.full((3, 3), float(i), "float32"), (0.0, 3.0)
+        )
+        for i in range(count)
+    ]
+
+
+class TestFromFilesDirScanDefault:
+    """`from_files` defaults GDAL_DISABLE_READDIR_ON_OPEN for sidecar-free folders (#1010)."""
+
+    def test_sidecar_free_folder_defaults_empty_dir(self, tmp_path):
+        """A folder with no sidecars gets GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR.
+
+        Test scenario:
+            The auto-default is persisted on the collection and handed to every timestep,
+            so each open skips GDAL's per-open directory rescan.
+        """
+        _write_folder_of_tifs(tmp_path)
+        col = DatasetCollection.from_files(str(tmp_path))
+        assert col._gdal_env.get(_READDIR) == "EMPTY_DIR", (
+            f"sidecar-free folder should default EMPTY_DIR, got {col._gdal_env}"
+        )
+        assert all(ds.gdal_env.get(_READDIR) == "EMPTY_DIR" for ds in col.datasets), (
+            "timesteps must inherit the directory-scan default"
+        )
+
+    def test_folder_with_aux_xml_leaves_scan_on(self, tmp_path):
+        """A folder holding a .aux.xml sidecar keeps the per-open rescan on (no EMPTY_DIR)."""
+        _write_folder_of_tifs(tmp_path)
+        (tmp_path / "t0.tif.aux.xml").write_text(
+            "<PAMDataset></PAMDataset>", encoding="utf-8"
+        )
+        col = DatasetCollection.from_files(str(tmp_path))
+        assert _READDIR not in col._gdal_env, (
+            f"a folder with a sidecar must not disable the scan: {col._gdal_env}"
+        )
+        assert col._gdal_env == {}, f"no env should be installed, got {col._gdal_env}"
+
+    def test_explicit_gdal_env_overrides_default(self, tmp_path):
+        """A caller's GDAL_DISABLE_READDIR_ON_OPEN wins over the sidecar-free default."""
+        _write_folder_of_tifs(tmp_path)
+        col = DatasetCollection.from_files(str(tmp_path), gdal_env={_READDIR: "FALSE"})
+        assert col._gdal_env.get(_READDIR) == "FALSE", (
+            f"an explicit gdal_env value must override the default, got {col._gdal_env}"
+        )
+
+    def test_explicit_gdal_env_merges_with_default(self, tmp_path):
+        """An unrelated caller key is layered on top of the sidecar-free default."""
+        _write_folder_of_tifs(tmp_path)
+        col = DatasetCollection.from_files(
+            str(tmp_path), gdal_env={"AWS_REQUEST_PAYER": "requester"}
+        )
+        assert col._gdal_env.get(_READDIR) == "EMPTY_DIR", (
+            "the auto-default should remain"
+        )
+        assert col._gdal_env.get("AWS_REQUEST_PAYER") == "requester", (
+            "the caller's key should be merged in"
+        )
+
+    def test_explicit_sequence_leaves_scan_on(self, tmp_path):
+        """An explicit file sequence gets no directory-scan default (no listing to trust)."""
+        paths = _write_folder_of_tifs(tmp_path)
+        col = DatasetCollection.from_files(paths)
+        assert col._gdal_env == {}, (
+            f"a file sequence must not default EMPTY_DIR, got {col._gdal_env}"
+        )
+
+
+class TestResolveFilesAndScanSafe:
+    """Unit tests for `_resolve_files_and_scan_safe` and the `_resolve_files` delegate."""
+
+    def test_folder_without_sidecars_is_scan_safe(self, tmp_path):
+        """A folder of plain rasters resolves the matched list with scan_safe True."""
+        _write_folder_of_tifs(tmp_path)
+        resolved, scan_safe = DatasetCollection._resolve_files_and_scan_safe(
+            str(tmp_path), "*.tif"
+        )
+        assert [Path(p).name for p in resolved] == ["t0.tif", "t1.tif"], (
+            f"resolved list wrong: {resolved}"
+        )
+        assert scan_safe is True, "no sidecars -> scan is safe to skip"
+
+    @pytest.mark.parametrize(
+        "sidecar", ["d.aux.xml", "d.ovr", "d.msk", "d.prj", "d.tfw", "d.wld", "d.rrd"]
+    )
+    def test_each_sidecar_suffix_is_detected(self, tmp_path, sidecar):
+        """Any recognised sidecar suffix in the folder flips scan_safe to False.
+
+        Args:
+            sidecar: A sidecar file name written alongside the rasters.
+        """
+        _write_folder_of_tifs(tmp_path)
+        (tmp_path / sidecar).write_text("", encoding="utf-8")
+        _, scan_safe = DatasetCollection._resolve_files_and_scan_safe(
+            str(tmp_path), "*.tif"
+        )
+        assert scan_safe is False, f"{sidecar!r} must keep the directory scan on"
+
+    def test_sidecar_not_matching_glob_still_counts(self, tmp_path):
+        """A sidecar is detected even though it does not match the raster glob."""
+        _write_folder_of_tifs(tmp_path)
+        (tmp_path / "overviews.ovr").write_text("", encoding="utf-8")
+        resolved, scan_safe = DatasetCollection._resolve_files_and_scan_safe(
+            str(tmp_path), "*.tif"
+        )
+        assert all(p.endswith(".tif") for p in resolved), (
+            "the .ovr must not be a timestep"
+        )
+        assert scan_safe is False, "a non-matching sidecar must still be detected"
+
+    def test_single_file_is_not_scan_safe(self, tmp_path):
+        """A single explicit file resolves with scan_safe False (nothing scanned)."""
+        path = write_raster(
+            tmp_path / "one.tif", np.zeros((2, 2), "float32"), (0.0, 2.0)
+        )
+        resolved, scan_safe = DatasetCollection._resolve_files_and_scan_safe(
+            path, "*.tif"
+        )
+        assert [Path(p).name for p in resolved] == ["one.tif"], (
+            f"wrong resolved: {resolved}"
+        )
+        assert scan_safe is False, "an explicit file is never auto-skipped"
+
+    def test_sequence_is_not_scan_safe(self, tmp_path):
+        """An explicit sequence resolves (order preserved) with scan_safe False."""
+        paths = _write_folder_of_tifs(tmp_path)
+        resolved, scan_safe = DatasetCollection._resolve_files_and_scan_safe(
+            paths, "*.tif"
+        )
+        assert [Path(p).name for p in resolved] == ["t0.tif", "t1.tif"], (
+            f"sequence order should be preserved: {resolved}"
+        )
+        assert scan_safe is False, "an explicit sequence is never auto-skipped"
+
+    def test_resolve_files_delegates_and_returns_list(self, tmp_path):
+        """`_resolve_files` returns exactly the path list from the scan-safe resolver."""
+        _write_folder_of_tifs(tmp_path)
+        expected, _ = DatasetCollection._resolve_files_and_scan_safe(
+            str(tmp_path), "*.tif"
+        )
+        assert DatasetCollection._resolve_files(str(tmp_path), "*.tif") == expected, (
+            "_resolve_files must still return the plain resolved list"
+        )


### PR DESCRIPTION
# Description

Performance fix for `DatasetCollection.from_files` on high-latency network storage (#1010). On an SMB / NFS share
GDAL rescans the containing directory on **every** raster open to discover sidecars (`.aux.xml` / `.ovr` / `.msk` /
`.prj` / world files) — a remote listing per file whose cost scales with the folder size, not the file size, so it
is ~20x slower than the raw byte read (a 14,823-file folder went from ~91 min to ~4.6 min for the reporter, with
byte-identical output).

`from_files` now reuses the single folder listing `_resolve_files` already performs to decide whether it is safe to
default `GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR`:

- New `_resolve_files_and_scan_safe(files, glob) -> (list[str], bool)` does the one `iterdir()` pass and returns the
  (unchanged) sorted path list plus a `scan_safe` flag that is `True` **only** for a folder whose listing shows zero
  sidecars (matched case-insensitively against `_SIDECAR_SUFFIXES`). A single explicit file, a sequence, or a folder
  holding any companion all yield `False` (leave the rescan on). `_resolve_files` delegates to `[0]`, so the shared
  `from_stac` / `read_multiple_files` callers are untouched.
- `from_files` defaults `EMPTY_DIR` into the collection's `gdal_env`, persisted via `_build` onto `self._gdal_env`,
  so **every** lazy per-timestep open gets it — not just the eager template. A caller's `gdal_env` always wins
  (merged on top).
- `_SIDECAR_SUFFIXES` covers the common raster companions (PAM stats incl. legacy `.aux`, overviews, masks,
  projection, the generic and per-format world files, ENVI `.hdr`, ESRI RAT `.vat.dbf`); an exotic format whose
  companion is not listed can pass `gdal_env` explicitly to keep the rescan on.

Pixel values are unchanged; only the redundant directory scan is skipped. No new dependencies.

# Issues
- Fixes #1010

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Performance enhancement — non-breaking, no public API change (`from_files` signature is unchanged, the new helper is
a private staticmethod, and the auto-default is caller-overridable); none of the boxes above fit exactly.

# How Has This Been Tested?

- New tests in `tests/dataset/io/test_gdal_env.py` — `TestFromFilesDirScanDefault` (sidecar-free folder → `EMPTY_DIR`
  persisted and inherited by both the bulk `datasets` path and the single-index `iloc` → `_dataset_at` lazy path; a
  `.aux.xml` folder leaves the rescan on; explicit `gdal_env` overrides / merges; explicit sequence gets no default)
  and `TestResolveFilesAndScanSafe` (every `_SIDECAR_SUFFIXES` entry detected — parametrized from the constant;
  uppercase and non-TIFF world-file regressions; a non-glob-matching sidecar still counts; single file / sequence;
  delegate equivalence; the three error branches).
- Full worktree suite green: `pytest -m "not plot"` → **8377 passed, 52 skipped**.
- `ruff` + `mypy` clean; `collection.py` doctests pass.
- Two rounds of adversarial review (`/review-rounds`): Round 1 hardened the sidecar heuristic (case-insensitive
  match, expanded companion set, single-return); Round 2 added `.vat.dbf` and made the suffix test track the
  constant. All findings resolved.

- [x] Test A — dir-scan default behaviour (env plumbing across all input shapes + both lazy read paths)
- [x] Test B — `_resolve_files_and_scan_safe` branch coverage (every suffix, case, non-TIFF, error paths)

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
