### PR TITLE
feat(dataset): scaled reads, band subsetting, geolocation warp, accessor hook (#1031, #1032, #1033, #1034)

### DIFF
--- a/src/pyramids/__init__.py
+++ b/src/pyramids/__init__.py
@@ -33,10 +33,13 @@ Config()
 # stays light — that heavy stack is only pulled in when these symbols are first
 # accessed, not at package import time.
 _LAZY_RESOURCE_EXPORTS = frozenset({"read_resource", "sniff_kind", "ResourceKind"})
+# `register_dataset_accessor` lives in the heavy Dataset stack; expose it lazily too
+# so a bare `import pyramids` does not pull that stack in just to reach the hook.
+_LAZY_DATASET_EXPORTS = frozenset({"register_dataset_accessor"})
 
 
 def __getattr__(name: str):
-    """Lazily import the resource-reader exports on first access (PEP 562)."""
+    """Lazily import the resource-reader / accessor exports on first access (PEP 562)."""
     if name in _LAZY_RESOURCE_EXPORTS:
         from pyramids._resource import ResourceKind, read_resource, sniff_kind
 
@@ -46,18 +49,24 @@ def __getattr__(name: str):
             ResourceKind=ResourceKind,
         )
         return globals()[name]
+    if name in _LAZY_DATASET_EXPORTS:
+        from pyramids.dataset import register_dataset_accessor
+
+        globals()["register_dataset_accessor"] = register_dataset_accessor
+        return globals()[name]
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def __dir__() -> list[str]:
     """Include the lazily-exported names in ``dir(pyramids)``."""
-    return sorted(set(globals()) | _LAZY_RESOURCE_EXPORTS)
+    return sorted(set(globals()) | _LAZY_RESOURCE_EXPORTS | _LAZY_DATASET_EXPORTS)
 
 
 __all__ = [
     "configure",
     "configure_lazy_vector",
     "read_resource",
+    "register_dataset_accessor",
     "sniff_kind",
     "ResourceKind",
     "__version__",

--- a/src/pyramids/base/_errors.py
+++ b/src/pyramids/base/_errors.py
@@ -61,6 +61,16 @@ class OutOfBoundsError(_PyramidsError):
     """Out-of-bounds error."""
 
 
+class GeolocationArrayError(_PyramidsError, ValueError):
+    """The dataset cannot be warped from geolocation arrays.
+
+    Raised by `Dataset.geolocate` / `Dataset.geolocation` when the dataset has no
+    GDAL ``GEOLOCATION`` metadata domain, or the domain is missing the required
+    ``X_DATASET`` / ``Y_DATASET`` coordinate arrays. Subclasses `ValueError` so an
+    ``except ValueError`` still catches it.
+    """
+
+
 class OverviewTargetError(_PyramidsError, ValueError):
     """The dataset cannot hold the overview levels the call was asked to write.
 

--- a/src/pyramids/base/_utils.py
+++ b/src/pyramids/base/_utils.py
@@ -967,3 +967,54 @@ def ogr_ds_to_gdal_dataset(ogr_ds: ogr.DataSource) -> gdal.Dataset:
             gdal_layer.CreateFeature(gdal_feature)
 
     return gdal_ds
+
+
+def apply_unpack(
+    arr: Any,
+    scale: float | np.ndarray | None,
+    offset: float | np.ndarray | None,
+) -> Any:
+    """Apply a scale/offset unpacking transform to a lazy or eager array.
+
+    Computes ``arr * scale + offset`` as `float64`, the single shared primitive
+    behind both the NetCDF CF `scale_factor`/`add_offset` path and the raster
+    :meth:`~pyramids.dataset.engines.IO.read_array` ``scaled=True`` path. When
+    both ``scale`` and ``offset`` are `None` the array is returned unchanged (no
+    float promotion), so an unset band is a genuine no-op. ``scale``/``offset``
+    may be scalars or a broadcastable `numpy` array (e.g. a per-band
+    ``(bands, 1, 1)`` factor); a `dask` array input keeps the arithmetic lazy.
+
+    Args:
+        arr: The raw array (dask or numpy, possibly a masked array).
+        scale: Multiplicative factor, or `None` to skip scaling.
+        offset: Additive offset, or `None` to skip offsetting.
+
+    Returns:
+        The (possibly transformed) array, cast to `float64` when a
+        transformation was applied.
+
+    Examples:
+        - A band with neither scale nor offset is returned unchanged:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.base._utils import apply_unpack
+            >>> apply_unpack(np.array([0, 1, 2]), None, None)
+            array([0, 1, 2])
+
+            ```
+        - Scale and offset are applied as float64:
+            ```python
+            >>> apply_unpack(np.array([0, 1, 2]), 0.1, 5.0)
+            array([5. , 5.1, 5.2])
+
+            ```
+    """
+    if scale is None and offset is None:
+        result = arr
+    else:
+        result = arr.astype(np.float64)
+        if scale is not None:
+            result = result * scale
+        if offset is not None:
+            result = result + offset
+    return result

--- a/src/pyramids/dataset/__init__.py
+++ b/src/pyramids/dataset/__init__.py
@@ -5,7 +5,11 @@ from pyramids.dataset._gcp import GroundControlPoint
 from pyramids.dataset._subdataset import SubDataset
 from pyramids.dataset.abstract_dataset import DEFAULT_NO_DATA_VALUE
 from pyramids.dataset.collection import DatasetCollection
-from pyramids.dataset.dataset import Dataset, NoDataSentinelWarning
+from pyramids.dataset.dataset import (
+    Dataset,
+    NoDataSentinelWarning,
+    register_dataset_accessor,
+)
 from pyramids.dataset.grid import Grid
 from pyramids.dataset.transform import GeoTransform
 from pyramids.dataset.window import Window
@@ -19,6 +23,7 @@ __all__ = [
     "GroundControlPoint",
     "NoDataSentinelWarning",
     "RasterMeta",
+    "register_dataset_accessor",
     "SubDataset",
     "Window",
 ]

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -142,6 +142,34 @@ def _invalidate_cached_accessors(ds: Any) -> None:
         ds.__dict__.pop(name, None)
 
 
+def _accessor_name_conflict(name: str) -> bool:
+    """Whether ``name`` would shadow an existing Dataset (or subclass) attribute.
+
+    Rejects a name that is a reserved engine name (engines are *instance*
+    attributes set in ``__init__``, so they are invisible to ``hasattr``), or that
+    already exists as a class-level attribute/method/property on `Dataset` **or any
+    of its imported subclasses**. The subclass walk is what catches names defined
+    only on `NetCDF` / `Variable` / `Container` (for example ``variable_names`` or
+    ``get_variable``) once ``pyramids.netcdf`` has been imported — checking only
+    `Dataset` would let such a name register and then shadow-split across the class
+    hierarchy.
+    """
+    conflict = name in _RESERVED_ACCESSOR_NAMES
+    if not conflict:
+        classes = [Dataset]
+        seen: set[type] = set()
+        while classes:
+            cls = classes.pop()
+            if cls in seen:
+                continue
+            seen.add(cls)
+            if hasattr(cls, name):
+                conflict = True
+                break
+            classes.extend(cls.__subclasses__())
+    return conflict
+
+
 def register_dataset_accessor(name: str) -> Callable[[type], type]:
     """Register a custom accessor on `Dataset` (and, by inheritance, `NetCDF`).
 
@@ -200,10 +228,10 @@ def register_dataset_accessor(name: str) -> Callable[[type], type]:
                 UserWarning,
                 stacklevel=2,
             )
-        elif name in _RESERVED_ACCESSOR_NAMES or hasattr(Dataset, name):
+        elif _accessor_name_conflict(name):
             raise ValueError(
                 f"cannot register accessor {name!r}: it shadows an existing Dataset "
-                f"attribute, method, or engine."
+                f"(or NetCDF) attribute, method, or engine."
             )
         setattr(Dataset, name, _CachedAccessor(name, accessor_cls))
         _ACCESSOR_REGISTRY[name] = accessor_cls

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -1251,7 +1251,7 @@ class Dataset(RasterBase):
         """Facade — :meth:`Georef.geolocate <pyramids.dataset.engines.Georef.geolocate>`."""
         return self.georef.geolocate(*args, **kwargs)
 
-    def _geolocation_source(self) -> "Dataset":
+    def _geolocation_source(self) -> Dataset:
         """The Dataset whose GDAL handle carries the ``GEOLOCATION`` domain.
 
         A base raster carries its geolocation arrays on its own handle, so the

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -207,6 +207,7 @@ def register_dataset_accessor(name: str):
 
     return decorator
 
+
 # Sentinel for `Dataset.from_band_files(no_data_value=...)` so the helper can
 # tell "caller didn't pass one — inherit from the source rasters" apart from
 # "caller explicitly passed `None`" (which means "stamp no no-data sentinel").

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 import warnings
 import weakref
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from numbers import Number
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Unpack, cast
@@ -91,12 +91,16 @@ _COLLABORATOR_ATTRS = (
 
 # Registry of third-party accessors registered via `register_dataset_accessor`
 # (name -> accessor class), plus the set of names a registration must not shadow.
-# `_RESERVED_ACCESSOR_NAMES` is seeded from the built-in engines; `pyramids.netcdf`
-# adds its own engine names (`_NETCDF_COLLABORATOR_ATTRS`) at import time. Engines
-# are *instance* attributes (set in `__init__`), so they are invisible to
+# `_RESERVED_ACCESSOR_NAMES` is seeded from the built-in engines. Engines are
+# *instance* attributes (set in `__init__`), so they are invisible to
 # `hasattr(Dataset, name)` — the reserved set is how a name clash with them is caught.
+# The NetCDF-specific engine names are seeded here too so they are reserved even
+# before `pyramids.netcdf` is imported (that module's circular-import carveout means
+# importing `pyramids.dataset` alone does not pull it in); `pyramids.netcdf` re-adds
+# them on import (idempotent), which also covers any names added there in future.
 _ACCESSOR_REGISTRY: dict[str, type] = {}
 _RESERVED_ACCESSOR_NAMES: set[str] = set(_COLLABORATOR_ATTRS)
+_RESERVED_ACCESSOR_NAMES.update({"interop", "varops", "selection"})
 
 
 class _CachedAccessor:
@@ -138,7 +142,7 @@ def _invalidate_cached_accessors(ds: Any) -> None:
         ds.__dict__.pop(name, None)
 
 
-def register_dataset_accessor(name: str):
+def register_dataset_accessor(name: str) -> Callable[[type], type]:
     """Register a custom accessor on `Dataset` (and, by inheritance, `NetCDF`).
 
     An xarray/pandas-style extension hook: a third-party package attaches a custom

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -89,6 +89,124 @@ _COLLABORATOR_ATTRS = (
     "georef",
 )
 
+# Registry of third-party accessors registered via `register_dataset_accessor`
+# (name -> accessor class), plus the set of names a registration must not shadow.
+# `_RESERVED_ACCESSOR_NAMES` is seeded from the built-in engines; `pyramids.netcdf`
+# adds its own engine names (`_NETCDF_COLLABORATOR_ATTRS`) at import time. Engines
+# are *instance* attributes (set in `__init__`), so they are invisible to
+# `hasattr(Dataset, name)` — the reserved set is how a name clash with them is caught.
+_ACCESSOR_REGISTRY: dict[str, type] = {}
+_RESERVED_ACCESSOR_NAMES: set[str] = set(_COLLABORATOR_ATTRS)
+
+
+class _CachedAccessor:
+    """Descriptor that lazily builds and caches a registered Dataset accessor.
+
+    Mirrors the pandas/xarray ``CachedAccessor``: a non-data descriptor (``__get__``
+    only) so that once the accessor is cached in the instance ``__dict__`` every
+    later lookup is a plain dict hit that never re-enters the descriptor. The
+    accessor receives a :func:`weakref.proxy` of the owning Dataset (matching the
+    engine layer's weak back-reference discipline) so the Dataset ↔ accessor graph
+    stays acyclic and GDAL handles are released promptly.
+    """
+
+    def __init__(self, name: str, accessor_cls: type) -> None:
+        self._name = name
+        self._accessor_cls = accessor_cls
+
+    def __get__(self, obj: Any, cls: type | None = None) -> Any:
+        if obj is None:
+            # Class access (e.g. `hasattr(Dataset, name)`) yields the accessor class.
+            result = self._accessor_cls
+        else:
+            result = self._accessor_cls(weakref.proxy(obj))
+            # Cache in the instance dict; being a non-data descriptor, the cached
+            # value shadows this descriptor on every subsequent access.
+            object.__setattr__(obj, self._name, result)
+        return result
+
+
+def _invalidate_cached_accessors(ds: Any) -> None:
+    """Drop any cached registered accessors so they rebuild against the live raster.
+
+    Called from ``_update_inplace`` (on both `Dataset` and `NetCDF`) after the
+    ``__dict__.update`` swap: the merge would otherwise keep an accessor built
+    against the *old* raster (the same stale-cache hazard handled for
+    ``_cf_crs_cache``).
+    """
+    for name in _ACCESSOR_REGISTRY:
+        ds.__dict__.pop(name, None)
+
+
+def register_dataset_accessor(name: str):
+    """Register a custom accessor on `Dataset` (and, by inheritance, `NetCDF`).
+
+    An xarray/pandas-style extension hook: a third-party package attaches a custom
+    namespace to every `Dataset` without subclassing or editing the built-in engine
+    set. The decorated class is instantiated lazily on first access as
+    ``accessor_cls(ds)`` — where ``ds`` is a transparent weak proxy of the Dataset —
+    and cached on the instance, so repeated access returns the same object. Because
+    registration is on the base `Dataset`, the accessor is available on `NetCDF`
+    and its `Variable`/`Container` subclasses too.
+
+    Your ``__init__(self, ds)`` receives a weak proxy: read through it (for example
+    ``self._ds.read_array()``); do not persist a strong reference to it.
+
+    Args:
+        name: The attribute name to expose on `Dataset`. It must not shadow an
+            existing attribute, method, property, or engine name.
+
+    Returns:
+        A class decorator that registers ``accessor_cls`` and returns it unchanged.
+
+    Raises:
+        ValueError: ``name`` shadows an existing Dataset attribute, method, or
+            engine (a name already registered is instead overwritten with a
+            `UserWarning`, matching pandas/xarray).
+
+    Examples:
+        - Register a custom accessor and use it on any Dataset:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.dataset import Dataset, register_dataset_accessor
+            >>> @register_dataset_accessor("summary")
+            ... class Summary:
+            ...     def __init__(self, ds):
+            ...         self._ds = ds
+            ...     def describe(self):
+            ...         return f"{self._ds.band_count}-band EPSG:{self._ds.epsg}"
+            >>> ds = Dataset.create_from_array(
+            ...     np.zeros((2, 3)), top_left_corner=(0, 0), cell_size=1.0, epsg=4326
+            ... )
+            >>> ds.summary.describe()
+            '1-band EPSG:4326'
+            >>> ds.summary is ds.summary  # built once, then cached per Dataset
+            True
+            >>> from pyramids.dataset.dataset import _ACCESSOR_REGISTRY
+            >>> delattr(Dataset, "summary"); _ = _ACCESSOR_REGISTRY.pop("summary")
+
+            ```
+    """
+
+    def decorator(accessor_cls: type) -> type:
+        if name in _ACCESSOR_REGISTRY:
+            warnings.warn(
+                f"registration of accessor {accessor_cls!r} under name {name!r} is "
+                f"overriding a preexisting accessor with the same name.",
+                UserWarning,
+                stacklevel=2,
+            )
+        elif name in _RESERVED_ACCESSOR_NAMES or hasattr(Dataset, name):
+            raise ValueError(
+                f"cannot register accessor {name!r}: it shadows an existing Dataset "
+                f"attribute, method, or engine."
+            )
+        setattr(Dataset, name, _CachedAccessor(name, accessor_cls))
+        _ACCESSOR_REGISTRY[name] = accessor_cls
+        return accessor_cls
+
+    return decorator
+
 # Sentinel for `Dataset.from_band_files(no_data_value=...)` so the helper can
 # tell "caller didn't pass one — inherit from the source rasters" apart from
 # "caller explicitly passed `None`" (which means "stamp no no-data sentinel").
@@ -435,6 +553,9 @@ class Dataset(RasterBase):
             collab = self.__dict__.get(attr)
             if collab is not None:
                 collab._ds = self_proxy
+        # Drop cached registered accessors so they rebuild against the new raster
+        # (the `__dict__.update` above would otherwise keep a stale one).
+        _invalidate_cached_accessors(self)
 
     def focal_mean(
         self, radius: int = 1, *, chunks=None, band: int = 0
@@ -1116,6 +1237,29 @@ class Dataset(RasterBase):
         """Facade — :meth:`Georef.orthorectify <pyramids.dataset.engines.Georef.orthorectify>`."""
         return self.georef.orthorectify(*args, **kwargs)
 
+    @property
+    def geolocation(self):
+        """Facade — :attr:`Georef.geolocation <pyramids.dataset.engines.Georef.geolocation>`."""
+        return self.georef.geolocation
+
+    @property
+    def has_geolocation(self):
+        """Facade — :attr:`Georef.has_geolocation <pyramids.dataset.engines.Georef.has_geolocation>`."""
+        return self.georef.has_geolocation
+
+    def geolocate(self, *args, **kwargs):
+        """Facade — :meth:`Georef.geolocate <pyramids.dataset.engines.Georef.geolocate>`."""
+        return self.georef.geolocate(*args, **kwargs)
+
+    def _geolocation_source(self) -> "Dataset":
+        """The Dataset whose GDAL handle carries the ``GEOLOCATION`` domain.
+
+        A base raster carries its geolocation arrays on its own handle, so the
+        default is ``self``. ``NetCDF`` overrides this to reopen the classic GDAL
+        handle, on which the domain is exposed (the multidimensional view drops it).
+        """
+        return self
+
     def warped_view(self, *args, **kwargs):
         """Facade — delegates to :meth:`Spatial.warped_view <pyramids.dataset.engines.Spatial.warped_view>`."""
         return self.spatial.warped_view(*args, **kwargs)
@@ -1240,6 +1384,10 @@ class Dataset(RasterBase):
     def get_band_by_color(self, *args, **kwargs):
         """Facade — delegates to :meth:`Bands.get_band_by_color <pyramids.dataset.engines.Bands.get_band_by_color>`."""
         return self.bands.get_band_by_color(*args, **kwargs)
+
+    def select_bands(self, *args, **kwargs):
+        """Facade — delegates to :meth:`Bands.select <pyramids.dataset.engines.Bands.select>`."""
+        return self.bands.select(*args, **kwargs)
 
     def change_no_data_value(self, *args, **kwargs):
         """Facade — concrete override of the abstract :meth:`RasterBase.change_no_data_value`.

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -156,13 +156,12 @@ def _accessor_name_conflict(name: str) -> bool:
     """
     conflict = name in _RESERVED_ACCESSOR_NAMES
     if not conflict:
+        # Walk Dataset's subclass DAG (Dataset -> NetCDF -> Variable/Container, plus any
+        # third-party subclass). `__subclasses__()` only yields more-derived classes, so
+        # the walk always terminates without needing a visited set.
         classes = [Dataset]
-        seen: set[type] = set()
         while classes:
             cls = classes.pop()
-            if cls in seen:
-                continue
-            seen.add(cls)
             if hasattr(cls, name):
                 conflict = True
                 break

--- a/src/pyramids/dataset/engines/_read_request.py
+++ b/src/pyramids/dataset/engines/_read_request.py
@@ -36,6 +36,8 @@ class ReadRequest:
         boundless: Whether to pad reads that extend past the raster edge.
         fill_value: Pad value for boundless reads.
         masked: Whether to wrap the result as a masked array.
+        scaled: Whether to apply each band's GDAL scale/offset (``raw*scale +
+            offset``) to the read result.
         threadsafe: Whether to read through a private per-thread handle.
 
     Examples:
@@ -45,7 +47,7 @@ class ReadRequest:
             >>> req = ReadRequest(
             ...     band=0, chunks=None, lock=None, out_shape=None,
             ...     resampling="nearest", boundless=False, fill_value=None,
-            ...     masked=False, threadsafe=False,
+            ...     masked=False, scaled=False, threadsafe=False,
             ... )
             >>> req.band
             0
@@ -58,7 +60,7 @@ class ReadRequest:
             >>> ReadRequest(
             ...     band=0, chunks=None, lock=None, out_shape=None,
             ...     resampling="nearest", boundless=False, fill_value=5.0,
-            ...     masked=False, threadsafe=False,
+            ...     masked=False, scaled=False, threadsafe=False,
             ... )
             Traceback (most recent call last):
             ValueError: read_array(fill_value=...) only applies to boundless reads; pass boundless=True as well.
@@ -74,6 +76,7 @@ class ReadRequest:
     boundless: bool
     fill_value: float | None
     masked: bool
+    scaled: bool
     threadsafe: bool
 
     def __post_init__(self) -> None:

--- a/src/pyramids/dataset/engines/_read_request.py
+++ b/src/pyramids/dataset/engines/_read_request.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 from typing import Any
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class ReadRequest:
     """A validated bundle of ``read_array`` options plus the resolved read target.
 
@@ -36,8 +36,8 @@ class ReadRequest:
         boundless: Whether to pad reads that extend past the raster edge.
         fill_value: Pad value for boundless reads.
         masked: Whether to wrap the result as a masked array.
-        scaled: Whether to apply each band's GDAL scale/offset (``raw*scale +
-            offset``) to the read result.
+        scaled: Whether to apply each band's GDAL scale/offset
+            (``raw * scale + offset``) to the read result.
         threadsafe: Whether to read through a private per-thread handle.
 
     Examples:

--- a/src/pyramids/dataset/engines/_read_strategies.py
+++ b/src/pyramids/dataset/engines/_read_strategies.py
@@ -47,7 +47,7 @@ class ReadStrategy(ABC):
             >>> req = ReadRequest(
             ...     band=0, chunks=4, lock=None, out_shape=None,
             ...     resampling="nearest", boundless=False, fill_value=None,
-            ...     masked=False, threadsafe=False,
+            ...     masked=False, scaled=False, threadsafe=False,
             ... )
             >>> next(s for s in READ_STRATEGIES if s.matches(req)).backend
             'dask'
@@ -60,7 +60,7 @@ class ReadStrategy(ABC):
             >>> req = ReadRequest(
             ...     band=0, chunks=None, lock=None, out_shape=None,
             ...     resampling="nearest", boundless=False, fill_value=None,
-            ...     masked=False, threadsafe=False,
+            ...     masked=False, scaled=False, threadsafe=False,
             ... )
             >>> next(s for s in READ_STRATEGIES if s.matches(req)).backend
             'numpy'

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -547,7 +547,7 @@ class Bands(_Engine["Dataset"]):
             indices.append(one_based)
         return indices
 
-    def select(self, bands: Sequence[int | str], *, lazy: bool = False) -> "Dataset":
+    def select(self, bands: Sequence[int | str], *, lazy: bool = False) -> Dataset:
         """Return a new Dataset with a subset of bands, in the requested order.
 
         Copies the chosen bands (via GDAL ``Translate`` with a ``bandList``) into a

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -7,6 +7,7 @@ Owns the Bands family of operations on a Dataset. Accessed as
 
 from __future__ import annotations
 
+import numbers
 import warnings
 from collections.abc import Iterable
 from pathlib import Path
@@ -531,7 +532,10 @@ class Bands(_Engine["Dataset"]):
                 raise TypeError(
                     f"band selector must be an int or str, not bool: {selector!r}"
                 )
-            if isinstance(selector, int):
+            if isinstance(selector, numbers.Integral):
+                # numbers.Integral admits numpy ints too (bool is rejected above);
+                # normalize to a plain int for GDAL's bandList.
+                selector = int(selector)
                 if not 1 <= selector <= count:
                     raise ValueError(
                         f"band index {selector} is out of range for a {count}-band "

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -526,35 +526,47 @@ class Bands(_Engine["Dataset"]):
                 "extract a variable first (e.g. with get_variable)."
             )
         names = self._ds.band_names
-        indices: list[int] = []
-        for selector in bands:
-            if isinstance(selector, bool):
-                raise TypeError(
-                    f"band selector must be an int or str, not bool: {selector!r}"
-                )
-            if isinstance(selector, numbers.Integral):
-                # numbers.Integral admits numpy ints too (bool is rejected above);
-                # normalize to a plain int for GDAL's bandList.
-                selector = int(selector)
-                if not 1 <= selector <= count:
-                    raise ValueError(
-                        f"band index {selector} is out of range for a {count}-band "
-                        f"dataset (valid 1..{count})."
-                    )
-                one_based = selector
-            elif isinstance(selector, str):
-                if selector not in names:
-                    raise ValueError(
-                        f"{selector!r} is not a band name; available: {names}"
-                    )
-                one_based = names.index(selector) + 1
-            else:
-                raise TypeError(
-                    "band selector must be an int index or str name, got "
-                    f"{type(selector).__name__}"
-                )
-            indices.append(one_based)
+        indices = [self._resolve_one_selector(sel, count, names) for sel in bands]
         return indices
+
+    def _resolve_one_selector(self, selector: Any, count: int, names: list[str]) -> int:
+        """Resolve a single band selector to a validated 1-based GDAL index.
+
+        Args:
+            selector: A 1-based ``int`` index (numpy ints accepted) or a band-name
+                ``str`` matched against ``names``.
+            count: The dataset's band count, for range validation.
+            names: The dataset's band names, for name resolution.
+
+        Returns:
+            The 1-based GDAL band index for ``selector``.
+
+        Raises:
+            TypeError: ``selector`` is a ``bool`` or an unsupported type.
+            ValueError: an index is out of range, or a name is not among ``names``.
+        """
+        if isinstance(selector, bool):
+            raise TypeError(
+                f"band selector must be an int or str, not bool: {selector!r}"
+            )
+        if isinstance(selector, numbers.Integral):
+            # numbers.Integral admits numpy ints too; normalize to a plain int.
+            one_based = int(selector)
+            if not 1 <= one_based <= count:
+                raise ValueError(
+                    f"band index {one_based} is out of range for a {count}-band "
+                    f"dataset (valid 1..{count})."
+                )
+        elif isinstance(selector, str):
+            if selector not in names:
+                raise ValueError(f"{selector!r} is not a band name; available: {names}")
+            one_based = names.index(selector) + 1
+        else:
+            raise TypeError(
+                "band selector must be an int index or str name, got "
+                f"{type(selector).__name__}"
+            )
+        return one_based
 
     def select(
         self, bands: list[int | str] | tuple[int | str, ...], *, lazy: bool = False

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -8,7 +8,7 @@ Owns the Bands family of operations on a Dataset. Accessed as
 from __future__ import annotations
 
 import warnings
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast, overload
 
@@ -488,6 +488,132 @@ class Bands(_Engine["Dataset"]):
             return None
         else:
             return self._ds.__class__(src, self._ds.access)
+
+    def _resolve_band_selectors(self, bands: Any) -> list[int]:
+        """Resolve band selectors to validated 1-based GDAL band indices.
+
+        Each selector is a **1-based** band index or a band name (matched against
+        :attr:`~pyramids.dataset.Dataset.band_names`, first match wins). Order is
+        preserved and duplicates are allowed. Everything is validated *before* any
+        GDAL call, so an invalid selector raises a clear error rather than a raw
+        GDAL ``RuntimeError`` (out-of-range) or a silent all-bands read (empty).
+
+        Args:
+            bands: A list or tuple of selectors — 1-based ``int`` indices and/or
+                band-name ``str``s.
+
+        Returns:
+            The 1-based GDAL band indices, in the requested order.
+
+        Raises:
+            TypeError: ``bands`` is not a list/tuple, or a selector is a ``bool``
+                or an unsupported type.
+            ValueError: ``bands`` is empty, an index is out of range, or a name is
+                not among the band names.
+        """
+        if not isinstance(bands, (list, tuple)):
+            raise TypeError(
+                "select expects a list or tuple of band indices or names, got "
+                f"{type(bands).__name__}"
+            )
+        if len(bands) == 0:
+            raise ValueError("select requires at least one band; got an empty list.")
+        count = self._ds.band_count
+        names = self._ds.band_names
+        indices: list[int] = []
+        for selector in bands:
+            if isinstance(selector, bool):
+                raise TypeError(
+                    f"band selector must be an int or str, not bool: {selector!r}"
+                )
+            if isinstance(selector, int):
+                if not 1 <= selector <= count:
+                    raise ValueError(
+                        f"band index {selector} is out of range for a {count}-band "
+                        f"dataset (valid 1..{count})."
+                    )
+                one_based = selector
+            elif isinstance(selector, str):
+                if selector not in names:
+                    raise ValueError(
+                        f"{selector!r} is not a band name; available: {names}"
+                    )
+                one_based = names.index(selector) + 1
+            else:
+                raise TypeError(
+                    "band selector must be an int index or str name, got "
+                    f"{type(selector).__name__}"
+                )
+            indices.append(one_based)
+        return indices
+
+    def select(self, bands: Sequence[int | str], *, lazy: bool = False) -> "Dataset":
+        """Return a new Dataset with a subset of bands, in the requested order.
+
+        Copies the chosen bands (via GDAL ``Translate`` with a ``bandList``) into a
+        fresh raster, carrying each band's per-band state — name/description,
+        no-data value, scale, offset, unit, colour table and interpretation, band
+        metadata, and the raster attribute table (category names). Band selectors
+        are **1-based** (matching the product band numbering, e.g. ``select([4, 8])``
+        for Sentinel-2 B04/B08) — note this differs from the **0-based** ``band``
+        argument of :meth:`~pyramids.dataset.engines.IO.read_array`. Duplicates are
+        allowed (e.g. to expand a single band into an RGB triplet).
+
+        The result is a **base** :class:`~pyramids.dataset.Dataset` even when called
+        on a subclass: a band subset is an ordinary classic-mode raster, so — as
+        with :meth:`~pyramids.dataset.Dataset.open_subdataset` — a ``NetCDF``
+        variable subset is returned as a plain raster rather than a re-parsed
+        multidimensional view.
+
+        Args:
+            bands: The bands to keep, as a list/tuple of 1-based ``int`` indices
+                and/or band-name ``str``s. Order is preserved; duplicates allowed.
+            lazy: When ``True``, return a VRT-backed view that references the source
+                (deferred, memory-light); when ``False`` (default), materialize an
+                in-memory copy.
+
+        Returns:
+            Dataset: A new base ``Dataset`` holding the selected bands in order.
+
+        Raises:
+            TypeError: ``bands`` is not a list/tuple, or a selector is a ``bool`` or
+                an unsupported type.
+            ValueError: ``bands`` is empty, an index is out of range, or a name is
+                not among the band names.
+
+        Examples:
+            - Select and reorder two bands of a three-band raster:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> arr = np.arange(3 * 4).reshape(3, 2, 2).astype("float32")
+                >>> ds = Dataset.create_from_array(
+                ...     arr, top_left_corner=(0, 0), cell_size=1.0, epsg=4326
+                ... )
+                >>> subset = ds.bands.select([3, 1])
+                >>> subset.band_count
+                2
+
+                ```
+        """
+        # Local import breaks the engines.bands -> dataset import cycle; select
+        # returns a base Dataset (a band subset is a classic raster, mirroring
+        # open_subdataset), so it cannot use `self._ds.__class__`.
+        from pyramids.dataset.dataset import Dataset
+
+        indices = self._resolve_band_selectors(bands)
+        options = gdal.TranslateOptions(
+            bandList=indices, format="VRT" if lazy else "MEM"
+        )
+        out = gdal.Translate("", self._ds.raster, options=options)
+        if not lazy:
+            # The MEM path drops the unit type; re-apply it per selected band (a
+            # harmless no-op on the VRT path, which carries units natively).
+            src_units = self._ds.band_units
+            for position, one_based in enumerate(indices):
+                out.GetRasterBand(position + 1).SetUnitType(src_units[one_based - 1] or "")
+        result = Dataset(out)
+        return result
 
     def _get_band_names(self) -> list[str]:
         """Get band names from band metadata if exists otherwise will return index [1,2, ...].

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -8,7 +8,7 @@ Owns the Bands family of operations on a Dataset. Accessed as
 from __future__ import annotations
 
 import warnings
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast, overload
 
@@ -519,6 +519,11 @@ class Bands(_Engine["Dataset"]):
         if len(bands) == 0:
             raise ValueError("select requires at least one band; got an empty list.")
         count = self._ds.band_count
+        if count == 0:
+            raise ValueError(
+                "this dataset has no bands to select; if it is a NetCDF container, "
+                "extract a variable first (e.g. with get_variable)."
+            )
         names = self._ds.band_names
         indices: list[int] = []
         for selector in bands:
@@ -547,7 +552,9 @@ class Bands(_Engine["Dataset"]):
             indices.append(one_based)
         return indices
 
-    def select(self, bands: Sequence[int | str], *, lazy: bool = False) -> Dataset:
+    def select(
+        self, bands: list[int | str] | tuple[int | str, ...], *, lazy: bool = False
+    ) -> Dataset:
         """Return a new Dataset with a subset of bands, in the requested order.
 
         Copies the chosen bands (via GDAL ``Translate`` with a ``bandList``) into a

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -611,7 +611,9 @@ class Bands(_Engine["Dataset"]):
             # harmless no-op on the VRT path, which carries units natively).
             src_units = self._ds.band_units
             for position, one_based in enumerate(indices):
-                out.GetRasterBand(position + 1).SetUnitType(src_units[one_based - 1] or "")
+                out.GetRasterBand(position + 1).SetUnitType(
+                    src_units[one_based - 1] or ""
+                )
         result = Dataset(out)
         return result
 

--- a/src/pyramids/dataset/engines/georef.py
+++ b/src/pyramids/dataset/engines/georef.py
@@ -18,7 +18,7 @@ from uuid import uuid4
 from osgeo import gdal
 
 from pyramids._io import silent_unlink
-from pyramids.base._errors import ReadOnlyError
+from pyramids.base._errors import GeolocationArrayError, ReadOnlyError
 from pyramids.base._utils import DEFAULT_RESAMPLING, resolve_resampling
 from pyramids.base.crs import sr_from_user_input
 from pyramids.dataset._gcp import GroundControlPoint
@@ -484,5 +484,145 @@ class Georef(_Engine["Dataset"]):
             gdal.WarpOptions(**warp_kwargs),
             access="read_only",
             error_message="GDAL could not warp the dataset from its GCPs.",
+            pin=lazy,
+        )
+
+    @property
+    def geolocation(self) -> dict[str, str] | None:
+        """The dataset's GDAL ``GEOLOCATION`` metadata domain, or ``None``.
+
+        Geolocation arrays are per-pixel longitude/latitude grids (the swath /
+        curvilinear georeferencing model), exposed by GDAL as the ``GEOLOCATION``
+        metadata domain. Returns the domain mapping (``X_DATASET``/``Y_DATASET``
+        pointing at the coordinate arrays, ``SRS``, band/offset/step keys) or
+        ``None`` when the dataset carries no such domain. Built on
+        :meth:`~pyramids.dataset.Dataset.get_meta_data`; on a ``NetCDF`` variable
+        the domain is read from the classic GDAL handle (see
+        :meth:`Dataset._geolocation_source`).
+
+        Returns:
+            dict[str, str] | None: The ``GEOLOCATION`` domain, or ``None``.
+
+        Examples:
+            - A plain raster carries no geolocation arrays:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_from_array(
+                ...     np.zeros((2, 2)), top_left_corner=(0, 0), cell_size=1.0, epsg=4326
+                ... )
+                >>> ds.geolocation is None
+                True
+
+                ```
+        """
+        source = self._ds._geolocation_source()
+        domain = cast("dict[str, str]", source.get_meta_data("GEOLOCATION"))
+        return domain or None
+
+    @property
+    def has_geolocation(self) -> bool:
+        """Whether the dataset carries geolocation arrays (a ``GEOLOCATION`` domain).
+
+        Returns:
+            bool: ``True`` when :attr:`geolocation` is present, else ``False``.
+
+        Examples:
+            - A plain raster has no geolocation arrays:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_from_array(
+                ...     np.zeros((2, 2)), top_left_corner=(0, 0), cell_size=1.0, epsg=4326
+                ... )
+                >>> ds.has_geolocation
+                False
+
+                ```
+        """
+        return self.geolocation is not None
+
+    def geolocate(
+        self,
+        *,
+        to_epsg: int | str | None = None,
+        method: str = DEFAULT_RESAMPLING,
+        cell_size: float | None = None,
+        lazy: bool = False,
+    ) -> Dataset:
+        """Warp the dataset **from its geolocation arrays** onto a regular grid.
+
+        Resamples a swath / curvilinear raster whose georeferencing is carried by
+        per-pixel longitude/latitude arrays (the GDAL ``GEOLOCATION`` domain) onto
+        a north-up affine grid — the geolocation-array analogue of
+        :meth:`georeference` (GCPs) and :meth:`orthorectify` (RPCs). The arrays are
+        read automatically from the ``GEOLOCATION`` domain.
+
+        GDAL's geolocation warping assumes a continuous source-to-target mapping;
+        products with large discontinuities (e.g. a dateline-crossing swath) can
+        produce artefacts.
+
+        Args:
+            to_epsg: Target CRS for the output. ``None`` warps into the geolocation
+                arrays' own CRS (their ``SRS`` key); otherwise reprojects to
+                ``to_epsg`` in the same pass (any form
+                :func:`pyramids.base.crs.sr_from_user_input` accepts).
+            method: Resampling method (see :meth:`Spatial.to_crs`). Default
+                ``"nearest neighbor"``.
+            cell_size: Output pixel size in target-CRS units (both axes). ``None``
+                lets GDAL pick a size that preserves the source resolution.
+            lazy: ``True`` returns a VRT-backed view (pixels warped per read);
+                ``False`` (default) materialises the result in memory.
+
+        Returns:
+            Dataset: The regularly-gridded raster as a base ``Dataset``.
+
+        Raises:
+            GeolocationArrayError: the dataset has no ``GEOLOCATION`` domain, or the
+                domain is missing the required ``X_DATASET`` / ``Y_DATASET`` arrays.
+            CRSError: ``to_epsg`` is not a recognisable CRS.
+            ValueError: ``method`` is not a known resampling method.
+            RuntimeError: GDAL could not build the warp.
+
+        Examples:
+            - Geolocate needs a ``GEOLOCATION`` domain (a plain raster has none):
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset
+                >>> ds = Dataset.create_from_array(
+                ...     np.zeros((2, 2)), top_left_corner=(0, 0), cell_size=1.0, epsg=4326
+                ... )
+                >>> ds.has_geolocation
+                False
+
+                ```
+        """
+        source = self._ds._geolocation_source()
+        domain = cast("dict[str, str]", source.get_meta_data("GEOLOCATION"))
+        if not domain:
+            raise GeolocationArrayError(
+                "dataset has no geolocation arrays (no GEOLOCATION metadata domain)."
+            )
+        missing = {"X_DATASET", "Y_DATASET"} - set(domain)
+        if missing:
+            raise GeolocationArrayError(
+                f"GEOLOCATION domain is missing required arrays: {sorted(missing)}"
+            )
+        warp_kwargs: dict = {
+            "format": "VRT" if lazy else "MEM",
+            "resampleAlg": resolve_resampling(method),
+            "xRes": cell_size,
+            "yRes": cell_size,
+            "geoloc": True,
+        }
+        if to_epsg is not None:
+            warp_kwargs["dstSRS"] = _dst_srs_arg(sr_from_user_input(to_epsg))
+        # Only a lazy (VRT) result reads through to the source, so only it needs
+        # the pin; a materialised MEM result owns its pixels.
+        return warp_to_dataset(
+            source,
+            gdal.WarpOptions(**warp_kwargs),
+            access="read_only",
+            error_message="GDAL could not geolocate the dataset.",
             pin=lazy,
         )

--- a/src/pyramids/dataset/engines/georef.py
+++ b/src/pyramids/dataset/engines/georef.py
@@ -497,8 +497,10 @@ class Georef(_Engine["Dataset"]):
         pointing at the coordinate arrays, ``SRS``, band/offset/step keys) or
         ``None`` when the dataset carries no such domain. Built on
         :meth:`~pyramids.dataset.Dataset.get_meta_data`; on a ``NetCDF`` variable
-        the domain is read from the classic GDAL handle (see
-        :meth:`Dataset._geolocation_source`).
+        the domain is read from the classic **on-disk** GDAL handle (see
+        :meth:`Dataset._geolocation_source`), so it reflects the source file, not
+        any in-place edits, and is unavailable for an in-memory (``/vsimem``) NetCDF
+        — geolocate before other spatial operations.
 
         Returns:
             dict[str, str] | None: The ``GEOLOCATION`` domain, or ``None``.
@@ -523,6 +525,10 @@ class Georef(_Engine["Dataset"]):
     @property
     def has_geolocation(self) -> bool:
         """Whether the dataset carries geolocation arrays (a ``GEOLOCATION`` domain).
+
+        ``True`` means a ``GEOLOCATION`` domain *exists*, not that :meth:`geolocate`
+        will succeed: a degenerate domain missing the required ``X_DATASET`` /
+        ``Y_DATASET`` coordinate arrays reports ``True`` here yet cannot be warped.
 
         Returns:
             bool: ``True`` when :attr:`geolocation` is present, else ``False``.

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -803,6 +803,9 @@ class IO(_Engine["Dataset"]):
         strategy = next(s for s in READ_STRATEGIES if s.matches(req))
         arr = strategy.read(self, req, window)
         self._ds._backend = strategy.backend
+        # Applied post-dispatch (not inside a strategy) because scaling is a uniform
+        # arithmetic transform over whatever backend the strategy returns (numpy /
+        # masked / dask) — unlike `masked`, which each strategy owns or rejects.
         if req.scaled:
             arr = self._apply_scale_offset(arr, req.band)
         # arr is assembled through many untyped GDAL/dask branches inside the

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -42,7 +42,7 @@ from pyramids.base._file_manager import (
     gdal_raster_open,
 )
 from pyramids.base._locks import DummyLock, default_lock
-from pyramids.base._utils import resolve_resampling
+from pyramids.base._utils import apply_unpack, resolve_resampling
 from pyramids.base.crs import crs_from_user_input, crs_spec, reproject_coordinates
 from pyramids.base.protocols import ArrayLike
 from pyramids.base.remote import is_network_backed
@@ -438,6 +438,7 @@ class IO(_Engine["Dataset"]):
         boundless: bool = False,
         fill_value: float | None = None,
         masked: bool = False,
+        scaled: bool = False,
         threadsafe: bool = False,
         bbox_rounding: str = "cover",
     ) -> ArrayLike:
@@ -563,6 +564,23 @@ class IO(_Engine["Dataset"]):
                 combining it with `chunks` or `threadsafe=True` raises
                 :class:`NotImplementedError`. Default is `False` (plain
                 array, unchanged behaviour).
+            scaled (bool, keyword-only):
+                When `True`, return real-world values by applying each
+                band's GDAL scale/offset as float — `real = raw * scale +
+                offset`, via `GetScale()`/`GetOffset()`. A band that
+                declares neither is returned unchanged (no float
+                promotion); when any selected band declares a scale or
+                offset the result is promoted to `float64`. Composes with
+                every read path (`window`, `bbox`, `out_shape`,
+                `boundless`, `masked`, `threadsafe`, and the lazy `chunks=`
+                path, where the scaling stays lazy as `dask` arithmetic).
+                With `masked=True` the mask is preserved and masked cells
+                are not exposed as scaled; with `masked=False` a declared
+                `no_data_value` sentinel **is** scaled (use `masked=True`
+                to keep it out of the values). On a NetCDF the equivalent
+                knob is `unpack=True`; both share the same primitive.
+                Default is `False` (raw stored values, unchanged
+                behaviour).
             threadsafe (bool, keyword-only):
                 Opt into per-thread GDAL handles so concurrent reads from
                 multiple threads never share a handle (same-handle
@@ -784,9 +802,51 @@ class IO(_Engine["Dataset"]):
         strategy = next(s for s in READ_STRATEGIES if s.matches(req))
         arr = strategy.read(self, req, window)
         self._ds._backend = strategy.backend
+        if scaled:
+            arr = self._apply_scale_offset(arr, band)
         # arr is assembled through many untyped GDAL/dask branches inside the
         # strategy; this is the method's own declared contract.
         return cast("ArrayLike", arr)
+
+    def _apply_scale_offset(self, arr: Any, band: int | None) -> Any:
+        """Apply each band's raw GDAL scale/offset to a read result.
+
+        Fetches the raw ``GetScale()``/``GetOffset()`` (``None`` when unset,
+        unlike the normalizing :attr:`Bands.scale`/:attr:`Bands.offset`), so a
+        band that declares neither is returned unchanged. Funnels the arithmetic
+        through the shared :func:`~pyramids.base._utils.apply_unpack` primitive,
+        broadcasting a per-band ``(bands, 1, 1)`` scale/offset for an all-bands
+        (3-D) read. Works uniformly on eager numpy, masked, and lazy dask arrays.
+
+        Args:
+            arr: The array returned by the read — 2-D for a single/one-band
+                read, 3-D ``(bands, rows, cols)`` for an all-bands read.
+            band: The band index the read resolved to, or ``None`` for an
+                all-bands read.
+
+        Returns:
+            The scaled array (``float64`` when any band declares a scale/offset),
+            or ``arr`` unchanged when no selected band declares either.
+        """
+        if arr.ndim == 2:
+            index = 0 if band is None else band
+            gdal_band = self._ds._iloc(index)
+            result = apply_unpack(arr, gdal_band.GetScale(), gdal_band.GetOffset())
+        else:
+            gdal_bands = [self._ds._iloc(i) for i in range(arr.shape[0])]
+            scales = [b.GetScale() for b in gdal_bands]
+            offsets = [b.GetOffset() for b in gdal_bands]
+            if all(s is None for s in scales) and all(o is None for o in offsets):
+                result = arr
+            else:
+                scale_arr = np.asarray(
+                    [1.0 if s is None else s for s in scales], dtype=np.float64
+                ).reshape(-1, 1, 1)
+                offset_arr = np.asarray(
+                    [0.0 if o is None else o for o in offsets], dtype=np.float64
+                ).reshape(-1, 1, 1)
+                result = apply_unpack(arr, scale_arr, offset_arr)
+        return result
 
     def _reopen_open_options(self) -> dict[str, tuple[str, ...]] | None:
         """Opener kwargs carrying the dataset's GDAL open options, or ``None``.

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -779,6 +779,7 @@ class IO(_Engine["Dataset"]):
             boundless=boundless,
             fill_value=fill_value,
             masked=masked,
+            scaled=scaled,
             threadsafe=threadsafe,
         )
         # Resolve the bbox CRS only when a bbox is actually given. resolve_read_window
@@ -802,8 +803,8 @@ class IO(_Engine["Dataset"]):
         strategy = next(s for s in READ_STRATEGIES if s.matches(req))
         arr = strategy.read(self, req, window)
         self._ds._backend = strategy.backend
-        if scaled:
-            arr = self._apply_scale_offset(arr, band)
+        if req.scaled:
+            arr = self._apply_scale_offset(arr, req.band)
         # arr is assembled through many untyped GDAL/dask branches inside the
         # strategy; this is the method's own declared contract.
         return cast("ArrayLike", arr)

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -804,8 +804,8 @@ class IO(_Engine["Dataset"]):
         arr = strategy.read(self, req, window)
         self._ds._backend = strategy.backend
         # Applied post-dispatch (not inside a strategy) because scaling is a uniform
-        # arithmetic transform over whatever backend the strategy returns (numpy /
-        # masked / dask) — unlike `masked`, which each strategy owns or rejects.
+        # arithmetic transform over whatever array the strategy returns — plain,
+        # masked, or dask — unlike `masked`, which each strategy owns or rejects.
         if req.scaled:
             arr = self._apply_scale_offset(arr, req.band)
         # arr is assembled through many untyped GDAL/dask branches inside the

--- a/src/pyramids/netcdf/_lazy.py
+++ b/src/pyramids/netcdf/_lazy.py
@@ -39,7 +39,7 @@ import numpy as np
 
 from pyramids.base._file_manager import CachingFileManager, gdal_mdarray_open
 from pyramids.base._locks import DummyLock, default_lock
-from pyramids.base._utils import import_dask
+from pyramids.base._utils import apply_unpack, import_dask
 from pyramids.base.remote import cloud_config_from_env
 from pyramids.netcdf._mdim import axis_flips
 from pyramids.netcdf.utils import _dtype_to_str
@@ -357,40 +357,11 @@ def _read_mdarray_chunk(
     return arr
 
 
-def apply_unpack(
-    arr: Any,
-    scale: float | None,
-    offset: float | None,
-) -> Any:
-    """Apply CF `scale_factor` / `add_offset` to a lazy or eager array.
-
-    The lazy dask branch funnels through this helper so the
-    transformation is expressed as `dask.array` arithmetic — the
-    compute graph stays lazy until the user explicitly materializes
-    it.
-
-    Args:
-        arr: The raw array (dask or numpy).
-        scale: CF `scale_factor`, or `None`.
-        offset: CF `add_offset`, or `None`.
-
-    Returns:
-        The (possibly transformed) array, cast to `float64` when a
-        transformation was applied.
-    """
-    if scale is None and offset is None:
-        result = arr
-    else:
-        result = arr.astype(np.float64)
-        if scale is not None:
-            result = result * scale
-        if offset is not None:
-            result = result + offset
-    return result
-
-
-# Backward-compatible private alias for the now-public ``apply_unpack`` (API-9). Kept so
-# any out-of-tree importer of the old underscore name keeps working.
+# ``apply_unpack`` is the single shared scale/offset primitive; it lives in
+# ``base/_utils.py`` so both the NetCDF CF path here and the raster read path
+# (``IO.read_array(scaled=True)``) call the same implementation. Re-exported here
+# so existing importers of ``pyramids.netcdf._lazy.apply_unpack`` keep working.
+# The ``_apply_unpack`` underscore alias (API-9) is kept for out-of-tree importers.
 _apply_unpack = apply_unpack
 
 

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -779,6 +779,8 @@ class NetCDF(Dataset):
         # Drop cached registered accessors so they rebuild against the new raster
         # (this override does not chain `super()`, so the call is repeated here).
         _invalidate_cached_accessors(self)
+        # Drop the memoised classic geolocation handle so it is re-resolved.
+        self.__dict__.pop("_geolocation_source_memo", None)
 
     def __str__(self):
         """Return a human-readable summary, or a `<Dataset: closed>` sentinel when closed.
@@ -1515,16 +1517,26 @@ class NetCDF(Dataset):
         Returns:
             Dataset: a base ``Dataset`` over the classic handle, or ``self``.
         """
-        var = self._source_var_name
-        parent = self._parent_nc
-        path = parent.file_name if parent is not None else self.file_name
-        handle = None
-        if var is not None and path and not str(path).startswith("/vsimem"):
-            try:
-                handle = gdal.Open(f'NETCDF:"{path}":{var}')
-            except RuntimeError:
-                handle = None
-        source = self if handle is None else Dataset(handle, access="read_only")
+        # Memoise the reopened handle (the classic source is a stable file property)
+        # so a common `if var.has_geolocation: var.geolocate(...)` flow does not
+        # reopen `NETCDF:<file>:<var>` two or three times, mirroring the memoisation
+        # of the sibling `_classic_geotransform`. `_update_inplace` clears it.
+        source = self.__dict__.get("_geolocation_source_memo")
+        if source is None:
+            var = self._source_var_name
+            parent = self._parent_nc
+            path = parent.file_name if parent is not None else self.file_name
+            handle = None
+            if var is not None and path and not str(path).startswith("/vsimem"):
+                try:
+                    handle = gdal.Open(f'NETCDF:"{path}":{var}')
+                except RuntimeError:
+                    handle = None
+            source = self if handle is None else Dataset(handle, access="read_only")
+            # Only cache a genuinely reopened handle; caching the `self` fallback
+            # would create a pointless self-reference and re-resolving it is cheap.
+            if source is not self:
+                self.__dict__["_geolocation_source_memo"] = source
         return source
 
     def _normalize_geostationary_geotransform(self) -> None:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -35,7 +35,11 @@ from pyramids.base.protocols import ArrayLike
 from pyramids.base.remote import is_remote
 from pyramids.dataset import Dataset
 from pyramids.dataset._plot_helpers import nonnull_group_kwargs
-from pyramids.dataset.dataset import _COLLABORATOR_ATTRS
+from pyramids.dataset.dataset import (
+    _COLLABORATOR_ATTRS,
+    _RESERVED_ACCESSOR_NAMES,
+    _invalidate_cached_accessors,
+)
 from pyramids.dataset.engines._read_window import resolve_read_window
 from pyramids.netcdf._axis import detect_axis_indices
 from pyramids.netcdf._kerchunk_facade import combine_kerchunk, to_kerchunk
@@ -103,6 +107,10 @@ if hasattr(gdal, "GDT_Int8"):
 # inherited engine. `_update_inplace` re-binds these alongside the Dataset ones
 # after the `__dict__` swap.
 _NETCDF_COLLABORATOR_ATTRS = ("interop", "varops", "selection")
+
+# The NetCDF engine names are also instance attributes, so they must be reserved
+# against `register_dataset_accessor` clashes once `pyramids.netcdf` is imported.
+_RESERVED_ACCESSOR_NAMES.update(_NETCDF_COLLABORATOR_ATTRS)
 
 
 class _LazyVariableDict(dict):
@@ -768,6 +776,9 @@ class NetCDF(Dataset):
             collab = self.__dict__.get(attr)
             if collab is not None:
                 collab._ds = self_proxy
+        # Drop cached registered accessors so they rebuild against the new raster
+        # (this override does not chain `super()`, so the call is repeated here).
+        _invalidate_cached_accessors(self)
 
     def __str__(self):
         """Return a human-readable summary, or a `<Dataset: closed>` sentinel when closed.
@@ -1489,6 +1500,32 @@ class NetCDF(Dataset):
 
         cache[var] = result
         return result
+
+    def _geolocation_source(self) -> Dataset:
+        """Reopen the classic ``NETCDF`` handle, which carries the ``GEOLOCATION`` domain.
+
+        Geolocation arrays are exposed by GDAL's classic ``NETCDF:<file>:<var>``
+        driver, but the multidimensional ``AsClassicDataset`` view a NetCDF variable
+        comes from drops that domain. Reopen the classic handle as a **base**
+        :class:`~pyramids.dataset.Dataset` (so no multidimensional re-parse happens)
+        when there is a real on-disk / VSI source and a variable name; otherwise fall
+        back to ``self`` — which then yields the generic "no geolocation arrays"
+        error (correct for a container: extract a variable first).
+
+        Returns:
+            Dataset: a base ``Dataset`` over the classic handle, or ``self``.
+        """
+        var = self._source_var_name
+        parent = self._parent_nc
+        path = parent.file_name if parent is not None else self.file_name
+        handle = None
+        if var is not None and path and not str(path).startswith("/vsimem"):
+            try:
+                handle = gdal.Open(f'NETCDF:"{path}":{var}')
+            except RuntimeError:
+                handle = None
+        source = self if handle is None else Dataset(handle, access="read_only")
+        return source
 
     def _normalize_geostationary_geotransform(self) -> None:
         """Georeference a geostationary variable read via the MDIM path.

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -1,7 +1,8 @@
 """Tests for helpers in :mod:`pyramids.base._utils`.
 
-Currently covers :func:`lazy_extra_hint`, the single source of the optional
-``[lazy]`` extra install hint reused by the zarr / dask call sites.
+Covers :func:`lazy_extra_hint` (the single source of the optional ``[lazy]`` extra
+install hint) and :func:`apply_unpack` (the shared scale/offset primitive behind both
+the NetCDF CF unpack path and the raster ``read_array(scaled=True)`` path).
 """
 
 from __future__ import annotations

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -22,7 +22,8 @@ class TestApplyUnpack:
         """Both None returns the array unchanged, with no float promotion."""
         arr = np.array([0, 1, 2], dtype="int16")
         out = apply_unpack(arr, None, None)
-        assert out is arr and out.dtype == np.int16, "identity, no promotion"
+        assert out is arr, "identity: the same array object is returned"
+        assert out.dtype == np.int16, "no float promotion when nothing is declared"
 
     def test_scalar_scale_and_offset(self):
         """A scalar scale/offset applies as float64."""

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -6,11 +6,55 @@ Currently covers :func:`lazy_extra_hint`, the single source of the optional
 
 from __future__ import annotations
 
+import numpy as np
 import pytest
 
-from pyramids.base._utils import lazy_extra_hint
+from pyramids.base._utils import apply_unpack, lazy_extra_hint
 
 pytestmark = pytest.mark.core
+
+
+class TestApplyUnpack:
+    """Tests for the shared scale/offset primitive ``apply_unpack``."""
+
+    def test_none_none_passthrough(self):
+        """Both None returns the array unchanged, with no float promotion."""
+        arr = np.array([0, 1, 2], dtype="int16")
+        out = apply_unpack(arr, None, None)
+        assert out is arr and out.dtype == np.int16, "identity, no promotion"
+
+    def test_scalar_scale_and_offset(self):
+        """A scalar scale/offset applies as float64."""
+        out = apply_unpack(np.array([0, 1, 2]), 0.1, 5.0)
+        assert out.dtype == np.float64, f"expected float64, got {out.dtype}"
+        np.testing.assert_allclose(out, [5.0, 5.1, 5.2])
+
+    def test_scale_only_and_offset_only(self):
+        """Scale-only and offset-only each apply their single operand."""
+        np.testing.assert_allclose(apply_unpack(np.array([1, 2]), 2.0, None), [2.0, 4.0])
+        np.testing.assert_allclose(apply_unpack(np.array([1, 2]), None, 3.0), [4.0, 5.0])
+
+    def test_ndarray_broadcast(self):
+        """A per-band (bands, 1, 1) scale/offset broadcasts over a 3-D array."""
+        arr = np.ones((2, 1, 1))
+        scale = np.array([2.0, 3.0]).reshape(-1, 1, 1)
+        offset = np.array([1.0, -1.0]).reshape(-1, 1, 1)
+        out = apply_unpack(arr, scale, offset)
+        np.testing.assert_allclose(out.ravel(), [3.0, 2.0])
+
+    def test_masked_array_mask_preserved(self):
+        """A masked-array input keeps its mask across the transform."""
+        arr = np.ma.MaskedArray([0, 1, 2], mask=[False, True, False])
+        out = apply_unpack(arr, 0.1, 5.0)
+        assert isinstance(out, np.ma.MaskedArray), "mask must survive"
+        np.testing.assert_array_equal(out.mask, [False, True, False])
+
+    def test_reexported_identity(self):
+        """The NetCDF module re-exports the same object (one shared primitive)."""
+        from pyramids.netcdf._lazy import _apply_unpack
+        from pyramids.netcdf._lazy import apply_unpack as lazy_fn
+
+        assert apply_unpack is lazy_fn is _apply_unpack, "one shared primitive"
 
 
 class TestLazyExtraHint:

--- a/tests/base/test_utils.py
+++ b/tests/base/test_utils.py
@@ -31,8 +31,12 @@ class TestApplyUnpack:
 
     def test_scale_only_and_offset_only(self):
         """Scale-only and offset-only each apply their single operand."""
-        np.testing.assert_allclose(apply_unpack(np.array([1, 2]), 2.0, None), [2.0, 4.0])
-        np.testing.assert_allclose(apply_unpack(np.array([1, 2]), None, 3.0), [4.0, 5.0])
+        np.testing.assert_allclose(
+            apply_unpack(np.array([1, 2]), 2.0, None), [2.0, 4.0]
+        )
+        np.testing.assert_allclose(
+            apply_unpack(np.array([1, 2]), None, 3.0), [4.0, 5.0]
+        )
 
     def test_ndarray_broadcast(self):
         """A per-band (bands, 1, 1) scale/offset broadcasts over a 3-D array."""

--- a/tests/dataset/engines/test_bands_select.py
+++ b/tests/dataset/engines/test_bands_select.py
@@ -146,3 +146,13 @@ class TestSelectNetCDF:
         sub = var.bands.select([1])
         assert type(sub) is Dataset, f"expected a base Dataset, got {type(sub)}"
         assert sub.band_count == 1
+
+    def test_container_gives_clear_error(self):
+        """Selecting bands on a 0-band NetCDF container points at get_variable."""
+        from pyramids.netcdf import NetCDF
+
+        container = NetCDF.read_file(
+            "tests/data/netcdf/none__4v__1d1-2d2-3d1__curv.nc"
+        )
+        with pytest.raises(ValueError, match="container"):
+            container.select_bands([1])

--- a/tests/dataset/engines/test_bands_select.py
+++ b/tests/dataset/engines/test_bands_select.py
@@ -17,7 +17,9 @@ MULTI_BANDS = "tests/data/geotiff/multi_bands.tif"
 def rich() -> Dataset:
     """A 4-band raster carrying per-band names/units/scale/offset/no-data/metadata."""
     arr = np.arange(4 * 4).reshape(4, 2, 2).astype("float32")
-    ds = Dataset.create_from_array(arr, top_left_corner=(0, 0), cell_size=1.0, epsg=4326)
+    ds = Dataset.create_from_array(
+        arr, top_left_corner=(0, 0), cell_size=1.0, epsg=4326
+    )
     ds.band_names = ["a", "b", "c", "d"]
     ds.band_units = ["m", "s", "kg", "K"]
     ds.scale = [0.1, 0.2, 0.3, 0.4]

--- a/tests/dataset/engines/test_bands_select.py
+++ b/tests/dataset/engines/test_bands_select.py
@@ -35,7 +35,8 @@ class TestSelect:
         """Selecting 1-based indices yields those bands' pixels in order."""
         ds = Dataset.read_file(MULTI_BANDS)
         sub = ds.bands.select([1, 3])
-        assert type(sub) is Dataset and sub.band_count == 2
+        assert type(sub) is Dataset
+        assert sub.band_count == 2
         np.testing.assert_array_equal(sub.read_array(band=0), ds.read_array(band=0))
         np.testing.assert_array_equal(sub.read_array(band=1), ds.read_array(band=2))
 
@@ -102,7 +103,8 @@ class TestSelectCarryAcross:
             pd.DataFrame({"value": [0, 1], "label": ["sea", "land"]}), band=0
         )
         rat = ds.bands.select([1]).get_attribute_table(band=0)
-        assert rat is not None and "label" in rat.columns, "RAT must survive select"
+        assert rat is not None, "RAT must survive select"
+        assert "label" in rat.columns, "RAT category names must survive select"
 
     def test_carries_color_table_and_interpretation(self):
         """The colour table and colour interpretation survive selection."""

--- a/tests/dataset/engines/test_bands_select.py
+++ b/tests/dataset/engines/test_bands_select.py
@@ -1,0 +1,146 @@
+"""`Dataset.bands.select` band subsetting into a new Dataset (#1032)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from pyramids.dataset import Dataset
+
+pytestmark = pytest.mark.core
+
+MULTI_BANDS = "tests/data/geotiff/multi_bands.tif"
+
+
+@pytest.fixture
+def rich() -> Dataset:
+    """A 4-band raster carrying per-band names/units/scale/offset/no-data/metadata."""
+    arr = np.arange(4 * 4).reshape(4, 2, 2).astype("float32")
+    ds = Dataset.create_from_array(arr, top_left_corner=(0, 0), cell_size=1.0, epsg=4326)
+    ds.band_names = ["a", "b", "c", "d"]
+    ds.band_units = ["m", "s", "kg", "K"]
+    ds.scale = [0.1, 0.2, 0.3, 0.4]
+    ds.offset = [1.0, 2.0, 3.0, 4.0]
+    ds.no_data_value = [-1.0, -2.0, -3.0, -4.0]
+    return ds
+
+
+class TestSelect:
+    """`Bands.select` — construction, ordering, and error handling."""
+
+    def test_select_by_index(self):
+        """Selecting 1-based indices yields those bands' pixels in order."""
+        ds = Dataset.read_file(MULTI_BANDS)
+        sub = ds.bands.select([1, 3])
+        assert type(sub) is Dataset and sub.band_count == 2
+        np.testing.assert_array_equal(sub.read_array(band=0), ds.read_array(band=0))
+        np.testing.assert_array_equal(sub.read_array(band=1), ds.read_array(band=2))
+
+    def test_select_by_name(self, rich):
+        """Selecting by band name resolves to the right bands."""
+        sub = rich.bands.select(["c", "a"])
+        assert sub.band_names == ["c", "a"], sub.band_names
+
+    def test_reorder(self, rich):
+        """Selection preserves the requested order (subset + reorder)."""
+        sub = rich.bands.select([4, 1])
+        assert sub.band_names == ["d", "a"], sub.band_names
+
+    def test_single_band(self):
+        """Selecting one band yields a 1-band Dataset."""
+        ds = Dataset.read_file(MULTI_BANDS)
+        assert ds.bands.select([2]).band_count == 1
+
+    def test_duplicates_allowed(self, rich):
+        """Duplicate selectors are allowed (e.g. gray -> RGB expansion)."""
+        assert rich.bands.select([1, 1, 2]).band_count == 3
+
+    def test_facade_parity(self, rich):
+        """`Dataset.select_bands` mirrors `Dataset.bands.select`."""
+        a = rich.select_bands([1, 2]).band_names
+        b = rich.bands.select([1, 2]).band_names
+        assert a == b == ["a", "b"]
+
+
+class TestSelectCarryAcross:
+    """`Bands.select` carries per-band state across the copy."""
+
+    def test_carries_all_per_band_state(self, rich):
+        """Names, units, scale, offset, and no-data follow the selected bands."""
+        sub = rich.select_bands([4, 2])
+        assert sub.band_names == ["d", "b"]
+        assert sub.band_units == ["K", "s"], "units must survive the MEM re-apply"
+        assert sub.scale == [0.4, 0.2]
+        assert sub.offset == [4.0, 2.0]
+        assert list(sub.no_data_value) == [-4.0, -2.0]
+
+    def test_carries_metadata(self, rich):
+        """Band metadata follows the selected bands."""
+        rich.bands.set_metadata_item("k", "v0", band=0)
+        rich.bands.set_metadata_item("k", "v3", band=3)
+        sub = rich.select_bands([4, 1])
+        assert sub.band_meta_data[0].get("k") == "v3"
+        assert sub.band_meta_data[1].get("k") == "v0"
+
+    def test_carries_attribute_table(self):
+        """The raster attribute table (category names) survives selection (#1024)."""
+        ds = Dataset.create_from_array(
+            np.array([[0, 1], [1, 0]], dtype="int32"),
+            top_left_corner=(0, 0),
+            cell_size=1.0,
+            epsg=4326,
+        )
+        ds.set_attribute_table(
+            pd.DataFrame({"value": [0, 1], "label": ["sea", "land"]}), band=0
+        )
+        rat = ds.bands.select([1]).get_attribute_table(band=0)
+        assert rat is not None and "label" in rat.columns, "RAT must survive select"
+
+
+class TestSelectErrors:
+    """`Bands.select` rejects invalid selectors before any GDAL call."""
+
+    @pytest.mark.parametrize(
+        "bands, exc",
+        [
+            ([99], ValueError),
+            (["nope"], ValueError),
+            ([], ValueError),
+            ("a", TypeError),
+            (1, TypeError),
+            ([True], TypeError),
+            ([1.5], TypeError),
+        ],
+    )
+    def test_invalid_selectors_raise(self, rich, bands, exc):
+        """Out-of-range, unknown-name, empty, non-list, bool, and float raise."""
+        with pytest.raises(exc):
+            rich.bands.select(bands)
+
+
+class TestSelectLazy:
+    """`Bands.select(lazy=...)` eager vs VRT-backed."""
+
+    def test_lazy_reads_same_pixels(self):
+        """A lazy selection reads the same pixels as the eager one."""
+        ds = Dataset.read_file(MULTI_BANDS)
+        eager = ds.bands.select([2, 1])
+        lazy = ds.bands.select([2, 1], lazy=True)
+        assert lazy.band_count == 2
+        np.testing.assert_array_equal(lazy.read_array(), eager.read_array())
+
+
+class TestSelectNetCDF:
+    """A NetCDF variable subset returns a base Dataset, not a NetCDF."""
+
+    def test_netcdf_variable_returns_base_dataset(self):
+        """Selecting bands of a NetCDF variable yields a plain raster."""
+        from pyramids.netcdf import NetCDF
+
+        var = NetCDF.read_file(
+            "tests/data/netcdf/none__4v__1d1-2d2-3d1__curv.nc"
+        ).get_variable("Tair")
+        sub = var.bands.select([1])
+        assert type(sub) is Dataset, f"expected a base Dataset, got {type(sub)}"
+        assert sub.band_count == 1

--- a/tests/dataset/engines/test_bands_select.py
+++ b/tests/dataset/engines/test_bands_select.py
@@ -64,6 +64,11 @@ class TestSelect:
         b = rich.bands.select([1, 2]).band_names
         assert a == b == ["a", "b"]
 
+    def test_numpy_int_selectors(self, rich):
+        """numpy-integer selectors are accepted like Python ints."""
+        sub = rich.bands.select([np.int64(4), np.int64(1)])
+        assert sub.band_names == ["d", "a"]
+
 
 class TestSelectCarryAcross:
     """`Bands.select` carries per-band state across the copy."""
@@ -98,6 +103,30 @@ class TestSelectCarryAcross:
         )
         rat = ds.bands.select([1]).get_attribute_table(band=0)
         assert rat is not None and "label" in rat.columns, "RAT must survive select"
+
+    def test_carries_color_table_and_interpretation(self):
+        """The colour table and colour interpretation survive selection."""
+        from osgeo import gdal
+
+        ds = Dataset.create_from_array(
+            np.array([[0, 1], [1, 0]], dtype="uint8"),
+            top_left_corner=(0, 0),
+            cell_size=1.0,
+            epsg=4326,
+        )
+        table = gdal.ColorTable()
+        table.SetColorEntry(0, (255, 0, 0, 255))
+        table.SetColorEntry(1, (0, 255, 0, 255))
+        band = ds.raster.GetRasterBand(1)
+        band.SetRasterColorTable(table)
+        band.SetRasterColorInterpretation(gdal.GCI_PaletteIndex)
+        # Hold the selected Dataset alive; the GDAL band is invalid once it is GC'd.
+        sub = ds.bands.select([1])
+        out = sub.raster.GetRasterBand(1)
+        assert out.GetRasterColorTable() is not None, "colour table must survive"
+        assert out.GetRasterColorInterpretation() == gdal.GCI_PaletteIndex, (
+            "colour interpretation must survive"
+        )
 
 
 class TestSelectErrors:

--- a/tests/dataset/engines/test_bands_select.py
+++ b/tests/dataset/engines/test_bands_select.py
@@ -151,8 +151,6 @@ class TestSelectNetCDF:
         """Selecting bands on a 0-band NetCDF container points at get_variable."""
         from pyramids.netcdf import NetCDF
 
-        container = NetCDF.read_file(
-            "tests/data/netcdf/none__4v__1d1-2d2-3d1__curv.nc"
-        )
+        container = NetCDF.read_file("tests/data/netcdf/none__4v__1d1-2d2-3d1__curv.nc")
         with pytest.raises(ValueError, match="container"):
             container.select_bands([1])

--- a/tests/dataset/engines/test_read_request.py
+++ b/tests/dataset/engines/test_read_request.py
@@ -38,6 +38,7 @@ def make_request(**overrides) -> ReadRequest:
         "boundless": False,
         "fill_value": None,
         "masked": False,
+        "scaled": False,
         "threadsafe": False,
     }
     base.update(overrides)

--- a/tests/dataset/engines/test_read_request.py
+++ b/tests/dataset/engines/test_read_request.py
@@ -61,6 +61,21 @@ class TestReadRequest:
         assert req.resampling == "nearest", "resampling should round-trip"
         assert req.boundless is False, "boundless should round-trip"
 
+    def test_scaled_roundtrips_and_is_universally_legal(self):
+        """``scaled`` round-trips and adds no ``__post_init__`` guard.
+
+        Test scenario:
+            ``scaled=True`` is stored verbatim and is legal alongside every other
+            option (it is a post-dispatch transform, not part of the matrix), so it
+            never introduces a new incompatibility.
+        """
+        assert make_request(scaled=True).scaled is True, "scaled should round-trip"
+        make_request(scaled=True, masked=True)
+        make_request(scaled=True, chunks=4)
+        make_request(scaled=True, out_shape=(4, 4), resampling="bilinear")
+        make_request(scaled=True, boundless=True, fill_value=0)
+        make_request(scaled=True, threadsafe=True)
+
     @pytest.mark.parametrize(
         "resampling",
         ["nearest", "NEAREST", " nearest ", "Nearest"],

--- a/tests/dataset/engines/test_read_request.py
+++ b/tests/dataset/engines/test_read_request.py
@@ -62,19 +62,26 @@ class TestReadRequest:
         assert req.boundless is False, "boundless should round-trip"
 
     def test_scaled_roundtrips_and_is_universally_legal(self):
-        """``scaled`` round-trips and adds no ``__post_init__`` guard.
+        """``scaled`` round-trips, adds no guard, and does not disable the matrix.
 
         Test scenario:
-            ``scaled=True`` is stored verbatim and is legal alongside every other
-            option (it is a post-dispatch transform, not part of the matrix), so it
-            never introduces a new incompatibility.
+            ``scaled=True`` is stored verbatim (alone and in combination), is legal
+            alongside every other option (a post-dispatch transform, not part of the
+            matrix), and does not suppress a pre-existing incompatibility guard.
         """
         assert make_request(scaled=True).scaled is True, "scaled should round-trip"
-        make_request(scaled=True, masked=True)
-        make_request(scaled=True, chunks=4)
-        make_request(scaled=True, out_shape=(4, 4), resampling="bilinear")
-        make_request(scaled=True, boundless=True, fill_value=0)
-        make_request(scaled=True, threadsafe=True)
+        for combo in (
+            {"masked": True},
+            {"chunks": 4},
+            {"out_shape": (4, 4), "resampling": "bilinear"},
+            {"boundless": True, "fill_value": 0},
+            {"threadsafe": True},
+        ):
+            assert make_request(scaled=True, **combo).scaled is True, (
+                f"scaled should round-trip alongside {combo}"
+            )
+        with pytest.raises(ValueError, match="fill_value"):
+            make_request(scaled=True, fill_value=5.0, boundless=False)
 
     @pytest.mark.parametrize(
         "resampling",

--- a/tests/dataset/engines/test_read_strategies.py
+++ b/tests/dataset/engines/test_read_strategies.py
@@ -47,6 +47,7 @@ def make_request(**overrides) -> ReadRequest:
         "boundless": False,
         "fill_value": None,
         "masked": False,
+        "scaled": False,
         "threadsafe": False,
     }
     base.update(overrides)

--- a/tests/dataset/engines/test_read_strategies.py
+++ b/tests/dataset/engines/test_read_strategies.py
@@ -455,3 +455,30 @@ class TestStrategySelection:
         assert isinstance(select(req), LazyRead), (
             "chunks must take precedence over out_shape"
         )
+
+    @pytest.mark.parametrize(
+        "combo",
+        [
+            {},
+            {"chunks": 4},
+            {"out_shape": (2, 2)},
+            {"boundless": True},
+            {"threadsafe": True},
+        ],
+        ids=["eager", "lazy", "decimated", "boundless", "threadsafe"],
+    )
+    def test_scaled_does_not_change_strategy_selection(self, combo):
+        """``scaled`` is a post-dispatch transform, so it never alters the matched path.
+
+        Args:
+            combo: A per-path option set that selects one strategy.
+
+        Test scenario:
+            For each option combination, ``scaled=True`` selects the same strategy
+            class as ``scaled=False`` — no strategy branches on ``scaled``.
+        """
+        without = type(select(make_request(scaled=False, **combo)))
+        with_scaled = type(select(make_request(scaled=True, **combo)))
+        assert with_scaled is without, (
+            f"scaled changed the path: {without} vs {with_scaled}"
+        )

--- a/tests/dataset/engines/test_read_strategies.py
+++ b/tests/dataset/engines/test_read_strategies.py
@@ -457,28 +457,32 @@ class TestStrategySelection:
         )
 
     @pytest.mark.parametrize(
-        "combo",
+        "combo, expected",
         [
-            {},
-            {"chunks": 4},
-            {"out_shape": (2, 2)},
-            {"boundless": True},
-            {"threadsafe": True},
+            ({}, EagerRead),
+            ({"masked": True}, EagerRead),
+            ({"chunks": 4}, LazyRead),
+            ({"out_shape": (2, 2)}, DecimatedRead),
+            ({"boundless": True}, BoundlessRead),
+            ({"threadsafe": True}, ThreadsafeRead),
         ],
-        ids=["eager", "lazy", "decimated", "boundless", "threadsafe"],
+        ids=["eager", "masked-eager", "lazy", "decimated", "boundless", "threadsafe"],
     )
-    def test_scaled_does_not_change_strategy_selection(self, combo):
-        """``scaled`` is a post-dispatch transform, so it never alters the matched path.
+    def test_scaled_does_not_change_strategy_selection(self, combo, expected):
+        """``scaled`` never alters the matched path (which stays the combo's expected one).
 
         Args:
             combo: A per-path option set that selects one strategy.
+            expected: The strategy class ``combo`` must select.
 
         Test scenario:
-            For each option combination, ``scaled=True`` selects the same strategy
-            class as ``scaled=False`` — no strategy branches on ``scaled``.
+            Both ``scaled=False`` and ``scaled=True`` select ``expected`` for the
+            combo — pinning the per-combo path (so a uniform-selection collapse is
+            caught) and proving no strategy branches on ``scaled``.
         """
-        without = type(select(make_request(scaled=False, **combo)))
-        with_scaled = type(select(make_request(scaled=True, **combo)))
-        assert with_scaled is without, (
-            f"scaled changed the path: {without} vs {with_scaled}"
+        assert isinstance(select(make_request(scaled=False, **combo)), expected), (
+            f"{combo} should select {expected.__name__}"
+        )
+        assert isinstance(select(make_request(scaled=True, **combo)), expected), (
+            f"scaled=True changed the path for {combo}"
         )

--- a/tests/dataset/io/test_read_array_scaled.py
+++ b/tests/dataset/io/test_read_array_scaled.py
@@ -102,6 +102,39 @@ class TestReadArrayScaled:
         out = scaled_single.read_array(band=0, out_shape=(1, 1), scaled=True)
         assert out.shape == (1, 1) and out.dtype == np.float64
 
+    def test_window_then_scaled(self, scaled_single):
+        """A windowed read is scaled over just the window."""
+        out = scaled_single.read_array(band=0, window=[0, 0, 2, 1], scaled=True)
+        raw = scaled_single.read_array(band=0, window=[0, 0, 2, 1])
+        assert out.dtype == np.float64
+        np.testing.assert_allclose(out, raw * 0.1 + 5.0)
+
+    def test_boundless_scaled(self, scaled_single):
+        """A boundless scaled read scales the whole padded window (fill included)."""
+        out = scaled_single.read_array(
+            band=0, window=[-1, -1, 2, 2], boundless=True, fill_value=0, scaled=True
+        )
+        assert out.dtype == np.float64 and out.shape == (2, 2)
+
+    def test_masked_3d_scaled(self, scaled_multi):
+        """An all-bands masked scaled read keeps the 3-D mask and scales the data."""
+        scaled_multi.no_data_value = [0, 0, 0]
+        out = scaled_multi.read_array(masked=True, scaled=True)
+        assert isinstance(out, np.ma.MaskedArray) and out.ndim == 3
+        assert out.dtype == np.float64
+        np.testing.assert_array_equal(
+            out.mask, scaled_multi.read_array(masked=True).mask
+        )
+
+    def test_threadsafe_scaled(self, scaled_single, tmp_path):
+        """A threadsafe scaled read returns scaled float64."""
+        path = tmp_path / "ts.tif"
+        scaled_single.to_file(str(path))
+        ds = Dataset.read_file(str(path))
+        out = ds.read_array(band=0, threadsafe=True, scaled=True)
+        assert out.dtype == np.float64
+        np.testing.assert_allclose(out, ds.read_array(band=0) * 0.1 + 5.0)
+
     def test_scaled_false_is_unchanged(self, scaled_single, scaled_multi):
         """`scaled=False` (default) is byte-identical to a plain read."""
         for ds in (scaled_single, scaled_multi):

--- a/tests/dataset/io/test_read_array_scaled.py
+++ b/tests/dataset/io/test_read_array_scaled.py
@@ -1,0 +1,121 @@
+"""`read_array(scaled=True)` applies per-band GDAL scale/offset (#1031)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pyramids.dataset import Dataset
+
+pytestmark = pytest.mark.core
+
+
+def _make(array: np.ndarray, scale=None, offset=None, no_data=None) -> Dataset:
+    """Build an in-memory Dataset, optionally with per-band scale/offset/no-data."""
+    ds = Dataset.create_from_array(
+        array, top_left_corner=(0, 0), cell_size=1.0, epsg=4326
+    )
+    if scale is not None:
+        ds.scale = scale
+    if offset is not None:
+        ds.offset = offset
+    if no_data is not None:
+        ds.no_data_value = no_data
+    return ds
+
+
+@pytest.fixture
+def scaled_single() -> Dataset:
+    """A 1-band int16 raster with scale 0.1 and offset 5.0."""
+    return _make(np.array([[0, 1], [2, 3]], dtype="int16"), scale=[0.1], offset=[5.0])
+
+
+@pytest.fixture
+def scaled_multi() -> Dataset:
+    """A 3-band int16 raster with per-band differing scale/offset."""
+    arr = np.arange(3 * 4).reshape(3, 2, 2).astype("int16")
+    return _make(arr, scale=[0.1, 2.0, 1.0], offset=[0.0, -1.0, 0.0])
+
+
+class TestReadArrayScaled:
+    """`IO.read_array(scaled=True)` and its `_apply_scale_offset` helper."""
+
+    def test_single_band_scaled(self, scaled_single):
+        """A scaled single-band read returns `raw * scale + offset` as float64."""
+        raw = scaled_single.read_array(band=0)
+        out = scaled_single.read_array(band=0, scaled=True)
+        assert out.dtype == np.float64, f"expected float64, got {out.dtype}"
+        np.testing.assert_allclose(out, raw * 0.1 + 5.0)
+
+    def test_identity_unset_returns_raw(self):
+        """A band with no scale/offset is returned unchanged, keeping its dtype."""
+        ds = _make(np.array([[0, 1]], dtype="int16"))
+        out = ds.read_array(band=0, scaled=True)
+        assert out.dtype == np.int16, "an unset band must not be promoted to float"
+        np.testing.assert_array_equal(out, ds.read_array(band=0))
+
+    def test_all_bands_per_band_factors(self, scaled_multi):
+        """An all-bands scaled read applies each band's own scale/offset."""
+        raw = scaled_multi.read_array()
+        out = scaled_multi.read_array(scaled=True)
+        assert out.shape == raw.shape and out.dtype == np.float64
+        expected = raw.astype(np.float64)
+        expected[0] = raw[0] * 0.1 + 0.0
+        expected[1] = raw[1] * 2.0 - 1.0
+        expected[2] = raw[2] * 1.0 + 0.0
+        np.testing.assert_allclose(out, expected)
+
+    def test_all_bands_all_unset_returns_raw(self):
+        """An all-bands read where no band declares scale/offset returns raw ints."""
+        ds = _make(np.arange(2 * 4).reshape(2, 2, 2).astype("int16"))
+        out = ds.read_array(scaled=True)
+        assert out.dtype == np.int16, "no promotion when nothing is declared"
+        np.testing.assert_array_equal(out, ds.read_array())
+
+    def test_masked_mask_preserved(self):
+        """`scaled=True` with `masked=True` keeps the mask and scales only data."""
+        ds = _make(
+            np.array([[0, -9999], [2, 3]], dtype="int16"),
+            scale=[0.1],
+            offset=[5.0],
+            no_data=[-9999],
+        )
+        out = ds.read_array(band=0, masked=True, scaled=True)
+        assert isinstance(out, np.ma.MaskedArray), "expected a masked array"
+        base_mask = ds.read_array(band=0, masked=True).mask
+        np.testing.assert_array_equal(out.mask, base_mask)
+        assert out[0, 0] == pytest.approx(5.0), "unmasked cell scaled"
+
+    def test_unmasked_sentinel_is_scaled(self):
+        """Without masking, the no-data sentinel is scaled like any other value."""
+        ds = _make(
+            np.array([[-9999, 1]], dtype="int16"),
+            scale=[0.1],
+            offset=[5.0],
+            no_data=[-9999],
+        )
+        out = ds.read_array(band=0, scaled=True)
+        assert out[0, 0] == pytest.approx(-9999 * 0.1 + 5.0), "sentinel scaled"
+
+    def test_out_shape_then_scaled(self, scaled_single):
+        """A decimated (out_shape) read is scaled to float64 at the requested size."""
+        out = scaled_single.read_array(band=0, out_shape=(1, 1), scaled=True)
+        assert out.shape == (1, 1) and out.dtype == np.float64
+
+    def test_scaled_false_is_unchanged(self, scaled_single, scaled_multi):
+        """`scaled=False` (default) is byte-identical to a plain read."""
+        for ds in (scaled_single, scaled_multi):
+            np.testing.assert_array_equal(
+                ds.read_array(scaled=False), ds.read_array()
+            )
+
+    def test_lazy_scaled_matches_eager(self, scaled_multi, tmp_path):
+        """A lazy (chunks) scaled read computes to the same values as the eager one."""
+        pytest.importorskip("dask.array")
+        # The chunked path reopens the source by path, so back it with a real file.
+        path = tmp_path / "scaled.tif"
+        scaled_multi.to_file(str(path))
+        ds = Dataset.read_file(str(path))
+        lazy = ds.read_array(chunks="auto", scaled=True)
+        assert hasattr(lazy, "compute"), "chunks= must return a lazy array"
+        np.testing.assert_allclose(lazy.compute(), ds.read_array(scaled=True))

--- a/tests/dataset/io/test_read_array_scaled.py
+++ b/tests/dataset/io/test_read_array_scaled.py
@@ -58,7 +58,8 @@ class TestReadArrayScaled:
         """An all-bands scaled read applies each band's own scale/offset."""
         raw = scaled_multi.read_array()
         out = scaled_multi.read_array(scaled=True)
-        assert out.shape == raw.shape and out.dtype == np.float64
+        assert out.shape == raw.shape
+        assert out.dtype == np.float64
         expected = raw.astype(np.float64)
         expected[0] = raw[0] * 0.1 + 0.0
         expected[1] = raw[1] * 2.0 - 1.0
@@ -100,7 +101,8 @@ class TestReadArrayScaled:
     def test_out_shape_then_scaled(self, scaled_single):
         """A decimated (out_shape) read is scaled to float64 at the requested size."""
         out = scaled_single.read_array(band=0, out_shape=(1, 1), scaled=True)
-        assert out.shape == (1, 1) and out.dtype == np.float64
+        assert out.shape == (1, 1)
+        assert out.dtype == np.float64
 
     def test_window_then_scaled(self, scaled_single):
         """A windowed read is scaled over just the window."""
@@ -114,13 +116,15 @@ class TestReadArrayScaled:
         out = scaled_single.read_array(
             band=0, window=[-1, -1, 2, 2], boundless=True, fill_value=0, scaled=True
         )
-        assert out.dtype == np.float64 and out.shape == (2, 2)
+        assert out.dtype == np.float64
+        assert out.shape == (2, 2)
 
     def test_masked_3d_scaled(self, scaled_multi):
         """An all-bands masked scaled read keeps the 3-D mask and scales the data."""
         scaled_multi.no_data_value = [0, 0, 0]
         out = scaled_multi.read_array(masked=True, scaled=True)
-        assert isinstance(out, np.ma.MaskedArray) and out.ndim == 3
+        assert isinstance(out, np.ma.MaskedArray)
+        assert out.ndim == 3
         assert out.dtype == np.float64
         np.testing.assert_array_equal(
             out.mask, scaled_multi.read_array(masked=True).mask

--- a/tests/dataset/io/test_read_array_scaled.py
+++ b/tests/dataset/io/test_read_array_scaled.py
@@ -105,9 +105,7 @@ class TestReadArrayScaled:
     def test_scaled_false_is_unchanged(self, scaled_single, scaled_multi):
         """`scaled=False` (default) is byte-identical to a plain read."""
         for ds in (scaled_single, scaled_multi):
-            np.testing.assert_array_equal(
-                ds.read_array(scaled=False), ds.read_array()
-            )
+            np.testing.assert_array_equal(ds.read_array(scaled=False), ds.read_array())
 
     def test_lazy_scaled_matches_eager(self, scaled_multi, tmp_path):
         """A lazy (chunks) scaled read computes to the same values as the eager one."""

--- a/tests/dataset/spatial/test_geolocate.py
+++ b/tests/dataset/spatial/test_geolocate.py
@@ -112,6 +112,17 @@ class TestGeolocate:
         with pytest.raises(ValueError):
             _make_geoloc_dataset(tmp_path).geolocate(to_epsg="not-a-crs")
 
+    def test_bad_method_raises(self, tmp_path):
+        """An unknown resampling method raises ValueError."""
+        with pytest.raises(ValueError):
+            _make_geoloc_dataset(tmp_path).geolocate(to_epsg=4326, method="bogus")
+
+    def test_lazy_pins_source_on_base_dataset(self, tmp_path):
+        """A lazy geolocate on a base Dataset pins its source and reads through."""
+        out = _make_geoloc_dataset(tmp_path).geolocate(to_epsg=4326, lazy=True)
+        assert out._warp_source is not None
+        assert out.read_array().size > 0
+
 
 class TestGeolocateNetCDF:
     """The classic-handle nuance: a NetCDF swath variable geolocates."""

--- a/tests/dataset/spatial/test_geolocate.py
+++ b/tests/dataset/spatial/test_geolocate.py
@@ -1,0 +1,151 @@
+"""Geolocation-array warp: `geolocate` + `geolocation` accessor (#1033)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from osgeo import osr
+
+from pyramids.base._errors import GeolocationArrayError
+from pyramids.dataset import Dataset
+
+pytestmark = pytest.mark.core
+
+CURV = "tests/data/netcdf/none__4v__1d1-2d2-3d1__curv.nc"
+
+
+def _make_geoloc_dataset(tmp_path, *, drop_x=False) -> Dataset:
+    """Build a small raster carrying a GDAL GEOLOCATION domain of lon/lat arrays."""
+    rows, cols = 4, 4
+    lon = np.tile(np.linspace(-10.0, -7.0, cols), (rows, 1)).astype("float64")
+    lat = np.tile(np.linspace(40.0, 37.0, rows).reshape(rows, 1), (1, cols))
+    lon_path = tmp_path / "lon.tif"
+    lat_path = tmp_path / "lat.tif"
+    for arr, path in [(lon, lon_path), (lat.astype("float64"), lat_path)]:
+        Dataset.create_from_array(
+            arr, top_left_corner=(0, 0), cell_size=1.0, epsg=4326
+        ).to_file(str(path))
+    data = np.arange(rows * cols).reshape(rows, cols).astype("float32")
+    ds = Dataset.create_from_array(
+        data, top_left_corner=(0, 0), cell_size=1.0, epsg=4326
+    )
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(4326)
+    domain = {
+        "X_DATASET": str(lon_path),
+        "Y_DATASET": str(lat_path),
+        "X_BAND": "1",
+        "Y_BAND": "1",
+        "PIXEL_OFFSET": "0",
+        "PIXEL_STEP": "1",
+        "LINE_OFFSET": "0",
+        "LINE_STEP": "1",
+        "SRS": srs.ExportToWkt(),
+    }
+    if drop_x:
+        del domain["X_DATASET"]
+    ds.set_meta_data(domain, domain="GEOLOCATION")
+    return ds
+
+
+class TestGeolocationAccessor:
+    """`geolocation` / `has_geolocation` on a base Dataset."""
+
+    def test_plain_raster_has_none(self):
+        """A plain raster has no geolocation arrays."""
+        ds = Dataset.create_from_array(
+            np.zeros((2, 2)), top_left_corner=(0, 0), cell_size=1.0, epsg=4326
+        )
+        assert ds.geolocation is None and ds.has_geolocation is False
+
+    def test_accessor_returns_domain(self, tmp_path):
+        """The accessor returns the GEOLOCATION domain dict when present."""
+        ds = _make_geoloc_dataset(tmp_path)
+        assert ds.has_geolocation is True
+        domain = ds.geolocation
+        assert domain["X_DATASET"].endswith("lon.tif")
+        assert domain["Y_DATASET"].endswith("lat.tif")
+
+
+class TestGeolocate:
+    """`geolocate` on a base Dataset with a synthetic GEOLOCATION domain."""
+
+    def test_geolocate_grids_to_requested_crs(self, tmp_path):
+        """geolocate produces a north-up affine grid in the requested CRS."""
+        ds = _make_geoloc_dataset(tmp_path)
+        out = ds.geolocate(to_epsg=4326)
+        assert type(out) is Dataset and out.epsg == 4326
+        gt = out.geotransform
+        assert gt[5] < 0 and gt[2] == 0 and gt[4] == 0, f"not north-up affine: {gt}"
+
+    def test_geolocate_to_epsg_none_uses_domain_srs(self, tmp_path):
+        """With to_epsg=None the result adopts the domain's own SRS."""
+        out = _make_geoloc_dataset(tmp_path).geolocate()
+        assert out.epsg == 4326
+
+    def test_geolocate_cell_size_honored(self, tmp_path):
+        """A requested cell_size sets the output resolution."""
+        out = _make_geoloc_dataset(tmp_path).geolocate(to_epsg=4326, cell_size=0.5)
+        assert out.geotransform[1] == pytest.approx(0.5)
+
+    def test_facade_parity(self, tmp_path):
+        """`ds.geolocate` mirrors `ds.georef.geolocate`."""
+        ds = _make_geoloc_dataset(tmp_path)
+        assert ds.geolocate(to_epsg=4326).epsg == ds.georef.geolocate(to_epsg=4326).epsg
+
+    def test_no_domain_raises(self):
+        """geolocate on a plain raster raises GeolocationArrayError."""
+        ds = Dataset.create_from_array(
+            np.zeros((2, 2)), top_left_corner=(0, 0), cell_size=1.0, epsg=4326
+        )
+        with pytest.raises(GeolocationArrayError, match="no geolocation arrays"):
+            ds.geolocate()
+
+    def test_missing_x_dataset_raises(self, tmp_path):
+        """A domain missing X_DATASET raises GeolocationArrayError naming it."""
+        ds = _make_geoloc_dataset(tmp_path, drop_x=True)
+        with pytest.raises(GeolocationArrayError, match="X_DATASET"):
+            ds.geolocate(to_epsg=4326)
+
+    def test_bad_crs_raises(self, tmp_path):
+        """An unrecognisable to_epsg raises (a ValueError subclass)."""
+        with pytest.raises(ValueError):
+            _make_geoloc_dataset(tmp_path).geolocate(to_epsg="not-a-crs")
+
+
+class TestGeolocateNetCDF:
+    """The classic-handle nuance: a NetCDF swath variable geolocates."""
+
+    def test_variable_geolocates(self):
+        """A NetCDF swath variable warps to the requested grid as a base Dataset."""
+        from pyramids.netcdf import NetCDF
+
+        var = NetCDF.read_file(CURV).get_variable("Tair")
+        out = var.geolocate(to_epsg=4326)
+        assert type(out) is Dataset and out.epsg == 4326
+        assert out.band_count == var.band_count
+
+    def test_variable_geolocation_accessor(self):
+        """The accessor reads the domain via the classic handle (multidim drops it)."""
+        from pyramids.netcdf import NetCDF
+
+        var = NetCDF.read_file(CURV).get_variable("Tair")
+        domain = var.geolocation
+        assert domain is not None and "X_DATASET" in domain and "Y_DATASET" in domain
+
+    def test_variable_geolocate_lazy_pins_source(self):
+        """A lazy geolocate pins its source and reads after the wrapper is dropped."""
+        from pyramids.netcdf import NetCDF
+
+        out = NetCDF.read_file(CURV).get_variable("Tair").geolocate(
+            to_epsg=4326, lazy=True
+        )
+        assert out._warp_source is not None
+        assert out.read_array().shape[0] == out.band_count
+
+    def test_container_raises(self):
+        """A NetCDF container (no variable extracted) has no geolocation arrays."""
+        from pyramids.netcdf import NetCDF
+
+        with pytest.raises(GeolocationArrayError):
+            NetCDF.read_file(CURV).geolocate()

--- a/tests/dataset/spatial/test_geolocate.py
+++ b/tests/dataset/spatial/test_geolocate.py
@@ -137,8 +137,10 @@ class TestGeolocateNetCDF:
         """A lazy geolocate pins its source and reads after the wrapper is dropped."""
         from pyramids.netcdf import NetCDF
 
-        out = NetCDF.read_file(CURV).get_variable("Tair").geolocate(
-            to_epsg=4326, lazy=True
+        out = (
+            NetCDF.read_file(CURV)
+            .get_variable("Tair")
+            .geolocate(to_epsg=4326, lazy=True)
         )
         assert out._warp_source is not None
         assert out.read_array().shape[0] == out.band_count

--- a/tests/dataset/spatial/test_geolocate.py
+++ b/tests/dataset/spatial/test_geolocate.py
@@ -56,7 +56,8 @@ class TestGeolocationAccessor:
         ds = Dataset.create_from_array(
             np.zeros((2, 2)), top_left_corner=(0, 0), cell_size=1.0, epsg=4326
         )
-        assert ds.geolocation is None and ds.has_geolocation is False
+        assert ds.geolocation is None
+        assert ds.has_geolocation is False
 
     def test_accessor_returns_domain(self, tmp_path):
         """The accessor returns the GEOLOCATION domain dict when present."""
@@ -74,9 +75,12 @@ class TestGeolocate:
         """geolocate produces a north-up affine grid in the requested CRS."""
         ds = _make_geoloc_dataset(tmp_path)
         out = ds.geolocate(to_epsg=4326)
-        assert type(out) is Dataset and out.epsg == 4326
+        assert type(out) is Dataset
+        assert out.epsg == 4326
         gt = out.geotransform
-        assert gt[5] < 0 and gt[2] == 0 and gt[4] == 0, f"not north-up affine: {gt}"
+        assert gt[5] < 0, f"not north-up: {gt}"
+        assert gt[2] == 0, f"not axis-aligned: {gt}"
+        assert gt[4] == 0, f"not axis-aligned: {gt}"
 
     def test_geolocate_to_epsg_none_uses_domain_srs(self, tmp_path):
         """With to_epsg=None the result adopts the domain's own SRS."""
@@ -109,13 +113,15 @@ class TestGeolocate:
 
     def test_bad_crs_raises(self, tmp_path):
         """An unrecognisable to_epsg raises (a ValueError subclass)."""
+        ds = _make_geoloc_dataset(tmp_path)
         with pytest.raises(ValueError):
-            _make_geoloc_dataset(tmp_path).geolocate(to_epsg="not-a-crs")
+            ds.geolocate(to_epsg="not-a-crs")
 
     def test_bad_method_raises(self, tmp_path):
         """An unknown resampling method raises ValueError."""
+        ds = _make_geoloc_dataset(tmp_path)
         with pytest.raises(ValueError):
-            _make_geoloc_dataset(tmp_path).geolocate(to_epsg=4326, method="bogus")
+            ds.geolocate(to_epsg=4326, method="bogus")
 
     def test_lazy_pins_source_on_base_dataset(self, tmp_path):
         """A lazy geolocate on a base Dataset pins its source and reads through."""
@@ -133,7 +139,8 @@ class TestGeolocateNetCDF:
 
         var = NetCDF.read_file(CURV).get_variable("Tair")
         out = var.geolocate(to_epsg=4326)
-        assert type(out) is Dataset and out.epsg == 4326
+        assert type(out) is Dataset
+        assert out.epsg == 4326
         assert out.band_count == var.band_count
 
     def test_variable_geolocation_accessor(self):
@@ -142,7 +149,9 @@ class TestGeolocateNetCDF:
 
         var = NetCDF.read_file(CURV).get_variable("Tair")
         domain = var.geolocation
-        assert domain is not None and "X_DATASET" in domain and "Y_DATASET" in domain
+        assert domain is not None
+        assert "X_DATASET" in domain
+        assert "Y_DATASET" in domain
 
     def test_variable_geolocate_lazy_pins_source(self):
         """A lazy geolocate pins its source and reads after the wrapper is dropped."""
@@ -160,5 +169,6 @@ class TestGeolocateNetCDF:
         """A NetCDF container (no variable extracted) has no geolocation arrays."""
         from pyramids.netcdf import NetCDF
 
+        container = NetCDF.read_file(CURV)
         with pytest.raises(GeolocationArrayError):
-            NetCDF.read_file(CURV).geolocate()
+            container.geolocate()

--- a/tests/dataset/test_accessor.py
+++ b/tests/dataset/test_accessor.py
@@ -116,6 +116,28 @@ class TestRegisterDatasetAccessor:
                 def __init__(self, ds):
                     self._ds = ds
 
+    @pytest.mark.parametrize(
+        "reserved", ["variable_names", "get_variable", "to_xarray"]
+    )
+    def test_collision_netcdf_only_name(self, reserved, cleanup_accessors):
+        """A name defined only on NetCDF is rejected once pyramids.netcdf is imported."""
+        import pyramids.netcdf  # noqa: F401  (registers NetCDF as a Dataset subclass)
+
+        class Bad:
+            def __init__(self, ds):
+                self._ds = ds
+
+        with pytest.raises(ValueError, match="shadows"):
+            register_dataset_accessor(reserved)(Bad)
+
+    def test_netcdf_engine_names_stay_reserved(self):
+        """The NetCDF engine names remain reserved (guards the dataset.py seed drift)."""
+        import pyramids.netcdf  # noqa: F401
+        from pyramids.dataset.dataset import _RESERVED_ACCESSOR_NAMES
+        from pyramids.netcdf.netcdf import _NETCDF_COLLABORATOR_ATTRS
+
+        assert set(_NETCDF_COLLABORATOR_ATTRS) <= _RESERVED_ACCESSOR_NAMES
+
     def test_reregister_warns_and_overwrites(self, cleanup_accessors):
         """Re-registering a name warns and installs the newer class."""
 

--- a/tests/dataset/test_accessor.py
+++ b/tests/dataset/test_accessor.py
@@ -1,0 +1,202 @@
+"""`register_dataset_accessor` extension hook (#1034)."""
+
+from __future__ import annotations
+
+import gc
+import weakref
+
+import numpy as np
+import pytest
+
+from pyramids.dataset import Dataset, register_dataset_accessor
+from pyramids.dataset.dataset import _ACCESSOR_REGISTRY
+
+pytestmark = pytest.mark.core
+
+
+@pytest.fixture
+def plain() -> Dataset:
+    """A small in-memory raster."""
+    return Dataset.create_from_array(
+        np.zeros((2, 3), dtype="float32"),
+        top_left_corner=(0, 0),
+        cell_size=1.0,
+        epsg=4326,
+    )
+
+
+@pytest.fixture
+def cleanup_accessors():
+    """Remove any accessors registered by a test so class state does not leak."""
+    before = set(_ACCESSOR_REGISTRY)
+    yield
+    for name in set(_ACCESSOR_REGISTRY) - before:
+        _ACCESSOR_REGISTRY.pop(name, None)
+        if name in vars(Dataset):
+            delattr(Dataset, name)
+
+
+class TestRegisterDatasetAccessor:
+    """Registration, laziness, caching, and collisions."""
+
+    def test_register_and_use(self, plain, cleanup_accessors):
+        """A registered accessor is reachable and reads through to the Dataset."""
+
+        @register_dataset_accessor("summary1")
+        class Summary:
+            def __init__(self, ds):
+                self._ds = ds
+
+            def n(self):
+                return self._ds.band_count
+
+        assert plain.summary1.n() == 1
+
+    def test_lazy_build(self, plain, cleanup_accessors):
+        """The accessor is built on first access, not at registration/open time."""
+        built = []
+
+        @register_dataset_accessor("summary2")
+        class Summary:
+            def __init__(self, ds):
+                built.append(1)
+                self._ds = ds
+
+        assert built == [], "must not be built before first access"
+        _ = plain.summary2
+        assert built == [1], "built exactly once on first access"
+
+    def test_cached_identity(self, plain, cleanup_accessors):
+        """Repeated access returns the same cached instance."""
+
+        @register_dataset_accessor("summary3")
+        class Summary:
+            def __init__(self, ds):
+                self._ds = ds
+
+        assert plain.summary3 is plain.summary3, "must be cached per Dataset"
+
+    def test_state_persists(self, plain, cleanup_accessors):
+        """State set on the accessor persists across accesses."""
+
+        @register_dataset_accessor("summary4")
+        class Summary:
+            def __init__(self, ds):
+                self._ds = ds
+
+        plain.summary4.tag = 42
+        assert plain.summary4.tag == 42
+
+    def test_collision_engine_name(self, cleanup_accessors):
+        """Registering an engine name raises ValueError."""
+        with pytest.raises(ValueError, match="shadows"):
+
+            @register_dataset_accessor("spatial")
+            class Bad:
+                def __init__(self, ds):
+                    self._ds = ds
+
+    def test_collision_netcdf_engine_name(self, cleanup_accessors):
+        """A NetCDF engine name is reserved once pyramids.netcdf is imported."""
+        import pyramids.netcdf  # noqa: F401  (populates the reserved set)
+
+        with pytest.raises(ValueError, match="shadows"):
+
+            @register_dataset_accessor("interop")
+            class Bad:
+                def __init__(self, ds):
+                    self._ds = ds
+
+    def test_collision_method_name(self, cleanup_accessors):
+        """Registering an existing Dataset method/property raises ValueError."""
+        with pytest.raises(ValueError, match="shadows"):
+
+            @register_dataset_accessor("crop")
+            class Bad:
+                def __init__(self, ds):
+                    self._ds = ds
+
+    def test_reregister_warns_and_overwrites(self, cleanup_accessors):
+        """Re-registering a name warns and installs the newer class."""
+
+        @register_dataset_accessor("summary5")
+        class First:
+            def __init__(self, ds):
+                self._ds = ds
+
+        with pytest.warns(UserWarning, match="overriding"):
+
+            @register_dataset_accessor("summary5")
+            class Second:
+                def __init__(self, ds):
+                    self._ds = ds
+
+        assert _ACCESSOR_REGISTRY["summary5"] is Second
+
+    def test_obj_none_introspection(self, cleanup_accessors):
+        """Class access returns the accessor class (so hasattr is safe)."""
+
+        @register_dataset_accessor("summary6")
+        class Summary:
+            def __init__(self, ds):
+                self._ds = ds
+
+        assert Dataset.summary6 is Summary
+        assert hasattr(Dataset, "summary6")
+
+
+class TestAccessorLifecycle:
+    """Invalidation, NetCDF inheritance, and cycle-free lifetime."""
+
+    def test_invalidated_on_update_inplace(self, plain, cleanup_accessors):
+        """An in-place op that swaps the raster drops the cached accessor."""
+        built = []
+
+        @register_dataset_accessor("summary7")
+        class Summary:
+            def __init__(self, ds):
+                built.append(1)
+                self._ds = ds
+
+        _ = plain.summary7
+        assert "summary7" in plain.__dict__ and built == [1]
+        plain.epsg = 3857  # triggers _update_inplace
+        assert "summary7" not in plain.__dict__, "cache dropped by _update_inplace"
+        built.clear()
+        _ = plain.summary7
+        assert built == [1], "rebuilt fresh after the swap"
+        assert plain.epsg == 3857, "the in-place op still applied"
+
+    def test_netcdf_inherits_accessor(self, cleanup_accessors):
+        """An accessor registered on Dataset is reachable on a NetCDF instance."""
+        from pyramids.netcdf import NetCDF
+
+        @register_dataset_accessor("summary8")
+        class Summary:
+            def __init__(self, ds):
+                self._ds = ds
+
+            def n(self):
+                return self._ds.band_count
+
+        nc = NetCDF.read_file(
+            "tests/data/netcdf/none__4v__1d1-2d2-3d1__curv.nc"
+        ).get_variable("Tair")
+        assert nc.summary8.n() == nc.band_count
+
+    def test_cycle_free_lifetime(self, cleanup_accessors):
+        """The weak back-reference keeps the Dataset collectable after use."""
+
+        @register_dataset_accessor("summary9")
+        class Summary:
+            def __init__(self, ds):
+                self._ds = ds
+
+        ds = Dataset.create_from_array(
+            np.zeros((2, 2)), top_left_corner=(0, 0), cell_size=1.0, epsg=4326
+        )
+        _ = ds.summary9
+        ref = weakref.ref(ds)
+        del ds
+        gc.collect()
+        assert ref() is None, "the accessor's weak proxy must not leak the Dataset"

--- a/tests/dataset/test_accessor.py
+++ b/tests/dataset/test_accessor.py
@@ -200,3 +200,51 @@ class TestAccessorLifecycle:
         del ds
         gc.collect()
         assert ref() is None, "the accessor's weak proxy must not leak the Dataset"
+
+    def test_invalidated_on_update_inplace_netcdf(self, cleanup_accessors):
+        """The NetCDF `_update_inplace` override also drops the cached accessor."""
+        from pyramids.netcdf import NetCDF
+
+        built = []
+
+        @register_dataset_accessor("summary10")
+        class Summary:
+            def __init__(self, ds):
+                built.append(1)
+                self._ds = ds
+
+        var = NetCDF.read_file(
+            "tests/data/netcdf/none__4v__1d1-2d2-3d1__curv.nc"
+        ).get_variable("Tair")
+        _ = var.summary10
+        assert "summary10" in var.__dict__ and built == [1]
+        var._update_inplace(var.raster)  # exercises the NetCDF override branch
+        assert "summary10" not in var.__dict__, "NetCDF override must drop the cache"
+        built.clear()
+        _ = var.summary10
+        assert built == [1], "rebuilt fresh after the NetCDF swap"
+
+    def test_pickle_rebuilds_accessor(self, tmp_path, cleanup_accessors):
+        """A cached accessor is not pickled and rebuilds lazily after unpickle."""
+        import pickle
+
+        @register_dataset_accessor("summary11")
+        class Summary:
+            def __init__(self, ds):
+                self._ds = ds
+
+            def n(self):
+                return self._ds.band_count
+
+        path = tmp_path / "p.tif"
+        Dataset.create_from_array(
+            np.zeros((2, 2), dtype="float32"),
+            top_left_corner=(0, 0),
+            cell_size=1.0,
+            epsg=4326,
+        ).to_file(str(path))
+        ds = Dataset.read_file(str(path))
+        _ = ds.summary11
+        restored = pickle.loads(pickle.dumps(ds))
+        assert "summary11" not in restored.__dict__, "accessor must not be pickled"
+        assert restored.summary11.n() == 1, "rebuilds lazily after unpickle"

--- a/tests/dataset/test_accessor.py
+++ b/tests/dataset/test_accessor.py
@@ -127,8 +127,9 @@ class TestRegisterDatasetAccessor:
             def __init__(self, ds):
                 self._ds = ds
 
+        decorator = register_dataset_accessor(reserved)
         with pytest.raises(ValueError, match="shadows"):
-            register_dataset_accessor(reserved)(Bad)
+            decorator(Bad)
 
     def test_netcdf_engine_names_stay_reserved(self):
         """The NetCDF engine names remain reserved (guards the dataset.py seed drift)."""
@@ -181,7 +182,8 @@ class TestAccessorLifecycle:
                 self._ds = ds
 
         _ = plain.summary7
-        assert "summary7" in plain.__dict__ and built == [1]
+        assert "summary7" in plain.__dict__
+        assert built == [1]
         plain.epsg = 3857  # triggers _update_inplace
         assert "summary7" not in plain.__dict__, "cache dropped by _update_inplace"
         built.clear()
@@ -239,7 +241,8 @@ class TestAccessorLifecycle:
             "tests/data/netcdf/none__4v__1d1-2d2-3d1__curv.nc"
         ).get_variable("Tair")
         _ = var.summary10
-        assert "summary10" in var.__dict__ and built == [1]
+        assert "summary10" in var.__dict__
+        assert built == [1]
         var._update_inplace(var.raster)  # exercises the NetCDF override branch
         assert "summary10" not in var.__dict__, "NetCDF override must drop the cache"
         built.clear()


### PR DESCRIPTION
# Description

Implements four verified, purely-additive dataset capabilities in one branch. No existing behaviour changes.

- **#1031 — `read_array(scaled=True)`**: apply per-band GDAL scale/offset on read (`real = raw * scale + offset`,
  as `float64`). The scale/offset *declaration* channel already existed but no read path consumed it. Adds a
  keyword-only `scaled=` to `IO.read_array` that composes with every read path (`window`/`bbox`/`out_shape`/
  `boundless`/`masked`/`threadsafe` and the lazy `chunks=` dask path). A band with neither scale nor offset is
  returned unchanged (no float promotion). The scale/offset math is unified into one shared primitive,
  `apply_unpack`, promoted to `base/_utils.py` and re-exported from `netcdf/_lazy.py`, so the raster path and the
  NetCDF CF `unpack=` path share the same implementation.

- **#1032 — `Dataset.bands.select([...]) -> Dataset`**: return a new raster with a chosen subset of bands, in the
  requested order, via `gdal.Translate(bandList=)`. Selectors are **1-based** indices and/or band names (order
  preserved, duplicates allowed). Carries per-band names/units/scale/offset/no-data/metadata/colour and the raster
  attribute table (category names). Adds the `Dataset.select_bands` facade. Returns a **base `Dataset`** (a band
  subset is a classic raster, mirroring `open_subdataset`).

- **#1033 — geolocation-array warp**: add `Dataset.geolocate(...)` and the `geolocation`/`has_geolocation`
  accessors on the `georef` engine to warp swath/curvilinear rasters carrying a GDAL `GEOLOCATION` domain onto a
  regular grid. Routed through the shared `warp_to_dataset` helper with `geoloc=True`; the accessor is built on
  #1040's `get_meta_data("GEOLOCATION")`. A polymorphic `_geolocation_source()` hook reopens the classic `NETCDF`
  handle (the multidimensional view drops the domain), so NetCDF swath variables work. New `GeolocationArrayError`.
  The external `SRC_GEOLOC_ARRAY` companion-array variant is deliberately out of scope.

- **#1034 — `register_dataset_accessor`**: an xarray/pandas-style extension hook so third-party packages attach a
  custom accessor to `Dataset` (and, by inheritance, `NetCDF`) without subclassing or editing the closed engine
  set. A `CachedAccessor` descriptor builds the accessor lazily on first access with a `weakref.proxy` back-ref
  (cycle-free, matching the engine layer) and caches it per instance; registration rejects names that shadow an
  existing attribute/method/engine, and cached accessors are invalidated across `_update_inplace` on both `Dataset`
  and `NetCDF`. Exported from `pyramids.dataset` and the top-level lazy namespace.

Design was produced with the `/gis-feature-request` (capability lens) and `/gis-architect-review` (architecture
lens) skills; the crystallized design lives in `planning/dataset-capabilities-1031-1034-design.md` (not committed).

Two design decisions flagged for reviewer awareness:
- **#1032 uses 1-based band selectors** (per the issue DoD and the product band mental model, e.g. Sentinel B04/B08),
  which differs from the 0-based `read_array(band=)`. Documented on the method.
- **#1032 returns a base `Dataset`** (not the subclass), following the `open_subdataset` precedent; this narrows the
  issue's "NetCDF stays NetCDF" checkbox, which predates that precedent.

# Issues

- Closes #1031 — apply band scale/offset in `read_array(scaled=True)`
- Closes #1032 — band subsetting via `Dataset.bands.select([...])`
- Closes #1033 — geolocation-array support (warp swath rasters via the `GEOLOCATION` domain)
- Closes #1034 — accessor-registration hook for third-party extensions

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

New test suites, all passing locally (`pixi run --frozen -e dev pytest <path> -m "not plot"`):

- [x] `tests/dataset/io/test_read_array_scaled.py` + `apply_unpack` unit tests in `tests/base/test_utils.py` (#1031)
- [x] `tests/dataset/engines/test_bands_select.py` (#1032)
- [x] `tests/dataset/spatial/test_geolocate.py` — synthetic georef leg + real NetCDF swath fixtures (#1033)
- [x] `tests/dataset/test_accessor.py` (#1034)

Regression: the full `tests/dataset` + `tests/netcdf` suites pass (5815 passed, 46 skipped) — the shared
`apply_unpack` move and the `_update_inplace` edits introduce no regressions. Doctests on the changed modules pass.

# Checklist:

- [ ] updated version number in pyproject.toml. — _handled by commitizen/CI, not edited manually_
- [ ] added changes to History.rst. — _changelog is commitizen-generated_
- [ ] updated the latest version in README file. — _handled by release automation_
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated. — _API docstrings (Google-style, with doctests) added on every new public symbol_
