### PR TITLE
fix(netcdf): describe the cube in a container summary, not a raster it does not have

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -645,24 +645,34 @@ raster fields it has no raster for: for a 12x5x5 cube at 0.25 degrees it reporte
 Before, both types printed the same block — `Cell size`, `Dimension`, `EPSG`, `projection`,
 `Variables`, `Metadata`, `File` — every line indented by 12 spaces.
 
-After, a container describes the store:
+After, a container describes the store — this is the real output for
+`tests/data/netcdf/cf__5v__1d4-3d1__geog__y-desc.nc`:
 
 ```
-<Container cube.nc>
-  dimensions : time=12, x=5, y=5
+<Container cf__5v__1d4-3d1__geog__y-desc.nc>
+  dimensions : valid_time=12, latitude=5, longitude=5
   variables  :
-    t2m   (12, 5, 5)  float32  K
+    expver      (12)  unknown
+    latitude    (5)  float64  degrees_north
+    longitude   (5)  float64  degrees_east
+    t2m         (12, 5, 5)  float32  K
+    valid_time  (12)  int64  seconds since 1970-01-01
   groups     : none
   CRS        : EPSG:4326
-  attributes : 27 global
+  attributes : 6 global
 ```
+
+The listing is every array in the store, so the coordinate and auxiliary variables appear alongside the data
+variables — a wider set than `variable_names` returns. On a grouped store each row is labelled by its full
+`group/name` path, the way `variable_names` spells its names. At most ten rows are shown, followed by a
+`... N more` line; the `dimensions` and `groups` lines truncate the same way once they get long.
 
 and a variable describes the raster it is:
 
 ```
-<Variable t2m - cube.nc>
+<Variable t2m - cf__5v__1d4-3d1__geog__y-desc.nc>
   grid    : 5 x 5 @ 0.25, EPSG:4326
-  bands   : 12 along time
+  bands   : 12 along valid_time
   units   : K
   dtype   : float32
   no-data : nan
@@ -675,8 +685,13 @@ Three fields are gone from the text on purpose:
 - the whole **`meta_data`** object, replaced by a count of global attributes;
 - the leading **12 spaces** on every line, which came from the f-string being indented inside the method.
 
-`repr()` is unchanged. If you were parsing `str()`, read the properties instead: `nc.cell_size`, `nc.rows`,
-`nc.columns`, `nc.epsg`, `nc.crs`, `nc.variable_names`, `nc.meta_data`.
+**`repr()` is unchanged, and still shows the placeholder.** Only `str()` / `print(nc)` route to the new summary.
+`repr()` remains `gdal.Info` on the underlying raster, so a bare `nc` in a notebook cell, a debugger's variable
+pane and pytest's assertion output all still report `Size is 512, 512` for a container. Use `print(nc)` where you
+want the summary.
+
+If you were parsing `str()`, read the properties instead: `nc.cell_size`, `nc.rows`, `nc.columns`, `nc.epsg`,
+`nc.crs`, `nc.variable_names`, `nc.meta_data`.
 
 **`NetCDF.variable_names` answers a different question, so the set of names changes.** Hard change, silent —
 nothing raises and nothing warns, and both the membership and the order can move. The property used to hand

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -634,6 +634,50 @@ replace the georeference wholesale.
 
 ### unreleased
 
+**`str(nc)` is a different shape, and the summary now depends on whether you hold a container or a variable.**
+Hard change, silent — nothing raises and nothing warns. Anything scraping the old text (log parsing, notebook
+snapshots, doctests) will stop matching.
+
+`__str__` was defined once on `NetCDF` and inherited by `Container` and `Variable` alike, so a container printed
+raster fields it has no raster for: for a 12x5x5 cube at 0.25 degrees it reported `Dimension: 512 * 512` at
+`Cell size: 1.0` — GDAL's in-memory placeholder for a multidimensional store. The summary is now chosen by type.
+
+Before, both types printed the same block — `Cell size`, `Dimension`, `EPSG`, `projection`,
+`Variables`, `Metadata`, `File` — every line indented by 12 spaces.
+
+After, a container describes the store:
+
+```
+<Container cube.nc>
+  dimensions : time=12, x=5, y=5
+  variables  :
+    t2m   (12, 5, 5)  float32  K
+  groups     : none
+  CRS        : EPSG:4326
+  attributes : 27 global
+```
+
+and a variable describes the raster it is:
+
+```
+<Variable t2m - cube.nc>
+  grid    : 5 x 5 @ 0.25, EPSG:4326
+  bands   : 12 along time
+  units   : K
+  dtype   : float32
+  no-data : nan
+```
+
+Three fields are gone from the text on purpose:
+
+- the raw **projection WKT**, which ran to thousands of characters on one line — the CRS now prints as
+  `EPSG:4326`, or the CRS name when there is no authority code;
+- the whole **`meta_data`** object, replaced by a count of global attributes;
+- the leading **12 spaces** on every line, which came from the f-string being indented inside the method.
+
+`repr()` is unchanged. If you were parsing `str()`, read the properties instead: `nc.cell_size`, `nc.rows`,
+`nc.columns`, `nc.epsg`, `nc.crs`, `nc.variable_names`, `nc.meta_data`.
+
 **`NetCDF.variable_names` answers a different question, so the set of names changes.** Hard change, silent —
 nothing raises and nothing warns, and both the membership and the order can move. The property used to hand
 back the CF classification's own list; it now filters the store's declared list, which means it walks sub-groups

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -574,20 +574,21 @@ def _resolve_index_selector(selector: Any, size: int, dim_name: str) -> tuple[in
 def _collapse_uniform(values: Any) -> Any:
     """Collapse a per-band sequence to its single value when every band agrees.
 
-    A 12-band variable reports ``dtype`` as ``['float32'] * 12``, ``band_units`` as
-    ``[''] * 12`` and ``no_data_value`` as a 12-tuple of ``nan`` -- true, but unreadable
+    A 12-band variable reports `dtype` as `['float32'] * 12`, `band_units` as
+    `[''] * 12` and `no_data_value` as a 12-tuple of `nan` -- true, but unreadable
     in a summary (#1090). One distinct value collapses to that value; a genuinely mixed
     sequence is left alone, because there the per-band detail is the information.
 
-    ``nan`` is compared by identity as well as equality, since ``nan != nan`` would
-    otherwise make an all-``nan`` no-data tuple look mixed.
+    Bands are compared through `_same_value` rather than `==`, so an all-`nan` no-data
+    tuple collapses too: `nan != nan` would otherwise make it look mixed.
 
     Args:
         values: A per-band sequence, or any scalar (returned unchanged).
 
     Returns:
-        Any: The single shared value, the original sequence when it varies, or
-        ``None`` when it is empty.
+        Any: The single shared value when every band agrees, the per-band values as a
+            list when they do not, `None` for an empty sequence, and the argument
+            unchanged when it is neither a list nor a tuple.
 
     Examples:
         - A uniform sequence reports the one value it holds:
@@ -702,20 +703,22 @@ def _store_label(nc: NetCDF) -> tuple[str, bool]:
 def _same_value(left: Any, right: Any) -> bool:
     """Whether two per-band entries are the same value, for any type a band can carry.
 
-    ``==`` alone is not enough twice over: it is False for two ``nan``s, and for a numpy array
-    it returns an elementwise array that ``all()`` cannot take a truth value from. Identity is
-    tried first (the common case, since GDAL hands back the same object per band), then a
-    guarded equality, then the ``nan`` special case.
+    `==` alone is not enough twice over: it is False for two `nan`s, and for a numpy array
+    it returns an elementwise array that `all()` cannot take a truth value from. Identity is
+    tried first as a cheap short-circuit -- it settles the values a band shares by object,
+    such as `None` for an unset no-data or the interned empty unit string -- then a guarded
+    equality, then the `nan` special case. Values rebuilt per band (a dtype name, a `nan`
+    read back from GDAL) are distinct objects, so they fall through to those two.
 
     Args:
         left: One band's value.
         right: The value being compared against.
 
     Returns:
-        bool: ``True`` when the two should be treated as one value.
+        bool: `True` when the two should be treated as one value.
 
     Examples:
-        - Equal scalars match, and two ``nan``s do too:
+        - Equal scalars match, and two `nan`s do too:
             ```python
             >>> _same_value("float32", "float32")
             True
@@ -723,7 +726,7 @@ def _same_value(left: Any, right: Any) -> bool:
             True
 
             ```
-        - A value whose ``==`` is not a plain bool does not raise:
+        - A value whose `==` is not a plain bool does not raise:
             ```python
             >>> import numpy as np
             >>> _same_value(np.array([1, 2]), np.array([1, 2]))
@@ -740,17 +743,17 @@ def _same_value(left: Any, right: Any) -> bool:
 
 
 def _both_nan(left: Any, right: Any) -> bool:
-    """Whether both values are float ``nan`` -- the one case ``==`` gets wrong.
+    """Whether both values are float `nan` -- the one case `==` gets wrong.
 
     Args:
         left: First value; any type, including a non-numeric one.
         right: Second value.
 
     Returns:
-        bool: ``True`` only when both are ``nan``.
+        bool: `True` only when both are `nan`.
 
     Examples:
-        - Two ``nan``s count as equal, which ``==`` alone would deny:
+        - Two `nan`s count as equal, which `==` alone would deny:
             ```python
             >>> _both_nan(float("nan"), float("nan"))
             True
@@ -758,7 +761,7 @@ def _both_nan(left: Any, right: Any) -> bool:
             False
 
             ```
-        - Anything else is False, including a value ``np.isnan`` cannot take:
+        - Anything else is False, including a value `np.isnan` cannot take:
             ```python
             >>> _both_nan(float("nan"), 1.0)
             False
@@ -847,9 +850,9 @@ def _variable_table_lines(variables: dict[str, VariableInfo]) -> list[str]:
     Rows are labelled by the map's **key**, not by `info.name`. The map spans sub-groups and is
     keyed by the full store path (`group/name`), while `info.name` is only the leaf: a grouped
     store carries the same leaf in every group, so labelling by name printed `CO` and `air_press`
-    two and three times over with nothing to tell the rows apart. The key spells a name the way
-    `variable_names` spells its own, so the two read alike -- though this map is the wider one,
-    covering the coordinates and bounds that the data-variable list leaves out.
+    twice each and `UTC_time` three times, with nothing to tell the rows apart. The key spells a
+    name the way `variable_names` spells its own, so the two read alike -- though this map is the
+    wider one, covering the coordinates and bounds that the data-variable list leaves out.
 
     The labels are padded to a common width so the shapes line up in a terminal. Only the
     displayed labels take part in that width, so one very long path hidden behind the cap
@@ -857,11 +860,16 @@ def _variable_table_lines(variables: dict[str, VariableInfo]) -> list[str]:
 
     Args:
         variables: The store's arrays, keyed by full path -- `meta_data.variables`, which
-            includes coordinates and bounds, not just the data variables.
+            includes coordinates and bounds, not just the data variables. Must not be empty.
 
     Returns:
         list[str]: The `variables  :` header followed by one indented row per array, and a
             `... N more` line when the cap hid some.
+
+    Raises:
+        ValueError: `variables` is empty, so there is no label to size the column from.
+            The caller tests that first -- an empty map is the classic-mode case, which
+            falls back to `_variable_name_lines`.
     """
     lines = ["  variables  :"]
     shown = list(variables.items())[:MAX_DISPLAY_VARIABLES]
@@ -912,9 +920,12 @@ def _global_attribute_count(nc: NetCDF, published: bool) -> int:
     on the rest. The already-open handle's `NC_GLOBAL#`-prefixed keys match the
     multidimensional count on 21 of the 22 classic-openable fixtures, so the handle answers.
 
-    This is an accuracy fix, not a speed one: in classic mode `meta_data` costs about 0.4 ms
-    and opens no file. (The three `gdal.Open` calls a classic `print(nc)` does make come from
-    the CRS lookup, which pays for a line the summary actually prints.)
+    This is an accuracy fix, not a speed one: in classic mode `meta_data` is cheap and this
+    function opens no file, reading `GetMetadata()` off the already-open handle. Whatever
+    opens a classic `print(nc)` does make come from the CRS lookup -- across the 22
+    classic-openable fixtures that is anywhere from 0 to 240 of them, and in every one of the
+    22 the count matches `_crs_label()` called alone -- and they pay for a line the summary
+    actually prints.
 
     Args:
         nc: The container to count for.
@@ -1008,15 +1019,15 @@ def _grid_lines(nc: NetCDF) -> list[str]:
 def _container_summary(nc: NetCDF) -> str:
     """Describe the store, reporting only what this container can actually know.
 
-    Sourced from ``meta_data.variables`` -- a ``dict[str, VariableInfo]`` carrying
+    Sourced from `meta_data.variables` -- a `dict[str, VariableInfo]` carrying
     name / shape / dtype / unit for every array including the coordinates. Looping
-    ``get_variable()`` instead would raise on every non-raster variable and produce a wall of
+    `get_variable()` instead would raise on every non-raster variable and produce a wall of
     text (#1090).
 
     This is the summary that costs something. In multidimensional mode the first call builds
     :attr:`meta_data`, which walks every array in the store: ~44 ms and one file open locally,
-    cached from then on, so a second ``print(nc)`` is ~0.5 ms. That is the same cost the
-    previous summary paid -- it interpolated ``meta_data`` too. The variable summary pays none
+    cached from then on, so a second `print(nc)` is ~0.5 ms. That is the same cost the
+    previous summary paid -- it interpolated `meta_data` too. The variable summary pays none
     of it.
 
     That list is deliberately **not** :attr:`variable_names`: it enumerates every array, so it
@@ -1024,27 +1035,27 @@ def _container_summary(nc: NetCDF) -> str:
     in metadata order rather than the store's declared one. A structural summary wants the whole
     picture; a caller asking "what can I extract" wants :attr:`variable_names`.
 
-    ``none`` is printed only where it is a fact. In multidimensional mode the store
+    `none` is printed only where it is a fact. In multidimensional mode the store
     publishes its dimensions, variables and groups, so an empty one genuinely means there
     are none. Classic (non-MDIM) mode publishes no such metadata at all, so the same word
     there would be a positive false claim about a store that does have dimensions -- those
-    lines are omitted instead, and the variable list falls back to ``variable_names``.
+    lines are omitted instead, and the variable list falls back to `variable_names`.
 
-    That fallback is thin: ``variable_names`` in classic mode parses subdataset metadata, and a
-    store whose bands GDAL exposes directly has no subdatasets, so it answers ``[]`` for nine
+    That fallback is thin: `variable_names` in classic mode parses subdataset metadata, and a
+    store whose bands GDAL exposes directly has no subdatasets, so it answers `[]` for nine
     of the eleven banded classic fixtures in the corpus and the line is omitted for them. It
     still earns its place for the subdataset-style stores, where it is the only variable
     listing available.
 
     The raster block appears only when the container carries bands. An MDIM container has
-    none -- that is the #1090 defect, where ``rows`` / ``columns`` / ``cell_size`` returned
+    none -- that is the #1090 defect, where `rows` / `columns` / `cell_size` returned
     GDAL's in-memory placeholder -- but a classic-mode container exposes the store's bands
     directly, and there those numbers are the real grid.
 
     The cell size within that block is dropped when GDAL reports no geotransform for the store.
-    A curvilinear or unstructured store has no affine mapping, so ``cell_size`` there is 1.0 by
+    A curvilinear or unstructured store has no affine mapping, so `cell_size` there is 1.0 by
     construction rather than by measurement; the shape and band count are still real, so the
-    line stays and only the ``@ ...`` term goes.
+    line stays and only the `@ ...` term goes.
 
     Args:
         nc: The container to describe.
@@ -1085,19 +1096,21 @@ def _variable_summary(nc: NetCDF) -> str:
     """Describe the raster this variable genuinely is.
 
     Per-band sequences are collapsed when uniform: a 12-band variable reports
-    ``float32`` rather than ``['float32'] * 12``. The band axis is named by its
-    dimension (``12 along time``) rather than ``Band_1 ... Band_12``, because the
+    `float32` rather than `['float32'] * 12`. The band axis is named by its
+    dimension (`12 along time`) rather than `Band_1 ... Band_12`, because the
     raster vocabulary for a time axis is a standing source of confusion (#1090).
 
-    Reads no pixels, computes no statistics, and touches no metadata: it reads band-level
-    properties only, so it performs no I/O and costs about 0.0 ms on an already-extracted
-    variable. The walk of the store was paid by :meth:`get_variable` before the caller could
-    hold a variable at all (~36 ms locally, one file open).
+    Reads no pixels, computes no statistics, and never builds :attr:`meta_data`: it reads
+    band-level properties off the open handle, so it opens no file. What it does cost is a
+    few milliseconds of per-band property reads -- most of it :attr:`dtype`, which resolves
+    each band through the dtype catalog -- not a walk of the store. That walk was paid by
+    :meth:`get_variable` before the caller could hold a variable at all (~36 ms locally,
+    one file open).
 
-    Note that ``repr()`` is a different contract and is unchanged -- it is still
-    ``gdal.Info``, so the surfaces that auto-display an object (a notebook cell, a debugger's
-    variable pane, pytest's assertion output) still show GDAL's ``Size is 512, 512``
-    placeholder for a container. Only ``str()`` / ``print()`` route here.
+    Note that `repr()` is a different contract and is unchanged -- it is still
+    `gdal.Info`, so the surfaces that auto-display an object (a notebook cell, a debugger's
+    variable pane, pytest's assertion output) still show GDAL's `Size is 512, 512`
+    placeholder for a container. Only `str()` / `print()` route here.
 
     Args:
         nc: The variable to describe.
@@ -1478,14 +1491,14 @@ class NetCDF(Dataset):
         The summary is chosen by **type**, through :meth:`_summary_text`, which
         :class:`Container` and :class:`Variable` override. Defining one summary here and
         letting both inherit it made the container describe raster fields it does not have:
-        ``rows`` / ``columns`` / ``cell_size`` fell through to GDAL's in-memory placeholder,
+        `rows` / `columns` / `cell_size` fell through to GDAL's in-memory placeholder,
         so a 12x5x5 cube at 0.25 degrees reported itself as 512 x 512 at cell size 1.0
         (#1090).
 
-        Type rather than ``band_count``: a container opened in classic mode carries the
-        store's bands directly, so ``band_count >= 1`` there and a band-count test would
-        label it a variable. The classes already encode the distinction ``read_file`` and
-        ``get_variable`` established, so they are the discriminator.
+        Type rather than `band_count`: a container opened in classic mode carries the
+        store's bands directly, so `band_count >= 1` there and a band-count test would
+        label it a variable. The classes already encode the distinction `read_file` and
+        `get_variable` established, so they are the discriminator.
 
         Mirrors `Dataset.__str__`: a closed handle returns the sentinel rather than
         raising, so the repr/str stays total for debuggers and logging (`__repr__`
@@ -1497,6 +1510,11 @@ class NetCDF(Dataset):
         notebook cell, a debugger's variable pane and pytest's assertion output all call
         `repr`, and a container still shows `Size is 512, 512` there. Reworking that is a
         separate question about `Dataset.__repr__` and its `gdal.Info` contract.
+
+        Returns:
+            str: The type-specific summary; `<Dataset: closed>` when the handle is closed,
+                or `<Container: summary unavailable>` / `<Variable: summary unavailable>`
+                when building the summary raised.
         """
         message = "<Dataset: closed>"
         if self._raster is not None:
@@ -1516,7 +1534,7 @@ class NetCDF(Dataset):
         return message
 
     def _summary_text(self) -> str:
-        """The summary body for a bare ``NetCDF``, which neither factory produces.
+        """The summary body for a bare `NetCDF`, which neither factory produces.
 
         :class:`Container` and :class:`Variable` override this; the base only has to cope
         with an instance of the deprecated alias itself. It defers to
@@ -1531,7 +1549,7 @@ class NetCDF(Dataset):
         return _variable_summary(self)
 
     def _crs_label(self) -> str:
-        """The CRS as a short label -- ``EPSG:4326``, a CRS name, or ``unknown``.
+        """The CRS as a short label -- `EPSG:4326`, a CRS name, or `unknown`.
 
         Never the raw WKT: it is thousands of characters on one line and drowns every
         other line of the summary (#1090).
@@ -9139,7 +9157,11 @@ class Variable(NetCDF):
         return None
 
     def _summary_text(self) -> str:
-        """Describe the raster this variable is; see :func:`_variable_summary`."""
+        """Describe the raster this variable is; see :func:`_variable_summary`.
+
+        Returns:
+            str: A short multi-line variable summary.
+        """
         return _variable_summary(self)
 
 
@@ -9171,5 +9193,9 @@ class Container(NetCDF):
     """
 
     def _summary_text(self) -> str:
-        """Describe the cube this container is; see :func:`_container_summary`."""
+        """Describe the cube this container is; see :func:`_container_summary`.
+
+        Returns:
+            str: A short multi-line container summary.
+        """
         return _container_summary(self)

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -35,7 +35,7 @@ from pyramids.base.crs import (
 )
 from pyramids.base.georeference import GeoReference
 from pyramids.base.protocols import ArrayLike
-from pyramids.base.remote import is_remote
+from pyramids.base.remote import is_remote, redact_credentials
 from pyramids.dataset import Dataset
 from pyramids.dataset._plot_helpers import nonnull_group_kwargs
 from pyramids.dataset.abstract_dataset import DEFAULT_NO_DATA_VALUE
@@ -628,6 +628,12 @@ def _store_label(nc: NetCDF) -> tuple[str, bool]:
     two distinguishable. The in-memory verdict is returned alongside the label rather than
     recovered by comparing it to `"in-memory"`, because that suffix defeats the comparison.
 
+    The base name goes through `redact_credentials` first. `file_name` is the dataset's GDAL
+    description, so a remote open keeps its query string, and the base name of
+    `/vsis3/bucket/cube.nc?X-Amz-Signature=...` still carries the signature. `str()` reaches
+    every log handler and pytest's assertion output, which is why `Dataset.__repr__` redacts
+    too.
+
     Args:
         nc: The container or variable to label.
 
@@ -663,6 +669,15 @@ def _store_label(nc: NetCDF) -> tuple[str, bool]:
             ('in-memory', True)
 
             ```
+        - A signed remote path keeps its name and loses its credentials:
+            ```python
+            >>> class _Signed:
+            ...     file_name = "/vsis3/bucket/cube.nc?X-Amz-Signature=deadbeef"
+            ...     driver_type = "netcdf"
+            >>> _store_label(_Signed())
+            ('cube.nc?X-Amz-Signature=<redacted>', False)
+
+            ```
     """
     source = getattr(nc, "file_name", "") or ""
     in_memory = (
@@ -670,7 +685,7 @@ def _store_label(nc: NetCDF) -> tuple[str, bool]:
         or source.startswith("/vsimem/")
         or getattr(nc, "driver_type", None) == "memory"
     )
-    label = "in-memory" if in_memory else Path(source).name
+    label = "in-memory" if in_memory else redact_credentials(Path(source).name)
     group = getattr(nc, "_group_path", None)
     if group:
         label = f"{label}:/{group}"

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -577,6 +577,28 @@ def _collapse_uniform(values: Any) -> Any:
     Returns:
         Any: The single shared value, the original sequence when it varies, or
         ``None`` when it is empty.
+
+    Examples:
+        - A uniform sequence reports the one value it holds:
+            ```python
+            >>> _collapse_uniform(["float32", "float32", "float32"])
+            'float32'
+
+            ```
+        - A sequence that genuinely varies keeps its per-band detail:
+            ```python
+            >>> _collapse_uniform(["float32", "int16"])
+            ['float32', 'int16']
+
+            ```
+        - An empty sequence has nothing to report, and a scalar is already collapsed:
+            ```python
+            >>> _collapse_uniform([]) is None
+            True
+            >>> _collapse_uniform("float32")
+            'float32'
+
+            ```
     """
     if not isinstance(values, (list, tuple)):
         return values
@@ -588,7 +610,33 @@ def _collapse_uniform(values: Any) -> Any:
 
 
 def _both_nan(left: Any, right: Any) -> bool:
-    """Whether both values are float ``nan`` -- the one case ``==`` gets wrong."""
+    """Whether both values are float ``nan`` -- the one case ``==`` gets wrong.
+
+    Args:
+        left: First value; any type, including a non-numeric one.
+        right: Second value.
+
+    Returns:
+        bool: ``True`` only when both are ``nan``.
+
+    Examples:
+        - Two ``nan``s count as equal, which ``==`` alone would deny:
+            ```python
+            >>> _both_nan(float("nan"), float("nan"))
+            True
+            >>> float("nan") == float("nan")
+            False
+
+            ```
+        - Anything else is False, including a value ``np.isnan`` cannot take:
+            ```python
+            >>> _both_nan(float("nan"), 1.0)
+            False
+            >>> _both_nan("K", "K")
+            False
+
+            ```
+    """
     try:
         return bool(np.isnan(left) and np.isnan(right))
     except (TypeError, ValueError):

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -895,6 +895,36 @@ def _variable_name_lines(names: list[str], published: bool) -> list[str]:
     return lines
 
 
+def _global_attribute_count(nc: NetCDF, published: bool) -> int:
+    """How many global attributes the store carries.
+
+    In multidimensional mode `meta_data` is the source, and the summary is already paying for
+    it to list the variables. In classic mode it is the wrong source: the classic metadata
+    top-up leaves `global_attributes` empty on more than half the corpus -- reporting no
+    attributes for a store that has eighteen -- and disagrees with the multidimensional count
+    on the rest. The already-open handle's `NC_GLOBAL#`-prefixed keys match the
+    multidimensional count on 21 of the 22 classic-openable fixtures, so the handle answers.
+
+    This is an accuracy fix, not a speed one: in classic mode `meta_data` costs about 0.4 ms
+    and opens no file. (The three `gdal.Open` calls a classic `print(nc)` does make come from
+    the CRS lookup, which pays for a line the summary actually prints.)
+
+    Args:
+        nc: The container to count for.
+        published: Whether the store publishes multidimensional metadata.
+
+    Returns:
+        int: The number of global attributes.
+    """
+    if published:
+        count = len(nc.meta_data.global_attributes or {})
+    else:
+        raster = getattr(nc, "_raster", None)
+        metadata = (raster.GetMetadata() if raster is not None else None) or {}
+        count = sum(1 for key in metadata if key.startswith("NC_GLOBAL#"))
+    return count
+
+
 def _container_summary(nc: NetCDF) -> str:
     """Describe the store, reporting only what this container can actually know.
 
@@ -912,8 +942,13 @@ def _container_summary(nc: NetCDF) -> str:
     publishes its dimensions, variables and groups, so an empty one genuinely means there
     are none. Classic (non-MDIM) mode publishes no such metadata at all, so the same word
     there would be a positive false claim about a store that does have dimensions -- those
-    lines are omitted instead, and the variable list falls back to ``variable_names``,
-    which classic mode does answer.
+    lines are omitted instead, and the variable list falls back to ``variable_names``.
+
+    That fallback is thin: ``variable_names`` in classic mode parses subdataset metadata, and a
+    store whose bands GDAL exposes directly has no subdatasets, so it answers ``[]`` for nine
+    of the eleven banded classic fixtures in the corpus and the line is omitted for them. It
+    still earns its place for the subdataset-style stores, where it is the only variable
+    listing available.
 
     The raster block appears only when the container carries bands. An MDIM container has
     none -- that is the #1090 defect, where ``rows`` / ``columns`` / ``cell_size`` returned
@@ -940,7 +975,10 @@ def _container_summary(nc: NetCDF) -> str:
         dims = _capped_join([f"{name}={size}" for name, size in sizes.items()])
         lines.append(f"  dimensions : {dims or 'none'}")
 
-    variables = nc.meta_data.variables or {}
+    # Classic mode never populates `meta_data.variables` -- true for all 22 classic-openable
+    # corpus fixtures -- so the table branch is unreachable there and the fallback is the
+    # only listing; skipping the lookup keeps that explicit rather than incidental.
+    variables = (nc.meta_data.variables or {}) if published else {}
     if variables:
         lines.extend(_variable_table_lines(variables))
     else:
@@ -960,9 +998,9 @@ def _container_summary(nc: NetCDF) -> str:
         joined = _capped_join(list(groups))
         lines.append(f"  groups     : {joined or 'none'}")
     lines.append(f"  CRS        : {nc._crs_label()}")
-    attributes = nc.meta_data.global_attributes or {}
+    attributes = _global_attribute_count(nc, published)
     if attributes or published:
-        lines.append(f"  attributes : {len(attributes)} global")
+        lines.append(f"  attributes : {attributes} global")
     return "\n".join(lines)
 
 

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -613,44 +613,68 @@ def _collapse_uniform(values: Any) -> Any:
     return first if uniform else list(values)
 
 
-def _store_label(nc: NetCDF) -> str:
+def _store_label(nc: NetCDF) -> tuple[str, bool]:
     """A short name for the store behind `nc`, for a summary header.
 
-    ``file_name`` is not always a path. An in-memory result built by an operation such as
-    ``to_crs`` carries the driver name (``"netcdf"``), which would read as a filename in the
-    header; anything without a suffix is treated as in-memory instead. A ``get_group()`` view
-    shares its root's path, so the group path is appended to keep the two distinguishable.
+    `file_name` is not always a path. An in-memory result built by an operation such as
+    `to_crs` carries the driver name (`"netcdf"`), which would read as a filename in the
+    header. The reliable signal is the driver, not the path -- `abstract_dataset.py` states
+    the same rule for `_require_writable`: in-memory means the `memory` driver, a `/vsimem/`
+    path, or no path at all. Testing the path for a suffix instead would call a real
+    extensionless file -- `mkstemp` output, an OPeNDAP endpoint, a content-typed download --
+    `in-memory`, which is a false claim about where the data came from.
+
+    A `get_group()` view shares its root's path, so the group path is appended to keep the
+    two distinguishable. The in-memory verdict is returned alongside the label rather than
+    recovered by comparing it to `"in-memory"`, because that suffix defeats the comparison.
 
     Args:
         nc: The container or variable to label.
 
     Returns:
-        str: A file name, optionally with a group path, or ``"in-memory"``.
+        tuple[str, bool]: The label -- a file name, optionally with a group path, or
+            `"in-memory"` -- and whether the store is in memory.
 
     Examples:
         - A plain filename is reduced to its base name:
             ```python
             >>> class _Store:
             ...     file_name = "/data/archive/cube.nc"
+            ...     driver_type = "netcdf"
             >>> _store_label(_Store())
-            'cube.nc'
+            ('cube.nc', False)
 
             ```
-        - A driver name is not a path, so it reads as in-memory:
+        - An extensionless path is still a real file:
+            ```python
+            >>> class _NoSuffix:
+            ...     file_name = "/tmp/tmpab12cd/cube"
+            ...     driver_type = "netcdf"
+            >>> _store_label(_NoSuffix())
+            ('cube', False)
+
+            ```
+        - The `memory` driver is what makes a store in-memory, whatever its `file_name` says:
             ```python
             >>> class _InMemory:
             ...     file_name = "netcdf"
+            ...     driver_type = "memory"
             >>> _store_label(_InMemory())
-            'in-memory'
+            ('in-memory', True)
 
             ```
     """
     source = getattr(nc, "file_name", "") or ""
-    label = Path(source).name if source and Path(source).suffix else "in-memory"
+    in_memory = (
+        not source
+        or source.startswith("/vsimem/")
+        or getattr(nc, "driver_type", None) == "memory"
+    )
+    label = "in-memory" if in_memory else Path(source).name
     group = getattr(nc, "_group_path", None)
     if group:
         label = f"{label}:/{group}"
-    return label
+    return label, in_memory
 
 
 def _same_value(left: Any, right: Any) -> bool:
@@ -822,7 +846,8 @@ def _container_summary(nc: NetCDF) -> str:
     Returns:
         str: A short multi-line summary.
     """
-    lines = [f"<Container {_store_label(nc)}>"]
+    label, _ = _store_label(nc)
+    lines = [f"<Container {label}>"]
     published = nc._is_md_array
 
     sizes = nc.dimension_sizes or {}
@@ -880,10 +905,10 @@ def _variable_summary(nc: NetCDF) -> str:
     # A variable subset's raster is an in-memory MDArray view, so it has no path of its own;
     # the container it came from does.
     parent = getattr(nc, "_parent_nc", None)
-    label = _store_label(nc)
-    if label == "in-memory" and parent is not None:
-        label = _store_label(parent)
-    header = f"<Variable {name}" + (f" - {label}" if label != "in-memory" else "")
+    label, in_memory = _store_label(nc)
+    if in_memory and parent is not None:
+        label, in_memory = _store_label(parent)
+    header = f"<Variable {name}" + ("" if in_memory else f" - {label}")
     lines = [header + ">"]
 
     # `cell_size` is always a float, and `:g` trims the trailing zeros that make a summary

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import gc
 import itertools
+import logging
 import math
 import os
 import threading
@@ -138,6 +139,12 @@ _RESERVED_ACCESSOR_NAMES.update(_NETCDF_COLLABORATOR_ATTRS)
 # it is here so a malformed or hostile one cannot turn enumeration into an
 # unbounded walk.
 _MAX_GROUP_DEPTH = 32
+
+
+# Module-level logger, matching `pyramids.netcdf.metadata`: the summary helpers swallow
+# every exception so `str()` stays total for debuggers and logging, and a swallowed error
+# that logs nothing is one nobody can diagnose. Both handlers report through this at DEBUG.
+logger = logging.getLogger(__name__)
 
 
 class _LazyVariableDict(dict):
@@ -1411,12 +1418,16 @@ class NetCDF(Dataset):
         if self._raster is not None:
             try:
                 message = self._summary_text()
-            except Exception:
+            except Exception as error:
                 # Total by contract, not just for a closed handle. `str()` runs in debuggers,
                 # logging and pytest introspection, where a raising summary masks the error the
                 # caller was actually looking at. The summary walks a dozen properties, any of
                 # which can fail on a half-built or exotic store, so degrade to a sentinel that
-                # still says what this is.
+                # still says what this is -- and log what went wrong, so the failure is
+                # diagnosable rather than merely survivable.
+                logger.debug(
+                    "%s summary failed: %r", type(self).__name__, error, exc_info=True
+                )
                 message = f"<{type(self).__name__}: summary unavailable>"
         return message
 
@@ -1454,7 +1465,10 @@ class NetCDF(Dataset):
                 if wkt:
                     name = osr.SpatialReference(wkt=wkt).GetName()
                     label = name or "unknown"
-        except Exception:
+        except Exception as error:
+            # `unknown` is also what a store with no CRS reports, so a genuine `epsg` / `crs`
+            # bug would be indistinguishable from an honest absence without this line.
+            logger.debug("CRS label failed: %r", error, exc_info=True)
             label = "unknown"
         return label
 

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -932,6 +932,79 @@ def _global_attribute_count(nc: NetCDF, published: bool) -> int:
     return count
 
 
+def _summary_line(label: str, value: str) -> str:
+    """One `  label      : value` line, with the label padded to the shared column.
+
+    Args:
+        label: The field name, unpadded.
+        value: The rendered value.
+
+    Returns:
+        str: The formatted line.
+
+    Examples:
+        - Every label lands the colons in the same column:
+            ```python
+            >>> _summary_line("CRS", "EPSG:4326")
+            '  CRS        : EPSG:4326'
+            >>> _summary_line("dimensions", "time=12")
+            '  dimensions : time=12'
+
+            ```
+    """
+    return f"  {label:<11}: {value}"
+
+
+def _optional_line(label: str, value: str, published: bool) -> list[str]:
+    """One summary line, or nothing when the store cannot answer the question.
+
+    `none` is a positive claim, so it is printed only where it is a fact. A multidimensional
+    store publishes its structure, so an empty value there genuinely means none; a classic
+    store publishes nothing, so the line is omitted rather than asserting an absence.
+
+    Args:
+        label: The field name.
+        value: The rendered value, empty when there is nothing to show.
+        published: Whether the store publishes its structure.
+
+    Returns:
+        list[str]: One line, or an empty list.
+    """
+    lines: list[str] = []
+    if value or published:
+        lines.append(_summary_line(label, value or "none"))
+    return lines
+
+
+def _grid_lines(nc: NetCDF) -> list[str]:
+    """The raster block, for a container that carries bands.
+
+    An MDIM container has none -- that is the #1090 defect, where `rows` / `columns` /
+    `cell_size` returned GDAL's in-memory placeholder -- but a classic-mode container exposes
+    the store's bands directly, and there those numbers are the real grid.
+
+    The cell size is dropped when GDAL reports no geotransform: a curvilinear or unstructured
+    store has no affine mapping, so `cell_size` there is 1.0 by construction rather than by
+    measurement. The shape and band count are still real, so only the `@ ...` term goes.
+
+    Args:
+        nc: The container to describe.
+
+    Returns:
+        list[str]: The `grid` line, or an empty list when there are no bands.
+    """
+    lines: list[str] = []
+    if nc.band_count:
+        grid = f"{nc.rows} x {nc.columns}"
+        if _has_georeference(nc):
+            # `cell_size` is always a float, and `:g` trims the trailing zeros that make a
+            # summary unreadable -- at the cost of rounding to 6 significant digits, so read
+            # the value from `cell_size` rather than from this line when it matters.
+            grid += f" @ {nc.cell_size:g}"
+        lines.append(_summary_line("grid", f"{grid}, {nc.band_count} band(s)"))
+    return lines
+
+
 def _container_summary(nc: NetCDF) -> str:
     """Describe the store, reporting only what this container can actually know.
 
@@ -984,9 +1057,8 @@ def _container_summary(nc: NetCDF) -> str:
     published = nc._is_md_array
 
     sizes = nc.dimension_sizes or {}
-    if sizes or published:
-        dims = _capped_join([f"{name}={size}" for name, size in sizes.items()])
-        lines.append(f"  dimensions : {dims or 'none'}")
+    dims = _capped_join([f"{name}={size}" for name, size in sizes.items()])
+    lines.extend(_optional_line("dimensions", dims, published))
 
     # Classic mode never populates `meta_data.variables` -- true for all 22 classic-openable
     # corpus fixtures -- so the table branch is unreachable there and the fallback is the
@@ -997,23 +1069,15 @@ def _container_summary(nc: NetCDF) -> str:
     else:
         lines.extend(_variable_name_lines(nc.variable_names or [], published))
 
-    if nc.band_count:
-        grid = f"  grid       : {nc.rows} x {nc.columns}"
-        if _has_georeference(nc):
-            # `cell_size` is always a float, and `:g` trims the trailing zeros that make a
-            # summary unreadable -- at the cost of rounding to 6 significant digits, so read
-            # the value from `cell_size` rather than from this line when it matters.
-            grid += f" @ {nc.cell_size:g}"
-        lines.append(f"{grid}, {nc.band_count} band(s)")
-
-    groups = nc.group_names or []
-    if groups or published:
-        joined = _capped_join(list(groups))
-        lines.append(f"  groups     : {joined or 'none'}")
-    lines.append(f"  CRS        : {nc._crs_label()}")
+    lines.extend(_grid_lines(nc))
+    groups = _capped_join(list(nc.group_names or []))
+    lines.extend(_optional_line("groups", groups, published))
+    lines.append(_summary_line("CRS", nc._crs_label()))
     attributes = _global_attribute_count(nc, published)
     if attributes or published:
-        lines.append(f"  attributes : {attributes} global")
+        # Not `_optional_line`: an MDIM store with no global attributes reports
+        # "0 global", which is a fact, where that helper would render "none".
+        lines.append(_summary_line("attributes", f"{attributes} global"))
     return "\n".join(lines)
 
 

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -82,7 +82,7 @@ from pyramids.netcdf.engines.interop import Interop
 from pyramids.netcdf.engines.selection import Selection
 from pyramids.netcdf.engines.variables import Variables
 from pyramids.netcdf.metadata import get_metadata
-from pyramids.netcdf.models import NetCDFMetadata
+from pyramids.netcdf.models import MAX_DISPLAY_VARIABLES, NetCDFMetadata
 from pyramids.netcdf.plot_options import CoordinateSpec, FacetSpec, Selectors
 from pyramids.netcdf.utils import (
     _read_attributes,
@@ -560,6 +560,134 @@ def _resolve_index_selector(selector: Any, size: int, dim_name: str) -> tuple[in
     return index, index + 1
 
 
+def _collapse_uniform(values: Any) -> Any:
+    """Collapse a per-band sequence to its single value when every band agrees.
+
+    A 12-band variable reports ``dtype`` as ``['float32'] * 12``, ``band_units`` as
+    ``[''] * 12`` and ``no_data_value`` as a 12-tuple of ``nan`` -- true, but unreadable
+    in a summary (#1090). One distinct value collapses to that value; a genuinely mixed
+    sequence is left alone, because there the per-band detail is the information.
+
+    ``nan`` is compared by identity as well as equality, since ``nan != nan`` would
+    otherwise make an all-``nan`` no-data tuple look mixed.
+
+    Args:
+        values: A per-band sequence, or any scalar (returned unchanged).
+
+    Returns:
+        Any: The single shared value, the original sequence when it varies, or
+        ``None`` when it is empty.
+    """
+    if not isinstance(values, (list, tuple)):
+        return values
+    if not values:
+        return None
+    first = values[0]
+    uniform = all(v is first or v == first or _both_nan(v, first) for v in values)
+    return first if uniform else list(values)
+
+
+def _both_nan(left: Any, right: Any) -> bool:
+    """Whether both values are float ``nan`` -- the one case ``==`` gets wrong."""
+    try:
+        return bool(np.isnan(left) and np.isnan(right))
+    except (TypeError, ValueError):
+        return False
+
+
+def _container_summary(nc: NetCDF) -> str:
+    """Describe the cube, never a raster.
+
+    Sourced from ``meta_data.variables`` -- a ``dict[str, VariableInfo]`` carrying
+    name / shape / dtype / unit for every array including the coordinates, costed once
+    for the whole store. Looping ``get_variable()`` instead would raise on every
+    non-raster variable and produce a wall of text (#1090).
+
+    Prints no ``rows`` / ``columns`` / ``cell_size`` / ``band_count``: a container has
+    no raster behind those, which is the whole defect this replaces.
+
+    Returns:
+        str: A short multi-line summary.
+    """
+    source = nc.file_name
+    lines = [f"<Container {Path(source).name if source else 'in-memory'}>"]
+
+    sizes = nc.dimension_sizes or {}
+    dims = ", ".join(f"{name}={size}" for name, size in sizes.items())
+    lines.append(f"  dimensions : {dims or 'none'}")
+
+    variables = nc.meta_data.variables or {}
+    if not variables:
+        lines.append("  variables  : none")
+    else:
+        lines.append("  variables  :")
+        shown = list(variables.values())[:MAX_DISPLAY_VARIABLES]
+        width = max(len(info.name) for info in shown)
+        for info in shown:
+            shape = "(" + ", ".join(str(n) for n in info.shape) + ")"
+            row = f"    {info.name:<{width}}  {shape}  {info.dtype}"
+            if info.unit:
+                row += f"  {info.unit}"
+            lines.append(row)
+        hidden = len(variables) - len(shown)
+        if hidden > 0:
+            lines.append(f"    ... {hidden} more")
+
+    groups = nc.group_names or []
+    lines.append(f"  groups     : {', '.join(groups) if groups else 'none'}")
+    lines.append(f"  CRS        : {nc._crs_label()}")
+    lines.append(f"  attributes : {len(nc.meta_data.global_attributes or {})} global")
+    return "\n".join(lines)
+
+
+def _variable_summary(nc: NetCDF) -> str:
+    """Describe the raster this variable genuinely is.
+
+    Per-band sequences are collapsed when uniform: a 12-band variable reports
+    ``float32`` rather than ``['float32'] * 12``. The band axis is named by its
+    dimension (``12 along time``) rather than ``Band_1 ... Band_12``, because the
+    raster vocabulary for a time axis is a standing source of confusion (#1090).
+
+    Stays cheap -- no band reads and no ``stats()`` -- since ``str()`` runs in
+    debuggers, logging and pytest introspection.
+
+    Returns:
+        str: A short multi-line summary.
+    """
+    name = nc._source_var_name or "?"
+    header = f"<Variable {name}"
+    # A variable subset's raster is an in-memory MDArray view, so it has no path of
+    # its own; the container it came from does.
+    parent = getattr(nc, '_parent_nc', None)
+    source = nc.file_name or (parent.file_name if parent is not None else '')
+    if source:
+        header += f" - {Path(source).name}"
+    lines = [header + ">"]
+
+    cell = nc.cell_size
+    cell_text = f"{cell:g}" if isinstance(cell, (int, float)) else str(cell)
+    lines.append(
+        f"  grid    : {nc.rows} x {nc.columns} @ {cell_text}, {nc._crs_label()}"
+    )
+
+    band_axis = nc._band_dim_name
+    bands = f"  bands   : {nc.band_count}"
+    if band_axis:
+        bands += f" along {band_axis}"
+    lines.append(bands)
+
+    units = _collapse_uniform(nc.band_units)
+    if units:
+        lines.append(f"  units   : {units}")
+    dtype = _collapse_uniform(nc.dtype)
+    if dtype:
+        lines.append(f"  dtype   : {dtype}")
+    nodata = _collapse_uniform(nc.no_data_value)
+    if nodata is not None:
+        lines.append(f"  no-data : {nodata}")
+    return "\n".join(lines)
+
+
 class NetCDF(Dataset):
     """NetCDF.
 
@@ -892,22 +1020,51 @@ class NetCDF(Dataset):
     def __str__(self):
         """Return a human-readable summary, or a `<Dataset: closed>` sentinel when closed.
 
+        Dispatches on the identity the class docstrings already use: a container is not a
+        raster (``band_count == 0``), a variable is (``band_count >= 1``). Defining one
+        summary here and letting both inherit it made the container describe raster fields
+        it does not have -- ``rows`` / ``columns`` / ``cell_size`` fell through to GDAL's
+        in-memory placeholder, so a 12x5x5 cube at 0.25 degrees reported itself as
+        512 x 512 at cell size 1.0 (#1090).
+
+        A bare ``NetCDF`` is never produced -- ``read_file`` returns a
+        :class:`Container` and ``get_variable`` a :class:`Variable` -- so this base
+        implementation only routes.
+
         Mirrors `Dataset.__str__`: a closed handle returns the sentinel rather than
         raising, so the repr/str stays total for debuggers and logging (`__repr__`
         already inherits this via `super()`).
         """
-        message = "<Dataset: closed>"
-        if self._raster is not None:
-            message = f"""
-            Cell size: {self.cell_size}
-            Dimension: {self.rows} * {self.columns}
-            EPSG: {self.epsg}
-            projection: {self.crs}
-            Variables: {self.variable_names}
-            Metadata: {self.meta_data}
-            File: {self.file_name}
-        """
+        if self._raster is None:
+            message = "<Dataset: closed>"
+        elif self.band_count == 0:
+            message = _container_summary(self)
+        else:
+            message = _variable_summary(self)
         return message
+
+    def _crs_label(self) -> str:
+        """The CRS as a short label -- ``EPSG:4326``, a CRS name, or ``unknown``.
+
+        Never the raw WKT: it is thousands of characters on one line and drowns every
+        other line of the summary (#1090).
+
+        Returns:
+            str: A one-line CRS label.
+        """
+        label = "unknown"
+        try:
+            epsg = self.epsg
+            if epsg:
+                label = f"EPSG:{epsg}"
+            else:
+                wkt = self.crs
+                if wkt:
+                    name = osr.SpatialReference(wkt=wkt).GetName()
+                    label = name or "unknown"
+        except Exception:
+            label = "unknown"
+        return label
 
     def __repr__(self):
         """__repr__."""

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -730,12 +730,19 @@ def _both_nan(left: Any, right: Any) -> bool:
 def _variable_table_lines(variables: dict[str, VariableInfo]) -> list[str]:
     """Tabulate the store's arrays, one row each, capped at `MAX_DISPLAY_VARIABLES`.
 
-    The names are padded to a common width so the shapes line up in a terminal. Only the
-    displayed names take part in that width, so one very long name hidden behind the cap
+    Rows are labelled by the map's **key**, not by `info.name`. The map spans sub-groups and is
+    keyed by the full store path (`group/name`), while `info.name` is only the leaf: a grouped
+    store carries the same leaf in every group, so labelling by name printed `CO` and `air_press`
+    two and three times over with nothing to tell the rows apart. The key spells a name the way
+    `variable_names` spells its own, so the two read alike -- though this map is the wider one,
+    covering the coordinates and bounds that the data-variable list leaves out.
+
+    The labels are padded to a common width so the shapes line up in a terminal. Only the
+    displayed labels take part in that width, so one very long path hidden behind the cap
     cannot stretch the whole table.
 
     Args:
-        variables: The store's arrays, keyed by name -- `meta_data.variables`, which
+        variables: The store's arrays, keyed by full path -- `meta_data.variables`, which
             includes coordinates and bounds, not just the data variables.
 
     Returns:
@@ -743,11 +750,11 @@ def _variable_table_lines(variables: dict[str, VariableInfo]) -> list[str]:
             `... N more` line when the cap hid some.
     """
     lines = ["  variables  :"]
-    shown = list(variables.values())[:MAX_DISPLAY_VARIABLES]
-    width = max(len(info.name) for info in shown)
-    for info in shown:
+    shown = list(variables.items())[:MAX_DISPLAY_VARIABLES]
+    width = max(len(path) for path, _ in shown)
+    for path, info in shown:
         extent = ", ".join(str(n) for n in info.shape)
-        row = f"    {info.name:<{width}}  ({extent})  {info.dtype}"
+        row = f"    {path:<{width}}  ({extent})  {info.dtype}"
         if info.unit:
             row += f"  {info.unit}"
         lines.append(row)

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -766,6 +766,28 @@ def _both_nan(left: Any, right: Any) -> bool:
         return False
 
 
+def _has_georeference(nc: NetCDF) -> bool:
+    """Whether the store carries a real affine mapping, so a cell size means something.
+
+    A curvilinear or unstructured store has none. `GetGeoTransform()` still answers for those --
+    with the identity `(0, 1, 0, 0, 0, 1)` -- so `cell_size` reads 1.0 by construction rather
+    than by measurement, the same class of placeholder as the 512 x 512 this summary exists to
+    stop printing. `can_return_null=True` is the signal that separates the two; comparing
+    against the identity tuple instead would also silence a genuine 1-unit grid at the origin.
+
+    Args:
+        nc: The container to test.
+
+    Returns:
+        bool: `True` when GDAL reports an affine transform for this store.
+    """
+    raster = getattr(nc, "_raster", None)
+    georeferenced = False
+    if raster is not None:
+        georeferenced = raster.GetGeoTransform(can_return_null=True) is not None
+    return georeferenced
+
+
 def _variable_table_lines(variables: dict[str, VariableInfo]) -> list[str]:
     """Tabulate the store's arrays, one row each, capped at `MAX_DISPLAY_VARIABLES`.
 
@@ -855,6 +877,11 @@ def _container_summary(nc: NetCDF) -> str:
     GDAL's in-memory placeholder -- but a classic-mode container exposes the store's bands
     directly, and there those numbers are the real grid.
 
+    The cell size within that block is dropped when GDAL reports no geotransform for the store.
+    A curvilinear or unstructured store has no affine mapping, so ``cell_size`` there is 1.0 by
+    construction rather than by measurement; the shape and band count are still real, so the
+    line stays and only the ``@ ...`` term goes.
+
     Args:
         nc: The container to describe.
 
@@ -877,14 +904,13 @@ def _container_summary(nc: NetCDF) -> str:
         lines.extend(_variable_name_lines(nc.variable_names or [], published))
 
     if nc.band_count:
-        # `cell_size` is always a float, and `:g` trims the trailing zeros that make a summary
-        # unreadable -- at the cost of rounding to 6 significant digits, so read the value from
-        # `cell_size` rather than from this line when it matters.
-        cell_text = f"{nc.cell_size:g}"
-        lines.append(
-            f"  grid       : {nc.rows} x {nc.columns} @ {cell_text}, "
-            f"{nc.band_count} band(s)"
-        )
+        grid = f"  grid       : {nc.rows} x {nc.columns}"
+        if _has_georeference(nc):
+            # `cell_size` is always a float, and `:g` trims the trailing zeros that make a
+            # summary unreadable -- at the cost of rounding to 6 significant digits, so read
+            # the value from `cell_size` rather than from this line when it matters.
+            grid += f" @ {nc.cell_size:g}"
+        lines.append(f"{grid}, {nc.band_count} band(s)")
 
     groups = nc.group_names or []
     if groups or published:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -786,8 +786,10 @@ def _container_summary(nc: NetCDF) -> str:
             lines.append(f"  variables  : {listed or 'none'}")
 
     if nc.band_count:
-        cell = nc.cell_size
-        cell_text = f"{cell:g}" if isinstance(cell, (int, float)) else str(cell)
+        # `cell_size` is always a float, and `:g` trims the trailing zeros that make a summary
+        # unreadable -- at the cost of rounding to 6 significant digits, so read the value from
+        # `cell_size` rather than from this line when it matters.
+        cell_text = f"{nc.cell_size:g}"
         lines.append(
             f"  grid       : {nc.rows} x {nc.columns} @ {cell_text}, "
             f"{nc.band_count} band(s)"
@@ -833,8 +835,10 @@ def _variable_summary(nc: NetCDF) -> str:
     header = f"<Variable {name}" + (f" - {label}" if label != "in-memory" else "")
     lines = [header + ">"]
 
-    cell = nc.cell_size
-    cell_text = f"{cell:g}" if isinstance(cell, (int, float)) else str(cell)
+    # `cell_size` is always a float, and `:g` trims the trailing zeros that make a summary
+    # unreadable -- at the cost of rounding to 6 significant digits, so read the value from
+    # `cell_size` rather than from this line when it matters.
+    cell_text = f"{nc.cell_size:g}"
     lines.append(
         f"  grid    : {nc.rows} x {nc.columns} @ {cell_text}, {nc._crs_label()}"
     )

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -605,8 +605,88 @@ def _collapse_uniform(values: Any) -> Any:
     if not values:
         return None
     first = values[0]
-    uniform = all(v is first or v == first or _both_nan(v, first) for v in values)
+    uniform = all(_same_value(v, first) for v in values)
     return first if uniform else list(values)
+
+
+def _store_label(nc: NetCDF) -> str:
+    """A short name for the store behind `nc`, for a summary header.
+
+    ``file_name`` is not always a path. An in-memory result built by an operation such as
+    ``to_crs`` carries the driver name (``"netcdf"``), which would read as a filename in the
+    header; anything without a suffix is treated as in-memory instead. A ``get_group()`` view
+    shares its root's path, so the group path is appended to keep the two distinguishable.
+
+    Args:
+        nc: The container or variable to label.
+
+    Returns:
+        str: A file name, optionally with a group path, or ``"in-memory"``.
+
+    Examples:
+        - A plain filename is reduced to its base name:
+            ```python
+            >>> class _Store:
+            ...     file_name = "/data/archive/cube.nc"
+            >>> _store_label(_Store())
+            'cube.nc'
+
+            ```
+        - A driver name is not a path, so it reads as in-memory:
+            ```python
+            >>> class _InMemory:
+            ...     file_name = "netcdf"
+            >>> _store_label(_InMemory())
+            'in-memory'
+
+            ```
+    """
+    source = getattr(nc, "file_name", "") or ""
+    label = Path(source).name if source and Path(source).suffix else "in-memory"
+    group = getattr(nc, "_group_path", None)
+    if group:
+        label = f"{label}:/{group}"
+    return label
+
+
+def _same_value(left: Any, right: Any) -> bool:
+    """Whether two per-band entries are the same value, for any type a band can carry.
+
+    ``==`` alone is not enough twice over: it is False for two ``nan``s, and for a numpy array
+    it returns an elementwise array that ``all()`` cannot take a truth value from. Identity is
+    tried first (the common case, since GDAL hands back the same object per band), then a
+    guarded equality, then the ``nan`` special case.
+
+    Args:
+        left: One band's value.
+        right: The value being compared against.
+
+    Returns:
+        bool: ``True`` when the two should be treated as one value.
+
+    Examples:
+        - Equal scalars match, and two ``nan``s do too:
+            ```python
+            >>> _same_value("float32", "float32")
+            True
+            >>> _same_value(float("nan"), float("nan"))
+            True
+
+            ```
+        - A value whose ``==`` is not a plain bool does not raise:
+            ```python
+            >>> import numpy as np
+            >>> _same_value(np.array([1, 2]), np.array([1, 2]))
+            False
+
+            ```
+    """
+    if left is right:
+        return True
+    try:
+        return bool(left == right) or _both_nan(left, right)
+    except (TypeError, ValueError):
+        return _both_nan(left, right)
 
 
 def _both_nan(left: Any, right: Any) -> bool:
@@ -644,47 +724,83 @@ def _both_nan(left: Any, right: Any) -> bool:
 
 
 def _container_summary(nc: NetCDF) -> str:
-    """Describe the cube, never a raster.
+    """Describe the store, reporting only what this container can actually know.
 
     Sourced from ``meta_data.variables`` -- a ``dict[str, VariableInfo]`` carrying
     name / shape / dtype / unit for every array including the coordinates, costed once
     for the whole store. Looping ``get_variable()`` instead would raise on every
     non-raster variable and produce a wall of text (#1090).
 
-    Prints no ``rows`` / ``columns`` / ``cell_size`` / ``band_count``: a container has
-    no raster behind those, which is the whole defect this replaces.
+    That list is deliberately **not** :attr:`variable_names`: it enumerates every array, so it
+    includes the coordinates and bounds that the data-variable list leaves out, and it is keyed
+    in metadata order rather than the store's declared one. A structural summary wants the whole
+    picture; a caller asking "what can I extract" wants :attr:`variable_names`.
+
+    ``none`` is printed only where it is a fact. In multidimensional mode the store
+    publishes its dimensions, variables and groups, so an empty one genuinely means there
+    are none. Classic (non-MDIM) mode publishes no such metadata at all, so the same word
+    there would be a positive false claim about a store that does have dimensions -- those
+    lines are omitted instead, and the variable list falls back to ``variable_names``,
+    which classic mode does answer.
+
+    The raster block appears only when the container carries bands. An MDIM container has
+    none -- that is the #1090 defect, where ``rows`` / ``columns`` / ``cell_size`` returned
+    GDAL's in-memory placeholder -- but a classic-mode container exposes the store's bands
+    directly, and there those numbers are the real grid.
+
+    Args:
+        nc: The container to describe.
 
     Returns:
         str: A short multi-line summary.
     """
-    source = nc.file_name
-    lines = [f"<Container {Path(source).name if source else 'in-memory'}>"]
+    lines = [f"<Container {_store_label(nc)}>"]
+    published = nc._is_md_array
 
     sizes = nc.dimension_sizes or {}
-    dims = ", ".join(f"{name}={size}" for name, size in sizes.items())
-    lines.append(f"  dimensions : {dims or 'none'}")
+    if sizes or published:
+        dims = ", ".join(f"{name}={size}" for name, size in sizes.items())
+        lines.append(f"  dimensions : {dims or 'none'}")
 
     variables = nc.meta_data.variables or {}
-    if not variables:
-        lines.append("  variables  : none")
-    else:
+    if variables:
         lines.append("  variables  :")
         shown = list(variables.values())[:MAX_DISPLAY_VARIABLES]
         width = max(len(info.name) for info in shown)
         for info in shown:
-            shape = "(" + ", ".join(str(n) for n in info.shape) + ")"
-            row = f"    {info.name:<{width}}  {shape}  {info.dtype}"
+            extent = ", ".join(str(n) for n in info.shape)
+            row = f"    {info.name:<{width}}  ({extent})  {info.dtype}"
             if info.unit:
                 row += f"  {info.unit}"
             lines.append(row)
         hidden = len(variables) - len(shown)
         if hidden > 0:
             lines.append(f"    ... {hidden} more")
+    else:
+        names = nc.variable_names or []
+        shown_names = names[:MAX_DISPLAY_VARIABLES]
+        listed = ", ".join(shown_names)
+        if len(names) > len(shown_names):
+            listed += f", ... {len(names) - len(shown_names)} more"
+        if listed or published:
+            lines.append(f"  variables  : {listed or 'none'}")
+
+    if nc.band_count:
+        cell = nc.cell_size
+        cell_text = f"{cell:g}" if isinstance(cell, (int, float)) else str(cell)
+        lines.append(
+            f"  grid       : {nc.rows} x {nc.columns} @ {cell_text}, "
+            f"{nc.band_count} band(s)"
+        )
 
     groups = nc.group_names or []
-    lines.append(f"  groups     : {', '.join(groups) if groups else 'none'}")
+    if groups or published:
+        joined = ", ".join(groups)
+        lines.append(f"  groups     : {joined or 'none'}")
     lines.append(f"  CRS        : {nc._crs_label()}")
-    lines.append(f"  attributes : {len(nc.meta_data.global_attributes or {})} global")
+    attributes = nc.meta_data.global_attributes or {}
+    if attributes or published:
+        lines.append(f"  attributes : {len(attributes)} global")
     return "\n".join(lines)
 
 
@@ -696,20 +812,25 @@ def _variable_summary(nc: NetCDF) -> str:
     dimension (``12 along time``) rather than ``Band_1 ... Band_12``, because the
     raster vocabulary for a time axis is a standing source of confusion (#1090).
 
-    Stays cheap -- no band reads and no ``stats()`` -- since ``str()`` runs in
-    debuggers, logging and pytest introspection.
+    Reads no pixels and computes no statistics, since ``str()`` runs in debuggers, logging and
+    pytest introspection. It is not free: the first call builds :attr:`meta_data`, which walks
+    the store's arrays and opens the file a second time for the classic-metadata top-up
+    (~47 ms locally). That cost is the same one the previous summary paid -- it interpolated
+    ``meta_data`` too -- and is cached from then on.
 
     Returns:
         str: A short multi-line summary.
     """
-    name = nc._source_var_name or "?"
-    header = f"<Variable {name}"
-    # A variable subset's raster is an in-memory MDArray view, so it has no path of
-    # its own; the container it came from does.
-    parent = getattr(nc, '_parent_nc', None)
-    source = nc.file_name or (parent.file_name if parent is not None else '')
-    if source:
-        header += f" - {Path(source).name}"
+    # `copy()` and some in-memory results carry no source name; "unnamed" says so rather than
+    # printing a bare "?" where a name belongs.
+    name = nc._source_var_name or "unnamed"
+    # A variable subset's raster is an in-memory MDArray view, so it has no path of its own;
+    # the container it came from does.
+    parent = getattr(nc, "_parent_nc", None)
+    label = _store_label(nc)
+    if label == "in-memory" and parent is not None:
+        label = _store_label(parent)
+    header = f"<Variable {name}" + (f" - {label}" if label != "in-memory" else "")
     lines = [header + ">"]
 
     cell = nc.cell_size
@@ -1068,28 +1189,49 @@ class NetCDF(Dataset):
     def __str__(self):
         """Return a human-readable summary, or a `<Dataset: closed>` sentinel when closed.
 
-        Dispatches on the identity the class docstrings already use: a container is not a
-        raster (``band_count == 0``), a variable is (``band_count >= 1``). Defining one
-        summary here and letting both inherit it made the container describe raster fields
-        it does not have -- ``rows`` / ``columns`` / ``cell_size`` fell through to GDAL's
-        in-memory placeholder, so a 12x5x5 cube at 0.25 degrees reported itself as
-        512 x 512 at cell size 1.0 (#1090).
+        The summary is chosen by **type**, through :meth:`_summary_text`, which
+        :class:`Container` and :class:`Variable` override. Defining one summary here and
+        letting both inherit it made the container describe raster fields it does not have:
+        ``rows`` / ``columns`` / ``cell_size`` fell through to GDAL's in-memory placeholder,
+        so a 12x5x5 cube at 0.25 degrees reported itself as 512 x 512 at cell size 1.0
+        (#1090).
 
-        A bare ``NetCDF`` is never produced -- ``read_file`` returns a
-        :class:`Container` and ``get_variable`` a :class:`Variable` -- so this base
-        implementation only routes.
+        Type rather than ``band_count``: a container opened in classic mode carries the
+        store's bands directly, so ``band_count >= 1`` there and a band-count test would
+        label it a variable. The classes already encode the distinction ``read_file`` and
+        ``get_variable`` established, so they are the discriminator.
 
         Mirrors `Dataset.__str__`: a closed handle returns the sentinel rather than
         raising, so the repr/str stays total for debuggers and logging (`__repr__`
         already inherits this via `super()`).
         """
-        if self._raster is None:
-            message = "<Dataset: closed>"
-        elif self.band_count == 0:
-            message = _container_summary(self)
-        else:
-            message = _variable_summary(self)
+        message = "<Dataset: closed>"
+        if self._raster is not None:
+            try:
+                message = self._summary_text()
+            except Exception:
+                # Total by contract, not just for a closed handle. `str()` runs in debuggers,
+                # logging and pytest introspection, where a raising summary masks the error the
+                # caller was actually looking at. The summary walks a dozen properties, any of
+                # which can fail on a half-built or exotic store, so degrade to a sentinel that
+                # still says what this is.
+                message = f"<{type(self).__name__}: summary unavailable>"
         return message
+
+    def _summary_text(self) -> str:
+        """The summary body for a bare ``NetCDF``, which neither factory produces.
+
+        :class:`Container` and :class:`Variable` override this; the base only has to cope
+        with an instance of the deprecated alias itself. It defers to
+        :attr:`_is_root_container` -- the predicate the package already owns for this
+        question -- rather than spelling the conjunction out again.
+
+        Returns:
+            str: A container or variable summary.
+        """
+        if self._is_root_container:
+            return _container_summary(self)
+        return _variable_summary(self)
 
     def _crs_label(self) -> str:
         """The CRS as a short label -- ``EPSG:4326``, a CRS name, or ``unknown``.
@@ -8696,6 +8838,10 @@ class Variable(NetCDF):
         """
         return None
 
+    def _summary_text(self) -> str:
+        """Describe the raster this variable is; see :func:`_variable_summary`."""
+        return _variable_summary(self)
+
 
 class Container(NetCDF):
     """A NetCDF container (the root MDIM group) holding variables, dimensions, attributes.
@@ -8723,3 +8869,7 @@ class Container(NetCDF):
 
             ```
     """
+
+    def _summary_text(self) -> str:
+        """Describe the cube this container is; see :func:`_container_summary`."""
+        return _container_summary(self)

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -82,7 +82,11 @@ from pyramids.netcdf.engines.interop import Interop
 from pyramids.netcdf.engines.selection import Selection
 from pyramids.netcdf.engines.variables import Variables
 from pyramids.netcdf.metadata import get_metadata
-from pyramids.netcdf.models import MAX_DISPLAY_VARIABLES, NetCDFMetadata
+from pyramids.netcdf.models import (
+    MAX_DISPLAY_VARIABLES,
+    NetCDFMetadata,
+    VariableInfo,
+)
 from pyramids.netcdf.plot_options import CoordinateSpec, FacetSpec, Selectors
 from pyramids.netcdf.utils import (
     _read_attributes,
@@ -723,6 +727,63 @@ def _both_nan(left: Any, right: Any) -> bool:
         return False
 
 
+def _variable_table_lines(variables: dict[str, VariableInfo]) -> list[str]:
+    """Tabulate the store's arrays, one row each, capped at `MAX_DISPLAY_VARIABLES`.
+
+    The names are padded to a common width so the shapes line up in a terminal. Only the
+    displayed names take part in that width, so one very long name hidden behind the cap
+    cannot stretch the whole table.
+
+    Args:
+        variables: The store's arrays, keyed by name -- `meta_data.variables`, which
+            includes coordinates and bounds, not just the data variables.
+
+    Returns:
+        list[str]: The `variables  :` header followed by one indented row per array, and a
+            `... N more` line when the cap hid some.
+    """
+    lines = ["  variables  :"]
+    shown = list(variables.values())[:MAX_DISPLAY_VARIABLES]
+    width = max(len(info.name) for info in shown)
+    for info in shown:
+        extent = ", ".join(str(n) for n in info.shape)
+        row = f"    {info.name:<{width}}  ({extent})  {info.dtype}"
+        if info.unit:
+            row += f"  {info.unit}"
+        lines.append(row)
+    hidden = len(variables) - len(shown)
+    if hidden > 0:
+        lines.append(f"    ... {hidden} more")
+    return lines
+
+
+def _variable_name_lines(names: list[str], published: bool) -> list[str]:
+    """Name the variables on one line, for a store that publishes no per-array metadata.
+
+    This is the classic-mode fallback: `meta_data.variables` is empty there, but
+    `variable_names` still answers, so the names are worth printing even without shapes
+    or dtypes.
+
+    Args:
+        names: The variable names to list.
+        published: Whether the store publishes its structure. Only then does an empty
+            list mean `none` rather than "not knowable", so only then is the line printed
+            at all -- see `_container_summary`.
+
+    Returns:
+        list[str]: A single `variables  :` line, or nothing when there is neither a name
+            to show nor the standing to call the store empty.
+    """
+    shown = names[:MAX_DISPLAY_VARIABLES]
+    listed = ", ".join(shown)
+    if len(names) > len(shown):
+        listed += f", ... {len(names) - len(shown)} more"
+    lines: list[str] = []
+    if listed or published:
+        lines.append(f"  variables  : {listed or 'none'}")
+    return lines
+
+
 def _container_summary(nc: NetCDF) -> str:
     """Describe the store, reporting only what this container can actually know.
 
@@ -764,26 +825,9 @@ def _container_summary(nc: NetCDF) -> str:
 
     variables = nc.meta_data.variables or {}
     if variables:
-        lines.append("  variables  :")
-        shown = list(variables.values())[:MAX_DISPLAY_VARIABLES]
-        width = max(len(info.name) for info in shown)
-        for info in shown:
-            extent = ", ".join(str(n) for n in info.shape)
-            row = f"    {info.name:<{width}}  ({extent})  {info.dtype}"
-            if info.unit:
-                row += f"  {info.unit}"
-            lines.append(row)
-        hidden = len(variables) - len(shown)
-        if hidden > 0:
-            lines.append(f"    ... {hidden} more")
+        lines.extend(_variable_table_lines(variables))
     else:
-        names = nc.variable_names or []
-        shown_names = names[:MAX_DISPLAY_VARIABLES]
-        listed = ", ".join(shown_names)
-        if len(names) > len(shown_names):
-            listed += f", ... {len(names) - len(shown_names)} more"
-        if listed or published:
-            lines.append(f"  variables  : {listed or 'none'}")
+        lines.extend(_variable_name_lines(nc.variable_names or [], published))
 
     if nc.band_count:
         # `cell_size` is always a float, and `:g` trims the trailing zeros that make a summary

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -936,9 +936,15 @@ def _container_summary(nc: NetCDF) -> str:
     """Describe the store, reporting only what this container can actually know.
 
     Sourced from ``meta_data.variables`` -- a ``dict[str, VariableInfo]`` carrying
-    name / shape / dtype / unit for every array including the coordinates, costed once
-    for the whole store. Looping ``get_variable()`` instead would raise on every
-    non-raster variable and produce a wall of text (#1090).
+    name / shape / dtype / unit for every array including the coordinates. Looping
+    ``get_variable()`` instead would raise on every non-raster variable and produce a wall of
+    text (#1090).
+
+    This is the summary that costs something. In multidimensional mode the first call builds
+    :attr:`meta_data`, which walks every array in the store: ~44 ms and one file open locally,
+    cached from then on, so a second ``print(nc)`` is ~0.5 ms. That is the same cost the
+    previous summary paid -- it interpolated ``meta_data`` too. The variable summary pays none
+    of it.
 
     That list is deliberately **not** :attr:`variable_names`: it enumerates every array, so it
     includes the coordinates and bounds that the data-variable list leaves out, and it is keyed
@@ -1019,11 +1025,18 @@ def _variable_summary(nc: NetCDF) -> str:
     dimension (``12 along time``) rather than ``Band_1 ... Band_12``, because the
     raster vocabulary for a time axis is a standing source of confusion (#1090).
 
-    Reads no pixels and computes no statistics, since ``str()`` runs in debuggers, logging and
-    pytest introspection. It is not free: the first call builds :attr:`meta_data`, which walks
-    the store's arrays and opens the file a second time for the classic-metadata top-up
-    (~47 ms locally). That cost is the same one the previous summary paid -- it interpolated
-    ``meta_data`` too -- and is cached from then on.
+    Reads no pixels, computes no statistics, and touches no metadata: it reads band-level
+    properties only, so it performs no I/O and costs about 0.0 ms on an already-extracted
+    variable. The walk of the store was paid by :meth:`get_variable` before the caller could
+    hold a variable at all (~36 ms locally, one file open).
+
+    Note that ``repr()`` is a different contract and is unchanged -- it is still
+    ``gdal.Info``, so the surfaces that auto-display an object (a notebook cell, a debugger's
+    variable pane, pytest's assertion output) still show GDAL's ``Size is 512, 512``
+    placeholder for a container. Only ``str()`` / ``print()`` route here.
+
+    Args:
+        nc: The variable to describe.
 
     Returns:
         str: A short multi-line summary.
@@ -1413,6 +1426,13 @@ class NetCDF(Dataset):
         Mirrors `Dataset.__str__`: a closed handle returns the sentinel rather than
         raising, so the repr/str stays total for debuggers and logging (`__repr__`
         already inherits this via `super()`).
+
+        This changes `str()` / `print()` only. `__repr__` is a separate contract --
+        `gdal.Info` on the underlying raster -- and is deliberately unchanged, so the
+        surfaces that auto-display an object still report the placeholder: a bare `nc` in a
+        notebook cell, a debugger's variable pane and pytest's assertion output all call
+        `repr`, and a container still shows `Size is 512, 512` there. Reworking that is a
+        separate question about `Dataset.__repr__` and its `gdal.Info` contract.
         """
         message = "<Dataset: closed>"
         if self._raster is not None:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -766,6 +766,52 @@ def _both_nan(left: Any, right: Any) -> bool:
         return False
 
 
+# How much of a one-line list a summary will print before it truncates. The point of the
+# summary is a line a debugger, a log handler or a notebook can show at a glance; a store with
+# 22 dimensions or seven flight-path group names blows well past that, so the list is cut by
+# width as well as by count -- ten names are still 316 characters when the names are long.
+_MAX_LIST_WIDTH = 96
+
+
+def _capped_join(items: list[str]) -> str:
+    """Join `items` with `", "`, truncating by both count and width.
+
+    Args:
+        items: The already-formatted entries to list.
+
+    Returns:
+        str: The joined text, with a `, ... N more` tail when anything was cut. Always shows
+            at least one entry, even one longer than the budget, so the line is never a bare
+            count.
+
+    Examples:
+        - A short list is joined whole:
+            ```python
+            >>> _capped_join(["time=12", "y=5", "x=5"])
+            'time=12, y=5, x=5'
+
+            ```
+        - A long one is cut, and says how much it cut:
+            ```python
+            >>> _capped_join([f"group_name_{n}" for n in range(9)])
+            'group_name_0, group_name_1, group_name_2, group_name_3, group_name_4, group_name_5, ... 3 more'
+
+            ```
+    """
+    shown: list[str] = []
+    used = 0
+    for item in items[:MAX_DISPLAY_VARIABLES]:
+        if shown and used + len(item) + 2 > _MAX_LIST_WIDTH:
+            break
+        used += len(item) + 2
+        shown.append(item)
+    listed = ", ".join(shown)
+    hidden = len(items) - len(shown)
+    if hidden > 0:
+        listed += f", ... {hidden} more"
+    return listed
+
+
 def _has_georeference(nc: NetCDF) -> bool:
     """Whether the store carries a real affine mapping, so a cell size means something.
 
@@ -842,10 +888,7 @@ def _variable_name_lines(names: list[str], published: bool) -> list[str]:
         list[str]: A single `variables  :` line, or nothing when there is neither a name
             to show nor the standing to call the store empty.
     """
-    shown = names[:MAX_DISPLAY_VARIABLES]
-    listed = ", ".join(shown)
-    if len(names) > len(shown):
-        listed += f", ... {len(names) - len(shown)} more"
+    listed = _capped_join(list(names))
     lines: list[str] = []
     if listed or published:
         lines.append(f"  variables  : {listed or 'none'}")
@@ -894,7 +937,7 @@ def _container_summary(nc: NetCDF) -> str:
 
     sizes = nc.dimension_sizes or {}
     if sizes or published:
-        dims = ", ".join(f"{name}={size}" for name, size in sizes.items())
+        dims = _capped_join([f"{name}={size}" for name, size in sizes.items()])
         lines.append(f"  dimensions : {dims or 'none'}")
 
     variables = nc.meta_data.variables or {}
@@ -914,7 +957,7 @@ def _container_summary(nc: NetCDF) -> str:
 
     groups = nc.group_names or []
     if groups or published:
-        joined = ", ".join(groups)
+        joined = _capped_join(list(groups))
         lines.append(f"  groups     : {joined or 'none'}")
     lines.append(f"  CRS        : {nc._crs_label()}")
     attributes = nc.meta_data.global_attributes or {}

--- a/tests/netcdf/test_netcdf_core.py
+++ b/tests/netcdf/test_netcdf_core.py
@@ -113,7 +113,7 @@ class TestInit:
 
 
 class TestStr:
-    """Tests for NetCDF.__str__."""
+    """Tests for NetCDF.__str__, which dispatches on the container/variable identity."""
 
     def test_str_contains_variable_info(self, nc_3d):
         """Verify __str__ includes variable names and dimension info.
@@ -125,14 +125,58 @@ class TestStr:
         result = str(nc_3d)
         assert "temperature" in result, f"Variable name not in __str__: {result}"
 
-    def test_str_contains_cell_size(self, nc_3d):
-        """Verify __str__ includes cell size.
+    def test_container_str_omits_raster_fields(self, nc_3d):
+        """A container summary must not report raster fields it has no raster for.
 
         Test scenario:
-            The cell_size value should appear in the string output.
+            `nc_3d` is a `Container` (`band_count == 0`), so `rows` / `columns` /
+            `cell_size` fall through to GDAL's in-memory placeholder -- a 10x12 cube
+            reported itself as 512 x 512 at cell size 1.0. This assertion previously
+            required "Cell size" to be *present*, which pinned that defect (#1090).
+        """
+        assert nc_3d.band_count == 0, (
+            "fixture must be a container for this to mean anything"
+        )
+        result = str(nc_3d)
+        for field in ("Cell size", "Dimension:", "512"):
+            assert field not in result, (
+                f"container summary leaked a raster field: {result}"
+            )
+
+    def test_container_str_reports_the_cube(self, nc_3d):
+        """The container summary describes dimensions, CRS and variables.
+
+        Test scenario:
+            The truth is in `dimension_sizes` and `meta_data.variables`, which the old
+            summary never consulted.
         """
         result = str(nc_3d)
-        assert "Cell size" in result, f"Cell size label not in __str__: {result}"
+        assert result.startswith("<Container"), f"unexpected header: {result}"
+        assert "dimensions :" in result, f"no dimensions line: {result}"
+        assert "EPSG:4326" in result, f"no CRS label: {result}"
+
+    def test_variable_str_reports_the_grid(self, nc_3d):
+        """A variable *is* a raster, so its summary keeps the grid.
+
+        Test scenario:
+            The dispatch must not strip raster fields from the type that genuinely has
+            them; `get_variable` returns a `Variable` with `band_count >= 1`.
+        """
+        variable = nc_3d.get_variable("temperature")
+        result = str(variable)
+        assert result.startswith("<Variable"), f"unexpected header: {result}"
+        assert "grid    :" in result, f"no grid line: {result}"
+        assert "bands   :" in result, f"no bands line: {result}"
+
+    def test_str_never_dumps_raw_wkt(self, nc_3d):
+        """Neither summary dumps the projection WKT.
+
+        Test scenario:
+            The old summary interpolated `self.crs`, putting a multi-thousand-character
+            WKT on one line and drowning every other field.
+        """
+        for result in (str(nc_3d), str(nc_3d.get_variable("temperature"))):
+            assert "GEOGCS" not in result, f"raw WKT leaked into the summary: {result}"
 
 
 class TestRepr:

--- a/tests/netcdf/test_netcdf_core.py
+++ b/tests/netcdf/test_netcdf_core.py
@@ -138,7 +138,10 @@ class TestStr:
             "fixture must be a container for this to mean anything"
         )
         result = str(nc_3d)
-        for field in ("Cell size", "Dimension:", "512"):
+        # The labels carry the signal. Asserting on "512" would pin GDAL's current placeholder
+        # value instead: it would pass if that value changed while the defect returned, and fail
+        # spuriously on any fixture with a dimension of length 512.
+        for field in ("Cell size", "Dimension:"):
             assert field not in result, (
                 f"container summary leaked a raster field: {result}"
             )

--- a/tests/netcdf/unit/test_summary_helpers.py
+++ b/tests/netcdf/unit/test_summary_helpers.py
@@ -2,8 +2,9 @@
 
 `__str__` used to be defined once on `NetCDF` and inherited by both subclasses, so a container
 fell through to `rows` / `columns` / `cell_size` — which for an MDIM store have no raster behind
-them and return GDAL's in-memory placeholder. `NetCDF.__str__` now dispatches on `band_count` to
-one of two module-level summaries.
+them and return GDAL's in-memory placeholder. `NetCDF.__str__` now picks the summary by **type**,
+through `_summary_text`, which `Container` and `Variable` override — a band-count test would
+mislabel a classic-mode container, which carries the store's bands directly.
 
 These cover the helpers directly; `tests/netcdf/test_netcdf_core.py::TestStr` covers the dispatch
 end to end.
@@ -178,7 +179,9 @@ class TestCrsLabel:
         """
         nc = NetCDF.read_file(_write_store(str(tmp_path / "name.nc")))
         try:
-            monkeypatch.setattr(type(nc), "epsg", property(lambda self: None))
+            monkeypatch.setattr(
+                type(nc), "epsg", property(lambda self: None), raising=True
+            )
             label = nc._crs_label()
             assert label not in ("", "unknown"), f"expected a CRS name, got {label!r}"
             assert "GEOGCS" not in label, f"the WKT leaked into the label: {label}"
@@ -189,7 +192,9 @@ class TestCrsLabel:
         """No EPSG and no CRS yields `unknown` rather than an empty label."""
         nc = NetCDF.read_file(_write_store(str(tmp_path / "none.nc")))
         try:
-            monkeypatch.setattr(type(nc), "epsg", property(lambda self: None))
+            monkeypatch.setattr(
+                type(nc), "epsg", property(lambda self: None), raising=True
+            )
             monkeypatch.setattr(type(nc), "crs", property(lambda self: ""))
             assert nc._crs_label() == "unknown"
         finally:
@@ -246,12 +251,60 @@ class TestContainerSummary:
         finally:
             nc.close()
 
-    def test_no_variables_reports_none(self, tmp_path, monkeypatch):
-        """A store the metadata reports as empty says `none`, not a blank block."""
+    def test_falls_back_to_variable_names(self, tmp_path, monkeypatch):
+        """With no multidim metadata, the variable list comes from `variable_names`.
+
+        Test scenario:
+            Classic (non-MDIM) mode publishes no `meta_data.variables` at all, so a summary that
+            only consulted it printed `variables : none` about a store that has variables — a
+            positive false claim. `variable_names` is the list classic mode does answer.
+        """
+        nc = NetCDF.read_file(_write_store(str(tmp_path / "fallback.nc")))
+        try:
+            monkeypatch.setattr(nc.meta_data, "variables", {})
+            assert "variables  : v0" in _container_summary(nc), _container_summary(nc)
+        finally:
+            nc.close()
+
+    def test_reports_none_only_when_the_store_published_nothing(
+        self, tmp_path, monkeypatch
+    ):
+        """`none` is printed when it is a fact, i.e. the store published an empty list.
+
+        Test scenario:
+            An MDIM store that genuinely holds no variables should say so; the word is only
+            wrong when the mode cannot answer the question at all.
+        """
         nc = NetCDF.read_file(_write_store(str(tmp_path / "empty.nc")))
         try:
             monkeypatch.setattr(nc.meta_data, "variables", {})
-            assert "variables  : none" in _container_summary(nc)
+            monkeypatch.setattr(type(nc), "variable_names", property(lambda self: []))
+            summary = _container_summary(nc)
+            assert "variables  : none" in summary, summary
+        finally:
+            nc.close()
+
+    def test_classic_mode_omits_what_it_cannot_know(self):
+        """A classic-mode container reports its grid, and claims nothing it cannot see.
+
+        Test scenario:
+            The classic driver exposes the store's bands directly, so `band_count >= 1` on a
+            `Container` — which is why the summary is chosen by type, not by band count. It
+            publishes no multidim metadata, so `dimensions` / `groups` are omitted rather than
+            reported as `none`.
+        """
+        path = "tests/data/netcdf/cf__5v__1d4-3d1__geog__y-desc.nc"
+        nc = NetCDF.read_file(path, open_as_multi_dimensional=False)
+        try:
+            assert nc.band_count > 0, (
+                "classic container must carry bands for this to bite"
+            )
+            summary = str(nc)
+            assert summary.startswith("<Container "), f"wrong header: {summary}"
+            assert "?" not in summary.split("\n")[0], f"placeholder name: {summary}"
+            assert "grid       :" in summary, f"real grid not reported: {summary}"
+            for claim in ("dimensions : none", "groups     : none"):
+                assert claim not in summary, f"asserted an unknown as fact: {summary}"
         finally:
             nc.close()
 
@@ -280,7 +333,9 @@ class _FakeVariable:
         self._band_dim_name = "time"
         self.band_units = ["K"] * 12
         self.dtype = ["float32"] * 12
-        self.no_data_value = (float("nan"),) * 12
+        # Distinct objects: a repeated one would pass the no-data assertion by identity
+        # rather than by the nan handling under test.
+        self.no_data_value = tuple(float("nan") for _ in range(12))
         self.__dict__.update(overrides)
 
     def _crs_label(self) -> str:

--- a/tests/netcdf/unit/test_summary_helpers.py
+++ b/tests/netcdf/unit/test_summary_helpers.py
@@ -26,6 +26,7 @@ from pyramids.netcdf.netcdf import (
     _capped_join,
     _collapse_uniform,
     _container_summary,
+    _global_attribute_count,
     _has_georeference,
     _store_label,
     _variable_summary,
@@ -428,6 +429,30 @@ class TestContainerSummary:
             assert "more" in dims[0], f"long list was not truncated: {dims[0]}"
         finally:
             nc.close()
+
+    def test_classic_attribute_count_matches_the_multidimensional_one(self):
+        """Both modes report the same number of global attributes for the same store.
+
+        Test scenario:
+            The classic metadata top-up leaves `global_attributes` empty on more than half the
+            corpus, so the classic summary reported no attributes for a store carrying eight.
+            The open handle's `NC_GLOBAL#` keys are the accurate source.
+        """
+        path = "tests/data/netcdf/cf__48v__1d17-3d21-4d10__y-asc.nc"
+        classic = NetCDF.read_file(path, open_as_multi_dimensional=False)
+        try:
+            counted = _global_attribute_count(classic, published=False)
+        finally:
+            classic.close()
+        mdim = NetCDF.read_file(path)
+        try:
+            expected = len(mdim.meta_data.global_attributes or {})
+        finally:
+            mdim.close()
+        assert counted == expected, (
+            f"classic counted {counted} global attributes, multidim says {expected}"
+        )
+        assert counted > 0, "fixture must carry global attributes for this to bite"
 
 
 class TestCappedJoin:

--- a/tests/netcdf/unit/test_summary_helpers.py
+++ b/tests/netcdf/unit/test_summary_helpers.py
@@ -23,8 +23,8 @@ from pyramids.netcdf import NetCDF
 from pyramids.netcdf.models import MAX_DISPLAY_VARIABLES
 from pyramids.netcdf.netcdf import (
     _both_nan,
-    _collapse_uniform,
     _capped_join,
+    _collapse_uniform,
     _container_summary,
     _has_georeference,
     _store_label,

--- a/tests/netcdf/unit/test_summary_helpers.py
+++ b/tests/netcdf/unit/test_summary_helpers.py
@@ -105,8 +105,9 @@ class TestCollapseUniform:
         # Distinct nan objects on purpose: `(float("nan"),) * 12` repeats one object, so the
         # identity check would collapse it even with the nan handling removed.
         result = _collapse_uniform(tuple(float("nan") for _ in range(12)))
-        assert isinstance(result, float) and np.isnan(result), (
-            f"expected a single nan, got {result!r}"
+        assert isinstance(result, float), f"expected a single float, got {result!r}"
+        assert np.isnan(result), (
+            f"expected the collapsed value to be nan, got {result!r}"
         )
 
     def test_empty_sequence_is_none(self):
@@ -241,8 +242,9 @@ class TestContainerSummary:
         )
         try:
             summary = _container_summary(nc)
-            assert "... " in summary and " more" in summary, (
-                f"expected a truncation line, got:\n{summary}"
+            assert "... " in summary, f"expected a truncation marker, got:\n{summary}"
+            assert " more" in summary, (
+                f"expected a hidden-count suffix, got:\n{summary}"
             )
             listed = sum(1 for line in summary.split("\n") if line.startswith("    v"))
             assert listed <= MAX_DISPLAY_VARIABLES, (

--- a/tests/netcdf/unit/test_summary_helpers.py
+++ b/tests/netcdf/unit/test_summary_helpers.py
@@ -24,6 +24,7 @@ from pyramids.netcdf.models import MAX_DISPLAY_VARIABLES
 from pyramids.netcdf.netcdf import (
     _both_nan,
     _collapse_uniform,
+    _capped_join,
     _container_summary,
     _has_georeference,
     _store_label,
@@ -406,6 +407,51 @@ class TestContainerSummary:
             assert "@ 1," in grid[0], f"dropped a real unit cell size: {grid[0]}"
         finally:
             nc.close()
+
+    def test_long_lists_are_capped_by_width(self):
+        """`dimensions` and `groups` stay readable on a store with many long names.
+
+        Test scenario:
+            The variable rows were capped, but `dimensions` and `groups` were joined whole:
+            22 dimensions rendered a 372-character line, and seven flight-path group names a
+            289-character one. A summary meant for a debugger or a log line cannot be that.
+        """
+        path = "tests/data/netcdf/none__111v__1d96-2d13-3d2__str.nc"
+        nc = NetCDF.read_file(path)
+        try:
+            summary = _container_summary(nc)
+            dims = [
+                ln for ln in summary.split("\n") if ln.strip().startswith("dimensions")
+            ]
+            assert dims, f"no dimensions line:\n{summary}"
+            assert len(dims[0]) < 120, f"line is {len(dims[0])} chars: {dims[0]}"
+            assert "more" in dims[0], f"long list was not truncated: {dims[0]}"
+        finally:
+            nc.close()
+
+
+class TestCappedJoin:
+    """`_capped_join` truncates a one-line list by count and by width."""
+
+    def test_a_short_list_is_joined_whole(self):
+        """Nothing is cut when the list fits."""
+        assert _capped_join(["time=12", "y=5", "x=5"]) == "time=12, y=5, x=5"
+
+    def test_an_empty_list_joins_to_nothing(self):
+        """An empty list yields the empty string, so the caller can decide to omit the line."""
+        assert _capped_join([]) == ""
+
+    def test_a_single_overlong_entry_is_still_shown(self):
+        """The first entry is never dropped, so the line is never a bare count."""
+        result = _capped_join(["x" * 200, "y"])
+        assert result.startswith("x" * 200), result
+        assert result.endswith("... 1 more"), result
+
+    def test_the_count_cap_applies_below_the_width_cap(self):
+        """Many short names are cut at `MAX_DISPLAY_VARIABLES`, not only by width."""
+        result = _capped_join([f"d{n}" for n in range(MAX_DISPLAY_VARIABLES + 4)])
+        assert result.count(",") == MAX_DISPLAY_VARIABLES, result
+        assert result.endswith("... 4 more"), result
 
 
 class TestStoreLabel:

--- a/tests/netcdf/unit/test_summary_helpers.py
+++ b/tests/netcdf/unit/test_summary_helpers.py
@@ -13,6 +13,7 @@ end to end.
 from __future__ import annotations
 
 import gc
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -24,6 +25,7 @@ from pyramids.netcdf.netcdf import (
     _both_nan,
     _collapse_uniform,
     _container_summary,
+    _store_label,
     _variable_summary,
 )
 
@@ -343,6 +345,54 @@ class TestContainerSummary:
                 )
         finally:
             nc.close()
+
+    def test_a_real_file_without_a_suffix_is_not_called_in_memory(self, tmp_path):
+        """An extensionless path is still a real file, and the header must name it.
+
+        Test scenario:
+            The label used to be chosen by `Path(source).suffix`, so `mkstemp` output, an
+            OPeNDAP endpoint or a content-typed download -- all extensionless -- were reported
+            as `in-memory`, a false claim about provenance. The driver is the reliable signal.
+        """
+        source = Path("tests/data/netcdf/cf__5v__1d4-3d1__geog__y-desc.nc")
+        target = tmp_path / "cube"
+        target.write_bytes(source.read_bytes())
+        nc = NetCDF.read_file(str(target))
+        try:
+            header = str(nc).split("\n")[0]
+            assert "in-memory" not in header, f"real file called in-memory: {header}"
+            assert "cube" in header, f"header does not name the file: {header}"
+        finally:
+            nc.close()
+
+
+class TestStoreLabel:
+    """`_store_label` reports the label and the in-memory verdict separately."""
+
+    def test_the_memory_driver_decides_not_the_suffix(self):
+        """A `memory`-driver store is in-memory whatever its `file_name` says."""
+
+        class _InMemory:
+            file_name = "netcdf"
+            driver_type = "memory"
+
+        assert _store_label(_InMemory()) == ("in-memory", True)
+
+    def test_a_group_scoped_in_memory_store_still_reports_in_memory(self):
+        """The group suffix must not hide the in-memory verdict from the caller.
+
+        Test scenario:
+            The variable header used to recover the verdict with `label == "in-memory"`. A
+            group-scoped store labels as `in-memory:/grp`, so that comparison failed and the
+            parent-store fallback was skipped. The verdict is returned, not re-derived.
+        """
+
+        class _InMemoryGroup:
+            file_name = ""
+            driver_type = "memory"
+            _group_path = "grp"
+
+        assert _store_label(_InMemoryGroup()) == ("in-memory:/grp", True)
 
 
 class _FakeVariable:

--- a/tests/netcdf/unit/test_summary_helpers.py
+++ b/tests/netcdf/unit/test_summary_helpers.py
@@ -25,6 +25,7 @@ from pyramids.netcdf.netcdf import (
     _both_nan,
     _collapse_uniform,
     _container_summary,
+    _has_georeference,
     _store_label,
     _variable_summary,
 )
@@ -362,6 +363,47 @@ class TestContainerSummary:
             header = str(nc).split("\n")[0]
             assert "in-memory" not in header, f"real file called in-memory: {header}"
             assert "cube" in header, f"header does not name the file: {header}"
+        finally:
+            nc.close()
+
+    def test_an_unreferenced_store_reports_no_cell_size(self):
+        """A store with no affine mapping prints its shape without inventing a cell size.
+
+        Test scenario:
+            A curvilinear or unstructured store has no geotransform, so `cell_size` reads 1.0
+            by construction. Printing `@ 1` there is the same class of placeholder-as-fact as
+            the `512 x 512 @ 1.0` this summary exists to stop printing.
+        """
+        path = "tests/data/netcdf/ugrid__1v__3d1.nc"
+        nc = NetCDF.read_file(path, open_as_multi_dimensional=False)
+        try:
+            assert nc.band_count > 0, "fixture must carry bands to reach the grid line"
+            assert not _has_georeference(nc), "fixture must be unreferenced to bite"
+            grid = [
+                ln
+                for ln in _container_summary(nc).split("\n")
+                if ln.strip().startswith("grid")
+            ]
+            assert grid, "no grid line rendered"
+            assert "@" not in grid[0], f"invented a cell size: {grid[0]}"
+            assert "8 x 4" in grid[0], f"lost the real shape: {grid[0]}"
+        finally:
+            nc.close()
+
+    def test_a_georeferenced_store_keeps_a_unit_cell_size(self):
+        """A genuine 1-unit grid still prints `@ 1`; only the null transform is suppressed."""
+        path = "tests/data/netcdf/cf__5v__1d4-4d1__y-asc.nc"
+        nc = NetCDF.read_file(path, open_as_multi_dimensional=False)
+        try:
+            assert _has_georeference(nc), (
+                "fixture must be georeferenced for this to mean it"
+            )
+            grid = [
+                ln
+                for ln in _container_summary(nc).split("\n")
+                if ln.strip().startswith("grid")
+            ]
+            assert "@ 1," in grid[0], f"dropped a real unit cell size: {grid[0]}"
         finally:
             nc.close()
 

--- a/tests/netcdf/unit/test_summary_helpers.py
+++ b/tests/netcdf/unit/test_summary_helpers.py
@@ -247,6 +247,58 @@ class TestCrsLabel:
             nc.close()
 
 
+class TestBaseDispatch:
+    """`NetCDF._summary_text` -- the fallback for a subclass that overrides neither."""
+
+    def test_a_container_reaches_the_container_summary(self):
+        """The base dispatch routes a root container to the container summary.
+
+        Test scenario:
+            `Container` and `Variable` override `_summary_text`, so the base is unreachable
+            through the public factories -- but it is live for any third-party subclass of
+            `NetCDF`, which the package supports. Its two arms are asserted directly.
+        """
+        path = "tests/data/netcdf/cf__5v__1d4-3d1__geog__y-desc.nc"
+        nc = NetCDF.read_file(path)
+        try:
+            assert nc._is_root_container, "fixture must be a root container"
+            assert NetCDF._summary_text(nc).startswith("<Container "), (
+                NetCDF._summary_text(nc)
+            )
+        finally:
+            nc.close()
+
+    def test_a_variable_reaches_the_variable_summary(self):
+        """The base dispatch routes a non-root object to the variable summary."""
+        path = "tests/data/netcdf/cf__5v__1d4-3d1__geog__y-desc.nc"
+        nc = NetCDF.read_file(path)
+        try:
+            variable = nc.get_variable("t2m")
+            assert not variable._is_root_container, "a variable is not a root container"
+            assert NetCDF._summary_text(variable).startswith("<Variable t2m"), (
+                NetCDF._summary_text(variable)
+            )
+        finally:
+            nc.close()
+
+    def test_a_group_view_names_its_group(self):
+        """A `get_group()` view is labelled by its group, not by its root's file name alone.
+
+        Test scenario:
+            A group view shares the root's open dataset and its `file_name`, so without the
+            `:/group` suffix the two print identically.
+        """
+        path = "tests/data/netcdf/none__35v__1d35__groups-nc4.nc"
+        nc = NetCDF.read_file(path)
+        try:
+            name = nc.group_names[0]
+            header = str(nc.get_group(name)).split("\n")[0]
+            assert f":/{name}" in header, f"group path missing from {header}"
+            assert str(nc).split("\n")[0] != header, "group view prints as its root"
+        finally:
+            nc.close()
+
+
 class TestSummaryLogging:
     """The summary swallows exceptions to stay total, and says so at DEBUG."""
 

--- a/tests/netcdf/unit/test_summary_helpers.py
+++ b/tests/netcdf/unit/test_summary_helpers.py
@@ -1,0 +1,337 @@
+"""Unit tests for the container / variable summary helpers (#1090).
+
+`__str__` used to be defined once on `NetCDF` and inherited by both subclasses, so a container
+fell through to `rows` / `columns` / `cell_size` — which for an MDIM store have no raster behind
+them and return GDAL's in-memory placeholder. `NetCDF.__str__` now dispatches on `band_count` to
+one of two module-level summaries.
+
+These cover the helpers directly; `tests/netcdf/test_netcdf_core.py::TestStr` covers the dispatch
+end to end.
+"""
+
+from __future__ import annotations
+
+import gc
+
+import numpy as np
+import pytest
+from osgeo import gdal
+
+from pyramids.netcdf import NetCDF
+from pyramids.netcdf.models import MAX_DISPLAY_VARIABLES
+from pyramids.netcdf.netcdf import (
+    _both_nan,
+    _collapse_uniform,
+    _container_summary,
+    _variable_summary,
+)
+
+pytestmark = pytest.mark.core
+
+
+def _write_store(path: str, variable_count: int = 1, unit: str | None = "K") -> str:
+    """Write a small NetCDF-4 store with `variable_count` data variables.
+
+    Args:
+        path: Output ``.nc`` path.
+        variable_count: How many 2-D data variables to create.
+        unit: CF ``units`` to stamp on each variable, or ``None`` for none.
+
+    Returns:
+        str: ``path``, for chaining.
+    """
+    ds = gdal.GetDriverByName("netCDF").CreateMultiDimensional(path, [], ["FORMAT=NC4"])
+    rg = ds.GetRootGroup()
+    d_y = rg.CreateDimension("y", "", "", 2)
+    d_x = rg.CreateDimension("x", "", "", 3)
+    lat = rg.CreateMDArray("y", [d_y], gdal.ExtendedDataType.Create(gdal.GDT_Float64))
+    lat.Write(np.array([51.0, 50.75]))
+    lon = rg.CreateMDArray("x", [d_x], gdal.ExtendedDataType.Create(gdal.GDT_Float64))
+    lon.Write(np.array([3.0, 3.25, 3.5]))
+    for arr, std, axis, units in (
+        (lat, "latitude", "Y", "degrees_north"),
+        (lon, "longitude", "X", "degrees_east"),
+    ):
+        for key, value in (("standard_name", std), ("axis", axis), ("units", units)):
+            attr = arr.CreateAttribute(key, [], gdal.ExtendedDataType.CreateString())
+            attr.Write(value)
+    made = []
+    for index in range(variable_count):
+        var = rg.CreateMDArray(
+            f"v{index}", [d_y, d_x], gdal.ExtendedDataType.Create(gdal.GDT_Float32)
+        )
+        var.Write(np.zeros((2, 3), "float32"))
+        if unit is not None:
+            attr = var.CreateAttribute(
+                "units", [], gdal.ExtendedDataType.CreateString()
+            )
+            attr.Write(unit)
+        made.append(var)
+    made = lat = lon = d_y = d_x = rg = None
+    ds.Close()
+    del ds
+    gc.collect()
+    return path
+
+
+class TestCollapseUniform:
+    """`_collapse_uniform` — one value when every band agrees, the sequence when they differ."""
+
+    def test_uniform_sequence_collapses(self):
+        """A sequence whose entries all match reports the single value.
+
+        Test scenario:
+            The reason the helper exists: a 12-band variable reports `['float32'] * 12`, which is
+            true and unreadable in a summary.
+        """
+        assert _collapse_uniform(["float32"] * 12) == "float32"
+
+    def test_mixed_sequence_is_left_alone(self):
+        """A genuinely mixed sequence keeps its per-band detail.
+
+        Test scenario:
+            Collapsing here would hide the information the caller needs.
+        """
+        assert _collapse_uniform(["float32", "int16"]) == ["float32", "int16"]
+
+    def test_all_nan_sequence_collapses(self):
+        """An all-`nan` no-data tuple collapses despite `nan != nan`.
+
+        Test scenario:
+            `no_data_value` comes back as a tuple of `nan`; plain equality would call it mixed and
+            print the whole tuple.
+        """
+        # Distinct nan objects on purpose: `(float("nan"),) * 12` repeats one object, so the
+        # identity check would collapse it even with the nan handling removed.
+        result = _collapse_uniform(tuple(float("nan") for _ in range(12)))
+        assert isinstance(result, float) and np.isnan(result), (
+            f"expected a single nan, got {result!r}"
+        )
+
+    def test_empty_sequence_is_none(self):
+        """An empty sequence yields `None`, so the caller omits the line."""
+        assert _collapse_uniform([]) is None
+
+    @pytest.mark.parametrize("value", ["float32", 3], ids=["str", "int"])
+    def test_scalar_passes_through(self, value):
+        """A non-sequence is returned unchanged.
+
+        Args:
+            value: A scalar the property might already have collapsed.
+
+        Test scenario:
+            Not every per-band property is a list; the helper must be safe to apply blindly.
+        """
+        assert _collapse_uniform(value) == value
+
+
+class TestBothNan:
+    """`_both_nan` — the one comparison `==` gets wrong."""
+
+    def test_two_nans_match(self):
+        """Two `nan`s are treated as equal."""
+        assert _both_nan(float("nan"), float("nan")) is True
+
+    @pytest.mark.parametrize(
+        "left, right", [(float("nan"), 1.0), (1.0, 1.0)], ids=["one-nan", "no-nan"]
+    )
+    def test_non_nan_pairs_do_not_match(self, left, right):
+        """Anything that is not a pair of `nan`s is False.
+
+        Args:
+            left: First value.
+            right: Second value.
+        """
+        assert _both_nan(left, right) is False
+
+    def test_non_numeric_is_survivable(self):
+        """A value `np.isnan` cannot handle returns False rather than raising.
+
+        Test scenario:
+            `band_units` holds strings, and the helper is applied to every per-band sequence, so
+            it must not raise on one.
+        """
+        assert _both_nan("K", "K") is False
+
+
+class TestCrsLabel:
+    """`NetCDF._crs_label` — a short label, never the raw WKT."""
+
+    def test_epsg_is_preferred(self, tmp_path):
+        """A store with an EPSG reports `EPSG:<code>`."""
+        nc = NetCDF.read_file(_write_store(str(tmp_path / "epsg.nc")))
+        try:
+            assert nc._crs_label() == f"EPSG:{nc.epsg}"
+        finally:
+            nc.close()
+
+    def test_falls_back_to_the_crs_name(self, tmp_path, monkeypatch):
+        """With no EPSG, the CRS *name* is used — still never the WKT.
+
+        Args:
+            tmp_path: pytest temp directory.
+            monkeypatch: Used to blank the EPSG so the fallback runs.
+
+        Test scenario:
+            A CRS with no authority code (a spherical-earth GRIB GEOGCS) has no `epsg`; dumping
+            its WKT instead would drown every other line of the summary.
+        """
+        nc = NetCDF.read_file(_write_store(str(tmp_path / "name.nc")))
+        try:
+            monkeypatch.setattr(type(nc), "epsg", property(lambda self: None))
+            label = nc._crs_label()
+            assert label not in ("", "unknown"), f"expected a CRS name, got {label!r}"
+            assert "GEOGCS" not in label, f"the WKT leaked into the label: {label}"
+        finally:
+            nc.close()
+
+    def test_unknown_when_nothing_resolves(self, tmp_path, monkeypatch):
+        """No EPSG and no CRS yields `unknown` rather than an empty label."""
+        nc = NetCDF.read_file(_write_store(str(tmp_path / "none.nc")))
+        try:
+            monkeypatch.setattr(type(nc), "epsg", property(lambda self: None))
+            monkeypatch.setattr(type(nc), "crs", property(lambda self: ""))
+            assert nc._crs_label() == "unknown"
+        finally:
+            nc.close()
+
+    def test_a_raising_crs_is_survivable(self, tmp_path, monkeypatch):
+        """A property that raises degrades to `unknown` instead of breaking `str()`.
+
+        Test scenario:
+            `str()` runs in debuggers and pytest introspection, so it must stay total.
+        """
+        nc = NetCDF.read_file(_write_store(str(tmp_path / "raise.nc")))
+
+        def _boom(self):
+            raise RuntimeError("no CRS")
+
+        try:
+            monkeypatch.setattr(type(nc), "epsg", property(_boom))
+            assert nc._crs_label() == "unknown"
+        finally:
+            nc.close()
+
+
+class TestContainerSummary:
+    """`_container_summary` — the branches a one-variable store does not reach."""
+
+    def test_units_are_shown_when_declared(self, tmp_path):
+        """A variable's CF units appear on its row."""
+        nc = NetCDF.read_file(_write_store(str(tmp_path / "units.nc"), unit="K"))
+        try:
+            assert " K" in _container_summary(nc)
+        finally:
+            nc.close()
+
+    def test_variable_list_is_truncated(self, tmp_path):
+        """More variables than the display cap are summarised, not listed.
+
+        Test scenario:
+            A store with dozens of variables would otherwise turn `print(nc)` into a wall of text.
+        """
+        count = MAX_DISPLAY_VARIABLES + 3
+        nc = NetCDF.read_file(
+            _write_store(str(tmp_path / "many.nc"), variable_count=count)
+        )
+        try:
+            summary = _container_summary(nc)
+            assert "... " in summary and " more" in summary, (
+                f"expected a truncation line, got:\n{summary}"
+            )
+            listed = sum(1 for line in summary.split("\n") if line.startswith("    v"))
+            assert listed <= MAX_DISPLAY_VARIABLES, (
+                f"listed {listed} variables, cap is {MAX_DISPLAY_VARIABLES}:\n{summary}"
+            )
+        finally:
+            nc.close()
+
+    def test_no_variables_reports_none(self, tmp_path, monkeypatch):
+        """A store the metadata reports as empty says `none`, not a blank block."""
+        nc = NetCDF.read_file(_write_store(str(tmp_path / "empty.nc")))
+        try:
+            monkeypatch.setattr(nc.meta_data, "variables", {})
+            assert "variables  : none" in _container_summary(nc)
+        finally:
+            nc.close()
+
+
+class _FakeVariable:
+    """The attributes `_variable_summary` reads, and nothing else.
+
+    A formatting function is worth testing against a stand-in: building a real NetCDF for every
+    combination of present/absent optional field would cost far more than it proves, and the
+    combinations are exactly what the branches are.
+    """
+
+    def __init__(self, **overrides):
+        """Start from a fully-populated variable and override the fields under test.
+
+        Args:
+            **overrides: Any attribute to replace on this stand-in.
+        """
+        self.file_name = "cube.nc"
+        self._parent_nc = None
+        self._source_var_name = "t2m"
+        self.cell_size = 0.25
+        self.rows = 5
+        self.columns = 5
+        self.band_count = 12
+        self._band_dim_name = "time"
+        self.band_units = ["K"] * 12
+        self.dtype = ["float32"] * 12
+        self.no_data_value = (float("nan"),) * 12
+        self.__dict__.update(overrides)
+
+    def _crs_label(self) -> str:
+        """The CRS label the real method would produce."""
+        return "EPSG:4326"
+
+
+class TestVariableSummary:
+    """`_variable_summary` — the optional lines appear only when there is something to say."""
+
+    def test_every_field_present(self):
+        """A fully-populated variable reports grid, bands, units, dtype and no-data."""
+        summary = _variable_summary(_FakeVariable())
+        assert summary.startswith("<Variable t2m - cube.nc>"), summary
+        for fragment in (
+            "grid    : 5 x 5 @ 0.25, EPSG:4326",
+            "bands   : 12 along time",
+            "units   : K",
+            "dtype   : float32",
+            "no-data : nan",
+        ):
+            assert fragment in summary, f"missing {fragment!r} in:\n{summary}"
+
+    def test_optional_fields_are_omitted_when_absent(self):
+        """Absent units / band axis / file name drop their line rather than print a blank.
+
+        Test scenario:
+            A variable built in memory has no path, a 2-D one has no band dimension, and an
+            unlabelled band has no units. None of those should leave a dangling label.
+        """
+        summary = _variable_summary(
+            _FakeVariable(
+                file_name="",
+                _band_dim_name=None,
+                band_units=[""] * 12,
+                no_data_value=(None,) * 12,
+            )
+        )
+        assert summary.startswith("<Variable t2m>"), summary
+        assert "units" not in summary, f"empty units should be omitted:\n{summary}"
+        assert "along" not in summary, f"absent band axis should be omitted:\n{summary}"
+        assert "no-data" not in summary, f"absent no-data should be omitted:\n{summary}"
+        assert "bands   : 12" in summary, f"band count is not optional:\n{summary}"
+
+    def test_file_name_falls_back_to_the_parent(self):
+        """A variable subset has no path of its own; the container it came from does.
+
+        Test scenario:
+            `get_variable` returns a view over an in-memory MDArray, so `file_name` is empty and
+            the header would otherwise lose the store it belongs to.
+        """
+        parent = _FakeVariable(file_name="/tmp/store/cube.nc")
+        summary = _variable_summary(_FakeVariable(file_name="", _parent_nc=parent))
+        assert summary.startswith("<Variable t2m - cube.nc>"), summary

--- a/tests/netcdf/unit/test_summary_helpers.py
+++ b/tests/netcdf/unit/test_summary_helpers.py
@@ -29,6 +29,7 @@ from pyramids.netcdf.netcdf import (
     _container_summary,
     _global_attribute_count,
     _has_georeference,
+    _same_value,
     _store_label,
     _variable_summary,
 )
@@ -171,6 +172,49 @@ class TestCollapseUniform:
             Not every per-band property is a list; the helper must be safe to apply blindly.
         """
         assert _collapse_uniform(value) == value
+
+
+class _Uncomparable:
+    """A value whose `==` raises, standing in for an exotic per-band entry.
+
+    `_same_value` guards against both halves of its `except` tuple. A numpy array supplies
+    the `ValueError` half -- `bool(array == array)` is ambiguous -- but nothing in the corpus
+    raises `TypeError` from `==`, so that half needs a stand-in.
+    """
+
+    def __eq__(self, other):
+        """Raise, the way a value with a hostile `__eq__` would."""
+        raise TypeError("cannot compare")
+
+
+class TestSameValue:
+    """`_same_value` — the comparison failures the per-band collapse has to survive."""
+
+    @pytest.mark.parametrize(
+        "left, right",
+        [
+            (np.array([1, 2]), np.array([1, 2])),
+            (_Uncomparable(), _Uncomparable()),
+        ],
+        ids=["ambiguous-array", "raising-eq"],
+    )
+    def test_a_raising_comparison_reports_not_the_same(self, left, right):
+        """A pair whose `==` raises answers False instead of propagating.
+
+        Args:
+            left: One band's value.
+            right: The value it is compared against.
+
+        Test scenario:
+            `bool(array == array)` raises `ValueError` (the truth value of a multi-element
+            array is ambiguous) and a hostile `__eq__` raises `TypeError`. `_collapse_uniform`
+            applies this to every per-band sequence, so a raise here would take `str()` down
+            with it -- the one thing the summary contract forbids. Distinct objects on purpose:
+            the identity fast path would answer True before `==` was ever reached.
+        """
+        assert _same_value(left, right) is False, (
+            f"a raising comparison must be False, got True for {left!r}"
+        )
 
 
 class TestBothNan:
@@ -536,6 +580,24 @@ class TestContainerSummary:
         finally:
             nc.close()
 
+    def test_a_released_handle_is_not_georeferenced(self):
+        """A container whose handle is gone reports no georeference rather than raising.
+
+        Test scenario:
+            The same store answers `True` while open, so the `False` here comes from the
+            `None` arm and not from the fixture. `close()` sets `_raster` to `None`, and the
+            helper is a plain function the package calls on whatever it is handed, so that
+            arm is live rather than defensive dead code -- without it the lookup would raise
+            `AttributeError` on a released handle, which `_container_summary` would then have
+            to swallow into `summary unavailable`.
+        """
+        path = "tests/data/netcdf/cf__5v__1d4-4d1__y-asc.nc"
+        nc = NetCDF.read_file(path, open_as_multi_dimensional=False)
+        assert _has_georeference(nc), "fixture must be georeferenced while it is open"
+        nc.close()
+        assert nc._raster is None, "close() must release the handle for this to bite"
+        assert _has_georeference(nc) is False, "a released handle has no geotransform"
+
     def test_long_lists_are_capped_by_width(self):
         """`dimensions` and `groups` stay readable on a store with many long names.
 
@@ -734,3 +796,18 @@ class TestVariableSummary:
         parent = _FakeVariable(file_name="/tmp/store/cube.nc")
         summary = _variable_summary(_FakeVariable(file_name="", _parent_nc=parent))
         assert summary.startswith("<Variable t2m - cube.nc>"), summary
+
+    def test_an_unreported_dtype_drops_its_line(self):
+        """A variable whose `dtype` reports nothing omits the line rather than printing it.
+
+        Test scenario:
+            `dtype` is the one optional line whose omission arm no fixture reached: units,
+            band axis and no-data all have an emptied case, but every stand-in kept a dtype.
+            An empty per-band sequence collapses to `None`, which must drop the label rather
+            than render `dtype   : None`.
+        """
+        summary = _variable_summary(_FakeVariable(dtype=[]))
+        assert "dtype" not in summary, (
+            f"an unreported dtype should be omitted:\n{summary}"
+        )
+        assert "bands   : 12" in summary, f"only the dtype line should go:\n{summary}"

--- a/tests/netcdf/unit/test_summary_helpers.py
+++ b/tests/netcdf/unit/test_summary_helpers.py
@@ -13,6 +13,7 @@ end to end.
 from __future__ import annotations
 
 import gc
+import logging
 from pathlib import Path
 
 import numpy as np
@@ -78,6 +79,28 @@ def _write_store(path: str, variable_count: int = 1, unit: str | None = "K") -> 
     del ds
     gc.collect()
     return path
+
+
+def _raise_from(nc, name: str):
+    """Make `name` raise on `nc` alone, by moving it to a throwaway subclass.
+
+    Patching the property onto `Container` itself would affect every live container for the
+    test's duration, and on undo would reinstall the inherited `NetCDF` property as an *own*
+    attribute of `Container`. Re-basing this one instance keeps the blast radius to it.
+
+    Args:
+        nc: The dataset to sabotage.
+        name: The property that should raise.
+
+    Returns:
+        The same object, now an instance of the throwaway subclass.
+    """
+
+    def _boom(self):
+        raise RuntimeError(f"{name} exploded")
+
+    nc.__class__ = type(f"_Raising_{name}", (type(nc),), {name: property(_boom)})
+    return nc
 
 
 class TestCollapseUniform:
@@ -220,6 +243,44 @@ class TestCrsLabel:
         try:
             monkeypatch.setattr(type(nc), "epsg", property(_boom))
             assert nc._crs_label() == "unknown"
+        finally:
+            nc.close()
+
+
+class TestSummaryLogging:
+    """The summary swallows exceptions to stay total, and says so at DEBUG."""
+
+    def test_a_failing_summary_is_logged(self, tmp_path, caplog):
+        """`str()` degrades to a sentinel and records why.
+
+        Test scenario:
+            A swallowed error that logs nothing cannot be diagnosed: the sentinel names neither
+            the property nor the exception, so without the log line the maintainer sees only
+            `summary unavailable`.
+        """
+        nc = NetCDF.read_file(_write_store(str(tmp_path / "boom.nc")))
+        try:
+            _raise_from(nc, "dimension_sizes")
+            with caplog.at_level(logging.DEBUG, logger="pyramids.netcdf.netcdf"):
+                rendered = str(nc)
+            assert rendered.endswith("summary unavailable>"), rendered
+            assert any("summary failed" in r.message for r in caplog.records), (
+                f"nothing logged; records={[r.message for r in caplog.records]}"
+            )
+        finally:
+            nc.close()
+
+    def test_a_failing_crs_label_is_logged(self, tmp_path, caplog):
+        """`unknown` is also an honest answer, so a failure behind it must be logged."""
+        nc = NetCDF.read_file(_write_store(str(tmp_path / "nocrs.nc")))
+        try:
+            _raise_from(nc, "epsg")
+            with caplog.at_level(logging.DEBUG, logger="pyramids.netcdf.netcdf"):
+                label = nc._crs_label()
+            assert label == "unknown", label
+            assert any("CRS label failed" in r.message for r in caplog.records), (
+                f"nothing logged; records={[r.message for r in caplog.records]}"
+            )
         finally:
             nc.close()
 

--- a/tests/netcdf/unit/test_summary_helpers.py
+++ b/tests/netcdf/unit/test_summary_helpers.py
@@ -310,6 +310,40 @@ class TestContainerSummary:
         finally:
             nc.close()
 
+    def test_grouped_store_qualifies_every_variable(self):
+        """A grouped store labels each row by its full path, so no two rows look alike.
+
+        Test scenario:
+            `meta_data.variables` spans sub-groups and is keyed by `group/name`, but every group
+            in this fixture carries the same leaf names, so rendering `info.name` printed `CO`,
+            `O3`, `UTC_time` and `air_press` two and three times with nothing to tell them apart.
+            The labels must carry the group path, the way `variable_names` spells its own names.
+        """
+        path = "tests/data/netcdf/none__35v__1d35__groups-nc4.nc"
+        nc = NetCDF.read_file(path)
+        try:
+            assert len(nc.group_names) > 1, "fixture must be grouped for this to bite"
+            summary = _container_summary(nc)
+            rows = [
+                line.strip()
+                for line in summary.split("\n")
+                if line.startswith("    ") and not line.strip().startswith("...")
+            ]
+            labels = [row.split("  ")[0] for row in rows]
+            assert labels, f"no variable rows rendered:\n{summary}"
+            assert len(labels) == len(set(labels)), (
+                f"duplicate variable labels {labels} in:\n{summary}"
+            )
+            qualified = [label for label in labels if "/" in label]
+            assert qualified, f"no group-qualified label in:\n{summary}"
+            groups = set(nc.group_names)
+            for label in qualified:
+                assert label.rsplit("/", 1)[0] in groups, (
+                    f"{label!r} is not qualified by one of the store's groups"
+                )
+        finally:
+            nc.close()
+
 
 class _FakeVariable:
     """The attributes `_variable_summary` reads, and nothing else.

--- a/tests/netcdf/unit/test_summary_helpers.py
+++ b/tests/netcdf/unit/test_summary_helpers.py
@@ -378,6 +378,24 @@ class TestStoreLabel:
 
         assert _store_label(_InMemory()) == ("in-memory", True)
 
+    def test_a_signed_remote_path_is_redacted(self):
+        """A signature in the store path must not reach the header.
+
+        Test scenario:
+            `file_name` is the GDAL description, so a remote open keeps its query string and
+            the base name still carries the credential. `str()` reaches every log handler and
+            pytest's assertion output.
+        """
+
+        class _Signed:
+            file_name = "/vsis3/bucket/cube.nc?X-Amz-Signature=deadbeef"
+            driver_type = "netcdf"
+
+        label, in_memory = _store_label(_Signed())
+        assert "deadbeef" not in label, f"signature leaked into the header: {label}"
+        assert label == "cube.nc?X-Amz-Signature=<redacted>", label
+        assert in_memory is False, "a signed remote path is not in-memory"
+
     def test_a_group_scoped_in_memory_store_still_reports_in_memory(self):
         """The group suffix must not hide the in-memory verdict from the caller.
 

--- a/tests/netcdf/unit/test_summary_helpers.py
+++ b/tests/netcdf/unit/test_summary_helpers.py
@@ -103,6 +103,24 @@ def _raise_from(nc, name: str):
     return nc
 
 
+def _override(nc, **properties):
+    """Give `nc` alone the supplied property values, via a throwaway subclass.
+
+    Args:
+        nc: The dataset to re-base.
+        **properties: Property name to fixed value.
+
+    Returns:
+        The same object, now an instance of the throwaway subclass.
+    """
+    namespace = {
+        name: property(lambda self, value=value: value)
+        for name, value in properties.items()
+    }
+    nc.__class__ = type("_Overridden", (type(nc),), namespace)
+    return nc
+
+
 class TestCollapseUniform:
     """`_collapse_uniform` — one value when every band agrees, the sequence when they differ."""
 
@@ -195,7 +213,7 @@ class TestCrsLabel:
         finally:
             nc.close()
 
-    def test_falls_back_to_the_crs_name(self, tmp_path, monkeypatch):
+    def test_falls_back_to_the_crs_name(self, tmp_path):
         """With no EPSG, the CRS *name* is used — still never the WKT.
 
         Args:
@@ -208,40 +226,31 @@ class TestCrsLabel:
         """
         nc = NetCDF.read_file(_write_store(str(tmp_path / "name.nc")))
         try:
-            monkeypatch.setattr(
-                type(nc), "epsg", property(lambda self: None), raising=True
-            )
+            _override(nc, epsg=None)
             label = nc._crs_label()
             assert label not in ("", "unknown"), f"expected a CRS name, got {label!r}"
             assert "GEOGCS" not in label, f"the WKT leaked into the label: {label}"
         finally:
             nc.close()
 
-    def test_unknown_when_nothing_resolves(self, tmp_path, monkeypatch):
+    def test_unknown_when_nothing_resolves(self, tmp_path):
         """No EPSG and no CRS yields `unknown` rather than an empty label."""
         nc = NetCDF.read_file(_write_store(str(tmp_path / "none.nc")))
         try:
-            monkeypatch.setattr(
-                type(nc), "epsg", property(lambda self: None), raising=True
-            )
-            monkeypatch.setattr(type(nc), "crs", property(lambda self: ""))
+            _override(nc, epsg=None, crs="")
             assert nc._crs_label() == "unknown"
         finally:
             nc.close()
 
-    def test_a_raising_crs_is_survivable(self, tmp_path, monkeypatch):
+    def test_a_raising_crs_is_survivable(self, tmp_path):
         """A property that raises degrades to `unknown` instead of breaking `str()`.
 
         Test scenario:
             `str()` runs in debuggers and pytest introspection, so it must stay total.
         """
         nc = NetCDF.read_file(_write_store(str(tmp_path / "raise.nc")))
-
-        def _boom(self):
-            raise RuntimeError("no CRS")
-
         try:
-            monkeypatch.setattr(type(nc), "epsg", property(_boom))
+            _raise_from(nc, "epsg")
             assert nc._crs_label() == "unknown"
         finally:
             nc.close()
@@ -398,7 +407,7 @@ class TestContainerSummary:
         nc = NetCDF.read_file(_write_store(str(tmp_path / "empty.nc")))
         try:
             monkeypatch.setattr(nc.meta_data, "variables", {})
-            monkeypatch.setattr(type(nc), "variable_names", property(lambda self: []))
+            _override(nc, variable_names=[])
             summary = _container_summary(nc)
             assert "variables  : none" in summary, summary
         finally:
@@ -421,7 +430,12 @@ class TestContainerSummary:
             )
             summary = str(nc)
             assert summary.startswith("<Container "), f"wrong header: {summary}"
-            assert "?" not in summary.split("\n")[0], f"placeholder name: {summary}"
+            # Not `"?" not in ...`: the `?` placeholder is gone from the source, so that
+            # assertion could no longer fail while still reading as load-bearing. The header
+            # being a Container at all is round-1 H1's real symptom.
+            assert not summary.startswith("<Variable"), (
+                f"classic container dispatched to the variable summary: {summary}"
+            )
             assert "grid       :" in summary, f"real grid not reported: {summary}"
             for claim in ("dimensions : none", "groups     : none"):
                 assert claim not in summary, f"asserted an unknown as fact: {summary}"


### PR DESCRIPTION
# Description

`str()` on a `Container` reported a raster the container does not have. For a 12 x 5 x 5 cube at
0.25 degrees it printed **`Dimension: 512 * 512`** at **`Cell size: 1.0`** — all three numbers
fabricated.

`__str__` was defined once on `NetCDF` and inherited by both subclasses, so a container fell
through to `rows` / `columns` / `cell_size`, which for an MDIM store have no raster behind them and
return GDAL's in-memory placeholder. `dimension_sizes` was sitting right there with the truth and
was never consulted.

A container now describes the store. Real output for
`tests/data/netcdf/cf__5v__1d4-3d1__geog__y-desc.nc`:

```
<Container cf__5v__1d4-3d1__geog__y-desc.nc>
  dimensions : valid_time=12, latitude=5, longitude=5
  variables  :
    expver      (12)  unknown
    latitude    (5)  float64  degrees_north
    longitude   (5)  float64  degrees_east
    t2m         (12, 5, 5)  float32  K
    valid_time  (12)  int64  seconds since 1970-01-01
  groups     : none
  CRS        : EPSG:4326
  attributes : 6 global
```

A `Variable` keeps the raster it genuinely is:

```
<Variable t2m - cf__5v__1d4-3d1__geog__y-desc.nc>
  grid    : 5 x 5 @ 0.25, EPSG:4326
  bands   : 12 along valid_time
  units   : K
  dtype   : float32
  no-data : nan
```

## What changed

- `NetCDF.__str__` picks the summary **by type**, through a `_summary_text` hook that `Container`
  and `Variable` override. A band-count test was tried first and is wrong: a container opened in
  classic mode carries the store's bands directly, so `band_count >= 1` there and 11 of 22 corpus
  fixtures were mislabelled as variables. The classes already encode the distinction `read_file`
  and `get_variable` established.
- The summaries are module-level functions (`_container_summary` / `_variable_summary`) rather than
  the unbound `Container.__str__(self)` form the issue sketched: that call is
  `incompatible type "NetCDF"; expected "Container"` under mypy.
- The container listing is sourced from `meta_data.variables`, so it covers coordinate and
  auxiliary arrays, and each row is labelled by the map's **full `group/name` key** — on a grouped
  store the leaf names repeat across groups, and labelling by leaf printed `CO` and `air_press`
  two and three times with nothing to tell the rows apart.
- The variable summary collapses uniform per-band sequences (`float32`, not `['float32'] * 12`) and
  names the band axis by its dimension (`12 along valid_time`, not `Band_1 ... Band_12`).
- Neither dumps raw WKT (`EPSG:4326`, or the CRS name) nor the whole metadata object (a count), and
  the f-string is no longer indented inside the method, so lines stop carrying 12 leading spaces.

### Placeholders are not reported as facts

The point of the change is that the summary says only what it can know, so several lines are
conditional rather than always printed:

- **`none` only where it is a fact.** MDIM stores publish their dimensions, variables and groups,
  so an empty one genuinely means none. Classic mode publishes no such metadata, so those lines are
  omitted rather than claimed empty.
- **No cell size without a geotransform.** A curvilinear or unstructured store has no affine
  mapping, so `cell_size` reads 1.0 by construction; three corpus fixtures were printing `@ 1` as
  though measured. Gated on `GetGeoTransform(can_return_null=True)`, so a genuine 1-unit grid keeps
  its `@ 1`.
- **In-memory is decided by the driver**, not by whether the path has a file extension — a real
  extensionless file (`mkstemp` output, an OPeNDAP endpoint, a content-typed download) was being
  reported as `in-memory`. This is the predicate `abstract_dataset._require_writable` already uses.
- **Global attributes are counted from the open handle in classic mode.** The classic metadata
  top-up leaves `global_attributes` empty on more than half the corpus — it reported no attributes
  for a store carrying eighteen. The handle's `NC_GLOBAL#` keys match the multidimensional count on
  21 of 22 fixtures.

### Safe to print anywhere

- **Credentials are redacted.** `file_name` is the GDAL description, so a remote open keeps its
  query string and the base name of a signed `/vsis3/` path carried the signature into every log
  handler. Routed through `redact_credentials`, as `Dataset.__repr__` is.
- **Total by contract.** A closed handle returns a sentinel, and any property that raises degrades
  to `<Container: summary unavailable>` rather than masking the error the caller was looking at —
  now logged at DEBUG through a module logger, matching `pyramids.netcdf.metadata`, so a swallowed
  failure is diagnosable.
- **Bounded.** Every list truncates by count *and* width. The longest summary line across the
  corpus went from 372 characters to 113 over 48 opens.
- **Cheap.** No band reads and no `stats()`. The variable summary performs no I/O at all (0.0 ms);
  the container summary builds `meta_data` once (~44 ms, one open) and is ~0.5 ms cached.

## Deliberate deviations from the issue's spec

- **The closed sentinel stays `<Dataset: closed>`**, not the proposed `<NetCDF: closed>`. The
  issue's actual rule — a closed handle returns a sentinel rather than raising — holds either way,
  so renaming it would be a gratuitous break.
- **`UgridDataset`, `LabeledDataset` and `LabeledArray` are not touched.** The issue's §3 table asks
  for summaries there too, but those are separate classes with their own `__repr__`s and are well
  outside the defect this PR closes. Happy to do them in a follow-up if wanted.
- **`__repr__` is unchanged and still shows the placeholder.** It is `gdal.Info` on the underlying
  raster — a different contract — so a notebook cell, a debugger's variable pane and pytest's
  assertion output still report `Size is 512, 512` for a container. `docs/migration.md` says so
  explicitly rather than implying the placeholder is gone everywhere.
- Part 2 of the issue (`variable_names` narrowing) needed no work here: it was fixed by `3d3a0117d`
  (#1084), which merged 17 minutes after the issue was filed. Verified before starting — see the
  issue body, which now records the evidence.

No new dependencies.

# Issues

- Closes #1090 — `Container.__str__` reported a 512x512 placeholder raster instead of the cube

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] The reporter's script, run unchanged, now prints the cube instead of a 512 x 512 placeholder.
- [x] `TestStr` in `tests/netcdf/test_netcdf_core.py` rewritten. `test_str_contains_cell_size`
  asserted `"Cell size"` appears in a **container's** summary — it pinned the defect. It is
  replaced by four contract tests: a container omits the raster fields and reports its cube, a
  variable keeps its grid and band axis, and neither summary leaks WKT.
- [x] `tests/netcdf/unit/test_summary_helpers.py` covers the helpers directly, including the
  grouped-store labelling, the unreferenced-store grid line, the width caps, the credential
  redaction, the classic attribute count, both arms of the base dispatch, and the DEBUG logging
  behind both swallowed-exception paths.
- [x] Verified non-vacuous: each regression test was re-run against the pre-fix rendering and fails.
- [x] Corpus sweep: `str()` over all 26 fixtures in both modes (48 opens) raises nothing.
- [x] `pytest tests/netcdf -m "not plot"` — **3091 passed, 72 skipped**.
- [x] `ruff format` / `ruff check` clean; `mypy` clean on the changed module; doctests green.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.
