### PR TITLE
fix(netcdf): range-check the datetime64 cast instead of catching it

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -640,17 +640,32 @@ Soft change, warned — a `RuntimeWarning` names the units. Only arrays that wer
 1677-09-21 to 2262-04-11 range does not raise on the cast, it wraps.
 
 ```python
+import numpy as np
+from pyramids.netcdf.utils import decode_cf_time
+
 decode_cf_time(np.array([400_000]), "days since 1970-01-01", "standard")
 # before -> np.datetime64('1896-01-21T00:50:52.580896768')   # the date is year 3065
-# after  -> cftime.DatetimeGregorian(3065, 3, 1)             # + RuntimeWarning
+# after  -> cftime.real_datetime(3065, 3, 1)                 # + UserWarning
 ```
 
 Both bounds are affected, and no large offset is needed to reach one: a store written against a
 `days since 0001-01-01` epoch is out of range at offset **zero**. Its in-range dates are unaffected — a
 20th-century date on that epoch still decodes to `datetime64[ns]` exactly as before.
 
+**Which object you get back is `cftime`'s choice, and it decides what still works downstream.** For a date
+Python's `datetime` can represent — the common far-future case above — it is `cftime.real_datetime`, a
+`datetime` subclass, so `pandas` gives `datetime64[us]` and `to_dataframe` / `to_parquet` / `to_csv` all keep
+working and now carry the *correct* date. Only a date Python cannot represent, which in practice means a
+pre-1582 origin on a mixed calendar, yields a true `cftime` datetime.
+
+**`LabeledDataset.to_parquet` raises on that second case**, where it previously wrote a file full of wrapped
+dates. Parquet has no type for a `cftime` datetime, so the write now fails with a `FailedToSaveError` naming the
+offending columns rather than an `ArrowInvalid` from inside pyarrow. This was already the behaviour for a
+non-standard calendar (`360_day`, `noleap`), which has always produced `cftime` objects — the change is that the
+error explains itself. Use `to_csv`, which writes these stores unchanged, or select an in-range window first.
+
 If you need `datetime64` regardless, the values were never trustworthy in this range; convert deliberately from
-the `cftime` objects, or read the axis with a calendar-aware library. Everything inside the range is unchanged.
+the returned objects, or read the axis with a calendar-aware library. Everything inside the range is unchanged.
 
 **`str(nc)` is a different shape, and the summary now depends on whether you hold a container or a variable.**
 Hard change, silent — nothing raises and nothing warns. Anything scraping the old text (log parsing, notebook

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -635,7 +635,7 @@ replace the georeference wholesale.
 ### unreleased
 
 **A time axis outside `datetime64[ns]`'s range now decodes to `cftime` objects instead of wrapping.**
-Soft change, warned — a `RuntimeWarning` names the units. Only arrays that were previously **wrong** change:
+Soft change, warned — a `UserWarning` names the axis and its units. Only arrays that were previously **wrong** change:
 `decode_cf_time` cast to `datetime64[ns]` under a guard that cannot fire, because a date beyond the type's
 1677-09-21 to 2262-04-11 range does not raise on the cast, it wraps.
 
@@ -648,13 +648,24 @@ decode_cf_time(np.array([400_000]), "days since 1970-01-01", "standard")
 # after  -> cftime.real_datetime(3065, 3, 1)                 # + UserWarning
 ```
 
+**A missing timestep is now `NaT` rather than the epoch.** `cftime` marks the offsets it cannot decode — a
+`NaN` or an `inf` — and that mark used to be dropped, leaving the fill value, which is the origin, so a missing
+timestep read back as a real date. It is now `NaT` in a `datetime64` result and `None` in an object one. Values
+change wherever an axis has missing offsets, and they change from wrong to right; the integer decode path has
+always behaved this way, so only the `cftime` path moves.
+
+**A `"months since …"` axis on a non-`360_day` calendar now raises a clearer error.** It always raised — a
+calendar month has no fixed length, so `cftime` allows the unit only on `360_day` — but the `ValueError` came
+from inside `cftime`, naming neither the axis nor the store. It now names the axis, units and calendar and
+chains the original. Nothing that previously succeeded now fails.
+
 Both bounds are affected, and no large offset is needed to reach one: a store written against a
 `days since 0001-01-01` epoch is out of range at offset **zero**. Its in-range dates are unaffected — a
 20th-century date on that epoch still decodes to `datetime64[ns]` exactly as before.
 
 **Which object you get back is `cftime`'s choice, and it decides what still works downstream.** It follows the
 **origin**, not the dates: when proleptic Gregorian rules already cover the origin — a `proleptic_gregorian`
-calendar, or a mixed-calendar origin at or after the 1582 reform — you get `cftime.real_datetime`, a `datetime`
+calendar, or a mixed-calendar origin after the 1582 reform — you get `cftime.real_datetime`, a `datetime`
 subclass, so `pandas` gives `datetime64[us]` and `to_dataframe` / `to_parquet` / `to_csv` all keep working and
 now carry the *correct* date. That covers the common far-future case above. A pre-1582 origin on a mixed
 calendar yields a true `cftime` datetime instead, for every value on the axis — including its post-1582 ones.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -634,6 +634,24 @@ replace the georeference wholesale.
 
 ### unreleased
 
+**A time axis outside `datetime64[ns]`'s range now decodes to `cftime` objects instead of wrapping.**
+Soft change, warned — a `RuntimeWarning` names the units. Only arrays that were previously **wrong** change:
+`decode_cf_time` cast to `datetime64[ns]` under a guard that cannot fire, because a date beyond the type's
+1677-09-21 to 2262-04-11 range does not raise on the cast, it wraps.
+
+```python
+decode_cf_time(np.array([400_000]), "days since 1970-01-01", "standard")
+# before -> np.datetime64('1896-01-21T00:50:52.580896768')   # the date is year 3065
+# after  -> cftime.DatetimeGregorian(3065, 3, 1)             # + RuntimeWarning
+```
+
+Both bounds are affected, and no large offset is needed to reach one: a store written against a
+`days since 0001-01-01` epoch is out of range at offset **zero**. Its in-range dates are unaffected — a
+20th-century date on that epoch still decodes to `datetime64[ns]` exactly as before.
+
+If you need `datetime64` regardless, the values were never trustworthy in this range; convert deliberately from
+the `cftime` objects, or read the axis with a calendar-aware library. Everything inside the range is unchanged.
+
 **`str(nc)` is a different shape, and the summary now depends on whether you hold a container or a variable.**
 Hard change, silent — nothing raises and nothing warns. Anything scraping the old text (log parsing, notebook
 snapshots, doctests) will stop matching.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -652,11 +652,12 @@ Both bounds are affected, and no large offset is needed to reach one: a store wr
 `days since 0001-01-01` epoch is out of range at offset **zero**. Its in-range dates are unaffected — a
 20th-century date on that epoch still decodes to `datetime64[ns]` exactly as before.
 
-**Which object you get back is `cftime`'s choice, and it decides what still works downstream.** For a date
-Python's `datetime` can represent — the common far-future case above — it is `cftime.real_datetime`, a
-`datetime` subclass, so `pandas` gives `datetime64[us]` and `to_dataframe` / `to_parquet` / `to_csv` all keep
-working and now carry the *correct* date. Only a date Python cannot represent, which in practice means a
-pre-1582 origin on a mixed calendar, yields a true `cftime` datetime.
+**Which object you get back is `cftime`'s choice, and it decides what still works downstream.** It follows the
+**origin**, not the dates: when proleptic Gregorian rules already cover the origin — a `proleptic_gregorian`
+calendar, or a mixed-calendar origin at or after the 1582 reform — you get `cftime.real_datetime`, a `datetime`
+subclass, so `pandas` gives `datetime64[us]` and `to_dataframe` / `to_parquet` / `to_csv` all keep working and
+now carry the *correct* date. That covers the common far-future case above. A pre-1582 origin on a mixed
+calendar yields a true `cftime` datetime instead, for every value on the axis — including its post-1582 ones.
 
 **`LabeledDataset.to_parquet` raises on that second case**, where it previously wrote a file full of wrapped
 dates. Parquet has no type for a `cftime` datetime, so the write now fails with a `FailedToSaveError` naming the

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -25,10 +25,12 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Literal, cast
 
+import cftime
 import numpy as np
 import pandas as pd
 from osgeo import gdal
 
+from pyramids.base._errors import FailedToSaveError
 from pyramids.base._utils import extra_hint, import_pyarrow
 from pyramids.base.remote import (
     _DODS_SCHEME,
@@ -48,12 +50,36 @@ from pyramids.netcdf.utils import (
 # (the estimate is dtype x selected size — no data is read to compute it).
 _LARGE_REALISE_BYTES = 512 * 1024 * 1024
 
+
 # The conda half of this hint names `pyramids-parquet`, not `pyarrow` as it once
 # did. That is a real conda-forge output of the pyramids feedstock (alongside
 # `pyramids`, `pyramids-viz`, `pyramids-lazy` and `pyramids-stac`), and it
 # depends on `pyarrow >=10.0.0` + `dask-geopandas >=0.5.0`, so it installs what
 # the `[parquet]` extra installs -- verified against the feedstock recipe and
 # anaconda.org before the message was switched over.
+def _cftime_columns(frame: pd.DataFrame) -> list[str]:
+    """Names of the columns holding true `cftime` datetimes, which Parquet cannot store.
+
+    Only a genuine `cftime` datetime is a problem. A `cftime.real_datetime` is a
+    `datetime.datetime` subclass, so `pandas` coerces it to `datetime64[us]` and Parquet
+    takes it -- including for a year-3065 date, which is the common out-of-range case.
+
+    Args:
+        frame: The tidy table about to be written.
+
+    Returns:
+        list[str]: The offending column names, in column order.
+    """
+    offenders = []
+    for name in frame.columns:
+        column = frame[name]
+        if column.dtype == object:
+            values = column.to_numpy()
+            if values.size and isinstance(values[0], cftime.datetime):
+                offenders.append(str(name))
+    return offenders
+
+
 _PARQUET_INSTALL_HINT = extra_hint(
     "Writing Parquet needs the optional 'pyarrow' dependency.",
     "parquet",
@@ -1047,10 +1073,27 @@ class LabeledDataset:
 
         Raises:
             OptionalPackageDoesNotExist: When pyarrow is not installed.
+            FailedToSaveError: A time axis decodes to dates outside
+                `datetime64[ns]`, so it is carried as `cftime` objects that Parquet
+                has no type for (#1087).
         """
         import_pyarrow(_PARQUET_INSTALL_HINT)
         path = Path(path)
-        self.to_dataframe().to_parquet(str(path), index=False, **kwargs)
+        frame = self.to_dataframe()
+        try:
+            frame.to_parquet(str(path), index=False, **kwargs)
+        except Exception as error:
+            unstorable = _cftime_columns(frame)
+            if not unstorable:
+                raise
+            raise FailedToSaveError(
+                f"cannot write {path}: the column(s) {', '.join(unstorable)} carry "
+                "cftime datetimes, which Parquet has no type for. That happens when a "
+                "time axis decodes to dates outside the 1677-09-21 to 2262-04-11 range "
+                "datetime64[ns] can represent, or uses a non-standard calendar, so the "
+                "dates are kept as objects rather than being wrapped to wrong values "
+                "(#1087). Write to CSV instead, or select an in-range window first."
+            ) from error
         return path
 
     def to_csv(self, path: str | Path, **kwargs: Any) -> Path:

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -728,6 +728,12 @@ class LabeledDataset:
 
         Returns:
             np.ndarray: Decoded datetimes for a time axis, else ``values``.
+
+        Raises:
+            ValueError: Propagated from ``decode_cf_time`` when ``cftime`` cannot decode
+                the axis -- most often a ``"months since …"`` unit on anything but the
+                ``360_day`` calendar, which ``is_cf_time_units`` admits because it is
+                purely syntactic and never sees the calendar.
         """
         unit = arr.GetUnit()
         if not is_cf_time_units(unit):
@@ -1086,9 +1092,12 @@ class LabeledDataset:
             OptionalPackageDoesNotExist: When pyarrow is not installed.
             FailedToSaveError: A column carries true `cftime` datetimes, which Parquet has
                 no type for -- a non-standard calendar (`360_day` / `noleap` …), or a
-                pre-1582 origin on a mixed one. A merely out-of-range date does not trigger
-                it: `cftime` hands those back as `cftime.real_datetime`, which `pandas`
-                stores as `datetime64[us]` and Parquet takes (#1087).
+                mixed-calendar origin no later than the 1582 reform. A merely out-of-range
+                date does not trigger it: `cftime` hands those back as
+                `cftime.real_datetime`, which `pandas` stores as `datetime64[us]` and
+                Parquet takes (#1087). Both conditions are required -- such a column *and*
+                a pyarrow message naming the type -- so a write that fails for an
+                unrelated reason (an unwritable path, a full disk) propagates unchanged.
         """
         import_pyarrow(_PARQUET_INSTALL_HINT)
         path = Path(path)

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -65,8 +65,11 @@ def _cftime_columns(frame: pd.DataFrame) -> list[str]:
         list[str]: The offending column names, in column order.
     """
     offenders = []
-    for name in frame.columns:
-        column = frame[name]
+    # Positional, not `frame[name]`: a duplicate column label makes that return a
+    # DataFrame, whose `.dtype` raises `AttributeError` -- inside an `except` block, which
+    # would replace the write failure with an unrelated one.
+    for position, name in enumerate(frame.columns):
+        column = frame.iloc[:, position]
         if column.dtype == object:
             # Every element, not just the first. `cftime` picks one class per array from
             # the units origin, so a column decoded in one go is uniform -- but a frame
@@ -1093,8 +1096,12 @@ class LabeledDataset:
         try:
             frame.to_parquet(str(path), index=False, **kwargs)
         except Exception as error:
+            # Both conditions: a frame can carry a cftime column and still fail for an
+            # unrelated reason (an unwritable path, a full disk), and re-labelling that as
+            # a time-axis problem would send the caller after the wrong thing. pyarrow
+            # names the offending type in its message, so require that too.
             unstorable = _cftime_columns(frame)
-            if not unstorable:
+            if not unstorable or "cftime" not in str(error):
                 raise
             raise FailedToSaveError(
                 f"cannot write {path}: the column(s) {', '.join(unstorable)} carry "

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -51,12 +51,6 @@ from pyramids.netcdf.utils import (
 _LARGE_REALISE_BYTES = 512 * 1024 * 1024
 
 
-# The conda half of this hint names `pyramids-parquet`, not `pyarrow` as it once
-# did. That is a real conda-forge output of the pyramids feedstock (alongside
-# `pyramids`, `pyramids-viz`, `pyramids-lazy` and `pyramids-stac`), and it
-# depends on `pyarrow >=10.0.0` + `dask-geopandas >=0.5.0`, so it installs what
-# the `[parquet]` extra installs -- verified against the feedstock recipe and
-# anaconda.org before the message was switched over.
 def _cftime_columns(frame: pd.DataFrame) -> list[str]:
     """Names of the columns holding true `cftime` datetimes, which Parquet cannot store.
 
@@ -84,6 +78,12 @@ def _cftime_columns(frame: pd.DataFrame) -> list[str]:
     return offenders
 
 
+# The conda half of this hint names `pyramids-parquet`, not `pyarrow` as it once
+# did. That is a real conda-forge output of the pyramids feedstock (alongside
+# `pyramids`, `pyramids-viz`, `pyramids-lazy` and `pyramids-stac`), and it
+# depends on `pyarrow >=10.0.0` + `dask-geopandas >=0.5.0`, so it installs what
+# the `[parquet]` extra installs -- verified against the feedstock recipe and
+# anaconda.org before the message was switched over.
 _PARQUET_INSTALL_HINT = extra_hint(
     "Writing Parquet needs the optional 'pyarrow' dependency.",
     "parquet",
@@ -714,8 +714,10 @@ class LabeledDataset:
         timestamps rather than raw numbers. A standard calendar yields
         ``datetime64[ns]`` **when the dates fit in it**; a non-standard calendar
         (``360_day`` / ``noleap`` …), or a date outside 1677-09-21 to 2262-04-11,
-        yields the decoded datetime objects instead, with a warning naming this
-        array (#1087). Non-time arrays pass through unchanged.
+        yields the decoded datetime objects instead. Only the out-of-range case
+        warns, and it names this array -- which is why ``arr``'s name is handed
+        down as ``context`` (#1087); a non-standard calendar has always returned
+        objects and is no surprise. Non-time arrays pass through unchanged.
 
         Args:
             arr: The source MDArray (its unit / calendar drive the decode).
@@ -1079,9 +1081,11 @@ class LabeledDataset:
 
         Raises:
             OptionalPackageDoesNotExist: When pyarrow is not installed.
-            FailedToSaveError: A time axis decodes to dates outside
-                `datetime64[ns]`, so it is carried as `cftime` objects that Parquet
-                has no type for (#1087).
+            FailedToSaveError: A column carries true `cftime` datetimes, which Parquet has
+                no type for -- a non-standard calendar (`360_day` / `noleap` …), or a
+                pre-1582 origin on a mixed one. A merely out-of-range date does not trigger
+                it: `cftime` hands those back as `cftime.real_datetime`, which `pandas`
+                stores as `datetime64[us]` and Parquet takes (#1087).
         """
         import_pyarrow(_PARQUET_INSTALL_HINT)
         path = Path(path)

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -707,9 +707,11 @@ class LabeledDataset:
 
         A coordinate with a ``<interval> since <date>`` unit is decoded with
         ``cftime`` so reads (``__getitem__`` / ``to_dataframe``) return real
-        timestamps rather than raw numbers. Standard calendars yield
-        ``datetime64[ns]``; non-standard calendars (``360_day`` / ``noleap`` …)
-        yield ``cftime`` objects. Non-time arrays pass through unchanged.
+        timestamps rather than raw numbers. A standard calendar yields
+        ``datetime64[ns]`` **when the dates fit in it**; a non-standard calendar
+        (``360_day`` / ``noleap`` …), or a date outside 1677-09-21 to 2262-04-11,
+        yields the decoded datetime objects instead, with a warning naming this
+        array (#1087). Non-time arrays pass through unchanged.
 
         Args:
             arr: The source MDArray (its unit / calendar drive the decode).
@@ -723,7 +725,7 @@ class LabeledDataset:
             return values
         cal_attr = _get_attr(arr, "calendar")
         calendar = cal_attr.ReadAsString() if cal_attr is not None else "standard"
-        return decode_cf_time(values, unit, calendar)
+        return decode_cf_time(values, unit, calendar, context=arr.GetName())
 
     def _coord_full(self, name: str) -> np.typing.NDArray:
         """Read a coordinate's full (unselected) values, memoized by name (ARC-49)."""

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -74,8 +74,12 @@ def _cftime_columns(frame: pd.DataFrame) -> list[str]:
     for name in frame.columns:
         column = frame[name]
         if column.dtype == object:
-            values = column.to_numpy()
-            if values.size and isinstance(values[0], cftime.datetime):
+            # Every element, not just the first. `cftime` picks one class per array from
+            # the units origin, so a column decoded in one go is uniform -- but a frame
+            # assembled from more than one decode need not be, and naming no column at all
+            # would put us back to re-raising pyarrow's own opaque error. This runs only
+            # after the write has already failed, so the scan costs nothing that matters.
+            if any(isinstance(value, cftime.datetime) for value in column.to_numpy()):
                 offenders.append(str(name))
     return offenders
 

--- a/src/pyramids/netcdf/utils.py
+++ b/src/pyramids/netcdf/utils.py
@@ -901,7 +901,9 @@ def _num2date(
     `cftime` raises a bare `ValueError` naming neither the axis nor the store. The commonest
     case is a `"months since ..."` axis on anything but `360_day`: a calendar month has no
     fixed length, so `cftime` refuses the unit, while `is_cf_time_units` -- which is purely
-    syntactic and never sees the calendar -- has already admitted the string (#1117).
+    syntactic and never sees the calendar -- has already admitted the string (#1117). The
+    other case is an offset landing outside `datetime`'s year 1 to 9999, which `cftime`
+    reports as an overflow rather than returning a datetime for.
 
     Args:
         values: The numeric offsets to decode.
@@ -914,8 +916,9 @@ def _num2date(
         The `cftime` result, masked where it could not decode a value.
 
     Raises:
-        ValueError: `cftime` cannot decode this units/calendar pair. Re-raised rather than
-            allowed through so the message says which axis, with the original chained.
+        ValueError: `cftime` cannot decode this axis -- an unsupported units/calendar pair,
+            or an offset that overflows `datetime`. Re-raised rather than allowed through
+            so the message says which axis, with the original chained.
     """
     try:
         decoded = cftime.num2date(
@@ -1090,16 +1093,14 @@ def decode_cf_time(
     values: the ``cftime`` fallback honours the mask ``cftime`` returns, so a ``NaN`` or an
     ``inf`` offset is missing there too rather than silently reading as the origin (#1116).
 
-    Anything the integer path cannot take
-    exactly -- an unparseable origin, a period such as ``"months"``, an instant the integer
-    nanosecond scale cannot reach, or a pre-1582 origin on a mixed Julian/Gregorian
-    calendar -- still goes to ``cftime``. That reach is not a fixed span of years: the gate
-    sums the offset's magnitude and the origin's distance from 1970, so a far-from-1970
-    epoch shortens it (off ``days since 1900-01-01``, an instant in 2116 already
-    declines). That
-    is a wider range than the integer path's, not a narrower one: a date ``cftime`` decodes
-    is still cast to ``datetime64[ns]`` whenever it fits, so 2255-2262 -- past the integer
-    scale but inside the type -- comes back as ``datetime64`` all the same.
+    Anything the integer path cannot take exactly -- an unparseable origin, a period such as
+    ``"months"``, an instant the integer nanosecond scale cannot reach, or a pre-1582 origin
+    on a mixed Julian/Gregorian calendar -- still goes to ``cftime``. That reach is not a
+    fixed span of years: the gate sums the offset's magnitude and the origin's distance from
+    1970, so a far-from-1970 epoch shortens it (off ``days since 1900-01-01`` it gives out in
+    March 2115). That is a wider range than the integer path's, not a narrower one: a date
+    ``cftime`` decodes is still cast to ``datetime64[ns]`` whenever it fits, so 2255-2262 --
+    past the integer scale but inside the type -- comes back as ``datetime64`` all the same.
 
     Args:
         values: The numeric values already read for the coordinate.
@@ -1122,16 +1123,21 @@ def decode_cf_time(
             ``NaT`` in a ``datetime64`` result and as ``None`` in an object one, since an
             object array of datetimes has no ``NaT`` (#1116).
             What that object array holds is ``cftime``'s own choice, not this
-            function's: ``cftime.real_datetime`` (a ``datetime.datetime`` subclass, which
-            ``pandas`` coerces to ``datetime64[us]``) for a date Python's ``datetime`` can
-            represent, and a true ``cftime`` datetime such as ``DatetimeGregorian`` for one
-            it cannot -- which in practice means a pre-1582 origin on a mixed calendar.
+            function's, and it is made once per array from the units origin rather than per
+            value: ``cftime.real_datetime`` (a ``datetime.datetime`` subclass, which
+            ``pandas`` coerces to ``datetime64[us]``) when the proleptic Gregorian rules
+            already cover that origin -- a ``proleptic_gregorian`` calendar, or a
+            mixed-calendar origin at or after the 1582 reform -- and a true ``cftime``
+            datetime such as ``DatetimeGregorian`` when they do not, which means a pre-1582
+            origin on a mixed calendar. Being an array-wide choice, such an axis stays
+            ``DatetimeGregorian`` even in the offsets that land after the reform.
 
     Raises:
-        ValueError: ``cftime`` cannot decode this units/calendar pair -- most often a
-            ``"months since …"`` axis on anything but ``360_day``, since a calendar month
-            has no fixed length. Re-raised with the axis, units and calendar named, because
-            ``cftime``'s own message identifies none of them (#1117).
+        ValueError: ``cftime`` cannot decode this axis -- most often a ``"months since …"``
+            axis on anything but ``360_day``, since a calendar month has no fixed length,
+            and otherwise an offset landing outside ``datetime``'s year 1 to 9999, which
+            ``cftime`` reports as an overflow. Re-raised with the axis, units and calendar
+            named, because ``cftime``'s own message identifies none of them (#1117).
 
     Examples:
         - A date past what ``datetime64[ns]`` holds keeps its real value, and says so:

--- a/src/pyramids/netcdf/utils.py
+++ b/src/pyramids/netcdf/utils.py
@@ -1072,6 +1072,70 @@ def _exact_ns_offsets(
     return offsets
 
 
+def _decode_via_cftime(
+    values: np.ndarray,
+    text: str,
+    calendar: str,
+    standard: bool,
+    context: str | None,
+) -> np.typing.NDArray:
+    """Decode through `cftime`, when the exact integer path cannot take the axis.
+
+    Split out of `decode_cf_time` so that function stays a router between the two decode
+    paths: everything here is the second path's own business -- honouring the mask, deciding
+    whether the result fits `datetime64[ns]`, and saying so when it does not.
+
+    Args:
+        values: The numeric offsets to decode.
+        text: The CF `"<period> since <origin>"` string.
+        calendar: The CF calendar name.
+        standard: Whether `calendar` is a Gregorian-family one, which is what decides
+            whether the result is a candidate for `datetime64[ns]` at all.
+        context: Optional name of the axis, for the warning.
+
+    Returns:
+        np.ndarray: `datetime64[ns]` when every present value fits it, else an object array
+            of the decoded datetimes with `None` where a value was missing.
+    """
+    raw = _num2date(values, text, calendar, standard, context)
+    # `cftime` masks the positions it could not decode -- a `NaN` or an `inf`
+    # offset -- and `np.asarray` drops that mask, leaving the fill value, which
+    # is the origin. Read as a real timestamp, that is a missing timestep
+    # silently becoming a date (#1116). Keep the mask and honour it below.
+    missing = np.ma.getmaskarray(np.ma.asarray(raw))
+    decoded = np.asarray(raw)
+    if standard:
+        # Range-checked, not try/except: the cast does not raise on an
+        # out-of-range date, it wraps (#1087). Out of range the decoded
+        # objects are kept as-is -- lossless, and already what a
+        # non-standard calendar returns. Masked positions are excluded: they
+        # hold the origin, so on a pre-1582 epoch they would fail the check and
+        # blame a range problem for what is a missing value.
+        present = decoded[~missing] if missing.any() else decoded
+        if _fits_datetime64_ns(present):
+            decoded = decoded.astype("datetime64[ns]")
+            if missing.any():
+                decoded = np.where(missing, np.datetime64("NaT", "ns"), decoded)
+        else:
+            # `UserWarning`, not `RuntimeWarning`: GDAL floods the latter,
+            # so the common "ignore RuntimeWarning" recipe around a GDAL
+            # read would silence a data-integrity warning.
+            axis = f"{context!r} " if context else ""
+            warnings.warn(
+                f"time axis {axis}({text!r}) decodes to dates outside the "
+                f"1677-09-21 to 2262-04-11 range datetime64[ns] can represent; "
+                f"returning the decoded datetime objects instead, because casting "
+                f"would silently wrap them to the wrong dates.",
+                UserWarning,
+                # 3, not 2: this sits one frame deeper than `decode_cf_time` now.
+                stacklevel=3,
+            )
+            decoded = _blank_missing(decoded, missing)
+    else:
+        decoded = _blank_missing(decoded, missing)
+    return decoded
+
+
 def decode_cf_time(
     values: np.ndarray,
     unit: str | bytes | None,
@@ -1189,41 +1253,7 @@ def decode_cf_time(
         if exact is not None:
             decoded = exact
         else:
-            raw = _num2date(values, text, calendar, standard, context)
-            # `cftime` masks the positions it could not decode -- a `NaN` or an `inf`
-            # offset -- and `np.asarray` drops that mask, leaving the fill value, which
-            # is the origin. Read as a real timestamp, that is a missing timestep
-            # silently becoming a date (#1116). Keep the mask and honour it below.
-            missing = np.ma.getmaskarray(np.ma.asarray(raw))
-            decoded = np.asarray(raw)
-            if standard:
-                # Range-checked, not try/except: the cast does not raise on an
-                # out-of-range date, it wraps (#1087). Out of range the decoded
-                # objects are kept as-is -- lossless, and already what a
-                # non-standard calendar returns. Masked positions are excluded: they
-                # hold the origin, so on a pre-1582 epoch they would fail the check and
-                # blame a range problem for what is a missing value.
-                present = decoded[~missing] if missing.any() else decoded
-                if _fits_datetime64_ns(present):
-                    decoded = decoded.astype("datetime64[ns]")
-                    if missing.any():
-                        decoded = np.where(missing, np.datetime64("NaT", "ns"), decoded)
-                else:
-                    # `UserWarning`, not `RuntimeWarning`: GDAL floods the latter,
-                    # so the common "ignore RuntimeWarning" recipe around a GDAL
-                    # read would silence a data-integrity warning.
-                    axis = f"{context!r} " if context else ""
-                    warnings.warn(
-                        f"time axis {axis}({text!r}) decodes to dates outside the "
-                        f"1677-09-21 to 2262-04-11 range datetime64[ns] can represent; "
-                        f"returning the decoded datetime objects instead, because casting "
-                        f"would silently wrap them to the wrong dates.",
-                        UserWarning,
-                        stacklevel=2,
-                    )
-                    decoded = _blank_missing(decoded, missing)
-            else:
-                decoded = _blank_missing(decoded, missing)
+            decoded = _decode_via_cftime(values, text, calendar, standard, context)
     return decoded
 
 

--- a/src/pyramids/netcdf/utils.py
+++ b/src/pyramids/netcdf/utils.py
@@ -915,10 +915,17 @@ def _fits_datetime64_ns(decoded: np.typing.NDArray) -> bool:
     """
     low, high = _DT64_NS_BOUNDS
     floor, ceiling = datetime(*low), datetime(*high)
-    try:
-        fits = all(floor <= value <= ceiling for value in decoded.ravel())
-    except TypeError:
-        fits = False
+    values = decoded.ravel()
+    # Screened first, so the `except` below can only ever absorb the one `TypeError` it is
+    # meant for. Without it, anything non-datetime in the array -- and `decoded.ravel()`
+    # itself, were it inside the `try` -- would read as "does not fit" and be reported as an
+    # out-of-range date, which is a misdiagnosis rather than a safe default.
+    fits = all(isinstance(value, (datetime, cftime.datetime)) for value in values)
+    if fits:
+        try:
+            fits = all(floor <= value <= ceiling for value in values)
+        except TypeError:
+            fits = False
     return fits
 
 
@@ -995,6 +1002,7 @@ def decode_cf_time(
     values: np.ndarray,
     unit: str | bytes | None,
     calendar: str = "standard",
+    context: str | None = None,
 ) -> np.typing.NDArray:
     """Decode numeric CF time offsets to datetimes.
 
@@ -1007,7 +1015,10 @@ def decode_cf_time(
     nanoseconds, rather than through ``cftime``. Behaviour differs from earlier releases
     in two ways, both of them consequences of dropping ``cftime``'s microsecond floor:
     a ``"nanoseconds since …"`` axis decodes instead of raising, and a ``NaN`` offset
-    decodes to ``NaT`` instead of to the origin. Anything the integer path cannot take
+    decodes to ``NaT`` instead of to the origin -- the latter **on that integer path only**.
+    The ``cftime`` fallback still reads a ``NaN`` as the origin rather than as missing,
+    because ``cftime`` returns a masked array and the mask is dropped on the way out; that
+    is a separate defect this function does not fix. Anything the integer path cannot take
     exactly -- an unparseable origin, a period such as ``"months"``, an instant the integer
     nanosecond scale cannot reach, or a pre-1582 origin on a mixed Julian/Gregorian
     calendar -- still goes to ``cftime``. That reach is not a fixed span of years: the gate
@@ -1023,6 +1034,9 @@ def decode_cf_time(
         unit: The coordinate's CF unit string (e.g. ``"days since 1979-01-01"``),
             or the bytes an undecoded attribute arrives as.
         calendar: The CF calendar name. Defaults to ``"standard"``.
+        context: Optional name of the axis being decoded, used only so the out-of-range
+            warning can say *which* axis it is about. A store with several time axes
+            otherwise warns with nothing but the units string to tell them apart.
 
     Returns:
         np.ndarray: Decoded datetimes for a time axis, else ``values`` unchanged. For a
@@ -1030,13 +1044,31 @@ def decode_cf_time(
             them is representable in that type, and an object array otherwise -- either
             because the calendar is not a standard one, or because a date falls outside
             ``datetime64[ns]``'s 1677-09-21 to 2262-04-11 range, which is warned about
-            (#1087). What that object array holds is ``cftime``'s own choice, not this
+            (#1087). The choice is array-wide, since one array has one dtype: a single
+            out-of-range value keeps its in-range neighbours as objects too.
+            What that object array holds is ``cftime``'s own choice, not this
             function's: ``cftime.real_datetime`` (a ``datetime.datetime`` subclass, which
             ``pandas`` coerces to ``datetime64[us]``) for a date Python's ``datetime`` can
             represent, and a true ``cftime`` datetime such as ``DatetimeGregorian`` for one
             it cannot -- which in practice means a pre-1582 origin on a mixed calendar.
 
     Examples:
+        - A date past what ``datetime64[ns]`` holds keeps its real value, and says so:
+            ```python
+            >>> import warnings
+            >>> import numpy as np
+            >>> from pyramids.netcdf.utils import decode_cf_time
+            >>> with warnings.catch_warnings(record=True) as caught:
+            ...     warnings.simplefilter("always")
+            ...     decoded = decode_cf_time(
+            ...         np.array([400_000]), "days since 1970-01-01", "standard"
+            ...     )
+            >>> decoded.dtype, decoded[0].year
+            (dtype('O'), 3065)
+            >>> caught[0].category.__name__
+            'UserWarning'
+
+            ```
         - The resolution the collection writer counts in, read back with its
           sub-microsecond digits intact:
             ```python
@@ -1086,10 +1118,11 @@ def decode_cf_time(
                     # `UserWarning`, not `RuntimeWarning`: GDAL floods the latter,
                     # so the common "ignore RuntimeWarning" recipe around a GDAL
                     # read would silence a data-integrity warning.
+                    axis = f"{context!r} " if context else ""
                     warnings.warn(
-                        f"{text!r} decodes to dates outside the 1677-09-21 to "
-                        f"2262-04-11 range datetime64[ns] can represent; returning "
-                        f"the decoded datetime objects instead, because casting "
+                        f"time axis {axis}({text!r}) decodes to dates outside the "
+                        f"1677-09-21 to 2262-04-11 range datetime64[ns] can represent; "
+                        f"returning the decoded datetime objects instead, because casting "
                         f"would silently wrap them to the wrong dates.",
                         UserWarning,
                         stacklevel=2,

--- a/src/pyramids/netcdf/utils.py
+++ b/src/pyramids/netcdf/utils.py
@@ -916,18 +916,24 @@ def _num2date(
         The `cftime` result, masked where it could not decode a value.
 
     Raises:
-        ValueError: `cftime` cannot decode this axis -- an unsupported units/calendar pair,
-            or an offset that overflows `datetime`. Re-raised rather than allowed through
-            so the message says which axis, with the original chained.
+        ValueError: `cftime` cannot decode this axis -- an unsupported units/calendar pair
+            (a `"months since ..."` axis on anything but `360_day`, an unparseable origin, a
+            period it does not know), or an offset landing outside `datetime`'s year 1-9999.
+            An offset large enough to overflow a 64-bit integer arrives as an
+            `OverflowError` and is normalised to `ValueError` too, so a caller has one
+            failure type to catch. Re-raised rather than allowed through, so the message
+            names the axis, units and calendar, with the original chained.
     """
     try:
         decoded = cftime.num2date(
             values, units, calendar, only_use_cftime_datetimes=not standard
         )
-    except ValueError as error:
+    except (ValueError, OverflowError) as error:
         axis = f"{context!r} " if context else ""
         hint = ""
-        if units.strip().lower().startswith("month"):
+        # Gated on the calendar as well as the unit: on `360_day` the unit *is* supported,
+        # so a failure there has some other cause and the hint would contradict itself.
+        if units.strip().lower().startswith("month") and calendar.lower() != "360_day":
             hint = (
                 " A calendar month has no fixed length, so this unit is only defined on "
                 "the 360_day calendar."
@@ -989,17 +995,22 @@ def _fits_datetime64_ns(decoded: np.typing.NDArray) -> bool:
     """
     low, high = _DT64_NS_BOUNDS
     floor, ceiling = datetime(*low), datetime(*high)
-    values = decoded.ravel()
-    # Screened first, so the `except` below can only ever absorb the one `TypeError` it is
-    # meant for. Without it, anything non-datetime in the array -- and `decoded.ravel()`
-    # itself, were it inside the `try` -- would read as "does not fit" and be reported as an
-    # out-of-range date, which is a misdiagnosis rather than a safe default.
-    fits = all(isinstance(value, (datetime, cftime.datetime)) for value in values)
-    if fits:
-        try:
-            fits = all(floor <= value <= ceiling for value in values)
-        except TypeError:
+    fits = True
+    for value in decoded.ravel():
+        # Screened per element, so the `except` can only ever absorb the one `TypeError` it
+        # is meant for: anything non-datetime would otherwise read as "does not fit" and be
+        # reported as an out-of-range date, which is a misdiagnosis rather than a safe
+        # default. Screening and comparing in one pass keeps the short-circuit -- a bad
+        # first element ends the scan rather than sweeping the whole axis twice.
+        if not isinstance(value, (datetime, cftime.datetime)):
             fits = False
+        else:
+            try:
+                fits = bool(floor <= value <= ceiling)
+            except TypeError:
+                fits = False
+        if not fits:
+            break
     return fits
 
 
@@ -1094,8 +1105,10 @@ def _decode_via_cftime(
         context: Optional name of the axis, for the warning.
 
     Returns:
-        np.ndarray: `datetime64[ns]` when every present value fits it, else an object array
-            of the decoded datetimes with `None` where a value was missing.
+        np.ndarray: For a Gregorian-family calendar, `datetime64[ns]` when every present
+            value fits it, else an object array. For any other calendar, always an object
+            array -- those decode to `cftime` datetimes that no range check could cast.
+            Either object array carries `None` where a value was missing.
     """
     raw = _num2date(values, text, calendar, standard, context)
     # `cftime` masks the positions it could not decode -- a `NaN` or an `inf`
@@ -1191,7 +1204,7 @@ def decode_cf_time(
             value: ``cftime.real_datetime`` (a ``datetime.datetime`` subclass, which
             ``pandas`` coerces to ``datetime64[us]``) when the proleptic Gregorian rules
             already cover that origin -- a ``proleptic_gregorian`` calendar, or a
-            mixed-calendar origin at or after the 1582 reform -- and a true ``cftime``
+            mixed-calendar origin after the 1582 reform -- and a true ``cftime``
             datetime such as ``DatetimeGregorian`` when they do not, which means a pre-1582
             origin on a mixed calendar. Being an array-wide choice, such an axis stays
             ``DatetimeGregorian`` even in the offsets that land after the reform.
@@ -1199,9 +1212,12 @@ def decode_cf_time(
     Raises:
         ValueError: ``cftime`` cannot decode this axis -- most often a ``"months since …"``
             axis on anything but ``360_day``, since a calendar month has no fixed length,
-            and otherwise an offset landing outside ``datetime``'s year 1 to 9999, which
-            ``cftime`` reports as an overflow. Re-raised with the axis, units and calendar
-            named, because ``cftime``'s own message identifies none of them (#1117).
+            and otherwise an unparseable origin or an offset landing outside ``datetime``'s
+            year 1 to 9999.
+            An offset so large the scale overflows a 64-bit integer arrives from ``cftime``
+            as an ``OverflowError`` and is normalised to this one type, so callers have a
+            single failure to catch. Re-raised with the axis, units and calendar named,
+            because ``cftime``'s own message identifies none of them (#1117).
 
     Examples:
         - A date past what ``datetime64[ns]`` holds keeps its real value, and says so:

--- a/src/pyramids/netcdf/utils.py
+++ b/src/pyramids/netcdf/utils.py
@@ -889,6 +889,77 @@ def _gregorian_scale_and_origin(
     return resolved
 
 
+def _num2date(
+    values: np.ndarray,
+    units: str,
+    calendar: str,
+    standard: bool,
+    context: str | None,
+) -> Any:
+    """Call `cftime.num2date`, turning its failures into an error that names the axis.
+
+    `cftime` raises a bare `ValueError` naming neither the axis nor the store. The commonest
+    case is a `"months since ..."` axis on anything but `360_day`: a calendar month has no
+    fixed length, so `cftime` refuses the unit, while `is_cf_time_units` -- which is purely
+    syntactic and never sees the calendar -- has already admitted the string (#1117).
+
+    Args:
+        values: The numeric offsets to decode.
+        units: The CF `"<period> since <origin>"` string.
+        calendar: The CF calendar name.
+        standard: Whether `calendar` is a Gregorian-family one.
+        context: Optional name of the axis, for the message.
+
+    Returns:
+        The `cftime` result, masked where it could not decode a value.
+
+    Raises:
+        ValueError: `cftime` cannot decode this units/calendar pair. Re-raised rather than
+            allowed through so the message says which axis, with the original chained.
+    """
+    try:
+        decoded = cftime.num2date(
+            values, units, calendar, only_use_cftime_datetimes=not standard
+        )
+    except ValueError as error:
+        axis = f"{context!r} " if context else ""
+        hint = ""
+        if units.strip().lower().startswith("month"):
+            hint = (
+                " A calendar month has no fixed length, so this unit is only defined on "
+                "the 360_day calendar."
+            )
+        raise ValueError(
+            f"cannot decode time axis {axis}({units!r}) with calendar "
+            f"{calendar!r}: {error}.{hint}"
+        ) from error
+    return decoded
+
+
+def _blank_missing(
+    decoded: np.typing.NDArray, missing: np.typing.NDArray
+) -> np.typing.NDArray:
+    """Put `None` where `cftime` could not decode a value, in an object array.
+
+    The `datetime64` path spells a missing value `NaT`; an object array of datetimes has no
+    such spelling, so `None` carries it instead. Without this the position holds the origin,
+    which reads as a real timestamp (#1116).
+
+    Args:
+        decoded: The decoded object array.
+        missing: The mask `cftime` returned alongside it.
+
+    Returns:
+        np.ndarray: `decoded`, with the masked positions blanked. Returned unchanged when
+            nothing is masked, which is the common case.
+    """
+    blanked = decoded
+    if missing.any():
+        blanked = decoded.astype(object)
+        blanked[missing] = None
+    return blanked
+
+
 def _fits_datetime64_ns(decoded: np.typing.NDArray) -> bool:
     """Whether every decoded datetime is representable as `datetime64[ns]`.
 
@@ -1015,10 +1086,11 @@ def decode_cf_time(
     nanoseconds, rather than through ``cftime``. Behaviour differs from earlier releases
     in two ways, both of them consequences of dropping ``cftime``'s microsecond floor:
     a ``"nanoseconds since …"`` axis decodes instead of raising, and a ``NaN`` offset
-    decodes to ``NaT`` instead of to the origin -- the latter **on that integer path only**.
-    The ``cftime`` fallback still reads a ``NaN`` as the origin rather than as missing,
-    because ``cftime`` returns a masked array and the mask is dropped on the way out; that
-    is a separate defect this function does not fix. Anything the integer path cannot take
+    decodes to ``NaT`` instead of to the origin. Both decode paths agree about missing
+    values: the ``cftime`` fallback honours the mask ``cftime`` returns, so a ``NaN`` or an
+    ``inf`` offset is missing there too rather than silently reading as the origin (#1116).
+
+    Anything the integer path cannot take
     exactly -- an unparseable origin, a period such as ``"months"``, an instant the integer
     nanosecond scale cannot reach, or a pre-1582 origin on a mixed Julian/Gregorian
     calendar -- still goes to ``cftime``. That reach is not a fixed span of years: the gate
@@ -1045,12 +1117,21 @@ def decode_cf_time(
             because the calendar is not a standard one, or because a date falls outside
             ``datetime64[ns]``'s 1677-09-21 to 2262-04-11 range, which is warned about
             (#1087). The choice is array-wide, since one array has one dtype: a single
-            out-of-range value keeps its in-range neighbours as objects too.
+            out-of-range value keeps its in-range neighbours as objects too. A value
+            ``cftime`` could not decode -- a ``NaN`` or an ``inf`` offset -- comes back as
+            ``NaT`` in a ``datetime64`` result and as ``None`` in an object one, since an
+            object array of datetimes has no ``NaT`` (#1116).
             What that object array holds is ``cftime``'s own choice, not this
             function's: ``cftime.real_datetime`` (a ``datetime.datetime`` subclass, which
             ``pandas`` coerces to ``datetime64[us]``) for a date Python's ``datetime`` can
             represent, and a true ``cftime`` datetime such as ``DatetimeGregorian`` for one
             it cannot -- which in practice means a pre-1582 origin on a mixed calendar.
+
+    Raises:
+        ValueError: ``cftime`` cannot decode this units/calendar pair -- most often a
+            ``"months since …"`` axis on anything but ``360_day``, since a calendar month
+            has no fixed length. Re-raised with the axis, units and calendar named, because
+            ``cftime``'s own message identifies none of them (#1117).
 
     Examples:
         - A date past what ``datetime64[ns]`` holds keeps its real value, and says so:
@@ -1102,18 +1183,25 @@ def decode_cf_time(
         if exact is not None:
             decoded = exact
         else:
-            decoded = np.asarray(
-                cftime.num2date(
-                    values, text, calendar, only_use_cftime_datetimes=not standard
-                )
-            )
+            raw = _num2date(values, text, calendar, standard, context)
+            # `cftime` masks the positions it could not decode -- a `NaN` or an `inf`
+            # offset -- and `np.asarray` drops that mask, leaving the fill value, which
+            # is the origin. Read as a real timestamp, that is a missing timestep
+            # silently becoming a date (#1116). Keep the mask and honour it below.
+            missing = np.ma.getmaskarray(np.ma.asarray(raw))
+            decoded = np.asarray(raw)
             if standard:
                 # Range-checked, not try/except: the cast does not raise on an
                 # out-of-range date, it wraps (#1087). Out of range the decoded
                 # objects are kept as-is -- lossless, and already what a
-                # non-standard calendar returns.
-                if _fits_datetime64_ns(decoded):
+                # non-standard calendar returns. Masked positions are excluded: they
+                # hold the origin, so on a pre-1582 epoch they would fail the check and
+                # blame a range problem for what is a missing value.
+                present = decoded[~missing] if missing.any() else decoded
+                if _fits_datetime64_ns(present):
                     decoded = decoded.astype("datetime64[ns]")
+                    if missing.any():
+                        decoded = np.where(missing, np.datetime64("NaT", "ns"), decoded)
                 else:
                     # `UserWarning`, not `RuntimeWarning`: GDAL floods the latter,
                     # so the common "ignore RuntimeWarning" recipe around a GDAL
@@ -1127,6 +1215,9 @@ def decode_cf_time(
                         UserWarning,
                         stacklevel=2,
                     )
+                    decoded = _blank_missing(decoded, missing)
+            else:
+                decoded = _blank_missing(decoded, missing)
     return decoded
 
 

--- a/src/pyramids/netcdf/utils.py
+++ b/src/pyramids/netcdf/utils.py
@@ -827,7 +827,10 @@ def is_cf_time_units(units: str | bytes | None) -> bool:
 # origin at or after it therefore puts every offset on the side where the two
 # agree, which is what makes the integer path below safe to take; an earlier
 # origin on a mixed calendar stays on `cftime`, which knows about the ten
-# missing days.
+# missing days. Note this `>=` is not the same threshold as the one deciding
+# which class `cftime` hands back: that one is strictly later, so an origin of
+# exactly 1582-10-15 is safe for the integer path yet still decodes to
+# `DatetimeGregorian` when the fallback is reached for some other reason.
 _GREGORIAN_CUTOVER = datetime(1582, 10, 15)
 # Bound on the nanosecond magnitudes the integer path will handle. Deliberately
 # under `int64`'s 9.223e18 so the check -- made in float64, where the rounding
@@ -913,7 +916,9 @@ def _num2date(
         context: Optional name of the axis, for the message.
 
     Returns:
-        The `cftime` result, masked where it could not decode a value.
+        np.ndarray | np.ma.MaskedArray: The `cftime` result -- a masked array when some
+            value could not be decoded (a `NaN` or an `inf` offset), and a plain array
+            when every one of them decoded.
 
     Raises:
         ValueError: `cftime` cannot decode this axis -- an unsupported units/calendar pair
@@ -990,8 +995,8 @@ def _fits_datetime64_ns(decoded: np.typing.NDArray) -> bool:
 
     Returns:
         bool: `True` when the whole array fits, so the cast is exact; `False` when any
-            value is out of range or cannot be compared, in which case keeping the
-            `cftime` objects is the lossless answer.
+            value is out of range, cannot be compared, or is not a datetime at all, in
+            which case keeping the `cftime` objects is the lossless answer.
     """
     low, high = _DT64_NS_BOUNDS
     floor, ceiling = datetime(*low), datetime(*high)
@@ -1109,6 +1114,10 @@ def _decode_via_cftime(
             value fits it, else an object array. For any other calendar, always an object
             array -- those decode to `cftime` datetimes that no range check could cast.
             Either object array carries `None` where a value was missing.
+
+    Raises:
+        ValueError: Propagated from `_num2date` when `cftime` cannot decode the axis at
+            all -- most often a `"months since ..."` axis on anything but `360_day`.
     """
     raw = _num2date(values, text, calendar, standard, context)
     # `cftime` masks the positions it could not decode -- a `NaN` or an `inf`
@@ -1204,10 +1213,12 @@ def decode_cf_time(
             value: ``cftime.real_datetime`` (a ``datetime.datetime`` subclass, which
             ``pandas`` coerces to ``datetime64[us]``) when the proleptic Gregorian rules
             already cover that origin -- a ``proleptic_gregorian`` calendar, or a
-            mixed-calendar origin after the 1582 reform -- and a true ``cftime``
-            datetime such as ``DatetimeGregorian`` when they do not, which means a pre-1582
-            origin on a mixed calendar. Being an array-wide choice, such an axis stays
-            ``DatetimeGregorian`` even in the offsets that land after the reform.
+            mixed-calendar origin strictly after the 1582 reform -- and a true ``cftime``
+            datetime such as ``DatetimeGregorian`` when they do not, which means a
+            mixed-calendar origin no later than the reform date itself
+            (``days since 1582-10-15`` already gives ``DatetimeGregorian``). Being an
+            array-wide choice, such an axis stays ``DatetimeGregorian`` even in the
+            offsets that land after the reform.
 
     Raises:
         ValueError: ``cftime`` cannot decode this axis -- most often a ``"months since …"``

--- a/src/pyramids/netcdf/utils.py
+++ b/src/pyramids/netcdf/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import warnings
 from collections.abc import Callable
 from datetime import datetime, timedelta
 from typing import Any, TypeAlias, cast
@@ -832,6 +833,16 @@ _GREGORIAN_CUTOVER = datetime(1582, 10, 15)
 # under `int64`'s 9.223e18 so the check -- made in float64, where the rounding
 # error at this scale is ~1e3 ns -- cannot pass a value that then overflows.
 _NS_LIMIT = 9.0e18
+# The same `int64` nanosecond limit as `_NS_LIMIT`, in calendar coordinates, for the
+# `cftime` path -- which holds decoded datetimes rather than nanosecond offsets and so
+# cannot compare against a magnitude. Rounded inward to whole microseconds, because a
+# `datetime` carries no nanoseconds: that makes the bound conservative by under a
+# microsecond at each end, which costs a sliver of range and never admits a value that
+# would wrap. `test_bounds_match_int64_nanoseconds` pins it to the derivation.
+_DT64_NS_BOUNDS = (
+    (1677, 9, 21, 0, 12, 43, 145225),
+    (2262, 4, 11, 23, 47, 16, 854775),
+)
 
 
 def _gregorian_scale_and_origin(
@@ -874,6 +885,37 @@ def _gregorian_scale_and_origin(
                 + elapsed.microseconds * 1_000,
             )
     return resolved
+
+
+def _fits_datetime64_ns(decoded: np.typing.NDArray) -> bool:
+    """Whether every decoded datetime is representable as `datetime64[ns]`.
+
+    `astype("datetime64[ns]")` does not raise on a date outside the type's range -- it
+    wraps, silently, into a plausible-looking date on the other side of the epoch (#1087).
+    So the range has to be checked before the cast rather than caught after it.
+
+    `cftime` refuses to compare a `DatetimeGregorian` with a `datetime` when either falls
+    before the 1582 Gregorian reform, because the two calendars disagree there. That
+    refusal is not a problem: the reform predates this type's floor, so a date `cftime`
+    will not compare is necessarily below 1677 and out of range anyway. Treating the
+    `TypeError` as "does not fit" is therefore the right answer and not merely a safe one --
+    `test_the_gregorian_reform_predates_the_floor` pins the invariant that makes it so.
+
+    Args:
+        decoded: The datetimes `cftime` produced, as an object array.
+
+    Returns:
+        bool: `True` when the whole array fits, so the cast is exact; `False` when any
+            value is out of range or cannot be compared, in which case keeping the
+            `cftime` objects is the lossless answer.
+    """
+    low, high = _DT64_NS_BOUNDS
+    floor, ceiling = datetime(*low), datetime(*high)
+    try:
+        fits = all(floor <= value <= ceiling for value in decoded.ravel())
+    except TypeError:
+        fits = False
+    return fits
 
 
 def _decode_gregorian_ns(
@@ -973,7 +1015,12 @@ def decode_cf_time(
         calendar: The CF calendar name. Defaults to ``"standard"``.
 
     Returns:
-        np.ndarray: Decoded datetimes for a time axis, else ``values`` unchanged.
+        np.ndarray: Decoded datetimes for a time axis, else ``values`` unchanged. For a
+            time axis the dtype depends on what the dates are: ``datetime64[ns]`` when
+            every one of them is representable in that type, and an object array of
+            ``cftime`` datetimes otherwise -- either because the calendar is not a
+            standard one, or because a date falls outside ``datetime64[ns]``'s
+            1677-09-21 to 2262-04-11 range, which is warned about (#1087).
 
     Examples:
         - The resolution the collection writer counts in, read back with its
@@ -1015,10 +1062,22 @@ def decode_cf_time(
                 )
             )
             if standard:
-                try:
+                # Range-checked, not try/except: the cast does not raise on an
+                # out-of-range date, it wraps (#1087). Out of range, the `cftime`
+                # objects are kept -- lossless, and already what a non-standard
+                # calendar returns.
+                if _fits_datetime64_ns(decoded):
                     decoded = decoded.astype("datetime64[ns]")
-                except (ValueError, TypeError):
-                    pass
+                else:
+                    warnings.warn(
+                        f"{text!r} decodes to dates outside the range "
+                        f"datetime64[ns] can represent "
+                        f"(1677-09-21 to 2262-04-11); returning cftime objects "
+                        f"instead of datetime64, which would silently wrap them "
+                        f"to the wrong dates.",
+                        RuntimeWarning,
+                        stacklevel=2,
+                    )
     return decoded
 
 

--- a/src/pyramids/netcdf/utils.py
+++ b/src/pyramids/netcdf/utils.py
@@ -833,12 +833,14 @@ _GREGORIAN_CUTOVER = datetime(1582, 10, 15)
 # under `int64`'s 9.223e18 so the check -- made in float64, where the rounding
 # error at this scale is ~1e3 ns -- cannot pass a value that then overflows.
 _NS_LIMIT = 9.0e18
-# The same `int64` nanosecond limit as `_NS_LIMIT`, in calendar coordinates, for the
-# `cftime` path -- which holds decoded datetimes rather than nanosecond offsets and so
-# cannot compare against a magnitude. Rounded inward to whole microseconds, because a
-# `datetime` carries no nanoseconds: that makes the bound conservative by under a
-# microsecond at each end, which costs a sliver of range and never admits a value that
-# would wrap. `test_bounds_match_int64_nanoseconds` pins it to the derivation.
+# The `int64` nanosecond limit `_NS_LIMIT` guards against, in calendar coordinates, for
+# the `cftime` path -- which holds decoded datetimes rather than nanosecond offsets and so
+# cannot compare against a magnitude. Taken in full (+/-9.223e18) rather than at
+# `_NS_LIMIT`'s conservative 9.0e18: this comparison is exact, so it needs no headroom for
+# float error. Rounded inward to whole microseconds, because a `datetime` carries no
+# nanoseconds: that makes the bound conservative by under a microsecond at each end, which
+# costs a sliver of range and never admits a value that would wrap.
+# `test_bounds_match_int64_nanoseconds` pins it to the derivation.
 _DT64_NS_BOUNDS = (
     (1677, 9, 21, 0, 12, 43, 145225),
     (2262, 4, 11, 23, 47, 16, 854775),
@@ -894,12 +896,14 @@ def _fits_datetime64_ns(decoded: np.typing.NDArray) -> bool:
     wraps, silently, into a plausible-looking date on the other side of the epoch (#1087).
     So the range has to be checked before the cast rather than caught after it.
 
-    `cftime` refuses to compare a `DatetimeGregorian` with a `datetime` when either falls
-    before the 1582 Gregorian reform, because the two calendars disagree there. That
-    refusal is not a problem: the reform predates this type's floor, so a date `cftime`
-    will not compare is necessarily below 1677 and out of range anyway. Treating the
-    `TypeError` as "does not fit" is therefore the right answer and not merely a safe one --
-    `test_the_gregorian_reform_predates_the_floor` pins the invariant that makes it so.
+    `cftime` refuses to compare a `DatetimeGregorian` with a `datetime` when the decoded
+    value itself falls before the 1582 Gregorian reform, because the two calendars disagree
+    there; the bound's own date does not enter into it, and a value on or after the reform
+    compares against any `datetime`. That refusal is not a problem: the reform predates
+    this type's floor, so a date `cftime` will not compare is necessarily below 1677 and
+    out of range anyway. Treating the `TypeError` as "does not fit" is therefore the right
+    answer and not merely a safe one -- `test_the_gregorian_reform_predates_the_floor` pins
+    the invariant that makes it so.
 
     Args:
         decoded: The datetimes `cftime` produced, as an object array.
@@ -1004,9 +1008,12 @@ def decode_cf_time(
     in two ways, both of them consequences of dropping ``cftime``'s microsecond floor:
     a ``"nanoseconds since …"`` axis decodes instead of raising, and a ``NaN`` offset
     decodes to ``NaT`` instead of to the origin. Anything the integer path cannot take
-    exactly -- an unparseable origin, a period such as ``"months"``, an instant outside
-    ``datetime64[ns]``'s 1678-2262 range, or a pre-1582 origin on a mixed
-    Julian/Gregorian calendar -- still goes to ``cftime``, unchanged.
+    exactly -- an unparseable origin, a period such as ``"months"``, an instant more than
+    about 285 years from 1970 (as far as the integer nanosecond scale reaches), or a
+    pre-1582 origin on a mixed Julian/Gregorian calendar -- still goes to ``cftime``. That
+    is a wider range than the integer path's, not a narrower one: a date ``cftime`` decodes
+    is still cast to ``datetime64[ns]`` whenever it fits, so 2255-2262 -- past the integer
+    scale but inside the type -- comes back as ``datetime64`` all the same.
 
     Args:
         values: The numeric values already read for the coordinate.

--- a/src/pyramids/netcdf/utils.py
+++ b/src/pyramids/netcdf/utils.py
@@ -1008,9 +1008,12 @@ def decode_cf_time(
     in two ways, both of them consequences of dropping ``cftime``'s microsecond floor:
     a ``"nanoseconds since …"`` axis decodes instead of raising, and a ``NaN`` offset
     decodes to ``NaT`` instead of to the origin. Anything the integer path cannot take
-    exactly -- an unparseable origin, a period such as ``"months"``, an instant more than
-    about 285 years from 1970 (as far as the integer nanosecond scale reaches), or a
-    pre-1582 origin on a mixed Julian/Gregorian calendar -- still goes to ``cftime``. That
+    exactly -- an unparseable origin, a period such as ``"months"``, an instant the integer
+    nanosecond scale cannot reach, or a pre-1582 origin on a mixed Julian/Gregorian
+    calendar -- still goes to ``cftime``. That reach is not a fixed span of years: the gate
+    sums the offset's magnitude and the origin's distance from 1970, so a far-from-1970
+    epoch shortens it (off ``days since 1900-01-01``, an instant in 2116 already
+    declines). That
     is a wider range than the integer path's, not a narrower one: a date ``cftime`` decodes
     is still cast to ``datetime64[ns]`` whenever it fits, so 2255-2262 -- past the integer
     scale but inside the type -- comes back as ``datetime64`` all the same.
@@ -1023,11 +1026,15 @@ def decode_cf_time(
 
     Returns:
         np.ndarray: Decoded datetimes for a time axis, else ``values`` unchanged. For a
-            time axis the dtype depends on what the dates are: ``datetime64[ns]`` when
-            every one of them is representable in that type, and an object array of
-            ``cftime`` datetimes otherwise -- either because the calendar is not a
-            standard one, or because a date falls outside ``datetime64[ns]``'s
-            1677-09-21 to 2262-04-11 range, which is warned about (#1087).
+            time axis the dtype depends on the dates: ``datetime64[ns]`` when every one of
+            them is representable in that type, and an object array otherwise -- either
+            because the calendar is not a standard one, or because a date falls outside
+            ``datetime64[ns]``'s 1677-09-21 to 2262-04-11 range, which is warned about
+            (#1087). What that object array holds is ``cftime``'s own choice, not this
+            function's: ``cftime.real_datetime`` (a ``datetime.datetime`` subclass, which
+            ``pandas`` coerces to ``datetime64[us]``) for a date Python's ``datetime`` can
+            represent, and a true ``cftime`` datetime such as ``DatetimeGregorian`` for one
+            it cannot -- which in practice means a pre-1582 origin on a mixed calendar.
 
     Examples:
         - The resolution the collection writer counts in, read back with its
@@ -1070,19 +1077,21 @@ def decode_cf_time(
             )
             if standard:
                 # Range-checked, not try/except: the cast does not raise on an
-                # out-of-range date, it wraps (#1087). Out of range, the `cftime`
-                # objects are kept -- lossless, and already what a non-standard
-                # calendar returns.
+                # out-of-range date, it wraps (#1087). Out of range the decoded
+                # objects are kept as-is -- lossless, and already what a
+                # non-standard calendar returns.
                 if _fits_datetime64_ns(decoded):
                     decoded = decoded.astype("datetime64[ns]")
                 else:
+                    # `UserWarning`, not `RuntimeWarning`: GDAL floods the latter,
+                    # so the common "ignore RuntimeWarning" recipe around a GDAL
+                    # read would silence a data-integrity warning.
                     warnings.warn(
-                        f"{text!r} decodes to dates outside the range "
-                        f"datetime64[ns] can represent "
-                        f"(1677-09-21 to 2262-04-11); returning cftime objects "
-                        f"instead of datetime64, which would silently wrap them "
-                        f"to the wrong dates.",
-                        RuntimeWarning,
+                        f"{text!r} decodes to dates outside the 1677-09-21 to "
+                        f"2262-04-11 range datetime64[ns] can represent; returning "
+                        f"the decoded datetime objects instead, because casting "
+                        f"would silently wrap them to the wrong dates.",
+                        UserWarning,
                         stacklevel=2,
                     )
     return decoded

--- a/tests/netcdf/cf/test_cf_time.py
+++ b/tests/netcdf/cf/test_cf_time.py
@@ -10,11 +10,19 @@ falling back to a proleptic-Gregorian ``datetime64``.
 
 from __future__ import annotations
 
+import warnings
+from datetime import datetime
+
 import cftime
 import numpy as np
 import pytest
 
-from pyramids.netcdf.utils import decode_cf_time, encode_cf_time
+from pyramids.netcdf.utils import (
+    _DT64_NS_BOUNDS,
+    _GREGORIAN_CUTOVER,
+    decode_cf_time,
+    encode_cf_time,
+)
 
 pytestmark = pytest.mark.core
 
@@ -133,3 +141,144 @@ class TestStandardCalendarCasing:
         assert decoded.dtype == np.dtype("datetime64[ns]"), (
             f"{calendar!r} should decode to datetime64, got {decoded.dtype}"
         )
+
+
+# The 1970 epoch makes the boundary arithmetic legible: `datetime64[ns]` spans
+# 1677-09-21T00:12:43.145224193 to 2262-04-11T23:47:16.854775807, so day 106_751 is the
+# last whole day inside it and day -106_751 the first.
+EPOCH_UNIT = "days since 1970-01-01"
+
+
+class TestDatetime64Range:
+    """`decode_cf_time` keeps `cftime` objects rather than wrapping past `datetime64[ns]` (#1087)."""
+
+    def test_bounds_match_int64_nanoseconds(self):
+        """The calendar bound is the `int64` nanosecond limit, rounded inward to microseconds.
+
+        Test scenario:
+            `_DT64_NS_BOUNDS` is written out as calendar components so the `cftime` path can
+            rebuild it in whatever class it was handed. That makes it a second spelling of the
+            same limit `_NS_LIMIT` guards, and the two must not drift: this pins the constant
+            to NumPy's own derivation.
+        """
+        low, high = _DT64_NS_BOUNDS
+        floor = np.datetime64(np.iinfo(np.int64).min + 1, "ns")
+        ceiling = np.datetime64(np.iinfo(np.int64).max, "ns")
+        assert np.datetime64(datetime(*low), "ns") >= floor, (
+            f"{low} is below datetime64[ns]'s floor {floor}"
+        )
+        assert np.datetime64(datetime(*high), "ns") <= ceiling, (
+            f"{high} is above datetime64[ns]'s ceiling {ceiling}"
+        )
+        assert np.datetime64(datetime(*low), "ns") - floor < np.timedelta64(1, "us"), (
+            "the floor is rounded inward by more than the microsecond it should cost"
+        )
+        assert ceiling - np.datetime64(datetime(*high), "ns") < np.timedelta64(
+            1, "us"
+        ), "the ceiling is rounded inward by more than the microsecond it should cost"
+
+    def test_the_gregorian_reform_predates_the_floor(self):
+        """The reform is below the type's floor, which is what lets a `TypeError` mean "no fit".
+
+        Test scenario:
+            `cftime` refuses to compare a `DatetimeGregorian` with a `datetime` when either
+            is pre-1582, and `_fits_datetime64_ns` reads that refusal as "does not fit". That
+            is only correct because every such date is below `datetime64[ns]`'s floor anyway.
+            If the floor ever moved earlier than the reform, the refusal would start hiding
+            representable dates and the guard would need to compare in the value's own
+            calendar instead.
+        """
+        low, _ = _DT64_NS_BOUNDS
+        assert _GREGORIAN_CUTOVER < datetime(*low), (
+            f"the reform {_GREGORIAN_CUTOVER} is no longer below the floor {datetime(*low)}; "
+            "an uncomparable date may now be in range"
+        )
+
+    @pytest.mark.parametrize("offset", [106_751, -106_751, 0, 10_000])
+    def test_dates_inside_the_range_still_decode_to_datetime64(self, offset):
+        """A representable date keeps the `datetime64[ns]` dtype it has always had.
+
+        Test scenario:
+            The guard must not cost the in-range case anything. `106_751` and `-106_751` are
+            the last whole days inside the type at each end.
+        """
+        decoded = decode_cf_time(
+            np.array([offset], dtype="int64"), EPOCH_UNIT, "standard"
+        )
+        assert decoded.dtype == np.dtype("datetime64[ns]"), (
+            f"day {offset} should stay datetime64, got {decoded.dtype}"
+        )
+
+    @pytest.mark.parametrize(
+        "offset, year",
+        [(106_752, 2262), (-106_752, 1677), (400_000, 3065), (-150_000, 1559)],
+    )
+    def test_dates_outside_the_range_keep_their_real_value(self, offset, year):
+        """A date past either bound comes back as `cftime`, carrying the date it really is.
+
+        Test scenario:
+            `.astype("datetime64[ns]")` does not raise on these -- it wraps to the far side of
+            the epoch, so day 400_000 (year 3065) read back as 1896 and day -150_000 (year
+            1559) as 2143. The value, not just the dtype, is what this pins.
+        """
+        with pytest.warns(RuntimeWarning, match="outside the range"):
+            decoded = decode_cf_time(
+                np.array([offset], dtype="int64"), EPOCH_UNIT, "standard"
+            )
+        assert decoded.dtype == np.dtype("object"), (
+            f"day {offset} should stay cftime, got {decoded.dtype}"
+        )
+        assert decoded[0].year == year, (
+            f"day {offset} should decode to year {year}, got {decoded[0]}"
+        )
+
+    def test_a_pre_gregorian_origin_in_range_is_not_downgraded(self):
+        """A `since 0001-01-01` store whose dates are in range still decodes to `datetime64`.
+
+        Test scenario:
+            A pre-1582 origin decodes through `cftime` to `DatetimeGregorian`, not to
+            `datetime`, and those two raise `TypeError` when compared. A bound built as a
+            plain `datetime` would therefore reject every such store -- including the corpus
+            fixtures written against that epoch, whose dates are ordinary 20th-century ones.
+        """
+        decoded = decode_cf_time(
+            np.array([700_000], dtype="int64"), "days since 0001-01-01", "standard"
+        )
+        assert decoded.dtype == np.dtype("datetime64[ns]"), (
+            f"an in-range date on a 0001 epoch should be datetime64, got {decoded.dtype}"
+        )
+        assert decoded[0] == np.datetime64("1917-07-14"), decoded[0]
+
+    def test_a_pre_gregorian_origin_out_of_range_is_not_wrapped(self):
+        """Offset zero on a `since 0001-01-01` store is out of range, and must not wrap.
+
+        Test scenario:
+            The bug needs no large offset: the origin alone is enough to leave the type's
+            range, and year 1 wrapped to 2169.
+        """
+        with pytest.warns(RuntimeWarning, match="outside the range"):
+            decoded = decode_cf_time(
+                np.array([0], dtype="int64"), "days since 0001-01-01", "standard"
+            )
+        assert decoded.dtype == np.dtype("object"), decoded.dtype
+        assert decoded[0].year == 1, decoded[0]
+
+    def test_an_in_range_axis_warns_about_nothing(self):
+        """The warning fires only when a value is actually out of range."""
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            decode_cf_time(np.array([0, 10_000], dtype="int64"), EPOCH_UNIT, "standard")
+
+    def test_a_non_standard_calendar_does_not_warn(self):
+        """A `360_day` axis already returns `cftime`; that is not the #1087 condition.
+
+        Test scenario:
+            The warning explains an unexpected dtype. A non-standard calendar's `cftime`
+            return is expected and documented, so warning about it would be noise.
+        """
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            decoded = decode_cf_time(
+                np.array([400_000], dtype="int64"), EPOCH_UNIT, "360_day"
+            )
+        assert decoded.dtype == np.dtype("object"), decoded.dtype

--- a/tests/netcdf/cf/test_cf_time.py
+++ b/tests/netcdf/cf/test_cf_time.py
@@ -11,7 +11,7 @@ falling back to a proleptic-Gregorian ``datetime64``.
 from __future__ import annotations
 
 import warnings
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import cftime
 import numpy as np
@@ -22,8 +22,10 @@ from pyramids.netcdf.utils import (
     _GREGORIAN_CUTOVER,
     _NS_LIMIT,
     _decode_gregorian_ns,
+    _fits_datetime64_ns,
     decode_cf_time,
     encode_cf_time,
+    is_cf_time_units,
 )
 
 pytestmark = pytest.mark.core
@@ -33,6 +35,109 @@ UNIT = "days since 1979-01-01"
 # 1677-09-21T00:12:43.145224193 to 2262-04-11T23:47:16.854775807, so day 106_751 is the
 # last whole day inside it and day -106_751 the first.
 EPOCH_UNIT = "days since 1970-01-01"
+
+
+# A zone suffix the origin parser does not take, so the integer fast path declines and the
+# same values go through the `cftime` fallback. That is the only way to exercise the two
+# paths against identical input.
+FALLBACK_UNIT = "days since 1900-01-01 00:00:00 UTC"
+FAST_UNIT = "days since 1900-01-01"
+
+
+class TestMissingValues:
+    """Both decode paths agree that an undecodable offset is missing (#1116)."""
+
+    @pytest.mark.parametrize("bad", [np.nan, np.inf], ids=["nan", "inf"])
+    def test_both_paths_report_the_same_missing_value(self, bad):
+        """A `NaN` or `inf` offset is `NaT` whichever path decodes it.
+
+        Test scenario:
+            `cftime` masks what it cannot decode, and `np.asarray` used to drop that mask,
+            leaving the fill value -- the origin. A missing timestep read back as a real
+            date, silently, while the integer path on the same values gave `NaT`.
+        """
+        values = np.array([0.0, bad, 100.0])
+        fast = decode_cf_time(values, FAST_UNIT, "standard")
+        slow = decode_cf_time(values, FALLBACK_UNIT, "standard")
+        assert fast.dtype == slow.dtype == np.dtype("datetime64[ns]"), (
+            f"{fast.dtype} vs {slow.dtype}"
+        )
+        np.testing.assert_array_equal(fast, slow)
+        assert np.isnat(slow[1]), f"the masked offset should be NaT, got {slow[1]}"
+        assert not np.isnat(slow[0]) and not np.isnat(slow[2]), slow
+
+    def test_an_object_result_blanks_the_missing_value(self):
+        """An object array has no `NaT`, so a missing value is `None` there.
+
+        Test scenario:
+            An out-of-range axis keeps its decoded objects, and those carry no `NaT`
+            spelling. Leaving the fill value would put the origin -- a real date -- where a
+            missing timestep belongs.
+        """
+        with pytest.warns(UserWarning):
+            decoded = decode_cf_time(
+                np.array([0.0, np.nan]), "days since 0001-01-01", "standard"
+            )
+        assert decoded.dtype == np.dtype("object"), decoded.dtype
+        assert decoded[1] is None, decoded[1]
+        assert decoded[0].year == 1, decoded[0]
+
+    def test_a_non_standard_calendar_blanks_it_too(self):
+        """The `360_day` path returns objects as well, and must blank the same way."""
+        decoded = decode_cf_time(
+            np.array([1.0, np.nan]), "days since 2000-01-01", "360_day"
+        )
+        assert decoded[1] is None, decoded[1]
+
+    def test_a_missing_value_is_not_mistaken_for_an_out_of_range_one(self):
+        """A masked offset on a pre-1582 epoch must not trigger the range warning.
+
+        Test scenario:
+            The mask's fill value is the origin, which on this epoch is out of range. Range-
+            checking it would fail, downgrade an otherwise representable axis to objects,
+            and blame a range problem for what is a missing value.
+        """
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            decoded = decode_cf_time(
+                np.array([700_000.0, np.nan]), "days since 0001-01-01", "standard"
+            )
+        assert decoded.dtype == np.dtype("datetime64[ns]"), decoded.dtype
+        assert np.isnat(decoded[1]), decoded[1]
+
+
+class TestUndecodableUnits:
+    """`cftime` failures are re-raised naming the axis, units and calendar (#1117)."""
+
+    def test_months_on_a_standard_calendar_names_the_axis(self):
+        """A `"months since"` axis fails with an explanation, not a bare cftime message.
+
+        Test scenario:
+            A calendar month has no fixed length, so `cftime` allows the unit only on
+            `360_day`. `is_cf_time_units` is purely syntactic and never sees the calendar,
+            so it admits the string and the failure surfaces here instead.
+        """
+        assert is_cf_time_units("months since 2000-01-01"), "the predicate admits it"
+        with pytest.raises(ValueError, match="months since 2000-01-01") as raised:
+            decode_cf_time(
+                np.array([1.0, 2.0]),
+                "months since 2000-01-01",
+                "standard",
+                context="valid_time",
+            )
+        message = str(raised.value)
+        assert "valid_time" in message, message
+        assert "standard" in message, message
+        assert "360_day" in message, message
+        assert raised.value.__cause__ is not None, "the cftime error should be chained"
+
+    def test_months_on_a_360_day_calendar_still_decodes(self):
+        """The unit is defined on `360_day`, so that path must keep working."""
+        decoded = decode_cf_time(
+            np.array([1.0, 2.0]), "months since 2000-01-01", "360_day"
+        )
+        assert decoded.dtype == np.dtype("object"), decoded.dtype
+        assert decoded[0].month == 2, decoded[0]
 
 
 class TestCfTimeRoundTrip:
@@ -399,3 +504,61 @@ class TestDatetime64Range:
                 np.array([400_000], dtype="int64"), EPOCH_UNIT, "360_day"
             )
         assert decoded.dtype == np.dtype("object"), decoded.dtype
+
+
+class TestFitsDatetime64Ns:
+    """The range guard itself, at the bounds and on values that are not dates."""
+
+    def test_the_bounds_themselves_are_admitted(self):
+        """The comparison is inclusive, so nothing representable is turned away.
+
+        Test scenario:
+            `_DT64_NS_BOUNDS` is already rounded inward to whole microseconds, so an
+            exclusive comparison would discard the last representable microsecond at each end
+            for nothing. Every axis decoded elsewhere in this file sits days away from the
+            bounds, so no other test would notice.
+        """
+        low, high = _DT64_NS_BOUNDS
+        edges = np.array([datetime(*low), datetime(*high)], dtype=object)
+        assert _fits_datetime64_ns(edges), "the bounds themselves must be admitted"
+
+    @pytest.mark.parametrize("end", [0, 1], ids=["floor", "ceiling"])
+    def test_one_microsecond_past_a_bound_is_refused(self, end):
+        """A microsecond beyond either bound does not fit, which is what makes it a bound.
+
+        Args:
+            end: Which end of `_DT64_NS_BOUNDS` to step past.
+
+        Test scenario:
+            Paired with the test above this pins the edge exactly -- one step in is admitted,
+            one step out is not -- rather than merely somewhere in the right region.
+        """
+        step = timedelta(microseconds=1)
+        edge = datetime(*_DT64_NS_BOUNDS[end]) + (-step if end == 0 else step)
+        assert not _fits_datetime64_ns(np.array([edge], dtype=object)), (
+            f"{edge} is past the bound and must not be admitted"
+        )
+
+    def test_a_value_that_is_not_a_datetime_does_not_fit(self):
+        """An object array of something other than datetimes is refused, not compared.
+
+        Test scenario:
+            "Does not fit" is the honest answer for a value that is not a date at all: the
+            cast would be wrong for it too, and the caller's fallback -- keeping the objects
+            -- is lossless either way.
+        """
+        assert not _fits_datetime64_ns(np.array(["1979-01-11"], dtype=object)), (
+            "a string is not a representable datetime"
+        )
+
+    def test_an_array_valued_element_is_refused_rather_than_raising(self):
+        """The type screen is what keeps a non-`TypeError` comparison from escaping.
+
+        Test scenario:
+            Comparing a `datetime` with an array yields an elementwise result whose truth
+            value raises `ValueError`, which the guard does not catch -- so without the screen
+            it would leave `decode_cf_time` entirely rather than falling back to the objects.
+        """
+        values = np.empty(1, dtype=object)
+        values[0] = np.array([0.0, 1.0])
+        assert not _fits_datetime64_ns(values), "an array element cannot be a date"

--- a/tests/netcdf/cf/test_cf_time.py
+++ b/tests/netcdf/cf/test_cf_time.py
@@ -323,6 +323,30 @@ class TestUndecodableUnits:
             decode_cf_time(np.array([1.0]), "months since not-a-date", "360_day")
         assert MONTH_HINT not in str(raised.value), str(raised.value)
 
+    @pytest.mark.parametrize(
+        "calendar", ["360_Day", "360_DAY"], ids=["mixed-case", "upper-case"]
+    )
+    def test_the_month_hint_is_withheld_whatever_the_calendar_casing(self, calendar):
+        """The calendar gate lowercases, as every other calendar check in the codec does.
+
+        Args:
+            calendar: `360_day` spelled in mixed or upper case.
+
+        Test scenario:
+            `cftime` takes a `"months since ..."` axis on these spellings exactly as it takes
+            the lowercase one -- asserted here rather than assumed -- so the unit is
+            supported and a failure has some other cause, here an unparseable origin.
+            Comparing the calendar as written would append a hint saying months are defined
+            only on `360_day` to an axis that is on `360_day`.
+        """
+        supported = decode_cf_time(np.array([1.0]), "months since 2000-01-01", calendar)
+        assert supported[0].month == 2, (
+            f"cftime no longer takes months on {calendar!r}, so the hint would be apt"
+        )
+        with pytest.raises(ValueError) as raised:
+            decode_cf_time(np.array([1.0]), "months since not-a-date", calendar)
+        assert MONTH_HINT not in str(raised.value), str(raised.value)
+
     def test_an_overflowing_offset_is_named_too(self):
         """An offset that overflows the scale arrives as `OverflowError` and is normalised.
 
@@ -694,6 +718,40 @@ class TestDatetime64Range:
         assert decoded[0].year == 1970, decoded[0]
         assert decoded[1].year == 3065, decoded[1]
 
+    def test_the_out_of_range_value_may_come_first(self):
+        """An axis out of range at the front is downgraded just as one out of range at the back.
+
+        Test scenario:
+            The range check scans element by element and stops at the first value that does
+            not fit. Drop that stop and the verdict becomes whatever the *last* element says,
+            so this axis -- year 3065 followed by an ordinary 1970 -- would cast and wrap the
+            3065 to 1896, which is the whole of #1087 back again.
+            `test_one_bad_value_downgrades_the_whole_axis` puts the bad value last, so it
+            cannot see that.
+        """
+        with pytest.warns(UserWarning, match="outside the"):
+            decoded = decode_cf_time(
+                np.array([400_000, 0], dtype="int64"), EPOCH_UNIT, "standard"
+            )
+        assert decoded.dtype == np.dtype("object"), decoded.dtype
+        assert decoded[0].year == 3065, decoded[0]
+        assert decoded[1].year == 1970, decoded[1]
+
+    def test_the_warning_is_attributed_to_the_caller(self):
+        """The warning points at the code that called `decode_cf_time`, not into the codec.
+
+        Test scenario:
+            The `warnings.warn` sits two frames below the caller now that the `cftime`
+            fallback is its own function, so `stacklevel` has to be 3. At 2 the warning is
+            attributed to `utils.py` instead, which reads as a pyramids-internal complaint
+            and puts it out of reach of a caller filtering warnings on their own module.
+        """
+        with pytest.warns(UserWarning, match="outside the") as caught:
+            decode_cf_time(np.array([400_000], dtype="int64"), EPOCH_UNIT, "standard")
+        assert caught[0].filename == __file__, (
+            f"the warning should be attributed to this file, got {caught[0].filename}"
+        )
+
     def test_the_warning_names_the_axis_when_given_one(self):
         """`context` puts the axis name in the message, for a store with several time axes."""
         with pytest.warns(UserWarning, match="'valid_time'"):
@@ -778,3 +836,26 @@ class TestFitsDatetime64Ns:
         values[0] = datetime(2000, 1, 1)
         values[1] = np.array([datetime(2000, 1, 1), datetime(2001, 1, 1)], dtype=object)
         assert not _fits_datetime64_ns(values), "an array element cannot be a date"
+
+    @pytest.mark.parametrize(
+        "leading",
+        [datetime(1, 1, 1), "1979-01-11"],
+        ids=["out-of-range-date", "not-a-date"],
+    )
+    def test_a_refusal_is_not_undone_by_a_later_value(self, leading):
+        """The first value that does not fit settles the answer, whatever follows it.
+
+        Args:
+            leading: A first element that does not fit -- a date below the floor, and a value
+                that is not a date at all, one for each of the two ways the scan refuses.
+
+        Test scenario:
+            The scan assigns its verdict per element and breaks on the first refusal. Without
+            the break the verdict would simply be the last element's, so a fitting date after
+            a refused one would report the whole array as castable. Every other test here
+            refuses on the last element, where a missing break makes no difference.
+        """
+        values = np.array([leading, datetime(2000, 1, 1)], dtype=object)
+        assert not _fits_datetime64_ns(values), (
+            f"{leading!r} does not fit, so neither does the array it leads"
+        )

--- a/tests/netcdf/cf/test_cf_time.py
+++ b/tests/netcdf/cf/test_cf_time.py
@@ -222,7 +222,7 @@ class TestDatetime64Range:
             the epoch, so day 400_000 (year 3065) read back as 1896 and day -150_000 (year
             1559) as 2143. The value, not just the dtype, is what this pins.
         """
-        with pytest.warns(RuntimeWarning, match="outside the range"):
+        with pytest.warns(UserWarning, match="outside the 1677-09-21"):
             decoded = decode_cf_time(
                 np.array([offset], dtype="int64"), EPOCH_UNIT, "standard"
             )
@@ -238,9 +238,10 @@ class TestDatetime64Range:
 
         Test scenario:
             A pre-1582 origin decodes through `cftime` to `DatetimeGregorian`, not to
-            `datetime`, and those two raise `TypeError` when compared. A bound built as a
-            plain `datetime` would therefore reject every such store -- including the corpus
-            fixtures written against that epoch, whose dates are ordinary 20th-century ones.
+            `datetime`. Comparing those two raises only when the decoded value is itself
+            pre-1582, so a 20th-century date on that epoch compares fine and must keep its
+            `datetime64` dtype. Corpus fixtures are written against this epoch, so getting
+            it wrong would downgrade them.
         """
         decoded = decode_cf_time(
             np.array([700_000], dtype="int64"), "days since 0001-01-01", "standard"
@@ -257,7 +258,7 @@ class TestDatetime64Range:
             The bug needs no large offset: the origin alone is enough to leave the type's
             range, and year 1 wrapped to 2169.
         """
-        with pytest.warns(RuntimeWarning, match="outside the range"):
+        with pytest.warns(UserWarning, match="outside the 1677-09-21"):
             decoded = decode_cf_time(
                 np.array([0], dtype="int64"), "days since 0001-01-01", "standard"
             )

--- a/tests/netcdf/cf/test_cf_time.py
+++ b/tests/netcdf/cf/test_cf_time.py
@@ -269,6 +269,38 @@ class TestDatetime64Range:
             warnings.simplefilter("error")
             decode_cf_time(np.array([0, 10_000], dtype="int64"), EPOCH_UNIT, "standard")
 
+    def test_a_multidimensional_axis_is_flattened_before_comparison(self):
+        """A 2-D array of in-range dates decodes, rather than raising on the range check.
+
+        Test scenario:
+            The check flattens before comparing. Iterating a 2-D object array yields rows, and
+            `floor <= row` is an elementwise array whose truth value raises `ValueError` -- not
+            the `TypeError` the guard catches, so it would escape `decode_cf_time` entirely.
+            The origin carries a zone suffix so the integer fast path declines and the values
+            reach the `cftime` branch under test.
+        """
+        values = np.array([[0, 10_000], [20_000, 15_000]], dtype="int64")
+        decoded = decode_cf_time(
+            values, "days since 1900-01-01 00:00:00 UTC", "standard"
+        )
+        assert decoded.shape == (2, 2), decoded.shape
+        assert decoded.dtype == np.dtype("datetime64[ns]"), decoded.dtype
+
+    def test_an_empty_axis_decodes_to_an_empty_datetime64(self):
+        """A zero-length time axis has nothing out of range, so it still casts.
+
+        Test scenario:
+            The range check is an `all()` over the values, which is vacuously true when there
+            are none. An empty axis must come back as empty `datetime64[ns]`, not as objects.
+        """
+        decoded = decode_cf_time(
+            np.array([], dtype="int64"),
+            "days since 1900-01-01 00:00:00 UTC",
+            "standard",
+        )
+        assert decoded.dtype == np.dtype("datetime64[ns]"), decoded.dtype
+        assert decoded.size == 0, decoded
+
     def test_a_non_standard_calendar_does_not_warn(self):
         """A `360_day` axis already returns `cftime`; that is not the #1087 condition.
 

--- a/tests/netcdf/cf/test_cf_time.py
+++ b/tests/netcdf/cf/test_cf_time.py
@@ -21,6 +21,7 @@ from pyramids.netcdf.utils import (
     _DT64_NS_BOUNDS,
     _GREGORIAN_CUTOVER,
     _NS_LIMIT,
+    _blank_missing,
     _decode_gregorian_ns,
     _fits_datetime64_ns,
     decode_cf_time,
@@ -42,6 +43,11 @@ EPOCH_UNIT = "days since 1970-01-01"
 # paths against identical input.
 FALLBACK_UNIT = "days since 1900-01-01 00:00:00 UTC"
 FAST_UNIT = "days since 1900-01-01"
+
+# The sentence `_num2date` appends to a `"months since"` failure and to nothing else.
+# `cftime`'s own message names `360_day` for several unrelated failures, so matching on that
+# alone would not tell the hint apart from the error it decorates.
+MONTH_HINT = "A calendar month has no fixed length"
 
 
 class TestMissingValues:
@@ -82,12 +88,88 @@ class TestMissingValues:
         assert decoded[1] is None, decoded[1]
         assert decoded[0].year == 1, decoded[0]
 
-    def test_a_non_standard_calendar_blanks_it_too(self):
+    @pytest.mark.parametrize("bad", [np.nan, np.inf], ids=["nan", "inf"])
+    def test_a_non_standard_calendar_blanks_it_too(self, bad):
         """The `360_day` path returns objects as well, and must blank the same way."""
         decoded = decode_cf_time(
-            np.array([1.0, np.nan]), "days since 2000-01-01", "360_day"
+            np.array([1.0, bad]), "days since 2000-01-01", "360_day"
         )
         assert decoded[1] is None, decoded[1]
+
+    def test_an_entirely_missing_axis_decodes_to_all_nat(self):
+        """An axis with nothing but missing values still comes back as `datetime64`.
+
+        Test scenario:
+            Excluding the masked positions leaves the range check an empty array, which is
+            vacuously in range. That must read as "casts exactly" -- an all-`NaT`
+            `datetime64` axis -- and not as an out-of-range downgrade to objects, which
+            would warn about a range problem an axis holding no dates cannot have.
+        """
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            decoded = decode_cf_time(
+                np.array([np.nan, np.nan]), FALLBACK_UNIT, "standard"
+            )
+        assert decoded.dtype == np.dtype("datetime64[ns]"), decoded.dtype
+        assert np.isnat(decoded).all(), decoded
+
+    def test_a_two_dimensional_axis_keeps_its_shape(self):
+        """Blanking a masked position must not flatten a multidimensional axis.
+
+        Test scenario:
+            The range check indexes the unmasked values out, which flattens; the `NaT`
+            write must not. A 2-D axis has to come back 2-D with the mask honoured in
+            place, so the missing cell is the one that was missing.
+        """
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            decoded = decode_cf_time(
+                np.array([[0.0, np.nan], [1.0, 2.0]]), FALLBACK_UNIT, "standard"
+            )
+        assert decoded.shape == (2, 2), decoded.shape
+        assert np.isnat(decoded[0, 1]), decoded[0, 1]
+        assert not np.isnat(decoded).ravel()[[0, 2, 3]].any(), decoded
+
+    def test_a_two_dimensional_object_axis_keeps_its_shape(self):
+        """The object path blanks in place too, so its shape survives as well."""
+        with pytest.warns(UserWarning):
+            decoded = decode_cf_time(
+                np.array([[0.0, np.nan], [1.0, 2.0]]),
+                "days since 0001-01-01",
+                "standard",
+            )
+        assert decoded.shape == (2, 2), decoded.shape
+        assert decoded[0, 1] is None, decoded[0, 1]
+        assert decoded[1, 0].year == 1, decoded[1, 0]
+
+
+class TestBlankMissing:
+    """`_blank_missing` on its own, for the two invariants a decode cannot show."""
+
+    def test_an_unmasked_array_is_returned_unchanged(self):
+        """Nothing masked is the common case, and must not cost a copy.
+
+        Test scenario:
+            The mask `cftime` returns is all-`False` for a clean axis, so the helper runs
+            on every fallback decode. It has to hand the array straight back rather than
+            rebuild it.
+        """
+        decoded = np.array(["a", "b"], dtype=object)
+        result = _blank_missing(decoded, np.array([False, False]))
+        assert result is decoded, "an unmasked array should be returned as-is"
+
+    def test_the_source_array_is_not_mutated(self):
+        """Blanking works on a copy, because the caller's array aliases `cftime`'s buffer.
+
+        Test scenario:
+            `np.asarray` on a masked array is a view of its `.data`, so writing `None`
+            through it would reach into what `cftime` returned. The helper copies first;
+            the caller's array must still hold its decoded value afterwards.
+        """
+        decoded = np.array(["a", "b"], dtype=object)
+        result = _blank_missing(decoded, np.array([False, True]))
+        assert result[1] is None, result[1]
+        assert decoded[1] == "b", f"the source array was mutated: {decoded.tolist()}"
 
     def test_a_missing_value_is_not_mistaken_for_an_out_of_range_one(self):
         """A masked offset on a pre-1582 epoch must not trigger the range warning.
@@ -128,8 +210,70 @@ class TestUndecodableUnits:
         message = str(raised.value)
         assert "valid_time" in message, message
         assert "standard" in message, message
-        assert "360_day" in message, message
+        assert MONTH_HINT in message, message
         assert raised.value.__cause__ is not None, "the cftime error should be chained"
+
+    @pytest.mark.parametrize(
+        "unit",
+        ["years since 2000-01-01", "days since not-a-date"],
+        ids=["unknown-period", "unparseable-origin"],
+    )
+    def test_a_non_month_failure_carries_no_month_hint(self, unit):
+        """Every `cftime` failure names the axis, but only a month one earns the hint.
+
+        Args:
+            unit: A units string `is_cf_time_units` admits and `cftime` refuses -- a period
+                it does not recognise, and an origin it cannot parse.
+
+        Test scenario:
+            The month hint explains one specific cause. Appending it to an unrelated
+            failure -- an unknown period, an unparseable origin -- would misdiagnose it, so
+            the message must carry the units and calendar and nothing else.
+        """
+        assert is_cf_time_units(unit), "the predicate admits it"
+        with pytest.raises(ValueError, match=unit) as raised:
+            decode_cf_time(np.array([1.0, 2.0]), unit, "standard", context="t")
+        message = str(raised.value)
+        assert "'t'" in message, message
+        assert "standard" in message, message
+        assert MONTH_HINT not in message, (
+            f"the month hint does not belong here: {message}"
+        )
+        assert raised.value.__cause__ is not None, "the cftime error should be chained"
+
+    def test_the_message_omits_the_axis_when_no_context_is_given(self):
+        """Without a `context` the message names the units alone, with no empty quotes.
+
+        Test scenario:
+            `context` is optional, and a caller that has no axis name must not produce a
+            message with a stray `''` where the name would go.
+        """
+        with pytest.raises(ValueError) as raised:
+            decode_cf_time(np.array([1.0]), "months since 2000-01-01", "standard")
+        message = str(raised.value)
+        assert "time axis ('months since 2000-01-01')" in message, message
+        assert "''" not in message, (
+            f"an empty axis name leaked into the message: {message}"
+        )
+
+    @pytest.mark.parametrize(
+        "unit",
+        ["  Months since 2000-01-01  ", "MONTHS since 2000-01-01"],
+        ids=["padded-and-capitalised", "upper-case"],
+    )
+    def test_the_month_hint_survives_casing_and_padding(self, unit):
+        """A units string is stored as written, so the hint must not depend on its spelling.
+
+        Args:
+            unit: A `"months since"` axis spelled with surrounding whitespace or in capitals.
+
+        Test scenario:
+            CF does not normalise the attribute, and the same defect writes the same
+            message whichever way the store spells the unit.
+        """
+        with pytest.raises(ValueError) as raised:
+            decode_cf_time(np.array([1.0]), unit, "standard")
+        assert MONTH_HINT in str(raised.value), str(raised.value)
 
     def test_months_on_a_360_day_calendar_still_decodes(self):
         """The unit is defined on `360_day`, so that path must keep working."""

--- a/tests/netcdf/cf/test_cf_time.py
+++ b/tests/netcdf/cf/test_cf_time.py
@@ -44,6 +44,30 @@ EPOCH_UNIT = "days since 1970-01-01"
 FALLBACK_UNIT = "days since 1900-01-01 00:00:00 UTC"
 FAST_UNIT = "days since 1900-01-01"
 
+
+@pytest.fixture
+def fallback_unit():
+    """`FALLBACK_UNIT`, having asserted it really does route to the `cftime` fallback.
+
+    Every test that uses it relies on the origin parser refusing the zone suffix. That holds
+    today, but if the parser ever learns the suffix these tests would quietly start
+    exercising the fast path instead -- and the one comparing the two paths would compare
+    the fast path with itself and still pass.
+
+    Returns:
+        str: The units string, guaranteed to take the `cftime` branch.
+    """
+    probe = np.array([0.0, 1.0])
+    assert _decode_gregorian_ns(probe, FALLBACK_UNIT, "standard") is None, (
+        f"{FALLBACK_UNIT!r} no longer routes to the cftime fallback; these tests would "
+        "silently stop covering it"
+    )
+    assert _decode_gregorian_ns(probe, FAST_UNIT, "standard") is not None, (
+        f"{FAST_UNIT!r} no longer takes the integer fast path"
+    )
+    return FALLBACK_UNIT
+
+
 # The sentence `_num2date` appends to a `"months since"` failure and to nothing else.
 # `cftime`'s own message names `360_day` for several unrelated failures, so matching on that
 # alone would not tell the hint apart from the error it decorates.
@@ -54,7 +78,7 @@ class TestMissingValues:
     """Both decode paths agree that an undecodable offset is missing (#1116)."""
 
     @pytest.mark.parametrize("bad", [np.nan, np.inf], ids=["nan", "inf"])
-    def test_both_paths_report_the_same_missing_value(self, bad):
+    def test_both_paths_report_the_same_missing_value(self, bad, fallback_unit):
         """A `NaN` or `inf` offset is `NaT` whichever path decodes it.
 
         Test scenario:
@@ -64,7 +88,7 @@ class TestMissingValues:
         """
         values = np.array([0.0, bad, 100.0])
         fast = decode_cf_time(values, FAST_UNIT, "standard")
-        slow = decode_cf_time(values, FALLBACK_UNIT, "standard")
+        slow = decode_cf_time(values, fallback_unit, "standard")
         assert fast.dtype == slow.dtype == np.dtype("datetime64[ns]"), (
             f"{fast.dtype} vs {slow.dtype}"
         )
@@ -97,7 +121,7 @@ class TestMissingValues:
         )
         assert decoded[1] is None, decoded[1]
 
-    def test_an_entirely_missing_axis_decodes_to_all_nat(self):
+    def test_an_entirely_missing_axis_decodes_to_all_nat(self, fallback_unit):
         """An axis with nothing but missing values still comes back as `datetime64`.
 
         Test scenario:
@@ -109,12 +133,12 @@ class TestMissingValues:
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             decoded = decode_cf_time(
-                np.array([np.nan, np.nan]), FALLBACK_UNIT, "standard"
+                np.array([np.nan, np.nan]), fallback_unit, "standard"
             )
         assert decoded.dtype == np.dtype("datetime64[ns]"), decoded.dtype
         assert np.isnat(decoded).all(), decoded
 
-    def test_a_two_dimensional_axis_keeps_its_shape(self):
+    def test_a_two_dimensional_axis_keeps_its_shape(self, fallback_unit):
         """Blanking a masked position must not flatten a multidimensional axis.
 
         Test scenario:
@@ -125,7 +149,7 @@ class TestMissingValues:
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             decoded = decode_cf_time(
-                np.array([[0.0, np.nan], [1.0, 2.0]]), FALLBACK_UNIT, "standard"
+                np.array([[0.0, np.nan], [1.0, 2.0]]), fallback_unit, "standard"
             )
         assert decoded.shape == (2, 2), decoded.shape
         assert np.isnat(decoded[0, 1]), decoded[0, 1]
@@ -159,18 +183,29 @@ class TestBlankMissing:
         result = _blank_missing(decoded, np.array([False, False]))
         assert result is decoded, "an unmasked array should be returned as-is"
 
-    def test_the_source_array_is_not_mutated(self):
-        """Blanking works on a copy, because the caller's array aliases `cftime`'s buffer.
+    def test_the_masked_source_buffer_is_not_mutated(self):
+        """Blanking works on a copy, because the array passed in aliases `cftime`'s buffer.
 
         Test scenario:
-            `np.asarray` on a masked array is a view of its `.data`, so writing `None`
-            through it would reach into what `cftime` returned. The helper copies first;
-            the caller's array must still hold its decoded value afterwards.
+            Built the way `decode_cf_time` builds it -- `np.asarray` of a masked array,
+            which is a *view* of that array's `.data`, not a copy. Writing `None` through
+            the view would reach back into what `cftime` returned. Asserting on a plain
+            array instead would pass even if the helper wrote in place, since there would
+            be nothing behind it to corrupt.
         """
-        decoded = np.array(["a", "b"], dtype=object)
-        result = _blank_missing(decoded, np.array([False, True]))
+        source = np.ma.masked_array(
+            np.array(["a", "b"], dtype=object), mask=[False, True]
+        )
+        decoded = np.asarray(source)
+        assert np.shares_memory(decoded, source.data), (
+            "the fixture must alias the masked buffer for this to mean anything"
+        )
+        result = _blank_missing(decoded, np.ma.getmaskarray(source))
         assert result[1] is None, result[1]
-        assert decoded[1] == "b", f"the source array was mutated: {decoded.tolist()}"
+        assert source.data[1] == "b", (
+            f"cftime's own buffer was mutated: {source.data.tolist()}"
+        )
+        assert decoded[1] == "b", f"the view was mutated: {decoded.tolist()}"
 
     def test_a_missing_value_is_not_mistaken_for_an_out_of_range_one(self):
         """A masked offset on a pre-1582 epoch must not trigger the range warning.
@@ -275,6 +310,36 @@ class TestUndecodableUnits:
         with pytest.raises(ValueError) as raised:
             decode_cf_time(np.array([1.0]), unit, "standard")
         assert MONTH_HINT in str(raised.value), str(raised.value)
+
+    def test_the_month_hint_is_withheld_on_a_360_day_calendar(self):
+        """On `360_day` the unit is supported, so the hint would contradict itself.
+
+        Test scenario:
+            The hint explains that months are only defined on `360_day`. Appending it to a
+            failure that happened *on* `360_day` -- an unparseable origin, say -- tells the
+            reader the opposite of what the message above it says.
+        """
+        with pytest.raises(ValueError) as raised:
+            decode_cf_time(np.array([1.0]), "months since not-a-date", "360_day")
+        assert MONTH_HINT not in str(raised.value), str(raised.value)
+
+    def test_an_overflowing_offset_is_named_too(self):
+        """An offset that overflows the scale arrives as `OverflowError` and is normalised.
+
+        Test scenario:
+            `cftime` raises `OverflowError`, not `ValueError`, once the offset is large
+            enough that the nanosecond scale overflows before a date is reached. Left
+            uncaught it escaped naming nothing; callers now have one failure type.
+        """
+        with pytest.raises(ValueError, match="days since 1970-01-01") as raised:
+            decode_cf_time(
+                np.array([1e9]),
+                "days since 1970-01-01",
+                "standard",
+                context="valid_time",
+            )
+        assert "valid_time" in str(raised.value), str(raised.value)
+        assert isinstance(raised.value.__cause__, OverflowError), raised.value.__cause__
 
     def test_months_on_a_360_day_calendar_still_decodes(self):
         """The unit is defined on `360_day`, so that path must keep working."""
@@ -414,9 +479,12 @@ class TestDatetime64Range:
         low, high = _DT64_NS_BOUNDS
         floor = np.datetime64(np.iinfo(np.int64).min + 1, "ns")
         ceiling = np.datetime64(np.iinfo(np.int64).max, "ns")
-        # The invariant that actually couples the two constants: the integer path's own
-        # ceiling must stay inside what this bound admits, or it could hand the cast a
-        # value this check has already called representable.
+        # The invariant that actually couples the two constants: the fast path must not
+        # accept an instant this bound would reject. The two never meet in one call --
+        # `decode_cf_time` uses the integer result directly and reaches the `cftime`
+        # fallback only when it declines -- so nothing enforces agreement between them
+        # except this. Were `_NS_LIMIT` raised past the bound, the same date would be
+        # representable down one path and out of range down the other.
         span = (np.datetime64(datetime(*high), "ns") - np.datetime64(0, "ns")).astype(
             "int64"
         )
@@ -534,7 +602,9 @@ class TestDatetime64Range:
             warnings.simplefilter("error")
             decode_cf_time(np.array([0, 10_000], dtype="int64"), EPOCH_UNIT, "standard")
 
-    def test_a_multidimensional_axis_is_flattened_before_comparison(self):
+    def test_a_multidimensional_axis_is_flattened_before_comparison(
+        self, fallback_unit
+    ):
         """A 2-D array of in-range dates decodes, rather than raising on the range check.
 
         Test scenario:
@@ -545,13 +615,11 @@ class TestDatetime64Range:
             reach the `cftime` branch under test.
         """
         values = np.array([[0, 10_000], [20_000, 15_000]], dtype="int64")
-        decoded = decode_cf_time(
-            values, "days since 1900-01-01 00:00:00 UTC", "standard"
-        )
+        decoded = decode_cf_time(values, fallback_unit, "standard")
         assert decoded.shape == (2, 2), decoded.shape
         assert decoded.dtype == np.dtype("datetime64[ns]"), decoded.dtype
 
-    def test_an_empty_axis_decodes_to_an_empty_datetime64(self):
+    def test_an_empty_axis_decodes_to_an_empty_datetime64(self, fallback_unit):
         """A zero-length time axis has nothing out of range, so it still casts.
 
         Test scenario:

--- a/tests/netcdf/cf/test_cf_time.py
+++ b/tests/netcdf/cf/test_cf_time.py
@@ -20,6 +20,7 @@ import pytest
 from pyramids.netcdf.utils import (
     _DT64_NS_BOUNDS,
     _GREGORIAN_CUTOVER,
+    _NS_LIMIT,
     _decode_gregorian_ns,
     decode_cf_time,
     encode_cf_time,
@@ -28,6 +29,10 @@ from pyramids.netcdf.utils import (
 pytestmark = pytest.mark.core
 
 UNIT = "days since 1979-01-01"
+# The 1970 epoch makes the boundary arithmetic legible: `datetime64[ns]` spans
+# 1677-09-21T00:12:43.145224193 to 2262-04-11T23:47:16.854775807, so day 106_751 is the
+# last whole day inside it and day -106_751 the first.
+EPOCH_UNIT = "days since 1970-01-01"
 
 
 class TestCfTimeRoundTrip:
@@ -144,12 +149,6 @@ class TestStandardCalendarCasing:
         )
 
 
-# The 1970 epoch makes the boundary arithmetic legible: `datetime64[ns]` spans
-# 1677-09-21T00:12:43.145224193 to 2262-04-11T23:47:16.854775807, so day 106_751 is the
-# last whole day inside it and day -106_751 the first.
-EPOCH_UNIT = "days since 1970-01-01"
-
-
 class TestDatetime64Range:
     """`decode_cf_time` keeps `cftime` objects rather than wrapping past `datetime64[ns]` (#1087)."""
 
@@ -165,25 +164,39 @@ class TestDatetime64Range:
         low, high = _DT64_NS_BOUNDS
         floor = np.datetime64(np.iinfo(np.int64).min + 1, "ns")
         ceiling = np.datetime64(np.iinfo(np.int64).max, "ns")
+        # The invariant that actually couples the two constants: the integer path's own
+        # ceiling must stay inside what this bound admits, or it could hand the cast a
+        # value this check has already called representable.
+        span = (np.datetime64(datetime(*high), "ns") - np.datetime64(0, "ns")).astype(
+            "int64"
+        )
+        assert _NS_LIMIT <= span, (
+            f"_NS_LIMIT {_NS_LIMIT:.3e} now exceeds the {span} ns this bound admits"
+        )
         assert np.datetime64(datetime(*low), "ns") >= floor, (
             f"{low} is below datetime64[ns]'s floor {floor}"
         )
         assert np.datetime64(datetime(*high), "ns") <= ceiling, (
             f"{high} is above datetime64[ns]'s ceiling {ceiling}"
         )
-        assert np.datetime64(datetime(*low), "ns") - floor < np.timedelta64(1, "us"), (
-            "the floor is rounded inward by more than the microsecond it should cost"
+        # Tightest possible, not merely "within a microsecond": one microsecond further out
+        # at either end would leave the range entirely. Compared as Python ints, because
+        # taking that step in `datetime64[ns]` overflows -- which is the point.
+        low_ns = int(np.datetime64(datetime(*low), "ns").astype("int64"))
+        high_ns = int(np.datetime64(datetime(*high), "ns").astype("int64"))
+        assert low_ns - 1_000 < int(np.iinfo(np.int64).min) + 1, (
+            "the floor could be rounded one microsecond closer to the real limit"
         )
-        assert ceiling - np.datetime64(datetime(*high), "ns") < np.timedelta64(
-            1, "us"
-        ), "the ceiling is rounded inward by more than the microsecond it should cost"
+        assert high_ns + 1_000 > int(np.iinfo(np.int64).max), (
+            "the ceiling could be rounded one microsecond closer to the real limit"
+        )
 
     def test_the_gregorian_reform_predates_the_floor(self):
         """The reform is below the type's floor, which is what lets a `TypeError` mean "no fit".
 
         Test scenario:
-            `cftime` refuses to compare a `DatetimeGregorian` with a `datetime` when either
-            is pre-1582, and `_fits_datetime64_ns` reads that refusal as "does not fit". That
+            `cftime` refuses to compare a `DatetimeGregorian` with a `datetime` when the
+            decoded value is pre-1582, and `_fits_datetime64_ns` reads that as "does not fit". That
             is only correct because every such date is below `datetime64[ns]`'s floor anyway.
             If the floor ever moved earlier than the reform, the refusal would start hiding
             representable dates and the guard would need to compare in the value's own
@@ -222,7 +235,7 @@ class TestDatetime64Range:
             the epoch, so day 400_000 (year 3065) read back as 1896 and day -150_000 (year
             1559) as 2143. The value, not just the dtype, is what this pins.
         """
-        with pytest.warns(UserWarning, match="outside the 1677-09-21"):
+        with pytest.warns(UserWarning, match="outside the"):
             decoded = decode_cf_time(
                 np.array([offset], dtype="int64"), EPOCH_UNIT, "standard"
             )
@@ -258,7 +271,7 @@ class TestDatetime64Range:
             The bug needs no large offset: the origin alone is enough to leave the type's
             range, and year 1 wrapped to 2169.
         """
-        with pytest.warns(UserWarning, match="outside the 1677-09-21"):
+        with pytest.warns(UserWarning, match="outside the"):
             decoded = decode_cf_time(
                 np.array([0], dtype="int64"), "days since 0001-01-01", "standard"
             )
@@ -325,6 +338,53 @@ class TestDatetime64Range:
         assert decoded.dtype == np.dtype("datetime64[ns]"), (
             f"day {offset} is inside datetime64[ns] and should cast, got {decoded.dtype}"
         )
+
+    def test_the_element_class_follows_the_origin_not_the_values(self):
+        """Which object comes back decides what still works downstream, so pin both cases.
+
+        Test scenario:
+            A date Python's `datetime` can represent yields `cftime.real_datetime`, a
+            `datetime` subclass that `pandas` coerces to `datetime64[us]` -- so a year-3065
+            axis still exports. A date it cannot, which in practice means a pre-1582 origin,
+            yields a true `cftime` datetime that Parquet has no type for.
+        """
+        with pytest.warns(UserWarning):
+            future = decode_cf_time(
+                np.array([400_000], dtype="int64"), EPOCH_UNIT, "standard"
+            )
+        assert isinstance(future[0], datetime), type(future[0])
+        assert not isinstance(future[0], cftime.datetime), type(future[0])
+        with pytest.warns(UserWarning):
+            ancient = decode_cf_time(
+                np.array([0], dtype="int64"), "days since 0001-01-01", "standard"
+            )
+        assert isinstance(ancient[0], cftime.datetime), type(ancient[0])
+
+    def test_one_bad_value_downgrades_the_whole_axis(self):
+        """The dtype decision is array-wide, because one array has one dtype.
+
+        Test scenario:
+            An in-range neighbour loses its `datetime64` representation when any value on
+            the axis is out of range. That is forced rather than chosen -- a mixed-dtype
+            array is not possible -- but it is worth pinning so the trade-off is visible.
+        """
+        with pytest.warns(UserWarning):
+            decoded = decode_cf_time(
+                np.array([0, 400_000], dtype="int64"), EPOCH_UNIT, "standard"
+            )
+        assert decoded.dtype == np.dtype("object"), decoded.dtype
+        assert decoded[0].year == 1970, decoded[0]
+        assert decoded[1].year == 3065, decoded[1]
+
+    def test_the_warning_names_the_axis_when_given_one(self):
+        """`context` puts the axis name in the message, for a store with several time axes."""
+        with pytest.warns(UserWarning, match="'valid_time'"):
+            decode_cf_time(
+                np.array([400_000], dtype="int64"),
+                EPOCH_UNIT,
+                "standard",
+                context="valid_time",
+            )
 
     def test_a_non_standard_calendar_does_not_warn(self):
         """A `360_day` axis already returns `cftime`; that is not the #1087 condition.

--- a/tests/netcdf/cf/test_cf_time.py
+++ b/tests/netcdf/cf/test_cf_time.py
@@ -20,6 +20,7 @@ import pytest
 from pyramids.netcdf.utils import (
     _DT64_NS_BOUNDS,
     _GREGORIAN_CUTOVER,
+    _decode_gregorian_ns,
     decode_cf_time,
     encode_cf_time,
 )
@@ -300,6 +301,29 @@ class TestDatetime64Range:
         )
         assert decoded.dtype == np.dtype("datetime64[ns]"), decoded.dtype
         assert decoded.size == 0, decoded
+
+    @pytest.mark.parametrize("offset", [104_400, 106_000, 106_751])
+    def test_the_band_past_the_integer_scale_still_casts(self, offset):
+        """Dates the integer path declines but the type can hold still decode to `datetime64`.
+
+        Test scenario:
+            `_NS_LIMIT` stops the integer path at 9.0e18 ns (2255-03-14), deliberately below
+            `int64` so a float comparison cannot overflow. `datetime64[ns]` itself reaches
+            2262-04-11, so there is a seven-year band where the fast path declines and the
+            `cftime` fallback is the only route. The new range check must not narrow the type
+            down to the integer scale's reach: these must still come back as `datetime64`,
+            unwarned.
+        """
+        values = np.array([offset], dtype="int64")
+        assert _decode_gregorian_ns(values, EPOCH_UNIT, "standard") is None, (
+            f"day {offset} must be past the integer scale for this to mean anything"
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            decoded = decode_cf_time(values, EPOCH_UNIT, "standard")
+        assert decoded.dtype == np.dtype("datetime64[ns]"), (
+            f"day {offset} is inside datetime64[ns] and should cast, got {decoded.dtype}"
+        )
 
     def test_a_non_standard_calendar_does_not_warn(self):
         """A `360_day` axis already returns `cftime`; that is not the #1087 condition.

--- a/tests/netcdf/cf/test_cf_time.py
+++ b/tests/netcdf/cf/test_cf_time.py
@@ -558,7 +558,10 @@ class TestFitsDatetime64Ns:
             Comparing a `datetime` with an array yields an elementwise result whose truth
             value raises `ValueError`, which the guard does not catch -- so without the screen
             it would leave `decode_cf_time` entirely rather than falling back to the objects.
+            The nested element sits beside a real date, so the screen has to reject on *any*
+            element rather than only on an array holding no dates at all.
         """
-        values = np.empty(1, dtype=object)
-        values[0] = np.array([0.0, 1.0])
+        values = np.empty(2, dtype=object)
+        values[0] = datetime(2000, 1, 1)
+        values[1] = np.array([datetime(2000, 1, 1), datetime(2001, 1, 1)], dtype=object)
         assert not _fits_datetime64_ns(values), "an array element cannot be a date"

--- a/tests/netcdf/cf/test_cf_time.py
+++ b/tests/netcdf/cf/test_cf_time.py
@@ -70,7 +70,8 @@ class TestMissingValues:
         )
         np.testing.assert_array_equal(fast, slow)
         assert np.isnat(slow[1]), f"the masked offset should be NaT, got {slow[1]}"
-        assert not np.isnat(slow[0]) and not np.isnat(slow[2]), slow
+        assert not np.isnat(slow[0]), f"the first offset is present, got {slow[0]}"
+        assert not np.isnat(slow[2]), f"the last offset is present, got {slow[2]}"
 
     def test_an_object_result_blanks_the_missing_value(self):
         """An object array has no `NaT`, so a missing value is `None` there.

--- a/tests/netcdf/selection/test_labeled_out_of_range_time.py
+++ b/tests/netcdf/selection/test_labeled_out_of_range_time.py
@@ -18,6 +18,7 @@ rather than being gated on the interop extra.
 from __future__ import annotations
 
 import warnings
+from datetime import datetime
 from pathlib import Path
 
 import cftime
@@ -232,6 +233,20 @@ class TestCftimeColumnDetection:
             }
         )
         assert _cftime_columns(frame) == ["ancient"], _cftime_columns(frame)
+
+    def test_a_column_whose_first_value_is_a_datetime_is_still_named(self):
+        """Any `cftime` element names the column, not only a leading one.
+
+        Test scenario:
+            `cftime` picks one class per array from the units origin, so a column decoded in
+            one go is uniform and a first-element check would do. A frame assembled from more
+            than one decode need not be, and inspecting only the first value would then name
+            no column -- leaving pyarrow's own opaque error to surface instead.
+        """
+        frame = pd.DataFrame(
+            {"time": [datetime(2000, 1, 1), cftime.DatetimeGregorian(1000, 1, 1)]}
+        )
+        assert _cftime_columns(frame) == ["time"], _cftime_columns(frame)
 
     def test_an_empty_object_column_is_not_indexed(self):
         """A zero-row object column has no first element, and must not be looked at.

--- a/tests/netcdf/selection/test_labeled_out_of_range_time.py
+++ b/tests/netcdf/selection/test_labeled_out_of_range_time.py
@@ -175,6 +175,69 @@ class TestOutOfRangeTimeExport:
         )
         assert "cftime" not in str(raised.value), raised.value
 
+    def test_a_cftime_axis_failing_for_another_reason_keeps_that_error(
+        self, tmp_path: Path
+    ):
+        """An unstorable column is not on its own enough to blame the time axis.
+
+        Test scenario:
+            The frame genuinely carries `DatetimeGregorian`, so the column scan alone says
+            "range problem". The write failed for something else entirely -- a duplicated
+            `index` argument, rejected before pyarrow is handed the frame at all -- and
+            answering that with advice about selecting an in-range window would send the
+            caller after a defect that is not there. Only the error text tells the two apart,
+            since pyarrow names the offending type in its own message.
+        """
+        pytest.importorskip("pyarrow")
+        store = _time_store(
+            tmp_path / "ancient.nc", "days since 0001-01-01", [0.0, 1.0]
+        )
+        dataset = LabeledDataset.read_file(store)
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                assert _cftime_columns(dataset.to_dataframe()) == ["time"], (
+                    "the axis must decode to cftime for this test to mean anything"
+                )
+                with pytest.raises(TypeError) as raised:
+                    dataset.to_parquet(tmp_path / "ancient.parquet", index=True)
+        finally:
+            dataset.close()
+        assert "index" in str(raised.value), str(raised.value)
+        assert "cftime datetimes" not in str(raised.value), (
+            f"an unrelated failure was re-labelled: {raised.value}"
+        )
+
+    def test_a_failure_that_merely_mentions_cftime_is_not_re_labelled(
+        self, tmp_path: Path
+    ):
+        """The error text is not enough on its own either; a column has to be to blame.
+
+        Test scenario:
+            The output directory is named `cftime`, so the "non-existent directory" message
+            carries the word while the frame carries no such value. Matching on the text
+            alone would answer a missing-directory error with an empty list of offending
+            columns and advice about a range this ordinary 1970-epoch store is well inside.
+        """
+        pytest.importorskip("pyarrow")
+        store = _time_store(tmp_path / "now.nc", "days since 1970-01-01", [0.0, 1.0])
+        dataset = LabeledDataset.read_file(store)
+        try:
+            assert _cftime_columns(dataset.to_dataframe()) == [], (
+                "this store must decode to datetime64 for this test to mean anything"
+            )
+            with pytest.raises(OSError) as raised:
+                dataset.to_parquet(tmp_path / "cftime" / "now.parquet")
+        finally:
+            dataset.close()
+        assert not isinstance(raised.value, FailedToSaveError), (
+            f"an unrelated failure was re-labelled: {raised.value}"
+        )
+        assert "cftime" in str(raised.value), (
+            f"the message must name the directory for this to reach the text clause: "
+            f"{raised.value}"
+        )
+
     def test_the_warning_names_the_axis_it_was_read_from(self, tmp_path: Path):
         """Reading the store warns with the coordinate's own name, not just its units.
 

--- a/tests/netcdf/selection/test_labeled_out_of_range_time.py
+++ b/tests/netcdf/selection/test_labeled_out_of_range_time.py
@@ -77,7 +77,6 @@ class TestOutOfRangeTimeExport:
             succeeded with 1896.
         """
         pytest.importorskip("pyarrow")
-        pandas = pytest.importorskip("pandas")
         store = _time_store(
             tmp_path / "future.nc", "days since 1970-01-01", [400_000.0, 400_001.0]
         )
@@ -89,7 +88,7 @@ class TestOutOfRangeTimeExport:
         finally:
             dataset.close()
         assert written.exists(), "the far-future axis should still export"
-        back = pandas.read_parquet(written)
+        back = pd.read_parquet(written)
         assert back["time"].iloc[0].year == 3065, back["time"].iloc[0]
 
     def test_a_cftime_axis_raises_a_pyramids_error(self, tmp_path: Path):
@@ -234,7 +233,7 @@ class TestCftimeColumnDetection:
         )
         assert _cftime_columns(frame) == ["ancient"], _cftime_columns(frame)
 
-    def test_a_column_whose_first_value_is_a_datetime_is_still_named(self):
+    def test_a_later_cftime_value_still_names_the_column(self):
         """Any `cftime` element names the column, not only a leading one.
 
         Test scenario:
@@ -248,13 +247,27 @@ class TestCftimeColumnDetection:
         )
         assert _cftime_columns(frame) == ["time"], _cftime_columns(frame)
 
-    def test_an_empty_object_column_is_not_indexed(self):
-        """A zero-row object column has no first element, and must not be looked at.
+    def test_a_duplicate_column_label_does_not_raise(self):
+        """A repeated column label must not turn the write failure into an `AttributeError`.
 
         Test scenario:
-            An empty selection is an ordinary frame, not a contrived one, and the size guard
-            is the only thing between it and an `IndexError` raised while the code is already
-            handling another error.
+            `frame[name]` returns a DataFrame when the label is duplicated, and `.dtype` on
+            that raises -- inside the `except` block, so it would replace the failure the
+            caller needs to see. The scan is positional for that reason.
+        """
+        frame = pd.DataFrame(
+            [[datetime(2000, 1, 1), cftime.DatetimeGregorian(1000, 1, 1)]],
+            columns=["time", "time"],
+        )
+        assert _cftime_columns(frame) == ["time"], _cftime_columns(frame)
+
+    def test_an_empty_object_column_names_nothing(self):
+        """A zero-row object column has nothing to find, so it is not named.
+
+        Test scenario:
+            An empty selection is an ordinary frame, not a contrived one, and this runs
+            while another error is already being handled -- so anything raised here would
+            replace the failure the caller actually needs to see.
         """
         frame = pd.DataFrame({"time": pd.Series([], dtype=object)})
         assert _cftime_columns(frame) == [], _cftime_columns(frame)

--- a/tests/netcdf/selection/test_labeled_out_of_range_time.py
+++ b/tests/netcdf/selection/test_labeled_out_of_range_time.py
@@ -20,12 +20,15 @@ from __future__ import annotations
 import warnings
 from pathlib import Path
 
+import cftime
 import numpy as np
+import pandas as pd
 import pytest
 from osgeo import gdal
 
 from pyramids.base._errors import FailedToSaveError
 from pyramids.netcdf import LabeledDataset
+from pyramids.netcdf.labeled import _cftime_columns
 
 pytestmark = pytest.mark.core
 
@@ -94,7 +97,8 @@ class TestOutOfRangeTimeExport:
         Test scenario:
             A pre-1582 origin decodes to `DatetimeGregorian`, which Parquet has no type for.
             Left alone, pyarrow raises `ArrowInvalid` from several frames deep with no
-            mention of the time axis or of why the objects are there.
+            mention of the time axis or of why the objects are there. It is chained rather
+            than dropped, since it is the only thing that says which value pyarrow choked on.
         """
         pytest.importorskip("pyarrow")
         store = _time_store(
@@ -104,10 +108,13 @@ class TestOutOfRangeTimeExport:
         try:
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore")
-                with pytest.raises(FailedToSaveError, match="cftime datetimes"):
+                with pytest.raises(
+                    FailedToSaveError, match="cftime datetimes"
+                ) as raised:
                     dataset.to_parquet(tmp_path / "ancient.parquet")
         finally:
             dataset.close()
+        assert raised.value.__cause__ is not None, "the pyarrow error should be chained"
 
     def test_csv_still_writes_a_cftime_axis(self, tmp_path: Path):
         """CSV has no such limit, so it remains the way out for these stores.
@@ -142,3 +149,97 @@ class TestOutOfRangeTimeExport:
             dataset.close()
         assert frame["time"].dtype == np.dtype("datetime64[ns]"), frame["time"].dtype
         assert written.exists()
+
+    def test_an_unrelated_parquet_failure_is_not_blamed_on_the_time_axis(
+        self, tmp_path: Path
+    ):
+        """A write that fails for another reason raises that error, not the #1087 one.
+
+        Test scenario:
+            The write is wrapped in a bare `except Exception`, so every failure reaches the
+            cftime check. On an ordinary `datetime64[ns]` axis there is nothing to blame, and
+            the original error -- here a missing output directory -- has to come back out
+            unchanged. Re-labelling it would send the caller hunting a range problem that
+            does not exist.
+        """
+        pytest.importorskip("pyarrow")
+        store = _time_store(tmp_path / "now.nc", "days since 1970-01-01", [0.0, 1.0])
+        dataset = LabeledDataset.read_file(store)
+        try:
+            with pytest.raises(OSError) as raised:
+                dataset.to_parquet(tmp_path / "absent" / "now.parquet")
+        finally:
+            dataset.close()
+        assert not isinstance(raised.value, FailedToSaveError), (
+            f"an unrelated failure was re-labelled: {raised.value}"
+        )
+        assert "cftime" not in str(raised.value), raised.value
+
+    def test_the_warning_names_the_axis_it_was_read_from(self, tmp_path: Path):
+        """Reading the store warns with the coordinate's own name, not just its units.
+
+        Test scenario:
+            `decode_cf_time` can name the axis only if it is told, and `LabeledDataset` is
+            the only caller that knows the name. A store with several time axes would
+            otherwise warn identically for each, leaving the reader nothing to tell them
+            apart.
+        """
+        store = _time_store(
+            tmp_path / "future.nc", "days since 1970-01-01", [400_000.0]
+        )
+        dataset = LabeledDataset.read_file(store)
+        try:
+            with pytest.warns(UserWarning, match="'time'") as caught:
+                dataset.to_dataframe()
+        finally:
+            dataset.close()
+        assert any("outside the" in str(record.message) for record in caught), [
+            str(record.message) for record in caught
+        ]
+
+
+class TestCftimeColumnDetection:
+    """`_cftime_columns` names the columns Parquet has no type for, and only those."""
+
+    def test_only_a_true_cftime_column_is_named(self):
+        """Numeric, string and `real_datetime` columns are all storable, so none is blamed.
+
+        Test scenario:
+            The helper decides which columns a failed Parquet write should blame, so a false
+            positive would misreport an unrelated failure as a range problem. Only
+            `DatetimeGregorian` is unstorable here: a `real_datetime` is a `datetime`
+            subclass Parquet takes (that is what makes the year-3065 export work), and a
+            string column is an object column that holds no dates at all.
+        """
+        frame = pd.DataFrame(
+            {
+                "value": np.array([1.0, 2.0]),
+                "label": np.array(["a", "b"], dtype=object),
+                "future": np.array(
+                    [
+                        cftime.real_datetime(3065, 1, 1),
+                        cftime.real_datetime(3065, 1, 2),
+                    ],
+                    dtype=object,
+                ),
+                "ancient": np.array(
+                    [
+                        cftime.DatetimeGregorian(1, 1, 1),
+                        cftime.DatetimeGregorian(1, 1, 2),
+                    ],
+                    dtype=object,
+                ),
+            }
+        )
+        assert _cftime_columns(frame) == ["ancient"], _cftime_columns(frame)
+
+    def test_an_empty_object_column_is_not_indexed(self):
+        """A zero-row object column has no first element, and must not be looked at.
+
+        Test scenario:
+            An empty selection is an ordinary frame, not a contrived one, and the size guard
+            is the only thing between it and an `IndexError` raised while the code is already
+            handling another error.
+        """
+        frame = pd.DataFrame({"time": pd.Series([], dtype=object)})
+        assert _cftime_columns(frame) == [], _cftime_columns(frame)

--- a/tests/netcdf/selection/test_labeled_out_of_range_time.py
+++ b/tests/netcdf/selection/test_labeled_out_of_range_time.py
@@ -1,0 +1,144 @@
+"""Exporting a store whose time axis leaves `datetime64[ns]`'s range (#1087).
+
+`decode_cf_time` no longer wraps such a date into a plausible-looking wrong one; it keeps
+whatever `cftime` decoded. What that means downstream depends on which object `cftime`
+chose, and these pin both halves through the public `LabeledDataset` exporters:
+
+- a date Python's `datetime` can represent comes back as `cftime.real_datetime`, which is a
+  `datetime` subclass, so `pandas` gives `datetime64[us]` and Parquet stores the *correct*
+  far-future date;
+- a date it cannot -- in practice a pre-1582 origin on a mixed calendar -- comes back as a
+  true `cftime` datetime, which Parquet has no type for, so `to_parquet` raises a pyramids
+  error naming the columns instead of a bare `ArrowInvalid` from inside pyarrow.
+
+The store is built with GDAL directly rather than through xarray, so these stay core tests
+rather than being gated on the interop extra.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import numpy as np
+import pytest
+from osgeo import gdal
+
+from pyramids.base._errors import FailedToSaveError
+from pyramids.netcdf import LabeledDataset
+
+pytestmark = pytest.mark.core
+
+
+def _time_store(path: Path, unit: str, offsets: list[float]) -> Path:
+    """Write a one-dimensional NetCDF store whose only axis is a CF time coordinate.
+
+    Args:
+        path: Output ``.nc`` path.
+        unit: The CF ``"<period> since <origin>"`` string to stamp on the axis.
+        offsets: The numeric offsets to store.
+
+    Returns:
+        Path: ``path``, for chaining.
+    """
+    dataset = gdal.GetDriverByName("netCDF").CreateMultiDimensional(
+        str(path), [], ["FORMAT=NC4"]
+    )
+    root = dataset.GetRootGroup()
+    dtype = gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    dim = root.CreateDimension("time", "", "", len(offsets))
+    axis = root.CreateMDArray("time", [dim], dtype)
+    axis.Write(np.asarray(offsets, dtype="float64"))
+    axis.SetUnit(unit)
+    for key, value in (
+        ("standard_name", "time"),
+        ("axis", "T"),
+        ("calendar", "standard"),
+    ):
+        attribute = axis.CreateAttribute(key, [], gdal.ExtendedDataType.CreateString())
+        attribute.Write(value)
+    return path
+
+
+class TestOutOfRangeTimeExport:
+    """The public exporters, on a time axis outside `datetime64[ns]`'s range."""
+
+    def test_a_far_future_axis_exports_the_real_date(self, tmp_path: Path):
+        """A year-3065 axis reaches Parquet as the date it actually is.
+
+        Test scenario:
+            This is the case the issue reported, end to end. `cftime` returns
+            `real_datetime` here, which `pandas` coerces to `datetime64[us]` -- wide enough
+            for year 3065 -- so the export both succeeds and is correct. Before the fix it
+            succeeded with 1896.
+        """
+        pytest.importorskip("pyarrow")
+        pandas = pytest.importorskip("pandas")
+        store = _time_store(
+            tmp_path / "future.nc", "days since 1970-01-01", [400_000.0, 400_001.0]
+        )
+        dataset = LabeledDataset.read_file(store)
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                written = dataset.to_parquet(tmp_path / "future.parquet")
+        finally:
+            dataset.close()
+        assert written.exists(), "the far-future axis should still export"
+        back = pandas.read_parquet(written)
+        assert back["time"].iloc[0].year == 3065, back["time"].iloc[0]
+
+    def test_a_cftime_axis_raises_a_pyramids_error(self, tmp_path: Path):
+        """A true `cftime` axis fails the Parquet write with an explanation, not `ArrowInvalid`.
+
+        Test scenario:
+            A pre-1582 origin decodes to `DatetimeGregorian`, which Parquet has no type for.
+            Left alone, pyarrow raises `ArrowInvalid` from several frames deep with no
+            mention of the time axis or of why the objects are there.
+        """
+        pytest.importorskip("pyarrow")
+        store = _time_store(
+            tmp_path / "ancient.nc", "days since 0001-01-01", [0.0, 1.0]
+        )
+        dataset = LabeledDataset.read_file(store)
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                with pytest.raises(FailedToSaveError, match="cftime datetimes"):
+                    dataset.to_parquet(tmp_path / "ancient.parquet")
+        finally:
+            dataset.close()
+
+    def test_csv_still_writes_a_cftime_axis(self, tmp_path: Path):
+        """CSV has no such limit, so it remains the way out for these stores.
+
+        Test scenario:
+            The Parquet error tells the caller to use CSV instead; that advice has to work.
+        """
+        store = _time_store(
+            tmp_path / "ancient.nc", "days since 0001-01-01", [0.0, 1.0]
+        )
+        dataset = LabeledDataset.read_file(store)
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                written = dataset.to_csv(tmp_path / "ancient.csv")
+        finally:
+            dataset.close()
+        assert written.exists(), "CSV should still write a cftime axis"
+        assert "0001-01-01" in written.read_text(encoding="utf-8")
+
+    def test_an_in_range_axis_is_untouched(self, tmp_path: Path):
+        """An ordinary axis keeps `datetime64[ns]` and exports as it always did."""
+        pytest.importorskip("pyarrow")
+        store = _time_store(tmp_path / "now.nc", "days since 1970-01-01", [0.0, 1.0])
+        dataset = LabeledDataset.read_file(store)
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("error")
+                frame = dataset.to_dataframe()
+                written = dataset.to_parquet(tmp_path / "now.parquet")
+        finally:
+            dataset.close()
+        assert frame["time"].dtype == np.dtype("datetime64[ns]"), frame["time"].dtype
+        assert written.exists()


### PR DESCRIPTION
# Description

`decode_cf_time` cast `cftime`'s decoded objects to `datetime64[ns]` inside a
`try/except (ValueError, TypeError)`. That guard catches a *failed* cast — but a date outside the
type's 1677-09-21 to 2262-04-11 range does not fail. It **wraps**, and the caller got a
plausible-looking date on the far side of the epoch with no error and no warning.

```python
decode_cf_time(np.array([400_000]), "days since 1970-01-01", "standard")
# before -> np.datetime64('1896-01-21T00:50:52.580896768')   # the date is year 3065
# after  -> cftime.DatetimeGregorian(3065, 3, 1)             # + RuntimeWarning
```

A climate projection read back four centuries in the *past*, a palaeo axis six centuries in the
*future*, and every downstream comparison, sort and plot silently agreed. It reached the public
API: `LabeledDataset.to_dataframe()` on a store with a far-future time axis printed the wrapped
dates, so `to_csv` and `to_parquet` inherited them. (`select_time` does not — it matches against
the raw numeric axis, not the decoded one.)

## What changed

- Range-check before the cast rather than relying on it to raise. Out of range, the `cftime`
  objects are kept — lossless, and already what a non-standard calendar returns.
- A `RuntimeWarning` names the units, so the dtype change is visible rather than being a second
  silent surprise. It fires only for the out-of-range standard-calendar case; a `360_day` axis
  already returns `cftime` by design and does not warn.

## On reusing the existing bound

The issue proposed a new `_within_datetime64_ns` helper. The concept already exists in this file —
`_NS_LIMIT` (`utils.py:834`) and the range test in `_decode_gregorian_ns` — which is why the
nanosecond path correctly *declines* instead of wrapping. It could not be called directly, though:
`_NS_LIMIT` is a nanosecond magnitude, and this path holds decoded datetimes, not offsets.

So the limit is expressed in calendar coordinates next to `_NS_LIMIT`, and
`test_bounds_match_int64_nanoseconds` pins it to NumPy's own derivation. It is rounded inward to
whole microseconds — a `datetime` carries no nanoseconds — which makes it conservative by under a
microsecond at each end and unable to admit a value that would wrap.

The two are **not** the same number, which an earlier draft of this description got wrong:
`_NS_LIMIT` is `9.0e18`, deliberately below `int64`'s `9.223e18` so a float comparison cannot
overflow, and that gap is 7.1 years — 2255-03-14 against 2262-04-11. This bound takes the limit in
full, because the datetime comparison is exact and needs no headroom. The band between them is real
and tested: 2255-2262 is past the integer fast path but inside the type, so those dates go through
`cftime` and are still cast to `datetime64`.

## Two findings that shaped the implementation

- **Both bounds wrap, and no large offset is needed to reach one.** A `days since 0001-01-01` store
  is out of range at offset **zero**, purely from its origin. Several corpus fixtures use that
  epoch (`none__4v__1d1-2d2-3d1__curv.nc`, `cf__12v…`, `cf__48v…`); their dates are ordinary
  20th-century ones and must keep decoding to `datetime64`. That is pinned by a test.
- **The guard reads a `TypeError` as "does not fit", and that is correct rather than merely safe.**
  `cftime` refuses to compare a `DatetimeGregorian` with a `datetime` when the decoded value itself
  is pre-1582 — the bound's own date does not enter into it. The Gregorian reform predates this
  type's floor, so any date it will not compare is necessarily below 1677 and out of range anyway.
  `test_the_gregorian_reform_predates_the_floor` pins that invariant, because if the floor ever
  moved earlier the refusal would start hiding representable dates.

  An earlier draft rebuilt the bounds in each value's own calendar class to sidestep the
  comparison. Mutation testing showed it changed no outcome, and it was strictly riskier — a failed
  construction would have downgraded *in-range* data — so the simpler form was kept.

No new dependencies.

## Two neighbouring defects, fixed here as well

Both were found while reviewing this branch, both sit in the function it already changes, and both are the same
shape of problem as #1087 — a wrong answer given silently.

- **#1116 — a missing timestep read back as a real date.** `cftime.num2date` masks what it cannot decode (a
  `NaN` or an `inf` offset) and `np.asarray` dropped that mask, leaving the fill value, which is the origin. The
  integer fast path has always written `NaT` for the same input, so the two paths disagreed. The mask is now
  honoured: `NaT` in a `datetime64` result, `None` in an object one. Masked positions are also excluded from the
  new range check, which otherwise blamed a range problem for a missing value on a pre-1582 epoch.
- **#1117 — a `"months since …"` axis raised a bare `ValueError` from inside cftime**, naming neither the axis
  nor the store, while this function's docstring said such units pass through unchanged. The refusal is correct
  (a calendar month has no fixed length, so cftime allows the unit only on `360_day`), but it now names the axis,
  units and calendar, chains the original, and is documented in `Raises:`.

# Issues

- Closes #1087 — `decode_cf_time` silently wrapped a date outside `datetime64[ns]`'s range
- Closes #1116 — `decode_cf_time` read a `NaN` offset as the origin on the cftime path
- Closes #1117 — `decode_cf_time` raised on a `months since` axis its docstring said it passed through

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

- [x] The issue's exact repro now returns the real dates (years 3065 and 4707) instead of 1896 and
  1785, with a warning.
- [x] **75 test cases** across `tests/netcdf/cf/test_cf_time.py` and
  `tests/netcdf/selection/test_labeled_out_of_range_time.py`: both bounds and one value past each
  (`106_751`/`106_752`, `-106_751`/`-106_752`), the value — not just the dtype — for out-of-range
  dates, the element-class split that decides what still exports, the array-wide downgrade in both
  orders, the pre-1582-origin store at offset zero, the in-range `0001-01-01` regression guard, the
  2255-2262 band between the two limits, the flatten and empty-axis paths, `NaN`/`inf` agreeing
  across both decode paths, the `months since` and overflow errors, the Parquet failure and the CSV
  escape, and the invariant pins for the reform boundary and the two constants.
- [x] Verified non-vacuous by mutation rather than by inspection: reverting the range check fails 5
  tests, removing the `break` in the range guard fails 3, neutering either the mask handling or the
  units wrapper fails 6, and each narrowed condition added later has its own killing test. Three
  surviving mutants are equivalent and are named in the commit that added their tests.
- [x] Full suite `pytest tests -m "not plot"` — **10641 passed, 87 skipped** (pre-merge); re-running
  on the tree merged with `main`.
- [x] Diff coverage on the changed sources: **100% line, 0 missing branches** (67/67 added
  statements).
- [x] `ruff format` / `ruff check` clean; `mypy` clean on the changed module; doctests green.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.

