### PR TITLE
chore(packaging): bump bundled GDAL 3.13.1 -> 3.13.3

### DIFF
--- a/ci/source-build/build-gdal-stack.sh
+++ b/ci/source-build/build-gdal-stack.sh
@@ -20,7 +20,7 @@
 set -euo pipefail
 
 export BUILD_PREFIX="${BUILD_PREFIX:-/usr/local}"
-export GDAL_VERSION="${GDAL_VERSION:-3.13.1}"
+export GDAL_VERSION="${GDAL_VERSION:-3.13.3}"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # glibc (manylinux/AlmaLinux, dnf) vs musl (musllinux/Alpine, apk).

--- a/ci/source-build/config.sh
+++ b/ci/source-build/config.sh
@@ -95,8 +95,8 @@ define curl       8.18.0    e9274a5f8ab5271c0e0e6762d2fce194d5f98acc568e4ce81684
     "https://curl.se/download/curl-8.18.0.tar.gz"                                                curl-8.18.0.tar.gz
 define libpng     1.6.54    ba7efce137409079989df4667706c339bebfbb10e9f413474718012a13c8cd4c \
     "https://github.com/pnggroup/libpng/archive/refs/tags/v1.6.54.tar.gz"                        libpng-1.6.54.tar.gz
-define giflib     5.2.2     be7ffbd057cadebe2aa144542fd90c6838c6a083b5e8a9048b8ee3b66b29d5fb \
-    "https://sourceforge.net/projects/giflib/files/giflib-5.2.2.tar.gz/download"                 giflib-5.2.2.tar.gz
+define giflib     6.1.3     b65b66b99f0424b93525f987386f22fc5efb9da2bfc92ad4a532249aaffbab0e \
+    "https://sourceforge.net/projects/giflib/files/giflib-6.1.3.tar.gz/download"                 giflib-6.1.3.tar.gz
 define libwebp    1.6.0     93a852c2b3efafee3723efd4636de855b46f9fe1efddd607e1f42f60fc8f2136 \
     "https://github.com/webmproject/libwebp/archive/refs/tags/v1.6.0.tar.gz"                     libwebp-1.6.0.tar.gz
 define zstd       1.5.7     37d7284556b20954e56e1ca85b80226768902e2edabd3b649e9e72c0c9012ee3 \

--- a/ci/source-build/config.sh
+++ b/ci/source-build/config.sh
@@ -9,7 +9,7 @@
 # Environment contract:
 #   BUILD_PREFIX  install prefix (default /usr/local)
 #   GDAL_VERSION  GDAL release to build (required; the SHA256 below pins the
-#                 default 3.13.1 — bump both together or the fetch fails)
+#                 default 3.13.3 — bump both together or the fetch fails)
 #
 # Contract with build-gdal-stack.sh:
 #   - runs in a scratch dir; every tarball extracts here and the source
@@ -36,7 +36,7 @@ if [[ "$(uname -s)" != "Linux" ]]; then
 fi
 
 BUILD_PREFIX="${BUILD_PREFIX:-/usr/local}"
-GDAL_VERSION="${GDAL_VERSION:?GDAL_VERSION must be set (e.g. 3.13.1)}"
+GDAL_VERSION="${GDAL_VERSION:?GDAL_VERSION must be set (e.g. 3.13.3)}"
 ARCH="$(uname -m)"
 
 case "${ARCH}" in
@@ -134,7 +134,7 @@ define blosc      1.21.6    9fcd60301aae28f97f1301b735f966cc19e7c49b6b4321b839b4
     "https://github.com/Blosc/c-blosc/archive/refs/tags/v1.21.6.tar.gz"                          c-blosc-1.21.6.tar.gz
 define pcre2      10.47     47fe8c99461250d42f89e6e8fdaeba9da057855d06eb7fc08d9ca03fd08d7bc7 \
     "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.47/pcre2-10.47.tar.bz2"    pcre2-10.47.tar.bz2
-define gdal       "${GDAL_VERSION}" e04e9813bd215b56753d5554330c53be25f3df2d7ed7e6413a19e6b66751c675 \
+define gdal       "${GDAL_VERSION}" 5e0c388d83da2d686cc00a40272882432cdb54edff43d4af173e532844a0a0ea \
     "https://download.osgeo.org/gdal/${GDAL_VERSION}/gdal-${GDAL_VERSION}.tar.gz"  "gdal-${GDAL_VERSION}.tar.gz"
 
 # Build order: leaves first, GDAL last. Each entry is a src_<dep> function.

--- a/docs/how-to/wheel-build-flow.md
+++ b/docs/how-to/wheel-build-flow.md
@@ -38,7 +38,7 @@ not resolve pyramids-gis on those platforms yet:
 
 The `win_arm64` wheels (`build-winarm64-wheels`, cp312–cp314; numpy/scipy ship
 no cp311 arm64 wheels) are built from source via vcpkg. GDAL comes from the
-vcpkg port (currently 3.12.4, trailing the 3.13.1 the other wheels ship);
+vcpkg port (currently 3.12.4, trailing the 3.13.3 the other wheels ship);
 like Linux, no HDF4. Because shapely and pyogrio publish no win_arm64 wheels
 on PyPI, the platform markers in `[project.dependencies]` skip them (and
 geopandas) there, and each wheel **vendors the vector stack** — shapely,

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -157,7 +157,7 @@ set on every build, so drivers cannot silently disappear from a release.
 
 > **Windows ARM64 note**: the `win_arm64` wheel ships Python 3.12–3.14
 > (numpy/scipy publish no cp311 ARM64 wheels), carries GDAL 3.12.4 (the
-> pinned vcpkg port version; the other platforms ship 3.13.1), has no
+> pinned vcpkg port version; the other platforms ship 3.13.3), has no
 > HDF4 driver (like Linux), and **vendors its vector stack** — shapely,
 > geopandas, and pyogrio ship inside the wheel under
 > `pyramids/_vendor/` because upstream publishes no ARM64 wheels for

--- a/pixi.lock
+++ b/pixi.lock
@@ -40,9 +40,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.5-py314hc02f841_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py314h12e4122_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.3-np2py314h8c49085_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-ha257d8a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-6.1.3-h280c20c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-1.14.6-nompi_h19486de_110.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
@@ -66,12 +66,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.2.0-h69a702a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.1-hd345f60_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.1-h0f7509b_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.1-h796c181_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-h4a79ac8_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.1-h55bb2a4_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-h7a6f0ee_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.3-h31aba09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.3-h6cf191a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.3-h79506db_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.3-h4b4a346_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.3-hdcacc8a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.3-hf032058_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.2.0-h69a702a_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.2.0-h6b99dfc_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
@@ -156,9 +156,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.8-h29ee22c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cftime-1.6.5-py314hc2f71db_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freexl-2.0.0-h82fd2cb_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py314h76c7e07_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.3-np2py314h81d6052_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.14.1-h57520ee_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h5dd31e5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-6.1.3-h80f16a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf4-4.2.15-hb6ba311_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-1.14.6-nompi_hf95b8e7_110.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-py311h3512406_2.conda
@@ -182,12 +182,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.7.0-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-16.2.0-h205dda4_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-16.2.0-he9431aa_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.1-h3e0fee2_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.1-hda4762a_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.1-h326d342_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-h48721e5_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.1-h49495bd_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-h7a3011c_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.3-hacbcee7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.3-hbcdde33_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.3-hf752de5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.3-h0973956_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.3-hdff80c0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.3-h5570542_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-16.2.0-he9431aa_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-16.2.0-hc864f27_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-16.2.0-h8acb6b2_4.conda
@@ -280,9 +280,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.8-had63097_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cftime-1.6.5-py314h26e5826_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3183152_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py314ha4b4608_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.3-np2py314h45d49e2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h0f9f378_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-6.1.3-ha3d0635_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-1.14.6-nompi_h13accda_110.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-py313hbf1d544_2.conda
@@ -304,12 +304,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h8c408c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-16.2.0-h13771c8_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.1-he8206cc_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.1-h811dcc7_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.1-h20f2fc6_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-h1350517_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.1-hadaec2f_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-h2a73bb1_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.3-h310b87c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.3-ha01a682_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.3-ha770a77_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.3-h882f8c9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.3-he08a439_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.3-hbbb2e8d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-16.2.0-h7e5c614_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-16.2.0-h2539e6c_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwy-1.4.0-ha8ee8a1_1.conda
@@ -390,9 +390,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h74c22ad_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.5-py314h2115a04_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py314h64e98ee_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.3-np2py314h407f0a6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-hd20048c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-6.1.3-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-1.14.6-nompi_had3affe_110.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
@@ -414,12 +414,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-16.2.0-h3cf6597_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.1-h21e278e_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.1-h0beeb9f_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.1-h5b851b9_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-haaeabaa_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.1-hde759b8_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h4736868_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.3-h0d10833_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.3-h74f30ea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.3-h27393ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.3-h5056e47_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.3-hb4851f4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.3-hafa6405_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-16.2.0-h07b0088_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-16.2.0-hdb7a957_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwy-1.4.0-hd2bdd19_1.conda
@@ -499,7 +499,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_10.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cftime-1.6.5-py314h2dcd201_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py314hf352b11_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.3-np2py314h4074017_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-1.14.6-nompi_hae35d4c_110.conda
@@ -517,12 +517,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.25-h1a1d4e4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.7.0-h3d046cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.1-hbfeefb7_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.1-h7378ee1_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.1-h1f15f23_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h152d30e_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.1-he7d31cb_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-h3353d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.3-hcd51406_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.3-h0828328_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.3-h531e138_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.3-h77fcb0c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.3-hd0cc1af_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.3-h69e0d2b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.13.0-default_h049141e_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwy-1.4.0-h2419aca_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_3.conda
@@ -623,10 +623,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.5-py314hc02f841_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.1.0-py314h5bd0f2a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py314h12e4122_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.3-np2py314h8c49085_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.3.1-h54a6638_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-ha257d8a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-6.1.3-h280c20c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hb7133d2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.8.0-py314hd6bf2bd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.15.1-nompi_py314hc32fe06_101.conda
@@ -661,12 +661,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.2.0-h69a702a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.1-hd345f60_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.1-h0f7509b_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.1-h796c181_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-h4a79ac8_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.1-h55bb2a4_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-h7a6f0ee_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.3-h31aba09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.3-h6cf191a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.3-h79506db_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.3-h4b4a346_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.3-hdcacc8a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.3-hf032058_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.2.0-h69a702a_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.2.0-h6b99dfc_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
@@ -1011,10 +1011,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cftime-1.6.5-py314hc2f71db_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cytoolz-1.1.0-py314hafb4487_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freexl-2.0.0-h82fd2cb_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py314h76c7e07_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.3-np2py314h81d6052_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.14.1-h57520ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gflags-2.3.1-h7ac5ae9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h5dd31e5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-6.1.3-h80f16a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glog-0.7.1-ha2f5727_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/google-crc32c-1.8.0-py314h94bc565_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/h5py-3.15.1-nompi_py314h2a0c532_101.conda
@@ -1049,12 +1049,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.7.0-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-16.2.0-h205dda4_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-16.2.0-he9431aa_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.1-h3e0fee2_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.1-hda4762a_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.1-h326d342_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-h48721e5_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.1-h49495bd_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-h7a3011c_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.3-hacbcee7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.3-hbcdde33_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.3-hf752de5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.3-h0973956_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.3-hdff80c0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.3-h5570542_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-16.2.0-he9431aa_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-16.2.0-hc864f27_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-16.2.0-h8acb6b2_4.conda
@@ -1478,10 +1478,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cftime-1.6.5-py314h26e5826_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.1.0-py314h4f144dc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3183152_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py314ha4b4608_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.3-np2py314h45d49e2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.3.1-h2fb4741_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h0f9f378_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-6.1.3-ha3d0635_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h90d9b41_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/google-crc32c-1.8.0-py314h19b641f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.15.1-nompi_py314hf613b1f_101.conda
@@ -1514,12 +1514,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h8c408c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-16.2.0-h13771c8_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.1-he8206cc_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.1-h811dcc7_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.1-h20f2fc6_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-h1350517_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.1-hadaec2f_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-h2a73bb1_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.3-h310b87c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.3-ha01a682_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.3-ha770a77_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.3-h882f8c9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.3-he08a439_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.3-hbbb2e8d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-16.2.0-h7e5c614_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-16.2.0-h2539e6c_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-3.8.0-he806f76_0.conda
@@ -1858,10 +1858,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.5-py314h2115a04_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.1.0-py314h6c2aa35_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py314h64e98ee_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.3-np2py314h407f0a6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.3.1-h784d473_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-hd20048c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-6.1.3-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-h6f9ecc1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/google-crc32c-1.8.0-py314h8744745_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.15.1-nompi_py314h1c8d760_101.conda
@@ -1894,12 +1894,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-16.2.0-h3cf6597_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.1-h21e278e_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.1-h0beeb9f_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.1-h5b851b9_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-haaeabaa_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.1-hde759b8_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h4736868_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.3-h0d10833_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.3-h74f30ea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.3-h27393ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.3-h5056e47_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.3-hb4851f4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.3-hafa6405_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-16.2.0-h07b0088_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-16.2.0-hdb7a957_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-3.8.0-ha595bda_0.conda
@@ -2240,7 +2240,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/cftime-1.6.5-py314h2dcd201_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.1.0-py314h5a2d7ad_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py314hf352b11_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.3-np2py314h4074017_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/google-crc32c-1.8.0-py314h720154c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.15.1-nompi_py314hc249e69_101.conda
@@ -2268,12 +2268,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.7.0-h3d046cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.1-hbfeefb7_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.1-h7378ee1_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.1-h1f15f23_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h152d30e_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.1-he7d31cb_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-h3353d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.3-hcd51406_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.3-h0828328_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.3-h531e138_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.3-h77fcb0c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.3-hd0cc1af_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.3-h69e0d2b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-3.7.0-hfe3f7e9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-3.7.0-he04ea4c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.82.1-he6cc664_0.conda
@@ -2538,10 +2538,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.5-py314hc02f841_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.1.0-py314h5bd0f2a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py314h12e4122_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.3-np2py314h8c49085_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.3.1-h54a6638_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-ha257d8a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-6.1.3-h280c20c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hb7133d2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.8.0-py314hd6bf2bd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.15.1-nompi_py314hc32fe06_101.conda
@@ -2576,12 +2576,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.2.0-h69a702a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.1-hd345f60_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.1-h0f7509b_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.1-h796c181_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-h4a79ac8_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.1-h55bb2a4_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-h7a6f0ee_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.3-h31aba09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.3-h6cf191a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.3-h79506db_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.3-h4b4a346_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.3-hdcacc8a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.3-hf032058_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.2.0-h69a702a_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.2.0-h6b99dfc_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
@@ -2916,10 +2916,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cftime-1.6.5-py314hc2f71db_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cytoolz-1.1.0-py314hafb4487_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freexl-2.0.0-h82fd2cb_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py314h76c7e07_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.3-np2py314h81d6052_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.14.1-h57520ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gflags-2.3.1-h7ac5ae9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h5dd31e5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-6.1.3-h80f16a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glog-0.7.1-ha2f5727_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/google-crc32c-1.8.0-py314h94bc565_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/h5py-3.15.1-nompi_py314h2a0c532_101.conda
@@ -2954,12 +2954,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.7.0-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-16.2.0-h205dda4_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-16.2.0-he9431aa_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.1-h3e0fee2_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.1-hda4762a_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.1-h326d342_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-h48721e5_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.1-h49495bd_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-h7a3011c_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.3-hacbcee7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.3-hbcdde33_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.3-hf752de5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.3-h0973956_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.3-hdff80c0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.3-h5570542_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-16.2.0-he9431aa_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-16.2.0-hc864f27_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-16.2.0-h8acb6b2_4.conda
@@ -3373,10 +3373,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cftime-1.6.5-py314h26e5826_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.1.0-py314h4f144dc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3183152_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py314ha4b4608_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.3-np2py314h45d49e2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.3.1-h2fb4741_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h0f9f378_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-6.1.3-ha3d0635_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h90d9b41_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/google-crc32c-1.8.0-py314h19b641f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.15.1-nompi_py314hf613b1f_101.conda
@@ -3409,12 +3409,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h8c408c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-16.2.0-h13771c8_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.1-he8206cc_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.1-h811dcc7_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.1-h20f2fc6_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-h1350517_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.1-hadaec2f_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-h2a73bb1_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.3-h310b87c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.3-ha01a682_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.3-ha770a77_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.3-h882f8c9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.3-he08a439_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.3-hbbb2e8d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-16.2.0-h7e5c614_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-16.2.0-h2539e6c_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-3.8.0-he806f76_0.conda
@@ -3746,10 +3746,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.5-py314h2115a04_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.1.0-py314h6c2aa35_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py314h64e98ee_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.3-np2py314h407f0a6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.3.1-h784d473_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-hd20048c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-6.1.3-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-h6f9ecc1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/google-crc32c-1.8.0-py314h8744745_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.15.1-nompi_py314h1c8d760_101.conda
@@ -3782,12 +3782,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-16.2.0-h3cf6597_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.1-h21e278e_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.1-h0beeb9f_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.1-h5b851b9_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-haaeabaa_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.1-hde759b8_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h4736868_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.3-h0d10833_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.3-h74f30ea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.3-h27393ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.3-h5056e47_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.3-hb4851f4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.3-hafa6405_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-16.2.0-h07b0088_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-16.2.0-hdb7a957_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-3.8.0-ha595bda_0.conda
@@ -4121,7 +4121,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/cftime-1.6.5-py314h2dcd201_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.1.0-py314h5a2d7ad_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py314hf352b11_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.3-np2py314h4074017_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/google-crc32c-1.8.0-py314h720154c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.15.1-nompi_py314hc249e69_101.conda
@@ -4149,12 +4149,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.7.0-h3d046cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.1-hbfeefb7_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.1-h7378ee1_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.1-h1f15f23_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h152d30e_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.1-he7d31cb_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-h3353d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.3-hcd51406_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.3-h0828328_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.3-h531e138_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.3-h77fcb0c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.3-hd0cc1af_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.3-h69e0d2b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-3.7.0-hfe3f7e9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-3.7.0-he04ea4c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.82.1-he6cc664_0.conda
@@ -4393,9 +4393,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.5-py314hc02f841_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.1.0-py314h5bd0f2a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py314h12e4122_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.3-np2py314h8c49085_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-ha257d8a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-6.1.3-h280c20c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.8.0-py314hd6bf2bd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.15.1-nompi_py314hc32fe06_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
@@ -4422,12 +4422,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.2.0-h69a702a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.1-hd345f60_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.1-h0f7509b_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.1-h796c181_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-h4a79ac8_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.1-h55bb2a4_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-h7a6f0ee_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.3-h31aba09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.3-h6cf191a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.3-h79506db_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.3-h4b4a346_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.3-hdcacc8a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.3-hf032058_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.2.0-h69a702a_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.2.0-h6b99dfc_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
@@ -4702,9 +4702,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cftime-1.6.5-py314hc2f71db_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cytoolz-1.1.0-py314hafb4487_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freexl-2.0.0-h82fd2cb_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py314h76c7e07_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.3-np2py314h81d6052_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.14.1-h57520ee_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h5dd31e5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-6.1.3-h80f16a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/google-crc32c-1.8.0-py314h94bc565_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/h5py-3.15.1-nompi_py314h2a0c532_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf4-4.2.15-hb6ba311_7.conda
@@ -4731,12 +4731,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.7.0-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-16.2.0-h205dda4_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-16.2.0-he9431aa_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.1-h3e0fee2_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.1-hda4762a_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.1-h326d342_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-h48721e5_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.1-h49495bd_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-h7a3011c_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.3-hacbcee7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.3-hbcdde33_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.3-hf752de5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.3-h0973956_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.3-hdff80c0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.3-h5570542_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-16.2.0-he9431aa_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-16.2.0-hc864f27_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-16.2.0-h8acb6b2_4.conda
@@ -5064,9 +5064,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cftime-1.6.5-py314h26e5826_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.1.0-py314h4f144dc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3183152_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py314ha4b4608_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.3-np2py314h45d49e2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h0f9f378_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-6.1.3-ha3d0635_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/google-crc32c-1.8.0-py314h19b641f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.15.1-nompi_py314hf613b1f_101.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
@@ -5091,12 +5091,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h8c408c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-16.2.0-h13771c8_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.1-he8206cc_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.1-h811dcc7_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.1-h20f2fc6_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-h1350517_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.1-hadaec2f_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-h2a73bb1_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.3-h310b87c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.3-ha01a682_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.3-ha770a77_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.3-h882f8c9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.3-he08a439_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.3-hbbb2e8d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-16.2.0-h7e5c614_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-16.2.0-h2539e6c_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwy-1.4.0-ha8ee8a1_1.conda
@@ -5365,9 +5365,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.5-py314h2115a04_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.1.0-py314h6c2aa35_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py314h64e98ee_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.3-np2py314h407f0a6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-hd20048c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-6.1.3-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/google-crc32c-1.8.0-py314h8744745_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.15.1-nompi_py314h1c8d760_101.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
@@ -5392,12 +5392,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-16.2.0-h3cf6597_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.1-h21e278e_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.1-h0beeb9f_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.1-h5b851b9_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-haaeabaa_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.1-hde759b8_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h4736868_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.3-h0d10833_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.3-h74f30ea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.3-h27393ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.3-h5056e47_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.3-hb4851f4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.3-hafa6405_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-16.2.0-h07b0088_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-16.2.0-hdb7a957_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwy-1.4.0-hd2bdd19_1.conda
@@ -5667,7 +5667,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/cftime-1.6.5-py314h2dcd201_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.1.0-py314h5a2d7ad_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py314hf352b11_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.3-np2py314h4074017_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/google-crc32c-1.8.0-py314h720154c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.15.1-nompi_py314hc249e69_101.conda
@@ -5688,12 +5688,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.25-h1a1d4e4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.7.0-h3d046cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.1-hbfeefb7_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.1-h7378ee1_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.1-h1f15f23_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h152d30e_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.1-he7d31cb_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-h3353d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.3-hcd51406_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.3-h0828328_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.3-h531e138_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.3-h77fcb0c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.3-hd0cc1af_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.3-h69e0d2b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.13.0-default_h049141e_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwy-1.4.0-h2419aca_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_3.conda
@@ -5933,10 +5933,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.5-py314hc02f841_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.1.0-py314h5bd0f2a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py314h12e4122_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.3-np2py314h8c49085_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/gflags-2.3.1-h54a6638_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-ha257d8a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-6.1.3-h280c20c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hb7133d2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.8.0-py314hd6bf2bd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.15.1-nompi_py314hc32fe06_101.conda
@@ -5971,12 +5971,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.2.0-h69a702a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.1-hd345f60_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.1-h0f7509b_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.1-h796c181_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-h4a79ac8_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.1-h55bb2a4_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-h7a6f0ee_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.3-h31aba09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.3-h6cf191a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.3-h79506db_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.3-h4b4a346_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.3-hdcacc8a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.3-hf032058_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.2.0-h69a702a_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.2.0-h6b99dfc_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
@@ -6288,10 +6288,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cftime-1.6.5-py314hc2f71db_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cytoolz-1.1.0-py314hafb4487_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freexl-2.0.0-h82fd2cb_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py314h76c7e07_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.3-np2py314h81d6052_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.14.1-h57520ee_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gflags-2.3.1-h7ac5ae9_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h5dd31e5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-6.1.3-h80f16a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glog-0.7.1-ha2f5727_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/google-crc32c-1.8.0-py314h94bc565_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/h5py-3.15.1-nompi_py314h2a0c532_101.conda
@@ -6326,12 +6326,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.7.0-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-16.2.0-h205dda4_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-16.2.0-he9431aa_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.1-h3e0fee2_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.1-hda4762a_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.1-h326d342_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-h48721e5_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.1-h49495bd_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-h7a3011c_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.3-hacbcee7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.3-hbcdde33_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.3-hf752de5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.3-h0973956_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.3-hdff80c0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.3-h5570542_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-16.2.0-he9431aa_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-16.2.0-hc864f27_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-16.2.0-h8acb6b2_4.conda
@@ -6697,10 +6697,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cftime-1.6.5-py314h26e5826_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.1.0-py314h4f144dc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3183152_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py314ha4b4608_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.3-np2py314h45d49e2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/gflags-2.3.1-h2fb4741_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h0f9f378_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-6.1.3-ha3d0635_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h90d9b41_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/google-crc32c-1.8.0-py314h19b641f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.15.1-nompi_py314hf613b1f_101.conda
@@ -6733,12 +6733,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h8c408c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-16.2.0-h13771c8_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.1-he8206cc_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.1-h811dcc7_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.1-h20f2fc6_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-h1350517_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.1-hadaec2f_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-h2a73bb1_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.3-h310b87c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.3-ha01a682_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.3-ha770a77_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.3-h882f8c9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.3-he08a439_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.3-hbbb2e8d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-16.2.0-h7e5c614_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-16.2.0-h2539e6c_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgoogle-cloud-3.8.0-he806f76_0.conda
@@ -7044,10 +7044,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.5-py314h2115a04_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.1.0-py314h6c2aa35_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py314h64e98ee_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.3-np2py314h407f0a6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gflags-2.3.1-h784d473_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-hd20048c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-6.1.3-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-h6f9ecc1_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/google-crc32c-1.8.0-py314h8744745_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.15.1-nompi_py314h1c8d760_101.conda
@@ -7080,12 +7080,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-16.2.0-h3cf6597_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.1-h21e278e_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.1-h0beeb9f_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.1-h5b851b9_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-haaeabaa_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.1-hde759b8_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h4736868_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.3-h0d10833_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.3-h74f30ea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.3-h27393ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.3-h5056e47_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.3-hb4851f4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.3-hafa6405_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-16.2.0-h07b0088_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-16.2.0-hdb7a957_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgoogle-cloud-3.8.0-ha595bda_0.conda
@@ -7393,7 +7393,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/cftime-1.6.5-py314h2dcd201_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.1.0-py314h5a2d7ad_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py314hf352b11_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.3-np2py314h4074017_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/google-crc32c-1.8.0-py314h720154c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.15.1-nompi_py314hc249e69_101.conda
@@ -7421,12 +7421,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libevent-2.1.12-h3671451_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.7.0-h3d046cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.1-hbfeefb7_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.1-h7378ee1_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.1-h1f15f23_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h152d30e_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.1-he7d31cb_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-h3353d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.3-hcd51406_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.3-h0828328_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.3-h531e138_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.3-h77fcb0c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.3-hd0cc1af_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.3-h69e0d2b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-3.7.0-hfe3f7e9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-storage-3.7.0-he04ea4c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libgrpc-1.82.1-he6cc664_0.conda
@@ -7668,9 +7668,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.1.0-py311h49ec1c0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.8.0-py311h52bc045_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py311hc9d0587_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.3-np2py311hb6a3fe8_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-ha257d8a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-6.1.3-h280c20c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.8.0-py311h2702b87_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.15.1-nompi_py311h0b2f468_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
@@ -7697,12 +7697,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.2.0-h69a702a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.1-hd345f60_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.1-h0f7509b_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.1-h796c181_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-h4a79ac8_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.1-h55bb2a4_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-h7a6f0ee_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.3-h31aba09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.3-h6cf191a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.3-h79506db_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.3-h4b4a346_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.3-hdcacc8a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.3-hf032058_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.2.0-h69a702a_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.2.0-h6b99dfc_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
@@ -7978,9 +7978,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cytoolz-1.1.0-py311hb9158a3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freexl-2.0.0-h82fd2cb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/frozenlist-1.8.0-py311h91c1192_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py311hffe92d3_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.3-np2py311hb9e4ebe_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.14.1-h57520ee_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h5dd31e5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-6.1.3-h80f16a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/google-crc32c-1.8.0-py311h90304e7_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/h5py-3.15.1-nompi_py311h330c8c8_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf4-4.2.15-hb6ba311_7.conda
@@ -8007,12 +8007,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.7.0-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-16.2.0-h205dda4_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-16.2.0-he9431aa_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.1-h3e0fee2_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.1-hda4762a_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.1-h326d342_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-h48721e5_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.1-h49495bd_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-h7a3011c_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.3-hacbcee7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.3-hbcdde33_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.3-hf752de5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.3-h0973956_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.3-hdff80c0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.3-h5570542_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-16.2.0-he9431aa_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-16.2.0-hc864f27_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-16.2.0-h8acb6b2_4.conda
@@ -8329,9 +8329,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.1.0-py311hc71d4c3_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3183152_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozenlist-1.8.0-py311ha09d3ca_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py311h8fd869c_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.3-np2py311h947041c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h0f9f378_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-6.1.3-ha3d0635_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/google-crc32c-1.8.0-py311h19ff24f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.15.1-nompi_py311hc8b82f0_101.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
@@ -8356,12 +8356,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h8c408c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-16.2.0-h13771c8_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.1-he8206cc_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.1-h811dcc7_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.1-h20f2fc6_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-h1350517_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.1-hadaec2f_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-h2a73bb1_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.3-h310b87c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.3-ha01a682_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.3-ha770a77_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.3-h882f8c9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.3-he08a439_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.3-hbbb2e8d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-16.2.0-h7e5c614_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-16.2.0-h2539e6c_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwy-1.4.0-ha8ee8a1_1.conda
@@ -8630,9 +8630,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.1.0-py311hc949640_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.8.0-py311hf75086c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py311hfd0d7fd_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.3-np2py311he597461_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-hd20048c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-6.1.3-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/google-crc32c-1.8.0-py311hf1b1034_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.15.1-nompi_py311hd5a25a3_101.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
@@ -8657,12 +8657,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-16.2.0-h3cf6597_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.1-h21e278e_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.1-h0beeb9f_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.1-h5b851b9_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-haaeabaa_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.1-hde759b8_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h4736868_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.3-h0d10833_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.3-h74f30ea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.3-h27393ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.3-h5056e47_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.3-hb4851f4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.3-hafa6405_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-16.2.0-h07b0088_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-16.2.0-hdb7a957_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwy-1.4.0-hd2bdd19_1.conda
@@ -8931,7 +8931,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.1.0-py311h3485c13_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.8.0-py311hdf60d3a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py311hf5951da_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.3-np2py311haee3e66_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/google-crc32c-1.8.0-py311h178015e_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.15.1-nompi_py311hc40ba4b_101.conda
@@ -8952,12 +8952,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.25-h1a1d4e4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.7.0-h3d046cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.1-hbfeefb7_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.1-h7378ee1_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.1-h1f15f23_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h152d30e_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.1-he7d31cb_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-h3353d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.3-hcd51406_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.3-h0828328_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.3-h531e138_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.3-h77fcb0c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.3-hd0cc1af_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.3-h69e0d2b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.13.0-default_h049141e_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwy-1.4.0-h2419aca_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_3.conda
@@ -9192,9 +9192,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.1.0-py312h4c3975b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.8.0-py312h447239a_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py312h5ea7aba_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.3-np2py312hde5bc3b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-ha257d8a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-6.1.3-h280c20c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.8.0-py312h03f33d3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.15.1-nompi_py312ha4f8f14_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
@@ -9221,12 +9221,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.2.0-h69a702a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.1-hd345f60_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.1-h0f7509b_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.1-h796c181_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-h4a79ac8_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.1-h55bb2a4_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-h7a6f0ee_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.3-h31aba09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.3-h6cf191a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.3-h79506db_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.3-h4b4a346_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.3-hdcacc8a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.3-hf032058_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.2.0-h69a702a_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.2.0-h6b99dfc_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
@@ -9500,9 +9500,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cytoolz-1.1.0-py312hefbd42c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freexl-2.0.0-h82fd2cb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/frozenlist-1.8.0-py312hb10c72c_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py312h73a449f_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.3-np2py312hd28de17_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.14.1-h57520ee_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h5dd31e5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-6.1.3-h80f16a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/google-crc32c-1.8.0-py312h6dea175_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/h5py-3.15.1-nompi_py312hb54937b_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf4-4.2.15-hb6ba311_7.conda
@@ -9529,12 +9529,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.7.0-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-16.2.0-h205dda4_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-16.2.0-he9431aa_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.1-h3e0fee2_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.1-hda4762a_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.1-h326d342_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-h48721e5_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.1-h49495bd_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-h7a3011c_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.3-hacbcee7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.3-hbcdde33_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.3-hf752de5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.3-h0973956_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.3-hdff80c0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.3-h5570542_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-16.2.0-he9431aa_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-16.2.0-hc864f27_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-16.2.0-h8acb6b2_4.conda
@@ -9849,9 +9849,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.1.0-py312h1a1c95f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3183152_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozenlist-1.8.0-py312h90c63f8_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py312h2b93078_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.3-np2py312h70a30f5_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h0f9f378_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-6.1.3-ha3d0635_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/google-crc32c-1.8.0-py312hb9001e9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.15.1-nompi_py312hcf08926_101.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
@@ -9876,12 +9876,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h8c408c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-16.2.0-h13771c8_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.1-he8206cc_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.1-h811dcc7_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.1-h20f2fc6_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-h1350517_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.1-hadaec2f_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-h2a73bb1_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.3-h310b87c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.3-ha01a682_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.3-ha770a77_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.3-h882f8c9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.3-he08a439_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.3-hbbb2e8d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-16.2.0-h7e5c614_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-16.2.0-h2539e6c_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwy-1.4.0-ha8ee8a1_1.conda
@@ -10148,9 +10148,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.1.0-py312h2bbb03f_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.8.0-py312ha0ce254_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py312hd14f2b4_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.3-np2py312he35bcab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-hd20048c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-6.1.3-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/google-crc32c-1.8.0-py312h090f823_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.15.1-nompi_py312h4eecd6b_101.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
@@ -10175,12 +10175,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-16.2.0-h3cf6597_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.1-h21e278e_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.1-h0beeb9f_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.1-h5b851b9_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-haaeabaa_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.1-hde759b8_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h4736868_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.3-h0d10833_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.3-h74f30ea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.3-h27393ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.3-h5056e47_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.3-hb4851f4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.3-hafa6405_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-16.2.0-h07b0088_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-16.2.0-hdb7a957_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwy-1.4.0-hd2bdd19_1.conda
@@ -10447,7 +10447,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.1.0-py312he06e257_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.8.0-py312hfdf67e6_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py312h78d3a78_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.3-np2py312h792ba28_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/google-crc32c-1.8.0-py312h3d708b0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.15.1-nompi_py312h03cd2ba_101.conda
@@ -10468,12 +10468,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.25-h1a1d4e4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.7.0-h3d046cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.1-hbfeefb7_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.1-h7378ee1_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.1-h1f15f23_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h152d30e_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.1-he7d31cb_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-h3353d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.3-hcd51406_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.3-h0828328_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.3-h531e138_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.3-h77fcb0c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.3-hd0cc1af_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.3-h69e0d2b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.13.0-default_h049141e_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwy-1.4.0-h2419aca_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_3.conda
@@ -10706,9 +10706,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.1.0-py313h07c4f96_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/frozenlist-1.8.0-py313h6b9daa2_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py313hc130033_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.3-np2py313hb3192b2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-ha257d8a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-6.1.3-h280c20c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.8.0-py313h74173ec_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.15.1-nompi_py313h253c126_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
@@ -10735,12 +10735,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.2.0-h69a702a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.1-hd345f60_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.1-h0f7509b_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.1-h796c181_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-h4a79ac8_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.1-h55bb2a4_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-h7a6f0ee_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.3-h31aba09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.3-h6cf191a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.3-h79506db_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.3-h4b4a346_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.3-hdcacc8a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.3-hf032058_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.2.0-h69a702a_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.2.0-h6b99dfc_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
@@ -11014,9 +11014,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cytoolz-1.1.0-py313he149459_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freexl-2.0.0-h82fd2cb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/frozenlist-1.8.0-py313hf71145f_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py313h06e5f52_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.3-np2py313h3529382_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.14.1-h57520ee_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h5dd31e5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-6.1.3-h80f16a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/google-crc32c-1.8.0-py313hfb67750_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/h5py-3.15.1-nompi_py313h624fb37_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf4-4.2.15-hb6ba311_7.conda
@@ -11043,12 +11043,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.7.0-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-16.2.0-h205dda4_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-16.2.0-he9431aa_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.1-h3e0fee2_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.1-hda4762a_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.1-h326d342_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-h48721e5_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.1-h49495bd_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-h7a3011c_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.3-hacbcee7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.3-hbcdde33_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.3-hf752de5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.3-h0973956_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.3-hdff80c0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.3-h5570542_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-16.2.0-he9431aa_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-16.2.0-hc864f27_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-16.2.0-h8acb6b2_4.conda
@@ -11363,9 +11363,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.1.0-py313h36bb7f5_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3183152_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/frozenlist-1.8.0-py313h1cd6d9b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py313h1cbe8e9_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.3-np2py313h13bd4ad_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h0f9f378_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-6.1.3-ha3d0635_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/google-crc32c-1.8.0-py313h49a2f01_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.15.1-nompi_py313h2a429bc_101.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
@@ -11390,12 +11390,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h8c408c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-16.2.0-h13771c8_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.1-he8206cc_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.1-h811dcc7_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.1-h20f2fc6_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-h1350517_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.1-hadaec2f_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-h2a73bb1_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.3-h310b87c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.3-ha01a682_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.3-ha770a77_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.3-h882f8c9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.3-he08a439_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.3-hbbb2e8d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-16.2.0-h7e5c614_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-16.2.0-h2539e6c_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwy-1.4.0-ha8ee8a1_1.conda
@@ -11663,9 +11663,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.1.0-py313h0997733_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/frozenlist-1.8.0-py313h750ce70_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py313h7a338b7_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.3-np2py313h97e9785_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-hd20048c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-6.1.3-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/google-crc32c-1.8.0-py313h11ab6f4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.15.1-nompi_py313h7aa1c8b_101.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
@@ -11690,12 +11690,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-16.2.0-h3cf6597_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.1-h21e278e_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.1-h0beeb9f_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.1-h5b851b9_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-haaeabaa_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.1-hde759b8_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h4736868_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.3-h0d10833_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.3-h74f30ea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.3-h27393ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.3-h5056e47_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.3-hb4851f4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.3-hafa6405_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-16.2.0-h07b0088_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-16.2.0-hdb7a957_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwy-1.4.0-hd2bdd19_1.conda
@@ -11963,7 +11963,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.1.0-py313h5ea7bf4_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/frozenlist-1.8.0-py313h0c48a3b_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py313hd6c750f_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.3-np2py313h177f10b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/google-crc32c-1.8.0-py313h5327936_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.15.1-nompi_py313hf7f959b_101.conda
@@ -11984,12 +11984,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.25-h1a1d4e4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.7.0-h3d046cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.1-hbfeefb7_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.1-h7378ee1_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.1-h1f15f23_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h152d30e_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.1-he7d31cb_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-h3353d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.3-hcd51406_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.3-h0828328_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.3-h531e138_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.3-h77fcb0c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.3-hd0cc1af_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.3-h69e0d2b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.13.0-default_h049141e_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwy-1.4.0-h2419aca_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_3.conda
@@ -12220,9 +12220,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cftime-1.6.5-py314hc02f841_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cytoolz-1.1.0-py314h5bd0f2a_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py314h12e4122_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.3-np2py314h8c49085_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-ha257d8a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-6.1.3-h280c20c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/google-crc32c-1.8.0-py314hd6bf2bd_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/h5py-3.15.1-nompi_py314hc32fe06_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
@@ -12249,12 +12249,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.2.0-h69a702a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.1-hd345f60_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.1-h0f7509b_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.1-h796c181_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-h4a79ac8_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.1-h55bb2a4_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-h7a6f0ee_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.3-h31aba09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.3-h6cf191a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.3-h79506db_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.3-h4b4a346_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.3-hdcacc8a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.3-hf032058_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.2.0-h69a702a_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.2.0-h6b99dfc_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
@@ -12530,9 +12530,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cftime-1.6.5-py314hc2f71db_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/cytoolz-1.1.0-py314hafb4487_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freexl-2.0.0-h82fd2cb_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py314h76c7e07_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.3-np2py314h81d6052_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.14.1-h57520ee_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h5dd31e5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-6.1.3-h80f16a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/google-crc32c-1.8.0-py314h94bc565_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/h5py-3.15.1-nompi_py314h2a0c532_101.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf4-4.2.15-hb6ba311_7.conda
@@ -12559,12 +12559,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.7.0-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-16.2.0-h205dda4_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-16.2.0-he9431aa_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.1-h3e0fee2_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.1-hda4762a_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.1-h326d342_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-h48721e5_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.1-h49495bd_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-h7a3011c_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.3-hacbcee7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.3-hbcdde33_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.3-hf752de5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.3-h0973956_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.3-hdff80c0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.3-h5570542_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-16.2.0-he9431aa_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-16.2.0-hc864f27_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-16.2.0-h8acb6b2_4.conda
@@ -12889,9 +12889,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cftime-1.6.5-py314h26e5826_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/cytoolz-1.1.0-py314h4f144dc_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3183152_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py314ha4b4608_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.3-np2py314h45d49e2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h0f9f378_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-6.1.3-ha3d0635_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/google-crc32c-1.8.0-py314h19b641f_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/h5py-3.15.1-nompi_py314hf613b1f_101.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
@@ -12916,12 +12916,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h8c408c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-16.2.0-h13771c8_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.1-he8206cc_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.1-h811dcc7_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.1-h20f2fc6_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-h1350517_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.1-hadaec2f_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-h2a73bb1_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.3-h310b87c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.3-ha01a682_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.3-ha770a77_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.3-h882f8c9_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.3-he08a439_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.3-hbbb2e8d_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-16.2.0-h7e5c614_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-16.2.0-h2539e6c_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwy-1.4.0-ha8ee8a1_1.conda
@@ -13191,9 +13191,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cftime-1.6.5-py314h2115a04_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cytoolz-1.1.0-py314h6c2aa35_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py314h64e98ee_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.3-np2py314h407f0a6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-hd20048c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-6.1.3-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/google-crc32c-1.8.0-py314h8744745_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/h5py-3.15.1-nompi_py314h1c8d760_101.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
@@ -13218,12 +13218,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-16.2.0-h3cf6597_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.1-h21e278e_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.1-h0beeb9f_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.1-h5b851b9_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-haaeabaa_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.1-hde759b8_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h4736868_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.3-h0d10833_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.3-h74f30ea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.3-h27393ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.3-h5056e47_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.3-hb4851f4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.3-hafa6405_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-16.2.0-h07b0088_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-16.2.0-hdb7a957_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwy-1.4.0-hd2bdd19_1.conda
@@ -13493,7 +13493,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/cftime-1.6.5-py314h2dcd201_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/cytoolz-1.1.0-py314h5a2d7ad_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py314hf352b11_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.3-np2py314h4074017_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/google-crc32c-1.8.0-py314h720154c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/h5py-3.15.1-nompi_py314hc249e69_101.conda
@@ -13514,12 +13514,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.25-h1a1d4e4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.7.0-h3d046cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.1-hbfeefb7_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.1-h7378ee1_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.1-h1f15f23_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h152d30e_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.1-he7d31cb_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-h3353d3b_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.3-hcd51406_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.3-h0828328_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.3-h531e138_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.3-h77fcb0c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.3-hd0cc1af_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.3-h69e0d2b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.13.0-default_h049141e_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwy-1.4.0-h2419aca_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_3.conda
@@ -13751,9 +13751,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/freexl-2.0.0-h9dce30a_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py314h12e4122_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.3-np2py314h8c49085_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-ha257d8a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-6.1.3-h280c20c_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf4-4.2.15-h2a13503_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/hdf5-2.2.0-nompi_hc529623_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
@@ -13777,12 +13777,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h3435931_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-16.2.0-h69a702a_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.1-hd345f60_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.1-h0f7509b_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.1-h796c181_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-h133e136_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.1-h55bb2a4_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-hc2d81f4_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.3-h31aba09_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.3-h6cf191a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.3-h79506db_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.3-h6662df4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.3-hdcacc8a_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.3-h63204bb_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.2.0-h69a702a_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.2.0-h6b99dfc_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
@@ -13853,9 +13853,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_10.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/c-ares-1.34.8-h29ee22c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/freexl-2.0.0-h82fd2cb_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py314h76c7e07_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.3-np2py314h81d6052_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.14.1-h57520ee_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h5dd31e5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-6.1.3-h80f16a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf4-4.2.15-hb6ba311_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/hdf5-2.2.0-nompi_hdc8a35d_100.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/icu-78.3-py311h3512406_2.conda
@@ -13879,12 +13879,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libffi-3.7.0-h376a255_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-16.2.0-h205dda4_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgcc-ng-16.2.0-he9431aa_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.1-h3e0fee2_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.1-hda4762a_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.1-h326d342_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-hfa11834_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.1-h49495bd_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-hb4028e1_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.3-hacbcee7_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.3-hbcdde33_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.3-hf752de5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.3-h3b0b5f5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.3-hdff80c0_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.3-h0cd1db0_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-16.2.0-he9431aa_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran5-16.2.0-hc864f27_4.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgomp-16.2.0-h8acb6b2_4.conda
@@ -13958,9 +13958,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h374f1ed_10.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.8-had63097_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/freexl-2.0.0-h3183152_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py314ha4b4608_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.3-np2py314h45d49e2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h0f9f378_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-6.1.3-ha3d0635_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf4-4.2.15-h8138101_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/hdf5-2.2.0-nompi_h6160fcd_100.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-py313hbf1d544_2.conda
@@ -13982,12 +13982,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h8c408c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgcc-16.2.0-h13771c8_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.1-he8206cc_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.1-h811dcc7_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.1-h20f2fc6_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-hdeea456_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.1-hadaec2f_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-ha928bd0_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.3-h310b87c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.3-ha01a682_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.3-ha770a77_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.3-h8f89cc3_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.3-he08a439_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.3-h3efdb02_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-16.2.0-h7e5c614_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-16.2.0-h2539e6c_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libhwy-1.4.0-ha8ee8a1_1.conda
@@ -14054,9 +14054,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h74c22ad_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/freexl-2.0.0-h3ab3353_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py314h64e98ee_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.3-np2py314h407f0a6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-hd20048c_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-6.1.3-h1a92334_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf4-4.2.15-h2ee6834_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/hdf5-2.2.0-nompi_h7eff4e6_100.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
@@ -14078,12 +14078,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-hcf2aa1b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-16.2.0-h3cf6597_4.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.1-h21e278e_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.1-h0beeb9f_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.1-h5b851b9_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-hbc024c0_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.1-hde759b8_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h59fab59_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.3-h0d10833_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.3-h74f30ea_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.3-h27393ca_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.3-hcffa2b5_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.3-hb4851f4_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.3-h7e39cce_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-16.2.0-h07b0088_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-16.2.0-hdb7a957_4.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libhwy-1.4.0-hd2bdd19_1.conda
@@ -14148,7 +14148,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/blosc-1.21.6-hfd34d9b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_10.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/freexl-2.0.0-hf297d47_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py314hf352b11_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.3-np2py314h4074017_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/hdf4-4.2.15-h5557f11_7.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/hdf5-2.2.0-nompi_hf525611_100.conda
@@ -14166,12 +14166,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/libdeflate-1.25-h1a1d4e4_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libexpat-2.8.1-hac47afa_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libffi-3.7.0-h3d046cb_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.1-hbfeefb7_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.1-h7378ee1_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.1-h1f15f23_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h3e1bca6_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.1-he7d31cb_8.conda
-      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-h47aba1c_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.3-hcd51406_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.3-h0828328_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.3-h531e138_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.3-h85408a6_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.3-hd0cc1af_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.3-h5940625_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwloc-2.13.0-default_h049141e_1000.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libhwy-1.4.0-h2419aca_1.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/libiconv-1.18-hc1393d2_3.conda
@@ -15127,43 +15127,43 @@ packages:
   run_exports: {}
   size: 54166
   timestamp: 1779999854010
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py311hc9d0587_8.conda
-  sha256: 7cdd7f6b4c3e041a69524bce2127f88cb3d1bc7c892ff76635a240fda531e45f
-  md5: ecdb1234ef486968e665fd49b8b5fbf7
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.3-np2py311hb6a3fe8_1.conda
+  sha256: 22e585371cf45316367917f5dd293f33a582dbbf9a4dda7bd6a3a59a0a541108
+  md5: 742c775251f7a13b936bc20404e9b910
   depends:
   - python
-  - libgdal-core 3.13.1.*
+  - libgdal-core 3.13.3.*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - libpng >=1.6.58,<1.7.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libsqlite >=3.53.3,<4.0a0
+  - libstdcxx >=15
+  - libgcc >=15
   - geos >=3.14.1,<3.14.2.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - lerc >=4.1.0,<5.0a0
-  - openssl >=3.5.7,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
   - json-c >=0.18,<0.19.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - pcre2 >=10.47,<10.48.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - blosc >=1.21.6,<2.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - libjxl >=0.12.0,<0.13.0a0
   - libcurl >=8.21.0,<9.0a0
-  - libarchive >=3.8.8,<3.9.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libarchive >=3.8.9,<3.9.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - lerc >=4.2.0,<5.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libdeflate >=1.25,<1.26.0a0
   - libiconv >=1.18,<2.0a0
-  - giflib >=5.2.2,<5.3.0a0
+  - blosc >=1.21.6,<2.0a0
   - numpy >=1.23,<3
   - python_abi 3.11.* *_cp311
   license: MIT
@@ -15171,91 +15171,91 @@ packages:
   purls:
   - pkg:pypi/gdal?source=hash-mapping
   run_exports: {}
-  size: 2558410
-  timestamp: 1784038266812
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py312h5ea7aba_8.conda
-  sha256: a23c04232ecee836266c0d5d730c293cde60adb2794e1be4eabc69dd08dd8d78
-  md5: 55f0883efe86f02faf3fdf06ffc7b93d
+  size: 2563083
+  timestamp: 1788235554900
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.3-np2py312hde5bc3b_1.conda
+  sha256: 6e2d64fdcc870a95bbad8b7e720c766637cd722fe352152bb3bbff7970959bca
+  md5: 8f43ef9291699cabeaed9369e87ed9b4
   depends:
   - python
-  - libgdal-core 3.13.1.*
+  - libgdal-core 3.13.3.*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - libpng >=1.6.58,<1.7.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libsqlite >=3.53.3,<4.0a0
+  - libstdcxx >=15
+  - libgcc >=15
   - geos >=3.14.1,<3.14.2.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - lerc >=4.1.0,<5.0a0
-  - openssl >=3.5.7,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
   - json-c >=0.18,<0.19.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - pcre2 >=10.47,<10.48.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - blosc >=1.21.6,<2.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - libjxl >=0.12.0,<0.13.0a0
   - libcurl >=8.21.0,<9.0a0
-  - libarchive >=3.8.8,<3.9.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libarchive >=3.8.9,<3.9.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - lerc >=4.2.0,<5.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libdeflate >=1.25,<1.26.0a0
   - libiconv >=1.18,<2.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - numpy >=1.25,<3
+  - blosc >=1.21.6,<2.0a0
   - python_abi 3.12.* *_cp312
+  - numpy >=1.25,<3
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
   run_exports: {}
-  size: 2525512
-  timestamp: 1784038266812
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py313hc130033_8.conda
-  sha256: 49580b85d72bc5ef6c7dd4490d1af8f9b53c594a7bd28bb37d6d63fd1056c2e9
-  md5: bb4155e2dc97fcc5393c9eef6046b1a7
+  size: 2531690
+  timestamp: 1788235554900
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.3-np2py313hb3192b2_1.conda
+  sha256: c1368633fd66d0f4f437add53a25297d1725a5dc9c768a7cebd3a773918f0567
+  md5: ca1983c320506107f6cec32da3737403
   depends:
   - python
-  - libgdal-core 3.13.1.*
+  - libgdal-core 3.13.3.*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - libpng >=1.6.58,<1.7.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libsqlite >=3.53.3,<4.0a0
+  - libstdcxx >=15
+  - libgcc >=15
   - geos >=3.14.1,<3.14.2.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - lerc >=4.1.0,<5.0a0
-  - openssl >=3.5.7,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
   - json-c >=0.18,<0.19.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - pcre2 >=10.47,<10.48.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - blosc >=1.21.6,<2.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - libjxl >=0.12.0,<0.13.0a0
   - libcurl >=8.21.0,<9.0a0
-  - libarchive >=3.8.8,<3.9.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libarchive >=3.8.9,<3.9.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - lerc >=4.2.0,<5.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libdeflate >=1.25,<1.26.0a0
   - libiconv >=1.18,<2.0a0
-  - giflib >=5.2.2,<5.3.0a0
+  - blosc >=1.21.6,<2.0a0
   - python_abi 3.13.* *_cp313
   - numpy >=1.25,<3
   license: MIT
@@ -15263,45 +15263,45 @@ packages:
   purls:
   - pkg:pypi/gdal?source=hash-mapping
   run_exports: {}
-  size: 2516251
-  timestamp: 1784038266812
-- conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.1-np2py314h12e4122_8.conda
-  sha256: 818439cc13e41c6c15b3e2ed1f19cf56b5edfd5de9e34676548ca5b21b5aa710
-  md5: b85dabdbbe9789c9454ab5225bca314c
+  size: 2522098
+  timestamp: 1788235554900
+- conda: https://conda.anaconda.org/conda-forge/linux-64/gdal-3.13.3-np2py314h8c49085_1.conda
+  sha256: 20e6cbe78987d5efcb1c44bbe5c9488e8bb1fa680f41d60b6ac6a1cc94a6f1de
+  md5: 1087c155101449aaaf7fb1dd5394ff3d
   depends:
   - python
-  - libgdal-core 3.13.1.*
+  - libgdal-core 3.13.3.*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - libpng >=1.6.58,<1.7.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libsqlite >=3.53.3,<4.0a0
+  - libstdcxx >=15
+  - libgcc >=15
   - geos >=3.14.1,<3.14.2.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - lerc >=4.1.0,<5.0a0
-  - openssl >=3.5.7,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
   - json-c >=0.18,<0.19.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - pcre2 >=10.47,<10.48.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - blosc >=1.21.6,<2.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - libjxl >=0.12.0,<0.13.0a0
   - libcurl >=8.21.0,<9.0a0
-  - libarchive >=3.8.8,<3.9.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libarchive >=3.8.9,<3.9.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - lerc >=4.2.0,<5.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libdeflate >=1.25,<1.26.0a0
   - libiconv >=1.18,<2.0a0
-  - giflib >=5.2.2,<5.3.0a0
+  - blosc >=1.21.6,<2.0a0
   - numpy >=1.25,<3
   - python_abi 3.14.* *_cp314
   license: MIT
@@ -15309,8 +15309,8 @@ packages:
   purls:
   - pkg:pypi/gdal?source=hash-mapping
   run_exports: {}
-  size: 2527486
-  timestamp: 1784038266812
+  size: 2532446
+  timestamp: 1788235554900
 - conda: https://conda.anaconda.org/conda-forge/linux-64/geos-3.14.1-h480dda7_0.conda
   sha256: 08896dcd94e14a83f247e91748444e610f344ab42d80cbf2b6082b481c3f8f4b
   md5: 4d4efd0645cd556fab54617c4ad477ef
@@ -15340,20 +15340,20 @@ packages:
     - gflags >=2.3.1,<2.4.0a0
   size: 130991
   timestamp: 1785044715896
-- conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-ha257d8a_1.conda
-  sha256: 3611c5d605cd56017704e6c01c7bd849e74a656a546d4c49d655fde49ddfeecc
-  md5: bd7c3a8586ed0101f094962100d30a63
+- conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-6.1.3-h280c20c_1.conda
+  sha256: 734cd8518063b707aa098932cb109f779b8cf5a3c31633f227d22557a6bfaf53
+  md5: 6d9a90cfee2c7343d6c05a1b37ef75fb
   depends:
-  - __glibc >=2.17,<3.0.a0
   - libgcc >=14
+  - __glibc >=2.17,<3.0.a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports:
     weak:
-    - giflib >=5.2.2,<5.3.0a0
-  size: 77403
-  timestamp: 1784694210187
+    - giflib >=6.1.3,<6.2.0a0
+  size: 87196
+  timestamp: 1785907555387
 - conda: https://conda.anaconda.org/conda-forge/linux-64/glog-0.7.1-hb7133d2_1.conda
   sha256: f24feeda3aeec3a2cbb9fe2e0fabc4785372e70b6cc838c96023e08e17f4bfa0
   md5: 6941f96b8a8056677d79b4f5a2c4aaca
@@ -16067,359 +16067,359 @@ packages:
     - libgcc
   size: 28403
   timestamp: 1787618684957
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.1-hd345f60_8.conda
-  sha256: 7b66ac1b6410c7e85adca90f02e6bba9c42a0578bb8e456399b8251e70f525d5
-  md5: f5f1ea626059f1ef28952ac00d979b07
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-core-3.13.3-h31aba09_1.conda
+  sha256: b447ca08212fe296e1788bb4ba74336fddfb40abf037cd377fe28aea4a625277
+  md5: 44c6780e3082468d8676aebdcd5068a6
   depends:
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - libpng >=1.6.58,<1.7.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libsqlite >=3.53.3,<4.0a0
+  - libstdcxx >=15
+  - libgcc >=15
   - geos >=3.14.1,<3.14.2.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - lerc >=4.1.0,<5.0a0
-  - openssl >=3.5.7,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
   - json-c >=0.18,<0.19.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - pcre2 >=10.47,<10.48.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - blosc >=1.21.6,<2.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - libjxl >=0.12.0,<0.13.0a0
   - libcurl >=8.21.0,<9.0a0
-  - libarchive >=3.8.8,<3.9.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libarchive >=3.8.9,<3.9.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - lerc >=4.2.0,<5.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libdeflate >=1.25,<1.26.0a0
   - libiconv >=1.18,<2.0a0
-  - giflib >=5.2.2,<5.3.0a0
+  - blosc >=1.21.6,<2.0a0
   constrains:
-  - libgdal 3.13.1.*
+  - libgdal 3.13.3.*
   license: MIT
   license_family: MIT
   purls: []
   run_exports:
     weak:
-    - libgdal-core >=3.13.1,<3.14.0a0
-  size: 15028669
-  timestamp: 1784038266812
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.1-h0f7509b_8.conda
-  sha256: f5484f5bbdc79eeb8ee1a48d23b45179ae417c1cd008bef784a5feb502502b11
-  md5: 485c9a94e2a1d8523a5caf4b74e996d1
+    - libgdal-core >=3.13.3,<3.14.0a0
+  size: 15195348
+  timestamp: 1788235554900
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-grib-3.13.3-h6cf191a_1.conda
+  sha256: 6fe9ad9c87b1621bc3df77d5a6b87b7f9e3a004ee540e9bf6dff01da3a93b767
+  md5: 380e2aa604eac8eb6824f852421a54e7
   depends:
-  - libgdal-core ==3.13.1 hd345f60_8
+  - libgdal-core ==3.13.3 h31aba09_1
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - libpng >=1.6.58,<1.7.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libsqlite >=3.53.3,<4.0a0
+  - libstdcxx >=15
+  - libgcc >=15
   - geos >=3.14.1,<3.14.2.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - lerc >=4.1.0,<5.0a0
-  - openssl >=3.5.7,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
   - json-c >=0.18,<0.19.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - pcre2 >=10.47,<10.48.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - blosc >=1.21.6,<2.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - libjxl >=0.12.0,<0.13.0a0
   - libcurl >=8.21.0,<9.0a0
-  - libarchive >=3.8.8,<3.9.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libarchive >=3.8.9,<3.9.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - lerc >=4.2.0,<5.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libdeflate >=1.25,<1.26.0a0
   - libiconv >=1.18,<2.0a0
-  - giflib >=5.2.2,<5.3.0a0
+  - blosc >=1.21.6,<2.0a0
   - libaec >=1.1.5,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 828083
-  timestamp: 1784038266812
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.1-h796c181_8.conda
-  sha256: f3176feba273ea33449f543abd15b1e35d59b413fc653663c31f7ca340bba8bf
-  md5: 573cab32e689c219c6351f4c3f8b26e2
+  size: 826007
+  timestamp: 1788235554900
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf4-3.13.3-h79506db_1.conda
+  sha256: 5355f91f3891819dcdfb85f4355dbbf5dbfb32ab9fe007f4a1007a623e45d7fe
+  md5: 4def4ad140f79182a50e7539412261e6
   depends:
-  - libgdal-core ==3.13.1 hd345f60_8
+  - libgdal-core ==3.13.3 h31aba09_1
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - libpng >=1.6.58,<1.7.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libsqlite >=3.53.3,<4.0a0
+  - libstdcxx >=15
+  - libgcc >=15
   - geos >=3.14.1,<3.14.2.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - lerc >=4.1.0,<5.0a0
-  - openssl >=3.5.7,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
   - json-c >=0.18,<0.19.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - pcre2 >=10.47,<10.48.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - blosc >=1.21.6,<2.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - libjxl >=0.12.0,<0.13.0a0
   - libcurl >=8.21.0,<9.0a0
-  - libarchive >=3.8.8,<3.9.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libarchive >=3.8.9,<3.9.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - lerc >=4.2.0,<5.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libdeflate >=1.25,<1.26.0a0
   - libiconv >=1.18,<2.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libaec >=1.1.5,<2.0a0
+  - blosc >=1.21.6,<2.0a0
   - hdf4 >=4.2.15,<4.2.16.0a0
+  - libaec >=1.1.5,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 607666
-  timestamp: 1784038266812
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-h133e136_8.conda
-  sha256: 5442f41436e76b98a552b01e620fe4fdd22a88ab41f43a0260da354a1fb7e22d
-  md5: ab800cbc1d4590dbb5a684714910dc2a
+  size: 607971
+  timestamp: 1788235554900
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.3-h4b4a346_1.conda
+  sha256: f5d11ab4307656450ea2d923090185f1da0ad28bad721cb84d9473bf78e62812
+  md5: 96cdeca58096749c975de8490c1030ba
   depends:
-  - libgdal-core ==3.13.1 hd345f60_8
+  - libgdal-core ==3.13.3 h31aba09_1
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - libpng >=1.6.58,<1.7.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libsqlite >=3.53.3,<4.0a0
+  - libstdcxx >=15
+  - libgcc >=15
   - geos >=3.14.1,<3.14.2.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - lerc >=4.1.0,<5.0a0
-  - openssl >=3.5.7,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - blosc >=1.21.6,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - libiconv >=1.18,<2.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - hdf5 >=2.1.0,<3.0a0
-  license: MIT
-  license_family: MIT
-  run_exports: {}
-  size: 786917
-  timestamp: 1784038266812
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.1-h4a79ac8_8.conda
-  sha256: b964422ec316427da33ab1de8f83ca656a877d7fdfecd7f044c328b758646221
-  md5: d036aa243844e65ade6f4cc048303ce1
-  depends:
-  - libgdal-core ==3.13.1 hd345f60_8
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - libpng >=1.6.58,<1.7.0a0
-  - libexpat >=2.8.1,<3.0a0
   - libjpeg-turbo >=3.2.0,<4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
+  - libpng >=1.6.58,<1.7.0a0
   - xerces-c >=3.3.0,<3.4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - lerc >=4.1.0,<5.0a0
-  - openssl >=3.5.7,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
   - json-c >=0.18,<0.19.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - pcre2 >=10.47,<10.48.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - blosc >=1.21.6,<2.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - libjxl >=0.12.0,<0.13.0a0
   - libcurl >=8.21.0,<9.0a0
-  - libarchive >=3.8.8,<3.9.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libarchive >=3.8.9,<3.9.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - lerc >=4.2.0,<5.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libdeflate >=1.25,<1.26.0a0
   - libiconv >=1.18,<2.0a0
-  - giflib >=5.2.2,<5.3.0a0
+  - blosc >=1.21.6,<2.0a0
   - hdf5 >=1.14.6,<1.14.7.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 783883
-  timestamp: 1784038266812
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.1-h55bb2a4_8.conda
-  sha256: a67097d70f294a850b1013754a74755cfb97c258a943e2ba42b6dfe84f44ef5f
-  md5: 7eece4f6575d51abdb1171130340487f
+  size: 787039
+  timestamp: 1788235554900
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-hdf5-3.13.3-h6662df4_1.conda
+  sha256: 4abaadf4f90d46b2c1d56bbb18df40b507d9e935aa55e33fef5210a107eb435e
+  md5: dda612df5dbc87efaa8fce317121bd77
   depends:
-  - libgdal-core ==3.13.1 hd345f60_8
+  - libgdal-core ==3.13.3 h31aba09_1
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - libpng >=1.6.58,<1.7.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libsqlite >=3.53.3,<4.0a0
+  - libstdcxx >=15
+  - libgcc >=15
   - geos >=3.14.1,<3.14.2.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - lerc >=4.1.0,<5.0a0
-  - openssl >=3.5.7,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
   - json-c >=0.18,<0.19.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - pcre2 >=10.47,<10.48.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - blosc >=1.21.6,<2.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - libjxl >=0.12.0,<0.13.0a0
   - libcurl >=8.21.0,<9.0a0
-  - libarchive >=3.8.8,<3.9.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libarchive >=3.8.9,<3.9.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - lerc >=4.2.0,<5.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libdeflate >=1.25,<1.26.0a0
   - libiconv >=1.18,<2.0a0
-  - giflib >=5.2.2,<5.3.0a0
+  - blosc >=1.21.6,<2.0a0
+  - hdf5 >=2.2.0,<3.0a0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 791081
+  timestamp: 1788235554900
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-jp2openjpeg-3.13.3-hdcacc8a_1.conda
+  sha256: ca796944fc9379eb48869da4c721e1e082373485e2434f07f6a3170ff080ce8f
+  md5: 9ae946b543522fe91363fc7f619cde93
+  depends:
+  - libgdal-core ==3.13.3 h31aba09_1
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=15
+  - libgcc >=15
+  - geos >=3.14.1,<3.14.2.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libarchive >=3.8.9,<3.9.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - lerc >=4.2.0,<5.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libiconv >=1.18,<2.0a0
+  - blosc >=1.21.6,<2.0a0
   - openjpeg >=2.5.4,<3.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 502691
-  timestamp: 1784038266812
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-h7a6f0ee_8.conda
-  sha256: cbcc60690856799df695b30b81e9d089723a15586dd9e68ac30ea7cfa65e638a
-  md5: 887edc7da5fe1d3f6c847a671082e39e
+  size: 502378
+  timestamp: 1788235554900
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.3-h63204bb_1.conda
+  sha256: 0ab82df40e6a6705d48627d3281b6c572441a7672fd03a1ba4dbf2a6500cdfd0
+  md5: 39aab2eedfe6cb1fc8f4b7d5f21cc6ad
   depends:
-  - libgdal-core ==3.13.1 hd345f60_8
-  - libgdal-hdf5 3.13.1.*
-  - libgdal-hdf4 3.13.1.*
+  - libgdal-core ==3.13.3 h31aba09_1
+  - libgdal-hdf5 3.13.3.*
+  - libgdal-hdf4 3.13.3.*
   - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - libpng >=1.6.58,<1.7.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libsqlite >=3.53.3,<4.0a0
+  - libstdcxx >=15
+  - libgcc >=15
   - geos >=3.14.1,<3.14.2.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - lerc >=4.1.0,<5.0a0
-  - openssl >=3.5.7,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
   - json-c >=0.18,<0.19.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - pcre2 >=10.47,<10.48.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - blosc >=1.21.6,<2.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - libjxl >=0.12.0,<0.13.0a0
   - libcurl >=8.21.0,<9.0a0
-  - libarchive >=3.8.8,<3.9.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libarchive >=3.8.9,<3.9.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - lerc >=4.2.0,<5.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libdeflate >=1.25,<1.26.0a0
   - libiconv >=1.18,<2.0a0
-  - giflib >=5.2.2,<5.3.0a0
+  - blosc >=1.21.6,<2.0a0
+  - hdf5 >=2.2.0,<3.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - libnetcdf >=4.10.1,<4.10.2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 808302
+  timestamp: 1788235554900
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.3-hf032058_1.conda
+  sha256: ac623386e593c2b5c30cab40923b66650a5f2dcec9b075376bf515fd6140ada6
+  md5: 374d9110eb681886c6b5fad4e2d27d66
+  depends:
+  - libgdal-core ==3.13.3 h31aba09_1
+  - libgdal-hdf5 3.13.3.*
+  - libgdal-hdf4 3.13.3.*
+  - __glibc >=2.17,<3.0.a0
+  - libstdcxx >=15
+  - libgcc >=15
+  - geos >=3.14.1,<3.14.2.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libarchive >=3.8.9,<3.9.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - lerc >=4.2.0,<5.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libiconv >=1.18,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
   - libnetcdf >=4.10.1,<4.10.2.0a0
   - hdf5 >=1.14.6,<1.14.7.0a0
-  - hdf4 >=4.2.15,<4.2.16.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 805961
-  timestamp: 1784038266812
-- conda: https://conda.anaconda.org/conda-forge/linux-64/libgdal-netcdf-3.13.1-hc2d81f4_8.conda
-  sha256: cfc60490abe4f6f9c013c2fcf145a35725b3ab66f081b1973f83dada58612391
-  md5: 527062d6b7347f62797999eea24bde4a
-  depends:
-  - libgdal-core ==3.13.1 hd345f60_8
-  - libgdal-hdf5 3.13.1.*
-  - libgdal-hdf4 3.13.1.*
-  - __glibc >=2.17,<3.0.a0
-  - libstdcxx >=14
-  - libgcc >=14
-  - libpng >=1.6.58,<1.7.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - lerc >=4.1.0,<5.0a0
-  - openssl >=3.5.7,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - blosc >=1.21.6,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - libiconv >=1.18,<2.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - hdf5 >=2.1.0,<3.0a0
-  - libnetcdf >=4.10.1,<4.10.2.0a0
-  - hdf4 >=4.2.15,<4.2.16.0a0
-  license: MIT
-  license_family: MIT
-  run_exports: {}
-  size: 805464
-  timestamp: 1784038266812
+  size: 807582
+  timestamp: 1788235554900
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.2.0-h69a702a_4.conda
   sha256: 7653be4d88a4d74676c38dd892914d027dcecc0c65c406be772d31cb641f8cfd
   md5: 5e92b8413fd1c8f8f3006f4661b12def
@@ -19591,88 +19591,88 @@ packages:
   run_exports: {}
   size: 54592
   timestamp: 1779999836719
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py311hffe92d3_8.conda
-  sha256: 19516740e64bc9e158b24966ce3a83d6c45a65cf91e83547bd407cc4bacd6ce0
-  md5: 4c3aba9afb4dfb487dc244d8300cc371
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.3-np2py311hb9e4ebe_1.conda
+  sha256: e50d5280d87107bbf54a5b2579cb86ef320a2335dc4eb3758c12cd3e73498a54
+  md5: 1237da8608db8a1c817482a196f35156
   depends:
   - python
-  - libgdal-core 3.13.1.*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libjxl >=0.12.0,<0.13.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
+  - libgdal-core 3.13.3.*
+  - libstdcxx >=15
+  - libgcc >=15
+  - liblzma >=5.8.3,<6.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
   - blosc >=1.21.6,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libwebp-base >=1.6.0,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - libdeflate >=1.25,<1.26.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - lerc >=4.1.0,<5.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libiconv >=1.18,<2.0a0
   - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - openssl >=3.5.7,<4.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
   - lz4-c >=1.10.0,<1.11.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libjxl >=0.12.0,<0.13.0a0
   - python 3.11.* *_cpython
-  - numpy >=1.23,<3
   - python_abi 3.11.* *_cp311
+  - numpy >=1.23,<3
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
   run_exports: {}
-  size: 2487584
-  timestamp: 1784038283198
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py312h73a449f_8.conda
-  sha256: fc3af9df30b549abc5498bc8a98f0e31290ba3b178c54127d1374d982bfde65e
-  md5: 9e8fccf33d38439c32b9d8f0af901990
+  size: 2484250
+  timestamp: 1788235557792
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.3-np2py312hd28de17_1.conda
+  sha256: 788d516008054bf810019e0ede34e4372851d9eb3744af9d77ffdcf7c91d655a
+  md5: beaabd388d61721fc7dfc3725bee51b9
   depends:
   - python
-  - libgdal-core 3.13.1.*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libjxl >=0.12.0,<0.13.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
+  - libgdal-core 3.13.3.*
+  - libstdcxx >=15
+  - libgcc >=15
+  - liblzma >=5.8.3,<6.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
   - blosc >=1.21.6,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libwebp-base >=1.6.0,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - libdeflate >=1.25,<1.26.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - lerc >=4.1.0,<5.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libiconv >=1.18,<2.0a0
   - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - openssl >=3.5.7,<4.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
   - lz4-c >=1.10.0,<1.11.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libjxl >=0.12.0,<0.13.0a0
   - python 3.12.* *_cpython
   - numpy >=1.25,<3
   - python_abi 3.12.* *_cp312
@@ -19681,100 +19681,100 @@ packages:
   purls:
   - pkg:pypi/gdal?source=hash-mapping
   run_exports: {}
-  size: 2456688
-  timestamp: 1784038283198
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py313h06e5f52_8.conda
-  sha256: 70dd88d74aa73d36cc9f71cd53b91daceb33a3a6be3e5228e76f6c7275ed5826
-  md5: 3640f1430c1f1acfcfdce6a2928ad4be
+  size: 2455327
+  timestamp: 1788235557792
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.3-np2py313h3529382_1.conda
+  sha256: d998c5baa8e7aff29c907d6c0970b5915c12161f834471fadf55b77cc9994571
+  md5: da97c98423b74f07c3e4ca548932a806
   depends:
   - python
-  - libgdal-core 3.13.1.*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libjxl >=0.12.0,<0.13.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
+  - libgdal-core 3.13.3.*
+  - libstdcxx >=15
+  - libgcc >=15
+  - liblzma >=5.8.3,<6.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
   - blosc >=1.21.6,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libwebp-base >=1.6.0,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - libdeflate >=1.25,<1.26.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - lerc >=4.1.0,<5.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libiconv >=1.18,<2.0a0
   - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - openssl >=3.5.7,<4.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
   - lz4-c >=1.10.0,<1.11.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libjxl >=0.12.0,<0.13.0a0
   - python 3.13.* *_cp313
-  - numpy >=1.25,<3
   - python_abi 3.13.* *_cp313
+  - numpy >=1.25,<3
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
   run_exports: {}
-  size: 2447911
-  timestamp: 1784038283198
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.1-np2py314h76c7e07_8.conda
-  sha256: 1443feb1926d7d505cd0f5c930e5c14cc7fd927b8984fd0fbbaeda12a096948f
-  md5: f2d10fea335296752c7b8fdf9c65c1aa
+  size: 2445639
+  timestamp: 1788235557792
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/gdal-3.13.3-np2py314h81d6052_1.conda
+  sha256: 21f6791c818ee21e59178811c119e97c9f8fcd79c2e7cfb34870cc72b27c2489
+  md5: a68312ad5d99ebf4abb095ae37c950ff
   depends:
   - python
-  - libgdal-core 3.13.1.*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libjxl >=0.12.0,<0.13.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
+  - libgdal-core 3.13.3.*
+  - libstdcxx >=15
+  - libgcc >=15
+  - liblzma >=5.8.3,<6.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
   - blosc >=1.21.6,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libwebp-base >=1.6.0,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - libdeflate >=1.25,<1.26.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - lerc >=4.1.0,<5.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libiconv >=1.18,<2.0a0
   - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - openssl >=3.5.7,<4.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
   - lz4-c >=1.10.0,<1.11.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libjxl >=0.12.0,<0.13.0a0
   - python 3.14.* *_cp314
-  - numpy >=1.25,<3
   - python_abi 3.14.* *_cp314
+  - numpy >=1.25,<3
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
   run_exports: {}
-  size: 2457828
-  timestamp: 1784038283198
+  size: 2458027
+  timestamp: 1788235557792
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/geos-3.14.1-h57520ee_0.conda
   sha256: 02b1f971fb9b560479e046915f90d20df71836f079a789eccd83bd03262c7bcb
   md5: 311434946d3846e12661fedd4bfad25d
@@ -19802,9 +19802,9 @@ packages:
     - gflags >=2.3.1,<2.4.0a0
   size: 118758
   timestamp: 1785044710617
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-5.2.2-h5dd31e5_1.conda
-  sha256: bcba20fab38b359fe982bd004e0b28e5ecfa07e43ca03733db2f6f26fad68f8f
-  md5: 6e6566364080aaac269deeff7d1bd6b0
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/giflib-6.1.3-h80f16a2_1.conda
+  sha256: 7b7bb926ccb31923aac95f9f29387f4bd0c70dfb3a79235f700e02bf627dce40
+  md5: 16caed058430a2b94922c02709a7e900
   depends:
   - libgcc >=14
   license: MIT
@@ -19812,9 +19812,9 @@ packages:
   purls: []
   run_exports:
     weak:
-    - giflib >=5.2.2,<5.3.0a0
-  size: 83028
-  timestamp: 1784694170460
+    - giflib >=6.1.3,<6.2.0a0
+  size: 93112
+  timestamp: 1785907534863
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/glog-0.7.1-ha2f5727_1.conda
   sha256: 007ae9f5f8afc76c9e6cf9fbb00259aa7b9b104cc238bc81f5da405ca80ffff4
   md5: 344bfac751a4186c645dd13458653518
@@ -20501,351 +20501,351 @@ packages:
     - libgcc
   size: 28397
   timestamp: 1787617760661
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.1-h3e0fee2_8.conda
-  sha256: 47472b8c803092e6c35c1860387391d6c9665bc85e6bfff2f4f54e01b7883029
-  md5: c66aa0599db8e91d693962279fc6c407
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-core-3.13.3-hacbcee7_1.conda
+  sha256: 36cfc0a3c7daf1431f3a332587b7c4f1e98070f1452ff367c66b48e489832364
+  md5: 909ac117905e435f6693cffe233b04f2
   depends:
-  - libgcc >=14
-  - libstdcxx >=14
-  - libjxl >=0.12.0,<0.13.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
+  - libstdcxx >=15
+  - libgcc >=15
+  - liblzma >=5.8.3,<6.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
   - blosc >=1.21.6,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libwebp-base >=1.6.0,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - libdeflate >=1.25,<1.26.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - lerc >=4.1.0,<5.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libiconv >=1.18,<2.0a0
   - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - openssl >=3.5.7,<4.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
   - lz4-c >=1.10.0,<1.11.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libjxl >=0.12.0,<0.13.0a0
   constrains:
-  - libgdal 3.13.1.*
+  - libgdal 3.13.3.*
   license: MIT
   license_family: MIT
   purls: []
   run_exports:
     weak:
-    - libgdal-core >=3.13.1,<3.14.0a0
-  size: 14890892
-  timestamp: 1784038283198
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.1-hda4762a_8.conda
-  sha256: e33d7a6bc0d50e2c64213119ed9b0cfea3bab6f2aa9548e0d2cf29435221949b
-  md5: 3ef9ff536fe4a54ee91b997891987dfd
+    - libgdal-core >=3.13.3,<3.14.0a0
+  size: 15139852
+  timestamp: 1788235557792
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-grib-3.13.3-hbcdde33_1.conda
+  sha256: 18240628d6fe95783bd1ef4a9dd705727aab2ef7ed0c38e79f1b9ee823c8783c
+  md5: aa8c04160b3b87d504f76279e0ca4171
   depends:
-  - libgdal-core ==3.13.1 h3e0fee2_8
-  - libgcc >=14
-  - libstdcxx >=14
-  - libjxl >=0.12.0,<0.13.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
+  - libgdal-core ==3.13.3 hacbcee7_1
+  - libstdcxx >=15
+  - libgcc >=15
+  - liblzma >=5.8.3,<6.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
   - blosc >=1.21.6,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libwebp-base >=1.6.0,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - libdeflate >=1.25,<1.26.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - lerc >=4.1.0,<5.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libiconv >=1.18,<2.0a0
   - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - openssl >=3.5.7,<4.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
   - lz4-c >=1.10.0,<1.11.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libjxl >=0.12.0,<0.13.0a0
   - libaec >=1.1.5,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 833573
-  timestamp: 1784038283198
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.1-h326d342_8.conda
-  sha256: 2f02346f4a60f4f144a1f008d3f012168a9fcb03726f30190b9cc3601d28c6c1
-  md5: 45f1970bce8b0d5479576dd55ebc4cd2
+  size: 833486
+  timestamp: 1788235557792
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf4-3.13.3-hf752de5_1.conda
+  sha256: 803f3dd5ff8757f7a016be077c04c9ff0ecfb26ac7a9f1eab364d066947ea506
+  md5: 760e54dfaf63b219faee97f4c8edc880
   depends:
-  - libgdal-core ==3.13.1 h3e0fee2_8
-  - libgcc >=14
-  - libstdcxx >=14
-  - libjxl >=0.12.0,<0.13.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
+  - libgdal-core ==3.13.3 hacbcee7_1
+  - libstdcxx >=15
+  - libgcc >=15
+  - liblzma >=5.8.3,<6.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
   - blosc >=1.21.6,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libwebp-base >=1.6.0,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - libdeflate >=1.25,<1.26.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - lerc >=4.1.0,<5.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libiconv >=1.18,<2.0a0
   - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - openssl >=3.5.7,<4.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
   - lz4-c >=1.10.0,<1.11.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - libaec >=1.1.5,<2.0a0
   - hdf4 >=4.2.15,<4.2.16.0a0
-  - libaec >=1.1.5,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 625047
-  timestamp: 1784038283198
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-h48721e5_8.conda
-  sha256: 21c68012844a2a4193a25831b0d25c274414a4a41993bf414adb995e3d7200e2
-  md5: 355b0d4bb2d773cc0ece64d367fc90ef
+  size: 626289
+  timestamp: 1788235557792
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.3-h0973956_1.conda
+  sha256: c1f3a29fb3c8c51f2199281636037a273c4a82b2d1b2a25a9d395b2c379bc71d
+  md5: 1632fd40062214f46a517c46d596ec5e
   depends:
-  - libgdal-core ==3.13.1 h3e0fee2_8
-  - libgcc >=14
-  - libstdcxx >=14
-  - libjxl >=0.12.0,<0.13.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
+  - libgdal-core ==3.13.3 hacbcee7_1
+  - libstdcxx >=15
+  - libgcc >=15
+  - liblzma >=5.8.3,<6.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
   - blosc >=1.21.6,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libwebp-base >=1.6.0,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - libdeflate >=1.25,<1.26.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - lerc >=4.1.0,<5.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libiconv >=1.18,<2.0a0
   - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - openssl >=3.5.7,<4.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
   - lz4-c >=1.10.0,<1.11.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libjxl >=0.12.0,<0.13.0a0
   - hdf5 >=1.14.6,<1.14.7.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 782877
-  timestamp: 1784038283198
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.1-hfa11834_8.conda
-  sha256: 454c468db4d9865e77de2fe50cdd4fdcd841c137ea130dbd25819f22cd640781
-  md5: 35ffee2540adb052f93210c01d2f6126
+  size: 787534
+  timestamp: 1788235557792
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-hdf5-3.13.3-h3b0b5f5_1.conda
+  sha256: 812041aea58214cb6292dcaec3129c5313bd83b0816cd7c9f1f07cbb79a15444
+  md5: 59c899a02058c48bb6b2ecd2ee946d4d
   depends:
-  - libgdal-core ==3.13.1 h3e0fee2_8
-  - libgcc >=14
-  - libstdcxx >=14
-  - libjxl >=0.12.0,<0.13.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
+  - libgdal-core ==3.13.3 hacbcee7_1
+  - libstdcxx >=15
+  - libgcc >=15
+  - liblzma >=5.8.3,<6.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
   - blosc >=1.21.6,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libwebp-base >=1.6.0,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - libdeflate >=1.25,<1.26.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - lerc >=4.1.0,<5.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libiconv >=1.18,<2.0a0
   - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - openssl >=3.5.7,<4.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
   - lz4-c >=1.10.0,<1.11.0a0
-  - hdf5 >=2.1.0,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - hdf5 >=2.2.0,<3.0a0
   license: MIT
   license_family: MIT
   run_exports: {}
-  size: 784462
-  timestamp: 1784038283198
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.1-h49495bd_8.conda
-  sha256: fca1595ff4163ba9e4c3a37332d99f75c5b0808ceb451b20d01f4f393ff713b5
-  md5: bb317491640755d13fd7868f3fb4b944
+  size: 790143
+  timestamp: 1788235557792
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-jp2openjpeg-3.13.3-hdff80c0_1.conda
+  sha256: ce4b3464bc7703b407cdcd3127058f94765aa836f359e3cbaff660bc3a69a615
+  md5: f7284b31a818eed7fd9eb805543b50dd
   depends:
-  - libgdal-core ==3.13.1 h3e0fee2_8
-  - libgcc >=14
-  - libstdcxx >=14
-  - libjxl >=0.12.0,<0.13.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
+  - libgdal-core ==3.13.3 hacbcee7_1
+  - libstdcxx >=15
+  - libgcc >=15
+  - liblzma >=5.8.3,<6.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
   - blosc >=1.21.6,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libwebp-base >=1.6.0,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - libdeflate >=1.25,<1.26.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - lerc >=4.1.0,<5.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libiconv >=1.18,<2.0a0
   - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - openssl >=3.5.7,<4.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
   - lz4-c >=1.10.0,<1.11.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libjxl >=0.12.0,<0.13.0a0
   - openjpeg >=2.5.4,<3.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 507078
-  timestamp: 1784038283198
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-h7a3011c_8.conda
-  sha256: a206e91b449323a5f2df78432f62ff09756964fb7e6cdefb1be767a73d71382a
-  md5: 951253e2a5f5efe2458dc5afa691bd78
+  size: 506752
+  timestamp: 1788235557792
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.3-h0cd1db0_1.conda
+  sha256: 0d52c69751284f70db02966984e14058e05f0f8ac3f3a518a337d8a9fbc72251
+  md5: e5abfcfb627415b8cdfa363cc155b1fe
   depends:
-  - libgdal-core ==3.13.1 h3e0fee2_8
-  - libgdal-hdf5 3.13.1.*
-  - libgdal-hdf4 3.13.1.*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libjxl >=0.12.0,<0.13.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
+  - libgdal-core ==3.13.3 hacbcee7_1
+  - libgdal-hdf5 3.13.3.*
+  - libgdal-hdf4 3.13.3.*
+  - libstdcxx >=15
+  - libgcc >=15
+  - liblzma >=5.8.3,<6.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
   - blosc >=1.21.6,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libwebp-base >=1.6.0,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - libdeflate >=1.25,<1.26.0a0
   - muparser >=2.3.5,<2.4.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - lerc >=4.1.0,<5.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libiconv >=1.18,<2.0a0
   - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - openssl >=3.5.7,<4.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libzlib >=1.3.2,<2.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
   - lz4-c >=1.10.0,<1.11.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - hdf5 >=2.2.0,<3.0a0
   - hdf4 >=4.2.15,<4.2.16.0a0
-  - hdf5 >=1.14.6,<1.14.7.0a0
   - libnetcdf >=4.10.1,<4.10.2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 803086
+  timestamp: 1788235557792
+- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.3-h5570542_1.conda
+  sha256: ee3d4ad72db268d7031d440dd6685400d5c318d7a7af9cde7456edd827ed65b9
+  md5: 366a37eb3d2e450008c7605b9b2d1675
+  depends:
+  - libgdal-core ==3.13.3 hacbcee7_1
+  - libgdal-hdf5 3.13.3.*
+  - libgdal-hdf4 3.13.3.*
+  - libstdcxx >=15
+  - libgcc >=15
+  - liblzma >=5.8.3,<6.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libwebp-base >=1.6.0,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libiconv >=1.18,<2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - libnetcdf >=4.10.1,<4.10.2.0a0
+  - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 800360
-  timestamp: 1784038283198
-- conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgdal-netcdf-3.13.1-hb4028e1_8.conda
-  sha256: ec7aa7385a5ae3ec21ed5fc4dab76148cc8e7770a5d885146e16a55982d53ebc
-  md5: 4b0fb8fa3b10b15f05fed3fff3e83e42
-  depends:
-  - libgdal-core ==3.13.1 h3e0fee2_8
-  - libgdal-hdf5 3.13.1.*
-  - libgdal-hdf4 3.13.1.*
-  - libgcc >=14
-  - libstdcxx >=14
-  - libjxl >=0.12.0,<0.13.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - blosc >=1.21.6,<2.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - lerc >=4.1.0,<5.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libiconv >=1.18,<2.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - json-c >=0.18,<0.19.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - openssl >=3.5.7,<4.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libnetcdf >=4.10.1,<4.10.2.0a0
-  - hdf4 >=4.2.15,<4.2.16.0a0
-  - hdf5 >=2.1.0,<3.0a0
-  license: MIT
-  license_family: MIT
-  run_exports: {}
-  size: 800024
-  timestamp: 1784038283198
+  size: 802417
+  timestamp: 1788235557792
 - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/libgfortran-16.2.0-he9431aa_4.conda
   sha256: 0052421483b466cf0d807cfae679a1f5604466ab366bc8416b531fb69228069c
   md5: 9370835617c4a9c7265fd34e92887bfa
@@ -25190,132 +25190,132 @@ packages:
   run_exports: {}
   size: 51326
   timestamp: 1780000211531
-- conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py311h8fd869c_8.conda
-  sha256: 3f5b1ff15116624d0cd98bee0545744be260436fb37765e3da2d347cdb985d60
-  md5: 815c7dc393c36124f71dc24d398d12ee
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.3-np2py311h947041c_1.conda
+  sha256: 4945e314505d3af8c2849a810ea627901cbd23c76a1564c5c5f0c5a0abaed424
+  md5: 3c8a09020f21b5602658006cae4e5aed
   depends:
   - python
-  - libgdal-core 3.13.1.*
+  - libgdal-core 3.13.3.*
   - __osx >=11.0
-  - libcxx >=19
-  - libjxl >=0.12.0,<0.13.0a0
+  - libcxx >=21
+  - liblzma >=5.8.3,<6.0a0
   - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - pcre2 >=10.47,<10.48.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - blosc >=1.21.6,<2.0a0
   - libexpat >=2.8.1,<3.0a0
-  - openssl >=3.5.7,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
+  - json-c >=0.18,<0.19.0a0
+  - muparser >=2.3.5,<2.4.0a0
   - zstd >=1.5.7,<1.6.0a0
-  - libiconv >=1.18,<2.0a0
-  - libwebp-base >=1.6.0,<2.0a0
   - libdeflate >=1.25,<1.26.0a0
-  - lerc >=4.1.0,<5.0a0
+  - libcurl >=8.21.0,<9.0a0
   - lz4-c >=1.10.0,<1.11.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - python_abi 3.11.* *_cp311
+  - libkml >=1.3.0,<1.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
   - numpy >=1.23,<3
+  - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
   run_exports: {}
-  size: 2506086
-  timestamp: 1784038615598
-- conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py312h2b93078_8.conda
-  sha256: 52368baab5265199fa3a5160bee8446ee4fdbd77871a99cd352e16fde79777a7
-  md5: 706a809af88bf9eaa2e4fa1b99a0dc0c
+  size: 2517096
+  timestamp: 1788235676181
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.3-np2py312h70a30f5_1.conda
+  sha256: 4a0a91cfd2166169da2a1ae675a9acefb3b1b5fa1651aa74d3e0fb4c7318ac31
+  md5: 2e98adad6d84751adcb7e30a76995af5
   depends:
   - python
-  - libgdal-core 3.13.1.*
+  - libgdal-core 3.13.3.*
   - __osx >=11.0
-  - libcxx >=19
-  - libjxl >=0.12.0,<0.13.0a0
+  - libcxx >=21
+  - liblzma >=5.8.3,<6.0a0
   - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - pcre2 >=10.47,<10.48.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - blosc >=1.21.6,<2.0a0
   - libexpat >=2.8.1,<3.0a0
-  - openssl >=3.5.7,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
+  - json-c >=0.18,<0.19.0a0
+  - muparser >=2.3.5,<2.4.0a0
   - zstd >=1.5.7,<1.6.0a0
-  - libiconv >=1.18,<2.0a0
-  - libwebp-base >=1.6.0,<2.0a0
   - libdeflate >=1.25,<1.26.0a0
-  - lerc >=4.1.0,<5.0a0
+  - libcurl >=8.21.0,<9.0a0
   - lz4-c >=1.10.0,<1.11.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - numpy >=1.25,<3
+  - libkml >=1.3.0,<1.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
   - python_abi 3.12.* *_cp312
+  - numpy >=1.25,<3
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
   run_exports: {}
-  size: 2485236
-  timestamp: 1784038615598
-- conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py313h1cbe8e9_8.conda
-  sha256: ec9a7c7d597ae43beb2fea2e60ad0255e07763d214aaa7b8fe76fe959bd17ba0
-  md5: fe9a2ea2968aee179d544a5fa5ee26a4
+  size: 2493406
+  timestamp: 1788235676181
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.3-np2py313h13bd4ad_1.conda
+  sha256: 15f0e2c97863542ed70534ae40e5ef8e92c82de42dd52cd08155ca53e6594697
+  md5: 37e9fc244f4bec32d7c5bcc642a0780f
   depends:
   - python
-  - libgdal-core 3.13.1.*
+  - libgdal-core 3.13.3.*
   - __osx >=11.0
-  - libcxx >=19
-  - libjxl >=0.12.0,<0.13.0a0
+  - libcxx >=21
+  - liblzma >=5.8.3,<6.0a0
   - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - pcre2 >=10.47,<10.48.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - blosc >=1.21.6,<2.0a0
   - libexpat >=2.8.1,<3.0a0
-  - openssl >=3.5.7,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
+  - json-c >=0.18,<0.19.0a0
+  - muparser >=2.3.5,<2.4.0a0
   - zstd >=1.5.7,<1.6.0a0
-  - libiconv >=1.18,<2.0a0
-  - libwebp-base >=1.6.0,<2.0a0
   - libdeflate >=1.25,<1.26.0a0
-  - lerc >=4.1.0,<5.0a0
+  - libcurl >=8.21.0,<9.0a0
   - lz4-c >=1.10.0,<1.11.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libarchive >=3.8.8,<3.9.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
   - numpy >=1.25,<3
   - python_abi 3.13.* *_cp313
   license: MIT
@@ -25323,44 +25323,44 @@ packages:
   purls:
   - pkg:pypi/gdal?source=hash-mapping
   run_exports: {}
-  size: 2482780
-  timestamp: 1784038615598
-- conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.1-np2py314ha4b4608_8.conda
-  sha256: a25fce791aba1706e026b7ca705b34db71c952948ddcb49974a0ead32a2b9583
-  md5: e9e6e4f1b67ad348cc4ca77e4e59076e
+  size: 2491964
+  timestamp: 1788235676181
+- conda: https://conda.anaconda.org/conda-forge/osx-64/gdal-3.13.3-np2py314h45d49e2_1.conda
+  sha256: 60410873122a4ed26e6d64ec32e0634219176bea133e69d3de186f63cb58aaac
+  md5: 57b0e0ba63d3a9cf1889b904f117185d
   depends:
   - python
-  - libgdal-core 3.13.1.*
+  - libgdal-core 3.13.3.*
   - __osx >=11.0
-  - libcxx >=19
-  - libjxl >=0.12.0,<0.13.0a0
+  - libcxx >=21
+  - liblzma >=5.8.3,<6.0a0
   - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - pcre2 >=10.47,<10.48.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - blosc >=1.21.6,<2.0a0
   - libexpat >=2.8.1,<3.0a0
-  - openssl >=3.5.7,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
+  - json-c >=0.18,<0.19.0a0
+  - muparser >=2.3.5,<2.4.0a0
   - zstd >=1.5.7,<1.6.0a0
-  - libiconv >=1.18,<2.0a0
-  - libwebp-base >=1.6.0,<2.0a0
   - libdeflate >=1.25,<1.26.0a0
-  - lerc >=4.1.0,<5.0a0
+  - libcurl >=8.21.0,<9.0a0
   - lz4-c >=1.10.0,<1.11.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libarchive >=3.8.8,<3.9.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
   - python_abi 3.14.* *_cp314
   - numpy >=1.25,<3
   license: MIT
@@ -25368,8 +25368,8 @@ packages:
   purls:
   - pkg:pypi/gdal?source=hash-mapping
   run_exports: {}
-  size: 2493353
-  timestamp: 1784038615598
+  size: 2502991
+  timestamp: 1788235676181
 - conda: https://conda.anaconda.org/conda-forge/osx-64/geos-3.14.1-he483b9e_0.conda
   sha256: 4d95fd55a9e649620b4e50ddafff064c4ec52d87e1ed64aa4cad13e643b32baf
   md5: d83030a79ce1276edc2332c1730efa17
@@ -25397,9 +25397,9 @@ packages:
     - gflags >=2.3.1,<2.4.0a0
   size: 98657
   timestamp: 1785044787379
-- conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-5.2.2-h0f9f378_1.conda
-  sha256: 7042b7399ea78f2558699002c09f8e9fd54ed5345836443bcbe942966552e332
-  md5: 55887f245ec965ca51a08c2c7627a636
+- conda: https://conda.anaconda.org/conda-forge/osx-64/giflib-6.1.3-ha3d0635_1.conda
+  sha256: 679bd42925d9c6fd0d36a714fb5c4535e87039935936bcfd42c60891ed02c966
+  md5: a1cfd0ecbd1b2a43ef39ad155dd4a778
   depends:
   - __osx >=11.0
   license: MIT
@@ -25407,9 +25407,9 @@ packages:
   purls: []
   run_exports:
     weak:
-    - giflib >=5.2.2,<5.3.0a0
-  size: 75191
-  timestamp: 1784694470016
+    - giflib >=6.1.3,<6.2.0a0
+  size: 86173
+  timestamp: 1785907665303
 - conda: https://conda.anaconda.org/conda-forge/osx-64/glog-0.7.1-h90d9b41_1.conda
   sha256: 3e058845bc450adc10f9ee4f34be155d76a4130dc68244cfc32d7cc3d42610ed
   md5: 18b5548f81de9790deb92f1523a2ae4a
@@ -26070,351 +26070,351 @@ packages:
   run_exports: {}
   size: 391885
   timestamp: 1787620487885
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.1-he8206cc_8.conda
-  sha256: 6504ba212e4520c3cc9b96a828c026e87d6f99a979a1cbc33c17bc231949869a
-  md5: 73d194605cac71a9a98b3c6793156c10
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-core-3.13.3-h310b87c_1.conda
+  sha256: 4bb342c8470e57992c5611f3297730b1d842db72543860909f8781463a7392e7
+  md5: f682f2f65bf75f83b0151b3527fa85a8
   depends:
   - __osx >=11.0
-  - libcxx >=19
-  - libjxl >=0.12.0,<0.13.0a0
+  - libcxx >=21
+  - liblzma >=5.8.3,<6.0a0
   - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - pcre2 >=10.47,<10.48.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - blosc >=1.21.6,<2.0a0
   - libexpat >=2.8.1,<3.0a0
-  - openssl >=3.5.7,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
+  - json-c >=0.18,<0.19.0a0
+  - muparser >=2.3.5,<2.4.0a0
   - zstd >=1.5.7,<1.6.0a0
-  - libiconv >=1.18,<2.0a0
-  - libwebp-base >=1.6.0,<2.0a0
   - libdeflate >=1.25,<1.26.0a0
-  - lerc >=4.1.0,<5.0a0
+  - libcurl >=8.21.0,<9.0a0
   - lz4-c >=1.10.0,<1.11.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libarchive >=3.8.8,<3.9.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
   constrains:
-  - libgdal 3.13.1.*
+  - libgdal 3.13.3.*
   license: MIT
   license_family: MIT
   purls: []
   run_exports:
     weak:
-    - libgdal-core >=3.13.1,<3.14.0a0
-  size: 12590334
-  timestamp: 1784038615598
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.1-h811dcc7_8.conda
-  sha256: 127c50e1992682e6bec30e7fceabc67201d4b743f8696e5771512d2d76d03b53
-  md5: f70923ff494a32904afed36ba68196c5
+    - libgdal-core >=3.13.3,<3.14.0a0
+  size: 12595706
+  timestamp: 1788235676181
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-grib-3.13.3-ha01a682_1.conda
+  sha256: 6e6c852edcf3080dfa6b92388e1dca43531576a0e5261cecad502d3cbdd68228
+  md5: eac4937d34ae583c68fe49789496dc13
   depends:
-  - libgdal-core ==3.13.1 he8206cc_8
+  - libgdal-core ==3.13.3 h310b87c_1
   - __osx >=11.0
-  - libcxx >=19
-  - libjxl >=0.12.0,<0.13.0a0
+  - libcxx >=21
+  - liblzma >=5.8.3,<6.0a0
   - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - pcre2 >=10.47,<10.48.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - blosc >=1.21.6,<2.0a0
   - libexpat >=2.8.1,<3.0a0
-  - openssl >=3.5.7,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
+  - json-c >=0.18,<0.19.0a0
+  - muparser >=2.3.5,<2.4.0a0
   - zstd >=1.5.7,<1.6.0a0
-  - libiconv >=1.18,<2.0a0
-  - libwebp-base >=1.6.0,<2.0a0
   - libdeflate >=1.25,<1.26.0a0
-  - lerc >=4.1.0,<5.0a0
+  - libcurl >=8.21.0,<9.0a0
   - lz4-c >=1.10.0,<1.11.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libarchive >=3.8.8,<3.9.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
   - libaec >=1.1.5,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 738725
-  timestamp: 1784038615598
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.1-h20f2fc6_8.conda
-  sha256: 87b4b192384f2596ee1f8a656f2b7a78d5c33f5aedd8f50e9ea43930efbb53a2
-  md5: 4b062388e2958aa944a7545d859cc7e1
+  size: 737780
+  timestamp: 1788235676181
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf4-3.13.3-ha770a77_1.conda
+  sha256: c34c17f86a183f354bfefb65d96fd4c3e0de4d593bcba500e2a9e3b77d22580e
+  md5: e08f3f59693d927e35afa2bd78eadcff
   depends:
-  - libgdal-core ==3.13.1 he8206cc_8
+  - libgdal-core ==3.13.3 h310b87c_1
   - __osx >=11.0
-  - libcxx >=19
-  - libjxl >=0.12.0,<0.13.0a0
+  - libcxx >=21
+  - liblzma >=5.8.3,<6.0a0
   - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - pcre2 >=10.47,<10.48.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - blosc >=1.21.6,<2.0a0
   - libexpat >=2.8.1,<3.0a0
-  - openssl >=3.5.7,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
+  - json-c >=0.18,<0.19.0a0
+  - muparser >=2.3.5,<2.4.0a0
   - zstd >=1.5.7,<1.6.0a0
-  - libiconv >=1.18,<2.0a0
-  - libwebp-base >=1.6.0,<2.0a0
   - libdeflate >=1.25,<1.26.0a0
-  - lerc >=4.1.0,<5.0a0
+  - libcurl >=8.21.0,<9.0a0
   - lz4-c >=1.10.0,<1.11.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libarchive >=3.8.8,<3.9.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
   - hdf4 >=4.2.15,<4.2.16.0a0
   - libaec >=1.1.5,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 597765
-  timestamp: 1784038615598
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-h1350517_8.conda
-  sha256: dd843c442dee7dda7a70b7c27c00d1d24366532736888c7de257e05c94c3744a
-  md5: 64d0ab1e9a7ad21e34510acbc32071ad
+  size: 595248
+  timestamp: 1788235676181
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.3-h882f8c9_1.conda
+  sha256: 0f5e154ac43cac3b472dd193f045ce91307d8b8c9e58b771119dd86f4ef30aef
+  md5: e80541515195ab89067079fa0bc1f6f9
   depends:
-  - libgdal-core ==3.13.1 he8206cc_8
+  - libgdal-core ==3.13.3 h310b87c_1
   - __osx >=11.0
-  - libcxx >=19
-  - libjxl >=0.12.0,<0.13.0a0
+  - libcxx >=21
+  - liblzma >=5.8.3,<6.0a0
   - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - pcre2 >=10.47,<10.48.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - blosc >=1.21.6,<2.0a0
   - libexpat >=2.8.1,<3.0a0
-  - openssl >=3.5.7,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
+  - json-c >=0.18,<0.19.0a0
+  - muparser >=2.3.5,<2.4.0a0
   - zstd >=1.5.7,<1.6.0a0
-  - libiconv >=1.18,<2.0a0
-  - libwebp-base >=1.6.0,<2.0a0
   - libdeflate >=1.25,<1.26.0a0
-  - lerc >=4.1.0,<5.0a0
+  - libcurl >=8.21.0,<9.0a0
   - lz4-c >=1.10.0,<1.11.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libarchive >=3.8.8,<3.9.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
   - hdf5 >=1.14.6,<1.14.7.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 726346
-  timestamp: 1784038615598
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.1-hdeea456_8.conda
-  sha256: db7eaf8281efeef901eb8d88cb2f7a82fd3928356e8ce11320c0c8ebdb86d4f7
-  md5: 3610699ad48fcd77c0ed95a9d1de6a88
+  size: 728059
+  timestamp: 1788235676181
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-hdf5-3.13.3-h8f89cc3_1.conda
+  sha256: 5ef7cd67226e6bd797c11dd3152eb4e56ff7fe14856a70b9dadd2aab98636c0f
+  md5: 9a42cdaea0c65f8e281af347ca697232
   depends:
-  - libgdal-core ==3.13.1 he8206cc_8
+  - libgdal-core ==3.13.3 h310b87c_1
   - __osx >=11.0
-  - libcxx >=19
-  - libjxl >=0.12.0,<0.13.0a0
+  - libcxx >=21
+  - liblzma >=5.8.3,<6.0a0
   - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - pcre2 >=10.47,<10.48.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - blosc >=1.21.6,<2.0a0
   - libexpat >=2.8.1,<3.0a0
-  - openssl >=3.5.7,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
+  - json-c >=0.18,<0.19.0a0
+  - muparser >=2.3.5,<2.4.0a0
   - zstd >=1.5.7,<1.6.0a0
-  - libiconv >=1.18,<2.0a0
-  - libwebp-base >=1.6.0,<2.0a0
   - libdeflate >=1.25,<1.26.0a0
-  - lerc >=4.1.0,<5.0a0
+  - libcurl >=8.21.0,<9.0a0
   - lz4-c >=1.10.0,<1.11.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - hdf5 >=2.1.0,<3.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - hdf5 >=2.2.0,<3.0a0
   license: MIT
   license_family: MIT
   run_exports: {}
-  size: 729287
-  timestamp: 1784038615598
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.1-hadaec2f_8.conda
-  sha256: f02d5858c0dbf4eb8d319b3f4ffaf999aac64a62e04ad90a915668a448c4c927
-  md5: 16ddfde6705757c20c5d88f36bb29a82
+  size: 732951
+  timestamp: 1788235676181
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-jp2openjpeg-3.13.3-he08a439_1.conda
+  sha256: e75520e626d4c3fa9a294bab07ebd9e1d23e284dbbb5d30993237ec72844a660
+  md5: 393663272a2023585924ee17d0f24702
   depends:
-  - libgdal-core ==3.13.1 he8206cc_8
+  - libgdal-core ==3.13.3 h310b87c_1
   - __osx >=11.0
-  - libcxx >=19
-  - libjxl >=0.12.0,<0.13.0a0
+  - libcxx >=21
+  - liblzma >=5.8.3,<6.0a0
   - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - pcre2 >=10.47,<10.48.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - blosc >=1.21.6,<2.0a0
   - libexpat >=2.8.1,<3.0a0
-  - openssl >=3.5.7,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
+  - json-c >=0.18,<0.19.0a0
+  - muparser >=2.3.5,<2.4.0a0
   - zstd >=1.5.7,<1.6.0a0
-  - libiconv >=1.18,<2.0a0
-  - libwebp-base >=1.6.0,<2.0a0
   - libdeflate >=1.25,<1.26.0a0
-  - lerc >=4.1.0,<5.0a0
+  - libcurl >=8.21.0,<9.0a0
   - lz4-c >=1.10.0,<1.11.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libarchive >=3.8.8,<3.9.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
   - openjpeg >=2.5.4,<3.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 498387
-  timestamp: 1784038615598
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-h2a73bb1_8.conda
-  sha256: 36f297d1c5f100f1db005178a09b2577b31caaee5ea39ced91fb4b37ea6ca040
-  md5: d6fce4b916d45dab2ee67c22c19422e9
+  size: 498916
+  timestamp: 1788235676181
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.3-h3efdb02_1.conda
+  sha256: ee832de6a0eb05719284741e61bfc330ce9fad87f93d510a2e7bc382a4420be9
+  md5: be486129353e3ebddf486c16222e3758
   depends:
-  - libgdal-core ==3.13.1 he8206cc_8
-  - libgdal-hdf5 3.13.1.*
-  - libgdal-hdf4 3.13.1.*
+  - libgdal-core ==3.13.3 h310b87c_1
+  - libgdal-hdf5 3.13.3.*
+  - libgdal-hdf4 3.13.3.*
   - __osx >=11.0
-  - libcxx >=19
-  - libjxl >=0.12.0,<0.13.0a0
+  - libcxx >=21
+  - liblzma >=5.8.3,<6.0a0
   - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - pcre2 >=10.47,<10.48.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - libwebp-base >=1.6.0,<2.0a0
   - blosc >=1.21.6,<2.0a0
   - libexpat >=2.8.1,<3.0a0
-  - openssl >=3.5.7,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
+  - json-c >=0.18,<0.19.0a0
+  - muparser >=2.3.5,<2.4.0a0
   - zstd >=1.5.7,<1.6.0a0
-  - libiconv >=1.18,<2.0a0
-  - libwebp-base >=1.6.0,<2.0a0
   - libdeflate >=1.25,<1.26.0a0
-  - lerc >=4.1.0,<5.0a0
+  - libcurl >=8.21.0,<9.0a0
   - lz4-c >=1.10.0,<1.11.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - libnetcdf >=4.10.1,<4.10.2.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
   - hdf4 >=4.2.15,<4.2.16.0a0
+  - libnetcdf >=4.10.1,<4.10.2.0a0
+  - hdf5 >=2.2.0,<3.0a0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 753317
+  timestamp: 1788235676181
+- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.3-hbbb2e8d_1.conda
+  sha256: c59102a733415b408b63c5d9dec0ea4398ee9058418fb7f59e185bf4468f048a
+  md5: 68c12aa11abf731a17f0c968e2775a83
+  depends:
+  - libgdal-core ==3.13.3 h310b87c_1
+  - libgdal-hdf5 3.13.3.*
+  - libgdal-hdf4 3.13.3.*
+  - __osx >=11.0
+  - libcxx >=21
+  - liblzma >=5.8.3,<6.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libiconv >=1.18,<2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - json-c >=0.18,<0.19.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - giflib >=6.1.3,<6.2.0a0
+  - lerc >=4.2.0,<5.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
   - hdf5 >=1.14.6,<1.14.7.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - libnetcdf >=4.10.1,<4.10.2.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 754889
-  timestamp: 1784038615598
-- conda: https://conda.anaconda.org/conda-forge/osx-64/libgdal-netcdf-3.13.1-ha928bd0_8.conda
-  sha256: f591c88a56fef25274e2b9976280f2d8badb93b78dfc8ae4a22cbfe8785464db
-  md5: b878cb7e175aae49d877cdee0d52e486
-  depends:
-  - libgdal-core ==3.13.1 he8206cc_8
-  - libgdal-hdf5 3.13.1.*
-  - libgdal-hdf4 3.13.1.*
-  - __osx >=11.0
-  - libcxx >=19
-  - libjxl >=0.12.0,<0.13.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - pcre2 >=10.47,<10.48.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - blosc >=1.21.6,<2.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - openssl >=3.5.7,<4.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libiconv >=1.18,<2.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - lerc >=4.1.0,<5.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - hdf5 >=2.1.0,<3.0a0
-  - libnetcdf >=4.10.1,<4.10.2.0a0
-  - hdf4 >=4.2.15,<4.2.16.0a0
-  license: MIT
-  license_family: MIT
-  run_exports: {}
-  size: 754466
-  timestamp: 1784038615598
+  size: 752653
+  timestamp: 1788235676181
 - conda: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-16.2.0-h7e5c614_4.conda
   sha256: a596fa89c4b1e0d3743d76bf18df31d2bf3317cb4a4391d5877e1a3e8eaaa4d0
   md5: ca9281db8c52184ade04b615b2f3959d
@@ -29398,42 +29398,42 @@ packages:
   run_exports: {}
   size: 51974
   timestamp: 1780000580140
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py311hfd0d7fd_8.conda
-  sha256: 3b067c38a4e2207ea398ef8a8abcec9ee50791c6bcccfcba29e88d21fa6da562
-  md5: 1daaaa660cf2ce79b3a347a2281d2076
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.3-np2py311he597461_1.conda
+  sha256: c7cccc57cf7997dd899ea72d9d3c5ff092f4e49f2c2c555048154b9ad66ee8b2
+  md5: dd2108686be5c9ccfebd064c640e016d
   depends:
   - python
-  - libgdal-core 3.13.1.*
-  - libcxx >=19
+  - libgdal-core 3.13.3.*
   - __osx >=11.0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libiconv >=1.18,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - blosc >=1.21.6,<2.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libcxx >=21
+  - giflib >=6.1.3,<6.2.0a0
   - pcre2 >=10.47,<10.48.0a0
   - libkml >=1.3.0,<1.4.0a0
-  - openssl >=3.5.7,<4.0a0
-  - lerc >=4.1.0,<5.0a0
+  - libiconv >=1.18,<2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libxml2
-  - libxml2-16 >=2.14.6
+  - libxml2-16 >=2.15.3
+  - libjxl >=0.12.0,<0.13.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libcurl >=8.21.0,<9.0a0
   - python 3.11.* *_cpython
   - numpy >=1.23,<3
   - python_abi 3.11.* *_cp311
@@ -29442,146 +29442,146 @@ packages:
   purls:
   - pkg:pypi/gdal?source=hash-mapping
   run_exports: {}
-  size: 2484780
-  timestamp: 1784038534322
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py312hd14f2b4_8.conda
-  sha256: 77d38789ebd69c166b5516b208d285e417cc56292da3bff79c9ba9265887937d
-  md5: cd0397baea549aaf0d7d8718bda60b25
+  size: 2491321
+  timestamp: 1788235755138
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.3-np2py312he35bcab_1.conda
+  sha256: 323de8bfabd4a1e43f7a4bfbad72dd6e2776c2b1bad9f741da79aac89e83d8c1
+  md5: d76de7cabea1b303a0479bcbae8c0780
   depends:
   - python
-  - libgdal-core 3.13.1.*
-  - libcxx >=19
+  - libgdal-core 3.13.3.*
   - __osx >=11.0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libiconv >=1.18,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - blosc >=1.21.6,<2.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libcxx >=21
+  - giflib >=6.1.3,<6.2.0a0
   - pcre2 >=10.47,<10.48.0a0
   - libkml >=1.3.0,<1.4.0a0
-  - openssl >=3.5.7,<4.0a0
-  - lerc >=4.1.0,<5.0a0
+  - libiconv >=1.18,<2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libxml2
-  - libxml2-16 >=2.14.6
+  - libxml2-16 >=2.15.3
+  - libjxl >=0.12.0,<0.13.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libcurl >=8.21.0,<9.0a0
   - python 3.12.* *_cpython
+  - numpy >=1.25,<3
   - python_abi 3.12.* *_cp312
-  - numpy >=1.25,<3
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
   run_exports: {}
-  size: 2460277
-  timestamp: 1784038534322
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py313h7a338b7_8.conda
-  sha256: 27a27fee9cb159c7f88c52ea830eac6264bfb697481e28211151333bccec10fb
-  md5: 2bb30824efa8275f17b9fe31fd0c4014
+  size: 2462423
+  timestamp: 1788235755138
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.3-np2py313h97e9785_1.conda
+  sha256: 699bf0d640b0cc8306a2fe2d11f036bcb06d7bfdd841f819061d84ee0d9507a8
+  md5: bf65a82bbacf7dbf12d8054d2860d770
   depends:
   - python
-  - libgdal-core 3.13.1.*
-  - libcxx >=19
+  - libgdal-core 3.13.3.*
   - __osx >=11.0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libiconv >=1.18,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - blosc >=1.21.6,<2.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libcxx >=21
+  - giflib >=6.1.3,<6.2.0a0
   - pcre2 >=10.47,<10.48.0a0
   - libkml >=1.3.0,<1.4.0a0
-  - openssl >=3.5.7,<4.0a0
-  - lerc >=4.1.0,<5.0a0
+  - libiconv >=1.18,<2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libxml2
-  - libxml2-16 >=2.14.6
+  - libxml2-16 >=2.15.3
+  - libjxl >=0.12.0,<0.13.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libcurl >=8.21.0,<9.0a0
   - python 3.13.* *_cp313
-  - python_abi 3.13.* *_cp313
   - numpy >=1.25,<3
+  - python_abi 3.13.* *_cp313
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
   run_exports: {}
-  size: 2453145
-  timestamp: 1784038534322
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.1-np2py314h64e98ee_8.conda
-  sha256: 6f13a54b475d5409c3f57776b73a513cb14c0866a3932807310d35b801b37373
-  md5: 5784cea8e02dbd329a4ef936becd5ea3
+  size: 2453092
+  timestamp: 1788235755138
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/gdal-3.13.3-np2py314h407f0a6_1.conda
+  sha256: ba93e25acfeec2d1cecfbf6441437d29fdc5b503d56ab1cdf1b1cc6fce3f4509
+  md5: 10a78a62cb44696b0a9398a06e4d6187
   depends:
   - python
-  - libgdal-core 3.13.1.*
-  - libcxx >=19
+  - libgdal-core 3.13.3.*
   - __osx >=11.0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libiconv >=1.18,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - blosc >=1.21.6,<2.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libcxx >=21
+  - giflib >=6.1.3,<6.2.0a0
   - pcre2 >=10.47,<10.48.0a0
   - libkml >=1.3.0,<1.4.0a0
-  - openssl >=3.5.7,<4.0a0
-  - lerc >=4.1.0,<5.0a0
+  - libiconv >=1.18,<2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libxml2
-  - libxml2-16 >=2.14.6
+  - libxml2-16 >=2.15.3
+  - libjxl >=0.12.0,<0.13.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libcurl >=8.21.0,<9.0a0
   - python 3.14.* *_cp314
-  - python_abi 3.14.* *_cp314
   - numpy >=1.25,<3
+  - python_abi 3.14.* *_cp314
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
   run_exports: {}
-  size: 2464340
-  timestamp: 1784038534322
+  size: 2464040
+  timestamp: 1788235755138
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/geos-3.14.1-h5afe852_0.conda
   sha256: 1ac5f5a3a35f2e4778025043c87993208d336e30539406e380e0952bb7ffd188
   md5: 4238412c29eff0bb2bb5c60a720c035a
@@ -29609,9 +29609,9 @@ packages:
     - gflags >=2.3.1,<2.4.0a0
   size: 93701
   timestamp: 1785044718935
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-5.2.2-hd20048c_1.conda
-  sha256: be9b4cf253c7d3bf20ccc9ff278ea7ec6f144ebbe8fdc9a131d18c35ff49692f
-  md5: 93963a54079e27fdb1bf8d289ad592d4
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/giflib-6.1.3-h1a92334_1.conda
+  sha256: ebfdf94fe2fb8e8d39702e26c747a9a692c0fcf78db737b56deeba4ed16dcb82
+  md5: 39725a84a4b2b6b3ae6177f58be48b91
   depends:
   - __osx >=11.0
   license: MIT
@@ -29619,9 +29619,9 @@ packages:
   purls: []
   run_exports:
     weak:
-    - giflib >=5.2.2,<5.3.0a0
-  size: 73137
-  timestamp: 1784694527697
+    - giflib >=6.1.3,<6.2.0a0
+  size: 82339
+  timestamp: 1785907599925
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/glog-0.7.1-h6f9ecc1_1.conda
   sha256: 1ac5991fd354de81baf3892fee0ad09438623698fcad73758521dfe90711ed44
   md5: 68937f90f7930d49e106b94e95d4536c
@@ -30290,351 +30290,351 @@ packages:
   run_exports: {}
   size: 365758
   timestamp: 1787617459249
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.1-h21e278e_8.conda
-  sha256: a8e4a60c350b076f7c3b8198bf32963279ab36174bf725809972d43b3a414232
-  md5: 966042991b66a9d32d4c4d878bcf287f
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-core-3.13.3-h0d10833_1.conda
+  sha256: 39115749e653af30b2bf9b359bd7d9839b62a6ad1934ca576c116f1109fd61dd
+  md5: 5b389503ff59a241b0560cf86e4b3413
   depends:
-  - libcxx >=19
   - __osx >=11.0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libiconv >=1.18,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - blosc >=1.21.6,<2.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libcxx >=21
+  - giflib >=6.1.3,<6.2.0a0
   - pcre2 >=10.47,<10.48.0a0
   - libkml >=1.3.0,<1.4.0a0
-  - openssl >=3.5.7,<4.0a0
-  - lerc >=4.1.0,<5.0a0
+  - libiconv >=1.18,<2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libxml2
-  - libxml2-16 >=2.14.6
+  - libxml2-16 >=2.15.3
+  - libjxl >=0.12.0,<0.13.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libcurl >=8.21.0,<9.0a0
   constrains:
-  - libgdal 3.13.1.*
+  - libgdal 3.13.3.*
   license: MIT
   license_family: MIT
   purls: []
   run_exports:
     weak:
-    - libgdal-core >=3.13.1,<3.14.0a0
-  size: 11486130
-  timestamp: 1784038534322
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.1-h0beeb9f_8.conda
-  sha256: 56e0853c9b8e5479c2964c2a8275c1225c30c0e1c83b8039f0da0bdec8658b60
-  md5: b8a107fd72f3205969a11afefda5e5e3
+    - libgdal-core >=3.13.3,<3.14.0a0
+  size: 11553949
+  timestamp: 1788235755138
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-grib-3.13.3-h74f30ea_1.conda
+  sha256: 6c0dfd1b20621dad00cf0c658ef6d3b9c1903b0ff274002cdf09976c8c15098c
+  md5: 58b507e4198e704932a49dbc4d66fadc
   depends:
-  - libgdal-core ==3.13.1 h21e278e_8
-  - libcxx >=19
+  - libgdal-core ==3.13.3 h0d10833_1
   - __osx >=11.0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libiconv >=1.18,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - blosc >=1.21.6,<2.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libcxx >=21
+  - giflib >=6.1.3,<6.2.0a0
   - pcre2 >=10.47,<10.48.0a0
   - libkml >=1.3.0,<1.4.0a0
-  - openssl >=3.5.7,<4.0a0
-  - lerc >=4.1.0,<5.0a0
+  - libiconv >=1.18,<2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libxml2
-  - libxml2-16 >=2.14.6
+  - libxml2-16 >=2.15.3
+  - libjxl >=0.12.0,<0.13.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libcurl >=8.21.0,<9.0a0
   - libaec >=1.1.5,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 724107
-  timestamp: 1784038534322
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.1-h5b851b9_8.conda
-  sha256: 940b8357e3f249519357674cfc31c204696e6f1ef165fd3c9c403288c4a8f166
-  md5: 972713d9d219c5a4afa468880aeec511
+  size: 728500
+  timestamp: 1788235755138
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf4-3.13.3-h27393ca_1.conda
+  sha256: 54f826e1e03fd365d78b6fe8b27dc0053d5df81b76536175dbdbb4b2009b4ba6
+  md5: 04e0a580dd2fd62f0d659ca817c62914
   depends:
-  - libgdal-core ==3.13.1 h21e278e_8
-  - libcxx >=19
+  - libgdal-core ==3.13.3 h0d10833_1
   - __osx >=11.0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libiconv >=1.18,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - blosc >=1.21.6,<2.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libcxx >=21
+  - giflib >=6.1.3,<6.2.0a0
   - pcre2 >=10.47,<10.48.0a0
   - libkml >=1.3.0,<1.4.0a0
-  - openssl >=3.5.7,<4.0a0
-  - lerc >=4.1.0,<5.0a0
+  - libiconv >=1.18,<2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libxml2
-  - libxml2-16 >=2.14.6
+  - libxml2-16 >=2.15.3
+  - libjxl >=0.12.0,<0.13.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libcurl >=8.21.0,<9.0a0
   - libaec >=1.1.5,<2.0a0
   - hdf4 >=4.2.15,<4.2.16.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 590797
-  timestamp: 1784038534322
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-haaeabaa_8.conda
-  sha256: d3e6781f68ac45937f7660fc36f31ec44d84f80ad83356efb797101cf428e609
-  md5: 53f20e82202043e18e4edf7ecae1cebd
+  size: 590632
+  timestamp: 1788235755138
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.3-h5056e47_1.conda
+  sha256: 6f83a3db031f8678cae749624e1b668a5bccd66062d3e44ca2db607764d8f53f
+  md5: 08d359d0e522827f9b0315fe106c17c7
   depends:
-  - libgdal-core ==3.13.1 h21e278e_8
-  - libcxx >=19
+  - libgdal-core ==3.13.3 h0d10833_1
   - __osx >=11.0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libiconv >=1.18,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - blosc >=1.21.6,<2.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libcxx >=21
+  - giflib >=6.1.3,<6.2.0a0
   - pcre2 >=10.47,<10.48.0a0
   - libkml >=1.3.0,<1.4.0a0
-  - openssl >=3.5.7,<4.0a0
-  - lerc >=4.1.0,<5.0a0
+  - libiconv >=1.18,<2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libxml2
-  - libxml2-16 >=2.14.6
+  - libxml2-16 >=2.15.3
+  - libjxl >=0.12.0,<0.13.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libcurl >=8.21.0,<9.0a0
   - hdf5 >=1.14.6,<1.14.7.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 713923
-  timestamp: 1784038534322
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.1-hbc024c0_8.conda
-  sha256: 51a89bfb5f559f369b263f265f4bee28c9b23820aabb076fd6383526a50764ad
-  md5: 6f2094f226d1fceb8cf2bbf26802e64e
+  size: 716335
+  timestamp: 1788235755138
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-hdf5-3.13.3-hcffa2b5_1.conda
+  sha256: 7f5170e0fd4e63e7081f78d0d6002579565df2ab11403cee5f89a7cd410dae57
+  md5: 734c341fb4b9a729ca0c8b4aec296814
   depends:
-  - libgdal-core ==3.13.1 h21e278e_8
-  - libcxx >=19
+  - libgdal-core ==3.13.3 h0d10833_1
   - __osx >=11.0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libiconv >=1.18,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - blosc >=1.21.6,<2.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libcxx >=21
+  - giflib >=6.1.3,<6.2.0a0
   - pcre2 >=10.47,<10.48.0a0
   - libkml >=1.3.0,<1.4.0a0
-  - openssl >=3.5.7,<4.0a0
-  - lerc >=4.1.0,<5.0a0
+  - libiconv >=1.18,<2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libxml2
-  - libxml2-16 >=2.14.6
-  - hdf5 >=2.1.0,<3.0a0
+  - libxml2-16 >=2.15.3
+  - libjxl >=0.12.0,<0.13.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - hdf5 >=2.2.0,<3.0a0
   license: MIT
   license_family: MIT
   run_exports: {}
-  size: 716685
-  timestamp: 1784038534322
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.1-hde759b8_8.conda
-  sha256: 66f937554ecfce91190e3f7c04c9107400795ea868e31bbb94650948c555a918
-  md5: 8c4cc5db140c31df86fde375f414d1f8
+  size: 720998
+  timestamp: 1788235755138
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-jp2openjpeg-3.13.3-hb4851f4_1.conda
+  sha256: 87c04dd964a294f1df3f5923f7257aab3aefea3db891ad8ff6c677eeb54df757
+  md5: bfa5321caaed7cbdef4f09961fc241a5
   depends:
-  - libgdal-core ==3.13.1 h21e278e_8
-  - libcxx >=19
+  - libgdal-core ==3.13.3 h0d10833_1
   - __osx >=11.0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libiconv >=1.18,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - blosc >=1.21.6,<2.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libcxx >=21
+  - giflib >=6.1.3,<6.2.0a0
   - pcre2 >=10.47,<10.48.0a0
   - libkml >=1.3.0,<1.4.0a0
-  - openssl >=3.5.7,<4.0a0
-  - lerc >=4.1.0,<5.0a0
+  - libiconv >=1.18,<2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libxml2
-  - libxml2-16 >=2.14.6
+  - libxml2-16 >=2.15.3
+  - libjxl >=0.12.0,<0.13.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libcurl >=8.21.0,<9.0a0
   - openjpeg >=2.5.4,<3.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 498141
-  timestamp: 1784038534322
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h4736868_8.conda
-  sha256: 7e53d2455639bae21b82356ec4dd0f2ea0b085a23b88458ed8e8c701144828fd
-  md5: 40ee13d76bb8bfcaebbc1b217be8be4d
+  size: 498348
+  timestamp: 1788235755138
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.3-h7e39cce_1.conda
+  sha256: 9e436d14b42e8b23c8837bae57110d008f1b02b329d72a3fc625223357aec4ee
+  md5: 7e0d080dc5daa436ea0ffac4cd2a42a3
   depends:
-  - libgdal-core ==3.13.1 h21e278e_8
-  - libgdal-hdf5 3.13.1.*
-  - libgdal-hdf4 3.13.1.*
-  - libcxx >=19
+  - libgdal-core ==3.13.3 h0d10833_1
+  - libgdal-hdf5 3.13.3.*
+  - libgdal-hdf4 3.13.3.*
   - __osx >=11.0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libiconv >=1.18,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - blosc >=1.21.6,<2.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libcxx >=21
+  - giflib >=6.1.3,<6.2.0a0
   - pcre2 >=10.47,<10.48.0a0
   - libkml >=1.3.0,<1.4.0a0
-  - openssl >=3.5.7,<4.0a0
-  - lerc >=4.1.0,<5.0a0
+  - libiconv >=1.18,<2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libxml2
-  - libxml2-16 >=2.14.6
+  - libxml2-16 >=2.15.3
+  - libjxl >=0.12.0,<0.13.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=2.2.0,<3.0a0
+  - libnetcdf >=4.10.1,<4.10.2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 734289
+  timestamp: 1788235755138
+- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.3-hafa6405_1.conda
+  sha256: e413b832e951099838c31c403af674e84c27baa314ff745809873e0a95305812
+  md5: 58716a033e2013fb9c35eab81044b1ac
+  depends:
+  - libgdal-core ==3.13.3 h0d10833_1
+  - libgdal-hdf5 3.13.3.*
+  - libgdal-hdf4 3.13.3.*
+  - __osx >=11.0
+  - libcxx >=21
+  - giflib >=6.1.3,<6.2.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - libiconv >=1.18,<2.0a0
+  - openssl >=3.5.8,<4.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - json-c >=0.18,<0.19.0a0
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libdeflate >=1.25,<1.26.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libjxl >=0.12.0,<0.13.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - libnetcdf >=4.10.1,<4.10.2.0a0
   - hdf5 >=1.14.6,<1.14.7.0a0
   - hdf4 >=4.2.15,<4.2.16.0a0
-  - libnetcdf >=4.10.1,<4.10.2.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 734651
-  timestamp: 1784038534322
-- conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgdal-netcdf-3.13.1-h59fab59_8.conda
-  sha256: ffb8d9feead479786063201bfaee1a749571080107b0e524731b7cf2f1fd4249
-  md5: 1e01e531681b4008be6d761a2a221c38
-  depends:
-  - libgdal-core ==3.13.1 h21e278e_8
-  - libgdal-hdf5 3.13.1.*
-  - libgdal-hdf4 3.13.1.*
-  - libcxx >=19
-  - __osx >=11.0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - libdeflate >=1.25,<1.26.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - libiconv >=1.18,<2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - blosc >=1.21.6,<2.0a0
-  - json-c >=0.18,<0.19.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - giflib >=5.2.2,<5.3.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - openssl >=3.5.7,<4.0a0
-  - lerc >=4.1.0,<5.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libnetcdf >=4.10.1,<4.10.2.0a0
-  - hdf4 >=4.2.15,<4.2.16.0a0
-  - hdf5 >=2.1.0,<3.0a0
-  license: MIT
-  license_family: MIT
-  run_exports: {}
-  size: 734315
-  timestamp: 1784038534322
+  size: 733690
+  timestamp: 1788235755138
 - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-16.2.0-h07b0088_4.conda
   sha256: 7582efbbffc6964093afd80e01c2ac60d89aa4e404cac664544675b9d4d1c5e7
   md5: aa6c627acd0f5709d9c79bf708a7b81b
@@ -33713,129 +33713,129 @@ packages:
   run_exports: {}
   size: 50237
   timestamp: 1779999895192
-- conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py311hf5951da_8.conda
-  sha256: bdcdf562e7dc797a649bda14f67162787eae9bb6ef74c6dc27dfafa5eba83b01
-  md5: 230eb64587cc9e39bce359a9d2b06f04
+- conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.3-np2py311haee3e66_1.conda
+  sha256: 0c3fdc40062ec7aebbf65d9b4b7368432b5c24c0524c9cede957ca36964519e5
+  md5: ab65c2d110fe886f95c618d2e8656600
   depends:
   - python
-  - libgdal-core 3.13.1.*
+  - libgdal-core 3.13.3.*
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - lerc >=4.1.0,<5.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
   - libdeflate >=1.25,<1.26.0a0
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - blosc >=1.21.6,<2.0a0
-  - openssl >=3.5.7,<4.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - muparser >=2.3.5,<2.4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - zstd >=1.5.7,<1.6.0a0
   - libexpat >=2.8.1,<3.0a0
-  - python_abi 3.11.* *_cp311
+  - libsqlite >=3.53.4,<4.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libiconv >=1.18,<2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libzlib >=1.3.2,<2.0a0
   - numpy >=1.23,<3
+  - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
   purls:
   - pkg:pypi/gdal?source=hash-mapping
   run_exports: {}
-  size: 2360247
-  timestamp: 1784038328399
-- conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py312h78d3a78_8.conda
-  sha256: 20d9323e2a7086f8a47a178694ab170a5c1338b72a9fdc12ecd096e05dae2da1
-  md5: 433ecdee143f26f6be2532d4f0a9e793
+  size: 2360732
+  timestamp: 1788235611204
+- conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.3-np2py312h792ba28_1.conda
+  sha256: 2cc334ed8cdd6a1d18d0ebe87c883ef973d0f1cc296388cca3c444937d7bbbf7
+  md5: 8dd0145c55236890fd4319f0308f6c19
   depends:
   - python
-  - libgdal-core 3.13.1.*
+  - libgdal-core 3.13.3.*
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - lerc >=4.1.0,<5.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
   - libdeflate >=1.25,<1.26.0a0
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - blosc >=1.21.6,<2.0a0
-  - openssl >=3.5.7,<4.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - muparser >=2.3.5,<2.4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - zstd >=1.5.7,<1.6.0a0
   - libexpat >=2.8.1,<3.0a0
-  - python_abi 3.12.* *_cp312
+  - libsqlite >=3.53.4,<4.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libiconv >=1.18,<2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libzlib >=1.3.2,<2.0a0
   - numpy >=1.25,<3
+  - python_abi 3.12.* *_cp312
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/gdal?source=hash-mapping
+  - pkg:pypi/gdal?source=compressed-mapping
   run_exports: {}
-  size: 2335840
-  timestamp: 1784038328399
-- conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py313hd6c750f_8.conda
-  sha256: 3d352fc49d72c9a6aa662cafdd99ed2ab5b5157ffe5e93354a39a09e5b5bb088
-  md5: 121622e189ee10ce5c9bc27b435a2324
+  size: 2336910
+  timestamp: 1788235611204
+- conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.3-np2py313h177f10b_1.conda
+  sha256: 9b9d1702d6f2e8aabd275654964dae12407419b4ab6544b5207389ddeedd66b8
+  md5: c128a40d71c386d3504a459b8d2694e8
   depends:
   - python
-  - libgdal-core 3.13.1.*
+  - libgdal-core 3.13.3.*
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - lerc >=4.1.0,<5.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
   - libdeflate >=1.25,<1.26.0a0
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - blosc >=1.21.6,<2.0a0
-  - openssl >=3.5.7,<4.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - muparser >=2.3.5,<2.4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - zstd >=1.5.7,<1.6.0a0
   - libexpat >=2.8.1,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libiconv >=1.18,<2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libzlib >=1.3.2,<2.0a0
   - numpy >=1.25,<3
   - python_abi 3.13.* *_cp313
   license: MIT
@@ -33843,43 +33843,43 @@ packages:
   purls:
   - pkg:pypi/gdal?source=hash-mapping
   run_exports: {}
-  size: 2327211
-  timestamp: 1784038328399
-- conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.1-np2py314hf352b11_8.conda
-  sha256: 2ffa304f2efd79c4854bd0c7dadc450ec24aa74882a832e31258a21ff81c4f24
-  md5: bdd40461334b15a445bafdbc201bd2a4
+  size: 2328123
+  timestamp: 1788235611204
+- conda: https://conda.anaconda.org/conda-forge/win-64/gdal-3.13.3-np2py314h4074017_1.conda
+  sha256: 258f6481485407b09305e954ea4ce13b7ef81707570fb2d6b5f71ae76bea72f5
+  md5: 82f583da6cbb107f5c481e631dd569cc
   depends:
   - python
-  - libgdal-core 3.13.1.*
+  - libgdal-core 3.13.3.*
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - lerc >=4.1.0,<5.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
   - libdeflate >=1.25,<1.26.0a0
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - blosc >=1.21.6,<2.0a0
-  - openssl >=3.5.7,<4.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - muparser >=2.3.5,<2.4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - zstd >=1.5.7,<1.6.0a0
   - libexpat >=2.8.1,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libiconv >=1.18,<2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libzlib >=1.3.2,<2.0a0
   - numpy >=1.25,<3
   - python_abi 3.14.* *_cp314
   license: MIT
@@ -33887,8 +33887,8 @@ packages:
   purls:
   - pkg:pypi/gdal?source=hash-mapping
   run_exports: {}
-  size: 2337659
-  timestamp: 1784038328399
+  size: 2336810
+  timestamp: 1788235611204
 - conda: https://conda.anaconda.org/conda-forge/win-64/geos-3.14.1-hdade9fe_0.conda
   sha256: 032a16d78e69a20ffae6216191a66977bc50f6c21cb75f9853b37298b95308c4
   md5: 8c75d7e401a4d799ce8d4bb922320967
@@ -34510,343 +34510,343 @@ packages:
     - libffi >=3.7.0,<3.8.0a0
   size: 50247
   timestamp: 1783521107166
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.1-hbfeefb7_8.conda
-  sha256: 7b3ccef114c1d39e2f6c329f08a4010fc7b4b06bb9777cda3f283213a53d7a94
-  md5: d870787bffe3a248c7828f28e44d2a32
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-core-3.13.3-hcd51406_1.conda
+  sha256: 08a7f54d669392f34fd95ef53da1fd7babd10c7735bf8762992f98c0c9cdd74f
+  md5: 0553b074c878e31b9090ec0542228ac1
   depends:
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - lerc >=4.1.0,<5.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
   - libdeflate >=1.25,<1.26.0a0
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - blosc >=1.21.6,<2.0a0
-  - openssl >=3.5.7,<4.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - muparser >=2.3.5,<2.4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - zstd >=1.5.7,<1.6.0a0
   - libexpat >=2.8.1,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libiconv >=1.18,<2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libzlib >=1.3.2,<2.0a0
   constrains:
-  - libgdal 3.13.1.*
+  - libgdal 3.13.3.*
   license: MIT
   license_family: MIT
   purls: []
   run_exports:
     weak:
-    - libgdal-core >=3.13.1,<3.14.0a0
-  size: 11339410
-  timestamp: 1784038328399
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.1-h7378ee1_8.conda
-  sha256: 3c1bb77acb5d43a09a68a8f03eaa21761c4eecb994e268ed7979e1d7bf1f5f22
-  md5: ed6ca7dff34e02d2f2b6cfd662fd5998
+    - libgdal-core >=3.13.3,<3.14.0a0
+  size: 11341531
+  timestamp: 1788235611204
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-grib-3.13.3-h0828328_1.conda
+  sha256: bcb397e9b2b77f604280dca749b3df68fe6c96e8bc46870151b7fbc74fde817c
+  md5: 16f351baa593f40f118dc94909459a3d
   depends:
-  - libgdal-core ==3.13.1 hbfeefb7_8
+  - libgdal-core ==3.13.3 hcd51406_1
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - lerc >=4.1.0,<5.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
   - libdeflate >=1.25,<1.26.0a0
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - blosc >=1.21.6,<2.0a0
-  - openssl >=3.5.7,<4.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - muparser >=2.3.5,<2.4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - zstd >=1.5.7,<1.6.0a0
   - libexpat >=2.8.1,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libiconv >=1.18,<2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libzlib >=1.3.2,<2.0a0
   - libaec >=1.1.5,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 750805
-  timestamp: 1784038328399
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.1-h1f15f23_8.conda
-  sha256: edc6c72642d4e0a31daafdd440439a11099dd0b57c9afc684a3a4d64be4462fb
-  md5: f2696886631562db93ea4f5fc3ba03f7
+  size: 750709
+  timestamp: 1788235611204
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf4-3.13.3-h531e138_1.conda
+  sha256: 34aefac1aac221c03f89212b69147fce65822f21d640619d38c3a34a98c979ec
+  md5: 3acf2b9a75700884e913f425ac3da53d
   depends:
-  - libgdal-core ==3.13.1 hbfeefb7_8
+  - libgdal-core ==3.13.3 hcd51406_1
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - lerc >=4.1.0,<5.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
   - libdeflate >=1.25,<1.26.0a0
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - blosc >=1.21.6,<2.0a0
-  - openssl >=3.5.7,<4.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - muparser >=2.3.5,<2.4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - zstd >=1.5.7,<1.6.0a0
   - libexpat >=2.8.1,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libiconv >=1.18,<2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libzlib >=1.3.2,<2.0a0
   - hdf4 >=4.2.15,<4.2.16.0a0
   - libaec >=1.1.5,<2.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 605310
-  timestamp: 1784038328399
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h152d30e_8.conda
-  sha256: 68fc9f813c4a72c36d904be3709f79202e30da40526e94ef12d81c4a303f9689
-  md5: cda799f3cea3af716739f0a323749b1e
+  size: 605165
+  timestamp: 1788235611204
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.3-h77fcb0c_1.conda
+  sha256: ccf4347fe03032eef9f9af019a05c611030979f029a6276bde89c6052c29ae27
+  md5: 42a6d0f577f8b6eef53c0d60d91f3dec
   depends:
-  - libgdal-core ==3.13.1 hbfeefb7_8
+  - libgdal-core ==3.13.3 hcd51406_1
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - lerc >=4.1.0,<5.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
   - libdeflate >=1.25,<1.26.0a0
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - blosc >=1.21.6,<2.0a0
-  - openssl >=3.5.7,<4.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - muparser >=2.3.5,<2.4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - zstd >=1.5.7,<1.6.0a0
   - libexpat >=2.8.1,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libiconv >=1.18,<2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libzlib >=1.3.2,<2.0a0
   - hdf5 >=1.14.6,<1.14.7.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 731381
-  timestamp: 1784038328399
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.1-h3e1bca6_8.conda
-  sha256: 641e9a644f370073267692caea94c8d48b3716b02953a02ebe5e5e3831999de7
-  md5: f21b8a9d2dc1b7a85d5d54568d05c243
+  size: 731398
+  timestamp: 1788235611204
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-hdf5-3.13.3-h85408a6_1.conda
+  sha256: 57dfd4f1abbc81d90fe1b0dab916cf394addbb9e8e14faa33ed584864ef8d883
+  md5: ef058283054d4484f8b747ba79a74810
   depends:
-  - libgdal-core ==3.13.1 hbfeefb7_8
+  - libgdal-core ==3.13.3 hcd51406_1
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - lerc >=4.1.0,<5.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
   - libdeflate >=1.25,<1.26.0a0
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - blosc >=1.21.6,<2.0a0
-  - openssl >=3.5.7,<4.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - muparser >=2.3.5,<2.4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - zstd >=1.5.7,<1.6.0a0
   - libexpat >=2.8.1,<3.0a0
-  - hdf5 >=2.1.0,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libiconv >=1.18,<2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - hdf5 >=2.2.0,<3.0a0
   license: MIT
   license_family: MIT
   run_exports: {}
-  size: 732686
-  timestamp: 1784038328399
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.1-he7d31cb_8.conda
-  sha256: 89e59a492d444ca04b24f1a121c23e452d6c010a8f9c5bf72c9b198360d80335
-  md5: 37a4ad8626331eb46b05878a6970829a
+  size: 733637
+  timestamp: 1788235611204
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-jp2openjpeg-3.13.3-hd0cc1af_1.conda
+  sha256: d695eab84973f86783b56f482b212e91165424e163b1ebbbe3cdb34e4718b660
+  md5: df2e41723bd86ab1678916fab55a1094
   depends:
-  - libgdal-core ==3.13.1 hbfeefb7_8
+  - libgdal-core ==3.13.3 hcd51406_1
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - lerc >=4.1.0,<5.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
   - libdeflate >=1.25,<1.26.0a0
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - blosc >=1.21.6,<2.0a0
-  - openssl >=3.5.7,<4.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - muparser >=2.3.5,<2.4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - zstd >=1.5.7,<1.6.0a0
   - libexpat >=2.8.1,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libiconv >=1.18,<2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libzlib >=1.3.2,<2.0a0
   - openjpeg >=2.5.4,<3.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 547153
-  timestamp: 1784038328399
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-h3353d3b_8.conda
-  sha256: 8714a7f669571e782e01ed0c58f30f73902d98d7cb4dd0c2f3b819f7332711d3
-  md5: 8d961f80a030667a5ccf5632686707b6
+  size: 547573
+  timestamp: 1788235611204
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.3-h5940625_1.conda
+  sha256: 34e197781cfd20921dad0fbc22b58a428a5d30a08db779fc12664d3636fbde4d
+  md5: 36a1d723dc0c09e98fc04dd700c4d7ef
   depends:
-  - libgdal-core ==3.13.1 hbfeefb7_8
-  - libgdal-hdf5 3.13.1.*
-  - libgdal-hdf4 3.13.1.*
+  - libgdal-core ==3.13.3 hcd51406_1
+  - libgdal-hdf5 3.13.3.*
+  - libgdal-hdf4 3.13.3.*
   - vc >=14.3,<15
   - vc14_runtime >=14.44.35208
   - ucrt >=10.0.20348.0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - lerc >=4.1.0,<5.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
   - libdeflate >=1.25,<1.26.0a0
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
   - blosc >=1.21.6,<2.0a0
-  - openssl >=3.5.7,<4.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
   - muparser >=2.3.5,<2.4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - zstd >=1.5.7,<1.6.0a0
   - libexpat >=2.8.1,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libiconv >=1.18,<2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libzlib >=1.3.2,<2.0a0
+  - hdf4 >=4.2.15,<4.2.16.0a0
+  - hdf5 >=2.2.0,<3.0a0
   - libnetcdf >=4.10.1,<4.10.2.0a0
+  license: MIT
+  license_family: MIT
+  run_exports: {}
+  size: 738956
+  timestamp: 1788235611204
+- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.3-h69e0d2b_1.conda
+  sha256: a9d12f88fd1f05d0f44328afae1bedeb48ee50534bce813f8c483e47e4b13067
+  md5: 54fff6fc2f93e88b4b56a2da64bf231e
+  depends:
+  - libgdal-core ==3.13.3 hcd51406_1
+  - libgdal-hdf5 3.13.3.*
+  - libgdal-hdf4 3.13.3.*
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
+  - libdeflate >=1.25,<1.26.0a0
+  - blosc >=1.21.6,<2.0a0
+  - libkml >=1.3.0,<1.4.0a0
+  - muparser >=2.3.5,<2.4.0a0
+  - xerces-c >=3.3.0,<3.4.0a0
+  - libwebp-base >=1.6.0,<2.0a0
+  - liblzma >=5.8.3,<6.0a0
+  - pcre2 >=10.47,<10.48.0a0
+  - openssl >=3.5.8,<4.0a0
+  - libxml2
+  - libxml2-16 >=2.15.3
+  - libjpeg-turbo >=3.2.0,<4.0a0
+  - libarchive >=3.8.9,<3.9.0a0
+  - lz4-c >=1.10.0,<1.11.0a0
+  - lerc >=4.2.0,<5.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  - libexpat >=2.8.1,<3.0a0
+  - libsqlite >=3.53.4,<4.0a0
+  - libjxl >=0.12.0,<0.13.0a0
+  - geos >=3.14.1,<3.14.2.0a0
+  - libspatialite >=5.1.0,<5.2.0a0
+  - libpng >=1.6.58,<1.7.0a0
+  - libiconv >=1.18,<2.0a0
+  - libcurl >=8.21.0,<9.0a0
+  - proj >=9.8.1,<9.9.0a0
+  - libzlib >=1.3.2,<2.0a0
   - hdf5 >=1.14.6,<1.14.7.0a0
+  - libnetcdf >=4.10.1,<4.10.2.0a0
   - hdf4 >=4.2.15,<4.2.16.0a0
   license: MIT
   license_family: MIT
   purls: []
   run_exports: {}
-  size: 738318
-  timestamp: 1784038328399
-- conda: https://conda.anaconda.org/conda-forge/win-64/libgdal-netcdf-3.13.1-h47aba1c_8.conda
-  sha256: a88fb82beb2abc2beea59571a18c9210d0ee01620e59b71b58f77651a489e36a
-  md5: a25ad316b57af975d7dfd279459ea320
-  depends:
-  - libgdal-core ==3.13.1 hbfeefb7_8
-  - libgdal-hdf5 3.13.1.*
-  - libgdal-hdf4 3.13.1.*
-  - vc >=14.3,<15
-  - vc14_runtime >=14.44.35208
-  - ucrt >=10.0.20348.0
-  - libspatialite >=5.1.0,<5.2.0a0
-  - lz4-c >=1.10.0,<1.11.0a0
-  - lerc >=4.1.0,<5.0a0
-  - pcre2 >=10.47,<10.48.0a0
-  - proj >=9.8.1,<9.9.0a0
-  - libxml2
-  - libxml2-16 >=2.14.6
-  - libdeflate >=1.25,<1.26.0a0
-  - libiconv >=1.18,<2.0a0
-  - liblzma >=5.8.3,<6.0a0
-  - libzlib >=1.3.2,<2.0a0
-  - libcurl >=8.21.0,<9.0a0
-  - xerces-c >=3.3.0,<3.4.0a0
-  - libjxl >=0.12.0,<0.13.0a0
-  - libsqlite >=3.53.3,<4.0a0
-  - libkml >=1.3.0,<1.4.0a0
-  - blosc >=1.21.6,<2.0a0
-  - openssl >=3.5.7,<4.0a0
-  - libpng >=1.6.58,<1.7.0a0
-  - libjpeg-turbo >=3.2.0,<4.0a0
-  - libarchive >=3.8.8,<3.9.0a0
-  - geos >=3.14.1,<3.14.2.0a0
-  - zstd >=1.5.7,<1.6.0a0
-  - libwebp-base >=1.6.0,<2.0a0
-  - muparser >=2.3.5,<2.4.0a0
-  - libexpat >=2.8.1,<3.0a0
-  - hdf4 >=4.2.15,<4.2.16.0a0
-  - hdf5 >=2.1.0,<3.0a0
-  - libnetcdf >=4.10.1,<4.10.2.0a0
-  license: MIT
-  license_family: MIT
-  run_exports: {}
-  size: 738062
-  timestamp: 1784038328399
+  size: 737996
+  timestamp: 1788235611204
 - conda: https://conda.anaconda.org/conda-forge/win-64/libgoogle-cloud-3.7.0-hfe3f7e9_0.conda
   sha256: 7caeceff8cc78b6ccdf416c3950ee7c86390be9c43969e6f0df11ffe46db8d32
   md5: 4957e887b8ff6e7c1108e217b879ebc3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -436,10 +436,10 @@ xarray = ">=2023.1.0"
 # spec like "3.13.1.*" concatenates into a nonexistent package name
 # (observed: micromamba "gdal3.13.1.* does not exist", macOS x86_64).
 [tool.pixi.feature.gdal.dependencies]
-gdal = ">=3.13.1,<3.13.2"
-libgdal-netcdf = ">=3.13.1,<3.13.2"
-libgdal-hdf4 = ">=3.13.1,<3.13.2"
-libgdal-grib = ">=3.13.1,<3.13.2"
+gdal = ">=3.13.3,<3.13.4"
+libgdal-netcdf = ">=3.13.3,<3.13.4"
+libgdal-hdf4 = ">=3.13.3,<3.13.4"
+libgdal-grib = ">=3.13.3,<3.13.4"
 libgdal-jp2openjpeg = ">=3.13,<3.14"
 
 # swig builds the osgeo bindings against libgdal; build-only, so it stays in the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -434,7 +434,8 @@ xarray = ">=2023.1.0"
 # the win_arm64 canary. Operator-leading form on purpose: ci/gdal-pin.py
 # consumers build conda matchspecs as "gdal${SPEC}", so a digit-leading
 # spec like "3.13.1.*" concatenates into a nonexistent package name
-# (observed: micromamba "gdal3.13.1.* does not exist", macOS x86_64).
+# (observed: micromamba "gdal3.13.1.* does not exist", macOS x86_64; the
+# same failure applies verbatim to 3.13.3.*).
 [tool.pixi.feature.gdal.dependencies]
 gdal = ">=3.13.3,<3.13.4"
 libgdal-netcdf = ">=3.13.3,<3.13.4"

--- a/src/pyramids/_io.py
+++ b/src/pyramids/_io.py
@@ -724,7 +724,8 @@ def read_file(
             # path with *different* options are never handed the same handle —
             # RELIES ON GDAL keying its shared-dataset cache on the concatenated
             # open options as well as path/access/thread. This holds on the conda
-            # pin (gdal >=3.13.3,<3.13.4 in pyproject.toml, verified on 3.13.1)
+            # pin (gdal >=3.13.3,<3.13.4 in pyproject.toml; verified on 3.13.1,
+            # unchanged through 3.13.3)
             # and every GDAL that has shipped this behaviour. Wheel/sdist installs
             # bring native GDAL out-of-band at an unpinned version; on a
             # hypothetical GDAL that ignored options in its shared key, two

--- a/src/pyramids/_io.py
+++ b/src/pyramids/_io.py
@@ -724,7 +724,7 @@ def read_file(
             # path with *different* options are never handed the same handle —
             # RELIES ON GDAL keying its shared-dataset cache on the concatenated
             # open options as well as path/access/thread. This holds on the conda
-            # pin (gdal >=3.13.1,<3.13.2 in pyproject.toml, verified on 3.13.1)
+            # pin (gdal >=3.13.3,<3.13.4 in pyproject.toml, verified on 3.13.1)
             # and every GDAL that has shipped this behaviour. Wheel/sdist installs
             # bring native GDAL out-of-band at an unpinned version; on a
             # hypothetical GDAL that ignored options in its shared key, two

--- a/tests/dataset/spatial/test_overviews.py
+++ b/tests/dataset/spatial/test_overviews.py
@@ -235,7 +235,7 @@ def test_get_overview(era5_image: gdal.Dataset, clean_overview_after_test):
 
 
 # The exact stranding -- levels dropped, a file named `.ovr` left in the working directory
-# -- was measured on GDAL 3.13.1. The win_arm64 wheel ships 3.12.4 (the vcpkg port ceiling),
+# -- was measured on GDAL 3.13.1 (re-confirmed on 3.13.3). The win_arm64 wheel ships 3.12.4 (the vcpkg port ceiling),
 # so the assertions that pin GDAL's own misbehaviour are gated the way #892 gated the
 # equivalent NetCDF sidecar assertions. The guard itself is not gated; only this canary.
 _GDAL_STRANDS_PATHLESS_VRT_OVERVIEWS = int(gdal.VersionInfo("VERSION_NUM")) >= 3130000

--- a/tests/netcdf/spatial/test_windowed_read_705.py
+++ b/tests/netcdf/spatial/test_windowed_read_705.py
@@ -68,12 +68,14 @@ def _irregular_lon_mdim() -> gdal.Dataset:
     return store
 
 
-# The raw multidim-view partial-window crash (`arrayStartIdx`) was a GDAL 3.13 regression (verified on
-# 3.13.1) that GDAL 3.13.3 fixes (verified on 3.13.3). Below 3.13 -- e.g. the win_arm64 wheel's
-# vcpkg-pinned 3.12.4 -- and from 3.13.3 on, the raw reversed-view read succeeds instead of raising, so
-# the pre-fix crash is asserted only inside the [3.13.0, 3.13.3) window; the eager-materialize fix
-# itself is exercised on every platform.
-_GDAL_RAW_VIEW_CRASHES = 3130000 <= int(gdal.VersionInfo("VERSION_NUM")) < 3130300
+# The raw multidim-view partial-window crash (`arrayStartIdx`) was a GDAL 3.13.0/3.13.1 regression in the
+# sliced-array view, fixed in 3.13.2 (upstream NEWS: "GDALSlicedMDArray::IAdviseRead(): fix wrong parent
+# bounds computation in case of step != 1", PR #14805; our reversed [::-1] view is step -1, and 3.13.3
+# ships no further multidim change). Below 3.13 -- e.g. the win_arm64 wheel's vcpkg-pinned 3.12.4 -- and
+# from 3.13.2 on, the raw reversed-view read succeeds instead of raising, so the pre-fix crash is asserted
+# only inside the [3.13.0, 3.13.2) window; the eager-materialize fix itself is exercised on every platform.
+# Verified locally: crash on 3.13.1, gone on 3.13.3 (3.13.2 not run here; fix version per upstream NEWS).
+_GDAL_RAW_VIEW_CRASHES = 3130000 <= int(gdal.VersionInfo("VERSION_NUM")) < 3130200
 
 
 class TestWindowedRead705:

--- a/tests/netcdf/spatial/test_windowed_read_705.py
+++ b/tests/netcdf/spatial/test_windowed_read_705.py
@@ -68,11 +68,12 @@ def _irregular_lon_mdim() -> gdal.Dataset:
     return store
 
 
-# The raw multidim-view partial-window crash (`arrayStartIdx`) is a GDAL >= 3.13 regression. The
-# win_arm64 wheel ships GDAL 3.12.4 (the vcpkg port ceiling), where the raw read succeeds instead of
-# raising, so the pre-fix crash is only asserted where that GDAL floor is met; the eager-materialize
-# fix itself is exercised on every platform.
-_GDAL_RAW_VIEW_CRASHES = int(gdal.VersionInfo("VERSION_NUM")) >= 3130000
+# The raw multidim-view partial-window crash (`arrayStartIdx`) was a GDAL 3.13 regression (verified on
+# 3.13.1) that GDAL 3.13.3 fixes (verified on 3.13.3). Below 3.13 -- e.g. the win_arm64 wheel's
+# vcpkg-pinned 3.12.4 -- and from 3.13.3 on, the raw reversed-view read succeeds instead of raising, so
+# the pre-fix crash is asserted only inside the [3.13.0, 3.13.3) window; the eager-materialize fix
+# itself is exercised on every platform.
+_GDAL_RAW_VIEW_CRASHES = 3130000 <= int(gdal.VersionInfo("VERSION_NUM")) < 3130300
 
 
 class TestWindowedRead705:


### PR DESCRIPTION
# Description

Bumps the bundled **GDAL 3.13.1 -> 3.13.3** on every platform that ships GDAL outside win_arm64. Upstream shipped
3.13.2 (2026-07-22) and 3.13.3 (2026-08-18) — both bug-fix-only — and conda-forge published 3.13.3 on 2026-09-01
(feedstock PR conda-forge/gdal-feedstock#1235). All five conda packages we pin come from that one feedstock, so
they move together.

What changed:

- **`pyproject.toml`** — the shared `gdal` feature pins `gdal` / `libgdal-netcdf` / `libgdal-hdf4` / `libgdal-grib`
  to `>=3.13.3,<3.13.4`; `libgdal-jp2openjpeg`'s `>=3.13,<3.14` already admits 3.13.3 and is left as-is. Feeds the
  macOS + Windows-x64 conda-extract wheels and every dev env.
- **`ci/source-build/config.sh` + `build-gdal-stack.sh`** — `GDAL_VERSION` default -> `3.13.3` and the
  `download.osgeo.org` gdal tarball SHA256 updated to
  `5e0c388d83da2d686cc00a40272882432cdb54edff43d4af173e532844a0a0ea` (MD5-cross-checked against the osgeo `.md5`
  sidecar). Drives the Linux from-source wheels; the distfile-cache key rotates automatically on this file's hash.
- **`pixi.lock`** — refreshed with `pixi update` scoped to the gdal stack. Only churn beyond the gdal stack is
  **giflib 5.2.2 -> 6.1.3**, pulled in as gdal 3.13.3's GIF-driver runtime dependency.
- **docs / comments** — `docs/installation.md`, `docs/how-to/wheel-build-flow.md`, and inline comments that state
  the shipped version updated to 3.13.3.

Why: 3.13.2/3.13.3 fix, among others, a **Unix file-read buffering regression** introduced in 3.13.0, **COG
multi-threaded overview building**, **netCDF subdataset-name parsing**, **/vsicurl multithreading** robustness, and
bump internal libtiff — all in code paths pyramids exercises. Patch-only: no API or behaviour break.

**Out of scope:** win_arm64 (vcpkg, `ci/vcpkg.json`) stays at 3.12.4 — bumping it needs a vcpkg baseline carrying a
3.13.x gdal port; tracked separately (see the open conda-forge "Enable core-only Windows ARM64 GDAL" feedstock PR
as the longer-term path). A follow-up to 3.13.4 can happen once it releases (upstream due 2026-09-21) and lands on
conda-forge.

# Issues

- Closes #1082

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Local (this branch, worktree off `main`):

- [x] Tarball integrity: downloaded `gdal-3.13.3.tar.gz` from download.osgeo.org, computed SHA256, and
      **cross-checked its MD5 against the osgeo `.md5` sidecar** (`be38e92214ab6103b2134f9f5b0946ce`, matches).
- [x] `pixi update` re-solved and refreshed the lock to gdal 3.13.3 (build `_1`) on all platforms; verified the
      lock diff is scoped to the gdal stack + giflib, with zero gdal-stack entries left at 3.13.1.
- [x] Static checks: `bash -n` on both shell scripts, `tomllib` parse of `pyproject.toml`, line-length <=120 on all
      edited lines.

Deferred to CI (a full local run needs a multi-GB env rebuild for the new pins):

- [ ] `main-package` matrix (macOS/Windows-x64/Linux, py311-py314) resolves the new conda pins and the suite is
      green.
- [ ] `bundle-pypi-wheels` dry-run: the Linux from-source build compiles GDAL 3.13.3 from the newly-pinned tarball.
- [ ] **Watch `tests/dataset/spatial/test_overviews.py`** — it version-gates an assertion on GDAL's own
      pathless-VRT-overview *stranding* misbehaviour at `VERSION_NUM >= 3.13.0`. 3.13.3 is a bug-fix release, so if
      upstream changed that observable behaviour this canary may need its gate adjusted; the CI matrix will surface
      it.

# Checklist:

- [ ] updated version number in pyproject.toml. (commitizen-managed; not applicable)
- [ ] added changes to History.rst. (changelog is commitizen-generated; not applicable)
- [ ] updated the latest version in README file. (not applicable)
- [ ] I have added tests that prove my fix is effective. (dependency version bump; covered by the existing suite)
- [ ] New and existing unit tests pass locally with my changes. (not run locally — deferred to CI; see above)
- [x] documentation are updated.
