### PR TITLE
fix(cog): promote sub-byte NBITS and gate the predictor on sample width

### DIFF
--- a/src/pyramids/base/_utils.py
+++ b/src/pyramids/base/_utils.py
@@ -402,6 +402,34 @@ def resolve_cog_predictor(gdal_dtype: int, nbits: int | None = None) -> int:
     Returns:
         int: ``3`` for floating-point types; for integer types, ``2`` when the
         width is predictor-safe (``None``/8/16/32/64) else ``1`` (no predictor).
+
+    Examples:
+        - An integer raster at its natural width uses the horizontal predictor:
+            ```python
+            >>> from osgeo import gdal
+            >>> from pyramids.base._utils import resolve_cog_predictor
+            >>> resolve_cog_predictor(gdal.GDT_UInt16)
+            2
+
+            ```
+        - A float raster uses the floating-point predictor:
+            ```python
+            >>> from osgeo import gdal
+            >>> from pyramids.base._utils import resolve_cog_predictor
+            >>> resolve_cog_predictor(gdal.GDT_Float32)
+            3
+
+            ```
+        - A sub-byte-aligned integer width falls back to no predictor:
+            ```python
+            >>> from osgeo import gdal
+            >>> from pyramids.base._utils import resolve_cog_predictor
+            >>> resolve_cog_predictor(gdal.GDT_UInt16, nbits=12)
+            1
+            >>> resolve_cog_predictor(gdal.GDT_UInt16, nbits=16)
+            2
+
+            ```
     """
     if gdal_dtype in INTEGER_GDAL_DTYPES:
         return 2 if nbits in (None, 8, 16, 32, 64) else 1

--- a/src/pyramids/base/_utils.py
+++ b/src/pyramids/base/_utils.py
@@ -374,8 +374,8 @@ def is_integer_gdal_dtype(gdal_dtype: int) -> bool:
     return gdal_dtype in INTEGER_GDAL_DTYPES
 
 
-def resolve_cog_predictor(gdal_dtype: int) -> int:
-    """Pick the DEFLATE/ZSTD predictor that suits a GDAL data type.
+def resolve_cog_predictor(gdal_dtype: int, nbits: int | None = None) -> int:
+    """Pick the DEFLATE/ZSTD predictor that suits a GDAL data type and bit width.
 
     Mirrors GDAL/libtiff semantics: ``PREDICTOR=2`` (horizontal differencing)
     for integer rasters, ``PREDICTOR=3`` (floating-point predictor) for float
@@ -385,13 +385,27 @@ def resolve_cog_predictor(gdal_dtype: int) -> int:
     the string aliases ``STANDARD`` / ``FLOATING_POINT`` are equally accepted
     when a caller passes them explicitly.
 
+    ``PREDICTOR=2`` is only accepted by libtiff for 8/16/32/64-bit samples. A
+    band carrying a sub-byte-aligned ``NBITS`` (e.g. ``12`` from a Sentinel-2
+    JP2 source) would make the COG driver reject the write, so a non-standard
+    ``nbits`` falls back to ``1`` (no predictor). Pass the *effective* output
+    width — after any promotion to the next supported width — so a promoted
+    ``12 -> 16`` still benefits from the predictor. ``None`` (the default) means
+    "the natural width of the dtype", which is always a supported width.
+
     Args:
         gdal_dtype (int): A GDAL data-type code (e.g. ``gdal.GDT_Float32``).
+        nbits (int | None): The effective sample width in bits, or ``None`` for
+            the dtype's natural width. ``PREDICTOR=2`` is only chosen for
+            integer rasters whose width is ``None`` or one of 8/16/32/64.
 
     Returns:
-        int: ``2`` for integer types, ``3`` for floating-point types.
+        int: ``3`` for floating-point types; for integer types, ``2`` when the
+        width is predictor-safe (``None``/8/16/32/64) else ``1`` (no predictor).
     """
-    return 2 if gdal_dtype in INTEGER_GDAL_DTYPES else 3
+    if gdal_dtype in INTEGER_GDAL_DTYPES:
+        return 2 if nbits in (None, 8, 16, 32, 64) else 1
+    return 3
 
 
 def default_cog_overview_resampling(gdal_dtype: int, has_color_table: bool) -> str:

--- a/src/pyramids/dataset/cog/facade.py
+++ b/src/pyramids/dataset/cog/facade.py
@@ -57,16 +57,17 @@ COG write policy (ARC-1). ``PREDICTOR`` and ``OVERVIEW_RESAMPLING`` are
 intentionally absent: both are resolved per-dtype inside ``to_cog`` (integer →
 ``PREDICTOR=2`` / ``mode`` overviews; float → ``PREDICTOR=3`` / ``average``
 overviews) unless the caller overrides them. The integer ``PREDICTOR=2`` rule is
-further gated on the sample width: a sub-byte-aligned source ``NBITS`` (e.g. the
-``12`` a ``SENTINEL2`` read carries) is promoted to the next libtiff-writable
-width and only then keeps ``PREDICTOR=2`` — a width the predictor cannot honour
-falls back to no predictor (see :func:`pyramids.base._utils.resolve_cog_predictor`
-and :func:`pyramids.dataset.cog.options._promote_nbits`). ``NBITS`` itself is
-also absent here: promoted per-source by ``Compression._to_options`` during
-``to_cog`` so the output never inherits a width that clips, while an explicit
-caller ``NBITS`` still wins. Kept
-here for back-compat and as documentation; :func:`write_cog` no longer applies it
-directly — it delegates to ``to_cog``.
+further gated on the sample width: a sub-natural ``NBITS`` on an *unsigned-integer*
+source (e.g. the ``12`` a ``SENTINEL2`` ``UInt16`` read carries) is promoted to
+the dtype's natural width (``UInt16 -> 16``, ``UInt32 -> 32``) and only then keeps
+``PREDICTOR=2`` — a width the predictor cannot honour falls back to no predictor
+(see :func:`pyramids.base._utils.resolve_cog_predictor` and
+:func:`pyramids.dataset.cog.options._promote_nbits`). ``NBITS`` itself is also
+absent here: promoted per-source by ``Compression._to_options`` during ``to_cog``
+so the output never inherits a width that clips, while an explicit caller ``NBITS``
+still wins (float and signed-integer sources are left untouched). Kept here for
+back-compat and as documentation; :func:`write_cog` no longer applies it directly
+— it delegates to ``to_cog``.
 """
 
 

--- a/src/pyramids/dataset/cog/facade.py
+++ b/src/pyramids/dataset/cog/facade.py
@@ -56,9 +56,16 @@ These mirror the kwarg defaults of
 COG write policy (ARC-1). ``PREDICTOR`` and ``OVERVIEW_RESAMPLING`` are
 intentionally absent: both are resolved per-dtype inside ``to_cog`` (integer →
 ``PREDICTOR=2`` / ``mode`` overviews; float → ``PREDICTOR=3`` / ``average``
-overviews) unless the caller overrides them. Kept here for back-compat and as
-documentation; :func:`write_cog` no longer applies it directly — it delegates
-to ``to_cog``.
+overviews) unless the caller overrides them. The integer ``PREDICTOR=2`` rule is
+further gated on the sample width: a sub-byte-aligned source ``NBITS`` (e.g. the
+``12`` a ``SENTINEL2`` read carries) is promoted to the next libtiff-writable
+width and only then keeps ``PREDICTOR=2`` — a width the predictor cannot honour
+falls back to no predictor (see :func:`pyramids.base._utils.resolve_cog_predictor`
+and :func:`pyramids.dataset.cog.options._promote_nbits`). ``NBITS`` itself is
+also absent here: promoted per-source inside ``to_cog`` so the output never
+inherits a width that clips, while an explicit caller ``NBITS`` still wins. Kept
+here for back-compat and as documentation; :func:`write_cog` no longer applies it
+directly — it delegates to ``to_cog``.
 """
 
 

--- a/src/pyramids/dataset/cog/facade.py
+++ b/src/pyramids/dataset/cog/facade.py
@@ -62,8 +62,9 @@ further gated on the sample width: a sub-byte-aligned source ``NBITS`` (e.g. the
 width and only then keeps ``PREDICTOR=2`` — a width the predictor cannot honour
 falls back to no predictor (see :func:`pyramids.base._utils.resolve_cog_predictor`
 and :func:`pyramids.dataset.cog.options._promote_nbits`). ``NBITS`` itself is
-also absent here: promoted per-source inside ``to_cog`` so the output never
-inherits a width that clips, while an explicit caller ``NBITS`` still wins. Kept
+also absent here: promoted per-source by ``Compression._to_options`` during
+``to_cog`` so the output never inherits a width that clips, while an explicit
+caller ``NBITS`` still wins. Kept
 here for back-compat and as documentation; :func:`write_cog` no longer applies it
 directly — it delegates to ``to_cog``.
 """

--- a/src/pyramids/dataset/cog/options.py
+++ b/src/pyramids/dataset/cog/options.py
@@ -193,8 +193,8 @@ def _reconcile_predictor_with_nbits(options: dict[str, Any]) -> None:
     a sub-byte-aligned ``NBITS`` through ``extra`` (overriding the promoted
     default), keeping the predictor would make GDAL reject the write. Mutates
     ``options`` in place, removing ``PREDICTOR`` so the caller's explicit narrow
-    width is honoured. A ``PREDICTOR`` the caller explicitly disabled
-    (``1``/``"NO"``) is left untouched.
+    width is honoured. An already-disabled predictor (``1`` or ``"NO"``,
+    case-insensitive) is left untouched.
 
     Args:
         options: The merged GDAL creation-option dict (post :func:`merge_options`).
@@ -227,11 +227,10 @@ def _reconcile_predictor_with_nbits(options: dict[str, Any]) -> None:
     except (TypeError, ValueError):
         return
     predictor = options.get("PREDICTOR")
-    if nbits_value not in _PREDICTOR_SAFE_NBITS and predictor not in (
-        None,
-        1,
-        "1",
-        "NO",
+    if (
+        nbits_value not in _PREDICTOR_SAFE_NBITS
+        and predictor is not None
+        and str(predictor).upper() not in ("1", "NO")
     ):
         options.pop("PREDICTOR", None)
 

--- a/src/pyramids/dataset/cog/options.py
+++ b/src/pyramids/dataset/cog/options.py
@@ -121,10 +121,17 @@ def _read_source_nbits(band: Any) -> int | None:
 
     Returns:
         The declared width in bits, or ``None`` when the band carries no
-        ``NBITS`` (its samples then use the dtype's natural width).
+        ``NBITS`` or a non-integer value (its samples then use the dtype's
+        natural width). A malformed value is ignored rather than raised, mirroring
+        the defensive parse in :func:`_reconcile_predictor_with_nbits`.
     """
     raw = band.GetMetadataItem("NBITS", "IMAGE_STRUCTURE")
-    return int(raw) if raw else None
+    if not raw:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
 
 
 def _promote_nbits(nbits: int | None) -> int | None:

--- a/src/pyramids/dataset/cog/options.py
+++ b/src/pyramids/dataset/cog/options.py
@@ -175,6 +175,26 @@ def _reconcile_predictor_with_nbits(options: dict[str, Any]) -> None:
 
     Args:
         options: The merged GDAL creation-option dict (post :func:`merge_options`).
+
+    Examples:
+        - A caller-forced narrow width drops the predictor:
+            ```python
+            >>> from pyramids.dataset.cog.options import _reconcile_predictor_with_nbits
+            >>> opts = {"NBITS": 12, "PREDICTOR": 2}
+            >>> _reconcile_predictor_with_nbits(opts)
+            >>> "PREDICTOR" in opts
+            False
+
+            ```
+        - A predictor-safe width leaves the predictor in place:
+            ```python
+            >>> from pyramids.dataset.cog.options import _reconcile_predictor_with_nbits
+            >>> opts = {"NBITS": 16, "PREDICTOR": 2}
+            >>> _reconcile_predictor_with_nbits(opts)
+            >>> opts["PREDICTOR"]
+            2
+
+            ```
     """
     nbits = options.get("NBITS")
     if nbits is None:

--- a/src/pyramids/dataset/cog/options.py
+++ b/src/pyramids/dataset/cog/options.py
@@ -98,6 +98,101 @@ omits it there.
 """
 
 
+_PREDICTOR_SAFE_NBITS: tuple[int, ...] = (8, 16, 32, 64)
+"""Sample widths (bits) libtiff accepts for ``PREDICTOR=2``.
+
+A band whose ``NBITS`` is not one of these (e.g. a 12-bit Sentinel-2 JP2 source)
+makes the COG driver reject ``PREDICTOR=2`` and, if the narrow width is inherited
+onto the output, silently clips values above its domain. :func:`_promote_nbits`
+widens such a source to the next value here, and :func:`_reconcile_predictor_with_nbits`
+drops the predictor if a caller nonetheless forces a narrow width.
+"""
+
+
+def _read_source_nbits(band: Any) -> int | None:
+    """Return a band's declared ``NBITS`` (bits per sample), or ``None``.
+
+    Reads the ``NBITS`` item from the band's ``IMAGE_STRUCTURE`` metadata domain,
+    where GDAL drivers (e.g. ``SENTINEL2``) report a sub-byte-aligned sample
+    width propagated from the source.
+
+    Args:
+        band: A GDAL raster band.
+
+    Returns:
+        The declared width in bits, or ``None`` when the band carries no
+        ``NBITS`` (its samples then use the dtype's natural width).
+    """
+    raw = band.GetMetadataItem("NBITS", "IMAGE_STRUCTURE")
+    return int(raw) if raw else None
+
+
+def _promote_nbits(nbits: int | None) -> int | None:
+    """Round a sub-byte-aligned width up to the next COG-writable sample width.
+
+    A width already ``None`` or in :data:`_PREDICTOR_SAFE_NBITS` needs no change
+    (returns ``None`` — nothing to override). A narrower/odd width (e.g. ``12``)
+    is promoted to the smallest value in :data:`_PREDICTOR_SAFE_NBITS` that can
+    hold it (``12 -> 16``), so the output neither clips nor trips the predictor.
+
+    Args:
+        nbits: The source band's declared width, or ``None``.
+
+    Returns:
+        The promoted width to write, or ``None`` when no promotion is needed.
+
+    Examples:
+        - A 12-bit source promotes to 16:
+            ```python
+            >>> from pyramids.dataset.cog.options import _promote_nbits
+            >>> _promote_nbits(12)
+            16
+
+            ```
+        - An already-supported width is left alone:
+            ```python
+            >>> _promote_nbits(16) is None
+            True
+            >>> _promote_nbits(None) is None
+            True
+
+            ```
+    """
+    if nbits is None or nbits in _PREDICTOR_SAFE_NBITS:
+        return None
+    return min(width for width in _PREDICTOR_SAFE_NBITS if width >= nbits)
+
+
+def _reconcile_predictor_with_nbits(options: dict[str, Any]) -> None:
+    """Drop ``PREDICTOR`` when the final ``NBITS`` cannot honour it.
+
+    ``PREDICTOR=2``/``3`` require an 8/16/32/64-bit sample. When a caller forces
+    a sub-byte-aligned ``NBITS`` through ``extra`` (overriding the promoted
+    default), keeping the predictor would make GDAL reject the write. Mutates
+    ``options`` in place, removing ``PREDICTOR`` so the caller's explicit narrow
+    width is honoured. A ``PREDICTOR`` the caller explicitly disabled
+    (``1``/``"NO"``) is left untouched.
+
+    Args:
+        options: The merged GDAL creation-option dict (post :func:`merge_options`).
+    """
+    nbits = options.get("NBITS")
+    if nbits is None:
+        return
+    try:
+        nbits_value = int(nbits)
+    except (TypeError, ValueError):
+        return
+    predictor = options.get("PREDICTOR")
+    if nbits_value not in _PREDICTOR_SAFE_NBITS and predictor not in (
+        None,
+        1,
+        "1",
+        "NO",
+    ):
+        options.pop("PREDICTOR", None)
+
+
 _PALETTE_GDAL_DTYPES: frozenset[int] = frozenset({gdal.GDT_Byte, gdal.GDT_UInt16})
 """GDAL dtypes for which a colour table (palette) is meaningful."""
 
@@ -374,18 +469,33 @@ class Compression:
         ``MAX_Z_ERROR``. ``None`` values are kept and dropped later by
         :func:`merge_options` / :func:`to_gdal_options`.
 
+        A source band whose ``NBITS`` is sub-byte-aligned (e.g. ``12`` from a
+        Sentinel-2 JP2 source) is promoted to the next libtiff-writable width via
+        :func:`_promote_nbits` and that width is emitted as ``NBITS`` — otherwise
+        the inherited narrow width both trips ``PREDICTOR=2`` and silently clips
+        values above its domain. The predictor is resolved against the *promoted*
+        width, so a promoted ``12 -> 16`` still uses ``PREDICTOR=2``. A caller can
+        still override ``NBITS`` through ``extra``; the write site then reconciles
+        the predictor via :func:`_reconcile_predictor_with_nbits`.
+
         Args:
-            source_band: Band 0 of the effective source, whose ``DataType``
-                drives the predictor default.
+            source_band: Band 0 of the effective source, whose ``DataType`` drives
+                the predictor default and whose ``NBITS`` drives the width.
 
         Returns:
             The compression slice of the GDAL creation-option dict
-            (``COMPRESS``/``LEVEL``/``QUALITY``/``MAX_Z_ERROR``/``PREDICTOR``).
+            (``COMPRESS``/``LEVEL``/``QUALITY``/``MAX_Z_ERROR``/``PREDICTOR``, plus
+            ``NBITS`` when a sub-byte-aligned source width is promoted).
         """
         compress = self.compress if self.compress is not None else "DEFLATE"
+        source_nbits = _read_source_nbits(source_band)
+        promoted_nbits = _promote_nbits(source_nbits)
+        # The width the output will actually use: the promoted one, else the
+        # source's own (already a supported width, or None for the dtype default).
+        effective_nbits = promoted_nbits if promoted_nbits is not None else source_nbits
         predictor = self.predictor
         if predictor is None:
-            predictor = resolve_cog_predictor(source_band.DataType)
+            predictor = resolve_cog_predictor(source_band.DataType, effective_nbits)
         options: dict[str, Any] = {
             "COMPRESS": compress,
             "LEVEL": self.level,
@@ -395,6 +505,8 @@ class Compression:
                 predictor if compress.upper() in _PREDICTOR_COMPRESSORS else None
             ),
         }
+        if promoted_nbits is not None:
+            options["NBITS"] = promoted_nbits
         return options
 
 

--- a/src/pyramids/dataset/cog/options.py
+++ b/src/pyramids/dataset/cog/options.py
@@ -104,8 +104,22 @@ _PREDICTOR_SAFE_NBITS: tuple[int, ...] = (8, 16, 32, 64)
 A band whose ``NBITS`` is not one of these (e.g. a 12-bit Sentinel-2 JP2 source)
 makes the COG driver reject ``PREDICTOR=2`` and, if the narrow width is inherited
 onto the output, silently clips values above its domain. :func:`_promote_nbits`
-widens such a source to the next value here, and :func:`_reconcile_predictor_with_nbits`
-drops the predictor if a caller nonetheless forces a narrow width.
+widens such a source to its dtype's natural width (always one of these), and
+:func:`_reconcile_predictor_with_nbits` drops the predictor if a caller
+nonetheless forces a narrow width.
+"""
+
+
+_UNSIGNED_INT_GDAL_DTYPES: frozenset[int] = frozenset(
+    {gdal.GDT_Byte, gdal.GDT_UInt16, gdal.GDT_UInt32, gdal.GDT_UInt64}
+)
+"""GDAL unsigned-integer dtypes whose ``NBITS`` promotion is meaningful.
+
+Only unsigned integers carry the sub-byte-``NBITS`` predictor/clip problem, and
+their natural container width (8/16/32/64) is the only ``NBITS`` GDAL accepts for
+the dtype. Float ``NBITS`` (half / 24-bit float) is a distinct, legitimate feature
+that must not be rewritten, and GDAL ignores ``NBITS`` on signed integers — so
+:func:`_promote_nbits` promotes only for these dtypes.
 """
 
 
@@ -134,56 +148,66 @@ def _read_source_nbits(band: Any) -> int | None:
         return None
 
 
-def _promote_nbits(nbits: int | None) -> int | None:
-    """Round a sub-byte-aligned width up to the next COG-writable sample width.
+def _promote_nbits(nbits: int | None, gdal_dtype: int) -> int | None:
+    """Promote a sub-natural integer ``NBITS`` to the dtype's natural width.
 
-    A width already ``None`` or in :data:`_PREDICTOR_SAFE_NBITS` needs no change
-    (returns ``None`` — nothing to override). A narrower/odd width (e.g. ``12``)
-    is promoted to the smallest value in :data:`_PREDICTOR_SAFE_NBITS` that can
-    hold it (``12 -> 16``), so the output neither clips nor trips the predictor.
+    The only ``NBITS`` GDAL accepts for an unsigned-integer dtype is its natural
+    container width (``Byte -> 8``, ``UInt16 -> 16``, ``UInt32 -> 32``,
+    ``UInt64 -> 64``) — always one of :data:`_PREDICTOR_SAFE_NBITS`, so promoting a
+    narrower/odd width to it is both predictor-safe and clip-safe. A width below
+    the natural one is promoted; a width already at/above it, ``None``, or on a
+    non-unsigned-integer dtype returns ``None`` (no override).
 
-    Promotion always widens the output to the next byte-aligned width, trading a
-    little storage (a 1-bit mask becomes 8-bit; an in-domain 12-bit raster
-    becomes 16-bit) for clip-safety on *derived* data whose values have grown
-    past the declared narrow domain — the #1023 case. A width above the largest
-    supported one (``> 64``, only reachable from hand-set / derived metadata since
-    GDAL integer dtypes top out at 64-bit) has no wider target, so it returns
-    ``None`` (no promotion; the predictor already falls back to ``1``) rather than
-    raising.
+    Promotion widens the output to the natural width, trading a little storage (a
+    1-bit mask becomes 8-bit; an in-domain 12-bit raster becomes 16-bit) for
+    clip-safety on *derived* data whose values have grown past the declared narrow
+    domain — the #1023 case. Float dtypes are deliberately left alone: a float
+    ``NBITS`` (half / 24-bit float) is a distinct, legitimate encoding that
+    widening would corrupt. GDAL ignores ``NBITS`` on signed integers, so those
+    are left alone too (the predictor still drops to ``1`` for a narrow width).
 
     Args:
         nbits: The source band's declared width, or ``None``.
+        gdal_dtype: The source band's GDAL data-type code (e.g. ``gdal.GDT_UInt16``).
 
     Returns:
-        The promoted width to write, or ``None`` when no promotion is needed or
-        possible.
+        The natural width to write as ``NBITS``, or ``None`` when no promotion is
+        needed or applicable.
 
     Examples:
-        - A 12-bit source promotes to 16:
+        - A 12-bit UInt16 source promotes to its natural 16:
             ```python
+            >>> from osgeo import gdal
             >>> from pyramids.dataset.cog.options import _promote_nbits
-            >>> _promote_nbits(12)
+            >>> _promote_nbits(12, gdal.GDT_UInt16)
             16
 
             ```
-        - An already-supported width is left alone:
+        - A 12-bit UInt32 source promotes to its natural 32 (not 16):
             ```python
-            >>> _promote_nbits(16) is None
-            True
-            >>> _promote_nbits(None) is None
-            True
+            >>> from osgeo import gdal
+            >>> from pyramids.dataset.cog.options import _promote_nbits
+            >>> _promote_nbits(12, gdal.GDT_UInt32)
+            32
 
             ```
-        - A width beyond 64 has no wider target and is left alone:
+        - An already-natural width, ``None``, or a float dtype is left alone:
             ```python
-            >>> _promote_nbits(128) is None
+            >>> from osgeo import gdal
+            >>> from pyramids.dataset.cog.options import _promote_nbits
+            >>> _promote_nbits(16, gdal.GDT_UInt16) is None
+            True
+            >>> _promote_nbits(None, gdal.GDT_UInt16) is None
+            True
+            >>> _promote_nbits(12, gdal.GDT_Float32) is None
             True
 
             ```
     """
-    if nbits is None or nbits in _PREDICTOR_SAFE_NBITS:
+    if nbits is None or gdal_dtype not in _UNSIGNED_INT_GDAL_DTYPES:
         return None
-    return next((width for width in _PREDICTOR_SAFE_NBITS if width >= nbits), None)
+    natural = gdal.GetDataTypeSize(gdal_dtype)
+    return natural if nbits < natural else None
 
 
 def _reconcile_predictor_with_nbits(options: dict[str, Any]) -> None:
@@ -511,14 +535,16 @@ class Compression:
         ``MAX_Z_ERROR``. ``None`` values are kept and dropped later by
         :func:`merge_options` / :func:`to_gdal_options`.
 
-        A source band whose ``NBITS`` is sub-byte-aligned (e.g. ``12`` from a
-        Sentinel-2 JP2 source) is promoted to the next libtiff-writable width via
-        :func:`_promote_nbits` and that width is emitted as ``NBITS`` — otherwise
-        the inherited narrow width both trips ``PREDICTOR=2`` and silently clips
-        values above its domain. The predictor is resolved against the *promoted*
-        width, so a promoted ``12 -> 16`` still uses ``PREDICTOR=2``. A caller can
-        still override ``NBITS`` through ``extra``; the write site then reconciles
-        the predictor via :func:`_reconcile_predictor_with_nbits`.
+        An **unsigned-integer** source band whose ``NBITS`` is below its natural
+        width (e.g. ``12`` from a Sentinel-2 JP2 ``UInt16`` source) is promoted to
+        that natural width via :func:`_promote_nbits` and the width is emitted as
+        ``NBITS`` — otherwise the inherited narrow width both trips ``PREDICTOR=2``
+        and silently clips values above its domain. The predictor is resolved
+        against the *promoted* width, so a promoted ``12 -> 16`` still uses
+        ``PREDICTOR=2``. Float and signed-integer dtypes are left alone (a float
+        ``NBITS`` is a distinct encoding; GDAL ignores ``NBITS`` on signed ints).
+        A caller can still override ``NBITS`` through ``extra``; the write site then
+        reconciles the predictor via :func:`_reconcile_predictor_with_nbits`.
 
         Args:
             source_band: Band 0 of the effective source, whose ``DataType`` drives
@@ -527,13 +553,14 @@ class Compression:
         Returns:
             The compression slice of the GDAL creation-option dict
             (``COMPRESS``/``LEVEL``/``QUALITY``/``MAX_Z_ERROR``/``PREDICTOR``, plus
-            ``NBITS`` when a sub-byte-aligned source width is promoted).
+            ``NBITS`` when a sub-natural unsigned-integer source width is promoted).
         """
         compress = self.compress if self.compress is not None else "DEFLATE"
         source_nbits = _read_source_nbits(source_band)
-        promoted_nbits = _promote_nbits(source_nbits)
-        # The width the output will actually use: the promoted one, else the
-        # source's own (already a supported width, or None for the dtype default).
+        promoted_nbits = _promote_nbits(source_nbits, source_band.DataType)
+        # The width the output will actually use: the promoted natural width, else
+        # the source's own (already natural, a float/signed width we leave alone, or
+        # None for the dtype default).
         effective_nbits = promoted_nbits if promoted_nbits is not None else source_nbits
         predictor = self.predictor
         if predictor is None:

--- a/src/pyramids/dataset/cog/options.py
+++ b/src/pyramids/dataset/cog/options.py
@@ -135,11 +135,21 @@ def _promote_nbits(nbits: int | None) -> int | None:
     is promoted to the smallest value in :data:`_PREDICTOR_SAFE_NBITS` that can
     hold it (``12 -> 16``), so the output neither clips nor trips the predictor.
 
+    Promotion always widens the output to the next byte-aligned width, trading a
+    little storage (a 1-bit mask becomes 8-bit; an in-domain 12-bit raster
+    becomes 16-bit) for clip-safety on *derived* data whose values have grown
+    past the declared narrow domain — the #1023 case. A width above the largest
+    supported one (``> 64``, only reachable from hand-set / derived metadata since
+    GDAL integer dtypes top out at 64-bit) has no wider target, so it returns
+    ``None`` (no promotion; the predictor already falls back to ``1``) rather than
+    raising.
+
     Args:
         nbits: The source band's declared width, or ``None``.
 
     Returns:
-        The promoted width to write, or ``None`` when no promotion is needed.
+        The promoted width to write, or ``None`` when no promotion is needed or
+        possible.
 
     Examples:
         - A 12-bit source promotes to 16:
@@ -157,10 +167,16 @@ def _promote_nbits(nbits: int | None) -> int | None:
             True
 
             ```
+        - A width beyond 64 has no wider target and is left alone:
+            ```python
+            >>> _promote_nbits(128) is None
+            True
+
+            ```
     """
     if nbits is None or nbits in _PREDICTOR_SAFE_NBITS:
         return None
-    return min(width for width in _PREDICTOR_SAFE_NBITS if width >= nbits)
+    return next((width for width in _PREDICTOR_SAFE_NBITS if width >= nbits), None)
 
 
 def _reconcile_predictor_with_nbits(options: dict[str, Any]) -> None:

--- a/src/pyramids/dataset/engines/cog.py
+++ b/src/pyramids/dataset/engines/cog.py
@@ -39,6 +39,7 @@ from pyramids.dataset.cog import (
     validate,
     validate_profile,
 )
+from pyramids.dataset.cog.options import _reconcile_predictor_with_nbits
 from pyramids.dataset.cog.validate import _resolve_read_config, config_context
 from pyramids.dataset.engines._base import _Engine
 from pyramids.dataset.engines._validate import world_to_pixel
@@ -363,6 +364,10 @@ class COG(_Engine["Dataset"]):
             )
 
         options = merge_options(defaults, extra)
+        # If a caller forced a sub-byte-aligned NBITS through `extra`, the
+        # promoted-width predictor computed above would make GDAL reject the
+        # write — drop the predictor so the caller's explicit width is honoured.
+        _reconcile_predictor_with_nbits(options)
         with config_context(config):
             self._translate_with_statistics_retry(path, options, src=source_ds)
         return Path(path)

--- a/tests/dataset/cog/test_nbits.py
+++ b/tests/dataset/cog/test_nbits.py
@@ -3,10 +3,11 @@
 A band whose ``NBITS`` is not 8/16/32/64 (e.g. the 12 a ``SENTINEL2`` read
 propagates) used to (a) make ``to_file(driver="COG")`` fail because ``PREDICTOR=2``
 is rejected for that width, and (b) silently clip values above the narrow domain
-when the width was inherited onto the output. These tests pin the fix: the width
-is promoted to the next libtiff-writable value, the predictor is resolved against
-that promoted width, and an explicit caller ``NBITS`` still wins (with the
-predictor reconciled away so the write does not fail).
+when the width was inherited onto the output. These tests pin the fix: an
+unsigned-integer source is promoted to its dtype's natural width, the predictor is
+resolved against that promoted width, float/signed dtypes are left untouched, and
+an explicit caller ``NBITS`` still wins (with the predictor reconciled away so the
+write does not fail).
 """
 
 from __future__ import annotations
@@ -96,39 +97,55 @@ class TestReadSourceNbits:
 
 
 class TestPromoteNbits:
-    """Width promotion in :func:`_promote_nbits`."""
+    """Dtype-aware width promotion in :func:`_promote_nbits`."""
 
     @pytest.mark.parametrize(
-        "nbits, expected",
-        [(1, 8), (4, 8), (12, 16), (24, 32), (40, 64)],
+        "nbits, dtype, expected",
+        [
+            (12, gdal.GDT_UInt16, 16),
+            (4, gdal.GDT_UInt16, 16),
+            (1, gdal.GDT_Byte, 8),
+            (12, gdal.GDT_UInt32, 32),
+            (20, gdal.GDT_UInt32, 32),
+            (40, gdal.GDT_UInt64, 64),
+        ],
     )
-    def test_narrow_widths_promote_to_next_supported(self, nbits, expected):
-        """A narrow width rounds up to the next libtiff-writable width.
+    def test_sub_natural_widths_promote_to_dtype_natural(self, nbits, dtype, expected):
+        """A sub-natural unsigned width promotes to the dtype's natural width.
 
         Args:
             nbits: The source width.
-            expected: The promoted width.
+            dtype: The source GDAL dtype.
+            expected: The natural width promoted to.
         """
-        got = _promote_nbits(nbits)
-        assert got == expected, f"promote({nbits}) should be {expected}, got {got}"
+        got = _promote_nbits(nbits, dtype)
+        assert got == expected, (
+            f"promote({nbits},{dtype}) should be {expected}, got {got}"
+        )
 
-    @pytest.mark.parametrize("nbits", [None, 8, 16, 32, 64])
-    def test_supported_or_none_needs_no_promotion(self, nbits):
-        """An already-supported width (or ``None``) returns ``None``.
+    @pytest.mark.parametrize(
+        "nbits, dtype",
+        [(None, gdal.GDT_UInt16), (16, gdal.GDT_UInt16), (32, gdal.GDT_UInt32)],
+    )
+    def test_natural_or_none_needs_no_promotion(self, nbits, dtype):
+        """An already-natural width or ``None`` returns ``None``.
 
         Args:
             nbits: A width needing no change.
+            dtype: The source GDAL dtype.
         """
-        assert _promote_nbits(nbits) is None, f"promote({nbits}) should be None"
+        assert _promote_nbits(nbits, dtype) is None, f"promote({nbits},{dtype}) -> None"
 
-    @pytest.mark.parametrize("nbits", [65, 96, 128])
-    def test_width_above_max_supported_returns_none(self, nbits):
-        """A width beyond 64 has no wider target and returns ``None`` (no crash).
+    @pytest.mark.parametrize(
+        "dtype", [gdal.GDT_Float32, gdal.GDT_Float64, gdal.GDT_Int16]
+    )
+    def test_non_unsigned_dtypes_are_left_alone(self, dtype):
+        """Float and signed-integer dtypes are never promoted (returns ``None``).
 
         Args:
-            nbits: A width larger than the largest predictor-safe width.
+            dtype: A non-unsigned-integer GDAL dtype.
         """
-        assert _promote_nbits(nbits) is None, f"promote({nbits}) should be None"
+        assert _promote_nbits(12, dtype) is None, f"promote(12,{dtype}) should be None"
 
 
 class TestReconcilePredictorWithNbits:
@@ -222,42 +239,93 @@ class TestCompressionToOptionsNbits:
         assert "NBITS" not in opts, f"NBITS should be absent, got {opts.get('NBITS')}"
         assert opts["PREDICTOR"] == 2, f"expected PREDICTOR=2, got {opts['PREDICTOR']}"
 
+    def test_uint16_below_one_byte_promotes_to_natural(self):
+        """A UInt16 source with ``NBITS<8`` promotes to 16 (not 8) with ``PREDICTOR=2``."""
+        ds, band = _mem_band(gdal.GDT_UInt16, nbits=4)
+        opts = Compression()._to_options(band)
+        assert opts["NBITS"] == 16, (
+            f"expected natural NBITS=16, got {opts.get('NBITS')}"
+        )
+        assert opts["PREDICTOR"] == 2, f"expected PREDICTOR=2, got {opts['PREDICTOR']}"
 
-def _nbits12_source_with_large_value(value: int = 5000) -> Dataset:
-    """Build a UInt16 Dataset holding ``value`` (>4095) but tagged ``NBITS=12``.
+    def test_uint32_promotes_to_natural_32(self):
+        """A UInt32 source with a sub-natural ``NBITS`` promotes to 32, not 16."""
+        ds, band = _mem_band(gdal.GDT_UInt32, nbits=12)
+        opts = Compression()._to_options(band)
+        assert opts["NBITS"] == 32, (
+            f"expected natural NBITS=32, got {opts.get('NBITS')}"
+        )
+        assert opts["PREDICTOR"] == 2, f"expected PREDICTOR=2, got {opts['PREDICTOR']}"
 
-    Mirrors a *derived* Sentinel-2 band: the values exceed the 12-bit domain
-    (e.g. after band math) yet the band still carries the inherited ``NBITS=12``.
+    def test_float_source_emits_no_nbits_and_predictor_3(self):
+        """A float source is never promoted: no ``NBITS`` emitted, ``PREDICTOR=3``.
+
+        Test scenario:
+            Emitting a promoted ``NBITS`` on a float band would mean half-float and
+            corrupt values, so the promotion must skip float dtypes entirely.
+        """
+        ds, band = _mem_band(gdal.GDT_Float32, nbits=12)
+        opts = Compression()._to_options(band)
+        assert "NBITS" not in opts, (
+            f"float NBITS should not be emitted: {opts.get('NBITS')}"
+        )
+        assert opts["PREDICTOR"] == 3, (
+            f"expected PREDICTOR=3 for float, got {opts['PREDICTOR']}"
+        )
+
+
+def _nbits_source(value, np_dtype, nbits: int, no_data_value) -> Dataset:
+    """Build a Dataset of ``np_dtype`` holding ``value`` but tagged with ``nbits``.
+
+    Mirrors a *derived* band whose values exceed its declared narrow domain (e.g.
+    Sentinel-2 band math past 4095) while still carrying the inherited ``NBITS``.
+    An explicit in-domain ``no_data_value`` keeps the fallback-nodata warning out
+    of the suite output.
     """
-    arr = np.full((4, 4), value, dtype=np.uint16)
+    arr = np.full((4, 4), value, dtype=np_dtype)
     ds = Dataset.create_from_array(
-        arr, top_left_corner=(0, 4), cell_size=1.0, epsg=4326
+        arr,
+        top_left_corner=(0, 4),
+        cell_size=1.0,
+        epsg=4326,
+        no_data_value=no_data_value,
     )
-    ds.raster.GetRasterBand(1).SetMetadataItem("NBITS", "12", "IMAGE_STRUCTURE")
+    ds.raster.GetRasterBand(1).SetMetadataItem("NBITS", str(nbits), "IMAGE_STRUCTURE")
     return ds
 
 
 class TestCogWriteNbits:
-    """End-to-end ``to_file(driver="COG")`` on a sub-byte-aligned source."""
+    """End-to-end ``to_file(driver="COG")`` on sub-natural NBITS sources."""
 
-    def test_write_succeeds_and_value_survives(self, tmp_path):
-        """A default COG write succeeds and a >4095 value round-trips.
+    @pytest.mark.parametrize(
+        "value, np_dtype, nbits",
+        [
+            (5000, np.uint16, 12),  # #1023 Sentinel-2 case (UInt16 9..15)
+            (5000, np.uint16, 4),  # UInt16 below one byte (M1)
+            (100000, np.uint32, 12),  # UInt32 sub-natural (M1)
+        ],
+    )
+    def test_write_succeeds_and_value_survives(self, value, np_dtype, nbits, tmp_path):
+        """A default COG write succeeds and an out-of-domain value round-trips.
 
         Args:
+            value: A value above the declared narrow ``nbits`` domain.
+            np_dtype: The source NumPy dtype.
+            nbits: The declared sub-natural width.
             tmp_path: pytest temp directory.
 
         Test scenario:
-            The 12-bit source is promoted so ``PREDICTOR=2`` is valid and the
-            5000 value is not clipped to 4095.
+            The source is promoted to its dtype's natural width so ``PREDICTOR=2``
+            is valid and the value is not clipped to the narrow domain.
         """
-        src = _nbits12_source_with_large_value(5000)
-        out = tmp_path / "nb12.tif"
+        src = _nbits_source(value, np_dtype, nbits, no_data_value=0)
+        out = tmp_path / "nb.tif"
         src.to_file(out, driver="COG")
         reopened = Dataset.read_file(out)
         peak = int(reopened.read_array().max())
         reopened.close()
         src.close()
-        assert peak == 5000, f"value clipped to {peak}; expected 5000"
+        assert peak == value, f"value clipped to {peak}; expected {value}"
 
     def test_explicit_narrow_nbits_is_honoured(self, tmp_path):
         """An explicit caller ``NBITS=12`` is applied to the output.
@@ -272,7 +340,7 @@ class TestCogWriteNbits:
             pins the honoured width, not clipping. The reopened output must report
             ``NBITS=12`` and its in-domain value must round-trip intact.
         """
-        src = _nbits12_source_with_large_value(3000)
+        src = _nbits_source(3000, np.uint16, 12, no_data_value=0)
         out = tmp_path / "nb12_forced.tif"
         src.to_file(out, driver="COG", creation_options=["NBITS=12"])
         src.close()

--- a/tests/dataset/cog/test_nbits.py
+++ b/tests/dataset/cog/test_nbits.py
@@ -121,6 +121,28 @@ class TestReconcilePredictorWithNbits:
         _reconcile_predictor_with_nbits(options)
         assert options.get("PREDICTOR") == 2, f"predictor should stay: {options}"
 
+    def test_noop_for_non_integer_nbits(self):
+        """A non-integer ``NBITS`` value is ignored (predictor untouched).
+
+        Test scenario:
+            A malformed ``NBITS`` that cannot be parsed to int must not raise and
+            must leave the predictor in place.
+        """
+        options = {"NBITS": "not-a-number", "PREDICTOR": 2}
+        _reconcile_predictor_with_nbits(options)
+        assert options.get("PREDICTOR") == 2, f"predictor should stay: {options}"
+
+    def test_noop_when_predictor_already_disabled(self):
+        """A narrow ``NBITS`` with an already-disabled predictor is left as-is.
+
+        Test scenario:
+            When the caller already set ``PREDICTOR=1`` (no predictor), a narrow
+            width needs no further change.
+        """
+        options = {"NBITS": 12, "PREDICTOR": 1}
+        _reconcile_predictor_with_nbits(options)
+        assert options.get("PREDICTOR") == 1, f"predictor should stay 1: {options}"
+
 
 class TestCompressionToOptionsNbits:
     """``Compression._to_options`` reads and promotes the source ``NBITS``."""

--- a/tests/dataset/cog/test_nbits.py
+++ b/tests/dataset/cog/test_nbits.py
@@ -20,6 +20,7 @@ from pyramids.dataset import Dataset
 from pyramids.dataset.cog import Compression
 from pyramids.dataset.cog.options import (
     _promote_nbits,
+    _read_source_nbits,
     _reconcile_predictor_with_nbits,
 )
 
@@ -66,6 +67,32 @@ class TestResolveCogPredictor:
         """
         got = resolve_cog_predictor(gdal.GDT_Float32, nbits)
         assert got == 3, f"expected 3 for float, got {got}"
+
+
+class TestReadSourceNbits:
+    """Reading ``NBITS`` from a band in :func:`_read_source_nbits`."""
+
+    def test_reads_integer_nbits(self):
+        """A well-formed ``NBITS`` string is returned as an int."""
+        _ds, band = _mem_band(gdal.GDT_UInt16, nbits=12)
+        assert _read_source_nbits(band) == 12, "should read NBITS=12"
+
+    def test_missing_nbits_is_none(self):
+        """A band with no ``NBITS`` metadata returns ``None``."""
+        _ds, band = _mem_band(gdal.GDT_UInt16, nbits=None)
+        assert _read_source_nbits(band) is None, "no NBITS should read None"
+
+    def test_non_integer_nbits_is_ignored(self):
+        """A malformed ``NBITS`` value returns ``None`` rather than raising.
+
+        Test scenario:
+            A hand-set non-integer width must not abort the read path.
+        """
+        ds = gdal.GetDriverByName("MEM").Create("", 4, 4, 1, gdal.GDT_UInt16)
+        ds.GetRasterBand(1).SetMetadataItem("NBITS", "not-a-number", "IMAGE_STRUCTURE")
+        assert _read_source_nbits(ds.GetRasterBand(1)) is None, (
+            "malformed NBITS -> None"
+        )
 
 
 class TestPromoteNbits:

--- a/tests/dataset/cog/test_nbits.py
+++ b/tests/dataset/cog/test_nbits.py
@@ -1,0 +1,208 @@
+"""Regression tests for sub-byte-aligned ``NBITS`` handling in COG writes.
+
+A band whose ``NBITS`` is not 8/16/32/64 (e.g. the 12 a ``SENTINEL2`` read
+propagates) used to (a) make ``to_file(driver="COG")`` fail because ``PREDICTOR=2``
+is rejected for that width, and (b) silently clip values above the narrow domain
+when the width was inherited onto the output. These tests pin the fix: the width
+is promoted to the next libtiff-writable value, the predictor is resolved against
+that promoted width, and an explicit caller ``NBITS`` still wins (with the
+predictor reconciled away so the write does not fail).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from osgeo import gdal
+
+from pyramids.base._utils import resolve_cog_predictor
+from pyramids.dataset import Dataset
+from pyramids.dataset.cog import Compression
+from pyramids.dataset.cog.options import (
+    _promote_nbits,
+    _reconcile_predictor_with_nbits,
+)
+
+pytestmark = pytest.mark.core
+
+
+def _mem_band(gdal_dtype: int = gdal.GDT_UInt16, nbits: int | None = None):
+    """Return a MEM dataset and its band 1, optionally tagged with ``NBITS``."""
+    ds = gdal.GetDriverByName("MEM").Create("", 4, 4, 1, gdal_dtype)
+    if nbits is not None:
+        ds.GetRasterBand(1).SetMetadataItem("NBITS", str(nbits), "IMAGE_STRUCTURE")
+    return ds, ds.GetRasterBand(1)
+
+
+class TestResolveCogPredictor:
+    """The ``nbits`` argument of :func:`resolve_cog_predictor`."""
+
+    @pytest.mark.parametrize("nbits", [None, 8, 16, 32, 64])
+    def test_integer_predictor_2_for_supported_widths(self, nbits):
+        """Integer rasters keep ``PREDICTOR=2`` at predictor-safe widths.
+
+        Args:
+            nbits: A width libtiff accepts for the horizontal predictor.
+        """
+        got = resolve_cog_predictor(gdal.GDT_UInt16, nbits)
+        assert got == 2, f"expected 2 for nbits={nbits}, got {got}"
+
+    @pytest.mark.parametrize("nbits", [1, 4, 12, 24, 40])
+    def test_integer_falls_back_to_no_predictor_for_narrow_widths(self, nbits):
+        """A sub-byte-aligned width drops to ``PREDICTOR=1`` (no predictor).
+
+        Args:
+            nbits: A width libtiff rejects for ``PREDICTOR=2``.
+        """
+        got = resolve_cog_predictor(gdal.GDT_UInt16, nbits)
+        assert got == 1, f"expected 1 for nbits={nbits}, got {got}"
+
+    @pytest.mark.parametrize("nbits", [None, 12, 16])
+    def test_float_always_predictor_3(self, nbits):
+        """Float rasters always use ``PREDICTOR=3`` regardless of width.
+
+        Args:
+            nbits: Any width; ignored for float.
+        """
+        got = resolve_cog_predictor(gdal.GDT_Float32, nbits)
+        assert got == 3, f"expected 3 for float, got {got}"
+
+
+class TestPromoteNbits:
+    """Width promotion in :func:`_promote_nbits`."""
+
+    @pytest.mark.parametrize(
+        "nbits, expected",
+        [(1, 8), (4, 8), (12, 16), (24, 32), (40, 64)],
+    )
+    def test_narrow_widths_promote_to_next_supported(self, nbits, expected):
+        """A narrow width rounds up to the next libtiff-writable width.
+
+        Args:
+            nbits: The source width.
+            expected: The promoted width.
+        """
+        got = _promote_nbits(nbits)
+        assert got == expected, f"promote({nbits}) should be {expected}, got {got}"
+
+    @pytest.mark.parametrize("nbits", [None, 8, 16, 32, 64])
+    def test_supported_or_none_needs_no_promotion(self, nbits):
+        """An already-supported width (or ``None``) returns ``None``.
+
+        Args:
+            nbits: A width needing no change.
+        """
+        assert _promote_nbits(nbits) is None, f"promote({nbits}) should be None"
+
+
+class TestReconcilePredictorWithNbits:
+    """Post-merge predictor reconciliation in :func:`_reconcile_predictor_with_nbits`."""
+
+    def test_drops_predictor_for_narrow_nbits(self):
+        """A narrow final ``NBITS`` drops the predictor so GDAL accepts the write.
+
+        Test scenario:
+            A caller-forced ``NBITS=12`` with ``PREDICTOR=2`` would be rejected;
+            the predictor key is removed.
+        """
+        options = {"NBITS": 12, "PREDICTOR": 2, "COMPRESS": "DEFLATE"}
+        _reconcile_predictor_with_nbits(options)
+        assert "PREDICTOR" not in options, f"predictor should be dropped: {options}"
+
+    def test_keeps_predictor_for_supported_nbits(self):
+        """A predictor-safe final ``NBITS`` leaves the predictor in place."""
+        options = {"NBITS": 16, "PREDICTOR": 2}
+        _reconcile_predictor_with_nbits(options)
+        assert options.get("PREDICTOR") == 2, f"predictor should stay: {options}"
+
+    def test_noop_without_nbits(self):
+        """No ``NBITS`` key leaves the options untouched."""
+        options = {"PREDICTOR": 2, "COMPRESS": "ZSTD"}
+        _reconcile_predictor_with_nbits(options)
+        assert options.get("PREDICTOR") == 2, f"predictor should stay: {options}"
+
+
+class TestCompressionToOptionsNbits:
+    """``Compression._to_options`` reads and promotes the source ``NBITS``."""
+
+    def test_narrow_nbits_promoted_and_predictor_kept(self):
+        """A 12-bit source emits ``NBITS=16`` and keeps ``PREDICTOR=2``.
+
+        Test scenario:
+            The promoted width is predictor-safe, so the write is both valid and
+            free of clipping.
+        """
+        ds, band = _mem_band(gdal.GDT_UInt16, nbits=12)
+        opts = Compression()._to_options(band)
+        assert opts["NBITS"] == 16, (
+            f"expected promoted NBITS=16, got {opts.get('NBITS')}"
+        )
+        assert opts["PREDICTOR"] == 2, f"expected PREDICTOR=2, got {opts['PREDICTOR']}"
+
+    def test_supported_nbits_emits_no_nbits_key(self):
+        """A 16-bit source needs no promotion and emits no ``NBITS``."""
+        ds, band = _mem_band(gdal.GDT_UInt16, nbits=16)
+        opts = Compression()._to_options(band)
+        assert "NBITS" not in opts, f"NBITS should be absent, got {opts.get('NBITS')}"
+        assert opts["PREDICTOR"] == 2, f"expected PREDICTOR=2, got {opts['PREDICTOR']}"
+
+    def test_no_source_nbits_emits_no_nbits_key(self):
+        """A band with no ``NBITS`` metadata emits none and keeps ``PREDICTOR=2``."""
+        ds, band = _mem_band(gdal.GDT_UInt16, nbits=None)
+        opts = Compression()._to_options(band)
+        assert "NBITS" not in opts, f"NBITS should be absent, got {opts.get('NBITS')}"
+        assert opts["PREDICTOR"] == 2, f"expected PREDICTOR=2, got {opts['PREDICTOR']}"
+
+
+def _nbits12_source_with_large_value(value: int = 5000) -> Dataset:
+    """Build a UInt16 Dataset holding ``value`` (>4095) but tagged ``NBITS=12``.
+
+    Mirrors a *derived* Sentinel-2 band: the values exceed the 12-bit domain
+    (e.g. after band math) yet the band still carries the inherited ``NBITS=12``.
+    """
+    arr = np.full((4, 4), value, dtype=np.uint16)
+    ds = Dataset.create_from_array(
+        arr, top_left_corner=(0, 4), cell_size=1.0, epsg=4326
+    )
+    ds.raster.GetRasterBand(1).SetMetadataItem("NBITS", "12", "IMAGE_STRUCTURE")
+    return ds
+
+
+class TestCogWriteNbits:
+    """End-to-end ``to_file(driver="COG")`` on a sub-byte-aligned source."""
+
+    def test_write_succeeds_and_value_survives(self, tmp_path):
+        """A default COG write succeeds and a >4095 value round-trips.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            The 12-bit source is promoted so ``PREDICTOR=2`` is valid and the
+            5000 value is not clipped to 4095.
+        """
+        src = _nbits12_source_with_large_value(5000)
+        out = tmp_path / "nb12.tif"
+        src.to_file(out, driver="COG")
+        reopened = Dataset.read_file(out)
+        peak = int(reopened.read_array().max())
+        reopened.close()
+        src.close()
+        assert peak == 5000, f"value clipped to {peak}; expected 5000"
+
+    def test_explicit_narrow_nbits_is_honoured(self, tmp_path):
+        """An explicit caller ``NBITS=12`` still writes (predictor reconciled).
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            Forcing the narrow width would clash with ``PREDICTOR=2``; the write
+            site drops the predictor so the caller's width is honoured without a
+            hard failure.
+        """
+        src = _nbits12_source_with_large_value(5000)
+        out = tmp_path / "nb12_forced.tif"
+        src.to_file(out, driver="COG", creation_options=["NBITS=12"])
+        src.close()
+        assert out.exists(), "explicit NBITS=12 write should succeed"

--- a/tests/dataset/cog/test_nbits.py
+++ b/tests/dataset/cog/test_nbits.py
@@ -94,6 +94,15 @@ class TestPromoteNbits:
         """
         assert _promote_nbits(nbits) is None, f"promote({nbits}) should be None"
 
+    @pytest.mark.parametrize("nbits", [65, 96, 128])
+    def test_width_above_max_supported_returns_none(self, nbits):
+        """A width beyond 64 has no wider target and returns ``None`` (no crash).
+
+        Args:
+            nbits: A width larger than the largest predictor-safe width.
+        """
+        assert _promote_nbits(nbits) is None, f"promote({nbits}) should be None"
+
 
 class TestReconcilePredictorWithNbits:
     """Post-merge predictor reconciliation in :func:`_reconcile_predictor_with_nbits`."""

--- a/tests/dataset/cog/test_nbits.py
+++ b/tests/dataset/cog/test_nbits.py
@@ -179,6 +179,17 @@ class TestReconcilePredictorWithNbits:
         _reconcile_predictor_with_nbits(options)
         assert options.get("PREDICTOR") == 1, f"predictor should stay 1: {options}"
 
+    @pytest.mark.parametrize("token", ["NO", "no", "No"])
+    def test_noop_for_case_insensitive_disabled_token(self, token):
+        """A string ``"NO"`` token (any case) is preserved for a narrow width.
+
+        Args:
+            token: A case variant of the disabled-predictor token.
+        """
+        options = {"NBITS": 12, "PREDICTOR": token}
+        _reconcile_predictor_with_nbits(options)
+        assert options.get("PREDICTOR") == token, f"predictor should stay: {options}"
+
 
 class TestCompressionToOptionsNbits:
     """``Compression._to_options`` reads and promotes the source ``NBITS``."""

--- a/tests/dataset/cog/test_nbits.py
+++ b/tests/dataset/cog/test_nbits.py
@@ -260,18 +260,26 @@ class TestCogWriteNbits:
         assert peak == 5000, f"value clipped to {peak}; expected 5000"
 
     def test_explicit_narrow_nbits_is_honoured(self, tmp_path):
-        """An explicit caller ``NBITS=12`` still writes (predictor reconciled).
+        """An explicit caller ``NBITS=12`` is applied to the output.
 
         Args:
             tmp_path: pytest temp directory.
 
         Test scenario:
-            Forcing the narrow width would clash with ``PREDICTOR=2``; the write
-            site drops the predictor so the caller's width is honoured without a
-            hard failure.
+            Forcing the narrow width would clash with the promoted ``PREDICTOR=2``;
+            the write site drops the predictor so the caller's width is honoured
+            rather than failing. Uses an in-domain value (3000 <= 4095) so the test
+            pins the honoured width, not clipping. The reopened output must report
+            ``NBITS=12`` and its in-domain value must round-trip intact.
         """
-        src = _nbits12_source_with_large_value(5000)
+        src = _nbits12_source_with_large_value(3000)
         out = tmp_path / "nb12_forced.tif"
         src.to_file(out, driver="COG", creation_options=["NBITS=12"])
         src.close()
-        assert out.exists(), "explicit NBITS=12 write should succeed"
+        reopened = Dataset.read_file(out)
+        band = reopened.raster.GetRasterBand(1)
+        applied_nbits = band.GetMetadataItem("NBITS", "IMAGE_STRUCTURE")
+        peak = int(reopened.read_array().max())
+        reopened.close()
+        assert applied_nbits == "12", f"caller NBITS not applied, got {applied_nbits!r}"
+        assert peak == 3000, f"in-domain value should round-trip, got {peak}"


### PR DESCRIPTION
# Description

Fixes a hard blocker for writing sub-byte-aligned rasters to COG. A band whose `NBITS` is not one of
`{8, 16, 32, 64}` — e.g. the `12` a `SENTINEL2` read propagates from its JP2 sources — hit two problems, both
tracing to the COG predictor being resolved from the GDAL dtype alone:

- **(a)** `to_file(driver="COG")` failed outright: `PREDICTOR=2` (forced for integer dtypes) is rejected by libtiff
  for a 12-bit sample.
- **(b)** When a write did succeed, the inherited narrow `NBITS` silently clipped any value above the domain (e.g.
  a derived/scaled band with values > 4095), with only a GDAL warning.

Changes:

- `src/pyramids/base/_utils.py` — `resolve_cog_predictor(gdal_dtype, nbits=None)`: integer rasters keep
  `PREDICTOR=2` only for a predictor-safe width (`None`/8/16/32/64), else fall back to `1` (no predictor).
- `src/pyramids/dataset/cog/options.py` — `Compression._to_options` reads the source band's `NBITS`, promotes a
  sub-byte-aligned width to the next writable one (`12 -> 16`, via `_promote_nbits`), emits it as `NBITS` so the
  output neither clips nor trips the predictor, and resolves the predictor against the promoted width. New
  `_reconcile_predictor_with_nbits` drops the predictor when a caller forces a narrow `NBITS`.
- `src/pyramids/dataset/engines/cog.py` — `to_cog` calls the reconciler after merging caller `extra`, so an
  explicit narrow `NBITS` is honoured (write succeeds) rather than crashing.
- `src/pyramids/dataset/cog/facade.py` — module docstring updated to state the `NBITS`/predictor interaction.

# Issues

- Closes #1023 — PREDICTOR=2 forced on sub-8-bit bands breaks COG writes; inherited NBITS silently clips.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran locally against the branch's `src` on the `dev` pixi environment:

- [x] New `tests/dataset/cog/test_nbits.py` — 31 passed (resolver `nbits` matrix, `_promote_nbits`,
  `_reconcile_predictor_with_nbits`, the `Compression._to_options` slice, and an end-to-end 12-bit COG round-trip
  asserting a 5000 value survives + an explicit `NBITS=12` write succeeds).
- [x] `pytest tests/dataset/cog` — 485 passed (no regressions).
- [x] `pytest --doctest-modules` on the three changed source modules — green (incl. the new `_promote_nbits`
  doctest).

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
