### PR TITLE
fix(netcdf): geotransform x-spacing + animate no-data/exclude/time labels

### DIFF
--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -1297,14 +1297,19 @@ class NetCDFPlot:
     ) -> Any:
         """Build the lazy ``data_getter`` and dispatch the animation render.
 
-        Resolves the per-frame coord labels (with CF time decoding when
-        applicable), builds a ``data_getter(i)`` closure that calls
-        :meth:`NetCDF.sel` + :meth:`NetCDF.read_array` once per frame,
+        Resolves the per-frame coord labels (CF time axes are decoded via
+        :meth:`NetCDF._decode_time_labels`, which falls back to the parent
+        container so a ``get_variable`` subset still yields calendar dates),
+        builds a ``data_getter(i)`` closure that reads one 2-D slice per frame,
         and forwards everything to
         :func:`pyramids.dataset._plot_helpers.render_array` with
-        ``mode="animate"``. The first frame doubles as the cleopatra
-        shape template so the ``ArrayGlyph`` constructor has a 2-D array
-        to size its axes against.
+        ``mode="animate"``. Each streamed frame is masked first — the
+        variable's no-data and any ``exclude_value`` are replaced with ``NaN``
+        (rendered transparent) — because cleopatra's animate masks only the
+        constructor template and blits every other frame verbatim, so raw
+        no-data would otherwise paint at the colour-scale extreme. The first
+        frame doubles as the cleopatra shape template so the ``ArrayGlyph``
+        constructor has a 2-D array to size its axes against.
 
         Args:
             nc: The variable subset being animated.
@@ -1316,7 +1321,10 @@ class NetCDFPlot:
                 :meth:`Analysis.plot` (e.g. ``rgb``, ``kind``,
                 ``coords``, ``_facet_stack``) before forwarding to
                 cleopatra's animate entry point.
-            exclude_value: Per-frame mask value forwarded to cleopatra.
+            exclude_value: An extra value to mask alongside the variable's
+                no-data. Both are replaced with ``NaN`` in every streamed frame
+                (and passed to cleopatra as the template ``exclude_value``), so a
+                caller value takes effect rather than being dropped.
             basemap: Forwarded to :func:`render_array`. A web-tile basemap
                 (``str`` / ``True``) draws on the animation's single
                 persistent ``Axes`` underneath the frames; a cleopatra

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -1430,19 +1430,35 @@ class NetCDFPlot:
             value
             for value in resolved_exclude
             if value is not None
-            and not (isinstance(value, float) and math.isnan(value))
+            and not (isinstance(value, (float, np.floating)) and math.isnan(value))
         ]
 
         def _mask_frame(frame: np.typing.NDArray) -> np.typing.NDArray:
             result = np.asarray(frame)
             if mask_values:
-                # Compare in the frame's own dtype: a fill that is not exactly
-                # representable after a float64 promotion (e.g. a float32 CF fill)
-                # still matches, and this mask then agrees with cleopatra's
-                # native-dtype template mask. Lift to float only afterwards, to
-                # hold NaN in the masked cells (a fresh array, so the read frame
-                # is never mutated).
-                selected = np.isin(result, np.asarray(mask_values, dtype=result.dtype))
+                selected = np.zeros(result.shape, dtype=bool)
+                for value in mask_values:
+                    try:
+                        # Compare in the frame's own dtype so a fill that is not
+                        # exactly representable after a float64 promotion (a float32
+                        # CF fill) still matches, agreeing with cleopatra's
+                        # native-dtype template mask.
+                        cast = np.asarray(value, dtype=result.dtype)
+                    except (OverflowError, ValueError):
+                        # An out-of-range or NaN `exclude_value` for an integer frame
+                        # cannot occur in the frame, so it masks nothing (rather than
+                        # raising OverflowError mid-animation).
+                        continue
+                    if result.dtype.kind in "iu" and not np.array_equal(
+                        cast, np.asarray(value)
+                    ):
+                        # A fractional `exclude_value` truncates when cast to an
+                        # integer dtype (10.7 -> 10) and would mask the wrong cells;
+                        # skip a value the frame's dtype cannot hold exactly.
+                        continue
+                    selected = selected | (result == cast)
+                # Lift to float only afterwards, to hold NaN in the masked cells (a
+                # fresh array, so the read frame is never mutated).
                 result = result.astype(float)
                 result[selected] = np.nan
             return result

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -1393,8 +1393,14 @@ class NetCDFPlot:
         if dim_values_raw is None:
             frame_labels: list[Any] = list(range(nc._band_dim_sizes[animate_axis]))
         else:
+            # Decode the subset's own (possibly subsetted) raw time values rather
+            # than calling `get_time_variable`, which reads the full stored axis and
+            # returns None on a `get_variable` subset that has lost the root group's
+            # dimension metadata — the reason the labels were the raw encoded integers
+            # (#1013). cleopatra's animate label is `str(label)[:10]`, so a decoded
+            # "1979-01-01" renders correctly while a raw int is truncated mid-number.
             decoded = (
-                nc.get_time_variable(animate_dim)
+                nc._decode_time_labels(animate_dim, list(dim_values_raw))
                 if animate_dim.lower() in ("time", "valid_time", "t")
                 else None
             )
@@ -1406,6 +1412,24 @@ class NetCDFPlot:
             if exclude_value is not None
             else [no_data_value[0]]
         )
+        # cleopatra masks the constructor template via `exclude_value` (so the colour
+        # scale is right) but blits each streamed frame verbatim with `im.set_data`,
+        # leaving no-data drawn at the scale extreme. Mask here — replace the exclude
+        # values with NaN, which matplotlib renders transparent — so every animation
+        # frame masks no-data exactly like the static path (#1013). The template still
+        # goes to cleopatra raw so its `exclude_value` masking sizes the colour scale.
+        mask_values = [
+            value
+            for value in resolved_exclude
+            if value is not None
+            and not (isinstance(value, float) and math.isnan(value))
+        ]
+
+        def _mask_frame(frame: np.typing.NDArray) -> np.typing.NDArray:
+            if not mask_values:
+                return frame
+            floated = np.asarray(frame, dtype=float)
+            return np.where(np.isin(floated, mask_values), np.nan, floated)
 
         # Per-frame data fetch. Rather than allocating a fresh `sel()`
         # subset for every frame — which re-resolves the variable and
@@ -1424,8 +1448,10 @@ class NetCDFPlot:
 
         def _data_getter(i: int) -> np.typing.NDArray:
             if i == 0:
-                return _frame_zero.copy()
-            return cast("np.typing.NDArray", nc.read_array(band=i * frame_stride))
+                return _mask_frame(_frame_zero.copy())
+            return _mask_frame(
+                cast("np.typing.NDArray", nc.read_array(band=i * frame_stride))
+            )
 
         template = _frame_zero
 

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -1407,11 +1407,11 @@ class NetCDFPlot:
             # dimension metadata — the reason the labels were the raw encoded integers
             # (#1013). cleopatra's animate label is `str(label)[:10]`, so a decoded
             # "1979-01-01" renders correctly while a raw int is truncated mid-number.
-            decoded = (
-                nc._decode_time_labels(animate_dim, list(dim_values_raw))
-                if animate_dim.lower() in ("time", "valid_time", "t")
-                else None
-            )
+            # Try to decode any axis (not just names like "time"): `_decode_time_labels`
+            # returns the dates when the dim resolves a parseable CF time `units` — so
+            # model axes such as `time_counter` / `forecast_period` decode too — and
+            # None for a non-time axis, which then keeps the raw coordinate labels.
+            decoded = nc._decode_time_labels(animate_dim, list(dim_values_raw))
             frame_labels = decoded if decoded is not None else list(dim_values_raw)
 
         no_data_value = [np.nan if v is None else v for v in nc.no_data_value]
@@ -1434,10 +1434,18 @@ class NetCDFPlot:
         ]
 
         def _mask_frame(frame: np.typing.NDArray) -> np.typing.NDArray:
-            if not mask_values:
-                return frame
-            floated = np.asarray(frame, dtype=float)
-            return np.where(np.isin(floated, mask_values), np.nan, floated)
+            result = np.asarray(frame)
+            if mask_values:
+                # Compare in the frame's own dtype: a fill that is not exactly
+                # representable after a float64 promotion (e.g. a float32 CF fill)
+                # still matches, and this mask then agrees with cleopatra's
+                # native-dtype template mask. Lift to float only afterwards, to
+                # hold NaN in the masked cells (a fresh array, so the read frame
+                # is never mutated).
+                selected = np.isin(result, np.asarray(mask_values, dtype=result.dtype))
+                result = result.astype(float)
+                result[selected] = np.nan
+            return result
 
         # Per-frame data fetch. Rather than allocating a fresh `sel()`
         # subset for every frame — which re-resolves the variable and

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -527,6 +527,86 @@ class CurvilinearCoordResolver:
         return result
 
 
+def _mask_exclude_values(
+    frame: np.typing.NDArray, mask_values: list[Any]
+) -> np.typing.NDArray:
+    """Return ``frame`` with every ``mask_values`` cell set to ``NaN``.
+
+    Values are matched in the frame's own dtype, so a fill that is not exactly
+    representable after a float64 promotion (a float32 CF fill) still matches and the
+    mask agrees with cleopatra's native-dtype template mask. A value the frame dtype
+    cannot hold exactly — a fractional or out-of-range ``exclude_value`` on an integer
+    frame — is skipped rather than truncating to the wrong cells or raising
+    ``OverflowError``. The masked result is a fresh float array, so the read frame is
+    never mutated; with nothing to mask the frame is returned unchanged.
+
+    Args:
+        frame: The 2-D data array for one animation frame.
+        mask_values: Values (the no-data plus any ``exclude_value``) to mask out.
+
+    Returns:
+        numpy.ndarray: ``frame`` with masked cells set to ``NaN`` (a float array), or
+        ``frame`` unchanged when there is nothing to mask.
+    """
+    result = np.asarray(frame)
+    if mask_values:
+        selected = np.zeros(result.shape, dtype=bool)
+        for value in mask_values:
+            try:
+                cast_value = np.asarray(value, dtype=result.dtype)
+            except (OverflowError, ValueError):
+                # An out-of-range or NaN `exclude_value` for an integer frame cannot
+                # occur in the frame, so it masks nothing (rather than raising).
+                continue
+            if result.dtype.kind in "iu" and not np.array_equal(
+                cast_value, np.asarray(value)
+            ):
+                # A fractional `exclude_value` truncates when cast to an integer dtype
+                # (10.7 -> 10) and would mask the wrong cells; skip what the frame's
+                # dtype cannot hold exactly.
+                continue
+            selected = selected | (result == cast_value)
+        # Lift to float only afterwards, to hold NaN in the masked cells.
+        result = result.astype(float)
+        result[selected] = np.nan
+    return result
+
+
+def _resolve_animate_labels(
+    nc: NetCDF, animate_dim: str, animate_axis: int
+) -> list[Any]:
+    """Resolve the per-frame labels for an animation axis.
+
+    Uses the axis's own raw coordinate values, CF-decoding them to calendar dates via
+    :meth:`NetCDF._decode_time_labels` when the dim resolves a parseable time
+    ``units`` (so ``time`` / ``time_counter`` / ``forecast_period`` label as dates)
+    and keeping the raw values otherwise. Falls back to positional indices when the
+    axis carries no stored coordinate values.
+
+    Args:
+        nc: The variable subset being animated.
+        animate_dim: Name of the band dim walked by the animation.
+        animate_axis: Index of ``animate_dim`` among the band dims.
+
+    Returns:
+        list: One label per frame — decoded date strings, raw coordinate values, or
+        positional indices.
+    """
+    dim_values_raw = nc._band_dim_values_map.get(animate_dim)
+    if dim_values_raw is None:
+        labels: list[Any] = list(range(nc._band_dim_sizes[animate_axis]))
+    else:
+        # Decode the subset's own (possibly subsetted) raw time values rather than
+        # `get_time_variable`, which reads the full stored axis and returns None on a
+        # `get_variable` subset that has lost the root group's dimension metadata (the
+        # reason the labels were raw encoded integers, #1013). cleopatra renders the
+        # label as `str(label)[:10]`, so a decoded "1979-01-01" shows while a raw int
+        # is truncated mid-number.
+        decoded = nc._decode_time_labels(animate_dim, list(dim_values_raw))
+        labels = decoded if decoded is not None else list(dim_values_raw)
+    return labels
+
+
 class NetCDFPlot:
     """Owns the plotting pipeline for a :class:`~pyramids.netcdf.netcdf.NetCDF`.
 
@@ -1397,71 +1477,27 @@ class NetCDFPlot:
                 ```
         """
         animate_axis = nc._band_dim_names.index(animate_dim)
-        dim_values_raw = nc._band_dim_values_map.get(animate_dim)
-        if dim_values_raw is None:
-            frame_labels: list[Any] = list(range(nc._band_dim_sizes[animate_axis]))
-        else:
-            # Decode the subset's own (possibly subsetted) raw time values rather
-            # than calling `get_time_variable`, which reads the full stored axis and
-            # returns None on a `get_variable` subset that has lost the root group's
-            # dimension metadata — the reason the labels were the raw encoded integers
-            # (#1013). cleopatra's animate label is `str(label)[:10]`, so a decoded
-            # "1979-01-01" renders correctly while a raw int is truncated mid-number.
-            # Try to decode any axis (not just names like "time"): `_decode_time_labels`
-            # returns the dates when the dim resolves a parseable CF time `units` — so
-            # model axes such as `time_counter` / `forecast_period` decode too — and
-            # None for a non-time axis, which then keeps the raw coordinate labels.
-            decoded = nc._decode_time_labels(animate_dim, list(dim_values_raw))
-            frame_labels = decoded if decoded is not None else list(dim_values_raw)
+        frame_labels = _resolve_animate_labels(nc, animate_dim, animate_axis)
 
+        # cleopatra masks the constructor template via `exclude_value` (so the colour
+        # scale is right) but blits each streamed frame verbatim with `im.set_data`,
+        # leaving no-data drawn at the scale extreme. Mask each streamed frame here —
+        # via `_mask_exclude_values`, replacing the exclude values with NaN, which
+        # matplotlib renders transparent — so every animation frame masks no-data
+        # exactly like the static path (#1013). The template still goes to cleopatra
+        # raw so its own `exclude_value` masking sizes the colour scale.
         no_data_value = [np.nan if v is None else v for v in nc.no_data_value]
         resolved_exclude = (
             [no_data_value[0], exclude_value]
             if exclude_value is not None
             else [no_data_value[0]]
         )
-        # cleopatra masks the constructor template via `exclude_value` (so the colour
-        # scale is right) but blits each streamed frame verbatim with `im.set_data`,
-        # leaving no-data drawn at the scale extreme. Mask here — replace the exclude
-        # values with NaN, which matplotlib renders transparent — so every animation
-        # frame masks no-data exactly like the static path (#1013). The template still
-        # goes to cleopatra raw so its `exclude_value` masking sizes the colour scale.
         mask_values = [
             value
             for value in resolved_exclude
             if value is not None
             and not (isinstance(value, (float, np.floating)) and math.isnan(value))
         ]
-
-        def _mask_frame(frame: np.typing.NDArray) -> np.typing.NDArray:
-            result = np.asarray(frame)
-            if mask_values:
-                selected = np.zeros(result.shape, dtype=bool)
-                for value in mask_values:
-                    try:
-                        # Compare in the frame's own dtype so a fill that is not
-                        # exactly representable after a float64 promotion (a float32
-                        # CF fill) still matches, agreeing with cleopatra's
-                        # native-dtype template mask.
-                        cast = np.asarray(value, dtype=result.dtype)
-                    except (OverflowError, ValueError):
-                        # An out-of-range or NaN `exclude_value` for an integer frame
-                        # cannot occur in the frame, so it masks nothing (rather than
-                        # raising OverflowError mid-animation).
-                        continue
-                    if result.dtype.kind in "iu" and not np.array_equal(
-                        cast, np.asarray(value)
-                    ):
-                        # A fractional `exclude_value` truncates when cast to an
-                        # integer dtype (10.7 -> 10) and would mask the wrong cells;
-                        # skip a value the frame's dtype cannot hold exactly.
-                        continue
-                    selected = selected | (result == cast)
-                # Lift to float only afterwards, to hold NaN in the masked cells (a
-                # fresh array, so the read frame is never mutated).
-                result = result.astype(float)
-                result[selected] = np.nan
-            return result
 
         # Per-frame data fetch. Rather than allocating a fresh `sel()`
         # subset for every frame — which re-resolves the variable and
@@ -1479,11 +1515,12 @@ class NetCDFPlot:
         _frame_zero = np.asarray(nc.read_array(band=0))
 
         def _data_getter(i: int) -> np.typing.NDArray:
-            if i == 0:
-                return _mask_frame(_frame_zero.copy())
-            return _mask_frame(
-                cast("np.typing.NDArray", nc.read_array(band=i * frame_stride))
+            frame = (
+                _frame_zero.copy()
+                if i == 0
+                else cast("np.typing.NDArray", nc.read_array(band=i * frame_stride))
             )
+            return _mask_exclude_values(np.asarray(frame), mask_values)
 
         template = _frame_zero
 

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4082,7 +4082,9 @@ class NetCDF(Dataset):
 
         Returns:
             list[str] or None: One formatted string per value, or ``None`` when no
-            parseable ``units`` attribute is available on this cube or its parent.
+            parseable ``units`` attribute is available on this cube or its parent
+            (including a present-but-unparseable one — a non-CF ``units`` string
+            degrades to raw labels rather than raising out of a plot).
         """
         labels: list[str] | None = None
         for owner in (self, getattr(self, "_parent_nc", None)):
@@ -4095,8 +4097,20 @@ class NetCDF(Dataset):
             if units is None:
                 continue
             calendar = time_dim.attrs.get("calendar", "standard")
-            func = create_time_conversion_func(units, time_format, calendar=calendar)
-            labels = [func(value) for value in raw_values]
+            try:
+                func = create_time_conversion_func(
+                    units, time_format, calendar=calendar
+                )
+                labels = [func(value) for value in raw_values]
+            except Exception:
+                # A present-but-non-CF `units` (e.g. "gregorian", or "days" with no
+                # "since <origin>") cannot be parsed into a time origin;
+                # `create_time_conversion_func` / cftime raise on it. This is a
+                # display-label nicety, so degrade to the raw labels (return None)
+                # instead of crashing the plot — honouring the "returns None"
+                # contract and matching the pre-#1013 subset behaviour.
+                labels = None
+                continue
             break
         return labels
 

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -861,7 +861,6 @@ class NetCDF(Dataset):
             # they differ on non-square grids (e.g. 2° lon, 1° lat), so a single `cell_size` for
             # both axes would stretch the latitude axis. Y is reported north-up: the top edge is the
             # northernmost latitude plus half a cell, and pixel height is negative.
-            x_cell = self.cell_size
             if len(self.lat) >= 2:
                 y_cell = abs(float(self.lat[1] - self.lat[0]))
                 y_top = max(float(self.lat[0]), float(self.lat[-1])) + y_cell / 2
@@ -870,10 +869,14 @@ class NetCDF(Dataset):
                 y_top = float(self.lat[0]) + y_cell / 2
             # West edge = min(lon) - half a cell, mirroring the north-up lat branch above. Taking
             # `lon[0]` unguarded put the origin at the EAST edge for a descending-longitude container,
-            # mirroring the X origin (ARC-32).
+            # mirroring the X origin (ARC-32). The X pixel size comes from the real lon spacing too:
+            # `self.cell_size` tracks GDAL's index-space geotransform (pixel width 1.0) for a
+            # multidim-opened container, which silently mis-georeferenced the X axis (#1014).
             if len(self.lon) >= 2:
+                x_cell = abs(float(self.lon[1] - self.lon[0]))
                 x_west = min(float(self.lon[0]), float(self.lon[-1])) - x_cell / 2
             else:
+                x_cell = self.cell_size
                 x_west = float(self.lon[0]) - x_cell / 2
             return (
                 x_west,
@@ -4051,6 +4054,51 @@ class NetCDF(Dataset):
                     )
                     time_stamp = list(map(func, time_vals.reshape(-1)))
         return time_stamp
+
+    def _decode_time_labels(
+        self,
+        var_name: str,
+        raw_values: list[Any],
+        time_format: str = "%Y-%m-%d",
+    ) -> list[str] | None:
+        """Decode already-read raw time values into formatted date strings.
+
+        Unlike :meth:`get_time_variable`, which reads the *full* stored axis, this
+        decodes the specific ``raw_values`` handed to it, using the CF ``units`` /
+        ``calendar`` for ``var_name`` resolved from this cube's own dimension
+        metadata or, failing that, its parent container's. A variable subset built
+        by :meth:`get_variable` keeps its (possibly subsetted) raw coordinate values
+        in ``_band_dim_values_map`` but loses the root group's dimension attributes,
+        so its own metadata is empty while the parent still carries the units —
+        which is why the animate frame labels came back as raw integers (#1013).
+        Decoding the passed values (not the parent's full axis) keeps the labels
+        aligned with a time-subsetted view.
+
+        Args:
+            var_name: Name of the time coordinate / dimension.
+            raw_values: The raw coordinate values to decode (one per frame).
+            time_format: strftime format for the output strings. Defaults to
+                ``"%Y-%m-%d"``.
+
+        Returns:
+            list[str] or None: One formatted string per value, or ``None`` when no
+            parseable ``units`` attribute is available on this cube or its parent.
+        """
+        labels: list[str] | None = None
+        for owner in (self, getattr(self, "_parent_nc", None)):
+            if owner is None:
+                continue
+            time_dim = owner.meta_data.get_dimension(var_name)
+            if time_dim is None:
+                continue
+            units = time_dim.attrs.get("units")
+            if units is None:
+                continue
+            calendar = time_dim.attrs.get("calendar", "standard")
+            func = create_time_conversion_func(units, time_format, calendar=calendar)
+            labels = [func(value) for value in raw_values]
+            break
+        return labels
 
     @property
     def dimension_sizes(self) -> dict[str, int]:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -876,6 +876,10 @@ class NetCDF(Dataset):
                 x_cell = abs(float(self.lon[1] - self.lon[0]))
                 x_west = min(float(self.lon[0]), float(self.lon[-1])) - x_cell / 2
             else:
+                # A single longitude gives no spacing to measure, so fall back to
+                # `self.cell_size`. On a multidim-opened container that is the
+                # index-space 1.0 — a projected one-column grid cannot recover its
+                # real cell size from a lone coordinate (same limit as the y branch).
                 x_cell = self.cell_size
                 x_west = float(self.lon[0]) - x_cell / 2
             return (
@@ -4101,16 +4105,19 @@ class NetCDF(Dataset):
                 func = create_time_conversion_func(
                     units, time_format, calendar=calendar
                 )
-                labels = [func(value) for value in raw_values]
             except Exception:
-                # A present-but-non-CF `units` (e.g. "gregorian", or "days" with no
-                # "since <origin>") cannot be parsed into a time origin;
-                # `create_time_conversion_func` / cftime raise on it. This is a
-                # display-label nicety, so degrade to the raw labels (return None)
-                # instead of crashing the plot — honouring the "returns None"
-                # contract and matching the pre-#1013 subset behaviour.
+                # Guard only the parse: a present-but-non-CF `units` (e.g.
+                # "gregorian", or "days" with no "since <origin>") cannot be parsed
+                # into a time origin; `create_time_conversion_func` / cftime raise on
+                # it. This is a display-label nicety, so degrade to the raw labels
+                # (return None) instead of crashing the plot — honouring the "returns
+                # None" contract and matching the pre-#1013 subset behaviour.
                 labels = None
                 continue
+            # The value conversion runs outside the guard, so a genuinely malformed
+            # coordinate value surfaces as an error rather than being hidden behind
+            # a silent raw-label fallback.
+            labels = [func(value) for value in raw_values]
             break
         return labels
 

--- a/tests/dataset/collection/test_to_netcdf.py
+++ b/tests/dataset/collection/test_to_netcdf.py
@@ -975,3 +975,40 @@ class TestToNetcdfRoundTrip:
         assert nc.time_stamp == ["1979-01-01", "1979-01-02"], (
             f"time_stamp did not decode: {nc.time_stamp!r}"
         )
+
+    def test_geotransform_round_trips_nonunit_cell_size(self, tmp_path):
+        """``NetCDF.geotransform`` round-trips a non-unit projected cell size on both axes.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            Write a collection on a projected 5000 m grid (EPSG:4647) and reopen —
+            expected: ``nc.geotransform`` equals the source transform on *both*
+            axes, not an index-space ``pixel width 1.0`` with a half-pixel-shifted
+            x origin. Regression test for #1014, where the reader took the x pixel
+            size from the index-space ``cell_size`` while y used the real coord
+            spacing.
+        """
+        nd, cell, ox, oy = -9999.0, 5000.0, 32239263.70388, 5756081.42235
+        paths = []
+        for i in range(3):
+            arr = np.full((5, 4), nd, dtype="float32")
+            arr[1:4, 1:3] = 10.0 + i
+            path = os.path.join(str(tmp_path), f"g{i}.tif")
+            Dataset.create_from_array(
+                arr,
+                geo=(ox, cell, 0.0, oy, 0.0, -cell),
+                epsg=4647,
+                no_data_value=nd,
+            ).to_file(path)
+            paths.append(path)
+        out = tmp_path / "gt.nc"
+        DatasetCollection.from_files(paths).to_netcdf(str(out))
+        nc = NetCDF.read_file(str(out))
+        expected = (ox, cell, 0.0, oy, 0.0, -cell)
+        got = tuple(float(v) for v in nc.geotransform)
+        assert got == pytest.approx(expected), (
+            f"geotransform did not round-trip: {got} != {expected}"
+        )
+        assert got[1] == pytest.approx(cell), f"x pixel size not the real spacing: {got[1]}"

--- a/tests/dataset/collection/test_to_netcdf.py
+++ b/tests/dataset/collection/test_to_netcdf.py
@@ -1011,4 +1011,6 @@ class TestToNetcdfRoundTrip:
         assert got == pytest.approx(expected), (
             f"geotransform did not round-trip: {got} != {expected}"
         )
-        assert got[1] == pytest.approx(cell), f"x pixel size not the real spacing: {got[1]}"
+        assert got[1] == pytest.approx(cell), (
+            f"x pixel size not the real spacing: {got[1]}"
+        )

--- a/tests/netcdf/plot/test_plot_animate.py
+++ b/tests/netcdf/plot/test_plot_animate.py
@@ -244,6 +244,30 @@ class TestNetCDFPlotAnimate:
             "1979-01-03",
         ]
 
+    def test_animate_without_no_data_leaves_frames_unmasked(self):
+        """A variable with no no-data introduces no spurious NaN into the frames.
+
+        Test scenario:
+            When ``no_data_value`` is unset and no ``exclude_value`` is passed the
+            frame mask is empty, so ``_data_getter`` returns each frame untouched —
+            covers the empty-mask branch of the animate masking.
+        """
+        nc = make_plot_3d_nc(n_times=3)
+        captured: dict = {}
+        with patch(
+            "pyramids.netcdf._plot._render_array",
+            side_effect=_make_fake_render(captured),
+        ):
+            nc.plot(variable="t2m", animate=True)
+        frame0 = np.asarray(captured["request"].mode.data_getter(0))
+        expected = np.asarray(nc.get_variable("t2m").read_array(band=0))
+        assert not np.any(np.isnan(frame0)), "no no-data means no NaN introduced"
+        assert_array_equal(
+            frame0,
+            expected,
+            err_msg="frame should be returned unchanged when the mask is empty",
+        )
+
     @pytest.mark.skipif(FrameLabel is None, reason="cleopatra < 0.26 has no FrameLabel")
     def test_animate_forwards_frame_label_to_render_array(self):
         """``frame_label=FrameLabel(...)`` forwards through NetCDF.plot to the animate render.

--- a/tests/netcdf/plot/test_plot_animate.py
+++ b/tests/netcdf/plot/test_plot_animate.py
@@ -21,7 +21,9 @@ def _default_interior(i: int) -> float:
     return 10.0 + i
 
 
-def _dated_projected_nc(tmp_path, *, dtype="float32", nodata=-9999.0, interior=None) -> NetCDF:
+def _dated_projected_nc(
+    tmp_path, *, dtype="float32", nodata=-9999.0, interior=None
+) -> NetCDF:
     """Round-trip a dated projected collection through ``to_netcdf`` and reopen it.
 
     Writes three 5x4 rasters on a projected 5000 m grid (EPSG:4647) with a
@@ -253,7 +255,9 @@ class TestNetCDFPlotAnimate:
             nc.plot(variable="Band_1", animate=True, exclude_value=0.1)
         frame0 = np.asarray(captured["request"].mode.data_getter(0))
         assert np.any(frame0 == np.float32(0.2)), "the 0.2 data value must survive"
-        assert not np.any(frame0 == np.float32(0.1)), "0.1 must be masked in native dtype"
+        assert not np.any(frame0 == np.float32(0.1)), (
+            "0.1 must be masked in native dtype"
+        )
 
     def test_animate_masks_integer_frame_no_data(self, tmp_path):
         """An integer variable's no-data is promoted to float and masked to NaN.

--- a/tests/netcdf/plot/test_plot_animate.py
+++ b/tests/netcdf/plot/test_plot_animate.py
@@ -16,6 +16,11 @@ from tests.netcdf.conftest import make_plot_3d_nc
 from tests.netcdf.plot._plot_helpers import _make_4d_nc, _make_fake_render
 
 
+def _default_interior(i: int) -> float:
+    """Default interior fill for :func:`_dated_projected_nc`: ``10.0 + i``."""
+    return 10.0 + i
+
+
 def _dated_projected_nc(tmp_path, *, dtype="float32", nodata=-9999.0, interior=None) -> NetCDF:
     """Round-trip a dated projected collection through ``to_netcdf`` and reopen it.
 
@@ -37,7 +42,7 @@ def _dated_projected_nc(tmp_path, *, dtype="float32", nodata=-9999.0, interior=N
         NetCDF: The reopened root container holding the ``Band_1`` variable.
     """
     if interior is None:
-        interior = lambda i: 10.0 + i
+        interior = _default_interior
     cell, ox, oy = 5000.0, 32239263.70388, 5756081.42235
     paths = []
     for i in range(3):
@@ -53,6 +58,7 @@ def _dated_projected_nc(tmp_path, *, dtype="float32", nodata=-9999.0, interior=N
         str(out), time_coords=pd.date_range("1979-01-01", periods=3, freq="D")
     )
     return NetCDF.read_file(str(out))
+
 
 pytestmark = pytest.mark.plot
 
@@ -235,7 +241,7 @@ class TestNetCDFPlotAnimate:
             The interior mixes ``0.1`` and ``0.2`` stored as ``float32``; excluding
             the Python float ``0.1`` (not exactly representable in ``float32``) must
             still mask the ``0.1`` cells — the comparison happens in the frame's
-            native dtype — while the ``0.2`` cells survive (finding L2).
+            native dtype — while the ``0.2`` cells survive (#1013).
         """
         block = np.array([[0.1, 0.2]] * 3, dtype="float32")
         nc = _dated_projected_nc(tmp_path, interior=lambda i: block)
@@ -255,7 +261,7 @@ class TestNetCDFPlotAnimate:
         Test scenario:
             An ``int16`` collection with a ``-9999`` no-data animates; the streamed
             frame is promoted to float and its no-data cells become ``NaN`` — the
-            int-to-float mask path (finding L4).
+            int-to-float mask path (#1013).
         """
         nc = _dated_projected_nc(
             tmp_path, dtype="int16", nodata=-9999, interior=lambda i: 10 + i
@@ -270,6 +276,48 @@ class TestNetCDFPlotAnimate:
         assert frame0.dtype.kind == "f", "integer frame should be promoted to float"
         assert np.any(np.isnan(frame0)), "no-data should be masked to NaN"
         assert not np.any(frame0 == -9999), "raw no-data should not remain"
+
+    def test_animate_integer_frame_fractional_exclude_is_noop(self, tmp_path):
+        """A fractional exclude_value on an integer raster masks nothing, not the wrong cells.
+
+        Test scenario:
+            On an ``int16`` frame, ``exclude_value=10.7`` cannot be held exactly, so
+            it is skipped — the real ``10`` cells survive and only the no-data is
+            masked (rather than the truncated ``10`` cells being wrongly blanked).
+        """
+        nc = _dated_projected_nc(
+            tmp_path, dtype="int16", nodata=-9999, interior=lambda i: 10 + i
+        )
+        captured: dict = {}
+        with patch(
+            "pyramids.netcdf._plot._render_array",
+            side_effect=_make_fake_render(captured),
+        ):
+            nc.plot(variable="Band_1", animate=True, exclude_value=10.7)
+        frame0 = np.asarray(captured["request"].mode.data_getter(0))
+        assert np.any(frame0 == 10.0), "a fractional exclude must not mask the 10 cells"
+        assert np.any(np.isnan(frame0)), "no-data should still be masked"
+
+    def test_animate_integer_frame_out_of_range_exclude_does_not_crash(self, tmp_path):
+        """An out-of-range exclude_value on an integer raster degrades, not crashes.
+
+        Test scenario:
+            ``exclude_value=40000`` overflows ``int16``; masking a streamed frame
+            must not raise ``OverflowError`` — it masks nothing extra while the
+            no-data is still masked and the real data survives.
+        """
+        nc = _dated_projected_nc(
+            tmp_path, dtype="int16", nodata=-9999, interior=lambda i: 10 + i
+        )
+        captured: dict = {}
+        with patch(
+            "pyramids.netcdf._plot._render_array",
+            side_effect=_make_fake_render(captured),
+        ):
+            nc.plot(variable="Band_1", animate=True, exclude_value=40000)
+        frame0 = np.asarray(captured["request"].mode.data_getter(0))
+        assert np.any(frame0 == 10.0), "real data must survive an out-of-range exclude"
+        assert np.any(np.isnan(frame0)), "no-data should still be masked"
 
     def test_animate_labels_decode_to_calendar_dates(self, tmp_path):
         """Frame labels are the CF-decoded dates of a round-tripped collection, not raw ints.
@@ -301,7 +349,7 @@ class TestNetCDFPlotAnimate:
         Test scenario:
             ``make_plot_3d_nc`` builds a ``time`` dim of plain integers with no CF
             ``units``, so decoding returns None and the animate path keeps the raw
-            ``[0, 1, 2]`` coordinate labels (finding L4).
+            ``[0, 1, 2]`` coordinate labels (#1013).
         """
         nc = make_plot_3d_nc(n_times=3)
         captured: dict = {}

--- a/tests/netcdf/plot/test_plot_animate.py
+++ b/tests/netcdf/plot/test_plot_animate.py
@@ -5,13 +5,48 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import numpy as np
+import pandas as pd
 import pytest
 from numpy.testing import assert_array_equal
 
+from pyramids.dataset import Dataset, DatasetCollection
 from pyramids.netcdf import FacetSpec, GeoReference, Selectors
 from pyramids.netcdf.netcdf import NetCDF
 from tests.netcdf.conftest import make_plot_3d_nc
 from tests.netcdf.plot._plot_helpers import _make_4d_nc, _make_fake_render
+
+
+def _dated_projected_nc(tmp_path) -> NetCDF:
+    """Round-trip a dated projected collection through ``to_netcdf`` and reopen it.
+
+    Writes three 5x4 rasters on a projected 5000 m grid (EPSG:4647) with a
+    ``-9999`` no-data surround around a small interior, encodes the time axis as
+    CF int64 nanoseconds via ``to_netcdf(time_coords=...)``, and reopens the file
+    — the #1013 repro shape. On the ``get_variable`` subset the time dimension
+    metadata is gone, so decoding the labels exercises the parent-container
+    fallback.
+
+    Args:
+        tmp_path: pytest temp directory.
+
+    Returns:
+        NetCDF: The reopened root container holding the ``Band_1`` variable.
+    """
+    nd, cell, ox, oy = -9999.0, 5000.0, 32239263.70388, 5756081.42235
+    paths = []
+    for i in range(3):
+        arr = np.full((5, 4), nd, dtype="float32")
+        arr[1:4, 1:3] = 10.0 + i
+        path = str(tmp_path / f"d{i}.tif")
+        Dataset.create_from_array(
+            arr, geo=(ox, cell, 0.0, oy, 0.0, -cell), epsg=4647, no_data_value=nd
+        ).to_file(path)
+        paths.append(path)
+    out = tmp_path / "anim.nc"
+    DatasetCollection.from_files(paths).to_netcdf(
+        str(out), time_coords=pd.date_range("1979-01-01", periods=3, freq="D")
+    )
+    return NetCDF.read_file(str(out))
 
 pytestmark = pytest.mark.plot
 
@@ -117,11 +152,10 @@ class TestNetCDFPlotAnimate:
         """CF-decoded date strings are used as the animation frame labels.
 
         Test scenario:
-            Build a 3-D NetCDF whose ``time`` dim carries CF
-            ``units="days since 2024-01-01"`` so ``get_time_variable()``
-            decodes the raw values into ``YYYY-MM-DD`` strings. Patch
-            :meth:`NetCDF.get_time_variable` to return a known label
-            list and assert those labels reach
+            The animate path decodes its own frame coordinates through
+            :meth:`NetCDF._decode_time_labels` (so a time-subsetted view stays
+            aligned). Patch that decoder to return a known ``YYYY-MM-DD`` list
+            and assert those labels — not the raw integer coords — reach
             :func:`pyramids.dataset._plot_helpers.render_array` via
             ``animation_axis_values``.
         """
@@ -130,7 +164,7 @@ class TestNetCDFPlotAnimate:
         captured: dict = {}
 
         with patch(
-            "pyramids.netcdf.netcdf.NetCDF.get_time_variable",
+            "pyramids.netcdf.netcdf.NetCDF._decode_time_labels",
             return_value=labels,
         ):
             with patch(
@@ -140,6 +174,75 @@ class TestNetCDFPlotAnimate:
                 nc.plot(variable="t2m", animate=True)
         assert captured["request"].mode.mode == "animate"
         assert captured["request"].mode.animation_axis_values == labels
+
+    def test_animate_masks_no_data_by_default(self, tmp_path):
+        """Every streamed animation frame has the variable's no-data masked to NaN.
+
+        Test scenario:
+            cleopatra's ``animate`` blits each streamed frame verbatim
+            (``im.set_data``) and only masks the constructor template, so pyramids
+            must pre-mask no-data or it renders at the colour-scale extreme — the
+            static path already masks it. Capture the ``RenderRequest`` for a
+            round-tripped dated collection and assert the first streamed frame has
+            the ``-9999`` no-data replaced with ``NaN``. Regression test for #1013.
+        """
+        nc = _dated_projected_nc(tmp_path)
+        captured: dict = {}
+        with patch(
+            "pyramids.netcdf._plot._render_array",
+            side_effect=_make_fake_render(captured),
+        ):
+            nc.plot(variable="Band_1", animate=True)
+        frame0 = np.asarray(captured["request"].mode.data_getter(0))
+        assert not np.any(frame0 == -9999.0), "no-data still present in the frame"
+        assert np.any(np.isnan(frame0)), "no-data was not masked to NaN"
+        assert -9999.0 in captured["request"].exclude_value
+
+    def test_animate_honours_exclude_value(self, tmp_path):
+        """A caller ``exclude_value`` is masked in the streamed frames, not dropped.
+
+        Test scenario:
+            Pass ``exclude_value=10.0`` — a real data value present in frame 0 —
+            and assert both the no-data value and ``10.0`` are absent from the
+            streamed frame (masked to ``NaN``) and that ``10.0`` reaches the
+            request's ``exclude_value``. Regression test for #1013, where
+            ``exclude_value`` was silently ignored on the animate path.
+        """
+        nc = _dated_projected_nc(tmp_path)
+        captured: dict = {}
+        with patch(
+            "pyramids.netcdf._plot._render_array",
+            side_effect=_make_fake_render(captured),
+        ):
+            nc.plot(variable="Band_1", animate=True, exclude_value=10.0)
+        frame0 = np.asarray(captured["request"].mode.data_getter(0))
+        assert not np.any(frame0 == 10.0), "excluded value not masked in the frame"
+        assert not np.any(frame0 == -9999.0), "no-data not masked in the frame"
+        assert 10.0 in captured["request"].exclude_value
+
+    def test_animate_labels_decode_to_calendar_dates(self, tmp_path):
+        """Frame labels are the CF-decoded dates of a round-tripped collection, not raw ints.
+
+        Test scenario:
+            ``to_netcdf`` encodes ``time`` as int64 nanoseconds; on the
+            ``get_variable`` subset the dimension metadata is gone, so the labels
+            must be decoded through the parent container. End-to-end (no patched
+            decoder): capture the request and assert ``animation_axis_values`` are
+            the ``YYYY-MM-DD`` strings, not the raw nanosecond integers. Regression
+            test for #1013.
+        """
+        nc = _dated_projected_nc(tmp_path)
+        captured: dict = {}
+        with patch(
+            "pyramids.netcdf._plot._render_array",
+            side_effect=_make_fake_render(captured),
+        ):
+            nc.plot(variable="Band_1", animate=True)
+        assert captured["request"].mode.animation_axis_values == [
+            "1979-01-01",
+            "1979-01-02",
+            "1979-01-03",
+        ]
 
     @pytest.mark.skipif(FrameLabel is None, reason="cleopatra < 0.26 has no FrameLabel")
     def test_animate_forwards_frame_label_to_render_array(self):

--- a/tests/netcdf/plot/test_plot_animate.py
+++ b/tests/netcdf/plot/test_plot_animate.py
@@ -16,11 +16,11 @@ from tests.netcdf.conftest import make_plot_3d_nc
 from tests.netcdf.plot._plot_helpers import _make_4d_nc, _make_fake_render
 
 
-def _dated_projected_nc(tmp_path) -> NetCDF:
+def _dated_projected_nc(tmp_path, *, dtype="float32", nodata=-9999.0, interior=None) -> NetCDF:
     """Round-trip a dated projected collection through ``to_netcdf`` and reopen it.
 
     Writes three 5x4 rasters on a projected 5000 m grid (EPSG:4647) with a
-    ``-9999`` no-data surround around a small interior, encodes the time axis as
+    ``nodata`` surround around a small interior block, encodes the time axis as
     CF int64 nanoseconds via ``to_netcdf(time_coords=...)``, and reopens the file
     — the #1013 repro shape. On the ``get_variable`` subset the time dimension
     metadata is gone, so decoding the labels exercises the parent-container
@@ -28,18 +28,24 @@ def _dated_projected_nc(tmp_path) -> NetCDF:
 
     Args:
         tmp_path: pytest temp directory.
+        dtype: numpy dtype string for the rasters. Defaults to ``"float32"``.
+        nodata: No-data value stamped on every raster. Defaults to ``-9999.0``.
+        interior: Optional callable ``i -> value`` filling the 3x2 interior block
+            of frame ``i`` (a scalar or a 3x2 array). Defaults to ``10.0 + i``.
 
     Returns:
         NetCDF: The reopened root container holding the ``Band_1`` variable.
     """
-    nd, cell, ox, oy = -9999.0, 5000.0, 32239263.70388, 5756081.42235
+    if interior is None:
+        interior = lambda i: 10.0 + i
+    cell, ox, oy = 5000.0, 32239263.70388, 5756081.42235
     paths = []
     for i in range(3):
-        arr = np.full((5, 4), nd, dtype="float32")
-        arr[1:4, 1:3] = 10.0 + i
+        arr = np.full((5, 4), nodata, dtype=dtype)
+        arr[1:4, 1:3] = interior(i)
         path = str(tmp_path / f"d{i}.tif")
         Dataset.create_from_array(
-            arr, geo=(ox, cell, 0.0, oy, 0.0, -cell), epsg=4647, no_data_value=nd
+            arr, geo=(ox, cell, 0.0, oy, 0.0, -cell), epsg=4647, no_data_value=nodata
         ).to_file(path)
         paths.append(path)
     out = tmp_path / "anim.nc"
@@ -199,16 +205,17 @@ class TestNetCDFPlotAnimate:
         assert -9999.0 in captured["request"].exclude_value
 
     def test_animate_honours_exclude_value(self, tmp_path):
-        """A caller ``exclude_value`` is masked in the streamed frames, not dropped.
+        """A caller ``exclude_value`` masks only that value; other data survives.
 
         Test scenario:
-            Pass ``exclude_value=10.0`` — a real data value present in frame 0 —
-            and assert both the no-data value and ``10.0`` are absent from the
-            streamed frame (masked to ``NaN``) and that ``10.0`` reaches the
-            request's ``exclude_value``. Regression test for #1013, where
+            The interior mixes ``10.0`` and ``20.0`` so frame 0 has a value that is
+            *not* excluded. Passing ``exclude_value=10.0`` masks the no-data and the
+            ``10.0`` cells to ``NaN`` while the ``20.0`` cells survive — proving the
+            mask is selective, not blanket. Regression test for #1013, where
             ``exclude_value`` was silently ignored on the animate path.
         """
-        nc = _dated_projected_nc(tmp_path)
+        block = np.array([[10.0, 20.0]] * 3, dtype="float32")
+        nc = _dated_projected_nc(tmp_path, interior=lambda i: block)
         captured: dict = {}
         with patch(
             "pyramids.netcdf._plot._render_array",
@@ -216,9 +223,53 @@ class TestNetCDFPlotAnimate:
         ):
             nc.plot(variable="Band_1", animate=True, exclude_value=10.0)
         frame0 = np.asarray(captured["request"].mode.data_getter(0))
+        assert np.any(frame0 == 20.0), "the non-excluded 20.0 data must survive"
         assert not np.any(frame0 == 10.0), "excluded value not masked in the frame"
         assert not np.any(frame0 == -9999.0), "no-data not masked in the frame"
         assert 10.0 in captured["request"].exclude_value
+
+    def test_animate_masks_float32_value_via_native_dtype(self, tmp_path):
+        """A float32 cell is masked even when the exclude_value is a wider float literal.
+
+        Test scenario:
+            The interior mixes ``0.1`` and ``0.2`` stored as ``float32``; excluding
+            the Python float ``0.1`` (not exactly representable in ``float32``) must
+            still mask the ``0.1`` cells — the comparison happens in the frame's
+            native dtype — while the ``0.2`` cells survive (finding L2).
+        """
+        block = np.array([[0.1, 0.2]] * 3, dtype="float32")
+        nc = _dated_projected_nc(tmp_path, interior=lambda i: block)
+        captured: dict = {}
+        with patch(
+            "pyramids.netcdf._plot._render_array",
+            side_effect=_make_fake_render(captured),
+        ):
+            nc.plot(variable="Band_1", animate=True, exclude_value=0.1)
+        frame0 = np.asarray(captured["request"].mode.data_getter(0))
+        assert np.any(frame0 == np.float32(0.2)), "the 0.2 data value must survive"
+        assert not np.any(frame0 == np.float32(0.1)), "0.1 must be masked in native dtype"
+
+    def test_animate_masks_integer_frame_no_data(self, tmp_path):
+        """An integer variable's no-data is promoted to float and masked to NaN.
+
+        Test scenario:
+            An ``int16`` collection with a ``-9999`` no-data animates; the streamed
+            frame is promoted to float and its no-data cells become ``NaN`` — the
+            int-to-float mask path (finding L4).
+        """
+        nc = _dated_projected_nc(
+            tmp_path, dtype="int16", nodata=-9999, interior=lambda i: 10 + i
+        )
+        captured: dict = {}
+        with patch(
+            "pyramids.netcdf._plot._render_array",
+            side_effect=_make_fake_render(captured),
+        ):
+            nc.plot(variable="Band_1", animate=True)
+        frame0 = np.asarray(captured["request"].mode.data_getter(0))
+        assert frame0.dtype.kind == "f", "integer frame should be promoted to float"
+        assert np.any(np.isnan(frame0)), "no-data should be masked to NaN"
+        assert not np.any(frame0 == -9999), "raw no-data should not remain"
 
     def test_animate_labels_decode_to_calendar_dates(self, tmp_path):
         """Frame labels are the CF-decoded dates of a round-tripped collection, not raw ints.
@@ -243,6 +294,23 @@ class TestNetCDFPlotAnimate:
             "1979-01-02",
             "1979-01-03",
         ]
+
+    def test_animate_keeps_raw_labels_when_time_units_absent(self):
+        """Without a parseable time units the frame labels stay the raw coordinates.
+
+        Test scenario:
+            ``make_plot_3d_nc`` builds a ``time`` dim of plain integers with no CF
+            ``units``, so decoding returns None and the animate path keeps the raw
+            ``[0, 1, 2]`` coordinate labels (finding L4).
+        """
+        nc = make_plot_3d_nc(n_times=3)
+        captured: dict = {}
+        with patch(
+            "pyramids.netcdf._plot._render_array",
+            side_effect=_make_fake_render(captured),
+        ):
+            nc.plot(variable="t2m", animate=True)
+        assert captured["request"].mode.animation_axis_values == [0, 1, 2]
 
     def test_animate_without_no_data_leaves_frames_unmasked(self):
         """A variable with no no-data introduces no spurious NaN into the frames.

--- a/tests/netcdf/unit/_netcdf_unit_helpers.py
+++ b/tests/netcdf/unit/_netcdf_unit_helpers.py
@@ -69,14 +69,22 @@ def _make_dataset_3d(bands=3, rows=10, cols=12, no_data=-9999.0):
     )
 
 
-def _make_nc_with_time_units(rows=4, cols=5, n_times=3):
+def _make_nc_with_time_units(rows=4, cols=5, n_times=3, units="days since 1979-01-01"):
     """Create an MDIM NetCDF with a time dimension that has a 'units' attr.
 
     This is needed to exercise the get_time_variable conversion path.
 
+    Args:
+        rows: Number of latitude rows.
+        cols: Number of longitude columns.
+        n_times: Number of time steps.
+        units: The CF ``units`` string stamped on the time variable. Defaults to
+            ``"days since 1979-01-01"``; pass a non-CF string (e.g. ``"gregorian"``)
+            to exercise the unparseable-units fallback.
+
     Returns:
-        NetCDF: An in-memory NetCDF with a time dimension carrying
-            a ``units`` attribute of ``"days since 1979-01-01"``.
+        NetCDF: An in-memory NetCDF with a time dimension carrying the given
+            ``units`` attribute.
     """
     src = gdal.GetDriverByName("MEM").CreateMultiDimensional("time_test")
     rg = src.GetRootGroup()
@@ -103,7 +111,7 @@ def _make_nc_with_time_units(rows=4, cols=5, n_times=3):
     # Add 'units' attribute to the time variable
     str_dtype = gdal.ExtendedDataType.CreateString()
     units_attr = t_vals.CreateAttribute("units", [], str_dtype)
-    units_attr.Write("days since 1979-01-01")
+    units_attr.Write(units)
 
     # Create a data variable
     data_arr = rg.CreateMDArray("temperature", [dim_t, dim_y, dim_x], dtype)

--- a/tests/netcdf/unit/_netcdf_unit_helpers.py
+++ b/tests/netcdf/unit/_netcdf_unit_helpers.py
@@ -69,7 +69,9 @@ def _make_dataset_3d(bands=3, rows=10, cols=12, no_data=-9999.0):
     )
 
 
-def _make_nc_with_time_units(rows=4, cols=5, n_times=3, units="days since 1979-01-01"):
+def _make_nc_with_time_units(
+    rows=4, cols=5, n_times=3, units="days since 1979-01-01", time_name="time"
+):
     """Create an MDIM NetCDF with a time dimension that has a 'units' attr.
 
     This is needed to exercise the get_time_variable conversion path.
@@ -81,6 +83,8 @@ def _make_nc_with_time_units(rows=4, cols=5, n_times=3, units="days since 1979-0
         units: The CF ``units`` string stamped on the time variable. Defaults to
             ``"days since 1979-01-01"``; pass a non-CF string (e.g. ``"gregorian"``)
             to exercise the unparseable-units fallback.
+        time_name: Name of the time dimension / variable. Defaults to ``"time"``;
+            pass e.g. ``"time_counter"`` to exercise a non-standard axis name.
 
     Returns:
         NetCDF: An in-memory NetCDF with a time dimension carrying the given
@@ -103,8 +107,8 @@ def _make_nc_with_time_units(rows=4, cols=5, n_times=3, units="days since 1979-0
     dim_y.SetIndexingVariable(y_vals)
 
     # Create time dimension with units attribute
-    dim_t = rg.CreateDimension("time", "TEMPORAL", None, n_times)
-    t_vals = rg.CreateMDArray("time", [dim_t], dtype)
+    dim_t = rg.CreateDimension(time_name, "TEMPORAL", None, n_times)
+    t_vals = rg.CreateMDArray(time_name, [dim_t], dtype)
     t_vals.Write(np.arange(n_times, dtype=np.float64))
     dim_t.SetIndexingVariable(t_vals)
 

--- a/tests/netcdf/unit/test_netcdf_unit_properties.py
+++ b/tests/netcdf/unit/test_netcdf_unit_properties.py
@@ -9,9 +9,32 @@ import pytest
 from shapely.geometry import box
 
 from tests.netcdf.conftest import make_2d_nc
-from tests.netcdf.unit._netcdf_unit_helpers import _make_3d_nc
+from tests.netcdf.unit._netcdf_unit_helpers import (
+    _make_3d_nc,
+    _make_nc_with_time_units,
+)
 
 pytestmark = pytest.mark.core
+
+
+class TestGeotransformAxisSpacing:
+    """Tests for the geotransform property's per-axis cell-size derivation."""
+
+    def test_single_column_falls_back_to_cell_size_on_x(self):
+        """A one-column grid derives the x pixel size from ``cell_size``, not spacing.
+
+        Test scenario:
+            With a single longitude value there is no ``lon[1] - lon[0]`` spacing,
+            so the x branch falls back to ``self.cell_size`` and places the west
+            edge half a cell left of the lone centre — covers the ``len(lon) < 2``
+            fallback added alongside the #1014 fix.
+        """
+        nc = _make_nc_with_time_units(rows=4, cols=1, n_times=2)
+        assert len(nc.lon) == 1, f"precondition: expected one lon value, got {nc.lon}"
+        gt = nc.geotransform
+        assert gt == (0.0, 1.0, 0, 4.0, 0, -1.0), (
+            f"single-column geotransform fallback wrong: {gt}"
+        )
 
 
 class TestGeotransformFallback:

--- a/tests/netcdf/unit/test_netcdf_unit_time.py
+++ b/tests/netcdf/unit/test_netcdf_unit_time.py
@@ -312,6 +312,21 @@ class TestDecodeTimeLabels:
             f"custom format not applied: {result}"
         )
 
+    def test_decodes_a_non_standard_time_dim_name(self):
+        """Decoding is driven by the units attribute, not an allow-list of dim names.
+
+        Test scenario:
+            A time axis named ``time_counter`` (outside the old
+            ``time``/``valid_time``/``t`` allow-list) with a parseable CF ``units``
+            still decodes, so model axes like NEMO's ``time_counter`` are labelled
+            with dates on the animate path (finding L3).
+        """
+        nc = _make_nc_with_time_units(n_times=2, time_name="time_counter")
+        result = nc._decode_time_labels("time_counter", [0, 1])
+        assert result == ["1979-01-01", "1979-01-02"], (
+            f"non-standard time dim name did not decode: {result}"
+        )
+
 
 class TestCubeDimensionNames:
     """`get_variable(...).dimension_names` must mirror the container's view.

--- a/tests/netcdf/unit/test_netcdf_unit_time.py
+++ b/tests/netcdf/unit/test_netcdf_unit_time.py
@@ -229,6 +229,77 @@ class TestGetTimeVariableWithUnits:
         assert len(result) == 2, f"Expected 2 timestamps, got {len(result)}"
 
 
+class TestDecodeTimeLabels:
+    """Tests for NetCDF._decode_time_labels (the animate frame-label decoder)."""
+
+    def test_decodes_passed_values_via_own_units(self):
+        """The container decodes the passed raw values through its own CF units.
+
+        Test scenario:
+            A container whose ``time`` dim carries ``units="days since
+            1979-01-01"`` decodes the passed offsets into ``YYYY-MM-DD`` strings.
+        """
+        nc = _make_nc_with_time_units(n_times=3)
+        result = nc._decode_time_labels("time", [0, 1, 2])
+        assert result == ["1979-01-01", "1979-01-02", "1979-01-03"], (
+            f"unexpected decoded labels: {result}"
+        )
+
+    def test_decodes_only_the_passed_values_not_the_full_axis(self):
+        """Only the passed values are decoded, keeping a subsetted view aligned.
+
+        Test scenario:
+            Passing a two-element slice of a three-step axis returns exactly two
+            labels, so a time-subsetted animation stays aligned with its frames.
+        """
+        nc = _make_nc_with_time_units(n_times=3)
+        result = nc._decode_time_labels("time", [1, 2])
+        assert result == ["1979-01-02", "1979-01-03"], (
+            f"expected only the two passed offsets decoded, got: {result}"
+        )
+
+    def test_subset_decodes_via_parent_container(self):
+        """A get_variable subset decodes its labels through the parent container.
+
+        Test scenario:
+            The subset has lost the time dim's CF units, so ``_decode_time_labels``
+            falls back to the parent container's units — the #1013 fix path.
+        """
+        nc = _make_nc_with_time_units(n_times=3)
+        var = nc.get_variable("temperature")
+        assert var.meta_data.get_dimension("time") is None, (
+            "precondition: the subset should not carry the time dim metadata"
+        )
+        result = var._decode_time_labels("time", [0, 1, 2])
+        assert result == ["1979-01-01", "1979-01-02", "1979-01-03"], (
+            f"subset did not decode via the parent container: {result}"
+        )
+
+    def test_returns_none_without_parseable_units(self):
+        """Returns None when neither the cube nor its parent carries time units.
+
+        Test scenario:
+            A container whose ``time`` dim has no ``units`` attribute (and no
+            parent) yields None, so the animate path keeps the raw coord labels.
+        """
+        nc = _make_3d_nc()
+        result = nc._decode_time_labels("time", [0, 1, 2])
+        assert result is None, f"expected None without units, got {result}"
+
+    def test_custom_time_format(self):
+        """Honours a custom strftime format.
+
+        Test scenario:
+            Passing ``time_format="%Y/%m/%d"`` renders the decoded dates with the
+            requested separator.
+        """
+        nc = _make_nc_with_time_units(n_times=2)
+        result = nc._decode_time_labels("time", [0, 1], time_format="%Y/%m/%d")
+        assert result == ["1979/01/01", "1979/01/02"], (
+            f"custom format not applied: {result}"
+        )
+
+
 class TestCubeDimensionNames:
     """`get_variable(...).dimension_names` must mirror the container's view.
 

--- a/tests/netcdf/unit/test_netcdf_unit_time.py
+++ b/tests/netcdf/unit/test_netcdf_unit_time.py
@@ -319,7 +319,7 @@ class TestDecodeTimeLabels:
             A time axis named ``time_counter`` (outside the old
             ``time``/``valid_time``/``t`` allow-list) with a parseable CF ``units``
             still decodes, so model axes like NEMO's ``time_counter`` are labelled
-            with dates on the animate path (finding L3).
+            with dates on the animate path (#1013).
         """
         nc = _make_nc_with_time_units(n_times=2, time_name="time_counter")
         result = nc._decode_time_labels("time_counter", [0, 1])

--- a/tests/netcdf/unit/test_netcdf_unit_time.py
+++ b/tests/netcdf/unit/test_netcdf_unit_time.py
@@ -286,6 +286,19 @@ class TestDecodeTimeLabels:
         result = nc._decode_time_labels("time", [0, 1, 2])
         assert result is None, f"expected None without units, got {result}"
 
+    def test_returns_none_on_unparseable_units(self):
+        """A present-but-unparseable units string degrades to None, not an error.
+
+        Test scenario:
+            A ``time`` dim whose ``units`` is a non-CF string (no ``since
+            <origin>``) makes ``create_time_conversion_func`` raise; the decoder
+            swallows it and returns None so ``plot(animate=True)`` keeps the raw
+            labels instead of crashing.
+        """
+        nc = _make_nc_with_time_units(n_times=2, units="gregorian")
+        result = nc._decode_time_labels("time", [0, 1])
+        assert result is None, f"expected None on unparseable units, got {result}"
+
     def test_custom_time_format(self):
         """Honours a custom strftime format.
 


### PR DESCRIPTION
# Description

Two NetCDF reader-side defects that only surface after a `DatasetCollection` is round-tripped through `to_netcdf`
— the container is reopened as a GDAL multidim view and each variable is served as a classic in-memory subset.
The written file is correct in both cases; the bugs are in how the reader/plot path derives values from it. No
cleopatra change is required — both fixes sit entirely in pyramids (data preparation and label decoding, not
drawing).

**`geotransform` (#1014).** The property derived the **Y** pixel size from the real lat spacing
(`abs(lat[1]-lat[0])`) but took the **X** pixel size from `self.cell_size`, which tracks GDAL's index-space
geotransform (pixel width `1.0`) for a multidim-opened container. So the X axis came back at width `1.0` with a
half-pixel-shifted origin while Y was correct. Fix: derive the X pixel size from the real lon spacing too,
mirroring the Y branch (and the property's own documented intent). A one-column grid falls back to `cell_size`
(spacing is unrecoverable from a single coordinate — the same limit the Y branch has).

**`plot(animate=...)` (#1013).** Three defects on the animate path, all confirmed against `main` by running the
issue's repro:

- **No-data drawn instead of masked, and `exclude_value` ignored.** cleopatra's `animate` masks only the
  constructor template and blits each streamed frame verbatim (`im.set_data`), never re-applying `exclude_value`.
  pyramids now pre-masks every streamed frame (no-data and any caller `exclude_value` → `NaN`, rendered
  transparent), matching the static path. Masking compares in the frame's **native dtype**, so a float32 CF fill
  still matches; a fractional or out-of-range `exclude_value` on an **integer** raster is skipped rather than
  truncating to the wrong cells or raising `OverflowError` mid-animation.
- **Frame labels showed the raw encoded time.** The `get_variable` subset has lost the time dimension's CF units,
  so labels fell back to the raw int64 nanoseconds; cleopatra renders the label as `str(label)[:10]`, truncating
  `283996800000000000` to `2839968000`. Fix: decode the subset's own frame coordinates via the parent container
  (new `NetCDF._decode_time_labels`), which keeps a time-subsetted view aligned. Decoding is driven by whether the
  axis resolves a parseable CF time `units` (so model axes like `time_counter` / `forecast_period` decode too), and
  degrades to raw labels — rather than raising — on a present-but-unparseable `units`.

The animate helper (`_render_animate`) was decomposed — the frame masking (`_mask_exclude_values`) and label
resolution (`_resolve_animate_labels`) are now module-level helpers — to keep its cognitive complexity under the
SonarCloud `python:S3776` threshold.

# Issues

- Closes #1014 — `NetCDF.geotransform` reports x pixel size 1.0 and a half-pixel-shifted origin
- Closes #1013 — `plot(animate=True)` draws no-data cells, ignores `exclude_value`, labels frames with the raw
  encoded time

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran each issue's self-contained repro against the branch (headless `Agg`): the geotransform round-trips exactly,
animation frames mask no-data to `NaN`, a caller `exclude_value` is masked, and frame labels decode to
`YYYY-MM-DD`. Added regression + branch-coverage tests (`--cov` omitted; it is unusable in this local env):

- [x] `test_geotransform_round_trips_nonunit_cell_size` (projected 5000 m round-trip) and the single-column X
  fallback in `test_netcdf_unit_properties.py`
- [x] `test_plot_animate.py` — no-data masking, `exclude_value` selectivity, float32 native-dtype masking, int16
  fractional / out-of-range `exclude_value` (no wrong-mask, no crash), CF-decoded date labels, raw-label fallback,
  and the empty-mask no-op
- [x] `test_netcdf_unit_time.py::TestDecodeTimeLabels` — self/parent-container decode, subsetted-value alignment,
  unparseable-units fallback, and a non-standard axis name (`time_counter`)
- [x] `tests/netcdf/` + `tests/dataset/collection/` full sweep on the final commit — 3051 passed, 38 skipped, 0
  failed; mypy clean on the changed modules; SonarCloud quality gate OK with 0 open issues

# Checklist:

- [ ] updated version number in pyproject.toml. (handled by commitizen / release CI)
- [ ] added changes to History.rst. (generated by commitizen)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated. (docstrings updated in-code; no user-facing docs affected)
