### PR TITLE
fix(io): stop /vsizip/ double-wrap on subdataset reopen; pin meta_data_domains name

### DIFF
--- a/src/pyramids/_io.py
+++ b/src/pyramids/_io.py
@@ -214,14 +214,18 @@ def read_vsi_bytes(path: str) -> bytes:
     return payload
 
 
-# A GDAL virtual-filesystem prefix (/vsizip/, /vsigzip/, /vsitar/, /vsicurl/, /vsis3/, …)
-# that already resolves the path. GDAL VSI handler names are always lowercase, so the
-# character class is lowercase-only (never widen to IGNORECASE — that would match an
-# ordinary "VSI"-named directory). Anchored to the start of the string or immediately
-# after a driver scheme / opening quote, so a real directory or archive member literally
-# named "vsi<x>" (e.g. a .vsix folder, or an inner "vsi1/" member) is NOT mistaken for a
-# resolved prefix — only a leading /vsi.../ or a driver-embedded X:/vsi.../ matches.
-_VSI_PREFIX_RE = re.compile(r'(?:^|[:"])/vsi[a-z0-9]+/')
+# A GDAL virtual-filesystem prefix (/vsizip/, /vsigzip/, /vsitar/, /vsicurl/,
+# /vsicurl_streaming/, /vsis3/, …) that already resolves the path. Handler names are
+# always lowercase (never widen to IGNORECASE — that would match a "VSI"-named
+# directory) and may carry an underscore (`vsicurl_streaming`), so the class is
+# [a-z0-9_]. The prefix is anchored to the start of the string, an opening quote, or a
+# *driver scheme* — a token of two or more name characters before the colon
+# (`NETCDF:`, `SENTINEL2_L2A:`). Requiring ≥2 characters excludes a Windows drive letter
+# (`C:`), which is exactly one, so a real archive under a drive-root directory named
+# `vsizip` (`C:/vsizip/a.zip`) — or any ordinary `vsi<x>` directory / inner member — is
+# NOT mistaken for a resolved prefix; only a leading /vsi…/ or a driver-embedded
+# <scheme>:/vsi…/ matches.
+_VSI_PREFIX_RE = re.compile(r'(?:^|"|[A-Za-z][A-Za-z0-9_]+:)/vsi[a-z0-9_]+/')
 
 
 def _is_resolved_vsi(path: str) -> bool:

--- a/src/pyramids/_io.py
+++ b/src/pyramids/_io.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import fnmatch
 import gzip
 import itertools
+import re
 import tarfile
 import time
 import warnings
@@ -213,16 +214,39 @@ def read_vsi_bytes(path: str) -> bytes:
     return payload
 
 
-def _is_zip(path: str):
-    return path.endswith(".zip") or path.__contains__(".zip")
+# GDAL virtual-filesystem prefix: /vsizip/, /vsigzip/, /vsitar/, /vsicurl/, /vsis3/, …
+# either at the start of a path or embedded in a driver connection string
+# (SENTINEL2_L2A:/vsizip/…, NETCDF:"/vsizip/…"). A path that already carries one is
+# resolved, so archive auto-detection must not prepend a second VSI prefix (#1055).
+_VSI_PREFIX_RE = re.compile(r"/vsi[a-z0-9]+/")
 
 
-def _is_gzip(path: str):
-    return path.endswith(".gz") or path.__contains__(".gz")
+def _is_resolved_vsi(path: str) -> bool:
+    """Whether ``path`` already routes through a GDAL ``/vsi*`` handler.
+
+    True for a bare ``/vsizip/…`` path and for a driver connection string that embeds
+    one (``SENTINEL2_L2A:/vsizip/…``). Such a path is already resolved, so the archive
+    detectors below leave it untouched instead of re-wrapping it (#1055).
+    """
+    return bool(_VSI_PREFIX_RE.search(path))
 
 
-def _is_tar(path: str):
-    return path.endswith(".tar.gz") or path.__contains__(".tar")
+def _is_zip(path: str) -> bool:
+    if _is_resolved_vsi(path):
+        return False
+    return path.endswith(".zip") or ".zip" in path
+
+
+def _is_gzip(path: str) -> bool:
+    if _is_resolved_vsi(path):
+        return False
+    return path.endswith(".gz") or ".gz" in path
+
+
+def _is_tar(path: str) -> bool:
+    if _is_resolved_vsi(path):
+        return False
+    return path.endswith(".tar.gz") or ".tar" in path
 
 
 def _get_zip_path(path: str, file_i: int = 0):

--- a/src/pyramids/_io.py
+++ b/src/pyramids/_io.py
@@ -225,7 +225,7 @@ def read_vsi_bytes(path: str) -> bytes:
 # `vsizip` (`C:/vsizip/a.zip`) — or any ordinary `vsi<x>` directory / inner member — is
 # NOT mistaken for a resolved prefix; only a leading /vsi…/ or a driver-embedded
 # <scheme>:/vsi…/ matches.
-_VSI_PREFIX_RE = re.compile(r'(?:^|"|[A-Za-z][A-Za-z0-9_]+:)/vsi[a-z0-9_]+/')
+_VSI_PREFIX_RE = re.compile(r'(?:^|"|[A-Za-z]\w+:)/vsi[a-z0-9_]+/')
 
 
 def _is_resolved_vsi(path: str) -> bool:

--- a/src/pyramids/_io.py
+++ b/src/pyramids/_io.py
@@ -214,38 +214,38 @@ def read_vsi_bytes(path: str) -> bytes:
     return payload
 
 
-# GDAL virtual-filesystem prefix: /vsizip/, /vsigzip/, /vsitar/, /vsicurl/, /vsis3/, …
-# either at the start of a path or embedded in a driver connection string
-# (SENTINEL2_L2A:/vsizip/…, NETCDF:"/vsizip/…"). A path that already carries one is
-# resolved, so archive auto-detection must not prepend a second VSI prefix (#1055).
-_VSI_PREFIX_RE = re.compile(r"/vsi[a-z0-9]+/")
+# A GDAL virtual-filesystem prefix (/vsizip/, /vsigzip/, /vsitar/, /vsicurl/, /vsis3/, …)
+# that already resolves the path. GDAL VSI handler names are always lowercase, so the
+# character class is lowercase-only (never widen to IGNORECASE — that would match an
+# ordinary "VSI"-named directory). Anchored to the start of the string or immediately
+# after a driver scheme / opening quote, so a real directory or archive member literally
+# named "vsi<x>" (e.g. a .vsix folder, or an inner "vsi1/" member) is NOT mistaken for a
+# resolved prefix — only a leading /vsi.../ or a driver-embedded X:/vsi.../ matches.
+_VSI_PREFIX_RE = re.compile(r'(?:^|[:"])/vsi[a-z0-9]+/')
 
 
 def _is_resolved_vsi(path: str) -> bool:
     """Whether ``path`` already routes through a GDAL ``/vsi*`` handler.
 
     True for a bare ``/vsizip/…`` path and for a driver connection string that embeds
-    one (``SENTINEL2_L2A:/vsizip/…``). Such a path is already resolved, so the archive
-    detectors below leave it untouched instead of re-wrapping it (#1055).
+    one (``SENTINEL2_L2A:/vsizip/…``, ``NETCDF:"/vsizip/…"``). Such a path is already
+    resolved: :func:`_parse_path` returns it unchanged rather than prepend a second
+    archive prefix (#1055). It is deliberately *not* consulted by the extension
+    detectors below — those stay pure so :func:`_infer_archive_kind` still classifies a
+    raw ``/vsi*`` archive path.
     """
     return bool(_VSI_PREFIX_RE.search(path))
 
 
 def _is_zip(path: str) -> bool:
-    if _is_resolved_vsi(path):
-        return False
     return path.endswith(".zip") or ".zip" in path
 
 
 def _is_gzip(path: str) -> bool:
-    if _is_resolved_vsi(path):
-        return False
     return path.endswith(".gz") or ".gz" in path
 
 
 def _is_tar(path: str) -> bool:
-    if _is_resolved_vsi(path):
-        return False
     return path.endswith(".tar.gz") or ".tar" in path
 
 
@@ -377,7 +377,11 @@ def _parse_path(path: str | Path, file_i: int = 0) -> str:
     # to GDAL /vsi* form BEFORE zip/tar/gzip detection so a remote /vsicurl/
     # path doesn't accidentally get treated as a compressed archive.
     path = remote._to_vsi(path)
-    if remote.is_remote(path):
+    if remote.is_remote(path) or _is_resolved_vsi(path):
+        # Already routed through a /vsi* handler — a bare /vsizip/… path (caught by
+        # is_remote) or one embedded in a driver connection string
+        # (SENTINEL2_L2A:/vsizip/…, which is_remote misses). Re-wrapping it would yield
+        # the unopenable /vsizip/SENTINEL2_L2A:/vsizip/… , so leave it as-is (#1055).
         new_path = path
     elif _is_zip(path):
         new_path = _get_zip_path(path, file_i=file_i)

--- a/tests/dataset/test_subdatasets_metadata_domains.py
+++ b/tests/dataset/test_subdatasets_metadata_domains.py
@@ -346,6 +346,20 @@ class TestMetadataDomains:
         assert isinstance(domains, list), "meta_data_domains must be a list"
         assert all(isinstance(d, str) for d in domains), "entries must be str"
 
+    def test_public_name_is_meta_data_domains_not_metadata_domains(self, plain):
+        """Pin the shipped name so code and docs cannot drift again (#1052).
+
+        The listing shipped as `meta_data_domains` (consistent with the `meta_data` /
+        `get_meta_data` siblings). PR #1040's body called it `metadata_domains`, which
+        never existed; this asserts the real name is present and the other is absent.
+        """
+        assert hasattr(plain, "meta_data_domains"), (
+            "meta_data_domains is the public name"
+        )
+        assert not hasattr(plain, "metadata_domains"), (
+            "metadata_domains must not exist; one canonical name only"
+        )
+
     def test_set_meta_data_round_trips_a_custom_domain(self, plain):
         """A custom domain can be written and read back, and appears in the list."""
         plain.set_meta_data({"A": "1", "B": "2"}, domain="MYDOMAIN")

--- a/tests/io/test_archives.py
+++ b/tests/io/test_archives.py
@@ -158,7 +158,9 @@ import tempfile
 import numpy as np
 
 from pyramids._io import (
+    _archive_dir_vsi,
     _get_tar_path,
+    _infer_archive_kind,
     _is_gzip,
     _is_resolved_vsi,
     _is_tar,
@@ -391,8 +393,8 @@ class TestHelperFunctions:
 class TestVsiPathNotDoubleWrapped:
     """A path already routed through a GDAL /vsi* handler is left alone (#1055)."""
 
-    def test_is_resolved_vsi_detects_bare_and_embedded_prefixes(self):
-        """It flags bare /vsi* paths and driver connection strings that embed one."""
+    def test_is_resolved_vsi_flags_only_real_prefixes(self):
+        """It matches a leading or driver-embedded /vsi*, not a directory named vsi<x>."""
         assert _is_resolved_vsi("/vsizip/a.zip/b.asc"), "bare /vsizip/ path"
         assert _is_resolved_vsi(
             "SENTINEL2_L2A:/vsizip/a.zip/x.SAFE/m.xml:60m:EPSG_32632"
@@ -402,35 +404,62 @@ class TestVsiPathNotDoubleWrapped:
         )
         assert not _is_resolved_vsi("data/a.zip"), "a real archive is not a vsi path"
         assert not _is_resolved_vsi("data/a.zip/b.asc"), "an archive member is not vsi"
-
-    def test_archive_detectors_skip_resolved_vsi_paths(self):
-        """_is_zip / _is_gzip / _is_tar do not fire on an already-/vsi* connection string."""
-        assert not _is_zip("SENTINEL2_L2A:/vsizip/a.zip/x.xml:60m"), (
-            "no re-wrap of a zip conn"
+        assert not _is_resolved_vsi("C:/data/vsix/a.zip"), (
+            "a .vsix folder is not a prefix"
         )
-        assert not _is_gzip("NETCDF:/vsigzip/a.gz/x.nc:v"), "no re-wrap of a gzip conn"
-        assert not _is_tar("X:/vsitar/a.tar/b"), "no re-wrap of a tar conn"
-        assert _is_zip("data/a.zip"), "a real .zip is still detected"
-        assert _is_zip("data/a.zip/1.asc"), "a real archive member is still detected"
+        assert not _is_resolved_vsi("archive.zip/vsi1/inner.asc"), (
+            "an inner vsi1/ member folder is not a prefix"
+        )
 
-    def test_parse_path_is_idempotent_on_a_vsizip_member(
+    def test_parse_path_leaves_a_driver_embedded_vsi_string_unchanged(self):
+        """_parse_path returns a driver-embedded /vsizip/ string unchanged — the real #1055 trigger.
+
+        is_remote is False for a driver-prefixed connection string, so before the fix it
+        reached the detectors and was double-wrapped into /vsizip/SENTINEL2_L2A:/vsizip/… .
+        """
+        conn = "SENTINEL2_L2A:/vsizip/data/product.zip/X.SAFE/MTD.xml:60m:EPSG_32632"
+        assert _parse_path(conn) == conn, (
+            "a resolved driver connection string passes through"
+        )
+        nc = 'NETCDF:"/vsizip/data/x.zip/multi.nc":tos'
+        assert _parse_path(nc) == nc, (
+            "a quoted /vsizip/ netCDF subdataset passes through"
+        )
+
+    def test_infer_archive_kind_still_resolves_a_raw_vsi_archive(self):
+        """The guard stays out of the detectors, so from_archive(kind='auto') still works on /vsi* input.
+
+        Regression guard: routing the guard through the shared detectors would make
+        _infer_archive_kind return None and _archive_dir_vsi raise on a raw /vsi* archive.
+        """
+        assert _infer_archive_kind("/vsizip/data/x.zip") == "zip", (
+            "raw /vsizip/ classifies"
+        )
+        assert _infer_archive_kind("/vsis3/bucket/a.zip") == "zip", (
+            "an /vsis3/ archive classifies"
+        )
+        assert _archive_dir_vsi("/vsizip/data/x.zip", "auto") == "/vsizip/data/x.zip", (
+            "auto-kind resolves a raw /vsi* archive, does not raise"
+        )
+
+    def test_parse_path_passes_a_bare_vsizip_member_through(
         self,
         multiple_compressed_file_zip: str,
         multiple_compressed_file_zip_content: List[str],
     ):
-        """_parse_path leaves an already-resolved /vsizip/ member unchanged, not double-wrapped."""
+        """A bare /vsizip/ member is returned unchanged (via the is_remote short-circuit)."""
         member = multiple_compressed_file_zip_content[0]
         resolved = f"/vsizip/{multiple_compressed_file_zip}/{member}"
         assert _parse_path(resolved) == resolved, (
-            "a resolved /vsizip/ path must pass through"
+            "a resolved /vsizip/ path passes through"
         )
 
-    def test_read_file_opens_a_vsizip_member(
+    def test_read_file_opens_a_bare_vsizip_member(
         self,
         multiple_compressed_file_zip: str,
         multiple_compressed_file_zip_content: List[str],
     ):
-        """The low-level reader opens an already-/vsizip/ member (the #1055 failure path)."""
+        """The low-level reader opens an already-/vsizip/ member without re-wrapping it."""
         member = multiple_compressed_file_zip_content[0]
         src = read_file(f"/vsizip/{multiple_compressed_file_zip}/{member}")
         assert isinstance(src, gdal.Dataset), "a resolved /vsizip/ member must open"
@@ -440,7 +469,7 @@ class TestVsiPathNotDoubleWrapped:
         multiple_compressed_file_zip: str,
         multiple_compressed_file_zip_content: List[str],
     ):
-        """SubDataset.open() succeeds for a /vsizip/-carrying name (the reported trigger)."""
+        """SubDataset.open() succeeds for a /vsizip/-carrying name (the reported drill-in)."""
         member = multiple_compressed_file_zip_content[0]
         name = f"/vsizip/{multiple_compressed_file_zip}/{member}"
         assert SubDataset(name, "member", 0).open().band_count >= 1, (

--- a/tests/io/test_archives.py
+++ b/tests/io/test_archives.py
@@ -394,13 +394,16 @@ class TestVsiPathNotDoubleWrapped:
     """A path already routed through a GDAL /vsi* handler is left alone (#1055)."""
 
     def test_is_resolved_vsi_flags_only_real_prefixes(self):
-        """It matches a leading or driver-embedded /vsi*, not a directory named vsi<x>."""
+        """It matches a leading or driver-embedded /vsi*, not a directory or drive named vsi<x>."""
         assert _is_resolved_vsi("/vsizip/a.zip/b.asc"), "bare /vsizip/ path"
         assert _is_resolved_vsi(
             "SENTINEL2_L2A:/vsizip/a.zip/x.SAFE/m.xml:60m:EPSG_32632"
         ), "driver-prefixed /vsizip/ connection string"
         assert _is_resolved_vsi('NETCDF:"/vsizip/a.zip/x.nc":tos'), (
             "quoted /vsizip/ path"
+        )
+        assert _is_resolved_vsi("NETCDF:/vsicurl_streaming/https://h/x.nc:v"), (
+            "an underscore-bearing handler (vsicurl_streaming) still matches"
         )
         assert not _is_resolved_vsi("data/a.zip"), "a real archive is not a vsi path"
         assert not _is_resolved_vsi("data/a.zip/b.asc"), "an archive member is not vsi"
@@ -409,6 +412,14 @@ class TestVsiPathNotDoubleWrapped:
         )
         assert not _is_resolved_vsi("archive.zip/vsi1/inner.asc"), (
             "an inner vsi1/ member folder is not a prefix"
+        )
+        # A drive-letter colon must not be read as a driver scheme (it is one char, a
+        # scheme is >= 2), so an archive under a drive-root dir named vsi<x> stays local.
+        assert not _is_resolved_vsi("C:/vsizip/a.zip/inner.tif"), (
+            "a Windows drive letter is not a driver scheme"
+        )
+        assert not _is_resolved_vsi("D:/vsitar/data.tar/inner.tif"), (
+            "a drive-root vsitar/ directory is a real archive path"
         )
 
     def test_parse_path_leaves_a_driver_embedded_vsi_string_unchanged(self):
@@ -469,7 +480,12 @@ class TestVsiPathNotDoubleWrapped:
         multiple_compressed_file_zip: str,
         multiple_compressed_file_zip_content: List[str],
     ):
-        """SubDataset.open() succeeds for a /vsizip/-carrying name (the reported drill-in)."""
+        """SubDataset.open() reopens a bare /vsizip/ member end-to-end (via the is_remote path).
+
+        The driver-embedded shape that #1055 actually reported is guarded by
+        test_parse_path_leaves_a_driver_embedded_vsi_string_unchanged; this exercises the
+        full SubDataset.open -> read_file -> _parse_path chain on a real openable member.
+        """
         member = multiple_compressed_file_zip_content[0]
         name = f"/vsizip/{multiple_compressed_file_zip}/{member}"
         assert SubDataset(name, "member", 0).open().band_count >= 1, (

--- a/tests/io/test_archives.py
+++ b/tests/io/test_archives.py
@@ -6,6 +6,8 @@ from osgeo import gdal
 
 from pyramids._io import _parse_path, extract_from_gz, read_file
 from pyramids.base._errors import FileFormatNotSupportedError
+from pyramids.dataset import Dataset
+from pyramids.dataset._subdataset import SubDataset
 
 
 class TestZipFiles:
@@ -158,6 +160,7 @@ import numpy as np
 from pyramids._io import (
     _get_tar_path,
     _is_gzip,
+    _is_resolved_vsi,
     _is_tar,
     _is_zip,
     extract_from_gz,
@@ -383,3 +386,75 @@ class TestHelperFunctions:
     def test_is_tar_non_tar(self):
         """_is_tar should return False for non-tar files."""
         assert _is_tar("file.tif") is False, "file.tif should not be tar"
+
+
+class TestVsiPathNotDoubleWrapped:
+    """A path already routed through a GDAL /vsi* handler is left alone (#1055)."""
+
+    def test_is_resolved_vsi_detects_bare_and_embedded_prefixes(self):
+        """It flags bare /vsi* paths and driver connection strings that embed one."""
+        assert _is_resolved_vsi("/vsizip/a.zip/b.asc"), "bare /vsizip/ path"
+        assert _is_resolved_vsi(
+            "SENTINEL2_L2A:/vsizip/a.zip/x.SAFE/m.xml:60m:EPSG_32632"
+        ), "driver-prefixed /vsizip/ connection string"
+        assert _is_resolved_vsi('NETCDF:"/vsizip/a.zip/x.nc":tos'), (
+            "quoted /vsizip/ path"
+        )
+        assert not _is_resolved_vsi("data/a.zip"), "a real archive is not a vsi path"
+        assert not _is_resolved_vsi("data/a.zip/b.asc"), "an archive member is not vsi"
+
+    def test_archive_detectors_skip_resolved_vsi_paths(self):
+        """_is_zip / _is_gzip / _is_tar do not fire on an already-/vsi* connection string."""
+        assert not _is_zip("SENTINEL2_L2A:/vsizip/a.zip/x.xml:60m"), (
+            "no re-wrap of a zip conn"
+        )
+        assert not _is_gzip("NETCDF:/vsigzip/a.gz/x.nc:v"), "no re-wrap of a gzip conn"
+        assert not _is_tar("X:/vsitar/a.tar/b"), "no re-wrap of a tar conn"
+        assert _is_zip("data/a.zip"), "a real .zip is still detected"
+        assert _is_zip("data/a.zip/1.asc"), "a real archive member is still detected"
+
+    def test_parse_path_is_idempotent_on_a_vsizip_member(
+        self,
+        multiple_compressed_file_zip: str,
+        multiple_compressed_file_zip_content: List[str],
+    ):
+        """_parse_path leaves an already-resolved /vsizip/ member unchanged, not double-wrapped."""
+        member = multiple_compressed_file_zip_content[0]
+        resolved = f"/vsizip/{multiple_compressed_file_zip}/{member}"
+        assert _parse_path(resolved) == resolved, (
+            "a resolved /vsizip/ path must pass through"
+        )
+
+    def test_read_file_opens_a_vsizip_member(
+        self,
+        multiple_compressed_file_zip: str,
+        multiple_compressed_file_zip_content: List[str],
+    ):
+        """The low-level reader opens an already-/vsizip/ member (the #1055 failure path)."""
+        member = multiple_compressed_file_zip_content[0]
+        src = read_file(f"/vsizip/{multiple_compressed_file_zip}/{member}")
+        assert isinstance(src, gdal.Dataset), "a resolved /vsizip/ member must open"
+
+    def test_subdataset_open_reopens_a_vsizip_name(
+        self,
+        multiple_compressed_file_zip: str,
+        multiple_compressed_file_zip_content: List[str],
+    ):
+        """SubDataset.open() succeeds for a /vsizip/-carrying name (the reported trigger)."""
+        member = multiple_compressed_file_zip_content[0]
+        name = f"/vsizip/{multiple_compressed_file_zip}/{member}"
+        assert SubDataset(name, "member", 0).open().band_count >= 1, (
+            "the drill-in reopens"
+        )
+
+    def test_bare_archive_member_still_resolves(
+        self,
+        multiple_compressed_file_zip: str,
+        multiple_compressed_file_zip_content: List[str],
+    ):
+        """The real archive.zip/member convenience path is unaffected by the guard."""
+        member = multiple_compressed_file_zip_content[0]
+        assert (
+            Dataset.read_file(f"{multiple_compressed_file_zip}/{member}").band_count
+            >= 1
+        ), "a bare archive member must still open"


### PR DESCRIPTION
# Description

Fixes two independent follow-ups surfaced while verifying the 0.55.0 subdataset/metadata work.

**#1055 (bug) — `SubDataset.open()` double-wraps `/vsizip/`.** A GDAL connection string that already routes through
a `/vsi*` handler — a subdataset of a container opened from a zip, e.g.
`SENTINEL2_L2A:/vsizip/…product.zip/….xml:60m:EPSG_32632`, or `NETCDF:"/vsizip/…x.zip/y.nc":var` — was re-wrapped in
a **second** `/vsizip/`, yielding the nonsensical `/vsizip/SENTINEL2_L2A:/vsizip/…` that GDAL cannot open.
`SubDataset.open()` (and any `read_file` of such a string) failed, even though `gdal.Open` accepts the name. The bug
is generic — any container-in-zip (Sentinel-1/-2, netCDF, HDF, GRIB) hits it.

Fix: a shared `_is_resolved_vsi(path)` guard is consulted **only inside `_parse_path`'s short-circuit** (alongside
`remote.is_remote`), so an already-resolved `/vsi*` path — bare, or embedded in a driver connection string — is
returned unchanged. The archive extension detectors `_is_zip` / `_is_gzip` / `_is_tar` stay **pure predicates**, so
`_infer_archive_kind` / `Dataset.from_archive(kind="auto")` still classify a raw `/vsi*` archive path (no
regression). The guard regex `(?:^|"|[A-Za-z]\w+:)/vsi[a-z0-9_]+/` is anchored to the string start, an opening quote,
or a **≥2-character driver scheme** — a one-character Windows drive letter (`C:`) cannot match, so a real archive
under a drive-root directory named `vsizip` is not mistaken for a resolved prefix.

**#1052 (naming) — `meta_data_domains` vs `metadata_domains`.** The domain-listing shipped as `meta_data_domains`
(consistent with the `meta_data` / `get_meta_data` siblings), but PR #1040's body documented a `metadata_domains`
that never existed. Per the issue's recommended option 1, we **keep the shipped name** — renaming would break the
released 0.55.0 API — and add a test pinning it (`meta_data_domains` exists, `metadata_domains` does not) so code and
docs cannot drift again. No live docstring / doc / changelog used the wrong name; the only disagreeing artifact was
the immutable PR body.

No new dependencies.

# Issues

- Closes #1055 — `SubDataset.open()` double-wraps `/vsizip/`; a subdataset of a zipped container cannot be reopened
- Closes #1052 — metadata-domain listing shipped as `meta_data_domains` but PR #1040 documented `metadata_domains`

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Ran the affected suites in the `dev` env (`pixi run --frozen -e dev pytest … -m "not plot and not live and not
slow and not vfs"`), plus `ruff` and the `_io.py` doctests. Two adversarial `/review-rounds` passes drove the final
design (relocating the guard to `_parse_path`, anchoring the regex).

- [x] `tests/io/test_archives.py::TestVsiPathNotDoubleWrapped`: the guard flags only real resolved-VSI shapes (bare,
  driver-embedded, quoted, `_streaming`) and not a `vsi<x>` directory or a Windows drive letter; `_parse_path`
  returns the driver-embedded string unchanged (the real #1055 trigger); `read_file` / `SubDataset.open` reopen a
  `/vsizip/` member; and `_infer_archive_kind` / `_archive_dir_vsi` still resolve a raw `/vsi*` archive under
  `kind="auto"` (regression guard).
- [x] `test_public_name_is_meta_data_domains_not_metadata_domains` pinning the #1052 name.
- [x] Regression sweeps: `tests/io` + `tests/dataset/io` + archive/remote + `tests/netcdf/io` → **794 + 3 passed**;
  `_io.py` doctests **6 passed**; ruff clean; SonarCloud 0 issues, gate OK.

# Checklist:

- [ ] updated version number in pyproject.toml. — handled by commitizen/CI
- [ ] added changes to History.rst. — changelog is commitizen-generated
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated. — no doc/docstring used the wrong name; behaviour docs unchanged
