### PR TITLE
feat(dataset): per-band metadata accessor, domain-aware methods, and band-family consolidation

### DIFF
--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2061,6 +2061,34 @@ class Dataset(RasterBase):
         self._epsg = self._get_epsg()
 
     @property
+    def band_meta_data(self) -> list[dict[str, str]]:
+        """Per-band metadata, one mapping per band, in band order.
+
+        The per-band sibling of :attr:`meta_data`. Facade — delegates to
+        :attr:`Bands.metadata <pyramids.dataset.engines.Bands.metadata>`; see it for
+        the empty-band and default-domain conventions.
+
+        Returns:
+            list[dict[str, str]]: One mapping per band (0-based, band order); an empty
+            ``dict`` for a band with no metadata.
+        """
+        return self.bands.metadata
+
+    @band_meta_data.setter
+    def band_meta_data(self, value: list[dict[str, str]]) -> None:
+        """Replace each band's metadata (one mapping per band).
+
+        Facade setter — delegates to
+        :attr:`Bands.metadata <pyramids.dataset.engines.Bands.metadata>`, which
+        replaces (does not merge) each band's default-domain metadata.
+
+        Raises:
+            ReadOnlyError: The dataset is a read-only on-disk file.
+            ValueError: ``value`` does not carry exactly one mapping per band.
+        """
+        self.bands.metadata = value
+
+    @property
     def file_name(self) -> str:
         """File name."""
         return super().file_name

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -1852,20 +1852,17 @@ class Dataset(RasterBase):
 
     @property
     def band_units(self) -> list[str]:
-        """Band units."""
-        return self._band_units
+        """Facade — delegates to :attr:`Bands.band_units <pyramids.dataset.engines.Bands.band_units>`."""
+        return self.bands.band_units
 
     @band_units.setter
     def band_units(self, value: list[str]):
-        """Band units setter.
+        """Facade setter.
 
         Raises:
-            ReadOnlyError: The dataset is opened read-only.
+            ReadOnlyError: The dataset is opened read-only on-disk.
         """
-        self._require_writable("set band units")
-        self._band_units = value
-        for i, val in enumerate(value):
-            self._iloc(i).SetUnitType(val)
+        self.bands.band_units = value
 
     def convert_units(self, target: str, band: int | None = None) -> Dataset:
         """Convert band values to ``target`` units, returning a new Dataset.
@@ -2100,49 +2097,37 @@ class Dataset(RasterBase):
 
     @property
     def scale(self) -> list[float]:
-        """Scale.
+        """Facade — delegates to :attr:`Bands.scale <pyramids.dataset.engines.Bands.scale>`.
 
-        The value of the scale is used to convert the pixel values to the real-world values.
+        The scale converts the pixel values to the real-world values.
         """
-        scale_list = []
-        for i in range(self.band_count):
-            band_scale = self._iloc(i).GetScale()
-            scale_list.append(band_scale if band_scale is not None else 1.0)
-        return scale_list
+        return self.bands.scale
 
     @scale.setter
     def scale(self, value: list[float]):
-        """Scale.
+        """Facade setter.
 
         Raises:
-            ReadOnlyError: The dataset is opened read-only.
+            ReadOnlyError: The dataset is opened read-only on-disk.
         """
-        self._require_writable("set the band scale")
-        for i, val in enumerate(value):
-            self._iloc(i).SetScale(val)
+        self.bands.scale = value
 
     @property
     def offset(self):
-        """Offset.
+        """Facade — delegates to :attr:`Bands.offset <pyramids.dataset.engines.Bands.offset>`.
 
-        The value of the offset is used to convert the pixel values to the real-world values.
+        The offset converts the pixel values to the real-world values.
         """
-        offset_list = []
-        for i in range(self.band_count):
-            band_offset = self._iloc(i).GetOffset()
-            offset_list.append(band_offset if band_offset is not None else 0)
-        return offset_list
+        return self.bands.offset
 
     @offset.setter
     def offset(self, value: list[float]):
-        """Offset.
+        """Facade setter.
 
         Raises:
-            ReadOnlyError: The dataset is opened read-only.
+            ReadOnlyError: The dataset is opened read-only on-disk.
         """
-        self._require_writable("set the band offset")
-        for i, val in enumerate(value):
-            self._iloc(i).SetOffset(val)
+        self.bands.offset = value
 
     @property
     def top_left_corner(self):

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -598,6 +598,89 @@ class Bands(_Engine["Dataset"]):
             gdal_const = color_name_to_gdal_constant(val)
             self._iloc(key).SetColorInterpretation(gdal_const)
 
+    @property
+    def metadata(self) -> list[dict[str, str]]:
+        """Per-band metadata (default domain), one mapping per band, in band order.
+
+        This is the per-band sibling of the dataset-level :attr:`Dataset.meta_data`.
+        It is where GDAL stores what a band physically *is* — for a Sentinel-2 band,
+        the centre wavelength, bandwidth, and solar irradiance; for Sentinel-1, the
+        swath and polarization; and so on for any format's per-band tags. Only the
+        default metadata domain is exposed (``IMAGE_STRUCTURE`` and other domains are
+        out of scope until domain support lands).
+
+        Returns:
+            list[dict[str, str]]: One mapping per band, indexed like
+            :attr:`Dataset.band_names` (0-based, band order). A band that carries no
+            metadata yields an empty ``dict`` (never ``None``), so callers can index
+            without guarding.
+
+        Examples:
+            - A two-band raster whose bands carry metadata reports it per band:
+
+              ```python
+              >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
+              >>> arr = np.zeros((2, 4, 4), dtype="int16")
+              >>> dataset = Dataset.create_from_array(
+              ...     arr, top_left_corner=(0, 0), cell_size=0.05, epsg=4326
+              ... )
+              >>> dataset.band_meta_data = [{"WAVELENGTH": "443"}, {"WAVELENGTH": "490"}]
+              >>> dataset.bands.metadata[0]["WAVELENGTH"]
+              '443'
+              >>> dataset.bands.metadata[1]["WAVELENGTH"]
+              '490'
+
+              ```
+
+            - A band with no metadata yields an empty mapping, not ``None``:
+
+              ```python
+              >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
+              >>> arr = np.zeros((1, 4, 4), dtype="int16")
+              >>> dataset = Dataset.create_from_array(
+              ...     arr, top_left_corner=(0, 0), cell_size=0.05, epsg=4326
+              ... )
+              >>> dataset.bands.metadata
+              [{}]
+
+              ```
+        """
+        return [self._iloc(i).GetMetadata() for i in range(self._ds.band_count)]
+
+    @metadata.setter
+    def metadata(self, value: list[dict[str, str]]) -> None:
+        """Replace each band's default-domain metadata, one mapping per band.
+
+        The assignment **replaces** each band's metadata with the mapping given for
+        it (``SetMetadata``), rather than merging into what is already there — a
+        whole-list assignment reads as "set each band's metadata to exactly this",
+        consistent with the other per-band list setters (``band_units``, ``scale``,
+        ``offset``). Assigning an empty mapping to a band therefore clears it. To edit
+        a single key without disturbing the rest, read the mapping, update it, and
+        assign the list back. (The dataset-level :attr:`Dataset.meta_data` setter
+        merges instead, because it is a single dict, not a per-band list.)
+
+        Args:
+            value: One mapping per band, in band order; its length must equal the
+                band count.
+
+        Raises:
+            ReadOnlyError: The dataset is a read-only on-disk file (setting band
+                metadata would spill a PAM ``.aux.xml`` sidecar); reopen with
+                ``read_only=False`` or edit an in-memory copy instead.
+            ValueError: ``value`` does not carry exactly one mapping per band.
+        """
+        self._ds._require_writable("set band metadata")
+        if len(value) != self._ds.band_count:
+            raise ValueError(
+                f"band_meta_data needs one mapping per band: expected "
+                f"{self._ds.band_count}, got {len(value)}."
+            )
+        for i, band_md in enumerate(value):
+            self._iloc(i).SetMetadata(band_md)
+
     def get_band_by_color(self, color_name: str) -> int | None:
         """Get the band associated with a given color.
 

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -788,6 +788,74 @@ class Bands(_Engine["Dataset"]):
         self._ds._require_writable("set band metadata")
         self._iloc(band).SetMetadataItem(key, value, domain)
 
+    @property
+    def band_units(self) -> list[str]:
+        """Per-band unit labels, one per band, in band order."""
+        return self._ds._band_units
+
+    @band_units.setter
+    def band_units(self, value: list[str]) -> None:
+        """Relabel each band's unit.
+
+        This only relabels; it does not convert the stored values — see
+        :meth:`Dataset.convert_units` for a value-transforming conversion.
+
+        Raises:
+            ReadOnlyError: The dataset is a read-only on-disk file.
+        """
+        self._ds._require_writable("set band units")
+        self._ds._band_units = value
+        for i, val in enumerate(value):
+            self._iloc(i).SetUnitType(val)
+
+    @property
+    def scale(self) -> list[float]:
+        """Per-band scale factors (pixel value -> real-world value).
+
+        Returns:
+            list[float]: One scale per band; ``1.0`` for a band with no scale set.
+        """
+        scale_list = []
+        for i in range(self._ds.band_count):
+            band_scale = self._iloc(i).GetScale()
+            scale_list.append(band_scale if band_scale is not None else 1.0)
+        return scale_list
+
+    @scale.setter
+    def scale(self, value: list[float]) -> None:
+        """Set each band's scale factor.
+
+        Raises:
+            ReadOnlyError: The dataset is a read-only on-disk file.
+        """
+        self._ds._require_writable("set the band scale")
+        for i, val in enumerate(value):
+            self._iloc(i).SetScale(val)
+
+    @property
+    def offset(self) -> list[float]:
+        """Per-band offsets (pixel value -> real-world value).
+
+        Returns:
+            list[float]: One offset per band; ``0`` for a band with no offset set.
+        """
+        offset_list = []
+        for i in range(self._ds.band_count):
+            band_offset = self._iloc(i).GetOffset()
+            offset_list.append(band_offset if band_offset is not None else 0)
+        return offset_list
+
+    @offset.setter
+    def offset(self, value: list[float]) -> None:
+        """Set each band's offset.
+
+        Raises:
+            ReadOnlyError: The dataset is a read-only on-disk file.
+        """
+        self._ds._require_writable("set the band offset")
+        for i, val in enumerate(value):
+            self._iloc(i).SetOffset(val)
+
     def get_band_by_color(self, color_name: str) -> int | None:
         """Get the band associated with a given color.
 

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import warnings
 from collections.abc import Iterable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, overload
 
 import geopandas as gpd
 import numpy as np
@@ -647,7 +647,7 @@ class Bands(_Engine["Dataset"]):
 
               ```
         """
-        return [self._iloc(i).GetMetadata() for i in range(self._ds.band_count)]
+        return self.get_metadata()
 
     @metadata.setter
     def metadata(self, value: list[dict[str, str]]) -> None:
@@ -672,14 +672,121 @@ class Bands(_Engine["Dataset"]):
                 ``read_only=False`` or edit an in-memory copy instead.
             ValueError: ``value`` does not carry exactly one mapping per band.
         """
+        self.set_metadata(value)
+
+    @overload
+    def get_metadata(
+        self, band: None = ..., domain: str = ...
+    ) -> list[dict[str, str]]: ...
+
+    @overload
+    def get_metadata(self, band: int, domain: str = ...) -> dict[str, str]: ...
+
+    def get_metadata(
+        self, band: int | None = None, domain: str = ""
+    ) -> list[dict[str, str]] | dict[str, str]:
+        """Read per-band metadata from a metadata domain.
+
+        The domain-aware form behind :attr:`metadata`. The default domain (``""``)
+        holds format-specific band semantics; other GDAL domains expose other tags,
+        e.g. ``"IMAGE_STRUCTURE"`` carries ``NBITS`` / ``COMPRESSION`` / ``PIXELTYPE``.
+
+        Args:
+            band: A 0-based band index to read just that band, or ``None`` (default)
+                to read every band in band order.
+            domain: The GDAL metadata domain to read; ``""`` (default) is the default
+                domain.
+
+        Returns:
+            list[dict[str, str]] | dict[str, str]: One mapping per band when ``band``
+            is ``None``; a single band's mapping when ``band`` is given. A band with
+            no metadata in the domain yields an empty ``dict`` (never ``None``).
+
+        Raises:
+            IndexError: ``band`` is out of range.
+
+        Examples:
+            - Read the ``IMAGE_STRUCTURE`` domain of a single band:
+
+              ```python
+              >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
+              >>> dataset = Dataset.create_from_array(
+              ...     np.zeros((4, 4), dtype="int16"),
+              ...     top_left_corner=(0, 0), cell_size=0.05, epsg=4326,
+              ... )
+              >>> dataset.bands.get_metadata(band=0, domain="IMAGE_STRUCTURE")
+              {}
+
+              ```
+        """
+        if band is None:
+            return [
+                cast("dict[str, str]", self._iloc(i).GetMetadata(domain))
+                for i in range(self._ds.band_count)
+            ]
+        return cast("dict[str, str]", self._iloc(band).GetMetadata(domain))
+
+    def set_metadata(
+        self,
+        value: list[dict[str, str]] | dict[str, str],
+        band: int | None = None,
+        domain: str = "",
+    ) -> None:
+        """Replace per-band metadata in a metadata domain.
+
+        The domain-aware form behind the :attr:`metadata` setter. Replaces (does not
+        merge) the metadata of the target band(s) in ``domain``; assigning an empty
+        mapping clears it. Use :meth:`set_metadata_item` to change one key in place.
+
+        Args:
+            value: One mapping per band (a list, when ``band`` is ``None``) or a
+                single band's mapping (a dict, when ``band`` is given).
+            band: A 0-based band index to set just that band, or ``None`` (default) to
+                set every band from a per-band list.
+            domain: The GDAL metadata domain to write; ``""`` (default) is the default
+                domain.
+
+        Raises:
+            ReadOnlyError: The dataset is a read-only on-disk file.
+            ValueError: ``band`` is ``None`` but ``value`` does not carry exactly one
+                mapping per band.
+            IndexError: ``band`` is out of range.
+        """
         self._ds._require_writable("set band metadata")
-        if len(value) != self._ds.band_count:
-            raise ValueError(
-                f"band_meta_data needs one mapping per band: expected "
-                f"{self._ds.band_count}, got {len(value)}."
-            )
-        for i, band_md in enumerate(value):
-            self._iloc(i).SetMetadata(band_md)
+        if band is None:
+            if len(value) != self._ds.band_count:
+                raise ValueError(
+                    f"band_meta_data needs one mapping per band: expected "
+                    f"{self._ds.band_count}, got {len(value)}."
+                )
+            for i, band_md in enumerate(cast("list[dict[str, str]]", value)):
+                self._iloc(i).SetMetadata(band_md, domain)
+        else:
+            self._iloc(band).SetMetadata(cast("dict[str, str]", value), domain)
+
+    def set_metadata_item(
+        self, key: str, value: str, band: int = 0, domain: str = ""
+    ) -> None:
+        """Set a single band-metadata key in place, leaving the rest untouched.
+
+        The merge counterpart to :meth:`set_metadata` (which replaces a band's whole
+        mapping): this updates or adds one ``key`` on one band via GDAL's
+        ``SetMetadataItem``.
+
+        Args:
+            key: The metadata key to set.
+            value: The value to store.
+            band: The 0-based band index. Defaults to the first band.
+            domain: The GDAL metadata domain to write; ``""`` (default) is the default
+                domain.
+
+        Raises:
+            ReadOnlyError: The dataset is a read-only on-disk file.
+            IndexError: ``band`` is out of range.
+        """
+        self._ds._require_writable("set band metadata")
+        self._iloc(band).SetMetadataItem(key, value, domain)
 
     def get_band_by_color(self, color_name: str) -> int | None:
         """Get the band associated with a given color.

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -722,10 +722,10 @@ class Bands(_Engine["Dataset"]):
         """
         if band is None:
             return [
-                cast("dict[str, str]", self._iloc(i).GetMetadata(domain))
+                cast(dict[str, str], self._iloc(i).GetMetadata(domain))
                 for i in range(self._ds.band_count)
             ]
-        return cast("dict[str, str]", self._iloc(band).GetMetadata(domain))
+        return cast(dict[str, str], self._iloc(band).GetMetadata(domain))
 
     def set_metadata(
         self,
@@ -760,10 +760,10 @@ class Bands(_Engine["Dataset"]):
                     f"band_meta_data needs one mapping per band: expected "
                     f"{self._ds.band_count}, got {len(value)}."
                 )
-            for i, band_md in enumerate(cast("list[dict[str, str]]", value)):
+            for i, band_md in enumerate(cast(list[dict[str, str]], value)):
                 self._iloc(i).SetMetadata(band_md, domain)
         else:
-            self._iloc(band).SetMetadata(cast("dict[str, str]", value), domain)
+            self._iloc(band).SetMetadata(cast(dict[str, str], value), domain)
 
     def set_metadata_item(
         self, key: str, value: str, band: int = 0, domain: str = ""

--- a/tests/dataset/unit/test_unit_properties.py
+++ b/tests/dataset/unit/test_unit_properties.py
@@ -271,6 +271,32 @@ class TestBandNamesUnitsSetters:
             )
 
 
+class TestBandFamilyEngineFacades:
+    """The per-band family (units/scale/offset) is owned by Bands; Dataset delegates."""
+
+    def test_band_units_facade_matches_engine(self, multi_band_dataset):
+        """Dataset.band_units delegates to Bands.band_units in both directions."""
+        multi_band_dataset.band_units = ["m", "kg", "s"]
+        assert multi_band_dataset.band_units == multi_band_dataset.bands.band_units, (
+            "band_units facade and engine disagree"
+        )
+        multi_band_dataset.bands.band_units = ["a", "b", "c"]
+        assert multi_band_dataset.band_units == ["a", "b", "c"], (
+            "setting via the engine is not visible on the facade"
+        )
+
+    def test_scale_offset_facade_matches_engine(self, multi_band_dataset):
+        """Dataset.scale/offset delegate to Bands.scale/offset."""
+        multi_band_dataset.scale = [0.1, 0.2, 0.3]
+        multi_band_dataset.offset = [1.0, 2.0, 3.0]
+        assert multi_band_dataset.scale == multi_band_dataset.bands.scale, (
+            "scale facade and engine disagree"
+        )
+        assert multi_band_dataset.offset == multi_band_dataset.bands.offset, (
+            "offset facade and engine disagree"
+        )
+
+
 class TestBandMetaData:
     """Tests for the per-band metadata accessor (#1027)."""
 

--- a/tests/dataset/unit/test_unit_properties.py
+++ b/tests/dataset/unit/test_unit_properties.py
@@ -339,6 +339,54 @@ class TestBandMetaData:
         with pytest.raises(ReadOnlyError, match="read-only"):
             ds.band_meta_data = [{"WAVELENGTH": "443"}, {"WAVELENGTH": "490"}]
 
+    def test_get_metadata_single_band(self, multi_band_dataset):
+        """get_metadata(band=i) returns just that band's mapping."""
+        multi_band_dataset.band_meta_data = [{"A": "1"}, {"B": "2"}, {"C": "3"}]
+        assert multi_band_dataset.bands.get_metadata(band=1) == {"B": "2"}, (
+            "band-selective get returned the wrong band"
+        )
+
+    def test_set_metadata_single_band(self, multi_band_dataset):
+        """set_metadata(dict, band=i) replaces only that band."""
+        multi_band_dataset.bands.set_metadata({"X": "9"}, band=2)
+        result = multi_band_dataset.band_meta_data
+        assert result == [{}, {}, {"X": "9"}], f"only band 2 should change: {result}"
+
+    def test_set_metadata_item_merges(self, multi_band_dataset):
+        """set_metadata_item adds/updates one key without clearing the rest."""
+        multi_band_dataset.bands.set_metadata({"KEEP": "1"}, band=0)
+        multi_band_dataset.bands.set_metadata_item("ADD", "2", band=0)
+        assert multi_band_dataset.bands.get_metadata(band=0) == {
+            "KEEP": "1",
+            "ADD": "2",
+        }, "set_metadata_item should merge, not replace"
+
+    def test_domain_isolation(self, multi_band_dataset):
+        """A non-default domain is read/written independently of the default one."""
+        multi_band_dataset.bands.set_metadata({"WAVELENGTH": "443"}, band=0)
+        multi_band_dataset.bands.set_metadata_item(
+            "NBITS", "12", band=0, domain="IMAGE_STRUCTURE"
+        )
+        assert multi_band_dataset.bands.get_metadata(
+            band=0, domain="IMAGE_STRUCTURE"
+        ) == {"NBITS": "12"}, "IMAGE_STRUCTURE domain not written/read"
+        assert multi_band_dataset.bands.get_metadata(band=0) == {"WAVELENGTH": "443"}, (
+            "the default domain must be untouched by an IMAGE_STRUCTURE write"
+        )
+
+    def test_set_metadata_read_only_raises(self, tmp_path):
+        """The domain-aware setter is guarded on a read-only on-disk file too."""
+        path = tmp_path / "bm.tif"
+        Dataset.create_from_array(
+            np.zeros((4, 4), dtype="int16"),
+            top_left_corner=(0, 0),
+            cell_size=0.05,
+            epsg=4326,
+        ).to_file(str(path))
+        ds = Dataset.read_file(str(path), read_only=True)
+        with pytest.raises(ReadOnlyError, match="read-only"):
+            ds.bands.set_metadata_item("A", "1", band=0)
+
 
 class TestConvertUnits:
     """Tests for the Dataset.convert_units value-conversion method."""

--- a/tests/dataset/unit/test_unit_properties.py
+++ b/tests/dataset/unit/test_unit_properties.py
@@ -5,6 +5,7 @@ import pandas as pd
 import pytest
 from osgeo import gdal, osr
 
+from pyramids.base._errors import ReadOnlyError
 from pyramids.base.crs import crs_from_user_input, crs_spec, sr_from_epsg
 from pyramids.dataset import Dataset
 from pyramids.dataset.abstract_dataset import RasterBase
@@ -268,6 +269,75 @@ class TestBandNamesUnitsSetters:
             assert actual == expected, (
                 f"Band {i} unit mismatch: expected {expected}, got {actual}"
             )
+
+
+class TestBandMetaData:
+    """Tests for the per-band metadata accessor (#1027)."""
+
+    def test_round_trip_per_band(self, multi_band_dataset):
+        """Setting then reading band_meta_data returns one mapping per band, in order."""
+        value = [{"WAVELENGTH": "443"}, {"WAVELENGTH": "490"}, {"WAVELENGTH": "560"}]
+        multi_band_dataset.band_meta_data = value
+        assert multi_band_dataset.band_meta_data == value, (
+            f"round-trip mismatch: {multi_band_dataset.band_meta_data}"
+        )
+
+    def test_facade_matches_engine(self, multi_band_dataset):
+        """The Dataset facade returns exactly what the Bands engine does."""
+        multi_band_dataset.band_meta_data = [{"a": "1"}, {"b": "2"}, {"c": "3"}]
+        assert multi_band_dataset.band_meta_data == multi_band_dataset.bands.metadata, (
+            "facade and engine property disagree"
+        )
+
+    def test_empty_band_is_empty_dict(self, multi_band_dataset):
+        """A band carrying no metadata yields an empty dict, never None."""
+        result = multi_band_dataset.band_meta_data
+        assert result == [{}, {}, {}], f"expected three empty dicts, got {result}"
+        assert all(isinstance(m, dict) for m in result), "each entry must be a dict"
+
+    def test_order_matches_band_names(self, multi_band_dataset):
+        """band_meta_data is indexed like band_names (0-based, band order)."""
+        multi_band_dataset.band_names = ["red", "green", "blue"]
+        multi_band_dataset.band_meta_data = [
+            {"NAME": "red"},
+            {"NAME": "green"},
+            {"NAME": "blue"},
+        ]
+        for i, name in enumerate(multi_band_dataset.band_names):
+            assert multi_band_dataset.band_meta_data[i]["NAME"] == name, (
+                f"band {i} metadata not aligned with band_names"
+            )
+
+    def test_setter_replaces_not_merges(self, multi_band_dataset):
+        """Assigning a new list replaces each band's metadata rather than merging."""
+        multi_band_dataset.band_meta_data = [
+            {"A": "1", "B": "2"},
+            {"A": "1"},
+            {"A": "1"},
+        ]
+        multi_band_dataset.band_meta_data = [{"A": "9"}, {}, {"C": "3"}]
+        assert multi_band_dataset.band_meta_data == [{"A": "9"}, {}, {"C": "3"}], (
+            f"setter should replace, got {multi_band_dataset.band_meta_data}"
+        )
+
+    def test_wrong_length_raises(self, multi_band_dataset):
+        """Assigning the wrong number of mappings raises ValueError."""
+        with pytest.raises(ValueError, match="one mapping per band"):
+            multi_band_dataset.band_meta_data = [{"A": "1"}]
+
+    def test_read_only_on_disk_raises(self, tmp_path):
+        """Setting band metadata on a read-only on-disk file raises ReadOnlyError."""
+        path = tmp_path / "bandmeta.tif"
+        Dataset.create_from_array(
+            np.zeros((2, 4, 4), dtype="int16"),
+            top_left_corner=(0, 0),
+            cell_size=0.05,
+            epsg=4326,
+        ).to_file(str(path))
+        ds = Dataset.read_file(str(path), read_only=True)
+        assert ds.access == "read_only", "fixture must be read-only for this test"
+        with pytest.raises(ReadOnlyError, match="read-only"):
+            ds.band_meta_data = [{"WAVELENGTH": "443"}, {"WAVELENGTH": "490"}]
 
 
 class TestConvertUnits:


### PR DESCRIPTION
# Description

`Dataset` exposed dataset-level metadata (`meta_data`) and a per-band property family (`band_names`, `band_units`,
`no_data_value`, `scale`, `offset`) but had **no accessor for per-band metadata** — GDAL's per-band `GetMetadata`,
where every format stores what a band physically *is* (Sentinel-2 `WAVELENGTH` / `SOLAR_IRRADIANCE`, Sentinel-1
`POLARIZATION`, per-band calibration tags, …). The only route was reaching past the wrapper into
`ds.raster.GetRasterBand(i).GetMetadata()`.

This implements the full band-metadata plan from `planning/band-metadata-1027-design.md`, landing everything on the
existing **`Bands` engine** (`ds.bands`) — where color tables, RATs, and band colours already live — with thin
`Dataset` facades, rather than bolting flat properties onto `Dataset`.

## What changed

- **Per-band metadata accessor** — `Bands.metadata` (`list[dict[str, str]]`, one mapping per band in band order;
  `{}` not `None` for an empty band) with a `Dataset.band_meta_data` facade. The setter **replaces** each band's
  default-domain metadata (consistent with the other per-band list setters), is guarded by `_require_writable`, and
  requires one mapping per band.
- **Domain-aware methods** — `Bands.get_metadata(band=None, domain="")` / `set_metadata(value, band=None, domain="")`
  read/replace one band or all bands in any GDAL metadata domain (the default domain, or `"IMAGE_STRUCTURE"` for
  `NBITS` / `COMPRESSION`, …); the `metadata` property is re-expressed on top of them. `Bands.set_metadata_item(key,
  value, band=0, domain="")` merges a single key in place. This is the shape #1028 (domains) and #1023 (per-band
  `NBITS`) plug into.
- **Consolidation** — `band_units` / `scale` / `offset`, previously implemented inline on `Dataset`, move to the
  `Bands` engine with `Dataset` facades, so the whole per-band family now lives in one place. Behaviour-preserving
  (the `_band_units` cache, writability guard, and empty-band defaults are unchanged).

```python
ds.band_meta_data[0]["WAVELENGTH"]                       # '443'
ds.band_meta_data = [{"WAVELENGTH": "443"}, {"WAVELENGTH": "490"}]
ds.bands.get_metadata(band=0, domain="IMAGE_STRUCTURE")  # {'NBITS': '12'}
ds.bands.set_metadata_item("BANDNAME", "B1", band=0)     # merge one key
```

# Issues

- Closes #1027 — expose per-band metadata via `Dataset.band_meta_data`

Also lays the groundwork referenced by #1028 (metadata domains) and #1023 (per-band `NBITS` via `IMAGE_STRUCTURE`),
without closing them.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- New tests in `tests/dataset/unit/test_unit_properties.py`: `TestBandMetaData` (round-trip, facade==engine, empty
  band → `{}`, order matches `band_names`, replace-not-merge, wrong-length → `ValueError`, read-only → `ReadOnlyError`,
  band-selective get/set, `set_metadata_item` merge, domain isolation) and `TestBandFamilyEngineFacades` (the
  migrated `band_units`/`scale`/`offset` delegate to the engine both ways).
- Doctests on the new `Bands.metadata` / `Bands.get_metadata` pass.
- Existing `TestScaleOffset` / `TestBandNamesUnitsSetters` / `TestConvertUnits` still pass (behaviour-preserving
  migration).
- Full non-plot suite green (**8631 passed**); `mypy` clean on the changed files.

# Checklist:

- [ ] updated version number in pyproject.toml. — N/A (commitizen/CI handles versions).
- [ ] added changes to History.rst. — N/A (changelog is generated).
- [ ] updated the latest version in README file. — N/A.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. — full Google-style docstrings + doctests on the new accessors.
