### PR TITLE
refactor(io): decompose read_array into ReadRequest + ReadStrategy (S3776 cx 61)

### DIFF
--- a/src/pyramids/dataset/engines/_read_request.py
+++ b/src/pyramids/dataset/engines/_read_request.py
@@ -37,6 +37,33 @@ class ReadRequest:
         fill_value: Pad value for boundless reads.
         masked: Whether to wrap the result as a masked array.
         threadsafe: Whether to read through a private per-thread handle.
+
+    Examples:
+        - A valid full eager read of band 0 passes the matrix and keeps its fields:
+            ```python
+            >>> from pyramids.dataset.engines._read_request import ReadRequest
+            >>> req = ReadRequest(
+            ...     band=0, chunks=None, lock=None, out_shape=None,
+            ...     resampling="nearest", boundless=False, fill_value=None,
+            ...     masked=False, threadsafe=False,
+            ... )
+            >>> req.band
+            0
+
+            ```
+        - An illegal option pairing (a fill value without a boundless read) is
+          rejected at construction:
+            ```python
+            >>> from pyramids.dataset.engines._read_request import ReadRequest
+            >>> ReadRequest(
+            ...     band=0, chunks=None, lock=None, out_shape=None,
+            ...     resampling="nearest", boundless=False, fill_value=5.0,
+            ...     masked=False, threadsafe=False,
+            ... )
+            Traceback (most recent call last):
+            ValueError: read_array(fill_value=...) only applies to boundless reads; pass boundless=True as well.
+
+            ```
     """
 
     band: int | None

--- a/src/pyramids/dataset/engines/_read_request.py
+++ b/src/pyramids/dataset/engines/_read_request.py
@@ -1,0 +1,93 @@
+"""The read-option request object for ``Dataset.read_array``.
+
+``read_array`` accepts a dozen loosely-coupled options (``chunks``, ``out_shape``,
+``boundless``, ``threadsafe``, ``masked``, ``fill_value``, ``resampling`` …) whose
+*combinations* are what decide which read path runs and which pairings are
+rejected. Grouping them into one frozen value object lets the whole
+option-compatibility matrix live in a single ``__post_init__`` instead of being
+inlined at the head of ``read_array``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ReadRequest:
+    """A validated bundle of ``read_array`` options plus the resolved read target.
+
+    ``__post_init__`` enforces the *option-combination* invariants that hold
+    regardless of which read path runs (the pairings that are never legal). It is
+    built from the raw options *before* the ``bbox``/``window`` are resolved, so
+    these guards keep firing ahead of window resolution exactly as they did inline.
+    The per-path preconditions that depend on the resolved ``window`` (e.g.
+    ``chunks=`` with a ``window=``) are enforced by each
+    :class:`~pyramids.dataset.engines._read_strategies.ReadStrategy`, which receives
+    the resolved window separately, so this stays the cross-cutting matrix only.
+
+    Attributes:
+        band: The 0-based band index to read, or ``None`` for all bands.
+        chunks: Dask chunk spec; non-``None`` selects the lazy path.
+        lock: Dask read lock (lazy path only).
+        out_shape: ``(rows, cols)`` decimated output shape, or ``None``.
+        resampling: Resampling name; only meaningful together with ``out_shape``.
+        boundless: Whether to pad reads that extend past the raster edge.
+        fill_value: Pad value for boundless reads.
+        masked: Whether to wrap the result as a masked array.
+        threadsafe: Whether to read through a private per-thread handle.
+    """
+
+    band: int | None
+    chunks: int | tuple | dict | str | None
+    lock: Any
+    out_shape: tuple[int, int] | None
+    resampling: str
+    boundless: bool
+    fill_value: float | None
+    masked: bool
+    threadsafe: bool
+
+    def __post_init__(self) -> None:
+        """Reject the option pairings that are never legal (see class docstring)."""
+        if self.fill_value is not None and not self.boundless:
+            raise ValueError(
+                "read_array(fill_value=...) only applies to boundless reads; "
+                "pass boundless=True as well."
+            )
+        if self.boundless and self.chunks is not None:
+            raise ValueError(
+                "read_array(chunks=..., boundless=True) is not supported; "
+                "boundless fills apply to eager windowed reads only."
+            )
+        if self.boundless and self.out_shape is not None:
+            raise NotImplementedError(
+                "read_array(out_shape=...) is not supported together with "
+                "boundless=True; decimated boundless reads are not combined "
+                "yet. Read boundless at native resolution and decimate the "
+                "result yourself."
+            )
+        if self.boundless and self.threadsafe:
+            raise NotImplementedError(
+                "read_array(boundless=True) is not supported together with "
+                "threadsafe=True; the boundless read uses the shared handle, "
+                "defeating the per-thread isolation. Read boundless without "
+                "threadsafe, or pad the result yourself."
+            )
+        if self.out_shape is not None and self.threadsafe:
+            raise NotImplementedError(
+                "read_array(out_shape=...) is not supported together with "
+                "threadsafe=True; the decimated read uses the shared handle, "
+                "defeating the per-thread isolation. Read decimated without "
+                "threadsafe, or decimate a threadsafe full read yourself."
+            )
+        if (
+            self.out_shape is None
+            and isinstance(self.resampling, str)
+            and (self.resampling.strip().lower() != "nearest")
+        ):
+            raise ValueError(
+                "read_array(resampling=...) only applies to out_shape reads; "
+                "pass out_shape=(rows, cols) as well."
+            )

--- a/src/pyramids/dataset/engines/_read_strategies.py
+++ b/src/pyramids/dataset/engines/_read_strategies.py
@@ -38,6 +38,34 @@ class ReadStrategy(ABC):
         backend: The array backend a successful read on this path produces —
             ``"numpy"`` for eager paths, ``"dask"`` for the lazy path. Recorded on
             the dataset after the read so ``Dataset`` reports the right backend.
+
+    Examples:
+        - Selecting the path for a chunked (lazy) request picks the dask backend:
+            ```python
+            >>> from pyramids.dataset.engines._read_request import ReadRequest
+            >>> from pyramids.dataset.engines._read_strategies import READ_STRATEGIES
+            >>> req = ReadRequest(
+            ...     band=0, chunks=4, lock=None, out_shape=None,
+            ...     resampling="nearest", boundless=False, fill_value=None,
+            ...     masked=False, threadsafe=False,
+            ... )
+            >>> next(s for s in READ_STRATEGIES if s.matches(req)).backend
+            'dask'
+
+            ```
+        - A plain request falls through to the eager (numpy) path:
+            ```python
+            >>> from pyramids.dataset.engines._read_request import ReadRequest
+            >>> from pyramids.dataset.engines._read_strategies import READ_STRATEGIES
+            >>> req = ReadRequest(
+            ...     band=0, chunks=None, lock=None, out_shape=None,
+            ...     resampling="nearest", boundless=False, fill_value=None,
+            ...     masked=False, threadsafe=False,
+            ... )
+            >>> next(s for s in READ_STRATEGIES if s.matches(req)).backend
+            'numpy'
+
+            ```
     """
 
     backend: str

--- a/src/pyramids/dataset/engines/_read_strategies.py
+++ b/src/pyramids/dataset/engines/_read_strategies.py
@@ -75,7 +75,7 @@ class ReadStrategy(ABC):
         """Return whether this strategy handles ``req``'s option combination."""
 
     @abstractmethod
-    def read(self, io: "IO", req: ReadRequest, window: Any) -> Any:
+    def read(self, io: IO, req: ReadRequest, window: Any) -> Any:
         """Validate this path's preconditions and read through ``io``.
 
         Args:
@@ -97,7 +97,7 @@ class LazyRead(ReadStrategy):
         """Match when a dask ``chunks`` spec was given."""
         return req.chunks is not None
 
-    def read(self, io: "IO", req: ReadRequest, window: Any) -> Any:
+    def read(self, io: IO, req: ReadRequest, window: Any) -> Any:
         """Reject eager-only pairings, then build the lazy array."""
         if window is not None:
             raise ValueError(
@@ -130,7 +130,7 @@ class DecimatedRead(ReadStrategy):
         """Match when a decimated ``out_shape`` was given."""
         return req.out_shape is not None
 
-    def read(self, io: "IO", req: ReadRequest, window: Any) -> Any:
+    def read(self, io: IO, req: ReadRequest, window: Any) -> Any:
         """Reject masked decimation, then read at the requested shape."""
         if req.masked:
             raise NotImplementedError(
@@ -152,7 +152,7 @@ class BoundlessRead(ReadStrategy):
         """Match when boundless padding was requested."""
         return req.boundless
 
-    def read(self, io: "IO", req: ReadRequest, window: Any) -> Any:
+    def read(self, io: IO, req: ReadRequest, window: Any) -> Any:
         """Require a pixel window, reject masked boundless, then pad-read."""
         if req.masked:
             raise NotImplementedError(
@@ -184,7 +184,7 @@ class ThreadsafeRead(ReadStrategy):
         """Match when a per-thread isolated read was requested."""
         return req.threadsafe
 
-    def read(self, io: "IO", req: ReadRequest, window: Any) -> Any:
+    def read(self, io: IO, req: ReadRequest, window: Any) -> Any:
         """Reject masked thread-safe reads, then read via the per-thread handle."""
         if req.masked:
             raise NotImplementedError(
@@ -205,7 +205,7 @@ class EagerRead(ReadStrategy):
         """Always match — this is the fallback path."""
         return True
 
-    def read(self, io: "IO", req: ReadRequest, window: Any) -> Any:
+    def read(self, io: IO, req: ReadRequest, window: Any) -> Any:
         """Read all bands or a single band directly, optionally masking the result."""
         band = req.band
         arr: Any

--- a/src/pyramids/dataset/engines/_read_strategies.py
+++ b/src/pyramids/dataset/engines/_read_strategies.py
@@ -1,0 +1,229 @@
+"""Read-path strategies for ``Dataset.read_array``.
+
+``read_array`` picks exactly one read path from the resolved options: lazy
+(``chunks``), decimated (``out_shape``), boundless, thread-safe, or the default
+eager read. Each path is a :class:`ReadStrategy` that (a) declares when it
+:meth:`matches` a :class:`~pyramids.dataset.engines._read_request.ReadRequest`,
+(b) enforces its own per-path preconditions, (c) performs the read against the IO
+engine, and (d) names the array backend it produces. The dispatch collapses to:
+pick the first matching strategy, read, record the backend.
+
+The per-path preconditions live here (rather than on ``ReadRequest``) because they
+depend on the *resolved* ``window`` — the value ``read_array`` computes from
+``bbox``/``window`` and a polygon-to-pixel conversion just before dispatch and
+passes to :meth:`ReadStrategy.read` alongside the request. The strategy order in
+:data:`READ_STRATEGIES` reproduces the original ``if/elif`` ladder exactly, so the
+same input still raises the same error.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from geopandas.geodataframe import GeoDataFrame
+
+from pyramids.dataset.engines._read_request import ReadRequest
+from pyramids.dataset.engines._validate import validate_band_index
+
+if TYPE_CHECKING:
+    from pyramids.dataset.engines.io import IO
+
+
+class ReadStrategy(ABC):
+    """One read path: when it applies, how it reads, and what backend it yields.
+
+    Attributes:
+        backend: The array backend a successful read on this path produces —
+            ``"numpy"`` for eager paths, ``"dask"`` for the lazy path. Recorded on
+            the dataset after the read so ``Dataset`` reports the right backend.
+    """
+
+    backend: str
+
+    @abstractmethod
+    def matches(self, req: ReadRequest) -> bool:
+        """Return whether this strategy handles ``req``'s option combination."""
+
+    @abstractmethod
+    def read(self, io: "IO", req: ReadRequest, window: Any) -> Any:
+        """Validate this path's preconditions and read through ``io``.
+
+        Args:
+            io: The IO engine bound to the dataset being read.
+            req: The validated option bundle selecting this path.
+            window: The resolved read window — a pixel ``Window``, a
+                ``GeoDataFrame`` (an unconverted geometry window handed to the
+                boundless path), a ``[col_off, row_off, cols, rows]`` list, or
+                ``None`` for a full read.
+        """
+
+
+class LazyRead(ReadStrategy):
+    """Dask-backed lazy read, selected by ``chunks=``."""
+
+    backend = "dask"
+
+    def matches(self, req: ReadRequest) -> bool:
+        """Match when a dask ``chunks`` spec was given."""
+        return req.chunks is not None
+
+    def read(self, io: "IO", req: ReadRequest, window: Any) -> Any:
+        """Reject eager-only pairings, then build the lazy array."""
+        if window is not None:
+            raise ValueError(
+                "read_array(chunks=..., window=...) is not supported; "
+                "read lazily and slice the resulting dask array instead."
+            )
+        if req.out_shape is not None:
+            raise NotImplementedError(
+                "read_array(out_shape=...) is not supported together with "
+                "chunks=; decimate eagerly, or coarsen the dask array."
+            )
+        if req.masked:
+            raise NotImplementedError(
+                "read_array(masked=True) is not supported together with "
+                "chunks=; read eagerly, or mask the dask array yourself."
+            )
+        # ``matches`` only selected this path because a chunk spec was given.
+        assert req.chunks is not None
+        return io._lazy_read_array(
+            band=req.band, chunks=req.chunks, lock=req.lock, threadsafe=req.threadsafe
+        )
+
+
+class DecimatedRead(ReadStrategy):
+    """Overview-decimated read, selected by ``out_shape=``."""
+
+    backend = "numpy"
+
+    def matches(self, req: ReadRequest) -> bool:
+        """Match when a decimated ``out_shape`` was given."""
+        return req.out_shape is not None
+
+    def read(self, io: "IO", req: ReadRequest, window: Any) -> Any:
+        """Reject masked decimation, then read at the requested shape."""
+        if req.masked:
+            raise NotImplementedError(
+                "read_array(out_shape=...) is not supported together with "
+                "masked=True; decimation and masking are not combined yet. "
+                "Read decimated without masked, or mask the result yourself."
+            )
+        # ``matches`` only selected this path because an out_shape was given.
+        assert req.out_shape is not None
+        return io._decimated_read(req.band, window, req.out_shape, req.resampling)
+
+
+class BoundlessRead(ReadStrategy):
+    """Edge-padded windowed read, selected by ``boundless=True``."""
+
+    backend = "numpy"
+
+    def matches(self, req: ReadRequest) -> bool:
+        """Match when boundless padding was requested."""
+        return req.boundless
+
+    def read(self, io: "IO", req: ReadRequest, window: Any) -> Any:
+        """Require a pixel window, reject masked boundless, then pad-read."""
+        if req.masked:
+            raise NotImplementedError(
+                "read_array(boundless=True) is not supported together "
+                "with masked=True; boundless fills and masking are not "
+                "combined yet. Read boundless without masked, or mask the "
+                "result yourself."
+            )
+        if window is None:
+            raise ValueError(
+                "read_array(boundless=True) requires a window; a full read "
+                "cannot extend past the raster."
+            )
+        if isinstance(window, GeoDataFrame):
+            raise ValueError(
+                "boundless reads need a pixel window (Window or "
+                "[col_off, row_off, cols, rows] list); geometry windows "
+                "are clipped by definition."
+            )
+        return io._boundless_read(req.band, window, req.fill_value)
+
+
+class ThreadsafeRead(ReadStrategy):
+    """Eager read via a private per-thread handle, selected by ``threadsafe=True``."""
+
+    backend = "numpy"
+
+    def matches(self, req: ReadRequest) -> bool:
+        """Match when a per-thread isolated read was requested."""
+        return req.threadsafe
+
+    def read(self, io: "IO", req: ReadRequest, window: Any) -> Any:
+        """Reject masked thread-safe reads, then read via the per-thread handle."""
+        if req.masked:
+            raise NotImplementedError(
+                "read_array(threadsafe=True) is not supported together "
+                "with masked=True; the mask band would be read from the "
+                "shared handle, defeating the per-thread isolation. Read "
+                "masked without threadsafe, or mask the result yourself."
+            )
+        return io._threadsafe_eager_read(band=req.band, window=window)
+
+
+class EagerRead(ReadStrategy):
+    """The default eager read on the shared handle; matches everything else."""
+
+    backend = "numpy"
+
+    def matches(self, req: ReadRequest) -> bool:
+        """Always match — this is the fallback path."""
+        return True
+
+    def read(self, io: "IO", req: ReadRequest, window: Any) -> Any:
+        """Read all bands or a single band directly, optionally masking the result."""
+        band = req.band
+        arr: Any
+        # The shared handle is used directly here; the captured cloud config is
+        # already installed by read_array's @under_gdal_env decorator.
+        if band is None and io._ds.band_count > 1:
+            if window is None:
+                arr = np.ones(
+                    (io._ds.band_count, io._ds.rows, io._ds.columns),
+                    dtype=io._ds.numpy_dtype[0],
+                )
+                for i in range(io._ds.band_count):
+                    arr[i, :, :] = io._ds._raster.GetRasterBand(i + 1).ReadAsArray()
+            else:
+                # ``window`` here is a resolved pixel window (``Window`` or a
+                # ``[col_off, row_off, cols, rows]`` list — any geometry window was
+                # converted to one before dispatch). Stack per-band block reads so
+                # ``_read_block`` applies the identical window to every band without
+                # re-parsing its dimensions here.
+                arr = np.stack(
+                    [io._read_block(i, window) for i in range(io._ds.band_count)],
+                    axis=0,
+                )
+        else:
+            validate_band_index(band, io._ds.band_count)
+            if band is None:
+                band = 0
+            if window is None:
+                arr = io._ds._iloc(band).ReadAsArray()
+            else:
+                arr = io._read_block(band, window)
+        if req.masked:
+            arr = io._to_masked(arr, band, window=window)
+        return arr
+
+
+READ_STRATEGIES: tuple[ReadStrategy, ...] = (
+    LazyRead(),
+    DecimatedRead(),
+    BoundlessRead(),
+    ThreadsafeRead(),
+    EagerRead(),
+)
+"""The read paths in selection order (first :meth:`~ReadStrategy.matches` wins).
+
+The order reproduces ``read_array``'s original ``if chunks / elif out_shape / elif
+boundless / elif threadsafe / else`` ladder, so multi-option inputs still resolve
+to the same path and raise the same precondition error.
+"""

--- a/src/pyramids/dataset/engines/_read_window.py
+++ b/src/pyramids/dataset/engines/_read_window.py
@@ -60,7 +60,9 @@ def resolve_read_window(window: Any, bbox: Any, *, crs: Any) -> Any:
             ```
     """
     if bbox is None:
-        return window
-    if window is not None:
+        result = window
+    elif window is not None:
         raise ValueError("read_array accepts either `window` or `bbox`, not both")
-    return FeatureCollection.from_bbox(bbox, epsg=crs)
+    else:
+        result = FeatureCollection.from_bbox(bbox, epsg=crs)
+    return result

--- a/src/pyramids/dataset/engines/_read_window.py
+++ b/src/pyramids/dataset/engines/_read_window.py
@@ -1,0 +1,40 @@
+"""Shared `bbox`/`window` resolution for the raster read paths.
+
+`Dataset.read_array` (via the IO engine) and `NetCDF.read_array` both accept a
+mutually-exclusive `bbox=` / `window=` pair and fold a `bbox` into a one-row
+`FeatureCollection` in a resolved CRS. That core lived in two places; it lives
+here once so both readers share it. The CRS is *injected* by the caller (the
+raster's EPSG for a plain `Dataset`, `crs_spec(epsg, crs)` for a `NetCDF`), so
+this stays independent of each reader's CRS conventions.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pyramids.feature import FeatureCollection
+
+
+def resolve_read_window(window: Any, bbox: Any, *, crs: Any) -> Any:
+    """Resolve a `bbox`/`window` read spec to a single window value.
+
+    Args:
+        window: The caller's `window=` argument (a `Window`, pixel list, or
+            geometry), or `None`.
+        bbox: The caller's `bbox=` argument `(min_x, min_y, max_x, max_y)`, or
+            `None`.
+        crs: The already-resolved CRS the `bbox` is expressed in (an EPSG code or
+            CRS string). Injected by the caller.
+
+    Returns:
+        `window` unchanged when `bbox` is `None`, otherwise a one-row
+        `FeatureCollection` built from `bbox` in `crs`.
+
+    Raises:
+        ValueError: Both `bbox` and `window` were given.
+    """
+    if bbox is None:
+        return window
+    if window is not None:
+        raise ValueError("read_array accepts either `window` or `bbox`, not both")
+    return FeatureCollection.from_bbox(bbox, epsg=crs)

--- a/src/pyramids/dataset/engines/_read_window.py
+++ b/src/pyramids/dataset/engines/_read_window.py
@@ -32,6 +32,32 @@ def resolve_read_window(window: Any, bbox: Any, *, crs: Any) -> Any:
 
     Raises:
         ValueError: Both `bbox` and `window` were given.
+
+    Examples:
+        - With no `bbox`, the caller's `window` is returned unchanged:
+            ```python
+            >>> from pyramids.dataset.engines._read_window import resolve_read_window
+            >>> resolve_read_window("keep-me", None, crs=4326)
+            'keep-me'
+
+            ```
+        - A `bbox` folds into a one-row FeatureCollection covering it, in the
+          injected CRS:
+            ```python
+            >>> from pyramids.dataset.engines._read_window import resolve_read_window
+            >>> fc = resolve_read_window(None, (0.0, 0.0, 2.0, 3.0), crs=4326)
+            >>> fc.total_bounds.tolist()
+            [0.0, 0.0, 2.0, 3.0]
+
+            ```
+        - Passing both `window` and `bbox` is rejected:
+            ```python
+            >>> from pyramids.dataset.engines._read_window import resolve_read_window
+            >>> resolve_read_window("w", (0, 0, 1, 1), crs=4326)
+            Traceback (most recent call last):
+            ValueError: read_array accepts either `window` or `bbox`, not both
+
+            ```
     """
     if bbox is None:
         return window

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -768,7 +768,10 @@ class IO(_Engine["Dataset"]):
         # attribute read — on a NetCDF it can trigger a state-mutating full-variable
         # CRS scan — so evaluating it eagerly on every read would change behaviour on
         # the bbox=None path (the original only read it inside `if bbox is not None`).
-        crs = None if bbox is None else (epsg if epsg is not None else self._ds.epsg)
+        if bbox is None:
+            crs = None
+        else:
+            crs = epsg if epsg is not None else self._ds.epsg
         window = resolve_read_window(window, bbox, crs=crs)
         # Resolve a geometry window (from `bbox=` or a polygon `window=`) to an integer pixel window
         # once, up front, so `bbox_rounding` applies uniformly no matter which read path runs. The

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -763,9 +763,13 @@ class IO(_Engine["Dataset"]):
             masked=masked,
             threadsafe=threadsafe,
         )
-        window = resolve_read_window(
-            window, bbox, crs=epsg if epsg is not None else self._ds.epsg
-        )
+        # Resolve the bbox CRS only when a bbox is actually given. resolve_read_window
+        # ignores `crs` for a bbox-less read, and `self._ds.epsg` is not always a free
+        # attribute read — on a NetCDF it can trigger a state-mutating full-variable
+        # CRS scan — so evaluating it eagerly on every read would change behaviour on
+        # the bbox=None path (the original only read it inside `if bbox is not None`).
+        crs = None if bbox is None else (epsg if epsg is not None else self._ds.epsg)
+        window = resolve_read_window(window, bbox, crs=crs)
         # Resolve a geometry window (from `bbox=` or a polygon `window=`) to an integer pixel window
         # once, up front, so `bbox_rounding` applies uniformly no matter which read path runs. The
         # boundless strategy deliberately rejects geometry windows (they are clipped by definition),

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -65,6 +65,7 @@ if TYPE_CHECKING:
     from pyramids.dataset.dataset import Dataset
 
 from pyramids.dataset.engines._base import _Engine
+from pyramids.dataset.engines._read_window import resolve_read_window
 from pyramids.dataset.engines._validate import (
     validate_band_index,
     window_out_of_bounds,
@@ -789,13 +790,9 @@ class IO(_Engine["Dataset"]):
                 "read_array(resampling=...) only applies to out_shape reads; "
                 "pass out_shape=(rows, cols) as well."
             )
-        if bbox is not None:
-            if window is not None:
-                raise ValueError(
-                    "read_array accepts either `window` or `bbox`, not both"
-                )
-            crs = epsg if epsg is not None else self._ds.epsg
-            window = FeatureCollection.from_bbox(bbox, epsg=crs)
+        window = resolve_read_window(
+            window, bbox, crs=epsg if epsg is not None else self._ds.epsg
+        )
         # Resolve a geometry window (from `bbox=` or a polygon `window=`) to an integer pixel window
         # once, up front, so `bbox_rounding` applies uniformly no matter which read path runs. The
         # boundless branch below deliberately rejects geometry windows (they are clipped by

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -65,6 +65,8 @@ if TYPE_CHECKING:
     from pyramids.dataset.dataset import Dataset
 
 from pyramids.dataset.engines._base import _Engine
+from pyramids.dataset.engines._read_request import ReadRequest
+from pyramids.dataset.engines._read_strategies import READ_STRATEGIES
 from pyramids.dataset.engines._read_window import resolve_read_window
 from pyramids.dataset.engines._validate import (
     validate_band_index,
@@ -750,159 +752,33 @@ class IO(_Engine["Dataset"]):
             - Dataset.get_tile: Read the dataset in chunks.
             - Dataset.get_block_arrangement: Get block arrangement to read the dataset in chunks.
         """
-        if fill_value is not None and not boundless:
-            raise ValueError(
-                "read_array(fill_value=...) only applies to boundless reads; "
-                "pass boundless=True as well."
-            )
-        if boundless and chunks is not None:
-            raise ValueError(
-                "read_array(chunks=..., boundless=True) is not supported; "
-                "boundless fills apply to eager windowed reads only."
-            )
-        if boundless and out_shape is not None:
-            raise NotImplementedError(
-                "read_array(out_shape=...) is not supported together with "
-                "boundless=True; decimated boundless reads are not combined "
-                "yet. Read boundless at native resolution and decimate the "
-                "result yourself."
-            )
-        if boundless and threadsafe:
-            raise NotImplementedError(
-                "read_array(boundless=True) is not supported together with "
-                "threadsafe=True; the boundless read uses the shared handle, "
-                "defeating the per-thread isolation. Read boundless without "
-                "threadsafe, or pad the result yourself."
-            )
-        if out_shape is not None and threadsafe:
-            raise NotImplementedError(
-                "read_array(out_shape=...) is not supported together with "
-                "threadsafe=True; the decimated read uses the shared handle, "
-                "defeating the per-thread isolation. Read decimated without "
-                "threadsafe, or decimate a threadsafe full read yourself."
-            )
-        if (
-            out_shape is None
-            and isinstance(resampling, str)
-            and (resampling.strip().lower() != "nearest")
-        ):
-            raise ValueError(
-                "read_array(resampling=...) only applies to out_shape reads; "
-                "pass out_shape=(rows, cols) as well."
-            )
+        req = ReadRequest(
+            band=band,
+            chunks=chunks,
+            lock=lock,
+            out_shape=out_shape,
+            resampling=resampling,
+            boundless=boundless,
+            fill_value=fill_value,
+            masked=masked,
+            threadsafe=threadsafe,
+        )
         window = resolve_read_window(
             window, bbox, crs=epsg if epsg is not None else self._ds.epsg
         )
         # Resolve a geometry window (from `bbox=` or a polygon `window=`) to an integer pixel window
         # once, up front, so `bbox_rounding` applies uniformly no matter which read path runs. The
-        # boundless branch below deliberately rejects geometry windows (they are clipped by
-        # definition), so leave those unconverted for it to reject.
+        # boundless strategy deliberately rejects geometry windows (they are clipped by definition),
+        # so leave those unconverted for it to reject.
         if isinstance(window, GeoDataFrame) and not boundless:
             window = self._convert_polygon_to_window(window, rounding=bbox_rounding)
-        if chunks is not None:
-            if window is not None:
-                raise ValueError(
-                    "read_array(chunks=..., window=...) is not supported; "
-                    "read lazily and slice the resulting dask array instead."
-                )
-            if out_shape is not None:
-                raise NotImplementedError(
-                    "read_array(out_shape=...) is not supported together with "
-                    "chunks=; decimate eagerly, or coarsen the dask array."
-                )
-            if masked:
-                raise NotImplementedError(
-                    "read_array(masked=True) is not supported together with "
-                    "chunks=; read eagerly, or mask the dask array yourself."
-                )
-            arr = self._lazy_read_array(
-                band=band, chunks=chunks, lock=lock, threadsafe=threadsafe
-            )
-            self._ds._backend = "dask"
-        elif out_shape is not None:
-            if masked:
-                raise NotImplementedError(
-                    "read_array(out_shape=...) is not supported together with "
-                    "masked=True; decimation and masking are not combined yet. "
-                    "Read decimated without masked, or mask the result yourself."
-                )
-            arr = self._decimated_read(band, window, out_shape, resampling)
-            self._ds._backend = "numpy"
-        elif boundless:
-            if masked:
-                raise NotImplementedError(
-                    "read_array(boundless=True) is not supported together "
-                    "with masked=True; boundless fills and masking are not "
-                    "combined yet. Read boundless without masked, or mask the "
-                    "result yourself."
-                )
-            if window is None:
-                raise ValueError(
-                    "read_array(boundless=True) requires a window; a full read "
-                    "cannot extend past the raster."
-                )
-            if isinstance(window, GeoDataFrame):
-                raise ValueError(
-                    "boundless reads need a pixel window (Window or "
-                    "[col_off, row_off, cols, rows] list); geometry windows "
-                    "are clipped by definition."
-                )
-            arr = self._boundless_read(band, window, fill_value)
-            self._ds._backend = "numpy"
-        elif threadsafe:
-            if masked:
-                raise NotImplementedError(
-                    "read_array(threadsafe=True) is not supported together "
-                    "with masked=True; the mask band would be read from the "
-                    "shared handle, defeating the per-thread isolation. Read "
-                    "masked without threadsafe, or mask the result yourself."
-                )
-            arr = self._threadsafe_eager_read(band=band, window=window)
-            self._ds._backend = "numpy"
-        else:
-            # The shared handle is used directly here; the captured cloud config is
-            # already installed by read_array's @under_gdal_env decorator.
-            if band is None and self._ds.band_count > 1:
-                if window is None:
-                    arr = np.ones(
-                        (
-                            self._ds.band_count,
-                            self._ds.rows,
-                            self._ds.columns,
-                        ),
-                        dtype=self._ds.numpy_dtype[0],
-                    )
-                    for i in range(self._ds.band_count):
-                        arr[i, :, :] = self._ds._raster.GetRasterBand(
-                            i + 1
-                        ).ReadAsArray()
-                else:
-                    # ``window`` here is a resolved pixel window (``Window``
-                    # or a ``[col_off, row_off, cols, rows]`` list — any
-                    # geometry window was converted to one above). Stack
-                    # per-band block reads so ``_read_block`` applies the
-                    # identical window to every band without re-parsing its
-                    # dimensions here.
-                    arr = np.stack(
-                        [
-                            self._read_block(i, window)
-                            for i in range(self._ds.band_count)
-                        ],
-                        axis=0,
-                    )
-            else:
-                validate_band_index(band, self._ds.band_count)
-                if band is None:
-                    band = 0
-                if window is None:
-                    arr = self._ds._iloc(band).ReadAsArray()
-                else:
-                    arr = self._read_block(band, window)
-            self._ds._backend = "numpy"
-            if masked:
-                arr = self._to_masked(arr, band, window=window)
-        # arr is assembled through many untyped GDAL/dask branches above; this
-        # is the method's own declared contract.
+        # Pick the one read path this request selects (first match wins, in the same
+        # order as the historical if/elif ladder), read, and record its backend.
+        strategy = next(s for s in READ_STRATEGIES if s.matches(req))
+        arr = strategy.read(self, req, window)
+        self._ds._backend = strategy.backend
+        # arr is assembled through many untyped GDAL/dask branches inside the
+        # strategy; this is the method's own declared contract.
         return cast("ArrayLike", arr)
 
     def _require_reopenable_path(self) -> str:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -2394,6 +2394,13 @@ class NetCDF(Dataset):
                     "read lazily and slice the resulting dask array instead."
                 )
             return window
+        # The bbox/window exclusivity check stays here, ahead of the chunks and
+        # no-CRS guards, so an invalid combination raises the same "not both"
+        # message it always has (the shared resolve_read_window would otherwise
+        # only see it last). resolve_read_window's own exclusivity guard is then
+        # dormant below (window is None past this point).
+        if window is not None:
+            raise ValueError("read_array accepts either `window` or `bbox`, not both")
         if chunks is not None:
             raise ValueError(
                 "read_array(chunks=..., bbox=...) is not supported; "
@@ -2407,8 +2414,8 @@ class NetCDF(Dataset):
                 "read_array(bbox=…) requires an explicit `epsg=` when the "
                 "NetCDF has no CRS at all — a bbox without a CRS is ambiguous"
             )
-        # The bbox+window exclusivity check and bbox -> FeatureCollection build are
-        # shared with Dataset.read_array via the injected, already-resolved CRS.
+        # The bbox -> FeatureCollection build is shared with Dataset.read_array via
+        # the injected, already-resolved CRS.
         return resolve_read_window(window, bbox, crs=crs)
 
     def _read_array_eager(

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -37,7 +37,6 @@ from pyramids.dataset import Dataset
 from pyramids.dataset._plot_helpers import nonnull_group_kwargs
 from pyramids.dataset.dataset import _COLLABORATOR_ATTRS
 from pyramids.dataset.engines._read_window import resolve_read_window
-from pyramids.feature import FeatureCollection
 from pyramids.netcdf._axis import detect_axis_indices
 from pyramids.netcdf._kerchunk_facade import combine_kerchunk, to_kerchunk
 from pyramids.netcdf._lazy import apply_unpack, build_lazy_array

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -36,6 +36,7 @@ from pyramids.base.remote import is_remote
 from pyramids.dataset import Dataset
 from pyramids.dataset._plot_helpers import nonnull_group_kwargs
 from pyramids.dataset.dataset import _COLLABORATOR_ATTRS
+from pyramids.dataset.engines._read_window import resolve_read_window
 from pyramids.feature import FeatureCollection
 from pyramids.netcdf._axis import detect_axis_indices
 from pyramids.netcdf._kerchunk_facade import combine_kerchunk, to_kerchunk
@@ -2393,8 +2394,6 @@ class NetCDF(Dataset):
                     "read lazily and slice the resulting dask array instead."
                 )
             return window
-        if window is not None:
-            raise ValueError("read_array accepts either `window` or `bbox`, not both")
         if chunks is not None:
             raise ValueError(
                 "read_array(chunks=..., bbox=...) is not supported; "
@@ -2408,7 +2407,9 @@ class NetCDF(Dataset):
                 "read_array(bbox=…) requires an explicit `epsg=` when the "
                 "NetCDF has no CRS at all — a bbox without a CRS is ambiguous"
             )
-        return FeatureCollection.from_bbox(bbox, epsg=crs)
+        # The bbox+window exclusivity check and bbox -> FeatureCollection build are
+        # shared with Dataset.read_array via the injected, already-resolved CRS.
+        return resolve_read_window(window, bbox, crs=crs)
 
     def _read_array_eager(
         self,

--- a/tests/dataset/engines/test_read_request.py
+++ b/tests/dataset/engines/test_read_request.py
@@ -1,0 +1,189 @@
+"""Tests for the ``ReadRequest`` option value-object.
+
+Covers ``ReadRequest.__post_init__`` — the option-incompatibility matrix that
+``read_array`` runs before resolving its window: each pairing that is never legal
+regardless of read path, the exact exception *type* each raises
+(``ValueError`` vs ``NotImplementedError``), the message text several read tests
+assert on, the valid combinations that must pass, and the check ordering that
+decides which error a multiply-invalid request raises.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from pyramids.dataset.engines._read_request import ReadRequest
+
+pytestmark = pytest.mark.core
+
+
+def make_request(**overrides) -> ReadRequest:
+    """Build a valid ``ReadRequest``, overriding individual option fields.
+
+    Args:
+        **overrides: Field values to replace on the otherwise-valid baseline
+            (a plain full eager read of band 0).
+
+    Returns:
+        ReadRequest: A constructed request (its ``__post_init__`` has run).
+    """
+    base = {
+        "band": 0,
+        "chunks": None,
+        "lock": None,
+        "out_shape": None,
+        "resampling": "nearest",
+        "boundless": False,
+        "fill_value": None,
+        "masked": False,
+        "threadsafe": False,
+    }
+    base.update(overrides)
+    return ReadRequest(**base)
+
+
+class TestReadRequest:
+    """``ReadRequest`` construction and the ``__post_init__`` matrix."""
+
+    def test_valid_default_request_constructs(self):
+        """A plain eager read passes the matrix and keeps its field values.
+
+        Test scenario:
+            The baseline request (no special options) constructs and exposes the
+            options it was given.
+        """
+        req = make_request(band=2)
+        assert req.band == 2, f"band should round-trip, got {req.band}"
+        assert req.chunks is None, "chunks should default to None"
+        assert req.resampling == "nearest", "resampling should round-trip"
+        assert req.boundless is False, "boundless should round-trip"
+
+    @pytest.mark.parametrize(
+        "resampling",
+        ["nearest", "NEAREST", " nearest ", "Nearest"],
+        ids=["lower", "upper", "padded", "title"],
+    )
+    def test_nearest_resampling_without_out_shape_is_allowed(self, resampling):
+        """``resampling`` naming ``nearest`` (any case/whitespace) needs no out_shape.
+
+        Args:
+            resampling: A spelling of ``nearest`` that must be treated as the
+                default and therefore not require ``out_shape``.
+
+        Test scenario:
+            Guard 6 compares ``resampling.strip().lower()`` to ``"nearest"``; all
+            these spellings are the default and must not raise.
+        """
+        req = make_request(resampling=resampling)
+        assert req.resampling == resampling, "resampling value should round-trip"
+
+    def test_is_frozen(self):
+        """``ReadRequest`` is immutable; assigning a field raises.
+
+        Test scenario:
+            A frozen dataclass rejects attribute assignment.
+        """
+        req = make_request()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            req.boundless = True  # type: ignore[misc]
+
+    def test_fill_value_without_boundless_raises(self):
+        """``fill_value`` outside a boundless read is a ``ValueError``.
+
+        Test scenario:
+            ``fill_value`` set with ``boundless=False`` → guard 1.
+        """
+        with pytest.raises(ValueError, match="fill_value") as exc:
+            make_request(fill_value=5.0, boundless=False)
+        assert "boundless" in str(exc.value), f"message should mention boundless: {exc.value}"
+
+    def test_fill_value_with_boundless_is_allowed(self):
+        """``fill_value`` with ``boundless=True`` passes the matrix.
+
+        Test scenario:
+            A boundless request may carry a fill value.
+        """
+        req = make_request(fill_value=5.0, boundless=True)
+        assert req.fill_value == 5.0, "fill_value should round-trip on a boundless read"
+
+    def test_boundless_with_chunks_raises_value_error(self):
+        """``boundless`` + ``chunks`` is a ``ValueError`` (guard 2).
+
+        Test scenario:
+            Boundless fills apply to eager windowed reads only.
+        """
+        with pytest.raises(ValueError, match="chunks") as exc:
+            make_request(boundless=True, chunks=4)
+        assert "boundless" in str(exc.value), f"message should mention boundless: {exc.value}"
+
+    def test_boundless_with_out_shape_raises_not_implemented(self):
+        """``boundless`` + ``out_shape`` is a ``NotImplementedError`` (guard 3).
+
+        Test scenario:
+            Decimated boundless reads are not combined yet.
+        """
+        with pytest.raises(NotImplementedError, match="out_shape"):
+            make_request(boundless=True, out_shape=(4, 4))
+
+    def test_boundless_with_threadsafe_raises_not_implemented(self):
+        """``boundless`` + ``threadsafe`` is a ``NotImplementedError`` (guard 4).
+
+        Test scenario:
+            The boundless read uses the shared handle, defeating isolation.
+        """
+        with pytest.raises(NotImplementedError, match="threadsafe=True"):
+            make_request(boundless=True, threadsafe=True)
+
+    def test_out_shape_with_threadsafe_raises_not_implemented(self):
+        """``out_shape`` + ``threadsafe`` is a ``NotImplementedError`` (guard 5).
+
+        Test scenario:
+            The decimated read uses the shared handle, defeating isolation.
+        """
+        with pytest.raises(NotImplementedError, match="threadsafe=True"):
+            make_request(out_shape=(4, 4), threadsafe=True)
+
+    def test_resampling_without_out_shape_raises_value_error(self):
+        """A non-nearest ``resampling`` without ``out_shape`` is a ``ValueError`` (guard 6).
+
+        Test scenario:
+            ``resampling`` only applies to decimated (``out_shape``) reads.
+        """
+        with pytest.raises(ValueError, match="resampling") as exc:
+            make_request(resampling="bilinear", out_shape=None)
+        assert "out_shape" in str(exc.value), f"message should mention out_shape: {exc.value}"
+
+    def test_resampling_with_out_shape_is_allowed(self):
+        """A non-nearest ``resampling`` with ``out_shape`` passes the matrix.
+
+        Test scenario:
+            ``out_shape`` present → ``resampling`` is meaningful and allowed.
+        """
+        req = make_request(resampling="bilinear", out_shape=(4, 4))
+        assert req.resampling == "bilinear", "resampling should round-trip with out_shape"
+
+    def test_ordering_boundless_out_shape_beats_threadsafe(self):
+        """A multiply-invalid request raises the earliest-checked guard.
+
+        Test scenario:
+            ``boundless`` + ``out_shape`` + ``threadsafe`` trips guard 3
+            (out_shape) before guard 4 (threadsafe), so the ``out_shape`` message
+            wins — matching the original inline check order.
+        """
+        with pytest.raises(NotImplementedError, match="out_shape") as exc:
+            make_request(boundless=True, out_shape=(4, 4), threadsafe=True)
+        assert "threadsafe" not in str(exc.value) or "out_shape" in str(exc.value), (
+            f"guard 3 (out_shape) must fire before guard 4 (threadsafe): {exc.value}"
+        )
+
+    def test_ordering_fill_value_beats_resampling(self):
+        """``fill_value`` (guard 1) fires before ``resampling`` (guard 6).
+
+        Test scenario:
+            ``fill_value`` set (no boundless) + a non-nearest ``resampling`` (no
+            out_shape) raises the ``fill_value`` ValueError, not the resampling one.
+        """
+        with pytest.raises(ValueError, match="fill_value"):
+            make_request(fill_value=1.0, boundless=False, resampling="cubic")

--- a/tests/dataset/engines/test_read_request.py
+++ b/tests/dataset/engines/test_read_request.py
@@ -174,7 +174,7 @@ class TestReadRequest:
         """
         with pytest.raises(NotImplementedError, match="out_shape") as exc:
             make_request(boundless=True, out_shape=(4, 4), threadsafe=True)
-        assert "threadsafe" not in str(exc.value) or "out_shape" in str(exc.value), (
+        assert "threadsafe" not in str(exc.value), (
             f"guard 3 (out_shape) must fire before guard 4 (threadsafe): {exc.value}"
         )
 

--- a/tests/dataset/engines/test_read_request.py
+++ b/tests/dataset/engines/test_read_request.py
@@ -97,7 +97,9 @@ class TestReadRequest:
         """
         with pytest.raises(ValueError, match="fill_value") as exc:
             make_request(fill_value=5.0, boundless=False)
-        assert "boundless" in str(exc.value), f"message should mention boundless: {exc.value}"
+        assert "boundless" in str(exc.value), (
+            f"message should mention boundless: {exc.value}"
+        )
 
     def test_fill_value_with_boundless_is_allowed(self):
         """``fill_value`` with ``boundless=True`` passes the matrix.
@@ -116,7 +118,9 @@ class TestReadRequest:
         """
         with pytest.raises(ValueError, match="chunks") as exc:
             make_request(boundless=True, chunks=4)
-        assert "boundless" in str(exc.value), f"message should mention boundless: {exc.value}"
+        assert "boundless" in str(exc.value), (
+            f"message should mention boundless: {exc.value}"
+        )
 
     def test_boundless_with_out_shape_raises_not_implemented(self):
         """``boundless`` + ``out_shape`` is a ``NotImplementedError`` (guard 3).
@@ -153,7 +157,9 @@ class TestReadRequest:
         """
         with pytest.raises(ValueError, match="resampling") as exc:
             make_request(resampling="bilinear", out_shape=None)
-        assert "out_shape" in str(exc.value), f"message should mention out_shape: {exc.value}"
+        assert "out_shape" in str(exc.value), (
+            f"message should mention out_shape: {exc.value}"
+        )
 
     def test_resampling_with_out_shape_is_allowed(self):
         """A non-nearest ``resampling`` with ``out_shape`` passes the matrix.
@@ -162,7 +168,9 @@ class TestReadRequest:
             ``out_shape`` present → ``resampling`` is meaningful and allowed.
         """
         req = make_request(resampling="bilinear", out_shape=(4, 4))
-        assert req.resampling == "bilinear", "resampling should round-trip with out_shape"
+        assert req.resampling == "bilinear", (
+            "resampling should round-trip with out_shape"
+        )
 
     def test_ordering_boundless_out_shape_beats_threadsafe(self):
         """A multiply-invalid request raises the earliest-checked guard.

--- a/tests/dataset/engines/test_read_strategies.py
+++ b/tests/dataset/engines/test_read_strategies.py
@@ -354,6 +354,28 @@ class TestEagerRead:
         assert result.mask[0, 0], "the nodata cell must be masked"
         assert not result.mask[1, 1], "a real-data cell must not be masked"
 
+    def test_multiband_masked_wrap_passes_band_none(self):
+        """``band=None`` + ``masked=True`` masks the stacked multiband read.
+
+        Test scenario:
+            The multiband branch feeds ``band=None`` (not ``0``) to ``_to_masked``;
+            the result is a masked array with the band axis preserved and the nodata
+            cell masked — pinning the ``band=None``-to-``_to_masked`` contract at the
+            unit boundary (also covered at the integration level).
+        """
+        bands = np.stack(
+            [np.arange(4 * 5, dtype="float32").reshape(4, 5) + b * 1000 for b in range(2)],
+            axis=0,
+        )
+        bands[0, 0, 0] = -9999.0
+        ds = Dataset.create_from_array(
+            bands, top_left_corner=(0.0, 4.0), cell_size=1.0, epsg=4326, no_data_value=-9999.0
+        )
+        result = EagerRead().read(ds.io, make_request(band=None, masked=True), None)
+        assert isinstance(result, np.ma.MaskedArray), "multiband masked read must return a MaskedArray"
+        assert result.shape == (2, 4, 5), f"expected (2, 4, 5), got {result.shape}"
+        assert result.mask[0, 0, 0], "the nodata cell must be masked in the multiband result"
+
 
 class TestStrategySelection:
     """``READ_STRATEGIES`` order reproduces the original if/elif ladder."""

--- a/tests/dataset/engines/test_read_strategies.py
+++ b/tests/dataset/engines/test_read_strategies.py
@@ -120,7 +120,9 @@ class TestLazyRead:
             expected: Whether ``LazyRead`` should claim the request.
         """
         req = make_request(chunks=chunks)
-        assert LazyRead().matches(req) is expected, f"matches({chunks}) should be {expected}"
+        assert LazyRead().matches(req) is expected, (
+            f"matches({chunks}) should be {expected}"
+        )
 
     def test_delegates_to_lazy_read_array(self, mocker):
         """A valid lazy read forwards band/chunks/lock/threadsafe to the helper.
@@ -267,7 +269,9 @@ class TestThreadsafeRead:
     def test_matches_on_threadsafe(self, threadsafe, expected):
         """``matches`` is true exactly when ``threadsafe`` is set."""
         req = make_request(threadsafe=threadsafe)
-        assert ThreadsafeRead().matches(req) is expected, "matches must track threadsafe"
+        assert ThreadsafeRead().matches(req) is expected, (
+            "matches must track threadsafe"
+        )
 
     def test_delegates_to_threadsafe_eager_read(self, mocker):
         """Forwards band/window (by keyword) to the per-thread read helper."""
@@ -298,7 +302,9 @@ class TestEagerRead:
     def test_matches_always(self):
         """``EagerRead`` is the fallback and matches any request."""
         assert EagerRead().matches(make_request()) is True, "eager must always match"
-        assert EagerRead().matches(make_request(chunks=4)) is True, "eager is the fallback"
+        assert EagerRead().matches(make_request(chunks=4)) is True, (
+            "eager is the fallback"
+        )
 
     def test_single_band_full_read(self, single_band):
         """A full single-band read returns the raster's array.
@@ -316,8 +322,12 @@ class TestEagerRead:
         Test scenario:
             ``Window(1, 1, 2, 2)`` returns the 2x2 sub-block at (row 1, col 1).
         """
-        result = EagerRead().read(single_band.io, make_request(band=0), Window(1, 1, 2, 2))
-        assert result.shape == (2, 2), f"windowed read should be 2x2, got {result.shape}"
+        result = EagerRead().read(
+            single_band.io, make_request(band=0), Window(1, 1, 2, 2)
+        )
+        assert result.shape == (2, 2), (
+            f"windowed read should be 2x2, got {result.shape}"
+        )
         expected = np.array([[7.0, 8.0], [13.0, 14.0]], dtype="float32")
         np.testing.assert_array_equal(result, expected, err_msg="window block mismatch")
 
@@ -363,8 +373,12 @@ class TestEagerRead:
         Test scenario:
             The nodata cell (0, 0) is masked; a data cell is not.
         """
-        result = EagerRead().read(single_band.io, make_request(band=0, masked=True), None)
-        assert isinstance(result, np.ma.MaskedArray), "masked read must return a MaskedArray"
+        result = EagerRead().read(
+            single_band.io, make_request(band=0, masked=True), None
+        )
+        assert isinstance(result, np.ma.MaskedArray), (
+            "masked read must return a MaskedArray"
+        )
         assert result.mask[0, 0], "the nodata cell must be masked"
         assert not result.mask[1, 1], "a real-data cell must not be masked"
 
@@ -378,17 +392,28 @@ class TestEagerRead:
             unit boundary (also covered at the integration level).
         """
         bands = np.stack(
-            [np.arange(4 * 5, dtype="float32").reshape(4, 5) + b * 1000 for b in range(2)],
+            [
+                np.arange(4 * 5, dtype="float32").reshape(4, 5) + b * 1000
+                for b in range(2)
+            ],
             axis=0,
         )
         bands[0, 0, 0] = -9999.0
         ds = Dataset.create_from_array(
-            bands, top_left_corner=(0.0, 4.0), cell_size=1.0, epsg=4326, no_data_value=-9999.0
+            bands,
+            top_left_corner=(0.0, 4.0),
+            cell_size=1.0,
+            epsg=4326,
+            no_data_value=-9999.0,
         )
         result = EagerRead().read(ds.io, make_request(band=None, masked=True), None)
-        assert isinstance(result, np.ma.MaskedArray), "multiband masked read must return a MaskedArray"
+        assert isinstance(result, np.ma.MaskedArray), (
+            "multiband masked read must return a MaskedArray"
+        )
         assert result.shape == (2, 4, 5), f"expected (2, 4, 5), got {result.shape}"
-        assert result.mask[0, 0, 0], "the nodata cell must be masked in the multiband result"
+        assert result.mask[0, 0, 0], (
+            "the nodata cell must be masked in the multiband result"
+        )
 
 
 class TestStrategySelection:
@@ -426,4 +451,6 @@ class TestStrategySelection:
             its own guard (not the decimated one) governs — matching the original.
         """
         req = make_request(chunks=4, out_shape=(2, 2))
-        assert isinstance(select(req), LazyRead), "chunks must take precedence over out_shape"
+        assert isinstance(select(req), LazyRead), (
+            "chunks must take precedence over out_shape"
+        )

--- a/tests/dataset/engines/test_read_strategies.py
+++ b/tests/dataset/engines/test_read_strategies.py
@@ -1,0 +1,393 @@
+"""Tests for the ``read_array`` read-path strategies.
+
+Covers the :class:`ReadStrategy` set that ``read_array`` dispatches to:
+``matches`` selection, each path's window-dependent precondition guards (exact
+exception type + message), delegation to the existing ``_*_read`` helpers, the
+declared backend per path, the ``READ_STRATEGIES`` selection order that
+reproduces the original ``if/elif`` ladder, and ``EagerRead``'s real read
+branches (single/multi band, windowed, masked) against a live IO engine.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pyramids.dataset import Dataset, Window
+from pyramids.dataset.engines._read_request import ReadRequest
+from pyramids.dataset.engines._read_strategies import (
+    READ_STRATEGIES,
+    BoundlessRead,
+    DecimatedRead,
+    EagerRead,
+    LazyRead,
+    ReadStrategy,
+    ThreadsafeRead,
+)
+from pyramids.feature import FeatureCollection
+
+pytestmark = pytest.mark.core
+
+
+def make_request(**overrides) -> ReadRequest:
+    """Build a valid ``ReadRequest`` with overridable option fields.
+
+    Args:
+        **overrides: Fields to replace on the valid full-eager-read baseline.
+
+    Returns:
+        ReadRequest: A constructed, matrix-valid request.
+    """
+    base = {
+        "band": 0,
+        "chunks": None,
+        "lock": None,
+        "out_shape": None,
+        "resampling": "nearest",
+        "boundless": False,
+        "fill_value": None,
+        "masked": False,
+        "threadsafe": False,
+    }
+    base.update(overrides)
+    return ReadRequest(**base)
+
+
+def select(req: ReadRequest) -> ReadStrategy:
+    """Return the first strategy in ``READ_STRATEGIES`` that matches ``req``."""
+    return next(s for s in READ_STRATEGIES if s.matches(req))
+
+
+@pytest.fixture(scope="function")
+def single_band() -> Dataset:
+    """A 6x6 float32 ramp, single band, nodata -9999, one cell set to nodata.
+
+    Returns:
+        Dataset: In-memory single-band dataset; value == row*6 + col, except
+        cell (0, 0) which is the nodata value.
+    """
+    arr = np.arange(36, dtype="float32").reshape(6, 6)
+    arr[0, 0] = -9999.0
+    return Dataset.create_from_array(
+        arr, top_left_corner=(0, 6), cell_size=1.0, epsg=4326, no_data_value=-9999.0
+    )
+
+
+@pytest.fixture(scope="function")
+def multi_band() -> Dataset:
+    """A 3-band, 4x5 float32 raster; value == band*1000 + row*5 + col.
+
+    Returns:
+        Dataset: In-memory three-band dataset on a unit grid.
+    """
+    bands = np.stack(
+        [np.arange(4 * 5, dtype="float32").reshape(4, 5) + b * 1000 for b in range(3)],
+        axis=0,
+    )
+    return Dataset.create_from_array(
+        bands, top_left_corner=(0.0, 4.0), cell_size=1.0, epsg=4326
+    )
+
+
+class TestReadStrategyABC:
+    """The abstract base class contract."""
+
+    def test_cannot_instantiate_abstract_base(self):
+        """``ReadStrategy`` is abstract and cannot be instantiated directly.
+
+        Test scenario:
+            The ABC leaves ``matches``/``read`` abstract, so construction raises.
+        """
+        with pytest.raises(TypeError, match="abstract"):
+            ReadStrategy()  # type: ignore[abstract]
+
+
+class TestLazyRead:
+    """``LazyRead`` (the ``chunks=`` path)."""
+
+    def test_backend_is_dask(self):
+        """The lazy path declares the ``dask`` backend."""
+        assert LazyRead().backend == "dask", "lazy reads must report the dask backend"
+
+    @pytest.mark.parametrize(
+        "chunks, expected", [(4, True), ("auto", True), (None, False)]
+    )
+    def test_matches_on_chunks(self, chunks, expected):
+        """``matches`` is true exactly when a chunk spec was given.
+
+        Args:
+            chunks: The request's ``chunks`` value.
+            expected: Whether ``LazyRead`` should claim the request.
+        """
+        req = make_request(chunks=chunks)
+        assert LazyRead().matches(req) is expected, f"matches({chunks}) should be {expected}"
+
+    def test_delegates_to_lazy_read_array(self, mocker):
+        """A valid lazy read forwards band/chunks/lock/threadsafe to the helper.
+
+        Test scenario:
+            ``LazyRead.read`` calls ``io._lazy_read_array`` with the request's
+            options and returns its result unchanged.
+        """
+        io = mocker.Mock()
+        io._lazy_read_array.return_value = "lazy-array"
+        req = make_request(band=2, chunks=8, lock="LK", threadsafe=True)
+        result = LazyRead().read(io, req, None)
+        assert result == "lazy-array", "the helper's return must pass through"
+        io._lazy_read_array.assert_called_once_with(
+            band=2, chunks=8, lock="LK", threadsafe=True
+        )
+
+    def test_rejects_window(self, mocker):
+        """A ``window`` with ``chunks`` raises ``ValueError``.
+
+        Test scenario:
+            Lazy reads cannot take a window; slice the dask array instead.
+        """
+        with pytest.raises(ValueError, match="chunks"):
+            LazyRead().read(mocker.Mock(), make_request(chunks=4), Window(0, 0, 2, 2))
+
+    def test_rejects_out_shape(self, mocker):
+        """``out_shape`` with ``chunks`` raises ``NotImplementedError``."""
+        req = make_request(chunks=4, out_shape=(2, 2))
+        with pytest.raises(NotImplementedError, match="out_shape"):
+            LazyRead().read(mocker.Mock(), req, None)
+
+    def test_rejects_masked(self, mocker):
+        """``masked`` with ``chunks`` raises ``NotImplementedError``."""
+        req = make_request(chunks=4, masked=True)
+        with pytest.raises(NotImplementedError, match="masked=True"):
+            LazyRead().read(mocker.Mock(), req, None)
+
+
+class TestDecimatedRead:
+    """``DecimatedRead`` (the ``out_shape=`` path)."""
+
+    def test_backend_is_numpy(self):
+        """The decimated path declares the ``numpy`` backend."""
+        assert DecimatedRead().backend == "numpy", "decimated reads are numpy-backed"
+
+    @pytest.mark.parametrize("out_shape, expected", [((2, 2), True), (None, False)])
+    def test_matches_on_out_shape(self, out_shape, expected):
+        """``matches`` is true exactly when an ``out_shape`` was given."""
+        req = make_request(out_shape=out_shape)
+        assert DecimatedRead().matches(req) is expected, "matches must track out_shape"
+
+    def test_delegates_to_decimated_read(self, mocker):
+        """Forwards band/window/out_shape/resampling to the decimation helper.
+
+        Test scenario:
+            ``DecimatedRead.read`` calls ``io._decimated_read`` positionally.
+        """
+        io = mocker.Mock()
+        io._decimated_read.return_value = "decimated"
+        window = Window(0, 0, 4, 4)
+        req = make_request(band=1, out_shape=(2, 3), resampling="bilinear")
+        result = DecimatedRead().read(io, req, window)
+        assert result == "decimated", "the helper's return must pass through"
+        io._decimated_read.assert_called_once_with(1, window, (2, 3), "bilinear")
+
+    def test_rejects_masked(self, mocker):
+        """``masked`` with ``out_shape`` raises ``NotImplementedError``."""
+        req = make_request(out_shape=(2, 2), masked=True)
+        with pytest.raises(NotImplementedError, match="masked=True"):
+            DecimatedRead().read(mocker.Mock(), req, None)
+
+
+class TestBoundlessRead:
+    """``BoundlessRead`` (the ``boundless=True`` path)."""
+
+    def test_backend_is_numpy(self):
+        """The boundless path declares the ``numpy`` backend."""
+        assert BoundlessRead().backend == "numpy", "boundless reads are numpy-backed"
+
+    @pytest.mark.parametrize("boundless, expected", [(True, True), (False, False)])
+    def test_matches_on_boundless(self, boundless, expected):
+        """``matches`` is true exactly when ``boundless`` is set."""
+        req = make_request(boundless=boundless)
+        assert BoundlessRead().matches(req) is expected, "matches must track boundless"
+
+    def test_delegates_to_boundless_read(self, mocker):
+        """Forwards band/window/fill_value to the boundless helper.
+
+        Test scenario:
+            ``BoundlessRead.read`` calls ``io._boundless_read`` positionally.
+        """
+        io = mocker.Mock()
+        io._boundless_read.return_value = "padded"
+        window = Window(-1, -1, 4, 4)
+        req = make_request(band=0, boundless=True, fill_value=7.0)
+        result = BoundlessRead().read(io, req, window)
+        assert result == "padded", "the helper's return must pass through"
+        io._boundless_read.assert_called_once_with(0, window, 7.0)
+
+    def test_rejects_masked(self, mocker):
+        """``masked`` with ``boundless`` raises ``NotImplementedError``."""
+        req = make_request(boundless=True, masked=True)
+        with pytest.raises(NotImplementedError, match="masked=True"):
+            BoundlessRead().read(mocker.Mock(), req, Window(0, 0, 2, 2))
+
+    def test_requires_a_window(self, mocker):
+        """A boundless read without a window raises ``ValueError``."""
+        with pytest.raises(ValueError, match="requires a window"):
+            BoundlessRead().read(mocker.Mock(), make_request(boundless=True), None)
+
+    def test_rejects_geometry_window(self, mocker):
+        """A geometry (``GeoDataFrame``) window with boundless raises ``ValueError``.
+
+        Test scenario:
+            Boundless needs a pixel window; a FeatureCollection is clipped by
+            definition and must be rejected.
+        """
+        geom_window = FeatureCollection.from_bbox((0, 0, 1, 1), epsg=4326)
+        with pytest.raises(ValueError, match="pixel window"):
+            BoundlessRead().read(mocker.Mock(), make_request(boundless=True), geom_window)
+
+
+class TestThreadsafeRead:
+    """``ThreadsafeRead`` (the ``threadsafe=True`` path)."""
+
+    def test_backend_is_numpy(self):
+        """The thread-safe path declares the ``numpy`` backend."""
+        assert ThreadsafeRead().backend == "numpy", "thread-safe reads are numpy-backed"
+
+    @pytest.mark.parametrize("threadsafe, expected", [(True, True), (False, False)])
+    def test_matches_on_threadsafe(self, threadsafe, expected):
+        """``matches`` is true exactly when ``threadsafe`` is set."""
+        req = make_request(threadsafe=threadsafe)
+        assert ThreadsafeRead().matches(req) is expected, "matches must track threadsafe"
+
+    def test_delegates_to_threadsafe_eager_read(self, mocker):
+        """Forwards band/window (by keyword) to the per-thread read helper."""
+        io = mocker.Mock()
+        io._threadsafe_eager_read.return_value = "ts-array"
+        window = Window(0, 0, 3, 3)
+        req = make_request(band=1, threadsafe=True)
+        result = ThreadsafeRead().read(io, req, window)
+        assert result == "ts-array", "the helper's return must pass through"
+        io._threadsafe_eager_read.assert_called_once_with(band=1, window=window)
+
+    def test_rejects_masked(self, mocker):
+        """``masked`` with ``threadsafe`` raises ``NotImplementedError``."""
+        req = make_request(threadsafe=True, masked=True)
+        with pytest.raises(NotImplementedError, match="masked=True"):
+            ThreadsafeRead().read(mocker.Mock(), req, None)
+
+
+class TestEagerRead:
+    """``EagerRead`` (the default shared-handle path) against a live IO engine."""
+
+    def test_backend_is_numpy(self):
+        """The eager path declares the ``numpy`` backend."""
+        assert EagerRead().backend == "numpy", "eager reads are numpy-backed"
+
+    def test_matches_always(self):
+        """``EagerRead`` is the fallback and matches any request."""
+        assert EagerRead().matches(make_request()) is True, "eager must always match"
+        assert EagerRead().matches(make_request(chunks=4)) is True, "eager is the fallback"
+
+    def test_single_band_full_read(self, single_band):
+        """A full single-band read returns the raster's array.
+
+        Test scenario:
+            ``band=0``, no window → the whole 6x6 band.
+        """
+        result = EagerRead().read(single_band.io, make_request(band=0), None)
+        assert result.shape == (6, 6), f"expected the full 6x6 band, got {result.shape}"
+        assert result[1, 0] == 6.0, f"value at (1, 0) should be 6.0, got {result[1, 0]}"
+
+    def test_single_band_windowed_read(self, single_band):
+        """A windowed single-band read returns the window's block.
+
+        Test scenario:
+            ``Window(1, 1, 2, 2)`` returns the 2x2 sub-block at (row 1, col 1).
+        """
+        result = EagerRead().read(single_band.io, make_request(band=0), Window(1, 1, 2, 2))
+        assert result.shape == (2, 2), f"windowed read should be 2x2, got {result.shape}"
+        expected = np.array([[7.0, 8.0], [13.0, 14.0]], dtype="float32")
+        np.testing.assert_array_equal(result, expected, err_msg="window block mismatch")
+
+    def test_single_band_none_reads_first_band(self, single_band):
+        """``band=None`` on a single-band raster reads band 0 in full.
+
+        Test scenario:
+            With one band the multiband branch is skipped, so ``band=None`` falls
+            through to ``band = 0`` and reads the whole band.
+        """
+        result = EagerRead().read(single_band.io, make_request(band=None), None)
+        assert result.shape == (6, 6), f"expected the full 6x6 band, got {result.shape}"
+        assert result[1, 0] == 6.0, f"value at (1, 0) should be 6.0, got {result[1, 0]}"
+
+    def test_multiband_full_read_stacks_bands(self, multi_band):
+        """A full read with ``band=None`` keeps the band axis.
+
+        Test scenario:
+            ``band=None`` on a 3-band raster returns ``(3, rows, cols)``.
+        """
+        result = EagerRead().read(multi_band.io, make_request(band=None), None)
+        assert result.shape == (3, 4, 5), f"expected (3, 4, 5), got {result.shape}"
+        assert result[2, 0, 0] == 2000.0, "band 2 origin should be 2000.0"
+
+    def test_multiband_windowed_read_stacks_bands(self, multi_band):
+        """A windowed read with ``band=None`` stacks the per-band blocks.
+
+        Test scenario:
+            ``band=None`` + ``Window(1, 1, 2, 2)`` returns ``(3, 2, 2)`` sliced
+            identically per band.
+        """
+        window = Window(1, 1, 2, 2)
+        result = EagerRead().read(multi_band.io, make_request(band=None), window)
+        full = EagerRead().read(multi_band.io, make_request(band=None), None)
+        assert result.shape == (3, 2, 2), f"expected (3, 2, 2), got {result.shape}"
+        np.testing.assert_array_equal(
+            result, full[:, 1:3, 1:3], err_msg="per-band window slice mismatch"
+        )
+
+    def test_masked_wrap_returns_masked_array(self, single_band):
+        """``masked=True`` wraps the eager result as a masked array.
+
+        Test scenario:
+            The nodata cell (0, 0) is masked; a data cell is not.
+        """
+        result = EagerRead().read(single_band.io, make_request(band=0, masked=True), None)
+        assert isinstance(result, np.ma.MaskedArray), "masked read must return a MaskedArray"
+        assert result.mask[0, 0], "the nodata cell must be masked"
+        assert not result.mask[1, 1], "a real-data cell must not be masked"
+
+
+class TestStrategySelection:
+    """``READ_STRATEGIES`` order reproduces the original if/elif ladder."""
+
+    def test_selects_lazy_for_chunks(self):
+        """A ``chunks`` request selects ``LazyRead``."""
+        assert isinstance(select(make_request(chunks=4)), LazyRead), "chunks → LazyRead"
+
+    def test_selects_decimated_for_out_shape(self):
+        """An ``out_shape`` request (no chunks) selects ``DecimatedRead``."""
+        req = make_request(out_shape=(2, 2))
+        assert isinstance(select(req), DecimatedRead), "out_shape → DecimatedRead"
+
+    def test_selects_boundless(self):
+        """A ``boundless`` request selects ``BoundlessRead``."""
+        assert isinstance(select(make_request(boundless=True)), BoundlessRead), (
+            "boundless → BoundlessRead"
+        )
+
+    def test_selects_threadsafe(self):
+        """A ``threadsafe`` request selects ``ThreadsafeRead``."""
+        req = make_request(threadsafe=True)
+        assert isinstance(select(req), ThreadsafeRead), "threadsafe → ThreadsafeRead"
+
+    def test_selects_eager_by_default(self):
+        """A plain request falls through to ``EagerRead``."""
+        assert isinstance(select(make_request()), EagerRead), "default → EagerRead"
+
+    def test_chunks_precedence_over_out_shape(self):
+        """When both ``chunks`` and ``out_shape`` are set, ``LazyRead`` wins.
+
+        Test scenario:
+            The ladder checks ``chunks`` first, so the lazy path is selected and
+            its own guard (not the decimated one) governs — matching the original.
+        """
+        req = make_request(chunks=4, out_shape=(2, 2))
+        assert isinstance(select(req), LazyRead), "chunks must take precedence over out_shape"

--- a/tests/dataset/engines/test_read_strategies.py
+++ b/tests/dataset/engines/test_read_strategies.py
@@ -58,7 +58,7 @@ def select(req: ReadRequest) -> ReadStrategy:
     return next(s for s in READ_STRATEGIES if s.matches(req))
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def single_band() -> Dataset:
     """A 6x6 float32 ramp, single band, nodata -9999, one cell set to nodata.
 
@@ -73,7 +73,7 @@ def single_band() -> Dataset:
     )
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def multi_band() -> Dataset:
     """A 3-band, 4x5 float32 raster; value == band*1000 + row*5 + col.
 
@@ -144,20 +144,26 @@ class TestLazyRead:
         Test scenario:
             Lazy reads cannot take a window; slice the dask array instead.
         """
+        strat = LazyRead()
+        io = mocker.Mock()
+        req = make_request(chunks=4)
+        window = Window(0, 0, 2, 2)
         with pytest.raises(ValueError, match="chunks"):
-            LazyRead().read(mocker.Mock(), make_request(chunks=4), Window(0, 0, 2, 2))
+            strat.read(io, req, window)
 
     def test_rejects_out_shape(self, mocker):
         """``out_shape`` with ``chunks`` raises ``NotImplementedError``."""
+        strat = LazyRead()
+        io = mocker.Mock()
         req = make_request(chunks=4, out_shape=(2, 2))
         with pytest.raises(NotImplementedError, match="out_shape"):
-            LazyRead().read(mocker.Mock(), req, None)
+            strat.read(io, req, None)
 
     def test_rejects_masked(self, mocker):
         """``masked`` with ``chunks`` raises ``NotImplementedError``."""
-        req = make_request(chunks=4, masked=True)
+        strat, io, req = LazyRead(), mocker.Mock(), make_request(chunks=4, masked=True)
         with pytest.raises(NotImplementedError, match="masked=True"):
-            LazyRead().read(mocker.Mock(), req, None)
+            strat.read(io, req, None)
 
 
 class TestDecimatedRead:
@@ -189,9 +195,11 @@ class TestDecimatedRead:
 
     def test_rejects_masked(self, mocker):
         """``masked`` with ``out_shape`` raises ``NotImplementedError``."""
+        strat = DecimatedRead()
+        io = mocker.Mock()
         req = make_request(out_shape=(2, 2), masked=True)
         with pytest.raises(NotImplementedError, match="masked=True"):
-            DecimatedRead().read(mocker.Mock(), req, None)
+            strat.read(io, req, None)
 
 
 class TestBoundlessRead:
@@ -223,14 +231,16 @@ class TestBoundlessRead:
 
     def test_rejects_masked(self, mocker):
         """``masked`` with ``boundless`` raises ``NotImplementedError``."""
-        req = make_request(boundless=True, masked=True)
+        strat, io = BoundlessRead(), mocker.Mock()
+        req, window = make_request(boundless=True, masked=True), Window(0, 0, 2, 2)
         with pytest.raises(NotImplementedError, match="masked=True"):
-            BoundlessRead().read(mocker.Mock(), req, Window(0, 0, 2, 2))
+            strat.read(io, req, window)
 
     def test_requires_a_window(self, mocker):
         """A boundless read without a window raises ``ValueError``."""
+        strat, io, req = BoundlessRead(), mocker.Mock(), make_request(boundless=True)
         with pytest.raises(ValueError, match="requires a window"):
-            BoundlessRead().read(mocker.Mock(), make_request(boundless=True), None)
+            strat.read(io, req, None)
 
     def test_rejects_geometry_window(self, mocker):
         """A geometry (``GeoDataFrame``) window with boundless raises ``ValueError``.
@@ -239,9 +249,11 @@ class TestBoundlessRead:
             Boundless needs a pixel window; a FeatureCollection is clipped by
             definition and must be rejected.
         """
+        strat, io = BoundlessRead(), mocker.Mock()
+        req = make_request(boundless=True)
         geom_window = FeatureCollection.from_bbox((0, 0, 1, 1), epsg=4326)
         with pytest.raises(ValueError, match="pixel window"):
-            BoundlessRead().read(mocker.Mock(), make_request(boundless=True), geom_window)
+            strat.read(io, req, geom_window)
 
 
 class TestThreadsafeRead:
@@ -269,9 +281,11 @@ class TestThreadsafeRead:
 
     def test_rejects_masked(self, mocker):
         """``masked`` with ``threadsafe`` raises ``NotImplementedError``."""
+        strat = ThreadsafeRead()
+        io = mocker.Mock()
         req = make_request(threadsafe=True, masked=True)
         with pytest.raises(NotImplementedError, match="masked=True"):
-            ThreadsafeRead().read(mocker.Mock(), req, None)
+            strat.read(io, req, None)
 
 
 class TestEagerRead:

--- a/tests/dataset/engines/test_read_window.py
+++ b/tests/dataset/engines/test_read_window.py
@@ -1,0 +1,85 @@
+"""Tests for the shared ``resolve_read_window`` bbox/window resolver.
+
+Covers the core that ``Dataset.read_array`` and ``NetCDF._resolve_bbox_to_window``
+now share: the ``bbox``/``window`` mutual-exclusivity check and the folding of a
+``bbox`` into a one-row ``FeatureCollection`` in the caller-injected CRS.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pyramids.dataset.engines._read_window import resolve_read_window
+from pyramids.dataset.window import Window
+from pyramids.feature import FeatureCollection
+
+pytestmark = pytest.mark.core
+
+
+class TestResolveReadWindow:
+    """``resolve_read_window(window, bbox, *, crs)`` behaviour."""
+
+    def test_no_bbox_returns_window_unchanged(self):
+        """With ``bbox=None`` the caller's ``window`` passes straight through.
+
+        Test scenario:
+            A pixel ``Window`` and ``bbox=None`` returns the very same object.
+        """
+        window = Window(1, 2, 3, 4)
+        result = resolve_read_window(window, None, crs=4326)
+        assert result is window, "window must be returned unchanged when bbox is None"
+
+    def test_no_bbox_no_window_returns_none(self):
+        """With both ``bbox`` and ``window`` ``None`` the result is ``None``.
+
+        Test scenario:
+            A full read (no window, no bbox) resolves to ``None``.
+        """
+        result = resolve_read_window(None, None, crs=4326)
+        assert result is None, f"expected None for a full read, got {result!r}"
+
+    def test_bbox_and_window_together_raises(self):
+        """Passing both ``bbox`` and ``window`` is a ``ValueError``.
+
+        Test scenario:
+            The exclusivity guard fires with the shared "not both" message.
+        """
+        with pytest.raises(ValueError, match="either .*window.* or .*bbox.*not both"):
+            resolve_read_window(Window(0, 0, 2, 2), (0, 0, 1, 1), crs=4326)
+
+    def test_bbox_builds_feature_collection_in_crs(self):
+        """A ``bbox`` alone folds into a one-row ``FeatureCollection`` covering it.
+
+        Test scenario:
+            ``bbox=(0, 0, 2, 3)`` with ``crs=4326`` returns a FeatureCollection
+            whose single geometry's bounds equal the bbox in EPSG:4326.
+        """
+        bbox = (0.0, 0.0, 2.0, 3.0)
+        result = resolve_read_window(None, bbox, crs=4326)
+        assert isinstance(result, FeatureCollection), (
+            f"a bbox must resolve to a FeatureCollection, got {type(result)}"
+        )
+        assert len(result) == 1, "bbox should yield exactly one feature row"
+        np.testing.assert_allclose(
+            result.total_bounds,
+            np.array(bbox),
+            err_msg="the feature's bounds must equal the requested bbox",
+        )
+
+    def test_bbox_forwards_injected_crs(self, mocker):
+        """The injected ``crs`` is forwarded verbatim to ``from_bbox``.
+
+        Test scenario:
+            ``resolve_read_window`` must pass its ``crs`` argument through as
+            ``FeatureCollection.from_bbox(bbox, epsg=crs)`` — the mechanism that
+            lets IO and NetCDF inject different CRS conventions.
+        """
+        sentinel = object()
+        spy = mocker.patch.object(
+            FeatureCollection, "from_bbox", return_value=sentinel
+        )
+        bbox = (0.0, 0.0, 1.0, 1.0)
+        result = resolve_read_window(None, bbox, crs="EPSG:3857")
+        assert result is sentinel, "the from_bbox result must be returned as-is"
+        spy.assert_called_once_with(bbox, epsg="EPSG:3857")

--- a/tests/dataset/engines/test_read_window.py
+++ b/tests/dataset/engines/test_read_window.py
@@ -45,8 +45,9 @@ class TestResolveReadWindow:
         Test scenario:
             The exclusivity guard fires with the shared "not both" message.
         """
+        window = Window(0, 0, 2, 2)
         with pytest.raises(ValueError, match="either .*window.* or .*bbox.*not both"):
-            resolve_read_window(Window(0, 0, 2, 2), (0, 0, 1, 1), crs=4326)
+            resolve_read_window(window, (0, 0, 1, 1), crs=4326)
 
     def test_bbox_builds_feature_collection_in_crs(self):
         """A ``bbox`` alone folds into a one-row ``FeatureCollection`` covering it.

--- a/tests/dataset/engines/test_read_window.py
+++ b/tests/dataset/engines/test_read_window.py
@@ -77,9 +77,7 @@ class TestResolveReadWindow:
             lets IO and NetCDF inject different CRS conventions.
         """
         sentinel = object()
-        spy = mocker.patch.object(
-            FeatureCollection, "from_bbox", return_value=sentinel
-        )
+        spy = mocker.patch.object(FeatureCollection, "from_bbox", return_value=sentinel)
         bbox = (0.0, 0.0, 1.0, 1.0)
         result = resolve_read_window(None, bbox, crs="EPSG:3857")
         assert result is sentinel, "the from_bbox result must be returned as-is"

--- a/tests/dataset/io/test_window.py
+++ b/tests/dataset/io/test_window.py
@@ -488,3 +488,25 @@ class TestWindowConveniences:
             Window(0,0,4,4).crop(0, 0) -> None.
         """
         assert Window(0, 0, 4, 4).crop(rows=0, cols=0) is None
+
+
+class TestBboxlessReadDoesNotResolveEpsg:
+    """A bbox-less read must not evaluate `epsg` (read_array decomposition review L1)."""
+
+    def test_full_read_does_not_touch_epsg(self, ramp_dataset, mocker):
+        """A ``bbox=None`` read resolves no CRS, so ``epsg`` is never accessed.
+
+        Test scenario:
+            ``epsg`` is not always a free attribute read — on a ``NetCDF`` it can
+            trigger a state-mutating full-variable CRS scan. Make the property raise
+            and confirm a plain full read still succeeds, proving ``read_array`` does
+            not evaluate ``epsg`` when no ``bbox`` is given.
+        """
+        mocker.patch.object(
+            Dataset,
+            "epsg",
+            new_callable=mocker.PropertyMock,
+            side_effect=AssertionError("epsg must not be read for a bbox-less read"),
+        )
+        result = ramp_dataset.read_array(band=0)
+        assert result.shape == (6, 6), f"expected a full 6x6 read, got {result.shape}"

--- a/tests/netcdf/spatial/test_netcdf_bbox.py
+++ b/tests/netcdf/spatial/test_netcdf_bbox.py
@@ -427,6 +427,27 @@ class TestNetCDFReadArrayBbox:
                 chunks="auto",
             )
 
+    def test_window_bbox_chunks_together_raises_not_both_first(self, root_nc: NetCDF):
+        """Test the window/bbox exclusivity fires before the ``chunks=`` + ``bbox=`` guard.
+
+        Args:
+            root_nc: Module-scope root NetCDF fixture.
+
+        Test scenario:
+            With ``window`` + ``bbox`` + ``chunks`` all set (multiply invalid), the
+            "not both" exclusivity message must win, matching the historical order where
+            the exclusivity check precedes the ``chunks=`` + ``bbox=`` guard. Pins the
+            precedence so the shared ``resolve_read_window`` refactor cannot silently
+            demote the exclusivity check below the ``chunks``/no-CRS guards.
+        """
+        with pytest.raises(ValueError, match="not both"):
+            root_nc.read_array(
+                variable="Band1",
+                window=[0, 0, 10, 10],
+                bbox=(10.0, -50.0, 50.0, -20.0),
+                chunks="auto",
+            )
+
     def test_crs_less_netcdf_without_epsg_raises(self, root_nc: NetCDF, mocker):
         """Test ``read_array(bbox=…)`` on a CRS-less NetCDF raises ``ValueError``.
 


### PR DESCRIPTION
# Description

Refactor `IO.read_array` to clear the SonarCloud `python:S3776` **cognitive-complexity 61** finding
by decomposing its inlined responsibilities into cohesive, reusable components — following the data,
not mechanical extract-method. `read_array`'s public 13-arg signature and every error message and
exception type are preserved; this is a behaviour-preserving refactor.

`read_array` was already a thin dispatcher over seven self-contained read helpers. The complexity
lived in three responsibilities inlined around them: a ~40-line option-incompatibility matrix, a
`bbox`/window resolution block duplicated in `NetCDF`, and a five-way `if/elif` read-path ladder
whose branches each repeated their own precondition checks and a bare `"numpy"`/`"dask"` backend
literal. Each of those is lifted into its own home:

- **`ReadRequest`** (`dataset/engines/_read_request.py`) — a frozen option value-object whose
  `__post_init__` runs the option-incompatibility matrix (the pairings that are never legal,
  regardless of which read path runs). It is built from the raw options **before** `bbox`/`window`
  resolution, so those guards keep firing ahead of window resolution exactly as they did inline.
- **`resolve_read_window`** (`dataset/engines/_read_window.py`) — the shared `bbox`/`window`
  exclusivity check + `FeatureCollection.from_bbox`, with the resolved CRS **injected** by the
  caller. Both `Dataset.read_array` (IO engine) and `NetCDF._resolve_bbox_to_window` now call it, so
  the duplicated resolution lives in one place while each reader keeps its own CRS conventions.
- **`ReadStrategy`** set (`dataset/engines/_read_strategies.py`) — `LazyRead` / `DecimatedRead` /
  `BoundlessRead` / `ThreadsafeRead` / `EagerRead`. Each declares when it `matches` a request,
  enforces its own window-dependent preconditions, delegates to the existing `_*_read` helper, and
  names the backend it yields. `READ_STRATEGIES` preserves the original ladder precedence
  (`chunks → out_shape → boundless → threadsafe → eager`), so multi-option inputs resolve to the
  same path and raise the same error.

`read_array`'s ~155-line body collapses to a ~10-line orchestrator: build the request, resolve the
window, pick the first matching strategy, read, record its backend. The seven read helpers, the
`Window` value object, `FeatureCollection.from_bbox`, and the `_validate.py` validators are all
reused as-is.

# Issues

- Closes #1021 — decompose `IO.read_array` (S3776 cognitive-complexity 61) into `ReadRequest` + `ReadStrategy`

## Type of change

- [x] Refactor / internal code-quality change (non-breaking, no functional change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Full non-plot suite in the dev env: `pixi run --frozen -e dev pytest -m "not plot" -q` →
      **8476 passed, 53 skipped, 404 deselected**.
- [x] Targeted read-path nets: `tests/dataset/io`, `tests/dataset/collection/test_lazy.py` (dask
      path), and `tests/netcdf` (which routes through the shared `resolve_read_window`) — all green.
- [x] `mypy` clean on the changed/new engine files
      (`_read_request.py`, `_read_strategies.py`, `_read_window.py`, `io.py`).

Reproduce:

```bash
pixi run --frozen -e dev pytest -m "not plot" -q
pixi run --frozen -e dev mypy src/pyramids/dataset/engines/io.py \
  src/pyramids/dataset/engines/_read_request.py \
  src/pyramids/dataset/engines/_read_strategies.py \
  src/pyramids/dataset/engines/_read_window.py
```

# Checklist:

- [ ] updated version number in pyproject.toml. — N/A (versions handled by commitizen/CI).
- [ ] added changes to History.rst. — N/A (changelog is generated).
- [ ] updated the latest version in README file. — N/A.
- [ ] I have added tests that prove my fix is effective or that my feature works. — behaviour-preserving
      refactor; pinned by the existing per-read-path test net (each strategy and each incompatibility
      guard already has a dedicated test).
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated. — no user-facing docs affected; the new components carry full docstrings.
