### PR TITLE
fix(tests): gate the xarray tests on the interop extra so the pure-wheel job passes

### DIFF
--- a/tests/base/test_extra_hint.py
+++ b/tests/base/test_extra_hint.py
@@ -57,6 +57,11 @@ class TestLazyExtraHintUnchanged:
         assert "conda install -c conda-forge pyramids-lazy" in hint
 
 
+# Needs the [interop] extra: `to_xarray` / `from_xarray` import xarray, which a
+# bare install does not have. The module-level `core` mark still selects these
+# under `-m core`, and `tests/conftest.py` turns this marker into the matching
+# skip when xarray is absent -- which is what the pure-wheel job needs.
+@pytest.mark.interop
 class TestImportXarray:
     """The two xarray guards share one importer.
 

--- a/tests/dataset/plot/test_plot_facade.py
+++ b/tests/dataset/plot/test_plot_facade.py
@@ -24,6 +24,8 @@ Config.set_matplotlib_backend("agg")
 
 # Must follow the cleopatra importorskip above: matplotlib arrives via the [viz] extra, so
 # importing it at the top of the file would error instead of skipping on a no-viz install.
+from importlib.metadata import version as _pkg_version
+
 import matplotlib.pyplot as plt
 
 
@@ -36,6 +38,31 @@ def _close_matplotlib_figures():
     """
     yield
     plt.close("all")
+
+
+def _cleopatra_version() -> tuple[int, ...]:
+    """The installed cleopatra version as a comparable tuple, `(0,)` when absent.
+
+    The [viz] extra's floor is `>=0.31.0`, so a supported environment can carry a
+    cleopatra either side of a behaviour change. A test that pins such a change has to
+    ask which one it has rather than assume, or an upstream release turns into a failing
+    pipeline on `main`.
+
+    Returns:
+        tuple[int, ...]: The numeric release components, e.g. `(0, 36, 0)`.
+    """
+    try:
+        raw = _pkg_version("cleopatra")
+    except Exception:
+        return (0,)
+    parts: list[int] = []
+    for chunk in raw.split(".")[:3]:
+        digits = "".join(c for c in chunk if c.isdigit())
+        parts.append(int(digits) if digits else 0)
+    return tuple(parts)
+
+
+_CLEOPATRA_VERSION = _cleopatra_version()
 
 
 class TestDatasetPlotFacade:
@@ -378,21 +405,29 @@ class TestDatasetPlotFigAx:
 
     @pytest.mark.plot
     @pytest.mark.xfail(
+        _CLEOPATRA_VERSION < (0, 36, 0),
         strict=True,
         raises=AttributeError,
         reason=(
-            "serapeum-org/cleopatra#326: cleopatra never derives an axes from a bare "
-            "figure, so it writes the projection marker onto ax=None. Remove this pin "
-            "once that lands and assert the success path instead."
+            "serapeum-org/cleopatra#326: before 0.36.0 cleopatra never derived an axes "
+            "from a bare figure, so it wrote the projection marker onto ax=None. The "
+            "pin is strict and version-gated: on an older cleopatra it must still "
+            "raise, and on 0.36.0 or newer the success path below must hold."
         ),
     )
     def test_fig_alone_is_not_yet_supported(self, dataset):
-        """`fig` without `ax` raises inside cleopatra until #326 lands.
+        """`fig` without `ax` was unsupported until cleopatra 0.36.0.
 
         Test scenario:
-            An axes carries its figure but not the reverse, so cleopatra leaves `ax` as
-            `None` and then dereferences it. This pin is strict: when cleopatra starts
-            adding the subplot itself the test XPASSes and fails, prompting the update.
+            An axes carries its figure but not the reverse, so before the fix cleopatra
+            left `ax` as `None` and then dereferenced it. From 0.36.0 it adds the
+            subplot itself and adopts the caller's figure, which is what this asserts.
+
+            The `xfail` is gated on the installed version rather than removed outright:
+            the floor is still `>=0.31.0`, so a supported environment may legitimately
+            have either behaviour, and a bare `strict=True` pin turned the upstream
+            release into a red pipeline on `main` (serapeum-org/cleopatra#326 closed
+            2026-09-05; 0.36.0 published the next day).
         """
         fig, _ = plt.subplots()
 

--- a/tests/netcdf/structure/test_variable_names_invariance.py
+++ b/tests/netcdf/structure/test_variable_names_invariance.py
@@ -372,6 +372,10 @@ class TestTheClassificationFollowsDeclarations:
             "the declared non-data arrays should still be excluded"
         )
 
+    # Needs the [interop] extra: the assertion goes through `to_xarray`, which
+    # imports xarray. `tests/conftest.py` turns this marker into a skip when the
+    # extra is absent, so the pure-wheel job no longer fails on it.
+    @pytest.mark.interop
     def test_the_xarray_export_promotes_the_same_arrays_and_no_others(self):
         """The classification's other consumer, on the fixture nothing covered.
 

--- a/tests/netcdf/test_group_qualified_names_resolve.py
+++ b/tests/netcdf/test_group_qualified_names_resolve.py
@@ -75,6 +75,11 @@ class TestOpenMdarrayWalksGroupPaths:
         assert dataset._variable_dim_names(rg, qualified) != []
 
 
+# Needs the [interop] extra: `to_xarray` / `from_xarray` import xarray, which a
+# bare install does not have. The module-level `core` mark still selects these
+# under `-m core`, and `tests/conftest.py` turns this marker into the matching
+# skip when xarray is absent -- which is what the pure-wheel job needs.
+@pytest.mark.interop
 class TestTheXarrayExportHandlesAGroupedStore:
     """It raised outright; before that it silently exported one variable."""
 
@@ -124,6 +129,11 @@ class TestTheXarrayExportHandlesAGroupedStore:
         assert not [w for w in caught if "skipped" in str(w.message)]
 
 
+# Needs the [interop] extra: `to_xarray` / `from_xarray` import xarray, which a
+# bare install does not have. The module-level `core` mark still selects these
+# under `-m core`, and `tests/conftest.py` turns this marker into the matching
+# skip when xarray is absent -- which is what the pure-wheel job needs.
+@pytest.mark.interop
 class TestTheLazyExportResolvesTheSameNames:
     """`to_xarray()`'s two arms must agree about which names exist.
 

--- a/tests/netcdf/test_round2_followups.py
+++ b/tests/netcdf/test_round2_followups.py
@@ -100,6 +100,11 @@ class TestTheBboxIdentityCheckIgnoresAxisOrder:
         assert max_y > min_y, "the y axis came back inverted"
 
 
+# Needs the [interop] extra: `to_xarray` / `from_xarray` import xarray, which a
+# bare install does not have. The module-level `core` mark still selects these
+# under `-m core`, and `tests/conftest.py` turns this marker into the matching
+# skip when xarray is absent -- which is what the pure-wheel job needs.
+@pytest.mark.interop
 class TestToXarrayPutsCfNonDataArraysInCoords:
     """Reading every readable array must not relabel them all as data."""
 

--- a/tests/netcdf/test_xarray_round_trip.py
+++ b/tests/netcdf/test_xarray_round_trip.py
@@ -22,7 +22,10 @@ from osgeo import gdal
 
 from pyramids.netcdf import NetCDF
 
-pytestmark = pytest.mark.core
+# Every test here goes through `to_xarray` / `from_xarray`, so the module is
+# gated on the [interop] extra rather than marked `core`: a bare wheel install
+# has no xarray, and `-m core` must not collect a test that cannot run there.
+pytestmark = pytest.mark.interop
 
 DATA = Path(__file__).parents[1] / "data" / "netcdf"
 BOUNDED = "cf__7v__1d3-2d3-3d1__y-asc.nc"


### PR DESCRIPTION
# Description

`Pure Wheel - Build & Test` is red on `main` — 9 jobs, every `test-wheel-core` leg across
ubuntu/windows/macos and Python 3.11–3.14, plus the `viz` extras leg. Two independent causes, both
fixed here.

**1. Tests that need `xarray` were marked `core`.**

That job is the only one that installs the built wheel **with no extras** and runs
`pytest -m "core and not vfs"`. 22 tests reach xarray through `to_xarray` / `from_xarray` but carried
the `core` marker, so the bare-wheel job collected them and they failed on the missing dependency:

```
FAILED tests/base/test_extra_hint.py::TestImportXarray::test_it_returns_the_module_itself
  - OptionalPackageDoesNotExist: unused: xarray is installed in this environment
```

The mechanism to handle this already exists — `tests/conftest.py` turns any registered extras marker
into the matching skip when that extra is absent — so the fix is the marker, not a hand-written skip:

- `tests/netcdf/test_xarray_round_trip.py` — every test is an xarray round trip, so the module mark
  becomes `interop` rather than `core`.
- `@pytest.mark.interop` on the four xarray classes and one test that live inside `core` modules
  (`test_extra_hint.py::TestImportXarray`, `test_round2_followups.py::TestToXarrayPutsCfNonDataArraysInCoords`,
  `test_group_qualified_names_resolve.py::TestTheXarrayExportHandlesAGroupedStore` and
  `::TestTheLazyExportResolvesTheSameNames`, and one test in `test_variable_names_invariance.py`).
  These keep `core` from the module and gain the skip, which is what the bare wheel needs.

Verified that only these two functions can pull xarray in: `import_xarray` has exactly two call sites in
`src/`, both inside the interop bridge (`interop.py:269` in `to_xarray`, `:592` in `from_xarray`). Every
other mention of xarray in `src/` is a comment or docstring, and `dataset/cog/facade.py` duck-types a
`DataArray` deliberately rather than importing one.

**2. The `viz` leg failed on a stale strict `xfail`, unrelated to any change here.**

`test_fig_alone_is_not_yet_supported` pinned serapeum-org/cleopatra#326 with `strict=True`. That issue
closed on 2026-09-05 and cleopatra **0.36.0** shipped the fix on 09-06; the wheel job installs the
latest from PyPI, so the test XPASSed and `strict` turned that into a failure. It would have gone red on
`main` on the next run regardless of what merged.

The pin is now gated on the installed version rather than removed, because the `[viz]` floor is
`>=0.31.0` and a supported environment may legitimately have either behaviour: below 0.36.0 it must
still raise, at 0.36.0 or above the success path must hold.

# Issues

- Closes #1109
- Closes #1110

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Test-only change; no source file is touched.

- [x] The 22 previously-failing tests no longer appear in a `core`-without-`interop` collection:
      `pytest -m "core and not vfs and not interop" tests/ --collect-only` → 8,945 collected,
      2,114 deselected, and none of the five affected modules/classes among them.
- [x] `pytest tests/dataset/plot/test_plot_facade.py -m plot` → 35 passed, 1 xfailed on the local
      cleopatra 0.33.0, which is the branch the version gate selects there. On 0.36.0 the gate is
      inactive and the success path runs — the XPASS in CI is the evidence it holds.
- [x] Version gate verified directly: `_CLEOPATRA_VERSION` parses to `(0, 33, 0)` locally and the
      `< (0, 36, 0)` condition is `True`.
- [x] `ruff check` and `ruff format --check` (with the 0.15.22 the pre-commit config pins) clean on all
      six touched files.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] documentation are updated.

## Known gap, not fixed here

`tests/guards/test_marker_hygiene.py` exists to catch exactly this and could not: it looks for a
module-level `import xarray` or `importorskip`, and these tests import nothing — they reach the optional
dependency at run time, through pyramids. Closing that needs more than a name-based heuristic
(`write_multidim_netcdf` matches on the word and needs no xarray at all), so it is left for its own
change rather than guessed at here.

