### PR TITLE
feat(dataset): pass GDAL open options through Dataset.read_file (#1025)

### DIFF
--- a/src/pyramids/_io.py
+++ b/src/pyramids/_io.py
@@ -693,7 +693,14 @@ def read_file(
             # one path with different options are not handed the same handle —
             # they simply do not share. Same options still share, keeping the
             # frequently-accessed-raster benefit the OpenShared branch is for.
-            src = gdal.OpenEx(path, access | gdal.OF_SHARED, open_options=options)
+            # OF_RASTER | OF_VERBOSE_ERROR restore the driver-kind restriction and
+            # verbose diagnostics that gdal.OpenShared implies but bare OpenEx
+            # (OF_ALL, terse errors) drops — this is a raster reader.
+            src = gdal.OpenEx(
+                path,
+                access | gdal.OF_SHARED | gdal.OF_RASTER | gdal.OF_VERBOSE_ERROR,
+                open_options=options,
+            )
         elif not options:
             # Update mode must NOT share: GDAL returns one handle per
             # path+access+thread, so two update-mode Datasets on the same file
@@ -704,8 +711,13 @@ def read_file(
             src = gdal.Open(path, access)
         else:
             # Same no-share intent, but OpenEx is the only entry that carries
-            # open options; OF_SHARED is deliberately absent here.
-            src = gdal.OpenEx(path, access | gdal.OF_UPDATE, open_options=options)
+            # open options; OF_SHARED is deliberately absent here. OF_RASTER |
+            # OF_VERBOSE_ERROR keep parity with the gdal.Open this replaces.
+            src = gdal.OpenEx(
+                path,
+                access | gdal.OF_UPDATE | gdal.OF_RASTER | gdal.OF_VERBOSE_ERROR,
+                open_options=options,
+            )
     except Exception as e:
         _raise_open_error(e, path)
     return src

--- a/src/pyramids/_io.py
+++ b/src/pyramids/_io.py
@@ -565,6 +565,27 @@ def _raise_open_error(error: Exception, path: str) -> NoReturn:
     raise error
 
 
+def normalize_open_options(
+    open_options: dict[str, str] | list[str] | tuple[str, ...] | None,
+) -> list[str] | None:
+    """Normalize GDAL open options to the ``["KEY=VALUE", ...]`` list GDAL takes.
+
+    Accepts a mapping (`{"L1B_MODE": "DATASTRIP"}`), GDAL's native list/tuple
+    (`["L1B_MODE=DATASTRIP"]`), or `None`.
+
+    Args:
+        open_options: The options in any accepted form, or `None`.
+
+    Returns:
+        list[str] | None: The `KEY=VALUE` list, or `None` when nothing was given.
+    """
+    if open_options is None:
+        return None
+    if isinstance(open_options, dict):
+        return [f"{key}={value}" for key, value in open_options.items()]
+    return list(open_options)
+
+
 def read_file(
     path: str | Path,
     read_only: bool = True,
@@ -572,6 +593,7 @@ def read_file(
     file_i: int = 0,
     *,
     vsi: str | None = None,
+    open_options: dict[str, str] | list[str] | tuple[str, ...] | None = None,
 ):
     """Open file (GeoTIFF and ASCII).
 
@@ -603,6 +625,14 @@ def read_file(
             extension (e.g. an Earth Engine download URL). Default ``None``
             (path opened directly / extension-sniffed as today).
 
+        open_options (dict | list | None): GDAL open options as a
+            mapping (``{"L1B_MODE": "DATASTRIP"}``) or GDAL's native
+            ``["KEY=VALUE"]`` list. Forwarded to the driver; a read-only
+            open with options goes through ``OpenEx(OF_SHARED)`` (GDAL
+            keys its shared cache on the options too, so different
+            options do not share a handle). ``None`` (default) opens as
+            before.
+
     Returns:
         gdal.Dataset: Opened dataset.
 
@@ -624,21 +654,37 @@ def read_file(
         )
     path = _resolve_read_path(path, vsi, file_i)
     access = gdal.GA_ReadOnly if read_only else gdal.GA_Update
+    options = normalize_open_options(open_options)
     try:
         if open_as_multi_dimensional:
             # OF_MULTIDIM_RASTER for formats that expose multi-dimensional data
             # (hdf, h5, nc, nc4, grib, grib2, jp2, ...).
-            src = gdal.OpenEx(path, access | gdal.OF_MULTIDIM_RASTER)
-        elif read_only:
+            src = gdal.OpenEx(
+                path, access | gdal.OF_MULTIDIM_RASTER, open_options=options or []
+            )
+        elif read_only and not options:
             # OpenShared for potentially frequently accessed raster files.
             src = gdal.OpenShared(path, access)
-        else:
+        elif read_only:
+            # OpenShared takes no open options, so carry them through OpenEx with
+            # OF_SHARED. GDAL keys its shared-handle cache on the open options as
+            # well as path/access/thread (verified on GDAL 3.13), so two reads of
+            # one path with different options are not handed the same handle —
+            # they simply do not share. Same options still share, keeping the
+            # frequently-accessed-raster benefit the OpenShared branch is for.
+            src = gdal.OpenEx(path, access | gdal.OF_SHARED, open_options=options)
+        elif not options:
             # Update mode must NOT share: GDAL returns one handle per
             # path+access+thread, so two update-mode Datasets on the same file
             # would alias one another — a write through one immediately visible
             # through the other, and a flush/close on either committing the
-            # other's in-flight edits.
+            # other's in-flight edits. Kept on gdal.Open when no options are
+            # given so the default open path is unchanged.
             src = gdal.Open(path, access)
+        else:
+            # Same no-share intent, but OpenEx is the only entry that carries
+            # open options; OF_SHARED is deliberately absent here.
+            src = gdal.OpenEx(path, access | gdal.OF_UPDATE, open_options=options)
     except Exception as e:
         _raise_open_error(e, path)
     return src

--- a/src/pyramids/_io.py
+++ b/src/pyramids/_io.py
@@ -688,11 +688,20 @@ def read_file(
             src = gdal.OpenShared(path, access)
         elif read_only:
             # OpenShared takes no open options, so carry them through OpenEx with
-            # OF_SHARED. GDAL keys its shared-handle cache on the open options as
-            # well as path/access/thread (verified on GDAL 3.13), so two reads of
-            # one path with different options are not handed the same handle —
-            # they simply do not share. Same options still share, keeping the
-            # frequently-accessed-raster benefit the OpenShared branch is for.
+            # OF_SHARED. Correctness of this branch — that two live reads of one
+            # path with *different* options are never handed the same handle —
+            # RELIES ON GDAL keying its shared-dataset cache on the concatenated
+            # open options as well as path/access/thread. This holds on the conda
+            # pin (gdal >=3.13.1,<3.13.2 in pyproject.toml, verified on 3.13.1)
+            # and every GDAL that has shipped this behaviour. Wheel/sdist installs
+            # bring native GDAL out-of-band at an unpinned version; on a
+            # hypothetical GDAL that ignored options in its shared key, two
+            # different-option reads would silently alias the first handle (wrong
+            # georef/data). test_two_opens_different_options_do_not_share_a_handle
+            # pins the guarantee via the observable geotransform, so such a
+            # regression fails loudly rather than returning stale data. Same
+            # options still share, keeping the frequently-accessed-raster benefit
+            # the OpenShared branch is for.
             # OF_RASTER | OF_VERBOSE_ERROR restore the driver-kind restriction and
             # verbose diagnostics that gdal.OpenShared implies but bare OpenEx
             # (OF_ALL, terse errors) drops — this is a raster reader.

--- a/src/pyramids/_io.py
+++ b/src/pyramids/_io.py
@@ -578,6 +578,27 @@ def normalize_open_options(
 
     Returns:
         list[str] | None: The `KEY=VALUE` list, or `None` when nothing was given.
+
+    Examples:
+        - A mapping is rendered into GDAL's `KEY=VALUE` list, one entry per pair:
+            ```python
+            >>> from pyramids._io import normalize_open_options
+            >>> normalize_open_options({"GEOREF_SOURCES": "INTERNAL"})
+            ['GEOREF_SOURCES=INTERNAL']
+
+            ```
+        - A native list or tuple is returned as a plain list, unchanged:
+            ```python
+            >>> normalize_open_options(("A=1", "B=2"))
+            ['A=1', 'B=2']
+
+            ```
+        - `None` (the no-options case) is preserved so callers can branch on it:
+            ```python
+            >>> normalize_open_options(None) is None
+            True
+
+            ```
     """
     if open_options is None:
         return None

--- a/src/pyramids/_io.py
+++ b/src/pyramids/_io.py
@@ -704,10 +704,12 @@ def read_file(
             # the OpenShared branch is for.
             # OF_RASTER | OF_VERBOSE_ERROR restore the driver-kind restriction and
             # verbose diagnostics that gdal.OpenShared implies but bare OpenEx
-            # (OF_ALL, terse errors) drops — this is a raster reader.
+            # (OF_ALL, terse errors) drops — this is a raster reader. Read-only is
+            # the absence of OF_UPDATE, so the flags are pure OF_* constants (no
+            # GA_* access flag mixed in).
             src = gdal.OpenEx(
                 path,
-                access | gdal.OF_SHARED | gdal.OF_RASTER | gdal.OF_VERBOSE_ERROR,
+                gdal.OF_SHARED | gdal.OF_RASTER | gdal.OF_VERBOSE_ERROR,
                 open_options=options,
             )
         elif not options:
@@ -721,10 +723,12 @@ def read_file(
         else:
             # Same no-share intent, but OpenEx is the only entry that carries
             # open options; OF_SHARED is deliberately absent here. OF_RASTER |
-            # OF_VERBOSE_ERROR keep parity with the gdal.Open this replaces.
+            # OF_VERBOSE_ERROR keep parity with the gdal.Open this replaces. Pure
+            # OF_* flags — OF_UPDATE is the update-mode flag (no GA_* access flag
+            # mixed in, which only worked by GA_Update == OF_UPDATE bit-equality).
             src = gdal.OpenEx(
                 path,
-                access | gdal.OF_UPDATE | gdal.OF_RASTER | gdal.OF_VERBOSE_ERROR,
+                gdal.OF_UPDATE | gdal.OF_RASTER | gdal.OF_VERBOSE_ERROR,
                 open_options=options,
             )
     except Exception as e:

--- a/src/pyramids/base/_file_manager.py
+++ b/src/pyramids/base/_file_manager.py
@@ -101,8 +101,13 @@ def _resolve_access(access: str) -> int:
     return cast(int, flag)
 
 
-def gdal_raster_open(path: str, access: str = "read_only", **_: Any) -> gdal.Dataset:
-    """Open a classic-mode raster (GeoTIFF, COG, PNG,...) via :func:`gdal.Open`.
+def gdal_raster_open(
+    path: str,
+    access: str = "read_only",
+    open_options: tuple[str, ...] | list[str] | None = None,
+    **_: Any,
+) -> gdal.Dataset:
+    """Open a classic-mode raster (GeoTIFF, COG, PNG,...) via GDAL.
 
     The `path` is rewritten through :func:`pyramids.base.remote._to_vsi`
     first, so callers can pass URL-scheme paths (`s3://bucket/file.tif`,
@@ -111,6 +116,10 @@ def gdal_raster_open(path: str, access: str = "read_only", **_: Any) -> gdal.Dat
     Args:
         path: File path or URL.
         access: Access mode string — see :func:`_resolve_access`.
+        open_options: GDAL open options as a `("KEY=VALUE", ...)` sequence, or
+            `None`. Passed by the file managers so a per-thread or per-chunk
+            reopen carries the same driver options the dataset was opened with
+            (#1025). A tuple so it stays hashable for the manager's cache key.
         **_: Extra keyword arguments are accepted and ignored so that a
             single uniform opener signature can be used as a
             `FileManager` `opener` callable.
@@ -118,7 +127,11 @@ def gdal_raster_open(path: str, access: str = "read_only", **_: Any) -> gdal.Dat
     Returns:
         osgeo.gdal.Dataset: The opened dataset handle.
     """
-    return gdal.Open(_to_vsi(path), _resolve_access(access))
+    vsi = _to_vsi(path)
+    if open_options:
+        flags = gdal.OF_UPDATE if _resolve_access(access) == gdal.GA_Update else 0
+        return gdal.OpenEx(vsi, flags, open_options=list(open_options))
+    return gdal.Open(vsi, _resolve_access(access))
 
 
 def gdal_mdarray_open(path: str, access: str = "read_only", **_: Any) -> gdal.Dataset:

--- a/src/pyramids/base/_file_manager.py
+++ b/src/pyramids/base/_file_manager.py
@@ -129,7 +129,12 @@ def gdal_raster_open(
     """
     vsi = _to_vsi(path)
     if open_options:
-        flags = gdal.OF_UPDATE if _resolve_access(access) == gdal.GA_Update else 0
+        # OF_RASTER | OF_VERBOSE_ERROR restore the raster-only kind restriction
+        # and verbose diagnostics gdal.Open implies; bare OpenEx would open
+        # OF_ALL and could hand back a vector handle for a dual-nature source.
+        flags = gdal.OF_RASTER | gdal.OF_VERBOSE_ERROR
+        if _resolve_access(access) == gdal.GA_Update:
+            flags |= gdal.OF_UPDATE
         return gdal.OpenEx(vsi, flags, open_options=list(open_options))
     return gdal.Open(vsi, _resolve_access(access))
 

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -144,6 +144,10 @@ def _reconstruct_dataset(
             around the re-open and re-attached to the instance so the worker's
             reads authenticate as the originating process's did. Defaults to
             `None` so a three-element recipe from an older pickle still loads.
+        open_options: The GDAL open options captured on the originating dataset,
+            as a hashable tuple, forwarded to `read_file` so the worker reopens
+            with the same driver behaviour. Defaults to `None` so a four-element
+            recipe from an older pickle (with no options) still loads (#1025).
 
     Returns:
         RasterBase: A freshly opened instance of `cls`, opened read-only.
@@ -180,7 +184,28 @@ class RasterBase(ABC):
         gdal_env: dict[str, str] | None = None,
         open_options: tuple[str, ...] | list[str] | None = None,
     ):
-        """__init__."""
+        """Wrap an already-open ``gdal.Dataset`` and snapshot its geo-properties.
+
+        Args:
+            src: An open :class:`osgeo.gdal.Dataset` to wrap. Callers normally go
+                through :meth:`read_file` rather than constructing directly.
+            access: The mode ``src`` was opened with — ``"read_only"`` (default)
+                or ``"write"``. Recorded so mutating operations can refuse a
+                read-only handle.
+            gdal_env: GDAL config (cloud credentials, HTTP knobs) this dataset was
+                opened with, captured so it is re-installed around every read that
+                reopens the file (``threadsafe=True`` handles, lazy ``chunks=``
+                reads, unpickle on a worker). Stored as a plain dict so it
+                survives pickling; ``None`` (default) captures nothing.
+            open_options: GDAL open options this dataset was opened with, as a
+                mapping-derived or native ``["KEY=VALUE"]`` sequence. Stored as a
+                tuple so it stays hashable for the file-manager cache key and
+                stable across pickling, and reapplied on the same reopen paths as
+                ``gdal_env``. ``None`` (default) captures nothing (#1025).
+
+        Raises:
+            TypeError: ``src`` is not an :class:`osgeo.gdal.Dataset`.
+        """
         if not isinstance(src, gdal.Dataset):
             raise TypeError(  # pragma: no cover
                 "src should be read using gdal (gdal dataset please read it using gdal"

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -346,18 +346,18 @@ class RasterBase(ABC):
 
         Serialising a live `gdal.Dataset` pointer is not possible
         (native C++ handle, no copy semantics). Instead we emit the
-        minimal recipe `(class, file_name, access, gdal_env)` and
+        recipe `(class, file_name, access, gdal_env, open_options)` and
         reconstruct on unpickle by calling `cls.read_file(path, ...)`
         under the captured GDAL config, so a signed remote dataset
-        re-opens on the worker with its credentials.
+        re-opens on the worker with its credentials and driver options.
 
         The GDAL handle is therefore opened **on the receiving process
         / thread**, which is the invariant dask.distributed needs.
 
-        Recipes written before the config existed still unpickle here (the
-        parameter defaults), but a recipe written by *this* version needs a
-        reader that accepts four arguments — so a mixed-version cluster has to
-        upgrade the workers, not only the client.
+        Recipes written before these fields existed still unpickle here (the
+        parameter defaults for `gdal_env` and `open_options`), but a recipe
+        written by *this* version needs a reader that accepts five arguments — so
+        a mixed-version cluster has to upgrade the workers, not only the client.
 
         Security:
             The recipe carries :attr:`gdal_env` verbatim, so pickling a dataset

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -360,10 +360,12 @@ class RasterBase(ABC):
         a mixed-version cluster has to upgrade the workers, not only the client.
 
         Security:
-            The recipe carries :attr:`gdal_env` verbatim, so pickling a dataset
-            opened with credentials serialises them. `dask.distributed` spills
-            graphs to disk and quotes task keys in error reports — treat such a
-            pickle as a secret, and prefer a short-lived token.
+            The recipe carries :attr:`gdal_env` **and** :attr:`open_options`
+            verbatim, so pickling a dataset opened with credentials — whether in
+            the config or as a driver open option that some drivers accept a
+            secret through — serialises them. `dask.distributed` spills graphs to
+            disk and quotes task keys in error reports — treat such a pickle as a
+            secret, and prefer a short-lived token.
 
         Raises:
             TypeError: The dataset has no on-disk path (empty
@@ -1048,6 +1050,13 @@ class RasterBase(ABC):
                 Path of file to open.
             read_only (bool):
                 File mode, set as False, to open in "update" mode.
+            file_i (int):
+                Which member to open when ``path`` is a multi-file archive.
+                Default ``0``.
+            open_options (dict | list | tuple | None):
+                GDAL open options as a mapping or ``["KEY=VALUE"]`` sequence,
+                forwarded to the driver and captured on the returned instance so
+                the reopen paths reapply them. Default ``None`` — no options.
 
         Returns:
             Dataset: The opened dataset instance.

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -1039,7 +1039,7 @@ class RasterBase(ABC):
         read_only=True,
         file_i: int = 0,
         *,
-        open_options: dict[str, str] | list[str] | None = None,
+        open_options: dict[str, str] | list[str] | tuple[str, ...] | None = None,
     ) -> RasterBase:
         """Read file.
 

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -123,6 +123,7 @@ def _reconstruct_dataset(
     path: str,
     access: str,
     gdal_env: dict[str, str] | None = None,
+    open_options: tuple[str, ...] | None = None,
 ) -> RasterBase:
     """Re-open a dataset from its pickle recipe tuple.
 
@@ -157,7 +158,11 @@ def _reconstruct_dataset(
     # The env is applied here rather than forwarded to read_file so every
     # subclass benefits without widening its own signature.
     with cloud_config_from_env(gdal_env, path=path):
-        dataset = cls.read_file(path, read_only=True)
+        dataset = cls.read_file(
+            path,
+            read_only=True,
+            open_options=list(open_options) if open_options else None,
+        )
     dataset.attach_gdal_env(gdal_env)
     return dataset
 
@@ -173,6 +178,7 @@ class RasterBase(ABC):
         access: str = "read_only",
         *,
         gdal_env: dict[str, str] | None = None,
+        open_options: tuple[str, ...] | list[str] | None = None,
     ):
         """__init__."""
         if not isinstance(src, gdal.Dataset):
@@ -193,6 +199,13 @@ class RasterBase(ABC):
         # the thread-local config there, so those credentials ride the source
         # path instead (see `pyramids.stac._vrt`).
         self._gdal_env: dict[str, str] = dict(gdal_env) if gdal_env else {}
+        # GDAL open options this dataset was opened with (a driver knob like
+        # `L1B_MODE=DATASTRIP`). Stored as a tuple so it stays hashable for
+        # the file-manager cache key and stable across pickling, and carried
+        # onto every reopen path the way `_gdal_env` is (threadsafe handles,
+        # lazy `chunks=` reads, unpickle) so a worker reopens with the same
+        # driver behaviour (#1025).
+        self._open_options: tuple[str, ...] = tuple(open_options or ())
         # Per-thread file manager for read_array(threadsafe=True); created
         # lazily by the IO engine and released by close().
         self._thread_manager: ThreadLocalFileManager | None = None
@@ -211,6 +224,16 @@ class RasterBase(ABC):
         self._block_size = [
             src.GetRasterBand(i).GetBlockSize() for i in range(1, self._band_count + 1)
         ]
+
+    @property
+    def open_options(self) -> list[str]:
+        """GDAL open options captured at read time, as a `KEY=VALUE` list.
+
+        Empty when the dataset was opened without any (the common case).
+        Reapplied on every path that reopens the file rather than reusing the
+        live handle, so driver behaviour survives a worker reopen (#1025).
+        """
+        return list(self._open_options)
 
     @property
     def gdal_env(self) -> dict[str, str]:
@@ -333,7 +356,13 @@ class RasterBase(ABC):
             )
         return (
             _reconstruct_dataset,
-            (type(self), path, self._access, dict(self._gdal_env)),
+            (
+                type(self),
+                path,
+                self._access,
+                dict(self._gdal_env),
+                tuple(self._open_options),
+            ),
         )
 
     def __enter__(self):
@@ -979,7 +1008,14 @@ class RasterBase(ABC):
 
     @classmethod
     @abstractmethod
-    def read_file(cls, path: str | Path, read_only=True) -> RasterBase:
+    def read_file(
+        cls,
+        path: str | Path,
+        read_only=True,
+        file_i: int = 0,
+        *,
+        open_options: dict[str, str] | list[str] | None = None,
+    ) -> RasterBase:
         """Read file.
 
         Args:

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -1797,7 +1797,7 @@ class DatasetCollection:
         end: datetime | None = None,
         meta: RasterMeta | None = None,
         gdal_env: dict[str, str] | None = None,
-        open_options: dict[str, str] | list[str] | None = None,
+        open_options: dict[str, str] | list[str] | tuple[str, ...] | None = None,
         validate: bool = False,
     ) -> DatasetCollection:
         r"""Build a collection from a folder of rasters or an explicit list of files.

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -2188,6 +2188,7 @@ class DatasetCollection:
         kind: str = "auto",
         member_glob: str = "*",
         meta: RasterMeta | None = None,
+        open_options: dict[str, str] | list[str] | tuple[str, ...] | None = None,
     ) -> DatasetCollection:
         """Build a collection from the raster members of an archive.
 
@@ -2216,6 +2217,9 @@ class DatasetCollection:
                 include, applied to top-level member names and sorted. Default
                 ``"*"`` (all). Pass e.g. ``"*.tif"`` to skip sidecar files.
             meta: Optional pre-computed :class:`RasterMeta` for the timesteps.
+            open_options: GDAL open options (mapping or ``["KEY=VALUE"]``) applied
+                to every per-member open, forwarded to :meth:`from_files`. Default
+                ``None`` — no options (#1025).
 
         Returns:
             DatasetCollection: A collection whose ``time_length`` is the number
@@ -2230,7 +2234,7 @@ class DatasetCollection:
         dir_vsi = _io._archive_dir_vsi(url_or_path, kind)
         members = _io._archive_members(dir_vsi, member_glob)
         member_paths = [f"{dir_vsi}/{m}" for m in members]
-        return cls.from_files(member_paths, meta=meta)
+        return cls.from_files(member_paths, meta=meta, open_options=open_options)
 
     @classmethod
     def read_multiple_files(

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -678,8 +678,11 @@ class DatasetCollection:
         self._meta = meta if meta is not None else RasterMeta.from_dataset(src)
         self._gdal_env: dict[str, str] = dict(gdal_env) if gdal_env else {}
         # GDAL open options every per-file open in this collection carries,
-        # mirroring _gdal_env (#1025).
-        self._open_options: list[str] = list(open_options) if open_options else []
+        # mirroring _gdal_env (#1025). Stored as a tuple for parity with
+        # RasterBase._open_options (hashable, stable) — it is only ever read.
+        self._open_options: tuple[str, ...] = (
+            tuple(open_options) if open_options else ()
+        )
         # When set (by from_zarr), the lazy `data` cube reads directly from this
         # resolved Zarr store instead of stacking per-file reads.
         self._zarr_store = zarr_store
@@ -1270,7 +1273,7 @@ class DatasetCollection:
                 meta,
                 self._gdal_env,
                 path_locks.setdefault(str(path), default_lock(f"data:{path}")),
-                open_options=tuple(self._open_options) or None,
+                open_options=self._open_options or None,
             )
             for path in self._files
         ]

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -432,7 +432,11 @@ def _finalize_after_write(data_result, resolved_store, meta, files) -> None:
 
 
 def _lazy_timestep(
-    path: str | Path, meta: RasterMeta, gdal_env: dict[str, str] | None, lock: Any
+    path: str | Path,
+    meta: RasterMeta,
+    gdal_env: dict[str, str] | None,
+    lock: Any,
+    open_options: tuple[str, ...] | None = None,
 ):
     """Build a spatially-tiled ``(B, Y, X)`` dask array for one timestep (ARC-45).
 
@@ -470,7 +474,12 @@ def _lazy_timestep(
         previous_chunks=(1, block_h, block_w),
     )
     manager = CachingFileManager(
-        gdal_raster_open, str(path), "read_only", lock=False, manager_id=str(path)
+        gdal_raster_open,
+        str(path),
+        "read_only",
+        kwargs={"open_options": open_options} if open_options else None,
+        lock=False,
+        manager_id=str(path),
     )
     return da.map_blocks(
         _read_chunk,
@@ -621,6 +630,7 @@ class DatasetCollection:
         meta: RasterMeta | None = None,
         datasets: list[Dataset] | None = None,
         gdal_env: dict[str, str] | None = None,
+        open_options: list[str] | None = None,
         zarr_store: Any = None,
     ):
         """Construct DatasetCollection object.
@@ -667,6 +677,9 @@ class DatasetCollection:
         self.time = time  # validates length + materialises a generator (see setter)
         self._meta = meta if meta is not None else RasterMeta.from_dataset(src)
         self._gdal_env: dict[str, str] = dict(gdal_env) if gdal_env else {}
+        # GDAL open options every per-file open in this collection carries,
+        # mirroring _gdal_env (#1025).
+        self._open_options: list[str] = list(open_options) if open_options else []
         # When set (by from_zarr), the lazy `data` cube reads directly from this
         # resolved Zarr store instead of stacking per-file reads.
         self._zarr_store = zarr_store
@@ -726,7 +739,12 @@ class DatasetCollection:
                 env = self._gdal_env or None
                 with cloud_config_from_env(self._gdal_env, path=list(self._files)):
                     self._datasets = [
-                        Dataset.read_file(str(p), gdal_env=env) for p in self._files
+                        Dataset.read_file(
+                            str(p),
+                            gdal_env=env,
+                            open_options=self._open_options or None,
+                        )
+                        for p in self._files
                     ]
             else:
                 self._datasets = [self._base] * self._time_length
@@ -760,7 +778,11 @@ class DatasetCollection:
         if handle is None:
             env = self._gdal_env or None
             with cloud_config_from_env(self._gdal_env, path=str(self._files[idx])):
-                handle = Dataset.read_file(str(self._files[idx]), gdal_env=env)
+                handle = Dataset.read_file(
+                    str(self._files[idx]),
+                    gdal_env=env,
+                    open_options=self._open_options or None,
+                )
             self._handle_cache[idx] = handle
         return handle
 
@@ -869,6 +891,14 @@ class DatasetCollection:
         Base Dataset
         """
         return self._base
+
+    @property
+    def open_options(self) -> list[str]:
+        """GDAL open options every per-file open in this collection carries.
+
+        Empty when the collection was built without any (#1025).
+        """
+        return list(self._open_options)
 
     @property
     def files(self):
@@ -1240,6 +1270,7 @@ class DatasetCollection:
                 meta,
                 self._gdal_env,
                 path_locks.setdefault(str(path), default_lock(f"data:{path}")),
+                open_options=tuple(self._open_options) or None,
             )
             for path in self._files
         ]
@@ -1763,6 +1794,7 @@ class DatasetCollection:
         end: datetime | None = None,
         meta: RasterMeta | None = None,
         gdal_env: dict[str, str] | None = None,
+        open_options: dict[str, str] | list[str] | None = None,
         validate: bool = False,
     ) -> DatasetCollection:
         r"""Build a collection from a folder of rasters or an explicit list of files.
@@ -1812,6 +1844,9 @@ class DatasetCollection:
                 open, and persisted on the collection for the lazy reads. Any key here
                 overrides the sidecar-scan default described above (e.g. pass
                 ``{"GDAL_DISABLE_READDIR_ON_OPEN": "FALSE"}`` to force the rescan on).
+            open_options: GDAL open options (mapping or ``["KEY=VALUE"]``)
+                applied to every per-file open in the collection, mirroring
+                ``gdal_env`` (#1025). Default ``None``.
             validate: When ``True``, check every file's header shape/dtype against the
                 template and raise :class:`AlignmentError` on a mismatch instead of
                 lazily corrupting the cube. Default ``False``.
@@ -1893,6 +1928,7 @@ class DatasetCollection:
             meta=meta,
             gdal_env=effective_env or None,
             validate=validate,
+            open_options=_io.normalize_open_options(open_options),
         )
 
     @classmethod
@@ -1904,6 +1940,7 @@ class DatasetCollection:
         meta: RasterMeta | None,
         gdal_env: dict[str, str] | None,
         validate: bool,
+        open_options: list[str] | None = None,
     ) -> DatasetCollection:
         """Open the first file as the template and construct the collection.
 
@@ -1915,11 +1952,13 @@ class DatasetCollection:
             # The template is reachable as `collection.base`, and the legacy
             # `DatasetCollection(src, N)` shape replicates it as every timestep, so it
             # needs the env for its own reads too — not just this open.
-            template = Dataset.read_file(files[0], gdal_env=gdal_env)
+            template = Dataset.read_file(
+                files[0], gdal_env=gdal_env, open_options=open_options
+            )
             if meta is None:
                 meta = RasterMeta.from_dataset(template)
         if validate:
-            cls._validate_headers(files, meta, gdal_env)
+            cls._validate_headers(files, meta, gdal_env, open_options)
         return cls(
             template,
             len(files),
@@ -1927,6 +1966,7 @@ class DatasetCollection:
             time=time_axis,
             meta=meta,
             gdal_env=gdal_env,
+            open_options=open_options,
         )
 
     @staticmethod
@@ -2007,7 +2047,10 @@ class DatasetCollection:
 
     @staticmethod
     def _validate_headers(
-        files: list[str], meta: RasterMeta, gdal_env: dict[str, str] | None
+        files: list[str],
+        meta: RasterMeta,
+        gdal_env: dict[str, str] | None,
+        open_options: list[str] | None = None,
     ) -> None:
         """Check every file's header (shape, dtype, geotransform, CRS) matches ``meta``.
 
@@ -2027,7 +2070,9 @@ class DatasetCollection:
         expected_dtype = str(np.dtype(meta.dtype))
         with cloud_config_from_env(gdal_env, path=list(files)):
             for path in files:
-                ds = Dataset.read_file(path, gdal_env=gdal_env)
+                ds = Dataset.read_file(
+                    path, gdal_env=gdal_env, open_options=open_options
+                )
                 try:
                     fm = RasterMeta.from_dataset(ds)
                 finally:

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -4242,6 +4242,10 @@ class Dataset(RasterBase):
         :meth:`from_band_files`. For "one Dataset per member" (a temporal stack)
         use :meth:`pyramids.dataset.DatasetCollection.from_archive` instead.
 
+        GDAL driver ``open_options`` are **not** threaded through this
+        band-stacking entry point; if a member needs a driver option, open it
+        directly with :meth:`read_file` (which accepts ``open_options=``).
+
         The archive's file name must carry a recognised extension (``.zip`` /
         ``.tar`` / ``.tar.gz`` / ``.gz``) — GDAL's archive handlers key off the
         extension. An extension-less download URL (e.g. an Earth Engine

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2453,6 +2453,10 @@ class Dataset(RasterBase):
             - :meth:`pyramids.dataset.DatasetCollection.from_archive`: open
               *every* member of an archive as a temporal stack.
         """
+        # Normalize once here so the value captured on the instance below is the
+        # KEY=VALUE list form (a raw dict would lose its values when the base
+        # __init__ tuple-ifies it). _io.read_file re-normalizes idempotently for
+        # its own direct callers — the double pass is intentional and harmless.
         options = _io.normalize_open_options(open_options)
         with cloud_config_from_env(gdal_env, path=str(path)):
             src = _io.read_file(

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2388,7 +2388,7 @@ class Dataset(RasterBase):
         *,
         vsi: str | None = None,
         gdal_env: dict[str, str] | None = None,
-        open_options: dict[str, str] | list[str] | None = None,
+        open_options: dict[str, str] | list[str] | tuple[str, ...] | None = None,
     ) -> Dataset:
         """Open a raster from a path, URL, or archive member.
 

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -349,10 +349,13 @@ class Dataset(RasterBase):
         access: str = "read_only",
         *,
         gdal_env: dict[str, str] | None = None,
+        open_options: tuple[str, ...] | list[str] | None = None,
     ):
         """__init__."""
         self.logger = logging.getLogger(__name__)
-        super().__init__(src, access=access, gdal_env=gdal_env)
+        super().__init__(
+            src, access=access, gdal_env=gdal_env, open_options=open_options
+        )
 
         self._no_data_value = [
             src.GetRasterBand(i).GetNoDataValue() for i in range(1, self.band_count + 1)
@@ -2371,6 +2374,7 @@ class Dataset(RasterBase):
         *,
         vsi: str | None = None,
         gdal_env: dict[str, str] | None = None,
+        open_options: dict[str, str] | list[str] | None = None,
     ) -> Dataset:
         """Open a raster from a path, URL, or archive member.
 
@@ -2416,6 +2420,13 @@ class Dataset(RasterBase):
                 :func:`pyramids.stac.build_vrt_from_stac` puts those credentials
                 in the source path instead. Default ``None`` — no extra config,
                 nothing captured.
+            open_options:
+                GDAL open options as a mapping
+                (``{"GEOREF_SOURCES": "INTERNAL"}``) or GDAL's native
+                ``["KEY=VALUE"]`` list. Forwarded to the driver and captured on
+                the returned :class:`Dataset`, so the paths that reopen the file
+                (``threadsafe=True`` handles, lazy ``chunks=`` reads, unpickle on
+                a worker) reopen with the same options. Default ``None``.
 
         Returns:
             Dataset:
@@ -2428,9 +2439,21 @@ class Dataset(RasterBase):
             - :meth:`pyramids.dataset.DatasetCollection.from_archive`: open
               *every* member of an archive as a temporal stack.
         """
+        options = _io.normalize_open_options(open_options)
         with cloud_config_from_env(gdal_env, path=str(path)):
-            src = _io.read_file(path, read_only=read_only, file_i=file_i, vsi=vsi)
-        return cls(src, access="read_only" if read_only else "write", gdal_env=gdal_env)
+            src = _io.read_file(
+                path,
+                read_only=read_only,
+                file_i=file_i,
+                vsi=vsi,
+                open_options=options,
+            )
+        return cls(
+            src,
+            access="read_only" if read_only else "write",
+            gdal_env=gdal_env,
+            open_options=options,
+        )
 
     @classmethod
     def from_bytes(

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -351,7 +351,21 @@ class Dataset(RasterBase):
         gdal_env: dict[str, str] | None = None,
         open_options: tuple[str, ...] | list[str] | None = None,
     ):
-        """__init__."""
+        """Wrap an open ``gdal.Dataset`` as a :class:`Dataset`.
+
+        A thin override of :meth:`RasterBase.__init__` that attaches a logger and
+        forwards every argument unchanged; see the base for the full contract.
+        Prefer :meth:`read_file` over constructing directly.
+
+        Args:
+            src: An open :class:`osgeo.gdal.Dataset` to wrap.
+            access: The mode ``src`` was opened with — ``"read_only"`` (default)
+                or ``"write"``.
+            gdal_env: GDAL config captured for reopen paths; ``None`` captures
+                nothing.
+            open_options: GDAL open options captured for reopen paths; ``None``
+                captures nothing (#1025).
+        """
         self.logger = logging.getLogger(__name__)
         super().__init__(
             src, access=access, gdal_env=gdal_env, open_options=open_options

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -788,6 +788,21 @@ class IO(_Engine["Dataset"]):
         # strategy; this is the method's own declared contract.
         return cast("ArrayLike", arr)
 
+    def _reopen_open_options(self) -> dict[str, tuple[str, ...]] | None:
+        """Opener kwargs carrying the dataset's GDAL open options, or ``None``.
+
+        Passed to the file managers so a per-thread or per-chunk reopen applies
+        the same driver options the dataset was opened with (#1025). Returns
+        `None` when there are none, so the manager's cache key is unchanged for
+        the common no-options case. The value is the captured tuple, which stays
+        hashable for that key.
+
+        Returns:
+            dict | None: `{"open_options": <tuple>}`, or `None`.
+        """
+        options = self._ds._open_options
+        return {"open_options": options} if options else None
+
     def _require_reopenable_path(self) -> str:
         """Return the dataset's path if per-thread handles can reopen it.
 
@@ -911,6 +926,7 @@ class IO(_Engine["Dataset"]):
                         gdal_raster_open,
                         self._require_reopenable_path(),
                         "read_only",
+                        kwargs=self._reopen_open_options(),
                     )
                     self._ds._thread_manager = manager
         return manager
@@ -1155,6 +1171,7 @@ class IO(_Engine["Dataset"]):
                 gdal_raster_open,
                 self._ds._file_name,
                 "read_only",
+                kwargs=self._reopen_open_options(),
                 lock=False,
                 # Release the parked handle when the returned dask array (which keeps this manager
                 # alive through its chunk tasks) is dropped, rather than leaving it until LRU

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -163,6 +163,7 @@ def _reconstruct_netcdf(
     is_subset: bool,
     source_var_name: str | None,
     group_path: str | None = None,
+    open_options: tuple[str, ...] | None = None,
 ) -> NetCDF:
     """Re-open a :class:`NetCDF` from its pickle recipe tuple.
 
@@ -192,6 +193,10 @@ def _reconstruct_netcdf(
         group_path: Sub-group path for a group view; when set, the
             rebuilt container is drilled into via
             :meth:`NetCDF.get_group`. Defaults to None.
+        open_options: GDAL open options captured on the originating container,
+            forwarded to :meth:`NetCDF.read_file` so the worker reopens with the
+            same driver behaviour. Defaults to None so a six-element recipe from
+            an older pickle (with no options) still loads (#1025).
 
     Returns:
         NetCDF: Container, group view, or variable-subset instance.
@@ -203,6 +208,7 @@ def _reconstruct_netcdf(
         path,
         read_only=True,
         open_as_multi_dimensional=is_md_array,
+        open_options=list(open_options) if open_options else None,
     )
     if group_path:
         result = container.get_group(group_path)
@@ -530,6 +536,7 @@ class NetCDF(Dataset):
                 bool(self._is_subset),
                 self._source_var_name,
                 self._group_path,
+                tuple(self._open_options),
             ),
         )
 
@@ -538,6 +545,8 @@ class NetCDF(Dataset):
         src: gdal.Dataset,
         access: str = "read_only",
         open_as_multi_dimensional: bool = True,
+        *,
+        open_options: tuple[str, ...] | list[str] | None = None,
     ):
         """Initialize a NetCDF dataset wrapper.
 
@@ -549,6 +558,10 @@ class NetCDF(Dataset):
                 `gdal.OF_MULTIDIM_RASTER` and supports groups, MDArrays,
                 and dimensions. If False it was opened in classic raster
                 mode (subdatasets, bands). Defaults to True.
+            open_options: GDAL open options this store was opened with,
+                captured so the base reopen paths (per-thread handles,
+                lazy `chunks=` reads) reapply them. `None` (default)
+                captures nothing (#1025).
         """
         if type(self) is NetCDF:
             # API-1 (#614): NetCDF is now the base of Container / Variable.
@@ -564,7 +577,7 @@ class NetCDF(Dataset):
                 DeprecationWarning,
                 stacklevel=2,
             )
-        super().__init__(src, access=access)
+        super().__init__(src, access=access, open_options=open_options)
         # set the is_subset to false before retrieving the variables
         if open_as_multi_dimensional:
             self._is_md_array = True
@@ -3682,6 +3695,7 @@ class NetCDF(Dataset):
         file_i: int = 0,
         *,
         vsi: str | None = None,
+        open_options: dict[str, str] | list[str] | None = None,
     ) -> NetCDF:
         """Open a NetCDF file from a path, URL, or archive member.
 
@@ -3715,6 +3729,11 @@ class NetCDF(Dataset):
                 download URL must first be fetched and saved with a
                 ``.zip`` name (or written to ``/vsimem/<name>.zip`` via
                 :func:`osgeo.gdal.FileFromMemBuffer`).
+            open_options: GDAL open options as a mapping
+                (``{"HONOUR_VALID_RANGE": "NO"}``) or GDAL's native
+                ``["KEY=VALUE"]`` list, forwarded to the netCDF driver and
+                captured on the returned container so the reopen paths reapply
+                them. Default ``None`` — no options (#1025).
 
                 **Platform caveat for NetCDF:** GDAL's netCDF driver
                 requires Linux ``userfaultfd`` to open a ``.nc`` from
@@ -3769,16 +3788,21 @@ class NetCDF(Dataset):
             - :meth:`pyramids.dataset.Dataset.read_file`: the same
               ``vsi=`` / ``file_i=`` surface for GeoTIFFs.
         """
+        options = _io.normalize_open_options(open_options)
         src = _io.read_file(
             path,
             read_only,
             open_as_multi_dimensional,
             file_i=file_i,
             vsi=vsi,
+            open_options=options,
         )
         access = "read_only" if read_only else "write"
         return Container(
-            src, access=access, open_as_multi_dimensional=open_as_multi_dimensional
+            src,
+            access=access,
+            open_as_multi_dimensional=open_as_multi_dimensional,
+            open_options=options,
         )
 
     @classmethod

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -3695,7 +3695,7 @@ class NetCDF(Dataset):
         file_i: int = 0,
         *,
         vsi: str | None = None,
-        open_options: dict[str, str] | list[str] | None = None,
+        open_options: dict[str, str] | list[str] | tuple[str, ...] | None = None,
     ) -> NetCDF:
         """Open a NetCDF file from a path, URL, or archive member.
 

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -501,15 +501,22 @@ class NetCDF(Dataset):
         """Emit the extended recipe tuple carrying NetCDF mode flags.
 
         Overrides :meth:`RasterBase.__reduce__` to include
-        `_is_md_array`, `_is_subset`, and `_source_var_name`,
-        which are required to reconstruct a container vs a
-        variable-subset with matching identity.
+        `_is_md_array`, `_is_subset`, `_source_var_name`, `_group_path`,
+        and `_open_options` (the seven-element recipe), which are
+        required to reconstruct a container, group view, or
+        variable-subset with matching identity and driver options.
 
         For variable-subset instances the `_file_name` attribute
         reflects the subset's GDAL description, which is typically
         empty or driver-specific. We therefore fall back to the
         parent container's `_file_name` when reconstructing a
         subset.
+
+        Security:
+            The recipe carries `_open_options` verbatim, so any secret a
+            driver accepts as an open option is serialised into the pickle
+            (spilled to disk / quoted in dask error reports). Treat such a
+            pickle as a secret.
 
         Raises:
             TypeError: The NetCDF has no on-disk path (empty

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -2582,6 +2582,9 @@ class NetCDF(Dataset):
         wrapped._offset = self._offset
         wrapped._parent_nc = self._parent_nc
         wrapped._source_var_name = self._source_var_name
+        # A wrapped subset reopens the parent file on unpickle, so it must carry
+        # the parent's captured GDAL open options too (#1025).
+        wrapped._open_options = self._open_options
         wrapped._gdal_md_arr_ref = None
         wrapped._gdal_rg_ref = None
         return wrapped
@@ -4661,6 +4664,9 @@ class NetCDF(Dataset):
         # Pin the parent so the shared dataset (and its SWIG wrappers) outlive the
         # view even if the caller drops the parent reference.
         view._parent_nc = self
+        # A group view's pickle recipe reopens the parent file, so it inherits the
+        # parent's captured GDAL open options (#1025).
+        view._open_options = self._open_options
         return view
 
     def get_variable_names(self) -> list[str]:
@@ -5003,6 +5009,9 @@ class NetCDF(Dataset):
         # --- RT-4: Track variable origin for round-trip ---
         cube._parent_nc = self
         cube._source_var_name = variable_name
+        # A variable subset's pickle recipe reopens the parent file, so it inherits
+        # the parent's captured GDAL open options (#1025).
+        cube._open_options = self._open_options
 
         # Geostationary (GOES) scan-angle x/y come through the MDIM read path in
         # radians; rescale them to projected metres so the cube is correctly

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -3798,6 +3798,9 @@ class NetCDF(Dataset):
             - :meth:`pyramids.dataset.Dataset.read_file`: the same
               ``vsi=`` / ``file_i=`` surface for GeoTIFFs.
         """
+        # Normalize once here so the captured form on the Container is the
+        # KEY=VALUE list; _io.read_file re-normalizes idempotently (see the note
+        # in Dataset.read_file).
         options = _io.normalize_open_options(open_options)
         src = _io.read_file(
             path,

--- a/tests/dataset/collection/test_lazy.py
+++ b/tests/dataset/collection/test_lazy.py
@@ -246,9 +246,9 @@ class TestDuplicatePathSharedLock:
         captured: list[Any] = []
         real = coll_mod._lazy_timestep
 
-        def spy(path, meta, gdal_env, lock):
+        def spy(path, meta, gdal_env, lock, **kwargs):
             captured.append(lock)
-            return real(path, meta, gdal_env, lock)
+            return real(path, meta, gdal_env, lock, **kwargs)
 
         monkeypatch.setattr(coll_mod, "_lazy_timestep", spy)
         collection = DatasetCollection.from_files([p, p])
@@ -292,9 +292,9 @@ class TestDuplicatePathSharedLock:
         captured: list[Any] = []
         real = coll_mod._lazy_timestep
 
-        def spy(path, meta, gdal_env, lock):
+        def spy(path, meta, gdal_env, lock, **kwargs):
             captured.append(lock)
-            return real(path, meta, gdal_env, lock)
+            return real(path, meta, gdal_env, lock, **kwargs)
 
         monkeypatch.setattr(coll_mod, "_lazy_timestep", spy)
         _ = DatasetCollection.from_files([p]).data

--- a/tests/dataset/io/test_open_options.py
+++ b/tests/dataset/io/test_open_options.py
@@ -27,9 +27,10 @@ from pyramids.netcdf import NetCDF
 from tests._helpers import write_raster
 from tests._marks import requires_dask
 
-_NETCDF_FIXTURE = (
-    Path(__file__).resolve().parents[2] / "data" / "netcdf" / "none__1v__1d1.nc"
-)
+_NETCDF_DIR = Path(__file__).resolve().parents[2] / "data" / "netcdf"
+_NETCDF_FIXTURE = _NETCDF_DIR / "none__1v__1d1.nc"
+_NETCDF_MULTIVAR = _NETCDF_DIR / "cf__6v__1d2-2d4__geog__y-asc.nc"
+_NETCDF_GROUPS = _NETCDF_DIR / "none__35v__1d35__groups-nc4.nc"
 
 pytestmark = pytest.mark.core
 
@@ -426,3 +427,32 @@ class TestNetCDFOpenOptions:
         )
         reopened = pickle.loads(pickle.dumps(nc))
         assert reopened.open_options == ["HONOUR_VALID_RANGE=NO"], "options lost on reopen"
+
+    def test_variable_subset_inherits_and_survives_pickle(self):
+        """A `get_variable` subset inherits the container's options and reopens with them.
+
+        Test scenario:
+            A subset's pickle recipe reopens the *parent* file and drills back in,
+            so a worker must reapply the captured options — dropping them would
+            silently read different data for a value-affecting option (M1).
+        """
+        nc = NetCDF.read_file(
+            str(_NETCDF_MULTIVAR), open_options={"HONOUR_VALID_RANGE": "NO"}
+        )
+        var = nc.get_variable(nc.variable_names[0])
+        assert var.open_options == ["HONOUR_VALID_RANGE=NO"], "subset dropped the option"
+        reopened = pickle.loads(pickle.dumps(var))
+        assert reopened.open_options == ["HONOUR_VALID_RANGE=NO"], "subset lost it on reopen"
+
+    def test_group_view_inherits_options(self):
+        """A `get_group` view inherits the container's captured options (M1).
+
+        Test scenario:
+            A group view shares the parent's dataset and reopens the parent on
+            unpickle, so it must carry the parent's options.
+        """
+        nc = NetCDF.read_file(
+            str(_NETCDF_GROUPS), open_options={"HONOUR_VALID_RANGE": "NO"}
+        )
+        group = nc.get_group(nc.group_names[0])
+        assert group.open_options == ["HONOUR_VALID_RANGE=NO"], "group view dropped it"

--- a/tests/dataset/io/test_open_options.py
+++ b/tests/dataset/io/test_open_options.py
@@ -176,8 +176,11 @@ class TestReadFileOpenOptions:
         """The shared cache keys on the options, so the two reads differ.
 
         Test scenario:
-            Read-only opens go through the shared cache; if it ignored the
-            options, the second open would inherit the first's georef.
+            Read-only opens with options go through `OpenEx(OF_SHARED)`; this pins
+            the GDAL guarantee the branch relies on — that the shared-dataset
+            cache key includes the open options — so if a future GDAL ignored
+            them, the second open would inherit the first's georef and this test
+            would fail loudly rather than returning stale data.
         """
         first = Dataset.read_file(
             georeferenced_tif, open_options={"GEOREF_SOURCES": "NONE"}
@@ -231,13 +234,17 @@ class TestReadFileLowLevel:
             src = None
 
     def test_multidim_with_options_opens(self):
-        """Multidimensional open forwards options through `OpenEx`.
+        """Multidimensional open forwards options through `OpenEx` (smoke/coverage).
 
         Test scenario:
             Opening a NetCDF with `open_as_multi_dimensional=True` and a
             recognised NetCDF open option must return a live handle, exercising
             the `open_options=options or []` multidim branch with a non-empty
-            option list.
+            option list. This is a smoke/line-coverage check only: GDAL treats an
+            unrecognised or ignored open option as a warning (not a `CE_Failure`),
+            so a successful open does not by itself prove the option was honoured —
+            proving an effect would need a fixture engineered around a specific
+            multidim option.
         """
         assert _NETCDF_FIXTURE.exists(), f"missing fixture: {_NETCDF_FIXTURE}"
         src = io_read_file(

--- a/tests/dataset/io/test_open_options.py
+++ b/tests/dataset/io/test_open_options.py
@@ -22,6 +22,7 @@ from pyramids._io import read_file as io_read_file
 from pyramids.base._file_manager import gdal_raster_open
 from pyramids.dataset import Dataset, DatasetCollection
 from pyramids.dataset import collection as collection_module
+from pyramids.netcdf import NetCDF
 from tests._helpers import write_raster
 from tests._marks import requires_dask
 
@@ -360,3 +361,32 @@ class TestCollectionOpenOptions:
         mocker.patch.object(collection_module, "_lazy_timestep", side_effect=spy)
         _ = collection.data
         assert seen == [("GEOREF_SOURCES=NONE",), ("GEOREF_SOURCES=NONE",)], seen
+
+
+class TestNetCDFOpenOptions:
+    """`NetCDF.read_file` honours the widened `open_options` contract (M2)."""
+
+    def test_read_file_accepts_and_captures(self):
+        """A `dict` option is accepted (no `TypeError`) and captured on the container."""
+        nc = NetCDF.read_file(
+            str(_NETCDF_FIXTURE), open_options={"HONOUR_VALID_RANGE": "NO"}
+        )
+        assert nc.open_options == ["HONOUR_VALID_RANGE=NO"], "option not captured"
+
+    def test_default_captures_nothing(self):
+        """An ordinary NetCDF open captures no options (backward-compatible)."""
+        nc = NetCDF.read_file(str(_NETCDF_FIXTURE))
+        assert nc.open_options == [], "a plain NetCDF open must capture nothing"
+
+    def test_options_survive_pickle_reopen(self):
+        """The captured options round-trip through the NetCDF pickle recipe.
+
+        Test scenario:
+            The recipe grew a seventh element (the captured options); a worker
+            reopen (unpickle) must reapply them rather than silently dropping.
+        """
+        nc = NetCDF.read_file(
+            str(_NETCDF_FIXTURE), open_options={"HONOUR_VALID_RANGE": "NO"}
+        )
+        reopened = pickle.loads(pickle.dumps(nc))
+        assert reopened.open_options == ["HONOUR_VALID_RANGE=NO"], "options lost on reopen"

--- a/tests/dataset/io/test_open_options.py
+++ b/tests/dataset/io/test_open_options.py
@@ -59,7 +59,9 @@ class TestNormalizeOpenOptions:
 
     def test_dict_becomes_key_value_list(self):
         """A mapping is rendered as GDAL's `KEY=VALUE` list."""
-        assert normalize_open_options({"L1B_MODE": "DATASTRIP"}) == ["L1B_MODE=DATASTRIP"]
+        assert normalize_open_options({"L1B_MODE": "DATASTRIP"}) == [
+            "L1B_MODE=DATASTRIP"
+        ]
 
     def test_list_passes_through(self):
         """A native list is returned as a list, unchanged in content."""
@@ -277,9 +279,7 @@ class TestGdalRasterOpen:
 
     def test_read_options_take_effect(self, georeferenced_tif):
         """Read-only + options reopens via `OpenEx` (flags 0) carrying them."""
-        src = gdal_raster_open(
-            georeferenced_tif, open_options=("GEOREF_SOURCES=NONE",)
-        )
+        src = gdal_raster_open(georeferenced_tif, open_options=("GEOREF_SOURCES=NONE",))
         try:
             assert src.GetGeoTransform() == _IDENTITY_GT, "read option not applied"
         finally:
@@ -446,7 +446,9 @@ class TestNetCDFOpenOptions:
             str(_NETCDF_FIXTURE), open_options={"HONOUR_VALID_RANGE": "NO"}
         )
         reopened = pickle.loads(pickle.dumps(nc))
-        assert reopened.open_options == ["HONOUR_VALID_RANGE=NO"], "options lost on reopen"
+        assert reopened.open_options == ["HONOUR_VALID_RANGE=NO"], (
+            "options lost on reopen"
+        )
 
     def test_variable_subset_inherits_and_survives_pickle(self):
         """A `get_variable` subset inherits the container's options and reopens with them.
@@ -460,9 +462,13 @@ class TestNetCDFOpenOptions:
             str(_NETCDF_MULTIVAR), open_options={"HONOUR_VALID_RANGE": "NO"}
         )
         var = nc.get_variable(nc.variable_names[0])
-        assert var.open_options == ["HONOUR_VALID_RANGE=NO"], "subset dropped the option"
+        assert var.open_options == ["HONOUR_VALID_RANGE=NO"], (
+            "subset dropped the option"
+        )
         reopened = pickle.loads(pickle.dumps(var))
-        assert reopened.open_options == ["HONOUR_VALID_RANGE=NO"], "subset lost it on reopen"
+        assert reopened.open_options == ["HONOUR_VALID_RANGE=NO"], (
+            "subset lost it on reopen"
+        )
 
     def test_group_view_inherits_options(self):
         """A `get_group` view inherits the container's captured options (M1).

--- a/tests/dataset/io/test_open_options.py
+++ b/tests/dataset/io/test_open_options.py
@@ -12,14 +12,22 @@ special fixture: `NONE` drops the internal georeference (identity geotransform),
 from __future__ import annotations
 
 import pickle
+from pathlib import Path
 
 import numpy as np
 import pytest
-from osgeo import gdal
 
 from pyramids._io import normalize_open_options
+from pyramids._io import read_file as io_read_file
+from pyramids.base._file_manager import gdal_raster_open
 from pyramids.dataset import Dataset, DatasetCollection
+from pyramids.dataset import collection as collection_module
 from tests._helpers import write_raster
+from tests._marks import requires_dask
+
+_NETCDF_FIXTURE = (
+    Path(__file__).resolve().parents[2] / "data" / "netcdf" / "none__1v__1d1.nc"
+)
 
 pytestmark = pytest.mark.core
 
@@ -52,6 +60,12 @@ class TestNormalizeOpenOptions:
     def test_list_passes_through(self):
         """A native list is returned as a list, unchanged in content."""
         assert normalize_open_options(["A=1", "B=2"]) == ["A=1", "B=2"]
+
+    def test_tuple_becomes_list(self):
+        """A tuple (the hashable form the file managers carry) becomes a list."""
+        result = normalize_open_options(("A=1", "B=2"))
+        assert result == ["A=1", "B=2"], f"expected a list, got {result!r}"
+        assert isinstance(result, list), "tuple input must be normalised to a list"
 
     def test_none_stays_none(self):
         """`None` (the no-options case) is preserved."""
@@ -110,6 +124,24 @@ class TestReadFileOpenOptions:
         result = np.asarray(dataset.read_array(threadsafe=True))
         assert result.shape == (8, 8)
 
+    @requires_dask
+    def test_options_survive_lazy_chunked_reopen(self, georeferenced_tif):
+        """A lazy chunked read reopens per chunk with the captured options.
+
+        Test scenario:
+            `read_array(chunks=...)` builds a dask array whose per-chunk opener is
+            a `CachingFileManager` fed the captured options; the graph must build
+            and compute back to the raster's values without losing them.
+        """
+        dataset = Dataset.read_file(
+            georeferenced_tif, open_options={"GEOREF_SOURCES": "NONE"}
+        )
+        lazy = dataset.read_array(chunks=4)
+        assert hasattr(lazy, "dask"), "expected a lazy dask array"
+        result = np.asarray(lazy.compute())
+        assert result.shape == (8, 8), f"unexpected shape {result.shape}"
+        assert np.allclose(result, 1.0), "lazy chunked read altered the values"
+
     def test_two_opens_different_options_do_not_share_a_handle(self, georeferenced_tif):
         """The shared cache keys on the options, so the two reads differ.
 
@@ -126,25 +158,205 @@ class TestReadFileOpenOptions:
         assert first.geotransform == _IDENTITY_GT
         assert second.geotransform == _REAL_GT
 
+    def test_no_options_dataset_survives_pickle(self, georeferenced_tif):
+        """A plain (no-options) dataset still round-trips through pickle.
+
+        Test scenario:
+            The pickle recipe grew a fifth element (the captured options); an
+            ordinary dataset must still carry an empty tuple through it and
+            reopen with no options and the real georef — i.e. the reconstruct
+            path's `open_options is None` branch.
+        """
+        dataset = Dataset.read_file(georeferenced_tif)
+        reopened = pickle.loads(pickle.dumps(dataset))
+        assert reopened.open_options == [], "a plain dataset must capture nothing"
+        assert reopened.geotransform == _REAL_GT, "georef lost on plain reopen"
+
+
+class TestReadFileLowLevel:
+    """Tests for `_io.read_file` open branches not reachable via the wrapper.
+
+    `Dataset.read_file` always opens read-only, so the update-mode and
+    multidimensional open branches of the low-level `_io.read_file` are covered
+    here directly.
+    """
+
+    def test_update_mode_with_options_reaches_gdal(self, georeferenced_tif):
+        """Update-mode + options goes through `OpenEx(OF_UPDATE)` carrying them.
+
+        Test scenario:
+            `read_only=False` with `GEOREF_SOURCES=NONE` must still forward the
+            option to the driver — the returned handle reports the identity
+            geotransform, proving the update branch passed the option through.
+        """
+        src = io_read_file(
+            georeferenced_tif,
+            read_only=False,
+            open_options={"GEOREF_SOURCES": "NONE"},
+        )
+        try:
+            assert src is not None, "update-mode open with options returned nothing"
+            assert src.GetGeoTransform() == _IDENTITY_GT, "option lost in update mode"
+        finally:
+            src = None
+
+    def test_multidim_with_options_opens(self):
+        """Multidimensional open forwards options through `OpenEx`.
+
+        Test scenario:
+            Opening a NetCDF with `open_as_multi_dimensional=True` and a
+            recognised NetCDF open option must return a live handle, exercising
+            the `open_options=options or []` multidim branch with a non-empty
+            option list.
+        """
+        assert _NETCDF_FIXTURE.exists(), f"missing fixture: {_NETCDF_FIXTURE}"
+        src = io_read_file(
+            str(_NETCDF_FIXTURE),
+            open_as_multi_dimensional=True,
+            open_options=["HONOUR_VALID_RANGE=YES"],
+        )
+        try:
+            assert src is not None, "multidim open with options returned nothing"
+        finally:
+            src = None
+
+
+class TestGdalRasterOpen:
+    """Tests for `gdal_raster_open` — the file managers' reopen opener."""
+
+    def test_no_options_uses_plain_open(self, georeferenced_tif):
+        """With no options the opener takes the plain `gdal.Open` path.
+
+        Test scenario:
+            The falsy-options branch keeps the real georef (no option applied).
+        """
+        src = gdal_raster_open(georeferenced_tif)
+        try:
+            assert src.GetGeoTransform() == _REAL_GT, "plain open must not alter georef"
+        finally:
+            src = None
+
+    def test_read_options_take_effect(self, georeferenced_tif):
+        """Read-only + options reopens via `OpenEx` (flags 0) carrying them."""
+        src = gdal_raster_open(
+            georeferenced_tif, open_options=("GEOREF_SOURCES=NONE",)
+        )
+        try:
+            assert src.GetGeoTransform() == _IDENTITY_GT, "read option not applied"
+        finally:
+            src = None
+
+    def test_update_access_with_options(self, georeferenced_tif):
+        """Update access + options selects the `OF_UPDATE` flag and applies them.
+
+        Test scenario:
+            `access="update"` with an option must resolve to the `OF_UPDATE`
+            ternary branch and still forward the option (identity geotransform).
+        """
+        src = gdal_raster_open(
+            georeferenced_tif,
+            access="update",
+            open_options=("GEOREF_SOURCES=NONE",),
+        )
+        try:
+            assert src is not None, "update-access open with options returned nothing"
+            assert src.GetGeoTransform() == _IDENTITY_GT, "update-mode option lost"
+        finally:
+            src = None
+
 
 class TestCollectionOpenOptions:
     """Tests for `DatasetCollection.from_files(open_options=...)`."""
 
-    def test_from_files_threads_the_option(self, tmp_path):
-        """The option reaches every per-file open in the collection.
+    @pytest.fixture
+    def two_files(self, tmp_path):
+        """Two georeferenced GeoTIFFs sharing one header.
 
-        Test scenario:
-            `GEOREF_SOURCES=NONE` on a two-file collection must drop the georef
-            on the eagerly-opened template.
+        Returns:
+            list[str]: Paths to two 8x8 rasters with the same `_REAL_GT`.
         """
-        paths = [
+        return [
             write_raster(
                 tmp_path / f"g{i}.tif", np.ones((8, 8), "float32"), (100.0, 200.0)
             )
             for i in range(2)
         ]
+
+    def test_from_files_threads_the_option(self, two_files):
+        """The option reaches the eagerly-opened template.
+
+        Test scenario:
+            `GEOREF_SOURCES=NONE` on a two-file collection must drop the georef
+            on the template and be exposed on the `open_options` property.
+        """
         collection = DatasetCollection.from_files(
-            paths, open_options={"GEOREF_SOURCES": "NONE"}
+            two_files, open_options={"GEOREF_SOURCES": "NONE"}
         )
         assert collection.open_options == ["GEOREF_SOURCES=NONE"]
         assert collection.base.geotransform == _IDENTITY_GT
+
+    def test_from_files_validate_threads_the_option(self, two_files):
+        """`validate=True` threads the option into the header check.
+
+        Test scenario:
+            The per-file `_validate_headers` open must carry the option too — all
+            files then report the identity georef, so the headers still agree and
+            validation passes.
+        """
+        collection = DatasetCollection.from_files(
+            two_files, open_options={"GEOREF_SOURCES": "NONE"}, validate=True
+        )
+        assert collection.open_options == ["GEOREF_SOURCES=NONE"]
+        assert collection.base.geotransform == _IDENTITY_GT
+
+    def test_datasets_property_threads_the_option(self, two_files):
+        """Each eagerly-materialised per-timestep handle carries the option.
+
+        Test scenario:
+            The `datasets` property opens every file; each `Dataset` must both
+            apply the option (identity georef) and capture it.
+        """
+        collection = DatasetCollection.from_files(
+            two_files, open_options={"GEOREF_SOURCES": "NONE"}
+        )
+        handles = collection.datasets
+        assert len(handles) == 2, f"expected two handles, got {len(handles)}"
+        for handle in handles:
+            assert handle.geotransform == _IDENTITY_GT, "option not applied per-file"
+            assert handle.open_options == ["GEOREF_SOURCES=NONE"], "option not captured"
+
+    def test_dataset_at_threads_the_option(self, two_files):
+        """The single-timestep accessor opens one file with the option.
+
+        Test scenario:
+            `_dataset_at` opens only index 0; that handle must apply and capture
+            the option without materialising the whole set.
+        """
+        collection = DatasetCollection.from_files(
+            two_files, open_options={"GEOREF_SOURCES": "NONE"}
+        )
+        handle = collection._dataset_at(0)
+        assert handle.geotransform == _IDENTITY_GT, "option not applied at index"
+        assert handle.open_options == ["GEOREF_SOURCES=NONE"], "option not captured"
+
+    @requires_dask
+    def test_lazy_data_forwards_the_option(self, two_files, mocker):
+        """The lazy `.data` graph threads the option into every per-timestep open.
+
+        Test scenario:
+            Building the dask stack calls `_lazy_timestep` once per file; each
+            call must receive the captured options as the hashable tuple form.
+        """
+        collection = DatasetCollection.from_files(
+            two_files, open_options={"GEOREF_SOURCES": "NONE"}
+        )
+        real = collection_module._lazy_timestep
+        seen: list = []
+
+        def spy(path, meta, gdal_env, lock, **kwargs):
+            seen.append(kwargs.get("open_options"))
+            return real(path, meta, gdal_env, lock, **kwargs)
+
+        mocker.patch.object(collection_module, "_lazy_timestep", side_effect=spy)
+        _ = collection.data
+        assert seen == [("GEOREF_SOURCES=NONE",), ("GEOREF_SOURCES=NONE",)], seen

--- a/tests/dataset/io/test_open_options.py
+++ b/tests/dataset/io/test_open_options.py
@@ -12,6 +12,7 @@ special fixture: `NONE` drops the internal georeference (identity geotransform),
 from __future__ import annotations
 
 import pickle
+import zipfile
 from pathlib import Path
 
 import numpy as np
@@ -398,6 +399,25 @@ class TestCollectionOpenOptions:
         mocker.patch.object(collection_module, "_lazy_timestep", side_effect=spy)
         _ = collection.data
         assert seen == [("GEOREF_SOURCES=NONE",), ("GEOREF_SOURCES=NONE",)], seen
+
+    def test_from_archive_threads_the_option(self, two_files, tmp_path):
+        """`from_archive` forwards the option to every per-member open (L1).
+
+        Test scenario:
+            Zipping the two rasters and opening the archive with
+            `GEOREF_SOURCES=NONE` must drop the georef on the eagerly-opened
+            template, proving the option reaches `from_files` through
+            `from_archive`.
+        """
+        archive = tmp_path / "scenes.zip"
+        with zipfile.ZipFile(archive, "w") as zf:
+            for member in two_files:
+                zf.write(member, arcname=Path(member).name)
+        collection = DatasetCollection.from_archive(
+            str(archive), open_options={"GEOREF_SOURCES": "NONE"}
+        )
+        assert collection.open_options == ["GEOREF_SOURCES=NONE"]
+        assert collection.base.geotransform == _IDENTITY_GT
 
 
 class TestNetCDFOpenOptions:

--- a/tests/dataset/io/test_open_options.py
+++ b/tests/dataset/io/test_open_options.py
@@ -22,6 +22,7 @@ from pyramids._io import read_file as io_read_file
 from pyramids.base._file_manager import gdal_raster_open
 from pyramids.dataset import Dataset, DatasetCollection
 from pyramids.dataset import collection as collection_module
+from pyramids.dataset.engines import io as io_engine
 from pyramids.netcdf import NetCDF
 from tests._helpers import write_raster
 from tests._marks import requires_dask
@@ -117,31 +118,59 @@ class TestReadFileOpenOptions:
         assert reopened.open_options == ["GEOREF_SOURCES=NONE"]
         assert reopened.geotransform == _IDENTITY_GT, "options lost on reopen"
 
-    def test_options_survive_threadsafe_reopen(self, georeferenced_tif):
-        """A per-thread reopen carries the options and still reads."""
-        dataset = Dataset.read_file(
-            georeferenced_tif, open_options={"GEOREF_SOURCES": "NONE"}
-        )
-        result = np.asarray(dataset.read_array(threadsafe=True))
-        assert result.shape == (8, 8)
-
-    @requires_dask
-    def test_options_survive_lazy_chunked_reopen(self, georeferenced_tif):
-        """A lazy chunked read reopens per chunk with the captured options.
+    def test_options_survive_threadsafe_reopen(self, georeferenced_tif, mocker):
+        """A per-thread reopen forwards the captured options to the opener.
 
         Test scenario:
-            `read_array(chunks=...)` builds a dask array whose per-chunk opener is
-            a `CachingFileManager` fed the captured options; the graph must build
-            and compute back to the raster's values without losing them.
+            `read_array(threadsafe=True)` reopens the file through the per-thread
+            manager. `GEOREF_SOURCES` is inert for array values, so asserting the
+            array alone cannot detect option loss on this path — instead spy on
+            the reopen opener and prove it receives the captured options.
         """
         dataset = Dataset.read_file(
             georeferenced_tif, open_options={"GEOREF_SOURCES": "NONE"}
         )
+        real = io_engine.gdal_raster_open
+        seen: list = []
+
+        def spy(*args, **kwargs):
+            seen.append(kwargs.get("open_options"))
+            return real(*args, **kwargs)
+
+        mocker.patch.object(io_engine, "gdal_raster_open", side_effect=spy)
+        result = np.asarray(dataset.read_array(threadsafe=True))
+        assert result.shape == (8, 8), f"unexpected shape {result.shape}"
+        assert seen, "the per-thread reopen opener was never called"
+        assert all(o == ("GEOREF_SOURCES=NONE",) for o in seen), seen
+
+    @requires_dask
+    def test_options_survive_lazy_chunked_reopen(self, georeferenced_tif, mocker):
+        """A lazy chunked read forwards the captured options to the per-chunk opener.
+
+        Test scenario:
+            `read_array(chunks=...)` builds a dask array whose per-chunk opener is
+            a `CachingFileManager`; spy on the reopen opener to prove it is fed the
+            captured options (again the georef option is inert for array values, so
+            the array assertion alone could not catch a dropped option).
+        """
+        dataset = Dataset.read_file(
+            georeferenced_tif, open_options={"GEOREF_SOURCES": "NONE"}
+        )
+        real = io_engine.gdal_raster_open
+        seen: list = []
+
+        def spy(*args, **kwargs):
+            seen.append(kwargs.get("open_options"))
+            return real(*args, **kwargs)
+
+        mocker.patch.object(io_engine, "gdal_raster_open", side_effect=spy)
         lazy = dataset.read_array(chunks=4)
         assert hasattr(lazy, "dask"), "expected a lazy dask array"
         result = np.asarray(lazy.compute())
         assert result.shape == (8, 8), f"unexpected shape {result.shape}"
         assert np.allclose(result, 1.0), "lazy chunked read altered the values"
+        assert seen, "the per-chunk reopen opener was never called"
+        assert all(o == ("GEOREF_SOURCES=NONE",) for o in seen), seen
 
     def test_two_opens_different_options_do_not_share_a_handle(self, georeferenced_tif):
         """The shared cache keys on the options, so the two reads differ.

--- a/tests/dataset/io/test_open_options.py
+++ b/tests/dataset/io/test_open_options.py
@@ -1,0 +1,150 @@
+"""Tests for GDAL open options threaded through Dataset.read_file (#1025).
+
+`Dataset.read_file(open_options=...)` forwards driver-specific open options to
+GDAL and captures them on the returned dataset, so the read paths that reopen
+the file rather than reuse the handle — `threadsafe=True` per-thread handles,
+lazy `chunks=` reads inside dask tasks, and unpickling on a worker — reopen with
+the same options. `GTiff`'s `GEOREF_SOURCES` gives an observable effect with no
+special fixture: `NONE` drops the internal georeference (identity geotransform),
+`INTERNAL` keeps it.
+"""
+
+from __future__ import annotations
+
+import pickle
+
+import numpy as np
+import pytest
+from osgeo import gdal
+
+from pyramids._io import normalize_open_options
+from pyramids.dataset import Dataset, DatasetCollection
+from tests._helpers import write_raster
+
+pytestmark = pytest.mark.core
+
+_REAL_GT = (100.0, 1.0, 0.0, 200.0, 0.0, -1.0)
+_IDENTITY_GT = (0.0, 1.0, 0.0, 0.0, 0.0, 1.0)
+
+
+@pytest.fixture
+def georeferenced_tif(tmp_path):
+    """A GeoTIFF carrying an internal geotransform.
+
+    Returns:
+        str: Path to an 8x8 raster whose internal georef is `_REAL_GT`.
+    """
+    return write_raster(
+        tmp_path / "geo.tif",
+        np.ones((8, 8), "float32"),
+        (100.0, 200.0),
+        cell_size=1.0,
+    )
+
+
+class TestNormalizeOpenOptions:
+    """Tests for the `dict` / list / `None` normaliser."""
+
+    def test_dict_becomes_key_value_list(self):
+        """A mapping is rendered as GDAL's `KEY=VALUE` list."""
+        assert normalize_open_options({"L1B_MODE": "DATASTRIP"}) == ["L1B_MODE=DATASTRIP"]
+
+    def test_list_passes_through(self):
+        """A native list is returned as a list, unchanged in content."""
+        assert normalize_open_options(["A=1", "B=2"]) == ["A=1", "B=2"]
+
+    def test_none_stays_none(self):
+        """`None` (the no-options case) is preserved."""
+        assert normalize_open_options(None) is None
+
+
+class TestReadFileOpenOptions:
+    """Tests for `Dataset.read_file(open_options=...)` end to end."""
+
+    def test_default_open_captures_nothing(self, georeferenced_tif):
+        """An ordinary open captures no options and keeps the real georef."""
+        dataset = Dataset.read_file(georeferenced_tif)
+        assert dataset.open_options == [], "an ordinary open must capture nothing"
+        assert dataset.geotransform == _REAL_GT
+
+    def test_dict_form_takes_effect(self, georeferenced_tif):
+        """A `dict` option reaches GDAL: `GEOREF_SOURCES=NONE` drops the georef.
+
+        Test scenario:
+            Without the option the geotransform is `_REAL_GT`; with it, GDAL
+            ignores the internal georef and returns the identity transform.
+        """
+        dataset = Dataset.read_file(
+            georeferenced_tif, open_options={"GEOREF_SOURCES": "NONE"}
+        )
+        assert dataset.geotransform == _IDENTITY_GT, "the option did not reach GDAL"
+        assert dataset.open_options == ["GEOREF_SOURCES=NONE"]
+
+    def test_list_form_takes_effect(self, georeferenced_tif):
+        """GDAL's native `["KEY=VALUE"]` form is accepted too."""
+        dataset = Dataset.read_file(
+            georeferenced_tif, open_options=["GEOREF_SOURCES=INTERNAL"]
+        )
+        assert dataset.geotransform == _REAL_GT
+        assert dataset.open_options == ["GEOREF_SOURCES=INTERNAL"]
+
+    def test_options_survive_pickle_reopen(self, georeferenced_tif):
+        """A worker reopen (unpickle) reapplies the captured options.
+
+        Test scenario:
+            Losing the options on the worker would silently change driver
+            behaviour there — the geotransform would flip back to `_REAL_GT`.
+        """
+        dataset = Dataset.read_file(
+            georeferenced_tif, open_options={"GEOREF_SOURCES": "NONE"}
+        )
+        reopened = pickle.loads(pickle.dumps(dataset))
+        assert reopened.open_options == ["GEOREF_SOURCES=NONE"]
+        assert reopened.geotransform == _IDENTITY_GT, "options lost on reopen"
+
+    def test_options_survive_threadsafe_reopen(self, georeferenced_tif):
+        """A per-thread reopen carries the options and still reads."""
+        dataset = Dataset.read_file(
+            georeferenced_tif, open_options={"GEOREF_SOURCES": "NONE"}
+        )
+        result = np.asarray(dataset.read_array(threadsafe=True))
+        assert result.shape == (8, 8)
+
+    def test_two_opens_different_options_do_not_share_a_handle(self, georeferenced_tif):
+        """The shared cache keys on the options, so the two reads differ.
+
+        Test scenario:
+            Read-only opens go through the shared cache; if it ignored the
+            options, the second open would inherit the first's georef.
+        """
+        first = Dataset.read_file(
+            georeferenced_tif, open_options={"GEOREF_SOURCES": "NONE"}
+        )
+        second = Dataset.read_file(
+            georeferenced_tif, open_options={"GEOREF_SOURCES": "INTERNAL"}
+        )
+        assert first.geotransform == _IDENTITY_GT
+        assert second.geotransform == _REAL_GT
+
+
+class TestCollectionOpenOptions:
+    """Tests for `DatasetCollection.from_files(open_options=...)`."""
+
+    def test_from_files_threads_the_option(self, tmp_path):
+        """The option reaches every per-file open in the collection.
+
+        Test scenario:
+            `GEOREF_SOURCES=NONE` on a two-file collection must drop the georef
+            on the eagerly-opened template.
+        """
+        paths = [
+            write_raster(
+                tmp_path / f"g{i}.tif", np.ones((8, 8), "float32"), (100.0, 200.0)
+            )
+            for i in range(2)
+        ]
+        collection = DatasetCollection.from_files(
+            paths, open_options={"GEOREF_SOURCES": "NONE"}
+        )
+        assert collection.open_options == ["GEOREF_SOURCES=NONE"]
+        assert collection.base.geotransform == _IDENTITY_GT

--- a/tests/netcdf/test_container_variable_types.py
+++ b/tests/netcdf/test_container_variable_types.py
@@ -226,13 +226,14 @@ class TestTypePreservation:
         out = tmp_path / "var_copy.nc"
         copied = variable.copy(str(out))
         _func, args = copied.__reduce__()
-        path, _access, _is_md, is_subset, source_var, group_path = args
+        path, _access, _is_md, is_subset, source_var, group_path, open_opts = args
         assert Path(path).name == "var_copy.nc", (
             f"recipe must target the copy, got {path!r}"
         )
         assert is_subset is False, "a copy must not be pickled as a parent subset"
         assert source_var is None, "a copy must not carry a parent source-variable name"
         assert group_path is None, "a copy must not be pickled as a group view"
+        assert open_opts == (), "a copy opened without options carries none in its recipe"
 
     def test_epsg_setter_inplace_preserves_variable_type(self, variable):
         """An in-place op (the ``epsg`` setter) does not downgrade a Variable.

--- a/tests/netcdf/test_container_variable_types.py
+++ b/tests/netcdf/test_container_variable_types.py
@@ -233,7 +233,9 @@ class TestTypePreservation:
         assert is_subset is False, "a copy must not be pickled as a parent subset"
         assert source_var is None, "a copy must not carry a parent source-variable name"
         assert group_path is None, "a copy must not be pickled as a group view"
-        assert open_opts == (), "a copy opened without options carries none in its recipe"
+        assert open_opts == (), (
+            "a copy opened without options carries none in its recipe"
+        )
 
     def test_epsg_setter_inplace_preserves_variable_type(self, variable):
         """An in-place op (the ``epsg`` setter) does not downgrade a Variable.


### PR DESCRIPTION
# Description

GDAL open options are the standard mechanism for driver-specific read behaviour, but the pyramids read entry
points never exposed them — the only way to pass one was to bypass pyramids and call `gdal.OpenEx` by hand,
forfeiting `/vsi` rewriting, archive handling, cloud-config capture, and the `Dataset`/`NetCDF` wrapper. This
threads an `open_options` keyword from every public read entry point down to a single GDAL open, and captures it
on the dataset so the paths that reopen the file rather than reuse the handle reapply it.

Raised for **pyramids-eo** (Sentinel-1/2 readers need `L1B_MODE` / `ALPHA`), but the capability is generic —
open options are how GDAL exposes per-driver behaviour for every format.

## What changed

- **`Dataset.read_file(open_options=...)`**, **`NetCDF.read_file(open_options=...)`**,
  **`DatasetCollection.from_files(open_options=...)`**, **`DatasetCollection.from_archive(open_options=...)`**, and
  the low-level **`_io.read_file`** / reopen opener **`gdal_raster_open`** — all accept a mapping
  (`{"L1B_MODE": "DATASTRIP"}`), GDAL's native `["KEY=VALUE"]` list, or a tuple, normalized by
  `normalize_open_options`.
- **Captured on the instance and reapplied on every reopen path** — stored as a hashable tuple on
  `RasterBase._open_options` and exposed via an `open_options` property (on `Dataset`/`NetCDF` and on
  `DatasetCollection`). The pickle recipes carry it (the `Dataset` recipe grew 4→5 elements, the `NetCDF` recipe
  6→7, both backward-compatible via defaulted parameters), and the per-thread and dask-chunk file managers pass it
  as a hashable tuple, so a dataset never silently loses its driver options on a worker. The manager cache key
  already folds in its opener kwargs, so handles are correctly distinguished by options.
- **`DatasetCollection`** threads the option through every per-file open — eager template, lazy per-timestep
  reads, the tiled dask reader's caching manager, header validation, and `from_archive`'s per-member opens —
  mirroring how `gdal_env` already flows.
- **NetCDF** honours the option on the container open and propagates it to variable subsets (`get_variable`) and
  group views (`get_group`), whose pickle recipes reopen the parent file — so a subset scattered to a distributed
  worker reopens with the same driver options rather than silently reading different data.

## GDAL open flags

Read-only opens *without* options keep `gdal.OpenShared`, and update opens without options keep `gdal.Open` — so
**no default open behaviour changes**. An open *with* options must go through `gdal.OpenEx` (the only entry that
carries them): read-only uses `OF_SHARED | OF_RASTER | OF_VERBOSE_ERROR`, update uses
`OF_UPDATE | OF_RASTER | OF_VERBOSE_ERROR`. `OF_RASTER | OF_VERBOSE_ERROR` restore the raster-only driver-kind
restriction and verbose diagnostics that `gdal.Open`/`OpenShared` imply but bare `OpenEx` (which opens `OF_ALL`)
would drop.

## The `OpenShared` interaction (the issue's one design caveat) — resolved, not worked around

The issue flagged that GDAL's shared-handle cache is keyed on path+access+thread, *not* open options, so two reads
of one path with different options could be handed the same wrongly-configured handle. **Tested on the pinned GDAL
3.13.1 and it does not hold** — the shared cache *does* key on open options, so a read-only open with options goes
through `OpenEx(OF_SHARED)` and same-options reads still share (keeping the frequently-accessed-raster benefit)
while different-options reads do not collide. A regression test pins that two opens with different options do not
share, documenting the exact GDAL guarantee the branch relies on.

# Issues

- Closes #1025

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

Purely additive — a new optional keyword defaulting to `None`, which reproduces the prior behaviour exactly.

# How Has This Been Tested?

- [x] New `tests/dataset/io/test_open_options.py` (28 tests): the `dict`/list/tuple normaliser; the observable
      `GTiff` `GEOREF_SOURCES` effect end to end; capture on the instance and reapplication on the pickle,
      `threadsafe=True` per-thread, and lazy `chunks=` reopen paths (the last two spy on the reopen opener because
      the georef option is inert for array values); the shared-cache-keys-on-options guard; the low-level
      update-mode and multidim branches; `gdal_raster_open`'s branches; `DatasetCollection` eager / `validate` /
      `datasets` / `_dataset_at` / lazy `.data` / `from_archive`; and NetCDF `read_file` capture, pickle, and
      variable-subset / group-view inheritance.
- [x] Full suite `pytest -m "not plot"` — **green (8587 passed, 53 skipped)**.
- [x] `mypy` clean on all changed modules; `pre-commit run --all-files` clean (ruff, ruff-format, bandit, mypy);
      doctests green.
- [x] **Two adversarial review rounds** (`/review-rounds`): round 1 (3 medium / 3 low / 2 nit) and round 2
      (1 medium / 3 low / 3 nit) all resolved, including the NetCDF subset/group-view option propagation and the
      `OF_RASTER`/`OF_VERBOSE_ERROR` flag parity.
- [x] **SonarCloud** quality gate `OK` on the PR HEAD — 0 bugs, 0 vulnerabilities, 0 code smells, 0 open issues.

# Checklist:

- [ ] updated version number in pyproject.toml. — handled by commitizen on release
- [ ] added changes to History.rst. — generated by commitizen
- [ ] updated the latest version in README file. — handled on release
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. — docstrings on `Dataset.read_file`, `NetCDF.read_file`, `_io.read_file`,
      `DatasetCollection.from_files` / `from_archive`, and the `open_options` properties and pickle recipes.
