### PR TITLE
fix(netcdf): georeference curvilinear variables to their real lon/lat extent (#1039)

### DIFF
--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -5210,9 +5210,12 @@ class NetCDF(Dataset):
         approximation of the curved grid — for a non-wrapping grid the bounding box is placed
         correctly, individual cells only approximately — but it reflects the data's real
         location instead of pixel indices, and pairs honestly with the WGS 84 CRS the
-        coordinates already imply. A grid crossing the antimeridian declines instead (the raw
-        min/max would span nearly the whole globe); its per-cell answer is the GEOLOCATION
-        domain (#1033).
+        coordinates already imply. A grid that *narrowly* straddles the antimeridian — its
+        longitudes leave a >180° gap, so raw min/max would span nearly the whole globe —
+        declines instead. A *wide* dateline-crossing grid (>180° of coverage, hence no such
+        gap) cannot be told apart from a legitimate wide grid by coordinates alone, so it is
+        approximated like any other and may be misplaced in longitude; its exact answer is the
+        GEOLOCATION domain (#1033).
 
         Args:
             cube: The variable subset whose 2-D coordinates georeference the grid.
@@ -5271,12 +5274,15 @@ class NetCDF(Dataset):
             or y_max > 90.0
         ):
             return None
-        # A grid crossing the antimeridian stores longitudes clustered at both ends of the
-        # range with a wide empty gap between, so raw min/max span nearly the whole globe and
+        # A grid that narrowly straddles the antimeridian stores longitudes clustered at both
+        # ends with a wide empty gap between, so raw min/max span nearly the whole globe and
         # misplace the domain in x. Decline (leave the index-space placeholder) rather than
         # fabricate a globe-spanning affine. A contiguous grid — including a genuinely
-        # circumpolar one whose longitudes fill the circle without a gap — has no such gap. The
-        # cheap span pre-check keeps the sort off the common (narrow-domain) path (#1039).
+        # circumpolar one whose longitudes fill the circle without a gap — has no such gap and
+        # is kept. This gap test cannot catch a *wide* dateline crossing (>180° coverage, gap
+        # <180°) without also falsely declining a polar grid whose meridians converge, so that
+        # rarer case is approximated rather than declined (#1039; GEOLOCATION is #1033). The
+        # cheap span pre-check keeps the sort off the common narrow-domain path.
         if (x_max - x_min) > 180.0:
             finite_lon = np.sort(lon2d[np.isfinite(lon2d)].ravel())
             if finite_lon.size >= 2 and float(np.max(np.diff(finite_lon))) > 180.0:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -5232,7 +5232,14 @@ class NetCDF(Dataset):
         crs = cube.crs
         if not crs or not sr_from_wkt(crs).IsGeographic():
             return None
-        curv = NetCDFPlot(cube)._resolve_curvilinear_coords(cube, coords=None)
+        with warnings.catch_warnings():
+            # The georeference path legitimately uses the resolver's model-name coordinate
+            # fallback; its plot-side "set the CF coordinates attribute / pass coords="
+            # DeprecationWarning does not apply here (there is no coords= on the read path), so
+            # silence that one warning for this internal resolution rather than surface it on
+            # every load of a non-CF-compliant curvilinear variable (round-2 review M1).
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
+            curv = NetCDFPlot(cube)._resolve_curvilinear_coords(cube, coords=None)
         if curv is None:
             return None
         lon2d = np.asarray(curv[0], dtype="f8")

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -5207,9 +5207,12 @@ class NetCDF(Dataset):
         that tagged with the grid's real CRS is a fabricated georeference that misplaces the
         data (#1039). Derive instead a north-up affine spanning the real lon/lat bounding
         box, so the variable is georeferenced to its true geographic extent. This is an
-        approximation of the curved grid — the domain is placed correctly, individual cells
-        only approximately — but it reflects the data's real location instead of pixel
-        indices, and pairs honestly with the WGS 84 CRS the coordinates already imply.
+        approximation of the curved grid — for a non-wrapping grid the bounding box is placed
+        correctly, individual cells only approximately — but it reflects the data's real
+        location instead of pixel indices, and pairs honestly with the WGS 84 CRS the
+        coordinates already imply. A grid crossing the antimeridian declines instead (the raw
+        min/max would span nearly the whole globe); its per-cell answer is the GEOLOCATION
+        domain (#1033).
 
         Args:
             cube: The variable subset whose 2-D coordinates georeference the grid.
@@ -5242,6 +5245,16 @@ class NetCDF(Dataset):
             or y_max <= y_min
         ):
             return None
+        # A grid crossing the antimeridian stores longitudes clustered at both ends of the
+        # range with a wide empty gap between, so raw min/max span nearly the whole globe and
+        # misplace the domain in x. Decline (leave the index-space placeholder) rather than
+        # fabricate a globe-spanning affine. A contiguous grid — including a genuinely
+        # circumpolar one whose longitudes fill the circle without a gap — has no such gap. The
+        # cheap span pre-check keeps the sort off the common (narrow-domain) path (#1039).
+        if (x_max - x_min) > 180.0:
+            finite_lon = np.sort(lon2d[np.isfinite(lon2d)].ravel())
+            if finite_lon.size >= 2 and float(np.max(np.diff(finite_lon))) > 180.0:
+                return None
         x_cell = (x_max - x_min) / (cube.columns - 1)
         y_cell = (y_max - y_min) / (cube.rows - 1)
         return (x_min - x_cell / 2, x_cell, 0.0, y_max + y_cell / 2, 0.0, -y_cell)

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -5072,9 +5072,11 @@ class NetCDF(Dataset):
         geotransform is immutable (``SetGeoTransform`` is a no-op on it), hence the VRT wrapper.
 
         A no-op when: the cube isn't a variable subset; the view is already georeferenced (the
-        common case — the derived geotransform matches); the file has no 1-D lon/lat matching
-        the grid shape (curvilinear 2-D coordinates, named coordinate variables, etc.); or the
-        CRS is geostationary. In that last case the 1-D ``x`` / ``y`` are **scan angles** (radians,
+        common case — the derived geotransform matches); the file has no coordinate evidence to
+        georeference the grid at all; or the CRS is geostationary. A curvilinear variable (2-D
+        lon/lat, no 1-D coordinate) is **not** a no-op here — it is re-georeferenced to a
+        bounding-box affine over its 2-D coordinates rather than left in index space (#1039).
+        In the geostationary case the 1-D ``x`` / ``y`` are **scan angles** (radians,
         packed with a ``scale_factor``), not projected coordinates, so a coordinate-derived
         geotransform is meaningless — it would overwrite the projected metre grid that
         :meth:`_normalize_geostationary_geotransform` just installed with a raw index-space one.
@@ -5150,13 +5152,15 @@ class NetCDF(Dataset):
         )
 
     def _coordinate_derived_geotransform(self, cube: NetCDF) -> tuple | None:
-        """Real-world geotransform from the parent's 1-D lon/lat, or ``None`` if not applicable.
+        """Real-world geotransform from the parent's lon/lat coordinates, or ``None``.
 
         Returns the north-up affine implied by the parent container's 1-D ``lon``/``lat`` (or
         ``x``/``y``) coordinate variables when they (a) match the subset's grid shape, (b) index the
         subset's spatial dimensions by name (CF coordinate-variable convention — guards a same-shaped
         but different staggered/rotated axis from adopting the wrong coordinates), and (c) actually
-        differ from the subset's current (index-space) geotransform. Otherwise ``None``.
+        differ from the subset's current (index-space) geotransform. When no 1-D coordinate indexes
+        the grid — a curvilinear variable whose lon/lat are 2-D — falls back to a bounding-box affine
+        over those 2-D coordinates (:meth:`_curvilinear_bbox_geotransform`, #1039). Otherwise ``None``.
         """
         result = None
         lon, lon_name = self._first_coordinate(("lon", "x"))
@@ -5186,7 +5190,61 @@ class NetCDF(Dataset):
                 abs(float(a) - float(b)) < 1e-6 for a, b in zip(real_gt, current)
             ):
                 result = real_gt
+        else:
+            # No usable 1-D coordinate indexes the grid: a curvilinear variable carries its
+            # lon/lat as 2-D arrays. Derive a north-up bounding-box affine from those so it is
+            # georeferenced to its real geographic extent rather than the index-space
+            # placeholder GDAL falls back to for a grid it cannot express affinely (#1039).
+            result = self._curvilinear_bbox_geotransform(cube)
         return result
+
+    def _curvilinear_bbox_geotransform(self, cube: NetCDF) -> tuple | None:
+        """North-up bounding-box affine from a variable's 2-D curvilinear lon/lat.
+
+        A curvilinear grid stores longitude/latitude as 2-D arrays (e.g. ROMS
+        ``lon_rho``/``lat_rho``, RASM ``xc``/``yc``) and has no single affine
+        geotransform, so GDAL's classic driver falls back to an index-space one. Reporting
+        that tagged with the grid's real CRS is a fabricated georeference that misplaces the
+        data (#1039). Derive instead a north-up affine spanning the real lon/lat bounding
+        box, so the variable is georeferenced to its true geographic extent. This is an
+        approximation of the curved grid — the domain is placed correctly, individual cells
+        only approximately — but it reflects the data's real location instead of pixel
+        indices, and pairs honestly with the WGS 84 CRS the coordinates already imply.
+
+        Args:
+            cube: The variable subset whose 2-D coordinates georeference the grid.
+
+        Returns:
+            tuple | None: The ``(x_min, x_cell, 0, y_max, 0, -y_cell)`` bounding-box affine,
+            or ``None`` when the variable is not curvilinear or its 2-D coordinates are
+            unreadable, mis-shaped, or degenerate — leaving the caller's fallback in place.
+        """
+        curv = NetCDFPlot(cube)._resolve_curvilinear_coords(cube, coords=None)
+        if curv is None:
+            return None
+        lon2d = np.asarray(curv[0], dtype="f8")
+        lat2d = np.asarray(curv[1], dtype="f8")
+        expected = (cube.rows, cube.columns)
+        if (
+            lon2d.ndim != 2
+            or lat2d.ndim != 2
+            or lon2d.shape != expected
+            or lat2d.shape != expected
+            or cube.rows < 2
+            or cube.columns < 2
+        ):
+            return None
+        x_min, x_max = float(np.nanmin(lon2d)), float(np.nanmax(lon2d))
+        y_min, y_max = float(np.nanmin(lat2d)), float(np.nanmax(lat2d))
+        if (
+            not np.isfinite([x_min, x_max, y_min, y_max]).all()
+            or x_max <= x_min
+            or y_max <= y_min
+        ):
+            return None
+        x_cell = (x_max - x_min) / (cube.columns - 1)
+        y_cell = (y_max - y_min) / (cube.rows - 1)
+        return (x_min - x_cell / 2, x_cell, 0.0, y_max + y_cell / 2, 0.0, -y_cell)
 
     def _attach_variable_metadata(
         self, cube: NetCDF, md_arr, spatial_dim_indices: tuple[int, int] | None

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -5222,6 +5222,13 @@ class NetCDF(Dataset):
             or ``None`` when the variable is not curvilinear or its 2-D coordinates are
             unreadable, mis-shaped, or degenerate — leaving the caller's fallback in place.
         """
+        # A degrees bounding box is only meaningful under a geographic CRS. A projected or
+        # rotated grid whose 2-D aux coords are lon/lat would otherwise get a degrees affine
+        # stamped under its metre CRS; this also skips the resolver read for a variable that
+        # carries no geographic CRS at all (round-1 review L1/N3).
+        crs = cube.crs
+        if not crs or not sr_from_wkt(crs).IsGeographic():
+            return None
         curv = NetCDFPlot(cube)._resolve_curvilinear_coords(cube, coords=None)
         if curv is None:
             return None
@@ -5235,14 +5242,23 @@ class NetCDF(Dataset):
             or lat2d.shape != expected
             or cube.rows < 2
             or cube.columns < 2
+            or not np.isfinite(lon2d).any()
+            or not np.isfinite(lat2d).any()
         ):
             return None
         x_min, x_max = float(np.nanmin(lon2d)), float(np.nanmax(lon2d))
         y_min, y_max = float(np.nanmin(lat2d)), float(np.nanmax(lat2d))
+        # Masked cells can carry a large finite _FillValue sentinel (ReadAsArray is raw), which
+        # np.nanmax would pick up. Reject a box outside plausible geographic bounds rather than
+        # trust a fabricated extent (round-1 review L2).
         if (
             not np.isfinite([x_min, x_max, y_min, y_max]).all()
             or x_max <= x_min
             or y_max <= y_min
+            or x_min < -360.0
+            or x_max > 360.0
+            or y_min < -90.0
+            or y_max > 90.0
         ):
             return None
         # A grid crossing the antimeridian stores longitudes clustered at both ends of the

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -5218,9 +5218,12 @@ class NetCDF(Dataset):
             cube: The variable subset whose 2-D coordinates georeference the grid.
 
         Returns:
-            tuple | None: The ``(x_min, x_cell, 0, y_max, 0, -y_cell)`` bounding-box affine,
-            or ``None`` when the variable is not curvilinear or its 2-D coordinates are
-            unreadable, mis-shaped, or degenerate — leaving the caller's fallback in place.
+            tuple | None: The north-up bounding-box affine
+            ``(x_min - x_cell/2, x_cell, 0, y_max + y_cell/2, 0, -y_cell)`` — the origin is the
+            north-west pixel *edge*, half a cell out from the extreme coordinate centres. Or
+            ``None`` when the CRS is not geographic, the variable is not curvilinear, its 2-D
+            coordinates are unreadable / mis-shaped / degenerate / out of geographic range, or
+            the grid crosses the antimeridian — leaving the caller's fallback in place.
         """
         # A degrees bounding box is only meaningful under a geographic CRS. A projected or
         # rotated grid whose 2-D aux coords are lon/lat would otherwise get a degrees affine

--- a/tests/netcdf/samples/test_curvilinear_crop.py
+++ b/tests/netcdf/samples/test_curvilinear_crop.py
@@ -96,6 +96,25 @@ def test_rasm_curvilinear_geotransform_is_geographic_not_index(sample):
         nc.close()
 
 
+def test_curvilinear_georeference_emits_no_deprecation_warning(sample):
+    """Deriving a curvilinear geotransform must not surface the plot-side deprecation (#1039 M1).
+
+    ROMS resolves its 2-D coords via the model-name fallback, whose plot-side ``coords=``
+    DeprecationWarning does not apply on the read path — get_variable must not raise it.
+    """
+    nc = NetCDF.read_file(sample(ROMS))
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", DeprecationWarning)
+            salt = nc.get_variable("salt")
+            gt = salt.geotransform
+        assert salt.epsg == 4326 and gt[0] < -87.0, (
+            "must still be georeferenced geographically"
+        )
+    finally:
+        nc.close()
+
+
 def test_none5v_not_confidently_curvilinear_stays_index_and_ungeoreferenced(sample):
     """A file whose 2-D lat/lon don't resolve as curvilinear keeps the index grid + no CRS (#1039).
 

--- a/tests/netcdf/samples/test_curvilinear_crop.py
+++ b/tests/netcdf/samples/test_curvilinear_crop.py
@@ -74,15 +74,22 @@ def test_roms_curvilinear_geotransform_is_geographic_not_index(sample):
 
 
 def test_rasm_curvilinear_geotransform_is_geographic_not_index(sample):
-    """RASM Tair (2-D xc/yc) reports a real lon/lat bbox affine + EPSG:4326, not index space (#1039)."""
+    """RASM Tair reports a real geographic bbox affine + EPSG:4326, not index space (#1039).
+
+    RASM is a circumpolar grid (2-D xc/yc reach the North Pole), so its longitude bbox
+    legitimately spans the full 0..360 circle with no antimeridian gap — this test pins the
+    tight real latitude window and the real (sub-degree) north-up pixel height; the
+    antimeridian-decline path is covered by test_curvilinear_bbox_declines_for_antimeridian.
+    """
     nc = NetCDF.read_file(sample(RASM))
     try:
         tair = nc.get_variable("Tair")
-        xmin, dx, _, ymax, _, dy = tair.geotransform
+        _, _, _, ymax, _, dy = tair.geotransform
         ymin = ymax + dy * tair.rows
         assert tair.epsg == 4326, f"curvilinear CRS must stay WGS84, got {tair.epsg}"
-        assert (xmin, dx, dy) != (0.0, 1.0, -1.0), "geotransform is still index-space"
-        assert -91.0 <= ymin < ymax <= 91.0, f"lat not geographic: [{ymin}, {ymax}]"
+        assert -1.0 < dy < 0.0, f"pixel height must be real degrees north-up, got {dy}"
+        assert 16.0 <= ymin < 18.0, f"south edge not at the real RASM latitude: {ymin}"
+        assert 88.0 < ymax <= 90.5, f"north edge must reach the pole, got {ymax}"
     finally:
         nc.close()
 
@@ -111,6 +118,67 @@ def test_none5v_not_confidently_curvilinear_stays_index_and_ungeoreferenced(samp
         )
         assert ymax == float(data.rows), (
             f"index-space origin must be (0, rows={data.rows}), got ymax={ymax}"
+        )
+    finally:
+        nc.close()
+
+
+def _synthetic_curvilinear(lon2d, lat2d, epsg=4326):
+    """A create_from_array NetCDF variable carrying explicit 2-D curvilinear coords.
+
+    Returns ``(nc, var)``; the caller closes ``nc``. Exercises the
+    ``_curvilinear_bbox_geotransform`` decline paths that no on-disk fixture reaches.
+    """
+    ny, nx = lon2d.shape
+    nc = NetCDF.create_from_array(
+        arr=np.zeros((1, ny, nx), dtype="float32"),
+        geo_ref=GeoReference(geo=(0.0, 1.0, 0.0, float(ny), 0.0, -1.0), epsg=epsg),
+        variable_name="c",
+    )
+    var = nc.get_variable("c")
+    var._curvilinear_coords = (lon2d.astype(float), lat2d.astype(float))
+    return nc, var
+
+
+def test_curvilinear_bbox_declines_for_antimeridian():
+    """A dateline-crossing curvilinear grid declines the bbox affine, not a globe span (#1039 M1)."""
+    ny, nx = 8, 12
+    lon_row = ((np.arange(nx) + 172.0 + 180.0) % 360.0) - 180.0  # 172..179, -180..-169
+    lon2d = np.tile(lon_row, (ny, 1))
+    lat2d = np.tile(np.linspace(9.0, -9.0, ny).reshape(ny, 1), (1, nx))
+    nc, var = _synthetic_curvilinear(lon2d, lat2d)
+    try:
+        assert var._curvilinear_bbox_geotransform(var) is None, (
+            "an antimeridian grid must decline, not span the globe in longitude"
+        )
+    finally:
+        nc.close()
+
+
+def test_curvilinear_bbox_declines_for_projected_crs():
+    """2-D lon/lat under a projected CRS declines — no degrees affine stamped under metres (#1039 L1)."""
+    ny, nx = 6, 8
+    lon2d = np.tile(np.linspace(-3.0, 3.0, nx), (ny, 1))
+    lat2d = np.tile(np.linspace(3.0, -3.0, ny).reshape(ny, 1), (1, nx))
+    nc, var = _synthetic_curvilinear(lon2d, lat2d, epsg=32632)
+    try:
+        assert var._curvilinear_bbox_geotransform(var) is None, (
+            "degrees coords must not be stamped under a projected CRS"
+        )
+    finally:
+        nc.close()
+
+
+def test_curvilinear_bbox_declines_for_fill_sentinel_coords():
+    """A large finite _FillValue sentinel in the 2-D coords declines, not an inflated bbox (#1039 L2)."""
+    ny, nx = 6, 8
+    lon2d = np.tile(np.linspace(-3.0, 3.0, nx), (ny, 1))
+    lon2d[0, 0] = 9.969209968386869e36  # NetCDF default _FillValue, unmasked
+    lat2d = np.tile(np.linspace(3.0, -3.0, ny).reshape(ny, 1), (1, nx))
+    nc, var = _synthetic_curvilinear(lon2d, lat2d)
+    try:
+        assert var._curvilinear_bbox_geotransform(var) is None, (
+            "a fill-sentinel longitude must not inflate the bounding box"
         )
     finally:
         nc.close()

--- a/tests/netcdf/samples/test_curvilinear_crop.py
+++ b/tests/netcdf/samples/test_curvilinear_crop.py
@@ -68,7 +68,8 @@ def test_roms_curvilinear_geotransform_is_geographic_not_index(sample):
         xmax = xmin + dx * salt.columns
         ymin = ymax + dy * salt.rows
         assert salt.epsg == 4326, f"curvilinear CRS must stay WGS84, got {salt.epsg}"
-        assert dx > 0 and dy < 0, f"must be a north-up affine, got dx={dx} dy={dy}"
+        assert dx > 0, f"x pixel width must be positive, got dx={dx}"
+        assert dy < 0, f"y pixel height must be negative (north-up), got dy={dy}"
         assert -95.0 <= xmin < xmax <= -87.0, f"lon not geographic: [{xmin}, {xmax}]"
         assert 27.0 <= ymin < ymax <= 31.0, f"lat not geographic: [{ymin}, {ymax}]"
     finally:
@@ -108,9 +109,8 @@ def test_curvilinear_georeference_emits_no_deprecation_warning(sample):
             warnings.simplefilter("error", DeprecationWarning)
             salt = nc.get_variable("salt")
             gt = salt.geotransform
-        assert salt.epsg == 4326 and gt[0] < -87.0, (
-            "must still be georeferenced geographically"
-        )
+        assert salt.epsg == 4326, f"CRS must stay WGS84, got {salt.epsg}"
+        assert gt[0] < -87.0, f"must be georeferenced geographically, got x_min={gt[0]}"
     finally:
         nc.close()
 

--- a/tests/netcdf/samples/test_curvilinear_crop.py
+++ b/tests/netcdf/samples/test_curvilinear_crop.py
@@ -23,6 +23,7 @@ pytestmark = pytest.mark.core
 
 ROMS = "cf__8v__1d3-2d3-3d1-4d1__curv-stag.nc"
 RASM = "none__4v__1d1-2d2-3d1__curv.nc"
+NONE5V = "none__5v__1d2-2d2-3d1__curv.nc"
 
 
 def _fc(coords):
@@ -82,6 +83,35 @@ def test_rasm_curvilinear_geotransform_is_geographic_not_index(sample):
         assert tair.epsg == 4326, f"curvilinear CRS must stay WGS84, got {tair.epsg}"
         assert (xmin, dx, dy) != (0.0, 1.0, -1.0), "geotransform is still index-space"
         assert -91.0 <= ymin < ymax <= 91.0, f"lat not geographic: [{ymin}, {ymax}]"
+    finally:
+        nc.close()
+
+
+def test_none5v_not_confidently_curvilinear_stays_index_and_ungeoreferenced(sample):
+    """A file whose 2-D lat/lon don't resolve as curvilinear keeps the index grid + no CRS (#1039).
+
+    ``none__5v`` (McIDAS image bands) carries 2-D lat/lon, but the curvilinear resolver rejects them, so
+    ``_curvilinear_bbox_geotransform`` must decline (its ``curv is None`` guard) and leave the caller's
+    fallback in place: the ``data`` variable keeps the index-space placeholder ``(0, 1, 0, rows, 0, -1)``
+    and reports no EPSG — the else-branch fallback must never fabricate a geographic affine or a CRS here.
+    """
+    nc = NetCDF.read_file(sample(NONE5V))
+    try:
+        data = nc.get_variable("data")
+        resolved = NetCDFPlot(data)._resolve_curvilinear_coords(data, coords=None)
+        assert resolved is None, (
+            "guard premise: the resolver must reject none__5v's 2-D coords"
+        )
+        assert data.epsg is None, (
+            f"ungeoreferenced file must keep epsg None, got {data.epsg}"
+        )
+        xmin, dx, _, ymax, _, dy = data.geotransform
+        assert (xmin, dx, dy) == (0.0, 1.0, -1.0), (
+            f"geotransform must stay index-space, got {data.geotransform}"
+        )
+        assert ymax == float(data.rows), (
+            f"index-space origin must be (0, rows={data.rows}), got ymax={ymax}"
+        )
     finally:
         nc.close()
 

--- a/tests/netcdf/samples/test_curvilinear_crop.py
+++ b/tests/netcdf/samples/test_curvilinear_crop.py
@@ -52,6 +52,40 @@ def test_roms_curvilinear_crop_masks_and_windows(sample):
         nc.close()
 
 
+def test_roms_curvilinear_geotransform_is_geographic_not_index(sample):
+    """ROMS salt reports a real lon/lat bounding-box affine, not the index grid (#1039).
+
+    The 2-D lon_rho/lat_rho span the Gulf of Mexico, so the geotransform must cover that real
+    extent (north-up) and keep EPSG:4326 — never the fabricated index placeholder (0,1,0,N,0,-1).
+    """
+    nc = NetCDF.read_file(sample(ROMS))
+    try:
+        salt = nc.get_variable("salt")
+        xmin, dx, _, ymax, _, dy = salt.geotransform
+        xmax = xmin + dx * salt.columns
+        ymin = ymax + dy * salt.rows
+        assert salt.epsg == 4326, f"curvilinear CRS must stay WGS84, got {salt.epsg}"
+        assert dx > 0 and dy < 0, f"must be a north-up affine, got dx={dx} dy={dy}"
+        assert -95.0 <= xmin < xmax <= -87.0, f"lon not geographic: [{xmin}, {xmax}]"
+        assert 27.0 <= ymin < ymax <= 31.0, f"lat not geographic: [{ymin}, {ymax}]"
+    finally:
+        nc.close()
+
+
+def test_rasm_curvilinear_geotransform_is_geographic_not_index(sample):
+    """RASM Tair (2-D xc/yc) reports a real lon/lat bbox affine + EPSG:4326, not index space (#1039)."""
+    nc = NetCDF.read_file(sample(RASM))
+    try:
+        tair = nc.get_variable("Tair")
+        xmin, dx, _, ymax, _, dy = tair.geotransform
+        ymin = ymax + dy * tair.rows
+        assert tair.epsg == 4326, f"curvilinear CRS must stay WGS84, got {tair.epsg}"
+        assert (xmin, dx, dy) != (0.0, 1.0, -1.0), "geotransform is still index-space"
+        assert -91.0 <= ymin < ymax <= 91.0, f"lat not geographic: [{ymin}, {ymax}]"
+    finally:
+        nc.close()
+
+
 def test_roms_crop_nonoverlapping_polygon_raises(sample):
     """A polygon that misses the curvilinear grid raises a clear error (not a crash)."""
     nc = NetCDF.read_file(sample(ROMS))

--- a/tests/netcdf/samples/test_curvilinear_crop.py
+++ b/tests/netcdf/samples/test_curvilinear_crop.py
@@ -7,6 +7,8 @@ bounding ``(row, col)`` index window — keeping the windowed 2-D coordinates so
 curvilinear.
 """
 
+import warnings
+
 import geopandas as gpd
 import numpy as np
 import pytest
@@ -180,6 +182,20 @@ def test_curvilinear_bbox_declines_for_fill_sentinel_coords():
         assert var._curvilinear_bbox_geotransform(var) is None, (
             "a fill-sentinel longitude must not inflate the bounding box"
         )
+    finally:
+        nc.close()
+
+
+def test_curvilinear_bbox_declines_for_all_nan_coords():
+    """All-NaN 2-D coords decline cleanly, with no numpy 'All-NaN slice' warning (#1039 N2)."""
+    lon2d = np.full((6, 8), np.nan)
+    lat2d = np.full((6, 8), np.nan)
+    nc, var = _synthetic_curvilinear(lon2d, lat2d)
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            result = var._curvilinear_bbox_geotransform(var)
+        assert result is None, "all-NaN coords must decline to the index-space fallback"
     finally:
         nc.close()
 


### PR DESCRIPTION
# Description

A curvilinear NetCDF variable (2-D longitude/latitude arrays — e.g. ROMS `lon_rho`/`lat_rho`, RASM `xc`/`yc`) has
no single affine geotransform, so GDAL's classic driver falls back to an index-space one (`(0,1,0,0,0,1)`).
pyramids reported that flipped north-up (`(0,1,0,N,0,-1)`) tagged with the grid's inferred **EPSG:4326** — a
fabricated affine georeference that placed the data in pixel space instead of its real geographic domain (e.g. a
Gulf-of-Mexico ROMS grid at lon −94→−88, lat 27→31 was reported as an index grid 0→371 × 0→191 tagged WGS 84).

Investigation showed the EPSG:4326 is **not** the fabrication: the coordinates genuinely are WGS 84 lon/lat, and
the CRS is relied upon by the cross-CRS curvilinear crop path (`_reconcile_mask_to_crs` reprojects a mask into the
grid's CRS only when `epsg` is truthy). So this keeps EPSG:4326 and fixes only the geotransform.

The fix extends the existing "re-georeference an index-space subset from its coordinates" machinery
(`_georeference_index_subset` → `_coordinate_derived_geotransform`, which already wraps the view in a VRT carrying
the coordinate-derived geotransform + CRS): when no 1-D coordinate indexes the grid, it now falls back to a new
`_curvilinear_bbox_geotransform` — a north-up bounding-box affine over the variable's 2-D curvilinear coordinates
(resolved via the existing `CurvilinearCoordResolver`, which already knows ROMS/RASM/WRF/NEMO/CF conventions). The
variable is then georeferenced to its true lon/lat extent and keeps EPSG:4326.

This is an approximation of the curved grid — the domain is placed correctly, individual cells only approximately
— but it reflects the data's real location instead of pixel indices, and pairs honestly with the CRS the
coordinates already imply. A variable whose 2-D coordinates cannot be confidently identified (no CRS inferred,
e.g. `none__5v__1d2-2d2-3d1__curv.nc`) is left honestly ungeoreferenced (index grid, `epsg=None`) rather than
gaining a fabricated georeference. The proper per-cell representation for heavily rotated / antimeridian-crossing
grids remains the GEOLOCATION-domain support tracked in #1033.

### Review refinements (two review passes)

- **Antimeridian handling.** A grid that *narrowly* straddles the dateline (its longitudes leave a >180° gap, so
  raw min/max would span nearly the whole globe) now **declines** to the index-space placeholder rather than
  fabricate a globe-spanning affine; a genuinely circumpolar grid (RASM, whose longitudes fill the circle without
  a gap) is unaffected. Known documented limit: a *wide* dateline-crossing grid (>180° coverage, no such gap)
  cannot be told apart from a legitimate wide grid by coordinates alone — strengthening the detector would
  false-decline polar grids — so it is approximated, not declined; the exact per-cell answer is the GEOLOCATION
  domain (#1033).
- **Hardened guards** on `_curvilinear_bbox_geotransform`: gate on a geographic CRS (a projected/rotated grid with
  2-D lon/lat aux coords is not stamped with a degrees affine under a metre CRS); reject a bounding box outside
  lon ±360 / lat ±90 (so an unmasked `_FillValue` sentinel cannot inflate the extent); and skip all-NaN coords
  before `nanmin`/`nanmax`.
- **No new read-path warning.** Deriving the geotransform resolves the 2-D coords via the plot resolver; its
  plot-side `coords=` `DeprecationWarning` (which has no analogue on the read path) is now silenced for this
  internal call, so loading a non-CF-compliant curvilinear variable no longer surfaces it.
- **Tests.** Added decline-path coverage (antimeridian, projected CRS, fill sentinel, all-NaN), a
  no-deprecation-warning regression, and tightened the RASM assertion to its real circumpolar latitude window.

# Issues

- Closes #1039 — curvilinear variables report a fabricated affine georeference (index geotransform tagged
  EPSG:4326).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All runs via the `dev` pixi environment against the branch worktree.

- New tests in `tests/netcdf/samples/test_curvilinear_crop.py`:
  - `test_roms_curvilinear_geotransform_is_geographic_not_index` — ROMS `salt` reports the real Gulf-of-Mexico
    lon/lat bbox affine (north-up) + `epsg==4326`, not the index grid.
  - `test_rasm_curvilinear_geotransform_is_geographic_not_index` — RASM `Tair` (2-D `xc`/`yc`) reports a real
    lon/lat affine + `epsg==4326`, not `(0,1,0,N,0,-1)`.
- Full NetCDF subtree regression: `pytest -m "not plot" tests/netcdf` → **2550 passed, 38 skipped**.
- Blast-radius checks pass: the `epsg==4326`-dependent `test_crop_mask_in_different_crs_is_reprojected` (EPSG is
  unchanged) and the CRS-inference corpus (`tests/base/test_crs_less_semantics.py`,
  `tests/base/test_crs_inference_netcdf.py`, untouched by this change).
- `mypy` clean on `netcdf.py`; `ruff-check` / `ruff-format` clean.
- Empirical: the issue reproduction now returns the real geographic bounding-box affine instead of the index grid.

Reproduce:

- [x] `pytest tests/netcdf/samples/test_curvilinear_crop.py -v`

# Checklist:

- [ ] updated version number in pyproject.toml. — N/A (versions handled by commitizen in CI).
- [ ] added changes to History.rst. — N/A (changelog is commitizen-generated).
- [ ] updated the latest version in README file. — N/A.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated. — N/A (internal behavior fix; docstrings updated in code).
