### PR TITLE
feat(dataset): consolidate subdataset parsers and warn on silent container opens

### DIFF
--- a/src/pyramids/base/_errors.py
+++ b/src/pyramids/base/_errors.py
@@ -350,6 +350,6 @@ class ContainerRasterWarning(UserWarning):
     ``warn_on_container=False`` to :meth:`~pyramids.dataset.Dataset.read_file`::
 
         import warnings
-        from pyramids.base._errors import ContainerRasterWarning
+        from pyramids.errors import ContainerRasterWarning
         warnings.filterwarnings("ignore", category=ContainerRasterWarning)
     """

--- a/src/pyramids/base/_errors.py
+++ b/src/pyramids/base/_errors.py
@@ -333,3 +333,23 @@ class GeometryWarning(UserWarning):
         from pyramids.base._errors import GeometryWarning
         warnings.filterwarnings("ignore", category=GeometryWarning)
     """
+
+
+class ContainerRasterWarning(UserWarning):
+    """Pyramids-emitted warning that an opened raster is a subdataset container.
+
+    Emitted by :meth:`pyramids.dataset.Dataset.read_file` when the path opens to a
+    *container* — a raster with no bands of its own whose payload is a set of nested
+    subdatasets (a NetCDF/HDF/Zarr store, a GRIB file, a WMS/WMTS endpoint, a
+    Sentinel-1/-2 product). Without it, such an open returns a silent 0-band
+    ``Dataset`` that fails much later somewhere unrelated; the warning names the
+    subdatasets and points at :attr:`pyramids.dataset.Dataset.subdatasets` /
+    :meth:`pyramids.dataset.Dataset.open_subdataset`.
+
+    Users who open containers on purpose can silence just this category, or pass
+    ``warn_on_container=False`` to :meth:`~pyramids.dataset.Dataset.read_file`::
+
+        import warnings
+        from pyramids.base._errors import ContainerRasterWarning
+        warnings.filterwarnings("ignore", category=ContainerRasterWarning)
+    """

--- a/src/pyramids/dataset/_subdataset.py
+++ b/src/pyramids/dataset/_subdataset.py
@@ -75,7 +75,7 @@ def subdatasets_of(raster: gdal.Dataset) -> list[SubDataset]:
 
     The single place the ``SUBDATASETS`` domain is turned into
     :class:`SubDataset` value objects. Both
-    :attr:`~pyramids.dataset.abstract_dataset.AbstractDataset.subdatasets` and the
+    :attr:`~pyramids.dataset.abstract_dataset.RasterBase.subdatasets` and the
     WMTS layer-hint helper in :mod:`pyramids.dataset._wms` build on it, so the
     enumeration lives in exactly one spot.
 

--- a/src/pyramids/dataset/_subdataset.py
+++ b/src/pyramids/dataset/_subdataset.py
@@ -19,6 +19,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from osgeo import gdal
+
     from pyramids.dataset.dataset import Dataset
 
 
@@ -66,3 +68,26 @@ class SubDataset:
         from pyramids.dataset.dataset import Dataset
 
         return Dataset.read_file(self.name)
+
+
+def subdatasets_of(raster: gdal.Dataset) -> list[SubDataset]:
+    """Build the :class:`SubDataset` list for a raw GDAL dataset handle.
+
+    The single place the ``SUBDATASETS`` domain is turned into
+    :class:`SubDataset` value objects. Both
+    :attr:`~pyramids.dataset.abstract_dataset.AbstractDataset.subdatasets` and the
+    WMTS layer-hint helper in :mod:`pyramids.dataset._wms` build on it, so the
+    enumeration lives in exactly one spot.
+
+    Args:
+        raster: An open ``gdal.Dataset``. A plain raster (no subdatasets) yields an
+            empty list.
+
+    Returns:
+        list[SubDataset]: One :class:`SubDataset` per nested raster, in GDAL's
+        order; ``[]`` when the handle has none.
+    """
+    return [
+        SubDataset(name, description, i)
+        for i, (name, description) in enumerate(raster.GetSubDatasets())
+    ]

--- a/src/pyramids/dataset/_subdataset.py
+++ b/src/pyramids/dataset/_subdataset.py
@@ -67,7 +67,9 @@ class SubDataset:
         # _subdataset cycle (abstract_dataset imports SubDataset at module load).
         from pyramids.dataset.dataset import Dataset
 
-        return Dataset.read_file(self.name)
+        # warn_on_container=False: opening a subdataset by its value object is a
+        # deliberate drill-in, so a nested-container warning here would be noise.
+        return Dataset.read_file(self.name, warn_on_container=False)
 
 
 def subdatasets_of(raster: gdal.Dataset) -> list[SubDataset]:

--- a/src/pyramids/dataset/_subdataset.py
+++ b/src/pyramids/dataset/_subdataset.py
@@ -86,6 +86,28 @@ def subdatasets_of(raster: gdal.Dataset) -> list[SubDataset]:
     Returns:
         list[SubDataset]: One :class:`SubDataset` per nested raster, in GDAL's
         order; ``[]`` when the handle has none.
+
+    Examples:
+        - Enumerate a NetCDF container's four subdatasets from a raw GDAL handle:
+            ```python
+            >>> from osgeo import gdal
+            >>> from pyramids.dataset._subdataset import subdatasets_of
+            >>> handle = gdal.Open("tests/data/netcdf/cf__6v__1d2-2d4__geog__y-asc.nc")
+            >>> subs = subdatasets_of(handle)
+            >>> len(subs)
+            4
+            >>> subs[0].index, subs[0].name.endswith(":Band1")
+            (0, True)
+
+            ```
+        - A plain single-band raster has no subdatasets:
+            ```python
+            >>> from osgeo import gdal
+            >>> from pyramids.dataset._subdataset import subdatasets_of
+            >>> subdatasets_of(gdal.Open("tests/data/geotiff/coello-without-color-table.tif"))
+            []
+
+            ```
     """
     return [
         SubDataset(name, description, i)

--- a/src/pyramids/dataset/_wms.py
+++ b/src/pyramids/dataset/_wms.py
@@ -46,6 +46,7 @@ from pyramids.base._coverage import resolve_native_srs as _resolve_native_srs_ne
 from pyramids.base._coverage import validate_bbox as _validate_bbox
 from pyramids.base._errors import CoverageError, WMSError
 from pyramids.base._ogc_api import gdal_http_config as _gdal_http_config
+from pyramids.dataset._subdataset import subdatasets_of
 
 if TYPE_CHECKING:
     from pyramids.dataset.dataset import Dataset
@@ -204,13 +205,17 @@ def _available_wmts_layers(endpoint: str) -> list[str]:
         caps = gdal.Open(f"WMTS:{endpoint}")
     except RuntimeError:
         caps = None
-    layers: list[str] = []
-    if caps is not None:
-        for key, value in caps.GetMetadata("SUBDATASETS").items():
-            # Split on the comma-prefixed ``,layer=`` GDAL subdataset key, not a
-            # bare ``layer=`` that a query-string in the caps URL might also carry.
-            if key.endswith("_NAME") and ",layer=" in value:
-                layers.append(value.split(",layer=", 1)[1].split(",", 1)[0])
+    if caps is None:
+        return []
+    # Enumerate the caps container's subdatasets through the shared builder (the same
+    # surface Dataset.subdatasets exposes), then pull the layer id from each
+    # ``WMTS:<url>,layer=<id>`` name. Split on the comma-prefixed ``,layer=`` key, not
+    # a bare ``layer=`` that a query-string in the caps URL might also carry.
+    layers = [
+        sub.name.split(",layer=", 1)[1].split(",", 1)[0]
+        for sub in subdatasets_of(caps)
+        if ",layer=" in sub.name
+    ]
     return sorted(set(layers))
 
 

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -163,10 +163,15 @@ def _reconstruct_dataset(
     # The env is applied here rather than forwarded to read_file so every
     # subclass benefits without widening its own signature.
     with cloud_config_from_env(gdal_env, path=path):
+        # warn_on_container=False: unpickling an already-opened container reopens a
+        # handle the caller previously held, so re-emitting the container warning here
+        # would be spurious. Only the base Dataset reaches this reconstruct (NetCDF has
+        # its own _reconstruct_netcdf), so read_file always accepts the keyword.
         dataset = cls.read_file(
             path,
             read_only=True,
             open_options=list(open_options) if open_options else None,
+            warn_on_container=False,
         )
     dataset.attach_gdal_env(gdal_env)
     return dataset

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -36,7 +36,7 @@ from pyramids.base._utils import (
 from pyramids.base.crs import epsg_of_crs, sr_from_epsg
 from pyramids.base.protocols import ArrayLike, FloatArray
 from pyramids.base.remote import cloud_config_from_env
-from pyramids.dataset._subdataset import SubDataset
+from pyramids.dataset._subdataset import SubDataset, subdatasets_of
 from pyramids.dataset.transform import GeoTransform
 from pyramids.dataset.window import Window
 
@@ -815,10 +815,7 @@ class RasterBase(ABC):
                 ```
         """
         self._require_open()
-        return [
-            SubDataset(name, description, i)
-            for i, (name, description) in enumerate(self._raster.GetSubDatasets())
-        ]
+        return subdatasets_of(self._raster)
 
     @property
     def meta_data_domains(self) -> list[str]:

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -1128,6 +1128,7 @@ class RasterBase(ABC):
         file_i: int = 0,
         *,
         open_options: dict[str, str] | list[str] | tuple[str, ...] | None = None,
+        warn_on_container: bool = True,
     ) -> RasterBase:
         """Read file.
 
@@ -1143,6 +1144,12 @@ class RasterBase(ABC):
                 GDAL open options as a mapping or ``["KEY=VALUE"]`` sequence,
                 forwarded to the driver and captured on the returned instance so
                 the reopen paths reapply them. Default ``None`` — no options.
+            warn_on_container (bool):
+                Whether to warn when the path opens to a subdataset container (a
+                0-band raster whose payload is nested subdatasets) rather than
+                returning it silently. Part of the contract so the pickle
+                reconstruct can suppress it; concrete readers may honour or ignore
+                it. Default ``True``.
 
         Returns:
             Dataset: The opened dataset instance.

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -20,7 +20,7 @@ import numpy as np
 from osgeo import gdal
 
 from pyramids import _io
-from pyramids.base._errors import AlignmentError, CRSError
+from pyramids.base._errors import AlignmentError, ContainerRasterWarning, CRSError
 from pyramids.base._utils import (
     DTYPE_CONVERSION_DF,
     RGB_CHANNEL_INTERPS,
@@ -2690,6 +2690,7 @@ class Dataset(RasterBase):
         vsi: str | None = None,
         gdal_env: dict[str, str] | None = None,
         open_options: dict[str, str] | list[str] | tuple[str, ...] | None = None,
+        warn_on_container: bool = True,
     ) -> Dataset:
         """Open a raster from a path, URL, or archive member.
 
@@ -2742,6 +2743,15 @@ class Dataset(RasterBase):
                 the returned :class:`Dataset`, so the paths that reopen the file
                 (``threadsafe=True`` handles, lazy ``chunks=`` reads, unpickle on
                 a worker) reopen with the same options. Default ``None``.
+            warn_on_container:
+                When the path opens to a *container* — a raster with no bands of
+                its own whose payload is a set of nested subdatasets (NetCDF/HDF/
+                Zarr, GRIB, WMS/WMTS, a Sentinel product) — emit a
+                :class:`~pyramids.base._errors.ContainerRasterWarning` naming the
+                subdatasets, instead of silently returning a 0-band dataset. Use
+                :attr:`subdatasets` to list them and :meth:`open_subdataset` to open
+                one. Set ``False`` to open a container quietly (callers that open
+                containers on purpose). Default ``True``.
 
         Returns:
             Dataset:
@@ -2767,12 +2777,25 @@ class Dataset(RasterBase):
                 vsi=vsi,
                 open_options=options,
             )
-        return cls(
+        dataset = cls(
             src,
             access="read_only" if read_only else "write",
             gdal_env=gdal_env,
             open_options=options,
         )
+        if warn_on_container and not dataset.band_count:
+            subdatasets = dataset.subdatasets
+            if subdatasets:
+                names = [redact_credentials(sub.name) for sub in subdatasets]
+                warnings.warn(
+                    f"{redact_credentials(str(path))!r} is a container raster with no "
+                    f"bands of its own; it has {len(names)} subdataset(s). Use "
+                    f".subdatasets to list them and .open_subdataset(<index or name>) "
+                    f"to open one. Available: {names}",
+                    ContainerRasterWarning,
+                    stacklevel=2,
+                )
+        return dataset
 
     @classmethod
     def from_bytes(

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2355,11 +2355,14 @@ class Dataset(RasterBase):
         # Open the classic-mode subdataset string as a base Dataset. read_file both
         # installs the captured GDAL env around the open (so remote credentials apply)
         # and re-attaches it to the result, so no separate context/attach is needed.
+        # warn_on_container=False: the caller deliberately drilled into a subdataset, so
+        # a container warning here (if the target is itself a nested container) is noise.
         return Dataset.read_file(
             name,
             read_only=self.access == "read_only",
             gdal_env=self._gdal_env or None,
             open_options=list(self._open_options) or None,
+            warn_on_container=False,
         )
 
     @property

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2750,7 +2750,7 @@ class Dataset(RasterBase):
                 When the path opens to a *container* — a raster with no bands of
                 its own whose payload is a set of nested subdatasets (NetCDF/HDF/
                 Zarr, GRIB, WMS/WMTS, a Sentinel product) — emit a
-                :class:`~pyramids.base._errors.ContainerRasterWarning` naming the
+                :class:`~pyramids.errors.ContainerRasterWarning` naming the
                 subdatasets, instead of silently returning a 0-band dataset. Use
                 :attr:`subdatasets` to list them and :meth:`open_subdataset` to open
                 one. Set ``False`` to open a container quietly (callers that open
@@ -2789,12 +2789,17 @@ class Dataset(RasterBase):
         if warn_on_container and not dataset.band_count:
             subdatasets = dataset.subdatasets
             if subdatasets:
-                names = [redact_credentials(sub.name) for sub in subdatasets]
+                count = len(subdatasets)
+                # Cap the preview so a many-variable container (tens of NetCDF/HDF
+                # variables) does not produce an unbounded warning string.
+                shown = [redact_credentials(sub.name) for sub in subdatasets[:10]]
+                if count > len(shown):
+                    shown.append(f"… and {count - 10} more")
                 warnings.warn(
                     f"{redact_credentials(str(path))!r} is a container raster with no "
-                    f"bands of its own; it has {len(names)} subdataset(s). Use "
+                    f"bands of its own; it has {count} subdataset(s). Use "
                     f".subdatasets to list them and .open_subdataset(<index or name>) "
-                    f"to open one. Available: {names}",
+                    f"to open one. Available: {shown}",
                     ContainerRasterWarning,
                     stacklevel=2,
                 )

--- a/src/pyramids/errors.py
+++ b/src/pyramids/errors.py
@@ -15,6 +15,11 @@ from a matching Python builtin (`ValueError` / `RuntimeError`) so
 existing `except ValueError:` / `except RuntimeError:` blocks keep
 working without change.
 
+The pyramids-emitted warning categories (`ContainerRasterWarning`,
+`GeometryWarning`) are re-exported here too, so a caller who wants to
+filter one writes ``warnings.filterwarnings("ignore",
+category=errors.ContainerRasterWarning)`` against this public module.
+
 The implementation lives in :mod:`pyramids.base._errors`; that module
 is private and its signatures may change without notice. Always import
 exception classes from here instead.
@@ -24,6 +29,7 @@ from __future__ import annotations
 
 from pyramids.base._errors import (
     AlignmentError,
+    ContainerRasterWarning,
     CoverageError,
     CRSError,
     DatasetNotFoundError,
@@ -31,6 +37,7 @@ from pyramids.base._errors import (
     FailedToSaveError,
     FeatureError,
     FileFormatNotSupportedError,
+    GeometryWarning,
     InvalidGeometryError,
     NoDataValueError,
     OGCAPIError,
@@ -48,6 +55,7 @@ from pyramids.base._errors import _PyramidsError as PyramidsError
 __all__ = [
     "PyramidsError",
     "AlignmentError",
+    "ContainerRasterWarning",
     "CoverageError",
     "CRSError",
     "DatasetNotFoundError",
@@ -55,6 +63,7 @@ __all__ = [
     "FailedToSaveError",
     "FeatureError",
     "FileFormatNotSupportedError",
+    "GeometryWarning",
     "InvalidGeometryError",
     "NoDataValueError",
     "OGCAPIError",

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4800,11 +4800,14 @@ class NetCDF(Dataset):
     def _classic_subdataset_variable_names(self) -> list[str]:
         """Data-variable names parsed from classic-mode subdataset metadata.
 
+        Reads the shared :attr:`~pyramids.dataset.abstract_dataset.AbstractDataset.subdatasets`
+        surface rather than parsing ``GetSubDatasets()`` a second time.
+
         Returns:
-            list[str]: The variable name from each `gdal.Dataset.GetSubDatasets()`
-            entry (the second whitespace-delimited token of its description).
+            list[str]: The variable name from each :attr:`subdatasets` entry (the
+            second whitespace-delimited token of its GDAL description).
         """
-        return [var[1].split(" ")[1] for var in self._raster.GetSubDatasets()]
+        return [sub.description.split(" ")[1] for sub in self.subdatasets]
 
     @staticmethod
     def _dimension_index(dim_names: list[str], target: str) -> int:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4800,7 +4800,7 @@ class NetCDF(Dataset):
     def _classic_subdataset_variable_names(self) -> list[str]:
         """Data-variable names parsed from classic-mode subdataset metadata.
 
-        Reads the shared :attr:`~pyramids.dataset.abstract_dataset.AbstractDataset.subdatasets`
+        Reads the shared :attr:`~pyramids.dataset.abstract_dataset.RasterBase.subdatasets`
         surface rather than parsing ``GetSubDatasets()`` a second time.
 
         Returns:

--- a/tests/dataset/remote/test_wms.py
+++ b/tests/dataset/remote/test_wms.py
@@ -255,6 +255,10 @@ class TestAvailableWmtsLayers:
                     ("WMTS:https://x,layer=A,tilematrixset=t", "layer A"),
                     ("WMTS:https://x,layer=B", "duplicate -> de-duplicated"),
                     ("WMTS:https://x", "no ,layer= key -> skipped"),
+                    (
+                        "WMTS:https://x",
+                        "desc has ,layer=Z but the name does not -> skipped",
+                    ),
                 ]
 
         monkeypatch.setattr(_wms.gdal, "Open", lambda _c: _Caps())

--- a/tests/dataset/remote/test_wms.py
+++ b/tests/dataset/remote/test_wms.py
@@ -247,12 +247,15 @@ class TestAvailableWmtsLayers:
 
         class _Caps:
             @staticmethod
-            def GetMetadata(_key):
-                return {
-                    "SUBDATASET_1_NAME": "WMTS:https://x,layer=B",
-                    "SUBDATASET_2_NAME": "WMTS:https://x,layer=A,tilematrixset=t",
-                    "SUBDATASET_1_DESC": "ignored, not a _NAME",
-                }
+            def GetSubDatasets():
+                # (name, description) pairs, as GDAL parses the SUBDATASETS domain —
+                # the same surface Dataset.subdatasets consumes.
+                return [
+                    ("WMTS:https://x,layer=B", "layer B"),
+                    ("WMTS:https://x,layer=A,tilematrixset=t", "layer A"),
+                    ("WMTS:https://x,layer=B", "duplicate -> de-duplicated"),
+                    ("WMTS:https://x", "no ,layer= key -> skipped"),
+                ]
 
         monkeypatch.setattr(_wms.gdal, "Open", lambda _c: _Caps())
         assert _wms._available_wmts_layers("https://x") == ["A", "B"]

--- a/tests/dataset/test_subdatasets_metadata_domains.py
+++ b/tests/dataset/test_subdatasets_metadata_domains.py
@@ -225,6 +225,23 @@ class TestContainerOpenWarning:
             )
         assert nc.subdatasets, "NetCDF opened a real container without the base warning"
 
+    def test_zero_band_raster_with_no_subdatasets_is_silent(self, mocker):
+        """A 0-band raster that lists no subdatasets does not warn (the guarded branch).
+
+        Test scenario:
+            The container opens 0-band, but its `subdatasets` come back empty (patched),
+            so `read_file` must take the inner `if subdatasets:` false path and stay silent.
+        """
+        mocker.patch(
+            "pyramids.dataset.abstract_dataset.RasterBase.subdatasets",
+            new_callable=mocker.PropertyMock,
+            return_value=[],
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", ContainerRasterWarning)
+            ds = Dataset.read_file(str(NETCDF_CONTAINER))
+        assert ds.band_count == 0, "still a 0-band container, just with nothing to list"
+
 
 class TestMetadataDomains:
     """Dataset-level metadata domains (#1028)."""

--- a/tests/dataset/test_subdatasets_metadata_domains.py
+++ b/tests/dataset/test_subdatasets_metadata_domains.py
@@ -243,7 +243,8 @@ class TestContainerOpenWarning:
         with warnings.catch_warnings():
             warnings.simplefilter("error", ContainerRasterWarning)
             ds = Dataset.read_file(str(GEOTIFF_PLAIN))
-        assert ds.band_count >= 1 and ds.subdatasets == [], "a plain raster never warns"
+        assert ds.band_count >= 1, "a plain raster has bands of its own"
+        assert ds.subdatasets == [], "a plain raster has no subdatasets"
 
     def test_netcdf_read_file_does_not_emit_base_container_warning(self):
         """`NetCDF.read_file` opens a container on purpose via its own path and stays quiet.

--- a/tests/dataset/test_subdatasets_metadata_domains.py
+++ b/tests/dataset/test_subdatasets_metadata_domains.py
@@ -10,20 +10,25 @@ from __future__ import annotations
 
 import dataclasses
 import pickle
+import warnings
 from pathlib import Path
 
 import numpy as np
 import pytest
 
-from pyramids.base._errors import ReadOnlyError
+from pyramids.base._errors import ContainerRasterWarning, ReadOnlyError
 from pyramids.dataset import Dataset
-from pyramids.dataset._subdataset import SubDataset
+from pyramids.dataset._subdataset import SubDataset, subdatasets_of
 
 pytestmark = pytest.mark.core
 
 # A classic-mode NetCDF whose GDAL handle exposes 4 subdatasets (Band1..Band4).
 NETCDF_CONTAINER = (
     Path(__file__).parents[1] / "data" / "netcdf" / "cf__6v__1d2-2d4__geog__y-asc.nc"
+)
+# A plain single-band GeoTIFF with no subdatasets.
+GEOTIFF_PLAIN = (
+    Path(__file__).parents[1] / "data" / "geotiff" / "coello-without-color-table.tif"
 )
 
 
@@ -88,6 +93,10 @@ class TestSubdatasetsProperty:
         assert [s.index for s in subs] == [0, 1, 2, 3], "indices must be 0..n in order"
         assert all(isinstance(s, SubDataset) for s in subs), "entries are SubDataset"
         assert subs[0].name.endswith(":Band1"), f"first name unexpected: {subs[0].name}"
+
+    def test_property_delegates_to_shared_builder(self, container):
+        """The property and the shared `subdatasets_of` builder agree entry-for-entry."""
+        assert subdatasets_of(container.raster) == container.subdatasets
 
 
 class TestOpenSubdataset:
@@ -177,6 +186,44 @@ class TestNetCDFRegression:
         assert container.variable_names[:3] == ["Band1", "Band2", "Band3"], (
             "the NetCDF variable surface must be unaffected"
         )
+
+
+class TestContainerOpenWarning:
+    """Opening a container via base `Dataset.read_file` is no longer silent (#1030)."""
+
+    def test_container_open_warns_and_names_subdatasets(self):
+        """A base read_file on a container warns and the message names its subdatasets."""
+        with pytest.warns(ContainerRasterWarning) as record:
+            ds = Dataset.read_file(str(NETCDF_CONTAINER))
+        assert ds.band_count == 0, "the container has no bands of its own"
+        message = str(record[0].message)
+        assert "subdataset" in message, "the warning explains it is a container"
+        assert "Band1" in message, "the warning names the available subdatasets"
+
+    def test_warn_on_container_false_is_silent(self):
+        """`warn_on_container=False` opens the container without warning."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", ContainerRasterWarning)
+            ds = Dataset.read_file(str(NETCDF_CONTAINER), warn_on_container=False)
+        assert len(ds.subdatasets) == 4, "the container still opens, just quietly"
+
+    def test_plain_raster_open_does_not_warn(self):
+        """A plain single-band raster opens with no container warning."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", ContainerRasterWarning)
+            ds = Dataset.read_file(str(GEOTIFF_PLAIN))
+        assert ds.band_count >= 1 and ds.subdatasets == [], "a plain raster never warns"
+
+    def test_netcdf_read_file_does_not_emit_base_container_warning(self):
+        """`NetCDF.read_file` opens a container on purpose via its own path and stays quiet."""
+        from pyramids.netcdf import NetCDF
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", ContainerRasterWarning)
+            nc = NetCDF.read_file(
+                str(NETCDF_CONTAINER), open_as_multi_dimensional=False
+            )
+        assert nc.subdatasets, "NetCDF opened a real container without the base warning"
 
 
 class TestMetadataDomains:

--- a/tests/dataset/test_subdatasets_metadata_domains.py
+++ b/tests/dataset/test_subdatasets_metadata_domains.py
@@ -18,7 +18,8 @@ import pytest
 
 from pyramids.base._errors import ContainerRasterWarning, ReadOnlyError
 from pyramids.dataset import Dataset
-from pyramids.dataset._subdataset import SubDataset, subdatasets_of
+from pyramids.dataset._subdataset import SubDataset
+from pyramids.netcdf import NetCDF
 
 pytestmark = pytest.mark.core
 
@@ -46,8 +47,6 @@ def plain() -> Dataset:
 @pytest.fixture
 def container():
     """A NetCDF container opened classic-mode, exposing 4 subdatasets."""
-    from pyramids.netcdf import NetCDF
-
     return NetCDF.read_file(str(NETCDF_CONTAINER), open_as_multi_dimensional=False)
 
 
@@ -95,8 +94,12 @@ class TestSubdatasetsProperty:
         assert subs[0].name.endswith(":Band1"), f"first name unexpected: {subs[0].name}"
 
     def test_property_delegates_to_shared_builder(self, container):
-        """The property and the shared `subdatasets_of` builder agree entry-for-entry."""
-        assert subdatasets_of(container.raster) == container.subdatasets
+        """The `subdatasets` property matches a list built straight from GetSubDatasets."""
+        expected = [
+            SubDataset(name, description, i)
+            for i, (name, description) in enumerate(container.raster.GetSubDatasets())
+        ]
+        assert container.subdatasets == expected
 
 
 class TestOpenSubdataset:
@@ -199,7 +202,10 @@ class TestContainerOpenWarning:
         with pytest.warns(ContainerRasterWarning) as record:
             ds = Dataset.read_file(str(NETCDF_CONTAINER))
         assert ds.band_count == 0, "the container has no bands of its own"
-        message = str(record[0].message)
+        container_warning = next(
+            w for w in record if issubclass(w.category, ContainerRasterWarning)
+        )
+        message = str(container_warning.message)
         assert "subdataset" in message, "the warning explains it is a container"
         assert "Band1" in message, "the warning names the available subdatasets"
 
@@ -218,9 +224,12 @@ class TestContainerOpenWarning:
         assert ds.band_count >= 1 and ds.subdatasets == [], "a plain raster never warns"
 
     def test_netcdf_read_file_does_not_emit_base_container_warning(self):
-        """`NetCDF.read_file` opens a container on purpose via its own path and stays quiet."""
-        from pyramids.netcdf import NetCDF
+        """`NetCDF.read_file` opens a container on purpose via its own path and stays quiet.
 
+        Guard test: `NetCDF.read_file` builds a `Container` directly and never reaches the
+        base warning branch, so this pins that exemption — it would catch a future refactor
+        that routed NetCDF opens back through `Dataset.read_file`.
+        """
         with warnings.catch_warnings():
             warnings.simplefilter("error", ContainerRasterWarning)
             nc = NetCDF.read_file(

--- a/tests/dataset/test_subdatasets_metadata_domains.py
+++ b/tests/dataset/test_subdatasets_metadata_domains.py
@@ -211,6 +211,26 @@ class TestContainerOpenWarning:
         assert "subdataset" in message, "the warning explains it is a container"
         assert "Band1" in message, "the warning names the available subdatasets"
 
+    def test_warning_caps_a_many_subdataset_container(self, mocker):
+        """The message lists at most ten subdataset names, then a `… and N more` tail."""
+        many = [SubDataset(f'NETCDF:"f.nc":v{i}', f"v{i}", i) for i in range(15)]
+        mocker.patch(
+            "pyramids.dataset.abstract_dataset.RasterBase.subdatasets",
+            new_callable=mocker.PropertyMock,
+            return_value=many,
+        )
+        with pytest.warns(ContainerRasterWarning) as record:
+            Dataset.read_file(str(NETCDF_CONTAINER))
+        message = str(
+            next(
+                w for w in record if issubclass(w.category, ContainerRasterWarning)
+            ).message
+        )
+        assert "15 subdataset(s)" in message, "the count reflects every subdataset"
+        assert "… and 5 more" in message, (
+            "the list caps at ten names with a summary tail"
+        )
+
     def test_warn_on_container_false_is_silent(self):
         """`warn_on_container=False` opens the container without warning."""
         with warnings.catch_warnings():

--- a/tests/dataset/test_subdatasets_metadata_domains.py
+++ b/tests/dataset/test_subdatasets_metadata_domains.py
@@ -19,7 +19,9 @@ import pytest
 from pyramids.base._errors import ContainerRasterWarning, ReadOnlyError
 from pyramids.dataset import Dataset
 from pyramids.dataset._subdataset import SubDataset
+from pyramids.dataset.abstract_dataset import _reconstruct_dataset
 from pyramids.netcdf import NetCDF
+from pyramids.netcdf.netcdf import _reconstruct_netcdf
 
 pytestmark = pytest.mark.core
 
@@ -278,6 +280,30 @@ class TestContainerOpenWarning:
         _, kwargs = patched.call_args
         assert kwargs["warn_on_container"] is False, (
             "opening a subdataset value object is a deliberate drill-in, so it must be quiet"
+        )
+
+    def test_only_base_dataset_reaches_the_reconstruct_that_suppresses(self, container):
+        """Pin the invariant the unpickle suppression relies on.
+
+        `_reconstruct_dataset` passes `warn_on_container=False`, a kwarg only the base
+        `Dataset.read_file` accepts. This asserts a base `Dataset` unpickles through
+        `_reconstruct_dataset` while `NetCDF` routes to its own `_reconstruct_netcdf`, so
+        the suppression can never reach a `read_file` override that lacks the keyword.
+        """
+        plain_ds = Dataset.read_file(str(GEOTIFF_PLAIN))
+        assert plain_ds.__reduce__()[0] is _reconstruct_dataset, (
+            "a base Dataset must unpickle through _reconstruct_dataset"
+        )
+        assert container.__reduce__()[0] is _reconstruct_netcdf, (
+            "NetCDF must route to its own reconstruct, never the base one"
+        )
+
+    def test_warning_is_importable_from_public_errors(self):
+        """The warning is re-exported from the public `pyramids.errors`, not just `_errors`."""
+        from pyramids.errors import ContainerRasterWarning as Exported
+
+        assert Exported is ContainerRasterWarning, (
+            "the documented way to filter the warning must import from pyramids.errors"
         )
 
 

--- a/tests/dataset/test_subdatasets_metadata_domains.py
+++ b/tests/dataset/test_subdatasets_metadata_domains.py
@@ -174,6 +174,9 @@ class TestOpenSubdataset:
         assert kwargs["open_options"] == ["HONOUR_VALID_RANGE=NO"], (
             "parent open options must be forwarded to the child open"
         )
+        assert kwargs["warn_on_container"] is False, (
+            "a deliberate drill-in must suppress the container warning on the child open"
+        )
         assert "gdal_env" in kwargs, "gdal_env must be forwarded to read_file"
 
 
@@ -241,6 +244,32 @@ class TestContainerOpenWarning:
             warnings.simplefilter("error", ContainerRasterWarning)
             ds = Dataset.read_file(str(NETCDF_CONTAINER))
         assert ds.band_count == 0, "still a 0-band container, just with nothing to list"
+
+    def test_unpickling_a_container_does_not_re_warn(self):
+        """Unpickling a base-Dataset container reopens quietly (the `_reconstruct` path).
+
+        Test scenario:
+            A 0-band container opened quietly is pickled, then unpickled; the reopen goes
+            through `_reconstruct_dataset`, which must pass `warn_on_container=False` so
+            deserialization does not re-emit the warning the caller already saw.
+        """
+        ds = Dataset.read_file(str(NETCDF_CONTAINER), warn_on_container=False)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", ContainerRasterWarning)
+            restored = pickle.loads(pickle.dumps(ds))
+        assert restored.band_count == 0, "the reopened container is unchanged"
+        assert len(restored.subdatasets) == 4, "and still lists its four subdatasets"
+
+    def test_value_object_open_suppresses_the_container_warning(
+        self, container, mocker
+    ):
+        """`SubDataset.open()` reopens the child with `warn_on_container=False`."""
+        patched = mocker.patch.object(Dataset, "read_file", return_value=object())
+        container.subdatasets[0].open()
+        _, kwargs = patched.call_args
+        assert kwargs["warn_on_container"] is False, (
+            "opening a subdataset value object is a deliberate drill-in, so it must be quiet"
+        )
 
 
 class TestMetadataDomains:


### PR DESCRIPTION
# Description

Completes the two Definition-of-Done items from #1030 that PR #1040 deferred (the `ds.subdatasets` /
`open_subdataset` core surface shipped in #1040; this is the tail).

**1. Consolidate the two private `SUBDATASETS` parsers onto one shared surface (`refactor`).**
Before this change three consumers parsed GDAL's `SUBDATASETS` domain independently: the new
`Dataset.subdatasets` property, `NetCDF._classic_subdataset_variable_names`, and the WMTS layer-hint helper
`_wms._available_wmts_layers`. This collapses them onto a single builder:

- New `subdatasets_of(raster)` in `dataset/_subdataset.py` — the one place the `SUBDATASETS` domain becomes
  `SubDataset` value objects. `AbstractDataset.subdatasets` now delegates to it.
- `NetCDF._classic_subdataset_variable_names` consumes `self.subdatasets` instead of re-reading
  `self._raster.GetSubDatasets()`.
- `_wms._available_wmts_layers` enumerates via `subdatasets_of(caps)` instead of hand-parsing
  `GetMetadata("SUBDATASETS")`. It keeps the raw `gdal.Open` handle, so the `WMTS:<url>` connection string never
  passes through `_io`'s URL-scheme rewriting (avoids a WMS regression).

Behaviour is unchanged — `GetSubDatasets()` is GDAL's canonical view of that same metadata domain.

**2. Opening a container is no longer a silent 0-band result (`feat`).**
Opening a container raster (NetCDF/HDF/Zarr, GRIB, WMS/WMTS, a Sentinel product) through the base
`Dataset.read_file` returned a `Dataset` with `band_count == 0`, no error and no warning — a silent empty object
that failed much later somewhere unrelated.

- New `ContainerRasterWarning`; `Dataset.read_file` emits it when the opened raster has no bands of its own but has
  subdatasets. The message names them and points at `.subdatasets` / `.open_subdataset`.
- New `warn_on_container=True` flag so callers that open a container on purpose can stay quiet. `NetCDF.read_file`
  has its own open path and is unaffected; `_available_wmts_layers` passes `warn_on_container=False` implicitly by
  using the raw handle.

No new dependencies.

# Issues

- Closes #1030 — refactor `_wms.py`/`netcdf.py` onto the shared subdataset surface, and stop the silent 0-band
  container open

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Ran the targeted and surrounding suites in the `dev` env (`pixi run --frozen -e dev pytest … -m "not plot and not
live"`), plus `ruff format --check` / `ruff check` on every changed file.

- [x] New tests in `tests/dataset/test_subdatasets_metadata_domains.py`: container open warns and names its
  subdatasets; `warn_on_container=False` is silent; a plain raster and `NetCDF.read_file` do not warn; the
  `subdatasets` property and the shared `subdatasets_of` builder agree entry-for-entry.
- [x] Updated `tests/dataset/remote/test_wms.py` so the WMTS layer-hint mock models the shared surface
  (`GetSubDatasets()`), preserving the id-extraction, de-duplication, and skip-non-layer semantics.
- [x] Regression sweeps: **NetCDF suite 2555 passed**, **dataset suite 3382 passed** (no plot/live/slow), so the
  parser consolidation does not change `variable_names` or WMS behaviour.

# Checklist:

- [ ] updated version number in pyproject.toml. — handled by commitizen/CI
- [ ] added changes to History.rst. — changelog is commitizen-generated
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. — docstrings for `read_file` (`warn_on_container`), `ContainerRasterWarning`, and
  `subdatasets_of`
