### PR TITLE
test(netcdf): complete no-data copy coverage for _add_md_array_to_group (#142)

### DIFF
--- a/tests/netcdf/unit/test_netcdf_unit_write.py
+++ b/tests/netcdf/unit/test_netcdf_unit_write.py
@@ -95,6 +95,35 @@ class TestMetaDataSetter:
 class TestAddMdArrayToGroupFallback:
     """Tests for _add_md_array_to_group NoData handling."""
 
+    @staticmethod
+    def _copy_elevation_with_nodata(nodata):
+        """Copy ``make_2d_nc``'s ``elevation`` into a fresh MEM group.
+
+        The source's ``GetNoDataValue`` is patched to ``nodata`` for the copy, so
+        the caller controls whether the source appears to define a no-data value.
+
+        Args:
+            nodata: The value ``GetNoDataValue`` should report on the source
+                (``None`` for a source with no no-data defined).
+
+        Returns:
+            The copied ``copied_var`` MDArray in the destination group.
+        """
+        nc = make_2d_nc()
+        src_arr = nc._raster.GetRootGroup().OpenMDArray("elevation")
+        dst_rg = (
+            gdal.GetDriverByName("MEM").CreateMultiDimensional("dst").GetRootGroup()
+        )
+        dtype = gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+        for d in src_arr.GetDimensions():
+            iv = d.GetIndexingVariable()
+            NetCDF.create_main_dimension(dst_rg, d.GetName(), dtype, iv.ReadAsArray())
+
+        with patch.object(type(src_arr), "GetNoDataValue", return_value=nodata):
+            NetCDF._add_md_array_to_group(dst_rg, "copied_var", src_arr)
+
+        return dst_rg.OpenMDArray("copied_var")
+
     def test_no_nodata_when_source_has_none(self):
         """When source has no nodata, the copy should also have no nodata.
 
@@ -102,25 +131,23 @@ class TestAddMdArrayToGroupFallback:
             Source variable with GetNoDataValue() returning None should
             not produce a phantom -9999 sentinel on the copy.
         """
-        nc = make_2d_nc()
-        src_rg = nc._raster.GetRootGroup()
-        src_arr = src_rg.OpenMDArray("elevation")
-
-        dst = gdal.GetDriverByName("MEM").CreateMultiDimensional("dst")
-        dst_rg = dst.GetRootGroup()
-        dtype = gdal.ExtendedDataType.Create(gdal.GDT_Float64)
-        for d in src_arr.GetDimensions():
-            iv = d.GetIndexingVariable()
-            NetCDF.create_main_dimension(dst_rg, d.GetName(), dtype, iv.ReadAsArray())
-
-        # Patch GetNoDataValue to return None (no nodata on source)
-        with patch.object(type(src_arr), "GetNoDataValue", return_value=None):
-            NetCDF._add_md_array_to_group(dst_rg, "copied_var", src_arr)
-
-        copied = dst_rg.OpenMDArray("copied_var")
+        copied = self._copy_elevation_with_nodata(None)
         assert copied is not None, "Copied variable should exist"
         ndv = copied.GetNoDataValue()
         assert ndv is None, f"Expected no nodata (None), got {ndv}"
+
+    def test_preserves_nodata_when_source_has_value(self):
+        """When source defines a nodata value, the copy should preserve it.
+
+        Test scenario:
+            Source variable with GetNoDataValue() returning a concrete value
+            (255.0) should carry that exact value onto the copy, not drop it
+            or replace it with a sentinel.
+        """
+        copied = self._copy_elevation_with_nodata(255.0)
+        assert copied is not None, "Copied variable should exist"
+        ndv = copied.GetNoDataValue()
+        assert ndv == pytest.approx(255.0), f"Expected nodata 255.0, got {ndv}"
 
 
 class TestSetVariableAttributes:

--- a/tests/netcdf/unit/test_netcdf_unit_write.py
+++ b/tests/netcdf/unit/test_netcdf_unit_write.py
@@ -128,7 +128,10 @@ class TestAddMdArrayToGroupFallback:
                 (``None`` for a source with no no-data defined).
             set_raises: When ``True``, the MDArray ``SetNoDataValueDouble`` is
                 patched to raise ``RuntimeError`` during the copy, exercising the
-                error-handling branch. Defaults to ``False``.
+                error-handling branch. The patch targets the shared ``gdal.MDArray``
+                class, so it also covers the destination array — whose
+                ``SetNoDataValueDouble`` is the call that actually raises. Defaults
+                to ``False``.
 
         Returns:
             The copied ``copied_var`` MDArray in the destination group.
@@ -192,14 +195,15 @@ class TestAddMdArrayToGroupFallback:
         ndv = copied.GetNoDataValue()
         assert ndv == pytest.approx(255.0), f"Expected nodata 255.0, got {ndv}"
 
-    def test_set_nodata_error_is_swallowed_without_sentinel(self):
-        """A GDAL error while setting no-data is swallowed; no sentinel is injected.
+    def test_set_nodata_error_is_swallowed(self):
+        """A GDAL error while setting the source no-data is swallowed, not propagated.
 
         Test scenario:
             The source reports a no-data value but SetNoDataValueDouble raises a
-            RuntimeError (a genuine GDAL failure). _add_md_array_to_group must not
-            propagate the error, and the copy ends up with no no-data value rather
-            than a phantom sentinel.
+            RuntimeError (a genuine GDAL failure). _add_md_array_to_group catches it
+            in its ``except (RuntimeError, TypeError, ValueError)`` branch, so the copy
+            is simply left with no no-data value instead of the error escaping. (Also
+            guards against a future regression that adds a sentinel fallback there.)
         """
         copied = self._copy_elevation_with_nodata(255.0, set_raises=True)
         assert copied is not None, "Copied variable should exist"

--- a/tests/netcdf/unit/test_netcdf_unit_write.py
+++ b/tests/netcdf/unit/test_netcdf_unit_write.py
@@ -93,6 +93,24 @@ class TestMetaDataSetter:
         )
 
 
+def _prepare_elevation_copy():
+    """Build ``make_2d_nc``'s ``elevation`` source and a matching empty MEM destination.
+
+    Returns:
+        A ``(src_arr, dst_rg)`` pair: the source ``elevation`` MDArray and a fresh
+        in-memory root group carrying its dimensions, ready to be passed to
+        ``NetCDF._add_md_array_to_group``.
+    """
+    nc = make_2d_nc()
+    src_arr = nc._raster.GetRootGroup().OpenMDArray("elevation")
+    dst_rg = gdal.GetDriverByName("MEM").CreateMultiDimensional("dst").GetRootGroup()
+    dtype = gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    for d in src_arr.GetDimensions():
+        iv = d.GetIndexingVariable()
+        NetCDF.create_main_dimension(dst_rg, d.GetName(), dtype, iv.ReadAsArray())
+    return src_arr, dst_rg
+
+
 class TestAddMdArrayToGroupFallback:
     """Tests for _add_md_array_to_group NoData handling."""
 
@@ -115,15 +133,7 @@ class TestAddMdArrayToGroupFallback:
         Returns:
             The copied ``copied_var`` MDArray in the destination group.
         """
-        nc = make_2d_nc()
-        src_arr = nc._raster.GetRootGroup().OpenMDArray("elevation")
-        dst_rg = (
-            gdal.GetDriverByName("MEM").CreateMultiDimensional("dst").GetRootGroup()
-        )
-        dtype = gdal.ExtendedDataType.Create(gdal.GDT_Float64)
-        for d in src_arr.GetDimensions():
-            iv = d.GetIndexingVariable()
-            NetCDF.create_main_dimension(dst_rg, d.GetName(), dtype, iv.ReadAsArray())
+        src_arr, dst_rg = _prepare_elevation_copy()
 
         with ExitStack() as stack:
             stack.enter_context(
@@ -140,6 +150,22 @@ class TestAddMdArrayToGroupFallback:
             NetCDF._add_md_array_to_group(dst_rg, "copied_var", src_arr)
 
         return dst_rg.OpenMDArray("copied_var")
+
+    def test_preserves_real_nodata_without_mocking(self):
+        """The real GDAL get/set round-trip carries the source's -9999.0 onto the copy.
+
+        Test scenario:
+            ``make_2d_nc``'s ``elevation`` carries a genuine ``no_data_value`` of
+            -9999.0. Copying it with no patching at all must preserve that exact value
+            on the copy, proving the real GetNoDataValue -> SetNoDataValueDouble
+            plumbing end to end rather than only the mocked contract.
+        """
+        src_arr, dst_rg = _prepare_elevation_copy()
+        NetCDF._add_md_array_to_group(dst_rg, "copied_var", src_arr)
+        copied = dst_rg.OpenMDArray("copied_var")
+        assert copied is not None, "Copied variable should exist"
+        ndv = copied.GetNoDataValue()
+        assert ndv == pytest.approx(-9999.0), f"Expected real nodata -9999.0, got {ndv}"
 
     def test_no_nodata_when_source_has_none(self):
         """When source has no nodata, the copy should also have no nodata.

--- a/tests/netcdf/unit/test_netcdf_unit_write.py
+++ b/tests/netcdf/unit/test_netcdf_unit_write.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import ExitStack
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -96,15 +97,20 @@ class TestAddMdArrayToGroupFallback:
     """Tests for _add_md_array_to_group NoData handling."""
 
     @staticmethod
-    def _copy_elevation_with_nodata(nodata):
+    def _copy_elevation_with_nodata(nodata, *, set_raises=False):
         """Copy ``make_2d_nc``'s ``elevation`` into a fresh MEM group.
 
         The source's ``GetNoDataValue`` is patched to ``nodata`` for the copy, so
         the caller controls whether the source appears to define a no-data value.
+        Patches are lifted before the copy is re-opened, so the returned array's
+        ``GetNoDataValue`` reports whatever ``_add_md_array_to_group`` actually set.
 
         Args:
             nodata: The value ``GetNoDataValue`` should report on the source
                 (``None`` for a source with no no-data defined).
+            set_raises: When ``True``, the MDArray ``SetNoDataValueDouble`` is
+                patched to raise ``RuntimeError`` during the copy, exercising the
+                error-handling branch. Defaults to ``False``.
 
         Returns:
             The copied ``copied_var`` MDArray in the destination group.
@@ -119,7 +125,18 @@ class TestAddMdArrayToGroupFallback:
             iv = d.GetIndexingVariable()
             NetCDF.create_main_dimension(dst_rg, d.GetName(), dtype, iv.ReadAsArray())
 
-        with patch.object(type(src_arr), "GetNoDataValue", return_value=nodata):
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch.object(type(src_arr), "GetNoDataValue", return_value=nodata)
+            )
+            if set_raises:
+                stack.enter_context(
+                    patch.object(
+                        type(src_arr),
+                        "SetNoDataValueDouble",
+                        side_effect=RuntimeError("simulated GDAL failure"),
+                    )
+                )
             NetCDF._add_md_array_to_group(dst_rg, "copied_var", src_arr)
 
         return dst_rg.OpenMDArray("copied_var")
@@ -148,6 +165,20 @@ class TestAddMdArrayToGroupFallback:
         assert copied is not None, "Copied variable should exist"
         ndv = copied.GetNoDataValue()
         assert ndv == pytest.approx(255.0), f"Expected nodata 255.0, got {ndv}"
+
+    def test_set_nodata_error_is_swallowed_without_sentinel(self):
+        """A GDAL error while setting no-data is swallowed; no sentinel is injected.
+
+        Test scenario:
+            The source reports a no-data value but SetNoDataValueDouble raises a
+            RuntimeError (a genuine GDAL failure). _add_md_array_to_group must not
+            propagate the error, and the copy ends up with no no-data value rather
+            than a phantom sentinel.
+        """
+        copied = self._copy_elevation_with_nodata(255.0, set_raises=True)
+        assert copied is not None, "Copied variable should exist"
+        ndv = copied.GetNoDataValue()
+        assert ndv is None, f"Expected no nodata after a swallowed error, got {ndv}"
 
 
 class TestSetVariableAttributes:


### PR DESCRIPTION
# Description

Completes the test coverage for issue #142 (`NetCDF._add_md_array_to_group` no-data handling on copy).

The bug the issue described — a bare `try/except Exception` that silently injected `-9999` when the source had no
no-data value — was **already fixed in the code** (commit `4ae1e942d`, PR #567), where the method was rewritten to
the guarded pattern:

```python
ndv = src_mdarray.GetNoDataValue()
if ndv is not None:
    try:
        new_md_array.SetNoDataValueDouble(ndv)
    except (RuntimeError, TypeError, ValueError):
        pass
```

There is no `-9999` fallback anywhere in `netcdf.py`. What remained open on the issue's Definition of Done was the
test coverage. **This PR is test-only** — it adds no production code — and closes that gap. `TestAddMdArrayToGroupFallback`
now exercises every no-data outcome of the copy:

- `test_no_nodata_when_source_has_none` — source reports `None` → copy has no no-data (no phantom sentinel).
- `test_preserves_nodata_when_source_has_value` — source reports a value → copy preserves it.
- `test_preserves_real_nodata_without_mocking` — the real GDAL get/set round-trip carries `make_2d_nc`'s genuine
  `-9999.0` onto the copy (no mocking), proving the actual plumbing rather than only the mocked contract.
- `test_set_nodata_error_is_swallowed` — a `SetNoDataValueDouble` GDAL error is caught by the `except` branch and the
  copy is simply left with no no-data value instead of the error escaping.

The shared source/destination setup is factored into a module-level `_prepare_elevation_copy` helper so the cases do
not duplicate it.

# Issues

- Closes #142 — `_add_md_array_to_group` no-data copy behavior (code fix already landed; this PR completes the tests).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue) — test-only; closes the bug issue's remaining DoD (no
  production code changed).
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All runs via the `dev` pixi environment on the branch worktree.

- The touched class: `pixi run -e dev pytest tests/netcdf/unit/test_netcdf_unit_write.py::TestAddMdArrayToGroupFallback -v`
  → **4 passed**.
- The full module: `pixi run -e dev pytest tests/netcdf/unit/test_netcdf_unit_write.py -q` → **24 passed**.
- The full non-plot suite: `pixi run -e dev pytest -m "not plot"` → **8475 passed, 53 skipped**. The single failure
  (`tests/io/test_archives.py::TestHttpsrequest::test_read_from_aws`) is an unrelated live-AWS `vfs` test that passes
  in isolation — a network flake, not caused by this diff.
- Two full review rounds (`/review-rounds`): round 1 raised one low + two nits (all fixed); round 2 was clean.

Reproduce:

- [x] `pytest tests/netcdf/unit/test_netcdf_unit_write.py::TestAddMdArrayToGroupFallback -v`
- [x] `pytest tests/netcdf/unit/test_netcdf_unit_write.py -q`

# Checklist:

- [ ] updated version number in pyproject.toml. — N/A (versions handled by commitizen in CI).
- [ ] added changes to History.rst. — N/A (changelog is commitizen-generated).
- [ ] updated the latest version in README file. — N/A.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated. — N/A (test-only change).
