### PR TITLE
fix(dataset): preserve category names, RAT, and metadata across warp and align

### DIFF
--- a/src/pyramids/dataset/engines/_warp.py
+++ b/src/pyramids/dataset/engines/_warp.py
@@ -47,6 +47,53 @@ def dst_srs_arg(dst_sr: osr.SpatialReference) -> str:
     return srs_arg
 
 
+def carry_raster_metadata(
+    source: gdal.Dataset,
+    dest: gdal.Dataset,
+    *,
+    categories_only: bool = False,
+) -> None:
+    """Carry a raster's descriptive metadata from `source` onto `dest`.
+
+    Two operations move pixels without their descriptive metadata and need this:
+    GDAL's warper drops per-band **category names** (the class legend), and
+    :func:`gdal.ReprojectImage` (used by :meth:`Spatial.align`) copies only pixels
+    onto a freshly built raster, so its output starts blank. The warp path already
+    keeps dataset/band metadata and the raster attribute table, so it asks for
+    `categories_only`; `align` copies everything.
+
+    A straight positional band copy is safe because every caller keeps the band
+    count; it is guarded on matching counts anyway and is a no-op otherwise.
+
+    Args:
+        source: The raster to read descriptive metadata from.
+        dest: The warped or rebuilt raster to stamp it onto.
+        categories_only: When `True`, copy only per-band category names (the warp
+            path keeps everything else); when `False`, also copy the dataset
+            metadata, per-band metadata, and each band's raster attribute table.
+    """
+    if not categories_only:
+        dataset_md = source.GetMetadata()
+        if dataset_md:
+            dest.SetMetadata(dataset_md)
+    if source.RasterCount != dest.RasterCount:
+        return
+    for i in range(1, source.RasterCount + 1):
+        s_band = source.GetRasterBand(i)
+        d_band = dest.GetRasterBand(i)
+        names = s_band.GetCategoryNames()
+        if names:
+            d_band.SetCategoryNames(names)
+        if categories_only:
+            continue
+        band_md = s_band.GetMetadata()
+        if band_md:
+            d_band.SetMetadata(band_md)
+        rat = s_band.GetDefaultRAT()
+        if rat is not None:
+            d_band.SetDefaultRAT(rat)
+
+
 def warp_to_dataset(
     source: Dataset,
     options: gdal.WarpOptions,
@@ -88,6 +135,11 @@ def warp_to_dataset(
     warped = gdal.Warp("", source.raster, options=options)
     if warped is None:
         raise RuntimeError(error_message)
+    # GDAL's warper carries dataset/band metadata and the RAT across but drops
+    # per-band category names, so a classified raster loses its legend on every
+    # warp (to_crs / warped_view / cutline crop / orthorectify / georeference).
+    # Re-attach them here, the one place every warp routes through (#1024).
+    carry_raster_metadata(source.raster, warped, categories_only=True)
     cls = source.__class__ if dataset_class is None else dataset_class
     result = cls(warped, access=access)
     if pin:

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -39,9 +39,8 @@ if TYPE_CHECKING:
     from pyramids.dataset.dataset import Dataset
 
 from pyramids.dataset.engines._base import _Engine
-from pyramids.dataset.engines._warp import carry_raster_metadata
+from pyramids.dataset.engines._warp import carry_raster_metadata, warp_to_dataset
 from pyramids.dataset.engines._warp import dst_srs_arg as _dst_srs_arg
-from pyramids.dataset.engines._warp import warp_to_dataset
 from pyramids.dataset.engines.vectorize import Vectorize
 
 

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -39,6 +39,7 @@ if TYPE_CHECKING:
     from pyramids.dataset.dataset import Dataset
 
 from pyramids.dataset.engines._base import _Engine
+from pyramids.dataset.engines._warp import carry_raster_metadata
 from pyramids.dataset.engines._warp import dst_srs_arg as _dst_srs_arg
 from pyramids.dataset.engines._warp import warp_to_dataset
 from pyramids.dataset.engines.vectorize import Vectorize
@@ -1575,6 +1576,10 @@ class Spatial(_Engine["Dataset"]):
             src.crs,
             method,
         )
+        # ReprojectImage moves only pixels onto the freshly built grid, so the
+        # output would otherwise lose the class legend, RAT, and band/dataset
+        # metadata. Carry them over from the (possibly reprojected) source (#1029).
+        carry_raster_metadata(reprojected_raster_b.raster, dst_obj.raster)
 
         return dst_obj
 

--- a/tests/dataset/spatial/test_metadata_preservation.py
+++ b/tests/dataset/spatial/test_metadata_preservation.py
@@ -1,0 +1,173 @@
+"""Descriptive-metadata preservation across warp and align (#1024, #1029).
+
+GDAL's warper carries dataset/band metadata and the raster attribute table but
+drops per-band **category names** (the class legend), so every warp path
+(`to_crs` / `warped_view` / the cutline crop / `orthorectify` / `georeference`,
+all routing through `warp_to_dataset`) used to lose the legend (#1024). `align`
+is worse: it rebuilds the raster with `_build_dataset` and copies only pixels via
+`gdal.ReprojectImage`, so it dropped categories, the RAT, and band + dataset
+metadata (#1029). These tests pin that the shared `carry_raster_metadata` helper
+now restores them.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from osgeo import gdal
+
+from pyramids.dataset import Dataset
+from pyramids.dataset.engines._warp import carry_raster_metadata
+
+pytestmark = pytest.mark.core
+
+LABELS = ["NODATA", "WATER", "VEGETATION", "URBAN", "SNOW"]
+
+
+@pytest.fixture
+def classified() -> Dataset:
+    """A 6x6 EPSG:32632 classified raster with categories, a RAT, and metadata.
+
+    Returns:
+        Dataset: Single-band in-memory raster whose band carries category names,
+        band metadata (`WAVELENGTH`), and a raster attribute table, and whose
+        dataset carries metadata (`PROCESSING_BASELINE`).
+    """
+    arr = (np.arange(36, dtype="int16").reshape(6, 6) % 5).astype("int16")
+    ds = Dataset.create_from_array(
+        arr, top_left_corner=(0.0, 6.0), cell_size=1.0, epsg=32632, no_data_value=0
+    )
+    band = ds.raster.GetRasterBand(1)
+    band.SetCategoryNames(LABELS)
+    band.SetMetadataItem("WAVELENGTH", "560")
+    ds.raster.SetMetadataItem("PROCESSING_BASELINE", "05.00")
+    rat = gdal.RasterAttributeTable()
+    rat.CreateColumn("Value", gdal.GFT_Integer, gdal.GFU_MinMax)
+    rat.CreateColumn("Class", gdal.GFT_String, gdal.GFU_Name)
+    for i, lbl in enumerate(LABELS):
+        rat.SetValueAsInt(i, 0, i)
+        rat.SetValueAsString(i, 1, lbl)
+    band.SetDefaultRAT(rat)
+    ds.raster.FlushCache()
+    return ds
+
+
+def _cats(ds: Dataset) -> object:
+    """Category names of band 1, or None."""
+    return ds.raster.GetRasterBand(1).GetCategoryNames()
+
+
+def _blank(bands: int = 1) -> Dataset:
+    """A fresh raster on the same grid carrying no descriptive metadata."""
+    shape = (6, 6) if bands == 1 else (bands, 6, 6)
+    return Dataset.create_from_array(
+        np.zeros(shape, dtype="int16"),
+        top_left_corner=(0.0, 6.0),
+        cell_size=1.0,
+        epsg=32632,
+    )
+
+
+class TestWarpPathKeepsCategories:
+    """`to_crs` / `warped_view` keep the class legend (#1024)."""
+
+    def test_to_crs_keeps_category_names(self, classified):
+        """`to_crs` reprojects and keeps the per-band category names."""
+        result = classified.to_crs(4326)
+        assert _cats(result) == LABELS, f"to_crs dropped categories: {_cats(result)}"
+
+    def test_warped_view_keeps_category_names(self, classified):
+        """`warped_view` keeps the per-band category names."""
+        result = classified.warped_view(4326)
+        assert _cats(result) == LABELS, (
+            f"warped_view dropped categories: {_cats(result)}"
+        )
+
+    def test_to_crs_still_keeps_dataset_and_band_metadata(self, classified):
+        """The warp path keeps band + dataset metadata (unchanged behaviour)."""
+        result = classified.to_crs(4326)
+        band_md = result.raster.GetRasterBand(1).GetMetadataItem("WAVELENGTH")
+        ds_md = result.raster.GetMetadataItem("PROCESSING_BASELINE")
+        assert band_md == "560", f"band metadata not kept: {band_md}"
+        assert ds_md == "05.00", f"dataset metadata not kept: {ds_md}"
+
+
+class TestAlignKeepsAllMetadata:
+    """`align` keeps categories, the RAT, and band + dataset metadata (#1029)."""
+
+    def test_align_keeps_category_names(self, classified):
+        """`align` onto the same grid keeps the per-band category names."""
+        result = classified.align(classified)
+        assert _cats(result) == LABELS, f"align dropped categories: {_cats(result)}"
+
+    def test_align_keeps_rat(self, classified):
+        """`align` keeps the band's raster attribute table."""
+        result = classified.align(classified)
+        rat = result.raster.GetRasterBand(1).GetDefaultRAT()
+        assert rat is not None, "align dropped the RAT"
+        assert rat.GetRowCount() == len(LABELS), (
+            f"RAT row count changed: {rat.GetRowCount()}"
+        )
+
+    def test_align_keeps_band_and_dataset_metadata(self, classified):
+        """`align` keeps band metadata and dataset metadata."""
+        result = classified.align(classified)
+        band_md = result.raster.GetRasterBand(1).GetMetadataItem("WAVELENGTH")
+        ds_md = result.raster.GetMetadataItem("PROCESSING_BASELINE")
+        assert band_md == "560", f"align dropped band metadata: {band_md}"
+        assert ds_md == "05.00", f"align dropped dataset metadata: {ds_md}"
+
+    def test_align_across_crs_keeps_category_names(self, classified):
+        """A reprojecting `align` (reference in another CRS) still keeps categories.
+
+        Test scenario:
+            The reference grid is EPSG:4326, so `align` reprojects the source via
+            `to_crs` first; the legend must survive both that warp and the
+            subsequent `ReprojectImage` rebuild.
+        """
+        ref = classified.to_crs(4326)
+        result = classified.align(ref)
+        assert _cats(result) == LABELS, (
+            f"cross-CRS align dropped categories: {_cats(result)}"
+        )
+
+
+class TestCarryRasterMetadata:
+    """The shared `carry_raster_metadata` helper."""
+
+    def test_categories_only_copies_just_categories(self, classified):
+        """`categories_only=True` copies the legend but not metadata or the RAT."""
+        dst = _blank()
+        carry_raster_metadata(classified.raster, dst.raster, categories_only=True)
+        assert dst.raster.GetRasterBand(1).GetCategoryNames() == LABELS, (
+            "categories not copied"
+        )
+        assert dst.raster.GetMetadataItem("PROCESSING_BASELINE") is None, (
+            "dataset metadata should not be copied in categories_only mode"
+        )
+        assert dst.raster.GetRasterBand(1).GetDefaultRAT() is None, (
+            "RAT should not be copied in categories_only mode"
+        )
+
+    def test_full_copy_carries_everything(self, classified):
+        """The default copies categories, band + dataset metadata, and the RAT."""
+        dst = _blank()
+        carry_raster_metadata(classified.raster, dst.raster)
+        band = dst.raster.GetRasterBand(1)
+        assert band.GetCategoryNames() == LABELS, "categories not copied"
+        assert band.GetMetadataItem("WAVELENGTH") == "560", "band metadata not copied"
+        assert dst.raster.GetMetadataItem("PROCESSING_BASELINE") == "05.00", (
+            "dataset metadata not copied"
+        )
+        assert band.GetDefaultRAT().GetRowCount() == len(LABELS), "RAT not copied"
+
+    def test_band_count_mismatch_skips_the_per_band_copy(self, classified):
+        """A band-count mismatch copies dataset metadata but skips per-band copies."""
+        dst = _blank(bands=2)
+        carry_raster_metadata(classified.raster, dst.raster)  # 1 band -> 2 bands
+        assert dst.raster.GetMetadataItem("PROCESSING_BASELINE") == "05.00", (
+            "dataset metadata should still be copied"
+        )
+        assert dst.raster.GetRasterBand(1).GetCategoryNames() is None, (
+            "per-band copy must be skipped when band counts differ"
+        )


### PR DESCRIPTION
# Description

Classified and annotated rasters were losing their descriptive metadata across pyramids' spatial operations. Two
distinct bugs, both fixed here through one shared helper:

- **The warp path dropped the class legend (#1024).** GDAL's warper carries dataset/band metadata and the raster
  attribute table across a reprojection but drops per-band **category names**, so `to_crs`, `warped_view`, the cutline
  crop, `orthorectify`, and `georeference` — all of which funnel through `warp_to_dataset` — returned a raster whose
  `GetCategoryNames()` was `None`. A plain `to_file` round-trip kept them, so the loss was warp-specific and easy to
  miss.
- **`align` dropped everything (#1029).** `Dataset.align` does not warp — it builds a fresh raster from the reference
  grid (`_build_dataset`) and copies only pixels with `gdal.ReprojectImage`, so its output started blank and lost the
  category names, the RAT, **and** band + dataset metadata.

## What changed

- New `carry_raster_metadata(source, dest, *, categories_only=False)` in `dataset/engines/_warp.py`. It re-attaches
  per-band category names, and (in full mode) dataset metadata, per-band metadata, and each band's RAT. Guarded on
  matching band counts (a positional copy is safe because every caller keeps the band count).
- `warp_to_dataset` calls it with `categories_only=True` right after the warp — the single choke point, so all five
  warp sites inherit the fix. The warp already keeps everything but the legend, so only categories are re-attached
  there.
- `align` calls the full copy after `ReprojectImage`, restoring categories, RAT, and band/dataset metadata from the
  (possibly reprojected) source.

Empirically verified on a synthetic categorical band (GDAL 3.13.1); before → after:

| Operation | category names | RAT | band md | dataset md |
|---|---|---|---|---|
| `to_crs` / `warped_view` | LOST → **KEPT** | KEPT | KEPT | KEPT |
| `align` | LOST → **KEPT** | LOST → **KEPT** | LOST → **KEPT** | LOST → **KEPT** |

`orthorectify` and `georeference` route through the same `warp_to_dataset`, so they inherit the category fix (covered
at the helper/warp-choke-point level rather than end-to-end, which would need GCP/RPC fixtures). The RAT already
survives the warp path, so it is copied only in `align`'s full mode, not on every warp.

# Issues

- Closes #1024 — `to_crs` / `warped_view` / warp path drop band category names (the class legend)
- Closes #1029 — `align` drops all band and dataset metadata (legend, RAT, band + dataset metadata)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- New `tests/dataset/spatial/test_metadata_preservation.py` (10 tests): `to_crs` / `warped_view` keep the legend,
  `align` keeps categories + RAT + band/dataset metadata (including a reprojecting-align case), and direct
  `carry_raster_metadata` tests (categories-only vs full copy, and the band-count-mismatch guard). Synthetic
  categorical band — no Sentinel fixture required.
- Full `tests/dataset/spatial` suite (to_crs, warped_view, align, cutline crop, warp helpers, georef, merge,
  resampling) — **481 passed**, no regressions.
- Full non-plot suite green; `mypy` clean on the changed files.

Reproduce:

```bash
pixi run --frozen -e dev pytest tests/dataset/spatial/test_metadata_preservation.py -m "not plot" -q
```

# Checklist:

- [ ] updated version number in pyproject.toml. — N/A (commitizen/CI handles versions).
- [ ] added changes to History.rst. — N/A (changelog is generated).
- [ ] updated the latest version in README file. — N/A.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated. — no user-facing docs affected; the new helper carries a full docstring.
