### PR TITLE
fix(netcdf): write CF-complete coordinates and grid_mapping from the multidim writers

### DIFF
--- a/src/pyramids/dataset/ops/_geobox_zarr.py
+++ b/src/pyramids/dataset/ops/_geobox_zarr.py
@@ -118,18 +118,32 @@ def write_geobox(
         arr.attrs["_ARRAY_DIMENSIONS"] = list(var_dims)
         return arr
 
+    # Local import breaks the pyramids.dataset <-> pyramids.netcdf import cycle
+    # (`pyramids.netcdf` imports `pyramids.dataset.Dataset`).
+    from osgeo import osr
+
+    from pyramids.netcdf.cf import build_coordinate_attrs, srs_to_grid_mapping
+
+    srs = osr.SpatialReference() if crs_wkt else None
+    if srs is not None and srs.ImportFromWkt(crs_wkt) != 0:
+        srs = None
+    is_geographic = None if srs is None else bool(srs.IsGeographic())
+
     x, y = pixel_centre_coords(geotransform, rows, cols)
-    _put("x", x, ["x"])
-    _put("y", y, ["y"])
+    # Stamp CF axis attributes on the coordinate arrays so a CF reader can
+    # georeference the GeoZarr store, mirroring the netCDF writers.
+    _put("x", x, ["x"]).attrs.update(build_coordinate_attrs("x", is_geographic))
+    _put("y", y, ["y"]).attrs.update(build_coordinate_attrs("y", is_geographic))
     sr = _put(GRID_MAPPING_VAR, np.array(int(epsg or 0), dtype="int64"), [])
-    sr.attrs.update(
-        {
-            "crs_wkt": crs_wkt,
-            "spatial_ref": crs_wkt,
-            "GeoTransform": " ".join(str(v) for v in geotransform),
-            "epsg": int(epsg or 0),
-        }
-    )
+    gm_attrs: dict[str, Any] = {
+        "crs_wkt": crs_wkt,
+        "spatial_ref": crs_wkt,
+        "GeoTransform": " ".join(str(v) for v in geotransform),
+        "epsg": int(epsg or 0),
+    }
+    if srs is not None:
+        gm_attrs["grid_mapping_name"] = srs_to_grid_mapping(srs)[0]
+    sr.attrs.update(gm_attrs)
 
     data = group[data_name]
     data.attrs["_ARRAY_DIMENSIONS"] = list(dims)

--- a/src/pyramids/dataset/ops/_geobox_zarr.py
+++ b/src/pyramids/dataset/ops/_geobox_zarr.py
@@ -128,8 +128,8 @@ def write_geobox(
     # (`pyramids.netcdf` imports `pyramids.dataset.Dataset`).
     from pyramids.netcdf.cf import (
         build_coordinate_attrs,
+        grid_mapping_var_attrs,
         srs_from_wkt,
-        srs_to_grid_mapping,
     )
 
     srs = srs_from_wkt(crs_wkt)
@@ -148,15 +148,9 @@ def write_geobox(
         "epsg": int(epsg or 0),
     }
     if srs is not None:
-        gm_name, gm_params = srs_to_grid_mapping(srs)
-        # Only assert `grid_mapping_name` when the projection was actually recognized:
-        # `srs_to_grid_mapping` returns the "latitude_longitude" fallback for a projected
-        # CRS outside its CF table, which would mislabel a metre grid as lon/lat. Then
-        # carry the full CF projection params (false_easting, ellipsoid, ...) so a
-        # WKT-agnostic CF reader can reconstruct the projection.
-        if not (srs.IsProjected() and gm_name == "latitude_longitude"):
-            gm_attrs["grid_mapping_name"] = gm_name
-            gm_attrs.update({k: v for k, v in gm_params.items() if k not in gm_attrs})
+        gm_attrs.update(
+            {k: v for k, v in grid_mapping_var_attrs(srs).items() if k not in gm_attrs}
+        )
     sr.attrs.update(gm_attrs)
 
     data = group[data_name]

--- a/src/pyramids/dataset/ops/_geobox_zarr.py
+++ b/src/pyramids/dataset/ops/_geobox_zarr.py
@@ -90,9 +90,10 @@ def write_geobox(
     itself and for consolidating metadata afterwards.
 
     The ``x`` / ``y`` arrays also carry CF ``axis`` / ``standard_name`` / ``units``
-    (via :func:`pyramids.netcdf.cf.build_coordinate_attrs`) and the ``spatial_ref``
-    scalar carries a CF ``grid_mapping_name``, so a CF reader can georeference the
-    store — mirroring the netCDF writers (#1017).
+    (via :func:`pyramids.netcdf.cf.build_coordinate_attrs`) and, for a projection the CF
+    table recognises, the ``spatial_ref`` scalar carries a CF ``grid_mapping_name`` plus
+    the projection params, so a CF reader can georeference the store — mirroring the
+    netCDF writers (#1017). A projected CRS outside the table is left ``crs_wkt``-only.
 
     Args:
         group: An open, writable :class:`zarr.hierarchy.Group`.

--- a/src/pyramids/dataset/ops/_geobox_zarr.py
+++ b/src/pyramids/dataset/ops/_geobox_zarr.py
@@ -147,7 +147,15 @@ def write_geobox(
         "epsg": int(epsg or 0),
     }
     if srs is not None:
-        gm_attrs["grid_mapping_name"] = srs_to_grid_mapping(srs)[0]
+        gm_name, gm_params = srs_to_grid_mapping(srs)
+        # Only assert `grid_mapping_name` when the projection was actually recognized:
+        # `srs_to_grid_mapping` returns the "latitude_longitude" fallback for a projected
+        # CRS outside its CF table, which would mislabel a metre grid as lon/lat. Then
+        # carry the full CF projection params (false_easting, ellipsoid, ...) so a
+        # WKT-agnostic CF reader can reconstruct the projection.
+        if not (srs.IsProjected() and gm_name == "latitude_longitude"):
+            gm_attrs["grid_mapping_name"] = gm_name
+            gm_attrs.update({k: v for k, v in gm_params.items() if k not in gm_attrs})
     sr.attrs.update(gm_attrs)
 
     data = group[data_name]

--- a/src/pyramids/dataset/ops/_geobox_zarr.py
+++ b/src/pyramids/dataset/ops/_geobox_zarr.py
@@ -125,13 +125,13 @@ def write_geobox(
 
     # Local import breaks the pyramids.dataset <-> pyramids.netcdf import cycle
     # (`pyramids.netcdf` imports `pyramids.dataset.Dataset`).
-    from osgeo import osr
+    from pyramids.netcdf.cf import (
+        build_coordinate_attrs,
+        srs_from_wkt,
+        srs_to_grid_mapping,
+    )
 
-    from pyramids.netcdf.cf import build_coordinate_attrs, srs_to_grid_mapping
-
-    srs = osr.SpatialReference() if crs_wkt else None
-    if srs is not None and srs.ImportFromWkt(crs_wkt) != 0:
-        srs = None
+    srs = srs_from_wkt(crs_wkt)
     is_geographic = None if srs is None else bool(srs.IsGeographic())
 
     x, y = pixel_centre_coords(geotransform, rows, cols)

--- a/src/pyramids/dataset/ops/_geobox_zarr.py
+++ b/src/pyramids/dataset/ops/_geobox_zarr.py
@@ -89,6 +89,11 @@ def write_geobox(
     ``grid_mapping`` attribute. The caller is responsible for the data array
     itself and for consolidating metadata afterwards.
 
+    The ``x`` / ``y`` arrays also carry CF ``axis`` / ``standard_name`` / ``units``
+    (via :func:`pyramids.netcdf.cf.build_coordinate_attrs`) and the ``spatial_ref``
+    scalar carries a CF ``grid_mapping_name``, so a CF reader can georeference the
+    store — mirroring the netCDF writers (#1017).
+
     Args:
         group: An open, writable :class:`zarr.hierarchy.Group`.
         data_name: Name of the already-written data array in ``group``.

--- a/src/pyramids/netcdf/_cube_netcdf_writer.py
+++ b/src/pyramids/netcdf/_cube_netcdf_writer.py
@@ -118,7 +118,7 @@ class CubeNetCDFWriter:
             axis, time_dim=time_dim, var_per_band=var_per_band
         )
         with open_streaming_multidim_netcdf(
-            path, dims, coords, var_specs, root_attrs
+            path, dims, coords, var_specs, root_attrs, crs_wkt=root_attrs.get("crs_wkt")
         ) as writer:
             self._stream(writer, dims=dims, var_per_band=var_per_band)
 

--- a/src/pyramids/netcdf/cf.py
+++ b/src/pyramids/netcdf/cf.py
@@ -205,6 +205,31 @@ _GDAL_PROJ_TO_CF: dict[str, str] = {
 }
 
 
+def srs_from_wkt(crs_wkt: str | None) -> osr.SpatialReference | None:
+    """Parse a WKT string into an OGR SpatialReference, or None when absent/malformed.
+
+    A shared, defensive parser for the CF writers: a falsy or unparseable ``crs_wkt``
+    degrades to None (write an un-georeferenced file) rather than raising. pyramids
+    enables ``osr.UseExceptions()`` at import, so a malformed WKT raises ``RuntimeError``
+    here; older GDAL returns a non-zero code — both are handled.
+
+    Args:
+        crs_wkt: A CRS WKT string, or None when the caller has no CRS.
+
+    Returns:
+        osr.SpatialReference or None: The parsed reference, or None when ``crs_wkt`` is
+        falsy or does not parse.
+    """
+    if not crs_wkt:
+        return None
+    srs = osr.SpatialReference()
+    try:
+        parsed = srs.ImportFromWkt(crs_wkt) == 0
+    except RuntimeError:
+        return None
+    return srs if parsed else None
+
+
 def srs_to_grid_mapping(
     srs: osr.SpatialReference,
 ) -> tuple[str, dict[str, Any]]:

--- a/src/pyramids/netcdf/cf.py
+++ b/src/pyramids/netcdf/cf.py
@@ -208,10 +208,11 @@ _GDAL_PROJ_TO_CF: dict[str, str] = {
 def srs_from_wkt(crs_wkt: str | None) -> osr.SpatialReference | None:
     """Parse a WKT string into an OGR SpatialReference, or None when absent/malformed.
 
-    A shared, defensive parser for the CF writers: a falsy or unparseable ``crs_wkt``
-    degrades to None (write an un-georeferenced file) rather than raising. pyramids
-    enables ``osr.UseExceptions()`` at import, so a malformed WKT raises ``RuntimeError``
-    here; older GDAL returns a non-zero code — both are handled.
+    A shared, defensive parser for the CF writers: a falsy, unparseable, or non-string
+    ``crs_wkt`` degrades to None (write an un-georeferenced file) rather than raising.
+    pyramids enables ``osr.UseExceptions()`` at import, so a malformed WKT raises
+    ``RuntimeError`` here (older GDAL returns a non-zero code instead) and a non-string
+    input raises ``TypeError`` — all degrade to None.
 
     Args:
         crs_wkt: A CRS WKT string, or None when the caller has no CRS.

--- a/src/pyramids/netcdf/cf.py
+++ b/src/pyramids/netcdf/cf.py
@@ -220,14 +220,17 @@ def srs_from_wkt(crs_wkt: str | None) -> osr.SpatialReference | None:
         osr.SpatialReference or None: The parsed reference, or None when ``crs_wkt`` is
         falsy or does not parse.
     """
-    if not crs_wkt:
-        return None
-    srs = osr.SpatialReference()
-    try:
-        parsed = srs.ImportFromWkt(crs_wkt) == 0
-    except RuntimeError:
-        return None
-    return srs if parsed else None
+    result: osr.SpatialReference | None = None
+    if crs_wkt:
+        srs = osr.SpatialReference()
+        try:
+            if srs.ImportFromWkt(crs_wkt) == 0:
+                result = srs
+        except (RuntimeError, TypeError):
+            # A malformed WKT (RuntimeError under osr.UseExceptions, else a non-zero
+            # code) or a non-str input degrades to no CRS rather than crashing the write.
+            result = None
+    return result
 
 
 def srs_to_grid_mapping(

--- a/src/pyramids/netcdf/cf.py
+++ b/src/pyramids/netcdf/cf.py
@@ -273,6 +273,30 @@ def srs_to_grid_mapping(
     return grid_mapping_name, params
 
 
+def grid_mapping_var_attrs(srs: osr.SpatialReference) -> dict[str, Any]:
+    """CF grid-mapping variable attributes for a CRS (``grid_mapping_name`` + params).
+
+    Wraps :func:`srs_to_grid_mapping` for the hand-rolled grid-mapping writers (GeoZarr and
+    UGRID): returns ``{"grid_mapping_name": ..., <CF params incl crs_wkt>}`` when the
+    projection is recognized (or the CRS is geographic), and an empty dict for a *projected*
+    CRS outside the CF table — where ``srs_to_grid_mapping`` falls back to
+    ``"latitude_longitude"`` and stamping it would mislabel a metre grid as lon/lat. The
+    caller merges these onto its grid-mapping variable without overwriting attributes it
+    already set (e.g. ``crs_wkt``).
+
+    Args:
+        srs: An OGR SpatialReference.
+
+    Returns:
+        dict: The grid-mapping attributes to merge, or ``{}`` for an unrecognized
+        projected CRS.
+    """
+    gm_name, gm_params = srs_to_grid_mapping(srs)
+    if srs.IsProjected() and gm_name == "latitude_longitude":
+        return {}
+    return {"grid_mapping_name": gm_name, **gm_params}
+
+
 def _extract_proj_params(srs: osr.SpatialReference, proj_name: str) -> dict[str, Any]:
     """Extract CF projection parameters from an OGR SpatialReference.
 

--- a/src/pyramids/netcdf/engines/interop.py
+++ b/src/pyramids/netcdf/engines/interop.py
@@ -30,6 +30,7 @@ from pyramids.netcdf._lazy import build_lazy_array
 from pyramids.netcdf._mdim import strip_netcdf_subdataset_prefix
 from pyramids.netcdf.cf import (
     build_coordinate_attrs,
+    srs_from_wkt,
     write_attributes_to_md_array,
     write_global_attributes,
 )
@@ -460,28 +461,6 @@ def _dim_type(name: str) -> str:
     return ""
 
 
-def _srs_from_wkt(crs_wkt: str | None) -> osr.SpatialReference | None:
-    """Build an OGR SpatialReference from a WKT string, or None when absent/invalid.
-
-    Args:
-        crs_wkt: A CRS WKT string, or None when the caller has no CRS.
-
-    Returns:
-        osr.SpatialReference or None: The parsed reference, or None when ``crs_wkt`` is
-        falsy or does not parse.
-    """
-    if not crs_wkt:
-        return None
-    srs = osr.SpatialReference()
-    try:
-        parsed = srs.ImportFromWkt(crs_wkt) == 0
-    except RuntimeError:
-        # A malformed WKT (GDAL raises when osr exceptions are on, else returns
-        # non-zero) degrades to no CRS rather than crashing the write.
-        return None
-    return srs if parsed else None
-
-
 def _cf_coord_attrs(
     coord_name: str,
     coord_attrs: dict[str, Any],
@@ -523,8 +502,10 @@ def _apply_grid_mapping(
     """Attach the CRS to each data MDArray so GDAL emits a CF ``grid_mapping`` variable.
 
     Calling ``SetSpatialRef`` on a data MDArray makes GDAL's netCDF writer auto-generate a
-    scalar CF ``grid_mapping`` variable (named ``crs``, carrying ``grid_mapping_name`` +
-    ``crs_wkt`` + the projection params) and link the data variable to it via
+    scalar CF ``grid_mapping`` variable (named by GDAL from the projection — ``crs`` for
+    geographic, e.g. ``transverse_mercator`` for a projected CRS — carrying
+    ``grid_mapping_name`` + ``crs_wkt`` + the projection params) and link the data
+    variable to it via
     ``<var>#grid_mapping`` — the same mechanism ``create_from_array`` uses on the netCDF driver.
     The generated variable is hidden from the multidim array listing, so it never leaks into
     ``get_variable_names`` / ``variables``, and the CRS round-trips (``MDArray.GetSpatialRef``).
@@ -554,7 +535,8 @@ def _build_multidim(
     CF-encoded on the way in and attributes go through pyramids' own CF helpers.
 
     When `crs_wkt` is given, the x/y coordinates gain CF `axis`/`standard_name`/`units`
-    attributes and a scalar `spatial_ref` grid-mapping variable is written and linked
+    attributes and a scalar CF grid-mapping variable (`crs` / `transverse_mercator` /
+    ..., named by GDAL from the projection) is written and linked
     from every data variable, so the file is georeferenceable by a CF reader (Panoply,
     QGIS, xarray); without it the coordinates keep only the caller's attributes.
 
@@ -579,7 +561,7 @@ def _build_multidim(
     """
     src = gdal.GetDriverByName("MEM").CreateMultiDimensional("pyramids")
     root = src.GetRootGroup()
-    srs = _srs_from_wkt(crs_wkt)
+    srs = srs_from_wkt(crs_wkt)
 
     gdal_dims: dict[str, gdal.Dimension] = {
         name: root.CreateDimension(name, _dim_type(name), "", int(size))
@@ -799,7 +781,8 @@ def _build_streaming_multidim(
     what lets the netCDF driver flush and unlock the file.
 
     When `crs_wkt` is given, the x/y coordinates gain CF `axis`/`standard_name`/`units`
-    attributes and a scalar `spatial_ref` grid-mapping variable is written and linked
+    attributes and a scalar CF grid-mapping variable (`crs` / `transverse_mercator` /
+    ..., named by GDAL from the projection) is written and linked
     from every data variable, so a CF reader can georeference the streamed file.
 
     Args:
@@ -822,7 +805,7 @@ def _build_streaming_multidim(
             coordinate array shape does not match its dimension size.
     """
     root = dataset.GetRootGroup()
-    srs = _srs_from_wkt(crs_wkt)
+    srs = srs_from_wkt(crs_wkt)
     gdal_dims: dict[str, gdal.Dimension] = {
         name: root.CreateDimension(name, _dim_type(name), "", int(size))
         for name, size in dims.items()

--- a/src/pyramids/netcdf/engines/interop.py
+++ b/src/pyramids/netcdf/engines/interop.py
@@ -662,7 +662,9 @@ def _build_multidim_from_xarray(dataset: Any) -> gdal.Dataset:
         for name, var in dataset.data_vars.items()
         if not (name in skip and var.ndim == 0)
     }
-    return _build_multidim(dims, coords, data_vars, dict(dataset.attrs), crs_wkt=crs_wkt)
+    return _build_multidim(
+        dims, coords, data_vars, dict(dataset.attrs), crs_wkt=crs_wkt
+    )
 
 
 def _create_copy_to_netcdf(mem_src: gdal.Dataset, path: str) -> None:

--- a/src/pyramids/netcdf/engines/interop.py
+++ b/src/pyramids/netcdf/engines/interop.py
@@ -453,12 +453,14 @@ def _dim_type(name: str) -> str:
     """
     lowered = name.lower()
     if lowered in ("x", "lon", "longitude"):
-        return str(gdal.DIM_TYPE_HORIZONTAL_X)
-    if lowered in ("y", "lat", "latitude"):
-        return str(gdal.DIM_TYPE_HORIZONTAL_Y)
-    if lowered in ("time", "t"):
-        return str(gdal.DIM_TYPE_TEMPORAL)
-    return ""
+        dim_type = str(gdal.DIM_TYPE_HORIZONTAL_X)
+    elif lowered in ("y", "lat", "latitude"):
+        dim_type = str(gdal.DIM_TYPE_HORIZONTAL_Y)
+    elif lowered in ("time", "t"):
+        dim_type = str(gdal.DIM_TYPE_TEMPORAL)
+    else:
+        dim_type = ""
+    return dim_type
 
 
 def _cf_coord_attrs(
@@ -612,14 +614,18 @@ def _crs_wkt_from_xarray(dataset: Any) -> str | None:
     Returns:
         str or None: The CRS WKT, or None when the dataset declares no CRS.
     """
+    result: str | None = None
     for name in ("spatial_ref", "crs"):
         if name in dataset.variables:
             attrs = dataset.variables[name].attrs
             wkt = attrs.get("crs_wkt") or attrs.get("spatial_ref")
             if wkt:
-                return str(wkt)
-    wkt = dataset.attrs.get("crs_wkt")
-    return str(wkt) if wkt else None
+                result = str(wkt)
+                break
+    if result is None:
+        wkt = dataset.attrs.get("crs_wkt")
+        result = str(wkt) if wkt else None
+    return result
 
 
 def _build_multidim_from_xarray(dataset: Any) -> gdal.Dataset:

--- a/src/pyramids/netcdf/engines/interop.py
+++ b/src/pyramids/netcdf/engines/interop.py
@@ -473,7 +473,13 @@ def _srs_from_wkt(crs_wkt: str | None) -> osr.SpatialReference | None:
     if not crs_wkt:
         return None
     srs = osr.SpatialReference()
-    return srs if srs.ImportFromWkt(crs_wkt) == 0 else None
+    try:
+        parsed = srs.ImportFromWkt(crs_wkt) == 0
+    except RuntimeError:
+        # A malformed WKT (GDAL raises when osr exceptions are on, else returns
+        # non-zero) degrades to no CRS rather than crashing the write.
+        return None
+    return srs if parsed else None
 
 
 def _cf_coord_attrs(

--- a/src/pyramids/netcdf/engines/interop.py
+++ b/src/pyramids/netcdf/engines/interop.py
@@ -611,13 +611,38 @@ def _build_multidim(
     return src
 
 
+def _crs_wkt_from_xarray(dataset: Any) -> str | None:
+    """Best-effort CRS WKT from an xarray Dataset's grid-mapping variable or global attrs.
+
+    Reads a ``spatial_ref`` / ``crs`` variable's ``crs_wkt`` / ``spatial_ref`` attribute
+    (the rioxarray / CF convention), then the dataset's global attributes. Returns None
+    when the source carries no CRS — ``from_xarray`` never fabricates one.
+
+    Args:
+        dataset: The source ``xarray.Dataset``.
+
+    Returns:
+        str or None: The CRS WKT, or None when the dataset declares no CRS.
+    """
+    for name in ("spatial_ref", "crs"):
+        if name in dataset.variables:
+            attrs = dataset.variables[name].attrs
+            wkt = attrs.get("crs_wkt") or attrs.get("spatial_ref")
+            if wkt:
+                return str(wkt)
+    wkt = dataset.attrs.get("crs_wkt")
+    return str(wkt) if wkt else None
+
+
 def _build_multidim_from_xarray(dataset: Any) -> gdal.Dataset:
     """Build an in-memory GDAL multidim container from an xarray Dataset.
 
     Extracts the plain `(dims, coords, data_vars, attrs)` spec from the
     `xarray.Dataset` and delegates to `_build_multidim`, so the GDAL multidim
     assembly lives in one place and this adapter only reads `.sizes` /
-    `.coords` / `.data_vars` / `.attrs` off xarray.
+    `.coords` / `.data_vars` / `.attrs` off xarray. When the dataset carries a CRS,
+    it is passed down so the x/y coordinates gain CF attributes and a `grid_mapping`
+    variable is written (see :func:`_build_multidim`).
 
     Args:
         dataset: The source `xarray.Dataset`.
@@ -625,20 +650,25 @@ def _build_multidim_from_xarray(dataset: Any) -> gdal.Dataset:
     Returns:
         gdal.Dataset: The in-memory `MEM` multidimensional dataset.
     """
+    crs_wkt = _crs_wkt_from_xarray(dataset)
     dims = {name: int(size) for name, size in dataset.sizes.items()}
     coords = {
         name: (np.asarray(coord.values), dict(coord.attrs))
         for name, coord in dataset.coords.items()
         if name in dims
     }
+    # When we re-generate a grid_mapping from the resolved CRS, drop any pre-existing
+    # scalar grid-mapping variable so the output carries a single one.
+    skip = {"spatial_ref", "crs"} if crs_wkt is not None else set()
     data_vars = {
         # `var.data` hands the underlying array through WITHOUT computing it, so a
         # dask-backed variable stays lazy and `_build_multidim` can stream it block by
         # block (ARC-48); `.values` would force a full materialisation up front.
         name: (tuple(var.dims), var.data, dict(var.attrs))
         for name, var in dataset.data_vars.items()
+        if not (name in skip and var.ndim == 0)
     }
-    return _build_multidim(dims, coords, data_vars, dict(dataset.attrs))
+    return _build_multidim(dims, coords, data_vars, dict(dataset.attrs), crs_wkt=crs_wkt)
 
 
 def _create_copy_to_netcdf(mem_src: gdal.Dataset, path: str) -> None:

--- a/src/pyramids/netcdf/engines/interop.py
+++ b/src/pyramids/netcdf/engines/interop.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from osgeo import gdal
+from osgeo import gdal, osr
 
 from pyramids.base._errors import OptionalPackageDoesNotExist
 from pyramids.base._utils import numpy_to_gdal_dtype
@@ -28,7 +28,11 @@ from pyramids.base.remote import is_remote
 from pyramids.dataset.engines._base import _Engine
 from pyramids.netcdf._lazy import build_lazy_array
 from pyramids.netcdf._mdim import strip_netcdf_subdataset_prefix
-from pyramids.netcdf.cf import write_attributes_to_md_array, write_global_attributes
+from pyramids.netcdf.cf import (
+    build_coordinate_attrs,
+    write_attributes_to_md_array,
+    write_global_attributes,
+)
 from pyramids.netcdf.utils import _read_attributes
 
 if TYPE_CHECKING:
@@ -382,13 +386,17 @@ def _write_data_var(
     var_dims: tuple[str, ...],
     var_values: Any,
     var_attrs: dict[str, Any],
-) -> None:
+) -> gdal.MDArray:
     """Create and fill one data variable's MDArray, streaming a dask-backed one block by block.
 
     A dask-backed variable (a lazily-loaded xarray var passed through by
     `_build_multidim_from_xarray`) is written block by block so it never becomes fully resident; a
     NumPy variable, or a temporal one that must be CF-encoded, is materialised and written in one
     shot (the prior behaviour).
+
+    Returns:
+        gdal.MDArray: The created (and filled) data-variable MDArray, so the caller can attach a
+            `grid_mapping` link to it.
 
     Raises:
         ValueError: When the variable references an unknown dimension, or its shape does not match
@@ -426,6 +434,101 @@ def _write_data_var(
     merged = dict(var_attrs)
     merged.update(cf_attrs)
     _apply_md_array_attrs(md_arr, merged)
+    return md_arr
+
+
+def _dim_type(name: str) -> str:
+    """CF dimension type for a coordinate name, or ``""`` when it is not spatial/temporal.
+
+    Declaring the horizontal / temporal dimension types lets GDAL's netCDF writer place
+    the CRS on the right axes (``SetSpatialRef`` otherwise warns that it is *assuming* the
+    last two dimensions are lon/lat).
+
+    Args:
+        name: The dimension name (case-insensitive).
+
+    Returns:
+        str: ``gdal.DIM_TYPE_HORIZONTAL_X`` / ``_Y`` / ``gdal.DIM_TYPE_TEMPORAL``, or ``""``.
+    """
+    lowered = name.lower()
+    if lowered in ("x", "lon", "longitude"):
+        return str(gdal.DIM_TYPE_HORIZONTAL_X)
+    if lowered in ("y", "lat", "latitude"):
+        return str(gdal.DIM_TYPE_HORIZONTAL_Y)
+    if lowered in ("time", "t"):
+        return str(gdal.DIM_TYPE_TEMPORAL)
+    return ""
+
+
+def _srs_from_wkt(crs_wkt: str | None) -> osr.SpatialReference | None:
+    """Build an OGR SpatialReference from a WKT string, or None when absent/invalid.
+
+    Args:
+        crs_wkt: A CRS WKT string, or None when the caller has no CRS.
+
+    Returns:
+        osr.SpatialReference or None: The parsed reference, or None when ``crs_wkt`` is
+        falsy or does not parse.
+    """
+    if not crs_wkt:
+        return None
+    srs = osr.SpatialReference()
+    return srs if srs.ImportFromWkt(crs_wkt) == 0 else None
+
+
+def _cf_coord_attrs(
+    coord_name: str,
+    coord_attrs: dict[str, Any],
+    temporal_attrs: dict[str, Any],
+    srs: osr.SpatialReference | None,
+) -> dict[str, Any]:
+    """Merge a coordinate's attributes, adding CF ``axis``/``standard_name``/``units`` for x/y.
+
+    GDAL's multidim writer emits only what it is handed, so a spatial coordinate written with a
+    bare attribute dict is unusable to a CF reader (Panoply: "X-dimension index is not set"). This
+    stamps the CF axis attributes from :func:`pyramids.netcdf.cf.build_coordinate_attrs` onto x/y
+    (lon/lat) coordinates. The caller's own attributes and the temporal encoding win over the CF
+    defaults; a non-spatial coordinate (e.g. ``band``, or a ``time`` axis already carrying its
+    ``units``/``calendar``) is left untouched.
+
+    Args:
+        coord_name: The coordinate/dimension name.
+        coord_attrs: The caller-supplied coordinate attributes.
+        temporal_attrs: The CF temporal encoding (``units``/``calendar``) for a datetime axis.
+        srs: The dataset's spatial reference, or None. Only decides degrees vs metres units;
+            the ``axis`` role is written even without a CRS.
+
+    Returns:
+        dict: The merged attribute dict to apply to the coordinate MDArray.
+    """
+    merged = dict(coord_attrs)
+    merged.update(temporal_attrs)
+    is_geographic = None if srs is None else bool(srs.IsGeographic())
+    cf = build_coordinate_attrs(coord_name, is_geographic)
+    if cf.get("axis") in ("X", "Y"):
+        cf.update(merged)
+        merged = cf
+    return merged
+
+
+def _apply_grid_mapping(
+    srs: osr.SpatialReference, data_arrays: dict[str, gdal.MDArray]
+) -> None:
+    """Attach the CRS to each data MDArray so GDAL emits a CF ``grid_mapping`` variable.
+
+    Calling ``SetSpatialRef`` on a data MDArray makes GDAL's netCDF writer auto-generate a
+    scalar CF ``grid_mapping`` variable (named ``crs``, carrying ``grid_mapping_name`` +
+    ``crs_wkt`` + the projection params) and link the data variable to it via
+    ``<var>#grid_mapping`` — the same mechanism ``create_from_array`` uses on the netCDF driver.
+    The generated variable is hidden from the multidim array listing, so it never leaks into
+    ``get_variable_names`` / ``variables``, and the CRS round-trips (``MDArray.GetSpatialRef``).
+
+    Args:
+        srs: The dataset's spatial reference.
+        data_arrays: Data-variable name to its MDArray.
+    """
+    for md_arr in data_arrays.values():
+        md_arr.SetSpatialRef(srs)
 
 
 def _build_multidim(
@@ -433,6 +536,7 @@ def _build_multidim(
     coords: dict[str, tuple[np.ndarray, dict[str, Any]]],
     data_vars: dict[str, tuple[tuple[str, ...], Any, dict[str, Any]]],
     global_attrs: dict[str, Any],
+    crs_wkt: str | None = None,
 ) -> gdal.Dataset:
     """Build an in-memory GDAL multidim container from plain arrays and attrs.
 
@@ -443,6 +547,11 @@ def _build_multidim(
     whose dimensions are resolved by name; `numpy` datetime/timedelta axes are
     CF-encoded on the way in and attributes go through pyramids' own CF helpers.
 
+    When `crs_wkt` is given, the x/y coordinates gain CF `axis`/`standard_name`/`units`
+    attributes and a scalar `spatial_ref` grid-mapping variable is written and linked
+    from every data variable, so the file is georeferenceable by a CF reader (Panoply,
+    QGIS, xarray); without it the coordinates keep only the caller's attributes.
+
     Args:
         dims: Dimension name to length.
         coords: Coordinate name (which must also be a dimension) to a
@@ -451,6 +560,8 @@ def _build_multidim(
         data_vars: Variable name to a `(dimension-name tuple, values, attrs)`
             triple.
         global_attrs: Root-group (global) attributes.
+        crs_wkt: The dataset CRS as a WKT string, or None. Drives the CF coordinate
+            attributes and the `grid_mapping` variable.
 
     Returns:
         gdal.Dataset: An in-memory `MEM` multidimensional dataset ready to be
@@ -462,9 +573,10 @@ def _build_multidim(
     """
     src = gdal.GetDriverByName("MEM").CreateMultiDimensional("pyramids")
     root = src.GetRootGroup()
+    srs = _srs_from_wkt(crs_wkt)
 
     gdal_dims: dict[str, gdal.Dimension] = {
-        name: root.CreateDimension(name, "", "", int(size))
+        name: root.CreateDimension(name, _dim_type(name), "", int(size))
         for name, size in dims.items()
     }
 
@@ -480,14 +592,18 @@ def _build_multidim(
         ext = gdal.ExtendedDataType.Create(numpy_to_gdal_dtype(values))
         md_arr = root.CreateMDArray(coord_name, [gdal_dims[coord_name]], ext)
         md_arr.Write(np.ascontiguousarray(values))
-        merged = dict(coord_attrs)
-        merged.update(cf_attrs)
-        _apply_md_array_attrs(md_arr, merged)
+        _apply_md_array_attrs(
+            md_arr, _cf_coord_attrs(coord_name, coord_attrs, cf_attrs, srs)
+        )
 
+    data_arrays: dict[str, gdal.MDArray] = {}
     for var_name, (var_dims, var_values, var_attrs) in data_vars.items():
-        _write_data_var(
+        data_arrays[var_name] = _write_data_var(
             root, gdal_dims, dims, var_name, var_dims, var_values, var_attrs
         )
+
+    if srs is not None:
+        _apply_grid_mapping(srs, data_arrays)
 
     if global_attrs:
         write_global_attributes(root, dict(global_attrs))
@@ -551,6 +667,7 @@ def write_multidim_netcdf(
     coords: dict[str, tuple[np.ndarray, dict[str, Any]]],
     data_vars: dict[str, tuple[tuple[str, ...], np.ndarray, dict[str, Any]]],
     global_attrs: dict[str, Any],
+    crs_wkt: str | None = None,
 ) -> None:
     """Write a plain multidim spec to a NetCDF file through GDAL.
 
@@ -567,13 +684,16 @@ def write_multidim_netcdf(
         data_vars: Variable name to a `(dimension-name tuple, values, attrs)`
             triple.
         global_attrs: Root-group (global) attributes.
+        crs_wkt: The dataset CRS as a WKT string, or None. When given, the x/y
+            coordinates gain CF attributes and a `grid_mapping` variable is written
+            (see :func:`_build_multidim`).
 
     Raises:
         ValueError: When a variable references an unknown dimension, or a
             coordinate/variable array shape does not match its dimension sizes.
         RuntimeError: When the GDAL netCDF writer fails to create the file.
     """
-    mem_src = _build_multidim(dims, coords, data_vars, global_attrs)
+    mem_src = _build_multidim(dims, coords, data_vars, global_attrs, crs_wkt)
     _create_copy_to_netcdf(mem_src, str(path))
 
 
@@ -632,6 +752,7 @@ def _build_streaming_multidim(
     coords: dict[str, tuple[np.ndarray, dict[str, Any]]],
     var_specs: dict[str, tuple[tuple[str, ...], np.dtype | str, dict[str, Any]]],
     global_attrs: dict[str, Any],
+    crs_wkt: str | None = None,
 ) -> dict[str, gdal.MDArray]:
     """Create dims, coord arrays, empty data vars, and global attrs on `dataset`.
 
@@ -641,6 +762,10 @@ def _build_streaming_multidim(
     manager only the data-variable MDArrays to drop before `Close()`, which is
     what lets the netCDF driver flush and unlock the file.
 
+    When `crs_wkt` is given, the x/y coordinates gain CF `axis`/`standard_name`/`units`
+    attributes and a scalar `spatial_ref` grid-mapping variable is written and linked
+    from every data variable, so a CF reader can georeference the streamed file.
+
     Args:
         dataset: A freshly created netCDF multidim dataset.
         dims: Dimension name to length.
@@ -649,6 +774,8 @@ def _build_streaming_multidim(
         var_specs: Variable name to a ``(dimension-name tuple, numpy dtype,
             attrs)`` triple.
         global_attrs: Root-group (global) attributes.
+        crs_wkt: The dataset CRS as a WKT string, or None. Drives the CF coordinate
+            attributes and the `grid_mapping` variable.
 
     Returns:
         dict[str, gdal.MDArray]: The created (empty, full-shape) data-variable
@@ -659,8 +786,9 @@ def _build_streaming_multidim(
             coordinate array shape does not match its dimension size.
     """
     root = dataset.GetRootGroup()
+    srs = _srs_from_wkt(crs_wkt)
     gdal_dims: dict[str, gdal.Dimension] = {
-        name: root.CreateDimension(name, "", "", int(size))
+        name: root.CreateDimension(name, _dim_type(name), "", int(size))
         for name, size in dims.items()
     }
 
@@ -676,9 +804,9 @@ def _build_streaming_multidim(
         ext = gdal.ExtendedDataType.Create(numpy_to_gdal_dtype(values))
         coord_arr = root.CreateMDArray(coord_name, [gdal_dims[coord_name]], ext)
         coord_arr.Write(np.ascontiguousarray(values))
-        merged = dict(coord_attrs)
-        merged.update(cf_attrs)
-        _apply_md_array_attrs(coord_arr, merged)
+        _apply_md_array_attrs(
+            coord_arr, _cf_coord_attrs(coord_name, coord_attrs, cf_attrs, srs)
+        )
 
     arrays: dict[str, gdal.MDArray] = {}
     for var_name, (var_dims, var_dtype, var_attrs) in var_specs.items():
@@ -693,6 +821,9 @@ def _build_streaming_multidim(
         _apply_md_array_attrs(md_arr, dict(var_attrs))
         arrays[var_name] = md_arr
 
+    if srs is not None:
+        _apply_grid_mapping(srs, arrays)
+
     if global_attrs:
         write_global_attributes(root, dict(global_attrs))
 
@@ -706,6 +837,7 @@ def open_streaming_multidim_netcdf(
     coords: dict[str, tuple[np.ndarray, dict[str, Any]]],
     var_specs: dict[str, tuple[tuple[str, ...], np.dtype | str, dict[str, Any]]],
     global_attrs: dict[str, Any],
+    crs_wkt: str | None = None,
 ):
     """Create a netCDF multidim file and yield a per-hyperslab writer.
 
@@ -735,6 +867,9 @@ def open_streaming_multidim_netcdf(
             attrs)`` triple. The first entry of the dimension tuple is the
             streamed (leading) dimension.
         global_attrs: Root-group (global) attributes.
+        crs_wkt: The dataset CRS as a WKT string, or None. When given, the x/y
+            coordinates gain CF attributes and a `grid_mapping` variable is written
+            (see :func:`_build_streaming_multidim`).
 
     Yields:
         _StreamingMultidimWriter: Call :meth:`~_StreamingMultidimWriter.write_slab`
@@ -756,7 +891,7 @@ def open_streaming_multidim_netcdf(
     arrays: dict[str, gdal.MDArray] = {}
     try:
         arrays = _build_streaming_multidim(
-            dataset, dims, coords, var_specs, global_attrs
+            dataset, dims, coords, var_specs, global_attrs, crs_wkt
         )
         yield _StreamingMultidimWriter(arrays)
         completed = True

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -2847,7 +2847,11 @@ class NetCDF(Dataset):
         root_attrs = self._stream_root_attrs(template)
 
         with _interop.open_streaming_multidim_netcdf(
-            str(path), dims, coords, var_specs, root_attrs,
+            str(path),
+            dims,
+            coords,
+            var_specs,
+            root_attrs,
             crs_wkt=root_attrs.get("crs_wkt"),
         ) as writer:
             for name in spatial_vars:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -2847,7 +2847,8 @@ class NetCDF(Dataset):
         root_attrs = self._stream_root_attrs(template)
 
         with _interop.open_streaming_multidim_netcdf(
-            str(path), dims, coords, var_specs, root_attrs
+            str(path), dims, coords, var_specs, root_attrs,
+            crs_wkt=root_attrs.get("crs_wkt"),
         ) as writer:
             for name in spatial_vars:
                 self._write_stream_variable(

--- a/src/pyramids/netcdf/ugrid/io.py
+++ b/src/pyramids/netcdf/ugrid/io.py
@@ -547,9 +547,14 @@ def _write_crs_variable(
     attrs: dict[str, Any] = {"crs_wkt": crs_wkt, "spatial_ref": crs_wkt}
     srs = srs_from_wkt(crs_wkt)
     if srs is not None:
+        gm_name, gm_params = srs_to_grid_mapping(srs)
         # A CF grid_mapping variable is identified by its `grid_mapping_name`; a reader
         # keys off it, so a bare `crs_wkt`-only variable is not fully CF-discoverable.
-        attrs["grid_mapping_name"] = srs_to_grid_mapping(srs)[0]
+        # Skip the name for a projected CRS outside cf's table (the "latitude_longitude"
+        # fallback would mislabel a metre grid), and carry the full CF projection params.
+        if not (srs.IsProjected() and gm_name == "latitude_longitude"):
+            attrs["grid_mapping_name"] = gm_name
+            attrs.update({k: v for k, v in gm_params.items() if k not in attrs})
     write_attributes_to_md_array(crs_arr, attrs)
 
 

--- a/src/pyramids/netcdf/ugrid/io.py
+++ b/src/pyramids/netcdf/ugrid/io.py
@@ -13,12 +13,13 @@ from __future__ import annotations
 from typing import Any, cast
 
 import numpy as np
-from osgeo import gdal, osr
+from osgeo import gdal
 
 from pyramids.netcdf._mdim import open_mdarray
 from pyramids.netcdf.cf import (
     build_coordinate_attrs,
     grid_mapping_to_srs,
+    srs_from_wkt,
     srs_to_grid_mapping,
     write_attributes_to_md_array,
 )
@@ -462,11 +463,8 @@ def write_ugrid_topology(
     write_attributes_to_md_array(topo_arr, topo_attrs)
     topo_arr.Write(np.array([0], dtype=np.int32))
 
-    is_geographic: bool | None = None
-    if crs_wkt is not None:
-        _srs = osr.SpatialReference()
-        if _srs.ImportFromWkt(crs_wkt) == 0:
-            is_geographic = bool(_srs.IsGeographic())
+    _srs = srs_from_wkt(crs_wkt)
+    is_geographic: bool | None = None if _srs is None else bool(_srs.IsGeographic())
 
     _write_coord_array(
         rg, f"{mesh_name}_node_x", [n_node_dim], mesh.node_x,
@@ -547,8 +545,8 @@ def _write_crs_variable(
     )
     crs_arr.Write(np.array([0], dtype=np.int32))
     attrs: dict[str, Any] = {"crs_wkt": crs_wkt, "spatial_ref": crs_wkt}
-    srs = osr.SpatialReference()
-    if srs.ImportFromWkt(crs_wkt) == 0:
+    srs = srs_from_wkt(crs_wkt)
+    if srs is not None:
         # A CF grid_mapping variable is identified by its `grid_mapping_name`; a reader
         # keys off it, so a bare `crs_wkt`-only variable is not fully CF-discoverable.
         attrs["grid_mapping_name"] = srs_to_grid_mapping(srs)[0]
@@ -562,7 +560,7 @@ def _write_coord_array(
     data: np.ndarray,
     *,
     axis: str | None = None,
-    is_geographic: bool | None = True,
+    is_geographic: bool | None = None,
 ) -> None:
     """Write a coordinate array to the GDAL group.
 

--- a/src/pyramids/netcdf/ugrid/io.py
+++ b/src/pyramids/netcdf/ugrid/io.py
@@ -13,11 +13,13 @@ from __future__ import annotations
 from typing import Any, cast
 
 import numpy as np
-from osgeo import gdal
+from osgeo import gdal, osr
 
 from pyramids.netcdf._mdim import open_mdarray
 from pyramids.netcdf.cf import (
+    build_coordinate_attrs,
     grid_mapping_to_srs,
+    srs_to_grid_mapping,
     write_attributes_to_md_array,
 )
 from pyramids.netcdf.ugrid.connectivity import Connectivity
@@ -455,8 +457,20 @@ def write_ugrid_topology(
     write_attributes_to_md_array(topo_arr, topo_attrs)
     topo_arr.Write(np.array([0], dtype=np.int32))
 
-    _write_coord_array(rg, f"{mesh_name}_node_x", [n_node_dim], mesh.node_x)
-    _write_coord_array(rg, f"{mesh_name}_node_y", [n_node_dim], mesh.node_y)
+    is_geographic: bool | None = None
+    if crs_wkt is not None:
+        _srs = osr.SpatialReference()
+        if _srs.ImportFromWkt(crs_wkt) == 0:
+            is_geographic = bool(_srs.IsGeographic())
+
+    _write_coord_array(
+        rg, f"{mesh_name}_node_x", [n_node_dim], mesh.node_x,
+        axis="x", is_geographic=is_geographic,
+    )
+    _write_coord_array(
+        rg, f"{mesh_name}_node_y", [n_node_dim], mesh.node_y,
+        axis="y", is_geographic=is_geographic,
+    )
 
     _write_connectivity_array(
         rg,
@@ -487,12 +501,16 @@ def write_ugrid_topology(
             f"{mesh_name}_face_x",
             [n_face_dim],
             cast("np.typing.NDArray", mesh.face_x),
+            axis="x",
+            is_geographic=is_geographic,
         )
         _write_coord_array(
             rg,
             f"{mesh_name}_face_y",
             [n_face_dim],
             cast("np.typing.NDArray", mesh.face_y),
+            axis="y",
+            is_geographic=is_geographic,
         )
 
     if crs_wkt is not None:
@@ -519,7 +537,13 @@ def _write_crs_variable(
         gdal.ExtendedDataType.Create(gdal.GDT_Int32),
     )
     crs_arr.Write(np.array([0], dtype=np.int32))
-    write_attributes_to_md_array(crs_arr, {"crs_wkt": crs_wkt})
+    attrs: dict[str, Any] = {"crs_wkt": crs_wkt, "spatial_ref": crs_wkt}
+    srs = osr.SpatialReference()
+    if srs.ImportFromWkt(crs_wkt) == 0:
+        # A CF grid_mapping variable is identified by its `grid_mapping_name`; a reader
+        # keys off it, so a bare `crs_wkt`-only variable is not fully CF-discoverable.
+        attrs["grid_mapping_name"] = srs_to_grid_mapping(srs)[0]
+    write_attributes_to_md_array(crs_arr, attrs)
 
 
 def _write_coord_array(
@@ -527,6 +551,9 @@ def _write_coord_array(
     name: str,
     dims: list,
     data: np.ndarray,
+    *,
+    axis: str | None = None,
+    is_geographic: bool | None = True,
 ) -> None:
     """Write a coordinate array to the GDAL group.
 
@@ -535,6 +562,10 @@ def _write_coord_array(
         name: Variable name.
         dims: List of GDAL dimensions.
         data: 1D numpy array of coordinate values.
+        axis: ``"x"`` or ``"y"`` to stamp CF ``axis``/``standard_name``/``units`` via
+            :func:`pyramids.netcdf.cf.build_coordinate_attrs`, or None for a bare array.
+        is_geographic: True for a geographic CRS (degrees), False for projected
+            (metres), None when there is no CRS. Only used when ``axis`` is set.
     """
     md_arr = rg.CreateMDArray(
         name,
@@ -542,6 +573,10 @@ def _write_coord_array(
         gdal.ExtendedDataType.Create(gdal.GDT_Float64),
     )
     md_arr.Write(data.astype(np.float64))
+    if axis is not None:
+        write_attributes_to_md_array(
+            md_arr, build_coordinate_attrs(axis, is_geographic)
+        )
 
 
 def _write_connectivity_array(

--- a/src/pyramids/netcdf/ugrid/io.py
+++ b/src/pyramids/netcdf/ugrid/io.py
@@ -467,12 +467,20 @@ def write_ugrid_topology(
     is_geographic: bool | None = None if _srs is None else bool(_srs.IsGeographic())
 
     _write_coord_array(
-        rg, f"{mesh_name}_node_x", [n_node_dim], mesh.node_x,
-        axis="x", is_geographic=is_geographic,
+        rg,
+        f"{mesh_name}_node_x",
+        [n_node_dim],
+        mesh.node_x,
+        axis="x",
+        is_geographic=is_geographic,
     )
     _write_coord_array(
-        rg, f"{mesh_name}_node_y", [n_node_dim], mesh.node_y,
-        axis="y", is_geographic=is_geographic,
+        rg,
+        f"{mesh_name}_node_y",
+        [n_node_dim],
+        mesh.node_y,
+        axis="y",
+        is_geographic=is_geographic,
     )
 
     _write_connectivity_array(

--- a/src/pyramids/netcdf/ugrid/io.py
+++ b/src/pyramids/netcdf/ugrid/io.py
@@ -412,6 +412,11 @@ def write_ugrid_topology(
     connectivity arrays, and optional face/edge center coordinates.
     Uses cf.write_attributes_to_md_array for all attribute writing.
 
+    When ``crs_wkt`` is given, the node/face coordinate arrays gain CF
+    ``axis`` / ``standard_name`` / ``units`` (degrees for a geographic CRS, metres for
+    a projected one) and the ``crs`` variable carries a ``grid_mapping_name``, so the
+    unstructured mesh is CF-discoverable like the structured writers (#1017).
+
     Args:
         rg: GDAL root group to write into.
         mesh: Mesh2d instance.
@@ -524,7 +529,11 @@ def _write_crs_variable(
     crs_wkt: str,
     scalar_dim: Any,
 ) -> None:
-    """Write a CRS variable with crs_wkt attribute.
+    """Write the CF ``crs`` grid-mapping variable.
+
+    Carries ``crs_wkt`` / ``spatial_ref`` (the WKT) and, when the WKT parses, the CF
+    ``grid_mapping_name`` — a reader keys off ``grid_mapping_name`` to recognise the
+    variable as a grid mapping, so a WKT-only variable is not fully CF-discoverable.
 
     Args:
         rg: GDAL root group.

--- a/src/pyramids/netcdf/ugrid/io.py
+++ b/src/pyramids/netcdf/ugrid/io.py
@@ -19,8 +19,8 @@ from pyramids.netcdf._mdim import open_mdarray
 from pyramids.netcdf.cf import (
     build_coordinate_attrs,
     grid_mapping_to_srs,
+    grid_mapping_var_attrs,
     srs_from_wkt,
-    srs_to_grid_mapping,
     write_attributes_to_md_array,
 )
 from pyramids.netcdf.ugrid.connectivity import Connectivity
@@ -558,14 +558,12 @@ def _write_crs_variable(
     attrs: dict[str, Any] = {"crs_wkt": crs_wkt, "spatial_ref": crs_wkt}
     srs = srs_from_wkt(crs_wkt)
     if srs is not None:
-        gm_name, gm_params = srs_to_grid_mapping(srs)
-        # A CF grid_mapping variable is identified by its `grid_mapping_name`; a reader
-        # keys off it, so a bare `crs_wkt`-only variable is not fully CF-discoverable.
-        # Skip the name for a projected CRS outside cf's table (the "latitude_longitude"
-        # fallback would mislabel a metre grid), and carry the full CF projection params.
-        if not (srs.IsProjected() and gm_name == "latitude_longitude"):
-            attrs["grid_mapping_name"] = gm_name
-            attrs.update({k: v for k, v in gm_params.items() if k not in attrs})
+        # A CF grid_mapping variable is identified by its `grid_mapping_name` (+ params);
+        # `grid_mapping_var_attrs` returns those for a recognized projection and {} for a
+        # projected CRS outside cf's table (avoiding the mislabelling lon/lat fallback).
+        attrs.update(
+            {k: v for k, v in grid_mapping_var_attrs(srs).items() if k not in attrs}
+        )
     write_attributes_to_md_array(crs_arr, attrs)
 
 

--- a/src/pyramids/netcdf/ugrid/io.py
+++ b/src/pyramids/netcdf/ugrid/io.py
@@ -537,9 +537,12 @@ def _write_crs_variable(
 ) -> None:
     """Write the CF ``crs`` grid-mapping variable.
 
-    Carries ``crs_wkt`` / ``spatial_ref`` (the WKT) and, when the WKT parses, the CF
-    ``grid_mapping_name`` — a reader keys off ``grid_mapping_name`` to recognise the
-    variable as a grid mapping, so a WKT-only variable is not fully CF-discoverable.
+    Always carries ``crs_wkt`` / ``spatial_ref`` (the WKT). When the projection is
+    recognised by :func:`pyramids.netcdf.cf.srs_to_grid_mapping`, it also carries the CF
+    ``grid_mapping_name`` and projection params (``false_easting``, ellipsoid, ...) — a
+    reader keys off ``grid_mapping_name`` to recognise the variable as a grid mapping. A
+    projected CRS outside the CF table is left ``crs_wkt``-only rather than mislabelled
+    with the ``latitude_longitude`` fallback name.
 
     Args:
         rg: GDAL root group.

--- a/tests/dataset/collection/test_to_netcdf.py
+++ b/tests/dataset/collection/test_to_netcdf.py
@@ -1014,3 +1014,121 @@ class TestToNetcdfRoundTrip:
         assert got[1] == pytest.approx(cell), (
             f"x pixel size not the real spacing: {got[1]}"
         )
+
+
+class TestToNetcdfCfCoordinates:
+    """CF-complete coordinates + grid_mapping so third-party CF readers (Panoply) work."""
+
+    @staticmethod
+    def _classic_md(path) -> dict:
+        """Return the classic-mode metadata dict (the CF view a tool like Panoply reads)."""
+        return gdal.Open(str(path)).GetMetadata()
+
+    def test_geographic_coords_carry_cf_axis_attributes(self, tmp_path):
+        """A geographic grid writes CF ``axis``/``standard_name``/degrees units on x/y.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            EPSG:4326 collection — expected: ``x`` carries ``degrees_east``/``longitude``/
+            ``X`` and ``y`` carries ``degrees_north``/``latitude``/``Y``, so a CF reader can
+            identify the axes (the #1017 Panoply "X-dimension index is not set" failure).
+        """
+        col, _ = _make_int16_collection(tmp_path)
+        out = tmp_path / "geo.nc"
+        col.to_netcdf(str(out))
+        md = self._classic_md(out)
+        assert md.get("x#units") == "degrees_east", f"x#units={md.get('x#units')!r}"
+        assert md.get("x#standard_name") == "longitude"
+        assert md.get("x#axis") == "X"
+        assert md.get("y#units") == "degrees_north"
+        assert md.get("y#axis") == "Y"
+
+    def test_grid_mapping_variable_written_and_linked(self, tmp_path):
+        """A CF grid_mapping variable is written and the data variable references it.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            Expected: ``Band_1#grid_mapping`` names a variable that carries
+            ``grid_mapping_name`` and ``crs_wkt``, so the CRS is CF-discoverable.
+        """
+        col, _ = _make_int16_collection(tmp_path)
+        out = tmp_path / "gm.nc"
+        col.to_netcdf(str(out))
+        md = self._classic_md(out)
+        gm = md.get("Band_1#grid_mapping")
+        assert gm, f"data variable should reference a grid_mapping var: {md}"
+        assert md.get(f"{gm}#grid_mapping_name"), "grid_mapping var lacks grid_mapping_name"
+        assert md.get(f"{gm}#crs_wkt"), "grid_mapping var lacks crs_wkt"
+
+    def test_grid_mapping_var_not_exposed_and_crs_round_trips(self, tmp_path):
+        """The auto grid_mapping variable stays out of variable_names and the CRS round-trips.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            Expected: ``variable_names == ["Band_1"]`` (no ``crs``/``spatial_ref`` leak) and
+            ``epsg == 4326`` on reopen — the fix does not regress the reader.
+        """
+        col, _ = _make_int16_collection(tmp_path)
+        out = tmp_path / "rt.nc"
+        col.to_netcdf(str(out))
+        nc = NetCDF.read_file(str(out))
+        assert nc.variable_names == ["Band_1"], (
+            f"grid_mapping var leaked into variable_names: {nc.variable_names}"
+        )
+        assert nc.epsg == 4326, f"CRS did not round-trip: {nc.epsg}"
+
+    def test_projected_coords_use_metre_units(self, tmp_path):
+        """A projected grid writes metre units and projection_x/y_coordinate standard names.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            EPSG:32632 (UTM 32N) collection — expected: ``x``/``y`` carry ``m`` and
+            ``projection_x_coordinate`` / ``projection_y_coordinate``.
+        """
+        paths = []
+        for i in range(2):
+            arr = np.arange(20, dtype="int16").reshape(4, 5) + 100 * i
+            p = os.path.join(str(tmp_path), f"p{i}.tif")
+            Dataset.create_from_array(
+                arr,
+                top_left_corner=(400000.0, 5800000.0),
+                cell_size=5000.0,
+                epsg=32632,
+                no_data_value=-9999,
+                path=p,
+            ).close()
+            paths.append(p)
+        out = tmp_path / "proj.nc"
+        DatasetCollection.from_files(paths).to_netcdf(str(out))
+        md = self._classic_md(out)
+        assert md.get("x#units") == "m", f"x#units={md.get('x#units')!r}"
+        assert md.get("x#standard_name") == "projection_x_coordinate"
+        assert md.get("y#standard_name") == "projection_y_coordinate"
+
+    def test_streaming_op_writes_cf_coords(self, tmp_path):
+        """A streaming raster op (``resample`` with ``path=``) also writes CF-complete coords.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            ``to_netcdf`` a collection, reopen, ``resample(..., path=)`` on the container —
+            expected: the streamed output carries the CF x/y attrs and a ``grid_mapping``,
+            since the fix covers the streaming ops, not only ``to_netcdf``.
+        """
+        col, _ = _make_int16_collection(tmp_path)
+        src = tmp_path / "src.nc"
+        col.to_netcdf(str(src))
+        out = tmp_path / "resampled.nc"
+        NetCDF.read_file(str(src)).resample(0.1, path=str(out))
+        md = self._classic_md(out)
+        assert md.get("x#units") == "degrees_east", f"x#units={md.get('x#units')!r}"
+        assert md.get("Band_1#grid_mapping"), "streamed op should write a grid_mapping"

--- a/tests/dataset/collection/test_to_netcdf.py
+++ b/tests/dataset/collection/test_to_netcdf.py
@@ -1061,7 +1061,9 @@ class TestToNetcdfCfCoordinates:
         md = self._classic_md(out)
         gm = md.get("Band_1#grid_mapping")
         assert gm, f"data variable should reference a grid_mapping var: {md}"
-        assert md.get(f"{gm}#grid_mapping_name"), "grid_mapping var lacks grid_mapping_name"
+        assert md.get(f"{gm}#grid_mapping_name"), (
+            "grid_mapping var lacks grid_mapping_name"
+        )
         assert md.get(f"{gm}#crs_wkt"), "grid_mapping var lacks crs_wkt"
 
     def test_grid_mapping_var_not_exposed_and_crs_round_trips(self, tmp_path):

--- a/tests/dataset/ops/test_geobox_zarr.py
+++ b/tests/dataset/ops/test_geobox_zarr.py
@@ -122,6 +122,32 @@ class TestWriteGeobox:
         assert group["x"].attrs["_ARRAY_DIMENSIONS"] == ["x"]
         assert group["y"].attrs["_ARRAY_DIMENSIONS"] == ["y"]
 
+    def test_xy_carry_cf_axis_attrs_and_grid_mapping_name(self, tmp_path):
+        """x/y gain CF axis attributes and spatial_ref gains grid_mapping_name (#1017).
+
+        Test scenario:
+            For a geographic CRS the ``x``/``y`` arrays carry ``axis``/``standard_name``/
+            ``units`` (degrees) and the ``spatial_ref`` scalar carries a CF
+            ``grid_mapping_name``, so a CF reader can georeference the GeoZarr store.
+        """
+        group = self._group_with_data(tmp_path, rows=4, cols=5)
+        write_geobox(
+            group,
+            data_name="data",
+            epsg=4326,
+            geotransform=_GT,
+            crs_wkt=_WKT_4326,
+            rows=4,
+            cols=5,
+            dims=["band", "y", "x"],
+        )
+        assert group["x"].attrs["axis"] == "X"
+        assert group["x"].attrs["standard_name"] == "longitude"
+        assert group["x"].attrs["units"] == "degrees_east"
+        assert group["y"].attrs["axis"] == "Y"
+        assert group["y"].attrs["units"] == "degrees_north"
+        assert group[GRID_MAPPING_VAR].attrs["grid_mapping_name"] == "latitude_longitude"
+
     def test_spatial_ref_attrs_and_value(self, tmp_path):
         """spatial_ref stores WKT + GeoTransform + epsg; value is the epsg.
 

--- a/tests/dataset/ops/test_geobox_zarr.py
+++ b/tests/dataset/ops/test_geobox_zarr.py
@@ -148,6 +148,28 @@ class TestWriteGeobox:
         assert group["y"].attrs["units"] == "degrees_north"
         assert group[GRID_MAPPING_VAR].attrs["grid_mapping_name"] == "latitude_longitude"
 
+    def test_malformed_crs_wkt_degrades_without_crashing(self, tmp_path):
+        """An unparseable crs_wkt degrades to axis-only coords instead of raising (L1).
+
+        Test scenario:
+            `write_geobox` with a malformed `crs_wkt` completes; x/y get the CF `axis`
+            role but no fabricated `units`, and no `grid_mapping_name` is written.
+        """
+        group = self._group_with_data(tmp_path, rows=4, cols=5)
+        write_geobox(
+            group,
+            data_name="data",
+            epsg=0,
+            geotransform=_GT,
+            crs_wkt="not a wkt",
+            rows=4,
+            cols=5,
+            dims=["band", "y", "x"],
+        )
+        assert group["x"].attrs["axis"] == "X"
+        assert "units" not in group["x"].attrs, "no CRS should not fabricate units"
+        assert "grid_mapping_name" not in group[GRID_MAPPING_VAR].attrs
+
     def test_spatial_ref_attrs_and_value(self, tmp_path):
         """spatial_ref stores WKT + GeoTransform + epsg; value is the epsg.
 

--- a/tests/dataset/ops/test_geobox_zarr.py
+++ b/tests/dataset/ops/test_geobox_zarr.py
@@ -76,6 +76,19 @@ class TestWriteGeobox:
         group.create_array("data", data=np.zeros((bands, rows, cols), dtype="float32"))
         return group
 
+    def _write(self, group, *, epsg, crs_wkt):
+        """Write the shared 4x5 / ``_GT`` / band-y-x geobox onto ``group``."""
+        write_geobox(
+            group,
+            data_name="data",
+            epsg=epsg,
+            geotransform=_GT,
+            crs_wkt=crs_wkt,
+            rows=4,
+            cols=5,
+            dims=["band", "y", "x"],
+        )
+
     def test_creates_spatial_ref_and_xy(self, tmp_path):
         """write_geobox adds spatial_ref + x/y arrays alongside data.
 
@@ -131,16 +144,7 @@ class TestWriteGeobox:
             ``grid_mapping_name``, so a CF reader can georeference the GeoZarr store.
         """
         group = self._group_with_data(tmp_path, rows=4, cols=5)
-        write_geobox(
-            group,
-            data_name="data",
-            epsg=4326,
-            geotransform=_GT,
-            crs_wkt=_WKT_4326,
-            rows=4,
-            cols=5,
-            dims=["band", "y", "x"],
-        )
+        self._write(group, epsg=4326, crs_wkt=_WKT_4326)
         assert group["x"].attrs["axis"] == "X"
         assert group["x"].attrs["standard_name"] == "longitude"
         assert group["x"].attrs["units"] == "degrees_east"
@@ -158,16 +162,7 @@ class TestWriteGeobox:
             role but no fabricated `units`, and no `grid_mapping_name` is written.
         """
         group = self._group_with_data(tmp_path, rows=4, cols=5)
-        write_geobox(
-            group,
-            data_name="data",
-            epsg=0,
-            geotransform=_GT,
-            crs_wkt="not a wkt",
-            rows=4,
-            cols=5,
-            dims=["band", "y", "x"],
-        )
+        self._write(group, epsg=0, crs_wkt="not a wkt")
         assert group["x"].attrs["axis"] == "X"
         assert "units" not in group["x"].attrs, "no CRS should not fabricate units"
         assert "grid_mapping_name" not in group[GRID_MAPPING_VAR].attrs
@@ -185,16 +180,7 @@ class TestWriteGeobox:
         srs = osr.SpatialReference()
         srs.ImportFromEPSG(32632)
         group = self._group_with_data(tmp_path, rows=4, cols=5)
-        write_geobox(
-            group,
-            data_name="data",
-            epsg=32632,
-            geotransform=_GT,
-            crs_wkt=srs.ExportToWkt(),
-            rows=4,
-            cols=5,
-            dims=["band", "y", "x"],
-        )
+        self._write(group, epsg=32632, crs_wkt=srs.ExportToWkt())
         sr = dict(group[GRID_MAPPING_VAR].attrs)
         assert sr["grid_mapping_name"] == "transverse_mercator", sr.get(
             "grid_mapping_name"
@@ -217,16 +203,7 @@ class TestWriteGeobox:
             "+proj=sinu +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs"
         )
         group = self._group_with_data(tmp_path, rows=4, cols=5)
-        write_geobox(
-            group,
-            data_name="data",
-            epsg=0,
-            geotransform=_GT,
-            crs_wkt=srs.ExportToWkt(),
-            rows=4,
-            cols=5,
-            dims=["band", "y", "x"],
-        )
+        self._write(group, epsg=0, crs_wkt=srs.ExportToWkt())
         sr = dict(group[GRID_MAPPING_VAR].attrs)
         assert sr.get("grid_mapping_name") != "latitude_longitude", (
             "a projected CRS must not be mislabeled as a lon/lat grid mapping"

--- a/tests/dataset/ops/test_geobox_zarr.py
+++ b/tests/dataset/ops/test_geobox_zarr.py
@@ -146,7 +146,9 @@ class TestWriteGeobox:
         assert group["x"].attrs["units"] == "degrees_east"
         assert group["y"].attrs["axis"] == "Y"
         assert group["y"].attrs["units"] == "degrees_north"
-        assert group[GRID_MAPPING_VAR].attrs["grid_mapping_name"] == "latitude_longitude"
+        assert (
+            group[GRID_MAPPING_VAR].attrs["grid_mapping_name"] == "latitude_longitude"
+        )
 
     def test_malformed_crs_wkt_degrades_without_crashing(self, tmp_path):
         """An unparseable crs_wkt degrades to axis-only coords instead of raising (L1).
@@ -194,7 +196,9 @@ class TestWriteGeobox:
             dims=["band", "y", "x"],
         )
         sr = dict(group[GRID_MAPPING_VAR].attrs)
-        assert sr["grid_mapping_name"] == "transverse_mercator", sr.get("grid_mapping_name")
+        assert sr["grid_mapping_name"] == "transverse_mercator", sr.get(
+            "grid_mapping_name"
+        )
         assert "false_easting" in sr, sr
         assert "latitude_of_projection_origin" in sr, sr
 
@@ -209,7 +213,9 @@ class TestWriteGeobox:
         from osgeo import osr
 
         srs = osr.SpatialReference()
-        srs.ImportFromProj4("+proj=sinu +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs")
+        srs.ImportFromProj4(
+            "+proj=sinu +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs"
+        )
         group = self._group_with_data(tmp_path, rows=4, cols=5)
         write_geobox(
             group,

--- a/tests/dataset/ops/test_geobox_zarr.py
+++ b/tests/dataset/ops/test_geobox_zarr.py
@@ -170,6 +170,63 @@ class TestWriteGeobox:
         assert "units" not in group["x"].attrs, "no CRS should not fabricate units"
         assert "grid_mapping_name" not in group[GRID_MAPPING_VAR].attrs
 
+    def test_projected_grid_mapping_has_name_and_cf_params(self, tmp_path):
+        """A recognized projected CRS gets its grid_mapping_name AND the CF params (L2).
+
+        Test scenario:
+            UTM 32N (EPSG:32632) — the ``spatial_ref`` scalar carries
+            ``grid_mapping_name="transverse_mercator"`` plus the projection params
+            (``false_easting`` / ``latitude_of_projection_origin`` / ...), not just the WKT.
+        """
+        from osgeo import osr
+
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(32632)
+        group = self._group_with_data(tmp_path, rows=4, cols=5)
+        write_geobox(
+            group,
+            data_name="data",
+            epsg=32632,
+            geotransform=_GT,
+            crs_wkt=srs.ExportToWkt(),
+            rows=4,
+            cols=5,
+            dims=["band", "y", "x"],
+        )
+        sr = dict(group[GRID_MAPPING_VAR].attrs)
+        assert sr["grid_mapping_name"] == "transverse_mercator", sr.get("grid_mapping_name")
+        assert "false_easting" in sr, sr
+        assert "latitude_of_projection_origin" in sr, sr
+
+    def test_projected_crs_outside_cf_table_is_not_mislabeled(self, tmp_path):
+        """A projected CRS outside cf's table is not labeled latitude_longitude (L1).
+
+        Test scenario:
+            A Sinusoidal metre grid is not in cf's grid-mapping table, so no
+            ``grid_mapping_name`` is asserted (rather than the wrong
+            ``latitude_longitude``); ``crs_wkt`` stays authoritative.
+        """
+        from osgeo import osr
+
+        srs = osr.SpatialReference()
+        srs.ImportFromProj4("+proj=sinu +lon_0=0 +x_0=0 +y_0=0 +datum=WGS84 +units=m +no_defs")
+        group = self._group_with_data(tmp_path, rows=4, cols=5)
+        write_geobox(
+            group,
+            data_name="data",
+            epsg=0,
+            geotransform=_GT,
+            crs_wkt=srs.ExportToWkt(),
+            rows=4,
+            cols=5,
+            dims=["band", "y", "x"],
+        )
+        sr = dict(group[GRID_MAPPING_VAR].attrs)
+        assert sr.get("grid_mapping_name") != "latitude_longitude", (
+            "a projected CRS must not be mislabeled as a lon/lat grid mapping"
+        )
+        assert sr["crs_wkt"], "crs_wkt must remain authoritative"
+
     def test_spatial_ref_attrs_and_value(self, tmp_path):
         """spatial_ref stores WKT + GeoTransform + epsg; value is the epsg.
 

--- a/tests/netcdf/test_interop_write_multidim.py
+++ b/tests/netcdf/test_interop_write_multidim.py
@@ -654,7 +654,7 @@ class TestCfCoordinateHelpers:
         Test scenario:
             `_srs_from_wkt` returns None so the writers skip CF injection.
         """
-        assert interop._srs_from_wkt(wkt) is None, f"expected None for {wkt!r}"
+        assert interop.srs_from_wkt(wkt) is None, f"expected None for {wkt!r}"
 
     def test_srs_from_wkt_invalid_returns_none(self):
         """An unparseable WKT string yields None rather than raising.
@@ -662,7 +662,7 @@ class TestCfCoordinateHelpers:
         Test scenario:
             `ImportFromWkt` fails, so the helper returns None (defensive).
         """
-        assert interop._srs_from_wkt("not a wkt") is None
+        assert interop.srs_from_wkt("not a wkt") is None
 
     def test_srs_from_wkt_valid(self):
         """A valid WKT parses to a usable SpatialReference.
@@ -670,7 +670,7 @@ class TestCfCoordinateHelpers:
         Test scenario:
             A WGS84 WKT round-trips to a geographic SpatialReference.
         """
-        out = interop._srs_from_wkt(self._srs(4326).ExportToWkt())
+        out = interop.srs_from_wkt(self._srs(4326).ExportToWkt())
         assert out is not None and out.IsGeographic(), "expected a geographic SRS"
 
     def test_cf_coord_attrs_geographic_x(self):

--- a/tests/netcdf/test_interop_write_multidim.py
+++ b/tests/netcdf/test_interop_write_multidim.py
@@ -213,6 +213,35 @@ class TestWriteMultidimNetcdf:
         )
         assert "bogus" not in _array_names(str(out)), "non-dim coord was written"
 
+    def test_crs_wkt_writes_cf_coords_and_grid_mapping(self, tmp_path):
+        """Passing crs_wkt stamps CF x/y attrs and a grid_mapping via the CreateCopy path.
+
+        Test scenario:
+            A geographic ``crs_wkt`` — expected: ``x``/``y`` carry CF ``standard_name`` /
+            ``axis`` and the data variable references a ``grid_mapping`` variable (the
+            ``_build_multidim`` + ``SetSpatialRef`` path, distinct from the streaming writer).
+        """
+        from osgeo import osr
+
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(4326)
+        out = tmp_path / "crs.nc"
+        write_multidim_netcdf(
+            out,
+            dims={"y": 2, "x": 3},
+            coords={
+                "y": (np.array([20.0, 10.0]), {}),
+                "x": (np.array([1.0, 2.0, 3.0]), {}),
+            },
+            data_vars={"temp": (("y", "x"), np.zeros((2, 3), "float32"), {})},
+            global_attrs={},
+            crs_wkt=srs.ExportToWkt(),
+        )
+        md = gdal.Open(str(out)).GetMetadata()
+        assert md.get("x#standard_name") == "longitude", md.get("x#standard_name")
+        assert md.get("x#axis") == "X"
+        assert md.get("temp#grid_mapping"), "data var should reference a grid_mapping"
+
     def test_units_attr_is_routed_to_the_unit_slot(self, tmp_path):
         """A ``units`` attribute is applied via ``SetUnit``, not as a plain attr.
 
@@ -674,6 +703,15 @@ class TestCfCoordinateHelpers:
         assert out is not None, "expected a parsed SRS"
         assert out.IsGeographic(), "expected a geographic SRS"
 
+    def test_srs_from_wkt_non_str_returns_none(self):
+        """A non-str, non-falsy input degrades to None instead of raising TypeError.
+
+        Test scenario:
+            Passing an int (outside the ``str | None`` contract) is caught and
+            returns None rather than propagating ``TypeError``.
+        """
+        assert interop.srs_from_wkt(12345) is None
+
     def test_cf_coord_attrs_geographic_x(self):
         """A geographic x axis gets degrees_east / longitude / X.
 
@@ -778,6 +816,22 @@ class TestCfCoordinateHelpers:
         ds = xr.Dataset(
             {"t": (("y", "x"), np.zeros((2, 2)))},
             coords={"spatial_ref": ((), 0, {"crs_wkt": wkt})},
+        )
+        assert interop._crs_wkt_from_xarray(ds) == wkt
+
+    def test_crs_wkt_from_xarray_crs_var_spatial_ref_attr(self):
+        """The CRS is read from a `crs` variable's `spatial_ref` attribute (fallback name/attr).
+
+        Test scenario:
+            No `spatial_ref` variable and no `crs_wkt` attr — a `crs` variable whose
+            `spatial_ref` attribute holds the WKT is used (exercises both the second
+            variable name and the `spatial_ref`-attr fallback).
+        """
+        xr = pytest.importorskip("xarray")
+        wkt = self._srs(4326).ExportToWkt()
+        ds = xr.Dataset(
+            {"t": (("y", "x"), np.zeros((2, 2)))},
+            coords={"crs": ((), 0, {"spatial_ref": wkt})},
         )
         assert interop._crs_wkt_from_xarray(ds) == wkt
 

--- a/tests/netcdf/test_interop_write_multidim.py
+++ b/tests/netcdf/test_interop_write_multidim.py
@@ -721,7 +721,9 @@ class TestCfCoordinateHelpers:
             A caller `long_name` and a temporal `units` override the CF defaults
             while the `axis` role is still added.
         """
-        out = interop._cf_coord_attrs("x", {"long_name": "custom"}, {"units": "special"}, None)
+        out = interop._cf_coord_attrs(
+            "x", {"long_name": "custom"}, {"units": "special"}, None
+        )
         assert out["long_name"] == "custom", out
         assert out["units"] == "special"
         assert out["axis"] == "X"

--- a/tests/netcdf/test_interop_write_multidim.py
+++ b/tests/netcdf/test_interop_write_multidim.py
@@ -652,7 +652,7 @@ class TestCfCoordinateHelpers:
             wkt: The falsy input (None or empty string).
 
         Test scenario:
-            `_srs_from_wkt` returns None so the writers skip CF injection.
+            `srs_from_wkt` returns None so the writers skip CF injection.
         """
         assert interop.srs_from_wkt(wkt) is None, f"expected None for {wkt!r}"
 
@@ -725,20 +725,32 @@ class TestCfCoordinateHelpers:
         assert out["axis"] == "X"
 
     @pytest.mark.parametrize(
-        "name, expected_nonempty",
-        [("x", True), ("lon", True), ("y", True), ("time", True), ("band", False), ("z", False)],
+        "name, expected",
+        [
+            ("x", gdal.DIM_TYPE_HORIZONTAL_X),
+            ("lon", gdal.DIM_TYPE_HORIZONTAL_X),
+            ("longitude", gdal.DIM_TYPE_HORIZONTAL_X),
+            ("y", gdal.DIM_TYPE_HORIZONTAL_Y),
+            ("lat", gdal.DIM_TYPE_HORIZONTAL_Y),
+            ("time", gdal.DIM_TYPE_TEMPORAL),
+            ("t", gdal.DIM_TYPE_TEMPORAL),
+            ("band", ""),
+            ("z", ""),
+        ],
     )
-    def test_dim_type(self, name, expected_nonempty):
-        """Spatial/temporal names map to a GDAL dimension type; others map to ``""``.
+    def test_dim_type(self, name, expected):
+        """Each dimension name maps to the exact GDAL dimension type (or ``""``).
 
         Args:
             name: The dimension name.
-            expected_nonempty: Whether a non-empty type is expected.
+            expected: The GDAL dimension-type constant expected.
 
         Test scenario:
-            x/lon/y/time are typed; band/z are not.
+            x/lon/longitude -> HORIZONTAL_X, y/lat -> HORIZONTAL_Y, time/t -> TEMPORAL
+            (asserting the exact constant, so a transposed X/Y mapping would fail);
+            band/z -> "".
         """
-        assert bool(interop._dim_type(name)) is expected_nonempty, name
+        assert interop._dim_type(name) == expected, name
 
     def test_crs_wkt_from_xarray_global_attr(self):
         """The CRS is read from a `crs_wkt` global attribute.

--- a/tests/netcdf/test_interop_write_multidim.py
+++ b/tests/netcdf/test_interop_write_multidim.py
@@ -671,7 +671,8 @@ class TestCfCoordinateHelpers:
             A WGS84 WKT round-trips to a geographic SpatialReference.
         """
         out = interop.srs_from_wkt(self._srs(4326).ExportToWkt())
-        assert out is not None and out.IsGeographic(), "expected a geographic SRS"
+        assert out is not None, "expected a parsed SRS"
+        assert out.IsGeographic(), "expected a geographic SRS"
 
     def test_cf_coord_attrs_geographic_x(self):
         """A geographic x axis gets degrees_east / longitude / X.
@@ -701,7 +702,8 @@ class TestCfCoordinateHelpers:
             `_cf_coord_attrs('x', ..., srs=None)` writes `axis=X` and no `units`.
         """
         attrs = interop._cf_coord_attrs("x", {}, {}, None)
-        assert attrs["axis"] == "X" and "units" not in attrs, attrs
+        assert attrs["axis"] == "X", attrs
+        assert "units" not in attrs, attrs
 
     def test_cf_coord_attrs_non_spatial_untouched(self):
         """A non-spatial coordinate keeps only the caller's attributes.

--- a/tests/netcdf/test_interop_write_multidim.py
+++ b/tests/netcdf/test_interop_write_multidim.py
@@ -630,3 +630,147 @@ class TestCreateCopyToNetcdf:
         target = str(tmp_path / "x.nc")
         with pytest.raises(RuntimeError, match="Failed to write NetCDF"):
             _create_copy_to_netcdf(mem, target)
+
+
+class TestCfCoordinateHelpers:
+    """Unit tests for the CF-coordinate / grid_mapping helpers (#1017)."""
+
+    @staticmethod
+    def _srs(epsg):
+        """Build an OGR SpatialReference for ``epsg``."""
+        from osgeo import osr
+
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(epsg)
+        return srs
+
+    @pytest.mark.parametrize("wkt", [None, ""])
+    def test_srs_from_wkt_absent_returns_none(self, wkt):
+        """A falsy WKT yields None (no CRS to inject).
+
+        Args:
+            wkt: The falsy input (None or empty string).
+
+        Test scenario:
+            `_srs_from_wkt` returns None so the writers skip CF injection.
+        """
+        assert interop._srs_from_wkt(wkt) is None, f"expected None for {wkt!r}"
+
+    def test_srs_from_wkt_invalid_returns_none(self):
+        """An unparseable WKT string yields None rather than raising.
+
+        Test scenario:
+            `ImportFromWkt` fails, so the helper returns None (defensive).
+        """
+        assert interop._srs_from_wkt("not a wkt") is None
+
+    def test_srs_from_wkt_valid(self):
+        """A valid WKT parses to a usable SpatialReference.
+
+        Test scenario:
+            A WGS84 WKT round-trips to a geographic SpatialReference.
+        """
+        out = interop._srs_from_wkt(self._srs(4326).ExportToWkt())
+        assert out is not None and out.IsGeographic(), "expected a geographic SRS"
+
+    def test_cf_coord_attrs_geographic_x(self):
+        """A geographic x axis gets degrees_east / longitude / X.
+
+        Test scenario:
+            `_cf_coord_attrs('x', ...)` with a geographic SRS.
+        """
+        attrs = interop._cf_coord_attrs("x", {}, {}, self._srs(4326))
+        assert attrs["units"] == "degrees_east", attrs
+        assert attrs["standard_name"] == "longitude"
+        assert attrs["axis"] == "X"
+
+    def test_cf_coord_attrs_projected_y(self):
+        """A projected y axis gets m / projection_y_coordinate / Y.
+
+        Test scenario:
+            `_cf_coord_attrs('y', ...)` with a projected SRS.
+        """
+        attrs = interop._cf_coord_attrs("y", {}, {}, self._srs(32632))
+        assert attrs["units"] == "m", attrs
+        assert attrs["standard_name"] == "projection_y_coordinate"
+
+    def test_cf_coord_attrs_no_crs_is_axis_only(self):
+        """Without a CRS a spatial axis gets only ``axis`` (no fabricated units).
+
+        Test scenario:
+            `_cf_coord_attrs('x', ..., srs=None)` writes `axis=X` and no `units`.
+        """
+        attrs = interop._cf_coord_attrs("x", {}, {}, None)
+        assert attrs["axis"] == "X" and "units" not in attrs, attrs
+
+    def test_cf_coord_attrs_non_spatial_untouched(self):
+        """A non-spatial coordinate keeps only the caller's attributes.
+
+        Test scenario:
+            `_cf_coord_attrs('band', {'foo': 'bar'}, ...)` injects nothing.
+        """
+        out = interop._cf_coord_attrs("band", {"foo": "bar"}, {}, None)
+        assert out == {"foo": "bar"}, out
+
+    def test_cf_coord_attrs_caller_and_temporal_win(self):
+        """Caller attributes and the temporal encoding win over the CF defaults.
+
+        Test scenario:
+            A caller `long_name` and a temporal `units` override the CF defaults
+            while the `axis` role is still added.
+        """
+        out = interop._cf_coord_attrs("x", {"long_name": "custom"}, {"units": "special"}, None)
+        assert out["long_name"] == "custom", out
+        assert out["units"] == "special"
+        assert out["axis"] == "X"
+
+    @pytest.mark.parametrize(
+        "name, expected_nonempty",
+        [("x", True), ("lon", True), ("y", True), ("time", True), ("band", False), ("z", False)],
+    )
+    def test_dim_type(self, name, expected_nonempty):
+        """Spatial/temporal names map to a GDAL dimension type; others map to ``""``.
+
+        Args:
+            name: The dimension name.
+            expected_nonempty: Whether a non-empty type is expected.
+
+        Test scenario:
+            x/lon/y/time are typed; band/z are not.
+        """
+        assert bool(interop._dim_type(name)) is expected_nonempty, name
+
+    def test_crs_wkt_from_xarray_global_attr(self):
+        """The CRS is read from a `crs_wkt` global attribute.
+
+        Test scenario:
+            An xarray dataset with only a `crs_wkt` attr resolves that WKT.
+        """
+        xr = pytest.importorskip("xarray")
+        wkt = self._srs(4326).ExportToWkt()
+        ds = xr.Dataset({"t": (("y", "x"), np.zeros((2, 2)))}, attrs={"crs_wkt": wkt})
+        assert interop._crs_wkt_from_xarray(ds) == wkt
+
+    def test_crs_wkt_from_xarray_spatial_ref_var(self):
+        """The CRS is read from a `spatial_ref` variable's `crs_wkt` attribute.
+
+        Test scenario:
+            An xarray dataset carrying a `spatial_ref` scalar with `crs_wkt`.
+        """
+        xr = pytest.importorskip("xarray")
+        wkt = self._srs(4326).ExportToWkt()
+        ds = xr.Dataset(
+            {"t": (("y", "x"), np.zeros((2, 2)))},
+            coords={"spatial_ref": ((), 0, {"crs_wkt": wkt})},
+        )
+        assert interop._crs_wkt_from_xarray(ds) == wkt
+
+    def test_crs_wkt_from_xarray_none_when_absent(self):
+        """A dataset with no CRS anywhere yields None.
+
+        Test scenario:
+            A bare xarray dataset resolves to None (from_xarray never fabricates one).
+        """
+        xr = pytest.importorskip("xarray")
+        ds = xr.Dataset({"t": (("y", "x"), np.zeros((2, 2)))})
+        assert interop._crs_wkt_from_xarray(ds) is None

--- a/tests/netcdf/test_netcdf_engines.py
+++ b/tests/netcdf/test_netcdf_engines.py
@@ -158,6 +158,35 @@ class TestInteropEngine:
         with pytest.raises(OptionalPackageDoesNotExist, match="xarray is required"):
             NetCDF.from_xarray(object())
 
+    def test_from_xarray_writes_cf_coords_from_crs(self, tmp_path):
+        """from_xarray of a CRS-bearing bare xarray writes CF x/y + a grid_mapping (#1017).
+
+        Test scenario:
+            A bare xarray with a ``crs_wkt`` global attribute — expected: the written
+            NetCDF's ``x``/``y`` carry CF ``units``/``standard_name`` and the data variable
+            references a ``grid_mapping`` variable, and the CRS round-trips (``variable_names
+            == ["temp"]``, no grid-mapping var leak).
+        """
+        xr = pytest.importorskip("xarray")
+        from osgeo import gdal, osr
+
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(4326)
+        ds = xr.Dataset(
+            {"temp": (("y", "x"), np.arange(20, dtype="float32").reshape(4, 5))},
+            coords={"x": np.arange(5) * 0.25 + 5.0, "y": 52.0 - np.arange(4) * 0.25},
+            attrs={"crs_wkt": srs.ExportToWkt()},
+        )
+        out = tmp_path / "fx.nc"
+        NetCDF.from_xarray(ds, path=str(out))
+        md = gdal.Open(str(out)).GetMetadata()
+        assert md.get("x#units") == "degrees_east", f"x#units={md.get('x#units')!r}"
+        assert md.get("x#standard_name") == "longitude"
+        assert md.get("temp#grid_mapping"), "data var should reference a grid_mapping"
+        reopened = NetCDF.read_file(str(out))
+        assert reopened.epsg == 4326, f"CRS did not round-trip: {reopened.epsg}"
+        assert reopened.variable_names == ["temp"], reopened.variable_names
+
 
 class TestVariablesEngine:
     """Edge / error branches of :class:`Variables`."""

--- a/tests/ugrid/test_io.py
+++ b/tests/ugrid/test_io.py
@@ -292,6 +292,41 @@ class TestWriteUgridTopology:
             err_msg="Node x-coordinates should match",
         )
 
+    def test_node_coords_carry_cf_attrs_and_crs_has_grid_mapping_name(self, tmp_path):
+        """With a CRS, node coords gain CF axis attrs and the crs var gets grid_mapping_name.
+
+        Test scenario:
+            Write a geographic mesh (EPSG:4326) — expected: ``mesh2d_node_x`` carries
+            ``degrees_east``/``longitude``/``X`` and ``mesh2d_node_y`` the latitude
+            counterparts, and the ``crs`` variable carries a CF ``grid_mapping_name``
+            (#1017).
+        """
+        from osgeo import osr
+
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(4326)
+        mesh = Mesh2d(
+            node_x=np.array([0.0, 1.0, 0.5]),
+            node_y=np.array([0.0, 0.0, 1.0]),
+            face_node_connectivity=Connectivity(
+                data=np.array([[0, 1, 2]], dtype=np.intp),
+                fill_value=-1,
+                cf_role="face_node_connectivity",
+                original_start_index=0,
+            ),
+        )
+        _, rg = self._write_and_reopen(tmp_path, mesh, crs_wkt=srs.ExportToWkt())
+        node_x = rg.OpenMDArray("mesh2d_node_x")
+        assert node_x.GetUnit() == "degrees_east", node_x.GetUnit()
+        x_attrs = _read_attributes(node_x)
+        assert x_attrs.get("axis") == "X"
+        assert x_attrs.get("standard_name") == "longitude"
+        node_y = rg.OpenMDArray("mesh2d_node_y")
+        assert node_y.GetUnit() == "degrees_north"
+        assert _read_attributes(node_y).get("axis") == "Y"
+        crs_attrs = _read_attributes(rg.OpenMDArray("crs"))
+        assert crs_attrs.get("grid_mapping_name") == "latitude_longitude", crs_attrs
+
     def test_writes_connectivity_with_fill_and_start_index(self, tmp_path):
         """Test that connectivity arrays have correct attributes.
 

--- a/tests/ugrid/test_io.py
+++ b/tests/ugrid/test_io.py
@@ -327,6 +327,38 @@ class TestWriteUgridTopology:
         crs_attrs = _read_attributes(rg.OpenMDArray("crs"))
         assert crs_attrs.get("grid_mapping_name") == "latitude_longitude", crs_attrs
 
+    def test_projected_crs_writes_grid_mapping_name_and_params(self, tmp_path):
+        """A projected mesh CRS gets metre coords + grid_mapping_name and CF params (L1/L2).
+
+        Test scenario:
+            UTM 32N (EPSG:32632) — expected: the node coords carry ``m`` /
+            ``projection_x_coordinate`` and the ``crs`` variable carries
+            ``grid_mapping_name="transverse_mercator"`` plus the CF projection params.
+        """
+        from osgeo import osr
+
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(32632)
+        mesh = Mesh2d(
+            node_x=np.array([0.0, 1.0, 0.5]),
+            node_y=np.array([0.0, 0.0, 1.0]),
+            face_node_connectivity=Connectivity(
+                data=np.array([[0, 1, 2]], dtype=np.intp),
+                fill_value=-1,
+                cf_role="face_node_connectivity",
+                original_start_index=0,
+            ),
+        )
+        _, rg = self._write_and_reopen(tmp_path, mesh, crs_wkt=srs.ExportToWkt())
+        node_x = rg.OpenMDArray("mesh2d_node_x")
+        assert node_x.GetUnit() == "m", node_x.GetUnit()
+        assert (
+            _read_attributes(node_x).get("standard_name") == "projection_x_coordinate"
+        )
+        crs_attrs = _read_attributes(rg.OpenMDArray("crs"))
+        assert crs_attrs.get("grid_mapping_name") == "transverse_mercator", crs_attrs
+        assert "false_easting" in crs_attrs, crs_attrs
+
     def test_writes_connectivity_with_fill_and_start_index(self, tmp_path):
         """Test that connectivity arrays have correct attributes.
 

--- a/tests/ugrid/test_io.py
+++ b/tests/ugrid/test_io.py
@@ -241,6 +241,20 @@ class TestWriteUgridTopology:
         rg2 = ds2.GetRootGroup()
         return nc_path, rg2
 
+    @staticmethod
+    def _tri_mesh():
+        """A single-triangle Mesh2d shared by the write tests."""
+        return Mesh2d(
+            node_x=np.array([0.0, 1.0, 0.5]),
+            node_y=np.array([0.0, 0.0, 1.0]),
+            face_node_connectivity=Connectivity(
+                data=np.array([[0, 1, 2]], dtype=np.intp),
+                fill_value=-1,
+                cf_role="face_node_connectivity",
+                original_start_index=0,
+            ),
+        )
+
     def test_writes_topology_variable_with_cf_role(self, tmp_path):
         """Test that the topology variable has cf_role=mesh_topology.
 
@@ -305,16 +319,7 @@ class TestWriteUgridTopology:
 
         srs = osr.SpatialReference()
         srs.ImportFromEPSG(4326)
-        mesh = Mesh2d(
-            node_x=np.array([0.0, 1.0, 0.5]),
-            node_y=np.array([0.0, 0.0, 1.0]),
-            face_node_connectivity=Connectivity(
-                data=np.array([[0, 1, 2]], dtype=np.intp),
-                fill_value=-1,
-                cf_role="face_node_connectivity",
-                original_start_index=0,
-            ),
-        )
+        mesh = self._tri_mesh()
         _, rg = self._write_and_reopen(tmp_path, mesh, crs_wkt=srs.ExportToWkt())
         node_x = rg.OpenMDArray("mesh2d_node_x")
         assert node_x.GetUnit() == "degrees_east", node_x.GetUnit()
@@ -339,16 +344,7 @@ class TestWriteUgridTopology:
 
         srs = osr.SpatialReference()
         srs.ImportFromEPSG(32632)
-        mesh = Mesh2d(
-            node_x=np.array([0.0, 1.0, 0.5]),
-            node_y=np.array([0.0, 0.0, 1.0]),
-            face_node_connectivity=Connectivity(
-                data=np.array([[0, 1, 2]], dtype=np.intp),
-                fill_value=-1,
-                cf_role="face_node_connectivity",
-                original_start_index=0,
-            ),
-        )
+        mesh = self._tri_mesh()
         _, rg = self._write_and_reopen(tmp_path, mesh, crs_wkt=srs.ExportToWkt())
         node_x = rg.OpenMDArray("mesh2d_node_x")
         assert node_x.GetUnit() == "m", node_x.GetUnit()


### PR DESCRIPTION
# Description

pyramids' *multidimensional* GDAL writers emitted coordinate variables with **empty attribute dicts** and never
wrote a CF `grid_mapping`, storing the CRS only in root attributes (`crs_wkt` / `epsg` / `GeoTransform`). A strict
CF reader (Panoply, ncview, QGIS-as-NetCDF, xarray with `decode_coords`) could not identify the axes — **Panoply
failed with "X-dimension index is not set"** — even though pyramids and GDAL read the files back fine. The
classic-raster `CreateCopy` writers were already CF-complete because GDAL's netCDF driver auto-generates that
metadata; only the multidim path was affected.

The fix is centralized in the two interop multidim writers (`_build_multidim` and `_build_streaming_multidim`),
which every affected path funnels through — so a single change covers `DatasetCollection.to_netcdf` **and** the
streaming raster ops (`NetCDF.crop` / `to_crs` / `resample` with `path=` on a root container):

- **CF coordinate attributes.** x/y gain `axis` / `standard_name` / `units` via `cf.build_coordinate_attrs`
  (degrees for geographic; metres and `projection_x/y_coordinate` for projected). The caller's own attributes and
  the temporal encoding still win; non-spatial coords (`band`) are untouched.
- **grid_mapping.** `SetSpatialRef` on each data MDArray makes GDAL's netCDF driver auto-generate a full CF
  `grid_mapping` variable (`grid_mapping_name` + `crs_wkt` + projection params) and link it via `<var>#grid_mapping`
  — the same mechanism `create_from_array` uses. The generated variable stays out of the multidim array listing, so
  it never leaks into `variable_names` / `get_variable_names`.
- **Dimension types.** The horizontal/temporal dimension types are declared so `SetSpatialRef` stops warning that
  it is *assuming* the last two dimensions are lon/lat.

The GeoZarr writer (`write_geobox`) gains the same CF x/y attributes and a `grid_mapping_name` on its `spatial_ref`
scalar.

The two remaining paths are also covered:

- **`from_xarray`** resolves the source's CRS (a `spatial_ref`/`crs` variable's `crs_wkt`/`spatial_ref` attribute,
  else a `crs_wkt` global attribute) and threads it into the multidim writer, so a bare-coordinate xarray that still
  carries a CRS gets CF x/y + a `grid_mapping` (a pre-existing scalar grid-mapping var is dropped so there is one; a
  source with no CRS is passed through unchanged — `from_xarray` never fabricates one).
- **UGRID** `write_ugrid_topology` stamps CF `axis`/`standard_name`/`units` on the node/face coordinate arrays and a
  `grid_mapping_name` (+ `spatial_ref`) on the `crs` variable.

**Back-compat is preserved:** the `GeoTransform` / `crs_wkt` / `epsg` root attrs are still written, the round-trip
read is unchanged (`variable_names == ['Band_1']`, correct `epsg` and geotransform), and the CRS now resolves via
the standard `grid_mapping`.

# Issues

- Closes #1017 — `to_netcdf` / streaming raster ops write CF-incomplete coordinates (bare x/y, no grid_mapping)

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Verified each writer's output against the CF view a tool like Panoply reads (classic-mode `GetMetadata`) and the
pyramids round-trip:

- Geographic (EPSG:4326): `x`=degrees_east/longitude/X, `y`=degrees_north/latitude/Y, `Band_1#grid_mapping`=`crs`
  with `crs_wkt` + ellipsoid params.
- Projected (EPSG:32632, UTM 32N): `x`/`y`=m/`projection_x/y_coordinate`, `Band_1#grid_mapping`=`transverse_mercator`.
- Streaming `resample(path=)`: same CF-complete output.
- Round-trip: `variable_names == ['Band_1']` (no grid-mapping var leak), `epsg`/geotransform preserved.
- GeoZarr: x/y carry CF axis attrs and `spatial_ref` carries `grid_mapping_name`.
- `from_xarray` of a CRS-bearing bare xarray: CF x/y + `grid_mapping`, round-trip `variable_names == ['temp']`.
- UGRID mesh: node/face coords carry CF axis attrs and the `crs` variable carries `grid_mapping_name`.

Automated (`--cov` omitted; unusable in this local env):

- [x] New regression tests: `test_to_netcdf.py::TestToNetcdfCfCoordinates` (geographic / projected coords,
  grid_mapping linked, no-leak round-trip, streaming op), `test_geobox_zarr.py::...::test_xy_carry_cf_axis_attrs...`,
  `test_netcdf_engines.py::...::test_from_xarray_writes_cf_coords_from_crs`, and
  `test_io.py::...::test_node_coords_carry_cf_attrs_and_crs_has_grid_mapping_name`
- [x] `tests/netcdf/` + `tests/dataset/collection/` + `tests/dataset/ops/` full sweep — 3226 passed, 38 skipped,
  0 failed; the ugrid + interop test areas green; mypy clean on the changed modules

# Checklist:

- [ ] updated version number in pyproject.toml. (handled by commitizen / release CI)
- [ ] added changes to History.rst. (generated by commitizen)
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated. (docstrings updated in-code; no user-facing docs affected)
