### PR TITLE
fix(dataset)!: stop inventing a no-data sentinel a band cannot store

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -299,11 +299,20 @@ a fabricated maximum indistinguishable from a measurement. A band that holds eve
 `NoDataValueError` naming the fix rather than reclassifying a real observation as a gap.
 
 A band that declares **no** sentinel is derived for too, on this path. That is not inventing a property the data
-lacked — the crop is what makes those cells absent — and it replaces a worse answer: the excluded cells were
-written with the substituted maximum and the output then declared `NaN`, so they read back as an ordinary
-measurement. Only `uint16` and `uint32` got that far; the same crop of a `uint8` or `int16` raster raised
-`TypeError: int() argument must be ... not 'NoneType'`. A floating band is unchanged, since `NaN` is offered
-first and is what that path already wrote.
+lacked — the crop is what makes those cells absent — and what it replaces was collide-or-crash. Measured on the
+previous release, a raster-mask crop of a band declaring nothing:
+
+| dtype | single band | multi-band |
+|---|---|---|
+| `uint16` / `uint32` | `TypeError` | wrote **and declared** the dtype maximum |
+| `uint8` / `int16` | `TypeError` | `TypeError` |
+| floating | `NaN`, declared | `NaN`, declared |
+
+The one case that completed is the one this issue exists for: `_check_no_data_value` turned the band's `None`
+into 65535, wrote it into the excluded cells and declared it, so every genuinely-65535 cell in the band became
+out-of-domain on the output. Every other integer case raised
+`TypeError: int() argument must be ... not 'NoneType'`, single- and multi-band alike. A floating band is
+unchanged — it gets `NaN`, which is what that path already wrote and declared.
 
 ```python
 # uint8 source with no storable sentinel, data in 1..7

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -279,6 +279,19 @@ Two knock-on effects to look for:
 - **A raster that declares no storable sentinel now really has no no-data**, so `count_domain_cells`, `apply`,
   `fill` and the statistics treat every cell as data. That is the honest answer for a band with no free value,
   and it is what a `uint8` raster already did.
+- **`Dataset.create(..., no_data_value=np.nan)` returns a different canvas**, not just a different declaration.
+  Creating a band fills it with the sentinel it just declared, so the substitution used to leave every cell
+  out of domain; with nothing storable to declare there is nothing meaningful to fill with, and the band keeps
+  the driver's zeros:
+
+  | `create(rows=3, columns=4, dtype=…, no_data_value=np.nan)` | Before | After |
+  |---|---|---|
+  | `uint16` | declares `65535`, holds `65535`, 0 domain cells | declares `NaN`, holds `0`, 12 domain cells |
+  | `uint32` | declares `4294967295`, holds that, 0 domain cells | declares `NaN`, holds `0`, 12 domain cells |
+
+  If you used that call as an out-of-domain canvas and wrote only the cells you cared about, the untouched ones
+  are now real zeros that every consumer counts as data. Create the raster with a sentinel the dtype can hold
+  instead, and the old behaviour returns unchanged.
 
 What has **not** changed is the repair applied when a caller asks for a sentinel that overflows the band:
 `Dataset.from_array(uint8_array)` still warns that the default `-9999` is out of range and stores `255`. There
@@ -321,11 +334,15 @@ out-of-domain on the output. Every other integer case raised
 unchanged — it gets `NaN`, which is what that path already wrote and declared.
 
 ```python
-# uint8 source with no storable sentinel, data in 1..7
+# uint8 source asked for a NaN sentinel, data in 1..7
 out = src.crop(mask)
 out.no_data_value      # (255.0,) -- derived, and declared
-# Before: ValueError: cannot convert float NaN to integer (multi-band),
-#         or a masked cell holding a value the output never declared.
+# Before: ValueError: cannot convert float NaN to integer (multi-band)
+
+# uint8 source declaring nothing at all
+out = src.crop(mask)
+out.no_data_value      # (255.0,) -- derived, and declared
+# Before: TypeError: int() argument must be ... not 'NoneType'
 ```
 
 A polygon (cutline) crop is the same story from the other side, with one deliberate difference: a band that
@@ -339,14 +356,42 @@ so it recognised nothing there and left the border in place: an integer raster c
 crop of a float one. It now gets the derived fill, is trimmed to the polygon, and declares what its border
 holds.
 
-| `crop(polygon)` of an 8x8 raster whose sentinel is unstorable | Before | After |
+| `crop(polygon)` of an 8x8 raster asked for a `NaN` sentinel | Before | After |
 |---|---|---|
-| `uint8` / `uint16` / `int16` | 6x6, border of undeclared `0` | 4x4, border declared |
+| `uint8` / `int16` | 6x6, border of undeclared `0` | 4x4, border declared |
+| `uint16` / `uint32` | 4x4, border declared `65535` | 4x4, border declared — now derived |
+| `int64` | 6x6, border of undeclared `0` | 4x4, border declared |
+| `uint64` | 6x6, border of undeclared `0` | 6x6 — unchanged, see below |
 | `float32` (a storable `NaN`) | 4x4 | 4x4 — unchanged |
+
+`uint16` and `uint32` were already trimmed and already declared, because the substitution being removed had
+given them `65535` / `4294967295` before the crop ever ran. What changes for them is only where the value comes
+from: derived against the band's data rather than fabricated, so it can no longer be a value the band holds.
+
+`uint64` is left alone deliberately. `-dstnodata` reaches GDAL as text it parses into a C double, and that
+dtype's maximum does not survive the trip — it arrives rounded to `2**63`, which GDAL announces and then writes
+into the pixels. Declaring the value we asked for would describe cells holding something else, so no fill is
+offered and the border stays undeclared.
 
 The declared sentinel of a well-formed raster is unchanged: a band that already declares a storable value keeps
 it, its data is never read to make the decision, and the warp options it produces are the ones it produced
 before.
+
+**A crop can now come back larger, for any raster whose cells come close to its sentinel.** Hard change, silent,
+and unrelated to whether a fill was derived. The trim that removes wholly-excluded rows and columns asked
+`is_no_data`, whose operational `rtol` of 0.001 treats everything within a part per thousand of the sentinel as
+no-data; it now asks `is_stored_no_data`, the tolerance the storage forces. Cells that merely lie near the
+sentinel are data again, so fewer rows qualify for removal and the result only ever grows:
+
+| `float32` declaring `-9999`, border holding `-9995` | Before | After |
+|---|---|---|
+| `crop(mask=polygon)` | 2x2 | 6x6 |
+| `crop(bbox=…)` | 2x2 | 6x6 |
+
+The old shape was reached by deleting real observations — elevation, depth and scaled-reflectance products sit
+in exactly that window — so the new one is the correct answer. But code that indexes, reprojects or asserts
+against a crop's shape will see it change. It applies to both crop routes and to bands with an ordinary,
+storable, declared sentinel.
 
 **`create_from_array` is now `from_array`, and takes a `GeoReference`.** Hard change, no deprecation alias — the
 old name and the old flat keywords are gone. The same rename applies to `UgridDataset.create_from_arrays` ->

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -254,54 +254,84 @@ spirit: a format that supports `Create` gives `"write"`, and a write-by-copy-onl
 dataset for those. If you relied on the copy being read-only as a guard, guard it yourself — there is no
 parameter to ask for the old mode.
 
-**`Dataset.no_data_value` can report a numpy scalar where it reported a Python `int`.** Hard change, silent —
-the number is the same, only its type differs. It affects one case: an unsigned band **wider than 8 bits**
-(`uint16`, `uint32`, `uint64`) created with a `NaN` no-data, where pyramids substitutes the dtype's maximum
-because `NaN` cannot be stored there. That substituted sentinel is now built as a numpy scalar instead of a
-Python `int`, so it agrees in type as well as value with the sentinel picked when a *requested* no-data
-overflows the band — previously the same answer read back as `65535` from one path and a numpy scalar from the
-other, and the `==` pinning their agreement could not see the difference.
-
-What a caller sees, for a `uint16` band created with `no_data_value=np.nan`:
-
-```python
-# Before
-ds.no_data_value      # (65535,)                  <- builtin int
-
-# After
-ds.no_data_value      # (np.float64(65535.0),)
-```
-
-Measured across the dtypes, with `Dataset.create(rows=3, columns=4, dtype=..., bands=1, no_data_value=...)`:
+**A no-data value the band cannot store is no longer replaced with the dtype's maximum.** Hard change, silent
+on the read path and loud on the write path. A `NaN` sentinel cannot be stored in an integer band, and the
+unsigned types wider than a byte used to answer that by substituting their own maximum: a `uint16` band asked
+for `NaN` came back declaring `65535`. Every genuinely-65535 cell in it — the saturated end of a scaled
+reflectance product, the void value of a DEM — was then out of domain, and `align` handed the raster to
+`gdal.ReprojectImage`, which rewrote those real 65535s to 65534 to keep them distinguishable from the sentinel.
+`uint8` was excluded from the substitution for exactly this reason (255 is white in 8-bit imagery); the wider
+types now follow the same rule, so there is one rule across all of them.
 
 | dtype and no-data | Before | After |
 |---|---|---|
-| `uint16` + `NaN` | `(65535,)` — `int` | `(np.float64(65535.0),)` |
-| `uint32` + `NaN` | `(4294967295,)` — `int` | `(np.float64(4294967295.0),)` |
-| `uint64` + `NaN` | `(18446744073709551615,)` — `int` | `(np.uint64(18446744073709551615),)` |
-| `uint8` + `NaN` | `(nan,)` | `(nan,)` — unchanged |
-| signed / floating + `NaN` | `(nan,)` | `(nan,)` — unchanged |
+| `uint16` + `NaN` | `(65535,)` | `(nan,)` |
+| `uint32` + `NaN` | `(4294967295,)` | `(nan,)` |
+| `uint64` + `NaN` | `(18446744073709551615,)` | `(nan,)` |
+| `uint8`, signed, floating + `NaN` | `(nan,)` | `(nan,)` — unchanged |
 | any dtype, `no_data_value=None` | `(None,)` | `(None,)` — unchanged |
 
-Two things the shape of that table decides for you:
+Two knock-on effects to look for:
 
-- **`uint8` is excluded.** A Byte band with a `NaN` no-data reports `(nan,)`, before and after — nothing is
-  substituted, because 255 is white in 8-bit imagery and fabricating it as a sentinel would put every white
-  pixel out of domain. Do not test this change on a Byte raster: it will not show there.
-- **Only `NaN` triggers it.** An *unset* no-data (`no_data_value=None`) reports `(None,)` on both sides. The
-  substitution is for a sentinel that cannot be stored, not for the absence of one.
+- **`change_no_data_value(None)` on a `uint16` / `uint32` / `uint64` raster now raises `NoDataValueError`**,
+  where it used to succeed and leave the dtype maximum behind. `uint8` and the signed types already raised.
+  Pass a sentinel the band can hold, or leave the band without one.
+- **A raster that declares no storable sentinel now really has no no-data**, so `count_domain_cells`, `apply`,
+  `fill` and the statistics treat every cell as data. That is the honest answer for a band with no free value,
+  and it is what a `uint8` raster already did.
 
-`float64`, not `uint16`: GDAL's `SetNoDataValue` takes a C double and the value is round-tripped through it. The
-one exception is `uint64`, whose maximum has no exact `float64`, so it stays a numpy `uint64`. A band with a
-concrete no-data already reported a numpy scalar before this release.
+What has **not** changed is the repair applied when a caller asks for a sentinel that overflows the band:
+`Dataset.from_array(uint8_array)` still warns that the default `-9999` is out of range and stores `255`. There
+the caller asked for a sentinel and it did not fit, so picking a storable one honours the request; the removed
+substitution fired when the caller asked for *no* sentinel, and answered a question nobody posed.
 
-Anything comparing with `==`, or reading the value into numpy, needs no change. Change what needs a builtin:
+**`crop` derives the value it writes into masked cells, and declares it on the result.** Hard change, and the
+fix for two bugs. Cropping has to put *something* in the cells the mask excludes, and it used to write the
+source's declared sentinel — which is why a multi-band `uint8` or `int16` crop raised
+`ValueError: cannot convert float NaN to integer` outright, and why a `uint16` crop silently relied on the
+substitution above.
 
-- `json.dumps(ds.no_data_value)` → `json.dumps([float(v) for v in ds.no_data_value])`
-- `"%d" % nodata` and `is`-comparisons against small ints
-- arithmetic where wrapping matters — only on the `uint64` row, whose value is a numpy *integer* scalar and
-  wraps at the dtype bound (`np.uint64(2**64 - 1) + 1 == 0`) instead of promoting. The `uint16` / `uint32` rows
-  are `float64` and do not wrap. `float(nodata)` first if you are doing arithmetic on any of them.
+The cropped output now carries a fill chosen **against the band's own data**: the band's sentinel when it can
+store one, otherwise the first value that fits the dtype and occurs nowhere in the band (`NaN`, then `-9999`,
+then the dtype's extremes, then a scan of the remaining range for the narrow integer types). That value is set
+as the **output's** `no_data_value`, so the result says which cells are absent instead of leaving a bare `0` or
+a fabricated maximum indistinguishable from a measurement. A band that holds every candidate raises
+`NoDataValueError` naming the fix rather than reclassifying a real observation as a gap.
+
+A band that declares **no** sentinel is derived for too, on this path. That is not inventing a property the data
+lacked — the crop is what makes those cells absent — and it replaces a worse answer: the excluded cells were
+written with the substituted maximum and the output then declared `NaN`, so they read back as an ordinary
+measurement. Only `uint16` and `uint32` got that far; the same crop of a `uint8` or `int16` raster raised
+`TypeError: int() argument must be ... not 'NoneType'`. A floating band is unchanged, since `NaN` is offered
+first and is what that path already wrote.
+
+```python
+# uint8 source with no storable sentinel, data in 1..7
+out = src.crop(mask)
+out.no_data_value      # (255.0,) -- derived, and declared
+# Before: ValueError: cannot convert float NaN to integer (multi-band),
+#         or a masked cell holding a value the output never declared.
+```
+
+A polygon (cutline) crop is the same story from the other side, with one deliberate difference: a band that
+declares no sentinel is left alone there. That path does not write the excluded cells itself — GDAL fills them —
+so stamping a `-dstnodata` would put a sentinel on the output that the source never had, which the netCDF
+fan-out would then carry onto a rebuilt variable. Only a band with a sentinel it *cannot store* gets one.
+
+For that band, the border outside the cutline was GDAL's default `0` — a real observation on most bands, and
+declared nowhere. The trim that removes the fully-outside rows and columns works by reading the sentinel back,
+so it recognised nothing there and left the border in place: an integer raster came back larger than the same
+crop of a float one. It now gets the derived fill, is trimmed to the polygon, and declares what its border
+holds.
+
+| `crop(polygon)` of an 8x8 raster whose sentinel is unstorable | Before | After |
+|---|---|---|
+| `uint8` / `uint16` / `int16` | 6x6, border of undeclared `0` | 4x4, border declared |
+| `float32` (a storable `NaN`) | 4x4 | 4x4 — unchanged |
+
+The declared sentinel of a well-formed raster is unchanged: a band that already declares a storable value keeps
+it, its data is never read to make the decision, and the warp options it produces are the ones it produced
+before.
 
 **`create_from_array` is now `from_array`, and takes a `GeoReference`.** Hard change, no deprecation alias — the
 old name and the old flat keywords are gone. The same rename applies to `UgridDataset.create_from_arrays` ->
@@ -575,9 +605,9 @@ Two consequences of "the band's own" worth stating, because the obvious reading 
 - **An integer sentinel is compared as an exact integer, not through a `float`.** That matters only at the
   64-bit limits, where it is the whole answer: `float(2**63 - 1)` rounds *up* past `int64`'s maximum, so a band
   whose sentinel is its own dtype maximum would be judged unable to hold it and mask nothing at all — with
-  `fill` then overwriting the very cells it was told to leave alone. `int64` and `uint64` maxima are exactly
-  the sentinels pyramids fabricates for an unsigned band with an unstorable no-data, so this is the ordinary
-  path for a 64-bit raster rather than a corner of one.
+  `fill` then overwriting the very cells it was told to leave alone. A 64-bit maximum is a sentinel a caller
+  reasonably declares, and the one a crop derives for a band that has none, so this is a path a 64-bit raster
+  reaches rather than a corner of one.
 
 For a caller, a cell within ~0.1% of the sentinel that used to be no-data to `count_domain_cells` / `apply` is now
 data; nothing that was masked before is unmasked *less* accurately, the change only ever keeps cells. On the test

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -308,6 +308,12 @@ previous release, a raster-mask crop of a band declaring nothing:
 | `uint8` / `int16` | `TypeError` | `TypeError` |
 | floating | `NaN`, declared | `NaN`, declared |
 
+Because the output now declares a sentinel the trim recognises, a raster-mask crop also removes rows and columns
+that the mask excluded entirely — so the result can be smaller than the mask's extent. That is not new behaviour,
+only newly reachable: a `float32` band, whose `NaN` was always storable, was trimmed the same way before. A 4x4
+raster masked along its first row and column comes back 3x3 for every dtype now, where the integer cases used to
+raise instead.
+
 The one case that completed is the one this issue exists for: `_check_no_data_value` turned the band's `None`
 into 65535, wrote it into the excluded cells and declared it, so every genuinely-65535 cell in the band became
 out-of-domain on the output. Every other integer case raised

--- a/docs/reference/dataset/analysis.md
+++ b/docs/reference/dataset/analysis.md
@@ -93,6 +93,12 @@ raster every consumer reads as empty. `combine` therefore derives the sentinel
   the dtype and occurs nowhere in the result, searched through the operands' own
   sentinels (every band, left operand first), then `-9999`, then the dtype's
   extremes — max before min for an unsigned dtype, whose min is the very usable `0`.
+  For the narrow integer widths (`int8`, `uint8`, `int16`, `uint16`) the search does
+  not stop there: the rest of the range is enumerated and the first unused value
+  taken, walking inward from the preferred extreme, so a result holding every
+  candidate still gets an answer. `int32` and wider refuse once the candidates are
+  exhausted, their ranges being too large to enumerate and a collision on all of
+  them correspondingly unlikely.
 
 An explicit `no_data_value=` is always honoured, with a `NoDataCollisionWarning`
 when the result holds it. `no_data_value=None` turns masking off entirely: every

--- a/docs/reference/dataset/spatial.md
+++ b/docs/reference/dataset/spatial.md
@@ -27,6 +27,26 @@ routes through the same polygon path. The same `bbox=` / `epsg=` pair
 is accepted by `DatasetCollection.crop` (built once and reused across
 timesteps) and by `Dataset.read_array` (for a windowed read).
 
+
+### What a crop declares
+
+The result declares the value its excluded cells hold, which is not always the source's. A band whose own
+sentinel is storable keeps it. A band whose sentinel cannot be stored — `NaN` on an integer band — has one
+derived against its own data: the first value that fits the dtype and occurs nowhere in the band. A floating
+band always gets `NaN`.
+
+A band that declares *nothing* depends on the mask. A raster mask writes the excluded cells itself, so it
+derives a fill and declares it; a polygon mask lets GDAL fill them, so the source's declaration — none — stands.
+`Int64` and `UInt64` are left alone on the polygon route as well, because `-dstnodata` reaches GDAL as a C
+double that a value beyond `2**53` does not survive.
+
+Two consequences worth knowing before you index against a result:
+
+- the output can be **smaller** than the mask's extent, because rows and columns lying entirely outside it are
+  trimmed once the result declares a sentinel the trim recognises;
+- `crop` raises `NoDataValueError` when a band holds every candidate sentinel and no value is free to mark a
+  cell as absent. It does **not** derive from `ValueError`.
+
 ```python
 from pyramids.dataset import Dataset
 

--- a/src/pyramids/base/_domain.py
+++ b/src/pyramids/base/_domain.py
@@ -742,6 +742,83 @@ def no_data_candidates(dtype: np.dtype, candidates: Sequence[Any] = ()) -> list[
     return list(seen.values())
 
 
+def _values_present_in_range(values: Any, floor: int, span: int) -> np.typing.NDArray:
+    """A mask over `[floor, floor + span)` marking which of them `values` holds.
+
+    Args:
+        values: The data to survey.
+        floor: The lowest value the mask covers.
+        span: How many consecutive values it covers.
+
+    Returns:
+        np.ndarray: A boolean mask, `True` where the value occurs.
+    """
+    seen = np.zeros(span, dtype=bool)
+    raw = np.asarray(values).ravel()
+    # In slices, not all at once: the cast below widens every cell to 8 bytes
+    # and the comparisons add two boolean temporaries, so a whole-array pass
+    # peaked at many times the band's own size. The mask being filled is at
+    # most 64 KiB either way.
+    for start in range(0, raw.size, _SCAN_CHUNK):
+        chunk = raw[start : start + _SCAN_CHUNK]
+        if np.issubdtype(chunk.dtype, np.floating):
+            # A float array reaching an integer target: `NaN` and the
+            # infinities have no integer to cast to, and numpy warns and
+            # yields a garbage index rather than raising.
+            chunk = chunk[np.isfinite(chunk)]
+        with np.errstate(invalid="ignore", over="ignore"):
+            present = chunk.astype("int64") - floor
+        inside = present[(present >= 0) & (present < span)]
+        seen[inside] = True
+    return seen
+
+
+def _first_unused_in_range(
+    target: np.dtype, extremes: list[Any], values: Any
+) -> Any | None:
+    """The value nearest the preferred extreme that `values` does not hold.
+
+    The preferred candidates being taken is not a reason to refuse: a narrow
+    integer band still has thousands of values the data never uses. The whole
+    range is enumerated when it is small enough to hold as a mask -- a `uint16`
+    needs 64 KiB -- and a free value taken from the end the dtype prefers.
+
+    Wider integer types are left to their extremes. Their ranges cannot be
+    enumerated, and a collision on every candidate is vanishingly unlikely
+    there anyway.
+
+    Args:
+        target: The dtype the value must be storable in.
+        extremes: That dtype's bounds, most preferred first.
+        values: The data the value must not occur in.
+
+    Returns:
+        Any | None: The free value as a Python `int`, or `None` when the range
+        is too wide to enumerate or every value in it is taken.
+    """
+    preferred, opposite = extremes[0], extremes[1]
+    floor = min(preferred, opposite)
+    span = max(preferred, opposite) - floor + 1
+    chosen = None
+    if span <= 65536:
+        unused = np.flatnonzero(~_values_present_in_range(values, floor, span))
+        if unused.size:
+            # From the preferred extreme inwards, not from the bottom of the
+            # range. `extremes` is ordered deliberately -- an unsigned band
+            # offers its maximum first because `0` is the likelier real
+            # observation -- and starting at the floor threw that away,
+            # answering `1` for a `uint8` band holding `0` and `255`. `crop`
+            # declares the value it gets, so a later write of `1` into the
+            # result would silently become a gap.
+            index = unused[-1] if preferred > opposite else unused[0]
+            # A Python `int`, like every other branch returns: the candidates
+            # and the `np.iinfo` extremes are Python scalars, and a numpy one
+            # here made the same logical answer reach `Dataset.no_data_value`
+            # as two different types depending on which branch found it.
+            chosen = int(index) + floor
+    return chosen
+
+
 def free_no_data(dtype: np.dtype, candidates: Sequence[Any], values: Any) -> Any | None:
     """First sentinel that fits `dtype` and occurs nowhere in `values`.
 
@@ -801,51 +878,7 @@ def free_no_data(dtype: np.dtype, candidates: Sequence[Any], values: Any) -> Any
             chosen = candidate.item() if hasattr(candidate, "item") else candidate
             break
     if chosen is None and extremes:
-        # The preferred candidates are all taken, but a narrow integer band
-        # still has thousands of values the data never uses -- refusing after
-        # trying two or three of them would be giving up early. Enumerate the
-        # whole range when it is small enough to hold as a mask (a `uint16`
-        # needs 64 KiB) and take a value the band does not contain. Wider
-        # integer types are left to the extremes: their range cannot be
-        # enumerated, and a collision on every candidate is vanishingly
-        # unlikely there anyway.
-        preferred, opposite = extremes[0], extremes[1]
-        floor = min(preferred, opposite)
-        span = max(preferred, opposite) - floor + 1
-        if span <= 65536:
-            seen = np.zeros(span, dtype=bool)
-            raw = np.asarray(values).ravel()
-            # In slices, not all at once: the cast below widens every cell to
-            # 8 bytes and the comparisons add two boolean temporaries, so a
-            # whole-array pass peaked at many times the band's own size. The
-            # mask being filled is at most 64 KiB either way.
-            for start in range(0, raw.size, _SCAN_CHUNK):
-                chunk = raw[start : start + _SCAN_CHUNK]
-                if np.issubdtype(chunk.dtype, np.floating):
-                    # A float array reaching an integer target: `NaN` and the
-                    # infinities have no integer to cast to, and numpy warns
-                    # and yields a garbage index rather than raising.
-                    chunk = chunk[np.isfinite(chunk)]
-                with np.errstate(invalid="ignore", over="ignore"):
-                    present = chunk.astype("int64") - floor
-                inside = present[(present >= 0) & (present < span)]
-                seen[inside] = True
-            unused = np.flatnonzero(~seen)
-            if unused.size:
-                # From the preferred extreme inwards, not from the bottom of
-                # the range. `extremes` is ordered deliberately -- an unsigned
-                # band offers its maximum first because `0` is the likelier
-                # real observation -- and starting the scan at the floor threw
-                # that away, answering `1` for a `uint8` band holding `0` and
-                # `255`. `crop` declares the value it gets, so a later write of
-                # `1` into the result would silently become a gap.
-                index = unused[-1] if preferred > opposite else unused[0]
-                # A Python `int`, like every other branch returns: the
-                # candidates and the `np.iinfo` extremes are Python scalars,
-                # and a numpy one here made the same logical answer reach
-                # `Dataset.no_data_value` as two different types depending on
-                # which branch found it.
-                chosen = int(index) + floor
+        chosen = _first_unused_in_range(target, extremes, values)
     return chosen
 
 

--- a/src/pyramids/base/_domain.py
+++ b/src/pyramids/base/_domain.py
@@ -656,22 +656,37 @@ def free_no_data(dtype: np.dtype, candidates: Sequence[Any], values: Any) -> Any
     if chosen is None and extremes:
         # The preferred candidates are all taken, but a narrow integer band
         # still has thousands of values the data never uses -- refusing after
-        # trying three of them would be giving up early. Enumerate the whole
-        # range when it is small enough to hold as a mask (a `uint16` needs
-        # 64 KiB), and take the first value the band does not contain. Wider
+        # trying two or three of them would be giving up early. Enumerate the
+        # whole range when it is small enough to hold as a mask (a `uint16`
+        # needs 64 KiB) and take a value the band does not contain. Wider
         # integer types are left to the extremes: their range cannot be
-        # enumerated, and a collision on all three candidates is vanishingly
+        # enumerated, and a collision on every candidate is vanishingly
         # unlikely there anyway.
-        low, high = extremes[0], extremes[1]
-        span = max(low, high) - min(low, high) + 1
+        preferred, opposite = extremes[0], extremes[1]
+        floor = min(preferred, opposite)
+        span = max(preferred, opposite) - floor + 1
         if span <= 65536:
             seen = np.zeros(span, dtype=bool)
-            present = np.asarray(values).ravel().astype("int64") - min(low, high)
+            raw = np.asarray(values).ravel()
+            if np.issubdtype(raw.dtype, np.floating):
+                # A float array reaching an integer target: `NaN` and the
+                # infinities have no integer to cast to, and numpy warns and
+                # yields a garbage index rather than raising.
+                raw = raw[np.isfinite(raw)]
+            present = raw.astype("int64") - floor
             inside = present[(present >= 0) & (present < span)]
             seen[inside] = True
             unused = np.flatnonzero(~seen)
             if unused.size:
-                chosen = target.type(int(unused[0]) + min(low, high))
+                # From the preferred extreme inwards, not from the bottom of
+                # the range. `extremes` is ordered deliberately -- an unsigned
+                # band offers its maximum first because `0` is the likelier
+                # real observation -- and starting the scan at the floor threw
+                # that away, answering `1` for a `uint8` band holding `0` and
+                # `255`. `crop` declares the value it gets, so a later write of
+                # `1` into the result would silently become a gap.
+                index = unused[-1] if preferred > opposite else unused[0]
+                chosen = target.type(int(index) + floor)
     return chosen
 
 

--- a/src/pyramids/base/_domain.py
+++ b/src/pyramids/base/_domain.py
@@ -533,12 +533,64 @@ def fits_dtype(value: Any, dtype: np.dtype) -> bool:
     return fits
 
 
-def occurs_in(values: Any, sentinel: Any) -> bool:
+def nan_bounds(values: Any) -> tuple[Any, Any]:
+    """The array's smallest and largest values, ignoring `NaN`.
+
+    `nanmin` / `nanmax` warn -- through `warnings.warn`, which `np.errstate`
+    does not reach -- when every value is `NaN`, and there is nothing unusual
+    about an all-`NaN` band: `crop` reaches one whenever a float raster is
+    entirely gaps. The answer in that case is that there are no bounds.
+
+    Args:
+        values: The array to measure.
+
+    Returns:
+        tuple[Any, Any]: `(min, max)` over the non-`NaN` values, or
+        `(nan, nan)` when there are none.
+
+    Examples:
+        - The `NaN` is ignored rather than propagated, which plain `min` and
+          `max` would do:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.base._domain import nan_bounds
+            >>> nan_bounds(np.array([3.0, np.nan, 1.0]))
+            (np.float64(1.0), np.float64(3.0))
+
+            ```
+        - An all-`NaN` array has no bounds, and says so without warning:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.base._domain import nan_bounds
+            >>> low, high = nan_bounds(np.full(4, np.nan))
+            >>> bool(np.isnan(low)), bool(np.isnan(high))
+            (True, True)
+
+            ```
+    """
+    array = np.asarray(values)
+    empty = np.dtype(array.dtype).kind == "f" and bool(np.isnan(array).all())
+    if array.size == 0 or empty:
+        bounds = (np.float64(np.nan), np.float64(np.nan))
+    else:
+        with np.errstate(invalid="ignore"):
+            bounds = (np.nanmin(array), np.nanmax(array))
+    return bounds
+
+
+def occurs_in(
+    values: Any, sentinel: Any, bounds: tuple[Any, Any] | None = None
+) -> bool:
     """Whether any value in `values` would read back as `sentinel`.
 
     Args:
         values: The array to search.
         sentinel: The candidate sentinel.
+        bounds: The array's `(min, max)` ignoring `NaN`, when the caller
+            already has them. Asking once and reusing the answer matters to
+            :func:`free_no_data`, which tests several candidates against the
+            same array and would otherwise make a full pass per candidate --
+            the prefilter costing more than the comparison it avoids.
 
     Returns:
         bool: `True` when at least one value matches the sentinel under the same
@@ -590,8 +642,7 @@ def occurs_in(values: Any, sentinel: Any) -> bool:
         # sentinel.
         with np.errstate(invalid="ignore"):
             comparable = np.isfinite(np.asarray(sentinel, dtype="float64"))
-            low = np.nanmin(array)
-            high = np.nanmax(array)
+            low, high = nan_bounds(array) if bounds is None else bounds
         in_range = not (comparable and np.isfinite(low) and np.isfinite(high)) or bool(
             low <= sentinel <= high
         )
@@ -683,7 +734,8 @@ def free_no_data(dtype: np.dtype, candidates: Sequence[Any], values: Any) -> Any
         values: The data the sentinel must not collide with.
 
     Returns:
-        Any | None: The chosen sentinel, or `None` when every candidate either
+        Any | None: The chosen sentinel as a Python scalar -- never a numpy
+        one, whichever branch found it -- or `None` when every candidate either
         does not fit `dtype` or already occurs in `values`.
 
     Examples:
@@ -707,9 +759,10 @@ def free_no_data(dtype: np.dtype, candidates: Sequence[Any], values: Any) -> Any
     """
     target = np.dtype(dtype)
     extremes = _dtype_extremes(target)
+    bounds = nan_bounds(values)
     chosen = None
     for candidate in no_data_candidates(target, candidates):
-        if not occurs_in(values, candidate):
+        if not occurs_in(values, candidate, bounds):
             chosen = candidate
             break
     if chosen is None and extremes:
@@ -738,7 +791,8 @@ def free_no_data(dtype: np.dtype, candidates: Sequence[Any], values: Any) -> Any
                     # infinities have no integer to cast to, and numpy warns
                     # and yields a garbage index rather than raising.
                     chunk = chunk[np.isfinite(chunk)]
-                present = chunk.astype("int64") - floor
+                with np.errstate(invalid="ignore", over="ignore"):
+                    present = chunk.astype("int64") - floor
                 inside = present[(present >= 0) & (present < span)]
                 seen[inside] = True
             unused = np.flatnonzero(~seen)
@@ -751,20 +805,25 @@ def free_no_data(dtype: np.dtype, candidates: Sequence[Any], values: Any) -> Any
                 # `255`. `crop` declares the value it gets, so a later write of
                 # `1` into the result would silently become a gap.
                 index = unused[-1] if preferred > opposite else unused[0]
-                chosen = target.type(int(index) + floor)
+                # A Python `int`, like every other branch returns: the
+                # candidates and the `np.iinfo` extremes are Python scalars,
+                # and a numpy one here made the same logical answer reach
+                # `Dataset.no_data_value` as two different types depending on
+                # which branch found it.
+                chosen = int(index) + floor
     return chosen
 
 
 __all__ = [
+    "DEFAULT_ATOL",
     "DEFAULT_NO_DATA_VALUE",
+    "DEFAULT_RTOL",
     "fits_dtype",
     "free_no_data",
-    "no_data_candidates",
-    "occurs_in",
-    "DEFAULT_ATOL",
-    "DEFAULT_RTOL",
     "inside_domain",
     "is_nan_sentinel",
     "is_no_data",
     "is_stored_no_data",
+    "no_data_candidates",
+    "occurs_in",
 ]

--- a/src/pyramids/base/_domain.py
+++ b/src/pyramids/base/_domain.py
@@ -484,7 +484,7 @@ def fits_dtype(value: Any, dtype: np.dtype) -> bool:
 
     Args:
         value: The candidate sentinel. Callers decide what a missing sentinel
-            means before asking; a `None` reaching here does not fit.
+            means before asking; neither a `None` nor a bool fits.
         dtype: The numpy dtype of the band the sentinel would be stored in.
 
     Returns:
@@ -507,6 +507,14 @@ def fits_dtype(value: Any, dtype: np.dtype) -> bool:
             (True, False)
 
             ```
+        - A bool never fits, though it would cast cleanly to `0` or `1`:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.base._domain import fits_dtype
+            >>> fits_dtype(True, np.dtype("uint8"))
+            False
+
+            ```
     """
     target = np.dtype(dtype)
     # `.item()` first: NEP 50 compares a *Python* scalar in the target dtype
@@ -516,7 +524,12 @@ def fits_dtype(value: Any, dtype: np.dtype) -> bool:
     # sentinel between rasters was on the losing side.
     if hasattr(value, "item") and np.ndim(value) == 0:
         value = value.item()
-    if value is None:
+    if value is None or isinstance(value, (bool, np.bool_)):
+        # A bool fits every numeric dtype as `0` or `1`, so accepting one
+        # would let `True` become a `1` sentinel and put every genuine 1 in
+        # the band out of domain. `Analysis._requested_no_data` rejects it
+        # with its own message before asking; the crop path asks directly,
+        # and would have stamped it.
         fits = False
     elif is_nan_sentinel(value):
         # `is_nan_sentinel`, not `isinstance(value, float) and isnan(value)`:

--- a/src/pyramids/base/_domain.py
+++ b/src/pyramids/base/_domain.py
@@ -773,9 +773,7 @@ def _values_present_in_range(values: Any, floor: int, span: int) -> np.typing.ND
     return seen
 
 
-def _first_unused_in_range(
-    target: np.dtype, extremes: list[Any], values: Any
-) -> Any | None:
+def _first_unused_in_range(extremes: list[Any], values: Any) -> Any | None:
     """The value nearest the preferred extreme that `values` does not hold.
 
     The preferred candidates being taken is not a reason to refuse: a narrow
@@ -788,8 +786,9 @@ def _first_unused_in_range(
     there anyway.
 
     Args:
-        target: The dtype the value must be storable in.
-        extremes: That dtype's bounds, most preferred first.
+        extremes: The dtype's bounds, most preferred first. They carry the
+            whole question -- which values exist, and which end to answer from
+            -- so the dtype itself is not needed.
         values: The data the value must not occur in.
 
     Returns:
@@ -878,7 +877,7 @@ def free_no_data(dtype: np.dtype, candidates: Sequence[Any], values: Any) -> Any
             chosen = candidate.item() if hasattr(candidate, "item") else candidate
             break
     if chosen is None and extremes:
-        chosen = _first_unused_in_range(target, extremes, values)
+        chosen = _first_unused_in_range(extremes, values)
     return chosen
 
 

--- a/src/pyramids/base/_domain.py
+++ b/src/pyramids/base/_domain.py
@@ -30,6 +30,7 @@ the sentinel" rather than "is this cell near it".
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Sequence
 from typing import Any, overload
 
@@ -44,7 +45,9 @@ DEFAULT_NO_DATA_VALUE = -9999
 DEFAULT_RTOL: float = 0.001
 
 # Cells per slice when scanning a band for an unused value. Bounds the scan's
-# temporaries to a few megabytes whatever the raster's size.
+# transient peak to roughly 25 MB whatever the raster's size -- the `int64`
+# cast is 8 MB of it, the offset another, and the range test and its gather the
+# rest. The mask being filled stays at 64 KiB regardless.
 _SCAN_CHUNK: int = 1 << 20
 
 # `numpy.isclose`'s own default absolute tolerance, named so a caller can opt
@@ -552,7 +555,8 @@ def nan_bounds(values: Any) -> tuple[Any, Any]:
     `nanmin` / `nanmax` warn -- through `warnings.warn`, which `np.errstate`
     does not reach -- when every value is `NaN`, and there is nothing unusual
     about an all-`NaN` band: `crop` reaches one whenever a float raster is
-    entirely gaps. The answer in that case is that there are no bounds.
+    entirely gaps. The answer in that case is that there are no bounds, which
+    is what they return once the warning is silenced.
 
     Args:
         values: The array to measure.
@@ -582,11 +586,15 @@ def nan_bounds(values: Any) -> tuple[Any, Any]:
             ```
     """
     array = np.asarray(values)
-    empty = np.dtype(array.dtype).kind == "f" and bool(np.isnan(array).all())
-    if array.size == 0 or empty:
+    if array.size == 0:
         bounds = (np.float64(np.nan), np.float64(np.nan))
     else:
-        with np.errstate(invalid="ignore"):
+        # The warning is caught rather than pre-empted with `isnan(...).all()`:
+        # that test costs a full pass and a full-size boolean temporary on top
+        # of the two reductions, to answer a question `nanmin` is about to
+        # answer anyway by returning `NaN`.
+        with np.errstate(invalid="ignore"), warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
             bounds = (np.nanmin(array), np.nanmax(array))
     return bounds
 
@@ -723,7 +731,15 @@ def no_data_candidates(dtype: np.dtype, candidates: Sequence[Any] = ()) -> list[
     """
     target = np.dtype(dtype)
     offered = [*candidates, DEFAULT_NO_DATA_VALUE, *_dtype_extremes(target)]
-    return [value for value in offered if fits_dtype(value, target)]
+    storable = [value for value in offered if fits_dtype(value, target)]
+    # De-duplicated, since every repeat costs `free_no_data` another full pass
+    # over the values -- and repeats are the normal case: `combine` offers one
+    # sentinel per operand band, and the bands of a stack usually share one.
+    # Keyed on the stored value so `-9999` and `np.int16(-9999)` count once.
+    seen: dict[Any, Any] = {}
+    for value in storable:
+        seen.setdefault(target.type(value).item(), value)
+    return list(seen.values())
 
 
 def free_no_data(dtype: np.dtype, candidates: Sequence[Any], values: Any) -> Any | None:
@@ -748,8 +764,9 @@ def free_no_data(dtype: np.dtype, candidates: Sequence[Any], values: Any) -> Any
 
     Returns:
         Any | None: The chosen sentinel as a Python scalar -- never a numpy
-        one, whichever branch found it -- or `None` when every candidate either
-        does not fit `dtype` or already occurs in `values`.
+        one, whichever branch found it and whoever offered it -- or `None` when
+        every candidate either does not fit `dtype` or already occurs in
+        `values`.
 
     Examples:
         - The package default is taken when the data does not hold it:
@@ -776,7 +793,12 @@ def free_no_data(dtype: np.dtype, candidates: Sequence[Any], values: Any) -> Any
     chosen = None
     for candidate in no_data_candidates(target, candidates):
         if not occurs_in(values, candidate, bounds):
-            chosen = candidate
+            # `.item()`, so a caller's own candidate is answered in the same
+            # currency as the package default and the extremes.
+            # `Dataset.no_data_value` hands back numpy scalars and `combine`
+            # forwards them here, so without this the same logical answer
+            # reached the result's declaration as two different types.
+            chosen = candidate.item() if hasattr(candidate, "item") else candidate
             break
     if chosen is None and extremes:
         # The preferred candidates are all taken, but a narrow integer band

--- a/src/pyramids/base/_domain.py
+++ b/src/pyramids/base/_domain.py
@@ -30,9 +30,16 @@ the sentinel" rather than "is this cell near it".
 
 from __future__ import annotations
 
-from typing import overload
+from collections.abc import Sequence
+from typing import Any, overload
 
 import numpy as np
+
+# The package-wide default sentinel. It lives here, in the module that owns
+# the no-data domain, rather than in `abstract_dataset` which imports from
+# `base/`; `abstract_dataset` re-exports it so every existing import path
+# keeps working.
+DEFAULT_NO_DATA_VALUE = -9999
 
 DEFAULT_RTOL: float = 0.001
 
@@ -460,7 +467,188 @@ def is_nan_sentinel(no_data_value: float | None) -> bool:
     return result
 
 
+def fits_dtype(value: Any, dtype: np.dtype) -> bool:
+    """Whether `dtype` can hold `value` as a distinguishable no-data sentinel.
+
+    A range test, not an exactness one: a float sentinel that `dtype` rounds --
+    `0.1` into `float32` -- still marks its own cells, because the value written
+    and the value compared against go through the same cast. What the test
+    rejects is a sentinel the dtype cannot represent *as itself*: `NaN` in an
+    integer band, `-9999` in a `uint8` one, `1e40` in a `float32` one (it lands
+    on `inf`, which would then mark every genuinely infinite cell). Stamping any
+    of those would mark real cells as no-data, or mark nothing at all.
+
+    Args:
+        value: The candidate sentinel. Callers decide what a missing sentinel
+            means before asking; a `None` reaching here does not fit.
+        dtype: The numpy dtype of the band the sentinel would be stored in.
+
+    Returns:
+        bool: `True` when the sentinel is representable in `dtype`.
+
+    Examples:
+        - An integer band cannot carry `NaN`, a float one can:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.base._domain import fits_dtype
+            >>> fits_dtype(np.nan, np.dtype("int32")), fits_dtype(np.nan, np.dtype("float32"))
+            (False, True)
+
+            ```
+        - `-9999` fits a signed band but not an unsigned one:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.base._domain import fits_dtype
+            >>> fits_dtype(-9999, np.dtype("int32")), fits_dtype(-9999, np.dtype("uint8"))
+            (True, False)
+
+            ```
+    """
+    target = np.dtype(dtype)
+    # `.item()` first: NEP 50 compares a *Python* scalar in the target dtype
+    # (weak) and a *numpy* scalar in its own (strong), so `0.1` fitted a
+    # `float32` band while the byte-identical `np.float64(0.1)` did not -- and
+    # `Dataset.no_data_value` hands back numpy scalars, so a caller forwarding a
+    # sentinel between rasters was on the losing side.
+    if hasattr(value, "item") and np.ndim(value) == 0:
+        value = value.item()
+    if value is None:
+        fits = False
+    elif is_nan_sentinel(value):
+        # `is_nan_sentinel`, not `isinstance(value, float) and isnan(value)`:
+        # `np.float32("nan")` does not subclass `float` and fell through to the
+        # comparison below, where `nan == nan` is False by definition.
+        fits = bool(np.issubdtype(target, np.floating))
+    else:
+        with np.errstate(invalid="ignore", over="ignore"):
+            try:
+                stored = np.asarray(value).astype(target)
+                fits = bool(stored == value) and bool(np.isfinite(stored))
+            except (ValueError, OverflowError, TypeError):
+                fits = False
+    return fits
+
+
+def occurs_in(values: Any, sentinel: Any) -> bool:
+    """Whether any value in `values` would read back as `sentinel`.
+
+    Args:
+        values: The array to search.
+        sentinel: The candidate sentinel.
+
+    Returns:
+        bool: `True` when at least one value matches the sentinel under the same
+        tolerance a reader would apply.
+    """
+    array = np.asarray(values)
+    occurs = False
+    if array.size:
+        # Prefilter on the extremes before allocating a full boolean array: a
+        # caller asking about many candidates would otherwise pay a full-size
+        # allocation each time, and a sentinel outside the data's range cannot
+        # occur in it.
+        #
+        # `nanmin`/`nanmax`, and a finiteness check on the bounds: plain
+        # `min`/`max` propagate a `NaN`, and every comparison against `NaN` is
+        # False, so a single `NaN` anywhere -- `0/0` in a normalised difference
+        # is enough -- made the prefilter answer "no collision" for every finite
+        # sentinel.
+        with np.errstate(invalid="ignore"):
+            comparable = np.isfinite(np.asarray(sentinel, dtype="float64"))
+            low = np.nanmin(array)
+            high = np.nanmax(array)
+        in_range = not (comparable and np.isfinite(low) and np.isfinite(high)) or bool(
+            low <= sentinel <= high
+        )
+        occurs = in_range and bool(is_stored_no_data(array, sentinel).any())
+    return occurs
+
+
+def free_no_data(dtype: np.dtype, candidates: Sequence[Any], values: Any) -> Any | None:
+    """First sentinel that fits `dtype` and occurs nowhere in `values`.
+
+    The one honest way to mark cells as absent in a band that declares no
+    sentinel: rather than inventing a number and hoping (`0`, or the dtype
+    maximum), take one the data provably does not contain, so no real
+    observation is reclassified as a gap.
+
+    Failure is reported by returning `None` rather than by raising, because the
+    remedy belongs to the caller and the two differ: `combine` can be told to
+    leave every cell unmasked, while a crop needs a wider dtype or an explicit
+    sentinel. `None` is unambiguous here -- it never fits a dtype, so it can
+    never be a successful answer.
+
+    Args:
+        dtype: The dtype the sentinel must be storable in.
+        candidates: Preferred sentinels, tried before the package default and
+            the dtype's extremes.
+        values: The data the sentinel must not collide with.
+
+    Returns:
+        Any | None: The chosen sentinel, or `None` when every candidate either
+        does not fit `dtype` or already occurs in `values`.
+
+    Examples:
+        - The package default is taken when the data does not hold it:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.base._domain import free_no_data
+            >>> free_no_data(np.dtype("int32"), [], np.array([1, 2, 3]))
+            -9999
+
+            ```
+        - An unsigned band reaches for its maximum before its minimum, since
+          `0` is the likelier real observation:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.base._domain import free_no_data
+            >>> free_no_data(np.dtype("uint8"), [], np.array([1, 2, 3], "uint8"))
+            255
+
+            ```
+    """
+    target = np.dtype(dtype)
+    extremes: list[Any] = []
+    if np.issubdtype(target, np.integer):
+        info = np.iinfo(target)
+        # Signed: `min` is the conventional sentinel and far from any real
+        # measurement. Unsigned: `min` is 0 -- the likeliest value for a future
+        # write, a mosaic fill or a legitimate observation to take -- so the
+        # maximum is tried first, which is also what the package's own band
+        # fallback picks for those dtypes.
+        extremes = [info.min, info.max] if info.min < 0 else [info.max, info.min]
+    chosen = None
+    for candidate in [*candidates, DEFAULT_NO_DATA_VALUE, *extremes]:
+        if fits_dtype(candidate, target) and not occurs_in(values, candidate):
+            chosen = candidate
+            break
+    if chosen is None and extremes:
+        # The preferred candidates are all taken, but a narrow integer band
+        # still has thousands of values the data never uses -- refusing after
+        # trying three of them would be giving up early. Enumerate the whole
+        # range when it is small enough to hold as a mask (a `uint16` needs
+        # 64 KiB), and take the first value the band does not contain. Wider
+        # integer types are left to the extremes: their range cannot be
+        # enumerated, and a collision on all three candidates is vanishingly
+        # unlikely there anyway.
+        low, high = extremes[0], extremes[1]
+        span = max(low, high) - min(low, high) + 1
+        if span <= 65536:
+            seen = np.zeros(span, dtype=bool)
+            present = np.asarray(values).ravel().astype("int64") - min(low, high)
+            inside = present[(present >= 0) & (present < span)]
+            seen[inside] = True
+            unused = np.flatnonzero(~seen)
+            if unused.size:
+                chosen = target.type(int(unused[0]) + min(low, high))
+    return chosen
+
+
 __all__ = [
+    "DEFAULT_NO_DATA_VALUE",
+    "fits_dtype",
+    "free_no_data",
+    "occurs_in",
     "DEFAULT_ATOL",
     "DEFAULT_RTOL",
     "inside_domain",

--- a/src/pyramids/base/_domain.py
+++ b/src/pyramids/base/_domain.py
@@ -837,6 +837,7 @@ __all__ = [
     "is_nan_sentinel",
     "is_no_data",
     "is_stored_no_data",
+    "nan_bounds",
     "no_data_candidates",
     "occurs_in",
 ]

--- a/src/pyramids/base/_domain.py
+++ b/src/pyramids/base/_domain.py
@@ -43,6 +43,10 @@ DEFAULT_NO_DATA_VALUE = -9999
 
 DEFAULT_RTOL: float = 0.001
 
+# Cells per slice when scanning a band for an unused value. Bounds the scan's
+# temporaries to a few megabytes whatever the raster's size.
+_SCAN_CHUNK: int = 1 << 20
+
 # `numpy.isclose`'s own default absolute tolerance, named so a caller can opt
 # out of it (`atol=0.0`) without restating a magic number.
 DEFAULT_ATOL: float = 1e-8
@@ -595,6 +599,69 @@ def occurs_in(values: Any, sentinel: Any) -> bool:
     return occurs
 
 
+def _dtype_extremes(target: np.dtype) -> list[Any]:
+    """The dtype's own bounds, in the order they should be tried.
+
+    Args:
+        target: The dtype the sentinel must be storable in.
+
+    Returns:
+        list[Any]: `[min, max]` for a signed integer dtype, `[max, min]` for an
+        unsigned one, and empty for everything else.
+    """
+    extremes: list[Any] = []
+    if np.issubdtype(target, np.integer):
+        info = np.iinfo(target)
+        # Signed: `min` is the conventional sentinel and far from any real
+        # measurement. Unsigned: `min` is 0 -- the likeliest value for a future
+        # write, a mosaic fill or a legitimate observation to take -- so the
+        # maximum is tried first, which is also what the package's own band
+        # fallback picks for those dtypes.
+        extremes = [info.min, info.max] if info.min < 0 else [info.max, info.min]
+    return extremes
+
+
+def no_data_candidates(dtype: np.dtype, candidates: Sequence[Any] = ()) -> list[Any]:
+    """The sentinels tried for a band of `dtype`, in preference order.
+
+    Only those the dtype can actually store: the caller's own candidates, then
+    the package default, then the dtype's extremes.
+
+    Exposed so a caller that can answer "does the band contain this" more
+    cheaply than by reading it -- from the band's own statistics, say -- asks
+    the same questions in the same order as :func:`free_no_data` would.
+
+    Args:
+        dtype: The dtype the sentinel must be storable in.
+        candidates: Preferred sentinels, tried before the package default.
+
+    Returns:
+        list[Any]: The storable candidates, most preferred first.
+
+    Examples:
+        - An unsigned band cannot hold the package default, and reaches for its
+          maximum before its minimum:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.base._domain import no_data_candidates
+            >>> no_data_candidates(np.dtype("uint8"))
+            [255, 0]
+
+            ```
+        - A signed band keeps the default first, then its own bounds:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.base._domain import no_data_candidates
+            >>> no_data_candidates(np.dtype("int16"))
+            [-9999, -32768, 32767]
+
+            ```
+    """
+    target = np.dtype(dtype)
+    offered = [*candidates, DEFAULT_NO_DATA_VALUE, *_dtype_extremes(target)]
+    return [value for value in offered if fits_dtype(value, target)]
+
+
 def free_no_data(dtype: np.dtype, candidates: Sequence[Any], values: Any) -> Any | None:
     """First sentinel that fits `dtype` and occurs nowhere in `values`.
 
@@ -639,18 +706,10 @@ def free_no_data(dtype: np.dtype, candidates: Sequence[Any], values: Any) -> Any
             ```
     """
     target = np.dtype(dtype)
-    extremes: list[Any] = []
-    if np.issubdtype(target, np.integer):
-        info = np.iinfo(target)
-        # Signed: `min` is the conventional sentinel and far from any real
-        # measurement. Unsigned: `min` is 0 -- the likeliest value for a future
-        # write, a mosaic fill or a legitimate observation to take -- so the
-        # maximum is tried first, which is also what the package's own band
-        # fallback picks for those dtypes.
-        extremes = [info.min, info.max] if info.min < 0 else [info.max, info.min]
+    extremes = _dtype_extremes(target)
     chosen = None
-    for candidate in [*candidates, DEFAULT_NO_DATA_VALUE, *extremes]:
-        if fits_dtype(candidate, target) and not occurs_in(values, candidate):
+    for candidate in no_data_candidates(target, candidates):
+        if not occurs_in(values, candidate):
             chosen = candidate
             break
     if chosen is None and extremes:
@@ -668,14 +727,20 @@ def free_no_data(dtype: np.dtype, candidates: Sequence[Any], values: Any) -> Any
         if span <= 65536:
             seen = np.zeros(span, dtype=bool)
             raw = np.asarray(values).ravel()
-            if np.issubdtype(raw.dtype, np.floating):
-                # A float array reaching an integer target: `NaN` and the
-                # infinities have no integer to cast to, and numpy warns and
-                # yields a garbage index rather than raising.
-                raw = raw[np.isfinite(raw)]
-            present = raw.astype("int64") - floor
-            inside = present[(present >= 0) & (present < span)]
-            seen[inside] = True
+            # In slices, not all at once: the cast below widens every cell to
+            # 8 bytes and the comparisons add two boolean temporaries, so a
+            # whole-array pass peaked at many times the band's own size. The
+            # mask being filled is at most 64 KiB either way.
+            for start in range(0, raw.size, _SCAN_CHUNK):
+                chunk = raw[start : start + _SCAN_CHUNK]
+                if np.issubdtype(chunk.dtype, np.floating):
+                    # A float array reaching an integer target: `NaN` and the
+                    # infinities have no integer to cast to, and numpy warns
+                    # and yields a garbage index rather than raising.
+                    chunk = chunk[np.isfinite(chunk)]
+                present = chunk.astype("int64") - floor
+                inside = present[(present >= 0) & (present < span)]
+                seen[inside] = True
             unused = np.flatnonzero(~seen)
             if unused.size:
                 # From the preferred extreme inwards, not from the bottom of
@@ -694,6 +759,7 @@ __all__ = [
     "DEFAULT_NO_DATA_VALUE",
     "fits_dtype",
     "free_no_data",
+    "no_data_candidates",
     "occurs_in",
     "DEFAULT_ATOL",
     "DEFAULT_RTOL",

--- a/src/pyramids/base/_domain.py
+++ b/src/pyramids/base/_domain.py
@@ -539,6 +539,37 @@ def occurs_in(values: Any, sentinel: Any) -> bool:
     Returns:
         bool: `True` when at least one value matches the sentinel under the same
         tolerance a reader would apply.
+
+    Examples:
+        - A value the band holds rules that sentinel out:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.base._domain import occurs_in
+            >>> occurs_in(np.array([1, 2, 255], "uint8"), 255)
+            True
+
+            ```
+        - One outside the data's range cannot occur in it:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.base._domain import occurs_in
+            >>> occurs_in(np.array([1, 2, 3], "uint8"), 255)
+            False
+
+            ```
+        - A `NaN` in the data does not hide a finite collision, which a plain
+          `min`/`max` prefilter would (every comparison against `NaN` is False):
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.base._domain import occurs_in
+            >>> occurs_in(np.array([1.0, np.nan, -9999.0]), -9999.0)
+            True
+
+            ```
+
+    See Also:
+        free_no_data: Uses this to reject a candidate the data already holds.
+        is_stored_no_data: The element-wise comparison this delegates to.
     """
     array = np.asarray(values)
     occurs = False

--- a/src/pyramids/dataset/abstract_dataset.py
+++ b/src/pyramids/dataset/abstract_dataset.py
@@ -28,6 +28,7 @@ import numpy as np
 from geopandas.geodataframe import GeoDataFrame
 from osgeo import gdal
 
+from pyramids.base._domain import DEFAULT_NO_DATA_VALUE
 from pyramids.base._errors import ReadOnlyError
 from pyramids.base._utils import (
     DEFAULT_RESAMPLING,
@@ -49,7 +50,6 @@ if TYPE_CHECKING:
 
 from pyramids.feature import FeatureCollection
 
-DEFAULT_NO_DATA_VALUE = -9999
 CATALOG = get_catalog()
 OVERVIEW_LEVELS = [2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048]
 # Overview-build resampling names (gdal.Dataset.BuildOverviews family). This is a

--- a/src/pyramids/dataset/collection.py
+++ b/src/pyramids/dataset/collection.py
@@ -18,9 +18,11 @@ import pandas as pd
 from pyproj import CRS
 
 from pyramids import _io
+from pyramids.base._domain import free_no_data, is_stored_no_data
 from pyramids.base._errors import (
     AlignmentError,
     DriverNotExistError,
+    NoDataValueError,
     OptionalPackageDoesNotExist,
 )
 from pyramids.base._file_manager import CachingFileManager, gdal_raster_open
@@ -576,6 +578,70 @@ def _target_epsg(to_epsg: int | str | Any) -> int | None:
         # the original defensive breadth for an input that is not CRS-like at all,
         # which this helper has always answered `None` for rather than propagating.
         return None
+
+
+def _agree_on_one_sentinel(datasets: list[Dataset]) -> None:
+    """Give every timestep of a stack the same no-data value, in place.
+
+    A collection declares one sentinel -- `base.no_data_value` -- and everything
+    that reads the stack through it (reductions, `count_domain_cells`,
+    `to_netcdf`, `to_zarr`, plotting) applies that one value to every step. So
+    a stack whose steps disagree is read wrongly rather than incompletely: with
+    `t0` declaring `-9999` and `t1` declaring `-32768`, a genuine `-9999`
+    observation in `t1` reads as a gap and `t1`'s actual gaps read as data.
+
+    `crop` is what produces such a stack. It derives a fill against each
+    raster's own values, so two timesteps of the same variable get different
+    answers whenever one of them happens to contain the other's fill. The steps
+    are reconciled here instead of at each call site: a value free across every
+    step is chosen, each step's own fill cells are rewritten to it, and all of
+    them then declare it.
+
+    A stack whose steps already agree -- every per-timestep operation that
+    inherits its sentinel rather than deriving one -- returns immediately, so
+    this is only paid for where it is needed. So does one where any step
+    declares nothing, since there is no fill to reconcile and imposing one
+    would invent a sentinel the sources never had.
+
+    Args:
+        datasets: One `Dataset` per timestep, modified in place.
+
+    Raises:
+        NoDataValueError: No value is free across every timestep, so the stack
+            cannot be given a sentinel that does not collide with real data.
+    """
+    if len(datasets) < 2:
+        return
+    declared = [ds.no_data_value for ds in datasets]
+    if any(value is None for row in declared for value in row):
+        return
+    for band in range(datasets[0].band_count):
+        fills = [row[band] for row in declared]
+        if all(is_stored_no_data(np.asarray(fills[0]), other) for other in fills[1:]):
+            continue
+        arrays = [np.asarray(ds.read_array(band=band)) for ds in datasets]
+        # Judged against real observations only: each step's own fill cells are
+        # the thing being replaced, so counting them would rule out every
+        # candidate already in use and force a needless third value.
+        real = np.concatenate(
+            [
+                array[~is_stored_no_data(array, fill)].ravel()
+                for array, fill in zip(arrays, fills, strict=True)
+            ]
+        )
+        dtype = np.dtype(datasets[0].numpy_dtype[band])
+        agreed = free_no_data(dtype, fills, real)
+        if agreed is None:
+            raise NoDataValueError(
+                f"the timesteps of this {dtype.name} stack declare different "
+                "no-data values and no value is free across all of them, so "
+                "the stack cannot be read through one sentinel; declare a "
+                "no-data value the data does not use before cropping"
+            )
+        for dataset, array, fill in zip(datasets, arrays, fills, strict=True):
+            array[is_stored_no_data(array, fill)] = agreed
+            dataset.write_array(array, band=band)
+            dataset.bands._change_no_data_value_attr(band, dtype.type(agreed))
 
 
 class DatasetCollection:
@@ -3649,7 +3715,16 @@ class DatasetCollection:
 
         Returns:
             DatasetCollection: A collection over `datasets`.
+
+        Notes:
+            The timesteps are reconciled onto one sentinel first -- see
+            :func:`_agree_on_one_sentinel`. A per-timestep operation that
+            inherits its sentinel leaves them already agreeing, so this costs
+            nothing for `to_crs` and `align`; `crop`, which derives a fill
+            against each raster's own values, can produce a stack that
+            disagrees.
         """
+        _agree_on_one_sentinel(datasets)
         collection = DatasetCollection(
             datasets[0], time_length=len(datasets), datasets=datasets
         )

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2538,27 +2538,22 @@ class Dataset(RasterBase):
         values; mutating the returned object never propagates to
         the underlying state.
 
-        **The entries are numbers, not necessarily Python `int`s.** An
-        unsigned band *wider than 8 bits* created with a `NaN` no-data takes
-        the dtype maximum, because `NaN` cannot be stored there, and that
-        substituted sentinel is now built as a numpy scalar rather than a
-        Python `int`, so that it agrees in *type* as well as value with the
-        fallback used when a requested sentinel overflows the band. A uint16
-        band that used to report `(65535,)` reports `(np.float64(65535.0),)`
-        — float64 because GDAL's `SetNoDataValue` takes a C double and the
-        value is round-tripped through it.
+        **The entries are numbers, not necessarily Python `int`s.** No dtype
+        fabricates a sentinel on a caller's behalf: a `NaN` asked of an integer
+        band is reported back as `NaN` and an **unset** no-data as `None`,
+        whatever the dtype, rather than being answered with a number the band's
+        real data may already hold. Writing such a sentinel to the band is the
+        step that refuses — `change_no_data_value(None)` on any integer raster
+        raises `NoDataValueError`, since there is nothing storable to write.
 
-        Two cases the example deliberately avoids, because neither
-        substitutes: a **Byte** band, which reports `(nan,)` (255 is ordinary
-        data in 8-bit imagery, see `bands._substitutes_dtype_max`), and an
-        **unset** no-data, which reports `(None,)` whatever the dtype.
-
-        Compare with `==` rather than `is`, and call `float(...)` /
-        `int(...)` before anything that needs a builtin (JSON, `%` formatting
-        of an `int`). Arithmetic wraps at the dtype bound instead of promoting
-        only on the one row that stays a numpy *integer*: `uint64`, whose
-        maximum has no exact float64, reports `np.uint64(2**64 - 1)`. See
-        `docs/migration.md`, dataset / unreleased.
+        A sentinel that is set still round-trips through GDAL's
+        `SetNoDataValue`, which takes a C double, so a `uint16` band asked for
+        `65535` reports `(np.float64(65535.0),)`. Compare with `==` rather than
+        `is`, and call `float(...)` / `int(...)` before anything that needs a
+        builtin (JSON, `%` formatting of an `int`). `uint64` is the one row
+        that stays a numpy *integer*, since its maximum has no exact float64:
+        it reports `np.uint64(2**64 - 1)`. See `docs/migration.md`,
+        dataset / unreleased.
         """
         return tuple(self._no_data_value)
 

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -2554,6 +2554,55 @@ class Dataset(RasterBase):
         that stays a numpy *integer*, since its maximum has no exact float64:
         it reports `np.uint64(2**64 - 1)`. See `docs/migration.md`,
         dataset / unreleased.
+
+        Returns:
+            tuple: One entry per band, in band order -- a number, or `None` for
+            a band that declares no sentinel.
+
+        Examples:
+            - A band created with a sentinel reports it, through GDAL's C
+              double:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset, GeoReference
+                >>> geo_ref = GeoReference(top_left_corner=(0.0, 5.0), cell_size=0.25, epsg=4326)
+                >>> raster = Dataset.from_array(
+                ...     np.ones((4, 4), "float32"), geo_ref=geo_ref, no_data_value=-9999.0
+                ... )
+                >>> raster.no_data_value
+                (np.float64(-9999.0),)
+
+                ```
+            - An integer band asked for `NaN` reports `NaN`, not a fabricated
+              maximum, so nothing in it is marked absent:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset, GeoReference
+                >>> geo_ref = GeoReference(top_left_corner=(0.0, 5.0), cell_size=0.25, epsg=4326)
+                >>> raster = Dataset.create(
+                ...     rows=4, columns=4, bands=1, dtype="uint16",
+                ...     no_data_value=np.nan, geo_ref=geo_ref,
+                ... )
+                >>> bool(np.isnan(raster.no_data_value[0]))
+                True
+
+                ```
+            - One entry per band, so a two-band raster reports a pair:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.dataset import Dataset, GeoReference
+                >>> geo_ref = GeoReference(top_left_corner=(0.0, 5.0), cell_size=0.25, epsg=4326)
+                >>> raster = Dataset.from_array(
+                ...     np.ones((2, 4, 4), "float32"), geo_ref=geo_ref, no_data_value=0.0
+                ... )
+                >>> len(raster.no_data_value)
+                2
+
+                ```
+
+        See Also:
+            change_no_data_value: Rewrites the cells as well as the
+                declaration, and refuses a sentinel the band cannot store.
         """
         return tuple(self._no_data_value)
 

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -20,7 +20,13 @@ from hpc.indexing import get_indices2, get_pixels2
 from osgeo import gdal
 from pandas import DataFrame
 
-from pyramids.base._domain import is_nan_sentinel, is_stored_no_data
+from pyramids.base._domain import (
+    fits_dtype,
+    free_no_data,
+    is_nan_sentinel,
+    is_stored_no_data,
+    occurs_in,
+)
 from pyramids.base._errors import (
     AlignmentError,
     NoDataCollisionWarning,
@@ -39,7 +45,7 @@ from pyramids.dataset._plot_helpers import (
     RgbSpec,
     render_array,
 )
-from pyramids.dataset.abstract_dataset import DEFAULT_NO_DATA_VALUE, RasterBase
+from pyramids.dataset.abstract_dataset import RasterBase
 from pyramids.dataset.window import Window
 from pyramids.feature import FeatureCollection
 
@@ -93,50 +99,6 @@ class _DeriveNoData:
 
 
 _DERIVE_NO_DATA = _DeriveNoData()
-
-
-def _fits_dtype(value: Any, dtype: np.dtype) -> bool:
-    """Whether `dtype` can hold `value` as a distinguishable no-data sentinel.
-
-    A range test, not an exactness one: a float sentinel that `dtype` rounds --
-    `0.1` into `float32` -- still marks its own cells, because the value written
-    and the value compared against go through the same cast. What the test
-    rejects is a sentinel the dtype cannot represent *as itself*: `NaN` in an
-    integer band, `-9999` in a `uint8` one, `1e40` in a `float32` one (it lands
-    on `inf`, which would then mark every genuinely infinite cell). Stamping any
-    of those would mark real cells as no-data, or mark nothing at all.
-
-    Args:
-        value: The candidate sentinel. Callers decide what a missing sentinel
-            means before asking; a `None` reaching here does not fit.
-        dtype: The numpy dtype of the band the sentinel would be stored in.
-
-    Returns:
-        bool: `True` when the sentinel is representable in `dtype`.
-    """
-    target = np.dtype(dtype)
-    # `.item()` first: NEP 50 compares a *Python* scalar in the target dtype
-    # (weak) and a *numpy* scalar in its own (strong), so `0.1` fitted a
-    # `float32` band while the byte-identical `np.float64(0.1)` did not -- and
-    # `Dataset.no_data_value` hands back numpy scalars, so a caller forwarding a
-    # sentinel between rasters was on the losing side.
-    if hasattr(value, "item") and np.ndim(value) == 0:
-        value = value.item()
-    if value is None:
-        fits = False
-    elif is_nan_sentinel(value):
-        # `is_nan_sentinel`, not `isinstance(value, float) and isnan(value)`:
-        # `np.float32("nan")` does not subclass `float` and fell through to the
-        # comparison below, where `nan == nan` is False by definition.
-        fits = bool(np.issubdtype(target, np.floating))
-    else:
-        with np.errstate(invalid="ignore", over="ignore"):
-            try:
-                stored = np.asarray(value).astype(target)
-                fits = bool(stored == value) and bool(np.isfinite(stored))
-            except (ValueError, OverflowError, TypeError):
-                fits = False
-    return fits
 
 
 @dataclass(frozen=True)
@@ -1038,7 +1000,7 @@ class Analysis(_Engine["Dataset"]):
         """
         if requested is not _DERIVE_NO_DATA:
             sentinel = cls._requested_no_data(requested, dtype)
-            if cls._occurs_in(values, sentinel):
+            if occurs_in(values, sentinel):
                 warnings.warn(
                     f"the requested no-data value {sentinel!r} is also a value "
                     "`func` computed, so those cells read back as gaps; pass a "
@@ -1060,7 +1022,15 @@ class Analysis(_Engine["Dataset"]):
         elif not excluded:
             sentinel = None
         else:
-            sentinel = cls._free_no_data(dtype, candidates, values)
+            sentinel = free_no_data(dtype, candidates, values)
+            if sentinel is None:
+                raise ValueError(
+                    f"the {np.dtype(dtype).name} result of `func` leaves no "
+                    "free value to mark the cells its operands masked out -- "
+                    "every candidate sentinel occurs in the result; widen the "
+                    "result dtype, or pass `no_data_value=None` to combine "
+                    "every cell unmasked"
+                )
         return sentinel
 
     @staticmethod
@@ -1085,7 +1055,7 @@ class Analysis(_Engine["Dataset"]):
                 f"the no-data value {requested!r} is a bool; pass the number you "
                 "mean, or `None` for a result with no sentinel"
             )
-        if not _fits_dtype(requested, dtype):
+        if not fits_dtype(requested, dtype):
             raise ValueError(
                 f"the no-data value {requested!r} cannot be stored in the "
                 f"{np.dtype(dtype).name} result of `func`; pass an explicit "
@@ -1093,84 +1063,6 @@ class Analysis(_Engine["Dataset"]):
                 "result with no sentinel"
             )
         return requested
-
-    @classmethod
-    def _free_no_data(
-        cls, dtype: np.dtype, candidates: Sequence[Any], values: Any
-    ) -> Any:
-        """First sentinel that fits `dtype` and occurs nowhere in `values`.
-
-        Args:
-            dtype: The dtype `func` produced.
-            candidates: The operands' sentinels, in preference order, tried
-                before the package default and the dtype's extremes.
-            values: The values `func` computed.
-
-        Returns:
-            Any: The chosen sentinel.
-
-        Raises:
-            ValueError: Every candidate either does not fit or collides.
-        """
-        target = np.dtype(dtype)
-        extremes: list[Any] = []
-        if np.issubdtype(target, np.integer):
-            info = np.iinfo(target)
-            # Signed: `min` is the conventional sentinel and far from any real
-            # measurement. Unsigned: `min` is 0 -- the likeliest value for a
-            # future write, a mosaic fill or a legitimate observation to take,
-            # and declaring it no-data would turn every later zero into a gap.
-            # 255 / 65535 is also what the package's own band fallback picks.
-            extremes = [info.min, info.max] if info.min < 0 else [info.max, info.min]
-        chosen = None
-        for candidate in [*candidates, DEFAULT_NO_DATA_VALUE, *extremes]:
-            if _fits_dtype(candidate, target) and not cls._occurs_in(values, candidate):
-                chosen = candidate
-                break
-        if chosen is None:
-            raise ValueError(
-                f"the {target.name} result of `func` leaves no free value to "
-                "mark the cells its operands masked out -- every candidate "
-                "sentinel occurs in the result; widen the result dtype, or pass "
-                "`no_data_value=None` to combine every cell unmasked"
-            )
-        return chosen
-
-    @staticmethod
-    def _occurs_in(values: Any, sentinel: Any) -> bool:
-        """Whether any computed value would read back as `sentinel`.
-
-        Args:
-            values: The values `func` computed.
-            sentinel: The candidate sentinel.
-
-        Returns:
-            bool: `True` when at least one value matches the sentinel under the
-            same tolerance a reader would apply.
-        """
-        array = np.asarray(values)
-        occurs = False
-        if array.size:
-            # Prefilter on the extremes before allocating a full boolean array:
-            # `_free_no_data` asks this once per candidate, so a 12-band stack
-            # is otherwise ~27 full-size allocations. A sentinel outside the
-            # result's range cannot occur in it, and the common candidates
-            # (-9999, a dtype extreme) usually are.
-            #
-            # `nanmin`/`nanmax`, and a finiteness check on the bounds: plain
-            # `min`/`max` propagate a `NaN`, and every comparison against `NaN`
-            # is False, so a single `NaN` anywhere in the result -- `0/0` in a
-            # normalised difference is enough -- made the prefilter answer "no
-            # collision" for every finite sentinel and silenced the warning.
-            with np.errstate(invalid="ignore"):
-                comparable = np.isfinite(np.asarray(sentinel, dtype="float64"))
-                low = np.nanmin(array) if array.size else np.nan
-                high = np.nanmax(array) if array.size else np.nan
-            in_range = not (
-                comparable and np.isfinite(low) and np.isfinite(high)
-            ) or bool(low <= sentinel <= high)
-            occurs = in_range and bool(is_stored_no_data(array, sentinel).any())
-        return occurs
 
     def fill(
         self, value: float | int, inplace: bool = False, path: str | Path | None = None

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -576,7 +576,9 @@ class Analysis(_Engine["Dataset"]):
                 * integer result that masked nothing — no sentinel at all;
                 * integer result that masked something — the first of the
                   operands' own sentinels, the package default, then the dtype's
-                  extremes that both fits and occurs nowhere in the result.
+                  extremes that both fits and occurs nowhere in the result --
+                  and, for the narrow integer widths, the rest of the range
+                  after those.
 
                 Pass an explicit value to choose it — it is honoured, with a
                 :class:`~pyramids.errors.NoDataCollisionWarning` if the result
@@ -979,7 +981,12 @@ class Analysis(_Engine["Dataset"]):
         * otherwise the first candidate that fits the dtype and occurs nowhere
           in the result, searched through the operands' own sentinels, then the
           package default, then the dtype's extremes (max before min for an
-          unsigned dtype, whose min is the very usable `0`).
+          unsigned dtype, whose min is the very usable `0`). For the narrow
+          integer widths the search continues into the rest of the range rather
+          than refusing there, walking inward from the preferred extreme, so an
+          `int8` result holding every candidate is answered as long as any of
+          its 256 values is unused. `int32` and wider still refuse once the
+          candidates are gone.
 
         Args:
             requested: The caller's `no_data_value`, or `_DERIVE_NO_DATA` when

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -1027,9 +1027,9 @@ class Analysis(_Engine["Dataset"]):
                 raise ValueError(
                     f"the {np.dtype(dtype).name} result of `func` leaves no "
                     "free value to mark the cells its operands masked out -- "
-                    "every candidate sentinel occurs in the result; widen the "
-                    "result dtype, or pass `no_data_value=None` to combine "
-                    "every cell unmasked"
+                    "every candidate sentinel occurs in the result; pass "
+                    "`no_data_value=None` to combine every cell unmasked, or "
+                    "have `func` return a wider dtype"
                 )
         return sentinel
 

--- a/src/pyramids/dataset/engines/analysis.py
+++ b/src/pyramids/dataset/engines/analysis.py
@@ -1054,7 +1054,7 @@ class Analysis(_Engine["Dataset"]):
         Raises:
             ValueError: `requested` cannot be stored in `dtype`.
         """
-        if isinstance(requested, bool):
+        if isinstance(requested, (bool, np.bool_)):
             # `True` fits every numeric dtype as `1`, so it would silently become
             # a `1.0` sentinel. The operators already refuse a bool as the
             # additive identity; refusing it here keeps one rule.

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -1634,6 +1634,17 @@ class Bands(_Engine["Dataset"]):
         `_fallback_no_data` still substitutes, and deliberately: it runs when
         the caller *asked* for a sentinel that overflows the band, where
         picking a storable one is a repair rather than an invention.
+
+        Args:
+            i: Index of the band the value belongs to.
+            val: The requested sentinel, or `None` / `NaN` for none.
+
+        Returns:
+            Any: The value as a scalar of the band's dtype, or `val` unchanged
+            when it is `None` / `NaN`.
+
+        Raises:
+            OverflowError: `val` is a number the band's dtype cannot hold.
         """
         # if not None or np.nan
         if val is not None and not np.isnan(val):
@@ -1657,6 +1668,12 @@ class Bands(_Engine["Dataset"]):
         a sentinel the band cannot hold, so choosing a storable one honours the
         request. There, the caller asked for *no* sentinel, and inventing one
         answers a question nobody posed.
+
+        Args:
+            i: Index of the band whose dtype decides the substitute.
+
+        Returns:
+            Any: A sentinel storable in that band's dtype.
         """
         np_dtype = np.dtype(self._ds.numpy_dtype[i])
         # np.issubdtype narrows at runtime but isn't recognised by the numpy

--- a/src/pyramids/dataset/engines/bands.py
+++ b/src/pyramids/dataset/engines/bands.py
@@ -80,63 +80,6 @@ def _is_read_only_error(error: BaseException) -> bool:
     return _GDAL_READ_ONLY_MESSAGE in str(error)
 
 
-def _substitutes_dtype_max(dtype: Any) -> bool:
-    """True when an unstorable `None` / NaN sentinel becomes this dtype's maximum.
-
-    Every unsigned integer type except `uint8`. NaN cannot be stored in any of
-    them, so something has to stand in -- but *what* stands in is only safe
-    when it is a value the data is unlikely to contain, and for 8-bit imagery
-    255 is white. Fabricating it as a sentinel on a raster that declares none
-    makes every white pixel out-of-domain, and `resample` / `align` then hand
-    it to `gdal.ReprojectImage`, which rewrites the real 255s to 254 to keep
-    them distinguishable.
-
-    That is not a new rule. It is what the code did before this branch, by
-    accident: the test was `dtype.startswith("u")` and Byte's dtype string is
-    `"byte"`, so Byte fell through to the pass-through branch. Replacing the
-    string test with an honest dtype test was right -- string-sniffing a type
-    name is not a check -- but it silently swept Byte in with the rest.
-    Restoring the exclusion keeps the better mechanism and the older, safer
-    answer.
-
-    Whether `uint16` and friends should also stop fabricating a maximum is a
-    real question, and the same one this branch answered "no sentinel" to for
-    the netCDF fan-out and the Zarr writer. It is a change to no-data policy
-    rather than to duplication, so it is not made here.
-
-    Args:
-        dtype: The band's numpy dtype, or its name.
-
-    Returns:
-        bool: True when the dtype maximum is the right stand-in.
-
-    Examples:
-        - The wider unsigned types substitute their maximum:
-            ```python
-            >>> from pyramids.dataset.engines.bands import _substitutes_dtype_max
-            >>> _substitutes_dtype_max("uint16"), _substitutes_dtype_max("uint32")
-            (True, True)
-
-            ```
-        - Byte does not, because 255 is ordinary data:
-            ```python
-            >>> from pyramids.dataset.engines.bands import _substitutes_dtype_max
-            >>> _substitutes_dtype_max("uint8")
-            False
-
-            ```
-        - Nor does anything signed or floating:
-            ```python
-            >>> from pyramids.dataset.engines.bands import _substitutes_dtype_max
-            >>> _substitutes_dtype_max("int16"), _substitutes_dtype_max("float32")
-            (False, False)
-
-            ```
-    """
-    as_dtype = np.dtype(dtype)
-    return np.issubdtype(as_dtype, np.unsignedinteger) and as_dtype != np.uint8
-
-
 class Bands(_Engine["Dataset"]):
     """Mixin providing band metadata, attribute table, and color table operations."""
 
@@ -1668,43 +1611,52 @@ class Bands(_Engine["Dataset"]):
         """Coerce one band's no-data value to its dtype.
 
         Non-``None``/``NaN`` values cast to the band's numpy dtype (may raise
-        ``OverflowError`` when out of range); ``None``/``NaN`` on an unsigned band
-        uses the dtype max, and passes through unchanged otherwise.
+        ``OverflowError`` when out of range); ``None``/``NaN`` passes through
+        unchanged, whatever the dtype.
+
+        A `None` here means "this band declares no sentinel", and no dtype
+        fabricates one to stand in. An integer band cannot store `NaN`, so the
+        request is refused downstream with `NoDataValueError` rather than
+        answered with a number the band's real data may already hold: the
+        wider unsigned types used to substitute their maximum, which turned a
+        `uint16` DEM holding 65535 into a raster with no domain at all. Byte
+        was excluded from that substitution first, because 255 is white in
+        8-bit imagery and `align` rewrote every white pixel to 254; the same
+        argument holds for 65535 and 4294967295, only less often.
+
+        That makes one rule across the three writers: none of them answers an
+        unstorable request with a storable number. They still differ in how
+        they say so -- `NetCDF._storable_no_data` collapses it to `None`, since
+        a rebuilt variable declares one scalar, while this path and the Zarr
+        writer hand the request back unchanged. Either way the band ends up
+        with nothing that marks a cell, which is the answer that matters.
+
+        `_fallback_no_data` still substitutes, and deliberately: it runs when
+        the caller *asked* for a sentinel that overflows the band, where
+        picking a storable one is a repair rather than an invention.
         """
         # if not None or np.nan
         if val is not None and not np.isnan(val):
             # cast to the band dtype (raises OverflowError when out of range)
             result = self._ds.numpy_dtype[i](val)
-        elif _substitutes_dtype_max(self._ds.numpy_dtype[i]):
-            # None/np.nan on an unsigned band would misbehave -- NaN is not
-            # storable there -- so the dtype max stands in. Asked of the dtype
-            # rather than of `dtype[i].startswith("u")`, which was a string
-            # test on a name; but Byte is deliberately excluded, see
-            # `_substitutes_dtype_max`.
-            #
-            # `_fallback_no_data` below asks the same way, and the two must
-            # agree on the *type* as well as the value, since both flow into
-            # `Dataset.no_data_value` and out to GDAL. A Python `int` here and
-            # a numpy scalar there made the same answer read back as `(255,)`
-            # from one path and a numpy scalar from the other, which the `==`
-            # pinning their agreement cannot see.
-            # Cast for the same reason `_fallback_no_data` casts: the
-            # `np.issubdtype` above narrows at runtime but the numpy stubs do
-            # not follow it.
-            np_dtype = np.dtype(self._ds.numpy_dtype[i])
-            unsigned_dtype = cast("np.dtype[np.unsignedinteger]", np_dtype)
-            result = np_dtype.type(np.iinfo(unsigned_dtype).max)
         else:
-            # None/np.nan on any non-unsigned dtype: pass through unchanged.
+            # None/np.nan on any dtype: pass through unchanged. An integer band
+            # cannot hold it, and the write refuses rather than inventing one.
             result = val
         return result
 
     def _fallback_no_data(self, i: int) -> Any:
         """Pick a dtype-valid no-data sentinel when the requested value overflows.
 
-        The dtype max for unsigned ints (matching the None/NaN branch), the dtype
-        min for signed ints too small to hold the default, and the default for
-        floats (which can always represent it).
+        The dtype max for unsigned ints, the dtype min for signed ints too small
+        to hold the default, and the default for floats (which can always
+        represent it).
+
+        Substituting is right here and wrong in :meth:`_coerce_band_no_data`,
+        which no longer does it: this path runs because the caller *asked* for
+        a sentinel the band cannot hold, so choosing a storable one honours the
+        request. There, the caller asked for *no* sentinel, and inventing one
+        answers a question nobody posed.
         """
         np_dtype = np.dtype(self._ds.numpy_dtype[i])
         # np.issubdtype narrows at runtime but isn't recognised by the numpy
@@ -1743,9 +1695,8 @@ class Bands(_Engine["Dataset"]):
 
         Returns:
             list: A new list with each entry coerced to the
-            corresponding band's numpy dtype (or the dtype's max
-            for unsigned integer bands when the input is `None` /
-            `NaN`).
+            corresponding band's numpy dtype. `None` / `NaN` passes
+            through unchanged; no dtype fabricates a sentinel for it.
         """
         no_data_value = list(no_data_value)
         # convert the no_data_value based on the dtype of each raster band.

--- a/src/pyramids/dataset/engines/io.py
+++ b/src/pyramids/dataset/engines/io.py
@@ -477,6 +477,23 @@ def _stack_bands(
 
 
 class IO(_Engine["Dataset"]):
+    """Mixin providing array, file, streaming and overview IO for Dataset.
+
+    Owns the reads (`read_array`, `read_windows`, `get_tile`,
+    `get_block_arrangement`), the writes (`write_array`, `to_file`, `to_bytes`,
+    `to_raster`, `to_xyz`, `to_terrain_rgb`), the block-wise passes
+    (`stream_transform`, `stream_reduce`, `map_blocks`) and the overview family
+    (`overview_count`, `create_overviews`, `recreate_overviews`, `get_overview`,
+    `get_overview_dataset`, `read_overview_array`). `Dataset` exposes a
+    same-named facade for each, so `ds.read_array(...)` and
+    `ds.io.read_array(...)` are equivalent.
+
+    `read_array` returns the band's stored values and does not consult a GDAL
+    mask or alpha band, so a caller comparing it against something GDAL
+    computed -- band statistics, a warp -- is comparing two different views of
+    the raster.
+    """
+
     @under_gdal_env
     def read_array(
         self,

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1269,7 +1269,9 @@ class Spatial(_Engine["Dataset"]):
         )
         return dst_obj
 
-    def fill_gaps(self, mask, src_array: np.ndarray) -> np.typing.NDArray:
+    def fill_gaps(
+        self, mask, src_array: np.ndarray, fills: list | None = None
+    ) -> np.typing.NDArray:
         """Fill gaps in src_array using nearest neighbors where mask indicates valid cells.
 
         Args:
@@ -1277,10 +1279,20 @@ class Spatial(_Engine["Dataset"]):
                 Mask dataset or array used to determine valid cells.
             src_array (np.ndarray):
                 Source array whose gaps will be filled.
+            fills (list | None):
+                The value each band's absent cells actually hold. `crop`
+                resolves this before stamping it into `src_array`, and it is
+                not always the source's declaration -- a band that declares
+                `NaN` on an integer dtype, or nothing at all, holds a derived
+                value instead. Locating the gaps by the declaration would then
+                match nothing on an integer array and quietly fill none of
+                them. `None` falls back to the declaration, which is right for
+                every caller that has not written a fill of its own.
 
         Returns:
             np.ndarray: The source array with gaps filled where applicable.
         """
+        gap_value = self._ds.no_data_value[0] if fills is None else fills[0]
         # align function only equate the no of rows and columns only
         # match no_data_value inserts no_data_value in src raster to all places like mask
         # still places that has no_data_value in the src raster, but it is not no_data_value in the mask
@@ -1293,7 +1305,7 @@ class Spatial(_Engine["Dataset"]):
         mask_noval = mask.no_data_value[0]
 
         if isinstance(mask, RasterBase) and isinstance(self._ds, RasterBase):
-            src_no_data = is_no_data(src_array, self._ds.no_data_value[0])
+            src_no_data = is_no_data(src_array, gap_value)
             mask_no_data = is_no_data(mask_array, mask_noval)
             elem_src = src_array.size - np.count_nonzero(src_array[src_no_data])
             elem_mask = mask_array.size - np.count_nonzero(mask_array[mask_no_data])
@@ -1304,7 +1316,7 @@ class Spatial(_Engine["Dataset"]):
                 gap_rows, gap_cols = np.nonzero(src_no_data & ~mask_no_data)
                 src_array = Vectorize._nearest_neighbour(
                     src_array,
-                    self._ds.no_data_value[0],
+                    gap_value,
                     gap_rows.tolist(),
                     gap_cols.tolist(),
                 )
@@ -1421,9 +1433,9 @@ class Spatial(_Engine["Dataset"]):
             if fill is None:
                 raise NoDataValueError(
                     f"band {band + 1} is a {dtype.name} raster holding every "
-                    "candidate sentinel, so no value is free to mark the cells "
-                    "the mask excludes; declare a no-data value the band does "
-                    "not use before cropping, or store it in a wider dtype"
+                    "candidate sentinel, so no value is free to mark a cell as "
+                    "absent; declare a no-data value the band does not use "
+                    "before cropping, or store it in a wider dtype"
                 )
             # As a scalar of the band's own dtype, so a derived fill and a
             # declared one are the same kind of thing to every consumer.
@@ -1474,10 +1486,14 @@ class Spatial(_Engine["Dataset"]):
             return None
         try:
             minimum, maximum = raster_band.ComputeRasterMinMax(False)
-        except RuntimeError:
-            # GDAL declines to compute a range -- no valid cells to sample
-            # being the reachable case. Either way the question is unanswered
-            # here, and the caller reads the band instead.
+        except RuntimeError as error:
+            # Only the intended failure is answered quietly: a band with no
+            # valid cells has no range, and the caller reads instead. An I/O
+            # failure on a remote source, a corrupt block or a driver refusal
+            # would otherwise be turned into a silent full materialisation --
+            # the streaming behaviour lost for a reason nobody sees.
+            if "no valid pixels" not in str(error):
+                raise
             return None
         return next(
             (
@@ -1722,7 +1738,7 @@ class Spatial(_Engine["Dataset"]):
         self._apply_mask_nodata(src_array, mask_no_data, band_count, fills)
 
         if fill_gaps:
-            src_array = self.fill_gaps(mask, src_array)
+            src_array = self.fill_gaps(mask, src_array, fills)
 
         self._write_bands(dst_obj, src_array, band_count)
         return dst_obj

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -356,6 +356,21 @@ def _survives_a_c_double(value: Any) -> bool:
 
 
 class Spatial(_Engine["Dataset"]):
+    """Mixin providing CRS, resampling, alignment and cropping operations for Dataset.
+
+    Owns `set_crs`, `to_crs`, `warped_view`, `wrap_longitude`, `resample`,
+    `fill_gaps`, `same_grid`, `align` and `crop`. `Dataset` exposes a same-named
+    facade for each, so `ds.crop(...)` and `ds.spatial.crop(...)` are
+    equivalent.
+
+    `crop` is the **single owner of the crop fill policy**: a rectangular array
+    has no way to hold an absent cell, so the cells a mask excludes need a
+    number, and it is not always the source's declared sentinel. See
+    :meth:`_crop_fill_values` for how one is derived when the band declares
+    nothing storable, and :meth:`_derived_crop_fills` for why the cutline route
+    answers that question differently from the raster-mask one.
+    """
+
     def _get_crs(self) -> str:
         """Get coordinate reference system."""
         return str(self._ds.raster.GetProjection())

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1322,7 +1322,7 @@ class Spatial(_Engine["Dataset"]):
                     "the other raster coordinate system"
                 )
 
-    def _crop_fill_values(self, src_array: np.ndarray | None = None) -> list:
+    def _crop_fill_values(self) -> list:
         """The value each band writes into the cells a mask excludes.
 
         Cropping asks a different question from "what sentinel does this band
@@ -1350,14 +1350,9 @@ class Spatial(_Engine["Dataset"]):
         `int16` raster raised `TypeError` on the assignment.
 
         A band whose sentinel is storable costs nothing to resolve -- the
-        answer is that sentinel, and the data is never read. Only the band that
-        needs a derived fill pays for a read, and only when `src_array` is not
-        already to hand, so the tiled crop keeps its streaming behaviour for
-        every well-formed raster.
-
-        Args:
-            src_array: The source values, when the caller already holds them.
-                `None` reads only the bands that actually need deriving.
+        answer is that sentinel, and the data is never read. Only a band that
+        needs a derived fill pays for a read, and only that band, so the tiled
+        crop keeps its streaming behaviour for every well-formed raster.
 
         Returns:
             list: One fill value per band, each storable in that band's dtype.
@@ -1374,12 +1369,7 @@ class Spatial(_Engine["Dataset"]):
             if fits_dtype(value, dtype):
                 fills.append(self._ds.numpy_dtype[band](value))
                 continue
-            if src_array is None:
-                values = self._ds.read_array(band=band)
-            elif src_array.ndim == 3:
-                values = src_array[band]
-            else:
-                values = src_array
+            values = self._ds.read_array(band=band)
             # `NaN` first: it is the conventional "absent" for a floating
             # band and the value this path already wrote there, so a float
             # crop is unchanged. An integer dtype cannot hold it, so those
@@ -1422,13 +1412,16 @@ class Spatial(_Engine["Dataset"]):
             list | None: One fill per band, or `None` when none is needed.
         """
         declared = self._ds.no_data_value
-        needed = any(
-            declared[band] is not None
-            and not fits_dtype(declared[band], np.dtype(self._ds.numpy_dtype[band]))
+        # Asked of the *declaration*, not of the resolved fills:
+        # `_crop_fill_values` derives for an undeclared band too, so a check on
+        # what it returns can never see one and a mixed raster would have been
+        # stamped after all.
+        undeclared = any(declared[band] is None for band in range(self._ds.band_count))
+        needed = not undeclared and any(
+            not fits_dtype(declared[band], np.dtype(self._ds.numpy_dtype[band]))
             for band in range(self._ds.band_count)
         )
-        fills = self._crop_fill_values() if needed else None
-        return None if fills is not None and None in fills else fills
+        return self._crop_fill_values() if needed else None
 
     @staticmethod
     def _warp_nodata(fills: list) -> str:
@@ -1467,8 +1460,8 @@ class Spatial(_Engine["Dataset"]):
         """Write the per-band fill value into the masked cells.
 
         `no_data_value` is resolved by the caller rather than here, so the
-        tiled crop pays for it once instead of on every tile and both crop
-        paths write the value the output declares. See
+        tiled crop pays for it once instead of on every tile and both arms of
+        the aligned crop write the value the output declares. See
         :meth:`_crop_fill_values` for why the fill is not simply the band's
         declared sentinel.
 

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -2889,19 +2889,30 @@ class Spatial(_Engine["Dataset"]):
         Note:
             **The result declares the value its excluded cells hold, which is not
             always the source's.** A band whose own sentinel is storable keeps it and
-            nothing changes. A band whose sentinel cannot be stored (`NaN` on an
-            integer band), or which declares none at all, has one derived against its
-            own data -- the first value that fits the dtype and occurs nowhere in the
-            band -- written into the excluded cells and declared on the output, so
-            they cannot be read back as measurements. A floating band always gets
-            `NaN`.
+            nothing changes. A band whose sentinel cannot be stored -- `NaN` on an
+            integer band -- has one derived against its own data: the first value that
+            fits the dtype and occurs nowhere in the band, written into the excluded
+            cells and declared on the output, so they cannot be read back as
+            measurements. A floating band always gets `NaN`.
 
-            The `bbox=` windowed fast path is the exception: it reads a pixel
-            rectangle and excludes no cell inside it, so it writes no fill and leaves
-            the source's declaration alone. The same box falling back to the cutline
-            warp *does* exclude cells, and declares what it wrote -- so the two routes
-            can report different `no_data_value` for one source, and only for a band
-            whose sentinel was unstorable to begin with.
+            A band that declares **nothing** depends on which mask is used, because
+            the two routes are forced to decide different things:
+
+            - a raster ``mask`` writes the excluded cells itself, into an array with
+              no way to hold "absent", so it derives a fill and declares it;
+            - a polygon / ``FeatureCollection`` mask lets GDAL fill them, so nothing
+              forces the question and the source's own declaration -- none -- stands.
+
+            The ``bbox=`` windowed fast path excludes no cell inside the rectangle it
+            reads, so it writes no fill and declares nothing new. The same box falling
+            back to the cutline warp *does* exclude cells; two routes to one region can
+            therefore report a different ``no_data_value``, for a band whose sentinel
+            was unstorable to begin with.
+
+            `Int64` and `UInt64` are a further exception on the cutline route.
+            ``-dstnodata`` reaches GDAL as a C double, which a value beyond 2**53 does
+            not survive, so no fill is offered for one and the border is left
+            undeclared.
 
         Raises:
             NoDataValueError: A band holds every candidate sentinel, so no value is

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -17,7 +17,8 @@ from geopandas.geodataframe import GeoDataFrame
 from osgeo import gdal, osr
 from pyproj import Transformer
 
-from pyramids.base._domain import is_no_data
+from pyramids.base._domain import fits_dtype, free_no_data, is_no_data
+from pyramids.base._errors import NoDataValueError
 from pyramids.base._utils import DEFAULT_RESAMPLING, resolve_resampling
 from pyramids.base.crs import (
     crs_equal,
@@ -1321,28 +1322,167 @@ class Spatial(_Engine["Dataset"]):
                     "the other raster coordinate system"
                 )
 
+    def _crop_fill_values(self, src_array: np.ndarray | None = None) -> list:
+        """The value each band writes into the cells a mask excludes.
+
+        Cropping asks a different question from "what sentinel does this band
+        declare". The declaration may honestly be *none* -- an integer band
+        cannot store `NaN`, and nothing fabricates one on its behalf -- but a
+        rectangular array has no way to hold an absent cell, so the excluded
+        ones still need a number.
+
+        Where the band declares a storable sentinel, that is the number. Where
+        it declares one it cannot store (`NaN` on an integer band) or declares
+        none at all, one is derived **against the data**: the first candidate
+        that fits the dtype and occurs nowhere in the band, so no real
+        observation is reclassified as a gap. The caller then declares it on
+        the cropped output, which is what makes the fill honest rather than a
+        guess -- the result says which cells are absent instead of leaving a
+        bare `0` or a fabricated maximum indistinguishable from data.
+
+        Deriving for a band that declares *nothing* is not inventing a property
+        the data lacked: the crop is what makes those cells absent, so
+        recording it describes what the operation did. Before, this path leant
+        on the unsigned substitution -- `_check_no_data_value` turned the
+        band's `None` into 65535, wrote that into the excluded cells and then
+        declared `NaN`, so the cells read back as an ordinary measurement. Only
+        `uint16` and `uint32` even got that far; the same crop of a `uint8` or
+        `int16` raster raised `TypeError` on the assignment.
+
+        A band whose sentinel is storable costs nothing to resolve -- the
+        answer is that sentinel, and the data is never read. Only the band that
+        needs a derived fill pays for a read, and only when `src_array` is not
+        already to hand, so the tiled crop keeps its streaming behaviour for
+        every well-formed raster.
+
+        Args:
+            src_array: The source values, when the caller already holds them.
+                `None` reads only the bands that actually need deriving.
+
+        Returns:
+            list: One fill value per band, each storable in that band's dtype.
+
+        Raises:
+            NoDataValueError: A band holds every candidate sentinel, so nothing
+                is free to mark its absent cells with.
+        """
+        declared = self._ds.no_data_value
+        fills = []
+        for band in range(self._ds.band_count):
+            dtype = np.dtype(self._ds.numpy_dtype[band])
+            value = declared[band]
+            if fits_dtype(value, dtype):
+                fills.append(self._ds.numpy_dtype[band](value))
+                continue
+            if src_array is None:
+                values = self._ds.read_array(band=band)
+            elif src_array.ndim == 3:
+                values = src_array[band]
+            else:
+                values = src_array
+            # `NaN` first: it is the conventional "absent" for a floating
+            # band and the value this path already wrote there, so a float
+            # crop is unchanged. An integer dtype cannot hold it, so those
+            # fall through to the package default and the extremes.
+            fill = free_no_data(dtype, [np.nan], values)
+            if fill is None:
+                raise NoDataValueError(
+                    f"band {band + 1} is a {dtype.name} raster holding every "
+                    "candidate sentinel, so no value is free to mark the cells "
+                    "the mask excludes; widen the dtype, or declare a no-data "
+                    "value the band does not use before cropping"
+                )
+            # As a scalar of the band's own dtype, so a derived fill and a
+            # declared one are the same kind of thing to every consumer. The
+            # extremes arrive from `np.iinfo` as Python `int`s.
+            fills.append(self._ds.numpy_dtype[band](fill))
+        return fills
+
+    def _derived_crop_fills(self) -> list | None:
+        """The per-band fill, but only when the declared sentinel cannot serve.
+
+        `None` means the warp is left exactly as it was, and it covers two
+        cases. A band declaring something storable needs nothing: GDAL's own
+        source-to-destination no-data propagation already does the right thing.
+        A band declaring *nothing* is deliberately left alone too, and this is
+        where the cutline path parts company with the raster-mask one.
+
+        The difference is who writes the cells. :meth:`_crop_fill_values`
+        derives for an undeclared band because that path writes the excluded
+        cells itself and must put a number in them, so it can say truthfully
+        what it wrote. Here GDAL fills them, and stamping `-dstnodata` on a
+        raster whose file declares no no-data would put a sentinel on the
+        output that the source never had -- which the netCDF fan-out then
+        carries onto a rebuilt variable, the invention
+        `NetCDF._storable_no_data` exists to refuse. A mixed raster (one band
+        unstorable, another undeclared) is left alone for the same reason,
+        `-dstnodata` taking a value per band with no spelling for "none".
+
+        Returns:
+            list | None: One fill per band, or `None` when none is needed.
+        """
+        declared = self._ds.no_data_value
+        needed = any(
+            declared[band] is not None
+            and not fits_dtype(declared[band], np.dtype(self._ds.numpy_dtype[band]))
+            for band in range(self._ds.band_count)
+        )
+        fills = self._crop_fill_values() if needed else None
+        return None if fills is not None and None in fills else fills
+
+    @staticmethod
+    def _warp_nodata(fills: list) -> str:
+        """Render per-band fills for `gdal.WarpOptions(dstNodata=...)`.
+
+        The binding stringifies whatever it is given, so a Python list would
+        reach GDAL as `"[255, 255]"`. GDAL wants one value per band, separated
+        by spaces.
+
+        An integer fill is rendered as an integer rather than through `float`:
+        a `uint64` band's maximum has no exact `float64`, so the round trip
+        would hand GDAL a value one larger than the dtype can hold.
+
+        Args:
+            fills: One fill value per band.
+
+        Returns:
+            str: The `-dstnodata` argument.
+        """
+        rendered = []
+        for fill in fills:
+            if np.issubdtype(np.asarray(fill).dtype, np.integer):
+                rendered.append(str(int(fill)))
+            else:
+                value = float(fill)
+                rendered.append("nan" if np.isnan(value) else repr(value))
+        return " ".join(rendered)
+
     def _apply_mask_nodata(
         self,
         src_array: np.ndarray,
         mask_no_data: np.ndarray,
         band_count: int,
-        no_data_value: list | None = None,
+        no_data_value: list,
     ) -> None:
-        """Write the source no-data value into the masked cells (per band).
+        """Write the per-band fill value into the masked cells.
 
-        `no_data_value` may be a caller-precomputed, dtype-checked per-band list; the
-        tiled crop passes it so the coercion runs once instead of per tile. When
-        `None` the multi-band path validates it here as before.
+        `no_data_value` is resolved by the caller rather than here, so the
+        tiled crop pays for it once instead of on every tile and both crop
+        paths write the value the output declares. See
+        :meth:`_crop_fill_values` for why the fill is not simply the band's
+        declared sentinel.
+
+        Args:
+            src_array: The source values, modified in place.
+            mask_no_data: True where the mask excludes the cell.
+            band_count: Number of bands in the source raster.
+            no_data_value: One fill value per band.
         """
         if band_count > 1:
-            # check the no_data_value complies with the src dtype before writing it
-            # into cells (a band full of values may never use its no_data_value).
-            if no_data_value is None:
-                no_data_value = self._ds._check_no_data_value(self._ds.no_data_value)
             for band in range(self._ds.band_count):
                 src_array[band, mask_no_data] = no_data_value[band]
         else:
-            src_array[mask_no_data] = self._ds.no_data_value[0]
+            src_array[mask_no_data] = no_data_value[0]
 
     def _write_bands(
         self, dst_obj: Any, src_array: np.ndarray, band_count: int
@@ -1414,8 +1554,12 @@ class Spatial(_Engine["Dataset"]):
             dst.SetProjection(src_sref.ExportToWkt())
 
         dst_obj = self._ds.__class__(dst)
-        # set the no data value
-        dst_obj._set_no_data_value(self._ds.no_data_value)
+        # The cropped output declares the value its masked cells actually hold,
+        # which is not always the source's: a band whose sentinel is unstorable
+        # (`NaN` on an integer band) has one derived against its data, and the
+        # result has to say so or those cells read back as ordinary numbers.
+        fills = self._crop_fill_values()
+        dst_obj._set_no_data_value(fills)
 
         # Apply the mask's no-data layout tile by tile for the raster-mask,
         # no-gap-fill case, so neither the full source (all bands) nor the full
@@ -1424,7 +1568,7 @@ class Spatial(_Engine["Dataset"]):
         # path. The numpy-array mask (already in memory) and the gap-filling
         # path (which interpolates across the whole array) stay eager below.
         if isinstance(mask, RasterBase) and not fill_gaps:
-            self._crop_aligned_tiled(mask, mask_noval, dst_obj, band_count)
+            self._crop_aligned_tiled(mask, mask_noval, dst_obj, band_count, fills)
             return dst_obj
 
         # read_array() is called with no chunks=, so it always returns a plain
@@ -1436,7 +1580,7 @@ class Spatial(_Engine["Dataset"]):
         src_array = cast(np.typing.NDArray, self._ds.read_array())
 
         mask_no_data = is_no_data(mask_array, mask_noval)
-        self._apply_mask_nodata(src_array, mask_no_data, band_count)
+        self._apply_mask_nodata(src_array, mask_no_data, band_count, fills)
 
         if fill_gaps:
             src_array = self.fill_gaps(mask, src_array)
@@ -1450,6 +1594,7 @@ class Spatial(_Engine["Dataset"]):
         mask_noval: int | float | None,
         dst_obj: Any,
         band_count: int,
+        fills: list,
     ) -> None:
         """Stamp the mask's no-data layout onto the source one window at a time.
 
@@ -1464,13 +1609,9 @@ class Spatial(_Engine["Dataset"]):
             mask_noval: The mask's no-data value used to locate masked cells.
             dst_obj: The destination Dataset the masked blocks are written into.
             band_count: Number of bands in the source raster.
+            fills: Per-band value to write into masked cells, resolved once by
+                the caller so it is neither re-derived nor re-checked per tile.
         """
-        # Coerce the per-band no-data value once here rather than on every tile.
-        no_data_value = (
-            self._ds._check_no_data_value(self._ds.no_data_value)
-            if band_count > 1
-            else None
-        )
         for xoff, yoff, xsize, ysize in self._ds.io._tile_offsets():
             window = [xoff, yoff, xsize, ysize]
             # read_array() is called with no chunks=, so it always returns a
@@ -1478,7 +1619,7 @@ class Spatial(_Engine["Dataset"]):
             mask_tile = cast(np.typing.NDArray, mask.read_array(band=0, window=window))
             src_tile = cast(np.typing.NDArray, self._ds.read_array(window=window))
             mask_no_data = is_no_data(mask_tile, mask_noval)
-            self._apply_mask_nodata(src_tile, mask_no_data, band_count, no_data_value)
+            self._apply_mask_nodata(src_tile, mask_no_data, band_count, fills)
             if band_count > 1:
                 for band in range(band_count):
                     dst_obj.raster.GetRasterBand(band + 1).WriteArray(
@@ -2227,6 +2368,14 @@ class Spatial(_Engine["Dataset"]):
         # from the source to the crop. cropToCutline already bounds the touch=False path.
         feature = self._cutline_in_source_crs(self._ds, feature)
         window = self._cutline_window_bounds(self._ds, feature) if touch else None
+        # The cells outside the cutline have to hold something, and GDAL's
+        # default is `0` -- indistinguishable from a real observation, and
+        # declared nowhere. A band whose own sentinel is storable keeps it
+        # (`fills` is then `None` and the warp is unchanged); one whose
+        # sentinel cannot be stored gets a value derived against its data, the
+        # same as the raster-mask crop, so `crop` answers the same way whichever
+        # mask it is given.
+        fills = self._derived_crop_fills()
         # Pin the resolution to the source's own so the windowed warp is a pixel-exact
         # subset and cannot resample; only needed when a window is set.
         gt = self._ds._raster.GetGeoTransform() if window else None
@@ -2252,6 +2401,7 @@ class Spatial(_Engine["Dataset"]):
                     if touch and cutline_all_touched
                     else None
                 ),
+                dstNodata=(None if fills is None else self._warp_nodata(fills)),
             )
             # `_base_dataset_class` already returns a `type[Dataset]`; the cast is for the
             # checker's benefit only.
@@ -2267,6 +2417,14 @@ class Spatial(_Engine["Dataset"]):
                     error_message="GDAL could not crop the dataset with the cutline.",
                 ),
             )
+            # `-dstnodata` already stamps the fill on the warp output's bands,
+            # and the output is a VRT that refuses a write, so the value is
+            # read back from there rather than set again. The trim below needs
+            # it: it finds the rows and columns lying entirely outside the
+            # cutline by reading the sentinel back, and with an unstorable one
+            # it matched nothing and trimmed nothing -- an integer raster kept
+            # a border of fill cells that the same crop of a float raster
+            # removed.
             if touch:
                 dst_obj = Spatial._correct_wrap_cutline_error(dst_obj)
 

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -2793,6 +2793,31 @@ class Spatial(_Engine["Dataset"]):
             fall back to the cutline warp, run all-touched so the result matches the
             windowed path; ``touch=False`` keeps the entirely-inside cutline crop.
 
+        Note:
+            **The result declares the value its excluded cells hold, which is not
+            always the source's.** A band whose own sentinel is storable keeps it and
+            nothing changes. A band whose sentinel cannot be stored (`NaN` on an
+            integer band), or which declares none at all, has one derived against its
+            own data -- the first value that fits the dtype and occurs nowhere in the
+            band -- written into the excluded cells and declared on the output, so
+            they cannot be read back as measurements. A floating band always gets
+            `NaN`.
+
+            The `bbox=` windowed fast path is the exception: it reads a pixel
+            rectangle and excludes no cell inside it, so it writes no fill and leaves
+            the source's declaration alone. The same box falling back to the cutline
+            warp *does* exclude cells, and declares what it wrote -- so the two routes
+            can report different `no_data_value` for one source, and only for a band
+            whose sentinel was unstorable to begin with.
+
+        Raises:
+            NoDataValueError: A band holds every candidate sentinel, so no value is
+                free to mark the cells the mask excludes. Note this does **not**
+                derive from ``ValueError``.
+            AlignmentError: A raster ``mask`` does not share the dataset's grid.
+            TypeError: ``mask`` is not a ``Dataset``, ``FeatureCollection`` or
+                ``GeoDataFrame``.
+
         Examples:
             - Crop the raster using a polygon mask.
 

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1399,8 +1399,8 @@ class Spatial(_Engine["Dataset"]):
                 raise NoDataValueError(
                     f"band {band + 1} is a {dtype.name} raster holding every "
                     "candidate sentinel, so no value is free to mark the cells "
-                    "the mask excludes; widen the dtype, or declare a no-data "
-                    "value the band does not use before cropping"
+                    "the mask excludes; declare a no-data value the band does "
+                    "not use before cropping, or store it in a wider dtype"
                 )
             # As a scalar of the band's own dtype, so a derived fill and a
             # declared one are the same kind of thing to every consumer.

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -17,7 +17,12 @@ from geopandas.geodataframe import GeoDataFrame
 from osgeo import gdal, osr
 from pyproj import Transformer
 
-from pyramids.base._domain import fits_dtype, free_no_data, is_no_data
+from pyramids.base._domain import (
+    fits_dtype,
+    free_no_data,
+    is_no_data,
+    is_stored_no_data,
+)
 from pyramids.base._errors import NoDataValueError
 from pyramids.base._utils import DEFAULT_RESAMPLING, resolve_resampling
 from pyramids.base.crs import (
@@ -2476,11 +2481,21 @@ class Spatial(_Engine["Dataset"]):
         """
         big_array = src.read_array()
         value_to_remove = src.no_data_value[0]
-        # `is_no_data`, not `==`: a NaN sentinel never equals itself, so `==` marks
-        # nothing and the all-no-data frame GDAL leaves after a cutline warp
-        # survives -- an oversized crop carrying a no-data border. The helper is
-        # already imported and used for exactly this three times in this module.
-        no_data_mask = is_no_data(big_array, value_to_remove)
+        # Not `==`: a NaN sentinel never equals itself, so `==` marks nothing
+        # and the all-no-data frame GDAL leaves after a cutline warp survives
+        # -- an oversized crop carrying a no-data border.
+        #
+        # `is_stored_no_data`, not `is_no_data`: this decides which rows and
+        # columns get *deleted*, which is exactly the "decides what a reader
+        # draws, counts or writes" case that predicate is documented for.
+        # `is_no_data`'s operational `rtol` of 0.001 deleted everything within
+        # a part per thousand of the sentinel -- and interior rows, not only
+        # the border -- so a `float32` band of `-9995` cropped against a
+        # `-9999` fill came back as a single cell. The sentinel is proved free
+        # of the band's values at storage tolerance, so that is the tolerance
+        # the consumer has to ask with, or it deletes data the search
+        # deliberately preserved.
+        no_data_mask = is_stored_no_data(big_array, value_to_remove)
         # Find rows and columns to be removed
         if big_array.ndim == 2:
             rows_to_remove = np.all(no_data_mask, axis=1)

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -348,10 +348,10 @@ def _survives_a_c_double(value: Any) -> bool:
     if isinstance(value, (float, np.floating)):
         survives = True
     else:
-        try:
-            survives = int(float(value)) == int(value)
-        except (OverflowError, ValueError):
-            survives = False
+        # No guard around the cast: every value reaching here is a fill, which
+        # `fits_dtype` has already established is a finite number of the band's
+        # own dtype, so the only question left is whether the double keeps it.
+        survives = int(float(value)) == int(value)
     return survives
 
 
@@ -1475,26 +1475,25 @@ class Spatial(_Engine["Dataset"]):
 
         Returns:
             Any: The first storable candidate outside the band's range, or
-            `None` when the range cannot be trusted (a mask or alpha band),
-            cannot be computed (no valid cells to sample), or contains every
-            candidate. In each of those the caller falls back to reading.
+            `None` when the range cannot be trusted (a mask or alpha band) or
+            contains every candidate. In both the caller falls back to reading.
+
+        Raises:
+            RuntimeError: GDAL could not read the band to compute its range.
         """
         raster_band = self._ds._raster.GetRasterBand(band + 1)
         if raster_band.GetMaskFlags() != gdal.GMF_ALL_VALID:
             # A mask or alpha band hides cells from GDAL that `read_array`
             # returns, so its range is not an answer about this band.
             return None
-        try:
-            minimum, maximum = raster_band.ComputeRasterMinMax(False)
-        except RuntimeError as error:
-            # Only the intended failure is answered quietly: a band with no
-            # valid cells has no range, and the caller reads instead. An I/O
-            # failure on a remote source, a corrupt block or a driver refusal
-            # would otherwise be turned into a silent full materialisation --
-            # the streaming behaviour lost for a reason nobody sees.
-            if "no valid pixels" not in str(error):
-                raise
-            return None
+        # No `try` around this. The one failure worth answering quietly -- a
+        # band with no valid cells to sample -- cannot happen past the mask
+        # check above, which only lets through bands where every cell is
+        # valid. What is left is an I/O failure on a remote source, a corrupt
+        # block or a driver refusal, and turning one of those into a silent
+        # full materialisation would lose the streaming behaviour for a reason
+        # nobody sees.
+        minimum, maximum = raster_band.ComputeRasterMinMax(False)
         return next(
             (
                 candidate

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -22,6 +22,7 @@ from pyramids.base._domain import (
     free_no_data,
     is_no_data,
     is_stored_no_data,
+    no_data_candidates,
 )
 from pyramids.base._errors import NoDataValueError
 from pyramids.base._utils import DEFAULT_RESAMPLING, resolve_resampling
@@ -1355,9 +1356,11 @@ class Spatial(_Engine["Dataset"]):
         `int16` raster raised `TypeError` on the assignment.
 
         A band whose sentinel is storable costs nothing to resolve -- the
-        answer is that sentinel, and the data is never read. Only a band that
-        needs a derived fill pays for a read, and only that band, so the tiled
-        crop keeps its streaming behaviour for every well-formed raster.
+        answer is that sentinel, and the data is never read. Nor is a floating
+        band, whose answer is always `NaN`. A band that needs a derived fill is
+        asked for its range first, which GDAL streams; only when every
+        candidate falls *inside* that range does the band have to be read, and
+        then only that band.
 
         Returns:
             list: One fill value per band, each storable in that band's dtype.
@@ -1385,8 +1388,11 @@ class Spatial(_Engine["Dataset"]):
                 # path wrote before the fill was derived at all.
                 fills.append(self._ds.numpy_dtype[band](np.nan))
                 continue
-            values = self._ds.read_array(band=band)
-            fill = free_no_data(dtype, [], values)
+            fill = self._fill_outside_the_band_range(band, dtype)
+            if fill is None:
+                # Every candidate lies inside the band's range, so which cells
+                # actually hold them can only be answered by looking.
+                fill = free_no_data(dtype, [], self._ds.read_array(band=band))
             if fill is None:
                 raise NoDataValueError(
                     f"band {band + 1} is a {dtype.name} raster holding every "
@@ -1399,6 +1405,45 @@ class Spatial(_Engine["Dataset"]):
             # extremes arrive from `np.iinfo` as Python `int`s.
             fills.append(self._ds.numpy_dtype[band](fill))
         return fills
+
+    def _fill_outside_the_band_range(self, band: int, dtype: np.dtype) -> Any:
+        """The first candidate sentinel the band's own range cannot contain.
+
+        A value below the band's minimum or above its maximum occurs nowhere in
+        it, and GDAL answers that from the band itself -- streaming it block by
+        block in C, with no Python array of the whole thing and no widening of
+        every cell to 8 bytes. The `uint8` DEM whose values stop at 7 gets its
+        `255` here, and never reads.
+
+        That matters most on the path this is called from. `_crop_aligned_tiled`
+        exists so neither the full source nor the full destination is held in
+        memory, and resolving the fill by materialising the band would have
+        undone it for exactly the large rasters it was written to protect.
+
+        Args:
+            band: Zero-based index of the band to resolve.
+            dtype: That band's numpy dtype.
+
+        Returns:
+            Any: The first storable candidate outside the band's range, or
+            `None` when every candidate falls inside it (or the range cannot be
+            computed, as for a band with no valid cells at all).
+        """
+        try:
+            minimum, maximum = self._ds._raster.GetRasterBand(
+                band + 1
+            ).ComputeRasterMinMax(False)
+        except RuntimeError:
+            # No valid cells to compute a range from; let the caller read.
+            return None
+        return next(
+            (
+                candidate
+                for candidate in no_data_candidates(dtype)
+                if not minimum <= candidate <= maximum
+            ),
+            None,
+        )
 
     def _derived_crop_fills(self) -> list | None:
         """The per-band fill, but only when the declared sentinel cannot serve.

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -332,6 +332,29 @@ def _stitch_lon_halves(ds: RasterBase, west_part: Any, east_part: Any) -> Datase
     return out
 
 
+def _survives_a_c_double(value: Any) -> bool:
+    """Whether `value` round-trips through the C double GDAL parses it into.
+
+    `gdal.WarpOptions(dstNodata=...)` takes text and parses it as a double, so
+    an integer beyond 2**53 reaches the warp as a different number. A float is
+    already one, and `NaN` is carried by name.
+
+    Args:
+        value: The candidate fill.
+
+    Returns:
+        bool: `True` when GDAL will receive exactly this value.
+    """
+    if isinstance(value, (float, np.floating)):
+        survives = True
+    else:
+        try:
+            survives = int(float(value)) == int(value)
+        except (OverflowError, ValueError):
+            survives = False
+    return survives
+
+
 class Spatial(_Engine["Dataset"]):
     def _get_crs(self) -> str:
         """Get coordinate reference system."""
@@ -1508,7 +1531,41 @@ class Spatial(_Engine["Dataset"]):
             not fits_dtype(declared[band], np.dtype(self._ds.numpy_dtype[band]))
             for band in range(self._ds.band_count)
         )
-        return self._crop_fill_values() if needed else None
+        fills = self._crop_fill_values() if needed else None
+        if fills is not None and not all(_survives_a_c_double(f) for f in fills):
+            # `-dstnodata` is text GDAL parses into a C double, and a 64-bit
+            # integer beyond 2**53 does not survive that: a `uint64` band's
+            # maximum arrives rounded to 2**63, which GDAL says out loud and
+            # then writes into the pixels. Declaring the value we asked for
+            # would describe cells that hold something else, so the warp is
+            # left alone instead -- an undeclared border, as before this
+            # branch, rather than a declaration that lies.
+            fills = None
+        return fills
+
+    @staticmethod
+    def _declare_fills(dst_obj: Any, fills: list) -> None:
+        """Record the fill on each band of a warp result, without writing cells.
+
+        `Bands._set_no_data_value` would also `Fill()` the band, which a warped
+        VRT refuses; only the declaration is wanted here, the pixels having
+        been written by the warp itself.
+
+        Args:
+            dst_obj: The warp result to declare the fills on.
+            fills: One fill value per band, in band order.
+        """
+        for index, fill in enumerate(fills):
+            band = dst_obj.raster.GetRasterBand(index + 1)
+            # The 64-bit integer types have their own accessors, and the plain
+            # one raises for them rather than falling back.
+            if band.DataType == gdal.GDT_Int64:
+                band.SetNoDataValueAsInt64(int(fill))
+            elif band.DataType == gdal.GDT_UInt64:
+                band.SetNoDataValueAsUInt64(int(fill))
+            else:
+                band.SetNoDataValue(float(fill))
+            dst_obj._no_data_value[index] = fill
 
     @staticmethod
     def _warp_nodata(fills: list) -> str:
@@ -1518,9 +1575,11 @@ class Spatial(_Engine["Dataset"]):
         reach GDAL as `"[255, 255]"`. GDAL wants one value per band, separated
         by spaces.
 
-        An integer fill is rendered as an integer rather than through `float`:
-        a `uint64` band's maximum has no exact `float64`, so the round trip
-        would hand GDAL a value one larger than the dtype can hold.
+        An integer fill is rendered as an integer rather than through `float`,
+        so nothing is lost on this side of the exchange. GDAL parses the text
+        back into a C double regardless, which is why a fill that cannot
+        survive that is filtered out before it reaches here -- rendering it
+        faithfully would not have saved it.
 
         Args:
             fills: One fill value per band.
@@ -2497,14 +2556,17 @@ class Spatial(_Engine["Dataset"]):
                     error_message="GDAL could not crop the dataset with the cutline.",
                 ),
             )
-            # `-dstnodata` already stamps the fill on the warp output's bands,
-            # and the output is a VRT that refuses a write, so the value is
-            # read back from there rather than set again. The trim below needs
-            # it: it finds the rows and columns lying entirely outside the
-            # cutline by reading the sentinel back, and with an unstorable one
-            # it matched nothing and trimmed nothing -- an integer raster kept
-            # a border of fill cells that the same crop of a float raster
-            # removed.
+            if fills is not None:
+                # Declared here rather than read back off the warp. GDAL does
+                # stamp `-dstnodata` on the output's bands for most widths, but
+                # an `Int64` / `UInt64` VRT reports no no-data at all through
+                # either accessor even with `<NoDataValue>` in its XML -- so
+                # those two came back declaring nothing, and the trim below,
+                # which finds the rows and columns lying entirely outside the
+                # cutline by reading the sentinel back, left the border in
+                # place. Setting it from what we asked for makes every width
+                # answer the same way.
+                self._declare_fills(dst_obj, fills)
             if touch:
                 dst_obj = Spatial._correct_wrap_cutline_error(dst_obj)
 

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1418,6 +1418,17 @@ class Spatial(_Engine["Dataset"]):
         every cell to 8 bytes. The `uint8` DEM whose values stop at 7 gets its
         `255` here, and never reads.
 
+        That equivalence holds only while GDAL and pyramids are looking at the
+        same cells. `ComputeRasterMinMax` skips whatever the band's mask marks
+        invalid, and `Dataset.read_array` ignores masks entirely, so on a
+        mask-banded or alpha-banded raster GDAL's range omits values the band
+        genuinely holds -- and the fill derived from it would be one of them,
+        which is the defect this whole path exists to avoid. The shortcut is
+        therefore taken only when the mask says every cell counts. A band with
+        an unstorable sentinel reports exactly that, since GDAL cannot register
+        a `NaN` no-data on an integer band, so the case this was written for
+        keeps its fast path.
+
         That matters most on the path this is called from. `_crop_aligned_tiled`
         exists so neither the full source nor the full destination is held in
         memory, and resolving the fill by materialising the band would have
@@ -1429,15 +1440,21 @@ class Spatial(_Engine["Dataset"]):
 
         Returns:
             Any: The first storable candidate outside the band's range, or
-            `None` when every candidate falls inside it (or the range cannot be
-            computed, as for a band with no valid cells at all).
+            `None` when the range cannot be trusted (a mask or alpha band),
+            cannot be computed (no valid cells to sample), or contains every
+            candidate. In each of those the caller falls back to reading.
         """
+        raster_band = self._ds._raster.GetRasterBand(band + 1)
+        if raster_band.GetMaskFlags() != gdal.GMF_ALL_VALID:
+            # A mask or alpha band hides cells from GDAL that `read_array`
+            # returns, so its range is not an answer about this band.
+            return None
         try:
-            minimum, maximum = self._ds._raster.GetRasterBand(
-                band + 1
-            ).ComputeRasterMinMax(False)
+            minimum, maximum = raster_band.ComputeRasterMinMax(False)
         except RuntimeError:
-            # No valid cells to compute a range from; let the caller read.
+            # GDAL declines to compute a range -- no valid cells to sample
+            # being the reachable case. Either way the question is unanswered
+            # here, and the caller reads the band instead.
             return None
         return next(
             (

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1348,12 +1348,14 @@ class Spatial(_Engine["Dataset"]):
 
         Deriving for a band that declares *nothing* is not inventing a property
         the data lacked: the crop is what makes those cells absent, so
-        recording it describes what the operation did. Before, this path leant
-        on the unsigned substitution -- `_check_no_data_value` turned the
-        band's `None` into 65535, wrote that into the excluded cells and then
-        declared `NaN`, so the cells read back as an ordinary measurement. Only
-        `uint16` and `uint32` even got that far; the same crop of a `uint8` or
-        `int16` raster raised `TypeError` on the assignment.
+        recording it describes what the operation did. What it replaces was
+        collide-or-crash. Only a *multi-band* `uint16` / `uint32` crop
+        completed at all, by leaning on the unsigned substitution:
+        `_check_no_data_value` turned the band's `None` into 65535, wrote it
+        into the excluded cells and declared it, putting every genuinely-65535
+        cell of the band out of domain -- the defect this issue is about. Every
+        other integer case, single- and multi-band alike, raised `TypeError` on
+        the assignment.
 
         A band whose sentinel is storable costs nothing to resolve -- the
         answer is that sentinel, and the data is never read. Nor is a floating

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -2617,7 +2617,7 @@ class Spatial(_Engine["Dataset"]):
             https://github.com/serapeum-org/pyramids/issues/74
         """
         big_array = src.read_array()
-        value_to_remove = src.no_data_value[0]
+        declared = src.no_data_value
         # Not `==`: a NaN sentinel never equals itself, so `==` marks nothing
         # and the all-no-data frame GDAL leaves after a cutline warp survives
         # -- an oversized crop carrying a no-data border.
@@ -2632,7 +2632,21 @@ class Spatial(_Engine["Dataset"]):
         # of the band's values at storage tolerance, so that is the tolerance
         # the consumer has to ask with, or it deletes data the search
         # deliberately preserved.
-        no_data_mask = is_stored_no_data(big_array, value_to_remove)
+        if big_array.ndim == 3:
+            # Per band, with each band's own sentinel. Asking band 0's of all
+            # of them was harmless while every band declared the same value,
+            # and stopped being so once a fill is derived per band: a raster
+            # whose second band declares `0` while its first declares `-9999`
+            # had its whole border judged against `-9999`, matched nothing in
+            # band 2, and was never trimmed at all.
+            no_data_mask = np.stack(
+                [
+                    is_stored_no_data(band_values, declared[index])
+                    for index, band_values in enumerate(big_array)
+                ]
+            )
+        else:
+            no_data_mask = is_stored_no_data(big_array, declared[0])
         # Find rows and columns to be removed
         if big_array.ndim == 2:
             rows_to_remove = np.all(no_data_mask, axis=1)

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1453,19 +1453,29 @@ class Spatial(_Engine["Dataset"]):
         `None` means the warp is left exactly as it was, and it covers two
         cases. A band declaring something storable needs nothing: GDAL's own
         source-to-destination no-data propagation already does the right thing.
-        A band declaring *nothing* is deliberately left alone too, and this is
-        where the cutline path parts company with the raster-mask one.
+        A band declaring *nothing* is left alone too, and that is where this
+        path parts company with the raster-mask one.
 
-        The difference is who writes the cells. :meth:`_crop_fill_values`
-        derives for an undeclared band because that path writes the excluded
-        cells itself and must put a number in them, so it can say truthfully
-        what it wrote. Here GDAL fills them, and stamping `-dstnodata` on a
-        raster whose file declares no no-data would put a sentinel on the
-        output that the source never had -- which the netCDF fan-out then
-        carries onto a rebuilt variable, the invention
-        `NetCDF._storable_no_data` exists to refuse. A mixed raster (one band
-        unstorable, another undeclared) is left alone for the same reason,
-        `-dstnodata` taking a value per band with no spelling for "none".
+        The difference is what each path is forced to decide.
+        :meth:`_crop_fill_values` writes the excluded cells itself, into a
+        numpy array that has no way to hold "absent", so it must put a number
+        there -- and having written one it declares it, because the alternative
+        is cells that read back as measurements. Here GDAL fills them, so
+        nothing forces the question, and the conservative answer is to leave
+        the source's own declaration alone.
+
+        What this is *not* is a guard for the netCDF fan-out. The fan-out
+        rebuilds a variable from whatever the crop declares
+        (`NetCDF._storable_no_data`), and it reads that from both paths alike
+        -- so a raster-mask crop of a variable whose file declares no no-data
+        already hands it a derived sentinel. Whether the two paths should be
+        made to agree, in which direction, is a question about that contract
+        rather than about this function; `tests/netcdf` pins what each does
+        today.
+
+        A mixed raster -- one band unstorable, another undeclared -- is left
+        alone as well, `-dstnodata` taking one value per band with no spelling
+        for "none".
 
         Returns:
             list | None: One fill per band, or `None` when none is needed.

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1403,8 +1403,9 @@ class Spatial(_Engine["Dataset"]):
                     "value the band does not use before cropping"
                 )
             # As a scalar of the band's own dtype, so a derived fill and a
-            # declared one are the same kind of thing to every consumer. The
-            # extremes arrive from `np.iinfo` as Python `int`s.
+            # declared one are the same kind of thing to every consumer.
+            # `free_no_data` answers in Python scalars whichever branch it
+            # takes, so every fill needs this and not just some.
             fills.append(self._ds.numpy_dtype[band](fill))
         return fills
 

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -1369,12 +1369,19 @@ class Spatial(_Engine["Dataset"]):
             if fits_dtype(value, dtype):
                 fills.append(self._ds.numpy_dtype[band](value))
                 continue
+            if np.issubdtype(dtype, np.floating):
+                # `NaN`, always, and without asking whether the band already
+                # holds one. A cell the crop excludes and a cell that was
+                # already `NaN` are both "no measurement", so a band carrying
+                # its own gaps is not a collision to route around -- treating
+                # it as one hands the band `-9999` instead and turns those
+                # pre-existing gaps into data. `Analysis._resolve_no_data`
+                # settles the floating case the same way, and it is what this
+                # path wrote before the fill was derived at all.
+                fills.append(self._ds.numpy_dtype[band](np.nan))
+                continue
             values = self._ds.read_array(band=band)
-            # `NaN` first: it is the conventional "absent" for a floating
-            # band and the value this path already wrote there, so a float
-            # crop is unchanged. An integer dtype cannot hold it, so those
-            # fall through to the package default and the extremes.
-            fill = free_no_data(dtype, [np.nan], values)
+            fill = free_no_data(dtype, [], values)
             if fill is None:
                 raise NoDataValueError(
                     f"band {band + 1} is a {dtype.name} raster holding every "

--- a/tests/base/test_free_no_data.py
+++ b/tests/base/test_free_no_data.py
@@ -12,6 +12,8 @@ engine, because `Spatial` resolves a crop's fill with the same three questions.
 
 from __future__ import annotations
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -162,14 +164,31 @@ class TestFreeNoData:
             A `uint8` band holding both `0` and `255` exhausts the preferred
             candidates, but 254 values remain unused. Refusing there would
             reject a crop that has an obvious correct answer -- and rasterio,
-            which writes a fixed `0`, would have collided with the data.
+            which writes a fixed `0`, would have collided with the data. The
+            answer comes off the top of the range, not the bottom: `crop`
+            declares it, and `1` is exactly the kind of value a later write
+            would use.
         """
         values = np.array([[0, 255], [0, 255]], dtype="uint8")
 
         chosen = free_no_data(np.dtype("uint8"), [], values)
 
-        assert chosen == 1
+        assert chosen == 254
         assert not occurs_in(values, chosen)
+
+    def test_a_signed_band_scans_from_its_minimum_inwards(self):
+        """The preferred extreme differs by signedness, and so does the scan.
+
+        Test scenario:
+            A signed band offers its minimum first, that being the
+            conventional sentinel and far from any real measurement, so the
+            scan walks up from there rather than down from the maximum.
+        """
+        values = np.array([-128, 127, 0], dtype="int8")
+
+        chosen = free_no_data(np.dtype("int8"), [], values)
+
+        assert chosen == -127
 
     def test_the_search_is_bounded_by_the_dtype_width(self):
         """A `uint16` range is 64 KiB of mask; wider types are not enumerated.
@@ -185,7 +204,7 @@ class TestFreeNoData:
         narrow = np.array([0, 1, 65535], dtype="uint16")
         wide = np.array([0, 1, 4294967295], dtype="uint32")
 
-        assert free_no_data(np.dtype("uint16"), [], narrow) == 2
+        assert free_no_data(np.dtype("uint16"), [], narrow) == 65534
         assert free_no_data(np.dtype("uint32"), [], wide) is None
 
     def test_it_reports_failure_as_none_rather_than_raising(self):
@@ -237,7 +256,7 @@ class TestTheSearchEdges:
 
         chosen = free_no_data(np.dtype("uint8"), [], values)
 
-        assert chosen == 1
+        assert chosen == 254
 
     def test_a_signed_band_scans_from_its_own_minimum(self):
         """The mask is offset by the dtype minimum, not by zero.
@@ -252,6 +271,23 @@ class TestTheSearchEdges:
 
         assert chosen not in set(values.tolist())
         assert np.iinfo("int8").min <= chosen <= np.iinfo("int8").max
+
+    def test_a_float_array_against_an_integer_target_does_not_warn(self):
+        """`NaN` has no integer to cast to, and numpy warns rather than raises.
+
+        Test scenario:
+            The scan indexes its mask with the values cast to `int64`. A float
+            array carrying `NaN` or an infinity produced
+            `RuntimeWarning: invalid value encountered in cast` and a garbage
+            index, so the non-finite cells are dropped before the cast.
+        """
+        values = np.array([0.0, 255.0, np.nan, np.inf])
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            chosen = free_no_data(np.dtype("uint8"), [], values)
+
+        assert chosen == 254
 
     def test_a_nan_candidate_is_taken_on_a_float_band(self):
         """`NaN` skips the range prefilter and is compared directly.

--- a/tests/base/test_free_no_data.py
+++ b/tests/base/test_free_no_data.py
@@ -208,3 +208,72 @@ class TestFreeNoData:
         chosen = free_no_data(np.dtype("float32"), [], np.array([1.0, 2.0]))
 
         assert chosen == DEFAULT_NO_DATA_VALUE
+
+
+class TestTheSearchEdges:
+    """Branches the ordinary crop and combine calls do not reach."""
+
+    def test_a_value_that_cannot_be_cast_does_not_fit(self):
+        """`fits_dtype` answers rather than propagating numpy's error.
+
+        Test scenario:
+            `astype` raises for a value numpy cannot interpret as the target
+            dtype. The question asked is "can this dtype hold it", and the
+            answer is no -- letting `ValueError` out would make every caller
+            wrap the call.
+        """
+        assert fits_dtype("not a number", np.dtype("int32")) is False
+
+    def test_values_outside_the_dtype_range_are_ignored_by_the_scan(self):
+        """The scan indexes a mask sized to the dtype, so it must bound first.
+
+        Test scenario:
+            The values need not share the band's dtype -- a caller may hand in
+            a wider array. `300` has no `uint8` slot, and indexing the mask
+            with it would raise or wrap onto a value the data does not hold.
+            It is dropped, and the answer still avoids the 0 and 255 present.
+        """
+        values = np.array([300, 0, 255], dtype="int16")
+
+        chosen = free_no_data(np.dtype("uint8"), [], values)
+
+        assert chosen == 1
+
+    def test_a_signed_band_scans_from_its_own_minimum(self):
+        """The mask is offset by the dtype minimum, not by zero.
+
+        Test scenario:
+            `int8` runs from -128, so a scan that assumed a zero-based range
+            would index negatively and silently answer from the wrong end.
+        """
+        values = np.array([-128, 127, 1], dtype="int8")
+
+        chosen = free_no_data(np.dtype("int8"), [], values)
+
+        assert chosen not in set(values.tolist())
+        assert np.iinfo("int8").min <= chosen <= np.iinfo("int8").max
+
+    def test_a_nan_candidate_is_taken_on_a_float_band(self):
+        """`NaN` skips the range prefilter and is compared directly.
+
+        Test scenario:
+            The crop offers `NaN` first for a band that declares nothing. It
+            is not finite, so `occurs_in` cannot use its min/max shortcut and
+            falls through to the element-wise test.
+        """
+        chosen = free_no_data(np.dtype("float32"), [np.nan], np.array([1.0, 2.0]))
+
+        assert np.isnan(chosen)
+
+    def test_a_nan_candidate_the_data_holds_is_skipped(self):
+        """A band already carrying `NaN` cannot use it to mark a gap.
+
+        Test scenario:
+            Those cells are indistinguishable from the ones the caller wants
+            marked, so the search moves on to the package default.
+        """
+        values = np.array([1.0, np.nan, 2.0], dtype="float32")
+
+        chosen = free_no_data(np.dtype("float32"), [np.nan], values)
+
+        assert chosen == DEFAULT_NO_DATA_VALUE

--- a/tests/base/test_free_no_data.py
+++ b/tests/base/test_free_no_data.py
@@ -1,0 +1,210 @@
+"""Picking a sentinel a band's data provably does not already hold.
+
+`free_no_data` is the one honest way to mark cells absent in a band that
+declares no storable sentinel. Inventing a number and hoping -- `0`, or the
+dtype's maximum -- reclassifies whatever real observation happens to sit on it,
+which is the defect that removing the unsigned substitution was about. Taking a
+value the data does not contain cannot do that.
+
+The helpers live in `pyramids.base._domain` rather than on the `Analysis`
+engine, because `Spatial` resolves a crop's fill with the same three questions.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pyramids.base._domain import (
+    DEFAULT_NO_DATA_VALUE,
+    fits_dtype,
+    free_no_data,
+    occurs_in,
+)
+
+pytestmark = pytest.mark.core
+
+
+class TestFitsDtype:
+    """Whether a dtype can hold a sentinel *as itself*."""
+
+    @pytest.mark.parametrize(
+        ("value", "dtype", "expected"),
+        [
+            (np.nan, "int32", False),
+            (np.nan, "float32", True),
+            (-9999, "int32", True),
+            (-9999, "uint8", False),
+            (-9999, "int8", False),
+            (255, "uint8", True),
+            (256, "uint8", False),
+            (1e40, "float32", False),
+            (None, "float64", False),
+        ],
+    )
+    def test_the_range_test(self, value, dtype: str, expected: bool):
+        """The cases that decide whether a sentinel is usable at all.
+
+        Args:
+            value: The candidate sentinel.
+            dtype: The band dtype name it would be stored in.
+            expected: Whether the dtype can represent it.
+
+        Test scenario:
+            A sentinel the dtype cannot represent would either mark real cells
+            -- `1e40` lands on `inf` in `float32` and would claim every
+            genuinely infinite cell -- or mark nothing at all. `None` is not a
+            sentinel, so it never fits.
+        """
+        assert fits_dtype(value, np.dtype(dtype)) is expected
+
+    def test_a_rounded_float_still_fits(self):
+        """Rounding is not a reason to reject a sentinel.
+
+        Test scenario:
+            `0.1` has no exact `float32`, but the value written and the value
+            compared against go through the same cast, so it still marks its
+            own cells. Rejecting it would push callers onto a wider dtype for
+            no gain.
+        """
+        assert fits_dtype(0.1, np.dtype("float32")) is True
+
+    def test_a_numpy_scalar_is_judged_like_its_python_value(self):
+        """`Dataset.no_data_value` hands back numpy scalars.
+
+        Test scenario:
+            Under NEP 50 a Python scalar is compared in the target dtype and a
+            numpy scalar in its own, so `0.1` fitted a `float32` band while the
+            byte-identical `np.float64(0.1)` did not -- and a caller forwarding
+            a sentinel between rasters was on the losing side.
+        """
+        assert fits_dtype(np.float64(0.1), np.dtype("float32")) is True
+
+
+class TestOccursIn:
+    """Whether any value would read back as the candidate sentinel."""
+
+    def test_a_value_the_band_holds_is_reported(self):
+        """Test scenario: the plain case the search depends on."""
+        assert occurs_in(np.array([1, 2, 255], dtype="uint8"), 255) is True
+
+    def test_a_value_outside_the_data_range_is_not(self):
+        """Test scenario: the prefilter's fast path must not misreport."""
+        assert occurs_in(np.array([1, 2, 3], dtype="uint8"), 255) is False
+
+    def test_an_empty_array_holds_nothing(self):
+        """Test scenario: a zero-size band leaves every candidate free."""
+        assert occurs_in(np.array([], dtype="float32"), 0) is False
+
+    def test_a_nan_in_the_data_does_not_hide_a_collision(self):
+        """The prefilter bug, pinned.
+
+        Test scenario:
+            Plain `min`/`max` propagate a `NaN`, and every comparison against
+            `NaN` is False, so a single `NaN` -- `0/0` in a normalised
+            difference is enough -- made the prefilter answer "no collision"
+            for every finite sentinel, and the search then handed back a value
+            the data actually held.
+        """
+        values = np.array([1.0, np.nan, -9999.0], dtype="float64")
+
+        assert occurs_in(values, -9999.0) is True
+
+
+class TestFreeNoData:
+    """The search itself: fits the dtype, and occurs nowhere in the data."""
+
+    def test_the_package_default_is_preferred(self):
+        """Test scenario: a signed band keeps the conventional sentinel."""
+        chosen = free_no_data(np.dtype("int32"), [], np.array([1, 2, 3]))
+
+        assert chosen == DEFAULT_NO_DATA_VALUE
+
+    def test_an_explicit_candidate_wins_over_the_default(self):
+        """Test scenario: callers can steer the choice without forcing it."""
+        chosen = free_no_data(np.dtype("int32"), [-1], np.array([1, 2, 3]))
+
+        assert chosen == -1
+
+    def test_a_candidate_the_data_holds_is_skipped(self):
+        """Test scenario: the whole point -- no real value is reclassified."""
+        chosen = free_no_data(
+            np.dtype("int32"), [-1], np.array([-1, 1, 2], dtype="int32")
+        )
+
+        assert chosen == DEFAULT_NO_DATA_VALUE
+
+    def test_an_unsigned_band_reaches_for_its_maximum_first(self):
+        """`0` is the likelier real observation, so it is tried last.
+
+        Test scenario:
+            `-9999` does not fit, so the extremes decide. For an unsigned band
+            `min` is `0` -- the value a future write, a mosaic fill or a
+            legitimate measurement is likeliest to take -- so the maximum is
+            offered first.
+        """
+        chosen = free_no_data(np.dtype("uint8"), [], np.array([1, 2, 3], "uint8"))
+
+        assert chosen == 255
+
+    def test_it_falls_to_the_minimum_when_the_maximum_is_taken(self):
+        """Test scenario: a band saturated at 255 still gets a free value."""
+        chosen = free_no_data(
+            np.dtype("uint8"), [], np.full((4, 4), 255, dtype="uint8")
+        )
+
+        assert chosen == 0
+
+    def test_a_narrow_band_searches_beyond_the_extremes(self):
+        """Both extremes taken is not a reason to give up on 256 values.
+
+        Test scenario:
+            A `uint8` band holding both `0` and `255` exhausts the preferred
+            candidates, but 254 values remain unused. Refusing there would
+            reject a crop that has an obvious correct answer -- and rasterio,
+            which writes a fixed `0`, would have collided with the data.
+        """
+        values = np.array([[0, 255], [0, 255]], dtype="uint8")
+
+        chosen = free_no_data(np.dtype("uint8"), [], values)
+
+        assert chosen == 1
+        assert not occurs_in(values, chosen)
+
+    def test_the_search_is_bounded_by_the_dtype_width(self):
+        """A `uint16` range is 64 KiB of mask; wider types are not enumerated.
+
+        Test scenario:
+            The bounded scan pays for itself on the narrow types a crop
+            actually reaches, so a `uint16` band holding both extremes still
+            gets an answer. A `uint32` band in the same position refuses
+            instead of allocating 4 GiB to prove what the candidates already
+            suggested -- a collision on all three is vanishingly unlikely
+            there, and the refusal names the fix.
+        """
+        narrow = np.array([0, 1, 65535], dtype="uint16")
+        wide = np.array([0, 1, 4294967295], dtype="uint32")
+
+        assert free_no_data(np.dtype("uint16"), [], narrow) == 2
+        assert free_no_data(np.dtype("uint32"), [], wide) is None
+
+    def test_it_reports_failure_as_none_rather_than_raising(self):
+        """The remedy belongs to the caller, so the helper only answers.
+
+        Test scenario:
+            A `uint8` band holding all 256 values has no sentinel available.
+            `combine` turns that into "pass `no_data_value=None`" and a crop
+            into "widen the dtype"; those are different advice, so the shared
+            search reports the fact and lets each caller phrase its own error.
+            `None` is unambiguous because it never fits a dtype, so it can
+            never be a successful answer.
+        """
+        values = np.arange(256, dtype="uint8")
+
+        assert free_no_data(np.dtype("uint8"), [], values) is None
+
+    def test_a_float_band_is_not_enumerated(self):
+        """Test scenario: floats have no extremes list, so the default decides."""
+        chosen = free_no_data(np.dtype("float32"), [], np.array([1.0, 2.0]))
+
+        assert chosen == DEFAULT_NO_DATA_VALUE

--- a/tests/dataset/analysis/test_combine.py
+++ b/tests/dataset/analysis/test_combine.py
@@ -708,16 +708,22 @@ class TestCombine:
         """When every candidate occurs in the result there is nothing to mark a gap with.
 
         Test scenario:
-            An int8 result holding both -128 and 127 exhausts the operands' sentinel, the
-            package default (which does not fit int8) and both dtype extremes, so
-            `combine` says so instead of picking a value the raster already uses.
+            The search does not stop at the operands' sentinel, the package default and
+            the dtype extremes -- for a narrow integer type it goes on to scan the rest
+            of the range, so a result merely holding -128 and 127 still has 254 values
+            to choose from. Refusing takes an int8 result that holds *all* 256, which is
+            the only state where no honest answer exists.
         """
-        # The three domain cells sum to 7 (the operands' sentinel), -128 and 127,
-        # so every candidate the search offers is already in the result.
-        left = np.array([[7, 1], [0, 1]], "int8")
-        right = np.array([[0, 6], [-128, 126]], "int8")
-        masked = Dataset.from_array(left, geo_ref=GEO_REF, no_data_value=7)
-        other = Dataset.from_array(right, geo_ref=GEO_REF, no_data_value=7)
+        # 257 cells over 256 distinct values: the duplicate is the one the mask
+        # excludes, so every int8 value survives in the result's domain.
+        values = np.concatenate(
+            [np.arange(-128, 128, dtype="int8"), np.array([-128], "int8")]
+        ).reshape(257, 1)
+        geo_ref = GeoReference(top_left_corner=(0, 257), cell_size=1, epsg=4326)
+        zeros = np.zeros((257, 1), "int8")
+        zeros[256, 0] = 1
+        masked = Dataset.from_array(values, geo_ref=geo_ref, no_data_value=None)
+        other = Dataset.from_array(zeros, geo_ref=geo_ref, no_data_value=1)
 
         with pytest.raises(ValueError, match="leaves no free value"):
             masked.combine(other, lambda a, b: (a + b).astype("int8"))

--- a/tests/dataset/collection/test_dataset_collection_unit.py
+++ b/tests/dataset/collection/test_dataset_collection_unit.py
@@ -1935,3 +1935,84 @@ class TestToCrsEager:
         monkeypatch.setattr(builtins, "__import__", fake_import)
         with pytest.raises(OptionalPackageDoesNotExist, match="lazy"):
             col.to_crs(3857, compute=False)
+
+
+class TestCroppedTimestepsAgreeOnOneSentinel:
+    """A stack is read through one no-data value, so its steps must share it."""
+
+    GEO = GeoReference(geo=(0.0, 1.0, 0.0, 4.0, 0.0, -1.0), epsg=4326)
+
+    def _stack(self) -> DatasetCollection:
+        """Two undeclared `int16` timesteps, the second holding a real -9999.
+
+        Returns:
+            DatasetCollection: The two-step stack.
+        """
+        first = np.arange(16, dtype="int16").reshape(4, 4)
+        second = np.arange(16, dtype="int16").reshape(4, 4)
+        second[3, 3] = -9999
+        steps = [
+            Dataset.from_array(values, geo_ref=self.GEO, no_data_value=None)
+            for values in (first, second)
+        ]
+        return DatasetCollection(steps[0], time_length=len(steps), datasets=steps)
+
+    def _mask(self) -> Dataset:
+        """A mask excluding the top-left cell.
+
+        Returns:
+            Dataset: The mask raster.
+        """
+        cells = np.ones((4, 4), dtype="int16")
+        cells[0, 0] = 0
+        return Dataset.from_array(cells, geo_ref=self.GEO, no_data_value=0)
+
+    def test_every_timestep_declares_the_same_value(self):
+        """The steps derive different fills, and are reconciled onto one.
+
+        Test scenario:
+            `crop` derives a fill against each raster's own values, so the
+            second step -- which already contains `-9999` -- gets `-32768`
+            while the first gets `-9999`. Read through the collection's single
+            declared sentinel, the second step's genuine `-9999` observation
+            became a gap and its actual fill became data.
+        """
+        cropped = self._stack().crop(self._mask())
+
+        declared = {step.no_data_value[0] for step in cropped.datasets}
+        assert len(declared) == 1, f"timesteps disagree: {declared}"
+        assert cropped.base.no_data_value[0] in declared
+
+    def test_the_real_observation_is_not_reclassified(self):
+        """The point of agreeing: no step's data becomes a gap.
+
+        Test scenario:
+            The agreed sentinel has to be free across every timestep, not just
+            the one it was derived from -- otherwise reconciling would simply
+            move the collision from one step to another.
+        """
+        cropped = self._stack().crop(self._mask())
+
+        agreed = cropped.datasets[0].no_data_value[0]
+        second = np.asarray(cropped.datasets[1].read_array())
+        assert (second == -9999).any(), "the real -9999 observation was overwritten"
+        assert agreed != -9999
+
+    def test_an_already_agreeing_stack_is_untouched(self):
+        """Nothing is paid where nothing needs reconciling.
+
+        Test scenario:
+            Every per-timestep operation that inherits its sentinel rather than
+            deriving one leaves the steps already agreeing, so the reconciler
+            must return before reading any band.
+        """
+        values = np.arange(16, dtype="float32").reshape(4, 4)
+        steps = [
+            Dataset.from_array(values.copy(), geo_ref=self.GEO, no_data_value=-9999.0)
+            for _ in range(2)
+        ]
+        stack = DatasetCollection(steps[0], time_length=2, datasets=steps)
+
+        cropped = stack.crop(self._mask())
+
+        assert {step.no_data_value[0] for step in cropped.datasets} == {-9999.0}

--- a/tests/dataset/collection/test_dataset_collection_unit.py
+++ b/tests/dataset/collection/test_dataset_collection_unit.py
@@ -25,10 +25,14 @@ import numpy as np
 import pytest
 from osgeo import gdal
 
-from pyramids.base._errors import AlignmentError, OptionalPackageDoesNotExist
+from pyramids.base._errors import (
+    AlignmentError,
+    NoDataValueError,
+    OptionalPackageDoesNotExist,
+)
 from pyramids.base.georeference import GeoReference
 from pyramids.dataset import Dataset, DatasetCollection
-from pyramids.dataset.collection import _target_epsg
+from pyramids.dataset.collection import _agree_on_one_sentinel, _target_epsg
 from tests.dataset.collection._helpers import make_int16_collection
 
 pytestmark = pytest.mark.core
@@ -2016,3 +2020,64 @@ class TestCroppedTimestepsAgreeOnOneSentinel:
         cropped = stack.crop(self._mask())
 
         assert {step.no_data_value[0] for step in cropped.datasets} == {-9999.0}
+
+    def test_a_single_step_stack_is_left_alone(self):
+        """Nothing to reconcile with fewer than two timesteps.
+
+        Test scenario:
+            The reconciler returns before reading anything, so a one-step
+            collection keeps whatever its single crop derived.
+        """
+        step = Dataset.from_array(
+            np.arange(16, dtype="int16").reshape(4, 4),
+            geo_ref=self.GEO,
+            no_data_value=None,
+        )
+        stack = DatasetCollection(step, time_length=1, datasets=[step])
+
+        cropped = stack.crop(self._mask())
+
+        assert cropped.datasets[0].no_data_value[0] == -9999
+
+    def test_a_stack_with_an_undeclared_step_is_left_alone(self):
+        """There is no fill to reconcile, and none to invent.
+
+        Test scenario:
+            A step declaring nothing has no sentinel cells to rewrite, and
+            imposing the other steps' value on it would put a sentinel on a
+            raster whose source never had one.
+        """
+        steps = [
+            Dataset.from_array(
+                np.arange(16, dtype="int16").reshape(4, 4),
+                geo_ref=self.GEO,
+                no_data_value=value,
+            )
+            for value in (-9999, None)
+        ]
+
+        _agree_on_one_sentinel(steps)
+
+        assert [step.no_data_value[0] for step in steps] == [-9999, None]
+
+    def test_a_stack_with_no_free_value_refuses(self):
+        """Better to say so than to pick a sentinel that collides.
+
+        Test scenario:
+            Two `int8` steps between them holding every value the dtype can
+            represent leave nothing free, so no single sentinel can mark a gap
+            without claiming one of their observations.
+        """
+        # Every value the dtype can represent, in both steps: each one's own
+        # sentinel is then a real observation in the other, so neither is free
+        # and the scan finds nothing left.
+        full = np.arange(-128, 128, dtype="int8").reshape(16, 16)
+        first, second = full, full.copy()
+        geo_ref = GeoReference(geo=(0.0, 1.0, 0.0, 16.0, 0.0, -1.0), epsg=4326)
+        steps = [
+            Dataset.from_array(values, geo_ref=geo_ref, no_data_value=sentinel)
+            for values, sentinel in ((first, -128), (second, 127))
+        ]
+
+        with pytest.raises(NoDataValueError, match="no value is free across"):
+            _agree_on_one_sentinel(steps)

--- a/tests/dataset/spatial/test_dataset_spatial.py
+++ b/tests/dataset/spatial/test_dataset_spatial.py
@@ -1908,6 +1908,37 @@ class TestCropFillValues:
         assert kept.shape == (4, 4), f"real data was trimmed away: {kept.shape}"
         assert int((kept == near_value).sum()) == 15
 
+    def test_a_fill_outside_the_band_range_costs_no_read(self, monkeypatch):
+        """The streaming crop must not materialise the band to pick a fill.
+
+        Args:
+            monkeypatch: pytest fixture, used to count `read_array` calls.
+
+        Test scenario:
+            `_crop_aligned_tiled` exists so neither the full source nor the
+            full destination is held in memory, and resolving the fill by
+            reading the band undid that for exactly the large rasters it
+            protects. A candidate below the band's minimum or above its maximum
+            occurs nowhere in it, and GDAL answers that from the band's own
+            streamed statistics -- so a `uint8` raster whose values stop at 7
+            gets its `255` without a single Python-side read.
+        """
+        values = np.full((8, 8), 7, dtype="uint8")
+        source = Dataset.from_array(values, geo_ref=self.GEO, no_data_value=None)
+        source.no_data_value = [np.nan]
+        calls = []
+        original = Dataset.read_array
+        monkeypatch.setattr(
+            Dataset,
+            "read_array",
+            lambda self, *a, **k: (calls.append(1), original(self, *a, **k))[1],
+        )
+
+        fills = source.spatial._crop_fill_values()
+
+        assert fills == [255]
+        assert calls == [], f"the band was read {len(calls)} times to pick a fill"
+
     def test_a_band_holding_every_candidate_refuses(self):
         """The honest failure, rather than a colliding fill.
 

--- a/tests/dataset/spatial/test_dataset_spatial.py
+++ b/tests/dataset/spatial/test_dataset_spatial.py
@@ -2034,6 +2034,51 @@ class TestCropFillValues:
         held = np.asarray(source.read_array(band=0))
         assert not (held == fill).any(), f"the fill {fill} is a value the band holds"
 
+    @pytest.mark.parametrize(
+        ("dtype", "declares", "shape"),
+        [
+            ("uint16", True, (4, 4)),
+            ("int32", True, (4, 4)),
+            ("int64", True, (4, 4)),
+            ("uint64", False, (6, 6)),
+        ],
+    )
+    def test_a_cutline_crop_across_the_integer_widths(
+        self, dtype: str, declares: bool, shape: tuple
+    ):
+        """The 64-bit widths do not behave like the rest, in two ways.
+
+        Args:
+            dtype: The source band dtype name.
+            declares: Whether the output should carry a sentinel.
+            shape: The expected trimmed shape.
+
+        Test scenario:
+            An `Int64` / `UInt64` warp result reports no no-data through either
+            accessor even with `<NoDataValue>` in its VRT XML, so reading the
+            value back left those widths declaring nothing and the border
+            untrimmed. It is set from what was asked for instead.
+
+            `uint64` is different again: its maximum cannot survive the C
+            double GDAL parses `-dstnodata` into, and arrives rounded to
+            `2**63`, which is what lands in the pixels. Declaring the value we
+            asked for would describe cells holding something else, so no fill
+            is offered and the border stays undeclared -- as it was before this
+            branch.
+        """
+        geo = GeoReference(geo=(0.0, 1.0, 0.0, 8.0, 0.0, -1.0), epsg=4326)
+        source = Dataset.from_array(
+            np.arange(64, dtype=dtype).reshape(8, 8), geo_ref=geo, no_data_value=None
+        )
+        source.no_data_value = [np.nan]
+        polygon = gpd.GeoDataFrame(geometry=[box(2.0, 2.0, 6.0, 6.0)], crs=4326)
+
+        cropped = source.crop(polygon)
+
+        assert np.asarray(cropped.read_array()).shape == shape
+        sentinel = cropped.no_data_value[0]
+        assert (sentinel is not None) is declares
+
     def test_a_band_holding_every_candidate_refuses(self):
         """The honest failure, rather than a colliding fill.
 

--- a/tests/dataset/spatial/test_dataset_spatial.py
+++ b/tests/dataset/spatial/test_dataset_spatial.py
@@ -1997,6 +1997,43 @@ class TestCropFillValues:
 
         assert source.spatial._fill_outside_the_band_range(0, np.dtype("uint8")) is None
 
+    @pytest.mark.parametrize("kind", ["mask band", "alpha band"])
+    def test_a_masked_band_is_not_resolved_from_gdals_range(self, kind: str):
+        """GDAL and `read_array` must be looking at the same cells.
+
+        Args:
+            kind: Which flavour of mask hides the value.
+
+        Test scenario:
+            `ComputeRasterMinMax` skips whatever the band's mask marks invalid
+            and `read_array` ignores masks entirely, so GDAL's range omits
+            values the band genuinely holds. Deriving a fill from it picked
+            `255` for a band whose hidden cell *is* `255`, and the crop then
+            declared a value two cells held -- the exact defect the derivation
+            exists to avoid. The shortcut is taken only when the mask says
+            every cell counts.
+        """
+        values = np.arange(100, dtype="uint8").reshape(10, 10) % 10
+        values[0, 0] = 255
+        bands = 1 if kind == "mask band" else 2
+        raster = gdal.GetDriverByName("MEM").Create("", 10, 10, bands, gdal.GDT_Byte)
+        raster.SetGeoTransform((0.0, 1.0, 0.0, 10.0, 0.0, -1.0))
+        raster.GetRasterBand(1).WriteArray(values)
+        hidden = np.full((10, 10), 255, dtype="uint8")
+        hidden[0, 0] = 0
+        if kind == "mask band":
+            raster.CreateMaskBand(gdal.GMF_PER_DATASET)
+            raster.GetRasterBand(1).GetMaskBand().WriteArray(hidden)
+        else:
+            raster.GetRasterBand(2).WriteArray(hidden)
+            raster.GetRasterBand(2).SetColorInterpretation(gdal.GCI_AlphaBand)
+        source = Dataset(raster)
+
+        fill = source.spatial._crop_fill_values()[0]
+
+        held = np.asarray(source.read_array(band=0))
+        assert not (held == fill).any(), f"the fill {fill} is a value the band holds"
+
     def test_a_band_holding_every_candidate_refuses(self):
         """The honest failure, rather than a colliding fill.
 

--- a/tests/dataset/spatial/test_dataset_spatial.py
+++ b/tests/dataset/spatial/test_dataset_spatial.py
@@ -1981,22 +1981,6 @@ class TestCropFillValues:
 
         assert source.spatial._fill_outside_the_band_range(0, np.dtype("uint8")) is None
 
-    def test_a_band_with_no_valid_cells_falls_back_to_reading(self):
-        """GDAL refuses to compute a range it has no pixels for.
-
-        Test scenario:
-            `ComputeRasterMinMax` raises `Failed to compute min/max, no valid
-            pixels found in sampling` when every cell is the band's declared
-            no-data. The cheap range test cannot answer there, and letting the
-            `RuntimeError` out would turn a resolvable crop into a crash, so it
-            reports "no answer" and the caller reads the band instead.
-        """
-        source = Dataset.from_array(
-            np.zeros((4, 4), dtype="uint8"), geo_ref=self.GEO, no_data_value=0
-        )
-
-        assert source.spatial._fill_outside_the_band_range(0, np.dtype("uint8")) is None
-
     @pytest.mark.parametrize("kind", ["mask band", "alpha band"])
     def test_a_masked_band_is_not_resolved_from_gdals_range(self, kind: str):
         """GDAL and `read_array` must be looking at the same cells.

--- a/tests/dataset/spatial/test_dataset_spatial.py
+++ b/tests/dataset/spatial/test_dataset_spatial.py
@@ -1965,6 +1965,38 @@ class TestCropFillValues:
 
         assert np.asarray(cropped.read_array()).shape == (3, 3)
 
+    def test_a_band_with_no_computable_range_falls_back_to_reading(self):
+        """GDAL refuses a range for a band with no valid pixels.
+
+        Test scenario:
+            `ComputeRasterMinMax` raises `Failed to compute min/max, no valid
+            pixels found in sampling` when every cell is the band's declared
+            no-data. The cheap range test cannot answer there, so it says so
+            and lets the caller fall back to reading the band rather than
+            letting a GDAL `RuntimeError` out of `crop`.
+        """
+        source = Dataset.from_array(
+            np.zeros((4, 4), dtype="uint8"), geo_ref=self.GEO, no_data_value=0
+        )
+
+        assert source.spatial._fill_outside_the_band_range(0, np.dtype("uint8")) is None
+
+    def test_a_band_with_no_valid_cells_falls_back_to_reading(self):
+        """GDAL refuses to compute a range it has no pixels for.
+
+        Test scenario:
+            `ComputeRasterMinMax` raises `Failed to compute min/max, no valid
+            pixels found in sampling` when every cell is the band's declared
+            no-data. The cheap range test cannot answer there, and letting the
+            `RuntimeError` out would turn a resolvable crop into a crash, so it
+            reports "no answer" and the caller reads the band instead.
+        """
+        source = Dataset.from_array(
+            np.zeros((4, 4), dtype="uint8"), geo_ref=self.GEO, no_data_value=0
+        )
+
+        assert source.spatial._fill_outside_the_band_range(0, np.dtype("uint8")) is None
+
     def test_a_band_holding_every_candidate_refuses(self):
         """The honest failure, rather than a colliding fill.
 

--- a/tests/dataset/spatial/test_dataset_spatial.py
+++ b/tests/dataset/spatial/test_dataset_spatial.py
@@ -1795,6 +1795,54 @@ class TestCropFillValues:
             f"a storable sentinel was invented for an undeclared band: {fill}"
         )
 
+    def test_a_mixed_raster_leaves_the_cutline_warp_alone(self):
+        """`-dstnodata` takes a value per band and cannot spell "none".
+
+        Test scenario:
+            One band declaring an unstorable sentinel and another declaring
+            nothing cannot be expressed in a single `-dstnodata`, and filling
+            the gap with a derived value for the undeclared band is the
+            invention the cutline path must not make. The warp is left exactly
+            as it was.
+        """
+        raster = gdal.GetDriverByName("MEM").Create("", 4, 4, 2, gdal.GDT_Byte)
+        raster.SetGeoTransform((0.0, 1.0, 0.0, 4.0, 0.0, -1.0))
+        raster.GetRasterBand(1).WriteArray(np.ones((4, 4), dtype="uint8"))
+        raster.GetRasterBand(2).WriteArray(np.ones((4, 4), dtype="uint8"))
+        # Band by band through GDAL: the `no_data_value` setter normalises the
+        # list, so a raster mixing a declared and an undeclared band -- which a
+        # file on disk can easily be -- cannot be built through it.
+        raster.GetRasterBand(1).SetNoDataValue(float("nan"))
+        source = Dataset(raster)
+        assert source.no_data_value[1] is None, "band 2 must declare nothing"
+
+        assert source.spatial._derived_crop_fills() is None
+
+    @pytest.mark.parametrize(
+        ("fills", "expected"),
+        [
+            ([np.uint8(255), np.uint8(0)], "255 0"),
+            ([np.float32("nan")], "nan"),
+            ([np.float32(1.5)], "1.5"),
+            ([np.uint64(2**64 - 1)], "18446744073709551615"),
+        ],
+    )
+    def test_the_warp_nodata_rendering(self, fills, expected: str):
+        """One value per band, and an integer rendered as an integer.
+
+        Args:
+            fills: The per-band fills to render.
+            expected: The `-dstnodata` argument GDAL should receive.
+
+        Test scenario:
+            The binding stringifies whatever it is handed, so a Python list
+            would arrive as `"[255, 0]"`. The `uint64` row is why integers do
+            not go through `float`: its maximum has no exact `float64`, and
+            the round trip would hand GDAL a value one larger than the dtype
+            can hold.
+        """
+        assert Spatial._warp_nodata(fills) == expected
+
     def test_a_band_holding_every_candidate_refuses(self):
         """The honest failure, rather than a colliding fill.
 

--- a/tests/dataset/spatial/test_dataset_spatial.py
+++ b/tests/dataset/spatial/test_dataset_spatial.py
@@ -13,6 +13,7 @@ from osgeo import gdal, osr
 from pyproj import CRS as PyprojCRS
 from shapely.geometry import Polygon, box
 
+from pyramids.base._errors import NoDataValueError
 from pyramids.base.georeference import GeoReference
 from pyramids.dataset import Dataset
 from pyramids.dataset.engines.spatial import Spatial
@@ -1568,3 +1569,247 @@ class TestCropBoundsTheReadToTheCrop:
         dataset = self._large_source()
         with pytest.raises(TypeError, match="FeatureCollection or GeoDataFrame"):
             dataset.spatial._crop_with_polygon_warp("not a feature", touch=True)
+
+
+class TestCropFillValues:
+    """What goes into the cells a crop excludes, when the band declares nothing.
+
+    A rectangular array has no way to hold an absent cell, so the excluded ones
+    need a number even when the band's honest answer to "what is your sentinel"
+    is *none*. Writing the declared sentinel is what used to happen, and it
+    failed two ways: an integer band declaring `NaN` raised
+    `ValueError: cannot convert float NaN to integer` outright, and a `uint16`
+    one only worked because the sentinel had been fabricated as 65535 upstream.
+
+    The fill is now derived against the band's own data and declared on the
+    output, so the result says which cells are absent rather than leaving a
+    number indistinguishable from a measurement.
+    """
+
+    GEO = GeoReference(geo=(0.0, 1.0, 0.0, 4.0, 0.0, -1.0), epsg=4326)
+
+    def _mask(self, dtype: str) -> Dataset:
+        """A 4x4 mask whose top-left cell is no-data.
+
+        Args:
+            dtype: The mask band dtype name.
+
+        Returns:
+            Dataset: A mask excluding exactly one cell.
+        """
+        values = np.ones((4, 4), dtype=dtype)
+        values[0, 0] = 0
+        return Dataset.from_array(values, geo_ref=self.GEO, no_data_value=0)
+
+    def _source(self, values: np.ndarray) -> Dataset:
+        """A raster that declares an unstorable `NaN` sentinel.
+
+        Args:
+            values: The band values, 2-D for one band or 3-D for several.
+
+        Returns:
+            Dataset: The source raster with `NaN` declared per band.
+        """
+        source = Dataset.from_array(values, geo_ref=self.GEO, no_data_value=None)
+        source.no_data_value = [np.nan] * source.band_count
+        return source
+
+    @pytest.mark.parametrize("dtype", ["uint8", "uint16", "int16", "float32"])
+    def test_a_single_band_crop_declares_the_fill_it_wrote(self, dtype: str):
+        """The output says which cells are absent, on every dtype.
+
+        Args:
+            dtype: The source band dtype name.
+
+        Test scenario:
+            The masked cell holds the output's own `no_data_value`, so a reader
+            can tell it from a measurement. `uint8` and `int16` raised before
+            this; `uint16` worked only via the removed substitution.
+        """
+        source = self._source(np.full((4, 4), 7, dtype=dtype))
+
+        cropped = source.crop(self._mask(dtype))
+
+        fill = cropped.no_data_value[0]
+        masked_cell = np.asarray(cropped.read_array())[0, 0]
+        assert masked_cell == fill or (np.isnan(fill) and np.isnan(masked_cell)), (
+            f"masked cell {masked_cell} is not the declared fill {fill}"
+        )
+
+    @pytest.mark.parametrize("dtype", ["uint8", "int16"])
+    def test_a_multi_band_crop_no_longer_raises(self, dtype: str):
+        """The crash, pinned as a pass.
+
+        Args:
+            dtype: An integer band dtype.
+
+        Test scenario:
+            The multi-band arm wrote the declared sentinel straight into an
+            integer array, so a band declaring `NaN` raised `ValueError:
+            cannot convert float NaN to integer` and cropping such a raster
+            was simply impossible.
+        """
+        source = self._source(np.full((2, 4, 4), 7, dtype=dtype))
+
+        cropped = source.crop(self._mask(dtype))
+
+        values = np.asarray(cropped.read_array())
+        assert values.shape[0] == 2
+        for band in range(2):
+            assert values[band][0, 0] == cropped.no_data_value[band]
+
+    def test_the_fill_avoids_a_value_the_band_holds(self):
+        """The reason the fill is derived rather than fixed.
+
+        Test scenario:
+            A `uint8` band saturated at 255 cannot take 255 as its fill without
+            marking every saturated cell absent -- the exact defect Byte was
+            excluded from the substitution for. rasterio's `mask()` writes a
+            fixed `0` here, which collides just as readily on a band that holds
+            zeros.
+        """
+        values = np.full((4, 4), 255, dtype="uint8")
+        source = self._source(values)
+
+        cropped = source.crop(self._mask("uint8"))
+
+        fill = cropped.no_data_value[0]
+        assert fill != 255
+        unmasked = np.asarray(cropped.read_array())[1:]
+        assert not (unmasked == fill).any(), "the fill collides with real data"
+
+    def test_a_band_with_a_storable_sentinel_keeps_it(self):
+        """Nothing is derived for a well-formed raster.
+
+        Test scenario:
+            The declared sentinel is storable, so it is the fill and the band's
+            values are never read to decide. This is the path every ordinary
+            crop takes, and it is unchanged.
+        """
+        values = np.full((4, 4), 7, dtype="int16")
+        source = Dataset.from_array(values, geo_ref=self.GEO, no_data_value=-32768)
+
+        cropped = source.crop(self._mask("int16"))
+
+        assert cropped.no_data_value[0] == -32768
+        assert np.asarray(cropped.read_array())[0, 0] == -32768
+
+    @pytest.mark.parametrize("dtype", ["uint8", "uint16", "int16", "float32"])
+    def test_a_polygon_crop_answers_the_same_way(self, dtype: str):
+        """`crop` should not depend on which kind of mask it was handed.
+
+        Args:
+            dtype: The source band dtype name.
+
+        Test scenario:
+            The cutline path warps rather than masking in memory, and GDAL's
+            default fill is `0` -- a real observation on most bands, declared
+            nowhere. The integer rasters therefore kept a border of fill cells
+            the trim could not recognise, while the float one, whose `NaN`
+            sentinel is storable, was trimmed to the polygon. All four now
+            agree, and each declares the value its border holds.
+        """
+        geo = GeoReference(geo=(0.0, 1.0, 0.0, 8.0, 0.0, -1.0), epsg=4326)
+        source = Dataset.from_array(
+            np.arange(64, dtype=dtype).reshape(8, 8), geo_ref=geo, no_data_value=None
+        )
+        source.no_data_value = [np.nan]
+        polygon = gpd.GeoDataFrame(geometry=[box(1.0, 1.0, 5.0, 5.0)], crs=4326)
+
+        cropped = source.crop(polygon)
+
+        values = np.asarray(cropped.read_array())
+        fill = cropped.no_data_value[0]
+        assert values.shape == (4, 4), f"{dtype} was not trimmed to the polygon"
+        assert values[0, 0] == 25, "the trim removed the wrong rows"
+        assert np.isnan(fill) or fill != 0, "the fill is GDAL's undeclared zero"
+
+    @pytest.mark.parametrize("dtype", ["uint8", "int16", "float32"])
+    def test_a_band_that_declares_nothing_gets_a_declared_fill(self, dtype: str):
+        """The crop is what makes those cells absent, so it records it.
+
+        Args:
+            dtype: The source band dtype name.
+
+        Test scenario:
+            Deriving here is not inventing a property the data lacked. Before,
+            this path leant on the unsigned substitution: `_check_no_data_value`
+            turned the band's `None` into 65535, wrote that into the excluded
+            cells and then declared `NaN`, so those cells read back as an
+            ordinary measurement -- and only `uint16` and `uint32` got that far,
+            the same crop of a `uint8` or `int16` raster raising `TypeError` on
+            the assignment.
+        """
+        source = Dataset.from_array(
+            np.full((4, 4), 7, dtype=dtype), geo_ref=self.GEO, no_data_value=None
+        )
+        assert source.no_data_value == (None,), "fixture must declare no sentinel"
+
+        cropped = source.crop(self._mask(dtype))
+
+        fill = cropped.no_data_value[0]
+        masked_cell = np.asarray(cropped.read_array())[0, 0]
+        assert fill is not None, "the excluded cells were written but not declared"
+        assert masked_cell == fill or (np.isnan(fill) and np.isnan(masked_cell)), (
+            f"masked cell {masked_cell} is not the declared fill {fill}"
+        )
+
+    def test_a_float_band_that_declares_nothing_still_gets_nan(self):
+        """`NaN` is offered first, so the floating case is untouched.
+
+        Test scenario:
+            A float band can store `NaN`, which is both the conventional
+            "absent" and what this path already wrote there. Deriving `-9999`
+            instead would have been a gratuitous change to a case that was
+            already right.
+        """
+        source = Dataset.from_array(
+            np.full((4, 4), 7.0, dtype="float32"), geo_ref=self.GEO, no_data_value=None
+        )
+
+        cropped = source.crop(self._mask("float32"))
+
+        assert np.isnan(cropped.no_data_value[0])
+
+    def test_a_polygon_crop_invents_nothing_for_an_undeclared_band(self):
+        """Where GDAL writes the cells, no sentinel is claimed for them.
+
+        Test scenario:
+            The cutline path parts company with the raster-mask one here, and
+            deliberately: it does not write the excluded cells itself, so
+            stamping `-dstnodata` would put a sentinel on the output that the
+            source never had. The netCDF fan-out rebuilds each variable from
+            what the crop declares, which is the invention
+            `NetCDF._storable_no_data` exists to refuse.
+        """
+        geo = GeoReference(geo=(0.0, 1.0, 0.0, 8.0, 0.0, -1.0), epsg=4326)
+        source = Dataset.from_array(
+            np.arange(64, dtype="uint8").reshape(8, 8), geo_ref=geo, no_data_value=None
+        )
+        polygon = gpd.GeoDataFrame(geometry=[box(1.0, 1.0, 5.0, 5.0)], crs=4326)
+
+        cropped = source.crop(polygon)
+
+        fill = cropped.no_data_value[0]
+        assert fill is None or np.isnan(fill), (
+            f"a storable sentinel was invented for an undeclared band: {fill}"
+        )
+
+    def test_a_band_holding_every_candidate_refuses(self):
+        """The honest failure, rather than a colliding fill.
+
+        Test scenario:
+            A `uint8` band covering all 256 values leaves nothing free to mark
+            the excluded cells with. Raising names the fix; writing a value
+            anyway would reclassify a real observation as a gap.
+        """
+        geo = GeoReference(geo=(0.0, 1.0, 0.0, 16.0, 0.0, -1.0), epsg=4326)
+        values = np.arange(256, dtype="uint8").reshape(16, 16)
+        source = Dataset.from_array(values, geo_ref=geo, no_data_value=None)
+        source.no_data_value = [np.nan]
+        mask_values = np.ones((16, 16), dtype="uint8")
+        mask_values[0, 0] = 0
+        mask = Dataset.from_array(mask_values, geo_ref=geo, no_data_value=0)
+
+        with pytest.raises(NoDataValueError, match="no value is free to mark"):
+            source.crop(mask)

--- a/tests/dataset/spatial/test_dataset_spatial.py
+++ b/tests/dataset/spatial/test_dataset_spatial.py
@@ -1938,6 +1938,33 @@ class TestCropFillValues:
         assert fills == [255]
         assert calls == [], f"the band was read {len(calls)} times to pick a fill"
 
+    @pytest.mark.parametrize("dtype", ["uint8", "int16", "float32"])
+    def test_fully_excluded_border_rows_are_trimmed(self, dtype: str):
+        """The output can be smaller than the mask's extent, on every dtype.
+
+        Args:
+            dtype: The source band dtype name.
+
+        Test scenario:
+            The trim that removes wholly-excluded rows and columns works by
+            reading the output's sentinel back, so it only ever fired for a
+            band whose sentinel was storable -- `float32` was trimmed this way
+            already, while the integer cases raised before reaching it. Now
+            that every band declares what its excluded cells hold, all three
+            agree, and callers will start depending on the shape.
+        """
+        cells = np.ones((4, 4), dtype=dtype)
+        cells[0, :] = 0
+        cells[:, 0] = 0
+        mask = Dataset.from_array(cells, geo_ref=self.GEO, no_data_value=0)
+        source = Dataset.from_array(
+            np.full((4, 4), 7, dtype=dtype), geo_ref=self.GEO, no_data_value=None
+        )
+
+        cropped = source.crop(mask)
+
+        assert np.asarray(cropped.read_array()).shape == (3, 3)
+
     def test_a_band_holding_every_candidate_refuses(self):
         """The honest failure, rather than a colliding fill.
 

--- a/tests/dataset/spatial/test_dataset_spatial.py
+++ b/tests/dataset/spatial/test_dataset_spatial.py
@@ -16,7 +16,7 @@ from shapely.geometry import Polygon, box
 from pyramids.base._errors import NoDataValueError
 from pyramids.base.georeference import GeoReference
 from pyramids.dataset import Dataset
-from pyramids.dataset.engines.spatial import Spatial
+from pyramids.dataset.engines.spatial import Spatial, _survives_a_c_double
 from pyramids.feature import FeatureCollection
 
 pytestmark = pytest.mark.core
@@ -1965,15 +1965,15 @@ class TestCropFillValues:
 
         assert np.asarray(cropped.read_array()).shape == (3, 3)
 
-    def test_a_band_with_no_computable_range_falls_back_to_reading(self):
-        """GDAL refuses a range for a band with no valid pixels.
+    def test_a_band_whose_every_cell_is_no_data_falls_back_to_reading(self):
+        """A declared sentinel means GDAL and `read_array` disagree already.
 
         Test scenario:
-            `ComputeRasterMinMax` raises `Failed to compute min/max, no valid
-            pixels found in sampling` when every cell is the band's declared
-            no-data. The cheap range test cannot answer there, so it says so
-            and lets the caller fall back to reading the band rather than
-            letting a GDAL `RuntimeError` out of `crop`.
+            The band's mask reports `NODATA` rather than `ALL_VALID`, so the
+            range is not consulted at all -- which is also what keeps
+            `ComputeRasterMinMax`'s "no valid pixels" refusal out of reach,
+            since every band that gets past the mask check has valid cells by
+            definition.
         """
         source = Dataset.from_array(
             np.zeros((4, 4), dtype="uint8"), geo_ref=self.GEO, no_data_value=0
@@ -2088,6 +2088,55 @@ class TestCropFillValues:
         cropped = source.crop(polygon)
 
         assert np.asarray(cropped.read_array()).shape == (2, 4, 4)
+
+    @pytest.mark.parametrize(
+        ("value", "survives"),
+        [
+            (-9999, True),
+            (0, True),
+            (np.int64(-(2**63)), True),
+            (np.uint64(2**64 - 1), False),
+            (np.int64(2**63 - 1), False),
+            (np.float32("nan"), True),
+            (1.5, True),
+        ],
+    )
+    def test_which_fills_survive_the_warp_channel(self, value, survives: bool):
+        """`-dstnodata` is text GDAL parses into a C double.
+
+        Args:
+            value: The candidate fill.
+            survives: Whether GDAL receives exactly this value.
+
+        Test scenario:
+            An integer beyond 2**53 reaches the warp as a different number, so
+            it is refused rather than declared. `-(2**63)` is a power of two
+            and survives; `2**63 - 1` and `2**64 - 1` do not. A float is
+            already a double, and `NaN` is carried by name.
+        """
+        assert _survives_a_c_double(value) is survives
+
+    def test_a_uint64_fill_the_channel_can_carry_is_declared(self):
+        """`UInt64` is refused for its maximum, not for its dtype.
+
+        Test scenario:
+            The candidates for an unsigned band are its maximum then its
+            minimum. A `uint64` band that already holds the maximum falls
+            through to `0`, which survives the C double exactly -- so the crop
+            declares it, through the accessor that dtype requires, and is
+            trimmed like any other width.
+        """
+        geo = GeoReference(geo=(0.0, 1.0, 0.0, 8.0, 0.0, -1.0), epsg=4326)
+        values = np.arange(1, 65, dtype="uint64").reshape(8, 8)
+        values[0, 0] = np.iinfo("uint64").max
+        source = Dataset.from_array(values, geo_ref=geo, no_data_value=None)
+        source.no_data_value = [np.nan]
+        polygon = gpd.GeoDataFrame(geometry=[box(2.0, 2.0, 6.0, 6.0)], crs=4326)
+
+        cropped = source.crop(polygon)
+
+        assert cropped.no_data_value[0] == 0
+        assert np.asarray(cropped.read_array()).shape == (4, 4)
 
     def test_a_band_holding_every_candidate_refuses(self):
         """The honest failure, rather than a colliding fill.

--- a/tests/dataset/spatial/test_dataset_spatial.py
+++ b/tests/dataset/spatial/test_dataset_spatial.py
@@ -2079,6 +2079,32 @@ class TestCropFillValues:
         sentinel = cropped.no_data_value[0]
         assert (sentinel is not None) is declares
 
+    def test_a_raster_with_per_band_sentinels_is_still_trimmed(self):
+        """The trim asks each band its own sentinel, not band 0's.
+
+        Test scenario:
+            Asking band 0's of every band was harmless while they all declared
+            the same value, and stopped being so once a fill is derived per
+            band. A raster whose second band declares `0` while its first is
+            handed `-9999` had its whole border judged against `-9999`, which
+            matched nothing in band 2, so the row was never wholly no-data and
+            nothing was trimmed -- 6x6 where a uniform raster gave 4x4.
+        """
+        raster = gdal.GetDriverByName("MEM").Create("", 8, 8, 2, gdal.GDT_Int16)
+        raster.SetGeoTransform((0.0, 1.0, 0.0, 8.0, 0.0, -1.0))
+        for band in (1, 2):
+            raster.GetRasterBand(band).WriteArray(
+                np.arange(64, dtype="int16").reshape(8, 8) + 1
+            )
+        raster.GetRasterBand(1).SetNoDataValue(float("nan"))
+        raster.GetRasterBand(2).SetNoDataValue(0.0)
+        source = Dataset(raster)
+        polygon = gpd.GeoDataFrame(geometry=[box(2.0, 2.0, 6.0, 6.0)], crs=4326)
+
+        cropped = source.crop(polygon)
+
+        assert np.asarray(cropped.read_array()).shape == (2, 4, 4)
+
     def test_a_band_holding_every_candidate_refuses(self):
         """The honest failure, rather than a colliding fill.
 

--- a/tests/dataset/spatial/test_dataset_spatial.py
+++ b/tests/dataset/spatial/test_dataset_spatial.py
@@ -1732,13 +1732,12 @@ class TestCropFillValues:
             dtype: The source band dtype name.
 
         Test scenario:
-            Deriving here is not inventing a property the data lacked. Before,
-            this path leant on the unsigned substitution: `_check_no_data_value`
-            turned the band's `None` into 65535, wrote that into the excluded
-            cells and then declared `NaN`, so those cells read back as an
-            ordinary measurement -- and only `uint16` and `uint32` got that far,
-            the same crop of a `uint8` or `int16` raster raising `TypeError` on
-            the assignment.
+            Deriving here is not inventing a property the data lacked, and what
+            it replaces was collide-or-crash. Only a *multi-band* `uint16` /
+            `uint32` crop completed: the unsigned substitution turned the
+            band's `None` into 65535, wrote it into the excluded cells and
+            declared it, putting every genuinely-65535 cell out of domain.
+            Every other integer case raised `TypeError` on the assignment.
         """
         source = Dataset.from_array(
             np.full((4, 4), 7, dtype=dtype), geo_ref=self.GEO, no_data_value=None

--- a/tests/dataset/spatial/test_dataset_spatial.py
+++ b/tests/dataset/spatial/test_dataset_spatial.py
@@ -1754,22 +1754,56 @@ class TestCropFillValues:
             f"masked cell {masked_cell} is not the declared fill {fill}"
         )
 
-    def test_a_float_band_that_declares_nothing_still_gets_nan(self):
-        """`NaN` is offered first, so the floating case is untouched.
+    @pytest.mark.parametrize(
+        "carries_its_own_gaps",
+        [False, True],
+        ids=["no NaN in the band", "a NaN already in the band"],
+    )
+    def test_a_float_band_that_declares_nothing_still_gets_nan(
+        self, carries_its_own_gaps: bool
+    ):
+        """`NaN`, whether or not the band already holds one.
+
+        Args:
+            carries_its_own_gaps: Whether the source already contains a `NaN`.
 
         Test scenario:
-            A float band can store `NaN`, which is both the conventional
-            "absent" and what this path already wrote there. Deriving `-9999`
-            instead would have been a gratuitous change to a case that was
-            already right.
+            A cell the crop excludes and a cell that was already `NaN` are
+            both "no measurement", so a band carrying its own gaps is not a
+            collision to route around. Treating it as one handed the band
+            `-9999` instead, which turned those pre-existing gaps into data on
+            the output -- and the earlier version of this test used a NaN-free
+            band, so it could not see that.
         """
-        source = Dataset.from_array(
-            np.full((4, 4), 7.0, dtype="float32"), geo_ref=self.GEO, no_data_value=None
-        )
+        values = np.full((4, 4), 7.0, dtype="float32")
+        if carries_its_own_gaps:
+            values[3, 3] = np.nan
+        source = Dataset.from_array(values, geo_ref=self.GEO, no_data_value=None)
 
         cropped = source.crop(self._mask("float32"))
 
         assert np.isnan(cropped.no_data_value[0])
+        assert np.isnan(np.asarray(cropped.read_array())[0, 0])
+
+    def test_a_float_band_holding_nan_and_the_default_still_crops(self):
+        """Two "taken" candidates used to exhaust the float search entirely.
+
+        Test scenario:
+            A raster carrying both `NaN` and a legacy `-9999` fill is an
+            ordinary artefact of a half-finished no-data conversion. Floating
+            dtypes have no extremes list and no bounded scan, so once both
+            candidates were ruled out the crop refused with `NoDataValueError`
+            -- a hard new failure where `main` succeeded.
+        """
+        values = np.full((4, 4), 5.0, dtype="float32")
+        values[3, 3] = np.nan
+        values[2, 2] = -9999.0
+        source = Dataset.from_array(values, geo_ref=self.GEO, no_data_value=None)
+
+        cropped = source.crop(self._mask("float32"))
+
+        assert np.isnan(cropped.no_data_value[0])
+        assert np.asarray(cropped.read_array()).shape == (4, 4)
 
     def test_a_polygon_crop_invents_nothing_for_an_undeclared_band(self):
         """Where GDAL writes the cells, no sentinel is claimed for them.

--- a/tests/dataset/spatial/test_dataset_spatial.py
+++ b/tests/dataset/spatial/test_dataset_spatial.py
@@ -1877,6 +1877,37 @@ class TestCropFillValues:
         """
         assert Spatial._warp_nodata(fills) == expected
 
+    @pytest.mark.parametrize(
+        ("dtype", "near_value"),
+        [("int16", -9995), ("float32", -9995.0)],
+        ids=["int16 four counts away", "float32 0.04% away"],
+    )
+    def test_data_near_the_fill_survives_the_trim(self, dtype: str, near_value):
+        """The fill is proved free at storage tolerance; the trim must agree.
+
+        Args:
+            dtype: The source band dtype name.
+            near_value: A real value close to, but not equal to, the fill.
+
+        Test scenario:
+            The trim that removes fully-excluded rows and columns asked with
+            `is_no_data`'s operational `rtol` of 0.001, while the search that
+            chose the fill proved it free at storage tolerance. Everything
+            within a part per thousand of `-9999` was therefore deleted --
+            interior rows included -- so a band of `-9995` came back as a
+            single cell, or raised "crop produced no valid pixels". Elevation,
+            depth and scaled-reflectance products sit in exactly that window.
+        """
+        values = np.full((4, 4), near_value, dtype=dtype)
+        values[0, 0] = 1
+        source = Dataset.from_array(values, geo_ref=self.GEO, no_data_value=None)
+
+        cropped = source.crop(self._mask(dtype))
+
+        kept = np.asarray(cropped.read_array())
+        assert kept.shape == (4, 4), f"real data was trimmed away: {kept.shape}"
+        assert int((kept == near_value).sum()) == 15
+
     def test_a_band_holding_every_candidate_refuses(self):
         """The honest failure, rather than a colliding fill.
 

--- a/tests/dataset/unit/test_dtype_strings_and_unsigned_nodata.py
+++ b/tests/dataset/unit/test_dtype_strings_and_unsigned_nodata.py
@@ -228,7 +228,8 @@ class TestChangeNoDataValueToAnUnstorableSentinel:
     """
 
     @pytest.mark.parametrize(
-        "numpy_dtype", [np.uint8, np.uint16, np.uint32, np.int16, np.int32]
+        "numpy_dtype",
+        [np.uint8, np.uint16, np.uint32, np.uint64, np.int16, np.int32, np.int64],
     )
     def test_an_integer_band_refuses_an_unstorable_sentinel(self, numpy_dtype):
         """The rule, across the integer types.
@@ -239,7 +240,10 @@ class TestChangeNoDataValueToAnUnstorableSentinel:
         Test scenario:
             `None` resolves to NaN, which no integer band can hold. Refusing
             says so; answering with the maximum invents a sentinel the caller
-            never asked for, at the value their data most likely uses.
+            never asked for, at the value their data most likely uses. The
+            64-bit widths are here because they are the ones whose extremes do
+            not survive a `float64` round trip, so they are likeliest to
+            diverge -- and `docs/migration.md` names `uint64` in its table.
         """
         dataset = _raster(numpy_dtype)
 

--- a/tests/dataset/unit/test_dtype_strings_and_unsigned_nodata.py
+++ b/tests/dataset/unit/test_dtype_strings_and_unsigned_nodata.py
@@ -6,16 +6,18 @@ complex codes collapsed onto numpy's two widths. The new strings are the
 correct ones (`uint8` is what the STAC `raster:bands.data_type` field wants),
 but the surface is public, so it is pinned here rather than left implicit.
 
-One consumer was branching on it. `_coerce_band_no_data` decided "is this band
-unsigned" with `dtype[i].startswith("u")`, which `"byte"` failed -- so the one
-unsigned type most rasters actually use took the signed pass-through branch and
-a `None` no-data was left unset instead of becoming the dtype max. It now asks
-the dtype, like `_fallback_no_data` beside it already did.
+One consumer used to branch on it. `_coerce_band_no_data` decided "is this band
+unsigned" with `dtype[i].startswith("u")`, which `"byte"` failed, and answered
+`None` with the dtype maximum for the ones that passed. Neither half survives:
+the string test was replaced by an honest dtype test, and then the substitution
+itself was removed. A `None` no-data now passes through on every dtype, because
+it is the caller saying this band declares no sentinel, and 65535 is as real a
+value in a `uint16` DEM as 255 is white in 8-bit imagery.
 
-Building the substituted sentinel as a numpy scalar rather than a Python `int`
-is what makes the two paths agree on type as well as value -- and it is visible
-on `Dataset.no_data_value`, which is why the last class here pins what a caller
-now reads back.
+The rest of the module pins what a caller reads back from that: an unstorable
+sentinel stays unstorable, `change_no_data_value` refuses rather than inventing
+one, and `_fallback_no_data` -- which repairs a sentinel the caller *asked* for
+-- keeps substituting, so the two are pinned as deliberately disagreeing.
 """
 
 from __future__ import annotations
@@ -24,6 +26,7 @@ import numpy as np
 import pytest
 from osgeo import gdal
 
+from pyramids.base._domain import DEFAULT_NO_DATA_VALUE
 from pyramids.base._errors import NoDataValueError
 from pyramids.base._utils import gdal_to_numpy_dtype
 from pyramids.dataset import Dataset, GeoReference
@@ -83,121 +86,94 @@ class TestTheReportedDtypeStrings:
         assert code == gdal.GDT_Byte
 
 
-class TestTheUnsignedNoDataDefault:
-    """`None` on an unsigned band means "use the dtype max"."""
+class TestTheUnsetSentinelPassesThrough:
+    """`None` means "this band declares no sentinel", on every dtype."""
 
     @pytest.mark.parametrize(
-        ("numpy_dtype", "expected"),
-        [
-            (np.uint16, 65535),
-            (np.uint32, 4294967295),
-        ],
+        "numpy_dtype",
+        [np.uint8, np.uint16, np.uint32, np.int16, np.int32, np.float32, np.float64],
     )
-    def test_an_unsigned_band_gets_its_dtype_max(self, numpy_dtype, expected):
-        """Byte is the case the string test missed.
+    def test_no_dtype_fabricates_a_sentinel(self, numpy_dtype):
+        """The one rule, checked across the width of the type table.
 
         Args:
-            numpy_dtype: An unsigned band dtype.
-            expected: The sentinel that dtype's maximum gives.
+            numpy_dtype: A band dtype, unsigned / signed / floating.
 
         Test scenario:
-            `None` cannot be stored in an unsigned band, so the intent has
-            always been to substitute the dtype's maximum. Deciding that from
-            the display string meant `uint8` -- reported as `byte` -- fell
-            through to the signed branch and kept `None`.
-        """
-        dataset = _raster(numpy_dtype)
-
-        assert dataset.bands._coerce_band_no_data(0, None) == expected
-
-    @pytest.mark.parametrize(
-        "numpy_dtype", [np.int16, np.int32, np.float32, np.float64]
-    )
-    def test_a_signed_or_float_band_passes_none_through(self, numpy_dtype):
-        """These can represent the absence, so nothing is substituted.
-
-        Args:
-            numpy_dtype: A signed or floating band dtype.
-
-        Test scenario:
-            Only the unsigned branch substitutes. Widening the test to "is it
-            an integer" would start stamping a sentinel on signed bands too.
+            The unsigned types wider than a byte used to answer `None` with
+            their own maximum. That put every genuinely-65535 cell of a
+            `uint16` raster out of domain, which is the same defect Byte was
+            excluded for. Parametrised across all three families so a future
+            "just the unsigned ones" special case fails here.
         """
         dataset = _raster(numpy_dtype)
 
         assert dataset.bands._coerce_band_no_data(0, None) is None
 
-    def test_it_agrees_with_the_overflow_fallback(self):
-        """Two places answer "is this unsigned"; they must not disagree.
+    @pytest.mark.parametrize(
+        ("numpy_dtype", "fallback"),
+        [(np.uint8, 255), (np.uint16, 65535), (np.uint32, 4294967295)],
+    )
+    def test_it_deliberately_disagrees_with_the_overflow_fallback(
+        self, numpy_dtype, fallback
+    ):
+        """Two paths, two questions; pinning that they answer differently.
+
+        Args:
+            numpy_dtype: An unsigned band dtype.
+            fallback: The sentinel the overflow repair picks for it.
 
         Test scenario:
-            `_fallback_no_data` picks a sentinel when the requested value
-            overflows and has always asked the dtype. Checked on `uint16`
-            rather than `uint8`, because the two deliberately *differ* on a
-            Byte band: `_fallback_no_data` substitutes 255 there (the caller
-            asked for a sentinel and it overflowed) while
-            `_coerce_band_no_data` does not (the caller asked for none, and
-            255 is white). The type is asserted too: both answers flow into
-            `Dataset.no_data_value` and out to GDAL, and `65535 ==
-            np.uint16(65535)` is True, so an `==` alone cannot see one path
-            returning a Python `int` and the other a numpy scalar.
+            `_fallback_no_data` fires when the caller asked for a sentinel the
+            band cannot hold, so substituting a storable one honours the
+            request. `_coerce_band_no_data(None)` fires when they asked for
+            none, where substituting answers a question nobody posed. The
+            disagreement used to hold for Byte alone; it now holds for every
+            unsigned width, and pinning it stops a tidy-up from making the two
+            agree again.
         """
-        # The dataset is bound to a name: the engine reaches its parent through
-        # a weakref proxy, so a temporary would be collected mid-test.
-        dataset = _raster(np.uint16)
-        bands = dataset.bands
-
-        coerced = bands._coerce_band_no_data(0, None)
-        fallback = bands._fallback_no_data(0)
-
-        assert coerced == fallback
-        assert type(coerced) is type(fallback), (
-            f"same value, different types: {type(coerced)} vs {type(fallback)}"
-        )
-        assert np.dtype(type(coerced)) == np.uint16
-
-    def test_a_byte_band_deliberately_disagrees(self):
-        """The one dtype where the two answers differ, and why.
-
-        Test scenario:
-            `_coerce_band_no_data(None)` means "the caller declared no
-            sentinel", and inventing 255 there marks every white pixel
-            missing. `_fallback_no_data` means "the caller's sentinel did not
-            fit", where substituting is what they asked for. Pinning the
-            disagreement stops a future tidy-up from making them agree again.
-        """
-        dataset = _raster(np.uint8)
+        dataset = _raster(numpy_dtype)
         bands = dataset.bands
 
         assert bands._coerce_band_no_data(0, None) is None
-        assert bands._fallback_no_data(0) == 255
+        assert bands._fallback_no_data(0) == fallback
+
+    def test_a_storable_sentinel_is_still_cast_to_the_band_dtype(self):
+        """Removing the substitution did not remove the coercion.
+
+        Test scenario:
+            The pass-through is only for `None` / `NaN`. A real value still
+            arrives as a numpy scalar of the band's own dtype, which is what
+            keeps the comparison against the band's values exact.
+        """
+        dataset = _raster(np.uint16)
+
+        coerced = dataset.bands._coerce_band_no_data(0, 4000)
+
+        assert coerced == 4000
+        assert np.dtype(type(coerced)) == np.uint16
 
 
 class TestTheSentinelOnThePublicProperty:
-    """The type change reaches `Dataset.no_data_value`, so it is pinned here.
+    """What a caller reads back from a band that cannot store its sentinel.
 
-    `_coerce_band_no_data` builds the substituted maximum as a numpy scalar of
-    the band dtype, for type parity with `_fallback_no_data`. GDAL's
-    `SetNoDataValue` takes a C double and refuses a numpy unsigned scalar, so
-    the value is retried as `float64` and that is what the property reports: a
-    uint16 band that read back `(65535,)` -- a Python `int` -- now reads back
-    `(np.float64(65535.0),)`. Same number, different type, and nothing warns.
-
-    Exercised on `uint16` rather than `uint8`: a Byte band does not substitute
-    at all, because 255 is white in 8-bit imagery and inventing it as a
-    sentinel marks every white pixel missing. See
-    `TestChangeNoDataValueOnAByteRaster`.
+    `Dataset.create(dtype="uint16", no_data_value=np.nan)` used to report
+    `(65535,)`: `NaN` is unstorable there, so the maximum stood in. It now
+    reports `(nan,)`, the same as a Byte or a signed band always did. The
+    consequence a downstream actually feels is the domain -- with 65535
+    declared, a band holding 65535 had those cells masked; with nothing
+    storable declared, they are data.
     """
 
     @staticmethod
-    def _unsigned_with_substituted_sentinel(dtype: str) -> Dataset:
-        """A raster whose no-data was substituted from the dtype maximum.
+    def _unsigned_asking_for_nan(dtype: str) -> Dataset:
+        """A raster whose requested `NaN` sentinel the band cannot store.
 
         Args:
             dtype: An unsigned band dtype name.
 
         Returns:
-            Dataset: A 4x4 raster whose requested `NaN` sentinel was replaced.
+            Dataset: A 4x4 raster created with `no_data_value=np.nan`.
         """
         return Dataset.create(
             rows=4,
@@ -208,41 +184,116 @@ class TestTheSentinelOnThePublicProperty:
             geo_ref=GEO,
         )
 
-    @pytest.mark.parametrize(
-        ("dtype", "expected"), [("uint16", 65535), ("uint32", 4294967295)]
-    )
-    def test_the_value_is_still_the_dtype_maximum(self, dtype: str, expected: int):
-        """Only the type changed; the number a caller compares against did not.
+    @pytest.mark.parametrize("dtype", ["uint16", "uint32"])
+    def test_the_unstorable_sentinel_is_reported_as_it_was_asked_for(self, dtype: str):
+        """No maximum is invented in its place.
 
         Args:
-            dtype: An unsigned band dtype name.
-            expected: That dtype's maximum.
+            dtype: An unsigned band dtype name wider than a byte.
 
         Test scenario:
-            Anything comparing with `==` is unaffected, which is why the change
-            is silent and why it is worth pinning rather than trusting.
+            Reporting the dtype maximum was a silent answer to a question the
+            caller did not ask, and it is the value their data is likeliest to
+            hold at saturation.
         """
-        (sentinel,) = self._unsigned_with_substituted_sentinel(dtype).no_data_value
+        (sentinel,) = self._unsigned_asking_for_nan(dtype).no_data_value
 
-        assert sentinel == expected
+        assert np.isnan(sentinel), f"expected NaN to pass through, got {sentinel!r}"
 
-    def test_it_is_a_numpy_scalar_rather_than_a_builtin(self):
-        """The part a downstream can trip over.
+    def test_the_dtype_maximum_stays_in_the_domain(self):
+        """The defect the substitution caused, stated as a cell count.
 
         Test scenario:
-            `json.dumps`, `%d` formatting and `is`-comparisons all behave
-            differently for a numpy scalar, and arithmetic on a numpy *integer*
-            scalar wraps at the dtype bound instead of promoting. Pinned so a
-            future change back to a builtin is a deliberate one.
+            A `uint16` band holding 65535 in half its cells has all of them as
+            data. Under the substitution those cells matched the fabricated
+            sentinel and `count_domain_cells` reported half as many, so a mean
+            or a histogram silently skipped the saturated end of the raster.
         """
-        (sentinel,) = self._unsigned_with_substituted_sentinel("uint16").no_data_value
+        values = np.full((4, 4), 65535, dtype=np.uint16)
+        values[:2] = 1
+        dataset = Dataset.from_array(values, geo_ref=GEO, no_data_value=np.nan)
 
-        assert isinstance(sentinel, np.generic), (
-            f"expected a numpy scalar, got {type(sentinel)}"
-        )
-        assert not isinstance(sentinel, int), (
-            f"expected the builtin int to be gone, got {type(sentinel)}"
-        )
+        assert dataset.count_domain_cells() == 16
+
+
+class TestChangeNoDataValueToAnUnstorableSentinel:
+    """Every integer band refuses; none of them invents a sentinel.
+
+    Byte and the signed types already refused. The wider unsigned types
+    succeeded and left their maximum behind -- 255 is white in 8-bit imagery
+    and 65535 is the saturated end of a `uint16` product, so the argument
+    against fabricating one is the same, only less often noticed. `align` then
+    hands the raster to `gdal.ReprojectImage`, which rewrites the real maxima
+    one lower to keep them distinguishable from the sentinel.
+    """
+
+    @pytest.mark.parametrize(
+        "numpy_dtype", [np.uint8, np.uint16, np.uint32, np.int16, np.int32]
+    )
+    def test_an_integer_band_refuses_an_unstorable_sentinel(self, numpy_dtype):
+        """The rule, across the integer types.
+
+        Args:
+            numpy_dtype: An integer band dtype.
+
+        Test scenario:
+            `None` resolves to NaN, which no integer band can hold. Refusing
+            says so; answering with the maximum invents a sentinel the caller
+            never asked for, at the value their data most likely uses.
+        """
+        dataset = _raster(numpy_dtype)
+
+        with pytest.raises(NoDataValueError):
+            dataset.change_no_data_value(None)
+
+    def test_a_float_band_still_accepts_it(self):
+        """The refusal is about storability, not about `None`.
+
+        Test scenario:
+            A floating band can represent the default sentinel, so nothing is
+            refused there. Pinning it keeps the refusal from widening into "no
+            band may resolve a `None`".
+        """
+        dataset = _raster(np.float32)
+
+        dataset.change_no_data_value(None)
+
+        assert dataset.no_data_value[0] == DEFAULT_NO_DATA_VALUE
+
+
+class TestTheOverflowFallbackIsUntouched:
+    """The repair path keeps substituting, and must not be swept up.
+
+    It runs when the caller *asked* for a sentinel that overflows the band --
+    the default `-9999` on a `uint8` raster is the common case -- where picking
+    a storable value is what they wanted. Removing the other substitution left
+    this one deliberately in place, so it is pinned separately.
+    """
+
+    @pytest.mark.parametrize(
+        ("numpy_dtype", "expected"),
+        [(np.uint8, 255), (np.uint16, 65535), (np.int8, -128)],
+    )
+    def test_it_substitutes_a_storable_sentinel(self, numpy_dtype, expected):
+        """Args: numpy_dtype: A band dtype too narrow for `-9999`.
+
+        Args:
+            numpy_dtype: A band dtype the default sentinel overflows.
+            expected: The storable sentinel picked in its place.
+
+        Test scenario:
+            Unsigned bands take their maximum, signed ones too narrow for the
+            default take their minimum. Unchanged by this branch.
+        """
+        dataset = _raster(numpy_dtype)
+
+        assert dataset.bands._fallback_no_data(0) == expected
+
+    def test_a_signed_band_that_fits_the_default_keeps_it(self):
+        """Test scenario: nothing is substituted when nothing overflows."""
+        dataset = _raster(np.int16)
+
+        assert dataset.bands._fallback_no_data(0) == DEFAULT_NO_DATA_VALUE
 
 
 class TestHalfPrecisionRasters:
@@ -302,124 +353,3 @@ class TestHalfPrecisionRasters:
 
         assert dataset.dtype == ["float16"]
         assert str(dataset)
-
-
-class TestChangeNoDataValueOnAByteRaster:
-    """A Byte band refuses an unstorable sentinel; it does not invent 255.
-
-    This class previously pinned the opposite, and was wrong to. Deciding "is
-    this band unsigned" from the dtype string missed `byte`, and replacing that
-    string test with `np.issubdtype` was right in mechanism -- but it swept Byte
-    in with the wider unsigned types, and Byte is the one where substituting the
-    maximum is wrong: 255 is white in 8-bit imagery, so declaring it as no-data
-    marks every white pixel missing, and `align` then hands it to
-    `gdal.ReprojectImage`, which rewrites the real 255s to 254.
-
-    Reported twice before it was fixed -- once as a should-fix ("shipping it
-    unannounced is what is not defensible") and again, at higher severity, once
-    the `ReprojectImage` consequence was measured.
-    """
-
-    def test_a_byte_band_refuses_an_unstorable_sentinel(self):
-        """The restored behaviour, matching every release before this branch.
-
-        Test scenario:
-            `None` resolves to NaN, which no integer band can hold. Refusing
-            says so; answering 255 invents a sentinel the caller never asked
-            for, at the value their imagery most likely uses for white.
-        """
-        dataset = _raster(np.uint8)
-
-        with pytest.raises(NoDataValueError):
-            dataset.change_no_data_value(None)
-
-    def test_a_signed_band_refuses_it_the_same_way(self):
-        """Byte is not a special case; it is the general one.
-
-        Test scenario:
-            `int16` has always refused. Byte refusing alongside it is the rule,
-            and the wider unsigned types substituting is the exception.
-        """
-        dataset = _raster(np.int16)
-
-        with pytest.raises(NoDataValueError):
-            dataset.change_no_data_value(None)
-
-    @pytest.mark.parametrize(
-        ("numpy_dtype", "expected"), [(np.uint16, 65535), (np.uint32, 4294967295)]
-    )
-    def test_the_wider_unsigned_types_are_unchanged(self, numpy_dtype, expected):
-        """Their behaviour predates this branch and is left alone.
-
-        Args:
-            numpy_dtype: An unsigned band dtype wider than a byte.
-            expected: The maximum it substitutes.
-
-        Test scenario:
-            Whether *they* should also stop fabricating a maximum is a real
-            question, and the same one this branch answered "no sentinel" to
-            for the netCDF fan-out and the Zarr writer. It is a change to
-            no-data policy rather than to duplication, so it is not made here
-            -- and this test is what says the decision was deliberate.
-        """
-        dataset = _raster(numpy_dtype)
-
-        dataset.change_no_data_value(None)
-
-        assert list(dataset.no_data_value) == [expected]
-
-
-class TestByteKeepsItsPassThrough:
-    """255 is white, not "missing", so it is not fabricated as a sentinel.
-
-    Replacing `dtype.startswith("u")` with an honest `np.issubdtype` test was
-    right -- string-sniffing a type name is not a check -- but it swept Byte in
-    with the wider unsigned types, and Byte is the one where the substitution
-    is wrong. A raster that declares *no* no-data was given 255, which makes
-    every white pixel out-of-domain; `align` then hands it to
-    `gdal.ReprojectImage`, which rewrites the real 255s to 254 to keep them
-    distinguishable from the sentinel.
-    """
-
-    def test_an_unset_sentinel_stays_unset_on_a_byte_band(self):
-        """The regression: `None` became 255.
-
-        Test scenario:
-            `None` means "this band has no no-data". Answering 255 invents one,
-            and invents it at the value 8-bit imagery uses for white.
-        """
-        dataset = _raster(np.uint8)
-
-        assert dataset.bands._coerce_band_no_data(0, None) is None
-
-    @pytest.mark.parametrize("dtype", [np.uint16, np.uint32])
-    def test_the_wider_unsigned_types_still_substitute(self, dtype):
-        """Args: dtype: An unsigned type wider than a byte.
-
-        Test scenario:
-            Their behaviour is unchanged from before this branch. Whether they
-            *should* substitute is a separate question about no-data policy;
-            this branch is about duplication and does not answer it.
-        """
-        dataset = _raster(dtype)
-
-        assert dataset.bands._coerce_band_no_data(0, None) == np.iinfo(dtype).max
-
-    def test_the_overflow_fallback_still_substitutes_for_a_byte(self):
-        """The other branch, which is reached for a different reason.
-
-        Test scenario:
-            `_fallback_no_data` fires when the caller *asked* for a sentinel
-            and it overflowed the band -- so substituting one is what they
-            wanted. `_coerce_band_no_data`'s `None` branch fires when they
-            asked for none. The two must not be conflated.
-        """
-        dataset = _raster(np.uint8)
-
-        assert dataset.bands._fallback_no_data(0) == 255
-
-    def test_a_signed_band_is_untouched(self):
-        """Test scenario: only unsigned types ever substituted; that holds."""
-        dataset = _raster(np.int16)
-
-        assert dataset.bands._coerce_band_no_data(0, None) is None

--- a/tests/netcdf/test_fanout_packing_carry.py
+++ b/tests/netcdf/test_fanout_packing_carry.py
@@ -24,6 +24,7 @@ import numpy as np
 import pytest
 from shapely.geometry import box
 
+from pyramids.dataset import Dataset, GeoReference
 from pyramids.netcdf import NetCDF
 
 pytestmark = pytest.mark.core
@@ -297,6 +298,34 @@ class TestTheFanOutInventsNoNoDataSentinel:
 
         assert set(cropped.no_data_value) == {None}, (
             f"a sentinel was invented: {set(cropped.no_data_value)}"
+        )
+
+    def test_a_raster_mask_crop_declares_the_fill_it_wrote(self):
+        """The other crop path, and it does not answer the same way.
+
+        Test scenario:
+            A polygon crop leaves an undeclared variable undeclared, because
+            GDAL fills the cells outside the cutline and nothing forces the
+            question. A raster-mask crop writes those cells itself, into an
+            array with no way to hold "absent", so it puts a derived value
+            there and declares it -- and the fan-out carries that onto the
+            rebuilt variable exactly as it carries anything else the crop
+            declares. Pinned because the divergence is real and easy to change
+            by accident in either direction.
+        """
+        container = NetCDF.read_file(str(INTEGER))
+        source = container.get_variable("air")
+        assert set(source.no_data_value) == {None}, "fixture must declare no no-data"
+        geo_ref = GeoReference(geo=source.geotransform, epsg=source.epsg)
+        cells = np.ones((source.rows, source.columns), dtype="uint8")
+        cells[0, 0] = 0
+        mask = Dataset.from_array(cells, geo_ref=geo_ref, no_data_value=0)
+
+        cropped = container.crop(mask).get_variable("air")
+
+        assert set(cropped.no_data_value) == {-9999.0}
+        assert set(source.crop(mask).no_data_value) == set(cropped.no_data_value), (
+            "the container route and the per-variable route must agree"
         )
 
     def test_the_data_itself_is_untouched(self):


### PR DESCRIPTION
# Description

An unsigned band wider than a byte answered a `NaN` no-data with its own maximum, because `NaN` cannot be stored
there. The substitution was silent and it had a cost: a `uint16` product saturating at 65535 came back with every
saturated cell out of domain, and `align` then handed the raster to `gdal.ReprojectImage`, which rewrote those real
65535s to 65534 to keep them distinguishable from the sentinel. `uint8` was excluded from the substitution for
exactly that reason — 255 is white in 8-bit imagery — so the exclusion was the rule and the substitution the
exception. It now holds for every width: a sentinel the band cannot store is reported as it was asked for, and
writing one refuses.

| dtype and no-data | Before | After |
|---|---|---|
| `uint16` / `uint32` / `uint64` + `NaN` | the dtype maximum | `(nan,)` |
| `uint8`, signed, floating + `NaN` | `(nan,)` | unchanged |
| any dtype, `no_data_value=None` | `(None,)` | unchanged |

## Cropping is what the substitution had been quietly paying for

A masked cell still needs a number, and the code wrote the declared sentinel — so an integer band declaring `NaN`
raised `ValueError: cannot convert float NaN to integer` on the multi-band path, and only worked on `uint16`
because the maximum had been fabricated upstream. The fill is now derived **against the band's own data**: its
sentinel where that is storable, `NaN` unconditionally for a floating band, otherwise the first value that fits the
dtype and occurs nowhere in the band. It is written into the excluded cells and declared on the output, so the
result says which cells are absent instead of leaving a number indistinguishable from a measurement.

This is deliberately better than rasterio's answer to the same problem, which writes a fixed `0` — a value most
bands genuinely hold — and declares nothing.

Deriving is cheap. A band whose sentinel is storable is never read; nor is a floating band. One that needs a
derived fill is asked for its range first, which GDAL streams block by block in C, and only when every candidate
falls *inside* that range is the band read at all. On a 4000×4000 `uint8` band that is 0 reads and no measurable
allocation.

## The two crop paths differ, on purpose

The raster-mask path writes the excluded cells itself, into an array with no way to hold "absent", so it derives a
fill for a band that declares *nothing* as well and can say truthfully what it wrote. The cutline path lets GDAL
fill them, so nothing forces the question and the source's declaration stands. `Int64` / `UInt64` are a further
exception there: `-dstnodata` reaches GDAL as a C double, which a value beyond `2**53` does not survive, so no fill
is offered rather than declaring one the pixels do not hold. All of this is stated in `crop`'s docstring, the
reference page and the migration guide, and pinned by tests on both routes.

## Also here

- `fits_dtype`, `occurs_in`, `free_no_data`, `nan_bounds` and `no_data_candidates` move from `Analysis` to
  `base/_domain.py`, which both callers now share. `free_no_data` reports failure by returning `None` rather than
  raising, because the remedy differs: `combine` can be told to leave every cell unmasked, a crop needs a wider
  dtype. `combine`'s `ValueError` and its wording are unchanged.
- The search no longer stops at the dtype extremes. A `uint8` band holding both `0` and `255` still has 254 values
  free, so the rest of the range is enumerated for the narrow integer widths, walking inward from the preferred
  extreme. `int32` and wider still refuse once the candidates are gone.
- `DatasetCollection.crop` reconciles its timesteps onto one sentinel. The fill is derived per raster, so two steps
  of the same variable disagree as soon as one contains the other's fill — and a stack is read through one declared
  value, so that made a genuine observation in one step read as a gap.

No new dependencies.

# Issues

- Fixes #1089 — unsigned no-data sentinel policy

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

### Breaking changes

1. **`Dataset.no_data_value` reports `(nan,)`** for a `uint16` / `uint32` / `uint64` band asked for an unstorable
   sentinel, where it reported the dtype maximum. Such a raster now genuinely has no no-data, so
   `count_domain_cells`, `apply`, `fill` and the statistics treat every cell as data.
2. **`change_no_data_value(None)` on a `uint16` / `uint32` / `uint64` raster raises `NoDataValueError`**, where it
   succeeded and left the dtype maximum behind. `uint8` and the signed types already raised.
3. **`Dataset.create(..., no_data_value=np.nan)` returns a different canvas**, not just a different declaration.
   Creating a band fills it with the sentinel it declared, so a `uint16` canvas that held 65535 with no domain
   cells now holds zeros with all of them in domain.
4. **A cropped raster declares the value its excluded cells hold**, which for a band with no storable sentinel —
   unstorable or undeclared — is derived rather than inherited, and the output can be trimmed smaller than the
   mask's extent as a result.
5. **A crop can come back larger, for any raster whose cells come close to its sentinel.** The trim that removes
   wholly-excluded rows asked `is_no_data`, whose operational `rtol` of 0.001 deleted everything within a part per
   thousand of the sentinel; it now asks `is_stored_no_data`. A `float32` raster declaring `-9999` whose border
   holds `-9995` came back 2×2 and now comes back 6×6, on both crop routes. The old shape was reached by deleting
   real observations, so the new one is correct — but it is a shape change for well-formed rasters.

What has **not** changed is the repair applied when a caller asks for a sentinel that overflows the band:
`Dataset.from_array(uint8_array)` still warns that the default `-9999` is out of range and stores `255`. There the
caller asked for a sentinel and it did not fit, so picking a storable one honours the request; the removed
substitution fired when the caller asked for *no* sentinel.

`docs/migration.md` (dataset / unreleased) records all five with before/after tables measured against the previous
release, and `docs/reference/dataset/spatial.md` and `analysis.md` carry the user-facing contract.

# How Has This Been Tested?

Every behavioural claim was measured against unmodified `origin/main` with the same script, rather than reasoned
about — `git archive origin/main src` into a scratch tree and `PYTHONPATH` swapped between the two.

- [x] **Crop of a band declaring an unstorable `NaN`** — `uint8` / `int16` multi-band raised `ValueError: cannot
      convert float NaN to integer` before and now succeed; each output declares its fill.
- [x] **The derived fill never collides with real data** — probed on `uint8` bands holding 7, all 255s, 255 and 3,
      and both `0` and `255` (where rasterio's fixed `0` would collide); fills were `255`, `0`, `0`, `254`.
- [x] **Data one part per thousand from the fill survives** — an `int16` band of `-9995` raised "crop produced no
      valid pixels" under the old trim tolerance and now keeps all 15 real cells.
- [x] **A float band holding its own `NaN`** — used to be handed `-9999`, putting its real gaps out of domain; a
      band holding both `NaN` and `-9999` refused outright. Both crop and declare `NaN`.
- [x] **A mask-banded / alpha-banded raster** — GDAL's range omits masked cells that `read_array` returns, so the
      shortcut answered `255` for a band whose hidden cell *is* `255`. Gated on `GMF_ALL_VALID`.
- [x] **Every integer width through the cutline route** — `uint16` / `int32` / `int64` declare and trim to 4×4;
      `uint64` refuses a fill its maximum cannot carry through the C double and is left undeclared.
- [x] **A collection crop** — two timesteps declared `-9999` and `-32768` while the second held a real `-9999`;
      they now agree, and that observation survives.
- [x] **The three writers agree** — `Dataset`, `NetCDF._storable_no_data` and the Zarr `_agreed_sentinel` probed
      together across five dtypes: none fabricates a number.
- [x] **Streaming is preserved** — `tracemalloc` on a 4000×4000 `uint8` band: 0 `read_array` calls, no measurable
      Python allocation.

Suites, on the final tree:

- [x] Full suite — **10814 passed, 87 skipped, 0 failed** (run in chunks under memory pressure)
- [x] `tests/dataset` 5341 · `tests/netcdf` + `tests/ugrid` 3388 · remainder 2085
- [x] Doctests on all seven changed modules — 88 passed, 8 skipped
- [x] **100 % coverage of all 194 added statements and branches**, every changed module
- [x] `mypy` clean on all seven changed sources; `ruff format --check` and `ruff check` clean (pinned 0.15.22)
- [x] SonarCloud: quality gate **OK**, **0 open issues**, 0 hotspots, analysed on this exact HEAD

Two `/review-rounds` passes were run against the branch: 21 findings in round 1 (1 Critical, 3 High) and 19 in
round 2 (0 Critical, 3 High), all 40 resolved. The Critical was silent data loss on `crop`; two of round 2's Highs
were defects introduced by round 1's own fixes.

# Checklist:

- [ ] updated version number in pyproject.toml. — handled by commitizen in CI
- [ ] added changes to History.rst. — `change-log.md` is commitizen-generated
- [ ] updated the latest version in README file. — release-time step
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.
