### PR TITLE
fix(netcdf): fold GDAL's unit slot into dimension attrs so a CF time axis decodes

### DIFF
--- a/src/pyramids/netcdf/_axis.py
+++ b/src/pyramids/netcdf/_axis.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 from typing import Any
 
 from pyramids.netcdf.cf import detect_axis
-from pyramids.netcdf.utils import _read_attributes
+from pyramids.netcdf.utils import read_cf_attributes
 
 
 def axis_role_of_dimension(dim: Any) -> str | None:
@@ -35,7 +35,7 @@ def axis_role_of_dimension(dim: Any) -> str | None:
     # Attribute-only detection (empty `name` disables the name-pattern fallback) so the CF-attribute
     # vs. dimension-name stages stay separated, matching the historical pipeline. Filter to the
     # spatial roles this classifier promises (`detect_axis` can also return `"T"`/`"Z"`).
-    role = detect_axis("", _read_attributes(indexing_var))
+    role = detect_axis("", read_cf_attributes(indexing_var))
     return role if role in ("X", "Y") else None
 
 

--- a/src/pyramids/netcdf/engines/interop.py
+++ b/src/pyramids/netcdf/engines/interop.py
@@ -34,7 +34,7 @@ from pyramids.netcdf.cf import (
     write_attributes_to_md_array,
     write_global_attributes,
 )
-from pyramids.netcdf.utils import _read_attributes
+from pyramids.netcdf.utils import _merge_unit, _read_attributes
 
 if TYPE_CHECKING:
     from pyramids.netcdf.netcdf import NetCDF
@@ -127,20 +127,6 @@ class Interop(_Engine["NetCDF"]):
             coords=_coords_from_dimensions(rg, ds),
             attrs=ds.global_attributes,
         )
-
-
-def _merge_unit(attrs: dict[str, Any], gdal_obj: Any) -> dict[str, Any]:
-    """Fold GDAL's ``GetUnit()`` back into ``attrs`` as a CF ``units`` entry.
-
-    GDAL's netCDF driver normalises the CF ``units`` attribute onto the
-    MDArray/indexing-variable unit slot rather than a regular attribute. Merge
-    it back so the value round-trips through ``xr.Dataset``. Existing ``units``
-    in ``attrs`` win; the dict is mutated in place and returned for chaining.
-    """
-    unit = gdal_obj.GetUnit()
-    if unit and "units" not in attrs:
-        attrs["units"] = unit
-    return attrs
 
 
 def _coords_from_dimensions(rg: Any, ds: NetCDF) -> dict[str, Any]:

--- a/src/pyramids/netcdf/engines/interop.py
+++ b/src/pyramids/netcdf/engines/interop.py
@@ -34,7 +34,7 @@ from pyramids.netcdf.cf import (
     write_attributes_to_md_array,
     write_global_attributes,
 )
-from pyramids.netcdf.utils import _merge_unit, _read_attributes
+from pyramids.netcdf.utils import read_cf_attributes
 
 if TYPE_CHECKING:
     from pyramids.netcdf.netcdf import NetCDF
@@ -141,7 +141,7 @@ def _coords_from_dimensions(rg: Any, ds: NetCDF) -> dict[str, Any]:
         if iv is None:
             continue
         dim_name = d.GetName()
-        coord_attrs = _merge_unit(_read_attributes(iv), iv)
+        coord_attrs = read_cf_attributes(iv)
         coords[dim_name] = ([dim_name], ds._md_array_to_numpy(iv), coord_attrs)
     return coords
 
@@ -162,7 +162,7 @@ def _data_vars_from_arrays(rg: Any, ds: NetCDF, chunks: Any = None) -> dict[str,
             arr_data = ds._md_array_to_numpy(md_arr)
         else:
             arr_data = _lazy_var_data(ds, var_name, chunks, md_arr)
-        var_attrs = _merge_unit(_read_attributes(md_arr), md_arr)
+        var_attrs = read_cf_attributes(md_arr)
         data_vars[var_name] = (arr_dim_names, arr_data, var_attrs)
     return data_vars
 

--- a/src/pyramids/netcdf/metadata.py
+++ b/src/pyramids/netcdf/metadata.py
@@ -241,11 +241,16 @@ class MetadataBuilder:
     ) -> None:
         """Top up `dimensions[*].attrs` from classic GDAL metadata.
 
-        The multidim NetCDF driver occasionally drops CF attributes
-        (notably `units` on time dims of CDS-Beta retrievals) from the
-        indexing variable. The same attributes remain reachable through
-        the classic driver as `<dim_name>#<attr_name>` keys on a
-        classic-mode `gdal.Dataset.GetMetadata()`. This helper merges
+        A multidim dimension can be missing CF attributes the classic
+        view still has. `units` is no longer one of them: GDAL always
+        moves it to the indexing variable's unit slot, under every
+        driver, and `DimensionInfo.from_gdal_dim` folds it back in
+        (#1078). This stays the only source for `calendar`, which has
+        no GDAL slot, and for either attribute on a dimension with
+        **no indexing variable**, where there is no slot to read. Both
+        remain reachable through the classic driver as
+        `<dim_name>#<attr_name>` keys on a classic-mode
+        `gdal.Dataset.GetMetadata()`. This helper merges
         the classic-API view in for any attribute in
         `_CLASSIC_DIM_FALLBACK_ATTRS` that the multidim path did not
         surface, leaving everything else untouched.

--- a/src/pyramids/netcdf/models.py
+++ b/src/pyramids/netcdf/models.py
@@ -15,6 +15,7 @@ from pyramids.netcdf.utils import (
     _get_block_size,
     _get_coord_variable_names,
     _get_group_name,
+    _merge_unit,
     _read_attributes,
     _read_dim_names,
     resolve_full_name,
@@ -277,9 +278,15 @@ class DimensionInfo:
             iv = None
             ivname = None
 
-        # Read attributes from the indexing variable (e.g., "units", "calendar")
+        # Read attributes from the indexing variable (e.g., "units", "calendar"), then
+        # fold the unit slot back in: GDAL moves a CF `units` attribute onto the object's
+        # own unit and drops it from the attribute list, under the netCDF and the HDF5
+        # driver alike. Without this, `units` reaches dimension metadata only through the
+        # classic-metadata top-up in `MetadataBuilder`, which yields nothing when the file
+        # was opened by the HDF5 driver — as any /vsi NetCDF-4 read on Windows is — so the
+        # time axis came back undecodable there (#1078).
         try:
-            iv_attrs = _read_attributes(iv) if iv is not None else {}
+            iv_attrs = _merge_unit(_read_attributes(iv), iv) if iv is not None else {}
         except Exception:
             iv_attrs = {}
 

--- a/src/pyramids/netcdf/models.py
+++ b/src/pyramids/netcdf/models.py
@@ -230,6 +230,12 @@ class DimensionInfo:
         variable when one exists (e.g. `units` and
         `calendar` on a time coordinate).
 
+        `units` is recovered from the indexing variable's
+        **unit slot** as well as from its attribute list:
+        GDAL normalises a CF `units` onto that slot and
+        drops it from the attributes, so reading attributes
+        alone yields `calendar` but never `units` (#1078).
+
         Args:
             d: The GDAL multidimensional `Dimension` object.
             group_full_name: Full name of the parent group

--- a/src/pyramids/netcdf/models.py
+++ b/src/pyramids/netcdf/models.py
@@ -15,9 +15,9 @@ from pyramids.netcdf.utils import (
     _get_block_size,
     _get_coord_variable_names,
     _get_group_name,
-    _merge_unit,
     _read_attributes,
     _read_dim_names,
+    read_cf_attributes,
     resolve_full_name,
 )
 
@@ -235,6 +235,7 @@ class DimensionInfo:
         GDAL normalises a CF `units` onto that slot and
         drops it from the attributes, so reading attributes
         alone yields `calendar` but never `units` (#1078).
+        Which driver GDAL picks does not change this.
 
         Args:
             d: The GDAL multidimensional `Dimension` object.
@@ -288,11 +289,12 @@ class DimensionInfo:
         # fold the unit slot back in: GDAL moves a CF `units` attribute onto the object's
         # own unit and drops it from the attribute list, under the netCDF and the HDF5
         # driver alike. Without this, `units` reaches dimension metadata only through the
-        # classic-metadata top-up in `MetadataBuilder`, which yields nothing when the file
-        # was opened by the HDF5 driver — as any /vsi NetCDF-4 read on Windows is — so the
-        # time axis came back undecodable there (#1078).
+        # classic-metadata top-up in `MetadataBuilder`, which yields nothing under the HDF5
+        # driver — the one GDAL selected for the reported `/vsicurl` NetCDF-4 read — so the
+        # time axis came back undecodable there (#1078). The guard below is for
+        # `_read_attributes`; `read_cf_attributes` already absorbs a failing unit slot.
         try:
-            iv_attrs = _merge_unit(_read_attributes(iv), iv) if iv is not None else {}
+            iv_attrs = read_cf_attributes(iv) if iv is not None else {}
         except Exception:
             iv_attrs = {}
 
@@ -455,6 +457,10 @@ class VariableInfo:
     dtype: str
     shape: list[int]
     dimensions: list[str]
+    # Verbatim: what the file's attribute list declares. Unlike `DimensionInfo.attrs`, the CF
+    # `units` is deliberately *not* folded in here, because `unit` below already carries it —
+    # a dimension has no such field, which is why it needs the fold-in (#1078). Read `unit`
+    # for a variable's CF units: one value in two shapes, not two values.
     attributes: dict[str, AttributeValue] = field(default_factory=dict)
     unit: str | None = None
     nodata: int | float | str | None = None

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -74,7 +74,11 @@ from pyramids.netcdf.engines.variables import Variables
 from pyramids.netcdf.metadata import get_metadata
 from pyramids.netcdf.models import NetCDFMetadata
 from pyramids.netcdf.plot_options import CoordinateSpec, FacetSpec, Selectors
-from pyramids.netcdf.utils import _read_attributes, create_time_conversion_func
+from pyramids.netcdf.utils import (
+    _read_attributes,
+    create_time_conversion_func,
+    read_cf_attributes,
+)
 
 if TYPE_CHECKING:
     from cleopatra.basemap.geo import Basemap
@@ -6959,7 +6963,7 @@ class NetCDF(Dataset):
         # Attribute-only detection (empty ``name`` disables the name-pattern fallback): the
         # name-based stage lives in ``_named_spatial_axes`` and must stay separate so the
         # CF-attribute pass keeps precedence over it.
-        role = detect_axis("", _read_attributes(coord))
+        role = detect_axis("", read_cf_attributes(coord))
         return role if role in ("X", "Y") else None
 
     @staticmethod

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4451,7 +4451,9 @@ class NetCDF(Dataset):
 
         Returns:
             list[str] or None: Formatted time strings, or None if the
-            time dimension is not found or lacks a `units` attribute.
+            time dimension is not found, lacks a `units` attribute, or
+            carries a `units` that is not a CF time origin (e.g. asking
+            for a spatial dimension, whose units are `degrees_north`).
         """
         time_stamp = None
         time_dim = self.meta_data.get_dimension(var_name)
@@ -4461,9 +4463,19 @@ class NetCDF(Dataset):
                 calendar = time_dim.attrs.get("calendar", "standard")
                 time_vals = self._read_variable(var_name)
                 if time_vals is not None:
-                    func = create_time_conversion_func(
-                        units, time_format, calendar=calendar
-                    )
+                    try:
+                        func = create_time_conversion_func(
+                            units, time_format, calendar=calendar
+                        )
+                    except Exception:
+                        # Guard only the parse, exactly as `_decode_time_labels` does. Every
+                        # dimension now carries its `units` (#1078), so a non-temporal one no
+                        # longer "lacks" the attribute and reaches this parse with something
+                        # like "degrees_north". Returning None keeps the documented contract
+                        # rather than turning a wrong-dimension query into an exception.
+                        return None
+                    # The value conversion stays outside the guard, so a genuinely malformed
+                    # coordinate value still surfaces instead of being hidden.
                     time_stamp = list(map(func, time_vals.reshape(-1)))
         return time_stamp
 

--- a/src/pyramids/netcdf/ugrid/dataset.py
+++ b/src/pyramids/netcdf/ugrid/dataset.py
@@ -50,7 +50,11 @@ from pyramids.netcdf.ugrid.spatial import (
     clip_mesh,
     subset_by_bounds,
 )
-from pyramids.netcdf.utils import _dtype_to_str, _read_attributes
+from pyramids.netcdf.utils import (
+    _dtype_to_str,
+    _read_attributes,
+    read_cf_attributes,
+)
 
 
 class UgridDataset:
@@ -1054,7 +1058,7 @@ def _read_data_variables(
         md_arr = open_mdarray(rg, var_name)
         if md_arr is None:
             continue
-        attrs = _read_attributes(md_arr)
+        attrs = read_cf_attributes(md_arr)
         dims = md_arr.GetDimensions()
         shape = tuple(d.GetSize() for d in dims) if dims else ()
         dim_names = tuple(d.GetName() for d in dims) if dims else ()

--- a/src/pyramids/netcdf/utils.py
+++ b/src/pyramids/netcdf/utils.py
@@ -891,35 +891,75 @@ def _read_attribute_value(attr: gdal.Attribute) -> AttributeValue:
     return _normalize_attr_value(val)
 
 
-def _merge_unit(attrs: dict[str, Any], gdal_obj: Any) -> dict[str, Any]:
+def _merge_unit(
+    attrs: dict[str, AttributeValue], gdal_obj: Any
+) -> dict[str, AttributeValue]:
     """Fold GDAL's ``GetUnit()`` back into ``attrs`` as a CF ``units`` entry.
 
-    GDAL normalises a CF ``units`` attribute onto the MDArray / indexing-variable
-    **unit slot** and drops it from the attribute list. That is not driver-specific —
-    the netCDF and HDF5 drivers both do it — so anything reading CF attributes off a
-    multidim object sees ``calendar`` and ``standard_name`` but no ``units`` unless the
-    unit slot is merged back in (#1078).
+    Prefer :func:`read_cf_attributes`, which pairs this with the attribute read; call this
+    directly only when the attributes were obtained some other way.
 
-    Existing ``units`` in ``attrs`` win, so a file that really does carry the attribute
-    keeps its own value. The dict is mutated in place and returned for chaining.
+    GDAL normalises a CF ``units`` attribute onto the MDArray / indexing-variable **unit
+    slot** and drops it from the attribute list. That is not driver-specific — the netCDF
+    and HDF5 drivers both do it — so a CF consumer reading attributes alone sees
+    ``calendar`` and ``standard_name`` but never ``units`` (#1078).
+
+    Existing ``units`` in ``attrs`` win, so a file that really does carry the attribute keeps
+    its own value. That incumbent is taken as-is while the slot value is type-checked, which is
+    deliberate but worth naming: the incumbent arrived through :func:`_read_attributes`, which
+    has already normalised it, whereas the slot value goes in unmediated.
+
+    The ``isinstance`` test enforces this mapping's declared value type. Real GDAL returns
+    ``str`` here, so on a live handle the check never fires; what it actually rejects is a
+    non-GDAL stand-in — a ``MagicMock`` in the unit tests will happily return a mock object
+    from ``GetUnit()``, and that must not end up in metadata that is later serialised.
+
+    A raising ``GetUnit`` is treated as "no unit". Reading metadata degrades rather than
+    fails throughout this module, and a unit slot that errors should not take the caller's
+    whole attribute read down with it.
 
     Args:
         attrs: Attributes already read from ``gdal_obj``; mutated in place.
         gdal_obj: Any GDAL object exposing ``GetUnit()`` (MDArray, indexing variable).
 
     Returns:
-        dict[str, Any]: ``attrs``, with ``units`` added when the unit slot held one.
+        dict[str, AttributeValue]: ``attrs``, with ``units`` added when the slot held one.
     """
     try:
         unit = gdal_obj.GetUnit()
     except (RuntimeError, AttributeError):
         unit = None
-    # Require a real non-empty string: GetUnit's contract is `str`, every other value in
-    # a CF attrs dict is one, and an object that merely *has* the attribute (a stand-in
-    # in a test, a partially-built handle) must not put a non-CF value into metadata.
     if isinstance(unit, str) and unit and "units" not in attrs:
         attrs["units"] = unit
     return attrs
+
+
+def read_cf_attributes(obj: Any) -> dict[str, AttributeValue]:
+    """Read a GDAL object's attributes the way a CF consumer needs them.
+
+    The CF reader for every consumer of ``units`` / ``calendar`` / ``standard_name`` /
+    ``axis``. Use this rather than :func:`_read_attributes` wherever the attributes are
+    interpreted as CF: attributes alone omit ``units``, because GDAL moves it to the object's
+    unit slot, so a site that reads them raw silently loses it — which is how a time axis came
+    back undecodable, CF axis detection by units never fired, and a UGRID variable's unit
+    vanished on a round trip (#1078).
+
+    :func:`_read_attributes` remains the right call for a verbatim view of what the file
+    declares (serialisation, round-trip writers); this one is for interpreting CF.
+
+    The slot is the CF ``units`` for the netCDF and HDF5 drivers, which is where this matters.
+    Another multidim driver (Zarr, HDF-EOS) may fill it from a format-specific field, in which
+    case the reported ``units`` is that driver's unit rather than a CF attribute the file
+    literally declares — a reason to read attributes raw when the question is "what does this
+    file say", not "what does this axis mean".
+
+    Args:
+        obj: Any GDAL object exposing ``GetAttributes()`` and ``GetUnit()``.
+
+    Returns:
+        dict[str, AttributeValue]: The object's attributes, including ``units``.
+    """
+    return _merge_unit(_read_attributes(obj), obj)
 
 
 def _read_attributes(obj: Any) -> dict[str, AttributeValue]:

--- a/src/pyramids/netcdf/utils.py
+++ b/src/pyramids/netcdf/utils.py
@@ -891,6 +891,37 @@ def _read_attribute_value(attr: gdal.Attribute) -> AttributeValue:
     return _normalize_attr_value(val)
 
 
+def _merge_unit(attrs: dict[str, Any], gdal_obj: Any) -> dict[str, Any]:
+    """Fold GDAL's ``GetUnit()`` back into ``attrs`` as a CF ``units`` entry.
+
+    GDAL normalises a CF ``units`` attribute onto the MDArray / indexing-variable
+    **unit slot** and drops it from the attribute list. That is not driver-specific —
+    the netCDF and HDF5 drivers both do it — so anything reading CF attributes off a
+    multidim object sees ``calendar`` and ``standard_name`` but no ``units`` unless the
+    unit slot is merged back in (#1078).
+
+    Existing ``units`` in ``attrs`` win, so a file that really does carry the attribute
+    keeps its own value. The dict is mutated in place and returned for chaining.
+
+    Args:
+        attrs: Attributes already read from ``gdal_obj``; mutated in place.
+        gdal_obj: Any GDAL object exposing ``GetUnit()`` (MDArray, indexing variable).
+
+    Returns:
+        dict[str, Any]: ``attrs``, with ``units`` added when the unit slot held one.
+    """
+    try:
+        unit = gdal_obj.GetUnit()
+    except (RuntimeError, AttributeError):
+        unit = None
+    # Require a real non-empty string: GetUnit's contract is `str`, every other value in
+    # a CF attrs dict is one, and an object that merely *has* the attribute (a stand-in
+    # in a test, a partially-built handle) must not put a non-CF value into metadata.
+    if isinstance(unit, str) and unit and "units" not in attrs:
+        attrs["units"] = unit
+    return attrs
+
+
 def _read_attributes(obj: Any) -> dict[str, AttributeValue]:
     """Read all attributes from a GDAL object into a dictionary.
 

--- a/tests/netcdf/samples/test_spatial_dim_selection.py
+++ b/tests/netcdf/samples/test_spatial_dim_selection.py
@@ -63,8 +63,12 @@ def test_explicit_x_dim_y_dim_selects_plane(sample):
     try:
         var = nc.get_variable("T", x_dim="lon", y_dim="lat")
         assert var.read_array().shape[-2:] == (64, 128)  # (lat, lon)
-        # Default (no override, no CF attrs) falls back to the last two dims (lev, lon).
-        assert nc.get_variable("T").read_array().shape[-2:] == (6, 128)
+        # The default now agrees with the override. `T` is (time, lat, lev, lon), and this
+        # file's lat/lon do declare `degrees_north`/`degrees_east` — on GDAL's unit slot,
+        # which nothing read until #1078, so CF detection saw no attributes and fell back to
+        # the trailing two dims, making a level x longitude plane the raster. Reading the slot
+        # detects the real axes, so the geographic plane is chosen without an override.
+        assert nc.get_variable("T").read_array().shape[-2:] == (64, 128)
     finally:
         nc.close()
 

--- a/tests/netcdf/structure/test_dimension_units_from_unit_slot.py
+++ b/tests/netcdf/structure/test_dimension_units_from_unit_slot.py
@@ -14,6 +14,11 @@ on the classic top-up — supplied it.
 
 The HDF5 driver is exercised directly, via `gdal.OpenEx(..., allowed_drivers=["HDF5"])`, which
 selects it in-process without `GDAL_SKIP` and without a subprocess.
+
+The same blindness hit every CF consumer that read attributes raw, not just the time axis: CF
+axis detection never fired on a file whose lat/lon declare only `units`, and a UGRID variable's
+unit was lost on a round trip. They all go through `read_cf_attributes` now, and both are
+covered here.
 """
 
 from __future__ import annotations
@@ -25,8 +30,13 @@ import pytest
 from osgeo import gdal
 
 from pyramids.netcdf import NetCDF
+from pyramids.netcdf._axis import detect_axis_indices
 from pyramids.netcdf.metadata import MetadataBuilder
 from pyramids.netcdf.models import DimensionInfo
+from pyramids.netcdf.ugrid.connectivity import Connectivity
+from pyramids.netcdf.ugrid.dataset import UgridDataset
+from pyramids.netcdf.ugrid.mesh import Mesh2d
+from pyramids.netcdf.ugrid.models import MeshTopologyInfo, MeshVariable
 from pyramids.netcdf.utils import _merge_unit, _read_attributes
 
 pytestmark = pytest.mark.core
@@ -86,6 +96,44 @@ def cf_time_path(tmp_path) -> str:
     return path
 
 
+def _write_units_only_grid(path: str) -> str:
+    """Write a grid whose coordinates declare `units` and nothing else.
+
+    No `standard_name`, no `axis` — so CF axis detection has only the units to go on, which is
+    the case that was silently failing.
+
+    Args:
+        path: Output ``.nc`` path.
+
+    Returns:
+        str: ``path``, for chaining.
+    """
+    ds = gdal.GetDriverByName("netCDF").CreateMultiDimensional(path, [], ["FORMAT=NC4"])
+    rg = ds.GetRootGroup()
+    d_lat = rg.CreateDimension("lat", "", "", 2)
+    d_lon = rg.CreateDimension("lon", "", "", 3)
+    lat = rg.CreateMDArray(
+        "lat", [d_lat], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    lat.Write(np.array([51.0, 51.25]))
+    lon = rg.CreateMDArray(
+        "lon", [d_lon], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    lon.Write(np.array([3.0, 3.25, 3.5]))
+    for arr, units in ((lat, "degrees_north"), (lon, "degrees_east")):
+        attr = arr.CreateAttribute("units", [], gdal.ExtendedDataType.CreateString())
+        attr.Write(units)
+    var = rg.CreateMDArray(
+        "v", [d_lat, d_lon], gdal.ExtendedDataType.Create(gdal.GDT_Float32)
+    )
+    var.Write(np.zeros((2, 3), "float32"))
+    lat = lon = var = d_lat = d_lon = rg = None
+    ds.Close()
+    del ds
+    gc.collect()
+    return path
+
+
 class TestUnitSlotIsFoldedIn:
     """The unit slot reaches dimension attrs without help from the classic top-up."""
 
@@ -101,6 +149,7 @@ class TestUnitSlotIsFoldedIn:
             load-bearing.
         """
         ds = gdal.OpenEx(cf_time_path, gdal.OF_MULTIDIM_RASTER)
+        array = None
         try:
             array = ds.GetRootGroup().OpenMDArray("time")
             assert "units" not in _read_attributes(array), (
@@ -110,6 +159,8 @@ class TestUnitSlotIsFoldedIn:
                 f"the unit slot must hold the CF units, got {array.GetUnit()!r}"
             )
         finally:
+            # Release the array before the dataset: an MDArray keeps the handle alive.
+            array = None
             ds = None
 
     def test_dimension_attrs_carry_units(self, cf_time_path):
@@ -164,6 +215,7 @@ class TestUnitSlotIsFoldedIn:
                 f"the HDF5 driver must still yield the CF units, got {dict(attrs)}"
             )
         finally:
+            time_dim = None
             ds = None
 
     def test_time_decodes_without_the_classic_topup(self, cf_time_path, monkeypatch):
@@ -243,19 +295,17 @@ class TestMergeUnit:
         attrs = {"units": "from the attribute"}
         assert _merge_unit(attrs, _Obj())["units"] == "from the attribute"
 
-    @pytest.mark.parametrize(
-        "unit", ["", None, 42, object()], ids=["empty", "none", "int", "object"]
-    )
-    def test_non_string_unit_is_ignored(self, unit):
-        """Only a real non-empty string becomes a CF attribute.
+    @pytest.mark.parametrize("unit", ["", None], ids=["empty", "none"])
+    def test_absent_unit_adds_nothing(self, unit):
+        """An empty or absent unit slot adds no CF attribute.
 
         Args:
             unit: The value the stand-in's `GetUnit` returns.
 
         Test scenario:
-            `GetUnit`'s contract is `str`, and every value in a CF attrs dict is one. An object
-            that merely *has* the method — a partially-built handle, a test stand-in — must not
-            put a non-CF value into metadata.
+            The ordinary case for any array that is not a coordinate — GDAL returns `''`. A
+            `units` key materialising with an empty value would be worse than none, since CF
+            consumers test for presence.
         """
 
         class _Obj:
@@ -279,3 +329,81 @@ class TestMergeUnit:
                 raise RuntimeError("no unit")
 
         assert _merge_unit({"axis": "T"}, _Obj()) == {"axis": "T"}
+
+
+class TestOtherCfConsumers:
+    """Every CF consumer reads through `read_cf_attributes`, not the raw attribute list."""
+
+    def test_axis_detection_uses_units(self, tmp_path):
+        """Axes are detected on a file whose coordinates declare only `units`.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            `axis_role_of_dimension` advertises classification by `units`
+            (`degrees_east`/`degrees_north`), but read the attribute list raw — where `units`
+            never appears — so that branch was dead for real files. Files written by GDAL
+            escaped it only because its writer also stamps `standard_name`/`axis`. This fixture
+            declares nothing but `units` on its coordinates, so that is the only signal there is.
+        """
+        path = _write_units_only_grid(str(tmp_path / "units_only.nc"))
+        ds = gdal.OpenEx(path, gdal.OF_MULTIDIM_RASTER)
+        array = None
+        try:
+            array = ds.GetRootGroup().OpenMDArray("v")
+            assert detect_axis_indices(array.GetDimensions()) == (1, 0), (
+                "lat/lon declaring only units must still be detected as the Y/X axes"
+            )
+        finally:
+            array = None
+            ds = None
+
+    def test_ugrid_variable_units_survive_a_round_trip(self, tmp_path):
+        """A mesh variable's `units` is still there after write then read.
+
+        Args:
+            tmp_path: pytest temp directory.
+
+        Test scenario:
+            `_read_data_variables` took `units` from the attribute list, so the value written
+            through GDAL's unit slot came back as `None` — silently, since a missing unit is a
+            legal state.
+        """
+        path = tmp_path / "mesh.nc"
+        mesh = Mesh2d(
+            node_x=np.array([0.0, 1.0, 0.5]),
+            node_y=np.array([0.0, 0.0, 1.0]),
+            face_node_connectivity=Connectivity(
+                data=np.array([[0, 1, 2]], dtype=np.intp),
+                fill_value=-1,
+                cf_role="face_node_connectivity",
+                original_start_index=0,
+            ),
+        )
+        topology = MeshTopologyInfo(
+            mesh_name="mesh2d",
+            topology_dimension=2,
+            node_x_var="mesh2d_node_x",
+            node_y_var="mesh2d_node_y",
+            face_node_var="mesh2d_face_nodes",
+        )
+        variable = MeshVariable(
+            name="h",
+            location="node",
+            mesh_name="mesh2d",
+            shape=(3,),
+            attributes={"units": "m", "standard_name": "height"},
+            units="m",
+            standard_name="height",
+            _data=np.array([1.0, 2.0, 3.0]),
+        )
+        UgridDataset(
+            mesh=mesh,
+            data_variables={"h": variable},
+            global_attributes={"Conventions": "CF-1.8 UGRID-1.0"},
+            topology_info=topology,
+        ).to_file(path)
+        assert UgridDataset.read_file(path).get_data("h").units == "m", (
+            "the mesh variable's units must survive the round trip"
+        )

--- a/tests/netcdf/structure/test_dimension_units_from_unit_slot.py
+++ b/tests/netcdf/structure/test_dimension_units_from_unit_slot.py
@@ -1,0 +1,217 @@
+"""CF `units` reaches dimension metadata whichever driver opened the file (#1078).
+
+GDAL moves a CF `units` attribute onto the MDArray / indexing-variable **unit slot** and drops
+it from the attribute list. That is not driver-specific — netCDF and HDF5 both do it — so
+`_read_attributes(indexing_variable)` never contains `units` on either.
+
+What differed was the compensation. `MetadataBuilder._topup_dim_attrs_from_classic` refills
+`units`/`calendar` from classic-mode metadata (`<dim>#<attr>` keys), which the netCDF driver
+publishes and the HDF5 driver does not. So the time axis decoded locally and came back as `None`
+over `/vsicurl` on Windows, where GDAL serves NetCDF-4 through the HDF5 driver.
+
+The fix folds the unit slot back in at the source, so it no longer depends on which driver — or
+on the classic top-up — supplied it. The driver cannot be swapped inside a test process
+(`GDAL_SKIP` is read when drivers register), so the HDF5 situation is reproduced by emptying the
+classic top-up, which is precisely what that driver leaves behind.
+"""
+
+from __future__ import annotations
+
+import gc
+
+import numpy as np
+import pytest
+from osgeo import gdal
+
+from pyramids.netcdf import NetCDF
+from pyramids.netcdf.metadata import MetadataBuilder
+from pyramids.netcdf.utils import _merge_unit, _read_attributes
+
+pytestmark = pytest.mark.core
+
+TIME_UNITS = "days since 1950-01-01"
+TIME_VALUES = (27996.0, 27997.0, 27998.0)
+EXPECTED_DATES = ["2026-08-26", "2026-08-27", "2026-08-28"]
+
+
+@pytest.fixture
+def cf_time_path(tmp_path) -> str:
+    """A NetCDF-4 cube whose time axis carries CF `units` and `calendar`.
+
+    Args:
+        tmp_path: pytest temp directory.
+
+    Returns:
+        str: Path to the written file.
+    """
+    path = str(tmp_path / "cf_time.nc")
+    ds = gdal.GetDriverByName("netCDF").CreateMultiDimensional(path, [], ["FORMAT=NC4"])
+    rg = ds.GetRootGroup()
+    d_time = rg.CreateDimension("time", "", "", len(TIME_VALUES))
+    d_lat = rg.CreateDimension("lat", "", "", 2)
+    d_lon = rg.CreateDimension("lon", "", "", 2)
+    time = rg.CreateMDArray(
+        "time", [d_time], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    time.Write(np.array(TIME_VALUES))
+    for key, value in (
+        ("units", TIME_UNITS),
+        ("calendar", "gregorian"),
+        ("standard_name", "time"),
+        ("axis", "T"),
+    ):
+        attr = time.CreateAttribute(key, [], gdal.ExtendedDataType.CreateString())
+        attr.Write(value)
+    lat = rg.CreateMDArray(
+        "lat", [d_lat], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    lat.Write(np.array([51.0, 51.25]))
+    lon = rg.CreateMDArray(
+        "lon", [d_lon], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    lon.Write(np.array([3.0, 3.25]))
+    var = rg.CreateMDArray(
+        "twl", [d_time, d_lat, d_lon], gdal.ExtendedDataType.Create(gdal.GDT_Float32)
+    )
+    var.Write(np.zeros((len(TIME_VALUES), 2, 2), "float32"))
+    time = lat = lon = var = d_time = d_lat = d_lon = rg = None
+    ds.Close()
+    del ds
+    gc.collect()
+    return path
+
+
+class TestUnitSlotIsFoldedIn:
+    """The unit slot reaches dimension attrs without help from the classic top-up."""
+
+    def test_gdal_drops_units_from_the_attribute_list(self, cf_time_path):
+        """The premise: GDAL exposes `units` only through the unit slot.
+
+        Args:
+            cf_time_path: The written cube fixture.
+
+        Test scenario:
+            Pins why the fold-in is needed at all. If a future GDAL starts listing `units` as an
+            ordinary attribute this fails, and the fold-in becomes redundant rather than silently
+            load-bearing.
+        """
+        ds = gdal.OpenEx(cf_time_path, gdal.OF_MULTIDIM_RASTER)
+        try:
+            array = ds.GetRootGroup().OpenMDArray("time")
+            assert "units" not in _read_attributes(array), (
+                "GDAL now lists units as an attribute; the fold-in may be redundant"
+            )
+            assert array.GetUnit() == TIME_UNITS, (
+                f"the unit slot must hold the CF units, got {array.GetUnit()!r}"
+            )
+        finally:
+            ds = None
+
+    def test_dimension_attrs_carry_units(self, cf_time_path):
+        """`get_dimension("time").attrs` includes the CF units.
+
+        Args:
+            cf_time_path: The written cube fixture.
+
+        Test scenario:
+            This is what `get_time_variable` reads, and what `get_time_values`' docstring points
+            callers at as the documented fallback.
+
+            A contract test, not the regression guard: under the netCDF driver it also passes
+            without the fix, because the classic top-up supplies `units` there. It pins the
+            end state whichever mechanism provides it;
+            `test_time_decodes_without_the_classic_topup` is the one that fails without the
+            fold-in.
+        """
+        nc = NetCDF.read_file(cf_time_path)
+        try:
+            attrs = nc.meta_data.get_dimension("time").attrs
+            assert attrs.get("units") == TIME_UNITS, (
+                f"expected the CF units in dimension attrs, got {dict(attrs)}"
+            )
+        finally:
+            nc.close()
+
+    def test_time_decodes_without_the_classic_topup(self, cf_time_path, monkeypatch):
+        """The time axis decodes when classic metadata supplies nothing.
+
+        Args:
+            cf_time_path: The written cube fixture.
+            monkeypatch: Used to empty the classic top-up.
+
+        Test scenario:
+            An empty classic top-up is exactly what the HDF5 driver leaves behind — it publishes
+            no `<dim>#<attr>` keys — and that is the state in which `get_time_variable()` returned
+            `None` (#1078). The driver itself cannot be swapped in-process, since `GDAL_SKIP` is
+            read when drivers register.
+        """
+        monkeypatch.setattr(
+            MetadataBuilder, "_read_classic_metadata_for_topup", lambda self: {}
+        )
+        nc = NetCDF.read_file(cf_time_path)
+        try:
+            attrs = nc.meta_data.get_dimension("time").attrs
+            assert attrs.get("units") == TIME_UNITS, (
+                "units must not depend on the classic top-up, which the HDF5 driver leaves empty"
+            )
+            assert nc.get_time_variable() == EXPECTED_DATES, (
+                f"expected decoded dates, got {nc.get_time_variable()}"
+            )
+        finally:
+            nc.close()
+
+
+class TestMergeUnit:
+    """`_merge_unit` contract — it must never overwrite or invent a CF value."""
+
+    def test_existing_units_wins(self):
+        """An attribute the file really carries is not replaced by the unit slot.
+
+        Test scenario:
+            A file may declare both; the attribute is the authoritative CF value.
+        """
+
+        class _Obj:
+            @staticmethod
+            def GetUnit():
+                return "from the slot"
+
+        attrs = {"units": "from the attribute"}
+        assert _merge_unit(attrs, _Obj())["units"] == "from the attribute"
+
+    @pytest.mark.parametrize(
+        "unit", ["", None, 42, object()], ids=["empty", "none", "int", "object"]
+    )
+    def test_non_string_unit_is_ignored(self, unit):
+        """Only a real non-empty string becomes a CF attribute.
+
+        Args:
+            unit: The value the stand-in's `GetUnit` returns.
+
+        Test scenario:
+            `GetUnit`'s contract is `str`, and every value in a CF attrs dict is one. An object
+            that merely *has* the method — a partially-built handle, a test stand-in — must not
+            put a non-CF value into metadata.
+        """
+
+        class _Obj:
+            @staticmethod
+            def GetUnit():
+                return unit
+
+        assert "units" not in _merge_unit({}, _Obj())
+
+    def test_failing_get_unit_is_survivable(self):
+        """A raising `GetUnit` leaves the attributes untouched.
+
+        Test scenario:
+            Metadata reads elsewhere degrade rather than raise; a unit slot that errors must not
+            take the whole dimension read down with it.
+        """
+
+        class _Obj:
+            @staticmethod
+            def GetUnit():
+                raise RuntimeError("no unit")
+
+        assert _merge_unit({"axis": "T"}, _Obj()) == {"axis": "T"}

--- a/tests/netcdf/structure/test_dimension_units_from_unit_slot.py
+++ b/tests/netcdf/structure/test_dimension_units_from_unit_slot.py
@@ -10,9 +10,10 @@ publishes and the HDF5 driver does not. So the time axis decoded locally and cam
 over `/vsicurl` on Windows, where GDAL serves NetCDF-4 through the HDF5 driver.
 
 The fix folds the unit slot back in at the source, so it no longer depends on which driver — or
-on the classic top-up — supplied it. The driver cannot be swapped inside a test process
-(`GDAL_SKIP` is read when drivers register), so the HDF5 situation is reproduced by emptying the
-classic top-up, which is precisely what that driver leaves behind.
+on the classic top-up — supplied it.
+
+The HDF5 driver is exercised directly, via `gdal.OpenEx(..., allowed_drivers=["HDF5"])`, which
+selects it in-process without `GDAL_SKIP` and without a subprocess.
 """
 
 from __future__ import annotations
@@ -25,6 +26,7 @@ from osgeo import gdal
 
 from pyramids.netcdf import NetCDF
 from pyramids.netcdf.metadata import MetadataBuilder
+from pyramids.netcdf.models import DimensionInfo
 from pyramids.netcdf.utils import _merge_unit, _read_attributes
 
 pytestmark = pytest.mark.core
@@ -66,6 +68,9 @@ def cf_time_path(tmp_path) -> str:
         "lat", [d_lat], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
     )
     lat.Write(np.array([51.0, 51.25]))
+    for key, value in (("units", "degrees_north"), ("standard_name", "latitude")):
+        attr = lat.CreateAttribute(key, [], gdal.ExtendedDataType.CreateString())
+        attr.Write(value)
     lon = rg.CreateMDArray(
         "lon", [d_lon], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
     )
@@ -132,18 +137,47 @@ class TestUnitSlotIsFoldedIn:
         finally:
             nc.close()
 
+    def test_units_survive_the_hdf5_driver(self, cf_time_path):
+        """The real HDF5 driver yields a dimension carrying the CF units.
+
+        Args:
+            cf_time_path: The written cube fixture.
+
+        Test scenario:
+            This is the driver the bug is about — the one GDAL selects for a `/vsi` NetCDF-4 read
+            on Windows — reached in-process via `allowed_drivers`. On `main` this dimension comes
+            back without `units`, because the classic top-up the netCDF path relies on publishes
+            no `<dim>#<attr>` keys under HDF5.
+        """
+        ds = gdal.OpenEx(
+            cf_time_path, gdal.OF_MULTIDIM_RASTER, allowed_drivers=["HDF5"]
+        )
+        try:
+            assert ds.GetDriver().ShortName == "HDF5", (
+                f"expected the HDF5 driver, got {ds.GetDriver().ShortName}"
+            )
+            time_dim = next(
+                d for d in ds.GetRootGroup().GetDimensions() if d.GetName() == "time"
+            )
+            attrs = DimensionInfo.from_gdal_dim(time_dim, "/").attrs
+            assert attrs.get("units") == TIME_UNITS, (
+                f"the HDF5 driver must still yield the CF units, got {dict(attrs)}"
+            )
+        finally:
+            ds = None
+
     def test_time_decodes_without_the_classic_topup(self, cf_time_path, monkeypatch):
-        """The time axis decodes when classic metadata supplies nothing.
+        """The time axis decodes end to end when classic metadata supplies nothing.
 
         Args:
             cf_time_path: The written cube fixture.
             monkeypatch: Used to empty the classic top-up.
 
         Test scenario:
-            An empty classic top-up is exactly what the HDF5 driver leaves behind — it publishes
-            no `<dim>#<attr>` keys — and that is the state in which `get_time_variable()` returned
-            `None` (#1078). The driver itself cannot be swapped in-process, since `GDAL_SKIP` is
-            read when drivers register.
+            Covers the user-facing symptom — `get_time_variable()` returning `None` — which
+            `NetCDF.read_file` cannot reach through the HDF5 driver directly, since it does not
+            expose `allowed_drivers`. An empty classic top-up is the state that driver leaves
+            behind, so this reproduces the same condition one layer up.
         """
         monkeypatch.setattr(
             MetadataBuilder, "_read_classic_metadata_for_topup", lambda self: {}
@@ -156,6 +190,36 @@ class TestUnitSlotIsFoldedIn:
             )
             assert nc.get_time_variable() == EXPECTED_DATES, (
                 f"expected decoded dates, got {nc.get_time_variable()}"
+            )
+        finally:
+            nc.close()
+
+
+class TestNonTemporalDimension:
+    """Giving every dimension its units must not turn a wrong query into an exception."""
+
+    def test_spatial_dimension_returns_none(self, cf_time_path):
+        """`get_time_variable("lat")` returns None rather than raising.
+
+        Args:
+            cf_time_path: The written cube fixture.
+
+        Test scenario:
+            The documented contract is `None` when the dimension has no usable `units`. Before
+            #1078 a spatial dimension had no `units` at all under the HDF5 driver, so it returned
+            `None` by accident. Now it carries `degrees_north`, which reaches the CF time parse —
+            so the parse must be guarded, or a wrong-dimension query becomes
+            `ValueError: Unrecognized time units`.
+        """
+        nc = NetCDF.read_file(cf_time_path)
+        try:
+            assert nc.meta_data.get_dimension("lat").attrs.get("units") == (
+                "degrees_north"
+            ), (
+                "the fixture's lat must carry non-temporal units for this to mean anything"
+            )
+            assert nc.get_time_variable("lat") is None, (
+                "a non-temporal dimension must return None, not raise"
             )
         finally:
             nc.close()


### PR DESCRIPTION
# Description

`get_time_variable()` returned `None` for a NetCDF-4 cube opened by the **HDF5** driver — which is what GDAL uses
for any `/vsi` NetCDF-4 read on Windows — because the time dimension's `attrs` carried no `units`. The documented
fallback in `get_time_values()` points callers at that same empty key, so the raw offsets came back with no epoch
to decode them against.

**The reported mechanism turned out to be wrong, and the fix follows the real one.** The issue states that the
HDF5 driver drops `units` while the netCDF driver keeps it. Both drop it: GDAL normalises a CF `units` onto the
object's own **unit slot** and removes it from the attribute list. Verified on one file, one variable, both
drivers — the indexing variable is identical:

```
netCDF : attrs={'calendar','standard_name','axis'}   GetUnit()='days since 1950-01-01'
HDF5   : attrs={'calendar','standard_name','axis'}   GetUnit()='days since 1950-01-01'
```

What differs is pyramids' own compensation. `MetadataBuilder._topup_dim_attrs_from_classic` already exists to
refill `units`/`calendar` from classic-mode `<dim>#<attr>` metadata. The netCDF driver publishes
`time#units`; the HDF5 driver publishes no `time#` keys at all, so the top-up is a no-op and the axis is
undecodable:

```
netCDF classic metadata : {'time#axis','time#calendar','time#standard_name','time#units'}
HDF5   classic metadata : {}
```

So the axis decoded locally and failed remotely — not because of the driver's attribute handling, but because the
recovery path depended on the driver.

## What changed

- Fold the unit slot back in where dimension attributes are read (`models.py`, `DimensionInfo.from_gdal_dim`).
  This is driver-independent and does not require reopening the file in classic mode.
- The helper already existed — `_merge_unit`, applied only on the xarray-interop path, whose call sites are
  literally `_merge_unit(_read_attributes(x), x)`. Moved to `netcdf/utils.py` so both call sites share one
  definition instead of growing a second copy.
- Hardened it as it became shared: require a real non-empty `str` (`GetUnit`'s contract is `str`, and every value
  in a CF attrs dict is one), and survive a raising `GetUnit` — a metadata read should degrade, not take the
  dimension down with it.
- **The classic top-up stays.** `calendar` has no GDAL slot to recover it from, so removing it would break
  calendars. The issue's framing implies the new path supersedes it; it does not.

`get_time_variable()` and `get_time_values()` need no change — they already read `attrs["units"]`.

## Side effects considered

- Every dimension now gains its unit, not only time (`lat` → `degrees_north`). That restores a CF attribute the
  file declared rather than inventing one, and the writer already routes a `units` key through `SetUnit`, so
  there is no double-write on round-trip.
- Two existing tests assert exact `attrs` dicts. One is the classic path (untouched); the other builds its
  dimension from a `MagicMock`, whose `GetUnit()` returns a truthy mock — the `isinstance(unit, str)` guard keeps
  a non-CF value out of metadata there.
- No new dependencies.

# Issues

- Closes #1078 — CF `units` missing from dimension attrs, so `get_time_variable()` returned `None`

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

9 new tests in `tests/netcdf/structure/test_dimension_units_from_unit_slot.py`, plus the full suite.

- [x] The premise is pinned: GDAL exposes `units` only through the unit slot, so the fold-in cannot become
  silently redundant if a future GDAL starts listing it as an ordinary attribute.
- [x] `get_dimension("time").attrs` carries the CF units, and `get_time_variable()` decodes to
  `['2026-08-26', '2026-08-27', '2026-08-28']` **with the classic top-up emptied** — which is exactly what the
  HDF5 driver leaves behind. The driver itself cannot be swapped inside a test process (`GDAL_SKIP` is read when
  drivers register), so the top-up is emptied instead of faking the driver.
- [x] `_merge_unit` contract: an existing `units` attribute wins over the slot; a non-string or empty unit is
  ignored; a raising `GetUnit` leaves attrs untouched.
- [x] Verified non-vacuous: with the fold-in reverted, `test_time_decodes_without_the_classic_topup` fails.
  `test_dimension_attrs_carry_units` also passes on `main` (the classic top-up supplies units under the netCDF
  driver), so it is labelled a contract test rather than the regression guard.
- [x] Reproduced end to end before and after under both drivers (`GDAL_SKIP=netCDF` forces HDF5): `attrs` gains
  `units` and `get_time_variable()` returns the dates on both.
- [x] `pytest tests/ -m "not plot"` — **9016 passed, 53 skipped**.
- [x] `ruff format` / `ruff check` clean; `mypy` clean on the three changed source files.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.
