### PR TITLE
feat(dataset): warn on outside-template rasterize + add snap_to_template mode (#46)

### DIFF
--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -3682,6 +3682,55 @@ class Dataset(RasterBase):
                 `column_name` is not `str` / `list` / `None`.
             CRSError: `features.epsg` is `None`, or
                 `template.epsg!= features.epsg`.
+
+        Examples:
+            - `cell_size` sizes the output to the feature bounds:
+
+              ```python
+              >>> import geopandas as gpd
+              >>> from shapely.geometry import box
+              >>> from pyramids.dataset import Dataset
+              >>> from pyramids.feature import FeatureCollection
+              >>> gdf = gpd.GeoDataFrame(
+              ...     {"class_id": [7]},
+              ...     geometry=[box(0.0, 0.0, 3.0, 3.0)],
+              ...     crs="EPSG:4326",
+              ... )
+              >>> raster = Dataset.from_features(
+              ...     FeatureCollection(gdf), cell_size=1.0, column_name="class_id"
+              ... )
+              >>> (raster.rows, raster.columns)
+              (3, 3)
+              >>> int(raster.read_array().max())
+              7
+
+              ```
+
+            - A `template` burns onto its fixed grid, so the output adopts the template's
+              shape (features outside it would warn and yield all-nodata — see #46):
+
+              ```python
+              >>> import numpy as np
+              >>> template = Dataset.create_from_array(
+              ...     np.zeros((5, 5), dtype="int32"),
+              ...     top_left_corner=(0.0, 5.0),
+              ...     cell_size=1.0,
+              ...     epsg=4326,
+              ... )
+              >>> inside = FeatureCollection(
+              ...     gpd.GeoDataFrame(
+              ...         {"class_id": [7]},
+              ...         geometry=[box(1.0, 1.0, 4.0, 4.0)],
+              ...         crs="EPSG:4326",
+              ...     )
+              ... )
+              >>> burned = Dataset.from_features(
+              ...     inside, template=template, column_name="class_id"
+              ... )
+              >>> (burned.rows, burned.columns)
+              (5, 5)
+
+              ```
         """
         return rasterize_features(
             features,

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -3675,7 +3675,8 @@ class Dataset(RasterBase):
                 features' bounds snapped outward onto the template's grid
                 lines — a small raster that still co-registers with the
                 template pixel-for-pixel (#46). Requires a square,
-                axis-aligned, north-up template and non-empty features.
+                axis-aligned template and features with valid (non-NaN)
+                geometry bounds.
             column_name (str | list[str] | None):
                 Attribute column(s) to burn as band values. `None`
                 burns every non-geometry column as a separate band.

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -3639,6 +3639,7 @@ class Dataset(RasterBase):
         *,
         cell_size: Any | None = None,
         template: Dataset | None = None,
+        snap_to_template: bool = False,
         column_name: str | list[str] | None = None,
     ) -> Dataset:
         """Rasterize a :class:`FeatureCollection` into a new :class:`Dataset`.
@@ -3648,8 +3649,11 @@ class Dataset(RasterBase):
         When a `template` Dataset is given, the output adopts its
         geotransform, cell size, row/column count, and no-data value —
         the vector is burned onto the template's fixed grid, so features
-        outside it are clipped. Otherwise `cell_size` controls the
-        resolution and the extent is derived from
+        outside it are clipped. With `snap_to_template=True` the template
+        supplies only the cell size and grid alignment while the extent is
+        cropped to the features (snapped onto the template's grid lines),
+        giving a small raster co-registered with the template. Otherwise
+        `cell_size` controls the resolution and the extent is derived from
         :attr:`FeatureCollection.total_bounds`.
 
         Args:
@@ -3665,6 +3669,13 @@ class Dataset(RasterBase):
                 empty FeatureCollection, produce an all-nodata raster
                 and emit a `UserWarning` (#46); use `cell_size` instead
                 to size the output to the features.
+            snap_to_template (bool):
+                When `True` (requires `template`), keep the template's
+                cell size and grid alignment but size the output to the
+                features' bounds snapped outward onto the template's grid
+                lines — a small raster that still co-registers with the
+                template pixel-for-pixel (#46). Requires a square,
+                axis-aligned, north-up template and non-empty features.
             column_name (str | list[str] | None):
                 Attribute column(s) to burn as band values. `None`
                 burns every non-geometry column as a separate band.
@@ -3731,12 +3742,31 @@ class Dataset(RasterBase):
               (5, 5)
 
               ```
+
+            - `snap_to_template=True` keeps the template's grid but crops to the features,
+              so the output is small yet co-registered (its origin is on the template's
+              grid lines):
+
+              ```python
+              >>> snapped = Dataset.from_features(
+              ...     inside,
+              ...     template=template,
+              ...     snap_to_template=True,
+              ...     column_name="class_id",
+              ... )
+              >>> (snapped.rows, snapped.columns)
+              (3, 3)
+              >>> snapped.top_left_corner
+              (1.0, 4.0)
+
+              ```
         """
         return rasterize_features(
             features,
             cls,
             cell_size=cell_size,
             template=template,
+            snap_to_template=snap_to_template,
             column_name=column_name,
         )
 

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -3646,9 +3646,11 @@ class Dataset(RasterBase):
         Burns the values from `column_name` (or every attribute
         column if `None`) into a single-band or multi-band raster.
         When a `template` Dataset is given, the output adopts its
-        geotransform, cell size, row/column count, and no-data value.
-        Otherwise `cell_size` controls the resolution and the extent
-        is derived from :attr:`FeatureCollection.total_bounds`.
+        geotransform, cell size, row/column count, and no-data value —
+        the vector is burned onto the template's fixed grid, so features
+        outside it are clipped. Otherwise `cell_size` controls the
+        resolution and the extent is derived from
+        :attr:`FeatureCollection.total_bounds`.
 
         Args:
             features (FeatureCollection):
@@ -3658,7 +3660,11 @@ class Dataset(RasterBase):
                 `template` is given.
             template (Dataset | None):
                 Optional template raster. When supplied, the output
-                inherits its geotransform and no-data value.
+                inherits its geotransform and no-data value. Features
+                that fall entirely outside the template extent produce
+                an all-nodata raster and raise a `UserWarning` (#46);
+                use `cell_size` instead to size the output to the
+                features.
             column_name (str | list[str] | None):
                 Attribute column(s) to burn as band values. `None`
                 burns every non-geometry column as a separate band.

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -3661,10 +3661,10 @@ class Dataset(RasterBase):
             template (Dataset | None):
                 Optional template raster. When supplied, the output
                 inherits its geotransform and no-data value. Features
-                that fall entirely outside the template extent produce
-                an all-nodata raster and raise a `UserWarning` (#46);
-                use `cell_size` instead to size the output to the
-                features.
+                that fall entirely outside the template extent, or an
+                empty FeatureCollection, produce an all-nodata raster
+                and emit a `UserWarning` (#46); use `cell_size` instead
+                to size the output to the features.
             column_name (str | list[str] | None):
                 Attribute column(s) to burn as band values. `None`
                 burns every non-geometry column as a separate band.

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -3676,7 +3676,9 @@ class Dataset(RasterBase):
                 lines — a small raster that still co-registers with the
                 template pixel-for-pixel (#46). Requires a square,
                 axis-aligned template and features with valid (non-NaN)
-                geometry bounds.
+                geometry bounds. The output is sized to the features, so a
+                fine-celled template with far-apart features can allocate a
+                large raster.
             column_name (str | list[str] | None):
                 Attribute column(s) to burn as band values. `None`
                 burns every non-geometry column as a separate band.
@@ -3689,7 +3691,10 @@ class Dataset(RasterBase):
 
         Raises:
             ValueError: `cell_size` missing or non-positive,
-                `column_name` empty or referencing missing columns.
+                `column_name` empty or referencing missing columns,
+                `snap_to_template` set without a `template`, or (in snap
+                mode) a rotated / non-square template or features with no
+                valid (non-NaN) geometry bounds.
             TypeError: `template` is not a Dataset, or
                 `column_name` is not `str` / `list` / `None`.
             CRSError: `features.epsg` is `None`, or

--- a/src/pyramids/dataset/ops/vectorize.py
+++ b/src/pyramids/dataset/ops/vectorize.py
@@ -43,8 +43,9 @@ def rasterize_features(
         template: Optional template raster. When supplied, the output
             inherits its geotransform and no-data value (the vector is
             burned onto the template's fixed grid). Features that fall
-            entirely outside the template extent produce an all-nodata
-            raster and raise a ``UserWarning`` (issue #46).
+            entirely outside the template extent, or an empty
+            FeatureCollection, produce an all-nodata raster and emit a
+            ``UserWarning`` (issue #46).
         column_name: Attribute column(s) to burn as band values.
             `None` burns every non-geometry column as a separate band.
 
@@ -79,9 +80,11 @@ def rasterize_features(
 
     if template is not None and _features_outside_template(features, template):
         warnings.warn(
-            "FeatureCollection falls entirely outside the template extent; the output "
-            "raster will be all-nodata. Check that the template covers the features and "
-            "that both use the same CRS.",
+            "FeatureCollection is empty or falls entirely outside the template extent; "
+            "the output raster will be all-nodata. Check that the template covers the "
+            "features and that both use the same CRS.",
+            # stacklevel targets the caller of Dataset.from_features (the primary API);
+            # a direct rasterize_features(...) call points one frame higher.
             stacklevel=3,
         )
 
@@ -111,18 +114,22 @@ def rasterize_features(
         no_data_value,
     )
 
-    with _feature_ogr.as_datasource(features, gdal_dataset=True) as vector_ds:
-        for ind in range(bands_count):
-            attribute = (
-                column_name[ind] if isinstance(column_name, list) else column_name
-            )
-            rasterize_opts = gdal.RasterizeOptions(
-                bands=[ind + 1],
-                burnValues=None,
-                attribute=attribute,
-                allTouched=True,
-            )
-            gdal.Rasterize(dataset_n.raster, vector_ds, options=rasterize_opts)
+    # An empty FeatureCollection has no layer field to burn (gdal.Rasterize would raise
+    # "Failed to find field ..."); the freshly created raster is already all-nodata, so
+    # skip the burn and return it (the warning above has already flagged the empty input).
+    if len(features):
+        with _feature_ogr.as_datasource(features, gdal_dataset=True) as vector_ds:
+            for ind in range(bands_count):
+                attribute = (
+                    column_name[ind] if isinstance(column_name, list) else column_name
+                )
+                rasterize_opts = gdal.RasterizeOptions(
+                    bands=[ind + 1],
+                    burnValues=None,
+                    attribute=attribute,
+                    allTouched=True,
+                )
+                gdal.Rasterize(dataset_n.raster, vector_ds, options=rasterize_opts)
 
     return dataset_n
 
@@ -209,18 +216,23 @@ def _features_outside_template(features: FeatureCollection, template: Dataset) -
 
     The template extent comes from :attr:`Dataset.bbox`, which uses the separate X and Y
     pixel sizes, so the check is correct for non-square grids (a single ``cell_size``
-    would mis-measure the Y extent).
+    would mis-measure the Y extent). An empty (or all-empty-geometry) FeatureCollection
+    has ``NaN`` bounds and also burns to all-nodata, so it is treated as outside too.
 
     Args:
         features: The vector being rasterised.
         template: The template raster whose extent the features are tested against.
 
     Returns:
-        bool: ``True`` when the feature bounds and the template extent are disjoint.
+        bool: ``True`` when the feature bounds are empty/degenerate or disjoint from the
+        template extent.
     """
     txmin, tymin, txmax, tymax = template.bbox
     fxmin, fymin, fxmax, fymax = features.total_bounds
-    return bool(fxmax <= txmin or fxmin >= txmax or fymax <= tymin or fymin >= tymax)
+    empty = any(np.isnan(v) for v in (fxmin, fymin, fxmax, fymax))
+    return bool(
+        empty or fxmax <= txmin or fxmin >= txmax or fymax <= tymin or fymin >= tymax
+    )
 
 
 def _resolve_burn_columns(

--- a/src/pyramids/dataset/ops/vectorize.py
+++ b/src/pyramids/dataset/ops/vectorize.py
@@ -25,6 +25,7 @@ def rasterize_features(
     *,
     cell_size: Any | None = None,
     template: Dataset | None = None,
+    snap_to_template: bool = False,
     column_name: str | list[str] | None = None,
 ) -> Dataset:
     """Burn a :class:`FeatureCollection` into a new raster.
@@ -46,6 +47,13 @@ def rasterize_features(
             entirely outside the template extent, or an empty
             FeatureCollection, produce an all-nodata raster and emit a
             ``UserWarning`` (issue #46).
+        snap_to_template: When ``True`` (requires `template`), the output
+            keeps the template's cell size and grid alignment but is sized
+            to the features' bounds snapped outward onto the template's
+            grid lines — a small, template-co-registered raster instead of
+            one spanning the whole template (issue #46). Requires a square,
+            axis-aligned, north-up template and a non-empty
+            FeatureCollection.
         column_name: Attribute column(s) to burn as band values.
             `None` burns every non-geometry column as a separate band.
 
@@ -64,7 +72,7 @@ def rasterize_features(
         CRSError: If the FeatureCollection has no CRS, or
             `template.epsg!= features.epsg`.
     """
-    _validate_rasterize_args(cell_size, template, column_name)
+    _validate_rasterize_args(cell_size, template, snap_to_template, column_name)
 
     ds_epsg = features.epsg
     if ds_epsg is None:
@@ -75,14 +83,20 @@ def rasterize_features(
         )
 
     xmin, ymax, rows, columns, cell_size, no_data_value = _resolve_raster_geometry(
-        features, dataset_cls, template, cell_size, ds_epsg
+        features, dataset_cls, template, cell_size, ds_epsg, snap_to_template
     )
 
     # Resolve (and validate) the burn columns before warning, so an invalid column_name
     # raises rather than emitting a warning about an output that is never produced.
     column_name, numpy_dtype = _resolve_burn_columns(features, column_name)
 
-    if template is not None and _features_outside_template(features, template):
+    # In snap mode the output is sized to the features, so it always covers them — the
+    # outside-template warning applies only to the full-template mode.
+    if (
+        template is not None
+        and not snap_to_template
+        and _features_outside_template(features, template)
+    ):
         warnings.warn(
             "FeatureCollection is empty or falls entirely outside the template extent; "
             "the output raster will likely be all-nodata. Check that the template covers "
@@ -139,19 +153,22 @@ def rasterize_features(
 def _validate_rasterize_args(
     cell_size: Any | None,
     template: Dataset | None,
+    snap_to_template: bool,
     column_name: str | list[str] | None,
 ) -> None:
     """Validate the scalar arguments of :func:`rasterize_features`.
 
     Raises:
-        ValueError: Neither ``cell_size`` nor ``template`` given, or a
-            non-positive ``cell_size``.
+        ValueError: Neither ``cell_size`` nor ``template`` given, a non-positive
+            ``cell_size``, or ``snap_to_template`` without a ``template``.
         TypeError: ``column_name`` is not ``str`` / ``list`` / ``None``.
     """
     if cell_size is None and template is None:
         raise ValueError("You have to enter either cell size or Dataset object.")
     if cell_size is not None and cell_size <= 0:
         raise ValueError(f"cell_size must be positive; got {cell_size!r}.")
+    if snap_to_template and template is None:
+        raise ValueError("snap_to_template=True requires a template Dataset.")
     if column_name is not None and not isinstance(column_name, (str, list)):
         raise TypeError(
             f"column_name must be str, list[str], or None; "
@@ -165,12 +182,15 @@ def _resolve_raster_geometry(
     template: Dataset | None,
     cell_size: Any | None,
     ds_epsg: int,
+    snap_to_template: bool = False,
 ) -> tuple[float, float, int, int, Any, Any]:
     """Resolve the output raster geometry for :func:`rasterize_features`.
 
-    With a ``template`` the geometry (origin, size, cell size, no-data) is
-    inherited from it after validating its type and CRS; otherwise it is derived
-    from the feature bounds and the requested ``cell_size``.
+    With a ``template`` the geometry (origin, size, cell size, no-data) is inherited from
+    it after validating its type and CRS; with ``snap_to_template`` the template supplies
+    only the cell size and grid alignment while the extent is the feature bounds snapped
+    onto the template grid; otherwise it is derived from the feature bounds and the
+    requested ``cell_size``.
 
     Returns:
         ``(xmin, ymax, rows, columns, cell_size, no_data_value)``.
@@ -178,6 +198,8 @@ def _resolve_raster_geometry(
     Raises:
         TypeError: ``template`` is not an instance of ``dataset_cls``.
         CRSError: ``template.epsg`` differs from the FeatureCollection's EPSG.
+        ValueError: ``snap_to_template`` with a rotated/non-square template or an empty
+            FeatureCollection.
     """
     if template is not None:
         if not isinstance(template, dataset_cls):
@@ -190,21 +212,69 @@ def _resolve_raster_geometry(
                 f"Dataset and vector are not the same EPSG. "
                 f"{template.epsg} != {ds_epsg}"
             )
-        xmin, ymax = template.top_left_corner
+        if snap_to_template:
+            xmin, ymax, rows, columns, cell_size = _snap_extent_to_template(
+                features, template
+            )
+        else:
+            xmin, ymax = template.top_left_corner
+            rows = template.rows
+            columns = template.columns
+            cell_size = template.cell_size
         no_data_value = (
             template.no_data_value[0]
             if template.no_data_value[0] is not None
             else np.nan
         )
-        rows = template.rows
-        columns = template.columns
-        cell_size = template.cell_size
     else:
         xmin, ymin, xmax, ymax = features.total_bounds
         no_data_value = dataset_cls.default_no_data_value
         columns = int(np.ceil((xmax - xmin) / cell_size))
         rows = int(np.ceil((ymax - ymin) / cell_size))
     return xmin, ymax, rows, columns, cell_size, no_data_value
+
+
+def _snap_extent_to_template(
+    features: FeatureCollection, template: Dataset
+) -> tuple[float, float, int, int, float]:
+    """Size the output to the features, snapped onto the template's grid (issue #46).
+
+    The output keeps the template's cell size and grid alignment (its pixel edges line up
+    with the template's), but spans only the feature bounds snapped *outward* to the
+    template's grid lines — a small raster co-registered with the template rather than one
+    covering the whole template.
+
+    Args:
+        features: The vector being rasterised (must be non-empty).
+        template: A square, axis-aligned, north-up template raster.
+
+    Returns:
+        ``(xmin, ymax, rows, columns, cell_size)`` for the snapped output grid.
+
+    Raises:
+        ValueError: The template is rotated or non-square, or the features are empty.
+    """
+    x0, px, rx, y0, ry, py = template.geotransform
+    if rx or ry:
+        raise ValueError("snap_to_template does not support a rotated template.")
+    if abs(px) != abs(py):
+        raise ValueError(
+            "snap_to_template requires a square template (equal X/Y pixel size); "
+            f"got {abs(px)} x {abs(py)}."
+        )
+    fxmin, fymin, fxmax, fymax = features.total_bounds
+    if any(np.isnan(v) for v in (fxmin, fymin, fxmax, fymax)):
+        raise ValueError(
+            "snap_to_template needs a non-empty FeatureCollection to size the output."
+        )
+    size = abs(px)
+    snap_xmin = x0 + np.floor((fxmin - x0) / size) * size
+    snap_xmax = x0 + np.ceil((fxmax - x0) / size) * size
+    snap_ymax = y0 - np.floor((y0 - fymax) / size) * size
+    snap_ymin = y0 - np.ceil((y0 - fymin) / size) * size
+    columns = max(1, int(round((snap_xmax - snap_xmin) / size)))
+    rows = max(1, int(round((snap_ymax - snap_ymin) / size)))
+    return float(snap_xmin), float(snap_ymax), rows, columns, size
 
 
 def _features_outside_template(features: FeatureCollection, template: Dataset) -> bool:

--- a/src/pyramids/dataset/ops/vectorize.py
+++ b/src/pyramids/dataset/ops/vectorize.py
@@ -54,7 +54,9 @@ def rasterize_features(
             grid lines — a small, template-co-registered raster instead of
             one spanning the whole template (issue #46). Requires a square,
             axis-aligned template and a FeatureCollection with valid
-            (non-NaN) geometry bounds.
+            (non-NaN) geometry bounds. The output is sized to the features,
+            so a fine-celled template with far-apart features can allocate a
+            large raster.
         column_name: Attribute column(s) to burn as band values.
             `None` burns every non-geometry column as a separate band.
 
@@ -66,8 +68,11 @@ def rasterize_features(
         without silent coercion.
 
     Raises:
-        ValueError: If `cell_size` is missing or non-positive, or
-            if `column_name` is empty / references missing columns.
+        ValueError: If `cell_size` is missing or non-positive, if
+            `column_name` is empty / references missing columns, if
+            `snap_to_template` is set without a `template`, or (in snap
+            mode) the template is rotated / non-square or the features
+            have no valid (non-NaN) geometry bounds.
         TypeError: If `template` is not a Dataset, or
             `column_name` is not `str` / `list` / `None`.
         CRSError: If the FeatureCollection has no CRS, or
@@ -283,7 +288,9 @@ def _snap_extent_to_template(
     size = abs(px)
     # Nudge by _SNAP_EPS (in cell units) so a bound mathematically on a grid line but a
     # few ULPs off does not push floor/ceil one cell too far — the snapped box stays tight
-    # and the output size is stable across CRSs, while still never under-covering.
+    # and the output size is stable across CRSs. Trade-off: a genuine feature edge lying
+    # within _SNAP_EPS (1e-9 cell) past a grid line is treated as on it, so it never
+    # over-covers by a spurious cell at the cost of that sub-nanocell ambiguity.
     snap_xmin = x0 + np.floor((fxmin - x0) / size + _SNAP_EPS) * size
     snap_xmax = x0 + np.ceil((fxmax - x0) / size - _SNAP_EPS) * size
     snap_ymax = y0 - np.floor((y0 - fymax) / size + _SNAP_EPS) * size

--- a/src/pyramids/dataset/ops/vectorize.py
+++ b/src/pyramids/dataset/ops/vectorize.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -40,7 +41,10 @@ def rasterize_features(
         cell_size: Cell size for the new raster. Required unless
             `template` is given.
         template: Optional template raster. When supplied, the output
-            inherits its geotransform and no-data value.
+            inherits its geotransform and no-data value (the vector is
+            burned onto the template's fixed grid). Features that fall
+            entirely outside the template extent produce an all-nodata
+            raster and raise a ``UserWarning`` (issue #46).
         column_name: Attribute column(s) to burn as band values.
             `None` burns every non-geometry column as a separate band.
 
@@ -72,6 +76,16 @@ def rasterize_features(
     xmin, ymax, rows, columns, cell_size, no_data_value = _resolve_raster_geometry(
         features, dataset_cls, template, cell_size, ds_epsg
     )
+
+    if template is not None and _features_outside_template(
+        features, xmin, ymax, rows, columns, cell_size
+    ):
+        warnings.warn(
+            "FeatureCollection falls entirely outside the template extent; the output "
+            "raster will be all-nodata. Check that the template covers the features and "
+            "that both use the same CRS.",
+            stacklevel=3,
+        )
 
     column_name, numpy_dtype = _resolve_burn_columns(features, column_name)
 
@@ -184,6 +198,44 @@ def _resolve_raster_geometry(
         columns = int(np.ceil((xmax - xmin) / cell_size))
         rows = int(np.ceil((ymax - ymin) / cell_size))
     return xmin, ymax, rows, columns, cell_size, no_data_value
+
+
+def _features_outside_template(
+    features: FeatureCollection,
+    xmin: float,
+    ymax: float,
+    rows: int,
+    columns: int,
+    cell_size: Any,
+) -> bool:
+    """Whether the feature bounds fall entirely outside the template extent (issue #46).
+
+    A template rasterisation burns onto the template's fixed grid, so features that lie
+    wholly outside it produce an all-nodata raster. Detecting the disjoint case lets
+    :func:`rasterize_features` warn rather than silently return an empty raster. A
+    partial overlap is not flagged — clipping features to the template grid is the
+    intended behaviour of a template.
+
+    Args:
+        features: The vector being rasterised.
+        xmin: Template origin x (left edge).
+        ymax: Template origin y (top edge).
+        rows: Template row count.
+        columns: Template column count.
+        cell_size: Template cell size.
+
+    Returns:
+        bool: ``True`` when the feature bounds and the template extent are disjoint.
+    """
+    template_xmax = xmin + columns * cell_size
+    template_ymin = ymax - rows * cell_size
+    fxmin, fymin, fxmax, fymax = features.total_bounds
+    return bool(
+        fxmax <= xmin
+        or fxmin >= template_xmax
+        or fymax <= template_ymin
+        or fymin >= ymax
+    )
 
 
 def _resolve_burn_columns(

--- a/src/pyramids/dataset/ops/vectorize.py
+++ b/src/pyramids/dataset/ops/vectorize.py
@@ -78,17 +78,19 @@ def rasterize_features(
         features, dataset_cls, template, cell_size, ds_epsg
     )
 
+    # Resolve (and validate) the burn columns before warning, so an invalid column_name
+    # raises rather than emitting a warning about an output that is never produced.
+    column_name, numpy_dtype = _resolve_burn_columns(features, column_name)
+
     if template is not None and _features_outside_template(features, template):
         warnings.warn(
             "FeatureCollection is empty or falls entirely outside the template extent; "
-            "the output raster will be all-nodata. Check that the template covers the "
-            "features and that both use the same CRS.",
+            "the output raster will likely be all-nodata. Check that the template covers "
+            "the features and that both use the same CRS.",
             # stacklevel targets the caller of Dataset.from_features (the primary API);
             # a direct rasterize_features(...) call points one frame higher.
             stacklevel=3,
         )
-
-    column_name, numpy_dtype = _resolve_burn_columns(features, column_name)
 
     # Integer raster dtypes cannot represent NaN. If the template
     # supplied None as no_data_value (defaulted to NaN above) and the
@@ -218,14 +220,17 @@ def _features_outside_template(features: FeatureCollection, template: Dataset) -
     pixel sizes, so the check is correct for non-square grids (a single ``cell_size``
     would mis-measure the Y extent). An empty (or all-empty-geometry) FeatureCollection
     has ``NaN`` bounds and also burns to all-nodata, so it is treated as outside too.
+    Rotated or south-up geotransforms are not handled — ``Dataset.bbox`` assumes an
+    axis-aligned, north-up grid (which ``Dataset.create`` always produces).
 
     Args:
         features: The vector being rasterised.
         template: The template raster whose extent the features are tested against.
 
     Returns:
-        bool: ``True`` when the feature bounds are empty/degenerate or disjoint from the
-        template extent.
+        bool: ``True`` when the feature bounds are empty (``NaN``) or disjoint from the
+        template extent. A zero-area feature *inside* the extent (e.g. a single point)
+        returns ``False``.
     """
     txmin, tymin, txmax, tymax = template.bbox
     fxmin, fymin, fxmax, fymax = features.total_bounds

--- a/src/pyramids/dataset/ops/vectorize.py
+++ b/src/pyramids/dataset/ops/vectorize.py
@@ -77,9 +77,7 @@ def rasterize_features(
         features, dataset_cls, template, cell_size, ds_epsg
     )
 
-    if template is not None and _features_outside_template(
-        features, xmin, ymax, rows, columns, cell_size
-    ):
+    if template is not None and _features_outside_template(features, template):
         warnings.warn(
             "FeatureCollection falls entirely outside the template extent; the output "
             "raster will be all-nodata. Check that the template covers the features and "
@@ -200,14 +198,7 @@ def _resolve_raster_geometry(
     return xmin, ymax, rows, columns, cell_size, no_data_value
 
 
-def _features_outside_template(
-    features: FeatureCollection,
-    xmin: float,
-    ymax: float,
-    rows: int,
-    columns: int,
-    cell_size: Any,
-) -> bool:
+def _features_outside_template(features: FeatureCollection, template: Dataset) -> bool:
     """Whether the feature bounds fall entirely outside the template extent (issue #46).
 
     A template rasterisation burns onto the template's fixed grid, so features that lie
@@ -216,26 +207,20 @@ def _features_outside_template(
     partial overlap is not flagged — clipping features to the template grid is the
     intended behaviour of a template.
 
+    The template extent comes from :attr:`Dataset.bbox`, which uses the separate X and Y
+    pixel sizes, so the check is correct for non-square grids (a single ``cell_size``
+    would mis-measure the Y extent).
+
     Args:
         features: The vector being rasterised.
-        xmin: Template origin x (left edge).
-        ymax: Template origin y (top edge).
-        rows: Template row count.
-        columns: Template column count.
-        cell_size: Template cell size.
+        template: The template raster whose extent the features are tested against.
 
     Returns:
         bool: ``True`` when the feature bounds and the template extent are disjoint.
     """
-    template_xmax = xmin + columns * cell_size
-    template_ymin = ymax - rows * cell_size
+    txmin, tymin, txmax, tymax = template.bbox
     fxmin, fymin, fxmax, fymax = features.total_bounds
-    return bool(
-        fxmax <= xmin
-        or fxmin >= template_xmax
-        or fymax <= template_ymin
-        or fymin >= ymax
-    )
+    return bool(fxmax <= txmin or fxmin >= txmax or fymax <= tymin or fymin >= tymax)
 
 
 def _resolve_burn_columns(

--- a/src/pyramids/dataset/ops/vectorize.py
+++ b/src/pyramids/dataset/ops/vectorize.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import warnings
 from typing import TYPE_CHECKING, Any
 
@@ -52,8 +53,8 @@ def rasterize_features(
             to the features' bounds snapped outward onto the template's
             grid lines — a small, template-co-registered raster instead of
             one spanning the whole template (issue #46). Requires a square,
-            axis-aligned, north-up template and a non-empty
-            FeatureCollection.
+            axis-aligned template and a FeatureCollection with valid
+            (non-NaN) geometry bounds.
         column_name: Attribute column(s) to burn as band values.
             `None` burns every non-geometry column as a separate band.
 
@@ -234,6 +235,13 @@ def _resolve_raster_geometry(
     return xmin, ymax, rows, columns, cell_size, no_data_value
 
 
+_SNAP_EPS = 1e-9
+"""Cell-unit nudge so floor/ceil snapping is stable for grid-aligned bounds (issue #46)."""
+
+_ROTATION_REL_TOL = 1e-6
+"""A geotransform rotation term below this fraction of the pixel size is treated as zero."""
+
+
 def _snap_extent_to_template(
     features: FeatureCollection, template: Dataset
 ) -> tuple[float, float, int, int, float]:
@@ -245,19 +253,23 @@ def _snap_extent_to_template(
     covering the whole template.
 
     Args:
-        features: The vector being rasterised (must be non-empty).
-        template: A square, axis-aligned, north-up template raster.
+        features: The vector being rasterised (must have valid, non-NaN bounds).
+        template: A square, axis-aligned template raster.
 
     Returns:
         ``(xmin, ymax, rows, columns, cell_size)`` for the snapped output grid.
 
     Raises:
-        ValueError: The template is rotated or non-square, or the features are empty.
+        ValueError: The template is rotated or non-square, or the features have no valid
+            (non-NaN) geometry bounds.
     """
     x0, px, rx, y0, ry, py = template.geotransform
-    if rx or ry:
+    # Tolerate ULP-level float noise: real GeoTIFFs (warped/reprojected) carry rotation
+    # terms of ~1e-16 and X/Y pixel sizes that differ by a few ULPs, which exact ==/!=
+    # comparisons would reject outright.
+    if abs(rx) > abs(px) * _ROTATION_REL_TOL or abs(ry) > abs(py) * _ROTATION_REL_TOL:
         raise ValueError("snap_to_template does not support a rotated template.")
-    if abs(px) != abs(py):
+    if not math.isclose(abs(px), abs(py), rel_tol=1e-9):
         raise ValueError(
             "snap_to_template requires a square template (equal X/Y pixel size); "
             f"got {abs(px)} x {abs(py)}."
@@ -265,13 +277,17 @@ def _snap_extent_to_template(
     fxmin, fymin, fxmax, fymax = features.total_bounds
     if any(np.isnan(v) for v in (fxmin, fymin, fxmax, fymax)):
         raise ValueError(
-            "snap_to_template needs a non-empty FeatureCollection to size the output."
+            "snap_to_template needs a FeatureCollection with valid (non-NaN) geometry "
+            "bounds to size the output."
         )
     size = abs(px)
-    snap_xmin = x0 + np.floor((fxmin - x0) / size) * size
-    snap_xmax = x0 + np.ceil((fxmax - x0) / size) * size
-    snap_ymax = y0 - np.floor((y0 - fymax) / size) * size
-    snap_ymin = y0 - np.ceil((y0 - fymin) / size) * size
+    # Nudge by _SNAP_EPS (in cell units) so a bound mathematically on a grid line but a
+    # few ULPs off does not push floor/ceil one cell too far — the snapped box stays tight
+    # and the output size is stable across CRSs, while still never under-covering.
+    snap_xmin = x0 + np.floor((fxmin - x0) / size + _SNAP_EPS) * size
+    snap_xmax = x0 + np.ceil((fxmax - x0) / size - _SNAP_EPS) * size
+    snap_ymax = y0 - np.floor((y0 - fymax) / size + _SNAP_EPS) * size
+    snap_ymin = y0 - np.ceil((y0 - fymin) / size - _SNAP_EPS) * size
     columns = max(1, int(round((snap_xmax - snap_xmin) / size)))
     rows = max(1, int(round((snap_ymax - snap_ymin) / size)))
     return float(snap_xmin), float(snap_ymax), rows, columns, size

--- a/tests/e2e/test_e2e_workflows.py
+++ b/tests/e2e/test_e2e_workflows.py
@@ -23,6 +23,7 @@ from osgeo import gdal
 from shapely.geometry import box
 
 from pyramids.dataset import Dataset, DatasetCollection
+from pyramids.dataset.ops.vectorize import _features_outside_template
 from pyramids.feature import FeatureCollection
 
 pytestmark = pytest.mark.core
@@ -236,6 +237,42 @@ class TestRasterizeRoundTrip:
 
         outside = [w for w in caught if "outside the template extent" in str(w.message)]
         assert not outside, f"an overlapping polygon must not warn; got: {outside}"
+
+    @pytest.mark.parametrize(
+        "feature_box, expected",
+        [
+            ((20.0, 2.0, 30.0, 8.0), True),  # east of the template
+            ((-30.0, 2.0, -20.0, 8.0), True),  # west of the template
+            ((2.0, 20.0, 8.0, 30.0), True),  # north of the template
+            ((2.0, -30.0, 8.0, -20.0), True),  # south of the template
+            ((2.0, 2.0, 8.0, 8.0), False),  # inside the template
+            ((5.0, 5.0, 15.0, 15.0), False),  # partial overlap (not flagged)
+        ],
+    )
+    def test_features_outside_template_by_direction(self, feature_box, expected):
+        """`_features_outside_template` flags a disjoint bbox in every direction (#46).
+
+        Args:
+            feature_box: `(minx, miny, maxx, maxy)` of the feature relative to a template
+                covering x[0, 10], y[0, 10].
+            expected: Whether the helper should report the feature as fully outside.
+
+        Test scenario:
+            A template at origin (0, 10), 10x10, cell size 1 covers x[0, 10] and y[0, 10].
+            Boxes to the east/west/north/south are disjoint (`True`); an inside box and a
+            partially overlapping box are not flagged (`False`).
+        """
+        minx, miny, maxx, maxy = feature_box
+        gdf = gpd.GeoDataFrame(
+            {"v": [1]}, geometry=[box(minx, miny, maxx, maxy)], crs="EPSG:4326"
+        )
+        fc = FeatureCollection(gdf)
+        result = _features_outside_template(
+            fc, xmin=0.0, ymax=10.0, rows=10, columns=10, cell_size=1.0
+        )
+        assert result is expected, (
+            f"box {feature_box} outside-template should be {expected}, got {result}"
+        )
 
     def test_from_features_rejects_non_positive_cell_size(self):
         """D-M2: cell_size=0 and negative values raise ``ValueError``."""

--- a/tests/e2e/test_e2e_workflows.py
+++ b/tests/e2e/test_e2e_workflows.py
@@ -267,9 +267,10 @@ class TestRasterizeRoundTrip:
             {"v": [1]}, geometry=[box(minx, miny, maxx, maxy)], crs="EPSG:4326"
         )
         fc = FeatureCollection(gdf)
-        result = _features_outside_template(
-            fc, xmin=0.0, ymax=10.0, rows=10, columns=10, cell_size=1.0
+        template = _make_dataset(
+            rows=10, cols=10, epsg=4326, cell_size=1.0, top_left=(0.0, 10.0)
         )
+        result = _features_outside_template(fc, template)
         assert result is expected, (
             f"box {feature_box} outside-template should be {expected}, got {result}"
         )

--- a/tests/e2e/test_e2e_workflows.py
+++ b/tests/e2e/test_e2e_workflows.py
@@ -320,45 +320,46 @@ class TestRasterizeRoundTrip:
             "a feature touching the template edge (zero overlap) is treated as outside"
         )
 
-    def test_from_features_warns_and_returns_all_nodata_for_empty_collection(self):
-        """An empty FeatureCollection warns and returns an all-nodata raster, not a crash (#46)."""
+    @pytest.mark.parametrize(
+        "class_ids, geometry",
+        [
+            (pd.Series([], dtype="int32"), []),  # truly empty (len 0)
+            ([7], [None]),  # rows with null geometry (len>0, NaN bounds)
+        ],
+        ids=["empty_collection", "null_geometry_rows"],
+    )
+    def test_from_features_warns_and_returns_all_nodata_without_geometry(
+        self, class_ids, geometry
+    ):
+        """Empty or null-geometry collections warn and return an all-nodata raster (#46).
+
+        Args:
+            class_ids: Burn-column values — empty for the zero-row case, one value for the
+                null-geometry row.
+            geometry: The geometry column — empty, or a single ``None``.
+
+        Test scenario:
+            Both an empty FeatureCollection (len 0, which skips the burn) and rows with null
+            geometry (len>0, NaN bounds, which burns nothing) warn and yield an all-nodata
+            raster on the template grid, without the cryptic GDAL "field not found" crash.
+        """
         template = _make_dataset(
             rows=5, cols=5, epsg=4326, cell_size=1.0, top_left=(0.0, 5.0)
         )
-        empty = FeatureCollection(
+        fc = FeatureCollection(
             gpd.GeoDataFrame(
-                {"class_id": pd.Series([], dtype="int32")},
-                geometry=[],
-                crs="EPSG:4326",
+                {"class_id": class_ids}, geometry=geometry, crs="EPSG:4326"
             )
         )
 
         with pytest.warns(UserWarning, match="empty or falls entirely outside"):
             raster = Dataset.from_features(
-                empty, template=template, column_name="class_id"
+                fc, template=template, column_name="class_id"
             )
 
         arr = raster.read_array()
-        assert arr.shape == (5, 5), "output should still adopt the template grid"
-        assert not np.any(np.isclose(arr, 1.0)), "an empty collection burns nothing"
-
-    def test_from_features_warns_and_returns_all_nodata_for_null_geometry_rows(self):
-        """Rows with null geometry (len>0, NaN bounds) warn and return all-nodata (#46 S2)."""
-        template = _make_dataset(
-            rows=5, cols=5, epsg=4326, cell_size=1.0, top_left=(0.0, 5.0)
-        )
-        null_geom = FeatureCollection(
-            gpd.GeoDataFrame({"class_id": [7]}, geometry=[None], crs="EPSG:4326")
-        )
-
-        with pytest.warns(UserWarning, match="empty or falls entirely outside"):
-            raster = Dataset.from_features(
-                null_geom, template=template, column_name="class_id"
-            )
-
-        arr = raster.read_array()
-        assert arr.shape == (5, 5), "output should still adopt the template grid"
-        assert not np.any(np.isclose(arr, 7.0)), "null geometry burns nothing"
+        assert arr.shape == (5, 5), "output should adopt the template grid"
+        assert not np.any(np.isclose(arr, 7.0)), "no geometry burns nothing"
 
     def test_interior_zero_area_point_is_not_flagged(self):
         """A zero-area point inside the template is not flagged as outside (#46).

--- a/tests/e2e/test_e2e_workflows.py
+++ b/tests/e2e/test_e2e_workflows.py
@@ -505,28 +505,26 @@ class TestRasterizeRoundTrip:
     def test_snap_to_template_degenerate_point_yields_covering_pixel(
         self, utm_template
     ):
-        """A point exactly on a grid corner snaps to a 1x1 pixel that covers it (#46).
+        """A point on a grid corner snaps to a valid 1x1 raster via the `max(1, ...)` clamp (#46).
 
         Test scenario:
             A zero-area `Point` on a template grid corner collapses the snapped span to
-            zero cells; the `max(1, ...)` clamp keeps a single covering pixel.
+            zero cells; the `max(1, ...)` clamp keeps a single 1x1 pixel co-registered with
+            the template. Whether GDAL burns a point lying exactly on a pixel corner is
+            platform-defined, so this asserts only the clamp and grid alignment — the
+            mid-cell test covers the burn.
         """
         x0, y0 = utm_template.top_left_corner
         cell = utm_template.cell_size
-        corner = Point(x0 + 2 * cell, y0 - 3 * cell)
-        out = Dataset.from_features(
-            self._fc_32636(corner),
-            template=utm_template,
-            snap_to_template=True,
-            column_name="class_id",
-        )
+        out = self._snap(Point(x0 + 2 * cell, y0 - 3 * cell), utm_template)
+
         assert out.rows == 1, f"degenerate point should give one row, got {out.rows}"
         assert out.columns == 1, (
             f"degenerate point should give one column, got {out.columns}"
         )
-        assert np.any(np.isclose(out.read_array(), 42.0)), (
-            "the point's pixel must be burned"
-        )
+        ox, oy = out.top_left_corner
+        assert (ox - x0) % cell == 0, "snapped x-origin on the template grid"
+        assert (y0 - oy) % cell == 0, "snapped y-origin on the template grid"
 
     def test_snap_to_template_fractional_grid_is_tight(self):
         """Grid-aligned bounds on a fractional-coordinate template give tight dims (#46).

--- a/tests/e2e/test_e2e_workflows.py
+++ b/tests/e2e/test_e2e_workflows.py
@@ -403,9 +403,8 @@ class TestRasterizeRoundTrip:
             f"snap output should crop to the features, got {(out.rows, out.columns)}"
         )
         ox, oy = out.top_left_corner
-        assert (ox - x0) % cell == 0 and (y0 - oy) % cell == 0, (
-            "snapped origin must lie on the template grid lines"
-        )
+        assert (ox - x0) % cell == 0, "snapped x-origin must lie on the template grid"
+        assert (y0 - oy) % cell == 0, "snapped y-origin must lie on the template grid"
         assert out.cell_size == cell, "snapped output keeps the template cell size"
         assert np.any(np.isclose(out.read_array(), 42.0)), (
             "the polygon should be burned"
@@ -433,7 +432,8 @@ class TestRasterizeRoundTrip:
             "snap mode sizes to the features, so it must not warn"
         )
         ox, oy = out.top_left_corner
-        assert (ox - x0) % cell == 0 and (y0 - oy) % cell == 0, "still grid-aligned"
+        assert (ox - x0) % cell == 0, "snapped x-origin still on the template grid"
+        assert (y0 - oy) % cell == 0, "snapped y-origin still on the template grid"
 
     def test_snap_to_template_requires_template(self):
         """snap_to_template without a template raises ValueError (#46)."""

--- a/tests/e2e/test_e2e_workflows.py
+++ b/tests/e2e/test_e2e_workflows.py
@@ -19,7 +19,7 @@ import geopandas as gpd
 import numpy as np
 import pandas as pd
 import pytest
-from osgeo import gdal
+from osgeo import gdal, osr
 from shapely.geometry import box
 
 from pyramids.dataset import Dataset, DatasetCollection
@@ -274,6 +274,73 @@ class TestRasterizeRoundTrip:
         assert result is expected, (
             f"box {feature_box} outside-template should be {expected}, got {result}"
         )
+
+    def test_features_outside_non_square_template_on_y_axis(self):
+        """A non-square template flags a feature outside on the Y axis (#46 M1).
+
+        Test scenario:
+            A template with X pixel 2 and Y pixel 1 (`gt=(0, 2, 0, 10, 0, -1)`, 5x5) has
+            true bbox x[0, 10], y[5, 10]. A feature at `box(2, 2, 4, 4)` is south of the
+            true `ymin=5`, so it must be flagged — a single-`cell_size` check would use the
+            X pixel for Y and miss it.
+        """
+        drv = gdal.GetDriverByName("MEM")
+        raster = drv.Create("", 5, 5, 1, gdal.GDT_Float32)
+        raster.SetGeoTransform((0.0, 2.0, 0.0, 10.0, 0.0, -1.0))
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(4326)
+        raster.SetProjection(srs.ExportToWkt())
+        template = Dataset(raster)
+
+        south = FeatureCollection(
+            gpd.GeoDataFrame(
+                {"v": [1]}, geometry=[box(2.0, 2.0, 4.0, 4.0)], crs="EPSG:4326"
+            )
+        )
+        assert _features_outside_template(south, template) is True, (
+            "a feature south of a non-square template must be flagged outside"
+        )
+
+    def test_features_touching_template_edge_is_outside(self):
+        """A feature touching a template edge (zero-area overlap) is flagged outside (#46).
+
+        Test scenario:
+            A box whose left edge coincides with the template's right edge (`fxmin == txmax`)
+            has zero-area overlap and is treated as outside, pinning the `>=`/`<=` semantics.
+        """
+        template = _make_dataset(
+            rows=10, cols=10, epsg=4326, cell_size=1.0, top_left=(0.0, 10.0)
+        )
+        touching = FeatureCollection(
+            gpd.GeoDataFrame(
+                {"v": [1]}, geometry=[box(10.0, 2.0, 12.0, 8.0)], crs="EPSG:4326"
+            )
+        )
+        assert _features_outside_template(touching, template) is True, (
+            "a feature touching the template edge (zero overlap) is treated as outside"
+        )
+
+    def test_from_features_warns_and_returns_all_nodata_for_empty_collection(self):
+        """An empty FeatureCollection warns and returns an all-nodata raster, not a crash (#46)."""
+        template = _make_dataset(
+            rows=5, cols=5, epsg=4326, cell_size=1.0, top_left=(0.0, 5.0)
+        )
+        empty = FeatureCollection(
+            gpd.GeoDataFrame(
+                {"class_id": pd.Series([], dtype="int32")},
+                geometry=[],
+                crs="EPSG:4326",
+            )
+        )
+
+        with pytest.warns(UserWarning, match="empty or falls entirely outside"):
+            raster = Dataset.from_features(
+                empty, template=template, column_name="class_id"
+            )
+
+        arr = raster.read_array()
+        assert arr.shape == (5, 5), "output should still adopt the template grid"
+        assert not np.any(np.isclose(arr, 1.0)), "an empty collection burns nothing"
 
     def test_from_features_rejects_non_positive_cell_size(self):
         """D-M2: cell_size=0 and negative values raise ``ValueError``."""

--- a/tests/e2e/test_e2e_workflows.py
+++ b/tests/e2e/test_e2e_workflows.py
@@ -12,6 +12,7 @@ Workflows covered:
 
 import shutil
 import tempfile
+import warnings
 from pathlib import Path
 
 import geopandas as gpd
@@ -187,6 +188,54 @@ class TestRasterizeRoundTrip:
         # Burned value should appear
         burned = arr[np.isclose(arr, 42.0)]
         assert burned.size > 0, "Burned value 42 should appear in the raster"
+
+    def test_from_features_warns_when_features_outside_template(self):
+        """Features disjoint from the template warn and yield an all-nodata raster (#46)."""
+        epsg = 32636
+        cell_size = 1000.0
+        rows, cols = 10, 10
+        top_left = (500000.0, 3400000.0)
+        ref = _make_dataset(
+            rows=rows, cols=cols, cell_size=cell_size, top_left=top_left, epsg=epsg
+        )
+
+        # Polygon shifted 100 cells east — entirely outside the template extent.
+        x0, y0 = top_left
+        far_x = x0 + 100 * cell_size
+        poly = box(far_x, y0 - 3 * cell_size, far_x + 3 * cell_size, y0)
+        gdf = gpd.GeoDataFrame({"class_id": [42]}, geometry=[poly], crs=f"EPSG:{epsg}")
+        fc = FeatureCollection(gdf)
+
+        with pytest.warns(UserWarning, match="outside the template extent"):
+            raster = Dataset.from_features(fc, template=ref, column_name="class_id")
+
+        arr = raster.read_array()
+        assert arr.shape == (rows, cols), "output should still adopt the template grid"
+        assert not np.any(np.isclose(arr, 42.0)), (
+            "no template cell should hold the burned value — the polygon is outside it"
+        )
+
+    def test_from_features_does_not_warn_when_features_overlap_template(self):
+        """A polygon inside the template rasterizes without the outside-extent warning (#46)."""
+        epsg = 32636
+        cell_size = 1000.0
+        rows, cols = 10, 10
+        top_left = (500000.0, 3400000.0)
+        ref = _make_dataset(
+            rows=rows, cols=cols, cell_size=cell_size, top_left=top_left, epsg=epsg
+        )
+
+        x0, y0 = top_left
+        poly = box(x0, y0 - 3 * cell_size, x0 + 3 * cell_size, y0)
+        gdf = gpd.GeoDataFrame({"class_id": [42]}, geometry=[poly], crs=f"EPSG:{epsg}")
+        fc = FeatureCollection(gdf)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            Dataset.from_features(fc, template=ref, column_name="class_id")
+
+        outside = [w for w in caught if "outside the template extent" in str(w.message)]
+        assert not outside, f"an overlapping polygon must not warn; got: {outside}"
 
     def test_from_features_rejects_non_positive_cell_size(self):
         """D-M2: cell_size=0 and negative values raise ``ValueError``."""

--- a/tests/e2e/test_e2e_workflows.py
+++ b/tests/e2e/test_e2e_workflows.py
@@ -167,6 +167,17 @@ class TestRasterizeRoundTrip:
         raster.SetProjection(srs.ExportToWkt())
         return Dataset(raster)
 
+    def _snap(self, geometry, template, epsg=32636):
+        """Rasterize a single `class_id=42` feature onto `template` in snap mode."""
+        fc = FeatureCollection(
+            gpd.GeoDataFrame(
+                {"class_id": [42]}, geometry=[geometry], crs=f"EPSG:{epsg}"
+            )
+        )
+        return Dataset.from_features(
+            fc, template=template, snap_to_template=True, column_name="class_id"
+        )
+
     def test_rasterize_polygon(self):
         """Burn a polygon attribute into a raster and verify the value."""
         epsg = 32636
@@ -551,16 +562,53 @@ class TestRasterizeRoundTrip:
             correct north-up output.
         """
         template = self._mem_template((0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
-        fc = FeatureCollection(
-            gpd.GeoDataFrame(
-                {"class_id": [42]}, geometry=[box(1.0, 1.0, 4.0, 4.0)], crs="EPSG:4326"
-            )
-        )
-        out = Dataset.from_features(
-            fc, template=template, snap_to_template=True, column_name="class_id"
-        )
+        out = self._snap(box(1.0, 1.0, 4.0, 4.0), template, epsg=4326)
+
         assert np.any(np.isclose(out.read_array(), 42.0)), (
             "a south-up template should still cover the feature"
+        )
+        ox, oy = out.top_left_corner
+        assert ox % 1.0 == 0, "x-origin lands on the south-up template lattice"
+        assert oy % 1.0 == 0, "y-origin lands on the south-up template lattice"
+        assert out.cell_size == 1.0, "output keeps the template cell size"
+
+    def test_snap_to_template_mid_cell_point_covers_the_point(self, utm_template):
+        """A point strictly inside a cell snaps to the 1x1 pixel that contains it (#46).
+
+        Test scenario:
+            An off-grid-line `Point` rounds to a single covering cell without needing the
+            `max(1, ...)` clamp.
+        """
+        x0, y0 = utm_template.top_left_corner
+        cell = utm_template.cell_size
+        out = self._snap(Point(x0 + 2.5 * cell, y0 - 3.5 * cell), utm_template)
+
+        assert out.rows == 1, f"mid-cell point should give one row, got {out.rows}"
+        assert out.columns == 1, (
+            f"mid-cell point should give one column, got {out.columns}"
+        )
+        assert np.any(np.isclose(out.read_array(), 42.0)), (
+            "the containing pixel must be burned"
+        )
+
+    def test_snap_to_template_straddling_edge_covers_full_feature(self, utm_template):
+        """A feature straddling the template edge snaps to cover its full extent (#46).
+
+        Test scenario:
+            A box from 8 to 12 cells (the template is 10 wide) snaps to cover through 12
+            cells — beyond the template footprint — so the whole feature is included.
+        """
+        x0, y0 = utm_template.top_left_corner
+        cell = utm_template.cell_size
+        straddle = box(x0 + 8 * cell, y0 - 4 * cell, x0 + 12 * cell, y0 - 1 * cell)
+        out = self._snap(straddle, utm_template)
+
+        ox, _ = out.top_left_corner
+        assert ox + out.columns * out.cell_size >= x0 + 12 * cell, (
+            "snap must extend past the template to cover the outside part of the feature"
+        )
+        assert np.any(np.isclose(out.read_array(), 42.0)), (
+            "the straddling feature is burned"
         )
 
     def test_from_features_rejects_non_positive_cell_size(self):

--- a/tests/e2e/test_e2e_workflows.py
+++ b/tests/e2e/test_e2e_workflows.py
@@ -137,6 +137,17 @@ class TestDatasetCollectionRoundTrip:
 class TestRasterizeRoundTrip:
     """Rasterize a FeatureCollection and verify the burned values."""
 
+    @pytest.fixture
+    def utm_template(self):
+        """A 10x10 UTM (EPSG:32636) template at a fixed origin, shared by template tests."""
+        return _make_dataset(
+            rows=10,
+            cols=10,
+            cell_size=1000.0,
+            top_left=(500000.0, 3400000.0),
+            epsg=32636,
+        )
+
     def test_rasterize_polygon(self):
         """Burn a polygon attribute into a raster and verify the value."""
         epsg = 32636
@@ -160,83 +171,50 @@ class TestRasterizeRoundTrip:
             f"Rasterized EPSG should be {epsg}, got {raster.epsg}"
         )
 
-    def test_rasterize_with_reference_dataset(self):
-        """Burn using a reference Dataset for geotransform."""
-        epsg = 32636
-        cell_size = 1000.0
-        rows, cols = 10, 10
-        top_left = (500000.0, 3400000.0)
-
-        # Reference raster
-        ref = _make_dataset(
-            rows=rows, cols=cols, cell_size=cell_size, top_left=top_left, epsg=epsg
+    def test_rasterize_with_reference_dataset(self, utm_template):
+        """Burn an inside polygon onto a template; it appears and emits no outside warning."""
+        x0, y0 = utm_template.top_left_corner
+        cell = utm_template.cell_size
+        inside = box(x0, y0 - 3 * cell, x0 + 3 * cell, y0)
+        fc = FeatureCollection(
+            gpd.GeoDataFrame({"class_id": [42]}, geometry=[inside], crs="EPSG:32636")
         )
-
-        # Create a polygon inside the raster extent
-        x0, y0 = top_left
-        poly = box(x0, y0 - 3 * cell_size, x0 + 3 * cell_size, y0)
-        gdf = gpd.GeoDataFrame({"class_id": [42]}, geometry=[poly], crs=f"EPSG:{epsg}")
-        fc = FeatureCollection(gdf)
-
-        raster = Dataset.from_features(fc, template=ref, column_name="class_id")
-        arr = raster.read_array()
-
-        # Same dimensions as reference
-        assert arr.shape == (
-            rows,
-            cols,
-        ), f"Rasterized shape should match reference ({rows},{cols}), got {arr.shape}"
-        # Burned value should appear
-        burned = arr[np.isclose(arr, 42.0)]
-        assert burned.size > 0, "Burned value 42 should appear in the raster"
-
-    def test_from_features_warns_when_features_outside_template(self):
-        """Features disjoint from the template warn and yield an all-nodata raster (#46)."""
-        epsg = 32636
-        cell_size = 1000.0
-        rows, cols = 10, 10
-        top_left = (500000.0, 3400000.0)
-        ref = _make_dataset(
-            rows=rows, cols=cols, cell_size=cell_size, top_left=top_left, epsg=epsg
-        )
-
-        # Polygon shifted 100 cells east — entirely outside the template extent.
-        x0, y0 = top_left
-        far_x = x0 + 100 * cell_size
-        poly = box(far_x, y0 - 3 * cell_size, far_x + 3 * cell_size, y0)
-        gdf = gpd.GeoDataFrame({"class_id": [42]}, geometry=[poly], crs=f"EPSG:{epsg}")
-        fc = FeatureCollection(gdf)
-
-        with pytest.warns(UserWarning, match="outside the template extent"):
-            raster = Dataset.from_features(fc, template=ref, column_name="class_id")
-
-        arr = raster.read_array()
-        assert arr.shape == (rows, cols), "output should still adopt the template grid"
-        assert not np.any(np.isclose(arr, 42.0)), (
-            "no template cell should hold the burned value — the polygon is outside it"
-        )
-
-    def test_from_features_does_not_warn_when_features_overlap_template(self):
-        """A polygon inside the template rasterizes without the outside-extent warning (#46)."""
-        epsg = 32636
-        cell_size = 1000.0
-        rows, cols = 10, 10
-        top_left = (500000.0, 3400000.0)
-        ref = _make_dataset(
-            rows=rows, cols=cols, cell_size=cell_size, top_left=top_left, epsg=epsg
-        )
-
-        x0, y0 = top_left
-        poly = box(x0, y0 - 3 * cell_size, x0 + 3 * cell_size, y0)
-        gdf = gpd.GeoDataFrame({"class_id": [42]}, geometry=[poly], crs=f"EPSG:{epsg}")
-        fc = FeatureCollection(gdf)
 
         with warnings.catch_warnings(record=True) as caught:
             warnings.simplefilter("always")
-            Dataset.from_features(fc, template=ref, column_name="class_id")
+            raster = Dataset.from_features(
+                fc, template=utm_template, column_name="class_id"
+            )
 
-        outside = [w for w in caught if "outside the template extent" in str(w.message)]
-        assert not outside, f"an overlapping polygon must not warn; got: {outside}"
+        arr = raster.read_array()
+        assert arr.shape == (10, 10), (
+            f"shape should match the template, got {arr.shape}"
+        )
+        assert np.any(np.isclose(arr, 42.0)), (
+            "burned value 42 should appear in the raster"
+        )
+        assert not [w for w in caught if "template extent" in str(w.message)], (
+            "an inside polygon must not emit the outside-template warning"
+        )
+
+    def test_from_features_warns_when_features_outside_template(self, utm_template):
+        """Features disjoint from the template warn and yield an all-nodata raster (#46)."""
+        x0, y0 = utm_template.top_left_corner
+        far = box(
+            x0 + 100000.0, y0 - 3000.0, x0 + 103000.0, y0
+        )  # ~100 km east, outside
+        fc = FeatureCollection(
+            gpd.GeoDataFrame({"class_id": [42]}, geometry=[far], crs="EPSG:32636")
+        )
+
+        with pytest.warns(UserWarning, match="outside the template extent"):
+            raster = Dataset.from_features(
+                fc, template=utm_template, column_name="class_id"
+            )
+
+        assert not np.any(np.isclose(raster.read_array(), 42.0)), (
+            "a polygon outside the template burns nothing"
+        )
 
     @pytest.mark.parametrize(
         "feature_box, expected",

--- a/tests/e2e/test_e2e_workflows.py
+++ b/tests/e2e/test_e2e_workflows.py
@@ -20,7 +20,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from osgeo import gdal, osr
-from shapely.geometry import box
+from shapely.geometry import Point, box
 
 from pyramids.dataset import Dataset, DatasetCollection
 from pyramids.dataset.ops.vectorize import _features_outside_template
@@ -341,6 +341,57 @@ class TestRasterizeRoundTrip:
         arr = raster.read_array()
         assert arr.shape == (5, 5), "output should still adopt the template grid"
         assert not np.any(np.isclose(arr, 1.0)), "an empty collection burns nothing"
+
+    def test_from_features_warns_and_returns_all_nodata_for_null_geometry_rows(self):
+        """Rows with null geometry (len>0, NaN bounds) warn and return all-nodata (#46 S2)."""
+        template = _make_dataset(
+            rows=5, cols=5, epsg=4326, cell_size=1.0, top_left=(0.0, 5.0)
+        )
+        null_geom = FeatureCollection(
+            gpd.GeoDataFrame({"class_id": [7]}, geometry=[None], crs="EPSG:4326")
+        )
+
+        with pytest.warns(UserWarning, match="empty or falls entirely outside"):
+            raster = Dataset.from_features(
+                null_geom, template=template, column_name="class_id"
+            )
+
+        arr = raster.read_array()
+        assert arr.shape == (5, 5), "output should still adopt the template grid"
+        assert not np.any(np.isclose(arr, 7.0)), "null geometry burns nothing"
+
+    def test_interior_zero_area_point_is_not_flagged(self):
+        """A zero-area point inside the template is not flagged as outside (#46).
+
+        Test scenario:
+            `Point(5, 5)` has bounds `[5, 5, 5, 5]` (not NaN) and lies inside a template
+            covering x[0, 10], y[0, 10], so the helper must return `False`.
+        """
+        template = _make_dataset(
+            rows=10, cols=10, epsg=4326, cell_size=1.0, top_left=(0.0, 10.0)
+        )
+        point = FeatureCollection(
+            gpd.GeoDataFrame({"v": [1]}, geometry=[Point(5.0, 5.0)], crs="EPSG:4326")
+        )
+        assert _features_outside_template(point, template) is False, (
+            "an interior zero-area point must not be flagged outside"
+        )
+
+    def test_cell_size_mode_does_not_warn(self):
+        """cell_size mode (no template) never emits the outside-template warning (#46)."""
+        fc = FeatureCollection(
+            gpd.GeoDataFrame(
+                {"v": [1]}, geometry=[box(0.0, 0.0, 3.0, 3.0)], crs="EPSG:4326"
+            )
+        )
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            Dataset.from_features(fc, cell_size=1.0, column_name="v")
+
+        template_warnings = [w for w in caught if "template extent" in str(w.message)]
+        assert not template_warnings, (
+            f"cell_size mode must not warn about a template; got: {template_warnings}"
+        )
 
     def test_from_features_rejects_non_positive_cell_size(self):
         """D-M2: cell_size=0 and negative values raise ``ValueError``."""

--- a/tests/e2e/test_e2e_workflows.py
+++ b/tests/e2e/test_e2e_workflows.py
@@ -157,6 +157,16 @@ class TestRasterizeRoundTrip:
             )
         )
 
+    @staticmethod
+    def _mem_template(geotransform, epsg=4326):
+        """A 5x5 in-memory Dataset with a custom geotransform (non-square/rotated tests)."""
+        raster = gdal.GetDriverByName("MEM").Create("", 5, 5, 1, gdal.GDT_Float32)
+        raster.SetGeoTransform(geotransform)
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(epsg)
+        raster.SetProjection(srs.ExportToWkt())
+        return Dataset(raster)
+
     def test_rasterize_polygon(self):
         """Burn a polygon attribute into a raster and verify the value."""
         epsg = 32636
@@ -271,14 +281,7 @@ class TestRasterizeRoundTrip:
             true `ymin=5`, so it must be flagged — a single-`cell_size` check would use the
             X pixel for Y and miss it.
         """
-        drv = gdal.GetDriverByName("MEM")
-        raster = drv.Create("", 5, 5, 1, gdal.GDT_Float32)
-        raster.SetGeoTransform((0.0, 2.0, 0.0, 10.0, 0.0, -1.0))
-        srs = osr.SpatialReference()
-        srs.ImportFromEPSG(4326)
-        raster.SetProjection(srs.ExportToWkt())
-        template = Dataset(raster)
-
+        template = self._mem_template((0.0, 2.0, 0.0, 10.0, 0.0, -1.0))
         south = FeatureCollection(
             gpd.GeoDataFrame(
                 {"v": [1]}, geometry=[box(2.0, 2.0, 4.0, 4.0)], crs="EPSG:4326"
@@ -447,19 +450,26 @@ class TestRasterizeRoundTrip:
 
     def test_snap_to_template_rejects_non_square_template(self):
         """snap_to_template with a non-square template raises ValueError (#46)."""
-        drv = gdal.GetDriverByName("MEM")
-        raster = drv.Create("", 5, 5, 1, gdal.GDT_Float32)
-        raster.SetGeoTransform((0.0, 2.0, 0.0, 10.0, 0.0, -1.0))
-        srs = osr.SpatialReference()
-        srs.ImportFromEPSG(4326)
-        raster.SetProjection(srs.ExportToWkt())
-        template = Dataset(raster)
+        template = self._mem_template((0.0, 2.0, 0.0, 10.0, 0.0, -1.0))
         fc = FeatureCollection(
             gpd.GeoDataFrame(
                 {"class_id": [42]}, geometry=[box(1.0, 6.0, 3.0, 8.0)], crs="EPSG:4326"
             )
         )
         with pytest.raises(ValueError, match="requires a square template"):
+            Dataset.from_features(
+                fc, template=template, snap_to_template=True, column_name="class_id"
+            )
+
+    def test_snap_to_template_rejects_rotated_template(self):
+        """snap_to_template with a rotated template raises ValueError (#46)."""
+        template = self._mem_template((0.0, 1.0, 0.5, 10.0, 0.5, -1.0))
+        fc = FeatureCollection(
+            gpd.GeoDataFrame(
+                {"class_id": [42]}, geometry=[box(1.0, 6.0, 3.0, 8.0)], crs="EPSG:4326"
+            )
+        )
+        with pytest.raises(ValueError, match="rotated template"):
             Dataset.from_features(
                 fc, template=template, snap_to_template=True, column_name="class_id"
             )

--- a/tests/e2e/test_e2e_workflows.py
+++ b/tests/e2e/test_e2e_workflows.py
@@ -483,13 +483,85 @@ class TestRasterizeRoundTrip:
                 crs="EPSG:32636",
             )
         )
-        with pytest.raises(ValueError, match="non-empty FeatureCollection"):
+        with pytest.raises(ValueError, match=r"valid \(non-NaN\) geometry bounds"):
             Dataset.from_features(
                 empty,
                 template=utm_template,
                 snap_to_template=True,
                 column_name="class_id",
             )
+
+    def test_snap_to_template_degenerate_point_yields_covering_pixel(
+        self, utm_template
+    ):
+        """A point exactly on a grid corner snaps to a 1x1 pixel that covers it (#46).
+
+        Test scenario:
+            A zero-area `Point` on a template grid corner collapses the snapped span to
+            zero cells; the `max(1, ...)` clamp keeps a single covering pixel.
+        """
+        x0, y0 = utm_template.top_left_corner
+        cell = utm_template.cell_size
+        corner = Point(x0 + 2 * cell, y0 - 3 * cell)
+        out = Dataset.from_features(
+            self._fc_32636(corner),
+            template=utm_template,
+            snap_to_template=True,
+            column_name="class_id",
+        )
+        assert out.rows == 1, f"degenerate point should give one row, got {out.rows}"
+        assert out.columns == 1, (
+            f"degenerate point should give one column, got {out.columns}"
+        )
+        assert np.any(np.isclose(out.read_array(), 42.0)), (
+            "the point's pixel must be burned"
+        )
+
+    def test_snap_to_template_fractional_grid_is_tight(self):
+        """Grid-aligned bounds on a fractional-coordinate template give tight dims (#46).
+
+        Test scenario:
+            A WGS84 template with 0.001 cells and a feature whose bounds are exactly 37→60
+            cells in X and 12→40 in Y must snap to exactly 23x28 — no float off-by-one.
+        """
+        template = self._mem_template((-123.456, 0.001, 0.0, 45.678, 0.0, -0.001))
+        xmin = -123.456 + 37 * 0.001
+        xmax = -123.456 + 60 * 0.001
+        ymax = 45.678 - 12 * 0.001
+        ymin = 45.678 - 40 * 0.001
+        fc = FeatureCollection(
+            gpd.GeoDataFrame(
+                {"class_id": [42]},
+                geometry=[box(xmin, ymin, xmax, ymax)],
+                crs="EPSG:4326",
+            )
+        )
+        out = Dataset.from_features(
+            fc, template=template, snap_to_template=True, column_name="class_id"
+        )
+        assert (out.rows, out.columns) == (28, 23), (
+            f"snap should be tight (28, 23), got {(out.rows, out.columns)}"
+        )
+
+    def test_snap_to_template_supports_south_up_template(self):
+        """A south-up template (positive Y pixel) snaps onto the same lattice (#46).
+
+        Test scenario:
+            north-up is not required — a south-up template still covers the feature in a
+            correct north-up output.
+        """
+        template = self._mem_template((0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
+        fc = FeatureCollection(
+            gpd.GeoDataFrame(
+                {"class_id": [42]}, geometry=[box(1.0, 1.0, 4.0, 4.0)], crs="EPSG:4326"
+            )
+        )
+        out = Dataset.from_features(
+            fc, template=template, snap_to_template=True, column_name="class_id"
+        )
+        assert np.any(np.isclose(out.read_array(), 42.0)), (
+            "a south-up template should still cover the feature"
+        )
 
     def test_from_features_rejects_non_positive_cell_size(self):
         """D-M2: cell_size=0 and negative values raise ``ValueError``."""

--- a/tests/e2e/test_e2e_workflows.py
+++ b/tests/e2e/test_e2e_workflows.py
@@ -148,6 +148,15 @@ class TestRasterizeRoundTrip:
             epsg=32636,
         )
 
+    @staticmethod
+    def _fc_32636(geometry, value=42):
+        """A single-feature EPSG:32636 FeatureCollection with a `class_id` column."""
+        return FeatureCollection(
+            gpd.GeoDataFrame(
+                {"class_id": [value]}, geometry=[geometry], crs="EPSG:32636"
+            )
+        )
+
     def test_rasterize_polygon(self):
         """Burn a polygon attribute into a raster and verify the value."""
         epsg = 32636
@@ -371,6 +380,106 @@ class TestRasterizeRoundTrip:
         assert not template_warnings, (
             f"cell_size mode must not warn about a template; got: {template_warnings}"
         )
+
+    def test_snap_to_template_crops_to_features_and_co_registers(self, utm_template):
+        """snap_to_template crops to the features but keeps the template's grid (#46 point 2).
+
+        Test scenario:
+            A small polygon inside the 10x10 template yields a smaller raster whose origin
+            lies on the template's grid lines and whose cell size equals the template's, so
+            it co-registers pixel-for-pixel; the burned value is present.
+        """
+        x0, y0 = utm_template.top_left_corner
+        cell = utm_template.cell_size
+        inside = box(x0 + 2 * cell, y0 - 4 * cell, x0 + 5 * cell, y0 - 1 * cell)
+        out = Dataset.from_features(
+            self._fc_32636(inside),
+            template=utm_template,
+            snap_to_template=True,
+            column_name="class_id",
+        )
+
+        assert (out.rows, out.columns) == (3, 3), (
+            f"snap output should crop to the features, got {(out.rows, out.columns)}"
+        )
+        ox, oy = out.top_left_corner
+        assert (ox - x0) % cell == 0 and (y0 - oy) % cell == 0, (
+            "snapped origin must lie on the template grid lines"
+        )
+        assert out.cell_size == cell, "snapped output keeps the template cell size"
+        assert np.any(np.isclose(out.read_array(), 42.0)), (
+            "the polygon should be burned"
+        )
+
+    def test_snap_to_template_covers_features_outside_footprint(self, utm_template):
+        """snap_to_template covers features beyond the template footprint, no warning (#46)."""
+        x0, y0 = utm_template.top_left_corner
+        cell = utm_template.cell_size
+        far = box(x0 + 100 * cell, y0 - 3 * cell, x0 + 103 * cell, y0)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            out = Dataset.from_features(
+                self._fc_32636(far),
+                template=utm_template,
+                snap_to_template=True,
+                column_name="class_id",
+            )
+
+        assert np.any(np.isclose(out.read_array(), 42.0)), (
+            "features beyond the footprint are still covered in snap mode"
+        )
+        assert not [w for w in caught if "template extent" in str(w.message)], (
+            "snap mode sizes to the features, so it must not warn"
+        )
+        ox, oy = out.top_left_corner
+        assert (ox - x0) % cell == 0 and (y0 - oy) % cell == 0, "still grid-aligned"
+
+    def test_snap_to_template_requires_template(self):
+        """snap_to_template without a template raises ValueError (#46)."""
+        fc = self._fc_32636(box(0.0, 0.0, 3.0, 3.0))
+        with pytest.raises(
+            ValueError, match="snap_to_template=True requires a template"
+        ):
+            Dataset.from_features(
+                fc, cell_size=1.0, snap_to_template=True, column_name="class_id"
+            )
+
+    def test_snap_to_template_rejects_non_square_template(self):
+        """snap_to_template with a non-square template raises ValueError (#46)."""
+        drv = gdal.GetDriverByName("MEM")
+        raster = drv.Create("", 5, 5, 1, gdal.GDT_Float32)
+        raster.SetGeoTransform((0.0, 2.0, 0.0, 10.0, 0.0, -1.0))
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(4326)
+        raster.SetProjection(srs.ExportToWkt())
+        template = Dataset(raster)
+        fc = FeatureCollection(
+            gpd.GeoDataFrame(
+                {"class_id": [42]}, geometry=[box(1.0, 6.0, 3.0, 8.0)], crs="EPSG:4326"
+            )
+        )
+        with pytest.raises(ValueError, match="requires a square template"):
+            Dataset.from_features(
+                fc, template=template, snap_to_template=True, column_name="class_id"
+            )
+
+    def test_snap_to_template_rejects_empty_features(self, utm_template):
+        """snap_to_template with an empty FeatureCollection raises ValueError (#46)."""
+        empty = FeatureCollection(
+            gpd.GeoDataFrame(
+                {"class_id": pd.Series([], dtype="int32")},
+                geometry=[],
+                crs="EPSG:32636",
+            )
+        )
+        with pytest.raises(ValueError, match="non-empty FeatureCollection"):
+            Dataset.from_features(
+                empty,
+                template=utm_template,
+                snap_to_template=True,
+                column_name="class_id",
+            )
 
     def test_from_features_rejects_non_positive_cell_size(self):
         """D-M2: cell_size=0 and negative values raise ``ValueError``."""


### PR DESCRIPTION
# Description

Resolves **both** points of the #46 verdict for `Dataset.from_features(features, template=...)`.

**Point 1 — warn instead of silently dropping data.** With a `template`, the vector is burned onto the template's
fixed grid, so a `FeatureCollection` lying wholly outside it silently produced an all-nodata raster (and an empty
collection crashed with a cryptic GDAL error). `rasterize_features` now detects that (feature `total_bounds` are
`NaN`/empty or disjoint from `template.bbox`) and emits a `UserWarning`, while still returning the raster (it does
not raise — an empty raster is valid, and tiled rasterization legitimately yields empty tiles). The empty burn is
skipped so it no longer crashes. Partial overlap is not flagged.

**Point 2 — `snap_to_template` mode (the capability #46 actually asked for).** `Dataset.from_features(fc,
template=ds, snap_to_template=True)` keeps the template's cell size and grid alignment but sizes the output to the
features' bounds **snapped outward onto the template's grid lines** — a small raster that co-registers with the
template pixel-for-pixel, instead of one spanning the whole template. Requires a square, axis-aligned, north-up
template and a non-empty FeatureCollection (raises `ValueError` otherwise); features beyond the template footprint
are still covered (snapped to the same lattice) and do not warn.

So there are now three sizing modes: `cell_size` (extent = feature bounds, unaligned), `template` (extent = whole
template, clipped), and `template + snap_to_template` (template grid, extent cropped to the features).

# Issues

- Closes #46 — `FeatureCollection` → raster with a template silently drops features outside the template extent

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

`tests/e2e/test_e2e_workflows.py::TestRasterizeRoundTrip` (all `core`-marked):

- [x] direction matrix, non-square template (Y-axis regression), touching-edge and interior zero-area point;
- [x] empty and null-geometry collections warn and return all-nodata without a crash; `cell_size` mode never warns;
      an inside polygon burns and does not warn;
- [x] `snap_to_template`: crops to the features and co-registers (origin on the template grid, template cell size);
      covers features beyond the footprint without warning; rejects no-template / non-square template / empty FC.

Local (`pixi run -e dev`): rasterize suite + `from_features` callers **122 passed**; `from_features` doctests
(cell_size, template, snap) pass; `ruff-format`, `ruff-check`, and `mypy` clean; SonarCloud gate green.

- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
