### PR TITLE
fix(netcdf): georeference and window CF-named coordinates on the HDF5 read path

### DIFF
--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1676,13 +1676,38 @@ class Spatial(_Engine["Dataset"]):
         return dst_obj
 
     @staticmethod
-    def _as_base_dataset(src: RasterBase) -> Dataset:
-        """Re-wrap `src` as the plain `Dataset` sitting directly above `RasterBase`.
+    def _base_dataset_class(source: type) -> type[Dataset]:
+        """The plain `Dataset` class sitting directly above `RasterBase` in `source`'s MRO.
 
         Intermediate GDAL results must not be built through a subclass: a subclass may override the
         constructors shared raster code calls — `NetCDF.create_from_array` takes `geo_ref=` where
         the base takes `geo=` — so a helper that is correct for a `Dataset` raises `TypeError` on a
-        `NetCDF`. Returns `src` unchanged when it already is the base class.
+        `NetCDF`.
+
+        Args:
+            source: The class to walk, normally `type(some_dataset)`.
+
+        Returns:
+            type[Dataset]: The base class, or `source` unchanged when the walk finds nothing. That
+            leaves such a caller exactly where it was, which is safer than the bare `next()` this
+            replaced — whose `StopIteration` would have aborted the crop outright. (`Dataset`
+            itself is not usable as the default: this module imports it lazily to break a cycle,
+            so the name does not exist at call time.)
+        """
+        found = next(
+            (c for c in source.__mro__ if RasterBase in getattr(c, "__bases__", ())),
+            source,
+        )
+        return cast("type[Dataset]", found)
+
+    @staticmethod
+    def _as_base_dataset(src: RasterBase) -> Dataset:
+        """Re-wrap `src` as the plain `Dataset` above `RasterBase`, preserving how it was opened.
+
+        See :meth:`_base_dataset_class` for why the subclass must not carry into an intermediate.
+        Returns `src` unchanged when it already is the base class, so the common path allocates
+        nothing; otherwise the new wrapper is given the same access mode and GDAL environment, or
+        it would silently come back read-only and without the source's open options.
 
         Args:
             src: The dataset to normalise.
@@ -1690,13 +1715,15 @@ class Spatial(_Engine["Dataset"]):
         Returns:
             Dataset: `src` itself, or a base-class wrapper over the same GDAL dataset.
         """
-        base_cls = next(
-            c
-            for c in src.__class__.__mro__
-            if RasterBase in getattr(c, "__bases__", ())
-        )
-        result = src if type(src) is base_cls else base_cls(src.raster)
-        return cast("Dataset", result)
+        base_cls = Spatial._base_dataset_class(src.__class__)
+        if type(src) is base_cls:
+            return cast("Dataset", src)
+        carried = {
+            name: getattr(src, name)
+            for name in ("access", "gdal_env", "open_options")
+            if getattr(src, name, None) is not None
+        }
+        return cast("Dataset", base_cls(src.raster, **carried))
 
     @staticmethod
     def _cutline_window_bounds(
@@ -1939,17 +1966,9 @@ class Spatial(_Engine["Dataset"]):
             if x_size > 0 and y_size > 0:
                 array = self._ds.read_array(window=[xoff, yoff, x_size, y_size])
                 new_gt = (x0 + xoff * dx, dx, 0.0, y0 + yoff * dy, 0.0, dy)
-                # Rebuild on the base Dataset class (never a subclass like NetCDF),
-                # whose create_from_array has the plain array->raster behaviour this
-                # path needs; mirrors _crop_with_polygon_warp's base-class walk.
-                base_cls = cast(
-                    "type[Dataset]",
-                    next(
-                        c
-                        for c in self._ds.__class__.__mro__
-                        if RasterBase in getattr(c, "__bases__", ())
-                    ),
-                )
+                # Rebuild on the base Dataset class (never a subclass like NetCDF), whose
+                # create_from_array has the plain array->raster behaviour this path needs.
+                base_cls = Spatial._base_dataset_class(self._ds.__class__)
                 dst = cast(
                     "Dataset",
                     base_cls.create_from_array(
@@ -2003,14 +2022,10 @@ class Spatial(_Engine["Dataset"]):
         # gdal.Warp's cutlineDSName needs a *path*; stage the vector in
         # /vsimem/ through the internal OGR bridge. The path is unlinked
         # automatically when the with-block exits.
-        # Use the base Dataset class (not a subclass like NetCDF) for intermediate GDAL warp results
-        # because _correct_wrap_cutline_error calls create_from_array which has different behavior in
-        # subclasses.
-        base_cls = next(
-            c
-            for c in self._ds.__class__.__mro__
-            if RasterBase in getattr(c, "__bases__", ())
-        )
+        # Intermediate GDAL warp results are built on the base Dataset class, never a subclass:
+        # `_correct_wrap_cutline_error` calls `create_from_array`, whose NetCDF override takes a
+        # different signature. See `_base_dataset_class`.
+        base_cls = Spatial._base_dataset_class(self._ds.__class__)
 
         # The warp output (VRT) may resolve the cutline lazily, so we must
         # complete every access that could touch the cutline path inside
@@ -2049,9 +2064,8 @@ class Spatial(_Engine["Dataset"]):
                     else None
                 ),
             )
-            # base_cls is a dynamic MRO walk that always resolves to Dataset itself
-            # (the class directly above RasterBase; see the comment above), never a
-            # subclass, so this is guaranteed to actually be a Dataset at runtime.
+            # `_base_dataset_class` already returns a `type[Dataset]`; the cast is for the
+            # checker's benefit only.
             # Routed through warp_to_dataset for the pin: with `touch` false the
             # result is the raw VRT, which reads through to the source on every
             # access and previously held nothing alive.

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1666,8 +1666,37 @@ class Spatial(_Engine["Dataset"]):
         # crop the src raster with the aligned mask
         dst_obj = self._crop_aligned(mask)
 
-        dst_obj = Spatial._correct_wrap_cutline_error(dst_obj)
+        # Hand the trim the *base* Dataset, not the subclass. `_crop_aligned` builds its result as
+        # `self._ds.__class__(...)`, so on a NetCDF receiver it is a NetCDF — and
+        # `_correct_wrap_cutline_error` calls `create_from_array(..., geo=...)`, whose NetCDF
+        # override takes `geo_ref=` and no `geo` at all, so the whole raster-mask crop died with
+        # `TypeError: create_from_array() got an unexpected keyword argument 'geo'` (#1073). The
+        # polygon path already avoids this the same way; only this one was missed.
+        dst_obj = Spatial._correct_wrap_cutline_error(Spatial._as_base_dataset(dst_obj))
         return dst_obj
+
+    @staticmethod
+    def _as_base_dataset(src: RasterBase) -> Dataset:
+        """Re-wrap `src` as the plain `Dataset` sitting directly above `RasterBase`.
+
+        Intermediate GDAL results must not be built through a subclass: a subclass may override the
+        constructors shared raster code calls — `NetCDF.create_from_array` takes `geo_ref=` where
+        the base takes `geo=` — so a helper that is correct for a `Dataset` raises `TypeError` on a
+        `NetCDF`. Returns `src` unchanged when it already is the base class.
+
+        Args:
+            src: The dataset to normalise.
+
+        Returns:
+            Dataset: `src` itself, or a base-class wrapper over the same GDAL dataset.
+        """
+        base_cls = next(
+            c
+            for c in src.__class__.__mro__
+            if RasterBase in getattr(c, "__bases__", ())
+        )
+        result = src if type(src) is base_cls else base_cls(src.raster)
+        return cast("Dataset", result)
 
     @staticmethod
     def _cutline_window_bounds(

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -43,9 +43,9 @@ from pyramids.netcdf.array_options import GeoReference
 if TYPE_CHECKING:
     from pyramids.netcdf.netcdf import NetCDF
 
-# The window must cover at most 1/N of the variable's cells before reading it through the MDArray
-# earns a second code path: the windowed read pays off by skipping most of the variable, and at
-# parity it is the same work plus an extra copy.
+# The window must cover strictly less than 1/N of the variable's cells before reading it through
+# the MDArray earns a second code path: the windowed read pays off by skipping most of the
+# variable, and at parity it is the same work plus an extra copy.
 #
 # Deliberately relative only, with no absolute floor on the variable's size. A floor would spare a
 # small local grid a shortcut that gains it nothing — but it gains nothing there either way, the

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -43,11 +43,15 @@ from pyramids.netcdf.array_options import GeoReference
 if TYPE_CHECKING:
     from pyramids.netcdf.netcdf import NetCDF
 
-# How much smaller than the whole variable a crop window must be before reading it through the
-# MDArray is worth a second code path. The windowed read only pays off when it skips most of the
-# variable; at parity it is the same work plus an extra copy, so a window covering half the grid
-# or more keeps the ordinary full-read crop.
-_MIN_WINDOW_SPEEDUP = 2
+# The window must cover at most 1/N of the variable's cells before reading it through the MDArray
+# earns a second code path: the windowed read pays off by skipping most of the variable, and at
+# parity it is the same work plus an extra copy.
+#
+# Deliberately relative only, with no absolute floor on the variable's size. A floor would spare a
+# small local grid a shortcut that gains it nothing — but it gains nothing there either way, the
+# two paths are asserted to agree cell for cell, and a floor high enough to matter (thousands of
+# cells) would take every test fixture below it and quietly stop exercising this path at all.
+_MIN_WINDOW_SAVING = 2
 
 
 class Selection(_Engine["NetCDF"]):
@@ -603,9 +607,14 @@ class Selection(_Engine["NetCDF"]):
         x_size, y_size = x_end - x_off, y_end - y_off
         if x_size <= 0 or y_size <= 0:
             return None
-        if x_size * y_size * _MIN_WINDOW_SPEEDUP >= nc.columns * nc.rows:
+        if x_size * y_size * _MIN_WINDOW_SAVING >= nc.columns * nc.rows:
             return None
-        raster = nc._window_via_mdarray(x_off, y_off, x_size, y_size)
+        try:
+            raster = nc._window_via_mdarray(x_off, y_off, x_size, y_size)
+        except (RuntimeError, AttributeError, ValueError):
+            # The shortcut is an optimisation the caller never asked for; anything it fails on must
+            # reach the ordinary full-read crop, not surface as an error out of `crop()`.
+            raster = None
         return None if raster is None else Dataset(raster)
 
     def _crop_curvilinear(

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -488,25 +488,87 @@ class Selection(_Engine["NetCDF"]):
                     "chunks= is only supported for curvilinear crop; the affine "
                     "(rectilinear) crop path is eager."
                 )
-            # Stamp the variable's known CRS onto its backing raster before the cutline warp.
-            # A NetCDF variable tracks its EPSG even when the raster (the AsClassicDataset MDArray
-            # view, or a wrap_longitude/materialized MEM raster) carries no projection string;
-            # without it GDAL's cutline warp warns ("the input vector layer has a SRS, but the
-            # source raster dataset does not") and — for a cutline in a different CRS — would clip
-            # the wrong region. The driver-less MDArray view does not persist SetProjection, so
-            # materialize it first (the affine crop reads it fully anyway). See issue #629.
-            if nc.epsg and nc._raster is not None and not nc._raster.GetProjection():
-                wkt = sr_from_epsg(int(nc.epsg)).ExportToWkt()
-                nc._raster.SetProjection(wkt)
-                if not nc._raster.GetProjection():
-                    nc._materialize_md_view()
+            # Crop the mask's window rather than the whole variable when that window can be read
+            # straight from the MDArray: the affine crop reads its source in full, which over a
+            # remote store means fetching the entire variable to clip a few cells. This has to run
+            # *before* the CRS stamping below, because materializing drops the root-group reference
+            # the windowed read needs — and the windowed raster carries the CRS already (#1071).
+            source = self._mask_window_source(mask)
+            if source is None:
+                # Stamp the variable's known CRS onto its backing raster before the cutline warp.
+                # A NetCDF variable tracks its EPSG even when the raster (the AsClassicDataset
+                # MDArray view, or a wrap_longitude/materialized MEM raster) carries no projection
+                # string; without it GDAL's cutline warp warns ("the input vector layer has a SRS,
+                # but the source raster dataset does not") and — for a cutline in a different CRS —
+                # would clip the wrong region. The driver-less MDArray view does not persist
+                # SetProjection, so materialize it first (that path reads it fully anyway).
+                # See issue #629.
+                if (
+                    nc.epsg
+                    and nc._raster is not None
+                    and not nc._raster.GetProjection()
+                ):
+                    wkt = sr_from_epsg(int(nc.epsg)).ExportToWkt()
                     nc._raster.SetProjection(wkt)
+                    if not nc._raster.GetProjection():
+                        nc._materialize_md_view()
+                        nc._raster.SetProjection(wkt)
+                source = nc
             # `nc.spatial.crop` is the base Dataset affine crop — exactly what the
             # NetCDF.crop override reached via `super().crop(...)`, bypassing this engine.
             result = nc._preserve_netcdf_metadata(
-                nc.spatial.crop(mask=mask, touch=touch)
+                source.spatial.crop(mask=mask, touch=touch)
             )
         return result
+
+    def _mask_window_source(self, mask: FeatureCollection) -> Dataset | None:
+        """A `Dataset` over just the mask's window, read straight from the MDArray.
+
+        The affine crop reads its whole source before clipping. That is cheap for a local file
+        and expensive for a remote one — the classic view a variable is backed by turns a small
+        windowed read into a strided gather, so clipping a few cells out of a 14 GB `/vsicurl`
+        NetCDF-4 costs seconds. Reading the window through
+        :meth:`~pyramids.netcdf.NetCDF._window_via_mdarray` instead is roughly an order of
+        magnitude cheaper, and the clip that follows is identical because the window is built to
+        contain the mask.
+
+        Declines (returns ``None``, leaving the caller to crop the full variable) whenever the
+        shortcut is not provably equivalent: a rotated or degenerate affine, a mask in a different
+        CRS (whose cutline the warp must reproject), a mask that misses the grid, a window that is
+        not appreciably smaller than the variable, or a read the MDArray cannot serve.
+
+        Args:
+            mask: The resolved polygon mask the crop will clip with.
+
+        Returns:
+            Dataset | None: A raster of the window carrying its sub-affine, or ``None``.
+        """
+        nc = self._ds
+        gt = nc._geotransform
+        if not gt or not gt[1] or not gt[5] or gt[2] or gt[4]:
+            return None
+        mask_epsg = getattr(mask, "epsg", None)
+        if nc.epsg and mask_epsg and int(mask_epsg) != int(nc.epsg):
+            return None
+        try:
+            xmin, ymin, xmax, ymax = (float(bound) for bound in mask.total_bounds)
+        except (AttributeError, TypeError, ValueError):
+            return None
+        columns = [(xmin - gt[0]) / gt[1], (xmax - gt[0]) / gt[1]]
+        rows = [(ymax - gt[3]) / gt[5], (ymin - gt[3]) / gt[5]]
+        # One cell of slack on every side so `touch=True` and half-open rounding cannot clip a
+        # boundary cell the full-read path would have kept.
+        x_off = max(0, math.floor(min(columns)) - 1)
+        y_off = max(0, math.floor(min(rows)) - 1)
+        x_end = min(nc.columns, math.ceil(max(columns)) + 1)
+        y_end = min(nc.rows, math.ceil(max(rows)) + 1)
+        x_size, y_size = x_end - x_off, y_end - y_off
+        if x_size <= 0 or y_size <= 0:
+            return None
+        if x_size * y_size * 2 >= nc.columns * nc.rows:
+            return None
+        raster = nc._window_via_mdarray(x_off, y_off, x_size, y_size)
+        return None if raster is None else Dataset(raster)
 
     def _crop_curvilinear(
         self,

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -468,6 +468,14 @@ class Selection(_Engine["NetCDF"]):
         affine cutline warp, so they mask on their 2-D coordinates; rectilinear grids use the affine
         crop and re-wrap to preserve NetCDF metadata. ``chunks`` is valid only on the curvilinear path.
 
+        The rectilinear path first offers the crop to :meth:`_mask_window_source`, which reads just
+        the mask's window from the MDArray when it can prove that equivalent, and otherwise declines
+        so the existing full-read crop runs unchanged (#1071). The returned crop is identical either
+        way; the difference is a side effect on the *receiver*, which the shortcut skips — a crop
+        that declines stamps the variable's CRS onto its backing raster, and may materialize the
+        multidim view, so a subsequent operation finds a raster that has already been fixed up. A
+        crop that takes the shortcut leaves the receiver untouched.
+
         Args:
             mask: The resolved polygon/raster mask to crop with.
             touch: If True, include cells touching the mask boundary. Defaults to True.
@@ -564,11 +572,15 @@ class Selection(_Engine["NetCDF"]):
         # unreprojected coordinates divided through this raster's affine -- a plausible-looking
         # window over the wrong part of the grid, which is wrong data rather than an error.
         # Unknown on either side is not "equal": decline and let the warp reproject the cutline.
+        # `crs` is a pyproj CRS on a GeoDataFrame/FeatureCollection but a plain WKT string on a
+        # Dataset mask, so normalise before comparing rather than assume either shape.
         mask_crs = getattr(mask, "crs", None)
+        if mask_crs is not None and hasattr(mask_crs, "to_wkt"):
+            mask_crs = mask_crs.to_wkt()
         source_crs = nc.crs
-        if not source_crs or mask_crs is None:
+        if not source_crs or not mask_crs:
             return None
-        if not crs_equal(source_crs, mask_crs.to_wkt()):
+        if not crs_equal(source_crs, mask_crs):
             return None
         try:
             xmin, ymin, xmax, ymax = (float(bound) for bound in mask.total_bounds)

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -26,7 +26,7 @@ import geopandas as gpd
 import numpy as np
 from shapely import box, contains_xy
 
-from pyramids.base.crs import crs_spec, sr_from_epsg, sr_from_user_input
+from pyramids.base.crs import crs_equal, crs_spec, sr_from_epsg, sr_from_user_input
 from pyramids.dataset import DEFAULT_NO_DATA_VALUE, Dataset
 from pyramids.dataset.engines._base import _Engine
 from pyramids.dataset.engines.spatial import (
@@ -42,6 +42,12 @@ from pyramids.netcdf.array_options import GeoReference
 
 if TYPE_CHECKING:
     from pyramids.netcdf.netcdf import NetCDF
+
+# How much smaller than the whole variable a crop window must be before reading it through the
+# MDArray is worth a second code path. The windowed read only pays off when it skips most of the
+# variable; at parity it is the same work plus an extra copy, so a window covering half the grid
+# or more keeps the ordinary full-read crop.
+_MIN_WINDOW_SPEEDUP = 2
 
 
 class Selection(_Engine["NetCDF"]):
@@ -521,7 +527,7 @@ class Selection(_Engine["NetCDF"]):
             )
         return result
 
-    def _mask_window_source(self, mask: FeatureCollection) -> Dataset | None:
+    def _mask_window_source(self, mask: Any) -> Dataset | None:
         """A `Dataset` over just the mask's window, read straight from the MDArray.
 
         The affine crop reads its whole source before clipping. That is cheap for a local file
@@ -533,12 +539,16 @@ class Selection(_Engine["NetCDF"]):
         contain the mask.
 
         Declines (returns ``None``, leaving the caller to crop the full variable) whenever the
-        shortcut is not provably equivalent: a rotated or degenerate affine, a mask in a different
-        CRS (whose cutline the warp must reproject), a mask that misses the grid, a window that is
-        not appreciably smaller than the variable, or a read the MDArray cannot serve.
+        shortcut is not provably equivalent: a rotated or degenerate affine, a mask whose CRS is
+        not known to equal the raster's (whose cutline the warp must reproject), non-finite mask
+        bounds, a mask that misses the grid, a window that is not appreciably smaller than the
+        variable, or a read the MDArray cannot serve.
 
         Args:
-            mask: The resolved polygon mask the crop will clip with.
+            mask: The resolved mask the crop will clip with — a `FeatureCollection`, a bare
+                `geopandas.GeoDataFrame` (passed straight through by `_resolve_crop_mask`), or a
+                `Dataset` whose footprint is used. Only `crs` and `total_bounds` are read, so any
+                of them is accepted; anything lacking them declines.
 
         Returns:
             Dataset | None: A raster of the window carrying its sub-affine, or ``None``.
@@ -547,12 +557,28 @@ class Selection(_Engine["NetCDF"]):
         gt = nc._geotransform
         if not gt or not gt[1] or not gt[5] or gt[2] or gt[4]:
             return None
-        mask_epsg = getattr(mask, "epsg", None)
-        if nc.epsg and mask_epsg and int(mask_epsg) != int(nc.epsg):
+        # Compare the CRSs themselves, the way `Spatial._cutline_window_bounds` does. An `epsg`
+        # comparison fails open twice over: `crop(mask=...)` accepts a bare `GeoDataFrame`, which
+        # has no `.epsg` at all, and a grid with no authority code (rotated pole, geostationary)
+        # reports `epsg` as `None`. Either way the guard would be skipped and the mask's
+        # unreprojected coordinates divided through this raster's affine -- a plausible-looking
+        # window over the wrong part of the grid, which is wrong data rather than an error.
+        # Unknown on either side is not "equal": decline and let the warp reproject the cutline.
+        mask_crs = getattr(mask, "crs", None)
+        source_crs = nc.crs
+        if not source_crs or mask_crs is None:
+            return None
+        if not crs_equal(source_crs, mask_crs.to_wkt()):
             return None
         try:
             xmin, ymin, xmax, ymax = (float(bound) for bound in mask.total_bounds)
         except (AttributeError, TypeError, ValueError):
+            return None
+        # An empty or all-null-geometry mask has non-finite bounds; `math.floor(nan)` raises
+        # `ValueError` and `math.floor(inf)` `OverflowError`. The full-read path reports that as a
+        # clean "Did not get any cutline features", so decline rather than turn it into a numeric
+        # error raised out of an optimisation the caller never asked for.
+        if not all(math.isfinite(bound) for bound in (xmin, ymin, xmax, ymax)):
             return None
         columns = [(xmin - gt[0]) / gt[1], (xmax - gt[0]) / gt[1]]
         rows = [(ymax - gt[3]) / gt[5], (ymin - gt[3]) / gt[5]]
@@ -565,7 +591,7 @@ class Selection(_Engine["NetCDF"]):
         x_size, y_size = x_end - x_off, y_end - y_off
         if x_size <= 0 or y_size <= 0:
             return None
-        if x_size * y_size * 2 >= nc.columns * nc.rows:
+        if x_size * y_size * _MIN_WINDOW_SPEEDUP >= nc.columns * nc.rows:
             return None
         raster = nc._window_via_mdarray(x_off, y_off, x_size, y_size)
         return None if raster is None else Dataset(raster)

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -251,6 +251,27 @@ _Y_DIM_NAMES = frozenset(
 _X_DIM_NAMES = frozenset(
     {"x", "lon", "longitude", "rlon", "west_east", "easting", "grid_longitude"}
 )
+# The same names in *preference* order, for the blind tail of `_coordinate_candidates` (the file
+# named none of them outright). A set has no order and sorting it alphabetically is an accident
+# that puts `grid_latitude` -- a rotated-pole axis -- ahead of plain `latitude`.
+_Y_NAME_PREFERENCE = (
+    "latitude",
+    "lat",
+    "y",
+    "northing",
+    "rlat",
+    "grid_latitude",
+    "south_north",
+)
+_X_NAME_PREFERENCE = (
+    "longitude",
+    "lon",
+    "x",
+    "easting",
+    "rlon",
+    "grid_longitude",
+    "west_east",
+)
 # Dimension names that clearly denote a non-spatial axis. Used to suppress the
 # "demoted grid" warning for legitimately non-spatial N-D aux variables
 # (e.g. a (time, level) table, time-bounds (time, nv)) — only a variable with
@@ -3731,19 +3752,24 @@ class NetCDF(Dataset):
             or y_off + y_size > sizes[y_index]
         ):
             return None
+        # The caller derived this window from the *wrapper* raster's rows/columns, but it is served
+        # from the raw MDArray. Those agree today only through a chain of non-local invariants
+        # (`_md_spatial_dims` is set once, in `get_variable`, and every reshaping operation
+        # materializes the view and so disables this path). Check it here rather than trust the
+        # chain: a mismatch would silently read a differently-sized grid at the same indices.
+        if sizes[x_index] != self.columns or sizes[y_index] != self.rows:
+            return None
         # A reversed axis is stored back-to-front, so the raster window maps to the mirrored raw
         # slice; read it forwards (negative steps are what the reversed view cannot serve) and undo
-        # the reversal on the small result below.
-        starts, counts = list(sizes), list(sizes)
+        # the reversal on the small result below. Every non-spatial axis is read whole, from 0, so
+        # it flattens into bands exactly as the classic view presents them.
+        starts, counts = [0] * len(sizes), list(sizes)
         for index, (offset, size, flipped) in (
             (x_index, (x_off, x_size, self._md_x_flipped)),
             (y_index, (y_off, y_size, self._md_y_flipped)),
         ):
             starts[index] = sizes[index] - offset - size if flipped else offset
             counts[index] = size
-        for index in range(len(sizes)):
-            if index not in (x_index, y_index):
-                starts[index] = 0
         try:
             block = md_arr.ReadAsArray(array_start_idx=starts, count=counts)
         except (RuntimeError, AttributeError):
@@ -3788,6 +3814,19 @@ class NetCDF(Dataset):
             # EPSG. A cutline warp against a projection-less raster warns and — for a cutline in
             # another CRS — clips the wrong region, so stamp it here rather than inherit nothing.
             target.SetProjection(sr_from_epsg(int(self.epsg)).ExportToWkt())
+        # `_copy_raw_view` gets scale/offset for free from `CreateCopy`; a hand-built MEM raster
+        # does not. Carry them over, or a packed variable (`scale_factor`/`add_offset`, ordinary in
+        # CF) would come back through the shortcut in raw counts while the full-read path returned
+        # the same window in physical units.
+        carried = min(target.RasterCount, self._raster.RasterCount)
+        for band_index in range(1, carried + 1):
+            source_band = self._raster.GetRasterBand(band_index)
+            target_band = target.GetRasterBand(band_index)
+            scale, offset = source_band.GetScale(), source_band.GetOffset()
+            if scale is not None:
+                target_band.SetScale(scale)
+            if offset is not None:
+                target_band.SetOffset(offset)
         self._reconcile_band_no_data(target)
         return target
 
@@ -5346,13 +5385,41 @@ class NetCDF(Dataset):
         return cube
 
     def _first_coordinate(self, candidates: tuple[str, ...]) -> tuple[Any, str | None]:
-        """The first readable coordinate variable among `candidates`, with the name it was found under."""
+        """The first *usable* coordinate variable among `candidates`, with the name it was found under.
+
+        Usable means a 1-D array of at least two values — what an affine can be derived from.
+        Scanning past the unusable ones matters because the candidate list is built partly from CF
+        attributes, and CF says a bounds variable inherits its parent's ``units`` and
+        ``standard_name``: ``latitude_bnds`` / ``lon_vertices`` therefore look exactly like axis
+        coordinates. Committing to the first name that merely *opens* would return that 2-D bounds
+        array, and the caller — which requires ``ndim == 1`` — would silently fall through to the
+        curvilinear branch and leave the variable in index space, defeating the #1071 rescue on a
+        very ordinary CF layout.
+
+        Falls back to the first readable array of any rank when nothing 1-D is found, so a genuinely
+        curvilinear file reaches :meth:`_curvilinear_bbox_geotransform` exactly as before.
+
+        Args:
+            candidates: Ordered names to try, from :meth:`_coordinate_candidates`.
+
+        Returns:
+            tuple[Any, str | None]: The coordinate values and the name they were found under, or
+            ``(None, None)`` when nothing readable matched.
+        """
         values, found = None, None
+        fallback, fallback_name = None, None
         for name in candidates:
             array = self._read_variable(name)
-            if array is not None:
-                values, found = np.asarray(array), name
+            if array is None:
+                continue
+            array = np.asarray(array)
+            if array.ndim == 1 and array.size >= 2:
+                values, found = array, name
                 break
+            if fallback is None:
+                fallback, fallback_name = array, name
+        if values is None:
+            values, found = fallback, fallback_name
         return values, found
 
     def _coordinate_candidates(self, axis: str) -> tuple[str, ...]:
@@ -5382,12 +5449,13 @@ class NetCDF(Dataset):
         """
         legacy = ("lon", "x") if axis == "X" else ("lat", "y")
         well_known = _X_DIM_NAMES if axis == "X" else _Y_DIM_NAMES
+        preferred = _X_NAME_PREFERENCE if axis == "X" else _Y_NAME_PREFERENCE
         rg = self._working_group()
         present = list(rg.GetMDArrayNames() or []) if rg is not None else []
         cf_named = [name for name in present if self._axis_role(rg, name) == axis]
         well_known_present = [name for name in present if name.lower() in well_known]
         ordered: list[str] = []
-        for name in (*legacy, *cf_named, *well_known_present, *sorted(well_known)):
+        for name in (*legacy, *cf_named, *well_known_present, *preferred):
             if name not in ordered:
                 ordered.append(name)
         return tuple(ordered)

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -5246,6 +5246,43 @@ class NetCDF(Dataset):
                 break
         return values, found
 
+    def _coordinate_candidates(self, axis: str) -> tuple[str, ...]:
+        """Ordered coordinate-variable names to try when georeferencing `axis` (``"X"`` / ``"Y"``).
+
+        The order is deliberate, and `_first_coordinate` takes the first that reads:
+
+        1. the two legacy names (``lon``/``x``, ``lat``/``y``) — kept first so a file that already
+           resolved keeps resolving to exactly the same coordinate;
+        2. names the file's own CF attributes identify as this axis (:meth:`_axis_role`), which is
+           the principled signal and catches a coordinate under any name;
+        3. the remaining well-known names (:data:`_X_DIM_NAMES` / :data:`_Y_DIM_NAMES`) matched
+           **case-insensitively against the names actually present**, so ``Latitude`` or ``LON``
+           resolve without another hardcoded spelling.
+
+        Stages 2 and 3 are why a CF-standard ``latitude`` / ``longitude`` grid is georeferenced at
+        all: the legacy pair never named them, so a variable whose driver does not supply an affine
+        (the HDF5 driver, which serves any ``/vsi`` NetCDF-4 read on Windows) was left in index
+        space (#1071). A frozenset is never iterated directly here — its order is not defined, and
+        this lookup is first-match.
+
+        Args:
+            axis: ``"X"`` for the longitude/easting axis, ``"Y"`` for latitude/northing.
+
+        Returns:
+            tuple[str, ...]: Candidate names, most-specific first, without duplicates.
+        """
+        legacy = ("lon", "x") if axis == "X" else ("lat", "y")
+        well_known = _X_DIM_NAMES if axis == "X" else _Y_DIM_NAMES
+        rg = self._working_group()
+        present = list(rg.GetMDArrayNames() or []) if rg is not None else []
+        cf_named = [name for name in present if self._axis_role(rg, name) == axis]
+        well_known_present = [name for name in present if name.lower() in well_known]
+        ordered: list[str] = []
+        for name in (*legacy, *cf_named, *well_known_present, *sorted(well_known)):
+            if name not in ordered:
+                ordered.append(name)
+        return tuple(ordered)
+
     @staticmethod
     def _coordinates_index_subset(cube: NetCDF, lon, lat, lon_name: str | None) -> bool:
         """Whether the parent's 1-D lon/lat legitimately index `cube`'s spatial grid.
@@ -5285,8 +5322,10 @@ class NetCDF(Dataset):
     def _coordinate_derived_geotransform(self, cube: NetCDF) -> tuple | None:
         """Real-world geotransform from the parent's lon/lat coordinates, or ``None``.
 
-        Returns the north-up affine implied by the parent container's 1-D ``lon``/``lat`` (or
-        ``x``/``y``) coordinate variables when they (a) match the subset's grid shape, (b) index the
+        Returns the north-up affine implied by the parent container's 1-D longitude/latitude
+        coordinate variables — located by :meth:`_coordinate_candidates`, so CF-standard
+        ``latitude``/``longitude`` and the other well-known spellings count, not just ``lon``/``lat``
+        or ``x``/``y`` (#1071) — when they (a) match the subset's grid shape, (b) index the
         subset's spatial dimensions by name (CF coordinate-variable convention — guards a same-shaped
         but different staggered/rotated axis from adopting the wrong coordinates), and (c) actually
         differ from the subset's current (index-space) geotransform. When no 1-D coordinate indexes
@@ -5294,8 +5333,8 @@ class NetCDF(Dataset):
         over those 2-D coordinates (:meth:`_curvilinear_bbox_geotransform`, #1039). Otherwise ``None``.
         """
         result = None
-        lon, lon_name = self._first_coordinate(("lon", "x"))
-        lat, _ = self._first_coordinate(("lat", "y"))
+        lon, lon_name = self._first_coordinate(self._coordinate_candidates("X"))
+        lat, _ = self._first_coordinate(self._coordinate_candidates("Y"))
         if self._coordinates_index_subset(cube, lon, lat, lon_name):
             # Anchor the affine on the coordinate that the *array's* first column / row actually
             # sits at. `_read_md_array` reverses an axis it decided was backwards, so after a flip

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -3682,6 +3682,115 @@ class NetCDF(Dataset):
             self._reconcile_band_no_data(result)
         return result
 
+    def _window_via_mdarray(
+        self, x_off: int, y_off: int, x_size: int, y_size: int
+    ) -> gdal.Dataset | None:
+        """Read one raster window straight from the MDArray, as a small north-up ``MEM`` raster.
+
+        The classic ``AsClassicDataset`` view is the wrong tool for a *small* window over a remote
+        store. A variable stored ``(time, longitude, latitude)`` is presented by that view as
+        ``rows=latitude, cols=longitude``, so every raster row is a strided gather and a windowed
+        read costs roughly what a full one does. Measured against a 14 GB ``/vsicurl`` NetCDF-4:
+        the same ``16x8x8`` window takes ~0.8 s through :meth:`osgeo.gdal.MDArray.Read` and ~7.5 s
+        through the classic view. (For a *whole*-array read the classic view wins, which is why
+        :meth:`_copy_raw_view` still uses it — this is a windowed-read shortcut, not a replacement.)
+
+        The window is given in **raster** space (north-up, post-flip, matching
+        :attr:`geotransform`); the raw indices are derived from it, so a reversed axis is read as a
+        forward contiguous slice and reversed afterwards with NumPy.
+
+        Args:
+            x_off: Column offset of the window in raster space.
+            y_off: Row offset of the window in raster space.
+            x_size: Window width in columns.
+            y_size: Window height in rows.
+
+        Returns:
+            gdal.Dataset | None: A ``MEM`` raster of the window carrying the sub-affine and the
+            wrapper's CRS, or ``None`` when the read is not possible (no root group, no source
+            variable, unresolved spatial dimensions, unknown flips, an out-of-range window, or a
+            failed read) — in which case the caller keeps its existing full-read path.
+        """
+        rg = self._gdal_rg_ref
+        var = self._source_var_name
+        spatial = self._md_spatial_dims
+        flips_known = isinstance(self._md_y_flipped, bool) and isinstance(
+            self._md_x_flipped, bool
+        )
+        if rg is None or var is None or spatial is None or not flips_known:
+            return None
+        x_index, y_index = spatial
+        try:
+            md_arr = rg.OpenMDArray(var)
+            sizes = [d.GetSize() for d in md_arr.GetDimensions()]
+        except (RuntimeError, AttributeError):
+            return None
+        if (
+            not (0 <= x_off and 0 <= y_off and x_size > 0 and y_size > 0)
+            or x_off + x_size > sizes[x_index]
+            or y_off + y_size > sizes[y_index]
+        ):
+            return None
+        # A reversed axis is stored back-to-front, so the raster window maps to the mirrored raw
+        # slice; read it forwards (negative steps are what the reversed view cannot serve) and undo
+        # the reversal on the small result below.
+        starts, counts = list(sizes), list(sizes)
+        for index, (offset, size, flipped) in (
+            (x_index, (x_off, x_size, self._md_x_flipped)),
+            (y_index, (y_off, y_size, self._md_y_flipped)),
+        ):
+            starts[index] = sizes[index] - offset - size if flipped else offset
+            counts[index] = size
+        for index in range(len(sizes)):
+            if index not in (x_index, y_index):
+                starts[index] = 0
+        try:
+            block = md_arr.ReadAsArray(array_start_idx=starts, count=counts)
+        except (RuntimeError, AttributeError):
+            return None
+        if block is None:
+            return None
+        block = np.asarray(block)
+        # The classic view flattens every non-spatial dimension into bands, in storage order, and
+        # presents the spatial pair as (rows, cols) — mirror that so band order is unchanged.
+        block = np.moveaxis(block, [y_index, x_index], [-2, -1]).reshape(
+            -1, y_size, x_size
+        )
+        if self._md_y_flipped:
+            block = block[:, ::-1, :]
+        if self._md_x_flipped:
+            block = block[:, :, ::-1]
+        target = gdal.GetDriverByName("MEM").Create(
+            "", x_size, y_size, block.shape[0], numpy_to_gdal_dtype(block.dtype)
+        )
+        if target is None:
+            return None
+        for band_index in range(block.shape[0]):
+            target.GetRasterBand(band_index + 1).WriteArray(
+                np.ascontiguousarray(block[band_index])
+            )
+        gt = self._geotransform
+        target.SetGeoTransform(
+            (
+                gt[0] + x_off * gt[1],
+                gt[1],
+                gt[2],
+                gt[3] + y_off * gt[5],
+                gt[4],
+                gt[5],
+            )
+        )
+        wrapper_srs = self._raster.GetSpatialRef() if self._raster is not None else None
+        if wrapper_srs is not None:
+            target.SetSpatialRef(wrapper_srs)
+        elif self.epsg:
+            # The MDArray view often carries no SRS of its own, while the variable still knows its
+            # EPSG. A cutline warp against a projection-less raster warns and — for a cutline in
+            # another CRS — clips the wrong region, so stamp it here rather than inherit nothing.
+            target.SetProjection(sr_from_epsg(int(self.epsg)).ExportToWkt())
+        self._reconcile_band_no_data(target)
+        return target
+
     def _copy_raw_view(self) -> gdal.Dataset | None:
         """Rebuild the **unreversed** classic view of the source variable and copy it into MEM.
 

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -272,6 +272,13 @@ _X_NAME_PREFERENCE = (
 # a name added to only one of them is either never matched or never tried.
 _Y_DIM_NAMES = frozenset(_Y_NAME_PREFERENCE)
 _X_DIM_NAMES = frozenset(_X_NAME_PREFERENCE)
+# Everything `_coordinate_candidates` needs for one axis, keyed by it: the two legacy names tried
+# first (kept for backward compatibility, so a file that already resolved keeps resolving to the
+# same coordinate), the membership set, and the blind-tail preference order.
+_AXIS_NAME_SOURCES = {
+    "X": (("lon", "x"), _X_DIM_NAMES, _X_NAME_PREFERENCE),
+    "Y": (("lat", "y"), _Y_DIM_NAMES, _Y_NAME_PREFERENCE),
+}
 # Dimension names that clearly denote a non-spatial axis. Used to suppress the
 # "demoted grid" warning for legitimately non-spatial N-D aux variables
 # (e.g. a (time, level) table, time-bounds (time, nv)) — only a variable with
@@ -5600,9 +5607,7 @@ class NetCDF(Dataset):
             "_coordinate_candidate_cache", {}
         )
         if axis not in cache:
-            legacy = ("lon", "x") if axis == "X" else ("lat", "y")
-            well_known = _X_DIM_NAMES if axis == "X" else _Y_DIM_NAMES
-            preferred = _X_NAME_PREFERENCE if axis == "X" else _Y_NAME_PREFERENCE
+            legacy, well_known, preferred = _AXIS_NAME_SOURCES[axis]
             rg, present = self._present_coordinate_names()
             cf_named = (
                 [name for name in present if self._axis_role(rg, name) == axis]

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -5512,11 +5512,19 @@ class NetCDF(Dataset):
             ``(None, None)`` when nothing readable matched.
         """
         values, found = None, None
-        for name in candidates:
-            array = self._read_variable(name)
-            if array is not None:
-                values, found = np.asarray(array), name
-                break
+        # These are probes: most candidates are absent, and in classic mode each miss is a real
+        # `gdal.Open("NETCDF:<file>:<name>")` that fails and pushes a GDAL error out to the user as
+        # a `RuntimeWarning` ("... is not a variable"). The misses are expected and handled — a
+        # name that does not read is simply the next one's turn — so quiet them here rather than
+        # let a routine lookup spray warnings the caller can do nothing about. Silencing the noise
+        # is the right lever; skipping the probes is not, because a readable coordinate is not
+        # always an enumerable one.
+        with gdal.quiet_errors():
+            for name in candidates:
+                array = self._read_variable(name)
+                if array is not None:
+                    values, found = np.asarray(array), name
+                    break
         return values, found
 
     def _bounds_array_names(self, rg: Any, present: list[str]) -> set[str]:
@@ -5552,19 +5560,21 @@ class NetCDF(Dataset):
         }
         return declared | conventional
 
-    def _present_coordinate_names(self) -> tuple[Any, list[str]]:
-        """The working group and the array names the store actually holds, bounds removed.
+    def _present_coordinate_names(self) -> tuple[gdal.Group | None, list[str]]:
+        """The working group and the array names it enumerates, CF bounds arrays removed.
 
-        Multidimensional mode lists them off the root group. Classic (non-MDIM) mode has no root
-        group, but its subdataset list names the same variables — enumerate that rather than
-        report nothing, because every candidate that is not present costs a real
-        ``gdal.Open("NETCDF:<file>:<name>")`` that fails and surfaces a ``RuntimeWarning`` to the
-        user: 12 per variable extraction, and up to 16 remote opens per variable over ``/vsicurl``,
-        precisely the case this path exists to make cheaper.
+        Multidimensional mode lists them off the working group; classic (non-MDIM) mode has no
+        group, so the subdataset list stands in.
+
+        This is what the store *enumerates*, which is narrower than what it can *read*: a
+        coordinate at the root is readable from a subgroup view without appearing here, and GDAL's
+        classic subdataset list holds only the >= 2-D data variables. Callers must therefore treat
+        an absent name as "not advertised", never as "not there" — see the tail in
+        :meth:`_coordinate_candidates`.
 
         Returns:
-            tuple[Any, list[str]]: The root group (``None`` in classic mode) and the names present,
-            with CF bounds arrays excluded.
+            tuple[gdal.Group | None, list[str]]: The working group (``None`` in classic mode) and
+            the enumerated names, with CF bounds arrays excluded.
         """
         rg = self._working_group()
         if rg is None:
@@ -5602,6 +5612,11 @@ class NetCDF(Dataset):
 
         Returns:
             tuple[str, ...]: Candidate names, most-specific first, without duplicates.
+
+        Raises:
+            KeyError: `axis` is neither ``"X"`` nor ``"Y"``. Deliberate: the earlier
+                ``if axis == "X" else`` form silently treated any typo as the Y axis and returned
+                latitude names for it.
         """
         cache: dict[str, tuple[str, ...]] = self.__dict__.setdefault(
             "_coordinate_candidate_cache", {}
@@ -5617,12 +5632,17 @@ class NetCDF(Dataset):
             well_known_present = [
                 name for name in present if name.lower() in well_known
             ]
-            # The blind tail is a last resort for a store whose names could not be enumerated at
-            # all. When they could, anything not in `present` is known to be absent, so probing it
-            # only buys a failed open and a warning.
-            tail = preferred if not present else ()
+            # The well-known tail is always offered, never trimmed against `present`. "Not
+            # enumerated" does not mean "not readable": the resolver reaches further than the
+            # enumerator — `_read_indexing_variable` finds a coordinate that lives in the *root*
+            # group from a subgroup view, and GDAL's classic subdataset list holds only the >= 2-D
+            # data variables, never the 1-D coordinates, which `NETCDF:"<file>":latitude` opens
+            # perfectly well. Trimming the tail therefore silently un-georeferenced group-scoped
+            # and classic-mode stores. It costs nothing on a file that resolves anyway, because
+            # the tail is last and the lookup is first-match; the names below it are only ever
+            # tried when everything else has already missed.
             ordered: list[str] = []
-            for name in (*legacy, *cf_named, *well_known_present, *tail):
+            for name in (*legacy, *cf_named, *well_known_present, *preferred):
                 if name not in ordered:
                     ordered.append(name)
             cache[axis] = tuple(ordered)

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -818,6 +818,16 @@ class NetCDF(Dataset):
         _invalidate_cached_accessors(self)
         # Drop the memoised classic geolocation handle so it is re-resolved.
         self.__dict__.pop("_geolocation_source_memo", None)
+        # ... and the resolved axis-coordinate names, which are read off the store's layout.
+        self.__dict__.pop("_coordinate_candidate_cache", None)
+        # An in-place swap installs a raster holding *different* values — the whole point of
+        # `apply(inplace=True)`, `fill` and `add_band`. The multidim references above are preserved
+        # deliberately (this is still that variable of that file), but they no longer describe what
+        # `self._raster` holds, so a read that goes back to the MDArray returns the pre-mutation
+        # data. Nothing else can notice: the swap keeps the grid size, so a shape check sees
+        # nothing. Record the divergence so `_window_via_mdarray` stops serving windows from the
+        # source, and the crop falls back to reading the raster it was actually given.
+        self._raster_diverged_from_source = True
 
     def __str__(self):
         """Return a human-readable summary, or a `<Dataset: closed>` sentinel when closed.
@@ -3732,6 +3742,39 @@ class NetCDF(Dataset):
             variable, unresolved spatial dimensions, unknown flips, an out-of-range window, or a
             failed read) — in which case the caller keeps its existing full-read path.
         """
+        plan = self._window_read_plan(x_off, y_off, x_size, y_size)
+        if plan is None:
+            return None
+        md_arr, starts, counts, spatial = plan
+        try:
+            block = md_arr.ReadAsArray(array_start_idx=starts, count=counts)
+        except (RuntimeError, AttributeError):
+            block = None
+        if block is None:
+            return None
+        target = self._window_raster(np.asarray(block), spatial, x_size, y_size)
+        if target is not None:
+            self._stamp_window_georeference(target, x_off, y_off)
+        return target
+
+    def _window_read_plan(
+        self, x_off: int, y_off: int, x_size: int, y_size: int
+    ) -> tuple[Any, list[int], list[int], tuple[int, int]] | None:
+        """Raw ``(array, start, count, spatial)`` for a raster window, or ``None`` to decline.
+
+        Owns every precondition of the windowed read and the raster-to-raw index mapping, so
+        :meth:`_window_via_mdarray` is left with read, build, stamp.
+
+        Args:
+            x_off: Column offset of the window in raster space.
+            y_off: Row offset of the window in raster space.
+            x_size: Window width in columns.
+            y_size: Window height in rows.
+
+        Returns:
+            tuple | None: The opened MDArray, its per-dimension start and count, and the
+            ``(x_index, y_index)`` spatial pair — or ``None`` when the read must not be served.
+        """
         rg = self._gdal_rg_ref
         var = self._source_var_name
         spatial = self._md_spatial_dims
@@ -3740,28 +3783,38 @@ class NetCDF(Dataset):
         )
         if rg is None or var is None or spatial is None or not flips_known:
             return None
+        # Reading from the MDArray is only equivalent while the wrapper's raster still *is* that
+        # variable. An in-place mutation (`apply(inplace=True)`, `fill`, `add_band`) swaps in a
+        # raster of the same size holding different values while keeping the multidim references,
+        # so every size and shape check still passes and the window would silently return the
+        # pre-mutation data (#1071 review).
+        if getattr(self, "_raster_diverged_from_source", False):
+            return None
         x_index, y_index = spatial
         try:
             md_arr = rg.OpenMDArray(var)
             sizes = [d.GetSize() for d in md_arr.GetDimensions()]
         except (RuntimeError, AttributeError):
             return None
-        if (
-            not (0 <= x_off and 0 <= y_off and x_size > 0 and y_size > 0)
-            or x_off + x_size > sizes[x_index]
-            or y_off + y_size > sizes[y_index]
-        ):
-            return None
+        in_range = (
+            0 <= x_off
+            and 0 <= y_off
+            and x_size > 0
+            and y_size > 0
+            and x_off + x_size <= sizes[x_index]
+            and y_off + y_size <= sizes[y_index]
+        )
         # The caller derived this window from the *wrapper* raster's rows/columns, but it is served
         # from the raw MDArray. Those agree today only through a chain of non-local invariants
         # (`_md_spatial_dims` is set once, in `get_variable`, and every reshaping operation
         # materializes the view and so disables this path). Check it here rather than trust the
         # chain: a mismatch would silently read a differently-sized grid at the same indices.
-        if sizes[x_index] != self.columns or sizes[y_index] != self.rows:
+        same_grid = sizes[x_index] == self.columns and sizes[y_index] == self.rows
+        if not (in_range and same_grid):
             return None
         # A reversed axis is stored back-to-front, so the raster window maps to the mirrored raw
         # slice; read it forwards (negative steps are what the reversed view cannot serve) and undo
-        # the reversal on the small result below. Every non-spatial axis is read whole, from 0, so
+        # the reversal on the small result later. Every non-spatial axis is read whole, from 0, so
         # it flattens into bands exactly as the classic view presents them.
         starts, counts = [0] * len(sizes), list(sizes)
         for index, (offset, size, flipped) in (
@@ -3770,13 +3823,27 @@ class NetCDF(Dataset):
         ):
             starts[index] = sizes[index] - offset - size if flipped else offset
             counts[index] = size
-        try:
-            block = md_arr.ReadAsArray(array_start_idx=starts, count=counts)
-        except (RuntimeError, AttributeError):
-            return None
-        if block is None:
-            return None
-        block = np.asarray(block)
+        return md_arr, starts, counts, (x_index, y_index)
+
+    def _window_raster(
+        self,
+        block: np.ndarray,
+        spatial: tuple[int, int],
+        x_size: int,
+        y_size: int,
+    ) -> gdal.Dataset | None:
+        """Lay a raw window out the way the classic view does, as a ``MEM`` raster.
+
+        Args:
+            block: The raw window as read, in the variable's own dimension order.
+            spatial: The ``(x_index, y_index)`` positions of the spatial axes in `block`.
+            x_size: Window width in columns.
+            y_size: Window height in rows.
+
+        Returns:
+            gdal.Dataset | None: The ``MEM`` raster, or ``None`` if it could not be allocated.
+        """
+        x_index, y_index = spatial
         # The classic view flattens every non-spatial dimension into bands, in storage order, and
         # presents the spatial pair as (rows, cols) — mirror that so band order is unchanged.
         # `moveaxis` and the flip slices are views; only the per-band `ascontiguousarray` below
@@ -3791,17 +3858,30 @@ class NetCDF(Dataset):
         target = gdal.GetDriverByName("MEM").Create(
             "", x_size, y_size, band_count, numpy_to_gdal_dtype(moved.dtype)
         )
-        if target is None:
-            return None
-        for band_index in range(band_count):
-            # `unravel_index` walks the non-spatial axes in C order — the same order the flat
-            # reshape would have produced, so band order matches the classic view exactly.
-            plane = (
-                moved[np.unravel_index(band_index, band_shape)] if band_shape else moved
-            )
-            target.GetRasterBand(band_index + 1).WriteArray(
-                np.ascontiguousarray(plane[rows, columns])
-            )
+        if target is not None:
+            for band_index in range(band_count):
+                # `unravel_index` walks the non-spatial axes in C order — the same order the flat
+                # reshape would have produced, so band order matches the classic view exactly.
+                plane = (
+                    moved[np.unravel_index(band_index, band_shape)]
+                    if band_shape
+                    else moved
+                )
+                target.GetRasterBand(band_index + 1).WriteArray(
+                    np.ascontiguousarray(plane[rows, columns])
+                )
+        return target
+
+    def _stamp_window_georeference(
+        self, target: gdal.Dataset, x_off: int, y_off: int
+    ) -> None:
+        """Give a window raster the sub-affine, CRS, scale/offset and no-data of its parent.
+
+        Args:
+            target: The window raster to stamp.
+            x_off: Column offset of the window in raster space.
+            y_off: Row offset of the window in raster space.
+        """
         gt = self._geotransform
         target.SetGeoTransform(
             (
@@ -3835,7 +3915,6 @@ class NetCDF(Dataset):
             if offset is not None:
                 target_band.SetOffset(offset)
         self._reconcile_band_no_data(target)
-        return target
 
     def _copy_raw_view(self) -> gdal.Dataset | None:
         """Rebuild the **unreversed** classic view of the source variable and copy it into MEM.
@@ -5398,19 +5477,15 @@ class NetCDF(Dataset):
         return cube
 
     def _first_coordinate(self, candidates: tuple[str, ...]) -> tuple[Any, str | None]:
-        """The first *usable* coordinate variable among `candidates`, with the name it was found under.
+        """The first readable coordinate variable among `candidates`, with the name it was found under.
 
-        Usable means a 1-D array of at least two values — what an affine can be derived from.
-        Scanning past the unusable ones matters because the candidate list is built partly from CF
-        attributes, and CF says a bounds variable inherits its parent's ``units`` and
-        ``standard_name``: ``latitude_bnds`` / ``lon_vertices`` therefore look exactly like axis
-        coordinates. Committing to the first name that merely *opens* would return that 2-D bounds
-        array, and the caller — which requires ``ndim == 1`` — would silently fall through to the
-        curvilinear branch and leave the variable in index space, defeating the #1071 rescue on a
-        very ordinary CF layout.
-
-        Falls back to the first readable array of any rank when nothing 1-D is found, so a genuinely
-        curvilinear file reaches :meth:`_curvilinear_bbox_geotransform` exactly as before.
+        Strictly first-match: rank is **not** a tiebreak. Preferring a 1-D array here would look
+        like a harmless way to skip a 2-D CF bounds array, but it also promotes a 1-D index axis
+        (``x``/``y``) over the 2-D ``lon``/``lat`` of a curvilinear file — and the caller relies on
+        getting that 2-D array back to route into :meth:`_curvilinear_bbox_geotransform`, so the
+        grid would keep an index-space affine instead of its real extent (#1039). Bounds arrays are
+        excluded from the candidate list itself, by :meth:`_bounds_array_names`, which is where the
+        distinction can actually be drawn.
 
         Args:
             candidates: Ordered names to try, from :meth:`_coordinate_candidates`.
@@ -5420,20 +5495,45 @@ class NetCDF(Dataset):
             ``(None, None)`` when nothing readable matched.
         """
         values, found = None, None
-        fallback, fallback_name = None, None
         for name in candidates:
             array = self._read_variable(name)
+            if array is not None:
+                values, found = np.asarray(array), name
+                break
+        return values, found
+
+    def _bounds_array_names(self, rg: Any, present: list[str]) -> set[str]:
+        """Names in `present` that are CF *bounds* arrays rather than axis coordinates.
+
+        CF says a bounds variable inherits its parent's ``units`` and ``standard_name``, so
+        ``latitude_bnds`` is indistinguishable from ``latitude`` by attributes alone and would
+        otherwise enter the candidate list and shadow the real coordinate (#1071 review).
+
+        Two signals, in order of authority: the ``bounds`` attribute a coordinate uses to name its
+        own bounds array — the CF-sanctioned link — and, for files that omit it, the conventional
+        ``_bnds`` / ``_bounds`` / ``_vertices`` suffixes.
+
+        Args:
+            rg: The store's multidimensional root group.
+            present: Array names in the working group.
+
+        Returns:
+            set[str]: Names to exclude from the axis-coordinate candidates.
+        """
+        declared: set[str] = set()
+        for name in present:
+            array = open_mdarray(rg, name)
             if array is None:
                 continue
-            array = np.asarray(array)
-            if array.ndim == 1 and array.size >= 2:
-                values, found = array, name
-                break
-            if fallback is None:
-                fallback, fallback_name = array, name
-        if values is None:
-            values, found = fallback, fallback_name
-        return values, found
+            target = _read_attributes(array).get("bounds")
+            if isinstance(target, str) and target:
+                declared.add(target)
+        conventional = {
+            name
+            for name in present
+            if name.lower().endswith(("_bnds", "_bounds", "_vertices"))
+        }
+        return declared | conventional
 
     def _coordinate_candidates(self, axis: str) -> tuple[str, ...]:
         """Ordered coordinate-variable names to try when georeferencing `axis` (``"X"`` / ``"Y"``).
@@ -5474,6 +5574,9 @@ class NetCDF(Dataset):
             preferred = _X_NAME_PREFERENCE if axis == "X" else _Y_NAME_PREFERENCE
             rg = self._working_group()
             present = list(rg.GetMDArrayNames() or []) if rg is not None else []
+            if rg is not None:
+                bounds = self._bounds_array_names(rg, present)
+                present = [name for name in present if name not in bounds]
             cf_named = [name for name in present if self._axis_role(rg, name) == axis]
             well_known_present = [
                 name for name in present if name.lower() in well_known

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -3779,21 +3779,28 @@ class NetCDF(Dataset):
         block = np.asarray(block)
         # The classic view flattens every non-spatial dimension into bands, in storage order, and
         # presents the spatial pair as (rows, cols) — mirror that so band order is unchanged.
-        block = np.moveaxis(block, [y_index, x_index], [-2, -1]).reshape(
-            -1, y_size, x_size
-        )
-        if self._md_y_flipped:
-            block = block[:, ::-1, :]
-        if self._md_x_flipped:
-            block = block[:, :, ::-1]
+        # `moveaxis` and the flip slices are views; only the per-band `ascontiguousarray` below
+        # copies, one band at a time. Reshaping to `(-1, y, x)` here instead would force a copy of
+        # the whole window (the moved axes are not contiguous) and each flip another, holding the
+        # window three times over for a variable with long non-spatial axes.
+        moved = np.moveaxis(block, [y_index, x_index], [-2, -1])
+        rows = slice(None, None, -1) if self._md_y_flipped else slice(None)
+        columns = slice(None, None, -1) if self._md_x_flipped else slice(None)
+        band_shape = moved.shape[:-2]
+        band_count = int(np.prod(band_shape)) if band_shape else 1
         target = gdal.GetDriverByName("MEM").Create(
-            "", x_size, y_size, block.shape[0], numpy_to_gdal_dtype(block.dtype)
+            "", x_size, y_size, band_count, numpy_to_gdal_dtype(moved.dtype)
         )
         if target is None:
             return None
-        for band_index in range(block.shape[0]):
+        for band_index in range(band_count):
+            # `unravel_index` walks the non-spatial axes in C order — the same order the flat
+            # reshape would have produced, so band order matches the classic view exactly.
+            plane = (
+                moved[np.unravel_index(band_index, band_shape)] if band_shape else moved
+            )
             target.GetRasterBand(band_index + 1).WriteArray(
-                np.ascontiguousarray(block[band_index])
+                np.ascontiguousarray(plane[rows, columns])
             )
         gt = self._geotransform
         target.SetGeoTransform(
@@ -3875,13 +3882,19 @@ class NetCDF(Dataset):
                 band.WriteArray(np.ascontiguousarray(band.ReadAsArray()[rows, cols]))
 
     def _reconcile_band_no_data(self, target: gdal.Dataset) -> None:
-        """Copy the wrapper's per-band no-data onto a raster rebuilt from the raw view.
+        """Copy the wrapper's per-band no-data onto a raster built from the same MDArray.
 
-        The rebuilt view reads the same MDArray, so band order, scale and offset already agree. Its
-        no-data need not: an ``AsClassicDataset`` view silently ignores ``SetNoDataValue``, but the
-        VRT that :meth:`_georeference_index_subset` may wrap around it does not, so a no-data set on
-        the wrapper would be lost when the raster is rebuilt. Only a value actually present on the
-        wrapper is copied — never ``None`` over a value the raw view supplies.
+        Both callers build `target` by re-reading the source variable: :meth:`_copy_raw_view`
+        rebuilds the whole unreversed view, :meth:`_window_via_mdarray` reads a single window. Band
+        order therefore already agrees in both cases, and the window read carries scale and offset
+        across itself (a hand-built ``MEM`` raster gets neither for free, where ``CreateCopy``
+        does). No-data is the one thing neither inherits: an ``AsClassicDataset`` view silently
+        ignores ``SetNoDataValue``, but the VRT that :meth:`_georeference_index_subset` may wrap
+        around it does not, so a no-data set on the wrapper would be lost. Only a value actually
+        present on the wrapper is copied — never ``None`` over a value the source supplies.
+
+        Args:
+            target: The rebuilt raster to reconcile against ``self._raster``.
         """
         bands = min(target.RasterCount, self._raster.RasterCount)
         for index in range(1, bands + 1):
@@ -5441,24 +5454,36 @@ class NetCDF(Dataset):
         space (#1071). A frozenset is never iterated directly here — its order is not defined, and
         this lookup is first-match.
 
+        Cached per axis on the container. Stage 2 opens **every** array in the group to read its
+        attributes, and the rescue asks for both axes of every variable it georeferences — over
+        ``/vsicurl`` that is a round trip per array per variable, for an answer that depends only
+        on the container's own layout and cannot change while it is open.
+
         Args:
             axis: ``"X"`` for the longitude/easting axis, ``"Y"`` for latitude/northing.
 
         Returns:
             tuple[str, ...]: Candidate names, most-specific first, without duplicates.
         """
-        legacy = ("lon", "x") if axis == "X" else ("lat", "y")
-        well_known = _X_DIM_NAMES if axis == "X" else _Y_DIM_NAMES
-        preferred = _X_NAME_PREFERENCE if axis == "X" else _Y_NAME_PREFERENCE
-        rg = self._working_group()
-        present = list(rg.GetMDArrayNames() or []) if rg is not None else []
-        cf_named = [name for name in present if self._axis_role(rg, name) == axis]
-        well_known_present = [name for name in present if name.lower() in well_known]
-        ordered: list[str] = []
-        for name in (*legacy, *cf_named, *well_known_present, *preferred):
-            if name not in ordered:
-                ordered.append(name)
-        return tuple(ordered)
+        cache: dict[str, tuple[str, ...]] = self.__dict__.setdefault(
+            "_coordinate_candidate_cache", {}
+        )
+        if axis not in cache:
+            legacy = ("lon", "x") if axis == "X" else ("lat", "y")
+            well_known = _X_DIM_NAMES if axis == "X" else _Y_DIM_NAMES
+            preferred = _X_NAME_PREFERENCE if axis == "X" else _Y_NAME_PREFERENCE
+            rg = self._working_group()
+            present = list(rg.GetMDArrayNames() or []) if rg is not None else []
+            cf_named = [name for name in present if self._axis_role(rg, name) == axis]
+            well_known_present = [
+                name for name in present if name.lower() in well_known
+            ]
+            ordered: list[str] = []
+            for name in (*legacy, *cf_named, *well_known_present, *preferred):
+                if name not in ordered:
+                    ordered.append(name)
+            cache[axis] = tuple(ordered)
+        return cache[axis]
 
     @staticmethod
     def _coordinates_index_subset(cube: NetCDF, lon, lat, lon_name: str | None) -> bool:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -245,15 +245,10 @@ _REDUCERS: dict[str, tuple[Any, Any]] = {
 # ``NetCDF._detect_spatial_axes`` as a fallback when the coordinate variables
 # carry no CF axis / standard_name / units attributes (e.g. NWM names them
 # plainly ``x`` / ``y``). Compared case-insensitively.
-_Y_DIM_NAMES = frozenset(
-    {"y", "lat", "latitude", "rlat", "south_north", "northing", "grid_latitude"}
-)
-_X_DIM_NAMES = frozenset(
-    {"x", "lon", "longitude", "rlon", "west_east", "easting", "grid_longitude"}
-)
-# The same names in *preference* order, for the blind tail of `_coordinate_candidates` (the file
-# named none of them outright). A set has no order and sorting it alphabetically is an accident
-# that puts `grid_latitude` -- a rotated-pole axis -- ahead of plain `latitude`.
+# Listed in *preference* order — most common and most specific first. The order matters for the
+# blind tail of `_coordinate_candidates` (a store whose names could not be enumerated): a set has
+# none, and sorting alphabetically is an accident that puts `grid_latitude`, a rotated-pole axis,
+# ahead of plain `latitude`.
 _Y_NAME_PREFERENCE = (
     "latitude",
     "lat",
@@ -272,6 +267,11 @@ _X_NAME_PREFERENCE = (
     "grid_longitude",
     "west_east",
 )
+# Membership views of the same names for the case-insensitive "is this well known" test. Derived,
+# not written out a second time: two hand-kept copies of one list drift, and the drift is silent —
+# a name added to only one of them is either never matched or never tried.
+_Y_DIM_NAMES = frozenset(_Y_NAME_PREFERENCE)
+_X_DIM_NAMES = frozenset(_X_NAME_PREFERENCE)
 # Dimension names that clearly denote a non-spatial axis. Used to suppress the
 # "demoted grid" warning for legitimately non-spatial N-D aux variables
 # (e.g. a (time, level) table, time-bounds (time, nv)) — only a variable with
@@ -3893,21 +3893,31 @@ class NetCDF(Dataset):
                 gt[5],
             )
         )
-        wrapper_srs = self._raster.GetSpatialRef() if self._raster is not None else None
+        source = self._raster
+        if source is None:
+            return
+        wrapper_srs = source.GetSpatialRef()
         if wrapper_srs is not None:
             target.SetSpatialRef(wrapper_srs)
-        elif self.epsg:
+        else:
             # The MDArray view often carries no SRS of its own, while the variable still knows its
-            # EPSG. A cutline warp against a projection-less raster warns and — for a cutline in
-            # another CRS — clips the wrong region, so stamp it here rather than inherit nothing.
-            target.SetProjection(sr_from_epsg(int(self.epsg)).ExportToWkt())
+            # projection. A cutline warp against a projection-less raster warns and — for a cutline
+            # in another CRS — clips the wrong region, so stamp it here rather than inherit
+            # nothing. Prefer the resolved WKT over the EPSG code: a CRS with no authority code (a
+            # rotated pole, a spherical-earth GRIB GEOGCS) has no `epsg` to fall back on and would
+            # otherwise be dropped entirely.
+            wkt = self.crs
+            if wkt:
+                target.SetProjection(wkt)
+            elif self.epsg:
+                target.SetProjection(sr_from_epsg(int(self.epsg)).ExportToWkt())
         # `_copy_raw_view` gets scale/offset for free from `CreateCopy`; a hand-built MEM raster
         # does not. Carry them over, or a packed variable (`scale_factor`/`add_offset`, ordinary in
         # CF) would come back through the shortcut in raw counts while the full-read path returned
         # the same window in physical units.
-        carried = min(target.RasterCount, self._raster.RasterCount)
+        carried = min(target.RasterCount, source.RasterCount)
         for band_index in range(1, carried + 1):
-            source_band = self._raster.GetRasterBand(band_index)
+            source_band = source.GetRasterBand(band_index)
             target_band = target.GetRasterBand(band_index)
             scale, offset = source_band.GetScale(), source_band.GetOffset()
             if scale is not None:
@@ -5573,16 +5583,31 @@ class NetCDF(Dataset):
             well_known = _X_DIM_NAMES if axis == "X" else _Y_DIM_NAMES
             preferred = _X_NAME_PREFERENCE if axis == "X" else _Y_NAME_PREFERENCE
             rg = self._working_group()
-            present = list(rg.GetMDArrayNames() or []) if rg is not None else []
+            cf_named: list[str] = []
             if rg is not None:
+                present = list(rg.GetMDArrayNames() or [])
                 bounds = self._bounds_array_names(rg, present)
                 present = [name for name in present if name not in bounds]
-            cf_named = [name for name in present if self._axis_role(rg, name) == axis]
+                cf_named = [
+                    name for name in present if self._axis_role(rg, name) == axis
+                ]
+            else:
+                # Classic (non-MDIM) mode has no root group, but the subdataset list names the
+                # same variables. Enumerate it rather than leave `present` empty: every candidate
+                # that is not present costs a real `gdal.Open("NETCDF:<file>:<name>")` that fails,
+                # and GDAL surfaces a RuntimeWarning to the user for each one — 12 per variable
+                # extraction, and up to 16 remote opens per variable over `/vsicurl`, which is
+                # precisely the case this whole path exists to make cheaper.
+                present = self._classic_subdataset_variable_names()
             well_known_present = [
                 name for name in present if name.lower() in well_known
             ]
+            # The blind tail is a last resort for a store whose names could not be enumerated at
+            # all. When they could, anything not in `present` is known to be absent, so probing it
+            # only buys a failed open and a warning.
+            tail = preferred if not present else ()
             ordered: list[str] = []
-            for name in (*legacy, *cf_named, *well_known_present, *preferred):
+            for name in (*legacy, *cf_named, *well_known_present, *tail):
                 if name not in ordered:
                     ordered.append(name)
             cache[axis] = tuple(ordered)

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -5545,6 +5545,27 @@ class NetCDF(Dataset):
         }
         return declared | conventional
 
+    def _present_coordinate_names(self) -> tuple[Any, list[str]]:
+        """The working group and the array names the store actually holds, bounds removed.
+
+        Multidimensional mode lists them off the root group. Classic (non-MDIM) mode has no root
+        group, but its subdataset list names the same variables — enumerate that rather than
+        report nothing, because every candidate that is not present costs a real
+        ``gdal.Open("NETCDF:<file>:<name>")`` that fails and surfaces a ``RuntimeWarning`` to the
+        user: 12 per variable extraction, and up to 16 remote opens per variable over ``/vsicurl``,
+        precisely the case this path exists to make cheaper.
+
+        Returns:
+            tuple[Any, list[str]]: The root group (``None`` in classic mode) and the names present,
+            with CF bounds arrays excluded.
+        """
+        rg = self._working_group()
+        if rg is None:
+            return None, self._classic_subdataset_variable_names()
+        present = list(rg.GetMDArrayNames() or [])
+        bounds = self._bounds_array_names(rg, present)
+        return rg, [name for name in present if name not in bounds]
+
     def _coordinate_candidates(self, axis: str) -> tuple[str, ...]:
         """Ordered coordinate-variable names to try when georeferencing `axis` (``"X"`` / ``"Y"``).
 
@@ -5582,23 +5603,12 @@ class NetCDF(Dataset):
             legacy = ("lon", "x") if axis == "X" else ("lat", "y")
             well_known = _X_DIM_NAMES if axis == "X" else _Y_DIM_NAMES
             preferred = _X_NAME_PREFERENCE if axis == "X" else _Y_NAME_PREFERENCE
-            rg = self._working_group()
-            cf_named: list[str] = []
-            if rg is not None:
-                present = list(rg.GetMDArrayNames() or [])
-                bounds = self._bounds_array_names(rg, present)
-                present = [name for name in present if name not in bounds]
-                cf_named = [
-                    name for name in present if self._axis_role(rg, name) == axis
-                ]
-            else:
-                # Classic (non-MDIM) mode has no root group, but the subdataset list names the
-                # same variables. Enumerate it rather than leave `present` empty: every candidate
-                # that is not present costs a real `gdal.Open("NETCDF:<file>:<name>")` that fails,
-                # and GDAL surfaces a RuntimeWarning to the user for each one — 12 per variable
-                # extraction, and up to 16 remote opens per variable over `/vsicurl`, which is
-                # precisely the case this whole path exists to make cheaper.
-                present = self._classic_subdataset_variable_names()
+            rg, present = self._present_coordinate_names()
+            cf_named = (
+                [name for name in present if self._axis_role(rg, name) == axis]
+                if rg is not None
+                else []
+            )
             well_known_present = [
                 name for name in present if name.lower() in well_known
             ]

--- a/tests/netcdf/spatial/test_hdf5_coordinate_georef.py
+++ b/tests/netcdf/spatial/test_hdf5_coordinate_georef.py
@@ -39,7 +39,11 @@ EXPECTED_GT = (-180.0, CELL, 0.0, LAT_FIRST + (N_LAT - 1) * CELL + CELL / 2, 0.0
 
 
 def _write_grid(
-    path: str, lat_name: str, lon_name: str, with_bounds: bool = False
+    path: str,
+    lat_name: str,
+    lon_name: str,
+    with_bounds: bool = False,
+    with_aliases: bool = False,
 ) -> str:
     """Write a netCDF-4 grid whose coordinates carry CF axis attributes.
 
@@ -49,6 +53,8 @@ def _write_grid(
         lon_name: Name to give the longitude coordinate (and its dimension).
         with_bounds: Also write ``<name>_bnds`` arrays, created *before* the coordinates so they
             enumerate first, and carrying the same CF attributes real files give them.
+        with_aliases: Also write legacy-spelled ``lat``/``lon`` copies over the same dimensions,
+            so a file carries both spellings and the candidate ordering is observable.
 
     Returns:
         str: ``path``, for chaining.
@@ -91,11 +97,22 @@ def _write_grid(
         for key, value in (("standard_name", std), ("axis", axis), ("units", units)):
             attr = arr.CreateAttribute(key, [], gdal.ExtendedDataType.CreateString())
             attr.Write(value)
+    aliases = []
+    if with_aliases:
+        for alias, dim, values in (
+            ("lat", d_lat, LAT_FIRST + CELL * np.arange(N_LAT)),
+            ("lon", d_lon, LON_FIRST + CELL * np.arange(N_LON)),
+        ):
+            arr = rg.CreateMDArray(
+                alias, [dim], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+            )
+            arr.Write(values)
+            aliases.append(arr)
     var = rg.CreateMDArray(
         "v", [d_lat, d_lon], gdal.ExtendedDataType.Create(gdal.GDT_Float32)
     )
     var.Write(np.arange(N_LAT * N_LON, dtype="float32").reshape(N_LAT, N_LON))
-    tagged = bounds = None
+    tagged = bounds = aliases = None
     lat = lon = var = d_lat = d_lon = rg = None
     ds.Close()
     del ds
@@ -220,17 +237,21 @@ class TestCoordinateCandidates:
             tmp_path: pytest temp directory.
 
         Test scenario:
-            The lookup is first-match, so ordering is behaviour. Anything that previously
-            resolved via `lon`/`x` must not start resolving to a different coordinate.
+            The lookup is first-match, so ordering is behaviour. On a file carrying *both*
+            spellings the legacy one must win, so a grid that resolved before the #1071 change
+            resolves to exactly the same coordinate after it. Asserting the literal tuple
+            `("lon", "x")` instead would only restate the code, and would keep passing if the
+            stage that consumes the order broke.
         """
-        path = _write_grid(str(tmp_path / "order.nc"), "latitude", "longitude")
+        path = _write_grid(
+            str(tmp_path / "order.nc"), "latitude", "longitude", with_aliases=True
+        )
         nc = NetCDF.read_file(path)
         try:
-            assert nc._coordinate_candidates("X")[:2] == ("lon", "x"), (
-                "the legacy X names must stay first"
-            )
-            assert nc._coordinate_candidates("Y")[:2] == ("lat", "y"), (
-                "the legacy Y names must stay first"
+            _, x_name = nc._first_coordinate(nc._coordinate_candidates("X"))
+            _, y_name = nc._first_coordinate(nc._coordinate_candidates("Y"))
+            assert (x_name, y_name) == ("lon", "lat"), (
+                f"the legacy spelling must win when both are present, got {x_name}/{y_name}"
             )
         finally:
             nc.close()

--- a/tests/netcdf/spatial/test_hdf5_coordinate_georef.py
+++ b/tests/netcdf/spatial/test_hdf5_coordinate_georef.py
@@ -1,0 +1,250 @@
+"""Regression tests for georeferencing a variable whose driver supplies no affine (#1071).
+
+`NetCDF._georeference_index_subset` rescues a variable that came back in index space by deriving
+the affine from the file's 1-D coordinate variables. It only matters when the driver that opened
+the file does not build the affine itself: GDAL's **netCDF** driver does, so the rescue is a no-op
+there, but the **HDF5** driver does not — and HDF5 is what serves any `/vsi` NetCDF-4 read on
+Windows, because the netCDF driver needs Linux `userfaultfd` for those paths.
+
+The bug: the rescue looked its coordinates up under `lon`/`x` and `lat`/`y` only, so a file naming
+them the way CF's own standard does — `longitude` / `latitude` — was never found, and the variable
+kept the index-space placeholder `(0, 1, 0, rows, 0, -1)`. Any `crop(bbox=...)` on it then read the
+bbox as pixel indices.
+
+The driver cannot be swapped per-open (`GDAL_SKIP` is read when drivers register, so setting it
+from a fixture does nothing), so rather than fake the driver these tests drive
+`_coordinate_derived_geotransform` directly with a cube that is already in index space — the exact
+state the HDF5 path produces, and the input the rescue exists to handle.
+"""
+
+from __future__ import annotations
+
+import gc
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from osgeo import gdal
+
+from pyramids.netcdf import NetCDF
+
+pytestmark = pytest.mark.core
+
+CELL = 0.25
+N_LAT, N_LON = 8, 12
+# Cell-centre coordinates -> the affine anchors half a cell outside them.
+LAT_FIRST, LON_FIRST = -89.875, -179.875
+EXPECTED_GT = (-180.0, CELL, 0.0, LAT_FIRST + (N_LAT - 1) * CELL + CELL / 2, 0.0, -CELL)
+
+
+def _write_grid(path: str, lat_name: str, lon_name: str) -> str:
+    """Write a netCDF-4 grid whose coordinates carry CF axis attributes.
+
+    Args:
+        path: Output ``.nc`` path.
+        lat_name: Name to give the latitude coordinate (and its dimension).
+        lon_name: Name to give the longitude coordinate (and its dimension).
+
+    Returns:
+        str: ``path``, for chaining.
+    """
+    ds = gdal.GetDriverByName("netCDF").CreateMultiDimensional(path)
+    rg = ds.GetRootGroup()
+    d_lat = rg.CreateDimension(lat_name, "", "", N_LAT)
+    d_lon = rg.CreateDimension(lon_name, "", "", N_LON)
+    lat = rg.CreateMDArray(
+        lat_name, [d_lat], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    lat.Write(LAT_FIRST + CELL * np.arange(N_LAT))
+    lon = rg.CreateMDArray(
+        lon_name, [d_lon], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    lon.Write(LON_FIRST + CELL * np.arange(N_LON))
+    for arr, std, axis, units in (
+        (lat, "latitude", "Y", "degrees_north"),
+        (lon, "longitude", "X", "degrees_east"),
+    ):
+        for key, value in (("standard_name", std), ("axis", axis), ("units", units)):
+            attr = arr.CreateAttribute(key, [], gdal.ExtendedDataType.CreateString())
+            attr.Write(value)
+    var = rg.CreateMDArray(
+        "v", [d_lat, d_lon], gdal.ExtendedDataType.Create(gdal.GDT_Float32)
+    )
+    var.Write(np.arange(N_LAT * N_LON, dtype="float32").reshape(N_LAT, N_LON))
+    lat = lon = var = d_lat = d_lon = rg = None
+    ds.Close()
+    del ds
+    gc.collect()
+    return path
+
+
+def _index_space_cube(dim_names: list[str]) -> SimpleNamespace:
+    """A stand-in variable subset carrying the index-space affine the HDF5 path produces.
+
+    `_md_y_flipped` is ``True`` because the file stores latitude ascending (south-to-north), which
+    `_read_md_array` reverses to north-up — so row 0 holds the *last* stored latitude, and the
+    affine must anchor there. Getting this wrong flips the grid, not just the numbers.
+
+    Args:
+        dim_names: The variable's dimension names, as `_md_array_dims` records them.
+
+    Returns:
+        SimpleNamespace: The attributes `_coordinate_derived_geotransform` reads off a cube.
+    """
+    mem = gdal.GetDriverByName("MEM").Create("", N_LON, N_LAT, 1, gdal.GDT_Float32)
+    mem.SetGeoTransform([0.0, 1.0, 0.0, float(N_LAT), 0.0, -1.0])
+    return SimpleNamespace(
+        _raster=mem,
+        rows=N_LAT,
+        columns=N_LON,
+        _md_array_dims=dim_names,
+        _md_x_flipped=False,
+        _md_y_flipped=True,
+        # Read only by the curvilinear fallback, which a shape mismatch drops into.
+        crs="",
+        _source_var_name="v",
+    )
+
+
+class TestCoordinateDerivedGeotransform:
+    """The affine is derived whatever the coordinates are named (#1071)."""
+
+    @pytest.mark.parametrize(
+        "lat_name, lon_name",
+        [("latitude", "longitude"), ("lat", "lon"), ("Latitude", "LONGITUDE")],
+        ids=["cf-standard", "short", "mixed-case"],
+    )
+    def test_affine_is_derived_for_any_coordinate_spelling(
+        self, tmp_path, lat_name, lon_name
+    ):
+        """An index-space cube is re-georeferenced from the container's coordinates.
+
+        Args:
+            tmp_path: pytest temp directory.
+            lat_name: Latitude coordinate/dimension name written to the file.
+            lon_name: Longitude coordinate/dimension name written to the file.
+
+        Test scenario:
+            Before the fix only the `lat`/`lon` spelling was looked up, so the CF-standard and
+            mixed-case files returned `None` and the variable kept the index-space placeholder.
+        """
+        path = _write_grid(str(tmp_path / f"{lat_name}.nc"), lat_name, lon_name)
+        nc = NetCDF.read_file(path)
+        try:
+            cube = _index_space_cube([lat_name, lon_name])
+            derived = nc._coordinate_derived_geotransform(cube)
+            assert derived is not None, (
+                f"{lat_name}/{lon_name} coordinates must yield an affine, got None"
+            )
+            assert derived == pytest.approx(EXPECTED_GT), (
+                f"unexpected affine for {lat_name}/{lon_name}: {derived}"
+            )
+        finally:
+            nc.close()
+
+    def test_already_georeferenced_cube_is_left_alone(self, tmp_path):
+        """A cube whose affine already matches the coordinates is not re-derived.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            The rescue must stay a no-op on the netCDF-driver path, where GDAL already built
+            the affine — otherwise every read pays for a redundant correction.
+        """
+        path = _write_grid(str(tmp_path / "ok.nc"), "latitude", "longitude")
+        nc = NetCDF.read_file(path)
+        try:
+            cube = _index_space_cube(["latitude", "longitude"])
+            cube._raster.SetGeoTransform(list(EXPECTED_GT))
+            assert nc._coordinate_derived_geotransform(cube) is None, (
+                "a correctly georeferenced cube must not be re-derived"
+            )
+        finally:
+            nc.close()
+
+    def test_shape_mismatch_declines(self, tmp_path):
+        """Coordinates that do not index the cube's grid are not adopted.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            Guards against a same-named but differently-sized axis being adopted, which would
+            georeference the variable to the wrong extent.
+        """
+        path = _write_grid(str(tmp_path / "shape.nc"), "latitude", "longitude")
+        nc = NetCDF.read_file(path)
+        try:
+            cube = _index_space_cube(["latitude", "longitude"])
+            cube.columns = N_LON + 3
+            assert nc._coordinate_derived_geotransform(cube) is None, (
+                "a coordinate whose length does not match the grid must be declined"
+            )
+        finally:
+            nc.close()
+
+
+class TestCoordinateCandidates:
+    """`_coordinate_candidates` ordering rules that the rescue depends on."""
+
+    def test_legacy_names_are_tried_first(self, tmp_path):
+        """`lon`/`lat` keep priority, so a file that already resolved resolves identically.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            The lookup is first-match, so ordering is behaviour. Anything that previously
+            resolved via `lon`/`x` must not start resolving to a different coordinate.
+        """
+        path = _write_grid(str(tmp_path / "order.nc"), "latitude", "longitude")
+        nc = NetCDF.read_file(path)
+        try:
+            assert nc._coordinate_candidates("X")[:2] == ("lon", "x"), (
+                "the legacy X names must stay first"
+            )
+            assert nc._coordinate_candidates("Y")[:2] == ("lat", "y"), (
+                "the legacy Y names must stay first"
+            )
+        finally:
+            nc.close()
+
+    def test_cf_named_coordinates_are_offered(self, tmp_path):
+        """The file's actual CF-named coordinates appear as candidates.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            `longitude`/`latitude` are absent from the legacy pair, so they must come from the
+            CF-attribute or well-known-name stage — otherwise the grid is unrescuable.
+        """
+        path = _write_grid(str(tmp_path / "cands.nc"), "latitude", "longitude")
+        nc = NetCDF.read_file(path)
+        try:
+            assert "longitude" in nc._coordinate_candidates("X")
+            assert "latitude" in nc._coordinate_candidates("Y")
+        finally:
+            nc.close()
+
+    def test_candidates_are_unique(self, tmp_path):
+        """No name is offered twice, so a miss is never retried.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            The stages overlap by construction (`lon` is both legacy and well-known), so the
+            builder must de-duplicate while preserving order.
+        """
+        path = _write_grid(str(tmp_path / "uniq.nc"), "lat", "lon")
+        nc = NetCDF.read_file(path)
+        try:
+            for axis in ("X", "Y"):
+                names = nc._coordinate_candidates(axis)
+                assert len(names) == len(set(names)), (
+                    f"duplicate candidate for {axis}: {names}"
+                )
+        finally:
+            nc.close()

--- a/tests/netcdf/spatial/test_hdf5_coordinate_georef.py
+++ b/tests/netcdf/spatial/test_hdf5_coordinate_georef.py
@@ -20,6 +20,7 @@ state the HDF5 path produces, and the input the rescue exists to handle.
 from __future__ import annotations
 
 import gc
+import warnings
 from types import SimpleNamespace
 
 import numpy as np
@@ -290,6 +291,109 @@ class TestCoordinateDerivedGeotransform:
             assert nc._coordinate_derived_geotransform(cube) is None, (
                 "a coordinate whose length does not match the grid must be declined"
             )
+        finally:
+            nc.close()
+
+
+def _write_grouped_grid(path: str) -> str:
+    """Write a grid whose coordinates live at the root and whose data variable is in a subgroup.
+
+    Args:
+        path: Output ``.nc`` path.
+
+    Returns:
+        str: ``path``, for chaining.
+    """
+    ds = gdal.GetDriverByName("netCDF").CreateMultiDimensional(path)
+    rg = ds.GetRootGroup()
+    d_lat = rg.CreateDimension("latitude", "", "", N_LAT)
+    d_lon = rg.CreateDimension("longitude", "", "", N_LON)
+    lat = rg.CreateMDArray(
+        "latitude", [d_lat], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    lat.Write(LAT_FIRST + CELL * np.arange(N_LAT))
+    lon = rg.CreateMDArray(
+        "longitude", [d_lon], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    lon.Write(LON_FIRST + CELL * np.arange(N_LON))
+    for arr, std, axis, units in (
+        (lat, "latitude", "Y", "degrees_north"),
+        (lon, "longitude", "X", "degrees_east"),
+    ):
+        for key, value in (("standard_name", std), ("axis", axis), ("units", units)):
+            attr = arr.CreateAttribute(key, [], gdal.ExtendedDataType.CreateString())
+            attr.Write(value)
+    group = rg.CreateGroup("forecast")
+    var = group.CreateMDArray(
+        "v", [d_lat, d_lon], gdal.ExtendedDataType.Create(gdal.GDT_Float32)
+    )
+    var.Write(np.arange(N_LAT * N_LON, dtype="float32").reshape(N_LAT, N_LON))
+    lat = lon = var = group = d_lat = d_lon = rg = None
+    ds.Close()
+    del ds
+    gc.collect()
+    return path
+
+
+class TestCoordinatesOutsideTheWorkingGroup:
+    """A coordinate that is readable but not enumerable must still be found."""
+
+    def test_root_coordinates_resolve_from_a_subgroup_variable(self, tmp_path):
+        """Coordinates at the root georeference a variable that lives in a subgroup.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            The resolver reaches further than the enumerator: a subgroup's dimensions belong to the
+            root group, so `GetIndexingVariable` finds `latitude`/`longitude` even though the
+            subgroup's own `GetMDArrayNames()` does not list them. Restricting the candidate names
+            to what the working group enumerates therefore leaves this file in index space — the
+            #1071 symptom, reintroduced for every group-scoped store.
+        """
+        path = _write_grouped_grid(str(tmp_path / "grouped.nc"))
+        nc = NetCDF.read_file(path)
+        try:
+            view = nc.get_group("forecast")
+            assert "longitude" not in (view._working_group().GetMDArrayNames() or []), (
+                "the subgroup must not enumerate the coordinate — that is the whole point"
+            )
+            assert "longitude" in view._coordinate_candidates("X"), (
+                "a coordinate outside the working group must still be offered"
+            )
+            cube = _index_space_cube(["latitude", "longitude"])
+            assert view._coordinate_derived_geotransform(cube) == pytest.approx(
+                EXPECTED_GT
+            ), "root-group coordinates must georeference a subgroup variable"
+        finally:
+            nc.close()
+
+    def test_coordinate_probing_is_quiet(self, tmp_path):
+        """Probing absent candidate names emits no warning to the caller.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            Most candidates are absent by design and each miss is a failed GDAL open, which GDAL
+            reports as a `RuntimeWarning` the caller can do nothing about. The misses are expected
+            and handled, so they must stay quiet — without that, the only way to silence them is to
+            stop probing, which loses the coordinates this rescue exists to find.
+
+            Opened in classic (non-MDIM) mode deliberately: only there does a miss become a real
+            `gdal.Open("NETCDF:<file>:<name>")` that fails and reports itself. The multidim path
+            resolves through the group and is silent either way, so an MDIM fixture would pass
+            whether or not the probes are quietened.
+        """
+        path = _write_grid(str(tmp_path / "quiet.nc"), "latitude", "longitude")
+        nc = NetCDF.read_file(path, open_as_multi_dimensional=False)
+        try:
+            assert nc._working_group() is None, "the fixture must be in classic mode"
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                nc._first_coordinate(nc._coordinate_candidates("X"))
+            noisy = [w for w in caught if "not a variable" in str(w.message)]
+            assert not noisy, f"coordinate probing emitted {len(noisy)} warning(s)"
         finally:
             nc.close()
 

--- a/tests/netcdf/spatial/test_hdf5_coordinate_georef.py
+++ b/tests/netcdf/spatial/test_hdf5_coordinate_georef.py
@@ -120,6 +120,73 @@ def _write_grid(
     return path
 
 
+CURV_ROWS, CURV_COLUMNS = 6, 7
+
+
+def _write_curvilinear_grid(path: str) -> str:
+    """Write a curvilinear grid: 2-D ``lon``/``lat`` plus 1-D index axes ``x``/``y``.
+
+    A very common real layout — the 2-D arrays carry the geography, the 1-D ones merely number
+    the columns and rows. Written by a module-level helper rather than inline in the test so every
+    GDAL handle is released when it returns; a test frame holding them keeps the file open on
+    Windows and the reader then rejects it as an unsupported format.
+
+    Args:
+        path: Output ``.nc`` path.
+
+    Returns:
+        str: ``path``, for chaining.
+    """
+    ds = gdal.GetDriverByName("netCDF").CreateMultiDimensional(path)
+    rg = ds.GetRootGroup()
+    d_y = rg.CreateDimension("y", "", "", CURV_ROWS)
+    d_x = rg.CreateDimension("x", "", "", CURV_COLUMNS)
+    x_index = rg.CreateMDArray(
+        "x", [d_x], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    x_index.Write(np.arange(CURV_COLUMNS, dtype="float64"))
+    y_index = rg.CreateMDArray(
+        "y", [d_y], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    y_index.Write(np.arange(CURV_ROWS, dtype="float64"))
+    lon2d = rg.CreateMDArray(
+        "lon", [d_y, d_x], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    lat2d = rg.CreateMDArray(
+        "lat", [d_y, d_x], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    grid_x, grid_y = np.meshgrid(
+        np.linspace(12.0, 15.0, CURV_COLUMNS), np.linspace(40.0, 43.0, CURV_ROWS)
+    )
+    lon2d.Write(grid_x)
+    lat2d.Write(grid_y)
+    for arr, std, units in (
+        (lon2d, "longitude", "degrees_east"),
+        (lat2d, "latitude", "degrees_north"),
+    ):
+        for key, value in (("standard_name", std), ("units", units)):
+            attr = arr.CreateAttribute(key, [], gdal.ExtendedDataType.CreateString())
+            attr.Write(value)
+    var = rg.CreateMDArray(
+        "v", [d_y, d_x], gdal.ExtendedDataType.Create(gdal.GDT_Float32)
+    )
+    var.Write(
+        np.arange(CURV_ROWS * CURV_COLUMNS, dtype="float32").reshape(
+            CURV_ROWS, CURV_COLUMNS
+        )
+    )
+    coords = var.CreateAttribute(
+        "coordinates", [], gdal.ExtendedDataType.CreateString()
+    )
+    coords.Write("lon lat")
+    x_index = y_index = lon2d = lat2d = var = coords = None
+    d_y = d_x = rg = None
+    ds.Close()
+    del ds
+    gc.collect()
+    return path
+
+
 def _index_space_cube(dim_names: list[str]) -> SimpleNamespace:
     """A stand-in variable subset carrying the index-space affine the HDF5 path produces.
 
@@ -222,6 +289,38 @@ class TestCoordinateDerivedGeotransform:
             cube.columns = N_LON + 3
             assert nc._coordinate_derived_geotransform(cube) is None, (
                 "a coordinate whose length does not match the grid must be declined"
+            )
+        finally:
+            nc.close()
+
+
+class TestCurvilinearIsNotDisturbed:
+    """Excluding bounds arrays must not disturb the 2-D coordinate rescue (#1039)."""
+
+    def test_curvilinear_grid_keeps_its_bbox_affine(self, tmp_path):
+        """A curvilinear file resolves to its real extent, not to its 1-D index axes.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            A curvilinear grid carries 2-D `lon`/`lat` *and*, very often, 1-D index coordinates
+            `x`/`y` that merely number the columns and rows. The 2-D array must win: it is what
+            routes the variable into the bounding-box fallback that gives it a real geotransform.
+            Preferring a 1-D coordinate here — an inviting way to skip a 2-D bounds array — picks
+            the index axis instead, whose derived affine equals the index-space one already in
+            place, so the fallback never runs and the grid keeps a placeholder georeference that
+            misplaces the data entirely (#1039).
+        """
+        path = _write_curvilinear_grid(str(tmp_path / "curvilinear.nc"))
+        nc = NetCDF.read_file(path)
+        try:
+            geotransform = nc.get_variable("v").geotransform
+            assert geotransform[0] == pytest.approx(11.75, abs=0.01), (
+                f"expected the real longitude origin, got index space: {geotransform}"
+            )
+            assert geotransform[1] == pytest.approx(0.5, abs=0.01), (
+                f"expected the real cell size, got index space: {geotransform}"
             )
         finally:
             nc.close()

--- a/tests/netcdf/spatial/test_hdf5_coordinate_georef.py
+++ b/tests/netcdf/spatial/test_hdf5_coordinate_georef.py
@@ -27,6 +27,7 @@ import pytest
 from osgeo import gdal
 
 from pyramids.netcdf import NetCDF
+from pyramids.netcdf.netcdf import _X_DIM_NAMES
 
 pytestmark = pytest.mark.core
 
@@ -37,13 +38,17 @@ LAT_FIRST, LON_FIRST = -89.875, -179.875
 EXPECTED_GT = (-180.0, CELL, 0.0, LAT_FIRST + (N_LAT - 1) * CELL + CELL / 2, 0.0, -CELL)
 
 
-def _write_grid(path: str, lat_name: str, lon_name: str) -> str:
+def _write_grid(
+    path: str, lat_name: str, lon_name: str, with_bounds: bool = False
+) -> str:
     """Write a netCDF-4 grid whose coordinates carry CF axis attributes.
 
     Args:
         path: Output ``.nc`` path.
         lat_name: Name to give the latitude coordinate (and its dimension).
         lon_name: Name to give the longitude coordinate (and its dimension).
+        with_bounds: Also write ``<name>_bnds`` arrays, created *before* the coordinates so they
+            enumerate first, and carrying the same CF attributes real files give them.
 
     Returns:
         str: ``path``, for chaining.
@@ -52,6 +57,17 @@ def _write_grid(path: str, lat_name: str, lon_name: str) -> str:
     rg = ds.GetRootGroup()
     d_lat = rg.CreateDimension(lat_name, "", "", N_LAT)
     d_lon = rg.CreateDimension(lon_name, "", "", N_LON)
+    bounds = []
+    if with_bounds:
+        d_nv = rg.CreateDimension("nv", "", "", 2)
+        for name, dim, size in ((lat_name, d_lat, N_LAT), (lon_name, d_lon, N_LON)):
+            arr = rg.CreateMDArray(
+                f"{name}_bnds",
+                [dim, d_nv],
+                gdal.ExtendedDataType.Create(gdal.GDT_Float64),
+            )
+            arr.Write(np.zeros((size, 2)))
+            bounds.append(arr)
     lat = rg.CreateMDArray(
         lat_name, [d_lat], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
     )
@@ -60,10 +76,18 @@ def _write_grid(path: str, lat_name: str, lon_name: str) -> str:
         lon_name, [d_lon], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
     )
     lon.Write(LON_FIRST + CELL * np.arange(N_LON))
-    for arr, std, axis, units in (
+    tagged = [
         (lat, "latitude", "Y", "degrees_north"),
         (lon, "longitude", "X", "degrees_east"),
-    ):
+    ]
+    if bounds:
+        # Real files tag bounds with the parent's units/standard_name, which is exactly why they
+        # are indistinguishable from the coordinate by attributes alone.
+        tagged += [
+            (bounds[0], "latitude", "Y", "degrees_north"),
+            (bounds[1], "longitude", "X", "degrees_east"),
+        ]
+    for arr, std, axis, units in tagged:
         for key, value in (("standard_name", std), ("axis", axis), ("units", units)):
             attr = arr.CreateAttribute(key, [], gdal.ExtendedDataType.CreateString())
             attr.Write(value)
@@ -71,6 +95,7 @@ def _write_grid(path: str, lat_name: str, lon_name: str) -> str:
         "v", [d_lat, d_lon], gdal.ExtendedDataType.Create(gdal.GDT_Float32)
     )
     var.Write(np.arange(N_LAT * N_LON, dtype="float32").reshape(N_LAT, N_LON))
+    tagged = bounds = None
     lat = lon = var = d_lat = d_lon = rg = None
     ds.Close()
     del ds
@@ -210,21 +235,60 @@ class TestCoordinateCandidates:
         finally:
             nc.close()
 
-    def test_cf_named_coordinates_are_offered(self, tmp_path):
-        """The file's actual CF-named coordinates appear as candidates.
+    def test_cf_attributes_alone_identify_a_coordinate(self, tmp_path):
+        """A coordinate under an unrecognised name is found from its CF attributes.
 
         Args:
             tmp_path: pytest temp directory.
 
         Test scenario:
-            `longitude`/`latitude` are absent from the legacy pair, so they must come from the
-            CF-attribute or well-known-name stage — otherwise the grid is unrescuable.
+            Deliberately uses names in neither the legacy pair nor `_X_DIM_NAMES`/`_Y_DIM_NAMES`,
+            so the only stage that can supply them is the `axis`/`standard_name` detection. Asking
+            for `latitude`/`longitude` instead would prove nothing: the well-known tail offers
+            those unconditionally, whether or not the file contains them.
         """
-        path = _write_grid(str(tmp_path / "cands.nc"), "latitude", "longitude")
+        path = _write_grid(str(tmp_path / "cf_only.nc"), "ordinate", "abscissa")
         nc = NetCDF.read_file(path)
         try:
-            assert "longitude" in nc._coordinate_candidates("X")
-            assert "latitude" in nc._coordinate_candidates("Y")
+            assert "abscissa" not in _X_DIM_NAMES, (
+                "the fixture name must not be well-known"
+            )
+            assert "abscissa" in nc._coordinate_candidates("X"), (
+                "the CF-attribute stage must offer a coordinate under any name"
+            )
+            assert "ordinate" in nc._coordinate_candidates("Y")
+            cube = _index_space_cube(["ordinate", "abscissa"])
+            assert nc._coordinate_derived_geotransform(cube) == pytest.approx(
+                EXPECTED_GT
+            ), "a CF-attribute-only coordinate must still yield the affine"
+        finally:
+            nc.close()
+
+    def test_bounds_variables_do_not_defeat_the_rescue(self, tmp_path):
+        """A CF bounds array is not mistaken for the axis coordinate.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            CF says a bounds variable inherits its parent's `units` and `standard_name`, so
+            `latitude_bnds` is indistinguishable from `latitude` by attributes alone and enters the
+            candidate list. Written here *before* the real coordinates so it enumerates first: the
+            lookup must scan past the 2-D array rather than commit to it, or the affine comes back
+            `None` and the variable stays in index space — the very #1071 symptom, on an ordinary
+            CF layout.
+        """
+        path = _write_grid(
+            str(tmp_path / "bounds.nc"), "latitude", "longitude", with_bounds=True
+        )
+        nc = NetCDF.read_file(path)
+        try:
+            _, x_name = nc._first_coordinate(nc._coordinate_candidates("X"))
+            assert x_name == "longitude", f"expected the 1-D coordinate, got {x_name!r}"
+            cube = _index_space_cube(["latitude", "longitude"])
+            assert nc._coordinate_derived_geotransform(cube) == pytest.approx(
+                EXPECTED_GT
+            ), "bounds variables must not defeat the affine rescue"
         finally:
             nc.close()
 

--- a/tests/netcdf/spatial/test_windowed_mdarray_crop.py
+++ b/tests/netcdf/spatial/test_windowed_mdarray_crop.py
@@ -23,6 +23,7 @@ from osgeo import gdal, osr
 from shapely.geometry import box
 
 import pyramids.netcdf.engines.selection as selection_module
+from pyramids.base.crs import crs_equal
 from pyramids.dataset import Dataset
 from pyramids.feature import FeatureCollection
 from pyramids.netcdf import NetCDF
@@ -513,7 +514,8 @@ class TestCropUsesTheWindow:
 
         monkeypatch.setattr(selection_module.Selection, "_mask_window_source", _spy)
         fast = NetCDF.read_file(grid_path).get_variable("v").crop(mask=mask, touch=True)
-        assert taken and any(taken), (
+        assert taken, "the crop never consulted the window shortcut at all"
+        assert any(taken), (
             "the crop did not take the window shortcut, so this comparison proves nothing"
         )
         monkeypatch.setattr(
@@ -648,6 +650,43 @@ class TestCropUsesTheWindow:
             f"EPSG:{epsg} mask: expected shortcut offered={expected}"
         )
 
+    def test_crop_after_an_in_place_mutation_sees_the_mutation(
+        self, grid_path, monkeypatch
+    ):
+        """`apply(inplace=True)` then `crop()` must return the transformed values.
+
+        Args:
+            grid_path: The written grid fixture.
+            monkeypatch: Used to disable the shortcut for the reference crop.
+
+        Test scenario:
+            An in-place update swaps in a raster of the *same size* holding different values while
+            keeping the multidim references, so every size and shape guard still passes. Reading
+            the window from the MDArray then returns the original on-disk data and discards the
+            mutation silently — wrong data from a public API, for the ordinary sequence
+            read -> transform -> crop.
+        """
+        mask = gpd.GeoDataFrame(
+            geometry=[box(-179.6, -89.6, -178.9, -89.1)], crs="EPSG:4326"
+        )
+
+        def _cropped():
+            var = NetCDF.read_file(grid_path).get_variable("v")
+            var.apply(lambda values: values + 1000.0, inplace=True)
+            return np.asarray(var.crop(mask=mask, touch=True).read_array())
+
+        fast = _cropped()
+        monkeypatch.setattr(
+            selection_module.Selection, "_mask_window_source", lambda self, mask: None
+        )
+        reference = _cropped()
+        assert fast.shape == reference.shape, (
+            f"shape differs: {fast.shape} vs {reference.shape}"
+        )
+        assert np.array_equal(fast, reference), (
+            "the crop discarded the in-place mutation and returned the pre-mutation data"
+        )
+
     def test_shortcut_declines_for_a_rotated_affine(self, grid_path):
         """A rotated or degenerate affine is not windowable by row/column arithmetic.
 
@@ -691,14 +730,19 @@ class TestCropUsesTheWindow:
 
         Test scenario:
             `total_bounds` is read defensively; anything that is not four numbers must reach the
-            ordinary crop path rather than surface a `TypeError` from the shortcut.
+            ordinary crop path rather than surface a `TypeError` from the shortcut. The stand-in
+            must carry a *matching* CRS, or it declines at the CRS guard and never reaches the
+            `total_bounds` unpacking this test exists to cover.
         """
         var = NetCDF.read_file(grid_path).get_variable("v")
 
         class _NoBounds:
-            epsg = 4326
+            crs = var.crs
             total_bounds = None
 
+        assert crs_equal(_NoBounds.crs, var.crs), (
+            "the stand-in must pass the CRS guard, or this test covers the wrong branch"
+        )
         assert var.selection._mask_window_source(_NoBounds()) is None
 
     def test_shortcut_declines_when_the_window_is_most_of_the_grid(self, grid_path):

--- a/tests/netcdf/spatial/test_windowed_mdarray_crop.py
+++ b/tests/netcdf/spatial/test_windowed_mdarray_crop.py
@@ -631,11 +631,8 @@ class TestCropUsesTheWindow:
             written for `GeoDataFrame`'s pyproj `crs` raises `AttributeError` on it. Matching CRS
             must be offered the window and a differing one declined, without either raising.
 
-            Deliberately exercises `_mask_window_source` rather than `crop()`: cropping a NetCDF
-            variable with a raster mask is broken independently of this shortcut (it raises
-            `TypeError: create_from_array() got an unexpected keyword argument 'geo'` on `main`
-            with the shortcut disabled), so an end-to-end assertion here would be testing that
-            unrelated defect.
+            Exercises `_mask_window_source` directly so the guard is pinned regardless of what the
+            surrounding crop does; the end-to-end raster-mask crop is covered separately.
         """
         var = NetCDF.read_file(grid_path).get_variable("v")
         template = gdal.GetDriverByName("MEM").Create("", 4, 3, 1, gdal.GDT_Float32)
@@ -649,6 +646,46 @@ class TestCropUsesTheWindow:
         assert (source is not None) is expected, (
             f"EPSG:{epsg} mask: expected shortcut offered={expected}"
         )
+
+    def test_raster_mask_crop_takes_the_mask_grid(self, grid_path, monkeypatch):
+        """Cropping with a `Dataset` mask returns the mask's grid, by either path.
+
+        Args:
+            grid_path: The written grid fixture.
+            monkeypatch: Used to disable the shortcut for the reference crop.
+
+        Test scenario:
+            A raster mask is an alignment target, not just a clip: the crop takes the mask's own
+            grid. This whole path used to raise `TypeError: create_from_array() got an unexpected
+            keyword argument 'geo'`, because the shared trim builds an intermediate through
+            `self.__class__` and the NetCDF override of `create_from_array` takes a different
+            signature (#1073). Asserts the result matches the mask *and* that the shortcut changes
+            nothing.
+        """
+        template = gdal.GetDriverByName("MEM").Create("", 4, 3, 1, gdal.GDT_Float32)
+        template.SetGeoTransform([-179.75, CELL, 0.0, -88.25, 0.0, -CELL])
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(4326)
+        template.SetSpatialRef(srs)
+
+        def _cropped():
+            var = NetCDF.read_file(grid_path).get_variable("v")
+            return var.crop(mask=Dataset(template), touch=True)
+
+        fast = _cropped()
+        assert (fast.rows, fast.columns) == (3, 4), (
+            f"expected the mask's 3x4 grid, got {(fast.rows, fast.columns)}"
+        )
+        assert np.allclose(
+            fast.geotransform, [-179.75, CELL, 0.0, -88.25, 0.0, -CELL]
+        ), f"expected the mask's affine, got {fast.geotransform}"
+        monkeypatch.setattr(
+            selection_module.Selection, "_mask_window_source", lambda self, mask: None
+        )
+        reference = _cropped()
+        assert np.array_equal(
+            _as_bands(fast.read_array()), _as_bands(reference.read_array())
+        ), "the windowed and full-read raster-mask crops differ"
 
     def test_crop_after_an_in_place_mutation_sees_the_mutation(
         self, grid_path, monkeypatch

--- a/tests/netcdf/spatial/test_windowed_mdarray_crop.py
+++ b/tests/netcdf/spatial/test_windowed_mdarray_crop.py
@@ -1,0 +1,241 @@
+"""The rectilinear crop reads only the mask's window from the MDArray (#1071).
+
+The affine crop reads its whole source before clipping. That is cheap locally and expensive over a
+remote store: a variable is backed by an `AsClassicDataset` view, and when the file stores its axes
+in a different order than the raster presents them (e.g. `(time, longitude, latitude)` shown as
+rows=latitude/cols=longitude) every raster row becomes a strided gather. Measured against a 14 GB
+`/vsicurl` NetCDF-4, the same 16x10x10 window cost ~7.5 s through the classic view and ~0.85 s
+through `MDArray.Read`, and the end-to-end crop fell from 33.6 s to 1.1 s.
+
+The shortcut must be invisible: these tests pin that a crop taking it produces exactly what the
+full-read path produces, and that the window read matches the full array cell for cell — including
+the Y flip, since the fixtures store latitude ascending and the raster is north-up.
+"""
+
+from __future__ import annotations
+
+import gc
+
+import geopandas as gpd
+import numpy as np
+import pytest
+from osgeo import gdal
+from shapely.geometry import box
+
+import pyramids.netcdf.engines.selection as selection_module
+from pyramids.netcdf import NetCDF
+
+pytestmark = pytest.mark.core
+
+CELL = 0.25
+N_LAT, N_LON = 8, 12
+LAT_FIRST, LON_FIRST = -89.875, -179.875
+
+
+@pytest.fixture
+def grid_path(tmp_path) -> str:
+    """A small netCDF-4 grid with CF coordinates and a distinct value per cell.
+
+    Args:
+        tmp_path: pytest temp directory.
+
+    Returns:
+        str: Path to the written file.
+    """
+    path = str(tmp_path / "grid.nc")
+    ds = gdal.GetDriverByName("netCDF").CreateMultiDimensional(path)
+    rg = ds.GetRootGroup()
+    d_lat = rg.CreateDimension("latitude", "", "", N_LAT)
+    d_lon = rg.CreateDimension("longitude", "", "", N_LON)
+    lat = rg.CreateMDArray(
+        "latitude", [d_lat], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    lat.Write(LAT_FIRST + CELL * np.arange(N_LAT))
+    lon = rg.CreateMDArray(
+        "longitude", [d_lon], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    lon.Write(LON_FIRST + CELL * np.arange(N_LON))
+    for arr, std, axis, units in (
+        (lat, "latitude", "Y", "degrees_north"),
+        (lon, "longitude", "X", "degrees_east"),
+    ):
+        for key, value in (("standard_name", std), ("axis", axis), ("units", units)):
+            attr = arr.CreateAttribute(key, [], gdal.ExtendedDataType.CreateString())
+            attr.Write(value)
+    var = rg.CreateMDArray(
+        "v", [d_lat, d_lon], gdal.ExtendedDataType.Create(gdal.GDT_Float32)
+    )
+    var.Write(np.arange(N_LAT * N_LON, dtype="float32").reshape(N_LAT, N_LON))
+    lat = lon = var = d_lat = d_lon = rg = None
+    ds.Close()
+    del ds
+    gc.collect()
+    return path
+
+
+def _as_bands(array) -> np.ndarray:
+    """Normalise a read to `(bands, rows, cols)` so 2-D and 3-D reads compare alike."""
+    values = np.asarray(array)
+    return values[None, ...] if values.ndim == 2 else values
+
+
+class TestWindowViaMdArray:
+    """`_window_via_mdarray` returns exactly the cells the full read holds."""
+
+    @pytest.mark.parametrize(
+        "x_off, y_off, x_size, y_size",
+        [(0, 0, N_LON, N_LAT), (2, 1, 5, 4), (7, 3, 4, 3), (0, 5, 3, 3)],
+        ids=["whole", "interior", "corner", "edge"],
+    )
+    def test_window_matches_the_full_read(
+        self, grid_path, x_off, y_off, x_size, y_size
+    ):
+        """A window equals the same slice of the full array.
+
+        Args:
+            grid_path: The written grid fixture.
+            x_off: Column offset of the window.
+            y_off: Row offset of the window.
+            x_size: Window width.
+            y_size: Window height.
+
+        Test scenario:
+            The fixture stores latitude ascending, so the raster is Y-flipped; a window read must
+            undo that flip to line up with the north-up full read. An off-by-one or a transposed
+            axis shows up as a mismatch rather than merely wrong-looking numbers.
+        """
+        var = NetCDF.read_file(grid_path).get_variable("v")
+        full = _as_bands(var.read_array())
+        window = var._window_via_mdarray(x_off, y_off, x_size, y_size)
+        assert window is not None, "the window read must be served"
+        got = _as_bands(window.ReadAsArray())
+        expected = full[:, y_off : y_off + y_size, x_off : x_off + x_size]
+        assert np.array_equal(got, expected), (
+            f"window ({x_off},{y_off},{x_size},{y_size}) does not match the full read"
+        )
+
+    def test_window_carries_the_sub_affine(self, grid_path):
+        """The window's geotransform is the parent's, shifted to the window origin.
+
+        Args:
+            grid_path: The written grid fixture.
+
+        Test scenario:
+            The clip that follows relies on this affine, so a wrong origin would silently move
+            the cropped region.
+        """
+        var = NetCDF.read_file(grid_path).get_variable("v")
+        parent = var.geotransform
+        window = var._window_via_mdarray(3, 2, 4, 4)
+        assert window is not None
+        got = window.GetGeoTransform()
+        assert got[0] == pytest.approx(parent[0] + 3 * parent[1])
+        assert got[3] == pytest.approx(parent[3] + 2 * parent[5])
+        assert got[1] == pytest.approx(parent[1])
+        assert got[5] == pytest.approx(parent[5])
+
+    @pytest.mark.parametrize(
+        "x_off, y_off, x_size, y_size",
+        [
+            (0, 0, N_LON + 1, N_LAT),
+            (0, 0, N_LON, N_LAT + 1),
+            (-1, 0, 2, 2),
+            (0, 0, 0, 2),
+        ],
+        ids=["too-wide", "too-tall", "negative-offset", "empty"],
+    )
+    def test_out_of_range_window_declines(
+        self, grid_path, x_off, y_off, x_size, y_size
+    ):
+        """A window the array cannot serve returns None rather than a partial read.
+
+        Args:
+            grid_path: The written grid fixture.
+            x_off: Column offset of the window.
+            y_off: Row offset of the window.
+            x_size: Window width.
+            y_size: Window height.
+
+        Test scenario:
+            The caller treats `None` as "use the full-read path", so declining must be explicit
+            rather than a truncated or wrapped read.
+        """
+        var = NetCDF.read_file(grid_path).get_variable("v")
+        assert var._window_via_mdarray(x_off, y_off, x_size, y_size) is None
+
+
+class TestCropUsesTheWindow:
+    """The crop shortcut is invisible: same result as reading the whole variable."""
+
+    @pytest.mark.parametrize(
+        "bounds",
+        [
+            (-179.6, -89.6, -178.9, -89.1),
+            (-179.9, -89.9, -179.2, -89.4),
+            (-178.0, -88.6, -177.2, -88.1),
+        ],
+        ids=["interior", "south-west-corner", "north-east"],
+    )
+    def test_crop_matches_the_full_read_path(self, grid_path, monkeypatch, bounds):
+        """Cropping through the window equals cropping the whole variable.
+
+        Args:
+            grid_path: The written grid fixture.
+            monkeypatch: Used to disable the shortcut for the reference crop.
+            bounds: The mask box to crop with.
+
+        Test scenario:
+            Shape, geotransform and every cell must agree — the shortcut is an optimisation, so
+            any difference at all is a defect.
+        """
+        mask = gpd.GeoDataFrame(geometry=[box(*bounds)], crs="EPSG:4326")
+        fast = NetCDF.read_file(grid_path).get_variable("v").crop(mask=mask, touch=True)
+        monkeypatch.setattr(
+            selection_module.Selection, "_mask_window_source", lambda self, mask: None
+        )
+        reference = (
+            NetCDF.read_file(grid_path).get_variable("v").crop(mask=mask, touch=True)
+        )
+        assert (fast.rows, fast.columns) == (reference.rows, reference.columns), (
+            f"shape differs: {(fast.rows, fast.columns)} vs "
+            f"{(reference.rows, reference.columns)}"
+        )
+        assert np.allclose(fast.geotransform, reference.geotransform), (
+            f"geotransform differs: {fast.geotransform} vs {reference.geotransform}"
+        )
+        assert np.array_equal(
+            _as_bands(fast.read_array()), _as_bands(reference.read_array())
+        ), "cropped values differ between the windowed and full-read paths"
+
+    def test_shortcut_declines_for_a_mask_in_another_crs(self, grid_path):
+        """A cutline in a different CRS falls back, so the warp reprojects it.
+
+        Args:
+            grid_path: The written grid fixture.
+
+        Test scenario:
+            The window is computed in the raster's own coordinates, so adopting a mask stated in
+            another CRS would window the wrong region.
+        """
+        var = NetCDF.read_file(grid_path).get_variable("v")
+        mask = gpd.GeoDataFrame(
+            geometry=[box(-19970000, -19970000, -19900000, -19900000)],
+            crs="EPSG:3857",
+        )
+        assert var.selection._mask_window_source(mask) is None
+
+    def test_shortcut_declines_when_the_window_is_most_of_the_grid(self, grid_path):
+        """A mask covering the grid falls back — the shortcut must earn its second code path.
+
+        Args:
+            grid_path: The written grid fixture.
+
+        Test scenario:
+            Reading nearly everything through the window path only adds risk, so the whole-grid
+            case keeps the ordinary read.
+        """
+        var = NetCDF.read_file(grid_path).get_variable("v")
+        mask = gpd.GeoDataFrame(
+            geometry=[box(-180.0, -90.0, -176.0, -87.0)], crs="EPSG:4326"
+        )
+        assert var.selection._mask_window_source(mask) is None

--- a/tests/netcdf/spatial/test_windowed_mdarray_crop.py
+++ b/tests/netcdf/spatial/test_windowed_mdarray_crop.py
@@ -236,18 +236,32 @@ class TestWindowViaMdArray:
             f"window ({x_off},{y_off},{x_size},{y_size}) does not match the full read"
         )
 
-    def test_window_falls_back_to_the_variable_crs(self, grid_path):
+    def test_window_falls_back_to_the_variable_crs(self, grid_path, monkeypatch):
         """A view with no SRS of its own still yields a projected window.
 
         Args:
             grid_path: The written grid fixture.
+            monkeypatch: Used to give the variable a CRS with no authority code.
 
         Test scenario:
             A multidim view frequently carries no SRS while the variable knows its projection. An
             unprojected window would make the cutline warp warn and, for a cutline in another CRS,
             clip the wrong region — so the fallback must produce a CRS, not nothing.
+
+            The variable's CRS is overridden with a WKT that has **no authority code**, so `epsg`
+            cannot supply it. An EPSG-backed fixture would be satisfied by an `epsg`-only fallback
+            too, and the test would not distinguish the two.
         """
         var = NetCDF.read_file(grid_path).get_variable("v")
+        srs = osr.SpatialReference()
+        srs.ImportFromProj4(
+            "+proj=longlat +a=6371229 +b=6371229 +no_defs"
+        )  # spherical earth: no EPSG code
+        code_less = srs.ExportToWkt()
+        assert srs.GetAuthorityCode(None) is None, (
+            "the fixture CRS must have no EPSG code, or this test cannot discriminate"
+        )
+        monkeypatch.setattr(var, "_get_crs", lambda: code_less)
         stand_in = gdal.GetDriverByName("MEM").Create(
             "", N_LON, N_LAT, 1, gdal.GDT_Float32
         )
@@ -257,6 +271,9 @@ class TestWindowViaMdArray:
         assert window is not None
         assert window.GetProjection(), (
             "an unprojected view must still yield a projected window"
+        )
+        assert "6371229" in window.GetProjection(), (
+            "the window must carry the variable's own CRS, not an EPSG round-trip"
         )
 
     def test_window_carries_scale_and_offset(self, grid_path):

--- a/tests/netcdf/spatial/test_windowed_mdarray_crop.py
+++ b/tests/netcdf/spatial/test_windowed_mdarray_crop.py
@@ -497,10 +497,24 @@ class TestCropUsesTheWindow:
 
         Test scenario:
             Shape, geotransform and every cell must agree — the shortcut is an optimisation, so
-            any difference at all is a defect.
+            any difference at all is a defect. The run is asserted to have *taken* the shortcut:
+            without that, a change to the window/variable size threshold would silently compare
+            the full-read path against itself and the test would pass while covering nothing.
         """
         mask = gpd.GeoDataFrame(geometry=[box(*bounds)], crs="EPSG:4326")
+        real_source = selection_module.Selection._mask_window_source
+        taken: list[bool] = []
+
+        def _spy(self, mask):
+            source = real_source(self, mask)
+            taken.append(source is not None)
+            return source
+
+        monkeypatch.setattr(selection_module.Selection, "_mask_window_source", _spy)
         fast = NetCDF.read_file(grid_path).get_variable("v").crop(mask=mask, touch=True)
+        assert taken and any(taken), (
+            "the crop did not take the window shortcut, so this comparison proves nothing"
+        )
         monkeypatch.setattr(
             selection_module.Selection, "_mask_window_source", lambda self, mask: None
         )
@@ -526,9 +540,9 @@ class TestCropUsesTheWindow:
 
         Test scenario:
             The window is computed in the raster's own coordinates, so adopting a mask stated in
-            another CRS would window the wrong region. The mask must be a `FeatureCollection`: the
-            check reads `mask.epsg`, which a bare `GeoDataFrame` does not have, so a plain frame
-            would decline further down for an unrelated reason and never exercise this guard.
+            another CRS would window the wrong region. Covers the `FeatureCollection` mask type;
+            the bare-`GeoDataFrame` case is covered separately, since the two reach the guard by
+            different attributes.
         """
         var = NetCDF.read_file(grid_path).get_variable("v")
         mask = FeatureCollection(
@@ -537,6 +551,68 @@ class TestCropUsesTheWindow:
         )
         assert int(mask.epsg) != int(var.epsg), "the mask must be in a different CRS"
         assert var.selection._mask_window_source(mask) is None
+
+    def test_bare_geodataframe_in_another_crs_declines(self, grid_path):
+        """A plain `GeoDataFrame` in a different CRS declines — it has no `.epsg` to read.
+
+        Args:
+            grid_path: The written grid fixture.
+
+        Test scenario:
+            `crop(mask=...)` accepts a bare `GeoDataFrame` and passes it through unchanged, so
+            this is the *common* mask type, not an edge case. An `epsg`-based guard is skipped
+            entirely for it, and the mask's unreprojected coordinates then get divided through the
+            raster's affine — a plausible window over the wrong part of the grid, returned as data
+            rather than an error.
+
+            The mask's coordinates are deliberately chosen to fall *inside* the grid's numeric
+            range while being stated in another CRS. A far-away box would decline for an unrelated
+            reason — an out-of-range window — and the test would pass without ever reaching the
+            CRS guard.
+        """
+        var = NetCDF.read_file(grid_path).get_variable("v")
+        mask = gpd.GeoDataFrame(
+            geometry=[box(-179.6, -89.6, -178.9, -89.1)], crs="EPSG:3857"
+        )
+        assert not hasattr(mask, "epsg"), (
+            "a bare GeoDataFrame must have no .epsg — that is the point of this test"
+        )
+        assert var.selection._mask_window_source(mask) is None
+
+    def test_bare_geodataframe_in_the_same_crs_still_uses_the_shortcut(self, grid_path):
+        """Tightening the CRS guard must not disable the optimisation for ordinary masks.
+
+        Args:
+            grid_path: The written grid fixture.
+
+        Test scenario:
+            The guard declines on *unknown or differing* CRS. A bare `GeoDataFrame` carrying the
+            raster's own CRS is neither, so it must still take the fast path — otherwise the fix
+            for the fail-open would have quietly removed the feature.
+        """
+        var = NetCDF.read_file(grid_path).get_variable("v")
+        mask = gpd.GeoDataFrame(
+            geometry=[box(-179.6, -89.6, -178.9, -89.1)], crs="EPSG:4326"
+        )
+        assert var.selection._mask_window_source(mask) is not None
+
+    def test_empty_mask_declines_instead_of_raising(self, grid_path):
+        """An empty mask keeps the full-read path's error, not a numeric conversion error.
+
+        Args:
+            grid_path: The written grid fixture.
+
+        Test scenario:
+            An empty or all-null-geometry frame has `total_bounds == [nan] * 4`, and
+            `math.floor(nan)` raises `ValueError: cannot convert float NaN to integer`. Turning a
+            clear domain error into that, from an optimisation the caller never asked for, is a
+            regression in the error contract.
+        """
+        var = NetCDF.read_file(grid_path).get_variable("v")
+        empty = gpd.GeoDataFrame(geometry=[], crs="EPSG:4326")
+        assert var.selection._mask_window_source(empty) is None
+        with pytest.raises(RuntimeError, match="cutline"):
+            var.crop(mask=empty, touch=True)
 
     def test_shortcut_declines_for_a_rotated_affine(self, grid_path):
         """A rotated or degenerate affine is not windowable by row/column arithmetic.

--- a/tests/netcdf/spatial/test_windowed_mdarray_crop.py
+++ b/tests/netcdf/spatial/test_windowed_mdarray_crop.py
@@ -236,6 +236,81 @@ class TestWindowViaMdArray:
             f"window ({x_off},{y_off},{x_size},{y_size}) does not match the full read"
         )
 
+    def test_window_falls_back_to_the_variable_crs(self, grid_path):
+        """A view with no SRS of its own still yields a projected window.
+
+        Args:
+            grid_path: The written grid fixture.
+
+        Test scenario:
+            A multidim view frequently carries no SRS while the variable knows its projection. An
+            unprojected window would make the cutline warp warn and, for a cutline in another CRS,
+            clip the wrong region — so the fallback must produce a CRS, not nothing.
+        """
+        var = NetCDF.read_file(grid_path).get_variable("v")
+        stand_in = gdal.GetDriverByName("MEM").Create(
+            "", N_LON, N_LAT, 1, gdal.GDT_Float32
+        )
+        assert stand_in.GetSpatialRef() is None, "the stand-in must start unprojected"
+        var._raster = stand_in
+        window = var._window_via_mdarray(1, 1, 4, 4)
+        assert window is not None
+        assert window.GetProjection(), (
+            "an unprojected view must still yield a projected window"
+        )
+
+    def test_window_carries_scale_and_offset(self, grid_path):
+        """A packed variable's scale/offset reach the window raster.
+
+        Args:
+            grid_path: The written grid fixture.
+
+        Test scenario:
+            `CreateCopy` supplies these for free on the full-read path; a hand-built MEM raster
+            gets neither. Without them a packed CF variable (`scale_factor`/`add_offset`) comes
+            back through the shortcut in raw counts while the full read returns physical units.
+
+            The values are set on a stand-in raster rather than on the wrapper's own: like
+            `SetSpatialRef`, an `AsClassicDataset` view silently ignores `SetScale`, so setting
+            them there would leave nothing to carry and the test would pass on an empty check.
+        """
+        var = NetCDF.read_file(grid_path).get_variable("v")
+        stand_in = gdal.GetDriverByName("MEM").Create(
+            "", N_LON, N_LAT, 1, gdal.GDT_Float32
+        )
+        stand_in.GetRasterBand(1).SetScale(0.01)
+        stand_in.GetRasterBand(1).SetOffset(5.0)
+        assert stand_in.GetRasterBand(1).GetScale() == pytest.approx(0.01), (
+            "the stand-in must actually keep the scale, or this test proves nothing"
+        )
+        var._raster = stand_in
+        window = var._window_via_mdarray(1, 1, 4, 4)
+        assert window is not None
+        assert window.GetRasterBand(1).GetScale() == pytest.approx(0.01), (
+            "the window dropped the band scale"
+        )
+        assert window.GetRasterBand(1).GetOffset() == pytest.approx(5.0), (
+            "the window dropped the band offset"
+        )
+
+    def test_window_declines_when_the_source_grid_differs(self, grid_path):
+        """A wrapper whose grid no longer matches the source array is not windowed.
+
+        Args:
+            grid_path: The written grid fixture.
+
+        Test scenario:
+            The offsets are computed against the wrapper's rows/columns but served from the raw
+            MDArray. They agree only through non-local invariants, so a mismatch is checked rather
+            than assumed — otherwise the read would return a differently-sized grid's cells at the
+            same indices. `columns` is a cached attribute, not a read of the raster, so the
+            mismatch has to be introduced there rather than by swapping the raster.
+        """
+        var = NetCDF.read_file(grid_path).get_variable("v")
+        var._columns = N_LON - 3
+        assert var.columns != N_LON, "the wrapper must disagree with the source array"
+        assert var._window_via_mdarray(0, 0, 2, 2) is None
+
     def test_window_prefers_the_wrapper_srs(self, grid_path):
         """A CRS already on the wrapper is carried onto the window verbatim.
 

--- a/tests/netcdf/spatial/test_windowed_mdarray_crop.py
+++ b/tests/netcdf/spatial/test_windowed_mdarray_crop.py
@@ -19,10 +19,11 @@ import gc
 import geopandas as gpd
 import numpy as np
 import pytest
-from osgeo import gdal
+from osgeo import gdal, osr
 from shapely.geometry import box
 
 import pyramids.netcdf.engines.selection as selection_module
+from pyramids.feature import FeatureCollection
 from pyramids.netcdf import NetCDF
 
 pytestmark = pytest.mark.core
@@ -73,6 +74,60 @@ def grid_path(tmp_path) -> str:
     return path
 
 
+N_TIME = 3
+
+
+@pytest.fixture
+def cube_path(tmp_path) -> str:
+    """A `(time, latitude, longitude)` grid with longitude stored east-to-west.
+
+    Exercises the two shapes a 2-D ascending-latitude grid cannot: a non-spatial dimension that
+    the window read must pin to index 0 and flatten into bands, and a reversed X axis.
+
+    Args:
+        tmp_path: pytest temp directory.
+
+    Returns:
+        str: Path to the written file.
+    """
+    path = str(tmp_path / "cube.nc")
+    ds = gdal.GetDriverByName("netCDF").CreateMultiDimensional(path)
+    rg = ds.GetRootGroup()
+    d_time = rg.CreateDimension("time", "", "", N_TIME)
+    d_lat = rg.CreateDimension("latitude", "", "", N_LAT)
+    d_lon = rg.CreateDimension("longitude", "", "", N_LON)
+    time = rg.CreateMDArray(
+        "time", [d_time], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    time.Write(np.arange(N_TIME, dtype="float64"))
+    lat = rg.CreateMDArray(
+        "latitude", [d_lat], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    lat.Write(LAT_FIRST + CELL * np.arange(N_LAT))
+    lon = rg.CreateMDArray(
+        "longitude", [d_lon], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    lon.Write((LON_FIRST + CELL * np.arange(N_LON))[::-1])
+    for arr, std, axis, units in (
+        (lat, "latitude", "Y", "degrees_north"),
+        (lon, "longitude", "X", "degrees_east"),
+    ):
+        for key, value in (("standard_name", std), ("axis", axis), ("units", units)):
+            attr = arr.CreateAttribute(key, [], gdal.ExtendedDataType.CreateString())
+            attr.Write(value)
+    var = rg.CreateMDArray(
+        "v", [d_time, d_lat, d_lon], gdal.ExtendedDataType.Create(gdal.GDT_Float32)
+    )
+    var.Write(
+        np.arange(N_TIME * N_LAT * N_LON, dtype="float32").reshape(N_TIME, N_LAT, N_LON)
+    )
+    time = lat = lon = var = d_time = d_lat = d_lon = rg = None
+    ds.Close()
+    del ds
+    gc.collect()
+    return path
+
+
 def _as_bands(array) -> np.ndarray:
     """Normalise a read to `(bands, rows, cols)` so 2-D and 3-D reads compare alike."""
     values = np.asarray(array)
@@ -112,6 +167,35 @@ class TestWindowViaMdArray:
         expected = full[:, y_off : y_off + y_size, x_off : x_off + x_size]
         assert np.array_equal(got, expected), (
             f"window ({x_off},{y_off},{x_size},{y_size}) does not match the full read"
+        )
+
+    def test_window_prefers_the_wrapper_srs(self, grid_path):
+        """A CRS already on the wrapper is carried onto the window verbatim.
+
+        Args:
+            grid_path: The written grid fixture.
+
+        Test scenario:
+            The EPSG fallback exists only for a view that carries no SRS of its own. When the
+            wrapper does have one — the VRT `_georeference_index_subset` installs, say — that exact
+            SRS must win, or a crop against a cutline would clip the wrong region. A deliberately
+            different code (3035, against the variable's 4326) is used so the assertion tells the
+            two branches apart; an `AsClassicDataset` view silently ignores `SetSpatialRef`, so the
+            wrapper is stood in for by a raster that does keep one.
+        """
+        var = NetCDF.read_file(grid_path).get_variable("v")
+        stand_in = gdal.GetDriverByName("MEM").Create(
+            "", N_LON, N_LAT, 1, gdal.GDT_Float32
+        )
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(3035)
+        stand_in.SetSpatialRef(srs)
+        var._raster = stand_in
+        window = var._window_via_mdarray(1, 1, 4, 4)
+        assert window is not None
+        assert window.GetSpatialRef() is not None, "the window must carry a CRS"
+        assert window.GetSpatialRef().GetAuthorityCode(None) == "3035", (
+            "the window must carry the wrapper's own SRS, not the EPSG fallback"
         )
 
     def test_window_carries_the_sub_affine(self, grid_path):
@@ -162,6 +246,132 @@ class TestWindowViaMdArray:
         """
         var = NetCDF.read_file(grid_path).get_variable("v")
         assert var._window_via_mdarray(x_off, y_off, x_size, y_size) is None
+
+
+class TestWindowViaMdArrayMultiBand:
+    """The window read over a `(time, y, x)` cube with a reversed X axis."""
+
+    @pytest.mark.parametrize(
+        "x_off, y_off, x_size, y_size",
+        [(0, 0, N_LON, N_LAT), (3, 2, 4, 4), (8, 0, 4, 3)],
+        ids=["whole", "interior", "edge"],
+    )
+    def test_window_matches_the_full_read(
+        self, cube_path, x_off, y_off, x_size, y_size
+    ):
+        """A window of a 3-D cube equals the same slice of the full read.
+
+        Args:
+            cube_path: The written cube fixture.
+            x_off: Column offset of the window in raster space.
+            y_off: Row offset of the window in raster space.
+            x_size: Window width.
+            y_size: Window height.
+
+        Test scenario:
+            Both axes are reversed here — latitude ascending and longitude east-to-west — and the
+            time dimension must be pinned to index 0 and flattened into bands in storage order. A
+            band read in the wrong order, or an axis un-reversed on the wrong side, shows up as a
+            mismatch against the classic view's own full read.
+        """
+        var = NetCDF.read_file(cube_path).get_variable("v")
+        full = _as_bands(var.read_array())
+        window = var._window_via_mdarray(x_off, y_off, x_size, y_size)
+        assert window is not None, "the window read must be served"
+        got = _as_bands(window.ReadAsArray())
+        expected = full[:, y_off : y_off + y_size, x_off : x_off + x_size]
+        assert got.shape == expected.shape, (
+            f"expected shape {expected.shape}, got {got.shape}"
+        )
+        assert np.array_equal(got, expected), (
+            f"window ({x_off},{y_off},{x_size},{y_size}) does not match the full read"
+        )
+
+    def test_window_keeps_every_band(self, cube_path):
+        """The window carries one band per non-spatial slice, not just the first.
+
+        Args:
+            cube_path: The written cube fixture.
+
+        Test scenario:
+            Pinning the time dimension to index 0 must select the whole axis for the band stack;
+            reading only one slice would silently drop the other time steps.
+        """
+        var = NetCDF.read_file(cube_path).get_variable("v")
+        window = var._window_via_mdarray(2, 2, 3, 3)
+        assert window is not None
+        assert window.RasterCount == N_TIME, (
+            f"expected {N_TIME} bands, got {window.RasterCount}"
+        )
+
+
+class TestWindowViaMdArrayDeclines:
+    """Every guard that makes the window read return `None` rather than a wrong raster."""
+
+    def test_missing_root_group_declines(self, grid_path):
+        """A variable whose multidim references were dropped cannot be windowed.
+
+        Args:
+            grid_path: The written grid fixture.
+
+        Test scenario:
+            `_materialize_md_view` nulls `_gdal_rg_ref`; the shortcut must then decline instead of
+            dereferencing `None`.
+        """
+        var = NetCDF.read_file(grid_path).get_variable("v")
+        var._gdal_rg_ref = None
+        assert var._window_via_mdarray(0, 0, 4, 4) is None
+
+    def test_unopenable_array_declines(self, grid_path, monkeypatch):
+        """A failing `OpenMDArray` falls back rather than propagating.
+
+        Args:
+            grid_path: The written grid fixture.
+            monkeypatch: Used to make the open raise.
+
+        Test scenario:
+            The caller treats `None` as "use the full-read path", so a GDAL error here must not
+            escape to the user.
+        """
+        var = NetCDF.read_file(grid_path).get_variable("v")
+
+        def _raise(_name):
+            raise RuntimeError("cannot open")
+
+        monkeypatch.setattr(var._gdal_rg_ref, "OpenMDArray", _raise)
+        assert var._window_via_mdarray(0, 0, 4, 4) is None
+
+    @pytest.mark.parametrize(
+        "outcome", ["raise", "none"], ids=["read-raises", "read-returns-none"]
+    )
+    def test_failed_read_declines(self, grid_path, monkeypatch, outcome):
+        """A read that fails or yields nothing declines instead of building an empty raster.
+
+        Args:
+            grid_path: The written grid fixture.
+            monkeypatch: Used to break the array read.
+            outcome: Whether the read raises or returns `None`.
+
+        Test scenario:
+            Both failure shapes must reach the same fallback; a `None` block reaching NumPy would
+            raise far from the cause.
+        """
+        var = NetCDF.read_file(grid_path).get_variable("v")
+        real_open = var._gdal_rg_ref.OpenMDArray
+
+        def _open(name):
+            array = real_open(name)
+
+            def _read(*args, **kwargs):
+                if outcome == "raise":
+                    raise RuntimeError("read failed")
+                return None
+
+            monkeypatch.setattr(array, "ReadAsArray", _read)
+            return array
+
+        monkeypatch.setattr(var._gdal_rg_ref, "OpenMDArray", _open)
+        assert var._window_via_mdarray(0, 0, 4, 4) is None
 
 
 class TestCropUsesTheWindow:
@@ -215,14 +425,70 @@ class TestCropUsesTheWindow:
 
         Test scenario:
             The window is computed in the raster's own coordinates, so adopting a mask stated in
-            another CRS would window the wrong region.
+            another CRS would window the wrong region. The mask must be a `FeatureCollection`: the
+            check reads `mask.epsg`, which a bare `GeoDataFrame` does not have, so a plain frame
+            would decline further down for an unrelated reason and never exercise this guard.
         """
         var = NetCDF.read_file(grid_path).get_variable("v")
-        mask = gpd.GeoDataFrame(
+        mask = FeatureCollection(
             geometry=[box(-19970000, -19970000, -19900000, -19900000)],
             crs="EPSG:3857",
         )
+        assert int(mask.epsg) != int(var.epsg), "the mask must be in a different CRS"
         assert var.selection._mask_window_source(mask) is None
+
+    def test_shortcut_declines_for_a_rotated_affine(self, grid_path):
+        """A rotated or degenerate affine is not windowable by row/column arithmetic.
+
+        Args:
+            grid_path: The written grid fixture.
+
+        Test scenario:
+            The window is derived by dividing through `gt[1]`/`gt[5]`, which only describes an
+            axis-aligned grid; a rotation term would place the window somewhere else entirely.
+        """
+        var = NetCDF.read_file(grid_path).get_variable("v")
+        gt = list(var.geotransform)
+        gt[2] = 0.1
+        var._geotransform = tuple(gt)
+        mask = gpd.GeoDataFrame(
+            geometry=[box(-179.6, -89.6, -178.9, -89.1)], crs="EPSG:4326"
+        )
+        assert var.selection._mask_window_source(mask) is None
+
+    def test_shortcut_declines_for_a_mask_off_the_grid(self, grid_path):
+        """A mask that misses the variable entirely yields no window.
+
+        Args:
+            grid_path: The written grid fixture.
+
+        Test scenario:
+            An empty window must decline rather than clamp to a zero-sized read, which the
+            MDArray could not serve anyway.
+        """
+        var = NetCDF.read_file(grid_path).get_variable("v")
+        mask = gpd.GeoDataFrame(
+            geometry=[box(120.0, 40.0, 121.0, 41.0)], crs="EPSG:4326"
+        )
+        assert var.selection._mask_window_source(mask) is None
+
+    def test_shortcut_declines_for_an_unusable_mask(self, grid_path):
+        """A mask with no readable bounds declines instead of raising.
+
+        Args:
+            grid_path: The written grid fixture.
+
+        Test scenario:
+            `total_bounds` is read defensively; anything that is not four numbers must reach the
+            ordinary crop path rather than surface a `TypeError` from the shortcut.
+        """
+        var = NetCDF.read_file(grid_path).get_variable("v")
+
+        class _NoBounds:
+            epsg = 4326
+            total_bounds = None
+
+        assert var.selection._mask_window_source(_NoBounds()) is None
 
     def test_shortcut_declines_when_the_window_is_most_of_the_grid(self, grid_path):
         """A mask covering the grid falls back — the shortcut must earn its second code path.

--- a/tests/netcdf/spatial/test_windowed_mdarray_crop.py
+++ b/tests/netcdf/spatial/test_windowed_mdarray_crop.py
@@ -23,6 +23,7 @@ from osgeo import gdal, osr
 from shapely.geometry import box
 
 import pyramids.netcdf.engines.selection as selection_module
+from pyramids.dataset import Dataset
 from pyramids.feature import FeatureCollection
 from pyramids.netcdf import NetCDF
 
@@ -613,6 +614,39 @@ class TestCropUsesTheWindow:
         assert var.selection._mask_window_source(empty) is None
         with pytest.raises(RuntimeError, match="cutline"):
             var.crop(mask=empty, touch=True)
+
+    @pytest.mark.parametrize("epsg, expected", [(4326, True), (3857, False)])
+    def test_raster_mask_crs_is_read_from_a_wkt_string(self, grid_path, epsg, expected):
+        """A `Dataset` mask states its CRS as WKT, not as a pyproj object.
+
+        Args:
+            grid_path: The written grid fixture.
+            epsg: CRS to stamp on the raster mask.
+            expected: Whether the shortcut should be offered for it.
+
+        Test scenario:
+            `crop(mask=...)` also accepts a raster, whose `crs` is a plain WKT string — a guard
+            written for `GeoDataFrame`'s pyproj `crs` raises `AttributeError` on it. Matching CRS
+            must be offered the window and a differing one declined, without either raising.
+
+            Deliberately exercises `_mask_window_source` rather than `crop()`: cropping a NetCDF
+            variable with a raster mask is broken independently of this shortcut (it raises
+            `TypeError: create_from_array() got an unexpected keyword argument 'geo'` on `main`
+            with the shortcut disabled), so an end-to-end assertion here would be testing that
+            unrelated defect.
+        """
+        var = NetCDF.read_file(grid_path).get_variable("v")
+        template = gdal.GetDriverByName("MEM").Create("", 4, 3, 1, gdal.GDT_Float32)
+        template.SetGeoTransform([-179.75, CELL, 0.0, -88.25, 0.0, -CELL])
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(epsg)
+        template.SetSpatialRef(srs)
+        mask = Dataset(template)
+        assert isinstance(mask.crs, str), "a Dataset mask must state its CRS as WKT"
+        source = var.selection._mask_window_source(mask)
+        assert (source is not None) is expected, (
+            f"EPSG:{epsg} mask: expected shortcut offered={expected}"
+        )
 
     def test_shortcut_declines_for_a_rotated_affine(self, grid_path):
         """A rotated or degenerate affine is not windowable by row/column arithmetic.

--- a/tests/netcdf/spatial/test_windowed_mdarray_crop.py
+++ b/tests/netcdf/spatial/test_windowed_mdarray_crop.py
@@ -128,6 +128,71 @@ def cube_path(tmp_path) -> str:
     return path
 
 
+N_LEVEL = 3
+
+
+@pytest.fixture
+def hypercube_path(tmp_path) -> str:
+    """A `(time, level, latitude, longitude)` grid — two non-spatial dimensions.
+
+    Three dimensions only ever collapse one axis into bands, which cannot tell a correct
+    flattening from one that transposes the two. Here `time` x `level` must flatten to
+    `N_TIME * N_LEVEL` bands in storage order, time slowest.
+
+    Args:
+        tmp_path: pytest temp directory.
+
+    Returns:
+        str: Path to the written file.
+    """
+    path = str(tmp_path / "hypercube.nc")
+    ds = gdal.GetDriverByName("netCDF").CreateMultiDimensional(path)
+    rg = ds.GetRootGroup()
+    d_time = rg.CreateDimension("time", "", "", N_TIME)
+    d_level = rg.CreateDimension("level", "", "", N_LEVEL)
+    d_lat = rg.CreateDimension("latitude", "", "", N_LAT)
+    d_lon = rg.CreateDimension("longitude", "", "", N_LON)
+    time = rg.CreateMDArray(
+        "time", [d_time], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    time.Write(np.arange(N_TIME, dtype="float64"))
+    level = rg.CreateMDArray(
+        "level", [d_level], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    level.Write(np.arange(N_LEVEL, dtype="float64"))
+    lat = rg.CreateMDArray(
+        "latitude", [d_lat], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    lat.Write(LAT_FIRST + CELL * np.arange(N_LAT))
+    lon = rg.CreateMDArray(
+        "longitude", [d_lon], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    lon.Write(LON_FIRST + CELL * np.arange(N_LON))
+    for arr, std, axis, units in (
+        (lat, "latitude", "Y", "degrees_north"),
+        (lon, "longitude", "X", "degrees_east"),
+    ):
+        for key, value in (("standard_name", std), ("axis", axis), ("units", units)):
+            attr = arr.CreateAttribute(key, [], gdal.ExtendedDataType.CreateString())
+            attr.Write(value)
+    var = rg.CreateMDArray(
+        "v",
+        [d_time, d_level, d_lat, d_lon],
+        gdal.ExtendedDataType.Create(gdal.GDT_Float32),
+    )
+    var.Write(
+        np.arange(N_TIME * N_LEVEL * N_LAT * N_LON, dtype="float32").reshape(
+            N_TIME, N_LEVEL, N_LAT, N_LON
+        )
+    )
+    time = level = lat = lon = var = None
+    d_time = d_level = d_lat = d_lon = rg = None
+    ds.Close()
+    del ds
+    gc.collect()
+    return path
+
+
 def _as_bands(array) -> np.ndarray:
     """Normalise a read to `(bands, rows, cols)` so 2-D and 3-D reads compare alike."""
     values = np.asarray(array)
@@ -285,6 +350,42 @@ class TestWindowViaMdArrayMultiBand:
         )
         assert np.array_equal(got, expected), (
             f"window ({x_off},{y_off},{x_size},{y_size}) does not match the full read"
+        )
+
+    @pytest.mark.parametrize(
+        "x_off, y_off, x_size, y_size",
+        [(0, 0, N_LON, N_LAT), (2, 1, 4, 3)],
+        ids=["whole", "interior"],
+    )
+    def test_two_non_spatial_dimensions_keep_band_order(
+        self, hypercube_path, x_off, y_off, x_size, y_size
+    ):
+        """A `(time, level, y, x)` variable flattens to bands in the classic view's own order.
+
+        Args:
+            hypercube_path: The written 4-D fixture.
+            x_off: Column offset of the window in raster space.
+            y_off: Row offset of the window in raster space.
+            x_size: Window width.
+            y_size: Window height.
+
+        Test scenario:
+            With a single non-spatial axis, a transposed flattening is indistinguishable from a
+            correct one — both yield the same band sequence. Two non-spatial axes separate them:
+            `time` must vary slowest and `level` fastest, exactly as `AsClassicDataset` orders
+            them, or band `k` of the window holds a different slice than band `k` of a full read.
+        """
+        var = NetCDF.read_file(hypercube_path).get_variable("v")
+        full = _as_bands(var.read_array())
+        window = var._window_via_mdarray(x_off, y_off, x_size, y_size)
+        assert window is not None, "the window read must be served"
+        got = _as_bands(window.ReadAsArray())
+        assert got.shape[0] == N_TIME * N_LEVEL, (
+            f"expected {N_TIME * N_LEVEL} bands, got {got.shape[0]}"
+        )
+        expected = full[:, y_off : y_off + y_size, x_off : x_off + x_size]
+        assert np.array_equal(got, expected), (
+            "band order or window placement differs from the classic view for a 4-D variable"
         )
 
     def test_window_keeps_every_band(self, cube_path):


### PR DESCRIPTION
# Description

Cropping a variable read from a remote NetCDF-4 file returned the wrong region, and slowly. Two independent causes,
both in the multidimensional read path:

**1. The affine was never rebuilt for CF-named coordinates.** GDAL's netCDF driver builds a geotransform from a
file's CF coordinate variables; the HDF5 driver does not — and HDF5 is what serves a NetCDF-4 file over `/vsi` on
Windows, because the netCDF driver needs Linux `userfaultfd` for those paths. `NetCDF` already carries a rescue for
exactly this (`_georeference_index_subset` → `_coordinate_derived_geotransform`), but it looked its coordinates up
under `lon`/`x` and `lat`/`y` only. A file that names them the way CF's own standard does — `longitude` /
`latitude` — was never found, so the variable kept the index-space placeholder `(0, 1, 0, rows, 0, -1)` and every
`crop(bbox=...)` read the bounding box as pixel indices. Two otherwise identical files, same driver, differed only
in the coordinate spelling: one was rescued, the other was not.

The names were not missing from the package — `_X_DIM_NAMES` / `_Y_DIM_NAMES` already listed `longitude`,
`latitude`, `rlon`, `rlat`, `easting`, `northing` and more. The rescue simply used its own narrower literal pair
instead. The fix routes it through a new `_coordinate_candidates(axis)`, which tries the legacy pair first (so
anything that resolved before resolves identically), then coordinates identified by their CF `axis` /
`standard_name` attributes, then the package's well-known names matched case-insensitively.

**2. The crop read the whole variable before clipping it.** Cheap for a local file, expensive for a remote one: a
variable is backed by an `AsClassicDataset` view, and when the file stores its axes in a different order than the
raster presents them — `(time, longitude, latitude)` shown as rows=latitude/cols=longitude — every raster row
becomes a strided gather. Measured against the 14 GB `/vsicurl` file from the issue, the same 16x10x10 window cost
~7.5 s through the classic view and ~0.85 s through `MDArray.Read`.

`NetCDF._window_via_mdarray` now reads one raster window straight from the MDArray: it maps the raster window onto
raw indices (a reversed axis is read forwards and un-reversed with NumPy), flattens the non-spatial dimensions into
bands exactly as the classic view does, and stamps the sub-affine plus the variable's CRS. `Selection._crop_one`
takes that window when the shortcut is provably equivalent and declines otherwise — a rotated affine, a mask in
another CRS, a mask off the grid, a window that is not appreciably smaller than the variable, or a read the array
cannot serve — falling back to the existing full-read path. It runs before the CRS-stamping branch because
materializing the view drops the root-group reference the windowed read needs; the windowed raster carries the CRS
itself.

End to end on the reported file: the geotransform goes from `(0, 1, 0, 720, 0, -1)` to
`(-180.0, 0.25, 0, 90.0, 0, -0.25)`, the crop returns the requested 10x10 geographic window instead of a 4x4 index
window, and it takes **1.1 s instead of 33.6 s**.

**3. The `.aux.xml` sidecar write against a read-only remote source — fixed by (1), with no code of its own.**
Item 3 of the issue reported `RuntimeError: Failed to open …nc.aux.xml to write` during `crop`. It is raised inside
GDAL's dataset destructor, so it surfaces as `Exception ignored in: <built-in function delete_Dataset>` and cannot be
caught by the caller. The cause is not the in-memory copies it appeared next to: with the variable in index space,
`crop` stamped a projection onto the raster to give the cutline warp a CRS, that raster is the read-only remote file,
and marking its metadata dirty makes GDAL flush a PAM sidecar next to a file it cannot write. Once (1) returns the
variable already georeferenced, nothing stamps a projection onto the remote file and no sidecar is ever dirtied.
Verified back to back against the reported file, same script:

| | `main` | this branch |
|---|---|---|
| `.aux.xml` write error | raised (ignored) | none |
| geotransform | `(0, 1, 0, 720, 0, -1)` | `(-180.0, 0.25, 0, 90.0, 0, -0.25)` |
| `crop(bbox=[3, 51, 5, 53])` | `rows=4 cols=4` (bbox read as pixel indices) | `rows=10 cols=10` |

No separate guard is included: suppressing PAM around the copies would have masked a symptom whose cause is gone, and
it changed nothing in every case that could be constructed.

No new dependencies.

# Issues

- Closes #1071 — CF-named coordinates left the variable in index space over /vsicurl
- Closes #1073 — crop(mask=<raster>) on a NetCDF variable raised TypeError from create_from_array

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Found and fixed during review

Three review passes over this branch turned up defects **in the change itself**. All are fixed here, each with a
regression test verified to fail when its fix is reverted.

Correctness:

- The crop shortcut's CRS guard read `mask.epsg`, but `crop(mask=...)` accepts a bare `GeoDataFrame`, which has
  none — so for the most common mask type the guard was skipped and an unreprojected mask was divided through the
  raster's affine, windowing the wrong region. Now compares the CRSs themselves, via `crs_equal`, treating unknown
  on either side as not-equal.
- CF says a bounds variable inherits its parent's `units` and `standard_name`, so `latitude_bnds` shadowed
  `latitude` and the #1071 rescue silently did nothing on an ordinary CF layout. Bounds arrays are excluded from
  the candidate list via the `bounds` attribute CF provides for exactly that purpose.
- `apply(inplace=True)` followed by `crop()` returned the **pre-mutation** data: the in-place swap deliberately
  keeps the multidim references, so the window read went back to the source, and no size or shape check can see it
  because the grid is unchanged. The divergence is now recorded on the swap and the shortcut refuses it.
- A curvilinear grid carrying both 2-D `lon`/`lat` and 1-D index axes resolved to the index axes and kept a
  placeholder georeference — the failure #1039 exists to prevent. Rank is not a usable discriminator here; the CF
  `bounds` link is.
- Coordinates that are **readable but not enumerable** — at the root of a group-scoped store, or 1-D coordinates in
  classic mode, which GDAL never lists as subdatasets — must still be probed. An intermediate commit trimmed the
  well-known-name tail against the enumerated names and silently un-georeferenced both cases, including two of the
  repo's own fixtures. The tail is restored; the warning noise it caused is handled where it belongs, by quietening
  the probes (`gdal.quiet_errors`), which leaves the warning count at zero without trading away the coordinates.
- An empty mask turned a clean "Did not get any cutline features" into `ValueError: cannot convert float NaN to
  integer`.

Robustness and cost:

- The window read no longer copies the block three times (`moveaxis` + flips are views; only the per-band write
  copies), the per-axis candidate list is cached, band scale/offset are carried onto the window, and the raw
  array's grid is checked against the wrapper's rather than assumed.
- The base-class MRO walk behind the #1073 fix is now defined once instead of three times, has a safe default
  rather than a bare `next()`, and carries `access` / `gdal_env` / `open_options` onto the re-wrapped intermediate.

Three tests were found to pass for the wrong reason and were rewritten so they fail when their fix is reverted: the
CF-attribute stage was satisfied by an unconditional fallback list, the crop-equivalence test never checked the
shortcut fired, and the wrong-CRS test declined for an unrelated reason. Two review items were declined with
written reasons (an absolute size floor that would take every fixture below it and stop exercising the path; a
redundant-but-conventional `pytestmark`), recorded in the review files.

# How Has This Been Tested?

50 new tests across two files, plus the full existing suite.

- [x] `tests/netcdf/spatial/test_hdf5_coordinate_georef.py` (12 tests) — the affine is derived for `latitude`/
  `longitude`, `lat`/`lon` and mixed case; CF attributes alone identify a coordinate under an unrecognised name;
  bounds variables do not shadow the real coordinate; a curvilinear grid keeps its bbox affine; root-group
  coordinates georeference a subgroup variable; probing is quiet; an already-georeferenced cube is left alone; and
  a coordinate whose length does not match the grid is declined. The driver cannot be swapped per-open (`GDAL_SKIP`
  is read when drivers register), so rather than fake the driver these tests drive
  `_coordinate_derived_geotransform` directly with a cube already in index space — the exact state the HDF5 path
  produces.
- [x] `tests/netcdf/spatial/test_windowed_mdarray_crop.py` (38 tests) — a window read matches the same slice of the
  full read for whole/interior/corner/edge windows, for 2-D, 3-D and 4-D variables, with either axis reversed
  (band order for two non-spatial dimensions is pinned separately, since one dimension cannot distinguish a
  transposed flattening); the window carries the sub-affine, the wrapper's SRS or the variable's own CRS, and band
  scale/offset; every decline path returns `None` rather than a wrong raster; and a crop taking the shortcut
  matches one with the shortcut disabled in shape, geotransform and every cell — asserting that the shortcut
  actually fired, so the comparison cannot go vacuous.
- [x] Every regression test above was verified **non-vacuous** by reverting its fix and confirming it fails.
- [x] `pytest tests/ -m "not plot"` — **9016 passed, 53 skipped**.
- [x] `ruff format` / `ruff check` clean; `mypy` clean on all three changed source files; doctests on the touched
  modules 24 passed / 10 skipped.
- [x] Reproduced against the reported 14 GB `/vsicurl` JRC file before and after, for all three reported items: on
  `main` the ignored `.aux.xml` write, a wrong 4x4 index window, and 1248 s; on this branch no sidecar error, the
  correct 10x10 geographic window, and 267 s in the same session (an earlier, faster session measured 33.6 s →
  1.1 s — the JRC endpoint slowed markedly between runs, and both figures come from back-to-back pairs).

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.


