### PR TITLE
feat(spatial): let align choose its resampling method

### DIFF
--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -27,6 +27,7 @@ from pyramids.base._utils import (
     import_dask,
     import_zarr,
     lazy_extra_hint,
+    resolve_resampling,
 )
 from pyramids.base.crs import crs_spec, epsg_from_user_input
 from pyramids.base.remote import cloud_config_from_env
@@ -3371,6 +3372,11 @@ class DatasetCollection:
         """
         if not isinstance(alignment_src, Dataset):
             raise TypeError("alignment_src input should be a Dataset object")
+        # Validate the method here so an invalid name fails fast at call time,
+        # matching `Dataset.align` and the `Raises:` contract above — regardless of
+        # `compute` (the deferred graph would otherwise only raise at `.compute()`)
+        # or timestep count (an empty collection never runs a per-step align).
+        resolve_resampling(method)
         from pyramids.dataset.ops.reproject import Aligner
 
         if alignment_src.epsg is not None:

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -3314,7 +3314,12 @@ class DatasetCollection:
         return self._finalize_per_timestep_result(new_datasets, inplace=inplace)
 
     def align(
-        self, alignment_src: Dataset, inplace: bool = False, *, compute: bool = True
+        self,
+        alignment_src: Dataset,
+        inplace: bool = False,
+        *,
+        method: str = DEFAULT_RESAMPLING,
+        compute: bool = True,
     ) -> DatasetCollection | None | Delayed:
         """Align every timestep to `alignment_src`.
 
@@ -3327,6 +3332,10 @@ class DatasetCollection:
             inplace (bool):
                 If True, mutate this collection in place and return None.
                 If False (default), return a new `DatasetCollection`.
+            method (str):
+                Resampling method applied to every timestep, case-insensitive. Default is "nearest neighbor",
+                so existing behaviour is unchanged. Accepts the same algorithm names as
+                :meth:`Dataset.align` / :meth:`Dataset.to_crs`. Keyword-only.
             compute (bool):
                 If True (default), align every timestep eagerly. If False, defer the
                 whole align into one `dask.delayed.Delayed` that builds the aligned
@@ -3347,6 +3356,13 @@ class DatasetCollection:
               >>> aligned = collection.align(dem_dataset)  # doctest: +SKIP
 
               ```
+
+            - Align with bilinear resampling instead of nearest neighbor:
+
+              ```python
+              >>> aligned = collection.align(dem_dataset, method="bilinear")  # doctest: +SKIP
+
+              ```
         """
         if not isinstance(alignment_src, Dataset):
             raise TypeError("alignment_src input should be a Dataset object")
@@ -3354,7 +3370,7 @@ class DatasetCollection:
 
         if alignment_src.epsg is not None:
             # Plan-once: one Aligner reused across every timestep (ARC-54).
-            op = Aligner(alignment_src)
+            op = Aligner(alignment_src, method=method)
 
             def per_step(ds: Dataset, do_compute: bool) -> Any:
                 return op(ds, compute=do_compute)
@@ -3362,10 +3378,10 @@ class DatasetCollection:
             # A reference with no EPSG code can't go through Aligner; align directly.
             def per_step(ds: Dataset, do_compute: bool) -> Any:
                 if do_compute:
-                    return ds.align(alignment_src)
+                    return ds.align(alignment_src, method=method)
                 import dask
 
-                return dask.delayed(ds.align)(alignment_src)
+                return dask.delayed(ds.align)(alignment_src, method=method)
 
         return self._apply_operator(per_step, inplace=inplace, compute=compute)
 

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -3349,6 +3349,11 @@ class DatasetCollection:
             `inplace=False`; `None` when `inplace=True`; a `Delayed` when
             `compute=False`.
 
+        Raises:
+            TypeError: `alignment_src` is not a `Dataset`, or `method` is not a string.
+            ValueError: `method` is not one of the supported interpolation methods, or
+                `compute=False` is combined with `inplace=True`.
+
         Examples:
             - Align every timestep to a DEM template:
 

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1451,6 +1451,7 @@ class Spatial(_Engine["Dataset"]):
     def align(
         self,
         alignment_src: Dataset,
+        *,
         method: str = DEFAULT_RESAMPLING,
     ) -> Dataset:
         """Align the current dataset (rows and columns) to match a given dataset.

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1483,15 +1483,23 @@ class Spatial(_Engine["Dataset"]):
             Dataset: A new aligned Dataset.
 
         Note:
+            - **`method` is keyword-only.** Pass it by name (`align(template, method="bilinear")`), matching
+              :meth:`DatasetCollection.align`. This deliberately differs from :meth:`Spatial.to_crs` /
+              :meth:`Spatial.resample`, which accept `method` positionally — a bare positional resampling name
+              after a `Dataset` template reads poorly and would collide with the collection API's `inplace` slot.
             - **Output dtype follows the template, not the source.** The aligned raster is built with
               `alignment_src`'s data type, so resampling a floating-point source onto an integer-typed template
-              with an interpolating `method` ("bilinear"/"cubic"/...) silently truncates the fractional results to
-              the template's integer type. Match the template dtype to the source, or use "nearest", to avoid it.
+              with an interpolating `method` ("bilinear"/"cubic"/...) silently drops the fractional part (the
+              interpolated values are cast to the template's integer type). Match the template dtype to the
+              source, or use "nearest", to avoid it.
             - **Cross-CRS aligns resample twice.** When the source and `alignment_src` CRSes differ, the data is
               first reprojected onto an intermediate grid and then resampled onto the template grid, so a
-              non-nearest `method` is applied twice and the result is slightly more smoothed than a same-CRS align
-              with the identical `method`. The output grid is always exact; only pixel values differ. Reproject the
-              source to the template CRS first if a single-pass warp is needed.
+              non-nearest `method` is applied twice. For interpolating kernels ("bilinear"/"cubic") that means the
+              result is a little more smoothed than a same-CRS align with the identical `method`; for aggregating
+              kernels it changes the statistic itself — "sum" double-aggregates and inflates the total, and
+              "average"/"mode"/... become differently weighted, not smoother. The output grid is always exact;
+              only pixel values differ. Reproject the source to the template CRS first when an aggregating `method`
+              must be exact (a single-pass warp).
 
         Examples:
             - The source dataset has a `top_left_corner` at (0, 0) with a 5*5 alignment, and a 0.05 degree cell size.

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -423,8 +423,8 @@ class Spatial(_Engine["Dataset"]):
                 (alias "nearest neighbor"), "bilinear", "cubic", "cubic_spline", "lanczos", "average",
                 "mode", "max", "min", "med", "q1", "q3", "sum", and "rms" (the GDAL warp algorithms;
                 "sum"/"rms" need GDAL >= 3.1/3.3). See https://gisgeography.com/raster-resampling/.
-                Note: the aggregating algorithms ("average", "mode", "med", "q1", "q3", "sum", "rms")
-                are not no-data-aware on this warp path — no-data cells inside a resampling kernel are
+                Note: the aggregating algorithms ("min", "max", "average", "mode", "med", "q1", "q3", "sum",
+                "rms") are not no-data-aware on this warp path — no-data cells inside a resampling kernel are
                 mixed into the result. Prefer "nearest" on rasters that carry a no-data marker.
             maintain_alignment (bool):
                 True to maintain the number of rows and columns of the raster the same after reprojection.
@@ -1467,17 +1467,28 @@ class Spatial(_Engine["Dataset"]):
             alignment_src (Dataset):
                 Spatial information source raster to get the spatial information (coordinate system, number of rows and
                 columns). The data values of the current dataset are resampled to this alignment.
-            method (str):
+            method (str, keyword-only):
                 Resampling method, case-insensitive. Default is "nearest neighbor". Accepts the same algorithm
                 names as :meth:`Spatial.to_crs`: "nearest" (alias "nearest neighbor"), "bilinear", "cubic",
                 "cubic_spline", "lanczos", "average", "mode", "max", "min", "med", "q1", "q3", "sum", and "rms"
                 (the GDAL warp algorithms; "sum"/"rms" need GDAL >= 3.1/3.3). The aggregating algorithms
-                ("average", "mode", "med", "q1", "q3", "sum", "rms") are not no-data-aware on this path — no-data
-                cells inside a resampling kernel are mixed into the result. Prefer "nearest" on rasters that carry
-                a no-data marker.
+                ("min", "max", "average", "mode", "med", "q1", "q3", "sum", "rms") are not no-data-aware on this
+                path — no-data cells inside a resampling kernel are mixed into the result. Prefer "nearest" on
+                rasters that carry a no-data marker.
 
         Returns:
             Dataset: A new aligned Dataset.
+
+        Note:
+            - **Output dtype follows the template, not the source.** The aligned raster is built with
+              `alignment_src`'s data type, so resampling a floating-point source onto an integer-typed template
+              with an interpolating `method` ("bilinear"/"cubic"/...) silently truncates the fractional results to
+              the template's integer type. Match the template dtype to the source, or use "nearest", to avoid it.
+            - **Cross-CRS aligns resample twice.** When the source and `alignment_src` CRSes differ, the data is
+              first reprojected onto an intermediate grid and then resampled onto the template grid, so a
+              non-nearest `method` is applied twice and the result is slightly more smoothed than a same-CRS align
+              with the identical `method`. The output grid is always exact; only pixel values differ. Reproject the
+              source to the template CRS first if a single-pass warp is needed.
 
         Examples:
             - The source dataset has a `top_left_corner` at (0, 0) with a 5*5 alignment, and a 0.05 degree cell size.

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -424,8 +424,10 @@ class Spatial(_Engine["Dataset"]):
                 "mode", "max", "min", "med", "q1", "q3", "sum", and "rms" (the GDAL warp algorithms;
                 "sum"/"rms" need GDAL >= 3.1/3.3). See https://gisgeography.com/raster-resampling/.
                 Note: the aggregating algorithms ("min", "max", "average", "mode", "med", "q1", "q3", "sum",
-                "rms") are not no-data-aware on this warp path — no-data cells inside a resampling kernel are
-                mixed into the result. Prefer "nearest" on rasters that carry a no-data marker.
+                "rms") honour the source no-data value when the raster declares one — no-data cells are excluded
+                from the kernel, and a kernel that is entirely no-data yields no-data. A raster with no no-data
+                marker has nothing to exclude, so every cell (including a sentinel fill such as 9999) counts as
+                valid data.
             maintain_alignment (bool):
                 True to maintain the number of rows and columns of the raster the same after reprojection.
                 Default is False.
@@ -1472,9 +1474,10 @@ class Spatial(_Engine["Dataset"]):
                 names as :meth:`Spatial.to_crs`: "nearest" (alias "nearest neighbor"), "bilinear", "cubic",
                 "cubic_spline", "lanczos", "average", "mode", "max", "min", "med", "q1", "q3", "sum", and "rms"
                 (the GDAL warp algorithms; "sum"/"rms" need GDAL >= 3.1/3.3). The aggregating algorithms
-                ("min", "max", "average", "mode", "med", "q1", "q3", "sum", "rms") are not no-data-aware on this
-                path — no-data cells inside a resampling kernel are mixed into the result. Prefer "nearest" on
-                rasters that carry a no-data marker.
+                ("min", "max", "average", "mode", "med", "q1", "q3", "sum", "rms") honour the source no-data
+                value when the raster declares one: no-data cells are excluded from the kernel and a kernel that
+                is entirely no-data yields no-data. A raster that carries no no-data marker has nothing to
+                exclude, so every cell — including a sentinel fill such as 9999 — is treated as valid data.
 
         Returns:
             Dataset: A new aligned Dataset.

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1451,6 +1451,7 @@ class Spatial(_Engine["Dataset"]):
     def align(
         self,
         alignment_src: Dataset,
+        method: str = DEFAULT_RESAMPLING,
     ) -> Dataset:
         """Align the current dataset (rows and columns) to match a given dataset.
 
@@ -1458,12 +1459,21 @@ class Spatial(_Engine["Dataset"]):
             - The coordinate system
             - The number of rows and columns
             - Cell size
-        Then resamples values from the current dataset using the nearest neighbor interpolation.
+        Then resamples values from the current dataset onto that grid using ``method`` (nearest neighbor by
+        default, so the historical behaviour is unchanged).
 
         Args:
             alignment_src (Dataset):
                 Spatial information source raster to get the spatial information (coordinate system, number of rows and
                 columns). The data values of the current dataset are resampled to this alignment.
+            method (str):
+                Resampling method, case-insensitive. Default is "nearest neighbor". Accepts the same algorithm
+                names as :meth:`Spatial.to_crs`: "nearest" (alias "nearest neighbor"), "bilinear", "cubic",
+                "cubic_spline", "lanczos", "average", "mode", "max", "min", "med", "q1", "q3", "sum", and "rms"
+                (the GDAL warp algorithms; "sum"/"rms" need GDAL >= 3.1/3.3). The aggregating algorithms
+                ("average", "mode", "med", "q1", "q3", "sum", "rms") are not no-data-aware on this path — no-data
+                cells inside a resampling kernel are mixed into the result. Prefer "nearest" on rasters that carry
+                a no-data marker.
 
         Returns:
             Dataset: A new aligned Dataset.
@@ -1522,8 +1532,29 @@ class Spatial(_Engine["Dataset"]):
 
             ![align-result](./../../_images/dataset/align-result.png)
 
+            - Choose a different resampling method (e.g. bilinear) while still landing on the template's exact
+              grid. The default stays nearest neighbor, so only callers that opt in change behaviour:
+
+              ```python
+              >>> import numpy as np
+              >>> from pyramids.dataset import Dataset
+              >>> source = Dataset.create_from_array(
+              ...     np.arange(25, dtype=np.float32).reshape(5, 5),
+              ...     top_left_corner=(0, 0), cell_size=0.05, epsg=4326,
+              ... )
+              >>> template = Dataset.create_from_array(
+              ...     np.zeros((10, 10), dtype=np.float32),
+              ...     top_left_corner=(0, 0), cell_size=0.025, epsg=4326,
+              ... )
+              >>> aligned = source.align(template, method="bilinear")
+              >>> (aligned.rows, aligned.columns, aligned.epsg)
+              (10, 10, 4326)
+
+              ```
+
         Raises:
-            TypeError: `alignment_src` is not a `RasterBase`.
+            TypeError: `alignment_src` is not a `RasterBase`, or `method` is not a string.
+            ValueError: `method` is not one of the supported interpolation methods.
             CRSError: Either raster has no CRS. Aligning needs both, and
                 pyramids will not assume WGS 84 for an unprojected grid
                 (ARC-26).
@@ -1535,6 +1566,10 @@ class Spatial(_Engine["Dataset"]):
                 "First parameter should be a Dataset read using Dataset.openRaster or a path to the raster, "
                 f"given {type(alignment_src)}"
             )
+
+        # Validate/resolve the method up front so a bad name is rejected before any warp runs, even on the
+        # same-CRS path (where `to_crs` below is skipped and would otherwise be the only validator).
+        resample_alg: int = resolve_resampling(method)
 
         # reproject the raster to match the projection of alignment_src
         # Both sides are required, and the check must sit OUTSIDE the inequality
@@ -1556,7 +1591,7 @@ class Spatial(_Engine["Dataset"]):
         # -- exactly that case -- so two spellings of one CRS would otherwise
         # warp the data through an identity transform.
         if not crs_equal(own_crs, target_crs):
-            reprojected_raster_b = self.to_crs(target_crs)  # type: ignore[assignment]
+            reprojected_raster_b = self.to_crs(target_crs, method=method)  # type: ignore[assignment]
         dst_obj = self._ds.__class__._build_dataset(
             src.columns,
             src.rows,
@@ -1566,14 +1601,13 @@ class Spatial(_Engine["Dataset"]):
             src.crs,
             self._ds.no_data_value,
         )
-        method = gdal.GRA_NearestNeighbour
-        # resample the reprojected_RasterB
+        # resample the reprojected_RasterB onto the freshly built target grid using the requested algorithm
         gdal.ReprojectImage(
             reprojected_raster_b.raster,
             dst_obj.raster,
             src.crs,
             src.crs,
-            method,
+            resample_alg,
         )
         # ReprojectImage moves only pixels onto the freshly built grid, so the
         # output would otherwise lose the class legend, RAT, and band/dataset

--- a/src/pyramids/dataset/ops/reproject.py
+++ b/src/pyramids/dataset/ops/reproject.py
@@ -210,9 +210,16 @@ def _deferred_align(reference: Dataset, method: str, ds: Dataset) -> Any:
 
 
 def _align_sync(reference: Dataset, method: str, ds: Dataset) -> Dataset:
-    """Synchronous align body — module-level for pickleability.
+    """Synchronous align body — module-level so it stays picklable for ``dask``.
 
-    `method` is the resampling algorithm name forwarded to
-    :meth:`Dataset.align` (nearest neighbor by default).
+    Args:
+        reference: The :class:`~pyramids.dataset.Dataset` whose geobox (CRS, rows,
+            columns, cell size) ``ds`` is aligned to.
+        method: Resampling method name forwarded to :meth:`Dataset.align`
+            (nearest neighbor by default).
+        ds: The source :class:`~pyramids.dataset.Dataset` to align.
+
+    Returns:
+        Dataset: ``ds`` resampled onto ``reference``'s grid with ``method``.
     """
     return ds.align(reference, method=method)

--- a/src/pyramids/dataset/ops/reproject.py
+++ b/src/pyramids/dataset/ops/reproject.py
@@ -176,7 +176,7 @@ class Aligner(Reprojector):
             Dataset or dask.delayed.Delayed.
         """
         if compute:
-            result = ds.align(self._reference)
+            result = ds.align(self._reference, method=self._plan.method)
         else:
             result = _deferred_align(self._reference, self._plan.method, ds)
         return result
@@ -212,11 +212,7 @@ def _deferred_align(reference: Dataset, method: str, ds: Dataset) -> Any:
 def _align_sync(reference: Dataset, method: str, ds: Dataset) -> Dataset:
     """Synchronous align body — module-level for pickleability.
 
-    `method` is accepted for API parity with :class:`Reprojector` but
-    :meth:`Dataset.align` currently fixes the resampling to nearest
-    neighbor (see :func:`osgeo.gdal.Warp`'s default). Argument kept so
-    that if :meth:`Dataset.align` grows a `method=` kwarg in future
-    the operator contract does not need to change.
+    `method` is the resampling algorithm name forwarded to
+    :meth:`Dataset.align` (nearest neighbor by default).
     """
-    del method  # reserved for future align(method=...) support
-    return ds.align(reference)
+    return ds.align(reference, method=method)

--- a/tests/dataset/collection/test_dataset_collection.py
+++ b/tests/dataset/collection/test_dataset_collection.py
@@ -196,6 +196,35 @@ class TestAlign:
         assert cube.base.rows == mask_obj.rows
         assert cube.base.columns == mask_obj.columns
 
+    def test_align_method_passthrough(
+        self,
+        match_alignment_multi_dataset,
+        src: DatasetCollection,
+    ):
+        """`method=` is forwarded to every timestep while still hitting the template grid."""
+        mask_obj = Dataset(src)
+        cube = DatasetCollection.read_multiple_files(
+            match_alignment_multi_dataset, with_order=False
+        )
+        cube.open_multi_dataset()
+        aligned = cube.align(mask_obj, method="bilinear")
+        assert aligned.base.rows == mask_obj.rows
+        assert aligned.base.columns == mask_obj.columns
+
+    def test_align_invalid_method_raises(
+        self,
+        match_alignment_multi_dataset,
+        src: DatasetCollection,
+    ):
+        """A bad method name is rejected (same validator as `Dataset.align`)."""
+        mask_obj = Dataset(src)
+        cube = DatasetCollection.read_multiple_files(
+            match_alignment_multi_dataset, with_order=False
+        )
+        cube.open_multi_dataset()
+        with pytest.raises(ValueError):
+            cube.align(mask_obj, method="not-a-real-method")
+
 
 class TestSaveDatasetCollection:
     def test_to_geotiff_with_path(

--- a/tests/dataset/collection/test_dataset_collection.py
+++ b/tests/dataset/collection/test_dataset_collection.py
@@ -225,6 +225,35 @@ class TestAlign:
         with pytest.raises(ValueError):
             cube.align(mask_obj, method="not-a-real-method")
 
+    def test_align_no_epsg_reference_method_passthrough(self, three_files):
+        """`method=` reaches the direct (non-`Aligner`) path for a no-EPSG reference.
+
+        Test scenario:
+            A reference whose CRS has no EPSG code (a bespoke orthographic PROJ4
+            string) cannot go through the plan-once `Aligner`, so `align` falls back
+            to calling `Dataset.align` per timestep. The `method` must still be
+            forwarded, and every timestep must land on the reference's CRS.
+        """
+        ref_4326 = Dataset.create_from_array(
+            np.zeros((2, 3), dtype=np.float32),
+            top_left_corner=(0.0, 4.0),
+            cell_size=2.0,
+            epsg=4326,
+        )
+        ref = ref_4326.to_crs(
+            "+proj=ortho +lat_0=0 +lon_0=0 +datum=WGS84 +units=m +no_defs"
+        )
+        assert ref.epsg is None, "reference must be EPSG-less for this path"
+
+        collection = DatasetCollection.from_files(three_files)
+        aligned = collection.align(ref, method="bilinear")
+        assert aligned.base.epsg is None, (
+            f"aligned collection must adopt the reference CRS, got {aligned.base.epsg}"
+        )
+        assert aligned.time_length == 3, (
+            f"time_length should be preserved, got {aligned.time_length}"
+        )
+
 
 class TestSaveDatasetCollection:
     def test_to_geotiff_with_path(

--- a/tests/dataset/collection/test_dataset_collection.py
+++ b/tests/dataset/collection/test_dataset_collection.py
@@ -225,6 +225,25 @@ class TestAlign:
         with pytest.raises(ValueError):
             cube.align(mask_obj, method="not-a-real-method")
 
+    def test_align_invalid_method_raises_before_compute(self, three_files):
+        """`compute=False` still rejects a bad method at call time, not at compute.
+
+        Test scenario:
+            The up-front `resolve_resampling` guard must fire before the deferred
+            graph is built, so `align(ref, method="<bad>", compute=False)` raises
+            `ValueError` immediately rather than returning a `Delayed` that only
+            fails when computed.
+        """
+        ref = Dataset.create_from_array(
+            np.zeros((2, 3), dtype=np.float32),
+            top_left_corner=(0.0, 4.0),
+            cell_size=2.0,
+            epsg=4326,
+        )
+        collection = DatasetCollection.from_files(three_files)
+        with pytest.raises(ValueError, match="does not exist"):
+            collection.align(ref, method="not-a-real-method", compute=False)
+
     def test_align_no_epsg_reference_method_passthrough(self, three_files):
         """`method=` reaches the direct (non-`Aligner`) path for a no-EPSG reference.
 

--- a/tests/dataset/collection/test_dataset_collection.py
+++ b/tests/dataset/collection/test_dataset_collection.py
@@ -203,10 +203,7 @@ class TestAlign:
     ):
         """`method=` is forwarded to every timestep while still hitting the template grid."""
         mask_obj = Dataset(src)
-        cube = DatasetCollection.read_multiple_files(
-            match_alignment_multi_dataset, with_order=False
-        )
-        cube.open_multi_dataset()
+        cube = DatasetCollection.from_files(match_alignment_multi_dataset)
         aligned = cube.align(mask_obj, method="bilinear")
         assert aligned.base.rows == mask_obj.rows
         assert aligned.base.columns == mask_obj.columns
@@ -218,10 +215,7 @@ class TestAlign:
     ):
         """A bad method name is rejected (same validator as `Dataset.align`)."""
         mask_obj = Dataset(src)
-        cube = DatasetCollection.read_multiple_files(
-            match_alignment_multi_dataset, with_order=False
-        )
-        cube.open_multi_dataset()
+        cube = DatasetCollection.from_files(match_alignment_multi_dataset)
         with pytest.raises(ValueError):
             cube.align(mask_obj, method="not-a-real-method")
 

--- a/tests/dataset/collection/test_reproject_compute.py
+++ b/tests/dataset/collection/test_reproject_compute.py
@@ -166,9 +166,7 @@ class TestAlignCompute:
             a collection on the reference grid (the method is forwarded, not dropped).
         """
         collection = DatasetCollection.from_files(three_files)
-        result = collection.align(
-            align_ref, method="bilinear", compute=False
-        ).compute()
+        result = collection.align(align_ref, method="bilinear", compute=False).compute()
         assert result.base.rows == align_ref.rows, (
             f"aligned rows {result.base.rows} != reference {align_ref.rows}"
         )

--- a/tests/dataset/collection/test_reproject_compute.py
+++ b/tests/dataset/collection/test_reproject_compute.py
@@ -156,3 +156,22 @@ class TestAlignCompute:
             ValueError, match="compute=False cannot be combined with inplace"
         ):
             collection.align(align_ref, inplace=True, compute=False)
+
+    @requires_dask
+    def test_delayed_align_method_passthrough(self, three_files, align_ref):
+        """``method=`` survives into the deferred ``_align_sync`` body.
+
+        Test scenario:
+            ``align(ref, method="bilinear", compute=False).compute()`` — expected:
+            a collection on the reference grid (the method is forwarded, not dropped).
+        """
+        collection = DatasetCollection.from_files(three_files)
+        result = collection.align(
+            align_ref, method="bilinear", compute=False
+        ).compute()
+        assert result.base.rows == align_ref.rows, (
+            f"aligned rows {result.base.rows} != reference {align_ref.rows}"
+        )
+        assert result.base.columns == align_ref.columns, (
+            f"aligned columns {result.base.columns} != reference {align_ref.columns}"
+        )

--- a/tests/dataset/collection/test_reproject_compute.py
+++ b/tests/dataset/collection/test_reproject_compute.py
@@ -175,3 +175,28 @@ class TestAlignCompute:
         assert result.base.columns == align_ref.columns, (
             f"aligned columns {result.base.columns} != reference {align_ref.columns}"
         )
+
+    @requires_dask
+    def test_delayed_align_no_epsg_reference_method_passthrough(
+        self, three_files, align_ref
+    ):
+        """Deferred align to a no-EPSG reference forwards ``method=`` too.
+
+        Test scenario:
+            A no-EPSG reference takes the direct (non-``Aligner``) branch, whose
+            deferred arm is ``dask.delayed(ds.align)(ref, method=method)``. Computing
+            the ``Delayed`` must yield a collection on the reference (EPSG-less) CRS.
+        """
+        ref = align_ref.to_crs(
+            "+proj=ortho +lat_0=0 +lon_0=0 +datum=WGS84 +units=m +no_defs"
+        )
+        assert ref.epsg is None, "reference must be EPSG-less for this path"
+
+        collection = DatasetCollection.from_files(three_files)
+        result = collection.align(ref, method="bilinear", compute=False).compute()
+        assert result.base.epsg is None, (
+            f"aligned collection must adopt the reference CRS, got {result.base.epsg}"
+        )
+        assert result.time_length == 3, (
+            f"time_length should be preserved, got {result.time_length}"
+        )

--- a/tests/dataset/spatial/test_dataset_spatial.py
+++ b/tests/dataset/spatial/test_dataset_spatial.py
@@ -499,21 +499,129 @@ class TestAlign:
 
     def test_align_bilinear_lands_on_template_grid_and_differs_from_nearest(self):
         """`method="bilinear"` resamples onto the template's exact grid and, on a
-        gradient, produces values distinct from nearest neighbor."""
+        gradient, produces values distinct from nearest neighbor.
+
+        Test scenario:
+            Upsample a 5x5 gradient onto a co-extensive 10x10 template. The output
+            adopts the template's grid (rows/cols/epsg/geotransform) and, because
+            the source is a gradient, its values must differ from nearest (proving
+            bilinear actually interpolated rather than replicating blocks).
+        """
         source, template = self._gradient_source_and_template()
         bilinear = source.align(template, method="bilinear")
         nearest = source.align(template, method="nearest")
 
-        assert (bilinear.rows, bilinear.columns, bilinear.epsg) == (10, 10, 4326)
-        assert bilinear.geotransform == template.geotransform
-        # Bilinear must actually interpolate — not fall back to block replication.
-        assert not np.allclose(bilinear.read_array(), nearest.read_array())
+        assert (bilinear.rows, bilinear.columns, bilinear.epsg) == (10, 10, 4326), (
+            f"bilinear align must land on the template grid, got "
+            f"{(bilinear.rows, bilinear.columns, bilinear.epsg)}"
+        )
+        assert bilinear.geotransform == template.geotransform, (
+            "bilinear align must copy the template geotransform exactly"
+        )
+        assert not np.allclose(bilinear.read_array(), nearest.read_array()), (
+            "bilinear must interpolate, not fall back to nearest block replication"
+        )
+
+    @pytest.mark.parametrize(
+        "method",
+        ["nearest", "bilinear", "cubic", "cubic_spline", "lanczos", "average", "mode"],
+    )
+    def test_align_supported_methods_land_on_template_grid(self, method):
+        """Every supported (non version-gated) method lands on the template grid.
+
+        Args:
+            method: A resampling-method name accepted by `resolve_resampling`.
+
+        Test scenario:
+            For each algorithm, `align` must run without error and return a raster
+            on the template's exact 10x10 / EPSG:4326 grid — verifying the name is
+            forwarded all the way into `gdal.ReprojectImage`.
+        """
+        source, template = self._gradient_source_and_template()
+        aligned = source.align(template, method=method)
+        assert (aligned.rows, aligned.columns, aligned.epsg) == (10, 10, 4326), (
+            f"method={method!r} must land on the template grid, got "
+            f"{(aligned.rows, aligned.columns, aligned.epsg)}"
+        )
+
+    @pytest.mark.parametrize("alias", ["NEAREST", "  Nearest Neighbor  ", "nearest"])
+    def test_align_method_is_case_and_whitespace_insensitive(self, alias):
+        """Method names are normalised the same way `to_crs` normalises them.
+
+        Args:
+            alias: A spelling of the nearest-neighbor method differing only in case
+                or surrounding whitespace.
+
+        Test scenario:
+            Each alias must produce byte-identical output to the canonical
+            `"nearest"`, confirming `align` defers name handling to
+            `resolve_resampling` (which lower-cases and strips).
+        """
+        source, template = self._gradient_source_and_template()
+        canonical = source.align(template, method="nearest")
+        aliased = source.align(template, method=alias)
+        np.testing.assert_array_equal(
+            aliased.read_array(),
+            canonical.read_array(),
+            err_msg=f"alias {alias!r} should resample identically to 'nearest'",
+        )
 
     def test_align_invalid_method_raises(self):
-        """An unsupported method name is rejected (same validator as `to_crs`)."""
+        """An unsupported method name raises `ValueError` (same validator as `to_crs`).
+
+        Test scenario:
+            A bogus name must raise `ValueError` whose message reports it "does not
+            exist" and lists the valid set, matching `resolve_resampling`.
+        """
         source, template = self._gradient_source_and_template()
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="does not exist") as exc_info:
             source.align(template, method="not-a-real-method")
+        assert "not-a-real-method" in str(exc_info.value), (
+            f"error should echo the bad method name, got: {exc_info.value}"
+        )
+
+    def test_align_non_string_method_raises_type_error(self):
+        """A non-string method raises `TypeError` before any warp runs.
+
+        Test scenario:
+            Passing an int must raise `TypeError` ("must be a string") from the
+            up-front `resolve_resampling` guard, not an obscure GDAL failure later.
+        """
+        source, template = self._gradient_source_and_template()
+        with pytest.raises(TypeError, match="must be a string"):
+            source.align(template, method=3)
+
+    def test_align_non_dataset_template_raises_type_error(self):
+        """A non-`RasterBase` template raises `TypeError`.
+
+        Test scenario:
+            Passing a plain string (not a `Dataset`) as the alignment template must
+            raise `TypeError` telling the caller to pass a `Dataset`.
+        """
+        source, _ = self._gradient_source_and_template()
+        with pytest.raises(TypeError, match="should be a Dataset"):
+            source.align("not-a-dataset", method="nearest")
+
+    def test_align_bilinear_across_different_crs(self):
+        """`method` is forwarded through the intermediate reprojection too.
+
+        Test scenario:
+            When source and template CRSes differ, `align` first reprojects via
+            `to_crs` and then resamples onto the template grid. A EPSG:4326 source
+            aligned to an EPSG:3857 template with `method="bilinear"` must adopt the
+            template's CRS and grid, exercising the different-CRS branch (the
+            `to_crs(target_crs, method=...)` call) rather than the same-CRS shortcut.
+        """
+        source, _ = self._gradient_source_and_template()
+        template = source.to_crs(to_epsg=3857)
+        aligned = source.align(template, method="bilinear")
+        assert aligned.epsg == 3857, f"expected EPSG:3857, got {aligned.epsg}"
+        assert (aligned.rows, aligned.columns) == (template.rows, template.columns), (
+            "aligned raster must match the template's row/column count"
+        )
+        assert aligned.geotransform == template.geotransform, (
+            "aligned raster must copy the template geotransform exactly"
+        )
 
     def test_align_bilinear_template_crs_no_epsg(self):
         """DoD: works when the template CRS is a PROJ4 string with no EPSG code."""

--- a/tests/dataset/spatial/test_dataset_spatial.py
+++ b/tests/dataset/spatial/test_dataset_spatial.py
@@ -656,44 +656,102 @@ class TestAlign:
             "cross-CRS bilinear must differ from nearest — method must affect values"
         )
 
-    def test_align_aggregating_method_honors_no_data(self):
-        """Aggregating kernels exclude a declared no-data value, but not an undeclared one.
+    @pytest.mark.parametrize(
+        "method", ["average", "min", "max", "mode", "med", "q1", "q3"]
+    )
+    def test_align_aggregating_method_excludes_declared_no_data(self, method):
+        """Every aggregating kernel excludes a *declared* no-data value.
+
+        Args:
+            method: A kernel-aggregating resampling method.
 
         Test scenario:
             Downsample (2x2 -> 1) a source whose top-left cell holds the sentinel
-            9999 with "average". When the raster *declares* 9999 as its no-data
-            value GDAL excludes it, so the output stays 1.0; when no no-data value
-            is set the sentinel is real data and is averaged in, pulling the cell
-            far above 1.0. This pins the documented no-data behaviour of the
-            `ReprojectImage` warp path.
+            9999, declared as the no-data value. GDAL must drop 9999 from the
+            kernel, so no output cell is pulled near it — every aggregate of the
+            surrounding 1.0s stays small. Pins the corrected no-data docstring claim
+            across all aggregators, not just "average".
         """
         arr = np.ones((4, 4), dtype=np.float32)
         arr[0, 0] = 9999.0
-        template = Dataset.create_from_array(
-            np.zeros((2, 2), dtype=np.float32),
-            top_left_corner=(0.0, 0.0),
-            cell_size=0.5,
-            epsg=4326,
-        )
-
-        with_nodata = Dataset.create_from_array(
+        source = Dataset.create_from_array(
             arr,
             top_left_corner=(0.0, 0.0),
             cell_size=0.25,
             epsg=4326,
             no_data_value=9999.0,
         )
-        aligned = with_nodata.align(template, method="average").read_array()
-        assert np.isclose(aligned.max(), 1.0), (
-            f"a declared no-data 9999 must be excluded from the average, got {aligned.max()}"
+        template = Dataset.create_from_array(
+            np.zeros((2, 2), dtype=np.float32),
+            top_left_corner=(0.0, 0.0),
+            cell_size=0.5,
+            epsg=4326,
+        )
+        aligned = source.align(template, method=method).read_array()
+        assert aligned.max() < 100.0, (
+            f"method={method!r} must exclude the declared 9999, got max {aligned.max()}"
         )
 
-        without_nodata = Dataset.create_from_array(
+    def test_align_undeclared_sentinel_is_treated_as_data(self):
+        """Without a no-data marker the 9999 sentinel is real data and mixes in.
+
+        Test scenario:
+            The same 2x2 -> 1 average, but with no no-data value declared, averages
+            the 9999 in (~2500.5) — confirming the caveat's other half: a raster
+            with no no-data marker has nothing to exclude.
+        """
+        arr = np.ones((4, 4), dtype=np.float32)
+        arr[0, 0] = 9999.0
+        source = Dataset.create_from_array(
             arr, top_left_corner=(0.0, 0.0), cell_size=0.25, epsg=4326
         )
-        mixed = without_nodata.align(template, method="average").read_array()
+        template = Dataset.create_from_array(
+            np.zeros((2, 2), dtype=np.float32),
+            top_left_corner=(0.0, 0.0),
+            cell_size=0.5,
+            epsg=4326,
+        )
+        mixed = source.align(template, method="average").read_array()
         assert mixed.max() > 100.0, (
-            f"an undeclared 9999 is valid data and must mix in, got {mixed.max()}"
+            f"an undeclared 9999 must mix into the average, got {mixed.max()}"
+        )
+
+    def test_align_output_dtype_follows_integer_template(self):
+        """The documented dtype Note: aligning onto an integer template drops fractions.
+
+        Test scenario:
+            Align a fractional float32 source onto an int32 template with "bilinear".
+            The output adopts the template's integer dtype, so the interpolated
+            fractional values are cast to whole numbers — whereas the same align
+            onto a float32 template keeps the fractions.
+        """
+        src_arr = np.arange(25, dtype=np.float32).reshape(5, 5) * 0.3
+        source = Dataset.create_from_array(
+            src_arr, top_left_corner=(0.0, 0.0), cell_size=0.05, epsg=4326
+        )
+        int_template = Dataset.create_from_array(
+            np.zeros((10, 10), dtype=np.int32),
+            top_left_corner=(0.0, 0.0),
+            cell_size=0.025,
+            epsg=4326,
+        )
+        aligned_int = source.align(int_template, method="bilinear").read_array()
+        assert np.issubdtype(aligned_int.dtype, np.integer), (
+            f"output must adopt the template's integer dtype, got {aligned_int.dtype}"
+        )
+        assert np.array_equal(aligned_int, aligned_int.astype(np.int64)), (
+            "interpolated values must be whole numbers on an integer template"
+        )
+
+        float_template = Dataset.create_from_array(
+            np.zeros((10, 10), dtype=np.float32),
+            top_left_corner=(0.0, 0.0),
+            cell_size=0.025,
+            epsg=4326,
+        )
+        aligned_float = source.align(float_template, method="bilinear").read_array()
+        assert not np.array_equal(aligned_float, np.floor(aligned_float)), (
+            "the float-template align should keep fractional interpolated values"
         )
 
     def test_align_bilinear_template_crs_no_epsg(self):

--- a/tests/dataset/spatial/test_dataset_spatial.py
+++ b/tests/dataset/spatial/test_dataset_spatial.py
@@ -524,13 +524,28 @@ class TestAlign:
 
     @pytest.mark.parametrize(
         "method",
-        ["nearest", "bilinear", "cubic", "cubic_spline", "lanczos", "average", "mode"],
+        [
+            "nearest",
+            "bilinear",
+            "cubic",
+            "cubic_spline",
+            "lanczos",
+            "average",
+            "mode",
+            "min",
+            "max",
+            "med",
+            "q1",
+            "q3",
+        ],
     )
     def test_align_supported_methods_land_on_template_grid(self, method):
         """Every supported (non version-gated) method lands on the template grid.
 
         Args:
-            method: A resampling-method name accepted by `resolve_resampling`.
+            method: A resampling-method name accepted by `resolve_resampling`
+                (every key of `INTERPOLATION_METHODS` except the version-gated
+                "sum"/"rms").
 
         Test scenario:
             For each algorithm, `align` must run without error and return a raster
@@ -621,6 +636,64 @@ class TestAlign:
         )
         assert aligned.geotransform == template.geotransform, (
             "aligned raster must copy the template geotransform exactly"
+        )
+
+    def test_align_cross_crs_values_depend_on_method(self):
+        """Cross-CRS align actually resamples values by `method`, not just the grid.
+
+        Test scenario:
+            Aligning a EPSG:4326 gradient onto a EPSG:3857 template with "bilinear"
+            must yield pixel values that differ from the "nearest" result (both land
+            on the same template grid), pinning that `method` is honoured across the
+            CRS boundary and not silently dropped to nearest.
+        """
+        source, _ = self._gradient_source_and_template()
+        template = source.to_crs(to_epsg=3857)
+        bilinear = source.align(template, method="bilinear").read_array()
+        nearest = source.align(template, method="nearest").read_array()
+        assert bilinear.shape == nearest.shape, "both must share the template grid"
+        assert not np.allclose(bilinear, nearest, equal_nan=True), (
+            "cross-CRS bilinear must differ from nearest — method must affect values"
+        )
+
+    def test_align_aggregating_method_honors_no_data(self):
+        """Aggregating kernels exclude a declared no-data value, but not an undeclared one.
+
+        Test scenario:
+            Downsample (2x2 -> 1) a source whose top-left cell holds the sentinel
+            9999 with "average". When the raster *declares* 9999 as its no-data
+            value GDAL excludes it, so the output stays 1.0; when no no-data value
+            is set the sentinel is real data and is averaged in, pulling the cell
+            far above 1.0. This pins the documented no-data behaviour of the
+            `ReprojectImage` warp path.
+        """
+        arr = np.ones((4, 4), dtype=np.float32)
+        arr[0, 0] = 9999.0
+        template = Dataset.create_from_array(
+            np.zeros((2, 2), dtype=np.float32),
+            top_left_corner=(0.0, 0.0),
+            cell_size=0.5,
+            epsg=4326,
+        )
+
+        with_nodata = Dataset.create_from_array(
+            arr,
+            top_left_corner=(0.0, 0.0),
+            cell_size=0.25,
+            epsg=4326,
+            no_data_value=9999.0,
+        )
+        aligned = with_nodata.align(template, method="average").read_array()
+        assert np.isclose(aligned.max(), 1.0), (
+            f"a declared no-data 9999 must be excluded from the average, got {aligned.max()}"
+        )
+
+        without_nodata = Dataset.create_from_array(
+            arr, top_left_corner=(0.0, 0.0), cell_size=0.25, epsg=4326
+        )
+        mixed = without_nodata.align(template, method="average").read_array()
+        assert mixed.max() > 100.0, (
+            f"an undeclared 9999 is valid data and must mix in, got {mixed.max()}"
         )
 
     def test_align_bilinear_template_crs_no_epsg(self):

--- a/tests/dataset/spatial/test_dataset_spatial.py
+++ b/tests/dataset/spatial/test_dataset_spatial.py
@@ -473,6 +473,64 @@ class TestAlign:
         assert dataset_aligned.columns == resampled_multi_band_dims[1]
         assert dataset.top_left_corner == dataset_aligned.top_left_corner
 
+    @staticmethod
+    def _gradient_source_and_template() -> tuple[Dataset, Dataset]:
+        """A 5x5 gradient source and a co-extensive 10x10 template (2x finer)."""
+        source = Dataset.create_from_array(
+            np.arange(25, dtype=np.float32).reshape(5, 5),
+            top_left_corner=(0.0, 0.0),
+            cell_size=0.05,
+            epsg=4326,
+        )
+        template = Dataset.create_from_array(
+            np.zeros((10, 10), dtype=np.float32),
+            top_left_corner=(0.0, 0.0),
+            cell_size=0.025,
+            epsg=4326,
+        )
+        return source, template
+
+    def test_align_default_is_nearest_unchanged(self):
+        """The default keeps the historical nearest-neighbor behaviour."""
+        source, template = self._gradient_source_and_template()
+        default = source.align(template)
+        nearest = source.align(template, method="nearest")
+        np.testing.assert_array_equal(default.read_array(), nearest.read_array())
+
+    def test_align_bilinear_lands_on_template_grid_and_differs_from_nearest(self):
+        """`method="bilinear"` resamples onto the template's exact grid and, on a
+        gradient, produces values distinct from nearest neighbor."""
+        source, template = self._gradient_source_and_template()
+        bilinear = source.align(template, method="bilinear")
+        nearest = source.align(template, method="nearest")
+
+        assert (bilinear.rows, bilinear.columns, bilinear.epsg) == (10, 10, 4326)
+        assert bilinear.geotransform == template.geotransform
+        # Bilinear must actually interpolate — not fall back to block replication.
+        assert not np.allclose(bilinear.read_array(), nearest.read_array())
+
+    def test_align_invalid_method_raises(self):
+        """An unsupported method name is rejected (same validator as `to_crs`)."""
+        source, template = self._gradient_source_and_template()
+        with pytest.raises(ValueError):
+            source.align(template, method="not-a-real-method")
+
+    def test_align_bilinear_template_crs_no_epsg(self):
+        """DoD: works when the template CRS is a PROJ4 string with no EPSG code."""
+        source, template = self._gradient_source_and_template()
+        proj4 = "+proj=ortho +lat_0=0 +lon_0=0 +datum=WGS84 +units=m +no_defs"
+        ortho_source = source.to_crs(proj4)
+        ortho_template = template.to_crs(proj4)
+        assert ortho_template.epsg is None
+
+        aligned = ortho_source.align(ortho_template, method="bilinear")
+        assert aligned.epsg is None
+        assert (aligned.rows, aligned.columns) == (
+            ortho_template.rows,
+            ortho_template.columns,
+        )
+        assert aligned.geotransform == ortho_template.geotransform
+
 
 class TestCrop:
     def test_crop_single_band_dataset_with_single_band_mask(


### PR DESCRIPTION
# Description

`Spatial.align` previously hard-coded nearest-neighbor resampling, with no way to choose the interpolation. A caller
who needed an exact template grid (CRS + extent + pixel dimensions) with a smoother interpolation — e.g. a
pixel-registered EO frame series — had to fall back to `to_crs` + crop and hope the pixel boundaries landed where
intended.

This threads a `method` parameter through the align stack, defaulting to `"nearest neighbor"` so existing behaviour is
unchanged, and validated against the same algorithm list `to_crs` already accepts (`resolve_resampling`):

- **`Spatial.align`** gains a keyword-only `method`. The name is resolved up front (fail-fast, even on the same-CRS
  path) and threaded into both the intermediate `to_crs` reprojection (different-CRS templates) and the final
  `gdal.ReprojectImage` onto the template grid.
- **`DatasetCollection.align`** gains a keyword-only `method`, forwarded to the plan-once `Aligner` and to the direct
  per-timestep `Dataset.align` on both the eager and deferred (`compute=False`) paths. It also validates `method`
  up-front, so an invalid name fails at call time regardless of `compute` or timestep count.
- **`dataset/ops/reproject.py`** wires the previously reserved-and-discarded `method` through `Aligner.__call__` and
  `_align_sync`.

`method` is keyword-only by design (matches `DatasetCollection.align`, avoids a bare positional resampling name after a
`Dataset` template, and sidesteps the collection API's `inplace` slot).

Docstrings gained accurate notes on three behaviours, all reproduced against the real warp paths:

- **No-data:** GDAL's aggregating kernels honour the source no-data value when the raster declares one (no-data cells
  are excluded, a fully-no-data kernel yields no-data). This corrects a pre-existing caveat on `to_crs` — now also on
  `align` — that had claimed these kernels were *not* no-data-aware.
- **Output dtype** follows the template, so interpolating a float source onto an integer template drops the fractional
  part.
- **Cross-CRS aligns resample twice** (reproject then align-onto-grid), so a non-nearest `method` is applied twice:
  interpolators over-smooth and aggregating kernels change the statistic (`sum` inflates). The grid is always exact;
  only pixel values differ.

No new dependencies.

## Deferred (documented, not changed — intentionally out of scope)

- A true single-pass cross-CRS warp is a larger rewrite of `align`'s warp topology; documented the double-resample
  instead.
- Making `method` keyword-only across the whole resampling family (`to_crs`/`resample`/`reproject_variable`) is a
  breaking change to released APIs; documented the deliberate divergence instead.

# Issues

- Closes #1043 — feat(spatial): let align choose its resampling method

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Added tests and ran them (plus the surrounding suites) locally against the branch:

- [x] `Dataset.align`: default-stays-nearest; `method="bilinear"` lands on the template grid and differs from nearest;
  the full non-version-gated method matrix (nearest…mode, min/max/med/q1/q3) lands on the grid; case/whitespace
  insensitivity; invalid method → `ValueError`, non-string → `TypeError`, non-`Dataset` template → `TypeError`;
  cross-CRS bilinear grid **and** value checks; PROJ4/no-EPSG template; no-data exclusion parametrized over every
  aggregating kernel plus the undeclared-sentinel-mixes-in contrast; and the integer-template dtype-cast behaviour.
- [x] `DatasetCollection.align`: eager `method=` passthrough; invalid method at call time incl. `compute=False`;
  no-EPSG-reference direct path; deferred (`compute=False`) passthrough through `Aligner` and `_align_sync`.
- [x] Coverage: the changed `align` surface is at ~100% line + branch. Touched trees (`tests/dataset/spatial`,
  `tests/dataset/collection`) — **897 passed**; the full non-e2e/non-plot suite is green; `align`/`to_crs`/`reproject`
  doctests pass.

Reproduce:

```bash
pixi run -e dev pytest tests/dataset/spatial/test_dataset_spatial.py::TestAlign \
  tests/dataset/collection/test_dataset_collection.py::TestAlign \
  tests/dataset/collection/test_reproject_compute.py::TestAlignCompute -v
```

# Checklist:

- [ ] updated version number in pyproject.toml. (handled by commitizen in CI)
- [ ] added changes to History.rst. (commitizen-generated changelog)
- [ ] updated the latest version in README file. (n/a)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (`align` docstrings on `Spatial` and `DatasetCollection`, `_align_sync`, and the
  no-data caveat on `to_crs`)
