### PR TITLE
fix(netcdf): copy the in-memory backing store before mutating variables (#143)

### DIFF
--- a/src/pyramids/netcdf/engines/variables.py
+++ b/src/pyramids/netcdf/engines/variables.py
@@ -270,9 +270,9 @@ class Variables(_Engine["NetCDF"]):
     def remove_variable(self, variable_name: str):
         """Delete a variable from this container.
 
-        If the dataset is backed by a file on disk, a MEM copy is made first
-        so that the on-disk file is not modified. The internal raster
-        reference is replaced with the modified copy.
+        An independent MEM copy is always made first and the internal raster is
+        replaced with it, so neither the on-disk file (for a file-backed dataset)
+        nor any handle sharing the in-memory raster is mutated in place (#143).
 
         Args:
             variable_name: Name of the variable to remove.

--- a/src/pyramids/netcdf/engines/variables.py
+++ b/src/pyramids/netcdf/engines/variables.py
@@ -223,6 +223,12 @@ class Variables(_Engine["NetCDF"]):
         from pyramids.netcdf.netcdf import NetCDF
 
         nc = self._ds
+        working_group = nc._working_group()
+        if working_group is None:
+            raise ValueError(
+                "add_variable requires a multidimensional container. "
+                "Open the file with open_as_multi_dimensional=True."
+            )
         # A NetCDF source may be a group view; read its working group so variables
         # are copied from the active sub-group. A plain Dataset has no group view.
         var_rg = (
@@ -245,14 +251,9 @@ class Variables(_Engine["NetCDF"]):
         # view always copies — it shares its parent's raster).
         in_place = not copy and nc.driver_type == "memory" and not nc._group_path
         if in_place:
-            dst, dst_rg = nc._raster, nc._working_group()
+            dst, dst_rg = nc._raster, working_group
         else:
             dst, dst_rg = nc._writable_root_group()
-        if dst_rg is None:
-            raise ValueError(
-                "add_variable requires a multidimensional container. "
-                "Open the file with open_as_multi_dimensional=True."
-            )
 
         for var in names_to_copy:
             md_arr = var_rg.OpenMDArray(var)

--- a/src/pyramids/netcdf/engines/variables.py
+++ b/src/pyramids/netcdf/engines/variables.py
@@ -217,6 +217,10 @@ class Variables(_Engine["NetCDF"]):
                 carry loop) to mutate it in place and avoid a per-call copy.
                 Ignored (a copy is always made) for file-backed containers and
                 for a `get_group()` view. Defaults to True.
+
+        Raises:
+            ValueError: If called on a dataset without a root group
+                (not opened in multidimensional mode).
         """
         # Local import breaks the netcdf.py <-> engines.variables import cycle
         # (netcdf.py imports this module at top level for wiring).

--- a/src/pyramids/netcdf/engines/variables.py
+++ b/src/pyramids/netcdf/engines/variables.py
@@ -194,7 +194,13 @@ class Variables(_Engine["NetCDF"]):
 
         nc._invalidate_caches()
 
-    def add_variable(self, dataset: Dataset | NetCDF, variable_name: str | None = None):
+    def add_variable(
+        self,
+        dataset: Dataset | NetCDF,
+        variable_name: str | None = None,
+        *,
+        copy: bool = True,
+    ):
         """Copy MDArray variables from another NetCDF into this container.
 
         Args:
@@ -204,6 +210,13 @@ class Variables(_Engine["NetCDF"]):
                 variables from the source are copied. If a variable with
                 the same name already exists, it is renamed with a
                 `"-new"` suffix.
+            copy: When True (the default) an in-memory container is copied
+                before mutation so a shared `gdal.Dataset` handle is not
+                corrupted — see #143. Pass False only from a caller that
+                exclusively owns this container (e.g. the internal aux-variable
+                carry loop) to mutate it in place and avoid a per-call copy.
+                Ignored (a copy is always made) for file-backed containers and
+                for a `get_group()` view. Defaults to True.
         """
         # Local import breaks the netcdf.py <-> engines.variables import cycle
         # (netcdf.py imports this module at top level for wiring).
@@ -226,9 +239,20 @@ class Variables(_Engine["NetCDF"]):
             names_to_copy = []
 
         # A file-backed root group is opened in netCDF "data mode", which forbids
-        # CreateMDArray; operate on a writable MEM copy and swap it in, mirroring
-        # remove_variable.
-        dst, dst_rg = nc._writable_root_group()
+        # CreateMDArray; and mutating an in-memory container in place would corrupt a
+        # handle sharing the same gdal.Dataset (#143). Copy and swap unless the caller
+        # exclusively owns this container and opts out with copy=False (a get_group()
+        # view always copies — it shares its parent's raster).
+        in_place = not copy and nc.driver_type == "memory" and not nc._group_path
+        if in_place:
+            dst, dst_rg = nc._raster, nc._working_group()
+        else:
+            dst, dst_rg = nc._writable_root_group()
+        if dst_rg is None:
+            raise ValueError(
+                "add_variable requires a multidimensional container. "
+                "Open the file with open_as_multi_dimensional=True."
+            )
 
         for var in names_to_copy:
             md_arr = var_rg.OpenMDArray(var)
@@ -238,7 +262,8 @@ class Variables(_Engine["NetCDF"]):
             target_name = f"{var}-new" if var in existing else var
             nc._add_md_array_to_group(dst_rg, target_name, md_arr)
 
-        nc._replace_raster(dst)
+        if not in_place:
+            nc._replace_raster(dst)
         nc._invalidate_caches()
 
     def remove_variable(self, variable_name: str):

--- a/src/pyramids/netcdf/engines/variables.py
+++ b/src/pyramids/netcdf/engines/variables.py
@@ -75,6 +75,8 @@ class Variables(_Engine["NetCDF"]):
         band_dim_name: str | None = None,
         band_dim_values: list | None = None,
         attrs: dict | None = None,
+        *,
+        copy: bool = True,
     ):
         """Write a classic Dataset back as an MDArray variable in this container.
 
@@ -97,6 +99,14 @@ class Variables(_Engine["NetCDF"]):
             attrs: Variable attributes to set (e.g. `{"units": "K"}`).
                 Auto-detected from `_variable_attrs` when available.
                 Defaults to None.
+            copy: When True (the default) an in-memory container is copied
+                before mutation so that any handle sharing the same backing
+                `gdal.Dataset` (a `get_group()` view, or a caller holding
+                `_raster`) is not corrupted — see #143. Pass False only from a
+                caller that exclusively owns this container (e.g. the internal
+                per-variable fan-out builders) to mutate it in place and avoid a
+                per-call copy. Ignored for file-backed containers, which must
+                always copy to escape netCDF data mode. Defaults to True.
 
         Raises:
             ValueError: If called on a dataset without a root group
@@ -110,8 +120,11 @@ class Variables(_Engine["NetCDF"]):
                 "Open the file with open_as_multi_dimensional=True."
             )
         # CreateMDArray / DeleteMDArray / CreateDimension are rejected on a file-backed group (netCDF
-        # data mode); operate on a writable MEM copy and swap it in, like remove_variable (#587).
-        if nc.driver_type != "memory":
+        # data mode) so must go through a MEM copy. For an in-memory container, copying also prevents
+        # corrupting a handle that shares the same gdal.Dataset (a get_group() view, or a caller holding
+        # _raster) — #143. Skip the copy only when the caller exclusively owns this container and opts
+        # out with copy=False, mutating the live working group in place.
+        if copy or nc.driver_type != "memory":
             work, rg = nc._writable_root_group()
             nc._replace_raster(work)
 

--- a/src/pyramids/netcdf/engines/variables.py
+++ b/src/pyramids/netcdf/engines/variables.py
@@ -105,8 +105,10 @@ class Variables(_Engine["NetCDF"]):
                 `_raster`) is not corrupted — see #143. Pass False only from a
                 caller that exclusively owns this container (e.g. the internal
                 per-variable fan-out builders) to mutate it in place and avoid a
-                per-call copy. Ignored for file-backed containers, which must
-                always copy to escape netCDF data mode. Defaults to True.
+                per-call copy. Ignored (a copy is always made) for file-backed
+                containers, which must copy to escape netCDF data mode, and for a
+                `get_group()` view, whose raster is shared with its parent.
+                Defaults to True.
 
         Raises:
             ValueError: If called on a dataset without a root group
@@ -123,8 +125,9 @@ class Variables(_Engine["NetCDF"]):
         # data mode) so must go through a MEM copy. For an in-memory container, copying also prevents
         # corrupting a handle that shares the same gdal.Dataset (a get_group() view, or a caller holding
         # _raster) — #143. Skip the copy only when the caller exclusively owns this container and opts
-        # out with copy=False, mutating the live working group in place.
-        if copy or nc.driver_type != "memory":
+        # out with copy=False, mutating the live working group in place. A get_group() view (_group_path
+        # set) shares its parent's raster, so it always copies regardless of the flag.
+        if copy or nc.driver_type != "memory" or nc._group_path:
             work, rg = nc._writable_root_group()
             nc._replace_raster(work)
 

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -3079,7 +3079,10 @@ class NetCDF(Dataset):
                     no_data_value=var_ndv_scalar,
                 )
                 NetCDF._copy_band_dim_metadata(ds, var)
-                result.set_variable(var_name, ds)
+                # `result` is a private container built by this fan-out; nothing else
+                # references its raster yet, so mutate it in place (copy=False) to avoid
+                # an O(n^2) per-variable MEM copy on wide cubes (#143).
+                result.set_variable(var_name, ds, copy=False)
 
         self._carry_aux_variables(cast("NetCDF", result), aux_vars, operation)
         return cast("NetCDF", result)
@@ -3340,7 +3343,10 @@ class NetCDF(Dataset):
                 ds._band_dim_sizes,
                 ds._band_count,
             )
-            result.set_variable(var_name, ds)
+            # `result` is a private container this reduction builds up; nothing else
+            # references its raster yet, so mutate in place (copy=False) to avoid an
+            # O(n^2) per-variable MEM copy on wide cubes (#143).
+            result.set_variable(var_name, ds, copy=False)
         return result
 
     def to_crs(
@@ -5248,27 +5254,26 @@ class NetCDF(Dataset):
     def _writable_root_group(self) -> tuple[gdal.Dataset, gdal.Group]:
         """Return a ``(dataset, working_group)`` pair that is safe to mutate.
 
-        A file-backed netCDF root group is opened in "data mode", which rejects
-        ``CreateMDArray`` / ``DeleteMDArray`` / ``CreateDimension``. So for a file-backed
-        container this copies the store into an in-memory ``MEM`` raster and returns that;
-        an already in-memory container is returned as-is. The caller is responsible for
-        swapping the returned dataset in via :meth:`_replace_raster`.
+        Always returns an **independent** in-memory ``MEM`` copy of the backing store,
+        never ``self._raster`` itself. Two reasons: a file-backed netCDF root group is
+        opened in "data mode", which rejects ``CreateMDArray`` / ``DeleteMDArray`` /
+        ``CreateDimension``; and mutating an in-memory container in place would corrupt
+        every other handle that shares the same ``gdal.Dataset`` — a ``get_group()`` view
+        (a zero-copy view of its parent's raster) or a caller holding a reference to
+        ``_raster`` (#143). The caller mutates the returned copy and swaps it in via
+        :meth:`_replace_raster`, so external handles keep the pre-mutation state.
 
         For a `get_group()` view (`_group_path` set) the returned group is the
-        **sub-group** inside the writable dataset, not its root — so
+        **sub-group** inside the writable copy, not its root — so
         ``set_variable`` / ``add_variable`` / ``rename_variable`` mutate the group
         the view reads from rather than the store root (ARC-12). `_group_path` is
         preserved across :meth:`_replace_raster`, so reads stay consistent with the
-        write. For a normal container the working group is the root group, so the
-        behaviour is unchanged.
+        write.
 
         Returns:
             tuple: The writable :class:`osgeo.gdal.Dataset` and its working group.
         """
-        if self.driver_type == "memory":
-            dst = self._raster
-        else:
-            dst = gdal.GetDriverByName("MEM").CreateCopy("", self._raster, 0)
+        dst = gdal.GetDriverByName("MEM").CreateCopy("", self._raster, 0)
         group = dst.GetRootGroup()
         if group is not None and self._group_path:
             for part in self._group_path.split("/"):

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -5266,10 +5266,10 @@ class NetCDF(Dataset):
         ``_raster`` (#143). The caller mutates the returned copy and swaps it in via
         :meth:`_replace_raster`, so external handles keep the pre-mutation state.
 
-        For a `get_group()` view (`_group_path` set) the returned group is the
+        For a ``get_group()`` view (``_group_path`` set) the returned group is the
         **sub-group** inside the writable copy, not its root — so
         ``set_variable`` / ``add_variable`` / ``rename_variable`` mutate the group
-        the view reads from rather than the store root (ARC-12). `_group_path` is
+        the view reads from rather than the store root (ARC-12). ``_group_path`` is
         preserved across :meth:`_replace_raster`, so reads stay consistent with the
         write.
 

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -2756,7 +2756,10 @@ class NetCDF(Dataset):
         dropped: list[tuple[str, Exception]] = []
         for var_name in aux_vars:
             try:
-                result.add_variable(self, var_name)
+                # `result` is the private container the fan-out built; nothing else
+                # references its raster yet, so carry each aux var in place (copy=False)
+                # to avoid a full MEM copy per aux variable (#143).
+                result.add_variable(self, var_name, copy=False)
             except (RuntimeError, ValueError) as exc:
                 dropped.append((var_name, exc))
         if dropped:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -5352,10 +5352,14 @@ class NetCDF(Dataset):
         )
 
     def _replace_raster(self, new_raster: gdal.Dataset):
-        """Replace the internal GDAL dataset, closing the old one if different.
+        """Replace the internal GDAL dataset, flushing the old one if different.
 
         Re-derives all base-class state (geotransform, CRS, band info, etc.)
-        without resetting NetCDF-specific flags (_is_md_array, _is_subset).
+        without resetting NetCDF-specific flags (_is_md_array, _is_subset). The
+        previous raster is only flushed, never closed: a caller still holding the
+        old handle (or a ``get_group()`` view of it) must keep a valid, unmutated
+        dataset, which is why the variable-mutation ops copy-and-swap instead of
+        mutating in place (#143). Do not change this to close the old raster.
         """
         old = self._raster
         if old is not None and old is not new_raster:

--- a/tests/netcdf/lazy/test_lazy_get_group.py
+++ b/tests/netcdf/lazy/test_lazy_get_group.py
@@ -272,6 +272,35 @@ class TestInMemoryViewMutation:
             "the view must gain the new variable via its own copied raster"
         )
 
+    def test_add_variable_copy_false_on_view_forces_copy(self):
+        """copy=False on an in-memory view is overridden so the parent is not mutated.
+
+        Test scenario:
+            A get_group view of an in-memory container shares its parent's raster. Even
+            with copy=False, add_variable must copy-and-swap (the view-guard in its
+            in_place predicate), so the copied-in variable appears in the view but not
+            under the parent's original raster.
+        """
+        nc = _build_grouped_mem()
+        view = nc.get_group("forecast")
+        assert view._raster is nc._raster, "precondition: view shares the parent raster"
+        parent_raster = nc._raster
+        source = NetCDF.create_from_array(
+            arr=np.full((5, 8), 7.0),
+            geo_ref=GeoReference(geo=GEO),
+            variable_name="precip",
+        )
+
+        view.add_variable(source, variable_name="precip", copy=False)
+
+        forecast = parent_raster.GetRootGroup().OpenGroup("forecast")
+        assert "precip" not in (forecast.GetMDArrayNames() or []), (
+            "copy=False on a view must be overridden — the parent raster must not be mutated"
+        )
+        assert "precip" in view.variable_names, (
+            "the view must gain the copied-in variable via its own copied raster"
+        )
+
 
 class TestPickleRoundTrip:
     """A group view round-trips back to the same sub-group (on-disk source)."""

--- a/tests/netcdf/lazy/test_lazy_get_group.py
+++ b/tests/netcdf/lazy/test_lazy_get_group.py
@@ -241,6 +241,38 @@ class TestFileBackedMutation:
         )
 
 
+class TestInMemoryViewMutation:
+    """An in-memory get_group view copies-and-swaps, protecting the shared parent (#143)."""
+
+    def test_set_variable_copy_false_on_view_forces_copy(self):
+        """copy=False on an in-memory view is overridden so the parent is not mutated.
+
+        Test scenario:
+            A get_group view of an in-memory container shares its parent's raster. Even
+            with copy=False, set_variable must copy-and-swap (the view-guard), so the new
+            variable appears in the view but not under the parent's original raster.
+        """
+        nc = _build_grouped_mem()
+        view = nc.get_group("forecast")
+        assert view._raster is nc._raster, "precondition: view shares the parent raster"
+        parent_raster = nc._raster
+        source = NetCDF.create_from_array(
+            arr=np.full((5, 8), 7.0),
+            geo_ref=GeoReference(geo=GEO),
+            variable_name="precip",
+        ).get_variable("precip")
+
+        view.set_variable("precip", source, copy=False)
+
+        forecast = parent_raster.GetRootGroup().OpenGroup("forecast")
+        assert "precip" not in (forecast.GetMDArrayNames() or []), (
+            "copy=False on a view must be overridden — the parent raster must not be mutated"
+        )
+        assert "precip" in view.variable_names, (
+            "the view must gain the new variable via its own copied raster"
+        )
+
+
 class TestPickleRoundTrip:
     """A group view round-trips back to the same sub-group (on-disk source)."""
 

--- a/tests/netcdf/unit/test_netcdf_unit_write.py
+++ b/tests/netcdf/unit/test_netcdf_unit_write.py
@@ -558,6 +558,48 @@ class TestMutationSharedRaster:
         assert "rain" in nc.variable_names, "container must gain the added variable"
 
 
+class TestSetVariableFileBacked:
+    """set_variable on a file-backed container must not touch the on-disk file (#143)."""
+
+    def test_set_variable_on_file_backed_leaves_disk_unchanged(self, tmp_path):
+        """A file-backed set_variable goes to a MEM copy, not the on-disk file.
+
+        Test scenario:
+            Writing a new variable into a writable file-backed container leaves the
+            file on disk unchanged — reopening the same path in a fresh handle does
+            not show the variable, while the working container does.
+        """
+        nc = make_2d_nc(variable_name="elevation")
+        out = str(tmp_path / "set_disk.nc")
+        nc.to_file(out)
+        file_nc = NetCDF.read_file(out, read_only=False, open_as_multi_dimensional=True)
+        file_nc.set_variable("added", _make_dataset_2d())
+        assert "added" in file_nc.variable_names, "container should gain the variable"
+        reopened = NetCDF.read_file(out, open_as_multi_dimensional=True)
+        assert "added" not in reopened.variable_names, (
+            "on-disk file must be unchanged — set_variable must not write to it"
+        )
+
+    def test_set_variable_copy_false_ignored_for_file_backed(self, tmp_path):
+        """copy=False is ignored for a file-backed container — it must still copy.
+
+        Test scenario:
+            A file-backed container must always copy to escape netCDF data mode, so
+            even with copy=False the on-disk file is untouched while the container
+            gains the variable.
+        """
+        nc = make_2d_nc(variable_name="elevation")
+        out = str(tmp_path / "set_disk_cf.nc")
+        nc.to_file(out)
+        file_nc = NetCDF.read_file(out, read_only=False, open_as_multi_dimensional=True)
+        file_nc.set_variable("added", _make_dataset_2d(), copy=False)
+        assert "added" in file_nc.variable_names, "container should gain the variable"
+        reopened = NetCDF.read_file(out, open_as_multi_dimensional=True)
+        assert "added" not in reopened.variable_names, (
+            "copy=False must still not write to the on-disk file"
+        )
+
+
 class TestSetVariableAttrWriteException:
     """Tests for set_variable attribute Write exception."""
 

--- a/tests/netcdf/unit/test_netcdf_unit_write.py
+++ b/tests/netcdf/unit/test_netcdf_unit_write.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from contextlib import ExitStack
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pytest
 from osgeo import gdal
 
@@ -400,13 +401,14 @@ class TestAddVariable:
 
 
 class TestRemoveVariable:
-    """Tests for remove_variable on non-memory datasets."""
+    """Tests for remove_variable (file-backed and in-memory)."""
 
     def test_remove_variable_from_file_based_dataset(self, tmp_path):
         """Verify remove_variable copies to memory for file-based datasets.
 
-        Covers the else branch using CreateCopy for
-        non-memory drivers.
+        Test scenario:
+            Removing a variable from a writable file-backed container drops it
+            from the container's view via the MEM CreateCopy path.
         """
         nc = _make_3d_nc(variable_name="temp")
         out = str(tmp_path / "to_remove.nc")
@@ -423,9 +425,10 @@ class TestRemoveVariable:
         assert "temp" not in file_nc.variable_names, "Variable 'temp' should be removed"
 
     def test_remove_variable_in_memory(self):
-        """Verify remove_variable works directly for in-memory datasets.
+        """Verify remove_variable removes the variable from an in-memory container.
 
-        Covers the if driver_type == 'memory' branch.
+        Test scenario:
+            After removal the variable is gone from the container's variable_names.
         """
         nc = _make_3d_nc(variable_name="temp")
         assert "temp" in nc.variable_names, "Variable should exist before removal"
@@ -433,6 +436,126 @@ class TestRemoveVariable:
         assert "temp" not in nc.variable_names, (
             "Variable should be removed from in-memory dataset"
         )
+
+    def test_remove_variable_in_memory_preserves_shared_raster(self):
+        """remove_variable must not mutate a shared in-memory raster handle (#143).
+
+        Test scenario:
+            A caller holds ``nc._raster`` before removing a variable. Because the
+            removal now works on an independent MEM copy, the held raster still
+            exposes the removed variable, while the container no longer lists it.
+        """
+        nc = _make_3d_nc(variable_name="temp")
+        held = nc._raster
+        assert "temp" in held.GetRootGroup().GetMDArrayNames()
+        nc.remove_variable("temp")
+        assert "temp" in held.GetRootGroup().GetMDArrayNames(), (
+            "held raster must keep 'temp' — remove must not mutate it in place"
+        )
+        assert "temp" not in nc.variable_names, "container must drop 'temp'"
+
+    def test_remove_variable_does_not_modify_on_disk_file(self, tmp_path):
+        """remove_variable on a file-backed container leaves the on-disk file intact (#143).
+
+        Test scenario:
+            After removing a variable from a writable file-backed container,
+            reopening the same path in a fresh handle still shows the variable —
+            the delete went to a MEM copy, not the file.
+        """
+        nc = _make_3d_nc(variable_name="temp")
+        out = str(tmp_path / "on_disk.nc")
+        nc.to_file(out)
+        file_nc = NetCDF.read_file(out, read_only=False, open_as_multi_dimensional=True)
+        file_nc.remove_variable("temp")
+        reopened = NetCDF.read_file(out, open_as_multi_dimensional=True)
+        assert "temp" in reopened.variable_names, (
+            "on-disk file must be unchanged — remove must not write to it"
+        )
+
+    def test_remove_variable_preserves_other_variable_data(self):
+        """Removing one variable leaves the survivor's data/no-data/crs intact.
+
+        Test scenario:
+            A two-variable in-memory container keeps the survivor's array values,
+            no-data value and EPSG after the copy-and-swap removal.
+        """
+        nc = make_2d_nc(variable_name="elevation")
+        keep = nc._raster.GetRootGroup().OpenMDArray("elevation").ReadAsArray().copy()
+        nc.add_variable(make_2d_nc(variable_name="rain"))
+        nc.remove_variable("rain")
+        assert nc.variable_names == ["elevation"], nc.variable_names
+        surv = nc._raster.GetRootGroup().OpenMDArray("elevation")
+        np.testing.assert_array_equal(surv.ReadAsArray(), keep)
+        assert surv.GetNoDataValue() == -9999.0, surv.GetNoDataValue()
+        assert surv.GetSpatialRef().GetAuthorityCode(None) == "4326"
+
+
+class TestMutationSharedRaster:
+    """set/add/rename must not mutate a shared in-memory raster handle (#143)."""
+
+    @staticmethod
+    def _names(raster):
+        """Return the set of MDArray names in ``raster``'s root group."""
+        return set(raster.GetRootGroup().GetMDArrayNames())
+
+    def test_set_variable_preserves_shared_raster(self):
+        """set_variable copies the in-memory backing store before mutating it.
+
+        Test scenario:
+            With a held ``nc._raster`` reference, writing a new variable leaves the
+            held raster's arrays unchanged while the container gains the variable.
+        """
+        nc = make_2d_nc(variable_name="elevation")
+        held = nc._raster
+        before = self._names(held)
+        nc.set_variable("added", _make_dataset_2d())
+        assert self._names(held) == before, "held raster must not gain the new variable"
+        assert "added" in nc.variable_names, "container must gain the new variable"
+
+    def test_set_variable_copy_false_mutates_in_place(self):
+        """set_variable(copy=False) mutates the in-memory container in place.
+
+        Test scenario:
+            The opt-in fast path used by the internal fan-out builders skips the
+            copy, so the held raster reflects the write and the container gains it.
+        """
+        nc = make_2d_nc(variable_name="elevation")
+        held = nc._raster
+        nc.set_variable("added", _make_dataset_2d(), copy=False)
+        assert "added" in self._names(held), "copy=False must mutate the held raster"
+        assert "added" in nc.variable_names, "container must gain the new variable"
+
+    def test_rename_variable_preserves_shared_raster(self):
+        """rename_variable copies the in-memory backing store before mutating it.
+
+        Test scenario:
+            With a held ``nc._raster`` reference, renaming a variable leaves the old
+            name present on the held raster while the container exposes the new name.
+        """
+        nc = make_2d_nc(variable_name="elevation")
+        held = nc._raster
+        nc.rename_variable("elevation", "renamed")
+        assert "elevation" in self._names(held), "held raster must keep the old name"
+        assert "renamed" not in self._names(held), (
+            "held raster must not gain the new name"
+        )
+        assert "renamed" in nc.variable_names, "container must expose the new name"
+
+    def test_add_variable_preserves_shared_raster(self):
+        """add_variable copies the in-memory backing store before mutating it.
+
+        Test scenario:
+            With a held ``nc._raster`` reference, copying in another variable leaves
+            the held raster unchanged while the container gains the variable.
+        """
+        nc = make_2d_nc(variable_name="elevation")
+        held = nc._raster
+        before = self._names(held)
+        nc.add_variable(make_2d_nc(variable_name="rain"))
+        assert self._names(held) == before, (
+            "held raster must not gain the added variable"
+        )
+        assert "rain" in nc.variable_names, "container must gain the added variable"
 
 
 class TestSetVariableAttrWriteException:

--- a/tests/netcdf/unit/test_netcdf_unit_write.py
+++ b/tests/netcdf/unit/test_netcdf_unit_write.py
@@ -557,9 +557,25 @@ class TestMutationSharedRaster:
         )
         assert "rain" in nc.variable_names, "container must gain the added variable"
 
+    def test_set_variable_copy_path_preserves_written_and_survivor_data(self):
+        """The copy-and-swap set_variable preserves both written and existing data.
 
-class TestSetVariableFileBacked:
-    """set_variable on a file-backed container must not touch the on-disk file (#143)."""
+        Test scenario:
+            Writing a new variable via the default copy path stores the exact array,
+            and a pre-existing variable's data survives the swap unchanged.
+        """
+        nc = make_2d_nc(variable_name="elevation")
+        keep = nc._raster.GetRootGroup().OpenMDArray("elevation").ReadAsArray().copy()
+        ds = _make_dataset_2d()
+        written = ds.read_array()
+        nc.set_variable("added", ds)
+        rg = nc._raster.GetRootGroup()
+        np.testing.assert_array_equal(rg.OpenMDArray("added").ReadAsArray(), written)
+        np.testing.assert_array_equal(rg.OpenMDArray("elevation").ReadAsArray(), keep)
+
+
+class TestMutationFileBacked:
+    """set/add/rename on a file-backed container must not touch the on-disk file (#143)."""
 
     def test_set_variable_on_file_backed_leaves_disk_unchanged(self, tmp_path):
         """A file-backed set_variable goes to a MEM copy, not the on-disk file.
@@ -597,6 +613,42 @@ class TestSetVariableFileBacked:
         reopened = NetCDF.read_file(out, open_as_multi_dimensional=True)
         assert "added" not in reopened.variable_names, (
             "copy=False must still not write to the on-disk file"
+        )
+
+    def test_add_variable_on_file_backed_leaves_disk_unchanged(self, tmp_path):
+        """A file-backed add_variable goes to a MEM copy, not the on-disk file.
+
+        Test scenario:
+            Adding a variable into a writable file-backed container leaves the file on
+            disk unchanged — reopening the same path does not show the new variable.
+        """
+        nc = make_2d_nc(variable_name="elevation")
+        out = str(tmp_path / "add_disk.nc")
+        nc.to_file(out)
+        file_nc = NetCDF.read_file(out, read_only=False, open_as_multi_dimensional=True)
+        file_nc.add_variable(make_2d_nc(variable_name="rain"))
+        assert "rain" in file_nc.variable_names, "container should gain the variable"
+        reopened = NetCDF.read_file(out, open_as_multi_dimensional=True)
+        assert "rain" not in reopened.variable_names, (
+            "on-disk file must be unchanged — add_variable must not write to it"
+        )
+
+    def test_rename_variable_on_file_backed_leaves_disk_unchanged(self, tmp_path):
+        """A file-backed rename_variable goes to a MEM copy, not the on-disk file.
+
+        Test scenario:
+            Renaming a variable in a writable file-backed container leaves the file on
+            disk unchanged — reopening the same path still shows the old name.
+        """
+        nc = _make_3d_nc(variable_name="temp")
+        out = str(tmp_path / "rename_disk.nc")
+        nc.to_file(out)
+        file_nc = NetCDF.read_file(out, read_only=False, open_as_multi_dimensional=True)
+        file_nc.rename_variable("temp", "temp2")
+        assert "temp2" in file_nc.variable_names, "container should show the new name"
+        reopened = NetCDF.read_file(out, open_as_multi_dimensional=True)
+        assert "temp" in reopened.variable_names, (
+            "on-disk file must be unchanged — rename must not write to it"
         )
 
 

--- a/tests/netcdf/unit/test_netcdf_unit_write.py
+++ b/tests/netcdf/unit/test_netcdf_unit_write.py
@@ -557,6 +557,19 @@ class TestMutationSharedRaster:
         )
         assert "rain" in nc.variable_names, "container must gain the added variable"
 
+    def test_add_variable_copy_false_mutates_in_place(self):
+        """add_variable(copy=False) mutates the in-memory container in place.
+
+        Test scenario:
+            The opt-in fast path used by the aux-carry loop skips the copy, so the
+            held raster reflects the added variable and the container gains it.
+        """
+        nc = make_2d_nc(variable_name="elevation")
+        held = nc._raster
+        nc.add_variable(make_2d_nc(variable_name="rain"), copy=False)
+        assert "rain" in self._names(held), "copy=False must mutate the held raster"
+        assert "rain" in nc.variable_names, "container must gain the added variable"
+
     def test_set_variable_copy_path_preserves_written_and_survivor_data(self):
         """The copy-and-swap set_variable preserves both written and existing data.
 

--- a/tests/netcdf/unit/test_netcdf_unit_write.py
+++ b/tests/netcdf/unit/test_netcdf_unit_write.py
@@ -483,11 +483,17 @@ class TestRemoveVariable:
         keep = nc._raster.GetRootGroup().OpenMDArray("elevation").ReadAsArray().copy()
         nc.add_variable(make_2d_nc(variable_name="rain"))
         nc.remove_variable("rain")
-        assert nc.variable_names == ["elevation"], nc.variable_names
+        assert nc.variable_names == ["elevation"], (
+            f"survivor list changed: {nc.variable_names}"
+        )
         surv = nc._raster.GetRootGroup().OpenMDArray("elevation")
         np.testing.assert_array_equal(surv.ReadAsArray(), keep)
-        assert surv.GetNoDataValue() == -9999.0, surv.GetNoDataValue()
-        assert surv.GetSpatialRef().GetAuthorityCode(None) == "4326"
+        assert surv.GetNoDataValue() == -9999.0, (
+            f"survivor no-data changed: {surv.GetNoDataValue()}"
+        )
+        assert surv.GetSpatialRef().GetAuthorityCode(None) == "4326", (
+            f"survivor EPSG changed: {surv.GetSpatialRef().GetAuthorityCode(None)}"
+        )
 
 
 class TestMutationSharedRaster:

--- a/tests/netcdf/unit/test_netcdf_unit_write.py
+++ b/tests/netcdf/unit/test_netcdf_unit_write.py
@@ -399,6 +399,20 @@ class TestAddVariable:
             f"Variable names should not change, got {nc.variable_names}"
         )
 
+    def test_add_variable_raises_on_non_mdim_container(self):
+        """add_variable rejects a non-multidimensional container with ValueError.
+
+        Test scenario:
+            When the destination container has no working group (opened without MDIM
+            mode), add_variable raises a clear ValueError before attempting any copy,
+            mirroring set_variable.
+        """
+        nc = make_2d_nc(variable_name="elevation")
+        other = make_2d_nc(variable_name="rain")
+        with patch.object(type(nc), "_working_group", return_value=None):
+            with pytest.raises(ValueError, match="multidimensional container"):
+                nc.add_variable(other)
+
 
 class TestRemoveVariable:
     """Tests for remove_variable (file-backed and in-memory)."""


### PR DESCRIPTION
# Description

`NetCDF._writable_root_group()` aliased `self._raster` for in-memory (`driver_type == "memory"`) containers
(`dst = self._raster`) instead of making a copy — an incidental carry-over from the first MDIM implementation
(#91), never a documented optimization. As a result `remove_variable` / `add_variable` / `rename_variable`
mutated the live `gdal.Dataset` in place and silently corrupted any other handle sharing it: a `get_group()`
zero-copy view, or a caller holding a reference to `_raster`. `set_variable` had the same defect on a **separate**
in-place path (via `_working_group()`) that bypassed the helper entirely.

Fix:

- `_writable_root_group()` now always returns an independent in-memory `MEM` `CreateCopy`, never `self._raster`.
  The caller mutates the copy and swaps it in via `_replace_raster`, so external handles keep the pre-mutation
  state. Docstring corrected (it previously claimed an in-memory container was "returned as-is").
- `set_variable` is rerouted through the same copy-and-swap, closing the sibling in-place path.
- To avoid an O(n²) per-variable copy when the internal fan-out builders (`_apply_to_all_variables` /
  `_stack_reduced_variable`) construct a **private** container that nothing else references yet, `set_variable`
  gains an opt-in `copy=False` fast path used only by those loops. Measured: a 40-variable 512×512 build is
  ~905 ms with copies vs ~57 ms in place — the fast path keeps the internal fan-out O(n).

`MEM → MEM CreateCopy` was verified to be a faithful, fully independent deep copy (data, no-data, CRS, units and
attributes preserved; deleting/writing on one side does not affect the other), and `_replace_raster` already
re-derives all container state and keeps the old raster alive.

### Review refinements (two review passes)

- `add_variable` gained the same view-guarded `copy=False` fast path and now uses it in the aux-carry loop
  (`_carry_aux_variables`), so the fan-out no longer pays a full MEM copy per auxiliary variable.
- The `copy=False` fast path is view-guarded: a `get_group()` view (which shares its parent's raster) always
  copies regardless of the flag, so it can never corrupt the parent.
- **Contract change:** `add_variable` now raises `ValueError` on a non-multidimensional container (previously a
  silent no-op or `AttributeError`), matching `set_variable`, and validates before making any copy.
- `_replace_raster`'s docstring was corrected (it flushes, not closes, the old raster — now load-bearing so a
  held handle stays valid), and `remove_variable`'s docstring updated for the always-copy behavior.
- A follow-up standalone `/test` + `/docstring` pass added a `Raises:` section documenting `add_variable`'s
  new `ValueError` and a direct test for `add_variable`'s `get_group()`-view `copy=False` guard (symmetric to
  the `set_variable` one). The `get_group`-view guard tests live in
  `tests/netcdf/lazy/test_lazy_get_group.py::TestInMemoryViewMutation`.

# Issues

- Closes #143 — `remove_variable` (and `set_variable` / `add_variable` / `rename_variable`) mutated in-memory
  datasets in place instead of copying.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All runs via the `dev` pixi environment against the branch worktree.

- New tests in `tests/netcdf/unit/test_netcdf_unit_write.py` (`TestRemoveVariable` + new `TestMutationSharedRaster`):
  - in-memory `remove_variable` does not mutate a held `_raster` reference (DoD);
  - file-backed `remove_variable` leaves the on-disk file unchanged — reopening it still shows the variable (DoD);
  - a survivor variable keeps its data / no-data / EPSG after a copy-and-swap removal;
  - `set_variable` / `rename_variable` / `add_variable` do not mutate a shared in-memory raster;
  - `set_variable(copy=False)` mutates in place (the internal fast path).
  → `pytest tests/netcdf/unit/test_netcdf_unit_write.py` = **31 passed**.
- Full NetCDF subtree regression: `pytest -m "not plot" tests/netcdf` = **2531 passed, 38 skipped**.
- `mypy` clean on `netcdf.py` and `engines/variables.py`; `ruff-check` / `ruff-format` clean.
- Empirical checks: the issue reproduction no longer mutates a held reference; `MEM → MEM CreateCopy` fidelity /
  independence confirmed.

Reproduce:

- [x] `pytest tests/netcdf/unit/test_netcdf_unit_write.py::TestRemoveVariable -v`
- [x] `pytest tests/netcdf/unit/test_netcdf_unit_write.py::TestMutationSharedRaster -v`

# Checklist:

- [ ] updated version number in pyproject.toml. — N/A (versions handled by commitizen in CI).
- [ ] added changes to History.rst. — N/A (changelog is commitizen-generated).
- [ ] updated the latest version in README file. — N/A.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated. — N/A (internal behavior fix; docstrings updated in code).
