### PR TITLE
fix(netcdf): resolve in-memory (from_bytes/vsimem) reads via _vsimem_path across all sites

### DIFF
--- a/src/pyramids/dataset/engines/georef.py
+++ b/src/pyramids/dataset/engines/georef.py
@@ -497,10 +497,11 @@ class Georef(_Engine["Dataset"]):
         pointing at the coordinate arrays, ``SRS``, band/offset/step keys) or
         ``None`` when the dataset carries no such domain. Built on
         :meth:`~pyramids.dataset.Dataset.get_meta_data`; on a ``NetCDF`` variable
-        the domain is read from the classic **on-disk** GDAL handle (see
-        :meth:`Dataset._geolocation_source`), so it reflects the source file, not
-        any in-place edits, and is unavailable for an in-memory (``/vsimem``) NetCDF
-        — geolocate before other spatial operations.
+        the domain is read from the classic ``NETCDF:`` GDAL handle — on-disk **or**
+        ``/vsimem`` (see :meth:`Dataset._geolocation_source`) — so it reflects the
+        source file, not any in-place edits (geolocate before other spatial
+        operations), and is available for an in-memory (``from_bytes`` / ``/vsimem``)
+        NetCDF too (#1053).
 
         Returns:
             dict[str, str] | None: The ``GEOLOCATION`` domain, or ``None``.

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -2540,7 +2540,11 @@ class NetCDF(Dataset):
                 "chunks=; read eagerly, or mask the dask array yourself."
             )
         parent = self._parent_nc if self._parent_nc is not None else self
-        path = strip_netcdf_subdataset_prefix(parent._file_name)
+        # Prefer the real /vsimem backing path over a cosmetic from_bytes `name=` that shadows
+        # _file_name, so a named in-memory lazy read reopens the true source (#1058; same family as
+        # #1050/#1053/#1057).
+        source = getattr(parent, "_vsimem_path", None) or parent._file_name
+        path = strip_netcdf_subdataset_prefix(source)
         var_name = self._source_var_name
         if var_name is None:
             raise ValueError(

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4590,7 +4590,7 @@ class NetCDF(Dataset):
         # the #1050/#1053 fixes to _classic_geotransform/_geolocation_source).
         path = getattr(self, "_vsimem_path", None) or self.file_name
         try:
-            ds = gdal.Open(f"NETCDF:{path}:{var}")
+            ds = gdal.Open(f'NETCDF:"{path}":{var}')
             if ds is not None:
                 result = ds.ReadAsArray()
             ds = None
@@ -5093,11 +5093,11 @@ class NetCDF(Dataset):
             # Prefer the real /vsimem backing path over a cosmetic from_bytes `name=` that
             # shadows file_name, so a named in-memory classic read reopens the true source (#1057).
             path = getattr(self, "_vsimem_path", None) or self.file_name
-            src = gdal.Open(f"{prefix}:{path}:{variable_name}")
+            src = gdal.Open(f'{prefix}:"{path}":{variable_name}')
             if src is None:
                 raise ValueError(
                     f"Could not open variable '{variable_name}' via "
-                    f"'{prefix}:{path}:{variable_name}'"
+                    f'\'{prefix}:"{path}":{variable_name}\''
                 )
             cube = Variable(src)
             cube._is_md_array = False

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1466,9 +1466,11 @@ class NetCDF(Dataset):
         Returns:
             tuple | None: The classic-driver geotransform, or ``None`` when
             there is no classic-openable source (a path-less in-memory ``MEM``
-            dataset with an empty ``file_name`` — a ``/vsimem`` source is
-            openable and is rescaled, #1050) or the classic open does not
-            produce a metre-scale geostationary geotransform.
+            dataset with no ``_vsimem_path`` and an empty ``file_name`` — a
+            ``/vsimem`` source, including a ``from_bytes`` read given a cosmetic
+            ``name`` that shadows ``file_name``, is openable and is rescaled,
+            #1050) or the classic open does not produce a metre-scale
+            geostationary geotransform.
         """
         parent = self._parent_nc
         var = self._source_var_name
@@ -1483,15 +1485,19 @@ class NetCDF(Dataset):
             return cache[var]
 
         result: tuple[float, ...] | None = None
-        path = parent.file_name
         # The classic netCDF driver reopens NETCDF:"<path>":<var> to rescale the scan-angle
-        # coordinates to projected metres; it needs a path GDAL can open. A `/vsimem/` path *is*
-        # openable (the driver reads the in-memory file directly — confirmed cross-platform), so
-        # only a truly path-less MEM dataset (empty file_name) is skipped. Excluding `/vsimem`
-        # here silently dropped the metre geotransform for every `from_bytes()` geostationary
-        # read — the only in-memory NetCDF reader on Windows/macOS — leaving a raw scan-angle
-        # geotransform under the metre CRS (#1050). A `/vsicurl` / `/vsizip` path that the netCDF
-        # driver cannot open (needs Linux userfaultfd) raises below and falls back to `None`.
+        # coordinates to projected metres; it needs a path GDAL can open. `from_bytes` records the
+        # real backing `/vsimem/...` path in `_vsimem_path`, while `file_name` may instead hold a
+        # caller-supplied cosmetic `name=` label — so prefer `_vsimem_path` to rescale a *named*
+        # in-memory read too (an on-disk read has no `_vsimem_path` and uses `file_name`, the real
+        # path). A `/vsimem/` path *is* openable (the driver reads the in-memory file directly —
+        # confirmed cross-platform); only a truly path-less MEM dataset (empty `file_name`, no
+        # `_vsimem_path`) is skipped. Excluding `/vsimem` here silently dropped the metre
+        # geotransform for every `from_bytes()` geostationary read — the only in-memory NetCDF
+        # reader on Windows/macOS — leaving a raw scan-angle geotransform under the metre CRS
+        # (#1050). A remote/archive path the netCDF driver cannot open raises below and falls back
+        # to `None`.
+        path = getattr(parent, "_vsimem_path", None) or parent.file_name
         if path:
             try:
                 src = gdal.Open(f'NETCDF:"{path}":{var}')

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4573,8 +4573,12 @@ class NetCDF(Dataset):
                 subdataset cannot be opened or read.
         """
         result: np.typing.NDArray | None = None
+        # Prefer the real /vsimem backing path over a cosmetic from_bytes `name=` that shadows
+        # file_name, so a named in-memory classic read reopens the true source (#1057; mirrors
+        # the #1050/#1053 fixes to _classic_geotransform/_geolocation_source).
+        path = getattr(self, "_vsimem_path", None) or self.file_name
         try:
-            ds = gdal.Open(f"NETCDF:{self.file_name}:{var}")
+            ds = gdal.Open(f"NETCDF:{path}:{var}")
             if ds is not None:
                 result = ds.ReadAsArray()
             ds = None
@@ -5074,11 +5078,14 @@ class NetCDF(Dataset):
             cube._gdal_md_arr_ref = md_arr_ref
             cube._gdal_rg_ref = rg_ref
         else:
-            src = gdal.Open(f"{prefix}:{self.file_name}:{variable_name}")
+            # Prefer the real /vsimem backing path over a cosmetic from_bytes `name=` that
+            # shadows file_name, so a named in-memory classic read reopens the true source (#1057).
+            path = getattr(self, "_vsimem_path", None) or self.file_name
+            src = gdal.Open(f"{prefix}:{path}:{variable_name}")
             if src is None:
                 raise ValueError(
                     f"Could not open variable '{variable_name}' via "
-                    f"'{prefix}:{self.file_name}:{variable_name}'"
+                    f"'{prefix}:{path}:{variable_name}'"
                 )
             cube = Variable(src)
             cube._is_md_array = False

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1538,17 +1538,16 @@ class NetCDF(Dataset):
         if source is None:
             var = self._source_var_name
             parent = self._parent_nc
-            path = parent.file_name if parent is not None else self.file_name
+            source_obj = parent if parent is not None else self
+            # Prefer `_vsimem_path` (the real backing `/vsimem/...` path that a cosmetic `from_bytes`
+            # `name=` shadows in `file_name`) and admit `/vsimem` — the classic driver opens it
+            # directly (confirmed cross-platform by #1050) — so an in-memory (`from_bytes`) swath
+            # exposes its GEOLOCATION domain exactly like an on-disk read (#1053), mirroring the
+            # sibling `_classic_geotransform`. Only a truly path-less MEM source (no `_vsimem_path`,
+            # empty `file_name`) or a container with no variable falls through to `self`.
+            path = getattr(source_obj, "_vsimem_path", None) or source_obj.file_name
             handle = None
-            # NOTE: the sibling `_classic_geotransform` was hardened to prefer `_vsimem_path` and
-            # admit `/vsimem` (#1050); this guard is intentionally left keying off `file_name`. For
-            # an *unnamed* `from_bytes` container `file_name` is the `/vsimem` path, so this guard
-            # skips it; for a *named* one the cosmetic `name` slips past (it isn't `/vsimem`) and the
-            # classic open of that bogus relative path fails → falls back to `self`. Either way an
-            # in-memory swath's GEOLOCATION domain is not exposed — geolocation-array behaviour (the
-            # #1033 domain) that would need its own swath fixture and a `_vsimem_path` preference to
-            # fix, out of scope for the #1050 geotransform fix. A tracked follow-up, not an oversight.
-            if var is not None and path and not str(path).startswith("/vsimem"):
+            if var is not None and path:
                 try:
                     handle = gdal.Open(f'NETCDF:"{path}":{var}')
                 except RuntimeError:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -527,8 +527,10 @@ class NetCDF(Dataset):
             pickle as a secret.
 
         Raises:
-            TypeError: The NetCDF has no on-disk path (empty
-                `_file_name` or a `/vsimem/` path). Pickling an
+            TypeError: The NetCDF is in-memory, not on-disk — an empty
+                `_file_name`, a `/vsimem/` path, or a `_vsimem_path`
+                backing store shadowed by a cosmetic `name=` (checked on
+                `self` or, for a subset, the parent). Pickling an
                 in-memory NetCDF is not supported.
         """
         path = self._file_name

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1540,11 +1540,14 @@ class NetCDF(Dataset):
             parent = self._parent_nc
             path = parent.file_name if parent is not None else self.file_name
             handle = None
-            # NOTE: the sibling `_classic_geotransform` now admits `/vsimem` (#1050); this guard is
-            # left excluding it on purpose. Whether the classic driver exposes the GEOLOCATION
-            # domain for an in-memory (`from_bytes`) swath is geolocation-array behaviour (the #1033
-            # domain), needing its own swath fixture and verification — out of scope for the #1050
-            # geotransform fix. Kept as a tracked follow-up, not an oversight.
+            # NOTE: the sibling `_classic_geotransform` was hardened to prefer `_vsimem_path` and
+            # admit `/vsimem` (#1050); this guard is intentionally left keying off `file_name`. For
+            # an *unnamed* `from_bytes` container `file_name` is the `/vsimem` path, so this guard
+            # skips it; for a *named* one the cosmetic `name` slips past (it isn't `/vsimem`) and the
+            # classic open of that bogus relative path fails → falls back to `self`. Either way an
+            # in-memory swath's GEOLOCATION domain is not exposed — geolocation-array behaviour (the
+            # #1033 domain) that would need its own swath fixture and a `_vsimem_path` preference to
+            # fix, out of scope for the #1050 geotransform fix. A tracked follow-up, not an oversight.
             if var is not None and path and not str(path).startswith("/vsimem"):
                 try:
                     handle = gdal.Open(f'NETCDF:"{path}":{var}')

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1483,9 +1483,15 @@ class NetCDF(Dataset):
 
         result: tuple[float, ...] | None = None
         path = parent.file_name
-        # The classic netCDF driver needs an on-disk / VSI source; an in-memory
-        # MEM dataset has no such path.
-        if path and not str(path).startswith("/vsimem"):
+        # The classic netCDF driver reopens NETCDF:"<path>":<var> to rescale the scan-angle
+        # coordinates to projected metres; it needs a path GDAL can open. A `/vsimem/` path *is*
+        # openable (the driver reads the in-memory file directly — confirmed cross-platform), so
+        # only a truly path-less MEM dataset (empty file_name) is skipped. Excluding `/vsimem`
+        # here silently dropped the metre geotransform for every `from_bytes()` geostationary
+        # read — the only in-memory NetCDF reader on Windows/macOS — leaving a raw scan-angle
+        # geotransform under the metre CRS (#1050). A `/vsicurl` / `/vsizip` path that the netCDF
+        # driver cannot open (needs Linux userfaultfd) raises below and falls back to `None`.
+        if path:
             try:
                 src = gdal.Open(f'NETCDF:"{path}":{var}')
             except RuntimeError:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -3279,7 +3279,11 @@ class NetCDF(Dataset):
             True when the source path exists on disk or is a remote (`/vsi*` / cloud) URL.
         """
         parent = var._parent_nc if var._parent_nc is not None else var
-        path = parent._file_name
+        # Prefer the real /vsimem backing path over a cosmetic from_bytes `name=` that shadows
+        # _file_name, so a *named* in-memory read is recognised as reopenable (streamable) too,
+        # matching the unnamed case and the lazy read fix (#1059; shadow family #1050/#1053/#1057/
+        # #1058). A pure MEM container (create_from_array) has neither, so it stays not-file-backed.
+        path = getattr(parent, "_vsimem_path", None) or parent._file_name
         if not path:
             return False
         path = strip_netcdf_subdataset_prefix(path)

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1540,6 +1540,11 @@ class NetCDF(Dataset):
             parent = self._parent_nc
             path = parent.file_name if parent is not None else self.file_name
             handle = None
+            # NOTE: the sibling `_classic_geotransform` now admits `/vsimem` (#1050); this guard is
+            # left excluding it on purpose. Whether the classic driver exposes the GEOLOCATION
+            # domain for an in-memory (`from_bytes`) swath is geolocation-array behaviour (the #1033
+            # domain), needing its own swath fixture and verification — out of scope for the #1050
+            # geotransform fix. Kept as a tracked follow-up, not an oversight.
             if var is not None and path and not str(path).startswith("/vsimem"):
                 try:
                     handle = gdal.Open(f'NETCDF:"{path}":{var}')

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -711,6 +711,14 @@ class NetCDF(Dataset):
         self._warp_source = None
         self._parent_nc = None
         self._cached_meta_data = None
+        # Drop and close the reopened geolocation-source handle (a base Dataset over
+        # NETCDF:"<file>":<var>, memoised by `_geolocation_source`). Left open it keeps the source
+        # file open past close(), defeating the handle-release contract the gc.collect() below
+        # enforces (#564); `_update_inplace` already pops it. Only a genuine reopen is cached
+        # (never `self`), so closing it is safe.
+        geoloc_memo = self.__dict__.pop("_geolocation_source_memo", None)
+        if isinstance(geoloc_memo, Dataset):
+            geoloc_memo.close()
         super().close()
         # Break the GDAL SWIG view/MDArray/root-group cycle left by variable
         # extraction so the source file is released now, not on the next GC.

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1465,9 +1465,10 @@ class NetCDF(Dataset):
 
         Returns:
             tuple | None: The classic-driver geotransform, or ``None`` when
-            there is no classic-openable source (e.g. an in-memory dataset) or
-            the classic open does not produce a metre-scale geostationary
-            geotransform.
+            there is no classic-openable source (a path-less in-memory ``MEM``
+            dataset with an empty ``file_name`` — a ``/vsimem`` source is
+            openable and is rescaled, #1050) or the classic open does not
+            produce a metre-scale geostationary geotransform.
         """
         parent = self._parent_nc
         var = self._source_var_name

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -532,11 +532,17 @@ class NetCDF(Dataset):
                 in-memory NetCDF is not supported.
         """
         path = self._file_name
-        if (not path) and (self._is_subset or self._group_path):
-            parent = getattr(self, "_parent_nc", None)
-            if parent is not None:
-                path = parent._file_name
-        if not path or path.startswith("/vsimem/"):
+        parent = getattr(self, "_parent_nc", None)
+        if (not path) and (self._is_subset or self._group_path) and parent is not None:
+            path = parent._file_name
+        # A cosmetic `from_bytes(name=...)` shadows `_file_name`; the real backing store is recorded
+        # in `_vsimem_path` (on self, or the parent container for a subset). Consult it so a *named*
+        # in-memory NetCDF raises the same immediate TypeError as an unnamed one, instead of pickling
+        # into a recipe that only fails on unpickle (#1059; shadow family #1050/#1053/#1057/#1058).
+        vsimem = getattr(self, "_vsimem_path", None) or (
+            getattr(parent, "_vsimem_path", None) if parent is not None else None
+        )
+        if not path or path.startswith("/vsimem/") or vsimem:
             raise TypeError(
                 f"NetCDF has no on-disk path (file_name={self._file_name!r}); "
                 "pickling an in-memory NetCDF is not supported. Call "

--- a/tests/dataset/spatial/test_geolocate.py
+++ b/tests/dataset/spatial/test_geolocate.py
@@ -189,9 +189,13 @@ class TestGeolocateNetCDF:
         assert "_geolocation_source_memo" in var.__dict__, (
             "precondition: the memo must be populated"
         )
+        memo = var.__dict__["_geolocation_source_memo"]
         var.close()
         assert "_geolocation_source_memo" not in var.__dict__, (
             "close() must drop the reopened geolocation-source handle so the source file is released"
+        )
+        assert memo._raster is None, (
+            "close() must also close the memo's GDAL handle, not merely drop the reference"
         )
 
 

--- a/tests/dataset/spatial/test_geolocate.py
+++ b/tests/dataset/spatial/test_geolocate.py
@@ -172,3 +172,58 @@ class TestGeolocateNetCDF:
         container = NetCDF.read_file(CURV)
         with pytest.raises(GeolocationArrayError):
             container.geolocate()
+
+
+class TestGeolocateFromBytes:
+    """An in-memory (`from_bytes` / `/vsimem`) swath variable exposes its GEOLOCATION domain (#1053).
+
+    `from_bytes` is the only in-memory NetCDF reader that works on Windows/macOS, so it is the
+    sanctioned way to read a downloaded L2 swath granule. Before #1053 the `/vsimem` exclusion in
+    `_geolocation_source` left an in-memory swath reporting no geolocation arrays — `has_geolocation`
+    False, `.geolocation` None, `.geolocate()` raising — even though the on-disk read works. The fix
+    mirrors #1050: resolve the classic handle via `_vsimem_path` and admit `/vsimem`.
+    """
+
+    @staticmethod
+    def _bytes():
+        with open(CURV, "rb") as fh:
+            return fh.read()
+
+    def test_from_bytes_variable_has_geolocation(self):
+        """An unnamed from_bytes swath variable exposes the GEOLOCATION domain, like on-disk."""
+        from pyramids.netcdf import NetCDF
+
+        on_disk = NetCDF.read_file(CURV).get_variable("Tair")
+        var = NetCDF.from_bytes(self._bytes()).get_variable("Tair")
+        assert on_disk.has_geolocation is True, "fixture must carry geolocation arrays"
+        assert var.has_geolocation is True, (
+            "an in-memory swath must expose its GEOLOCATION domain (#1053)"
+        )
+        domain = var.geolocation
+        assert domain is not None
+        assert "X_DATASET" in domain
+        assert "Y_DATASET" in domain
+
+    def test_named_from_bytes_variable_has_geolocation(self):
+        """A named from_bytes read resolves through `_vsimem_path`, not the cosmetic name (#1053)."""
+        from pyramids.netcdf import NetCDF
+
+        container = NetCDF.from_bytes(self._bytes(), name="swath.nc")
+        assert container.file_name == "swath.nc", (
+            "the cosmetic name must shadow file_name for this test to exercise the fix"
+        )
+        var = container.get_variable("Tair")
+        assert var.has_geolocation is True, (
+            "a named in-memory swath must still expose geolocation — the name must not shadow "
+            "the /vsimem path"
+        )
+
+    def test_from_bytes_variable_geolocates(self):
+        """geolocate() warps an in-memory swath variable to the requested grid as a base Dataset."""
+        from pyramids.netcdf import NetCDF
+
+        var = NetCDF.from_bytes(self._bytes()).get_variable("Tair")
+        out = var.geolocate(to_epsg=4326)
+        assert type(out) is Dataset
+        assert out.epsg == 4326
+        assert out.band_count == var.band_count

--- a/tests/dataset/spatial/test_geolocate.py
+++ b/tests/dataset/spatial/test_geolocate.py
@@ -183,8 +183,12 @@ class TestGeolocateNetCDF:
         from pyramids.netcdf import NetCDF
 
         var = NetCDF.read_file(CURV).get_variable("Tair")
-        assert var.geolocation is not None, "precondition: fixture must carry geolocation arrays"
-        assert "_geolocation_source_memo" in var.__dict__, "precondition: the memo must be populated"
+        assert var.geolocation is not None, (
+            "precondition: fixture must carry geolocation arrays"
+        )
+        assert "_geolocation_source_memo" in var.__dict__, (
+            "precondition: the memo must be populated"
+        )
         var.close()
         assert "_geolocation_source_memo" not in var.__dict__, (
             "close() must drop the reopened geolocation-source handle so the source file is released"

--- a/tests/dataset/spatial/test_geolocate.py
+++ b/tests/dataset/spatial/test_geolocate.py
@@ -173,6 +173,23 @@ class TestGeolocateNetCDF:
         with pytest.raises(GeolocationArrayError):
             container.geolocate()
 
+    def test_close_drops_geolocation_source_memo(self):
+        """`close()` releases the reopened geolocation handle it memoised (#564 handle contract).
+
+        `_geolocation_source` memoises a base `Dataset` over the classic `NETCDF:"<file>":<var>`
+        handle. `close()` must drop and close it, otherwise that handle keeps the source file open
+        past `close()`.
+        """
+        from pyramids.netcdf import NetCDF
+
+        var = NetCDF.read_file(CURV).get_variable("Tair")
+        assert var.geolocation is not None, "precondition: fixture must carry geolocation arrays"
+        assert "_geolocation_source_memo" in var.__dict__, "precondition: the memo must be populated"
+        var.close()
+        assert "_geolocation_source_memo" not in var.__dict__, (
+            "close() must drop the reopened geolocation-source handle so the source file is released"
+        )
+
 
 class TestGeolocateFromBytes:
     """An in-memory (`from_bytes` / `/vsimem`) swath variable exposes its GEOLOCATION domain (#1053).

--- a/tests/netcdf/io/test_netcdf_from_bytes.py
+++ b/tests/netcdf/io/test_netcdf_from_bytes.py
@@ -177,6 +177,24 @@ class TestNetCDFFromBytes:
         with pytest.raises(TypeError, match=r"to_file"):
             pickle.dumps(nc)
 
+    def test_named_not_picklable(self, netcdf_bytes: bytes):
+        """A *named* in-memory NetCDF is also unpicklable — the cosmetic name must not defeat the guard.
+
+        Args:
+            netcdf_bytes: Raw bytes of the NetCDF fixture.
+
+        Test scenario:
+            ``pickle.dumps(NetCDF.from_bytes(bytes, name="downloaded.nc"))`` — expected: an immediate
+            ``TypeError`` (not a recipe that fails only on unpickle), because ``_vsimem_path`` marks it
+            in-memory regardless of the cosmetic ``file_name`` (#1059).
+        """
+        nc = NetCDF.from_bytes(netcdf_bytes, name="downloaded.nc")
+        assert nc.file_name == "downloaded.nc", (
+            "precondition: the cosmetic name shadows file_name"
+        )
+        with pytest.raises(TypeError, match=r"to_file"):
+            pickle.dumps(nc)
+
     @pytest.mark.parametrize("bad", ["a string", 7, None])
     def test_non_bytes_raises_type_error(self, bad):
         """Non bytes-like input raises ``TypeError``.

--- a/tests/netcdf/io/test_netcdf_from_bytes.py
+++ b/tests/netcdf/io/test_netcdf_from_bytes.py
@@ -195,6 +195,31 @@ class TestNetCDFFromBytes:
         with pytest.raises(TypeError, match=r"to_file"):
             pickle.dumps(nc)
 
+    def test_named_subset_not_picklable(self, netcdf_bytes: bytes):
+        """A variable subset of a *named* in-memory NetCDF is also unpicklable (#1059).
+
+        Args:
+            netcdf_bytes: Raw bytes of the NetCDF fixture.
+
+        Test scenario:
+            The subset's own ``file_name`` is empty and falls back to the cosmetic
+            parent name (``downloaded.nc``), so *only* the parent container's
+            ``_vsimem_path`` marks the pair in-memory. ``pickle.dumps`` of the subset
+            must raise ``TypeError`` immediately — not pickle into a recipe that points
+            at the phantom ``downloaded.nc`` and fails only on unpickle, matching the
+            container case and guarding the ``__reduce__`` parent branch (#1059).
+        """
+        nc = NetCDF.from_bytes(netcdf_bytes, name="downloaded.nc")
+        subset = nc.get_variable(nc.variable_names[0])
+        assert getattr(subset, "_vsimem_path", None) is None, (
+            "precondition: the subset carries no _vsimem_path of its own"
+        )
+        assert nc._vsimem_path, (
+            "precondition: only the parent records the /vsimem backing path"
+        )
+        with pytest.raises(TypeError, match=r"to_file"):
+            pickle.dumps(subset)
+
     @pytest.mark.parametrize("bad", ["a string", 7, None])
     def test_non_bytes_raises_type_error(self, bad):
         """Non bytes-like input raises ``TypeError``.

--- a/tests/netcdf/io/test_netcdf_from_bytes.py
+++ b/tests/netcdf/io/test_netcdf_from_bytes.py
@@ -125,6 +125,27 @@ class TestNetCDFFromBytes:
         nc = NetCDF.from_bytes(netcdf_bytes, name="era5")
         assert nc.file_name == "era5", f"name= not applied: {nc.file_name!r}"
 
+    def test_named_classic_mode_reads_variable(self, netcdf_bytes: bytes):
+        """A named classic-mode read opens its variables via the real ``/vsimem`` path.
+
+        Args:
+            netcdf_bytes: Raw bytes of the NetCDF fixture.
+
+        Test scenario:
+            ``NetCDF.from_bytes(bytes, name="downloaded.nc", open_as_multi_dimensional=False)``
+            then ``get_variable(...)`` — expected: it reads, not ``RuntimeError``. The classic
+            subdataset open must use the real ``/vsimem`` backing path, not the cosmetic ``name=``
+            that shadows ``file_name`` (#1057; mirrors the #1050/#1053 fixes).
+        """
+        nc = NetCDF.from_bytes(
+            netcdf_bytes, name="downloaded.nc", open_as_multi_dimensional=False
+        )
+        assert nc.file_name == "downloaded.nc", (
+            "precondition: the cosmetic name must shadow file_name for this test to bite"
+        )
+        var = nc.get_variable(nc.variable_names[0])
+        assert var.read_array().size > 0, "named classic read returned no data"
+
     def test_vsimem_cleaned_up_on_gc(self, netcdf_bytes: bytes):
         """Dropping the last reference removes the ``/vsimem/`` file.
 

--- a/tests/netcdf/io/test_read_variable_helpers.py
+++ b/tests/netcdf/io/test_read_variable_helpers.py
@@ -265,6 +265,7 @@ class TestReadClassicVariable:
         """
         mock_self = Mock()
         mock_self.file_name = "file.nc"
+        mock_self._vsimem_path = None  # a real on-disk container has no /vsimem backing
         ds = Mock()
         arr = np.arange(4).reshape(2, 2)
         ds.ReadAsArray.return_value = arr
@@ -274,6 +275,25 @@ class TestReadClassicVariable:
 
         gopen.assert_called_once_with("NETCDF:file.nc:salt")
         assert result is arr, "classic read must return ReadAsArray() verbatim"
+
+    def test_prefers_vsimem_path_over_cosmetic_file_name(self):
+        """A ``from_bytes`` backing path is used even when a cosmetic name shadows ``file_name``.
+
+        Test scenario:
+            When ``_vsimem_path`` is set (a ``from_bytes`` container) and ``file_name`` is a
+            cosmetic ``name=`` label, the classic open must target the real ``/vsimem`` path,
+            not the label (#1057).
+        """
+        mock_self = Mock()
+        mock_self.file_name = "downloaded.nc"
+        mock_self._vsimem_path = "/vsimem/abc.nc"
+        ds = Mock()
+        ds.ReadAsArray.return_value = np.zeros((2, 2))
+
+        with patch("pyramids.netcdf.netcdf.gdal.Open", return_value=ds) as gopen:
+            NetCDF._read_classic_variable(mock_self, "salt")
+
+        gopen.assert_called_once_with("NETCDF:/vsimem/abc.nc:salt")
 
     def test_returns_none_when_open_returns_none(self):
         """A ``None`` from ``gdal.Open`` yields ``None``.

--- a/tests/netcdf/io/test_read_variable_helpers.py
+++ b/tests/netcdf/io/test_read_variable_helpers.py
@@ -273,7 +273,7 @@ class TestReadClassicVariable:
         with patch("pyramids.netcdf.netcdf.gdal.Open", return_value=ds) as gopen:
             result = NetCDF._read_classic_variable(mock_self, "salt")
 
-        gopen.assert_called_once_with("NETCDF:file.nc:salt")
+        gopen.assert_called_once_with('NETCDF:"file.nc":salt')
         assert result is arr, "classic read must return ReadAsArray() verbatim"
 
     def test_prefers_vsimem_path_over_cosmetic_file_name(self):
@@ -293,7 +293,7 @@ class TestReadClassicVariable:
         with patch("pyramids.netcdf.netcdf.gdal.Open", return_value=ds) as gopen:
             NetCDF._read_classic_variable(mock_self, "salt")
 
-        gopen.assert_called_once_with("NETCDF:/vsimem/abc.nc:salt")
+        gopen.assert_called_once_with('NETCDF:"/vsimem/abc.nc":salt')
 
     def test_returns_none_when_open_returns_none(self):
         """A ``None`` from ``gdal.Open`` yields ``None``.

--- a/tests/netcdf/lazy/test_chunked_read.py
+++ b/tests/netcdf/lazy/test_chunked_read.py
@@ -820,3 +820,27 @@ class TestLazyHandleLifetime:
         reopened = NetCDF.read_file(three_d_path, open_as_multi_dimensional=True)
         eager = np.asarray(reopened.get_variable(variable).read_array())
         assert eager.size > 0, "the eager reopen read should return data"
+
+
+@requires_dask
+class TestNamedFromBytesLazy:
+    """A named ``from_bytes`` lazy (dask) read reopens the real ``/vsimem`` path (#1058).
+
+    `_read_array_lazy` keyed off `_file_name`, which a cosmetic ``name=`` shadows, so
+    `from_bytes(data, name=...).get_variable(v).read_array(chunks="auto")` reopened the label as a
+    bogus path and raised ``RuntimeError`` on compute — the same shadow bug as #1050/#1053/#1057.
+    """
+
+    def test_named_from_bytes_lazy_read_matches_unnamed(self, three_d_path):
+        """A named container's lazy read computes the same values as the unnamed control."""
+        with open(three_d_path, "rb") as fh:
+            data = fh.read()
+        unnamed = NetCDF.from_bytes(data)
+        var_name = unnamed.variable_names[0]
+        expected = np.asarray(unnamed.get_variable(var_name).read_array(chunks="auto"))
+        named = NetCDF.from_bytes(data, name="downloaded.nc")
+        assert named.file_name == "downloaded.nc", (
+            "precondition: the cosmetic name must shadow file_name"
+        )
+        got = np.asarray(named.get_variable(var_name).read_array(chunks="auto"))
+        assert_allclose(got, expected)

--- a/tests/netcdf/selection/test_reduce.py
+++ b/tests/netcdf/selection/test_reduce.py
@@ -537,3 +537,24 @@ class TestIsFileBacked:
         assert NetCDF._is_file_backed(var) is True, (
             "a top-level variable's own file must count"
         )
+
+    def test_named_from_bytes_subset_is_file_backed(self):
+        """A named `from_bytes` subset is file-backed via `_vsimem_path`, like the unnamed one (#1059).
+
+        The cosmetic `name=` shadows `_file_name`; without preferring `_vsimem_path` a named in-memory
+        cube would report not-file-backed and lose the streaming reduce the unnamed cube keeps.
+        """
+        with open(_ERA5_T2M, "rb") as fh:
+            data = fh.read()
+        unnamed = NetCDF.from_bytes(data)
+        var_name = unnamed.variable_names[0]
+        assert NetCDF._is_file_backed(unnamed.get_variable(var_name)) is True, (
+            "an unnamed in-memory subset is reopenable via its /vsimem path"
+        )
+        named = NetCDF.from_bytes(data, name="downloaded.nc")
+        assert named.file_name == "downloaded.nc", (
+            "precondition: the cosmetic name shadows file_name"
+        )
+        assert NetCDF._is_file_backed(named.get_variable(var_name)) is True, (
+            "a named in-memory subset must also be recognised as file-backed (via _vsimem_path)"
+        )

--- a/tests/netcdf/spatial/test_geostationary_crs.py
+++ b/tests/netcdf/spatial/test_geostationary_crs.py
@@ -228,10 +228,11 @@ class TestGeostationaryFromBytes:
 class TestNonGeostationaryFromBytesUnaffected:
     """A non-geostationary `from_bytes` / `/vsimem` variable read is untouched by #1050.
 
-    `_classic_geotransform` runs only from `_normalize_geostationary_geotransform`, which
-    returns early unless `_is_geostationary()`. So the #1050 guard relaxation — `/vsimem`
-    paths now reach the classic driver — must not perturb an ordinary lat/lon read: no
-    scan-angle rescale, and the EPSG and geotransform stay identical to the on-disk read.
+    `_classic_geotransform` (where the relaxed `/vsimem` guard lives) runs only from
+    `_normalize_geostationary_geotransform`, which returns early unless `_is_geostationary()`.
+    So for an ordinary lat/lon read the classic re-open is never reached — this test confirms
+    that upstream geostationary short-circuit still holds for a `/vsimem` read: no scan-angle
+    rescale, and the EPSG and geotransform stay identical to the on-disk read.
     No other test drives a non-geostationary variable through `from_bytes(...).get_variable(...)`.
     """
 

--- a/tests/netcdf/spatial/test_geostationary_crs.py
+++ b/tests/netcdf/spatial/test_geostationary_crs.py
@@ -189,6 +189,41 @@ class TestGeostationaryFromBytes:
             b, a, rtol=0, atol=1e-6, err_msg="from_bytes footprint must match on-disk"
         )
 
+    def test_from_bytes_named_rescales_scan_angles_to_metres(self, tmp_path):
+        """A `from_bytes(data, name=...)` read rescales too — the cosmetic name must not shadow
+        the real `/vsimem` path the classic driver reopens (#1050).
+
+        `from_bytes` records the caller's `name=` as the container's `file_name` (cosmetic) while
+        keeping the real backing `/vsimem/...` path in `_vsimem_path`. `_classic_geotransform` must
+        resolve through `_vsimem_path`; keying off `file_name` alone would open a nonexistent path
+        and silently leave the granule under a raw scan-angle geotransform — the exact #1050 defect
+        on the documented `from_bytes(data, name="downloaded.nc")` spelling.
+        """
+        path = str(tmp_path / "geos.nc")
+        _write_geostationary_mdim(path)
+        with open(path, "rb") as fh:
+            data = fh.read()
+        on_disk = NetCDF.read_file(path).get_variable("CMI_C02")
+        container = NetCDF.from_bytes(data, name="downloaded.nc")
+        assert container.file_name == "downloaded.nc", (
+            "the cosmetic name must shadow file_name for this test to exercise the M1 path"
+        )
+        named = container.get_variable("CMI_C02")
+        assert named._geostationary_scaled is True, (
+            "a named in-memory read must still rescale scan angles to metres — the cosmetic name "
+            "must not shadow the /vsimem path"
+        )
+        assert abs(named.geotransform[1]) > 1.0, (
+            f"pixel size must be metres, not radians/index: {named.geotransform}"
+        )
+        np.testing.assert_allclose(
+            named.geotransform,
+            on_disk.geotransform,
+            rtol=0,
+            atol=1e-6,
+            err_msg="named from_bytes geotransform must match the on-disk metre geotransform",
+        )
+
 
 class TestNonGeostationaryFromBytesUnaffected:
     """A non-geostationary `from_bytes` / `/vsimem` variable read is untouched by #1050.

--- a/tests/netcdf/spatial/test_geostationary_crs.py
+++ b/tests/netcdf/spatial/test_geostationary_crs.py
@@ -141,6 +141,55 @@ class TestGeostationaryCRS:
         assert maxy - miny > 0.1, f"degenerate height: {warped.bbox}"
 
 
+class TestGeostationaryFromBytes:
+    """An in-memory (`from_bytes` / `/vsimem`) geostationary read rescales to metres (#1050).
+
+    `from_bytes` is the only in-memory NetCDF reader that works on Windows/macOS, so this is
+    the sanctioned way to read a downloaded GOES/Himawari granule. Before #1050 the `/vsimem`
+    path skipped the classic-driver rescale, leaving a raw scan-angle geotransform under the
+    metre CRS — silently.
+    """
+
+    @staticmethod
+    def _pair(tmp_path):
+        """Read the same synthetic granule on-disk and via ``from_bytes``; return both cubes."""
+        path = str(tmp_path / "geos.nc")
+        _write_geostationary_mdim(path)
+        with open(path, "rb") as fh:
+            data = fh.read()
+        on_disk = NetCDF.read_file(path).get_variable("CMI_C02")
+        from_bytes = NetCDF.from_bytes(data).get_variable("CMI_C02")
+        return on_disk, from_bytes
+
+    def test_from_bytes_rescales_scan_angles_to_metres(self, tmp_path):
+        """from_bytes rescales the scan-angle geotransform to metres, matching the on-disk read."""
+        on_disk, from_bytes = self._pair(tmp_path)
+        assert from_bytes._geostationary_scaled is True, (
+            "in-memory read must rescale scan angles to metres"
+        )
+        assert abs(from_bytes.geotransform[1]) > 1.0, (
+            f"pixel size must be metres, not radians/index: {from_bytes.geotransform}"
+        )
+        np.testing.assert_allclose(
+            from_bytes.geotransform,
+            on_disk.geotransform,
+            rtol=0,
+            atol=1e-6,
+            err_msg="from_bytes geotransform must match the on-disk metre geotransform",
+        )
+
+    def test_from_bytes_to_crs_matches_on_disk_footprint(self, tmp_path):
+        """to_crs(4326) yields the real footprint, not the sub-satellite nadir point it collapsed to."""
+        on_disk, from_bytes = self._pair(tmp_path)
+        a = on_disk.to_crs(4326).bbox
+        b = from_bytes.to_crs(4326).bbox
+        assert b[2] - b[0] > 0.1, f"degenerate (nadir-collapsed) width: {b}"
+        assert b[3] - b[1] > 0.1, f"degenerate (nadir-collapsed) height: {b}"
+        np.testing.assert_allclose(
+            b, a, rtol=0, atol=1e-6, err_msg="from_bytes footprint must match on-disk"
+        )
+
+
 class TestGeostationaryContainerOps:
     """Container operations preserve the geostationary CRS via WKT (#706).
 

--- a/tests/netcdf/spatial/test_geostationary_crs.py
+++ b/tests/netcdf/spatial/test_geostationary_crs.py
@@ -190,6 +190,45 @@ class TestGeostationaryFromBytes:
         )
 
 
+class TestNonGeostationaryFromBytesUnaffected:
+    """A non-geostationary `from_bytes` / `/vsimem` variable read is untouched by #1050.
+
+    `_classic_geotransform` runs only from `_normalize_geostationary_geotransform`, which
+    returns early unless `_is_geostationary()`. So the #1050 guard relaxation — `/vsimem`
+    paths now reach the classic driver — must not perturb an ordinary lat/lon read: no
+    scan-angle rescale, and the EPSG and geotransform stay identical to the on-disk read.
+    No other test drives a non-geostationary variable through `from_bytes(...).get_variable(...)`.
+    """
+
+    def test_latlon_from_bytes_variable_not_rescaled(self, noah_nc_path):
+        """A lat/lon `from_bytes` variable keeps its degree geotransform, EPSG, and unscaled flag."""
+        with open(noah_nc_path, "rb") as fh:
+            data = fh.read()
+        container = NetCDF.read_file(noah_nc_path)
+        var_name = container.variable_names[0]
+        on_disk = container.get_variable(var_name)
+        from_bytes = NetCDF.from_bytes(data).get_variable(var_name)
+        assert on_disk._is_geostationary() is False, (
+            "fixture must be a plain lat/lon grid"
+        )
+        assert from_bytes._is_geostationary() is False, (
+            "from_bytes must not misclassify a lat/lon grid as geostationary"
+        )
+        assert from_bytes._geostationary_scaled is False, (
+            "a non-geostationary read must never be scan-angle rescaled"
+        )
+        assert from_bytes.epsg == on_disk.epsg, (
+            f"epsg drifted from the on-disk read: {from_bytes.epsg} != {on_disk.epsg}"
+        )
+        np.testing.assert_allclose(
+            from_bytes.geotransform,
+            on_disk.geotransform,
+            rtol=0,
+            atol=1e-9,
+            err_msg="from_bytes must not perturb a non-geostationary geotransform",
+        )
+
+
 class TestGeostationaryContainerOps:
     """Container operations preserve the geostationary CRS via WKT (#706).
 

--- a/tests/netcdf/unit/test_netcdf_unit_read.py
+++ b/tests/netcdf/unit/test_netcdf_unit_read.py
@@ -36,7 +36,7 @@ class TestReadVariable:
         """Verify _read_variable works in classic mode via subdataset string.
 
         Covers the classic-mode branch that opens via
-        gdal.Open(f'NETCDF:{path}:{var}').
+        gdal.Open(f'NETCDF:"{path}":{var}').
         """
         nc = NetCDF.read_file(
             "tests/data/netcdf/cf__6v__1d2-2d4__geog__y-asc.nc",

--- a/tests/netcdf/unit/test_netcdf_unit_read.py
+++ b/tests/netcdf/unit/test_netcdf_unit_read.py
@@ -337,6 +337,38 @@ class TestGetVariableYFlipAndErrors:
             with pytest.raises(ValueError, match="Could not open variable"):
                 nc.get_variable("fake_var")
 
+    def test_get_variable_classic_open_uses_quoted_subdataset_string(self):
+        """Classic get_variable opens the subdataset via a QUOTED path (L1, #1050).
+
+        The classic-open string must be ``NETCDF:"<path>":<var>``. The quotes keep
+        a path that itself holds a colon (a Windows drive letter like ``C:``) or a
+        space from being mis-split by GDAL's ``NETCDF:file:var`` tokenizer. A
+        record-and-delegate wrapper over ``gdal.Open`` captures the real open
+        string, so a silent drop of the quotes at this second reopen site is
+        caught; the ``/vsimem`` integration test cannot bite it, since its backing
+        path has no special characters.
+        """
+        real_open = gdal.Open
+        opened: list[str] = []
+
+        def recording_open(arg, *args, **kwargs):
+            """Record the open string, then delegate to the real ``gdal.Open``."""
+            opened.append(arg)
+            return real_open(arg, *args, **kwargs)
+
+        nc = NetCDF.read_file(
+            "tests/data/netcdf/cf__6v__1d2-2d4__geog__y-asc.nc",
+            open_as_multi_dimensional=False,
+        )
+        var = nc.variable_names[0]
+        path = getattr(nc, "_vsimem_path", None) or nc.file_name
+        expected = f'NETCDF:"{path}":{var}'
+        with patch("pyramids.netcdf.netcdf.gdal.Open", side_effect=recording_open):
+            nc.get_variable(var)
+        assert expected in opened, (
+            f"classic get_variable must open the quoted {expected!r}; got {opened!r}"
+        )
+
     def test_get_variable_band_dim_read_error(self):
         """Verify get_variable falls back to range when ReadAsArray fails.
 


### PR DESCRIPTION
# Description

`NetCDF._classic_geotransform` reopens `NETCDF:"<path>":<var>` with the classic netCDF driver to rescale a
geostationary variable's scan-angle coordinates to projected metres — the one thing that georeferences a
geostationary granule correctly. Its guard, however, excluded **any** `/vsimem/` path:

```python
if path and not str(path).startswith("/vsimem"):
```

The classic driver opens a `/vsimem` file fine (verified cross-platform, including Windows), so this exclusion
silently dropped the metre geotransform for every `NetCDF.from_bytes()` geostationary read — which is **the only
in-memory NetCDF reader that works on Windows/macOS** (GDAL's netCDF driver needs Linux `userfaultfd` for other
`/vsi*` paths, so the library's own docstring routes users there). The result: a raw scan-angle geotransform
under the metre geostationary CRS, with no exception and no warning. `to_crs`/`crop`/`plot`/`to_file` then
silently mis-place the data — `to_crs(4326)` collapses the whole granule to the sub-satellite nadir point.

Fix: resolve the reopen path via `_vsimem_path` (the real backing path a cosmetic `from_bytes(name=...)` label
shadows in `file_name`) and relax the guard to `if path:`, so both named and unnamed in-memory reads are
rescaled and only a truly path-less MEM dataset (empty `file_name`, no `_vsimem_path`) is skipped. A
`/vsicurl` / `/vsizip` path the netCDF driver cannot open still raises and falls back to `None` gracefully.

Verified: a `from_bytes` geostationary read now reports the same metre geotransform as the on-disk read
(`gt[0] = 2.94591e6`, pixel `2004.02 m`, `_geostationary_scaled = True`), and `to_crs(4326)` returns the real
footprint (`-47°→-33°E, 5°→14°N`) instead of the collapsed nadir `(-75, 0)`.

**Follow-up fixed in the same PR (#1053).** The sibling `NetCDF._geolocation_source` carried the identical
`/vsimem` exclusion for the GDAL `GEOLOCATION` domain (per-pixel lon/lat swath arrays, #1033). A swath variable
read via `from_bytes()` therefore reported `has_geolocation = False`, `.geolocation = None`, and `.geolocate()`
raised `GeolocationArrayError`, even though the on-disk read works and the classic driver opens `/vsimem`. Fixed
the same way — resolve the classic handle via `_vsimem_path` and drop the `/vsimem` exclusion — so an in-memory
swath (both the unnamed and `name=`-labelled spellings) exposes its geolocation arrays exactly like an on-disk
read.

**Follow-up fixed in the same PR (#1057).** Two further classic-open sites — `NetCDF._read_classic_variable` and
the non-multidimensional `get_variable` fallback — reopened `NETCDF:<file>:<var>` keyed off `self.file_name`. A
*named* classic-mode read (`from_bytes(data, name="…", open_as_multi_dimensional=False)`) therefore opened the
cosmetic label as a bogus relative path and `get_variable` raised `RuntimeError`. Resolved the same way
(`getattr(self, "_vsimem_path", None) or self.file_name`) at both sites, and corrected the now-stale
`geolocation` property docstring in `georef.py` (which still claimed geolocation is read from an on-disk handle
and is unavailable in-memory).

**Shadow-family completion in the same PR (#1058, #1059).** A systematic sweep of every `file_name`-keyed
reopen/guard site in `netcdf.py` (the "cosmetic `name=` shadows the real `/vsimem` backing path" family) found and
fixed three more: `_read_array_lazy` (#1058 — a named `from_bytes` lazy/dask read raised `RuntimeError` on
compute), `_is_file_backed` (#1059 — a named in-memory cube reported not-file-backed and lost its streaming reduce
to an eager whole-cube read, ~2× peak RAM), and `__reduce__` (#1059 — a cosmetic `name=` defeated the `/vsimem`
pickle guard, so a named in-memory NetCDF pickled into a recipe that failed only on unpickle instead of raising an
immediate `TypeError`). All now resolve/consult `_vsimem_path`. After this sweep **every** classic/lazy reopen and
in-memory guard prefers `_vsimem_path` over a cosmetic `file_name`; the two classic-open strings were also quoted
(`NETCDF:"<path>":<var>`) to match their siblings.

# Issues

- Closes #1050 — in-memory (`from_bytes` / `/vsimem`) geostationary reads keep an unscaled geotransform under
  the metre CRS.
- Closes #1053 — in-memory (`from_bytes` / `/vsimem`) swath reads report no geolocation arrays.
- Closes #1057 — named `from_bytes` classic (non-MDIM) reads mis-open the cosmetic name.
- Closes #1058 — named `from_bytes` lazy (dask) reads mis-open the cosmetic name.
- Closes #1059 — `_is_file_backed` and `__reduce__` ignore `_vsimem_path` for named `from_bytes` reads.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

All runs via the `dev` pixi environment against the branch worktree; the full cross-platform matrix runs on CI.

**Geostationary geotransform (#1050)** — `tests/netcdf/spatial/test_geostationary_crs.py`:

- `TestGeostationaryFromBytes` — a `from_bytes` read rescales to metres (`_geostationary_scaled` True,
  `abs(pixel) > 1`) and matches the on-disk geotransform; `to_crs(4326)` yields the real, non-degenerate
  footprint (not the nadir-collapsed point); a `name=`-labelled read rescales too (resolves via `_vsimem_path`).
- `TestNonGeostationaryFromBytesUnaffected` — a lat/lon `from_bytes` read is not perturbed (EPSG + geotransform
  match on-disk, no scan-angle rescale).
- Full file: **18 passed**. All new tests are non-vacuous (they fail on the pre-fix code).

**Geolocation arrays (#1053)** — `tests/dataset/spatial/test_geolocate.py`:

- `TestGeolocateFromBytes` — an in-memory swath variable (unnamed and `name=`-labelled) exposes its
  `GEOLOCATION` domain matching on-disk, and `geolocate(to_epsg=4326)` warps it to a base `Dataset`.
- Full file: **18 passed**.

**Classic (non-MDIM) named reads (#1057)** — `tests/netcdf/io/`:

- `test_netcdf_from_bytes.py::test_named_classic_mode_reads_variable` — a `name=`-labelled classic-mode
  `from_bytes` read now opens its variables (was `RuntimeError`).
- `test_read_variable_helpers.py::test_prefers_vsimem_path_over_cosmetic_file_name` — unit-pins that the classic
  open targets the real `/vsimem` path, not the cosmetic name.
- `tests/netcdf/io/` + `tests/netcdf/samples/` regression: **944 passed** (on-disk classic reads unchanged).

Shared: `mypy` clean on `netcdf.py`; earlier full NetCDF-subtree regression on the base fix commit
(`pytest -m "not plot" tests/netcdf`) → **2558 passed, 38 skipped**; CI validates the full matrix on the latest
head.

Reproduce:

- [x] `pytest tests/netcdf/spatial/test_geostationary_crs.py::TestGeostationaryFromBytes -v`
- [x] `pytest tests/dataset/spatial/test_geolocate.py::TestGeolocateFromBytes -v`

# Checklist:

- [ ] updated version number in pyproject.toml. — N/A (versions handled by commitizen in CI).
- [ ] added changes to History.rst. — N/A (changelog is commitizen-generated).
- [ ] updated the latest version in README file. — N/A.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated. — N/A (internal behavior fix; the guard comments document the rationale).
