### PR TITLE
feat(merge): restrict merge_rasters to a bbox instead of the full extent

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -33,13 +33,17 @@ pyramids convert in.asc out.tif                       # re-encode; --driver GTif
 pyramids warp in.tif out.tif --crs 4326 --resampling bilinear
 pyramids clip in.tif out.tif --bbox 440000 475000 480000 515000    # or: --vector aoi.geojson
 pyramids merge tileA.tif tileB.tif tileC.tif mosaic.tif            # two or more inputs, last arg = output
+pyramids merge tileA.tif tileB.tif aoi.tif --bbox 4.1 51.9 4.6 52.2 --bbox-crs 4326   # read only the window
 pyramids overview dem.tif --levels 2 4 8 --resampling average      # build image pyramids IN PLACE
 ```
 
 - **`convert`** — re-save a raster in another format (driver inferred from the extension, or `--driver`).
 - **`warp`** — reproject to `--crs` with an optional `--resampling`.
 - **`clip`** — crop by `--bbox MINX MINY MAXX MAXY` (in the raster CRS) **or** by a polygon `--vector`.
-- **`merge`** — mosaic two-or-more rasters; the **last** positional argument is the output.
+- **`merge`** — mosaic two-or-more rasters; the **last** positional argument is the output. `--bbox MINX MINY
+  MAXX MAXY` restricts the mosaic to that window and reads only it, which is what makes a small area of interest
+  cheap to pull from remote sources instead of transferring every source in full. The window is in the mosaic's
+  own CRS unless `--bbox-crs` names another.
 - **`overview`** — build power-of-two overviews (`--levels 2 4 8 …`) into the file itself.
 
 ## Cloud-Optimized GeoTIFF

--- a/src/pyramids/cli.py
+++ b/src/pyramids/cli.py
@@ -691,10 +691,18 @@ def _cmd_merge(args: argparse.Namespace) -> int:
         int: `0` on success.
 
     Raises:
-        ValueError: Fewer than two input rasters are given.
+        ValueError: Fewer than two input rasters are given, `--bbox-crs` is given
+            without `--bbox`, or the window itself is malformed.
     """
     if len(args.inputs) < 2:
         raise ValueError("merge needs at least two input rasters.")
+    # A --bbox-crs with no --bbox would be accepted and then dropped, so a typo in
+    # the window (or forgetting it) would look like a successful full-extent merge.
+    if args.bbox_crs is not None and not args.bbox:
+        raise ValueError(
+            "merge --bbox-crs names the CRS of --bbox, but no --bbox was given; "
+            "pass --bbox MINX MINY MAXX MAXY as well, or drop --bbox-crs."
+        )
     _refuse_existing(args.output, args.overwrite)
     merge_rasters(
         args.inputs,

--- a/src/pyramids/cli.py
+++ b/src/pyramids/cli.py
@@ -683,7 +683,8 @@ def _cmd_merge(args: argparse.Namespace) -> int:
     """Handle `pyramids merge` — mosaic rasters into one file.
 
     Args:
-        args: Parsed arguments with `inputs` (>= 2 paths) and `output`.
+        args: Parsed arguments with `inputs` (>= 2 paths), `output`, and the
+            optional `bbox` / `bbox_crs` window.
 
     Returns:
         int: `0` on success.
@@ -694,7 +695,12 @@ def _cmd_merge(args: argparse.Namespace) -> int:
     if len(args.inputs) < 2:
         raise ValueError("merge needs at least two input rasters.")
     _refuse_existing(args.output, args.overwrite)
-    merge_rasters(args.inputs, args.output)
+    merge_rasters(
+        args.inputs,
+        args.output,
+        bbox=tuple(args.bbox) if args.bbox else None,
+        bbox_crs=args.bbox_crs,
+    )
     print(f"wrote {args.output}")
     return 0
 
@@ -879,6 +885,18 @@ def _build_parser() -> argparse.ArgumentParser:
     merge = sub.add_parser("merge", help="mosaic rasters into one file")
     merge.add_argument("inputs", nargs="+", help="source raster paths (two or more)")
     merge.add_argument("output", help=_HELP_DST_RASTER)
+    merge.add_argument(
+        "--bbox",
+        nargs=4,
+        type=float,
+        metavar=("MINX", "MINY", "MAXX", "MAXY"),
+        help="restrict the merge to this window, so only it is read",
+    )
+    merge.add_argument(
+        "--bbox-crs",
+        dest="bbox_crs",
+        help="CRS of --bbox (default: the mosaic's own CRS)",
+    )
     merge.add_argument("--overwrite", action="store_true", help=_HELP_OVERWRITE)
     merge.set_defaults(func=_cmd_merge)
 

--- a/src/pyramids/cli.py
+++ b/src/pyramids/cli.py
@@ -8,7 +8,8 @@ standard-library :mod:`argparse` (no extra dependency):
 - `pyramids bounds FILE [--crs CRS] [--json]` — bounding box
 - `pyramids clip SRC DST (--bbox MINX MINY MAXX MAXY | --vector PATH)` — crop
 - `pyramids warp SRC DST --crs CRS [--resampling M]` — reproject
-- `pyramids merge SRC... DST` — mosaic
+- `pyramids merge SRC... DST [--bbox MINX MINY MAXX MAXY] [--bbox-crs CRS]` —
+  mosaic, reading only the window when one is given
 - `pyramids overview FILE [--resampling M] [--levels N...]` — build overviews
 - `pyramids sample FILE --points "x,y;x,y..." [--json]` — point sampling
 - `pyramids convert SRC DST [--driver NAME]` — format conversion

--- a/src/pyramids/dataset/_stac.py
+++ b/src/pyramids/dataset/_stac.py
@@ -522,8 +522,6 @@ def _from_stac_solar_day(
     patch_url: Callable[[str], str] | None,
     signer: Any,
     collection_cls: Any,
-    bbox: Sequence[float] | None = None,
-    bbox_crs: Any = None,
 ) -> DatasetCollection:
     """Mosaic same-solar-day items of one asset into one timestep each.
 
@@ -561,14 +559,7 @@ def _from_stac_solar_day(
     per_day_paths: list[str] = []
     for day in sorted(groups):
         out_path = os.path.join(out_dir, f"{day}.tif")
-        merge_rasters(
-            groups[day],
-            out_path,
-            method="first",
-            signer=signer,
-            bbox=bbox,
-            bbox_crs=bbox_crs,
-        )
+        merge_rasters(groups[day], out_path, method="first", signer=signer)
         per_day_paths.append(out_path)
 
     # collection_cls is always the real DatasetCollection class (passed by every

--- a/src/pyramids/dataset/_stac.py
+++ b/src/pyramids/dataset/_stac.py
@@ -522,6 +522,8 @@ def _from_stac_solar_day(
     patch_url: Callable[[str], str] | None,
     signer: Any,
     collection_cls: Any,
+    bbox: Sequence[float] | None = None,
+    bbox_crs: Any = None,
 ) -> DatasetCollection:
     """Mosaic same-solar-day items of one asset into one timestep each.
 
@@ -559,7 +561,14 @@ def _from_stac_solar_day(
     per_day_paths: list[str] = []
     for day in sorted(groups):
         out_path = os.path.join(out_dir, f"{day}.tif")
-        merge_rasters(groups[day], out_path, method="first", signer=signer)
+        merge_rasters(
+            groups[day],
+            out_path,
+            method="first",
+            signer=signer,
+            bbox=bbox,
+            bbox_crs=bbox_crs,
+        )
         per_day_paths.append(out_path)
 
     # collection_cls is always the real DatasetCollection class (passed by every

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -3482,7 +3482,7 @@ class DatasetCollection:
         method: str = "last",
         *,
         bbox: Sequence[float] | None = None,
-        bbox_crs: Any = None,
+        bbox_crs: int | str | None = None,
     ) -> None:
         """Merge this collection's timesteps into one raster.
 

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -3514,15 +3514,27 @@ class DatasetCollection:
                 ``"sum"``.
             bbox (Sequence[float] | None):
                 Optional ``(west, south, east, north)`` window, forwarded to
-                :func:`~pyramids.dataset.merge.merge_rasters`. Restricts what is
-                read rather than cropping afterwards, which matters most when the
-                timesteps are remote. ``None`` (default) merges the full extent.
-            bbox_crs (Any):
+                :func:`~pyramids.dataset.merge.merge_rasters`. ``None`` (default)
+                merges the full extent.
+
+                For a **file-backed** collection this restricts what is read rather
+                than cropping afterwards, which is what makes a small area of
+                interest cheap to pull from remote timesteps. For an **in-memory**
+                collection it only narrows the output: every timestep is staged to
+                disk at full extent before the merge runs, so nothing is saved on
+                the read.
+            bbox_crs (int | str | None):
                 CRS of ``bbox``; ``None`` (default) means it is already in the
                 mosaic's CRS.
 
         Returns:
             None
+
+        Raises:
+            TypeError: ``bbox`` is not four numbers.
+            ValueError: ``bbox`` is malformed, does not overlap the mosaic, or
+                cannot be projected into the mosaic's CRS. Validation happens
+                before any I/O.
         """
         if self._files:
             merge_rasters(

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -3480,6 +3480,9 @@ class DatasetCollection:
         init: float | int | str = "nan",
         n: float | int | str = "nan",
         method: str = "last",
+        *,
+        bbox: Sequence[float] | None = None,
+        bbox_crs: Any = None,
     ) -> None:
         """Merge this collection's timesteps into one raster.
 
@@ -3509,6 +3512,14 @@ class DatasetCollection:
                 :func:`~pyramids.dataset.merge.merge_rasters`: one of
                 ``"first"``, ``"last"`` (default), ``"min"``, ``"max"``,
                 ``"sum"``.
+            bbox (Sequence[float] | None):
+                Optional ``(west, south, east, north)`` window, forwarded to
+                :func:`~pyramids.dataset.merge.merge_rasters`. Restricts what is
+                read rather than cropping afterwards, which matters most when the
+                timesteps are remote. ``None`` (default) merges the full extent.
+            bbox_crs (Any):
+                CRS of ``bbox``; ``None`` (default) means it is already in the
+                mosaic's CRS.
 
         Returns:
             None
@@ -3521,6 +3532,8 @@ class DatasetCollection:
                 init=init,
                 n=n,
                 method=method,
+                bbox=bbox,
+                bbox_crs=bbox_crs,
             )
             return
         # In-memory collection (legacy `DatasetCollection(src,
@@ -3541,6 +3554,8 @@ class DatasetCollection:
                 init=init,
                 n=n,
                 method=method,
+                bbox=bbox,
+                bbox_crs=bbox_crs,
             )
 
     def apply(

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -1653,14 +1653,14 @@ class DatasetCollection:
                 order).
             patch_url: Optional low-level callable rewriting each href
                 (runs before `signer`).
-            bbox: M6 — **input filter**, `(minx, miny, maxx, maxy)` in
+            bbox: **input filter**, `(minx, miny, maxx, maxy)` in
                 **lon/lat** (EPSG:4326). Selects *which STAC items* are read:
                 items whose footprint doesn't intersect it are dropped before
                 their hrefs are resolved. It does **not** clip the output — that
                 is the `grid`'s bounds (see :class:`~pyramids.dataset.Grid`).
                 (Note the difference from odc-stac, where `bbox` sets the output
                 extent.)
-            max_items: M6 — cap the number of items consumed (after
+            max_items: cap the number of items consumed (after
                 bbox filtering). Useful for quick-look workflows.
             signer: Optional signer (e.g. a
                 :class:`pyramids.stac.signers.Signer`). Its

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -56,30 +56,42 @@ def _validated_bbox(bbox: Sequence[float]) -> tuple[float, float, float, float]:
         ValueError: A coordinate is not finite, or the box is inverted or empty in
             either axis.
     """
-    if isinstance(bbox, (str, bytes)) or not isinstance(bbox, Sequence):
+    # Accept any non-string iterable rather than testing `isinstance(bbox, Sequence)`:
+    # `np.ndarray` does not register as a `Sequence`, and `GeoDataFrame.total_bounds`
+    # -- the most natural way a caller here produces a bbox -- returns exactly that.
+    # Strings are excluded first because a 4-character one would otherwise unpack into
+    # four coordinates.
+    if isinstance(bbox, (str, bytes)):
         raise TypeError(
-            f"merge_rasters: bbox must be a sequence of four numbers "
-            f"(west, south, east, north), got {type(bbox).__name__}: {bbox!r}"
-        )
-    if len(bbox) != 4:
-        raise ValueError(
-            f"merge_rasters: bbox must have exactly 4 values "
-            f"(west, south, east, north), got {len(bbox)}: {tuple(bbox)!r}"
+            f"merge_rasters: bbox must be four numbers (west, south, east, north), "
+            f"got {type(bbox).__name__}: {bbox!r}"
         )
     try:
-        west, south, east, north = (float(v) for v in bbox)
+        values = list(bbox)
+    except TypeError as exc:
+        raise TypeError(
+            f"merge_rasters: bbox must be four numbers (west, south, east, north), "
+            f"got {type(bbox).__name__}: {bbox!r}"
+        ) from exc
+    if len(values) != 4:
+        raise ValueError(
+            f"merge_rasters: bbox must have exactly 4 values "
+            f"(west, south, east, north), got {len(values)}: {tuple(values)!r}"
+        )
+    try:
+        west, south, east, north = (float(v) for v in values)
     except (TypeError, ValueError) as exc:
         raise TypeError(
-            f"merge_rasters: bbox values must be numbers, got {tuple(bbox)!r}"
+            f"merge_rasters: bbox values must be numbers, got {tuple(values)!r}"
         ) from exc
     if not all(np.isfinite(v) for v in (west, south, east, north)):
         raise ValueError(
-            f"merge_rasters: bbox values must all be finite, got {tuple(bbox)!r}"
+            f"merge_rasters: bbox values must all be finite, got {tuple(values)!r}"
         )
     if west >= east or south >= north:
         raise ValueError(
             f"merge_rasters: bbox must be (west, south, east, north) with west < east "
-            f"and south < north, got {tuple(bbox)!r}. A zero-area or inverted box "
+            f"and south < north, got {tuple(values)!r}. A zero-area or inverted box "
             "selects nothing."
         )
     return west, south, east, north

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -682,6 +682,93 @@ def _as_srs(crs: int | str) -> osr.SpatialReference:
     return srs
 
 
+def _open_source_with_srs(path: str) -> tuple[gdal.Dataset, osr.SpatialReference]:
+    """Open one merge source and read its CRS off that same handle.
+
+    The dataset and its CRS are produced together and consumed together, so they
+    are read in one place rather than reopening the file to ask for the CRS.
+
+    Args:
+        path: Path (or ``/vsi*`` URL) of the source raster.
+
+    Returns:
+        tuple[gdal.Dataset, osr.SpatialReference]: The open dataset and its CRS.
+
+    Raises:
+        RuntimeError: GDAL could not open the source.
+        ValueError: The source carries no CRS.
+    """
+    dataset = gdal.Open(path)
+    if dataset is None:
+        raise RuntimeError(f"gdal.Open returned None for source {path!r}.")
+    wkt = dataset.GetProjection()
+    if not wkt:
+        raise ValueError(
+            f"source {path!r} has no CRS; every source must carry a CRS to "
+            "be merged/reprojected."
+        )
+    srs = osr.SpatialReference()
+    srs.ImportFromWkt(wkt)
+    return dataset, srs
+
+
+def _resolve_target_srs(
+    source_srs: list[osr.SpatialReference], dst_crs: int | str | None
+) -> osr.SpatialReference | None:
+    """Return the CRS every source must end up in, or ``None`` if none need to move.
+
+    Args:
+        source_srs: One CRS per source, in `src_paths` order.
+        dst_crs: The caller's explicit target CRS, or ``None`` to auto-detect.
+
+    Returns:
+        osr.SpatialReference | None: The target CRS, or ``None`` when no `dst_crs`
+        was given and every source already shares one — the case where the sources
+        can be composited untouched.
+
+    Raises:
+        ValueError: `dst_crs` could not be parsed as a CRS.
+    """
+    if dst_crs is not None:
+        target = _as_srs(dst_crs)
+    else:
+        # Auto-detect: no reproject when every source already shares a CRS. An
+        # empty source list never indexes, since the slice is empty too.
+        disagree = any(not source_srs[0].IsSame(other) for other in source_srs[1:])
+        target = source_srs[0] if disagree else None
+    return target
+
+
+def _warp_to_srs(
+    dataset: gdal.Dataset, target_wkt: str, resample_alg: Any
+) -> gdal.Dataset:
+    """Reproject one open source onto `target_wkt` as an in-memory VRT.
+
+    Args:
+        dataset: The open source dataset.
+        target_wkt: The target CRS as WKT.
+        resample_alg: Resampling algorithm, already resolved for GDAL.
+
+    Returns:
+        gdal.Dataset: A warped VRT over `dataset`, in the target CRS.
+
+    Raises:
+        RuntimeError: :func:`gdal.Warp` failed.
+    """
+    warped = gdal.Warp(
+        "",
+        dataset,
+        options=gdal.WarpOptions(
+            format="VRT", dstSRS=target_wkt, resampleAlg=resample_alg
+        ),
+    )
+    if warped is None:
+        raise RuntimeError(
+            "gdal.Warp returned None reprojecting a source to the target CRS."
+        )
+    return warped
+
+
 def _prepare_sources(
     src_paths: list[str],
     dst_crs: int | str | None,
@@ -733,50 +820,27 @@ def _prepare_sources(
     opened: list = []
     source_srs: list[osr.SpatialReference] = []
     for path in src_paths:
-        dataset = gdal.Open(path)
-        if dataset is None:
-            raise RuntimeError(f"gdal.Open returned None for source {path!r}.")
-        wkt = dataset.GetProjection()
-        if not wkt:
-            raise ValueError(
-                f"source {path!r} has no CRS; every source must carry a CRS to "
-                "be merged/reprojected."
-            )
-        srs = osr.SpatialReference()
-        srs.ImportFromWkt(wkt)
+        dataset, srs = _open_source_with_srs(path)
         opened.append(dataset)
         source_srs.append(srs)
 
-    target_srs = _as_srs(dst_crs) if dst_crs is not None else None
+    target_srs = _resolve_target_srs(source_srs, dst_crs)
     if target_srs is None:
-        # Auto-detect: no reproject when every source already shares a CRS.
-        disagree = any(not source_srs[0].IsSame(other) for other in source_srs[1:])
-        if not disagree:
-            return opened, opened
-        target_srs = source_srs[0]
-
-    # At least one source needs reprojecting (or dst_crs forces a target). Feed
-    # the compositor open datasets uniformly — gdal.BuildVRT rejects a mix of
-    # path strings and dataset objects.
-    target_wkt = target_srs.ExportToWkt()
-    sources: list = []
-    for dataset, srs in zip(opened, source_srs):
-        if srs.IsSame(target_srs):
-            sources.append(dataset)
-            continue
-        warped = gdal.Warp(
-            "",
-            dataset,
-            options=gdal.WarpOptions(
-                format="VRT", dstSRS=target_wkt, resampleAlg=resample_alg
-            ),
-        )
-        if warped is None:
-            raise RuntimeError(
-                "gdal.Warp returned None reprojecting a source to the target CRS."
-            )
-        sources.append(warped)
-    return sources, sources
+        # Every source already shares a CRS and no target was forced.
+        result = (opened, opened)
+    else:
+        # At least one source needs reprojecting (or dst_crs forces a target). Feed
+        # the compositor open datasets uniformly — gdal.BuildVRT rejects a mix of
+        # path strings and dataset objects.
+        target_wkt = target_srs.ExportToWkt()
+        sources: list = [
+            dataset
+            if srs.IsSame(target_srs)
+            else _warp_to_srs(dataset, target_wkt, resample_alg)
+            for dataset, srs in zip(opened, source_srs)
+        ]
+        result = (sources, sources)
+    return result
 
 
 def _reduce_strip(

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -848,7 +848,9 @@ def _warp_onto_strip(
         raise RuntimeError(
             f"gdal.Warp returned None warping source {path!r} onto the union grid."
         )
-    array = warped.ReadAsArray().astype("float64")
+    # np.asarray pins the type: GDAL's ReadAsArray is untyped, so without it the
+    # float64 cube is inferred as Any and leaks out of the annotated return.
+    array = np.asarray(warped.ReadAsArray()).astype("float64")
     if array.ndim == 2:
         array = array[np.newaxis, ...]
     return array

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -64,34 +64,34 @@ def _validated_bbox(bbox: Sequence[float]) -> tuple[float, float, float, float]:
     # four coordinates.
     if isinstance(bbox, (str, bytes)):
         raise TypeError(
-            f"merge_rasters: bbox must be four numbers (west, south, east, north), "
+            f"bbox must be four numbers (west, south, east, north), "
             f"got {type(bbox).__name__}: {bbox!r}"
         )
     try:
         values = list(bbox)
     except TypeError as exc:
         raise TypeError(
-            f"merge_rasters: bbox must be four numbers (west, south, east, north), "
+            f"bbox must be four numbers (west, south, east, north), "
             f"got {type(bbox).__name__}: {bbox!r}"
         ) from exc
     if len(values) != 4:
         raise ValueError(
-            f"merge_rasters: bbox must have exactly 4 values "
+            f"bbox must have exactly 4 values "
             f"(west, south, east, north), got {len(values)}: {tuple(values)!r}"
         )
     try:
         west, south, east, north = (float(v) for v in values)
     except (TypeError, ValueError) as exc:
         raise TypeError(
-            f"merge_rasters: bbox values must be numbers, got {tuple(values)!r}"
+            f"bbox values must be numbers, got {tuple(values)!r}"
         ) from exc
     if not all(np.isfinite(v) for v in (west, south, east, north)):
         raise ValueError(
-            f"merge_rasters: bbox values must all be finite, got {tuple(values)!r}"
+            f"bbox values must all be finite, got {tuple(values)!r}"
         )
     if west >= east or south >= north:
         raise ValueError(
-            f"merge_rasters: bbox must be (west, south, east, north) with west < east "
+            f"bbox must be (west, south, east, north) with west < east "
             f"and south < north, got {tuple(values)!r}. A zero-area or inverted box "
             "selects nothing."
         )
@@ -175,12 +175,12 @@ def _bbox_in_projection(
         )
     except Exception as exc:
         raise ValueError(
-            f"merge_rasters: bbox {tuple(bbox)!r} could not be reprojected from "
+            f"bbox {tuple(bbox)!r} could not be reprojected from "
             f"{bbox_crs!r} into the mosaic CRS: {exc}"
         ) from exc
     if not all(np.isfinite(v) for v in (west, south, east, north)):
         raise ValueError(
-            f"merge_rasters: bbox {tuple(bbox)!r} does not project from {bbox_crs!r} "
+            f"bbox {tuple(bbox)!r} does not project from {bbox_crs!r} "
             "into the mosaic CRS; it likely falls outside that CRS's area of use."
         )
     # `transform_bounds` signals an antimeridian crossing by returning west > east
@@ -192,7 +192,7 @@ def _bbox_in_projection(
     # shape here, where reprojection is what produced it.
     if west > east:
         raise ValueError(
-            f"merge_rasters: bbox {tuple(bbox)!r} crosses the antimeridian when "
+            f"bbox {tuple(bbox)!r} crosses the antimeridian when "
             f"reprojected from {bbox_crs!r} into the mosaic CRS (it spans "
             f"{west} to {east}). Split it into one window either side of "
             "180 deg and merge them separately."
@@ -243,14 +243,14 @@ def _restrict_grid(
     # rotated mosaic is not something merge_rasters handles either way.
     if row_skew or col_skew:
         raise ValueError(
-            "merge_rasters: cannot resolve a bbox against a rotated or sheared mosaic "
+            "cannot resolve a bbox against a rotated or sheared mosaic "
             f"(geotransform skew terms {row_skew!r}, {col_skew!r}); the window would "
             "be applied as if the grid were axis-aligned, mis-georeferencing the "
             "output."
         )
     if not pixel_w or not pixel_h:
         raise ValueError(
-            f"merge_rasters: mosaic has a zero pixel size ({pixel_w!r}, {pixel_h!r}); "
+            f"mosaic has a zero pixel size ({pixel_w!r}, {pixel_h!r}); "
             "the bbox window cannot be resolved onto its grid."
         )
 
@@ -267,7 +267,7 @@ def _restrict_grid(
     # into the complement of the requested area.
     if west > east:
         raise ValueError(
-            f"merge_rasters: bbox {tuple(bbox)!r} crosses the seam of the mosaic's "
+            f"bbox {tuple(bbox)!r} crosses the seam of the mosaic's "
             f"longitude convention (it spans {west} to {east} once rewritten to "
             "match). Split it either side of the seam and merge them separately."
         )
@@ -294,7 +294,7 @@ def _restrict_grid(
     # sends the caller to check their extents when the problem is the size of the box.
     if col_stop <= col_start or row_stop <= row_start:
         raise ValueError(
-            f"merge_rasters: bbox {tuple(bbox)!r} selects no whole pixel of the "
+            f"bbox {tuple(bbox)!r} selects no whole pixel of the "
             "mosaic; it is degenerately thin in at least one axis. Widen it to at "
             "least one cell."
         )
@@ -303,7 +303,7 @@ def _restrict_grid(
     row_start, row_stop = max(0, row_start), min(y_size, row_stop)
     if col_stop <= col_start or row_stop <= row_start:
         raise ValueError(
-            f"merge_rasters: bbox {tuple(bbox)!r} does not overlap the mosaic "
+            f"bbox {tuple(bbox)!r} does not overlap the mosaic "
             "extent; nothing would be written."
         )
 

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -38,6 +38,11 @@ _MERGE_STRIP_ROWS = 512
 # window `_restrict_grid` resolves, so they agree for any tolerance, zero included.
 _GRID_SNAP_TOLERANCE = 1e-6
 
+# Value a strip accumulator starts at, per reduction, so the first real sample wins:
+# +inf loses every fmin, -inf loses every fmax, 0 is the additive identity. Cells that
+# never receive a sample keep this value and are replaced by the fill at the end.
+_REDUCE_IDENTITY = {"min": np.inf, "max": -np.inf, "sum": 0.0}
+
 
 def _validated_bbox(bbox: Sequence[float]) -> tuple[float, float, float, float]:
     """Coerce `bbox` to four finite floats in ``(west, south, east, north)`` order.
@@ -682,93 +687,6 @@ def _as_srs(crs: int | str) -> osr.SpatialReference:
     return srs
 
 
-def _open_source_with_srs(path: str) -> tuple[gdal.Dataset, osr.SpatialReference]:
-    """Open one merge source and read its CRS off that same handle.
-
-    The dataset and its CRS are produced together and consumed together, so they
-    are read in one place rather than reopening the file to ask for the CRS.
-
-    Args:
-        path: Path (or ``/vsi*`` URL) of the source raster.
-
-    Returns:
-        tuple[gdal.Dataset, osr.SpatialReference]: The open dataset and its CRS.
-
-    Raises:
-        RuntimeError: GDAL could not open the source.
-        ValueError: The source carries no CRS.
-    """
-    dataset = gdal.Open(path)
-    if dataset is None:
-        raise RuntimeError(f"gdal.Open returned None for source {path!r}.")
-    wkt = dataset.GetProjection()
-    if not wkt:
-        raise ValueError(
-            f"source {path!r} has no CRS; every source must carry a CRS to "
-            "be merged/reprojected."
-        )
-    srs = osr.SpatialReference()
-    srs.ImportFromWkt(wkt)
-    return dataset, srs
-
-
-def _resolve_target_srs(
-    source_srs: list[osr.SpatialReference], dst_crs: int | str | None
-) -> osr.SpatialReference | None:
-    """Return the CRS every source must end up in, or ``None`` if none need to move.
-
-    Args:
-        source_srs: One CRS per source, in `src_paths` order.
-        dst_crs: The caller's explicit target CRS, or ``None`` to auto-detect.
-
-    Returns:
-        osr.SpatialReference | None: The target CRS, or ``None`` when no `dst_crs`
-        was given and every source already shares one — the case where the sources
-        can be composited untouched.
-
-    Raises:
-        ValueError: `dst_crs` could not be parsed as a CRS.
-    """
-    if dst_crs is not None:
-        target = _as_srs(dst_crs)
-    else:
-        # Auto-detect: no reproject when every source already shares a CRS. An
-        # empty source list never indexes, since the slice is empty too.
-        disagree = any(not source_srs[0].IsSame(other) for other in source_srs[1:])
-        target = source_srs[0] if disagree else None
-    return target
-
-
-def _warp_to_srs(
-    dataset: gdal.Dataset, target_wkt: str, resample_alg: Any
-) -> gdal.Dataset:
-    """Reproject one open source onto `target_wkt` as an in-memory VRT.
-
-    Args:
-        dataset: The open source dataset.
-        target_wkt: The target CRS as WKT.
-        resample_alg: Resampling algorithm, already resolved for GDAL.
-
-    Returns:
-        gdal.Dataset: A warped VRT over `dataset`, in the target CRS.
-
-    Raises:
-        RuntimeError: :func:`gdal.Warp` failed.
-    """
-    warped = gdal.Warp(
-        "",
-        dataset,
-        options=gdal.WarpOptions(
-            format="VRT", dstSRS=target_wkt, resampleAlg=resample_alg
-        ),
-    )
-    if warped is None:
-        raise RuntimeError(
-            "gdal.Warp returned None reprojecting a source to the target CRS."
-        )
-    return warped
-
-
 def _prepare_sources(
     src_paths: list[str],
     dst_crs: int | str | None,
@@ -820,27 +738,142 @@ def _prepare_sources(
     opened: list = []
     source_srs: list[osr.SpatialReference] = []
     for path in src_paths:
-        dataset, srs = _open_source_with_srs(path)
+        dataset = gdal.Open(path)
+        if dataset is None:
+            raise RuntimeError(f"gdal.Open returned None for source {path!r}.")
+        wkt = dataset.GetProjection()
+        if not wkt:
+            raise ValueError(
+                f"source {path!r} has no CRS; every source must carry a CRS to "
+                "be merged/reprojected."
+            )
+        srs = osr.SpatialReference()
+        srs.ImportFromWkt(wkt)
         opened.append(dataset)
         source_srs.append(srs)
 
-    target_srs = _resolve_target_srs(source_srs, dst_crs)
+    target_srs = _as_srs(dst_crs) if dst_crs is not None else None
     if target_srs is None:
-        # Every source already shares a CRS and no target was forced.
-        result = (opened, opened)
+        # Auto-detect: no reproject when every source already shares a CRS.
+        disagree = any(not source_srs[0].IsSame(other) for other in source_srs[1:])
+        if not disagree:
+            return opened, opened
+        target_srs = source_srs[0]
+
+    # At least one source needs reprojecting (or dst_crs forces a target). Feed
+    # the compositor open datasets uniformly — gdal.BuildVRT rejects a mix of
+    # path strings and dataset objects.
+    target_wkt = target_srs.ExportToWkt()
+    sources: list = []
+    for dataset, srs in zip(opened, source_srs):
+        if srs.IsSame(target_srs):
+            sources.append(dataset)
+            continue
+        warped = gdal.Warp(
+            "",
+            dataset,
+            options=gdal.WarpOptions(
+                format="VRT", dstSRS=target_wkt, resampleAlg=resample_alg
+            ),
+        )
+        if warped is None:
+            raise RuntimeError(
+                "gdal.Warp returned None reprojecting a source to the target CRS."
+            )
+        sources.append(warped)
+    return sources, sources
+
+
+def _source_misses_strip(
+    bounds: tuple[float, float, float, float],
+    strip_lat: tuple[float, float],
+    strip_bounds: Sequence[float],
+) -> bool:
+    """Return whether a source's extent lies entirely outside this strip.
+
+    Warping such a source would only add all-no-data, leaving the accumulator and
+    coverage mask unchanged. Both axes are tested: a strip spans the *windowed*
+    grid's width, so on a wide east-west mosaic a latitude-only test still warped
+    every source sharing the strip's band, which is the cost a window exists to
+    avoid.
+
+    Args:
+        bounds: The source's ``(west, south, east, north)`` extent.
+        strip_lat: The strip's ``(south, north)`` edges.
+        strip_bounds: The strip's ``(west, south, east, north)`` extent.
+
+    Returns:
+        bool: `True` when the source cannot contribute to this strip.
+    """
+    src_west, src_south, src_east, src_north = bounds
+    strip_south, strip_north = strip_lat
+    strip_west, strip_east = strip_bounds[0], strip_bounds[2]
+    outside_lat = src_north <= strip_south or src_south >= strip_north
+    outside_lon = src_east <= strip_west or src_west >= strip_east
+    return outside_lat or outside_lon
+
+
+def _warp_onto_strip(
+    path: Any,
+    strip_bounds: Sequence[float],
+    x_size: int,
+    ysize: int,
+    src_nodata: float | int | str | None,
+) -> np.ndarray:
+    """Warp one source onto a strip's window and read it as a 3-D float64 cube.
+
+    Args:
+        path: Source path or an already-open :class:`gdal.Dataset`.
+        strip_bounds: The strip's ``(west, south, east, north)`` window.
+        x_size: Strip width in pixels.
+        ysize: Strip height in pixels.
+        src_nodata: The sources' no-data value, or `None`.
+
+    Returns:
+        np.ndarray: The warped strip, always ``(bands, rows, cols)``, no-data as NaN.
+
+    Raises:
+        RuntimeError: :func:`gdal.Warp` failed for this source.
+    """
+    warp_opts = gdal.WarpOptions(
+        format="MEM",
+        outputBounds=strip_bounds,
+        width=x_size,
+        height=ysize,
+        srcNodata=src_nodata,
+        dstNodata=float("nan"),
+    )
+    warped = gdal.Warp("", path, options=warp_opts)
+    if warped is None:
+        raise RuntimeError(
+            f"gdal.Warp returned None warping source {path!r} onto the union grid."
+        )
+    array = warped.ReadAsArray().astype("float64")
+    if array.ndim == 2:
+        array = array[np.newaxis, ...]
+    return array
+
+
+def _fold_into(
+    acc: np.ndarray, array: np.ndarray, valid: np.ndarray, method: str
+) -> None:
+    """Fold one warped source into the strip accumulator, in place.
+
+    Args:
+        acc: The strip accumulator, modified in place.
+        array: The warped source strip, no-data as NaN.
+        valid: Mask of the finite cells in `array`.
+        method: One of ``"min"``, ``"max"``, ``"sum"``.
+
+    Returns:
+        None
+    """
+    if method == "min":
+        np.fmin(acc, array, out=acc)  # fmin/fmax ignore NaN
+    elif method == "max":
+        np.fmax(acc, array, out=acc)
     else:
-        # At least one source needs reprojecting (or dst_crs forces a target). Feed
-        # the compositor open datasets uniformly — gdal.BuildVRT rejects a mix of
-        # path strings and dataset objects.
-        target_wkt = target_srs.ExportToWkt()
-        sources: list = [
-            dataset
-            if srs.IsSame(target_srs)
-            else _warp_to_srs(dataset, target_wkt, resample_alg)
-            for dataset, srs in zip(opened, source_srs)
-        ]
-        result = (sources, sources)
-    return result
+        np.add(acc, array, out=acc, where=valid)
 
 
 def _reduce_strip(
@@ -877,53 +910,18 @@ def _reduce_strip(
         RuntimeError: GDAL failed to warp a source onto the strip.
     """
     _, ysize, x_size = shape
-    strip_south, strip_north = strip_lat
-    if method == "min":
-        acc = np.full(shape, np.inf, dtype="float64")
-    elif method == "max":
-        acc = np.full(shape, -np.inf, dtype="float64")
-    else:
-        acc = np.zeros(shape, dtype="float64")
+    acc = np.full(shape, _REDUCE_IDENTITY[method], dtype="float64")
     # A boolean "has any valid source" mask suffices: min/max/sum never divide by a
     # count, only test presence below, so a bool cube (1 byte/px) replaces int64.
     covered = np.zeros(shape, dtype=bool)
 
-    strip_west, _, strip_east, _ = strip_bounds
-    for path, (src_west, south, src_east, north) in zip(src_paths, src_bounds):
-        # Skip a source whose extent misses this strip — warping it would only add
-        # all-no-data, leaving acc/covered unchanged. Both axes are tested: a strip
-        # spans the *windowed* grid's width, so on a wide east–west mosaic a narrow
-        # window otherwise still warped every source sharing its latitude band, which
-        # is precisely the cost the window exists to avoid.
-        if north <= strip_south or south >= strip_north:
+    for path, bounds in zip(src_paths, src_bounds):
+        if _source_misses_strip(bounds, strip_lat, strip_bounds):
             continue
-        if src_east <= strip_west or src_west >= strip_east:
-            continue
-        warp_opts = gdal.WarpOptions(
-            format="MEM",
-            outputBounds=strip_bounds,
-            width=x_size,
-            height=ysize,
-            srcNodata=src_nodata,
-            dstNodata=float("nan"),
-        )
-        warped = gdal.Warp("", path, options=warp_opts)
-        if warped is None:
-            raise RuntimeError(
-                f"gdal.Warp returned None warping source {path!r} onto the union grid."
-            )
-        array = warped.ReadAsArray().astype("float64")
-        warped = None
-        if array.ndim == 2:
-            array = array[np.newaxis, ...]
+        array = _warp_onto_strip(path, strip_bounds, x_size, ysize, src_nodata)
         valid = ~np.isnan(array)
         covered |= valid
-        if method == "min":
-            np.fmin(acc, array, out=acc)  # fmin/fmax ignore NaN
-        elif method == "max":
-            np.fmax(acc, array, out=acc)
-        else:
-            np.add(acc, array, out=acc, where=valid)
+        _fold_into(acc, array, valid, method)
         del array, valid
 
     # No-coverage cells are still +inf/-inf/0 in acc; replace them with the fill.

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -86,13 +86,9 @@ def _validated_bbox(bbox: Sequence[float]) -> tuple[float, float, float, float]:
     try:
         west, south, east, north = (float(v) for v in values)
     except (TypeError, ValueError) as exc:
-        raise TypeError(
-            f"bbox values must be numbers, got {tuple(values)!r}"
-        ) from exc
+        raise TypeError(f"bbox values must be numbers, got {tuple(values)!r}") from exc
     if not all(np.isfinite(v) for v in (west, south, east, north)):
-        raise ValueError(
-            f"bbox values must all be finite, got {tuple(values)!r}"
-        )
+        raise ValueError(f"bbox values must all be finite, got {tuple(values)!r}")
     if west >= east or south >= north:
         raise ValueError(
             f"bbox must be (west, south, east, north) with west < east "

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -130,6 +130,20 @@ def _bbox_in_projection(
             f"merge_rasters: bbox {tuple(bbox)!r} does not project from {bbox_crs!r} "
             "into the mosaic CRS; it likely falls outside that CRS's area of use."
         )
+    # `transform_bounds` signals an antimeridian crossing by returning west > east
+    # rather than by widening the envelope. Taken at face value that reads as a box
+    # spanning the long way round: sorting the two edges would resolve the ~2 deg
+    # window this describes into its ~358 deg complement -- silently the wrong area,
+    # and a near-global read from a call whose whole purpose is a bounded one.
+    # `_validated_bbox` already refuses an inverted bbox on input; refuse the same
+    # shape here, where reprojection is what produced it.
+    if west > east:
+        raise ValueError(
+            f"merge_rasters: bbox {tuple(bbox)!r} crosses the antimeridian when "
+            f"reprojected from {bbox_crs!r} into the mosaic CRS (it spans "
+            f"{west} to {east}). Split it into one window either side of "
+            "180 deg and merge them separately."
+        )
     return west, south, east, north
 
 

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -15,6 +15,7 @@ from typing import Any
 
 import numpy as np
 from osgeo import gdal, osr
+from pyproj.exceptions import ProjError
 
 from pyramids.base._utils import DEFAULT_RESAMPLING, resolve_resampling
 from pyramids.base.remote import signer_cloud_config
@@ -139,7 +140,7 @@ def _match_longitude_convention(
 
 
 def _bbox_in_projection(
-    bbox: Sequence[float], bbox_crs: Any, projection: str
+    bbox: Sequence[float], bbox_crs: int | str | None, projection: str
 ) -> tuple[float, float, float, float]:
     """Express `bbox` in `projection`'s coordinates.
 
@@ -173,7 +174,7 @@ def _bbox_in_projection(
         west, south, east, north = bbox_transform(
             (west, south, east, north), bbox_crs, projection
         )
-    except Exception as exc:
+    except (ProjError, ValueError, TypeError) as exc:
         raise ValueError(
             f"bbox {tuple(bbox)!r} could not be reprojected from "
             f"{bbox_crs!r} into the mosaic CRS: {exc}"
@@ -206,7 +207,7 @@ def _restrict_grid(
     y_size: int,
     projection: str,
     bbox: Sequence[float],
-    bbox_crs: Any,
+    bbox_crs: int | str | None,
 ) -> tuple[tuple[float, float, float, float, float, float], int, int]:
     """Clip a union grid to `bbox`, snapped outward onto the grid's own pixels.
 
@@ -376,7 +377,7 @@ def merge_rasters(
     signer: Any = None,
     *,
     bbox: Sequence[float] | None = None,
-    bbox_crs: Any = None,
+    bbox_crs: int | str | None = None,
 ) -> None:
     """Merge a group of rasters into one raster, resolving overlaps by ``method``.
 
@@ -861,7 +862,7 @@ def _merge_reduce(
     no_data_value: float | int | str,
     n: float | int | str,
     bbox: Sequence[float] | None = None,
-    bbox_crs: Any = None,
+    bbox_crs: int | str | None = None,
 ) -> None:
     """Merge sources by reducing overlapping pixels with min/max/sum.
 

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -808,10 +808,16 @@ def _reduce_strip(
     # count, only test presence below, so a bool cube (1 byte/px) replaces int64.
     covered = np.zeros(shape, dtype=bool)
 
-    for path, (_, south, _, north) in zip(src_paths, src_bounds):
-        # Skip a source whose latitude extent misses this strip — warping it would
-        # only add all-no-data, leaving acc/covered unchanged.
+    strip_west, _, strip_east, _ = strip_bounds
+    for path, (src_west, south, src_east, north) in zip(src_paths, src_bounds):
+        # Skip a source whose extent misses this strip — warping it would only add
+        # all-no-data, leaving acc/covered unchanged. Both axes are tested: a strip
+        # spans the *windowed* grid's width, so on a wide east–west mosaic a narrow
+        # window otherwise still warped every source sharing its latitude band, which
+        # is precisely the cost the window exists to avoid.
         if north <= strip_south or south >= strip_north:
+            continue
+        if src_east <= strip_west or src_west >= strip_east:
             continue
         warp_opts = gdal.WarpOptions(
             format="MEM",

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -19,6 +19,7 @@ from osgeo import gdal, osr
 from pyramids.base._utils import DEFAULT_RESAMPLING, resolve_resampling
 from pyramids.base.remote import signer_cloud_config
 from pyramids.dataset.dataset import _INHERIT_NO_DATA, Dataset
+from pyramids.feature.bbox import normalise_longitude
 from pyramids.feature.bbox import transform as bbox_transform
 
 _VRT_METHODS = ("first", "last")
@@ -95,6 +96,46 @@ def _validated_bbox(bbox: Sequence[float]) -> tuple[float, float, float, float]:
             "selects nothing."
         )
     return west, south, east, north
+
+
+def _match_longitude_convention(
+    west: float, east: float, projection: str, grid_west: float, grid_east: float
+) -> tuple[float, float]:
+    """Rewrite a lon/lat window into the longitude convention the mosaic uses.
+
+    Global grids derived from climate NetCDF commonly run ``0..360`` while callers
+    write bboxes as ``-180..180``. Left alone the two conventions overlap only
+    partially, and the clamp in `_restrict_grid` silently reduces the window to that
+    partial overlap — the caller gets the eastern sliver of the area they asked for
+    and a successful return.
+
+    Args:
+        west: Window's western edge, in the mosaic's CRS.
+        east: Window's eastern edge, in the mosaic's CRS.
+        projection: The mosaic's CRS as WKT, or any form
+            :meth:`osr.SpatialReference.SetFromUserInput` accepts.
+        grid_west: The mosaic's western edge.
+        grid_east: The mosaic's eastern edge.
+
+    Returns:
+        tuple[float, float]: ``(west, east)``, rewritten when the conventions differ
+        and left untouched otherwise (including for every projected CRS).
+    """
+    result = (west, east)
+    srs = osr.SpatialReference()
+    try:
+        srs.SetFromUserInput(projection)
+        geographic = bool(srs.IsGeographic())
+    except (RuntimeError, TypeError):
+        geographic = False
+    if geographic:
+        if grid_east > 180.0 and west < 0.0:
+            rewritten = normalise_longitude((west, 0.0, east, 0.0), "0..360")
+            result = (rewritten[0], rewritten[2])
+        elif grid_west < 0.0 and west > 180.0:
+            rewritten = normalise_longitude((west, 0.0, east, 0.0), "-180..180")
+            result = (rewritten[0], rewritten[2])
+    return result
 
 
 def _bbox_in_projection(
@@ -207,6 +248,24 @@ def _restrict_grid(
         raise ValueError(
             f"merge_rasters: mosaic has a zero pixel size ({pixel_w!r}, {pixel_h!r}); "
             "the bbox window cannot be resolved onto its grid."
+        )
+
+    # Put the window in the mosaic's longitude convention before measuring offsets
+    # against it. A -180..180 window against a 0..360 mosaic otherwise overlaps only
+    # partially, and the clamp below would quietly return that sliver as a success.
+    grid_edges = sorted((origin_x, origin_x + x_size * pixel_w))
+    west, east = _match_longitude_convention(
+        west, east, projection, grid_edges[0], grid_edges[1]
+    )
+    # Rewriting can itself put the window across the seam (a window spanning the prime
+    # meridian becomes 350..10 in 0..360). Reject it for the same reason the
+    # antimeridian case is rejected: sorting the edges below would silently resolve it
+    # into the complement of the requested area.
+    if west > east:
+        raise ValueError(
+            f"merge_rasters: bbox {tuple(bbox)!r} crosses the seam of the mosaic's "
+            f"longitude convention (it spans {west} to {east} once rewritten to "
+            "match). Split it either side of the seam and merge them separately."
         )
 
     # Column/row offsets of the window's edges on the union grid. Divide by the signed

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -351,15 +351,25 @@ def merge_rasters(
             This is not a convenience for cropping afterwards: without it GDAL is
             given no reason to read less, so a mosaic of remote sources pulls the
             **entire** source extent through ``/vsicurl`` even when the caller
-            wants a fraction of it. A full Sentinel-2 tile is 10980x10980 px;
-            restricting it to a ~20x14 km area of interest turns a ~236 MiB
-            transfer into a few MiB.
+            wants a fraction of it. A full Sentinel-2 tile is 10980x10980 px
+            (verified against a public Earth Search COG), so an area of interest
+            covering a fraction of one tile still costs the whole tile without a
+            window. How much that saves depends on the ratio between the source
+            footprint and the window.
 
-            The window is applied differently per method but means the same thing
-            in both: z-order passes it to :func:`gdal.Translate` as ``projWin``,
-            so only the byte ranges the window touches are requested; the
-            reduction methods clip the union grid to it, snapped outward onto the
-            grid's own pixels so the result stays a strict sub-grid.
+            The window is resolved once, onto the mosaic's own pixel grid, and
+            used by both methods: z-order passes it to :func:`gdal.Translate` as
+            ``projWin``, so only the byte ranges the window touches are requested;
+            the reduction methods clip the union grid to it. Snapping outward onto
+            whole pixels keeps the result a strict sub-grid, and resolving it once
+            means both methods return the same grid for the same arguments.
+
+            A bbox must be ordered ``west < east`` and ``south < north``. A window
+            crossing the antimeridian (``west > east``) is rejected rather than
+            silently reinterpreted as its own complement; split it and merge the
+            two halves. :meth:`pyramids.dataset.Dataset.crop` handles the seam
+            directly, but a mosaic is composited on one grid, which a seam-crossing
+            window would not have.
         bbox_crs (Any):
             CRS that ``bbox`` is expressed in — an EPSG code (``4326``), an
             authority string (``"EPSG:4326"``), a WKT, or anything
@@ -764,6 +774,12 @@ def _merge_reduce(
         method: One of ``"min"``, ``"max"``, ``"sum"``.
         no_data_value: Output no-data value and no-coverage fill.
         n: Source pixel value to treat as no-data (``"nan"`` means none).
+        bbox: Optional ``(west, south, east, north)`` window. When given, the union
+            grid is clipped to it before the output is created, so only the window
+            is allocated and read — clipping the strip loop alone would not help,
+            because the output is sized from the union before the loop runs.
+        bbox_crs: CRS of `bbox`, or ``None`` when it is already in the union grid's
+            CRS (which is `dst_crs` when the caller passed one).
 
     Raises:
         RuntimeError: GDAL failed to build the union mosaic or to warp a source.

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -55,9 +55,11 @@ def _validated_bbox(bbox: Sequence[float]) -> tuple[float, float, float, float]:
         tuple[float, float, float, float]: ``(west, south, east, north)``.
 
     Raises:
-        TypeError: `bbox` is not a sequence of four numbers.
-        ValueError: A coordinate is not finite, or the box is inverted or empty in
-            either axis.
+        TypeError: `bbox` is a string or bytes, is not iterable, or holds a
+            non-numeric element. Any other iterable of four numbers is accepted,
+            `np.ndarray` included.
+        ValueError: There are not exactly four values, a coordinate is not finite,
+            or the box is inverted or empty in either axis.
     """
     # Accept any non-string iterable rather than testing `isinstance(bbox, Sequence)`:
     # `np.ndarray` does not register as a `Sequence`, and `GeoDataFrame.total_bounds`
@@ -159,7 +161,10 @@ def _bbox_in_projection(
 
     Raises:
         TypeError: `bbox` is not four numbers.
-        ValueError: The bbox is inverted, or does not project to a finite extent.
+        ValueError: The bbox is inverted, does not project to a finite extent, or
+            crosses the antimeridian once reprojected. `transform_bounds` signals
+            that last case by returning ``west > east``, which would otherwise be
+            read as a box spanning the long way round.
     """
     west, south, east, north = _validated_bbox(bbox)
     if bbox_crs is None:
@@ -474,7 +479,14 @@ def merge_rasters(
             two halves. :meth:`pyramids.dataset.Dataset.crop` handles the seam
             directly, but a mosaic is composited on one grid, which a seam-crossing
             window would not have.
-        bbox_crs (Any):
+
+            For a lon/lat mosaic the window is rewritten into the mosaic's own
+            longitude convention first, so a ``-180..180`` bbox reads correctly
+            against a ``0..360`` grid (and the reverse). A window that ends up
+            spanning that convention's seam is rejected on the same grounds as an
+            antimeridian one. A window extending past the mosaic is clipped to it;
+            one that misses it entirely raises.
+        bbox_crs (int | str | None):
             CRS that ``bbox`` is expressed in — an EPSG code (``4326``), an
             authority string (``"EPSG:4326"``), a WKT, or anything
             :meth:`pyproj.CRS.from_user_input` accepts. ``None`` (default) means

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -17,6 +17,7 @@ import numpy as np
 from osgeo import gdal, osr
 
 from pyramids.base._utils import DEFAULT_RESAMPLING, resolve_resampling
+from pyramids.base.crs import reproject_coordinates
 from pyramids.base.remote import signer_cloud_config
 from pyramids.dataset.dataset import _INHERIT_NO_DATA, Dataset
 
@@ -27,6 +28,108 @@ _MERGE_METHODS = _VRT_METHODS + _REDUCE_METHODS
 # Rows per strip for the min/max/sum reduction. The union grid is reduced one
 # full-width strip at a time so peak memory is O(strip) rather than O(grid).
 _MERGE_STRIP_ROWS = 512
+
+
+def _bbox_in_projection(
+    bbox: Sequence[float], epsg: Any, projection: str
+) -> tuple[float, float, float, float]:
+    """Express `bbox` in `projection`'s coordinates.
+
+    Args:
+        bbox: ``(west, south, east, north)`` in `epsg`, or already in `projection`
+            when `epsg` is ``None``.
+        epsg: CRS the bbox is given in — any form
+            :func:`pyramids.base.crs.reproject_coordinates` accepts. ``None`` means
+            the bbox is already in the target CRS.
+        projection: The target CRS as WKT (a grid's ``GetProjection()``).
+
+    Returns:
+        tuple[float, float, float, float]: ``(west, south, east, north)`` in the
+        target CRS.
+
+    Raises:
+        ValueError: The bbox does not project to a finite extent — it falls outside
+            the target CRS's area of use.
+    """
+    west, south, east, north = (float(v) for v in bbox)
+    if epsg is None:
+        return west, south, east, north
+    # All four corners, not two: a reprojected rectangle is a curved quadrilateral,
+    # so its envelope needs every corner, and taking only (W,S) and (E,N) would cut
+    # inside the requested area wherever an edge bows outward.
+    xs, ys = reproject_coordinates(
+        [west, east, west, east],
+        [south, north, north, south],
+        from_crs=epsg,
+        to_crs=projection,
+        precision=None,
+    )
+    if not all(np.isfinite(xs)) or not all(np.isfinite(ys)):
+        raise ValueError(
+            f"merge_rasters: bbox {tuple(bbox)!r} does not project from {epsg!r} into "
+            "the mosaic CRS; it likely falls outside that CRS's area of use."
+        )
+    return min(xs), min(ys), max(xs), max(ys)
+
+
+def _restrict_grid(
+    geotransform: Sequence[float],
+    x_size: int,
+    y_size: int,
+    projection: str,
+    bbox: Sequence[float],
+    epsg: Any,
+) -> tuple[tuple[float, float, float, float, float, float], int, int]:
+    """Clip a union grid to `bbox`, snapped outward onto the grid's own pixels.
+
+    Snapping outward (floor the offsets, ceil the far edges) keeps the result a
+    strict sub-grid of the union: every output pixel still lines up with a source
+    pixel, so the strip reduction stays byte-identical to a whole-grid pass over
+    the same area. Rounding inward would drop a partially-covered edge pixel the
+    caller asked for.
+
+    Args:
+        geotransform: The union grid's GDAL geotransform.
+        x_size: Union grid width in pixels.
+        y_size: Union grid height in pixels.
+        projection: The union grid's CRS as WKT.
+        bbox: ``(west, south, east, north)`` window to keep.
+        epsg: CRS of `bbox`, or ``None`` when it is already in `projection`.
+
+    Returns:
+        tuple: ``(geotransform, x_size, y_size)`` for the clipped grid.
+
+    Raises:
+        ValueError: The bbox does not overlap the mosaic at all — a silent empty
+            output would look like a successful merge of nothing.
+    """
+    west, south, east, north = _bbox_in_projection(bbox, epsg, projection)
+    origin_x, pixel_w, _, origin_y, _, pixel_h = (float(v) for v in geotransform)
+
+    # Column/row offsets of the window's edges on the union grid. `pixel_h` is
+    # negative for a north-up grid, so the north edge is the smaller row index.
+    col_start = int(np.floor((west - origin_x) / pixel_w))
+    col_stop = int(np.ceil((east - origin_x) / pixel_w))
+    row_start = int(np.floor((north - origin_y) / pixel_h))
+    row_stop = int(np.ceil((south - origin_y) / pixel_h))
+
+    col_start, col_stop = max(0, col_start), min(x_size, col_stop)
+    row_start, row_stop = max(0, row_start), min(y_size, row_stop)
+    if col_stop <= col_start or row_stop <= row_start:
+        raise ValueError(
+            f"merge_rasters: bbox {tuple(bbox)!r} does not overlap the mosaic "
+            "extent; nothing would be written."
+        )
+
+    clipped = (
+        origin_x + col_start * pixel_w,
+        pixel_w,
+        0.0,
+        origin_y + row_start * pixel_h,
+        0.0,
+        pixel_h,
+    )
+    return clipped, col_stop - col_start, row_stop - row_start
 
 
 def _source_bounds(
@@ -85,6 +188,9 @@ def merge_rasters(
     dst_crs: int | str | None = None,
     resampling: str = DEFAULT_RESAMPLING,
     signer: Any = None,
+    *,
+    bbox: Sequence[float] | None = None,
+    epsg: Any = None,
 ) -> None:
     """Merge a group of rasters into one raster, resolving overlaps by ``method``.
 
@@ -154,6 +260,29 @@ def merge_rasters(
             without wrapping the call in a ``with CloudConfig(...)`` block.
             ``None`` (default) leaves source hrefs untouched and installs no
             extra config.
+        bbox (Sequence[float] | None):
+            Optional ``(west, south, east, north)`` window to restrict the merge
+            to. ``None`` (default) merges the full extent of every source, which
+            is what the function has always done.
+
+            This is not a convenience for cropping afterwards: without it GDAL is
+            given no reason to read less, so a mosaic of remote sources pulls the
+            **entire** source extent through ``/vsicurl`` even when the caller
+            wants a fraction of it. A full Sentinel-2 tile is 10980x10980 px;
+            restricting it to a ~20x14 km area of interest turns a ~236 MiB
+            transfer into a few MiB.
+
+            The window is applied differently per method but means the same thing
+            in both: z-order passes it to :func:`gdal.Translate` as ``projWin``,
+            so only the byte ranges the window touches are requested; the
+            reduction methods clip the union grid to it, snapped outward onto the
+            grid's own pixels so the result stays a strict sub-grid.
+        epsg (Any):
+            CRS that ``bbox`` is expressed in — an EPSG code (``4326``), an
+            authority string (``"EPSG:4326"``), a WKT, or anything
+            :func:`pyramids.base.crs.reproject_coordinates` accepts. ``None``
+            (default) means ``bbox`` is already in the mosaic's own CRS. Ignored
+            when ``bbox`` is ``None``.
 
     Returns:
         None
@@ -170,7 +299,9 @@ def merge_rasters(
     Raises:
         TypeError: ``resampling`` is not a string.
         ValueError: ``method``/``resampling`` is not a supported value,
-            ``dst_crs`` cannot be parsed as a CRS, or a source carries no CRS.
+            ``dst_crs`` cannot be parsed as a CRS, a source carries no CRS, or
+            ``bbox`` does not overlap the mosaic / cannot be projected into its
+            CRS.
         RuntimeError: GDAL failed to open a source, reproject it, or build the
             source mosaic.
 
@@ -246,7 +377,7 @@ def merge_rasters(
         sources, _keepalive = _prepare_sources(src_paths, dst_crs, resampling)
 
         if method in _REDUCE_METHODS:
-            _merge_reduce(sources, str(dst), method, no_data_value, n)
+            _merge_reduce(sources, str(dst), method, no_data_value, n, bbox, epsg)
             return
 
         # z-order: "last" keeps natural order (last source wins); "first"
@@ -264,9 +395,34 @@ def merge_rasters(
                 "check that all paths are readable rasters with consistent "
                 "band counts and CRS."
             )
+        if bbox is not None:
+            # Validate the window against the mosaic's own extent before handing it
+            # to Translate. GDAL does not treat a disjoint `projWin` as an error --
+            # it writes a 1x1 raster of no-data at the window's origin, which reads
+            # back as a successful merge of nothing. Reusing `_restrict_grid` here
+            # is purely for its overlap check (Translate does the real windowing),
+            # so both methods reject the same bbox with the same message.
+            _restrict_grid(
+                vrt_ds.GetGeoTransform(),
+                vrt_ds.RasterXSize,
+                vrt_ds.RasterYSize,
+                vrt_ds.GetProjection(),
+                bbox,
+                epsg,
+            )
+
+        # `projWin` is what stops the read at the window: without it GDAL has no
+        # reason to restrict what it pulls through /vsicurl and materialises the
+        # whole mosaic extent. `projWinSRS` lets the caller's bbox stay in its own
+        # CRS -- GDAL reprojects the window itself, so no bbox has to be converted
+        # here. Order is (ulx, uly, lrx, lry) = (west, north, east, south).
         translate_opts = gdal.TranslateOptions(
             creationOptions=["COMPRESS=LZW"],
             noData=str(no_data_value),
+            projWin=None if bbox is None else [bbox[0], bbox[3], bbox[2], bbox[1]],
+            projWinSRS=(
+                None if (bbox is None or epsg is None) else _as_srs(epsg).ExportToWkt()
+            ),
         )
         out_ds = gdal.Translate(str(dst), vrt_ds, options=translate_opts)
         if out_ds is None:
@@ -492,6 +648,8 @@ def _merge_reduce(
     method: str,
     no_data_value: float | int | str,
     n: float | int | str,
+    bbox: Sequence[float] | None = None,
+    epsg: Any = None,
 ) -> None:
     """Merge sources by reducing overlapping pixels with min/max/sum.
 
@@ -529,6 +687,14 @@ def _merge_reduce(
     x_size, y_size = template.RasterXSize, template.RasterYSize
     band_count = template.RasterCount
     template = None
+
+    # Clip the grid itself, not just the strip loop: the output is created at
+    # `x_size`/`y_size` below and the loop walks every row of it, so restricting
+    # only the loop would still allocate -- and read -- the full union extent.
+    if bbox is not None:
+        geotransform, x_size, y_size = _restrict_grid(
+            geotransform, x_size, y_size, projection, bbox, epsg
+        )
 
     src_nodata = None if str(n).lower() == "nan" else float(n)
     fill = float(no_data_value)

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -17,9 +17,9 @@ import numpy as np
 from osgeo import gdal, osr
 
 from pyramids.base._utils import DEFAULT_RESAMPLING, resolve_resampling
-from pyramids.base.crs import reproject_coordinates
 from pyramids.base.remote import signer_cloud_config
 from pyramids.dataset.dataset import _INHERIT_NO_DATA, Dataset
+from pyramids.feature.bbox import transform as bbox_transform
 
 _VRT_METHODS = ("first", "last")
 _REDUCE_METHODS = ("min", "max", "sum")
@@ -29,18 +29,73 @@ _MERGE_METHODS = _VRT_METHODS + _REDUCE_METHODS
 # full-width strip at a time so peak memory is O(strip) rather than O(grid).
 _MERGE_STRIP_ROWS = 512
 
+# Fraction of a pixel within which a window edge is treated as landing exactly on
+# a grid line. Reprojection and float arithmetic put an edge a few ulps past a
+# boundary; snapping outward on that noise costs a spurious row or column and
+# shifts the reduce path's origin away from the z-order path's.
+_GRID_SNAP_TOLERANCE = 1e-6
+
+
+def _validated_bbox(bbox: Sequence[float]) -> tuple[float, float, float, float]:
+    """Coerce `bbox` to four finite floats in ``(west, south, east, north)`` order.
+
+    Validated up front, and in one place, because every downstream consumer fails
+    differently and late: a string of the right length is happily unpacked into four
+    coordinates, a ``NaN`` reaches the grid arithmetic and surfaces as ``cannot
+    convert float NaN to integer``, and an inverted bbox is rejected on one merge
+    path while GDAL silently normalises it on the other.
+
+    Args:
+        bbox: The caller's window, expected to be four numbers.
+
+    Returns:
+        tuple[float, float, float, float]: ``(west, south, east, north)``.
+
+    Raises:
+        TypeError: `bbox` is not a sequence of four numbers.
+        ValueError: A coordinate is not finite, or the box is inverted or empty in
+            either axis.
+    """
+    if isinstance(bbox, (str, bytes)) or not isinstance(bbox, Sequence):
+        raise TypeError(
+            f"merge_rasters: bbox must be a sequence of four numbers "
+            f"(west, south, east, north), got {type(bbox).__name__}: {bbox!r}"
+        )
+    if len(bbox) != 4:
+        raise ValueError(
+            f"merge_rasters: bbox must have exactly 4 values "
+            f"(west, south, east, north), got {len(bbox)}: {tuple(bbox)!r}"
+        )
+    try:
+        west, south, east, north = (float(v) for v in bbox)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(
+            f"merge_rasters: bbox values must be numbers, got {tuple(bbox)!r}"
+        ) from exc
+    if not all(np.isfinite(v) for v in (west, south, east, north)):
+        raise ValueError(
+            f"merge_rasters: bbox values must all be finite, got {tuple(bbox)!r}"
+        )
+    if west >= east or south >= north:
+        raise ValueError(
+            f"merge_rasters: bbox must be (west, south, east, north) with west < east "
+            f"and south < north, got {tuple(bbox)!r}. A zero-area or inverted box "
+            "selects nothing."
+        )
+    return west, south, east, north
+
 
 def _bbox_in_projection(
-    bbox: Sequence[float], epsg: Any, projection: str
+    bbox: Sequence[float], bbox_crs: Any, projection: str
 ) -> tuple[float, float, float, float]:
     """Express `bbox` in `projection`'s coordinates.
 
     Args:
-        bbox: ``(west, south, east, north)`` in `epsg`, or already in `projection`
-            when `epsg` is ``None``.
-        epsg: CRS the bbox is given in — any form
-            :func:`pyramids.base.crs.reproject_coordinates` accepts. ``None`` means
-            the bbox is already in the target CRS.
+        bbox: ``(west, south, east, north)`` in `bbox_crs`, or already in
+            `projection` when `bbox_crs` is ``None``.
+        bbox_crs: CRS the bbox is given in — any form
+            :meth:`pyproj.CRS.from_user_input` accepts. ``None`` means the bbox is
+            already in the target CRS.
         projection: The target CRS as WKT (a grid's ``GetProjection()``).
 
     Returns:
@@ -48,28 +103,34 @@ def _bbox_in_projection(
         target CRS.
 
     Raises:
-        ValueError: The bbox does not project to a finite extent — it falls outside
-            the target CRS's area of use.
+        TypeError: `bbox` is not four numbers.
+        ValueError: The bbox is inverted, or does not project to a finite extent.
     """
-    west, south, east, north = (float(v) for v in bbox)
-    if epsg is None:
+    west, south, east, north = _validated_bbox(bbox)
+    if bbox_crs is None:
         return west, south, east, north
-    # All four corners, not two: a reprojected rectangle is a curved quadrilateral,
-    # so its envelope needs every corner, and taking only (W,S) and (E,N) would cut
-    # inside the requested area wherever an edge bows outward.
-    xs, ys = reproject_coordinates(
-        [west, east, west, east],
-        [south, north, north, south],
-        from_crs=epsg,
-        to_crs=projection,
-        precision=None,
-    )
-    if not all(np.isfinite(xs)) or not all(np.isfinite(ys)):
-        raise ValueError(
-            f"merge_rasters: bbox {tuple(bbox)!r} does not project from {epsg!r} into "
-            "the mosaic CRS; it likely falls outside that CRS's area of use."
+    # Delegate to the shared bbox reprojector rather than transforming corners here.
+    # Corners are not enough: a reprojected rectangle is a curved quadrilateral whose
+    # extreme point generally lies in the *interior* of an edge, so a corner envelope
+    # under-covers the requested area -- measured at ~0.035 deg (~4 km) off the north
+    # edge for an EPSG:3035 window into a lon/lat mosaic. `feature.bbox.transform`
+    # densifies every edge (via `pyproj.Transformer.transform_bounds`), which is also
+    # what GDAL does internally for `projWinSRS`, so both merge paths agree.
+    try:
+        west, south, east, north = bbox_transform(
+            (west, south, east, north), bbox_crs, projection
         )
-    return min(xs), min(ys), max(xs), max(ys)
+    except Exception as exc:
+        raise ValueError(
+            f"merge_rasters: bbox {tuple(bbox)!r} could not be reprojected from "
+            f"{bbox_crs!r} into the mosaic CRS: {exc}"
+        ) from exc
+    if not all(np.isfinite(v) for v in (west, south, east, north)):
+        raise ValueError(
+            f"merge_rasters: bbox {tuple(bbox)!r} does not project from {bbox_crs!r} "
+            "into the mosaic CRS; it likely falls outside that CRS's area of use."
+        )
+    return west, south, east, north
 
 
 def _restrict_grid(
@@ -78,7 +139,7 @@ def _restrict_grid(
     y_size: int,
     projection: str,
     bbox: Sequence[float],
-    epsg: Any,
+    bbox_crs: Any,
 ) -> tuple[tuple[float, float, float, float, float, float], int, int]:
     """Clip a union grid to `bbox`, snapped outward onto the grid's own pixels.
 
@@ -94,7 +155,7 @@ def _restrict_grid(
         y_size: Union grid height in pixels.
         projection: The union grid's CRS as WKT.
         bbox: ``(west, south, east, north)`` window to keep.
-        epsg: CRS of `bbox`, or ``None`` when it is already in `projection`.
+        bbox_crs: CRS of `bbox`, or ``None`` when it is already in `projection`.
 
     Returns:
         tuple: ``(geotransform, x_size, y_size)`` for the clipped grid.
@@ -103,15 +164,37 @@ def _restrict_grid(
         ValueError: The bbox does not overlap the mosaic at all — a silent empty
             output would look like a successful merge of nothing.
     """
-    west, south, east, north = _bbox_in_projection(bbox, epsg, projection)
-    origin_x, pixel_w, _, origin_y, _, pixel_h = (float(v) for v in geotransform)
+    west, south, east, north = _bbox_in_projection(bbox, bbox_crs, projection)
+    origin_x, pixel_w, row_skew, origin_y, col_skew, pixel_h = (
+        float(v) for v in geotransform
+    )
+    if row_skew or col_skew:
+        raise ValueError(
+            "merge_rasters: bbox is not supported for a rotated or sheared mosaic "
+            f"(geotransform skew terms {row_skew!r}, {col_skew!r}); the window would "
+            "be applied as if the grid were axis-aligned, mis-georeferencing the "
+            "output."
+        )
+    if not pixel_w or not pixel_h:
+        raise ValueError(
+            f"merge_rasters: mosaic has a zero pixel size ({pixel_w!r}, {pixel_h!r}); "
+            "the bbox window cannot be resolved onto its grid."
+        )
 
-    # Column/row offsets of the window's edges on the union grid. `pixel_h` is
-    # negative for a north-up grid, so the north edge is the smaller row index.
-    col_start = int(np.floor((west - origin_x) / pixel_w))
-    col_stop = int(np.ceil((east - origin_x) / pixel_w))
-    row_start = int(np.floor((north - origin_y) / pixel_h))
-    row_stop = int(np.ceil((south - origin_y) / pixel_h))
+    # Column/row offsets of the window's edges on the union grid. Divide by the signed
+    # pixel size so a south-up grid (`pixel_h > 0`) maps its edges the same way round;
+    # `min`/`max` then order them without assuming a north-up raster.
+    cols = sorted(((west - origin_x) / pixel_w, (east - origin_x) / pixel_w))
+    rows = sorted(((north - origin_y) / pixel_h, (south - origin_y) / pixel_h))
+
+    # Snap outward, but only past a real boundary: an edge that lands on a pixel line
+    # to within float noise must not add a spurious row or column. Without this the
+    # reduce path picks up an extra pixel and shifts its origin relative to the
+    # z-order path, so the two return different rasters for identical arguments.
+    col_start = int(np.floor(cols[0] + _GRID_SNAP_TOLERANCE))
+    col_stop = int(np.ceil(cols[1] - _GRID_SNAP_TOLERANCE))
+    row_start = int(np.floor(rows[0] + _GRID_SNAP_TOLERANCE))
+    row_stop = int(np.ceil(rows[1] - _GRID_SNAP_TOLERANCE))
 
     col_start, col_stop = max(0, col_start), min(x_size, col_stop)
     row_start, row_stop = max(0, row_start), min(y_size, row_stop)
@@ -190,7 +273,7 @@ def merge_rasters(
     signer: Any = None,
     *,
     bbox: Sequence[float] | None = None,
-    epsg: Any = None,
+    bbox_crs: Any = None,
 ) -> None:
     """Merge a group of rasters into one raster, resolving overlaps by ``method``.
 
@@ -277,12 +360,14 @@ def merge_rasters(
             so only the byte ranges the window touches are requested; the
             reduction methods clip the union grid to it, snapped outward onto the
             grid's own pixels so the result stays a strict sub-grid.
-        epsg (Any):
+        bbox_crs (Any):
             CRS that ``bbox`` is expressed in — an EPSG code (``4326``), an
             authority string (``"EPSG:4326"``), a WKT, or anything
-            :func:`pyramids.base.crs.reproject_coordinates` accepts. ``None``
-            (default) means ``bbox`` is already in the mosaic's own CRS. Ignored
-            when ``bbox`` is ``None``.
+            :meth:`pyproj.CRS.from_user_input` accepts. ``None`` (default) means
+            ``bbox`` is already in the mosaic's own CRS — which, when ``dst_crs``
+            is given, is ``dst_crs``, since sources are reprojected before the
+            window is applied. Ignored when ``bbox`` is ``None``. Named to match
+            :meth:`pyramids.dataset.engines.cog.COG.read_part`.
 
     Returns:
         None
@@ -377,7 +462,7 @@ def merge_rasters(
         sources, _keepalive = _prepare_sources(src_paths, dst_crs, resampling)
 
         if method in _REDUCE_METHODS:
-            _merge_reduce(sources, str(dst), method, no_data_value, n, bbox, epsg)
+            _merge_reduce(sources, str(dst), method, no_data_value, n, bbox, bbox_crs)
             return
 
         # z-order: "last" keeps natural order (last source wins); "first"
@@ -395,34 +480,42 @@ def merge_rasters(
                 "check that all paths are readable rasters with consistent "
                 "band counts and CRS."
             )
+        proj_win = None
         if bbox is not None:
-            # Validate the window against the mosaic's own extent before handing it
-            # to Translate. GDAL does not treat a disjoint `projWin` as an error --
-            # it writes a 1x1 raster of no-data at the window's origin, which reads
-            # back as a successful merge of nothing. Reusing `_restrict_grid` here
-            # is purely for its overlap check (Translate does the real windowing),
-            # so both methods reject the same bbox with the same message.
-            _restrict_grid(
+            # Resolve the window here, in the mosaic's own CRS, and hand Translate a
+            # `projWin` that already lies on the mosaic's pixel boundaries -- rather
+            # than passing the caller's bbox with `projWinSRS` and letting GDAL
+            # reproject it. Two independent reprojections of the same window round to
+            # opposite sides of a pixel edge, and the two merge paths then return
+            # different rasters for identical arguments (measured 3x3 at x=111364.8
+            # against 4x3 at x=0.0 for `dst_crs=3857`). One resolver for both paths
+            # makes them agree by construction, and `_restrict_grid` also rejects a
+            # disjoint window, which GDAL does not: it writes a 1x1 no-data raster at
+            # the window's origin, which reads back as a successful merge of nothing.
+            clipped, window_x, window_y = _restrict_grid(
                 vrt_ds.GetGeoTransform(),
                 vrt_ds.RasterXSize,
                 vrt_ds.RasterYSize,
                 vrt_ds.GetProjection(),
                 bbox,
-                epsg,
+                bbox_crs,
             )
+            # (ulx, uly, lrx, lry) — already snapped, so GDAL's own rounding is a
+            # no-op and the output grid matches the reduction path's exactly.
+            proj_win = [
+                clipped[0],
+                clipped[3],
+                clipped[0] + window_x * clipped[1],
+                clipped[3] + window_y * clipped[5],
+            ]
 
         # `projWin` is what stops the read at the window: without it GDAL has no
         # reason to restrict what it pulls through /vsicurl and materialises the
-        # whole mosaic extent. `projWinSRS` lets the caller's bbox stay in its own
-        # CRS -- GDAL reprojects the window itself, so no bbox has to be converted
-        # here. Order is (ulx, uly, lrx, lry) = (west, north, east, south).
+        # whole mosaic extent.
         translate_opts = gdal.TranslateOptions(
             creationOptions=["COMPRESS=LZW"],
             noData=str(no_data_value),
-            projWin=None if bbox is None else [bbox[0], bbox[3], bbox[2], bbox[1]],
-            projWinSRS=(
-                None if (bbox is None or epsg is None) else _as_srs(epsg).ExportToWkt()
-            ),
+            projWin=proj_win,
         )
         out_ds = gdal.Translate(str(dst), vrt_ds, options=translate_opts)
         if out_ds is None:
@@ -649,7 +742,7 @@ def _merge_reduce(
     no_data_value: float | int | str,
     n: float | int | str,
     bbox: Sequence[float] | None = None,
-    epsg: Any = None,
+    bbox_crs: Any = None,
 ) -> None:
     """Merge sources by reducing overlapping pixels with min/max/sum.
 
@@ -693,7 +786,7 @@ def _merge_reduce(
     # only the loop would still allocate -- and read -- the full union extent.
     if bbox is not None:
         geotransform, x_size, y_size = _restrict_grid(
-            geotransform, x_size, y_size, projection, bbox, epsg
+            geotransform, x_size, y_size, projection, bbox, bbox_crs
         )
 
     src_nodata = None if str(n).lower() == "nan" else float(n)

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -237,9 +237,13 @@ def _restrict_grid(
     origin_x, pixel_w, row_skew, origin_y, col_skew, pixel_h = (
         float(v) for v in geotransform
     )
+    # Defensive: gdal.BuildVRT produces an axis-aligned union grid, so a skewed
+    # geotransform should not reach here. Guard it anyway rather than silently
+    # mis-georeferencing, and do not imply that dropping the bbox would help — a
+    # rotated mosaic is not something merge_rasters handles either way.
     if row_skew or col_skew:
         raise ValueError(
-            "merge_rasters: bbox is not supported for a rotated or sheared mosaic "
+            "merge_rasters: cannot resolve a bbox against a rotated or sheared mosaic "
             f"(geotransform skew terms {row_skew!r}, {col_skew!r}); the window would "
             "be applied as if the grid were axis-aligned, mis-georeferencing the "
             "output."

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -187,8 +187,10 @@ def _restrict_grid(
         tuple: ``(geotransform, x_size, y_size)`` for the clipped grid.
 
     Raises:
-        ValueError: The bbox does not overlap the mosaic at all — a silent empty
-            output would look like a successful merge of nothing.
+        ValueError: The mosaic is rotated/sheared or has a zero pixel size; the bbox
+            selects no whole pixel; or it does not overlap the mosaic at all — a
+            silent empty output would look like a successful merge of nothing.
+        TypeError: `bbox` is not four numbers.
     """
     west, south, east, north = _bbox_in_projection(bbox, bbox_crs, projection)
     origin_x, pixel_w, row_skew, origin_y, col_skew, pixel_h = (
@@ -221,6 +223,18 @@ def _restrict_grid(
     col_stop = int(np.ceil(cols[1] - _GRID_SNAP_TOLERANCE))
     row_start = int(np.floor(rows[0] + _GRID_SNAP_TOLERANCE))
     row_stop = int(np.ceil(rows[1] - _GRID_SNAP_TOLERANCE))
+
+    # Check for a collapsed window *before* clamping. The tolerance is applied inward
+    # at both edges, so a box that starts on a pixel boundary and spans less than the
+    # tolerance snaps to zero width -- even sitting squarely inside the mosaic. That is
+    # a different fault from a box that misses the mosaic, and reporting the latter
+    # sends the caller to check their extents when the problem is the size of the box.
+    if col_stop <= col_start or row_stop <= row_start:
+        raise ValueError(
+            f"merge_rasters: bbox {tuple(bbox)!r} selects no whole pixel of the "
+            "mosaic; it is degenerately thin in at least one axis. Widen it to at "
+            "least one cell."
+        )
 
     col_start, col_stop = max(0, col_start), min(x_size, col_stop)
     row_start, row_stop = max(0, row_start), min(y_size, row_stop)

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -33,8 +33,9 @@ _MERGE_STRIP_ROWS = 512
 
 # Fraction of a pixel within which a window edge is treated as landing exactly on
 # a grid line. Reprojection and float arithmetic put an edge a few ulps past a
-# boundary; snapping outward on that noise costs a spurious row or column and
-# shifts the reduce path's origin away from the z-order path's.
+# boundary, and snapping outward on that noise costs a spurious row or column.
+# Note this is not what keeps the two merge paths consistent: both consume the one
+# window `_restrict_grid` resolves, so they agree for any tolerance, zero included.
 _GRID_SNAP_TOLERANCE = 1e-6
 
 
@@ -280,9 +281,8 @@ def _restrict_grid(
     rows = sorted(((north - origin_y) / pixel_h, (south - origin_y) / pixel_h))
 
     # Snap outward, but only past a real boundary: an edge that lands on a pixel line
-    # to within float noise must not add a spurious row or column. Without this the
-    # reduce path picks up an extra pixel and shifts its origin relative to the
-    # z-order path, so the two return different rasters for identical arguments.
+    # to within float noise must not add a spurious row or column, which would both
+    # widen the read and shift the output's origin off the caller's request.
     col_start = int(np.floor(cols[0] + _GRID_SNAP_TOLERANCE))
     col_stop = int(np.ceil(cols[1] - _GRID_SNAP_TOLERANCE))
     row_start = int(np.floor(rows[0] + _GRID_SNAP_TOLERANCE))
@@ -496,11 +496,14 @@ def merge_rasters(
         same integer inputs.
 
     Raises:
-        TypeError: ``resampling`` is not a string.
+        TypeError: ``resampling`` is not a string, or ``bbox`` is not four numbers
+            (a string, a scalar, or a sequence holding a non-numeric element).
         ValueError: ``method``/``resampling`` is not a supported value,
             ``dst_crs`` cannot be parsed as a CRS, a source carries no CRS, or
-            ``bbox`` does not overlap the mosaic / cannot be projected into its
-            CRS.
+            ``bbox`` is malformed (wrong length, non-finite, inverted, zero-area),
+            crosses the antimeridian or the mosaic's longitude seam once
+            reprojected, selects no whole pixel, does not overlap the mosaic, or
+            cannot be projected into its CRS.
         RuntimeError: GDAL failed to open a source, reproject it, or build the
             source mosaic.
 

--- a/tests/cli/test_cli_commands.py
+++ b/tests/cli/test_cli_commands.py
@@ -277,7 +277,6 @@ class TestMergeCommand:
         assert rc == 1, "single-input merge must exit 1"
         assert "at least two" in capsys.readouterr().err, "expected guidance"
 
-
     def test_merge_bbox_restricts_the_mosaic(self, src_raster, tmp_path):
         """`--bbox` narrows the mosaic to the requested window.
 
@@ -294,9 +293,7 @@ class TestMergeCommand:
             no_data_value=-9999.0,
         ).to_file(second)
         out_path = str(tmp_path / "windowed.tif")
-        rc = main(
-            ["merge", src_raster, second, out_path, "--bbox", "1", "1", "5", "5"]
-        )
+        rc = main(["merge", src_raster, second, out_path, "--bbox", "1", "1", "5", "5"])
         assert rc == 0, "a windowed merge must succeed"
         windowed = Dataset.read_file(out_path)
         assert windowed.columns == 4, f"expected 4 columns, got {windowed.columns}"
@@ -411,6 +408,7 @@ class TestMergeCommand:
         )
         assert rc == 1, "an inverted bbox must exit 1"
         assert "error: " in capsys.readouterr().err, "expected one-line error"
+
 
 class TestOverviewCommand:
     """`pyramids overview`."""

--- a/tests/cli/test_cli_commands.py
+++ b/tests/cli/test_cli_commands.py
@@ -359,6 +359,28 @@ class TestMergeCommand:
         assert main(["merge", src_raster, second, out_path]) == 0
         assert Dataset.read_file(out_path).columns > 8, "mosaic must span both tiles"
 
+    def test_bbox_crs_without_bbox_exits_one(self, src_raster, tmp_path, capsys):
+        """`--bbox-crs` alone is refused rather than silently dropped.
+
+        Test scenario:
+            merge_rasters ignores bbox_crs when bbox is None, so forgetting --bbox
+            (or mistyping it) would otherwise look like a successful full-extent
+            merge — the classic silently-ignored-flag trap.
+        """
+        second = str(tmp_path / "b.tif")
+        Dataset.create_from_array(
+            np.ones((8, 8), dtype="float32"),
+            top_left_corner=(4, 8),
+            cell_size=1.0,
+            epsg=4326,
+            no_data_value=-9999.0,
+        ).to_file(second)
+        rc = main(
+            ["merge", src_raster, second, str(tmp_path / "x.tif"), "--bbox-crs", "3857"]
+        )
+        assert rc == 1, "--bbox-crs without --bbox must exit 1"
+        assert "error: " in capsys.readouterr().err, "expected one-line error"
+
     def test_merge_malformed_bbox_exits_one(self, src_raster, tmp_path, capsys):
         """An inverted `--bbox` exits 1 with a message rather than a traceback.
 

--- a/tests/cli/test_cli_commands.py
+++ b/tests/cli/test_cli_commands.py
@@ -15,6 +15,7 @@ import numpy as np
 import pytest
 from osgeo import gdal
 
+from pyramids.base.crs import reproject_coordinates
 from pyramids.cli import main
 from pyramids.dataset import Dataset
 from pyramids.feature import FeatureCollection
@@ -276,6 +277,118 @@ class TestMergeCommand:
         assert rc == 1, "single-input merge must exit 1"
         assert "at least two" in capsys.readouterr().err, "expected guidance"
 
+
+    def test_merge_bbox_restricts_the_mosaic(self, src_raster, tmp_path):
+        """`--bbox` narrows the mosaic to the requested window.
+
+        Test scenario:
+            The flag is the CLI's only route to the windowed merge; without a test
+            a typo in the `nargs`/`type` wiring would surface only at runtime.
+        """
+        second = str(tmp_path / "b.tif")
+        Dataset.create_from_array(
+            np.ones((8, 8), dtype="float32"),
+            top_left_corner=(4, 8),
+            cell_size=1.0,
+            epsg=4326,
+            no_data_value=-9999.0,
+        ).to_file(second)
+        out_path = str(tmp_path / "windowed.tif")
+        rc = main(
+            ["merge", src_raster, second, out_path, "--bbox", "1", "1", "5", "5"]
+        )
+        assert rc == 0, "a windowed merge must succeed"
+        windowed = Dataset.read_file(out_path)
+        assert windowed.columns == 4, f"expected 4 columns, got {windowed.columns}"
+        assert windowed.rows == 4, f"expected 4 rows, got {windowed.rows}"
+
+    def test_merge_bbox_crs_reprojects_the_window(self, src_raster, tmp_path):
+        """`--bbox-crs` reads the window in the CRS it names.
+
+        Test scenario:
+            A dropped `--bbox-crs` would be read as if the window were already in
+            the mosaic's CRS, silently selecting the wrong area rather than failing.
+        """
+        second = str(tmp_path / "b.tif")
+        Dataset.create_from_array(
+            np.ones((8, 8), dtype="float32"),
+            top_left_corner=(4, 8),
+            cell_size=1.0,
+            epsg=4326,
+            no_data_value=-9999.0,
+        ).to_file(second)
+        xs, ys = reproject_coordinates(
+            [1.0, 5.0], [1.0, 5.0], from_crs=4326, to_crs=3857, precision=None
+        )
+        out_path = str(tmp_path / "windowed_crs.tif")
+        rc = main(
+            [
+                "merge",
+                src_raster,
+                second,
+                out_path,
+                "--bbox",
+                str(xs[0]),
+                str(ys[0]),
+                str(xs[1]),
+                str(ys[1]),
+                "--bbox-crs",
+                "3857",
+            ]
+        )
+        assert rc == 0, "a reprojected window must succeed"
+        windowed = Dataset.read_file(out_path)
+        assert 4 <= windowed.columns <= 5, f"expected ~4 cols, got {windowed.columns}"
+        assert 4 <= windowed.rows <= 5, f"expected ~4 rows, got {windowed.rows}"
+
+    def test_merge_without_bbox_is_unchanged(self, src_raster, tmp_path):
+        """Omitting `--bbox` still mosaics the full extent.
+
+        Test scenario:
+            The window is opt-in; adding the flags must not alter the default.
+        """
+        second = str(tmp_path / "b.tif")
+        Dataset.create_from_array(
+            np.ones((8, 8), dtype="float32"),
+            top_left_corner=(4, 8),
+            cell_size=1.0,
+            epsg=4326,
+            no_data_value=-9999.0,
+        ).to_file(second)
+        out_path = str(tmp_path / "full.tif")
+        assert main(["merge", src_raster, second, out_path]) == 0
+        assert Dataset.read_file(out_path).columns > 8, "mosaic must span both tiles"
+
+    def test_merge_malformed_bbox_exits_one(self, src_raster, tmp_path, capsys):
+        """An inverted `--bbox` exits 1 with a message rather than a traceback.
+
+        Test scenario:
+            merge_rasters raises ValueError for an inverted window; the CLI must
+            turn that into a clean one-line error like every other subcommand.
+        """
+        second = str(tmp_path / "b.tif")
+        Dataset.create_from_array(
+            np.ones((8, 8), dtype="float32"),
+            top_left_corner=(4, 8),
+            cell_size=1.0,
+            epsg=4326,
+            no_data_value=-9999.0,
+        ).to_file(second)
+        rc = main(
+            [
+                "merge",
+                src_raster,
+                second,
+                str(tmp_path / "bad.tif"),
+                "--bbox",
+                "5",
+                "1",
+                "1",
+                "5",
+            ]
+        )
+        assert rc == 1, "an inverted bbox must exit 1"
+        assert "error: " in capsys.readouterr().err, "expected one-line error"
 
 class TestOverviewCommand:
     """`pyramids overview`."""

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -1888,3 +1888,63 @@ class TestBboxAntimeridian:
         )
         assert west < east, f"west {west} should stay below east {east}"
         assert south < north, f"south {south} should stay below north {north}"
+
+
+class TestBboxLongitudeConvention:
+    """A lon/lat window is read in the mosaic's own longitude convention."""
+
+    SIGNED_GRID = (-180.0, 1.0, 0.0, 90.0, 0.0, -1.0)
+    WRAPPED_GRID = (0.0, 1.0, 0.0, 90.0, 0.0, -1.0)
+
+    def test_signed_window_on_a_wrapped_mosaic(self):
+        """A -180..180 window resolves against a 0..360 mosaic.
+
+        Test scenario:
+            Global grids from climate NetCDF commonly run 0..360 while callers write
+            signed bboxes. Untranslated, the two overlap only partially and the clamp
+            returned that sliver as a success — the eastern part of the requested
+            area, with no error.
+        """
+        clipped, x_size, y_size = merge_mod._restrict_grid(
+            self.WRAPPED_GRID, 360, 180, "EPSG:4326", (-10.0, -5.0, -2.0, 5.0), None
+        )
+        assert (x_size, y_size) == (8, 10), f"expected 8x10, got {x_size}x{y_size}"
+        assert clipped[0] == 350.0, f"expected origin 350.0, got {clipped[0]}"
+
+    def test_wrapped_window_on_a_signed_mosaic(self):
+        """A 0..360 window resolves against a -180..180 mosaic.
+
+        Test scenario:
+            The translation has to work in both directions, not just the one the
+            climate-grid case motivates.
+        """
+        clipped, x_size, y_size = merge_mod._restrict_grid(
+            self.SIGNED_GRID, 360, 180, "EPSG:4326", (350.0, -5.0, 358.0, 5.0), None
+        )
+        assert (x_size, y_size) == (8, 10), f"expected 8x10, got {x_size}x{y_size}"
+        assert clipped[0] == -10.0, f"expected origin -10.0, got {clipped[0]}"
+
+    def test_window_across_the_seam_is_refused(self):
+        """A window spanning the mosaic's longitude seam raises.
+
+        Test scenario:
+            A signed window over the prime meridian becomes 350..10 in 0..360 — west
+            past east. Sorting those edges would resolve it into the complement, the
+            same trap the antimeridian guard exists for.
+        """
+        with pytest.raises(ValueError, match="crosses the seam"):
+            merge_mod._restrict_grid(
+                self.WRAPPED_GRID, 360, 180, "EPSG:4326", (-10.0, -5.0, 10.0, 5.0), None
+            )
+
+    def test_projected_mosaic_is_untouched(self):
+        """Longitude rewriting never applies to a projected CRS.
+
+        Test scenario:
+            Easting values can legitimately be negative or exceed 180; treating them
+            as longitudes would corrupt every projected window.
+        """
+        _, x_size, y_size = merge_mod._restrict_grid(
+            (0.0, 1.0, 0.0, 4.0, 0.0, -1.0), 6, 4, "EPSG:3857", (1.0, 1.0, 4.0, 3.0), None
+        )
+        assert (x_size, y_size) == (3, 2), f"expected 3x2, got {x_size}x{y_size}"

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -1853,11 +1853,10 @@ class TestBboxAntimeridian:
 
     ANTIMERIDIAN_BBOX = (700000.0, 100000.0, 950000.0, 300000.0)
     UTM_60N = 32660
-
-    @staticmethod
-    def _lonlat():
-        """Return the lon/lat CRS a global mosaic carries."""
-        return "EPSG:4326"
+    # A constant rather than a helper call: inside a `pytest.raises` block a second
+    # invocation could itself be the one that raises, which is what the assertion is
+    # meant to pin down.
+    LONLAT = "EPSG:4326"
 
     def test_wrapped_envelope_is_refused(self):
         """A reprojection that wraps past 180 deg raises instead of inverting.
@@ -1870,7 +1869,7 @@ class TestBboxAntimeridian:
         """
         with pytest.raises(ValueError, match="crosses the antimeridian"):
             merge_mod._bbox_in_projection(
-                self.ANTIMERIDIAN_BBOX, self.UTM_60N, self._lonlat()
+                self.ANTIMERIDIAN_BBOX, self.UTM_60N, self.LONLAT
             )
 
     def test_wrapped_window_does_not_become_its_complement(self):
@@ -1888,7 +1887,7 @@ class TestBboxAntimeridian:
                 global_grid,
                 36000,
                 18000,
-                self._lonlat(),
+                self.LONLAT,
                 self.ANTIMERIDIAN_BBOX,
                 self.UTM_60N,
             )
@@ -1902,7 +1901,7 @@ class TestBboxAntimeridian:
             pins that it does not.
         """
         west, south, east, north = merge_mod._bbox_in_projection(
-            (500000.0, 100000.0, 600000.0, 300000.0), 32633, self._lonlat()
+            (500000.0, 100000.0, 600000.0, 300000.0), 32633, self.LONLAT
         )
         assert west < east, f"west {west} should stay below east {east}"
         assert south < north, f"south {south} should stay below north {north}"

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -1644,11 +1644,19 @@ class TestBboxGridGeometry:
     """`_restrict_grid` on grids that are not the north-up, axis-aligned default."""
 
     def test_south_up_grid_is_not_rejected(self):
-        """A positive pixel height still resolves a window.
+        """A positive pixel height still resolves a window — a helper invariant only.
 
         Test scenario:
             Ordering the row offsets by value, rather than assuming north-up, is what
             stops a south-up grid raising a spurious "does not overlap".
+
+            This pins `_restrict_grid` on its own terms and is NOT evidence that
+            pyramids merges south-up rasters. The case cannot be reached end-to-end:
+            the union grid always comes from `gdal.BuildVRT`, which skips south-up
+            sources outright ("does not support positive NS resolution"), and
+            `_merge_reduce`'s strip loop would hand `gdal.Warp` an `outputBounds` with
+            `minY > maxY` if one ever did arrive. The ordering stays as defensive code
+            so the helper remains correct in isolation.
         """
         gt, x_size, y_size = merge_mod._restrict_grid(
             (0.0, 1.0, 0.0, 0.0, 0.0, 1.0), 6, 4, "", (1.0, 1.0, 4.0, 3.0), None

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -16,9 +16,10 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from osgeo import gdal
+from osgeo import gdal, osr
 
 import pyramids.dataset.merge as merge_mod
+from pyramids.base.crs import reproject_coordinates
 from pyramids.base.remote import CloudConfig
 from pyramids.dataset import Dataset
 from pyramids.dataset.merge import (
@@ -1220,3 +1221,266 @@ class TestMergeNoneGuards:
         out = str(tmp_path / "o.tif")
         with pytest.raises(RuntimeError, match="Warp returned None"):
             _merge_reduce([pa, pb], out, "min", -1.0, "nan")
+
+
+class TestMergeRastersBbox:
+    """Tests for the ``bbox=`` / ``epsg=`` window on ``merge_rasters`` (issue #1064).
+
+    The fixture pair spans a 6x4 union grid on EPSG:4326 at 1.0-degree cells with
+    its top-left at ``(0, 4)``, so a native window is easy to state in pixels: the
+    bbox ``(1, 1, 4, 3)`` selects columns 1..4 and rows 1..3, i.e. 3x2.
+    """
+
+    WINDOW = (1.0, 1.0, 4.0, 3.0)
+
+    @staticmethod
+    def _grid(path):
+        """Return ``(x_size, y_size, geotransform)`` of a written raster."""
+        ds = gdal.Open(str(path))
+        return ds.RasterXSize, ds.RasterYSize, ds.GetGeoTransform()
+
+    @pytest.mark.parametrize("method", ["last", "first", "min", "max", "sum"])
+    def test_bbox_restricts_the_output_grid(self, overlapping_pair, tmp_path, method):
+        """Every method writes only the windowed sub-grid.
+
+        Args:
+            overlapping_pair: Two 4x4 rasters on a shared 6x4 union grid.
+            tmp_path: pytest temp directory.
+            method: The overlap-resolution rule under test.
+
+        Test scenario:
+            Both code paths are covered - z-order via ``projWin`` and the reduction
+            path via the clipped union grid - and both must yield the 3x2 window
+            rather than the full 6x4 mosaic.
+        """
+        out = tmp_path / f"win_{method}.tif"
+        merge_rasters(list(overlapping_pair), out, method=method, bbox=self.WINDOW)
+        x_size, y_size, _ = self._grid(out)
+        assert (x_size, y_size) == (3, 2), (
+            f"{method}: expected the 3x2 window, got {x_size}x{y_size}"
+        )
+
+    @pytest.mark.parametrize("method", ["last", "min"])
+    def test_bbox_output_matches_the_same_slice_of_the_full_merge(
+        self, overlapping_pair, tmp_path, method
+    ):
+        """The window holds the same pixels the full merge puts there.
+
+        Args:
+            overlapping_pair: Two 4x4 rasters on a shared 6x4 union grid.
+            tmp_path: pytest temp directory.
+            method: One z-order and one reduction method.
+
+        Test scenario:
+            Restricting the read must not shift or resample anything - a shape-only
+            assertion would pass even if the window were taken from the wrong place.
+        """
+        full = tmp_path / f"full_{method}.tif"
+        windowed = tmp_path / f"win_{method}.tif"
+        merge_rasters(list(overlapping_pair), full, method=method)
+        merge_rasters(list(overlapping_pair), windowed, method=method, bbox=self.WINDOW)
+
+        full_arr = gdal.Open(str(full)).ReadAsArray()
+        win_arr = gdal.Open(str(windowed)).ReadAsArray()
+        assert np.allclose(win_arr, full_arr[1:3, 1:4], equal_nan=True), (
+            f"{method}: window {win_arr.tolist()} != full slice "
+            f"{full_arr[1:3, 1:4].tolist()}"
+        )
+
+    @pytest.mark.parametrize("method", ["last", "max"])
+    def test_windowed_grid_stays_aligned_to_the_full_grid(
+        self, overlapping_pair, tmp_path, method
+    ):
+        """The window's origin lands on a full-merge pixel edge, at the same scale.
+
+        Args:
+            overlapping_pair: Two 4x4 rasters on a shared 6x4 union grid.
+            tmp_path: pytest temp directory.
+            method: One z-order and one reduction method.
+
+        Test scenario:
+            A window that shifted the origin off-grid or changed the cell size would
+            silently resample; the snap is what keeps a windowed merge a strict
+            sub-grid of the unwindowed one.
+        """
+        full = tmp_path / f"a_{method}.tif"
+        windowed = tmp_path / f"b_{method}.tif"
+        merge_rasters(list(overlapping_pair), full, method=method)
+        merge_rasters(list(overlapping_pair), windowed, method=method, bbox=self.WINDOW)
+
+        _, _, full_gt = self._grid(full)
+        _, _, win_gt = self._grid(windowed)
+        assert win_gt[1] == full_gt[1], f"{method}: x cell size changed"
+        assert win_gt[5] == full_gt[5], f"{method}: y cell size changed"
+        col = (win_gt[0] - full_gt[0]) / full_gt[1]
+        row = (win_gt[3] - full_gt[3]) / full_gt[5]
+        assert col == pytest.approx(round(col)), f"{method}: x origin off-grid ({col})"
+        assert row == pytest.approx(round(row)), f"{method}: y origin off-grid ({row})"
+
+    @pytest.mark.parametrize("method", ["last", "max"])
+    def test_bbox_in_another_crs_selects_the_same_area(
+        self, overlapping_pair, tmp_path, method
+    ):
+        """``epsg=`` lets the bbox stay in the caller's own CRS.
+
+        Args:
+            overlapping_pair: Two 4x4 rasters on a shared EPSG:4326 union grid.
+            tmp_path: pytest temp directory.
+            method: One z-order and one reduction method.
+
+        Test scenario:
+            The same window is given in EPSG:3857 and must select the same area. A
+            reprojected rectangle is a curved quadrilateral, so its envelope can be
+            a pixel wider than the native one - the assertion allows that but not a
+            full-extent result.
+        """
+        xs, ys = reproject_coordinates(
+            [self.WINDOW[0], self.WINDOW[2]],
+            [self.WINDOW[1], self.WINDOW[3]],
+            from_crs=4326,
+            to_crs=3857,
+            precision=None,
+        )
+        bbox_3857 = (xs[0], ys[0], xs[1], ys[1])
+        out = tmp_path / f"m_{method}.tif"
+        merge_rasters(
+            list(overlapping_pair), out, method=method, bbox=bbox_3857, epsg=3857
+        )
+        x_size, y_size, _ = self._grid(out)
+        assert 3 <= x_size <= 4, f"{method}: expected ~3 cols, got {x_size}"
+        assert 2 <= y_size <= 3, f"{method}: expected ~2 rows, got {y_size}"
+
+    @pytest.mark.parametrize("method", ["last", "first", "min", "max", "sum"])
+    def test_disjoint_bbox_raises_for_every_method(
+        self, overlapping_pair, tmp_path, method
+    ):
+        """A window that misses the mosaic fails loudly on every path.
+
+        Args:
+            overlapping_pair: Two 4x4 rasters on a shared 6x4 union grid.
+            tmp_path: pytest temp directory.
+            method: The overlap-resolution rule under test.
+
+        Test scenario:
+            GDAL does not treat a disjoint ``projWin`` as an error - it writes a 1x1
+            no-data raster at the window's origin, which reads back as a successful
+            merge of nothing. Both paths must reject it instead.
+        """
+        with pytest.raises(ValueError, match="does not overlap"):
+            merge_rasters(
+                list(overlapping_pair),
+                tmp_path / f"x_{method}.tif",
+                method=method,
+                bbox=(100.0, 100.0, 101.0, 101.0),
+            )
+
+    @pytest.mark.parametrize("method", ["last", "sum"])
+    def test_no_bbox_is_unchanged(self, overlapping_pair, tmp_path, method):
+        """Omitting ``bbox`` merges the full extent, as before.
+
+        Args:
+            overlapping_pair: Two 4x4 rasters on a shared 6x4 union grid.
+            tmp_path: pytest temp directory.
+            method: One z-order and one reduction method.
+
+        Test scenario:
+            The window is opt-in; the default path must not change.
+        """
+        out = tmp_path / f"f_{method}.tif"
+        merge_rasters(list(overlapping_pair), out, method=method)
+        x_size, y_size, _ = self._grid(out)
+        assert (x_size, y_size) == (6, 4), (
+            f"{method}: default merge should stay 6x4, got {x_size}x{y_size}"
+        )
+
+
+class TestRestrictGrid:
+    """Unit tests for the grid-clipping helper behind the reduction path."""
+
+    GEOTRANSFORM = (0.0, 1.0, 0.0, 4.0, 0.0, -1.0)
+
+    def test_snaps_outward_onto_the_grid(self):
+        """A window inside a pixel grows to cover whole pixels.
+
+        Test scenario:
+            Rounding inward would silently drop a partially-covered edge pixel the
+            caller asked for, so the clip floors the near edges and ceils the far
+            ones.
+        """
+        gt, x_size, y_size = merge_mod._restrict_grid(
+            self.GEOTRANSFORM, 6, 4, "", (1.4, 1.4, 3.6, 2.6), None
+        )
+        assert (x_size, y_size) == (3, 2), f"expected 3x2, got {x_size}x{y_size}"
+        assert gt[0] == 1.0, f"x origin not snapped: {gt[0]}"
+        assert gt[3] == 3.0, f"y origin not snapped: {gt[3]}"
+
+    def test_clamps_to_the_grid_extent(self):
+        """A window larger than the mosaic clips to the mosaic.
+
+        Test scenario:
+            Asking for more than exists must not produce a grid larger than the
+            union, which would read outside every source.
+        """
+        _, x_size, y_size = merge_mod._restrict_grid(
+            self.GEOTRANSFORM, 6, 4, "", (-50.0, -50.0, 50.0, 50.0), None
+        )
+        assert (x_size, y_size) == (6, 4), f"expected 6x4, got {x_size}x{y_size}"
+
+    def test_disjoint_window_raises(self):
+        """A non-overlapping window raises rather than returning an empty grid.
+
+        Test scenario:
+            A zero-sized grid would be written as a valid-looking empty raster.
+        """
+        with pytest.raises(ValueError, match="does not overlap"):
+            merge_mod._restrict_grid(
+                self.GEOTRANSFORM, 6, 4, "", (100.0, 100.0, 101.0, 101.0), None
+            )
+
+
+class TestBboxInProjection:
+    """Unit tests for the bbox reprojection helper."""
+
+    def test_passthrough_when_no_epsg_given(self):
+        """With ``epsg=None`` the bbox is already in the target CRS.
+
+        Test scenario:
+            No reprojection should occur, and no CRS is needed to decide that.
+        """
+        result = merge_mod._bbox_in_projection((1.0, 2.0, 3.0, 4.0), None, "")
+        assert result == (1.0, 2.0, 3.0, 4.0), f"passthrough changed the bbox: {result}"
+
+    def test_uses_all_four_corners(self):
+        """The envelope covers all four reprojected corners, not just two.
+
+        Test scenario:
+            A reprojected rectangle is a curved quadrilateral; taking only (W,S) and
+            (E,N) would cut inside the requested area wherever an edge bows outward.
+            Round-tripping 4326 -> 3857 -> 4326 must recover the input.
+        """
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(3857)
+        west, south, east, north = merge_mod._bbox_in_projection(
+            (1.0, 1.0, 4.0, 3.0), 4326, srs.ExportToWkt()
+        )
+        assert west < east, "envelope must be non-degenerate in x"
+        assert south < north, "envelope must be non-degenerate in y"
+        back = merge_mod._bbox_in_projection(
+            (west, south, east, north), 3857, "EPSG:4326"
+        )
+        assert back == pytest.approx((1.0, 1.0, 4.0, 3.0), abs=1e-6), (
+            f"round trip lost the window: {back}"
+        )
+
+    def test_unprojectable_bbox_raises(self):
+        """A bbox outside the target CRS's domain raises instead of yielding inf.
+
+        Test scenario:
+            An orthographic projection can only represent the hemisphere it faces;
+            the antipodal side reprojects to non-finite coordinates. Left unchecked
+            those would flow into the grid arithmetic and produce a nonsense window
+            rather than an error.
+        """
+        ortho = "+proj=ortho +lat_0=0 +lon_0=0 +datum=WGS84 +units=m +no_defs"
+        with pytest.raises(ValueError, match="does not project"):
+            merge_mod._bbox_in_projection((175.0, -5.0, 179.0, 5.0), 4326, ortho)

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import numpy as np
 import pytest
-from osgeo import gdal, osr
+from osgeo import gdal
 
 import pyramids.dataset.merge as merge_mod
 from pyramids.base.crs import reproject_coordinates
@@ -1450,28 +1450,6 @@ class TestBboxInProjection:
         result = merge_mod._bbox_in_projection((1.0, 2.0, 3.0, 4.0), None, "")
         assert result == (1.0, 2.0, 3.0, 4.0), f"passthrough changed the bbox: {result}"
 
-    def test_uses_all_four_corners(self):
-        """The envelope covers all four reprojected corners, not just two.
-
-        Test scenario:
-            A reprojected rectangle is a curved quadrilateral; taking only (W,S) and
-            (E,N) would cut inside the requested area wherever an edge bows outward.
-            Round-tripping 4326 -> 3857 -> 4326 must recover the input.
-        """
-        srs = osr.SpatialReference()
-        srs.ImportFromEPSG(3857)
-        west, south, east, north = merge_mod._bbox_in_projection(
-            (1.0, 1.0, 4.0, 3.0), 4326, srs.ExportToWkt()
-        )
-        assert west < east, "envelope must be non-degenerate in x"
-        assert south < north, "envelope must be non-degenerate in y"
-        back = merge_mod._bbox_in_projection(
-            (west, south, east, north), 3857, "EPSG:4326"
-        )
-        assert back == pytest.approx((1.0, 1.0, 4.0, 3.0), abs=1e-6), (
-            f"round trip lost the window: {back}"
-        )
-
     def test_unprojectable_bbox_raises(self):
         """A bbox outside the target CRS's domain raises instead of yielding inf.
 
@@ -1484,3 +1462,219 @@ class TestBboxInProjection:
         ortho = "+proj=ortho +lat_0=0 +lon_0=0 +datum=WGS84 +units=m +no_defs"
         with pytest.raises(ValueError, match="does not project"):
             merge_mod._bbox_in_projection((175.0, -5.0, 179.0, 5.0), 4326, ortho)
+
+
+class TestBboxValidation:
+    """`bbox` is validated once, up front, for both merge paths."""
+
+    @pytest.mark.parametrize(
+        ("bad", "exc", "why"),
+        [
+            ("1234", TypeError, "a 4-character string is not four coordinates"),
+            (b"1234", TypeError, "bytes are not four coordinates"),
+            (12.0, TypeError, "a scalar is not a sequence"),
+            ((1.0, 2.0, 3.0), ValueError, "three values is not a bbox"),
+            ((1.0, 2.0, 3.0, 4.0, 5.0), ValueError, "five values is not a bbox"),
+            ((1.0, float("nan"), 3.0, 4.0), ValueError, "NaN is not a coordinate"),
+            ((1.0, 2.0, float("inf"), 4.0), ValueError, "inf is not a coordinate"),
+            ((4.0, 1.0, 1.0, 3.0), ValueError, "west > east is inverted"),
+            ((1.0, 3.0, 4.0, 1.0), ValueError, "south > north is inverted"),
+            ((1.0, 1.0, 1.0, 3.0), ValueError, "zero width selects nothing"),
+            ((1.0, 1.0, 4.0, 1.0), ValueError, "zero height selects nothing"),
+        ],
+    )
+    def test_rejects_malformed_bbox(self, bad, exc, why):
+        """A malformed bbox is refused with a typed error rather than opaque fallout.
+
+        Args:
+            bad: The malformed bbox.
+            exc: The exception type expected.
+            why: What makes it malformed.
+
+        Test scenario:
+            Unvalidated, `"1234"` unpacked into four coordinates and silently became
+            a window, and a NaN surfaced from deep in the grid arithmetic as
+            "cannot convert float NaN to integer".
+        """
+        with pytest.raises(exc):
+            merge_mod._validated_bbox(bad)
+
+    @pytest.mark.parametrize("method", ["last", "max"])
+    def test_malformed_bbox_rejected_on_both_paths(
+        self, overlapping_pair, tmp_path, method
+    ):
+        """Both merge paths reject the same malformed bbox the same way.
+
+        Args:
+            overlapping_pair: Two 4x4 rasters on a shared 6x4 union grid.
+            tmp_path: pytest temp directory.
+            method: One z-order and one reduction method.
+
+        Test scenario:
+            An inverted bbox used to be rejected on one path and silently normalised
+            by GDAL on the other.
+        """
+        with pytest.raises(ValueError):
+            merge_rasters(
+                list(overlapping_pair),
+                tmp_path / f"bad_{method}.tif",
+                method=method,
+                bbox=(4.0, 1.0, 1.0, 3.0),
+            )
+
+
+class TestBboxPathAgreement:
+    """The z-order and reduction paths must select the identical window."""
+
+    @staticmethod
+    def _grid(path):
+        """Return ``(x_size, y_size, origin_x, origin_y)`` of a written raster."""
+        ds = gdal.Open(str(path))
+        gt = ds.GetGeoTransform()
+        return ds.RasterXSize, ds.RasterYSize, round(gt[0], 6), round(gt[3], 6)
+
+    @pytest.mark.parametrize(
+        ("label", "kwargs"),
+        [
+            ("native", {"bbox": (1.0, 1.0, 4.0, 3.0)}),
+            ("reprojected", {"bbox": (1.0, 1.0, 4.0, 3.0), "bbox_crs": 4326}),
+            (
+                "dst_crs_reprojected",
+                {"dst_crs": 3857, "bbox": (1.0, 1.0, 4.0, 3.0), "bbox_crs": 4326},
+            ),
+        ],
+    )
+    def test_paths_return_the_same_grid(
+        self, overlapping_pair, tmp_path, label, kwargs
+    ):
+        """`last` and `max` produce the same output grid for the same window.
+
+        Args:
+            overlapping_pair: Two 4x4 rasters on a shared 6x4 union grid.
+            tmp_path: pytest temp directory.
+            label: Names the window form under test.
+            kwargs: The window arguments passed to both methods.
+
+        Test scenario:
+            The two paths once reprojected the window independently and rounded to
+            opposite sides of a pixel edge, returning different rasters for identical
+            arguments (3x3 at x=111364.8 against 4x3 at x=0.0 under `dst_crs=3857`).
+            This is the regression guard for that.
+        """
+        z_order = tmp_path / f"z_{label}.tif"
+        reduce_ = tmp_path / f"r_{label}.tif"
+        merge_rasters(list(overlapping_pair), z_order, method="last", **kwargs)
+        merge_rasters(list(overlapping_pair), reduce_, method="max", **kwargs)
+        assert self._grid(z_order) == self._grid(reduce_), (
+            f"{label}: z-order {self._grid(z_order)} != reduce {self._grid(reduce_)}"
+        )
+
+
+class TestBboxReprojectionCurvature:
+    """The reprojected window must cover the whole requested area, not a chord."""
+
+    def test_envelope_covers_a_curved_edge(self):
+        """The envelope of a strongly curved reprojection is not the corner envelope.
+
+        Test scenario:
+            EPSG:3035 (Lambert azimuthal) into lon/lat bows each edge outward, so the
+            extreme latitude lies in an edge's interior. A four-corner envelope fell
+            0.035 deg (~4 km) short of the true north edge. Densely sampling the edges
+            gives the bound the implementation must at least reach.
+        """
+        bbox = (3000000.0, 3000000.0, 4500000.0, 4000000.0)
+        computed = merge_mod._bbox_in_projection(bbox, 3035, "EPSG:4326")
+
+        samples_x, samples_y = [], []
+        for step in np.linspace(0.0, 1.0, 200):
+            samples_x += [bbox[0] + step * (bbox[2] - bbox[0])] * 2 + [bbox[0], bbox[2]]
+            samples_y += [bbox[1], bbox[3]] + [bbox[1] + step * (bbox[3] - bbox[1])] * 2
+        lons, lats = reproject_coordinates(
+            samples_x, samples_y, from_crs=3035, to_crs=4326, precision=None
+        )
+        corner_north = max(
+            reproject_coordinates(
+                [bbox[0], bbox[2], bbox[0], bbox[2]],
+                [bbox[1], bbox[3], bbox[3], bbox[1]],
+                from_crs=3035,
+                to_crs=4326,
+                precision=None,
+            )[1]
+        )
+        assert max(lats) - corner_north > 0.01, (
+            "precondition: this CRS pair must actually curve, otherwise the test "
+            "cannot distinguish a corner envelope from a densified one"
+        )
+        assert computed[3] > corner_north, (
+            f"north edge {computed[3]} is only the corner bound {corner_north}; the "
+            "envelope is not densified"
+        )
+        assert computed[3] == pytest.approx(max(lats), abs=0.005), (
+            f"north edge {computed[3]} does not reach the densified bound {max(lats)}"
+        )
+
+
+class TestBboxGridGeometry:
+    """`_restrict_grid` on grids that are not the north-up, axis-aligned default."""
+
+    def test_south_up_grid_is_not_rejected(self):
+        """A positive pixel height still resolves a window.
+
+        Test scenario:
+            Ordering the row offsets by value, rather than assuming north-up, is what
+            stops a south-up grid raising a spurious "does not overlap".
+        """
+        gt, x_size, y_size = merge_mod._restrict_grid(
+            (0.0, 1.0, 0.0, 0.0, 0.0, 1.0), 6, 4, "", (1.0, 1.0, 4.0, 3.0), None
+        )
+        assert (x_size, y_size) == (3, 2), f"expected 3x2, got {x_size}x{y_size}"
+        assert gt[3] == 1.0, f"south-up origin should be the low edge, got {gt[3]}"
+
+    @pytest.mark.parametrize(
+        "geotransform",
+        [
+            (0.0, 1.0, 0.5, 4.0, 0.0, -1.0),
+            (0.0, 1.0, 0.0, 4.0, 0.2, -1.0),
+        ],
+        ids=["row_skew", "col_skew"],
+    )
+    def test_rotated_or_sheared_grid_is_refused(self, geotransform):
+        """A skewed geotransform is refused rather than silently mis-georeferenced.
+
+        Args:
+            geotransform: A grid carrying a non-zero skew term.
+
+        Test scenario:
+            The window arithmetic assumes an axis-aligned grid; applying it to a
+            rotated one would place the output in the wrong location.
+        """
+        with pytest.raises(ValueError, match="rotated or sheared"):
+            merge_mod._restrict_grid(geotransform, 6, 4, "", (1.0, 1.0, 4.0, 3.0), None)
+
+    def test_zero_pixel_size_is_refused(self):
+        """A degenerate geotransform is refused rather than dividing by zero.
+
+        Test scenario:
+            A zero pixel size would raise ZeroDivisionError from inside the offset
+            arithmetic.
+        """
+        with pytest.raises(ValueError, match="zero pixel size"):
+            merge_mod._restrict_grid(
+                (0.0, 0.0, 0.0, 4.0, 0.0, -1.0), 6, 4, "", (1.0, 1.0, 4.0, 3.0), None
+            )
+
+    def test_edge_on_a_pixel_boundary_adds_no_extra_pixel(self):
+        """A window landing exactly on grid lines yields exactly that many pixels.
+
+        Test scenario:
+            Float noise puts an edge a few ulps past a boundary; snapping outward on
+            that noise costs a spurious row or column and shifts the origin, which is
+            how the two merge paths came to disagree.
+        """
+        nudged = (1.0 + 1e-12, 1.0 - 1e-12, 4.0 - 1e-12, 3.0 + 1e-12)
+        _, x_size, y_size = merge_mod._restrict_grid(
+            (0.0, 1.0, 0.0, 4.0, 0.0, -1.0), 6, 4, "", nudged, None
+        )
+        assert (x_size, y_size) == (3, 2), (
+            f"a boundary-aligned window should be 3x2, got {x_size}x{y_size}"
+        )

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -1224,7 +1224,7 @@ class TestMergeNoneGuards:
 
 
 class TestMergeRastersBbox:
-    """Tests for the ``bbox=`` / ``epsg=`` window on ``merge_rasters`` (issue #1064).
+    """Tests for the ``bbox=`` / ``bbox_crs=`` window on ``merge_rasters`` (issue #1064).
 
     The fixture pair spans a 6x4 union grid on EPSG:4326 at 1.0-degree cells with
     its top-left at ``(0, 4)``, so a native window is easy to state in pixels: the
@@ -1594,6 +1594,16 @@ class TestBboxPathAgreement:
         assert self._grid(z_order) == self._grid(reduce_), (
             f"{label}: z-order {self._grid(z_order)} != reduce {self._grid(reduce_)}"
         )
+        # Matching geometry is not enough: two paths can agree on the grid and still
+        # disagree on which source won a pixel. Comparing content is meaningful for
+        # this fixture because the later raster also holds the larger value (B=20
+        # over A=10), so `last` and `max` must resolve the overlap identically.
+        z_values = gdal.Open(str(z_order)).ReadAsArray()
+        r_values = gdal.Open(str(reduce_)).ReadAsArray()
+        assert np.array_equal(z_values, r_values, equal_nan=True), (
+            f"{label}: the two paths agree on the grid but not on its content\n"
+            f"z-order:\n{z_values}\nreduce:\n{r_values}"
+        )
 
 
 class TestBboxReprojectionCurvature:
@@ -1812,12 +1822,12 @@ class TestCollectionMergeBbox:
             A silently-ignored `bbox_crs` would read the window as if it were in the
             mosaic's CRS, selecting the wrong area instead of failing.
         """
-        west, east = reproject_coordinates(
+        xs, ys = reproject_coordinates(
             [1.0, 4.0], [1.0, 3.0], from_crs=4326, to_crs=3857, precision=None
         )
         out = tmp_path / "win_crs.tif"
         two_day_collection.merge(
-            out, bbox=(west[0], east[0], west[1], east[1]), bbox_crs=3857
+            out, bbox=(xs[0], ys[0], xs[1], ys[1]), bbox_crs=3857
         )
         ds = gdal.Open(str(out))
         assert 3 <= ds.RasterXSize <= 4, f"expected ~3 cols, got {ds.RasterXSize}"

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -1908,6 +1908,29 @@ class TestBboxAntimeridian:
         assert south < north, f"south {south} should stay below north {north}"
 
 
+class TestBboxReprojectionFailure:
+    """A CRS the transformer cannot build is reported against the bbox."""
+
+    @pytest.mark.parametrize(
+        "bad_crs",
+        ["not-a-crs", 999999],
+        ids=["garbage_string", "unknown_epsg"],
+    )
+    def test_unusable_bbox_crs_raises_a_clear_error(self, bad_crs):
+        """An unusable `bbox_crs` raises rather than escaping as a pyproj error.
+
+        Args:
+            bad_crs: A CRS pyproj cannot resolve.
+
+        Test scenario:
+            The handler around the transform exists so the caller learns which bbox
+            and which CRS failed. Left uncaught they would get a bare pyproj CRSError
+            naming neither.
+        """
+        with pytest.raises(ValueError, match="could not be reprojected"):
+            merge_mod._bbox_in_projection((1.0, 1.0, 4.0, 3.0), bad_crs, "EPSG:4326")
+
+
 class TestBboxLongitudeConvention:
     """A lon/lat window is read in the mosaic's own longitude convention."""
 

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -21,7 +21,7 @@ from osgeo import gdal
 import pyramids.dataset.merge as merge_mod
 from pyramids.base.crs import reproject_coordinates
 from pyramids.base.remote import CloudConfig
-from pyramids.dataset import Dataset
+from pyramids.dataset import Dataset, DatasetCollection
 from pyramids.dataset.merge import (
     _as_srs,
     _cloud_config,
@@ -1678,3 +1678,91 @@ class TestBboxGridGeometry:
         assert (x_size, y_size) == (3, 2), (
             f"a boundary-aligned window should be 3x2, got {x_size}x{y_size}"
         )
+
+
+class TestCollectionMergeBbox:
+    """`DatasetCollection.merge` forwards the window to `merge_rasters`."""
+
+    @pytest.fixture
+    def two_day_collection(self, tmp_path):
+        """A file-backed collection of two 4x4 tiles on a shared 6x4 union grid."""
+        for index, left in enumerate((0, 2)):
+            write_raster(
+                tmp_path / f"2024-01-0{index + 1}.tif",
+                np.full((4, 4), 10.0 + index, dtype="float32"),
+                (left, 4),
+            )
+        return DatasetCollection.from_files(
+            str(tmp_path), glob="*.tif", date_format="%Y-%m-%d"
+        )
+
+    def test_merge_without_bbox_is_the_full_union(self, two_day_collection, tmp_path):
+        """The default still merges the whole union grid.
+
+        Args:
+            two_day_collection: Collection of two overlapping tiles.
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            The window is opt-in; adding the parameter must not change the default.
+        """
+        out = tmp_path / "full.tif"
+        two_day_collection.merge(out)
+        ds = gdal.Open(str(out))
+        assert (ds.RasterXSize, ds.RasterYSize) == (6, 4), (
+            f"expected the full 6x4 union, got {ds.RasterXSize}x{ds.RasterYSize}"
+        )
+
+    def test_merge_with_bbox_restricts_the_output(self, two_day_collection, tmp_path):
+        """A bbox reaches `merge_rasters` and restricts the merge.
+
+        Args:
+            two_day_collection: Collection of two overlapping tiles.
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            Without this the motivating STAC workflow could not use the window at
+            all — the collection is how those mosaics are actually built.
+        """
+        out = tmp_path / "win.tif"
+        two_day_collection.merge(out, bbox=(1.0, 1.0, 4.0, 3.0))
+        ds = gdal.Open(str(out))
+        assert (ds.RasterXSize, ds.RasterYSize) == (3, 2), (
+            f"expected the 3x2 window, got {ds.RasterXSize}x{ds.RasterYSize}"
+        )
+
+    def test_merge_bbox_crs_is_forwarded(self, two_day_collection, tmp_path):
+        """`bbox_crs` reaches `merge_rasters` rather than being dropped.
+
+        Args:
+            two_day_collection: Collection of two overlapping tiles.
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            A silently-ignored `bbox_crs` would read the window as if it were in the
+            mosaic's CRS, selecting the wrong area instead of failing.
+        """
+        west, east = reproject_coordinates(
+            [1.0, 4.0], [1.0, 3.0], from_crs=4326, to_crs=3857, precision=None
+        )
+        out = tmp_path / "win_crs.tif"
+        two_day_collection.merge(
+            out, bbox=(west[0], east[0], west[1], east[1]), bbox_crs=3857
+        )
+        ds = gdal.Open(str(out))
+        assert 3 <= ds.RasterXSize <= 4, f"expected ~3 cols, got {ds.RasterXSize}"
+        assert 2 <= ds.RasterYSize <= 3, f"expected ~2 rows, got {ds.RasterYSize}"
+
+    def test_merge_rejects_a_malformed_bbox(self, two_day_collection, tmp_path):
+        """Validation is not bypassed by going through the collection.
+
+        Args:
+            two_day_collection: Collection of two overlapping tiles.
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            The collection forwards the window unchanged, so `merge_rasters`' checks
+            must still apply.
+        """
+        with pytest.raises(ValueError):
+            two_day_collection.merge(tmp_path / "bad.tif", bbox=(4.0, 1.0, 1.0, 3.0))

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -1768,3 +1768,63 @@ class TestCollectionMergeBbox:
         """
         with pytest.raises(ValueError):
             two_day_collection.merge(tmp_path / "bad.tif", bbox=(4.0, 1.0, 1.0, 3.0))
+
+
+class TestBboxAntimeridian:
+    """A window that wraps the antimeridian must be refused, not inverted."""
+
+    ANTIMERIDIAN_BBOX = (700000.0, 100000.0, 950000.0, 300000.0)
+    UTM_60N = 32660
+
+    @staticmethod
+    def _lonlat():
+        """Return the lon/lat CRS a global mosaic carries."""
+        return "EPSG:4326"
+
+    def test_wrapped_envelope_is_refused(self):
+        """A reprojection that wraps past 180 deg raises instead of inverting.
+
+        Test scenario:
+            `pyproj.transform_bounds` signals an antimeridian crossing by returning
+            west > east rather than by widening the envelope. This UTM 60N window is
+            about 2.25 deg wide and reprojects to (178.797, ..., -178.955); read at
+            face value that is a box spanning the long way round.
+        """
+        with pytest.raises(ValueError, match="crosses the antimeridian"):
+            merge_mod._bbox_in_projection(
+                self.ANTIMERIDIAN_BBOX, self.UTM_60N, self._lonlat()
+            )
+
+    def test_wrapped_window_does_not_become_its_complement(self):
+        """The wrapped window never resolves to the rest of the world.
+
+        Test scenario:
+            `_restrict_grid` sorts the two column offsets, so before this was caught
+            the ~2.25 deg request resolved to 35776 columns of a global 0.01 deg grid
+            — a 357.76 deg window, the complement of the one asked for. That is both
+            the wrong area and a near-global read from a call made to bound one.
+        """
+        global_grid = (-180.0, 0.01, 0.0, 90.0, 0.0, -0.01)
+        with pytest.raises(ValueError, match="crosses the antimeridian"):
+            merge_mod._restrict_grid(
+                global_grid,
+                36000,
+                18000,
+                self._lonlat(),
+                self.ANTIMERIDIAN_BBOX,
+                self.UTM_60N,
+            )
+
+    def test_an_ordinary_reprojected_window_still_passes(self):
+        """The guard rejects only wrapped envelopes, not every reprojection.
+
+        Test scenario:
+            A guard keyed on west > east would break every ordinary cross-CRS window
+            if reprojection could produce that ordering for other reasons; this
+            pins that it does not.
+        """
+        west, south, east, north = merge_mod._bbox_in_projection(
+            (500000.0, 100000.0, 600000.0, 300000.0), 32633, self._lonlat()
+        )
+        assert west < east, f"west {west} should stay below east {east}"
+        assert south < north, f"south {south} should stay below north {north}"

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -1475,6 +1475,8 @@ class TestBboxValidation:
             (12.0, TypeError, "a scalar is not a sequence"),
             ((1.0, 2.0, 3.0), ValueError, "three values is not a bbox"),
             ((1.0, 2.0, 3.0, 4.0, 5.0), ValueError, "five values is not a bbox"),
+            ((1.0, "south", 3.0, 4.0), TypeError, "a non-numeric element"),
+            ((1.0, None, 3.0, 4.0), TypeError, "None is not a coordinate"),
             ((1.0, float("nan"), 3.0, 4.0), ValueError, "NaN is not a coordinate"),
             ((1.0, 2.0, float("inf"), 4.0), ValueError, "inf is not a coordinate"),
             ((4.0, 1.0, 1.0, 3.0), ValueError, "west > east is inverted"),

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -1826,9 +1826,7 @@ class TestCollectionMergeBbox:
             [1.0, 4.0], [1.0, 3.0], from_crs=4326, to_crs=3857, precision=None
         )
         out = tmp_path / "win_crs.tif"
-        two_day_collection.merge(
-            out, bbox=(xs[0], ys[0], xs[1], ys[1]), bbox_crs=3857
-        )
+        two_day_collection.merge(out, bbox=(xs[0], ys[0], xs[1], ys[1]), bbox_crs=3857)
         ds = gdal.Open(str(out))
         assert 3 <= ds.RasterXSize <= 4, f"expected ~3 cols, got {ds.RasterXSize}"
         assert 2 <= ds.RasterYSize <= 3, f"expected ~2 rows, got {ds.RasterYSize}"
@@ -1985,7 +1983,12 @@ class TestBboxLongitudeConvention:
             as longitudes would corrupt every projected window.
         """
         _, x_size, y_size = merge_mod._restrict_grid(
-            (0.0, 1.0, 0.0, 4.0, 0.0, -1.0), 6, 4, "EPSG:3857", (1.0, 1.0, 4.0, 3.0), None
+            (0.0, 1.0, 0.0, 4.0, 0.0, -1.0),
+            6,
+            4,
+            "EPSG:3857",
+            (1.0, 1.0, 4.0, 3.0),
+            None,
         )
         assert (x_size, y_size) == (3, 2), f"expected 3x2, got {x_size}x{y_size}"
 
@@ -2009,7 +2012,9 @@ class TestReduceWindowPrunesSources:
         paths = []
         for index in range(6):
             path = tmp_path / f"tile{index}.tif"
-            write_raster(path, np.full((4, 4), float(index), dtype="float32"), (index * 4, 4))
+            write_raster(
+                path, np.full((4, 4), float(index), dtype="float32"), (index * 4, 4)
+            )
             paths.append(str(path))
 
         calls = []
@@ -2020,7 +2025,9 @@ class TestReduceWindowPrunesSources:
             return real_warp(*args, **kwargs)
 
         monkeypatch.setattr(merge_mod.gdal, "Warp", counting_warp)
-        merge_rasters(paths, tmp_path / "win.tif", method="max", bbox=(1.0, 1.0, 3.0, 3.0))
+        merge_rasters(
+            paths, tmp_path / "win.tif", method="max", bbox=(1.0, 1.0, 3.0, 3.0)
+        )
         assert len(calls) == 1, (
             f"a window inside one tile should warp one source, got {len(calls)} warps"
         )

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -1321,7 +1321,7 @@ class TestMergeRastersBbox:
     def test_bbox_in_another_crs_selects_the_same_area(
         self, overlapping_pair, tmp_path, method
     ):
-        """``epsg=`` lets the bbox stay in the caller's own CRS.
+        """``bbox_crs=`` lets the bbox stay in the caller's own CRS.
 
         Args:
             overlapping_pair: Two 4x4 rasters on a shared EPSG:4326 union grid.
@@ -1344,7 +1344,7 @@ class TestMergeRastersBbox:
         bbox_3857 = (xs[0], ys[0], xs[1], ys[1])
         out = tmp_path / f"m_{method}.tif"
         merge_rasters(
-            list(overlapping_pair), out, method=method, bbox=bbox_3857, epsg=3857
+            list(overlapping_pair), out, method=method, bbox=bbox_3857, bbox_crs=3857
         )
         x_size, y_size, _ = self._grid(out)
         assert 3 <= x_size <= 4, f"{method}: expected ~3 cols, got {x_size}"
@@ -1441,8 +1441,8 @@ class TestRestrictGrid:
 class TestBboxInProjection:
     """Unit tests for the bbox reprojection helper."""
 
-    def test_passthrough_when_no_epsg_given(self):
-        """With ``epsg=None`` the bbox is already in the target CRS.
+    def test_passthrough_when_no_bbox_crs_given(self):
+        """With ``bbox_crs=None`` the bbox is already in the target CRS.
 
         Test scenario:
             No reprojection should occur, and no CRS is needed to decide that.

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -1948,3 +1948,67 @@ class TestBboxLongitudeConvention:
             (0.0, 1.0, 0.0, 4.0, 0.0, -1.0), 6, 4, "EPSG:3857", (1.0, 1.0, 4.0, 3.0), None
         )
         assert (x_size, y_size) == (3, 2), f"expected 3x2, got {x_size}x{y_size}"
+
+
+class TestReduceWindowPrunesSources:
+    """The reduction path skips sources the window does not touch."""
+
+    def test_narrow_window_does_not_warp_every_source(self, tmp_path, monkeypatch):
+        """A narrow window warps only the sources it overlaps.
+
+        Args:
+            tmp_path: pytest temp directory.
+            monkeypatch: Used to count `gdal.Warp` calls.
+
+        Test scenario:
+            A strip spans the windowed grid's width, but the per-source prune tested
+            latitude only. On a wide east-west mosaic every source shares the same
+            latitude band, so all of them were warped per strip however narrow the
+            window — the exact cost the window exists to avoid.
+        """
+        paths = []
+        for index in range(6):
+            path = tmp_path / f"tile{index}.tif"
+            write_raster(path, np.full((4, 4), float(index), dtype="float32"), (index * 4, 4))
+            paths.append(str(path))
+
+        calls = []
+        real_warp = gdal.Warp
+
+        def counting_warp(*args, **kwargs):
+            calls.append(kwargs.get("outputBounds"))
+            return real_warp(*args, **kwargs)
+
+        monkeypatch.setattr(merge_mod.gdal, "Warp", counting_warp)
+        merge_rasters(paths, tmp_path / "win.tif", method="max", bbox=(1.0, 1.0, 3.0, 3.0))
+        assert len(calls) == 1, (
+            f"a window inside one tile should warp one source, got {len(calls)} warps"
+        )
+
+    def test_pruning_does_not_drop_needed_sources(self, tmp_path):
+        """A window spanning several tiles still reduces all of them.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            An east/west prune that is too eager would silently drop contributing
+            sources, leaving no-data where real values belong.
+        """
+        for index in range(3):
+            write_raster(
+                tmp_path / f"t{index}.tif",
+                np.full((4, 4), float(index + 1), dtype="float32"),
+                (index * 4, 4),
+            )
+        out = tmp_path / "spanning.tif"
+        merge_rasters(
+            sorted(str(p) for p in tmp_path.glob("t*.tif")),
+            out,
+            method="max",
+            bbox=(0.0, 0.0, 12.0, 4.0),
+        )
+        values = Dataset.read_file(str(out)).read_array()
+        assert np.nanmax(values) == 3.0, (
+            f"the easternmost tile must still contribute, got max {np.nanmax(values)}"
+        )

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -1501,6 +1501,30 @@ class TestBboxValidation:
         with pytest.raises(exc):
             merge_mod._validated_bbox(bad)
 
+    @pytest.mark.parametrize(
+        "accepted",
+        [
+            np.array([1.0, 1.0, 4.0, 3.0]),
+            [1.0, 1.0, 4.0, 3.0],
+            (1, 1, 4, 3),
+        ],
+        ids=["ndarray", "list", "ints"],
+    )
+    def test_accepts_any_iterable_of_four_numbers(self, accepted):
+        """A bbox need not be a `Sequence` to be accepted.
+
+        Args:
+            accepted: A well-formed bbox in a container that should be allowed.
+
+        Test scenario:
+            `np.ndarray` does not register as a `collections.abc.Sequence`, so an
+            isinstance check on that ABC rejected `GeoDataFrame.total_bounds` — the
+            most natural way a caller in this codebase produces a bbox.
+        """
+        assert merge_mod._validated_bbox(accepted) == (1.0, 1.0, 4.0, 3.0), (
+            f"{type(accepted).__name__} should be accepted as a bbox"
+        )
+
     @pytest.mark.parametrize("method", ["last", "max"])
     def test_malformed_bbox_rejected_on_both_paths(
         self, overlapping_pair, tmp_path, method

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -1689,6 +1689,42 @@ class TestBboxGridGeometry:
                 (0.0, 0.0, 0.0, 4.0, 0.0, -1.0), 6, 4, "", (1.0, 1.0, 4.0, 3.0), None
             )
 
+    def test_degenerately_thin_window_is_diagnosed_as_thin(self):
+        """A sub-tolerance window inside the mosaic is not called disjoint.
+
+        Test scenario:
+            The tolerance is applied inward at both edges, so a box starting on a
+            pixel boundary and spanning less than it snaps to zero width while
+            sitting squarely inside the mosaic. Reporting "does not overlap" sent
+            the caller to inspect their extents instead of their box width.
+        """
+        with pytest.raises(ValueError, match="selects no whole pixel"):
+            merge_mod._restrict_grid(
+                (0.0, 1.0, 0.0, 4.0, 0.0, -1.0),
+                6,
+                4,
+                "",
+                (1.0, 1.0, 1.0000001, 3.0),
+                None,
+            )
+
+    def test_disjoint_window_is_still_diagnosed_as_disjoint(self):
+        """A box that genuinely misses the mosaic keeps the overlap message.
+
+        Test scenario:
+            The thin-window check runs first, so it must not swallow the disjoint
+            case it was split out from.
+        """
+        with pytest.raises(ValueError, match="does not overlap"):
+            merge_mod._restrict_grid(
+                (0.0, 1.0, 0.0, 4.0, 0.0, -1.0),
+                6,
+                4,
+                "",
+                (100.0, 100.0, 104.0, 103.0),
+                None,
+            )
+
     def test_edge_on_a_pixel_boundary_adds_no_extra_pixel(self):
         """A window landing exactly on grid lines yields exactly that many pixels.
 


### PR DESCRIPTION
# Description

`merge_rasters` had no way to limit a merge to an area of interest, so it materialised the **full extent** of every
source. For a remote source that means pulling the whole scene through `/vsicurl` to keep a fraction of it. Verified
against the reporter's own href before writing any code:

```
source grid : 10980 x 10980 | bands 1        # a full Sentinel-2 MGRS tile, ~110x110 km
merge VRT   : 10980 x 10980 = 120560400 px   # rebuilt with merge_rasters' exact options
```

Neither path had anything to restrict it: `BuildVRTOptions` was given no `outputBounds`, and `TranslateOptions` no
`projWin`. A ~20x14 km AOI therefore cost a ~236 MiB transfer.

This adds keyword-only **`bbox`** and **`bbox_crs`**, threaded through the callers that build a mosaic:
`DatasetCollection.merge` and `pyramids merge --bbox ... --bbox-crs ...`.

## One window, resolved once, shared by both paths

The two merge methods have different mechanics, and the interesting part of this change is making them agree
**exactly** rather than approximately:

- **z-order** (`first` / `last`) writes through `gdal.Translate`.
- **reduce** (`min` / `max` / `sum`) clips the union grid. Bounding the strip loop alone would not have been enough:
  the output is `gdal.Create`d at the template's full size *before* the loop runs, so the whole union would still be
  allocated and read.

An earlier revision let each path resolve the window independently — z-order by handing GDAL a `projWin` plus
`projWinSRS`, reduce by reprojecting the envelope itself. That is what the first review round caught: under
`dst_crs=3857` the same arguments produced **3x3 at x=111364.8** from one path and **4x3 at x=0.0** from the other.
Both were defensible roundings of the same request; neither matched.

Now `_restrict_grid` resolves the window **once** against the union grid and both paths consume its result — z-order
receives a pre-snapped `projWin` in the mosaic's own CRS and no `projWinSRS` at all, so GDAL is never asked to
reproject a second time. The window is snapped **outward** onto the union's own pixels (with a small float
tolerance, so an edge landing on a grid line does not buy a spurious extra row), keeping the result a strict
sub-grid — the strip reduction stays byte-identical to a whole-grid pass over the same area. A test asserts the two
paths return an identical grid for native, reprojected, and `dst_crs`-reprojected windows.

## Failure modes found while testing

None of these are in the report; each is covered by a test.

- **GDAL does not treat a disjoint `projWin` as an error.** It wrote a **1x1 raster of no-data at geotransform
  origin `(0, 0)`** — a successful-looking merge of nothing. Both paths now reject it with one shared message.
- **A reprojected rectangle is a curved quadrilateral, and its extremum lies in an edge's *interior*, not at a
  corner.** A four-corner envelope is not enough: measured on EPSG:3035 -> EPSG:4326, it fell **0.0352 deg (~3.9 km)**
  short of the true north edge, silently cutting inside the requested area. `_bbox_in_projection` therefore delegates
  to the existing `pyramids.feature.bbox.transform`, which densifies the edges via
  `pyproj.Transformer.transform_bounds`; the same case now falls **0.00072 deg** short. The test first asserts the CRS
  pair actually curves, then asserts the densified bound is reached — a 4326/3857 pair would have passed either way.
- **A bbox outside the target CRS's domain reprojects to non-finite coordinates**, which would flow into the grid
  arithmetic and yield a nonsense window rather than an error.
- **A skewed or zero-pixel geotransform** would be silently mis-georeferenced by window arithmetic that assumes an
  axis-aligned grid; both are now refused as defensive guards. (Review round 2 established that neither is
  reachable through `merge_rasters` — `gdal.BuildVRT` produces an axis-aligned union grid and skips south-up
  sources outright — so the south-up handling and its test are labelled as helper-level invariants, not as
  evidence that pyramids merges such rasters.)
- **`bbox` was unvalidated**, so `"1234"` unpacked into four coordinates and became a window, and a `NaN` surfaced
  from deep in the arithmetic as `cannot convert float NaN to integer`. `_validated_bbox` rejects the wrong type,
  wrong length, non-finite, inverted, and zero-area cases up front, identically for both paths.

`bbox=None` is unchanged: the default merges the full extent exactly as before.

# Issues

- Closes #1064 — `merge_rasters` reads every source's full extent with no way to restrict it to an area of interest

## Type of change

Check relevant points.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

Additive and keyword-only; every existing call keeps its current behaviour.

# How Has This Been Tested?

**Full suite:** `pytest tests -m "not plot"` -> **8938 passed**, 80 skipped, 49 deselected, 4 failed in 539s. All 4
failures were run against unmodified `main` in the same environment and fail identically there — a stale local
cleopatra (`ModuleNotFoundError: No module named 'cleopatra.styling'`), plus a lazy-import and a
cross-process-pickle test that are environment-dependent. This branch introduces **zero** new failures.

**Merge suite:** **144 passing** in `tests/dataset/spatial/test_merge.py` — 77 pre-existing (untouched) and 67
new — plus 5 new `merge` cases in `tests/cli/test_cli_commands.py`.

**Coverage:** `merge.py` at **98%** line + branch, with **every line this branch adds covered**; the three
remaining misses are all pre-existing. Measuring it needed `dask.array` *and* `pyproj` imported before coverage
starts — under the tracer `dask.array.fft` reads `np.fft.fft.__module__` as `None`, and pyproj's enum lookup raises
`Invalid value supplied 'TransformDirection.FORWARD'`, which failed every reprojection test and made that whole
block look untested.

- [x] Every method (`first`, `last`, `min`, `max`, `sum`) writes only the windowed sub-grid.
- [x] The two paths return an **identical** output grid — same size, same origin — for a native window, a
      reprojected window, and a window reprojected under `dst_crs`. This is the regression guard for the 3x3-vs-4x3
      disagreement described above.
- [x] The window holds the **same pixels** the full merge puts there — asserted against the equivalent slice, since
      a shape-only check would pass with the window taken from the wrong place.
- [x] The windowed grid stays aligned to the full grid: same cell size, origin on a whole-pixel offset — a window
      that shifted off-grid would silently resample.
- [x] `bbox_crs=` selects the same area when the bbox is given in another CRS, and the envelope reaches the
      densified bound on a strongly curved CRS pair.
- [x] Antimeridian and longitude-convention seams are refused rather than silently inverted.
- [x] `pyramids merge --bbox` / `--bbox-crs`, including `--bbox-crs` without `--bbox` being refused.
- [x] A disjoint bbox raises for **every** method (the 1x1-raster trap above).
- [x] Malformed bboxes are rejected identically on both paths.
- [x] Grid geometry: south-up grids resolve, skewed and zero-pixel geotransforms are refused, and a window landing
      exactly on grid lines yields exactly that many pixels.
- [x] `bbox=None` still merges the full extent, including through `DatasetCollection.merge`.

All 19 pre-commit hooks pass (ruff, ruff-format, mypy, bandit, checkov included).

## Correctness issues found and fixed in review

Two rounds of review ran over the diff. The findings worth calling out:

- **A reprojected window crossing the antimeridian became its own complement.** `transform_bounds` signals the
  crossing by returning `west > east`; the grid helper sorted the two edges and accepted it. A UTM 60N window
  ~2.25 deg wide resolved to a **357.76 deg** window on a global grid — wrong area, and a near-global read from a
  call whose only purpose is to bound one. Now rejected.
- **A `-180..180` window against a `0..360` mosaic** silently returned the partial overlap. The window is now
  rewritten into the mosaic's own longitude convention first, using the `normalise_longitude` helper the codebase
  already had and merge was the only consumer not using.
- **The reduction path pruned sources by latitude only**, so a narrow window still warped every source in the same
  latitude band once per strip — the exact cost the window exists to avoid. Verified by counting `gdal.Warp` calls:
  six down to one.
- **A `numpy` array bbox was rejected**, `GeoDataFrame.total_bounds` included, because `ndarray` does not register
  as a `collections.abc.Sequence`.
- **A window thinner than the snap tolerance reported "does not overlap the mosaic"** while sitting inside it,
  sending the reader to check their extents rather than their box.

# Checklist:

- [ ] updated version number in pyproject.toml. — *not applicable: commitizen owns versioning*
- [ ] added changes to History.rst. — *not applicable: the changelog is generated*
- [ ] updated the latest version in README file. — *not applicable*
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. — Google-style docstrings for `bbox` / `bbox_crs` on every entry point and all
      four new helpers, the `merge` subcommand's synopsis in the CLI module docstring, and `docs/reference/cli.md`.
