### PR TITLE
fix(netcdf): return the MDArray for a non-numeric variable instead of raising

### DIFF
--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4942,15 +4942,16 @@ class NetCDF(Dataset):
         view's geotransform to match. See :meth:`_y_axis_is_bottom_up` /
         :meth:`_x_axis_is_right_to_left` for how each decision is made.
 
-        A **non-numeric** variable (a character/string column, which GDAL cannot expose as a
-        raster) is returned as the raw `MDArray`, exactly like a 1-D variable — read it with
-        `Read()` (#1067).
+        A **non-numeric** variable — a string/character column or a compound (struct) type,
+        neither of which GDAL can expose as a raster — is returned as the raw `MDArray`
+        whatever its rank, exactly like a 1-D variable; read it with `Read()` (#1067).
 
         Returns a tuple `(classic_dataset, md_array, root_group, x_index,
         y_index, y_flipped, x_flipped)` so callers can keep the GDAL objects alive and
         reuse the resolved plane indices (`x_index`/`y_index` are `None` for a
-        1-D or non-numeric variable). `y_flipped` / `x_flipped` record which axes were reversed here; the eager
-        materialize path needs them to re-apply the same flips to the unreversed array.
+        1-D or non-numeric variable). `y_flipped` / `x_flipped` record which axes were reversed
+        here; the eager materialize path needs them to re-apply the same flips to the unreversed
+        array.
         `AsClassicDataset` returns a **view** whose C++ backing depends on the
         MDArray and root group; if the Python SWIG wrappers for those are
         garbage-collected the view becomes a dangling pointer (segfault on
@@ -4974,9 +4975,10 @@ class NetCDF(Dataset):
 
         if md_arr.GetDataType().GetClass() != gdal.GEDTC_NUMERIC:
             # `AsClassicDataset` exposes numeric arrays only ("Only arrays with numeric data types
-            # can be exposed as classic GDALDataset"). A character column is stored two-dimensionally
-            # (records x max string length), so `_resolve_spatial_dims` always resolves a pair for it
-            # (its last-two fallback never declines) and the raster view would raise. Return the
+            # can be exposed as classic GDALDataset"), so a string/character or compound array of
+            # any rank must not reach it. A character column is stored two-dimensionally
+            # (records x max string length), so `_resolve_spatial_dims` always resolves a pair for
+            # it (its last-two fallback never declines) and the raster view would raise. Return the
             # MDArray itself — the same shape the 1-D branch above returns — so the caller reads it
             # with `Read()` like any other array (#1067).
             return md_arr, md_arr, rg, None, None, False, False
@@ -5063,10 +5065,11 @@ class NetCDF(Dataset):
 
                 A variable GDAL cannot expose as a raster comes back as
                 the raw `gdal.MDArray` instead: a 1-D variable (a
-                coordinate axis or data series) and any **non-numeric**
-                variable — a character/string column, which NetCDF stores
-                two-dimensionally as `(records, max string length)`. Read
-                those with `Read()` (#1067).
+                coordinate axis or data series), and any **non-numeric**
+                variable of any rank — a character/string column (which
+                NetCDF stores two-dimensionally as
+                `(records, max string length)`) or a compound (struct)
+                type. Read those with `Read()` (#1067).
 
         Raises:
             ValueError: If `variable_name` is not present in the dataset.

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -5500,11 +5500,21 @@ class NetCDF(Dataset):
         cube._band_dim_values_map = {
             d.GetName(): NetCDF._read_band_dim_values(d) for d in band_dims
         }
+        band_count = getattr(cube, "_band_count", None)
+        if band_count is None:
+            # A variable GDAL cannot expose as a raster comes back as a raw `gdal.MDArray`, which
+            # has no band model at all (see `_read_md_array`: a 1-D variable, or a non-numeric one
+            # of any rank). Rank <= 2 exits at the `band_dims` branch above, but a rank >= 3 raw
+            # array reaches here, where deriving a primary band view would read the `_band_count`
+            # an MDArray does not have (#1067).
+            cube._band_dim_name = None
+            cube._band_dim_values = None
+            return
         cube._band_dim_name, cube._band_dim_values = NetCDF._derive_primary_band_view(
             cube._band_dim_names,
             cube._band_dim_values_map,
             cube._band_dim_sizes,
-            cube._band_count,
+            band_count,
         )
 
     @staticmethod

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -2752,8 +2752,10 @@ class NetCDF(Dataset):
         Returns:
             bool: ``True`` when the variable has at least two dimensions with a
             recognised ``(y, x)`` pair among them; ``False`` for a 1-D / scalar
-            auxiliary variable, a 2-D variable with no spatial axes, or a name
-            that cannot be opened as an MDArray.
+            auxiliary variable, a 2-D variable with no spatial axes, a
+            **non-numeric** (character/compound) variable GDAL cannot rasterise
+            whatever its dimensions are named, or a name that cannot be opened as
+            an MDArray.
 
         Examples:
             - A gridded ``t2m(valid_time, lat, lon)`` variable is spatial, so
@@ -2775,6 +2777,16 @@ class NetCDF(Dataset):
         """
         md = open_mdarray(rg, var_name)
         if md is None:
+            return False
+        if md.GetDataType().GetClass() != gdal.GEDTC_NUMERIC:
+            # GDAL cannot expose a non-numeric array as a raster, so it can never be operated on
+            # spatially however its dimensions are named. Without this, a character or compound
+            # variable gridded over `lat`/`lon` is classed spatial, handed to `get_variable`, and
+            # comes back as the raw MDArray `_read_md_array` returns — which the container fan-out
+            # then calls `crop`/`to_crs`/`reduce` on. Classing it auxiliary instead lets
+            # `_carry_aux_variables` copy it through untouched, so those ops succeed on a mixed
+            # file, and keeps this "can GDAL rasterise it?" decision in step with the one in
+            # `_read_md_array` (#1067).
             return False
         var_dims = [d.GetName() for d in md.GetDimensions()]
         if len(var_dims) < 2:
@@ -5056,6 +5068,9 @@ class NetCDF(Dataset):
                 omitted, the latitude dimension is auto-detected, else
                 the second-to-last dimension is used.
 
+                Both are ignored for a variable that has no raster plane to
+                map them onto — a 1-D or non-numeric one (see `Returns`).
+
         Returns:
             NetCDF | gdal.MDArray: A subset backed by a classic dataset where every
                 non-spatial dimension is mapped onto bands. The new
@@ -5484,12 +5499,20 @@ class NetCDF(Dataset):
         array) when available, else the last two. The legacy `_band_dim_name`/`_band_dim_values`
         fields point at the first non-spatial dim so existing 3-D consumers are unaffected.
 
-        `cube` may be a raw `gdal.MDArray` with no band model (see `_read_md_array`). The
-        per-dimension `_band_dim_names` / `_band_dim_sizes` / `_band_dim_values_map` tracking is
-        still recorded for it, but the legacy pair is left as `None`: deriving a primary band view
-        needs a band count the MDArray does not have (#1067).
+        `cube` may be a raw `gdal.MDArray` with no band model (see `_read_md_array`), in which case
+        all five fields are cleared to the same empty defaults the no-band-dimension case uses —
+        there is no raster plane to split its axes around, so any tracking derived here would
+        describe a band model that does not exist (#1067).
         """
-        if len(dims) > 2:
+        if not isinstance(cube, NetCDF):
+            # A variable GDAL cannot expose as a raster comes back as a raw `gdal.MDArray` (see
+            # `_read_md_array`: a 1-D variable, or a non-numeric one of any rank), which has no
+            # band model to describe. Clear the tracking rather than deriving it: the last-two-
+            # dimensions-are-spatial fallback below would invent a band split for axes that are
+            # not a raster plane (a string column's trailing axis is its max length), and
+            # `_read_band_dim_values` would pay a real coordinate read to record it (#1067).
+            band_dims = []
+        elif len(dims) > 2:
             spatial = (
                 set(spatial_dim_indices)
                 if spatial_dim_indices is not None
@@ -5512,21 +5535,11 @@ class NetCDF(Dataset):
         cube._band_dim_values_map = {
             d.GetName(): NetCDF._read_band_dim_values(d) for d in band_dims
         }
-        band_count = getattr(cube, "_band_count", None)
-        if band_count is None:
-            # A variable GDAL cannot expose as a raster comes back as a raw `gdal.MDArray`, which
-            # has no band model at all (see `_read_md_array`: a 1-D variable, or a non-numeric one
-            # of any rank). Rank <= 2 exits at the `band_dims` branch above, but a rank >= 3 raw
-            # array reaches here, where deriving a primary band view would read the `_band_count`
-            # an MDArray does not have (#1067).
-            cube._band_dim_name = None
-            cube._band_dim_values = None
-            return
         cube._band_dim_name, cube._band_dim_values = NetCDF._derive_primary_band_view(
             cube._band_dim_names,
             cube._band_dim_values_map,
             cube._band_dim_sizes,
-            band_count,
+            cube._band_count,
         )
 
     @staticmethod

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -5057,7 +5057,7 @@ class NetCDF(Dataset):
                 the second-to-last dimension is used.
 
         Returns:
-            NetCDF: A subset backed by a classic dataset where every
+            NetCDF | gdal.MDArray: A subset backed by a classic dataset where every
                 non-spatial dimension is mapped onto bands. The new
                 `_band_dim_names` / `_band_dim_values_map` /
                 `_band_dim_sizes` fields drive `sel()`; the legacy
@@ -5067,10 +5067,11 @@ class NetCDF(Dataset):
                 A variable GDAL cannot expose as a raster comes back as
                 the raw `gdal.MDArray` instead: a 1-D variable (a
                 coordinate axis or data series), and any **non-numeric**
-                variable of any rank — a character/string column (which
-                NetCDF stores two-dimensionally as
-                `(records, max string length)`) or a compound (struct)
-                type. Read those with `Read()` (#1067).
+                variable of any rank — a character/string column
+                (however the driver exposes it) or a compound (struct)
+                type. Such a raw array carries no band model, so the
+                band-dim tracking above is only partly populated. Read
+                it with `Read()` (#1067).
 
         Raises:
             ValueError: If `variable_name` is not present in the dataset.
@@ -5426,7 +5427,9 @@ class NetCDF(Dataset):
         When `md_arr` is `None` (e.g. the file-backed gdal.Open path) the band/attr metadata is
         cleared to empty defaults. `cube` may also be a raw `gdal.MDArray` rather than a `NetCDF`
         — a 1-D variable, or a non-numeric one of any rank (see `_read_md_array`) — which has no
-        band model, so the helpers below fall back rather than read band attributes off it.
+        band model, so `_track_band_dimensions` and `_apply_attribute_no_data` fall back rather
+        than read band attributes off it. `_copy_variable_attrs` is unaffected — it reads the
+        MDArray, not the cube.
         """
         if md_arr is None:
             self._clear_variable_metadata(cube)
@@ -5480,6 +5483,11 @@ class NetCDF(Dataset):
         The spatial (X/Y) dimensions are taken from `spatial_dim_indices` (resolved on the unflipped
         array) when available, else the last two. The legacy `_band_dim_name`/`_band_dim_values`
         fields point at the first non-spatial dim so existing 3-D consumers are unaffected.
+
+        `cube` may be a raw `gdal.MDArray` with no band model (see `_read_md_array`). The
+        per-dimension `_band_dim_names` / `_band_dim_sizes` / `_band_dim_values_map` tracking is
+        still recorded for it, but the legacy pair is left as `None`: deriving a primary band view
+        needs a band count the MDArray does not have (#1067).
         """
         if len(dims) > 2:
             spatial = (

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4975,12 +4975,13 @@ class NetCDF(Dataset):
 
         if md_arr.GetDataType().GetClass() != gdal.GEDTC_NUMERIC:
             # `AsClassicDataset` exposes numeric arrays only ("Only arrays with numeric data types
-            # can be exposed as classic GDALDataset"), so a string/character or compound array of
-            # any rank must not reach it. A character column is stored two-dimensionally
-            # (records x max string length), so `_resolve_spatial_dims` always resolves a pair for
-            # it (its last-two fallback never declines) and the raster view would raise. Return the
-            # MDArray itself — the same shape the 1-D branch above returns — so the caller reads it
-            # with `Read()` like any other array (#1067).
+            # can be exposed as classic GDALDataset"), so the test is on the dtype *class* — string
+            # (however the driver exposes a character column) or compound — not on any particular
+            # shape. Rank alone cannot save such an array: `_resolve_spatial_dims` resolves a pair
+            # for anything with >= 2 dimensions (its last-two fallback never declines), which is how
+            # a character column reached the raster view and raised (#1067). Return the MDArray
+            # itself — the same shape the 1-D branch above returns — so the caller reads it with
+            # `Read()` like any other array.
             return md_arr, md_arr, rg, None, None, False, False
 
         # Resolve on the original array — the flips below rename the reversed dimensions and drop
@@ -5023,7 +5024,7 @@ class NetCDF(Dataset):
 
     def get_variable(
         self, variable_name: str, x_dim: str | None = None, y_dim: str | None = None
-    ) -> NetCDF:
+    ) -> NetCDF | gdal.MDArray:
         """Extract a single variable as a classic-raster NetCDF object.
 
         The returned object carries origin metadata so modified data
@@ -5422,8 +5423,10 @@ class NetCDF(Dataset):
     ) -> None:
         """Populate band-dim tracking, variable attributes, and packing on a variable subset.
 
-        When `md_arr` is `None` (e.g. the file-backed gdal.Open path or a 1-D string variable) the
-        band/attr metadata is cleared to empty defaults.
+        When `md_arr` is `None` (e.g. the file-backed gdal.Open path) the band/attr metadata is
+        cleared to empty defaults. `cube` may also be a raw `gdal.MDArray` rather than a `NetCDF`
+        — a 1-D variable, or a non-numeric one of any rank (see `_read_md_array`) — which has no
+        band model, so the helpers below fall back rather than read band attributes off it.
         """
         if md_arr is None:
             self._clear_variable_metadata(cube)
@@ -5445,7 +5448,8 @@ class NetCDF(Dataset):
         attributes and record it on the Python-side per-band list that :attr:`no_data_value` and the
         plot mask read. The view ignores ``SetNoDataValue``, so only the wrapper list is updated.
 
-        A 1-D variable comes back as a raw ``gdal.MDArray`` with no band model (no
+        A variable GDAL cannot expose as a raster — a 1-D one, or a non-numeric one of any rank
+        (see :meth:`_read_md_array`) — comes back as a raw ``gdal.MDArray`` with no band model (no
         ``_no_data_value``), so there is nothing to stamp and it is left untouched.
         """
         current = getattr(cube, "_no_data_value", None)

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4942,10 +4942,14 @@ class NetCDF(Dataset):
         view's geotransform to match. See :meth:`_y_axis_is_bottom_up` /
         :meth:`_x_axis_is_right_to_left` for how each decision is made.
 
+        A **non-numeric** variable (a character/string column, which GDAL cannot expose as a
+        raster) is returned as the raw `MDArray`, exactly like a 1-D variable — read it with
+        `Read()` (#1067).
+
         Returns a tuple `(classic_dataset, md_array, root_group, x_index,
         y_index, y_flipped, x_flipped)` so callers can keep the GDAL objects alive and
         reuse the resolved plane indices (`x_index`/`y_index` are `None` for a
-        1-D variable). `y_flipped` / `x_flipped` record which axes were reversed here; the eager
+        1-D or non-numeric variable). `y_flipped` / `x_flipped` record which axes were reversed here; the eager
         materialize path needs them to re-apply the same flips to the unreversed array.
         `AsClassicDataset` returns a **view** whose C++ backing depends on the
         MDArray and root group; if the Python SWIG wrappers for those are
@@ -4966,6 +4970,15 @@ class NetCDF(Dataset):
             # A classic 2-D raster view needs >=2 dimensions, so AsClassicDataset cannot represent a
             # 1-D variable (a coordinate axis or a 1-D data series). Return the MDArray itself, matching
             # the 1-D string path and avoiding GDAL's "Invalid iXDim and/or iYDim" error (#582).
+            return md_arr, md_arr, rg, None, None, False, False
+
+        if md_arr.GetDataType().GetClass() != gdal.GEDTC_NUMERIC:
+            # `AsClassicDataset` exposes numeric arrays only ("Only arrays with numeric data types
+            # can be exposed as classic GDALDataset"). A character column is stored two-dimensionally
+            # (records x max string length), so `_resolve_spatial_dims` always resolves a pair for it
+            # (its last-two fallback never declines) and the raster view would raise. Return the
+            # MDArray itself — the same shape the 1-D branch above returns — so the caller reads it
+            # with `Read()` like any other array (#1067).
             return md_arr, md_arr, rg, None, None, False, False
 
         # Resolve on the original array — the flips below rename the reversed dimensions and drop
@@ -5047,6 +5060,13 @@ class NetCDF(Dataset):
                 `_band_dim_sizes` fields drive `sel()`; the legacy
                 `_band_dim_name` / `_band_dim_values` track the first
                 non-spatial dim.
+
+                A variable GDAL cannot expose as a raster comes back as
+                the raw `gdal.MDArray` instead: a 1-D variable (a
+                coordinate axis or data series) and any **non-numeric**
+                variable — a character/string column, which NetCDF stores
+                two-dimensionally as `(records, max string length)`. Read
+                those with `Read()` (#1067).
 
         Raises:
             ValueError: If `variable_name` is not present in the dataset.

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -2752,10 +2752,8 @@ class NetCDF(Dataset):
         Returns:
             bool: ``True`` when the variable has at least two dimensions with a
             recognised ``(y, x)`` pair among them; ``False`` for a 1-D / scalar
-            auxiliary variable, a 2-D variable with no spatial axes, a
-            **non-numeric** (character/compound) variable GDAL cannot rasterise
-            whatever its dimensions are named, or a name that cannot be opened as
-            an MDArray.
+            auxiliary variable, a 2-D variable with no spatial axes, or a name
+            that cannot be opened as an MDArray.
 
         Examples:
             - A gridded ``t2m(valid_time, lat, lon)`` variable is spatial, so
@@ -2778,16 +2776,6 @@ class NetCDF(Dataset):
         md = open_mdarray(rg, var_name)
         if md is None:
             return False
-        if self._variable_is_non_numeric(rg, var_name):
-            # GDAL cannot expose a non-numeric array as a raster, so it can never be operated on
-            # spatially however its dimensions are named. Without this, a character or compound
-            # variable gridded over `lat`/`lon` is classed spatial, handed to `get_variable`, and
-            # comes back as the raw MDArray `_read_md_array` returns — which the container fan-out
-            # then calls `crop`/`to_crs`/`reduce` on. Classing it auxiliary instead lets
-            # `_carry_aux_variables` copy it through untouched, so those ops succeed on a mixed
-            # file, and keeps this "can GDAL rasterise it?" decision in step with the one in
-            # `_read_md_array` (#1067).
-            return False
         var_dims = [d.GetName() for d in md.GetDimensions()]
         if len(var_dims) < 2:
             return False
@@ -2795,28 +2783,6 @@ class NetCDF(Dataset):
             self._cf_spatial_axes(rg, var_dims) is not None
             or self._named_spatial_axes(var_dims) is not None
         )
-
-    @staticmethod
-    def _variable_is_non_numeric(rg: Any, var_name: str) -> bool:
-        """True when ``var_name``'s data type is one GDAL cannot expose as a raster.
-
-        GDAL sorts extended data types into three classes; only ``GEDTC_NUMERIC`` can back a
-        classic raster, so a character/string (``GEDTC_STRING``) or struct (``GEDTC_COMPOUND``)
-        variable is non-spatial by dtype alone — see :meth:`_read_md_array`, which returns such a
-        variable as a raw ``MDArray`` for the same reason (#1067).
-
-        Args:
-            rg: The root :class:`osgeo.gdal.Group` of the open store.
-            var_name: Name of the variable to classify.
-
-        Returns:
-            bool: ``True`` for a non-numeric variable; ``False`` for a numeric one or a name
-            that cannot be opened as an MDArray.
-        """
-        md = open_mdarray(rg, var_name)
-        if md is None:
-            return False
-        return bool(md.GetDataType().GetClass() != gdal.GEDTC_NUMERIC)
 
     def _spatial_variable_names(self, rg: Any = None) -> list[str]:
         """Names of the container's gridded variables (have a recognised (y, x) pair).
@@ -3251,10 +3217,6 @@ class NetCDF(Dataset):
         / ensemble / bounds) don't count, so a legitimately non-spatial N-D aux variable (e.g.
         ``(time, level)``) does not trip the warning. ``warn_demoted=False`` suppresses the message
         on the eager fallback recursion, which already warned on the outer call.
-
-        A **non-numeric** grid is demoted for a different reason — GDAL cannot rasterise it at all,
-        whatever its axes are called (see :meth:`_variable_is_spatial`) — so it gets its own message
-        rather than advice about axis metadata that would not help (#1067).
         """
         demoted = [
             n
@@ -3268,26 +3230,13 @@ class NetCDF(Dataset):
             )
             >= 2
         ]
-        if not (demoted and warn_demoted):
-            return
-        non_numeric = [n for n in demoted if self._variable_is_non_numeric(rg, n)]
-        unrecognised = [n for n in demoted if n not in non_numeric]
-        if unrecognised:
+        if demoted and warn_demoted:
             warnings.warn(
-                f"{operation}() is carrying {len(unrecognised)} multi-dimensional "
-                f"variable(s) {unrecognised} through unchanged because their axes were "
+                f"{operation}() is carrying {len(demoted)} multi-dimensional "
+                f"variable(s) {demoted} through unchanged because their axes were "
                 f"not recognised as spatial (no CF axis attributes or known x/y "
                 f"names); they will NOT be cropped/reprojected. Add CF axis "
                 f"metadata (standard_name / axis) or rename the axes to y/x.",
-                stacklevel=4,
-            )
-        if non_numeric:
-            warnings.warn(
-                f"{operation}() is carrying {len(non_numeric)} multi-dimensional "
-                f"variable(s) {non_numeric} through unchanged because their data type is "
-                f"not numeric, so GDAL cannot expose them as a raster; they will NOT be "
-                f"cropped/reprojected. This is independent of their axes — adding CF axis "
-                f"metadata will not change it.",
                 stacklevel=4,
             )
 
@@ -5107,9 +5056,6 @@ class NetCDF(Dataset):
                 omitted, the latitude dimension is auto-detected, else
                 the second-to-last dimension is used.
 
-                Both are ignored for a variable that has no raster plane to
-                map them onto — a 1-D or non-numeric one (see `Returns`).
-
         Returns:
             NetCDF | gdal.MDArray: A subset backed by a classic dataset where every
                 non-spatial dimension is mapped onto bands. The new
@@ -5538,20 +5484,12 @@ class NetCDF(Dataset):
         array) when available, else the last two. The legacy `_band_dim_name`/`_band_dim_values`
         fields point at the first non-spatial dim so existing 3-D consumers are unaffected.
 
-        `cube` may be a raw `gdal.MDArray` with no band model (see `_read_md_array`), in which case
-        all five fields are cleared to the same empty defaults the no-band-dimension case uses —
-        there is no raster plane to split its axes around, so any tracking derived here would
-        describe a band model that does not exist (#1067).
+        `cube` may be a raw `gdal.MDArray` with no band model (see `_read_md_array`). The
+        per-dimension `_band_dim_names` / `_band_dim_sizes` / `_band_dim_values_map` tracking is
+        still recorded for it, but the legacy pair is left as `None`: deriving a primary band view
+        needs a band count the MDArray does not have (#1067).
         """
-        if not isinstance(cube, NetCDF):
-            # A variable GDAL cannot expose as a raster comes back as a raw `gdal.MDArray` (see
-            # `_read_md_array`: a 1-D variable, or a non-numeric one of any rank), which has no
-            # band model to describe. Clear the tracking rather than deriving it: the last-two-
-            # dimensions-are-spatial fallback below would invent a band split for axes that are
-            # not a raster plane (a string column's trailing axis is its max length), and
-            # `_read_band_dim_values` would pay a real coordinate read to record it (#1067).
-            band_dims = []
-        elif len(dims) > 2:
+        if len(dims) > 2:
             spatial = (
                 set(spatial_dim_indices)
                 if spatial_dim_indices is not None
@@ -5574,11 +5512,21 @@ class NetCDF(Dataset):
         cube._band_dim_values_map = {
             d.GetName(): NetCDF._read_band_dim_values(d) for d in band_dims
         }
+        band_count = getattr(cube, "_band_count", None)
+        if band_count is None:
+            # A variable GDAL cannot expose as a raster comes back as a raw `gdal.MDArray`, which
+            # has no band model at all (see `_read_md_array`: a 1-D variable, or a non-numeric one
+            # of any rank). Rank <= 2 exits at the `band_dims` branch above, but a rank >= 3 raw
+            # array reaches here, where deriving a primary band view would read the `_band_count`
+            # an MDArray does not have (#1067).
+            cube._band_dim_name = None
+            cube._band_dim_values = None
+            return
         cube._band_dim_name, cube._band_dim_values = NetCDF._derive_primary_band_view(
             cube._band_dim_names,
             cube._band_dim_values_map,
             cube._band_dim_sizes,
-            cube._band_count,
+            band_count,
         )
 
     @staticmethod

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -2778,7 +2778,7 @@ class NetCDF(Dataset):
         md = open_mdarray(rg, var_name)
         if md is None:
             return False
-        if md.GetDataType().GetClass() != gdal.GEDTC_NUMERIC:
+        if self._variable_is_non_numeric(rg, var_name):
             # GDAL cannot expose a non-numeric array as a raster, so it can never be operated on
             # spatially however its dimensions are named. Without this, a character or compound
             # variable gridded over `lat`/`lon` is classed spatial, handed to `get_variable`, and
@@ -2795,6 +2795,28 @@ class NetCDF(Dataset):
             self._cf_spatial_axes(rg, var_dims) is not None
             or self._named_spatial_axes(var_dims) is not None
         )
+
+    @staticmethod
+    def _variable_is_non_numeric(rg: Any, var_name: str) -> bool:
+        """True when ``var_name``'s data type is one GDAL cannot expose as a raster.
+
+        GDAL sorts extended data types into three classes; only ``GEDTC_NUMERIC`` can back a
+        classic raster, so a character/string (``GEDTC_STRING``) or struct (``GEDTC_COMPOUND``)
+        variable is non-spatial by dtype alone — see :meth:`_read_md_array`, which returns such a
+        variable as a raw ``MDArray`` for the same reason (#1067).
+
+        Args:
+            rg: The root :class:`osgeo.gdal.Group` of the open store.
+            var_name: Name of the variable to classify.
+
+        Returns:
+            bool: ``True`` for a non-numeric variable; ``False`` for a numeric one or a name
+            that cannot be opened as an MDArray.
+        """
+        md = open_mdarray(rg, var_name)
+        if md is None:
+            return False
+        return bool(md.GetDataType().GetClass() != gdal.GEDTC_NUMERIC)
 
     def _spatial_variable_names(self, rg: Any = None) -> list[str]:
         """Names of the container's gridded variables (have a recognised (y, x) pair).
@@ -3229,6 +3251,10 @@ class NetCDF(Dataset):
         / ensemble / bounds) don't count, so a legitimately non-spatial N-D aux variable (e.g.
         ``(time, level)``) does not trip the warning. ``warn_demoted=False`` suppresses the message
         on the eager fallback recursion, which already warned on the outer call.
+
+        A **non-numeric** grid is demoted for a different reason — GDAL cannot rasterise it at all,
+        whatever its axes are called (see :meth:`_variable_is_spatial`) — so it gets its own message
+        rather than advice about axis metadata that would not help (#1067).
         """
         demoted = [
             n
@@ -3242,13 +3268,26 @@ class NetCDF(Dataset):
             )
             >= 2
         ]
-        if demoted and warn_demoted:
+        if not (demoted and warn_demoted):
+            return
+        non_numeric = [n for n in demoted if self._variable_is_non_numeric(rg, n)]
+        unrecognised = [n for n in demoted if n not in non_numeric]
+        if unrecognised:
             warnings.warn(
-                f"{operation}() is carrying {len(demoted)} multi-dimensional "
-                f"variable(s) {demoted} through unchanged because their axes were "
+                f"{operation}() is carrying {len(unrecognised)} multi-dimensional "
+                f"variable(s) {unrecognised} through unchanged because their axes were "
                 f"not recognised as spatial (no CF axis attributes or known x/y "
                 f"names); they will NOT be cropped/reprojected. Add CF axis "
                 f"metadata (standard_name / axis) or rename the axes to y/x.",
+                stacklevel=4,
+            )
+        if non_numeric:
+            warnings.warn(
+                f"{operation}() is carrying {len(non_numeric)} multi-dimensional "
+                f"variable(s) {non_numeric} through unchanged because their data type is "
+                f"not numeric, so GDAL cannot expose them as a raster; they will NOT be "
+                f"cropped/reprojected. This is independent of their axes — adding CF axis "
+                f"metadata will not change it.",
                 stacklevel=4,
             )
 

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -5056,6 +5056,9 @@ class NetCDF(Dataset):
                 omitted, the latitude dimension is auto-detected, else
                 the second-to-last dimension is used.
 
+                Both are ignored for a variable that has no raster plane to
+                map them onto — a 1-D or non-numeric one (see `Returns`).
+
         Returns:
             NetCDF | gdal.MDArray: A subset backed by a classic dataset where every
                 non-spatial dimension is mapped onto bands. The new
@@ -5484,10 +5487,11 @@ class NetCDF(Dataset):
         array) when available, else the last two. The legacy `_band_dim_name`/`_band_dim_values`
         fields point at the first non-spatial dim so existing 3-D consumers are unaffected.
 
-        `cube` may be a raw `gdal.MDArray` with no band model (see `_read_md_array`). The
-        per-dimension `_band_dim_names` / `_band_dim_sizes` / `_band_dim_values_map` tracking is
-        still recorded for it, but the legacy pair is left as `None`: deriving a primary band view
-        needs a band count the MDArray does not have (#1067).
+        `cube` may be a raw `gdal.MDArray` with no band model (see `_read_md_array`). A rank <= 2
+        one takes the empty-`band_dims` exit below, which clears all five fields; a rank >= 3 one
+        still gets the per-dimension `_band_dim_names` / `_band_dim_sizes` / `_band_dim_values_map`
+        tracking, but its legacy pair is left as `None`, because deriving a primary band view needs
+        a band count the MDArray does not have (#1067).
         """
         if len(dims) > 2:
             spatial = (

--- a/tests/netcdf/spatial/test_crop_nonspatial_aux.py
+++ b/tests/netcdf/spatial/test_crop_nonspatial_aux.py
@@ -376,6 +376,28 @@ class TestNonNumericGriddedAux:
             f"named, got {cube._spatial_variable_names()}"
         )
 
+    def test_demotion_warning_names_the_dtype_not_the_axes(self):
+        """The demotion warning blames the data type, not missing axis metadata (#1067).
+
+        Test scenario:
+            ``label(y, x)`` is demoted because GDAL cannot rasterise a string array, not
+            because its axes went unrecognised — they are literally ``y``/``x``. Expected: the
+            warning says so, and does not advise adding CF axis metadata, which would not help.
+        """
+        cube = _era5_like_cube(with_aux=False)
+        _attach_string_grid(cube, "label", ["y", "x"])
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            cube.crop(mask=_MASK, touch=True)
+        messages = [str(w.message) for w in caught if "label" in str(w.message)]
+        assert messages, f"a demotion warning naming 'label' is expected, got {caught}"
+        assert any("not numeric" in m for m in messages), (
+            f"the warning must name the data type as the reason, got {messages}"
+        )
+        assert not any("rename the axes to y/x" in m for m in messages), (
+            f"advising axis metadata is misleading for a dtype demotion, got {messages}"
+        )
+
 
 def _dim(name):
     """A Mock GDAL dimension whose ``GetName()`` returns ``name``."""

--- a/tests/netcdf/spatial/test_crop_nonspatial_aux.py
+++ b/tests/netcdf/spatial/test_crop_nonspatial_aux.py
@@ -318,6 +318,9 @@ def _fake_rg(var_dims, coord_attrs=None):
         if name in var_dims:
             md = Mock()
             md.GetDimensions.return_value = [_dim(d) for d in var_dims[name]]
+            # Model a real data variable: `_variable_is_spatial` also tests the dtype class, and a
+            # bare Mock reports one that is not GEDTC_NUMERIC — i.e. never spatial (#1067).
+            md.GetDataType.return_value.GetClass.return_value = gdal.GEDTC_NUMERIC
             return md
         if name in coord_attrs:
             coord = Mock()

--- a/tests/netcdf/spatial/test_crop_nonspatial_aux.py
+++ b/tests/netcdf/spatial/test_crop_nonspatial_aux.py
@@ -114,6 +114,34 @@ def _era5_like_cube(*, with_spatial=True, with_aux=True, with_second_spatial=Fal
     return nc
 
 
+def _attach_string_grid(nc, name, dim_names):
+    """Attach a string variable on existing root-group dimensions, straight through GDAL.
+
+    :func:`_attach` cannot express this — it builds a numeric ``ExtendedDataType`` and writes
+    a numpy buffer. The values are deliberately left unwritten: GDAL's SWIG bindings only
+    write a string MDArray of rank <= 1 (``MDArray.Write`` raises "not a unicode string,
+    bytes, bytearray or memoryview" above that), and only the dtype *class* drives the
+    classification under test.
+
+    Args:
+        nc: The in-memory container to attach the variable to.
+        name: Variable name.
+        dim_names: Ordered names of existing root-group dimensions for the variable's axes.
+
+    Returns:
+        Container: ``nc``, for chaining.
+    """
+    rg = nc._raster.GetRootGroup()
+    existing = {d.GetName(): d for d in (rg.GetDimensions() or [])}
+    rg.CreateMDArray(
+        name,
+        [existing[d] for d in dim_names],
+        gdal.ExtendedDataType.CreateString(),
+    )
+    nc._invalidate_caches()
+    return nc
+
+
 def _raw_values(cube, var_name):
     """Read a variable's raw MDArray values straight from the root group."""
     return np.asarray(cube._raster.GetRootGroup().OpenMDArray(var_name).ReadAsArray())
@@ -284,6 +312,69 @@ class TestMultiSpatialPlusAux:
         for name in ("t2m", "tp", "number"):
             assert name in cropped.variable_names, f"{name} should be in the result"
         assert cropped.get_variable("tp").band_count == 4, "tp keeps its 4 bands"
+
+
+_CONTAINER_OPS = {
+    "crop": lambda cube: cube.crop(mask=_MASK, touch=True),
+    "to_crs": lambda cube: cube.to_crs(3857),
+    "reduce": lambda cube: cube.reduce("valid_time", "mean"),
+}
+
+
+class TestNonNumericGriddedAux:
+    """A non-numeric variable on recognised y/x axes is auxiliary, so the fan-out survives it.
+
+    ``_variable_is_spatial`` used to classify purely by dimension names, so a character
+    variable gridded over ``y``/``x`` was called spatial, handed to ``get_variable``, and came
+    back as the raw ``gdal.MDArray`` GDAL cannot rasterise. The fan-out then called raster
+    methods on it and every container operation died with ``AttributeError: 'MDArray' object
+    has no attribute 'crop'`` / ``'to_crs'`` / ``'no_data_value'`` (#1067).
+    """
+
+    @pytest.mark.parametrize("op_name", list(_CONTAINER_OPS), ids=list(_CONTAINER_OPS))
+    def test_container_op_succeeds_and_keeps_both_variables(self, op_name):
+        """A container op completes on a mixed numeric/non-numeric grid (#1067).
+
+        Args:
+            op_name: Which container operation to fan out — ``crop``, ``to_crs`` or
+                ``reduce``, all three of which reached the raw MDArray before the fix.
+
+        Test scenario:
+            ``t2m(valid_time, y, x)`` (numeric) plus a string ``label(y, x)`` on the *same*
+            recognised axes — expected: the operation returns instead of raising, ``t2m`` is
+            still raster-backed in the result, and ``label`` is carried into it as an
+            auxiliary variable rather than being fed to the raster machinery.
+        """
+        cube = _era5_like_cube(with_aux=False)
+        _attach_string_grid(cube, "label", ["y", "x"])
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = _CONTAINER_OPS[op_name](cube)
+        assert "t2m" in result.variable_names, (
+            f"the numeric grid must survive {op_name}(), got {result.variable_names}"
+        )
+        assert "label" in result.variable_names, (
+            f"the non-numeric grid must be carried through {op_name}() as an auxiliary "
+            f"variable, got {result.variable_names}"
+        )
+        assert isinstance(result.get_variable("t2m"), NetCDF), (
+            "the numeric grid must still come back raster-backed, not as a raw MDArray"
+        )
+
+    def test_non_numeric_grid_is_not_listed_spatial(self):
+        """The string grid is excluded from the fan-out's spatial variable list.
+
+        Test scenario:
+            ``t2m(valid_time, y, x)`` plus ``label(y, x)`` — expected:
+            ``_spatial_variable_names() == ["t2m"]``. This is what routes ``label`` into
+            ``_carry_aux_variables`` instead of ``get_variable``.
+        """
+        cube = _era5_like_cube(with_aux=False)
+        _attach_string_grid(cube, "label", ["y", "x"])
+        assert cube._spatial_variable_names() == ["t2m"], (
+            "a non-numeric variable must never be listed spatial, whatever its axes are "
+            f"named, got {cube._spatial_variable_names()}"
+        )
 
 
 def _dim(name):

--- a/tests/netcdf/spatial/test_crop_nonspatial_aux.py
+++ b/tests/netcdf/spatial/test_crop_nonspatial_aux.py
@@ -114,34 +114,6 @@ def _era5_like_cube(*, with_spatial=True, with_aux=True, with_second_spatial=Fal
     return nc
 
 
-def _attach_string_grid(nc, name, dim_names):
-    """Attach a string variable on existing root-group dimensions, straight through GDAL.
-
-    :func:`_attach` cannot express this — it builds a numeric ``ExtendedDataType`` and writes
-    a numpy buffer. The values are deliberately left unwritten: GDAL's SWIG bindings only
-    write a string MDArray of rank <= 1 (``MDArray.Write`` raises "not a unicode string,
-    bytes, bytearray or memoryview" above that), and only the dtype *class* drives the
-    classification under test.
-
-    Args:
-        nc: The in-memory container to attach the variable to.
-        name: Variable name.
-        dim_names: Ordered names of existing root-group dimensions for the variable's axes.
-
-    Returns:
-        Container: ``nc``, for chaining.
-    """
-    rg = nc._raster.GetRootGroup()
-    existing = {d.GetName(): d for d in (rg.GetDimensions() or [])}
-    rg.CreateMDArray(
-        name,
-        [existing[d] for d in dim_names],
-        gdal.ExtendedDataType.CreateString(),
-    )
-    nc._invalidate_caches()
-    return nc
-
-
 def _raw_values(cube, var_name):
     """Read a variable's raw MDArray values straight from the root group."""
     return np.asarray(cube._raster.GetRootGroup().OpenMDArray(var_name).ReadAsArray())
@@ -314,91 +286,6 @@ class TestMultiSpatialPlusAux:
         assert cropped.get_variable("tp").band_count == 4, "tp keeps its 4 bands"
 
 
-_CONTAINER_OPS = {
-    "crop": lambda cube: cube.crop(mask=_MASK, touch=True),
-    "to_crs": lambda cube: cube.to_crs(3857),
-    "reduce": lambda cube: cube.reduce("valid_time", "mean"),
-}
-
-
-class TestNonNumericGriddedAux:
-    """A non-numeric variable on recognised y/x axes is auxiliary, so the fan-out survives it.
-
-    ``_variable_is_spatial`` used to classify purely by dimension names, so a character
-    variable gridded over ``y``/``x`` was called spatial, handed to ``get_variable``, and came
-    back as the raw ``gdal.MDArray`` GDAL cannot rasterise. The fan-out then called raster
-    methods on it and every container operation died with ``AttributeError: 'MDArray' object
-    has no attribute 'crop'`` / ``'to_crs'`` / ``'no_data_value'`` (#1067).
-    """
-
-    @pytest.mark.parametrize("op_name", list(_CONTAINER_OPS), ids=list(_CONTAINER_OPS))
-    def test_container_op_succeeds_and_keeps_both_variables(self, op_name):
-        """A container op completes on a mixed numeric/non-numeric grid (#1067).
-
-        Args:
-            op_name: Which container operation to fan out — ``crop``, ``to_crs`` or
-                ``reduce``, all three of which reached the raw MDArray before the fix.
-
-        Test scenario:
-            ``t2m(valid_time, y, x)`` (numeric) plus a string ``label(y, x)`` on the *same*
-            recognised axes — expected: the operation returns instead of raising, ``t2m`` is
-            still raster-backed in the result, and ``label`` is carried into it as an
-            auxiliary variable rather than being fed to the raster machinery.
-        """
-        cube = _era5_like_cube(with_aux=False)
-        _attach_string_grid(cube, "label", ["y", "x"])
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            result = _CONTAINER_OPS[op_name](cube)
-        assert "t2m" in result.variable_names, (
-            f"the numeric grid must survive {op_name}(), got {result.variable_names}"
-        )
-        assert "label" in result.variable_names, (
-            f"the non-numeric grid must be carried through {op_name}() as an auxiliary "
-            f"variable, got {result.variable_names}"
-        )
-        assert isinstance(result.get_variable("t2m"), NetCDF), (
-            "the numeric grid must still come back raster-backed, not as a raw MDArray"
-        )
-
-    def test_non_numeric_grid_is_not_listed_spatial(self):
-        """The string grid is excluded from the fan-out's spatial variable list.
-
-        Test scenario:
-            ``t2m(valid_time, y, x)`` plus ``label(y, x)`` — expected:
-            ``_spatial_variable_names() == ["t2m"]``. This is what routes ``label`` into
-            ``_carry_aux_variables`` instead of ``get_variable``.
-        """
-        cube = _era5_like_cube(with_aux=False)
-        _attach_string_grid(cube, "label", ["y", "x"])
-        assert cube._spatial_variable_names() == ["t2m"], (
-            "a non-numeric variable must never be listed spatial, whatever its axes are "
-            f"named, got {cube._spatial_variable_names()}"
-        )
-
-    def test_demotion_warning_names_the_dtype_not_the_axes(self):
-        """The demotion warning blames the data type, not missing axis metadata (#1067).
-
-        Test scenario:
-            ``label(y, x)`` is demoted because GDAL cannot rasterise a string array, not
-            because its axes went unrecognised — they are literally ``y``/``x``. Expected: the
-            warning says so, and does not advise adding CF axis metadata, which would not help.
-        """
-        cube = _era5_like_cube(with_aux=False)
-        _attach_string_grid(cube, "label", ["y", "x"])
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
-            cube.crop(mask=_MASK, touch=True)
-        messages = [str(w.message) for w in caught if "label" in str(w.message)]
-        assert messages, f"a demotion warning naming 'label' is expected, got {caught}"
-        assert any("not numeric" in m for m in messages), (
-            f"the warning must name the data type as the reason, got {messages}"
-        )
-        assert not any("rename the axes to y/x" in m for m in messages), (
-            f"advising axis metadata is misleading for a dtype demotion, got {messages}"
-        )
-
-
 def _dim(name):
     """A Mock GDAL dimension whose ``GetName()`` returns ``name``."""
     dim = Mock()
@@ -431,9 +318,6 @@ def _fake_rg(var_dims, coord_attrs=None):
         if name in var_dims:
             md = Mock()
             md.GetDimensions.return_value = [_dim(d) for d in var_dims[name]]
-            # Model a real data variable: `_variable_is_spatial` also tests the dtype class, and a
-            # bare Mock reports one that is not GEDTC_NUMERIC — i.e. never spatial (#1067).
-            md.GetDataType.return_value.GetClass.return_value = gdal.GEDTC_NUMERIC
             return md
         if name in coord_attrs:
             coord = Mock()

--- a/tests/netcdf/unit/test_netcdf_unit_read.py
+++ b/tests/netcdf/unit/test_netcdf_unit_read.py
@@ -108,16 +108,22 @@ class TestReadMdArrayNonNumeric:
 
     @staticmethod
     def _mixed_multidim(driver: str, path: str = "test"):
-        """Build a multidim dataset with a 2-D string and a 2-D numeric variable."""
+        """Build a multidim dataset mixing a character column and a numeric grid.
+
+        `units` is the string column — `(record, strlen)`, the layout a character variable has.
+        `obs` is a plain numeric grid on its own `(record, level)` axes rather than sharing the
+        string-length axis, which would be a meaningless grid to assert against.
+        """
         ds = gdal.GetDriverByName(driver).CreateMultiDimensional(path)
         rg = ds.GetRootGroup()
         records = rg.CreateDimension("record", None, None, 4)
         strlen = rg.CreateDimension("strlen", None, None, 3)
+        level = rg.CreateDimension("level", None, None, 3)
         rg.CreateMDArray(
             "units", [records, strlen], gdal.ExtendedDataType.CreateString()
         )
         numeric = rg.CreateMDArray(
-            "obs", [records, strlen], gdal.ExtendedDataType.Create(gdal.GDT_Float32)
+            "obs", [records, level], gdal.ExtendedDataType.Create(gdal.GDT_Float32)
         )
         numeric.Write(np.arange(12, dtype="float32").reshape(4, 3))
         return ds

--- a/tests/netcdf/unit/test_netcdf_unit_read.py
+++ b/tests/netcdf/unit/test_netcdf_unit_read.py
@@ -294,6 +294,33 @@ class TestReadMdArrayNonNumeric:
             "the returned array must keep its non-numeric dtype"
         )
 
+    def test_non_numeric_gridded_variable_is_not_spatial(self):
+        """A character variable on recognised y/x axes is auxiliary, not spatial (#1067).
+
+        Test scenario:
+            A string `label(lat, lon)` next to a numeric `t2m(lat, lon)` — expected: only `t2m`
+            is reported spatial. `_variable_is_spatial` classifies by dimension names, so without
+            a dtype test `label` was handed to the container fan-out, which called raster
+            operations on the raw MDArray `get_variable` returns for it.
+        """
+        ds = gdal.GetDriverByName("MEM").CreateMultiDimensional("test")
+        rg = ds.GetRootGroup()
+        lat = rg.CreateDimension("lat", None, None, 3)
+        lon = rg.CreateDimension("lon", None, None, 4)
+        rg.CreateMDArray("label", [lat, lon], gdal.ExtendedDataType.CreateString())
+        numeric = rg.CreateMDArray(
+            "t2m", [lat, lon], gdal.ExtendedDataType.Create(gdal.GDT_Float32)
+        )
+        numeric.Write(np.zeros((3, 4), dtype="float32"))
+        nc = Container(ds)
+        assert nc._spatial_variable_names() == ["t2m"], (
+            "only the numeric grid is spatial; the string grid must be carried as auxiliary, "
+            f"got {nc._spatial_variable_names()}"
+        )
+        assert nc._variable_is_spatial(rg, "label") is False, (
+            "a non-numeric variable is never spatial, whatever its dimensions are named"
+        )
+
 
 class TestNeedsYFlip:
     """Tests for the _needs_y_flip instance method."""

--- a/tests/netcdf/unit/test_netcdf_unit_read.py
+++ b/tests/netcdf/unit/test_netcdf_unit_read.py
@@ -249,6 +249,45 @@ class TestReadMdArrayNonNumeric:
         finally:
             nc.close()
 
+    @pytest.mark.parametrize("sizes", [(4, 3), (2, 4, 3)], ids=["rank2", "rank3"])
+    @pytest.mark.parametrize("dtype_name", ["string", "compound"])
+    def test_get_variable_returns_md_array_for_any_rank(self, sizes, dtype_name):
+        """`get_variable` returns the MDArray for a non-numeric variable of any rank.
+
+        Args:
+            sizes: Dimension sizes, covering a rank-2 and a rank-3 array.
+            dtype_name: Which non-numeric dtype class to build.
+
+        Test scenario:
+            The `_read_md_array` guard alone is not enough: `get_variable` goes on to attach
+            band-dimension metadata, which derives a primary band view from a band model a raw
+            MDArray does not have. Only a rank >= 3 array reaches that code (rank <= 2 exits at
+            the empty-`band_dims` branch), so this used to raise
+            `AttributeError: '_band_count'` — expected now: the MDArray, for both ranks and both
+            non-numeric dtype classes.
+        """
+        if dtype_name == "string":
+            dtype = gdal.ExtendedDataType.CreateString()
+        else:
+            dtype = gdal.ExtendedDataType.CreateCompound(
+                "record_t",
+                4,
+                [
+                    gdal.EDTComponent.Create(
+                        "a", 0, gdal.ExtendedDataType.Create(gdal.GDT_Int32)
+                    )
+                ],
+            )
+        nc = Container(self._single_var_multidim(dtype, sizes))
+        variable = nc.get_variable("v")
+        assert isinstance(variable, gdal.MDArray), (
+            f"a non-numeric rank-{len(sizes)} variable must come back as an MDArray, "
+            f"got {type(variable).__name__}"
+        )
+        assert variable.GetDataType().GetClass() != gdal.GEDTC_NUMERIC, (
+            "the returned array must keep its non-numeric dtype"
+        )
+
 
 class TestNeedsYFlip:
     """Tests for the _needs_y_flip instance method."""

--- a/tests/netcdf/unit/test_netcdf_unit_read.py
+++ b/tests/netcdf/unit/test_netcdf_unit_read.py
@@ -120,6 +120,65 @@ class TestReadMdArrayNonNumeric:
         numeric.Write(np.arange(12, dtype="float32").reshape(4, 3))
         return ds
 
+    @staticmethod
+    def _single_var_multidim(dtype, sizes):
+        """Build a MEM multidim dataset holding one array `v` of `dtype` over `sizes`."""
+        ds = gdal.GetDriverByName("MEM").CreateMultiDimensional("test")
+        rg = ds.GetRootGroup()
+        dims = [
+            rg.CreateDimension(f"d{i}", None, None, size)
+            for i, size in enumerate(sizes)
+        ]
+        rg.CreateMDArray("v", dims, dtype)
+        return ds
+
+    def test_read_md_array_3d_string_returns_md_array(self):
+        """The guard is shape-agnostic: a 3-D string variable is not made a raster.
+
+        Test scenario:
+            `_read_md_array` on a 3-D `(2, 4, 3)` string array — expected: the MDArray
+            itself, proving the guard keys on the dtype class rather than on the 2-D
+            `(records, max string length)` layout alone.
+        """
+        ds = self._single_var_multidim(gdal.ExtendedDataType.CreateString(), (2, 4, 3))
+        nc = Container(ds)
+        result_src, result_md, _rg, x_index, y_index, _yf, _xf = nc._read_md_array("v")
+        assert result_src is result_md, (
+            "a 3-D string array must come back as the MDArray"
+        )
+        assert x_index is None, f"no raster plane for a string array, got x={x_index}"
+        assert y_index is None, f"no raster plane for a string array, got y={y_index}"
+
+    def test_read_md_array_compound_returns_md_array(self):
+        """A compound (user-defined struct) variable is also returned as the MDArray.
+
+        Test scenario:
+            `_read_md_array` on a 2-D array of a two-field compound type — expected: the
+            MDArray itself. `AsClassicDataset` rejects every non-numeric dtype class, not
+            just strings, so the guard must test `!= GEDTC_NUMERIC` rather than
+            `== GEDTC_STRING`.
+        """
+        compound = gdal.ExtendedDataType.CreateCompound(
+            "record_t",
+            8,
+            [
+                gdal.EDTComponent.Create(
+                    "a", 0, gdal.ExtendedDataType.Create(gdal.GDT_Int32)
+                ),
+                gdal.EDTComponent.Create(
+                    "b", 4, gdal.ExtendedDataType.Create(gdal.GDT_Int32)
+                ),
+            ],
+        )
+        nc = Container(self._single_var_multidim(compound, (4, 3)))
+        result_src, result_md, _rg, x_index, y_index, _yf, _xf = nc._read_md_array("v")
+        assert result_src is result_md, "a compound array must come back as the MDArray"
+        assert result_md.GetDataType().GetClass() == gdal.GEDTC_COMPOUND, (
+            "the returned array must keep its compound dtype"
+        )
+        assert x_index is None, f"no raster plane for a compound array, got x={x_index}"
+        assert y_index is None, f"no raster plane for a compound array, got y={y_index}"
+
     def test_read_md_array_2d_string_returns_md_array(self):
         """A 2-D string variable returns the MDArray instead of raising.
 

--- a/tests/netcdf/unit/test_netcdf_unit_read.py
+++ b/tests/netcdf/unit/test_netcdf_unit_read.py
@@ -96,12 +96,14 @@ class TestReadMdArray1D:
 
 
 class TestReadMdArrayNonNumeric:
-    """A non-numeric (character/string) variable comes back as the raw MDArray (#1067).
+    """A non-numeric variable — string/character or compound — comes back as the raw MDArray (#1067).
 
     NetCDF stores a character column two-dimensionally as `(records, max string length)`, so
     `_resolve_spatial_dims` resolves a plane for it via its last-two fallback and the old code
     called `AsClassicDataset` — which accepts numeric arrays only and raised
-    "Only arrays with numeric data types can be exposed as classic GDALDataset".
+    "Only arrays with numeric data types can be exposed as classic GDALDataset". The guard keys
+    on the dtype class, so it covers a compound type and any rank >= 2 as well, not just the 2-D
+    string case from the issue.
     """
 
     @staticmethod

--- a/tests/netcdf/unit/test_netcdf_unit_read.py
+++ b/tests/netcdf/unit/test_netcdf_unit_read.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import gc
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -92,6 +93,100 @@ class TestReadMdArray1D:
             "For string 1D arrays, src and md_arr should be the same object"
         )
         assert result_rg is not None, "root group ref should not be None"
+
+
+class TestReadMdArrayNonNumeric:
+    """A non-numeric (character/string) variable comes back as the raw MDArray (#1067).
+
+    NetCDF stores a character column two-dimensionally as `(records, max string length)`, so
+    `_resolve_spatial_dims` resolves a plane for it via its last-two fallback and the old code
+    called `AsClassicDataset` — which accepts numeric arrays only and raised
+    "Only arrays with numeric data types can be exposed as classic GDALDataset".
+    """
+
+    @staticmethod
+    def _mixed_multidim(driver: str, path: str = "test"):
+        """Build a multidim dataset with a 2-D string and a 2-D numeric variable."""
+        ds = gdal.GetDriverByName(driver).CreateMultiDimensional(path)
+        rg = ds.GetRootGroup()
+        records = rg.CreateDimension("record", None, None, 4)
+        strlen = rg.CreateDimension("strlen", None, None, 3)
+        rg.CreateMDArray(
+            "units", [records, strlen], gdal.ExtendedDataType.CreateString()
+        )
+        numeric = rg.CreateMDArray(
+            "obs", [records, strlen], gdal.ExtendedDataType.Create(gdal.GDT_Float32)
+        )
+        numeric.Write(np.arange(12, dtype="float32").reshape(4, 3))
+        return ds
+
+    def test_read_md_array_2d_string_returns_md_array(self):
+        """A 2-D string variable returns the MDArray instead of raising.
+
+        Test scenario:
+            `_read_md_array` on a `(record, strlen)` string array — expected: `src` is the
+            MDArray itself (as for the 1-D case) and the plane indices are `None`, rather
+            than the `RuntimeError` `AsClassicDataset` raises for a non-numeric dtype.
+        """
+        nc = Container(self._mixed_multidim("MEM"))
+        result_src, result_md, result_rg, x_index, y_index, y_flip, x_flip = (
+            nc._read_md_array("units")
+        )
+        assert result_src is result_md, "a string array must come back as the MDArray"
+        assert result_rg is not None, "root group ref should not be None"
+        assert x_index is None, f"no raster plane for a string array, got x={x_index}"
+        assert y_index is None, f"no raster plane for a string array, got y={y_index}"
+        assert not y_flip, "a non-raster array cannot be flipped"
+        assert not x_flip, "a non-raster array cannot be flipped"
+
+    def test_read_md_array_2d_numeric_still_classic(self):
+        """The numeric path is unchanged: a 2-D numeric variable still becomes a classic view."""
+        nc = Container(self._mixed_multidim("MEM"))
+        result_src, result_md, _rg, x_index, y_index, _yf, _xf = nc._read_md_array(
+            "obs"
+        )
+        assert result_src is not result_md, "a numeric array must become a classic view"
+        assert isinstance(result_src, gdal.Dataset), (
+            f"expected a classic gdal.Dataset, got {type(result_src).__name__}"
+        )
+        assert (x_index, y_index) == (1, 0), (
+            f"numeric plane indices should resolve, got {(x_index, y_index)}"
+        )
+
+    def test_get_variable_on_mixed_file_reads_both(self, tmp_path):
+        """A file mixing numeric and character variables is fully readable (#1067).
+
+        Test scenario:
+            Write a real `.nc` holding a 2-D string `units` and a 2-D numeric `obs`, both with
+            resolvable spatial dims — expected: `get_variable("units")` returns a readable
+            `gdal.MDArray` (it used to raise) while `get_variable("obs")` still returns a
+            raster-backed variable.
+        """
+        path = str(tmp_path / "mixed.nc")
+        ds = self._mixed_multidim("netCDF", path)
+        ds.Close()
+        del ds
+        gc.collect()
+
+        nc = NetCDF.read_file(path)
+        try:
+            assert set(nc.variable_names) == {"units", "obs"}, (
+                f"both variables must be discoverable, got {nc.variable_names}"
+            )
+            string_var = nc.get_variable("units")
+            assert isinstance(string_var, gdal.MDArray), (
+                f"a character variable must come back as an MDArray, got {type(string_var)}"
+            )
+            assert string_var.GetDataType().GetClass() == gdal.GEDTC_STRING, (
+                "the returned array must keep its string dtype"
+            )
+            assert len(string_var.Read()) == 12, "the MDArray must be readable"
+            numeric_var = nc.get_variable("obs")
+            assert isinstance(numeric_var, NetCDF), (
+                f"a numeric variable must still be raster-backed, got {type(numeric_var)}"
+            )
+        finally:
+            nc.close()
 
 
 class TestNeedsYFlip:

--- a/tests/netcdf/unit/test_netcdf_unit_read.py
+++ b/tests/netcdf/unit/test_netcdf_unit_read.py
@@ -294,33 +294,6 @@ class TestReadMdArrayNonNumeric:
             "the returned array must keep its non-numeric dtype"
         )
 
-    def test_non_numeric_gridded_variable_is_not_spatial(self):
-        """A character variable on recognised y/x axes is auxiliary, not spatial (#1067).
-
-        Test scenario:
-            A string `label(lat, lon)` next to a numeric `t2m(lat, lon)` — expected: only `t2m`
-            is reported spatial. `_variable_is_spatial` classifies by dimension names, so without
-            a dtype test `label` was handed to the container fan-out, which called raster
-            operations on the raw MDArray `get_variable` returns for it.
-        """
-        ds = gdal.GetDriverByName("MEM").CreateMultiDimensional("test")
-        rg = ds.GetRootGroup()
-        lat = rg.CreateDimension("lat", None, None, 3)
-        lon = rg.CreateDimension("lon", None, None, 4)
-        rg.CreateMDArray("label", [lat, lon], gdal.ExtendedDataType.CreateString())
-        numeric = rg.CreateMDArray(
-            "t2m", [lat, lon], gdal.ExtendedDataType.Create(gdal.GDT_Float32)
-        )
-        numeric.Write(np.zeros((3, 4), dtype="float32"))
-        nc = Container(ds)
-        assert nc._spatial_variable_names() == ["t2m"], (
-            "only the numeric grid is spatial; the string grid must be carried as auxiliary, "
-            f"got {nc._spatial_variable_names()}"
-        )
-        assert nc._variable_is_spatial(rg, "label") is False, (
-            "a non-numeric variable is never spatial, whatever its dimensions are named"
-        )
-
 
 class TestNeedsYFlip:
     """Tests for the _needs_y_flip instance method."""


### PR DESCRIPTION
# Description

`NetCDF.get_variable()` raised for any character/string variable, so a file mixing numeric and `NC_CHAR`
columns could only be read in part:

```
RuntimeError: Only arrays with numeric data types can be exposed as classic GDALDataset
```

This surfaced in earthlens while reading Copernicus CDS in-situ observation products — long-format tables
where the variable *name* and its *units* are string columns, so reading the units means reading a string
column.

NetCDF stores a character column two-dimensionally as `(records, max string length)`. `_resolve_spatial_dims`
therefore always resolves a plane for it — its last-two-dimensions fallback never declines — and
`_read_md_array` called `AsClassicDataset` unconditionally, which GDAL accepts for numeric arrays only.
The existing early return that hands back the raw `MDArray` only covers a **1-D** variable
(`if len(dims) == 1`), so a 2-D string column fell straight through to the raising call.

Fix: guard on the data-type class before the classic-view conversion and return the `MDArray` — the same
7-tuple shape the 1-D branch already returns, so `get_variable` needs no change and the caller reads it with
`Read()`:

```python
if md_arr.GetDataType().GetClass() != gdal.GEDTC_NUMERIC:
    return md_arr, md_arr, rg, None, None, False, False
```

`!= GEDTC_NUMERIC` rather than `== GEDTC_STRING` so compound types are covered too. Every numeric path is
byte-identical; only what used to raise changes.

# Issues

- Closes #1067 — `get_variable` raises on a string (`NC_CHAR`) variable.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

New `TestReadMdArrayNonNumeric` in `tests/netcdf/unit/test_netcdf_unit_read.py` (3 tests):

- `test_read_md_array_2d_string_returns_md_array` — a `(record, strlen)` string array comes back as the
  MDArray with `None` plane indices instead of raising.
- `test_read_md_array_2d_numeric_still_classic` — the numeric path is unchanged: still a classic
  `gdal.Dataset` view with plane indices `(1, 0)`.
- `test_get_variable_on_mixed_file_reads_both` — the issue's Definition of Done: a real `.nc` mixing a 2-D
  string `units` and a 2-D numeric `obs`, both with resolvable spatial dims. `get_variable("units")` returns
  a readable `gdal.MDArray`; `get_variable("obs")` still returns a raster-backed variable.

**Non-vacuity proven**: with the guard disabled, both string tests fail with the exact
`RuntimeError: Only arrays with numeric data types...`, while the numeric control still passes.

Also verified the 1-D string path is untouched (`expver` in `cf__5v__1d4-3d1__geog__y-desc.nc` still returns
an `MDArray`).

- `pytest tests/netcdf/unit/test_netcdf_unit_read.py` → **39 passed**
- `pytest -m "not plot" tests/netcdf` → **2570 passed, 38 skipped**
- `mypy` clean on `netcdf.py`; `ruff format --check` / `ruff check` clean.

Reproduce:

- [x] `pytest tests/netcdf/unit/test_netcdf_unit_read.py::TestReadMdArrayNonNumeric -v`

**Note on the issue's reproducer section**: the issue states a synthetic reproducer is not possible without
the CDS file. It is — GDAL's own multidim writer produces a 2-D non-numeric array that reproduces the failure
exactly, which is what the new tests use. The xarray/h5py attempts came back **1-D** on read (hitting the
existing `len(dims) == 1` early return), so it was the rank, not the dtype, that spared them.

# Checklist:

- [ ] updated version number in pyproject.toml. — N/A (versions handled by commitizen in CI).
- [ ] added changes to History.rst. — N/A (changelog is commitizen-generated).
- [ ] updated the latest version in README file. — N/A.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. — `get_variable` and `_read_md_array` docstrings now state that a
      non-numeric (and 1-D) variable comes back as the raw `MDArray`.
