### PR TITLE
feat(dataset): subdatasets enumeration/open + dataset-level metadata domains

### DIFF
--- a/src/pyramids/dataset/__init__.py
+++ b/src/pyramids/dataset/__init__.py
@@ -2,6 +2,7 @@
 
 from pyramids.base._raster_meta import RasterMeta
 from pyramids.dataset._gcp import GroundControlPoint
+from pyramids.dataset._subdataset import SubDataset
 from pyramids.dataset.abstract_dataset import DEFAULT_NO_DATA_VALUE
 from pyramids.dataset.collection import DatasetCollection
 from pyramids.dataset.dataset import Dataset, NoDataSentinelWarning
@@ -18,5 +19,6 @@ __all__ = [
     "GroundControlPoint",
     "NoDataSentinelWarning",
     "RasterMeta",
+    "SubDataset",
     "Window",
 ]

--- a/src/pyramids/dataset/_subdataset.py
+++ b/src/pyramids/dataset/_subdataset.py
@@ -1,0 +1,68 @@
+"""The :class:`SubDataset` value object — one nested raster inside a container.
+
+A *container* raster has no pixels of its own; its payload is a set of named
+sub-rasters that GDAL calls **subdatasets**. Containers are how GDAL models
+NetCDF, HDF4/HDF5, Zarr, GRIB, WMS/WMTS, and the Sentinel-1 (`SAFE`) and
+Sentinel-2 (`SENTINEL2`) products. `SubDataset` is a lightweight, picklable
+description of one such nested raster — its openable connection string, GDAL's
+own blurb, and its position in the container's list — with :meth:`SubDataset.open`
+to materialise it.
+
+The description string is driver-specific (a Sentinel-2 entry looks nothing like
+a NetCDF one), so this value object deliberately exposes it **raw** and parses
+nothing; a format-specific layer parses it if it needs to.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pyramids.dataset.dataset import Dataset
+
+
+@dataclass(frozen=True)
+class SubDataset:
+    """One nested raster inside a container, as GDAL reports it.
+
+    Attributes:
+        name: The fully-qualified GDAL connection string for the subdataset (for
+            example ``'SENTINEL2_L2A:/path/MTD_MSIL2A.xml:60m:EPSG_32632'`` or
+            ``'NETCDF:"file.nc":temperature'``). It is openable on its own.
+        description: GDAL's human-readable description of the subdataset. Its
+            format is driver-specific — do not parse it generically.
+        index: The 0-based position of this subdataset in the container's list.
+
+    Examples:
+        - A subdataset carries the openable name, GDAL's description, and its index:
+            ```python
+            >>> from pyramids.dataset._subdataset import SubDataset
+            >>> sd = SubDataset(name='NETCDF:"f.nc":temp', description='[2x3] temp', index=0)
+            >>> sd.name
+            'NETCDF:"f.nc":temp'
+            >>> sd.index
+            0
+
+            ```
+    """
+
+    name: str
+    description: str
+    index: int
+
+    def open(self) -> Dataset:
+        """Open this subdataset as a base :class:`~pyramids.dataset.dataset.Dataset`.
+
+        Returns:
+            Dataset: The opened subdataset. This always returns a **base**
+            ``Dataset``; to preserve the parent container's concrete class (e.g.
+            keep a ``NetCDF`` a ``NetCDF``), call
+            :meth:`~pyramids.dataset.dataset.Dataset.open_subdataset` on the parent
+            instead.
+        """
+        # Local import: breaks the _subdataset -> dataset -> abstract_dataset ->
+        # _subdataset cycle (abstract_dataset imports SubDataset at module load).
+        from pyramids.dataset.dataset import Dataset
+
+        return Dataset.read_file(self.name)

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -821,7 +821,7 @@ class RasterBase(ABC):
         ]
 
     @property
-    def metadata_domains(self) -> list[str]:
+    def meta_data_domains(self) -> list[str]:
         """The GDAL metadata domains this dataset actually exposes.
 
         Returns:
@@ -842,7 +842,7 @@ class RasterBase(ABC):
         ``NetCDFMetadata`` while this returns the raw default-domain dict. Other
         domains expose GDAL's named metadata, e.g. ``"IMAGE_STRUCTURE"``
         (``COMPRESSION`` / ``INTERLEAVE`` / ``NBITS``) or ``"RPC"``. Use
-        :attr:`metadata_domains` to see which domains exist.
+        :attr:`meta_data_domains` to see which domains exist.
 
         Args:
             domain: The GDAL metadata domain to read; ``""`` (default) is the

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -833,13 +833,15 @@ class RasterBase(ABC):
         self._require_open()
         return cast("list[str]", self._raster.GetMetadataDomainList() or [])
 
-    def get_meta_data(self, domain: str = "") -> dict[str, str]:
+    def get_meta_data(self, domain: str = "") -> dict[str, str] | list[str]:
         """Read this dataset's metadata from a specific GDAL domain.
 
-        The domain-aware companion to :attr:`meta_data`. ``get_meta_data("")`` is
-        identical to :attr:`meta_data`; other domains expose GDAL's named metadata —
-        for example ``"IMAGE_STRUCTURE"`` (``COMPRESSION`` / ``INTERLEAVE`` /
-        ``NBITS``), ``"RPC"``, or an ``xml:*`` product-XML domain. Use
+        The domain-aware companion to :attr:`meta_data`. On a base :class:`Dataset`,
+        ``get_meta_data("")`` returns the same mapping as :attr:`meta_data`; on a
+        ``NetCDF`` the two differ — there :attr:`meta_data` is a processed
+        ``NetCDFMetadata`` while this returns the raw default-domain dict. Other
+        domains expose GDAL's named metadata, e.g. ``"IMAGE_STRUCTURE"``
+        (``COMPRESSION`` / ``INTERLEAVE`` / ``NBITS``) or ``"RPC"``. Use
         :attr:`metadata_domains` to see which domains exist.
 
         Args:
@@ -847,10 +849,12 @@ class RasterBase(ABC):
                 default domain.
 
         Returns:
-            dict[str, str]: The domain's metadata; ``{}`` when the domain is absent.
+            dict[str, str] | list[str]: The domain's metadata. Most domains return a
+            ``KEY=VALUE`` mapping (``{}`` when the domain is absent); an ``xml:*``
+            domain returns a list of one XML string, mirroring GDAL's ``GetMetadata``.
 
         Examples:
-            - The default domain matches :attr:`meta_data`:
+            - The default domain matches :attr:`meta_data` on a base ``Dataset``:
                 ```python
                 >>> import numpy as np
                 >>> from pyramids.dataset import Dataset
@@ -863,7 +867,7 @@ class RasterBase(ABC):
                 ```
         """
         self._require_open()
-        return cast("dict[str, str]", self._raster.GetMetadata(domain))
+        return cast("dict[str, str] | list[str]", self._raster.GetMetadata(domain))
 
     @staticmethod
     def get_x_lon_dimension_array(pivot_x, cell_size, columns) -> FloatArray:

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -36,6 +36,7 @@ from pyramids.base._utils import (
 from pyramids.base.crs import epsg_of_crs, sr_from_epsg
 from pyramids.base.protocols import ArrayLike, FloatArray
 from pyramids.base.remote import cloud_config_from_env
+from pyramids.dataset._subdataset import SubDataset
 from pyramids.dataset.transform import GeoTransform
 from pyramids.dataset.window import Window
 
@@ -784,6 +785,85 @@ class RasterBase(ABC):
         """Meta data."""
         self._require_open()
         return self._raster.GetMetadata()
+
+    @property
+    def subdatasets(self) -> list[SubDataset]:
+        """The container's subdatasets (nested rasters), in GDAL's order.
+
+        A normal raster returns ``[]``. A *container* — a NetCDF/HDF/Zarr store, a
+        Sentinel-1/-2 product, a WMS endpoint — returns one entry per nested
+        raster. Open one with
+        :meth:`~pyramids.dataset.dataset.Dataset.open_subdataset` (keeps this
+        class) or :meth:`SubDataset.open` (a base ``Dataset``).
+
+        Returns:
+            list[SubDataset]: One :class:`~pyramids.dataset._subdataset.SubDataset`
+            per nested raster, in the order GDAL lists them; ``[]`` for a raster
+            that has none.
+
+        Examples:
+            - A plain raster has no subdatasets:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_from_array(
+                ...     np.zeros((2, 2)), top_left_corner=(0, 0), cell_size=1.0, epsg=4326
+                ... )
+                >>> ds.subdatasets
+                []
+
+                ```
+        """
+        self._require_open()
+        return [
+            SubDataset(name, description, i)
+            for i, (name, description) in enumerate(self._raster.GetSubDatasets())
+        ]
+
+    @property
+    def metadata_domains(self) -> list[str]:
+        """The GDAL metadata domains this dataset actually exposes.
+
+        Returns:
+            list[str]: Domain names — ``""`` is the default domain, and named
+            domains such as ``"IMAGE_STRUCTURE"``, ``"SUBDATASETS"``, ``"RPC"`` or
+            an ``xml:*`` product-XML domain appear when present. ``[]`` when the
+            handle exposes none (GDAL's ``None`` is normalised away).
+        """
+        self._require_open()
+        return cast("list[str]", self._raster.GetMetadataDomainList() or [])
+
+    def get_meta_data(self, domain: str = "") -> dict[str, str]:
+        """Read this dataset's metadata from a specific GDAL domain.
+
+        The domain-aware companion to :attr:`meta_data`. ``get_meta_data("")`` is
+        identical to :attr:`meta_data`; other domains expose GDAL's named metadata —
+        for example ``"IMAGE_STRUCTURE"`` (``COMPRESSION`` / ``INTERLEAVE`` /
+        ``NBITS``), ``"RPC"``, or an ``xml:*`` product-XML domain. Use
+        :attr:`metadata_domains` to see which domains exist.
+
+        Args:
+            domain: The GDAL metadata domain to read; ``""`` (default) is the
+                default domain.
+
+        Returns:
+            dict[str, str]: The domain's metadata; ``{}`` when the domain is absent.
+
+        Examples:
+            - The default domain matches :attr:`meta_data`:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_from_array(
+                ...     np.zeros((2, 2)), top_left_corner=(0, 0), cell_size=1.0, epsg=4326
+                ... )
+                >>> ds.get_meta_data() == ds.meta_data
+                True
+
+                ```
+        """
+        self._require_open()
+        return cast("dict[str, str]", self._raster.GetMetadata(domain))
 
     @staticmethod
     def get_x_lon_dimension_array(pivot_x, cell_size, columns) -> FloatArray:

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2074,13 +2074,22 @@ class Dataset(RasterBase):
         self.__dict__.pop("_cf_crs_cache", None)
         self._epsg = self._get_epsg()
 
-    def set_meta_data(self, value: dict[str, str], domain: str = "") -> None:
+    def set_meta_data(
+        self, value: dict[str, str] | list[str], domain: str = ""
+    ) -> None:
         """Replace a *named* GDAL metadata domain.
 
         Writes ``value`` into ``domain`` with ``SetMetadata`` — a **replace**, not a
-        merge, consistent with the band-level
+        merge (the replace semantics match the band-level
         :meth:`Bands.set_metadata <pyramids.dataset.engines.Bands.set_metadata>`;
-        assigning ``{}`` clears the domain.
+        unlike it, this method **refuses the default domain** — see below). Assigning
+        ``{}`` (or ``[]``) empties the domain's keys, though the domain name itself may
+        still be listed by :attr:`meta_data_domains`.
+
+        Most domains take a ``KEY=VALUE`` mapping; an ``xml:*`` domain instead takes a
+        single-element ``list[str]`` of one XML document, mirroring what
+        :meth:`get_meta_data` returns for it (passing a ``dict`` to an ``xml:*`` domain
+        is a mistake — GDAL flattens it to ``["KEY=VALUE"]``).
 
         The **default** domain (``""``) is deliberately rejected: it holds
         GDAL/CF-managed keys — ``AREA_OR_POINT`` and the CF axis metadata that drives
@@ -2090,7 +2099,9 @@ class Dataset(RasterBase):
         refreshes those caches.
 
         Args:
-            value: The metadata mapping to write into ``domain``.
+            value: The metadata to write into ``domain`` — a ``dict[str, str]``
+                mapping for a ``KEY=VALUE`` domain, or a single-element ``list[str]``
+                for an ``xml:*`` domain.
             domain: The named GDAL metadata domain to write (for example
                 ``"IMAGE_STRUCTURE"``, ``"RPC"``, or a custom domain). The empty
                 default domain is not accepted.
@@ -2118,7 +2129,10 @@ class Dataset(RasterBase):
         a classic-mode raster reference, so it is opened as an ordinary raster
         (unlike :meth:`SubDataset.open`, this carries the parent's access mode, GDAL
         env, and open options). The parent's open options are reapplied verbatim to
-        the child open. For a ``NetCDF`` container, use
+        the child open. If the parent is open in update mode the child is opened in
+        update mode too; not every driver supports updating a subdataset connection
+        string, so a write-mode open can fail for some containers. For a ``NetCDF``
+        container, use
         :meth:`~pyramids.netcdf.netcdf.NetCDF.get_variable` / ``NetCDF.variables``
         instead when you want the multidimensional, ``NetCDF``-preserving view of a
         variable — those handle the multidim open a raw subdataset string cannot.

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2075,30 +2075,38 @@ class Dataset(RasterBase):
         self._epsg = self._get_epsg()
 
     def set_meta_data(self, value: dict[str, str], domain: str = "") -> None:
-        """Replace this dataset's metadata in a specific GDAL domain.
+        """Replace a *named* GDAL metadata domain.
 
-        The domain-aware companion to the :attr:`meta_data` setter. Unlike that
-        setter (which *merges* per key via ``SetMetadataItem``), this **replaces**
-        the whole domain (``SetMetadata``), consistent with the band-level
-        :meth:`Bands.set_metadata <pyramids.dataset.engines.Bands.set_metadata>`.
-        Assigning ``{}`` clears the domain. Writing the default domain (``""``) also
-        refreshes the CF/EPSG caches, exactly like the :attr:`meta_data` setter.
+        Writes ``value`` into ``domain`` with ``SetMetadata`` — a **replace**, not a
+        merge, consistent with the band-level
+        :meth:`Bands.set_metadata <pyramids.dataset.engines.Bands.set_metadata>`;
+        assigning ``{}`` clears the domain.
+
+        The **default** domain (``""``) is deliberately rejected: it holds
+        GDAL/CF-managed keys — ``AREA_OR_POINT`` and the CF axis metadata that drives
+        CRS inference — and a whole-domain replace would silently drop them (and the
+        CRS/EPSG caches would then re-derive from the corrupted state). Use the
+        :attr:`meta_data` setter for the default domain; it merges per key and
+        refreshes those caches.
 
         Args:
             value: The metadata mapping to write into ``domain``.
-            domain: The GDAL metadata domain to write; ``""`` (default) is the
-                default domain.
+            domain: The named GDAL metadata domain to write (for example
+                ``"IMAGE_STRUCTURE"``, ``"RPC"``, or a custom domain). The empty
+                default domain is not accepted.
 
         Raises:
+            ValueError: ``domain`` is the empty default domain — use the
+                :attr:`meta_data` setter instead.
             ReadOnlyError: The dataset is a read-only on-disk file.
         """
+        if not domain:
+            raise ValueError(
+                "set_meta_data writes named domains only; use the `meta_data` setter "
+                "for the default domain (it merges per key and refreshes CRS caches)."
+            )
         self._require_writable("set metadata")
         self._raster.SetMetadata(value, domain)
-        if domain == "":
-            # Default-domain metadata feeds CF CRS inference (axis units); drop the
-            # memoised answers so they re-derive, matching the meta_data setter.
-            self.__dict__.pop("_cf_crs_cache", None)
-            self._epsg = self._get_epsg()
 
     def open_subdataset(self, key: int | str) -> Dataset:
         """Open one of this container's subdatasets, carrying its open context.
@@ -2109,46 +2117,54 @@ class Dataset(RasterBase):
         The result is a **base** :class:`Dataset`: a subdataset connection string is
         a classic-mode raster reference, so it is opened as an ordinary raster
         (unlike :meth:`SubDataset.open`, this carries the parent's access mode, GDAL
-        env, and open options). For a ``NetCDF`` container, use
+        env, and open options). The parent's open options are reapplied verbatim to
+        the child open. For a ``NetCDF`` container, use
         :meth:`~pyramids.netcdf.netcdf.NetCDF.get_variable` / ``NetCDF.variables``
         instead when you want the multidimensional, ``NetCDF``-preserving view of a
         variable — those handle the multidim open a raw subdataset string cannot.
 
         Args:
-            key: A 0-based index into :attr:`subdatasets`, or a subdataset's full
+            key: An index into :attr:`subdatasets` (0-based; negative indices count
+                from the end, per Python list semantics), or a subdataset's full
                 ``name`` (its GDAL connection string).
 
         Returns:
             Dataset: The opened subdataset as a base ``Dataset``.
 
         Raises:
+            TypeError: ``key`` is neither an ``int`` index nor a ``str`` name.
             IndexError: ``key`` is an out-of-range index.
             ValueError: ``key`` is a name that is not among this container's
                 subdatasets.
         """
         subs = self.subdatasets
+        if isinstance(key, bool):
+            raise TypeError(f"key must be an int index or a str name, not bool: {key!r}")
         if isinstance(key, int):
-            name = subs[key].name
-        else:
-            match = next((sub.name for sub in subs if sub.name == key), None)
-            if match is None:
-                available = [sub.name for sub in subs]
+            name = subs[key].name  # negative indices follow Python list semantics
+        elif isinstance(key, str):
+            if key not in {sub.name for sub in subs}:
+                # Connection strings can embed credentials (signed URLs, SAS tokens);
+                # redact before echoing them in the error.
+                available = [redact_credentials(sub.name) for sub in subs]
                 raise ValueError(
-                    f"{key!r} is not a subdataset of this dataset; "
-                    f"available: {available}"
+                    f"{redact_credentials(key)!r} is not a subdataset of this "
+                    f"dataset; available: {available}"
                 )
-            name = match
-        # Open the classic-mode subdataset string as a base Dataset, applying the
-        # captured GDAL env via the context manager (the __reduce__ idiom) so remote
-        # credentials still apply at open time, then re-attach it to the result.
-        with cloud_config_from_env(self._gdal_env, path=name):
-            result = Dataset.read_file(
-                name,
-                read_only=self.access == "read_only",
-                open_options=list(self._open_options) or None,
+            name = key
+        else:
+            raise TypeError(
+                f"key must be an int index or a str name, got {type(key).__name__}"
             )
-        result.attach_gdal_env(self._gdal_env)
-        return result
+        # Open the classic-mode subdataset string as a base Dataset. read_file both
+        # installs the captured GDAL env around the open (so remote credentials apply)
+        # and re-attaches it to the result, so no separate context/attach is needed.
+        return Dataset.read_file(
+            name,
+            read_only=self.access == "read_only",
+            gdal_env=self._gdal_env or None,
+            open_options=list(self._open_options) or None,
+        )
 
     @property
     def band_meta_data(self) -> list[dict[str, str]]:

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2153,7 +2153,9 @@ class Dataset(RasterBase):
         """
         subs = self.subdatasets
         if isinstance(key, bool):
-            raise TypeError(f"key must be an int index or a str name, not bool: {key!r}")
+            raise TypeError(
+                f"key must be an int index or a str name, not bool: {key!r}"
+            )
         if isinstance(key, int):
             name = subs[key].name  # negative indices follow Python list semantics
         elif isinstance(key, str):

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2074,6 +2074,82 @@ class Dataset(RasterBase):
         self.__dict__.pop("_cf_crs_cache", None)
         self._epsg = self._get_epsg()
 
+    def set_meta_data(self, value: dict[str, str], domain: str = "") -> None:
+        """Replace this dataset's metadata in a specific GDAL domain.
+
+        The domain-aware companion to the :attr:`meta_data` setter. Unlike that
+        setter (which *merges* per key via ``SetMetadataItem``), this **replaces**
+        the whole domain (``SetMetadata``), consistent with the band-level
+        :meth:`Bands.set_metadata <pyramids.dataset.engines.Bands.set_metadata>`.
+        Assigning ``{}`` clears the domain. Writing the default domain (``""``) also
+        refreshes the CF/EPSG caches, exactly like the :attr:`meta_data` setter.
+
+        Args:
+            value: The metadata mapping to write into ``domain``.
+            domain: The GDAL metadata domain to write; ``""`` (default) is the
+                default domain.
+
+        Raises:
+            ReadOnlyError: The dataset is a read-only on-disk file.
+        """
+        self._require_writable("set metadata")
+        self._raster.SetMetadata(value, domain)
+        if domain == "":
+            # Default-domain metadata feeds CF CRS inference (axis units); drop the
+            # memoised answers so they re-derive, matching the meta_data setter.
+            self.__dict__.pop("_cf_crs_cache", None)
+            self._epsg = self._get_epsg()
+
+    def open_subdataset(self, key: int | str) -> Dataset:
+        """Open one of this container's subdatasets, carrying its open context.
+
+        Resolves ``key`` against :attr:`subdatasets` and reopens the chosen nested
+        raster with this dataset's access mode, GDAL environment, and open options.
+
+        The result is a **base** :class:`Dataset`: a subdataset connection string is
+        a classic-mode raster reference, so it is opened as an ordinary raster
+        (unlike :meth:`SubDataset.open`, this carries the parent's access mode, GDAL
+        env, and open options). For a ``NetCDF`` container, use
+        :meth:`~pyramids.netcdf.netcdf.NetCDF.get_variable` / ``NetCDF.variables``
+        instead when you want the multidimensional, ``NetCDF``-preserving view of a
+        variable — those handle the multidim open a raw subdataset string cannot.
+
+        Args:
+            key: A 0-based index into :attr:`subdatasets`, or a subdataset's full
+                ``name`` (its GDAL connection string).
+
+        Returns:
+            Dataset: The opened subdataset as a base ``Dataset``.
+
+        Raises:
+            IndexError: ``key`` is an out-of-range index.
+            ValueError: ``key`` is a name that is not among this container's
+                subdatasets.
+        """
+        subs = self.subdatasets
+        if isinstance(key, int):
+            name = subs[key].name
+        else:
+            match = next((sub.name for sub in subs if sub.name == key), None)
+            if match is None:
+                available = [sub.name for sub in subs]
+                raise ValueError(
+                    f"{key!r} is not a subdataset of this dataset; "
+                    f"available: {available}"
+                )
+            name = match
+        # Open the classic-mode subdataset string as a base Dataset, applying the
+        # captured GDAL env via the context manager (the __reduce__ idiom) so remote
+        # credentials still apply at open time, then re-attach it to the result.
+        with cloud_config_from_env(self._gdal_env, path=name):
+            result = Dataset.read_file(
+                name,
+                read_only=self.access == "read_only",
+                open_options=list(self._open_options) or None,
+            )
+        result.attach_gdal_env(self._gdal_env)
+        return result
+
     @property
     def band_meta_data(self) -> list[dict[str, str]]:
         """Per-band metadata, one mapping per band, in band order.

--- a/tests/dataset/test_subdatasets_metadata_domains.py
+++ b/tests/dataset/test_subdatasets_metadata_domains.py
@@ -2,7 +2,7 @@
 
 Covers the `SubDataset` value object, `RasterBase.subdatasets` enumeration,
 `Dataset.open_subdataset`, and the domain-aware `get_meta_data` / `set_meta_data`
-/ `metadata_domains` accessors — including that a `NetCDF` container inherits
+/ `meta_data_domains` accessors — including that a `NetCDF` container inherits
 `subdatasets` without losing its own variable surface.
 """
 
@@ -144,6 +144,29 @@ class TestOpenSubdataset:
         with pytest.raises(TypeError, match="int index or a str name"):
             container.open_subdataset(1.5)  # type: ignore[arg-type]
 
+    def test_open_subdataset_carries_access_mode(self, container):
+        """The child is opened in the parent container's access mode."""
+        child = container.open_subdataset(0)
+        assert child.access == container.access, (
+            f"child access {child.access!r} must match parent {container.access!r}"
+        )
+
+    def test_open_subdataset_forwards_open_context(self, container, mocker):
+        """open_subdataset forwards access mode, gdal_env, and open options to read_file."""
+        container._open_options = ("HONOUR_VALID_RANGE=NO",)
+        sentinel = object()
+        patched = mocker.patch.object(Dataset, "read_file", return_value=sentinel)
+        result = container.open_subdataset(0)
+        assert result is sentinel, "open_subdataset must return read_file's result"
+        _, kwargs = patched.call_args
+        assert kwargs["read_only"] == (container.access == "read_only"), (
+            "parent access mode must be forwarded"
+        )
+        assert kwargs["open_options"] == ["HONOUR_VALID_RANGE=NO"], (
+            "parent open options must be forwarded to the child open"
+        )
+        assert "gdal_env" in kwargs, "gdal_env must be forwarded to read_file"
+
 
 class TestNetCDFRegression:
     """A NetCDF container inherits `subdatasets` without losing its own surface."""
@@ -168,17 +191,17 @@ class TestMetadataDomains:
         result = plain.get_meta_data("IMAGE_STRUCTURE")
         assert isinstance(result, dict), f"expected a dict, got {type(result)}"
 
-    def test_metadata_domains_is_list_of_str(self, plain):
-        """`metadata_domains` is a list of domain names (None normalised away)."""
-        domains = plain.metadata_domains
-        assert isinstance(domains, list), "metadata_domains must be a list"
+    def test_meta_data_domains_is_list_of_str(self, plain):
+        """`meta_data_domains` is a list of domain names (None normalised away)."""
+        domains = plain.meta_data_domains
+        assert isinstance(domains, list), "meta_data_domains must be a list"
         assert all(isinstance(d, str) for d in domains), "entries must be str"
 
     def test_set_meta_data_round_trips_a_custom_domain(self, plain):
         """A custom domain can be written and read back, and appears in the list."""
         plain.set_meta_data({"A": "1", "B": "2"}, domain="MYDOMAIN")
         assert plain.get_meta_data("MYDOMAIN") == {"A": "1", "B": "2"}, "round-trip"
-        assert "MYDOMAIN" in plain.metadata_domains, "written domain must be listed"
+        assert "MYDOMAIN" in plain.meta_data_domains, "written domain must be listed"
 
     def test_set_meta_data_replaces_the_domain(self, plain):
         """The setter replaces a domain's metadata rather than merging."""
@@ -202,12 +225,25 @@ class TestMetadataDomains:
         result = plain.get_meta_data("xml:TEST")
         assert result == ["<root>hi</root>"], f"xml domain must be a list, got {result!r}"
 
-    def test_metadata_domains_normalizes_none(self, plain, mocker):
+    def test_set_meta_data_writes_xml_domain_as_list(self, plain):
+        """An xml:* domain round-trips through set_meta_data as a single-element list."""
+        plain.set_meta_data(["<root>v</root>"], domain="xml:FOO")
+        result = plain.get_meta_data("xml:FOO")
+        assert result == ["<root>v</root>"], f"xml domain must round-trip, got {result!r}"
+
+    def test_set_meta_data_empty_dict_empties_keys_but_keeps_domain(self, plain):
+        """Assigning {} empties a domain's keys while the domain name stays listed."""
+        plain.set_meta_data({"A": "1"}, domain="D")
+        plain.set_meta_data({}, domain="D")
+        assert plain.get_meta_data("D") == {}, "an empty dict must empty the domain keys"
+        assert "D" in plain.meta_data_domains, "the emptied domain name is still listed"
+
+    def test_meta_data_domains_normalizes_none(self, plain, mocker):
         """A GDAL handle returning None for the domain list normalises to []."""
         mocker.patch.object(
             plain._raster, "GetMetadataDomainList", return_value=None
         )
-        assert plain.metadata_domains == [], "None must normalise to an empty list"
+        assert plain.meta_data_domains == [], "None must normalise to an empty list"
 
     def test_meta_data_setter_still_merges(self, plain):
         """The existing `meta_data` setter is unchanged (per-key merge)."""

--- a/tests/dataset/test_subdatasets_metadata_domains.py
+++ b/tests/dataset/test_subdatasets_metadata_domains.py
@@ -67,6 +67,12 @@ class TestSubDataset:
         sd = SubDataset("N", "d", 2)
         assert pickle.loads(pickle.dumps(sd)) == sd, "pickle must round-trip"
 
+    def test_exported_from_package(self):
+        """SubDataset is importable from the public pyramids.dataset namespace."""
+        from pyramids.dataset import SubDataset as Exported
+
+        assert Exported is SubDataset, "SubDataset must be re-exported from the package"
+
 
 class TestSubdatasetsProperty:
     """`RasterBase.subdatasets` enumeration."""
@@ -122,6 +128,17 @@ class TestOpenSubdataset:
         assert type(sub) is Dataset, f"expected a base Dataset, got {type(sub)}"
         assert sub.band_count == 1, "the Band1 subdataset has one band"
 
+    def test_bool_index_raises(self, container):
+        """A bool key is rejected, not silently treated as index 0/1."""
+        with pytest.raises(TypeError, match="not bool"):
+            container.open_subdataset(True)
+
+    def test_negative_index_opens_from_end(self, container):
+        """A negative index counts from the end, per Python list semantics."""
+        last = container.open_subdataset(-1)
+        assert type(last) is Dataset, f"expected a base Dataset, got {type(last)}"
+        assert last.band_count == 1, "the last subdataset has one band"
+
 
 class TestNetCDFRegression:
     """A NetCDF container inherits `subdatasets` without losing its own surface."""
@@ -164,11 +181,21 @@ class TestMetadataDomains:
         plain.set_meta_data({"C": "3"}, domain="D")
         assert plain.get_meta_data("D") == {"C": "3"}, "set_meta_data must replace"
 
-    def test_set_meta_data_default_domain_writes_and_refreshes(self, plain):
-        """Writing the default domain updates it and refreshes the CF/EPSG caches."""
-        plain.set_meta_data({"X": "1"})
-        assert plain.get_meta_data() == {"X": "1"}, "default domain must be written"
-        assert plain.epsg == 4326, "CRS must survive the default-domain write"
+    def test_set_meta_data_rejects_default_domain(self, plain):
+        """set_meta_data refuses the default domain (it would drop GDAL-managed keys).
+
+        The default domain holds georeferencing keys (AREA_OR_POINT, CF axis
+        metadata); a whole-domain replace would silently wipe them, so the setter
+        points callers at the merging meta_data setter instead.
+        """
+        with pytest.raises(ValueError, match="named domains only"):
+            plain.set_meta_data({"X": "1"})
+
+    def test_get_meta_data_xml_domain_returns_list(self, plain):
+        """An xml:* domain returns a list of XML strings, mirroring GDAL."""
+        plain._raster.SetMetadata(["<root>hi</root>"], "xml:TEST")
+        result = plain.get_meta_data("xml:TEST")
+        assert result == ["<root>hi</root>"], f"xml domain must be a list, got {result!r}"
 
     def test_metadata_domains_normalizes_none(self, plain, mocker):
         """A GDAL handle returning None for the domain list normalises to []."""

--- a/tests/dataset/test_subdatasets_metadata_domains.py
+++ b/tests/dataset/test_subdatasets_metadata_domains.py
@@ -139,6 +139,11 @@ class TestOpenSubdataset:
         assert type(last) is Dataset, f"expected a base Dataset, got {type(last)}"
         assert last.band_count == 1, "the last subdataset has one band"
 
+    def test_non_int_non_str_key_raises_type_error(self, container):
+        """A key that is neither an int index nor a str name raises TypeError."""
+        with pytest.raises(TypeError, match="int index or a str name"):
+            container.open_subdataset(1.5)  # type: ignore[arg-type]
+
 
 class TestNetCDFRegression:
     """A NetCDF container inherits `subdatasets` without losing its own surface."""

--- a/tests/dataset/test_subdatasets_metadata_domains.py
+++ b/tests/dataset/test_subdatasets_metadata_domains.py
@@ -1,0 +1,184 @@
+"""Subdatasets (#1030) and dataset-level metadata domains (#1028).
+
+Covers the `SubDataset` value object, `RasterBase.subdatasets` enumeration,
+`Dataset.open_subdataset`, and the domain-aware `get_meta_data` / `set_meta_data`
+/ `metadata_domains` accessors — including that a `NetCDF` container inherits
+`subdatasets` without losing its own variable surface.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import pickle
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from pyramids.base._errors import ReadOnlyError
+from pyramids.dataset import Dataset
+from pyramids.dataset._subdataset import SubDataset
+
+pytestmark = pytest.mark.core
+
+# A classic-mode NetCDF whose GDAL handle exposes 4 subdatasets (Band1..Band4).
+NETCDF_CONTAINER = (
+    Path(__file__).parents[1] / "data" / "netcdf" / "cf__6v__1d2-2d4__geog__y-asc.nc"
+)
+
+
+@pytest.fixture
+def plain() -> Dataset:
+    """A 2x3 in-memory raster with no subdatasets."""
+    return Dataset.create_from_array(
+        np.zeros((2, 3), dtype="float32"),
+        top_left_corner=(0, 0),
+        cell_size=1.0,
+        epsg=4326,
+    )
+
+
+@pytest.fixture
+def container():
+    """A NetCDF container opened classic-mode, exposing 4 subdatasets."""
+    from pyramids.netcdf import NetCDF
+
+    return NetCDF.read_file(str(NETCDF_CONTAINER), open_as_multi_dimensional=False)
+
+
+class TestSubDataset:
+    """The `SubDataset` frozen value object."""
+
+    def test_fields_and_equality(self):
+        """It carries name/description/index and compares by value."""
+        sd = SubDataset("NAME", "desc", 0)
+        assert (sd.name, sd.description, sd.index) == ("NAME", "desc", 0)
+        assert sd == SubDataset("NAME", "desc", 0), "value equality expected"
+        assert sd != SubDataset("OTHER", "desc", 0), "differing name must differ"
+
+    def test_is_frozen(self):
+        """It is immutable."""
+        sd = SubDataset("N", "d", 0)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            sd.name = "X"  # type: ignore[misc]
+
+    def test_pickle_round_trip(self):
+        """It survives a pickle round-trip (it is plain data)."""
+        sd = SubDataset("N", "d", 2)
+        assert pickle.loads(pickle.dumps(sd)) == sd, "pickle must round-trip"
+
+
+class TestSubdatasetsProperty:
+    """`RasterBase.subdatasets` enumeration."""
+
+    def test_plain_raster_has_none(self, plain):
+        """A normal raster reports no subdatasets."""
+        assert plain.subdatasets == [], "a plain raster has no subdatasets"
+
+    def test_container_enumerates_in_order(self, container):
+        """A container reports one entry per nested raster, in order."""
+        subs = container.subdatasets
+        assert len(subs) == 4, f"expected 4 subdatasets, got {len(subs)}"
+        assert [s.index for s in subs] == [0, 1, 2, 3], "indices must be 0..n in order"
+        assert all(isinstance(s, SubDataset) for s in subs), "entries are SubDataset"
+        assert subs[0].name.endswith(":Band1"), f"first name unexpected: {subs[0].name}"
+
+
+class TestOpenSubdataset:
+    """`Dataset.open_subdataset` — opens a nested raster as a base Dataset."""
+
+    def test_open_by_index(self, container):
+        """Opening by 0-based index yields a base Dataset with the band."""
+        sub = container.open_subdataset(0)
+        assert type(sub) is Dataset, f"expected a base Dataset, got {type(sub)}"
+        assert sub.band_count == 1, "the Band1 subdataset has one band"
+
+    def test_open_by_name(self, container):
+        """Opening by connection-string name yields the same raster."""
+        name = container.subdatasets[0].name
+        sub = container.open_subdataset(name)
+        assert type(sub) is Dataset, f"expected a base Dataset, got {type(sub)}"
+        assert sub.band_count == 1, "the Band1 subdataset has one band"
+
+    def test_unknown_name_raises(self, container):
+        """An unknown subdataset name raises ValueError."""
+        with pytest.raises(ValueError, match="not a subdataset"):
+            container.open_subdataset('NETCDF:"nope.nc":var')
+
+    def test_out_of_range_index_raises(self, container):
+        """An out-of-range index raises IndexError."""
+        with pytest.raises(IndexError):
+            container.open_subdataset(999)
+
+    def test_opened_subdataset_pickles(self, container):
+        """An opened subdataset round-trips through pickle (its name reopens)."""
+        sub = container.open_subdataset(0)
+        reopened = pickle.loads(pickle.dumps(sub))
+        assert reopened.band_count == 1, "reopened subdataset must have its band"
+
+    def test_value_object_open_returns_base_dataset(self, container):
+        """`SubDataset.open()` opens the nested raster as a base Dataset."""
+        sub = container.subdatasets[0].open()
+        assert type(sub) is Dataset, f"expected a base Dataset, got {type(sub)}"
+        assert sub.band_count == 1, "the Band1 subdataset has one band"
+
+
+class TestNetCDFRegression:
+    """A NetCDF container inherits `subdatasets` without losing its own surface."""
+
+    def test_inherits_subdatasets_and_keeps_variable_surface(self, container):
+        """`subdatasets` works on a NetCDF and `variable_names` still works."""
+        assert len(container.subdatasets) == 4, "NetCDF must inherit subdatasets"
+        assert container.variable_names[:3] == ["Band1", "Band2", "Band3"], (
+            "the NetCDF variable surface must be unaffected"
+        )
+
+
+class TestMetadataDomains:
+    """Dataset-level metadata domains (#1028)."""
+
+    def test_default_domain_matches_meta_data(self, plain):
+        """`get_meta_data()` equals `meta_data` on a plain Dataset."""
+        assert plain.get_meta_data() == plain.meta_data, "default domain must match"
+
+    def test_read_named_domain(self, plain):
+        """A named domain reads as a dict (empty if absent)."""
+        result = plain.get_meta_data("IMAGE_STRUCTURE")
+        assert isinstance(result, dict), f"expected a dict, got {type(result)}"
+
+    def test_metadata_domains_is_list_of_str(self, plain):
+        """`metadata_domains` is a list of domain names (None normalised away)."""
+        domains = plain.metadata_domains
+        assert isinstance(domains, list), "metadata_domains must be a list"
+        assert all(isinstance(d, str) for d in domains), "entries must be str"
+
+    def test_set_meta_data_round_trips_a_custom_domain(self, plain):
+        """A custom domain can be written and read back, and appears in the list."""
+        plain.set_meta_data({"A": "1", "B": "2"}, domain="MYDOMAIN")
+        assert plain.get_meta_data("MYDOMAIN") == {"A": "1", "B": "2"}, "round-trip"
+        assert "MYDOMAIN" in plain.metadata_domains, "written domain must be listed"
+
+    def test_set_meta_data_replaces_the_domain(self, plain):
+        """The setter replaces a domain's metadata rather than merging."""
+        plain.set_meta_data({"A": "1", "B": "2"}, domain="D")
+        plain.set_meta_data({"C": "3"}, domain="D")
+        assert plain.get_meta_data("D") == {"C": "3"}, "set_meta_data must replace"
+
+    def test_meta_data_setter_still_merges(self, plain):
+        """The existing `meta_data` setter is unchanged (per-key merge)."""
+        plain.meta_data = {"A": "1"}
+        plain.meta_data = {"B": "2"}
+        assert plain.get_meta_data() == {"A": "1", "B": "2"}, "meta_data still merges"
+
+    def test_set_meta_data_read_only_raises(self, tmp_path):
+        """Writing metadata on a read-only on-disk dataset raises ReadOnlyError."""
+        path = tmp_path / "m.tif"
+        Dataset.create_from_array(
+            np.zeros((2, 2), dtype="float32"),
+            top_left_corner=(0, 0),
+            cell_size=1.0,
+            epsg=4326,
+        ).to_file(str(path))
+        ds = Dataset.read_file(str(path), read_only=True)
+        with pytest.raises(ReadOnlyError, match="read-only"):
+            ds.set_meta_data({"A": "1"}, domain="D")

--- a/tests/dataset/test_subdatasets_metadata_domains.py
+++ b/tests/dataset/test_subdatasets_metadata_domains.py
@@ -164,6 +164,19 @@ class TestMetadataDomains:
         plain.set_meta_data({"C": "3"}, domain="D")
         assert plain.get_meta_data("D") == {"C": "3"}, "set_meta_data must replace"
 
+    def test_set_meta_data_default_domain_writes_and_refreshes(self, plain):
+        """Writing the default domain updates it and refreshes the CF/EPSG caches."""
+        plain.set_meta_data({"X": "1"})
+        assert plain.get_meta_data() == {"X": "1"}, "default domain must be written"
+        assert plain.epsg == 4326, "CRS must survive the default-domain write"
+
+    def test_metadata_domains_normalizes_none(self, plain, mocker):
+        """A GDAL handle returning None for the domain list normalises to []."""
+        mocker.patch.object(
+            plain._raster, "GetMetadataDomainList", return_value=None
+        )
+        assert plain.metadata_domains == [], "None must normalise to an empty list"
+
     def test_meta_data_setter_still_merges(self, plain):
         """The existing `meta_data` setter is unchanged (per-key merge)."""
         plain.meta_data = {"A": "1"}

--- a/tests/dataset/test_subdatasets_metadata_domains.py
+++ b/tests/dataset/test_subdatasets_metadata_domains.py
@@ -223,26 +223,30 @@ class TestMetadataDomains:
         """An xml:* domain returns a list of XML strings, mirroring GDAL."""
         plain._raster.SetMetadata(["<root>hi</root>"], "xml:TEST")
         result = plain.get_meta_data("xml:TEST")
-        assert result == ["<root>hi</root>"], f"xml domain must be a list, got {result!r}"
+        assert result == ["<root>hi</root>"], (
+            f"xml domain must be a list, got {result!r}"
+        )
 
     def test_set_meta_data_writes_xml_domain_as_list(self, plain):
         """An xml:* domain round-trips through set_meta_data as a single-element list."""
         plain.set_meta_data(["<root>v</root>"], domain="xml:FOO")
         result = plain.get_meta_data("xml:FOO")
-        assert result == ["<root>v</root>"], f"xml domain must round-trip, got {result!r}"
+        assert result == ["<root>v</root>"], (
+            f"xml domain must round-trip, got {result!r}"
+        )
 
     def test_set_meta_data_empty_dict_empties_keys_but_keeps_domain(self, plain):
         """Assigning {} empties a domain's keys while the domain name stays listed."""
         plain.set_meta_data({"A": "1"}, domain="D")
         plain.set_meta_data({}, domain="D")
-        assert plain.get_meta_data("D") == {}, "an empty dict must empty the domain keys"
+        assert plain.get_meta_data("D") == {}, (
+            "an empty dict must empty the domain keys"
+        )
         assert "D" in plain.meta_data_domains, "the emptied domain name is still listed"
 
     def test_meta_data_domains_normalizes_none(self, plain, mocker):
         """A GDAL handle returning None for the domain list normalises to []."""
-        mocker.patch.object(
-            plain._raster, "GetMetadataDomainList", return_value=None
-        )
+        mocker.patch.object(plain._raster, "GetMetadataDomainList", return_value=None)
         assert plain.meta_data_domains == [], "None must normalise to an empty list"
 
     def test_meta_data_setter_still_merges(self, plain):


### PR DESCRIPTION
# Description

Two related gaps, both from the pyramids-eo container-reader work, implemented together on the shared
metadata/subdataset surface:

- **#1030 — subdatasets.** A *container* raster (NetCDF/HDF/Zarr, Sentinel-1/-2, WMS) has no pixels of its own; its
  payload is a set of nested rasters GDAL calls subdatasets. There was no way to enumerate or open them through the
  public API — a container opened as a silently 0-band `Dataset`, and the `SUBDATASETS` domain was parsed in two
  private, incompatible places (`_wms.py`, `netcdf.py`).
- **#1028 — metadata domains.** GDAL organises metadata into domains; `meta_data` only ever read/wrote the default
  one, so everything under a named domain (`IMAGE_STRUCTURE`, `RPC`, `xml:*`, …) was invisible.

Designed via `/gis-feature-request` (`planning/subdatasets-1030-1028-design.md`): a **frozen `SubDataset` value
object** plus **plain accessors on `RasterBase`/`Dataset`** — deliberately **no new engine**, so `_COLLABORATOR_ATTRS`,
`_Engine.__slots__`, `_update_inplace`, and pickling are all untouched.

## What changed

- **`SubDataset`** (`dataset/_subdataset.py`) — frozen value object: `name` (openable connection string),
  `description` (raw; driver-specific), `index`, and `open() -> Dataset`.
- **`RasterBase.subdatasets -> list[SubDataset]`** (empty for a plain raster) — on the base, so `NetCDF` inherits it.
- **`RasterBase.metadata_domains -> list[str]`** (`GetMetadataDomainList`, `None` normalised to `[]`).
- **`RasterBase.get_meta_data(domain="") -> dict[str, str]`** — domain-aware read; default domain matches `meta_data`.
- **`Dataset.open_subdataset(index|name) -> Dataset`** — resolves against `subdatasets` and reopens the nested raster
  as a **base `Dataset`**, carrying this dataset's access mode / GDAL env / open options.
- **`Dataset.set_meta_data(value, domain="") -> None`** — replaces a domain (`SetMetadata`), guarded by
  `_require_writable`, consistent with the band-level `Bands.set_metadata` (#1038). The existing `meta_data`
  getter/setter (per-key merge) are unchanged.

### Design correction found during implementation

The design's first plan — preserve the container's class via `type(self).read_file(name)` — proved unworkable for
`NetCDF`: `NetCDF.read_file` has no `gdal_env` kwarg **and** defaults to multidim mode, which cannot open a *classic*
subdataset connection string (`NETCDF:"…":Band1`). Resolution: `open_subdataset` returns a **base `Dataset`** (a
subdataset string is a classic-mode raster reference); `NetCDF.get_variable`/`variables` remain the multidim,
class-preserving path for a NetCDF's variables. Documented in the design doc's R1-UPDATE.

```python
ds = Dataset.read_file(".../MTD_MSIL2A.xml")   # a container
ds.subdatasets                                  # [SubDataset(name=..., index=0), ...]
ds.open_subdataset(0)                           # the first nested raster, as a Dataset
ds.get_meta_data("IMAGE_STRUCTURE")             # {'COMPRESSION': ...}
ds.set_meta_data({"K": "v"}, domain="MYDOMAIN")
ds.metadata_domains                             # ['', 'SUBDATASETS', ...]
```

# Issues

- Closes #1030 — enumerate and open subdatasets (`Dataset.subdatasets` / `open_subdataset`)
- Closes #1028 — read and write non-default GDAL metadata domains

Follow-ons (separate, per the design's Phase B): #1030 PB-1 0-band container warning, PB-2 reimplement `ds.rpcs` over
the generic accessor, PB-3 `_wms.py` consumes `subdatasets`, PB-4 (deferred) NetCDF `variable_names` over
`subdatasets`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- New `tests/dataset/test_subdatasets_metadata_domains.py` (19 tests): `SubDataset` value object
  (fields/equality/frozen/pickle); enumeration (plain raster → `[]`; a classic-mode NetCDF container → ordered
  entries); `open_subdataset` by index & name, unknown-name/OOB errors, opened-subdataset pickle round-trip,
  `SubDataset.open()`; a **NetCDF-inherits-subdatasets regression** (variable surface intact); and metadata domains
  (default matches `meta_data`, named read, custom-domain round-trip + listing, replace-not-merge, `meta_data` setter
  still merges, read-only → `ReadOnlyError`).
- Doctests on the new accessors pass; `mypy` clean on the changed files.
- Full non-plot suite green (**8704 passed**).

# Checklist:

- [ ] updated version number in pyproject.toml. — N/A (commitizen/CI handles versions).
- [ ] added changes to History.rst. — N/A (changelog is generated).
- [ ] updated the latest version in README file. — N/A.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. — Google-style docstrings + doctests on all new accessors.
