### PR TITLE
fix(base)!: serve an antimeridian bbox in the OGC readers instead of refusing it

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -165,6 +165,34 @@ that leaked out of an empty table lookup. Only affects code catching the old typ
 
 ### unreleased
 
+**The web-service readers accept a bbox that crosses the antimeridian.** Additive if you pass an ordinary box; a
+hard change if you relied on `minx > maxx` being rejected. `Dataset.from_wcs`, `from_wms`, `from_wmts` and
+`from_ogc_coverages` used to raise `ValueError: bbox must have minx < maxx and miny < maxy` for
+`(170, -10, -170, 10)` — while `Dataset.crop` had served exactly that box for a long time, by splitting at the
+180 degree seam. The readers now split too: two requests, one per side, concatenated into one raster whose
+geotransform continues past the seam (`170 .. 180` then `180 .. 190`) instead of jumping back to `-180`.
+
+- **A transposed longitude pair is no longer caught, and that is the price.** A network reader has no grid to
+  measure the bbox against — it is fetching the grid — so `(6, 51, 5, 52)`, a west/east pair entered the wrong
+  way round, now reads as a 359 degree wrap and issues two large requests rather than raising. If you were
+  relying on that `ValueError` to catch swapped arguments, check the bbox yourself before the call. **Latitude
+  is unaffected**: `miny >= maxy` is still an error, because there is no seam in latitude.
+- **Two wrapping bboxes are refused rather than approximated**, both on the `from_wms` / `from_wmts` side: one
+  with a projected `crs`, where there is no 180 degree meridian and `minx > maxx` really is inverted; and one
+  with a corner outside `-180 .. 180`, where "west of the seam" stops meaning anything.
+- **`from_wms`'s `size` is the width of the whole result**, divided between the two halves at one shared
+  resolution, with the seam snapped to the nearest pixel boundary. The two widths sum to the `size` you asked
+  for, odd or even, so a wrapping request returns the image dimensions a non-wrapping one would.
+- **`from_wmts` measures the seam offset in the layer's native CRS** rather than assuming 360 — about
+  40,075,017 m for a Web Mercator layer — and only computes it when there is a seam, so a non-wrapping read is
+  byte-identical to before.
+- **`from_ogc_coverages` sizes the two halves together** when no `resolution` is given: the combined span is
+  capped once and the resulting pixel size applied to both. Sizing each half against the cap on its own would
+  give them different pixel sizes and row counts, which cannot be concatenated at all.
+- **The stitched result of a seam read is a plain `Dataset`**, because the merge rebuilds through
+  `Dataset.from_array`. Only relevant if you call these classmethods on a `Dataset` subclass; nothing in
+  `pyramids` does.
+
 **Two rasters can now be combined directly, and `Dataset` gained arithmetic operators.** Additive — nothing that
 worked before behaves differently. `ds.combine(other, func)` runs a binary function over two aligned rasters and
 returns a `Dataset` on the left operand's grid, and `-`, `+`, `*`, `/` between two rasters are thin wrappers over
@@ -649,6 +677,24 @@ ignored: there is no frame to transform into.
 ## feature
 
 ### unreleased
+
+**`FeatureCollection.from_wfs` and `from_ogc_features` accept an antimeridian bbox.** Same change as the raster
+readers, for the same reason, and with the same caveat about a transposed longitude pair no longer being caught.
+The vector side has a sharper motivation, though: a wrapping rect handed to OGR whole does **not** raise. It is
+silently normalised into its complement, so a filter written as `(170, -10, -170, 10)` — the 20 degrees around
+Fiji — quietly returned the other 340 degrees of the planet. The bbox is now split at the seam, each half
+requested on its own, and the two results merged with duplicates removed.
+
+- **A wrapping bbox costs two requests.** A non-wrapping one still costs exactly one; the split is a no-op for it.
+- **Duplicates are removed by geometry and attributes, never by FID.** A feature that straddles the seam comes
+  back from both halves, and servers assign FIDs per request, so the same feature can arrive under two different
+  ids — keying on the FID would drop real features rather than duplicate ones. Matching on the geometry's WKB
+  plus the attribute values is what actually de-duplicates it. The accepted cost: two rows the source genuinely
+  holds twice, identical in geometry *and* in every attribute, are indistinguishable and collapse to one. This
+  only applies to a wrapping bbox — a single-request read is passed through untouched.
+- `FeatureCollection.fishnet` still refuses a wrapping bbox. Its bounds are in the target `crs`, which may be
+  projected and so has no seam; there is no coherent column numbering across a wrap; and a cell containing ±180
+  would have to be a `MultiPolygon`.
 
 **`pyramids.feature.bbox` no longer carries `Transformer` and `crs_from_user_input`.** Both were incidental
 re-exports — names the module imported to implement `transform`, never advertised in its docs or `__all__`. The

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -189,9 +189,10 @@ geotransform continues past the seam (`170 .. 180` then `180 .. 190`) instead of
 - **`from_ogc_coverages` sizes the two halves together** when no `resolution` is given: the combined span is
   capped once and the resulting pixel size applied to both. Sizing each half against the cap on its own would
   give them different pixel sizes and row counts, which cannot be concatenated at all.
-- **The stitched result of a seam read is a plain `Dataset`**, because the merge rebuilds through
-  `Dataset.from_array`. Only relevant if you call these classmethods on a `Dataset` subclass; nothing in
-  `pyramids` does.
+- **A seam read through `from_wcs` or `from_ogc_coverages` returns a plain `Dataset`**, even when called on a
+  subclass, because those two merge by rebuilding through `Dataset.from_array`. `from_wms` and `from_wmts` stitch
+  into a GDAL handle and wrap it with the class they were called on, so a subclass survives there. Only relevant
+  if you call these classmethods on a `Dataset` subclass; nothing in `pyramids` does.
 
 **Two rasters can now be combined directly, and `Dataset` gained arithmetic operators.** Additive — nothing that
 worked before behaves differently. `ds.combine(other, func)` runs a binary function over two aligned rasters and

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -197,6 +197,10 @@ geotransform continues past the seam (`170 .. 180` then `180 .. 190`) instead of
 - **`from_ogc_coverages` sizes the two halves together** when no `resolution` is given: the combined span is
   capped once and the resulting pixel size applied to both. Sizing each half against the cap on its own would
   give them different pixel sizes and row counts, which cannot be concatenated at all.
+- **A wrapping `from_wcs(direct=True)` read should pass `resolution=`.** Direct mode has no descriptor to read, so
+  the two halves are independent `GetCoverage` requests; with a `resolution` they are snapped onto one lattice,
+  and without one nothing constrains the server to grid them alike. A mismatch is refused with
+  `antimeridian halves were produced at different resolutions` rather than stitched into a misaligned raster.
 - **A seam read through `from_wcs` or `from_ogc_coverages` returns a plain `Dataset`**, even when called on a
   subclass, because those two merge by rebuilding through `Dataset.from_array`. `from_wms` and `from_wmts` stitch
   into a GDAL handle and wrap it with the class they were called on, so a subclass survives there. Only relevant

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -182,7 +182,15 @@ geotransform continues past the seam (`170 .. 180` then `180 .. 190`) instead of
   with a corner outside `-180 .. 180`, where "west of the seam" stops meaning anything.
 - **`from_wms`'s `size` is the width of the whole result**, divided between the two halves at one shared
   resolution, with the seam snapped to the nearest pixel boundary. The two widths sum to the `size` you asked
-  for, odd or even, so a wrapping request returns the image dimensions a non-wrapping one would.
+  for, odd or even, so a wrapping request returns the image dimensions a non-wrapping one would. A wrapping
+  request needs at least 2 pixels of width, since one pixel cannot straddle the seam.
+- **`from_wms(resolution=...)` is now capped at 25,000 px per axis.** Hard change, and it applies to ordinary
+  non-wrapping reads too: `from_wms(bbox=(5, 51, 6, 52), resolution=0.00001)` used to return a 100,000 x 100,000
+  image and now raises `ValueError`. The cap exists because accepting a wrap made a transposed bbox silently
+  span 359 degrees — at a fine resolution that becomes two `GetMap` requests of a few hundred thousand columns
+  each, which no server will serve. `size=(width, height)` is **not** capped: a size you state outright cannot be
+  amplified by a mistake in `bbox`, so it is still taken verbatim. If you were relying on a very fine
+  `resolution`, pass `size=` instead.
 - **`from_wmts` measures the seam offset in the layer's native CRS** rather than assuming 360 — about
   40,075,017 m for a Web Mercator layer — and only computes it when there is a seam, so a non-wrapping read is
   byte-identical to before.

--- a/src/pyramids/base/_bbox.py
+++ b/src/pyramids/base/_bbox.py
@@ -4,12 +4,18 @@
 `pyproj.Transformer.transform_bounds`, with the latitudes clamped when the
 destination is geographic.
 
-It lives under `base` rather than in `feature.bbox` because the coverage
-readers need it, and `base` importing `feature` inverts the layering -- it also
-pulled geopandas into any process that touched `base._coverage`. Nothing here
-needs shapely or geopandas, only pyproj, so the move costs those callers
-nothing. `pyramids.feature.bbox` re-exports it, so the name callers already use
-still resolves.
+`split_antimeridian` severs a `west > east` bbox at the 180 degree seam.
+
+Both live under `base` rather than in `feature.bbox` because the coverage
+readers need them, and `base` importing `feature` inverts the layering -- it
+also pulled geopandas into any process that touched `base._coverage`. Nothing
+here needs shapely or geopandas, only pyproj, so the move costs those callers
+nothing. `pyramids.feature.bbox` re-exports both, so the names callers already
+use still resolve.
+
+`split_antimeridian` moved down for the same reason `transform` did: the OGC
+readers refused a wrapping bbox that `Dataset.crop` already splits, and fixing
+that meant `base._coverage` reaching a primitive that only `feature` could see.
 """
 
 from __future__ import annotations
@@ -86,3 +92,48 @@ def transform(
         miny = max(miny, -90.0)
         maxy = min(maxy, 90.0)
     return (minx, miny, maxx, maxy)
+
+
+def split_antimeridian(bbox: Bbox) -> list[Bbox]:
+    """Split a bbox into one or two bboxes, severing the antimeridian.
+
+    Returns the input unchanged (as a single-element list) when `west <= east`.
+    When `west > east` the bbox is treated as crossing the 180 deg meridian
+    and is split into an eastern `(west, south, 180, north)` and a western
+    `(-180, south, east, north)` half.
+
+    Args:
+        bbox: A `(west, south, east, north)` tuple in degrees.
+
+    Returns:
+        A list of one bbox (no crossing) or two bboxes (crossing), each with
+        `west <= east`.
+
+    Examples:
+        - A bbox that does not cross the antimeridian is returned as-is:
+            ```python
+            >>> split_antimeridian((-10.0, -5.0, 10.0, 5.0))
+            [(-10.0, -5.0, 10.0, 5.0)]
+
+            ```
+        - A crossing bbox is split into an eastern and a western half:
+            ```python
+            >>> split_antimeridian((175.0, -22.0, -175.0, -12.0))
+            [(175.0, -22.0, 180.0, -12.0), (-180.0, -22.0, -175.0, -12.0)]
+
+            ```
+        - The two halves can be fed to separate spatial queries:
+            ```python
+            >>> halves = split_antimeridian((170.0, 0.0, -170.0, 10.0))
+            >>> [round(h[2] - h[0], 1) for h in halves]
+            [10.0, 10.0]
+
+            ```
+    """
+    west, south, east, north = bbox
+    if west <= east:
+        return [(west, south, east, north)]
+    return [
+        (west, south, 180.0, north),
+        (-180.0, south, east, north),
+    ]

--- a/src/pyramids/base/_coverage.py
+++ b/src/pyramids/base/_coverage.py
@@ -259,6 +259,16 @@ def seam_halves(
     180 degree meridian, which is where the seam is for the geographic CRS an
     OGC request declares.
 
+    Note:
+        This is, and must stay, a pass-through to
+        :func:`pyramids.base._bbox.split_antimeridian`. The two names are
+        deliberate -- `split_antimeridian` is the geometry primitive, re-exported
+        from `pyramids.feature.bbox` and used by the crop engine, while this is the
+        network readers' entry to the seam contract that lives beside
+        :func:`check_seam_bbox` and :func:`window_overlaps`. Keeping a second name
+        is only safe while it holds no logic of its own: any rule about *how* a
+        bbox splits belongs in the primitive, so the two cannot drift apart.
+
     Args:
         bbox: A validated ``(minx, miny, maxx, maxy)``, possibly wrapping.
 

--- a/src/pyramids/base/_coverage.py
+++ b/src/pyramids/base/_coverage.py
@@ -28,8 +28,8 @@ from typing import Any, cast
 
 from osgeo import gdal, osr
 
-from pyramids.base._bbox import transform as bbox_transform
 from pyramids.base._bbox import split_antimeridian
+from pyramids.base._bbox import transform as bbox_transform
 from pyramids.base._errors import CoverageError, CRSError
 from pyramids.base._grid import grid_size
 from pyramids.base.crs import sr_from_user_input

--- a/src/pyramids/base/_coverage.py
+++ b/src/pyramids/base/_coverage.py
@@ -29,6 +29,7 @@ from typing import Any, cast
 from osgeo import gdal, osr
 
 from pyramids.base._bbox import transform as bbox_transform
+from pyramids.base._bbox import split_antimeridian
 from pyramids.base._errors import CoverageError, CRSError
 from pyramids.base._grid import grid_size
 from pyramids.base.crs import sr_from_user_input
@@ -36,6 +37,8 @@ from pyramids.base.crs import sr_from_user_input
 
 def validate_bbox(
     bbox: tuple[float, float, float, float],
+    *,
+    allow_antimeridian: bool = False,
 ) -> tuple[float, float, float, float]:
     """Validate a ``(minx, miny, maxx, maxy)`` bbox.
 
@@ -43,6 +46,14 @@ def validate_bbox(
         bbox: Four numbers, or anything `float()` accepts for each of them --
             a bbox read out of JSON arrives as strings often enough that
             coercing is worth more than refusing.
+        allow_antimeridian: Accept ``minx > maxx`` as a box crossing the 180
+            degree seam rather than an inverted one. Off by default, because
+            for most callers an inverted box is a mistake and silently reading
+            it as a wrap would hide it. A reader that can actually serve the
+            wrap -- by splitting it with :func:`seam_halves` and merging the
+            results, as :meth:`Dataset.crop` does -- passes `True`. The Y axis
+            is never wrapped: there is no seam in latitude, so ``miny >= maxy``
+            stays an error either way.
 
     Returns:
         tuple[float, float, float, float]: The bbox as floats.
@@ -50,7 +61,9 @@ def validate_bbox(
     Raises:
         ValueError: `bbox` is not four values, one of them is text `float()`
             cannot read, any of them is not finite, or the box is empty or
-            inverted on either axis.
+            inverted on either axis. With `allow_antimeridian`, ``minx > maxx``
+            is no longer inverted -- but ``minx == maxx`` still is, since a
+            zero-width box is empty whichever way it is read.
         TypeError: One of the four is a value `float()` refuses outright, such
             as `None` or a list. Raised by the coercion rather than by a check
             here -- the message names the type, which is what the caller needs.
@@ -83,9 +96,48 @@ def validate_bbox(
     # the failure is the server's and reads as a network problem.
     if not all(isfinite(v) for v in (minx, miny, maxx, maxy)):
         raise ValueError(f"bbox must be four finite numbers, got {bbox!r}")
-    if minx >= maxx or miny >= maxy:
+    wraps = allow_antimeridian and minx > maxx
+    if (minx >= maxx and not wraps) or miny >= maxy:
         raise ValueError(f"bbox must have minx < maxx and miny < maxy, got {bbox!r}")
     return minx, miny, maxx, maxy
+
+
+def seam_halves(
+    bbox: tuple[float, float, float, float],
+) -> list[tuple[float, float, float, float]]:
+    """The one or two ``west < east`` boxes a request should actually ask for.
+
+    A network reader has no grid to measure when it validates a bbox -- it is
+    fetching the grid. So unlike :func:`pyramids.dataset.engines.spatial._antimeridian_halves`,
+    which reads the seam out of a dataset it already holds, this splits at the
+    180 degree meridian, which is where the seam is for the geographic CRS an
+    OGC request declares.
+
+    Args:
+        bbox: A validated ``(minx, miny, maxx, maxy)``, possibly wrapping.
+
+    Returns:
+        list[tuple[float, float, float, float]]: One box when it does not wrap,
+            two in west-to-east order when it does.
+
+    Examples:
+        - An ordinary box is handed back untouched, so a caller can split
+          unconditionally and only branch on the length:
+            ```python
+            >>> from pyramids.base._coverage import seam_halves
+            >>> seam_halves((10.0, -5.0, 20.0, 5.0))
+            [(10.0, -5.0, 20.0, 5.0)]
+
+            ```
+        - A wrapping box becomes the two halves either side of the seam:
+            ```python
+            >>> from pyramids.base._coverage import seam_halves
+            >>> seam_halves((170.0, -10.0, -170.0, 10.0))
+            [(170.0, -10.0, 180.0, 10.0), (-180.0, -10.0, -170.0, 10.0)]
+
+            ```
+    """
+    return split_antimeridian(bbox)
 
 
 def resolution_pair(

--- a/src/pyramids/base/_coverage.py
+++ b/src/pyramids/base/_coverage.py
@@ -413,6 +413,58 @@ def native_resolution(src: gdal.Dataset) -> tuple[float, float]:
     return (abs(gt[1]), abs(gt[5]))
 
 
+def seam_offset(
+    bbox: tuple[float, float, float, float],
+    crs: str,
+    native_srs: Any,
+) -> float:
+    """The x distance between the -180 and +180 meridians in the layer's own CRS.
+
+    What every seam-alignment check needs to know the east half really does
+    continue where the west one stops: 360 for a geographic layer, the full world
+    width (about 40 075 017 m) for a Web-Mercator one. Measured rather than
+    assumed, because all three raster readers window the source in *its* CRS, not
+    in the request's -- a WMTS layer is cropped in the pyramid's CRS, and a WCS or
+    OGC API coverage in the coverage's. Assuming 360 there makes the check compare
+    metres against degrees and reject every well-formed pair.
+
+    Args:
+        bbox: The request bbox, used only for the latitude band the meridians are
+            measured across.
+        crs: The CRS ``bbox`` is expressed in.
+        native_srs: The layer's native spatial reference.
+
+    Returns:
+        float: The seam-to-seam x span in the native CRS's units.
+
+    Examples:
+        - A lon/lat layer measures the seam as the 360 degrees it is:
+            ```python
+            >>> from osgeo import osr
+            >>> from pyramids.base._coverage import seam_offset
+            >>> native = osr.SpatialReference()
+            >>> _ = native.ImportFromEPSG(4326)
+            >>> seam_offset((170.0, -10.0, -170.0, 10.0), "EPSG:4326", native)
+            360.0
+
+            ```
+        - A Web Mercator layer measures the same seam in metres, so the check the
+          offset feeds is done in the units the halves are actually cropped in:
+            ```python
+            >>> from osgeo import osr
+            >>> from pyramids.base._coverage import seam_offset
+            >>> native = osr.SpatialReference()
+            >>> _ = native.ImportFromEPSG(3857)
+            >>> round(seam_offset((170.0, -10.0, -170.0, 10.0), "EPSG:4326", native))
+            40075017
+
+            ```
+    """
+    _, miny, _, maxy = bbox
+    world = native_projwin((-180.0, miny, 180.0, maxy), crs, native_srs)
+    return world[2] - world[0]
+
+
 def window_overlaps(projwin: list[float], src: gdal.Dataset) -> bool:
     """Whether a native-CRS ``[ulx, uly, lrx, lry]`` window meets `src`'s own extent.
 

--- a/src/pyramids/base/_coverage.py
+++ b/src/pyramids/base/_coverage.py
@@ -715,9 +715,10 @@ def translate_to_mem(
     colliding. Bounding the read is the **caller's** job, and the callers do not
     all bound it the same way -- the WCS and OGC coverage reads size through
     :func:`read_size`, while the WMS GetMap path sizes through its own
-    ``_output_size`` with no pixel ceiling, because the server has already been
-    told the size it should render. Where :func:`read_size` is used, it is
-    where the :data:`MAX_PX` ceiling is enforced.
+    ``_output_size``. Both now enforce the same :data:`MAX_PX` ceiling, but only
+    over a size they *derive* from a resolution: a ``size=`` the caller states
+    outright is taken verbatim on the WMS path, because a stated number cannot be
+    silently amplified the way a derived one can.
 
     Args:
         src: The opened network dataset to read from.

--- a/src/pyramids/base/_coverage.py
+++ b/src/pyramids/base/_coverage.py
@@ -111,6 +111,80 @@ def validate_bbox(
     return minx, miny, maxx, maxy
 
 
+def check_seam_bbox(bbox: tuple[float, float, float, float], crs: str) -> None:
+    """Refuse a ``minx > maxx`` bbox this reader cannot read as an antimeridian wrap.
+
+    A no-op for an ordinary box. For a wrapping one it asserts the two things the
+    seam split silently assumes, so a transposed or projected-CRS bbox fails with a
+    message naming the problem instead of producing a raster stitched at a seam
+    that is not there.
+
+    Every raster reader needs this, which is why it lives here rather than beside
+    one of them. Without it a wrapping bbox given in a projected CRS is cut at
+    ``+/-180`` *metres*: a transposed Web Mercator box around Scandinavia splits
+    into two windows over central Europe and comes back with no error at all,
+    where before the wrap was accepted it was a clean :class:`ValueError`. The
+    corner-range half matters just as much -- a half that overhangs ``180`` yields
+    an inverted window that :func:`window_overlaps` then discards, so the caller
+    silently receives a fraction of what they asked for.
+
+    Args:
+        bbox: The validated ``(minx, miny, maxx, maxy)``, possibly wrapping.
+        crs: The CRS ``bbox`` is expressed in (the WMS request CRS).
+
+    Raises:
+        ValueError: ``bbox`` wraps but ``crs`` is not geographic — the 180 degree
+            seam is a lon/lat feature, and in a projected CRS ``minx > maxx`` is
+            just an inverted box. Or it wraps but a corner lies outside
+            ``-180 .. 180``, where "west of the seam" and "east of it" stop
+            meaning anything.
+
+    Examples:
+        - An ordinary box passes in any CRS, projected included, because nothing
+          about it needs a seam:
+            ```python
+            >>> from pyramids.base._coverage import check_seam_bbox
+            >>> check_seam_bbox((5.0, 51.0, 6.0, 52.0), "EPSG:3857") is None
+            True
+
+            ```
+        - A wrapping box in a projected CRS is refused rather than stitched at a
+          seam that CRS does not have:
+            ```python
+            >>> from pyramids.base._coverage import check_seam_bbox
+            >>> box = (170.0, -10.0, -170.0, 10.0)
+            >>> check_seam_bbox(box, "EPSG:3857")  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+            ValueError: bbox (170.0, ...) has minx > maxx, ...it has no such seam...
+
+            ```
+        - So is a wrapping box reaching outside ``-180 .. 180``, where the two
+          sides of the seam stop being well defined:
+            ```python
+            >>> from pyramids.base._coverage import check_seam_bbox
+            >>> box = (190.0, -10.0, -170.0, 10.0)
+            >>> check_seam_bbox(box, "EPSG:4326")  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+            ValueError: an antimeridian bbox must have both corners within -18...
+
+            ```
+    """
+    minx, _, maxx, _ = bbox
+    if minx > maxx:
+        if not sr_from_user_input(crs).IsGeographic():
+            raise ValueError(
+                f"bbox {bbox!r} has minx > maxx, which reads as a box crossing the "
+                f"180 degree seam - but crs={crs!r} is not a geographic (lon/lat) "
+                "CRS, so it has no such seam. Pass the bbox in a lon/lat CRS, or "
+                "give it as minx < maxx."
+            )
+        if minx > 180.0 or maxx < -180.0:
+            raise ValueError(
+                "an antimeridian bbox must have both corners within -180..180 "
+                f"degrees, got {bbox!r}"
+            )
+
+
 def seam_halves(
     bbox: tuple[float, float, float, float],
 ) -> list[tuple[float, float, float, float]]:

--- a/src/pyramids/base/_coverage.py
+++ b/src/pyramids/base/_coverage.py
@@ -111,6 +111,69 @@ def validate_bbox(
     return minx, miny, maxx, maxy
 
 
+def _is_lonlat_degrees_from_greenwich(srs: osr.SpatialReference) -> bool:
+    """Whether ``180`` is this CRS's antimeridian and ``360`` its seam offset.
+
+    ``IsGeographic()`` alone does not settle either. A geographic CRS may count
+    its longitudes from a different prime meridian -- EPSG:4807 (NTF, Paris) puts
+    zero about 2.34 degrees east of Greenwich, so its antimeridian is not at 180 --
+    and may express them in grads rather than degrees, where the half-turn is 200.
+    Splitting such a bbox at 180 would cut it in the wrong place and then check the
+    halves against a 360 that is not the width of the world in those units.
+
+    Both are vanishingly rare as an OGC request CRS, which is why the check is a
+    refusal rather than a conversion: the caller is far likelier to have transposed
+    two corners than to genuinely want a wrap in grads from Paris.
+
+    Args:
+        srs: The CRS the bbox is expressed in.
+
+    Returns:
+        bool: True when the CRS is geographic, in degrees, and counted from
+            Greenwich.
+
+    Examples:
+        - Plain lon/lat qualifies, and so does CRS84:
+            ```python
+            >>> from pyramids.base.crs import sr_from_user_input
+            >>> from pyramids.base._coverage import _is_lonlat_degrees_from_greenwich
+            >>> _is_lonlat_degrees_from_greenwich(sr_from_user_input("EPSG:4326"))
+            True
+
+            ```
+        - A projected CRS does not, having no meridian to speak of:
+            ```python
+            >>> from pyramids.base.crs import sr_from_user_input
+            >>> from pyramids.base._coverage import _is_lonlat_degrees_from_greenwich
+            >>> _is_lonlat_degrees_from_greenwich(sr_from_user_input("EPSG:3857"))
+            False
+
+            ```
+        - Nor does a geographic CRS counted from Paris, whose antimeridian is not
+          at 180:
+            ```python
+            >>> from pyramids.base.crs import sr_from_user_input
+            >>> from pyramids.base._coverage import _is_lonlat_degrees_from_greenwich
+            >>> _is_lonlat_degrees_from_greenwich(sr_from_user_input("EPSG:4807"))
+            False
+
+            ```
+    """
+    if not srs.IsGeographic():
+        return False
+    # GetAngularUnits reports radians per unit: degrees are pi/180, grads pi/200.
+    degrees = abs(srs.GetAngularUnits() - 0.017453292519943295) < 1e-12
+    # The offset is the PRIMEM node's second value, in degrees. There is no
+    # GetPrimeMeridian on this binding, and a CRS carrying no PRIMEM at all is
+    # Greenwich by definition.
+    offset = srs.GetAttrValue("PRIMEM", 1)
+    try:
+        greenwich = offset is None or abs(float(offset)) < 1e-9
+    except ValueError:
+        greenwich = False
+    return bool(degrees and greenwich)
+
+
 def check_seam_bbox(bbox: tuple[float, float, float, float], crs: str) -> None:
     """Refuse a ``minx > maxx`` bbox this reader cannot read as an antimeridian wrap.
 
@@ -171,12 +234,12 @@ def check_seam_bbox(bbox: tuple[float, float, float, float], crs: str) -> None:
     """
     minx, _, maxx, _ = bbox
     if minx > maxx:
-        if not sr_from_user_input(crs).IsGeographic():
+        if not _is_lonlat_degrees_from_greenwich(sr_from_user_input(crs)):
             raise ValueError(
                 f"bbox {bbox!r} has minx > maxx, which reads as a box crossing the "
                 f"180 degree seam - but crs={crs!r} is not a geographic (lon/lat) "
-                "CRS, so it has no such seam. Pass the bbox in a lon/lat CRS, or "
-                "give it as minx < maxx."
+                "CRS in degrees from Greenwich, so it has no such seam. Pass the "
+                "bbox in a lon/lat CRS, or give it as minx < maxx."
             )
         if minx > 180.0 or maxx < -180.0:
             raise ValueError(

--- a/src/pyramids/base/_coverage.py
+++ b/src/pyramids/base/_coverage.py
@@ -517,8 +517,11 @@ def window_overlaps(projwin: list[float], src: gdal.Dataset) -> bool:
     # under-reports one axis and drops halves that do have data. min/max over the
     # four also makes the bound axis-order agnostic, which covers a south-up or
     # west-positive grid without a separate case.
-    corners = [
-        (gt[0] + x * gt[1] + y * gt[2], gt[3] + x * gt[4] + y * gt[5])
+    corners: list[tuple[float, float]] = [
+        (
+            float(gt[0] + x * gt[1] + y * gt[2]),
+            float(gt[3] + x * gt[4] + y * gt[5]),
+        )
         for x, y in (
             (0, 0),
             (src.RasterXSize, 0),

--- a/src/pyramids/base/_coverage.py
+++ b/src/pyramids/base/_coverage.py
@@ -469,13 +469,23 @@ def window_overlaps(projwin: list[float], src: gdal.Dataset) -> bool:
     """Whether a native-CRS ``[ulx, uly, lrx, lry]`` window meets `src`'s own extent.
 
     The seam readers split an antimeridian ``bbox`` into two halves and fetch each
-    one; a half that misses the coverage entirely must be skipped rather than
-    requested, because GDAL refuses a window fully outside the raster ("Computed
-    -srcwin ... falls completely outside raster extent") and that refusal would
-    fail the whole read instead of yielding the one half that does have data. This
-    is the network equivalent of the overlap test in
+    one; a half that misses the coverage entirely is skipped rather than requested.
+    GDAL does not refuse such a window -- it warns ("Computed source window ...
+    falls completely outside source raster extent") and fills the result with
+    no-data -- so the point is not to avoid an error but to avoid paying for a
+    request whose answer is a block of nothing, and then concatenating that block
+    into the stitch as though it were data. This is the network equivalent of the
+    overlap test in
     :func:`pyramids.dataset.engines.spatial._crop_seam_halves`, which reads the
     extent off a dataset it already holds.
+
+    Note:
+        The extent is bounded by all four corners, so a rotated geotransform
+        (``gt[2]`` / ``gt[4]`` non-zero) is measured rather than under-reported --
+        two opposite corners are not enough, because a rotated grid reaches beyond
+        both of them on one axis. No reader can currently deliver a rotated source
+        here, since ``gdal.Translate(projWin=...)`` refuses a rotated geotransform
+        outright, so this is a defensive bound rather than a supported path.
 
     Args:
         projwin: ``[ulx, uly, lrx, lry]`` in `src`'s CRS, as
@@ -502,13 +512,22 @@ def window_overlaps(projwin: list[float], src: gdal.Dataset) -> bool:
             ```
     """
     gt = src.GetGeoTransform()
-    # Both far corners, so a rotated geotransform (gt[2] / gt[4] non-zero) is
-    # bounded rather than mis-measured; min/max then makes the result axis-order
-    # agnostic for a south-up or west-positive grid.
-    far_x = float(gt[0] + src.RasterXSize * gt[1] + src.RasterYSize * gt[2])
-    far_y = float(gt[3] + src.RasterXSize * gt[4] + src.RasterYSize * gt[5])
-    minx, maxx = sorted((float(gt[0]), far_x))
-    miny, maxy = sorted((float(gt[3]), far_y))
+    # All four corners, not two: on a rotated grid the axis-aligned extent is set
+    # by corners the diagonal does not touch, so an origin/far-corner pair
+    # under-reports one axis and drops halves that do have data. min/max over the
+    # four also makes the bound axis-order agnostic, which covers a south-up or
+    # west-positive grid without a separate case.
+    corners = [
+        (gt[0] + x * gt[1] + y * gt[2], gt[3] + x * gt[4] + y * gt[5])
+        for x, y in (
+            (0, 0),
+            (src.RasterXSize, 0),
+            (0, src.RasterYSize),
+            (src.RasterXSize, src.RasterYSize),
+        )
+    ]
+    minx, maxx = min(c[0] for c in corners), max(c[0] for c in corners)
+    miny, maxy = min(c[1] for c in corners), max(c[1] for c in corners)
     win_minx, win_maxx = sorted((projwin[0], projwin[2]))
     win_miny, win_maxy = sorted((projwin[3], projwin[1]))
     return win_minx < maxx and win_maxx > minx and win_miny < maxy and win_maxy > miny

--- a/src/pyramids/base/_coverage.py
+++ b/src/pyramids/base/_coverage.py
@@ -519,7 +519,12 @@ def seam_offset(
         native_srs: The layer's native spatial reference.
 
     Returns:
-        float: The seam-to-seam x span in the native CRS's units.
+        float: The seam-to-seam x span in the native CRS's units, which is ``0``
+            for a CRS whose x runs continuously through the antimeridian.
+
+    Raises:
+        ValueError: Either meridian projects to a non-finite x in the native CRS,
+            so there is no offset to align the halves against.
 
     Examples:
         - A lon/lat layer measures the seam as the 360 degrees it is:

--- a/src/pyramids/base/_coverage.py
+++ b/src/pyramids/base/_coverage.py
@@ -36,12 +36,13 @@ from math import isfinite
 from typing import Any, cast
 
 from osgeo import gdal, osr
+from pyproj import CRS, Transformer
 
 from pyramids.base._bbox import split_antimeridian
 from pyramids.base._bbox import transform as bbox_transform
 from pyramids.base._errors import CoverageError, CRSError
 from pyramids.base._grid import grid_size
-from pyramids.base.crs import sr_from_user_input
+from pyramids.base.crs import crs_from_user_input, sr_from_user_input
 
 
 def validate_bbox(
@@ -495,11 +496,21 @@ def seam_offset(
 
     What every seam-alignment check needs to know the east half really does
     continue where the west one stops: 360 for a geographic layer, the full world
-    width (about 40 075 017 m) for a Web-Mercator one. Measured rather than
-    assumed, because all three raster readers window the source in *its* CRS, not
-    in the request's -- a WMTS layer is cropped in the pyramid's CRS, and a WCS or
+    width (about 40 075 017 m) for a Web-Mercator one, and -- importantly -- **0**
+    for a CRS whose x runs continuously across the antimeridian. Measured rather
+    than assumed, because all three raster readers window the source in *its* CRS,
+    not in the request's: a WMTS layer is cropped in the pyramid's CRS, a WCS or
     OGC API coverage in the coverage's. Assuming 360 there makes the check compare
     metres against degrees and reject every well-formed pair.
+
+    The measurement is the +180 and -180 meridians taken as **points** on the
+    bbox's own mid-latitude. Measuring instead across a world-spanning box, as this
+    once did, reports a regional CRS's distortion at its far edges rather than the
+    seam: UTM zone 60N came out at 29 238 222 m, when the true answer is 0 -- lon
+    179.9, 180 and -179.9 land at 822 836, 833 979 and 845 122 m, running straight
+    on through. UTM 60N and 1N are the natural CRSs for a coverage that actually
+    straddles the antimeridian (New Zealand, Fiji, the Aleutians), so getting 0
+    there is not an edge case; it is the main one.
 
     Args:
         bbox: The request bbox, used only for the latitude band the meridians are
@@ -532,10 +543,38 @@ def seam_offset(
             40075017
 
             ```
+        - A UTM zone spanning the antimeridian has no jump there at all, so its two
+          halves tile with no offset and the check must not expect one:
+            ```python
+            >>> from osgeo import osr
+            >>> from pyramids.base._coverage import seam_offset
+            >>> native = osr.SpatialReference()
+            >>> _ = native.ImportFromEPSG(32660)
+            >>> round(seam_offset((170.0, -10.0, -170.0, 10.0), "EPSG:4326", native))
+            0
+
+            ```
     """
     _, miny, _, maxy = bbox
-    world = native_projwin((-180.0, miny, 180.0, maxy), crs, native_srs)
-    return world[2] - world[0]
+    transformer = Transformer.from_crs(
+        crs_from_user_input(crs),
+        CRS.from_wkt(native_srs.ExportToWkt()),
+        always_xy=True,
+    )
+    # The two meridians as points on the bbox's own mid-latitude, not the width of
+    # a world-spanning box. Transforming the whole world into a regional CRS
+    # measures that CRS's distortion at its far edges rather than the seam.
+    middle = (miny + maxy) / 2.0
+    east_x, _ = transformer.transform(180.0, middle)
+    west_x, _ = transformer.transform(-180.0, middle)
+    offset = float(east_x - west_x)
+    if not isfinite(offset):
+        raise ValueError(
+            "the 180 degree meridian does not project into the coverage's CRS, so "
+            "an antimeridian read cannot be aligned against it; request a bbox "
+            "that does not cross the seam"
+        )
+    return offset
 
 
 def window_overlaps(projwin: list[float], src: gdal.Dataset) -> bool:

--- a/src/pyramids/base/_coverage.py
+++ b/src/pyramids/base/_coverage.py
@@ -18,6 +18,15 @@ error: a ``RuntimeError`` (GDAL raises under ``gdal.UseExceptions()``) and a
 :func:`open_network_dataset` and :func:`translate_to_mem` own that sequence and
 that classification; the readers pass in their own exception class and the words
 that name the request, so the messages stay branded per protocol.
+
+The antimeridian split is here for the same reason. A ``bbox`` whose ``minx``
+exceeds its ``maxx`` crosses the 180 degree seam, and every reader serves it the
+same way: :func:`validate_bbox` with ``allow_antimeridian=True`` stops calling it
+inverted, :func:`seam_halves` cuts it into the one or two ``west < east`` boxes to
+actually request, and :func:`window_overlaps` drops a half that misses the
+coverage before it costs a request. What each reader still owns is the merge,
+because that is where the protocols differ -- a WMS divides a pixel width between
+the halves, a vector reader de-duplicates features across them.
 """
 
 from __future__ import annotations
@@ -328,6 +337,55 @@ def native_resolution(src: gdal.Dataset) -> tuple[float, float]:
     """Return the source raster's absolute native ``(x_res, y_res)`` from its geotransform."""
     gt = src.GetGeoTransform()
     return (abs(gt[1]), abs(gt[5]))
+
+
+def window_overlaps(projwin: list[float], src: gdal.Dataset) -> bool:
+    """Whether a native-CRS ``[ulx, uly, lrx, lry]`` window meets `src`'s own extent.
+
+    The seam readers split an antimeridian ``bbox`` into two halves and fetch each
+    one; a half that misses the coverage entirely must be skipped rather than
+    requested, because GDAL refuses a window fully outside the raster ("Computed
+    -srcwin ... falls completely outside raster extent") and that refusal would
+    fail the whole read instead of yielding the one half that does have data. This
+    is the network equivalent of the overlap test in
+    :func:`pyramids.dataset.engines.spatial._crop_seam_halves`, which reads the
+    extent off a dataset it already holds.
+
+    Args:
+        projwin: ``[ulx, uly, lrx, lry]`` in `src`'s CRS, as
+            :func:`pyramids.base._coverage.native_projwin` returns it.
+        src: The opened coverage, read for its geotransform and pixel size.
+
+    Returns:
+        bool: True when the window and the source extent share area. Touching
+            edges do not count as overlap -- a zero-area intersection has no
+            pixels to read.
+
+    Examples:
+        - A window inside the raster overlaps, one beyond its east edge does not:
+            ```python
+            >>> from osgeo import gdal
+            >>> from pyramids.base._coverage import window_overlaps
+            >>> src = gdal.GetDriverByName("MEM").Create("", 10, 10, 1)
+            >>> _ = src.SetGeoTransform((0.0, 1.0, 0.0, 10.0, 0.0, -1.0))
+            >>> window_overlaps([2.0, 8.0, 4.0, 6.0], src)
+            True
+            >>> window_overlaps([20.0, 8.0, 30.0, 6.0], src)
+            False
+
+            ```
+    """
+    gt = src.GetGeoTransform()
+    # Both far corners, so a rotated geotransform (gt[2] / gt[4] non-zero) is
+    # bounded rather than mis-measured; min/max then makes the result axis-order
+    # agnostic for a south-up or west-positive grid.
+    far_x = float(gt[0] + src.RasterXSize * gt[1] + src.RasterYSize * gt[2])
+    far_y = float(gt[3] + src.RasterXSize * gt[4] + src.RasterYSize * gt[5])
+    minx, maxx = sorted((float(gt[0]), far_x))
+    miny, maxy = sorted((float(gt[3]), far_y))
+    win_minx, win_maxx = sorted((projwin[0], projwin[2]))
+    win_miny, win_maxy = sorted((projwin[3], projwin[1]))
+    return win_minx < maxx and win_maxx > minx and win_miny < maxy and win_maxy > miny
 
 
 def open_network_dataset(

--- a/src/pyramids/dataset/_ogc_coverages.py
+++ b/src/pyramids/dataset/_ogc_coverages.py
@@ -381,8 +381,16 @@ def _fetch_windows(
                 projwins = [pw for pw in projwins if _window_overlaps(pw, src)]
             sizes = _window_sizes(projwins, res)
             projwins = _align_to_sizes(projwins, sizes)
-            for projwin, size in zip(projwins, sizes, strict=True):
-                mems.append(_translate_window(src, projwin, size, coverage))
+            try:
+                for projwin, size in zip(projwins, sizes, strict=True):
+                    mems.append(_translate_window(src, projwin, size, coverage))
+            except BaseException:
+                # A second window that fails must not strand the first: this is
+                # the path the seam split introduced, and the rest of this reader
+                # is explicit about ownership.
+                for mem in mems:
+                    mem.Close()
+                raise
         finally:
             # release the opened coverage handle on every path, error or not.
             src = None
@@ -468,10 +476,12 @@ def from_ogc_coverages(
     )
 
     parts: list[Dataset] = []
+    adopted = 0
     try:
         for mem in mems:
             mem.SetSpatialRef(native_srs)
             parts.append(dataset_cls(mem, access="write"))
+            adopted += 1
         if not parts:
             raise ValueError(
                 f"bbox {bbox!r} crosses the antimeridian but neither half overlaps "
@@ -497,6 +507,10 @@ def from_ogc_coverages(
     finally:
         for part in parts:
             part.close()
+        # A raise part-way through the adoption above leaves the tail of `mems`
+        # wrapped by nothing, so `parts` cannot close them.
+        for mem in mems[adopted:]:
+            mem.Close()
 
     if output_crs is not None:
         ds = ds.to_crs(output_crs, method=resample)

--- a/src/pyramids/dataset/_ogc_coverages.py
+++ b/src/pyramids/dataset/_ogc_coverages.py
@@ -28,6 +28,13 @@ unadvertised coverage fails fast with a clear :class:`ValueError`, and so
 transport / driver failures surface as
 :class:`~pyramids.base._errors.OGCAPIError`.
 
+It also serves an **antimeridian** ``bbox`` -- one whose ``minx > maxx`` -- the
+way :meth:`pyramids.dataset.Dataset.crop` does: the window is split at the 180
+degree seam (:func:`pyramids.base._coverage.seam_halves`), both halves are read
+off the same open coverage, and the two are concatenated along longitude. Such a
+``bbox`` used to be refused with ``ValueError: bbox must have minx < maxx and
+miny < maxy``.
+
 This is the OGC-API-era sibling of :mod:`pyramids.dataset._wcs` (the WCS reader);
 the two share their bbox/CRS/window helpers through the protocol-neutral
 :mod:`pyramids.base._coverage`, and share their ``/collections`` discovery with
@@ -54,15 +61,25 @@ from pyramids.base._coverage import open_network_dataset as _open_network_datase
 from pyramids.base._coverage import read_size as _read_size
 from pyramids.base._coverage import resolution_pair as _resolution_pair
 from pyramids.base._coverage import resolve_native_srs as _resolve_native_srs
+from pyramids.base._coverage import seam_halves as _seam_halves
 from pyramids.base._coverage import translate_to_mem as _translate_to_mem
 from pyramids.base._coverage import validate_bbox as _validate_bbox
+from pyramids.base._coverage import window_overlaps as _window_overlaps
 from pyramids.base._errors import CoverageError, OGCAPIError
 from pyramids.base._ogc_api import append_path as _append_path
 from pyramids.base._ogc_api import gdal_http_config as _gdal_http_config
 from pyramids.base._ogc_api import get_collections as _get_collections
 from pyramids.base._ogc_api import not_advertised
 
+# Borrowed rather than reimplemented, so a seam read here, a seam read over WCS
+# and `Dataset.crop` all stitch the same way: `_stitch_lon_halves` is the crop
+# engine's longitude concatenation, which keeps the west half's geotransform so
+# longitude continues past the seam rather than jumping back to -180.
+from pyramids.dataset.engines.spatial import _stitch_lon_halves
+
 if TYPE_CHECKING:
+    from osgeo import osr
+
     from pyramids.dataset.dataset import Dataset
 
 _OPEN_OPTIONS = ["API=COVERAGE", "IMAGE_FORMAT=GEOTIFF", "CACHE=NO"]
@@ -131,6 +148,113 @@ def _translate_window(
     )
 
 
+def _window_sizes(
+    projwins: list[list[float]], res: tuple[float, float] | None
+) -> list[tuple[int, int]]:
+    """Pixel ``(width, height)`` for each window, on one shared grid when there are two.
+
+    One window is sized exactly as it always was, straight through
+    :func:`~pyramids.base._coverage.read_size`. Two windows are the halves of an
+    antimeridian read and have to stitch afterwards, which they can only do on a
+    common grid: sizing each half on its own with no ``res`` would cap **each** at
+    :data:`~pyramids.base._coverage.DEFAULT_MAX_PX` on its longer side, giving the
+    two different pixel sizes and different row counts. So the combined span is
+    sized once and the resolution read back out of it, then applied to both halves
+    -- which also keeps the whole seam-crossing read inside the same pixel budget
+    an unwrapped read of the same width would get.
+
+    Args:
+        projwins: One or two ``[ulx, uly, lrx, lry]`` windows in the coverage's
+            native CRS, in west-to-east order.
+        res: The caller's ``(x_res, y_res)``, or ``None`` to size from the cap.
+
+    Returns:
+        list[tuple[int, int]]: The ``(width, height)`` for each window, in the
+            same order.
+
+    Raises:
+        ValueError: A window exceeds the pixel ceiling, or `res` has a
+            non-positive axis (both raised by
+            :func:`~pyramids.base._coverage.read_size`).
+    """
+    grid_res = res
+    if grid_res is None and len(projwins) > 1:
+        span_x = sum(abs(pw[2] - pw[0]) for pw in projwins)
+        ulx, uly, _, lry = projwins[0]
+        width, height = _read_size([ulx, uly, ulx + span_x, lry], None)
+        grid_res = (span_x / width, abs(uly - lry) / height)
+    return [_read_size(projwin, grid_res) for projwin in projwins]
+
+
+def _fetch_windows(
+    connection: str,
+    coverage: str,
+    windows: list[tuple[float, float, float, float]],
+    coverage_crs: str | None,
+    res: tuple[float, float] | None,
+    config: dict[str, str],
+) -> tuple[list[gdal.Dataset], osr.SpatialReference]:
+    """Open the coverage once and materialise every requested window from it.
+
+    `windows` holds one box for an ordinary request and two for one crossing the
+    antimeridian. Reading both halves off a single open handle is what lets them
+    stitch: they share the coverage's CRS, its lattice and -- via
+    :func:`_window_sizes` -- one resolution.
+
+    Args:
+        connection: The ``OGCAPI:`` connection string for the coverage.
+        coverage: The coverage identifier, used in error messages.
+        windows: One or two ``(minx, miny, maxx, maxy)`` CRS84 boxes, each with
+            ``minx < maxx``, in west-to-east order.
+        coverage_crs: The CRS shim for a coverage the service advertises in a CRS
+            absent from PROJ, or ``None``.
+        res: The caller's normalised ``(x_res, y_res)``, or ``None``.
+        config: GDAL config options (auth / timeout) to install around the read.
+
+    Returns:
+        tuple[list[gdal.Dataset], osr.SpatialReference]: The ``MEM`` raster for
+            each window that had data, and the coverage's native CRS. With two
+            windows a half that misses the coverage entirely is dropped, so the
+            list can be shorter than `windows` -- and empty when neither overlaps.
+
+    Raises:
+        ValueError: ``coverage_crs`` cannot be interpreted, a window does not
+            project to a finite native-CRS extent, or a window exceeds the pixel
+            ceiling.
+        OGCAPIError: The ``OGCAPI`` driver is unavailable, the coverage could not
+            be opened or has no resolvable CRS, or GDAL produced no raster.
+    """
+    mems: list[gdal.Dataset] = []
+    with gdal.config_options(config):
+        src = _open_coverage(connection, coverage)
+        try:
+            # _resolve_native_srs is the shared, protocol-neutral resolver;
+            # normalise its CoverageError (CRS-less coverage, no coverage_crs shim)
+            # to this reader's OGCAPIError so the documented Raises contract holds
+            # and the message names OGC API. A bad coverage_crs raises ValueError,
+            # which propagates.
+            try:
+                native_srs = _resolve_native_srs(src, coverage_crs)
+            except CoverageError as exc:
+                raise OGCAPIError(
+                    f"OGC API coverage {coverage!r} has no resolvable spatial reference; "
+                    "the service advertised no usable CRS for the coverage"
+                ) from exc
+            projwins = [_native_projwin(w, "EPSG:4326", native_srs) for w in windows]
+            if len(projwins) > 1:
+                # Overlap-filtered before fetching, as _crop_seam_halves does:
+                # only for a split request, so a single window keeps its own
+                # error rather than silently returning nothing.
+                projwins = [pw for pw in projwins if _window_overlaps(pw, src)]
+            sizes = _window_sizes(projwins, res)
+            for projwin, size in zip(projwins, sizes, strict=True):
+                mems.append(_translate_window(src, projwin, size, coverage))
+        finally:
+            # release the opened coverage handle on every path, error or not.
+            src = None
+    return mems, native_srs
+
+
 def from_ogc_coverages(
     dataset_cls: type[Dataset],
     endpoint: str,
@@ -161,45 +285,72 @@ def from_ogc_coverages(
     and the bbox cannot be projected. Passing ``coverage_crs`` (any proj4 / WKT /
     authority string) supplies that CRS explicitly, mirroring :meth:`from_wcs`.
 
+    ``bbox`` may cross the antimeridian. ``minx > maxx`` is read as a box wrapping
+    the 180 degree seam (it used to be refused as inverted): the window is split at
+    the seam, both halves are read off the same open coverage, and the two are
+    concatenated along longitude. The merged raster keeps the **west** half's
+    geotransform, so its longitudes continue past the seam -- 170..180 then
+    180..190 -- rather than jumping back to -180. A half that misses the coverage
+    entirely is dropped before it is requested, so a one-sided overlap returns just
+    that half. With no ``resolution`` the pixel cap is applied to the combined span
+    once and shared by both halves, so a seam read is budgeted like the unwrapped
+    read of the same width rather than twice over.
+
+    Note:
+        The stitched result of a seam-crossing read is a plain
+        :class:`~pyramids.dataset.Dataset`, not `dataset_cls`, because the merge
+        rebuilds the raster through :meth:`Dataset.from_array`. Every
+        single-window read still returns `dataset_cls`.
+
     Raises:
         ValueError: ``bbox`` is malformed, ``coverage`` is not advertised by the
-            service, or ``coverage_crs`` cannot be interpreted.
+            service, ``coverage_crs`` cannot be interpreted, or a seam-crossing
+            ``bbox`` overlaps no part of the coverage / produced two halves that do
+            not meet at the seam.
         OGCAPIError: The ``OGCAPI`` driver is unavailable, the service could not be
             reached, or it returned an error / a non-raster body.
     """
-    box = _validate_bbox(bbox)
+    box = _validate_bbox(bbox, allow_antimeridian=True)
     res = _resolution_pair(resolution)
+    # One window normally, two when the bbox wraps the seam. Splitting
+    # unconditionally keeps the ordinary request on exactly the path it had.
+    windows = _seam_halves(box)
 
     collections = _get_collections(endpoint, auth, timeout)
     if collections and coverage not in collections:
         raise not_advertised("coverage", coverage, endpoint, collections)
 
-    connection = _coverage_connection(endpoint, coverage)
-    config = _gdal_http_config(auth, timeout)
-    with gdal.config_options(config):
-        src = _open_coverage(connection, coverage)
-        try:
-            # _resolve_native_srs is the shared, protocol-neutral resolver;
-            # normalise its CoverageError (CRS-less coverage, no coverage_crs shim)
-            # to this reader's OGCAPIError so the documented Raises contract holds
-            # and the message names OGC API. A bad coverage_crs raises ValueError,
-            # which propagates.
-            try:
-                native_srs = _resolve_native_srs(src, coverage_crs)
-            except CoverageError as exc:
-                raise OGCAPIError(
-                    f"OGC API coverage {coverage!r} has no resolvable spatial reference; "
-                    "the service advertised no usable CRS for the coverage"
-                ) from exc
-            projwin = _native_projwin(box, "EPSG:4326", native_srs)
-            size = _read_size(projwin, res)
-            mem = _translate_window(src, projwin, size, coverage)
-        finally:
-            # release the opened coverage handle on every path, error or not.
-            src = None
+    mems, native_srs = _fetch_windows(
+        _coverage_connection(endpoint, coverage),
+        coverage,
+        windows,
+        coverage_crs,
+        res,
+        _gdal_http_config(auth, timeout),
+    )
 
-    mem.SetSpatialRef(native_srs)
-    ds = dataset_cls(mem, access="write")
+    parts: list[Dataset] = []
+    try:
+        for mem in mems:
+            mem.SetSpatialRef(native_srs)
+            parts.append(dataset_cls(mem, access="write"))
+        if not parts:
+            raise ValueError(
+                f"bbox {bbox!r} crosses the antimeridian but neither half overlaps "
+                f"the extent of coverage {coverage!r}"
+            )
+        if len(parts) == 1:
+            # Hand ownership of the only part to the caller, so the cleanup below
+            # does not close the raster being returned.
+            ds, parts = parts[0], []
+        else:
+            # _stitch_lon_halves copies both halves into a new raster, so the parts
+            # stay owned here and are closed by the finally. Its first argument is
+            # only read for band names; the west half carries the same ones.
+            ds = _stitch_lon_halves(parts[0], parts[0], parts[1])
+    finally:
+        for part in parts:
+            part.close()
 
     if output_crs is not None:
         ds = ds.to_crs(output_crs, method=resample)

--- a/src/pyramids/dataset/_ogc_coverages.py
+++ b/src/pyramids/dataset/_ogc_coverages.py
@@ -240,6 +240,17 @@ def _window_sizes(
     total, height = _read_size(
         [west[0], west[1], west[0] + _span(west) + _span(east), west[3]], grid_res
     )
+    if total < 2:
+        # The same floor `_seam_windows` puts on a WMS wrap, and for the same
+        # reason: two requests cannot share one pixel, so a resolution this coarse
+        # has no honest answer. Without it the east half takes `total - 1 == 0`
+        # columns and GDAL rejects the zero-width window with a message naming
+        # neither the seam nor the resolution.
+        raise ValueError(
+            f"a bbox crossing the antimeridian is read as two windows, so it needs "
+            f"at least 2 pixels of width; resolution {grid_res[0]} over this bbox "
+            f"gives {total}. Pass a finer resolution."
+        )
     west_width = max(1, min(total - 1, round(_span(west) / grid_res[0])))
     return [(west_width, height), (total - west_width, height)]
 

--- a/src/pyramids/dataset/_ogc_coverages.py
+++ b/src/pyramids/dataset/_ogc_coverages.py
@@ -176,6 +176,40 @@ def _window_sizes(
         ValueError: A window exceeds the pixel ceiling, or `res` has a
             non-positive axis (both raised by
             :func:`~pyramids.base._coverage.read_size`).
+
+    Examples:
+        - One window with an explicit resolution is sized straight from it:
+            ```python
+            >>> from pyramids.dataset._ogc_coverages import _window_sizes
+            >>> _window_sizes([[170.0, 10.0, 175.0, -10.0]], (0.05, 0.05))
+            [(100, 400)]
+
+            ```
+        - Two halves of a seam read share one resolution, so their widths are in
+          proportion to their spans and their heights are identical -- which is
+          what lets them be concatenated afterwards:
+            ```python
+            >>> from pyramids.dataset._ogc_coverages import _window_sizes
+            >>> halves = [[170.0, 10.0, 180.0, -10.0], [-180.0, 10.0, -175.0, -10.0]]
+            >>> sizes = _window_sizes(halves, None)
+            >>> sizes
+            [(512, 1024), (256, 1024)]
+            >>> sizes[0][1] == sizes[1][1]
+            True
+
+            ```
+        - The cap is spent on the combined span, not once per half, so the two
+          widths add up to what a single unwrapped window of that span would get --
+          15 degrees against 20 of latitude, so the tall side takes the 1024 cap and
+          the width follows the aspect ratio:
+            ```python
+            >>> from pyramids.dataset._ogc_coverages import _window_sizes
+            >>> halves = [[170.0, 10.0, 180.0, -10.0], [-180.0, 10.0, -175.0, -10.0]]
+            >>> sizes = _window_sizes(halves, None)
+            >>> sum(width for width, _ in sizes)
+            768
+
+            ```
     """
     grid_res = res
     if grid_res is None and len(projwins) > 1:

--- a/src/pyramids/dataset/_ogc_coverages.py
+++ b/src/pyramids/dataset/_ogc_coverages.py
@@ -187,7 +187,9 @@ def _window_sizes(
     Raises:
         ValueError: A window exceeds the pixel ceiling, or `res` has a
             non-positive axis (both raised by
-            :func:`~pyramids.base._coverage.read_size`).
+            :func:`~pyramids.base._coverage.read_size`); or `res` is so coarse that
+            the combined span sizes to under two pixels, which cannot be split
+            between two windows.
 
     Examples:
         - One window with an explicit resolution is sized straight from it:

--- a/src/pyramids/dataset/_ogc_coverages.py
+++ b/src/pyramids/dataset/_ogc_coverages.py
@@ -272,8 +272,10 @@ def _span(projwin: list[float]) -> float:
             10.0
 
             ```
-        - Corner order does not matter, so a window read off a west-positive grid
-          measures the same:
+        - The absolute value is defensive only. `native_projwin` always returns
+          ``ulx <= lrx``, and :func:`_align_to_sizes` moves the far edge eastward
+          unconditionally, so a genuinely west-positive window would not survive
+          the rest of this path even though `_span` measures it:
             ```python
             >>> from pyramids.dataset._ogc_coverages import _span
             >>> _span([180.0, 10.0, 170.0, -10.0])
@@ -529,7 +531,10 @@ def from_ogc_coverages(
         for part in parts:
             part.close()
         # A raise part-way through the adoption above leaves the tail of `mems`
-        # wrapped by nothing, so `parts` cannot close them.
+        # wrapped by nothing, so nothing else drops their GDAL handle. (`close()`
+        # on an adopted part clears that part's reference, not this list's -- both
+        # die with the frame either way; this is about releasing the handle
+        # promptly, not about who owns the object.)
         for mem in mems[adopted:]:
             mem.Close()
 

--- a/src/pyramids/dataset/_ogc_coverages.py
+++ b/src/pyramids/dataset/_ogc_coverages.py
@@ -161,9 +161,19 @@ def _window_sizes(
     common grid: sizing each half on its own with no ``res`` would cap **each** at
     :data:`~pyramids.base._coverage.DEFAULT_MAX_PX` on its longer side, giving the
     two different pixel sizes and different row counts. So the combined span is
-    sized once and the resolution read back out of it, then applied to both halves
-    -- which also keeps the whole seam-crossing read inside the same pixel budget
-    an unwrapped read of the same width would get.
+    sized once and the resolution read back out of it -- which also keeps the whole
+    seam-crossing read inside the same pixel budget an unwrapped read of the same
+    width would get.
+
+    Deriving one resolution is necessary but not sufficient, and the difference is
+    where this used to go wrong. Rounding each half's width against that resolution
+    independently leaves the two on cell sizes that differ in the sixth decimal,
+    because neither span is an exact multiple of it. So the west width is rounded
+    and the **east takes the remainder** of the combined width, exactly as
+    :func:`pyramids.dataset._wms._seam_windows` does; the caller then passes both
+    through :func:`_align_to_sizes`, which trims each window to the whole number of
+    pixels it will actually be read at. Only after that do the halves genuinely
+    share one grid rather than merely share the number it was derived from.
 
     Args:
         projwins: One or two ``[ulx, uly, lrx, lry]`` windows in the coverage's

--- a/src/pyramids/dataset/_ogc_coverages.py
+++ b/src/pyramids/dataset/_ogc_coverages.py
@@ -257,6 +257,12 @@ def _window_sizes(
     return [(west_width, height), (total - west_width, height)]
 
 
+# The CRS an OGC API - Coverages bbox is contractually expressed in. Named rather
+# than repeated so the three places that assume it are visibly the same
+# assumption, not three independent guesses.
+CRS84 = "EPSG:4326"
+
+
 def _span(projwin: list[float]) -> float:
     """The absolute x extent of a ``[ulx, uly, lrx, lry]`` window.
 
@@ -396,7 +402,7 @@ def _fetch_windows(
                     f"OGC API coverage {coverage!r} has no resolvable spatial reference; "
                     "the service advertised no usable CRS for the coverage"
                 ) from exc
-            projwins = [_native_projwin(w, "EPSG:4326", native_srs) for w in windows]
+            projwins = [_native_projwin(w, CRS84, native_srs) for w in windows]
             if len(projwins) > 1:
                 # Overlap-filtered before fetching, as _crop_seam_halves does,
                 # but only for a split request. A lone window is left to GDAL,
@@ -481,7 +487,7 @@ def from_ogc_coverages(
     # This reader's bbox is contractually CRS84, so the projected half of the
     # guard cannot fire -- the corner-range half can, and an overhanging half
     # would otherwise be dropped without a word.
-    _check_seam_bbox(box, "EPSG:4326")
+    _check_seam_bbox(box, CRS84)
     res = _resolution_pair(resolution)
     # One window normally, two when the bbox wraps the seam. Splitting
     # unconditionally keeps the ordinary request on exactly the path it had.
@@ -527,7 +533,7 @@ def from_ogc_coverages(
                 parts[0],
                 parts[0],
                 parts[1],
-                _seam_offset(box, "EPSG:4326", native_srs),
+                _seam_offset(box, CRS84, native_srs),
             )
     finally:
         for part in parts:

--- a/src/pyramids/dataset/_ogc_coverages.py
+++ b/src/pyramids/dataset/_ogc_coverages.py
@@ -63,6 +63,7 @@ from pyramids.base._coverage import read_size as _read_size
 from pyramids.base._coverage import resolution_pair as _resolution_pair
 from pyramids.base._coverage import resolve_native_srs as _resolve_native_srs
 from pyramids.base._coverage import seam_halves as _seam_halves
+from pyramids.base._coverage import seam_offset as _seam_offset
 from pyramids.base._coverage import translate_to_mem as _translate_to_mem
 from pyramids.base._coverage import validate_bbox as _validate_bbox
 from pyramids.base._coverage import window_overlaps as _window_overlaps
@@ -212,13 +213,108 @@ def _window_sizes(
 
             ```
     """
+    if len(projwins) < 2:
+        return [_read_size(projwin, res) for projwin in projwins]
     grid_res = res
-    if grid_res is None and len(projwins) > 1:
+    if grid_res is None:
         span_x = sum(abs(pw[2] - pw[0]) for pw in projwins)
         ulx, uly, _, lry = projwins[0]
-        width, height = _read_size([ulx, uly, ulx + span_x, lry], None)
-        grid_res = (span_x / width, abs(uly - lry) / height)
-    return [_read_size(projwin, grid_res) for projwin in projwins]
+        total, height = _read_size([ulx, uly, ulx + span_x, lry], None)
+        grid_res = (span_x / total, abs(uly - lry) / height)
+    # Round the west half, then take the east as the remainder of the combined
+    # width, exactly as `_seam_windows` does for WMS. Rounding each half on its own
+    # gives them cell sizes that differ in the sixth decimal, which the stitch
+    # cannot represent: it keeps the west geotransform, so the east half's declared
+    # edge drifts from where its data actually ends.
+    west, east = projwins
+    total, height = _read_size(
+        [west[0], west[1], west[0] + _span(west) + _span(east), west[3]], grid_res
+    )
+    west_width = max(1, min(total - 1, round(_span(west) / grid_res[0])))
+    return [(west_width, height), (total - west_width, height)]
+
+
+def _span(projwin: list[float]) -> float:
+    """The absolute x extent of a ``[ulx, uly, lrx, lry]`` window.
+
+    Args:
+        projwin: A native-CRS window.
+
+    Returns:
+        float: ``abs(lrx - ulx)``.
+
+    Examples:
+        - The width of an ordinary window:
+            ```python
+            >>> from pyramids.dataset._ogc_coverages import _span
+            >>> _span([170.0, 10.0, 180.0, -10.0])
+            10.0
+
+            ```
+        - Corner order does not matter, so a window read off a west-positive grid
+          measures the same:
+            ```python
+            >>> from pyramids.dataset._ogc_coverages import _span
+            >>> _span([180.0, 10.0, 170.0, -10.0])
+            10.0
+
+            ```
+    """
+    return abs(projwin[2] - projwin[0])
+
+
+def _align_to_sizes(
+    projwins: list[list[float]], sizes: list[tuple[int, int]]
+) -> list[list[float]]:
+    """Trim each window to the whole number of pixels it will actually be read at.
+
+    :func:`_window_sizes` gives the two halves of a seam read one cell size and
+    splits the combined width between them, which means neither half's requested
+    span is any longer an exact multiple of that cell size. `gdal.Translate` honours
+    the window and the size it is given, so leaving the spans untouched would make
+    it resample each half by a fraction of a pixel and hand back two grids that no
+    longer share one. Snapping the far edge to ``ulx + width * cell`` is what keeps
+    the promise the sizes make.
+
+    A single window is returned untouched: its size came straight from its own
+    span, so there is nothing to reconcile.
+
+    Args:
+        projwins: One or two ``[ulx, uly, lrx, lry]`` windows.
+        sizes: The ``(width, height)`` chosen for each, in the same order.
+
+    Returns:
+        list[list[float]]: The windows, with the far x edge snapped for a split
+            read.
+
+    Examples:
+        - A single window is handed back as it was:
+            ```python
+            >>> from pyramids.dataset._ogc_coverages import _align_to_sizes
+            >>> _align_to_sizes([[170.0, 10.0, 175.0, -10.0]], [(100, 400)])
+            [[170.0, 10.0, 175.0, -10.0]]
+
+            ```
+        - Two halves are snapped onto the cell size their widths imply, so both
+          report the same one:
+            ```python
+            >>> from pyramids.dataset._ogc_coverages import _align_to_sizes
+            >>> halves = [[170.0, 10.0, 180.0, -10.0], [-180.0, 10.0, -175.0, -10.0]]
+            >>> snapped = _align_to_sizes(halves, [(512, 1024), (256, 1024)])
+            >>> cells = [(w[2] - w[0]) / n for w, (n, _) in zip(snapped, [(512, 0), (256, 0)])]
+            >>> cells[0] == cells[1]
+            True
+
+            ```
+    """
+    if len(projwins) < 2:
+        return projwins
+    west, east = projwins
+    cell = _span(west) / sizes[0][0]
+    return [
+        [west[0], west[1], west[0] + sizes[0][0] * cell, west[3]],
+        [east[0], east[1], east[0] + sizes[1][0] * cell, east[3]],
+    ]
 
 
 def _fetch_windows(
@@ -284,6 +380,7 @@ def _fetch_windows(
                 # nothing to size.
                 projwins = [pw for pw in projwins if _window_overlaps(pw, src)]
             sizes = _window_sizes(projwins, res)
+            projwins = _align_to_sizes(projwins, sizes)
             for projwin, size in zip(projwins, sizes, strict=True):
                 mems.append(_translate_window(src, projwin, size, coverage))
         finally:
@@ -388,7 +485,15 @@ def from_ogc_coverages(
             # _stitch_lon_halves copies both halves into a new raster, so the parts
             # stay owned here and are closed by the finally. Its first argument is
             # only read for band names; the west half carries the same ones.
-            ds = _stitch_lon_halves(parts[0], parts[0], parts[1])
+            # The seam offset is measured in the coverage's own CRS: the halves are
+            # windowed in that CRS, so for a projected coverage they meet at the
+            # world width in metres, not at 360.
+            ds = _stitch_lon_halves(
+                parts[0],
+                parts[0],
+                parts[1],
+                _seam_offset(box, "EPSG:4326", native_srs),
+            )
     finally:
         for part in parts:
             part.close()

--- a/src/pyramids/dataset/_ogc_coverages.py
+++ b/src/pyramids/dataset/_ogc_coverages.py
@@ -242,9 +242,11 @@ def _fetch_windows(
                 ) from exc
             projwins = [_native_projwin(w, "EPSG:4326", native_srs) for w in windows]
             if len(projwins) > 1:
-                # Overlap-filtered before fetching, as _crop_seam_halves does:
-                # only for a split request, so a single window keeps its own
-                # error rather than silently returning nothing.
+                # Overlap-filtered before fetching, as _crop_seam_halves does,
+                # but only for a split request. A lone window is left to GDAL,
+                # which warns and fills a miss with no-data rather than raising;
+                # filtering it too would empty the list and leave _window_sizes
+                # nothing to size.
                 projwins = [pw for pw in projwins if _window_overlaps(pw, src)]
             sizes = _window_sizes(projwins, res)
             for projwin, size in zip(projwins, sizes, strict=True):

--- a/src/pyramids/dataset/_ogc_coverages.py
+++ b/src/pyramids/dataset/_ogc_coverages.py
@@ -56,6 +56,7 @@ from urllib.parse import quote, urlunsplit
 
 from osgeo import gdal
 
+from pyramids.base._coverage import check_seam_bbox as _check_seam_bbox
 from pyramids.base._coverage import native_projwin as _native_projwin
 from pyramids.base._coverage import open_network_dataset as _open_network_dataset
 from pyramids.base._coverage import read_size as _read_size
@@ -347,6 +348,10 @@ def from_ogc_coverages(
             reached, or it returned an error / a non-raster body.
     """
     box = _validate_bbox(bbox, allow_antimeridian=True)
+    # This reader's bbox is contractually CRS84, so the projected half of the
+    # guard cannot fire -- the corner-range half can, and an overhanging half
+    # would otherwise be dropped without a word.
+    _check_seam_bbox(box, "EPSG:4326")
     res = _resolution_pair(resolution)
     # One window normally, two when the bbox wraps the seam. Splitting
     # unconditionally keeps the ordinary request on exactly the path it had.

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -50,7 +50,7 @@ import urllib.request
 from functools import lru_cache
 from math import ceil
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, NamedTuple, cast
 from xml.etree import ElementTree as ET  # nosec B405 - server XML; DoS accepted, no XXE
 
 from osgeo import gdal
@@ -578,21 +578,48 @@ def _open_getcoverage_bytes(payload: bytes, coverage: str) -> gdal.Dataset:
     return mem
 
 
+class _DirectRequest(NamedTuple):
+    """Everything a direct ``GetCoverage`` needs except the window itself.
+
+    These thirteen values travel together from :func:`from_wcs` to every window's
+    request, unchanged -- only the bbox differs between the two halves of a seam
+    read. Naming the group keeps the helpers that forward it to a readable
+    signature instead of a fourteen-parameter list where the one argument that
+    actually varies is lost among the ones that do not.
+
+    Attributes:
+        dataset_cls: The class each part is wrapped as.
+        endpoint: The WCS service URL.
+        coverage: The coverage identifier.
+        crs: The CRS the request windows are expressed in.
+        version: The WCS protocol version, or `None` for the default.
+        wcs_format: The requested response format, or `None`.
+        resolution: The caller's raw resolution, forwarded to the request.
+        subset_axes: WCS 2.0 axis labels, or `None` for the default.
+        coverage_crs: The CRS shim, or `None`.
+        auth: Optional basic-auth credentials.
+        timeout: HTTP timeout in seconds.
+        extra_params: Optional extra KVP overrides.
+    """
+
+    dataset_cls: type[Dataset]
+    endpoint: str
+    coverage: str
+    crs: str
+    version: str | None
+    wcs_format: str | None
+    resolution: float | tuple[float, float] | None
+    subset_axes: tuple[str, str] | None
+    coverage_crs: str | None
+    auth: tuple[str, str] | None
+    timeout: float
+    extra_params: dict[str, str] | None
+
+
 def _collect_direct_parts(
-    dataset_cls: type[Dataset],
-    endpoint: str,
-    coverage: str,
+    request: _DirectRequest,
     windows: list[tuple[float, float, float, float]],
-    crs: str,
-    version: str | None,
-    wcs_format: str | None,
-    resolution: float | tuple[float, float] | None,
     res: tuple[float, float] | None,
-    subset_axes: tuple[str, str] | None,
-    coverage_crs: str | None,
-    auth: tuple[str, str] | None,
-    timeout: float,
-    extra_params: dict[str, str] | None,
 ) -> tuple[list[Dataset], str | None, tuple[float, float] | None]:
     """Fetch every window through direct mode and report how to finalize them.
 
@@ -602,20 +629,9 @@ def _collect_direct_parts(
     coverage. Keeping both inline made the caller's branching hard to follow.
 
     Args:
-        dataset_cls: The class each part is wrapped as.
-        endpoint: The WCS service URL.
-        coverage: The coverage identifier.
+        request: The service and protocol parameters every window shares.
         windows: The one or two ``west < east`` boxes to request.
-        crs: The CRS `windows` are expressed in.
-        version: The WCS protocol version, or `None` for the default.
-        wcs_format: The requested response format, or `None`.
-        resolution: The caller's raw resolution, forwarded to the request.
-        res: The same resolution normalised to a pair, used for seam snapping.
-        subset_axes: WCS 2.0 axis labels, or `None` for the default.
-        coverage_crs: The CRS shim, or `None`.
-        auth: Optional basic-auth credentials.
-        timeout: HTTP timeout in seconds.
-        extra_params: Optional extra KVP overrides.
+        res: `request.resolution` normalised to a pair, used for seam snapping.
 
     Returns:
         tuple[list[Dataset], str | None, tuple[float, float] | None]: The fetched
@@ -638,25 +654,25 @@ def _collect_direct_parts(
     native_wkt: str | None = None
     for window in windows:
         part, native_wkt = _from_wcs_direct(
-            dataset_cls,
-            endpoint,
-            coverage,
+            request.dataset_cls,
+            request.endpoint,
+            request.coverage,
             window,
-            crs,
-            version,
-            wcs_format,
-            resolution,
-            subset_axes,
-            coverage_crs,
-            auth,
-            timeout,
-            extra_params,
+            request.crs,
+            request.version,
+            request.wcs_format,
+            request.resolution,
+            request.subset_axes,
+            request.coverage_crs,
+            request.auth,
+            request.timeout,
+            request.extra_params,
         )
         parts.append(part)
     # 1.0.0 direct sends RESX/RESY, so the server already grids to `res`; skip the
     # redundant client-side resample. 2.0.x has no request-side resolution, so it
     # resamples client-side in _finalize.
-    finalize_res = None if (version or "2.0.0").startswith("1.0") else res
+    finalize_res = None if (request.version or "2.0.0").startswith("1.0") else res
     return parts, native_wkt, finalize_res
 
 
@@ -961,20 +977,22 @@ def from_wcs(
     try:
         if direct:
             direct_parts, native_wkt, finalize_res = _collect_direct_parts(
-                dataset_cls,
-                endpoint,
-                coverage,
+                _DirectRequest(
+                    dataset_cls,
+                    endpoint,
+                    coverage,
+                    crs,
+                    version,
+                    wcs_format,
+                    resolution,
+                    subset_axes,
+                    coverage_crs,
+                    auth,
+                    timeout,
+                    extra_params,
+                ),
                 windows,
-                crs,
-                version,
-                wcs_format,
-                resolution,
                 res,
-                subset_axes,
-                coverage_crs,
-                auth,
-                timeout,
-                extra_params,
             )
             parts.extend(direct_parts)
             # Direct mode has no descriptor to measure against, so 360 is an

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -681,9 +681,11 @@ def _from_wcs_discovery(
             native_srs = _resolve_native_srs(src, coverage_crs)
             for window in windows:
                 projwin = _native_projwin(window, crs, native_srs)
-                # Overlap-filtered before fetching, as _crop_seam_halves does:
-                # only for a split request, so a single window keeps its own
-                # error rather than silently returning nothing.
+                # Overlap-filtered before fetching, as _crop_seam_halves does,
+                # but only for a split request. A lone window is left to GDAL,
+                # which warns and fills a miss with no-data rather than raising;
+                # filtering it too would turn that long-standing outcome into
+                # "neither half overlaps" for a bbox that never wrapped.
                 if len(windows) > 1 and not _window_overlaps(projwin, src):
                     continue
                 mems.append(_translate_window(src, projwin, coverage))

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -862,8 +862,13 @@ def from_wcs(
             native_wkt = native_srs.ExportToWkt()
             # Discovery mode windows the coverage in the coverage's own CRS, which
             # may be projected -- then the halves meet at the world width in metres,
-            # not at 360. Measured, not assumed.
-            stitch_offset = _seam_offset(box, crs, native_srs)
+            # not at 360. Measured, not assumed -- and only when there is a seam to
+            # measure, as the other two readers already do: the whole-world
+            # transform is wasted work on an ordinary single-window read, and it
+            # can raise for a CRS the meridians do not project into.
+            stitch_offset = (
+                _seam_offset(box, crs, native_srs) if len(mems) > 1 else 360.0
+            )
             for mem in mems:
                 mem.SetSpatialRef(native_srs)
                 parts.append(dataset_cls(mem, access="write"))

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -64,6 +64,7 @@ from pyramids.base._coverage import read_size as _read_size
 from pyramids.base._coverage import resolution_pair as _resolution_pair
 from pyramids.base._coverage import resolve_native_srs as _resolve_native_srs_neutral
 from pyramids.base._coverage import seam_halves as _seam_halves
+from pyramids.base._coverage import seam_offset as _seam_offset
 from pyramids.base._coverage import translate_to_mem as _translate_to_mem
 from pyramids.base._coverage import validate_bbox as _validate_bbox
 from pyramids.base._coverage import window_overlaps as _window_overlaps
@@ -824,6 +825,11 @@ def from_wcs(
             # skip the redundant client-side resample. 2.0.x has no request-side
             # resolution, so it resamples client-side in _finalize.
             finalize_res = None if (version or "2.0.0").startswith("1.0") else res
+            # Direct mode asks in `crs` and is answered in `crs`, and
+            # `check_seam_bbox` has already proven that geographic, so the halves
+            # are in degrees and the seam is 360 wide. There is no descriptor here
+            # to measure anything against.
+            stitch_offset = 360.0
         else:
             mems, native_srs = _from_wcs_discovery(
                 endpoint,
@@ -839,6 +845,10 @@ def from_wcs(
             )
             # WKT round-trips more faithfully than proj4 for exotic / compound CRS.
             native_wkt = native_srs.ExportToWkt()
+            # Discovery mode windows the coverage in the coverage's own CRS, which
+            # may be projected -- then the halves meet at the world width in metres,
+            # not at 360. Measured, not assumed.
+            stitch_offset = _seam_offset(box, crs, native_srs)
             for mem in mems:
                 mem.SetSpatialRef(native_srs)
                 parts.append(dataset_cls(mem, access="write"))
@@ -856,7 +866,10 @@ def from_wcs(
             # _stitch_lon_halves copies both halves into a new raster, so the parts
             # stay owned here and are closed by the finally. Its first argument is
             # only read for band names; the west half carries the same ones.
-            ds = _stitch_lon_halves(parts[0], parts[0], parts[1])
+            # The seam offset is measured in the coverage's own CRS: the halves are
+            # windowed in that CRS, so for a projected coverage they meet at the
+            # world width in metres, not at 360.
+            ds = _stitch_lon_halves(parts[0], parts[0], parts[1], stitch_offset)
     finally:
         for part in parts:
             part.close()

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -56,6 +56,7 @@ from osgeo import gdal
 from pyproj.exceptions import CRSError as _PyprojCRSError
 
 from pyramids.base._artifacts import mint_vsimem, unregister_vsimem
+from pyramids.base._coverage import check_seam_bbox as _check_seam_bbox
 from pyramids.base._coverage import native_projwin as _native_projwin
 from pyramids.base._coverage import native_resolution as _native_resolution
 from pyramids.base._coverage import open_network_dataset as _open_network_dataset
@@ -790,6 +791,9 @@ def from_wcs(
             non-raster body.
     """
     box = _validate_bbox(bbox, allow_antimeridian=True)
+    # A wrap only means anything in a lon/lat crs, and only inside -180..180.
+    # Without this the split cuts a projected bbox at +/-180 metres.
+    _check_seam_bbox(box, crs)
     res = _resolution_pair(resolution)
     # One window normally, two when the bbox wraps the seam. Splitting
     # unconditionally keeps the ordinary request on exactly the path it had.

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -48,6 +48,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from functools import lru_cache
+from math import ceil
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 from xml.etree import ElementTree as ET  # nosec B405 - server XML; DoS accepted, no XXE
@@ -577,6 +578,64 @@ def _open_getcoverage_bytes(payload: bytes, coverage: str) -> gdal.Dataset:
     return mem
 
 
+def _snap_direct_halves(
+    windows: list[tuple[float, float, float, float]],
+    res: tuple[float, float],
+) -> list[tuple[float, float, float, float]]:
+    """Put two direct-mode seam halves on one lattice by snapping each to `res`.
+
+    The discovery path reads both halves off a single open coverage, so they share
+    a lattice by construction, and the WMS path divides one pixel width between
+    them. Direct mode has neither: it issues two independent ``GetCoverage``
+    requests and the server grids each from its own extent, so the west half's east
+    edge lands on 180 only by luck. A request of ``(170.3, -10, -170, 10)`` at
+    ``0.5`` degrees puts the seam 0.6 of a pixel out, and the alignment check then
+    refuses the pair.
+
+    Snapping each half outward to a whole number of ``res`` cells from the seam
+    makes both edges land on the same lattice, so the halves abut exactly. It grows
+    the request by under one cell per side, which is the same bargain
+    :func:`pyramids.dataset._wms._seam_windows` strikes.
+
+    Args:
+        windows: The two ``west < east`` halves, in west-to-east order.
+        res: The caller's ``(x_res, y_res)``, already normalised.
+
+    Returns:
+        list[tuple[float, float, float, float]]: The snapped halves.
+
+    Examples:
+        - A west half that does not end on a cell boundary is widened until it
+          does, so its east edge reaches the seam exactly:
+            ```python
+            >>> from pyramids.dataset._wcs import _snap_direct_halves
+            >>> halves = [(170.3, -10.0, 180.0, 10.0), (-180.0, -10.0, -170.0, 10.0)]
+            >>> west, east = _snap_direct_halves(halves, (0.5, 0.5))
+            >>> west
+            (170.0, -10.0, 180.0, 10.0)
+            >>> east
+            (-180.0, -10.0, -170.0, 10.0)
+
+            ```
+        - Halves already on the lattice are handed back unchanged:
+            ```python
+            >>> from pyramids.dataset._wcs import _snap_direct_halves
+            >>> halves = [(170.0, -10.0, 180.0, 10.0), (-180.0, -10.0, -175.0, 10.0)]
+            >>> _snap_direct_halves(halves, (0.5, 0.5))[0]
+            (170.0, -10.0, 180.0, 10.0)
+
+            ```
+    """
+    west, east = windows
+    cell = abs(res[0])
+    west_columns = ceil((180.0 - west[0]) / cell)
+    east_columns = ceil((east[2] + 180.0) / cell)
+    return [
+        (180.0 - west_columns * cell, west[1], 180.0, west[3]),
+        (-180.0, east[1], -180.0 + east_columns * cell, east[3]),
+    ]
+
+
 def _from_wcs_direct(
     dataset_cls: type[Dataset],
     endpoint: str,
@@ -819,6 +878,15 @@ def from_wcs(
     native_wkt: str | None = None
     try:
         if direct:
+            if len(windows) > 1 and res is not None:
+                # Direct mode issues two independent GetCoverage requests and the
+                # server grids each from its own extent, so the west half's east
+                # edge lands on 180 only by luck. Snapping both to the requested
+                # resolution puts them on one lattice. Without a resolution there
+                # is nothing to snap to and the alignment check is what catches a
+                # server that grids the halves differently -- loudly, which is the
+                # right outcome, but see `Dataset.from_wcs` on the caveat.
+                windows = _snap_direct_halves(windows, res)
             for window in windows:
                 part, native_wkt = _from_wcs_direct(
                     dataset_cls,
@@ -840,10 +908,12 @@ def from_wcs(
             # skip the redundant client-side resample. 2.0.x has no request-side
             # resolution, so it resamples client-side in _finalize.
             finalize_res = None if (version or "2.0.0").startswith("1.0") else res
-            # Direct mode asks in `crs` and is answered in `crs`, and
-            # `check_seam_bbox` has already proven that geographic, so the halves
-            # are in degrees and the seam is 360 wide. There is no descriptor here
-            # to measure anything against.
+            # Direct mode has no descriptor to measure against, so 360 is an
+            # assumption -- a reasonable one, because the request names `crs` and
+            # `check_seam_bbox` has proven that geographic, but the server is what
+            # decides the response CRS. A shim that ignores `CRS=` and answers in
+            # its own projected grid fails the alignment check loudly rather than
+            # stitching something wrong, which is the outcome to prefer here.
             stitch_offset = 360.0
         else:
             mems, native_srs = _from_wcs_discovery(

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -578,6 +578,88 @@ def _open_getcoverage_bytes(payload: bytes, coverage: str) -> gdal.Dataset:
     return mem
 
 
+def _collect_direct_parts(
+    dataset_cls: type[Dataset],
+    endpoint: str,
+    coverage: str,
+    windows: list[tuple[float, float, float, float]],
+    crs: str,
+    version: str | None,
+    wcs_format: str | None,
+    resolution: float | tuple[float, float] | None,
+    res: tuple[float, float] | None,
+    subset_axes: tuple[str, str] | None,
+    coverage_crs: str | None,
+    auth: tuple[str, str] | None,
+    timeout: float,
+    extra_params: dict[str, str] | None,
+) -> tuple[list[Dataset], str | None, tuple[float, float] | None]:
+    """Fetch every window through direct mode and report how to finalize them.
+
+    Split out of :func:`from_wcs` because the two request modes share only their
+    bookkeeping: direct mode issues one independent ``GetCoverage`` per window and
+    has no descriptor, while discovery mode reads every window off one open
+    coverage. Keeping both inline made the caller's branching hard to follow.
+
+    Args:
+        dataset_cls: The class each part is wrapped as.
+        endpoint: The WCS service URL.
+        coverage: The coverage identifier.
+        windows: The one or two ``west < east`` boxes to request.
+        crs: The CRS `windows` are expressed in.
+        version: The WCS protocol version, or `None` for the default.
+        wcs_format: The requested response format, or `None`.
+        resolution: The caller's raw resolution, forwarded to the request.
+        res: The same resolution normalised to a pair, used for seam snapping.
+        subset_axes: WCS 2.0 axis labels, or `None` for the default.
+        coverage_crs: The CRS shim, or `None`.
+        auth: Optional basic-auth credentials.
+        timeout: HTTP timeout in seconds.
+        extra_params: Optional extra KVP overrides.
+
+    Returns:
+        tuple[list[Dataset], str | None, tuple[float, float] | None]: The fetched
+            parts, the native CRS as WKT, and the resolution `_finalize` should
+            resample to (`None` when the server has already gridded to it).
+
+    Raises:
+        WCSError: A request failed or returned a non-raster body.
+    """
+    if len(windows) > 1 and res is not None:
+        # Direct mode issues two independent GetCoverage requests and the server
+        # grids each from its own extent, so the west half's east edge lands on 180
+        # only by luck. Snapping both to the requested resolution puts them on one
+        # lattice. Without a resolution there is nothing to snap to and the
+        # alignment check is what catches a server that grids the halves
+        # differently -- loudly, which is the right outcome, but see
+        # `Dataset.from_wcs` on the caveat.
+        windows = _snap_direct_halves(windows, res)
+    parts: list[Dataset] = []
+    native_wkt: str | None = None
+    for window in windows:
+        part, native_wkt = _from_wcs_direct(
+            dataset_cls,
+            endpoint,
+            coverage,
+            window,
+            crs,
+            version,
+            wcs_format,
+            resolution,
+            subset_axes,
+            coverage_crs,
+            auth,
+            timeout,
+            extra_params,
+        )
+        parts.append(part)
+    # 1.0.0 direct sends RESX/RESY, so the server already grids to `res`; skip the
+    # redundant client-side resample. 2.0.x has no request-side resolution, so it
+    # resamples client-side in _finalize.
+    finalize_res = None if (version or "2.0.0").startswith("1.0") else res
+    return parts, native_wkt, finalize_res
+
+
 def _snap_direct_halves(
     windows: list[tuple[float, float, float, float]],
     res: tuple[float, float],
@@ -878,36 +960,23 @@ def from_wcs(
     native_wkt: str | None = None
     try:
         if direct:
-            if len(windows) > 1 and res is not None:
-                # Direct mode issues two independent GetCoverage requests and the
-                # server grids each from its own extent, so the west half's east
-                # edge lands on 180 only by luck. Snapping both to the requested
-                # resolution puts them on one lattice. Without a resolution there
-                # is nothing to snap to and the alignment check is what catches a
-                # server that grids the halves differently -- loudly, which is the
-                # right outcome, but see `Dataset.from_wcs` on the caveat.
-                windows = _snap_direct_halves(windows, res)
-            for window in windows:
-                part, native_wkt = _from_wcs_direct(
-                    dataset_cls,
-                    endpoint,
-                    coverage,
-                    window,
-                    crs,
-                    version,
-                    wcs_format,
-                    resolution,
-                    subset_axes,
-                    coverage_crs,
-                    auth,
-                    timeout,
-                    extra_params,
-                )
-                parts.append(part)
-            # 1.0.0 direct sends RESX/RESY, so the server already grids to `res`;
-            # skip the redundant client-side resample. 2.0.x has no request-side
-            # resolution, so it resamples client-side in _finalize.
-            finalize_res = None if (version or "2.0.0").startswith("1.0") else res
+            direct_parts, native_wkt, finalize_res = _collect_direct_parts(
+                dataset_cls,
+                endpoint,
+                coverage,
+                windows,
+                crs,
+                version,
+                wcs_format,
+                resolution,
+                res,
+                subset_axes,
+                coverage_crs,
+                auth,
+                timeout,
+                extra_params,
+            )
+            parts.extend(direct_parts)
             # Direct mode has no descriptor to measure against, so 360 is an
             # assumption -- a reasonable one, because the request names `crs` and
             # `check_seam_bbox` has proven that geographic, but the server is what

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -9,7 +9,7 @@ or raster-I/O libraries. GDAL performs ``GetCapabilities`` /
 ``DescribeCoverage``, negotiates
 the WCS version, and issues the version-correct ``GetCoverage`` (the ``1.0.0``
 ``bbox`` + ``resx/resy`` form versus the ``2.0.x`` ``subsets`` + ``scaling``
-form). pyramids adds the two things the driver does *not* handle on its own:
+form). pyramids adds the three things the driver does *not* handle on its own:
 
 * **A CRS shim.** Some servers (e.g. ISRIC SoilGrids) advertise a coverage CRS
   under an authority code that the local PROJ database does not know
@@ -21,6 +21,13 @@ form). pyramids adds the two things the driver does *not* handle on its own:
   query ``bbox`` into the coverage's native CRS with ``pyproj`` (already a core
   dependency) and hand GDAL a native-CRS window. This is what makes subsetting
   land on the right pixels even when the server only honours its native CRS.
+* **Antimeridian bboxes.** A ``bbox`` whose ``minx > maxx`` is read as crossing
+  the 180 degree seam, the same way :meth:`pyramids.dataset.Dataset.crop` reads
+  it. The request is split into the two ``west < east`` halves either side of the
+  seam (:func:`pyramids.base._coverage.seam_halves`), each half is fetched through
+  the normal path, and the two are concatenated along longitude into one raster.
+  Before this, such a ``bbox`` was refused with ``ValueError: bbox must have
+  minx < maxx and miny < maxy``.
 
 For ``GetCoverage``-only "shim" servers that ``502``/``400`` on capabilities /
 describe, ``from_wcs(..., direct=True)`` bypasses GDAL's driver entirely and
@@ -55,8 +62,10 @@ from pyramids.base._coverage import open_network_dataset as _open_network_datase
 from pyramids.base._coverage import read_size as _read_size
 from pyramids.base._coverage import resolution_pair as _resolution_pair
 from pyramids.base._coverage import resolve_native_srs as _resolve_native_srs_neutral
+from pyramids.base._coverage import seam_halves as _seam_halves
 from pyramids.base._coverage import translate_to_mem as _translate_to_mem
 from pyramids.base._coverage import validate_bbox as _validate_bbox
+from pyramids.base._coverage import window_overlaps as _window_overlaps
 from pyramids.base._errors import CoverageError, WCSError
 from pyramids.base._ogc_api import (
     HTTP_RETRY_ATTEMPTS,
@@ -69,6 +78,14 @@ from pyramids.base._ogc_api import gdal_http_config as _gdal_http_config
 from pyramids.base._ogc_api import http_get_with_retry as _http_get_with_retry
 from pyramids.base._ogc_api import read_http_error as _read_http_error
 from pyramids.base.crs import crs_from_user_input
+
+# The stitch the crop engine already owns: it concatenates two longitude-adjacent
+# rasters keeping the west half's geotransform, so longitude continues past the
+# seam (170..180 then 180..190) instead of jumping back to -180. Reused rather
+# than reimplemented so a WCS / OGC API seam read and `Dataset.crop` produce the
+# same raster. Importing it here is not a cycle: `engines.spatial` pulls in
+# `Dataset` only under TYPE_CHECKING and through a function-local import.
+from pyramids.dataset.engines.spatial import _stitch_lon_halves
 
 # Cap on how much of an HTTP-error body is inlined into a WCSError message; the
 # full body is still carried on WCSError.response_body. Keeps a multi-KB HTML
@@ -601,6 +618,83 @@ def _from_wcs_direct(
     return ds, native_wkt
 
 
+def _from_wcs_discovery(
+    endpoint: str,
+    coverage: str,
+    windows: list[tuple[float, float, float, float]],
+    crs: str,
+    version: str | None,
+    wcs_format: str | None,
+    coverage_crs: str | None,
+    auth: tuple[str, str] | None,
+    timeout: float,
+    extra_params: dict[str, str] | None,
+) -> tuple[list[gdal.Dataset], osr.SpatialReference]:
+    """Discovery path: validate the coverage, then read every window off one handle.
+
+    ``GetCapabilities`` validates the coverage name, GDAL's WCS driver is opened
+    once on the service descriptor, and each window in `windows` is materialised
+    from that single handle. `windows` holds one box for an ordinary request and
+    two for one crossing the antimeridian, so a seam read costs one connection and
+    two ``GetCoverage`` calls rather than two full handshakes -- and, because both
+    halves come off the same source lattice, they land on a shared grid and stitch
+    without resampling.
+
+    Args:
+        endpoint: The WCS service URL.
+        coverage: The coverage identifier to read.
+        windows: One or two ``(minx, miny, maxx, maxy)`` boxes in `crs`, each with
+            ``minx < maxx``, in west-to-east order.
+        crs: The CRS the windows are expressed in.
+        version: The WCS version to pin, or ``None`` to let GDAL negotiate.
+        wcs_format: The preferred response format, or ``None``.
+        coverage_crs: The CRS shim for a coverage whose advertised CRS is absent
+            from PROJ, or ``None``.
+        auth: Optional ``(user, password)`` for HTTP Basic auth.
+        timeout: Request timeout in seconds.
+        extra_params: Extra ``GetCoverage`` query parameters, or ``None``.
+
+    Returns:
+        tuple[list[gdal.Dataset], osr.SpatialReference]: The ``MEM`` raster for
+            each window that had data, and the coverage's native CRS. With two
+            windows a half that misses the coverage entirely is dropped, so the
+            list can be shorter than `windows` -- and empty when neither half
+            overlaps.
+
+    Raises:
+        ValueError: `coverage` is not advertised by the service, ``coverage_crs``
+            cannot be interpreted, or a window does not project to a finite
+            native-CRS extent.
+        WCSError: The service could not be reached, the coverage has no resolvable
+            CRS, or GDAL could not produce a raster for a window.
+    """
+    _, coverages = _get_capabilities(endpoint, version, auth, timeout)
+    if coverages and coverage not in coverages:
+        raise not_advertised("coverage", coverage, endpoint, coverages)
+    descriptor = _service_descriptor(
+        endpoint, coverage, version, wcs_format, extra_params
+    )
+    mems: list[gdal.Dataset] = []
+    with gdal.config_options(_gdal_http_config(auth, timeout)):
+        src = _open_service(descriptor, coverage)
+        try:
+            native_srs = _resolve_native_srs(src, coverage_crs)
+            for window in windows:
+                projwin = _native_projwin(window, crs, native_srs)
+                # Overlap-filtered before fetching, as _crop_seam_halves does:
+                # only for a split request, so a single window keeps its own
+                # error rather than silently returning nothing.
+                if len(windows) > 1 and not _window_overlaps(projwin, src):
+                    continue
+                mems.append(_translate_window(src, projwin, coverage))
+        finally:
+            # Release the opened coverage handle on every path, error or not
+            # (mirrors from_wmts / from_ogc_coverages); a raise from resolve /
+            # projwin / translate must not leak the live network handle.
+            src = None
+    return mems, native_srs
+
+
 def _finalize(
     ds: Dataset,
     output_crs: str | None,
@@ -666,61 +760,100 @@ def from_wcs(
     caller-supplied parameters — for ``GetCoverage``-only "WCS shim" endpoints that
     502/400 on capabilities/describe.
 
+    ``bbox`` may cross the antimeridian. ``minx > maxx`` is read as a box wrapping
+    the 180 degree seam (it used to be refused as inverted): the request is split
+    at the seam into a ``(minx, ..., 180)`` and a ``(-180, ..., maxx)`` half, each
+    half is fetched through whichever path ``direct`` selects, and the two are
+    concatenated along longitude. The merged raster keeps the **west** half's
+    geotransform, so its longitudes continue past the seam -- 170..180 then
+    180..190 -- rather than jumping back to -180; reproject it if you need the
+    wrapped frame back. In discovery mode a half that misses the coverage entirely
+    is dropped before it is requested and the surviving half is returned on its
+    own; direct mode has no descriptor to measure the coverage against, so both
+    halves are always requested there.
+
+    Note:
+        The stitched result of a seam-crossing read is a plain
+        :class:`~pyramids.dataset.Dataset`, not `dataset_cls`, because the merge
+        rebuilds the raster through :meth:`Dataset.from_array`. Every
+        single-window read still returns `dataset_cls`.
+
     Raises:
         ValueError: ``bbox`` is malformed, ``coverage`` is not advertised (discovery
-            mode), ``coverage_crs`` cannot be interpreted, or (direct mode) the WCS
-            version is unsupported / ``1.0.0`` lacks a ``resolution``.
+            mode), ``coverage_crs`` cannot be interpreted, (direct mode) the WCS
+            version is unsupported / ``1.0.0`` lacks a ``resolution``, or a
+            seam-crossing ``bbox`` overlaps no part of the coverage / produced two
+            halves that do not meet at the seam.
         WCSError: The server could not be reached or returned an error / a
             non-raster body.
     """
-    minx, miny, maxx, maxy = _validate_bbox(bbox)
+    box = _validate_bbox(bbox, allow_antimeridian=True)
     res = _resolution_pair(resolution)
-    window = (minx, miny, maxx, maxy)
+    # One window normally, two when the bbox wraps the seam. Splitting
+    # unconditionally keeps the ordinary request on exactly the path it had.
+    windows = _seam_halves(box)
 
-    if direct:
-        ds, native_wkt = _from_wcs_direct(
-            dataset_cls,
-            endpoint,
-            coverage,
-            window,
-            crs,
-            version,
-            wcs_format,
-            resolution,
-            subset_axes,
-            coverage_crs,
-            auth,
-            timeout,
-            extra_params,
-        )
-        # 1.0.0 direct sends RESX/RESY, so the server already grids to `res`; skip
-        # the redundant client-side resample. 2.0.x has no request-side resolution,
-        # so it resamples client-side in _finalize.
-        finalize_res = None if (version or "2.0.0").startswith("1.0") else res
-    else:
-        _, coverages = _get_capabilities(endpoint, version, auth, timeout)
-        if coverages and coverage not in coverages:
-            raise not_advertised("coverage", coverage, endpoint, coverages)
-        descriptor = _service_descriptor(
-            endpoint, coverage, version, wcs_format, extra_params
-        )
-        config = _gdal_http_config(auth, timeout)
-        with gdal.config_options(config):
-            src = _open_service(descriptor, coverage)
-            try:
-                native_srs = _resolve_native_srs(src, coverage_crs)
-                projwin = _native_projwin(window, crs, native_srs)
-                mem = _translate_window(src, projwin, coverage)
-            finally:
-                # Release the opened coverage handle on every path, error or not
-                # (mirrors from_wmts / from_ogc_coverages); a raise from resolve /
-                # projwin / translate must not leak the live network handle.
-                src = None
-        mem.SetSpatialRef(native_srs)
-        ds = dataset_cls(mem, access="write")
-        # WKT round-trips more faithfully than proj4 for exotic / compound CRS.
-        native_wkt = native_srs.ExportToWkt()
-        finalize_res = res
+    parts: list[Dataset] = []
+    native_wkt: str | None = None
+    try:
+        if direct:
+            for window in windows:
+                part, native_wkt = _from_wcs_direct(
+                    dataset_cls,
+                    endpoint,
+                    coverage,
+                    window,
+                    crs,
+                    version,
+                    wcs_format,
+                    resolution,
+                    subset_axes,
+                    coverage_crs,
+                    auth,
+                    timeout,
+                    extra_params,
+                )
+                parts.append(part)
+            # 1.0.0 direct sends RESX/RESY, so the server already grids to `res`;
+            # skip the redundant client-side resample. 2.0.x has no request-side
+            # resolution, so it resamples client-side in _finalize.
+            finalize_res = None if (version or "2.0.0").startswith("1.0") else res
+        else:
+            mems, native_srs = _from_wcs_discovery(
+                endpoint,
+                coverage,
+                windows,
+                crs,
+                version,
+                wcs_format,
+                coverage_crs,
+                auth,
+                timeout,
+                extra_params,
+            )
+            # WKT round-trips more faithfully than proj4 for exotic / compound CRS.
+            native_wkt = native_srs.ExportToWkt()
+            for mem in mems:
+                mem.SetSpatialRef(native_srs)
+                parts.append(dataset_cls(mem, access="write"))
+            finalize_res = res
+        if not parts:
+            raise ValueError(
+                f"bbox {bbox!r} crosses the antimeridian but neither half overlaps "
+                f"the extent of coverage {coverage!r}"
+            )
+        if len(parts) == 1:
+            # Hand ownership of the only part to the caller, so the cleanup below
+            # does not close the raster being returned.
+            ds, parts = parts[0], []
+        else:
+            # _stitch_lon_halves copies both halves into a new raster, so the parts
+            # stay owned here and are closed by the finally. Its first argument is
+            # only read for band names; the west half carries the same ones.
+            ds = _stitch_lon_halves(parts[0], parts[0], parts[1])
+    finally:
+        for part in parts:
+            part.close()
 
     return _finalize(ds, output_crs, finalize_res, resample, native_wkt, output)
 

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -690,7 +690,16 @@ def _from_wcs_discovery(
                 # "neither half overlaps" for a bbox that never wrapped.
                 if len(windows) > 1 and not _window_overlaps(projwin, src):
                     continue
-                mems.append(_translate_window(src, projwin, coverage))
+                try:
+                    mems.append(_translate_window(src, projwin, coverage))
+                except BaseException:
+                    # A second window that fails must not strand the first. This
+                    # is the path the seam split introduced, and the rest of this
+                    # reader is explicit about ownership.
+                    for mem in mems:
+                        mem.Close()
+                    mems.clear()
+                    raise
         finally:
             # Release the opened coverage handle on every path, error or not
             # (mirrors from_wmts / from_ogc_coverages); a raise from resolve /
@@ -801,6 +810,8 @@ def from_wcs(
     windows = _seam_halves(box)
 
     parts: list[Dataset] = []
+    mems: list[gdal.Dataset] = []
+    adopted = 0
     native_wkt: str | None = None
     try:
         if direct:
@@ -852,6 +863,7 @@ def from_wcs(
             for mem in mems:
                 mem.SetSpatialRef(native_srs)
                 parts.append(dataset_cls(mem, access="write"))
+                adopted += 1
             finalize_res = res
         if not parts:
             raise ValueError(
@@ -873,6 +885,10 @@ def from_wcs(
     finally:
         for part in parts:
             part.close()
+        # A raise part-way through the adoption above leaves the tail of `mems`
+        # wrapped by nothing, so `parts` cannot close them.
+        for mem in mems[adopted:]:
+            mem.Close()
 
     return _finalize(ds, output_crs, finalize_res, resample, native_wkt, output)
 

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -965,7 +965,10 @@ def from_wcs(
         for part in parts:
             part.close()
         # A raise part-way through the adoption above leaves the tail of `mems`
-        # wrapped by nothing, so `parts` cannot close them.
+        # wrapped by nothing, so nothing else drops their GDAL handle. (`close()`
+        # on an adopted part clears that part's reference, not this list's -- both
+        # die with the frame either way; this is about releasing the handle
+        # promptly, not about who owns the object.)
         for mem in mems[adopted:]:
             mem.Close()
 

--- a/src/pyramids/dataset/_wcs.py
+++ b/src/pyramids/dataset/_wcs.py
@@ -681,25 +681,29 @@ def _from_wcs_discovery(
         src = _open_service(descriptor, coverage)
         try:
             native_srs = _resolve_native_srs(src, coverage_crs)
-            for window in windows:
-                projwin = _native_projwin(window, crs, native_srs)
-                # Overlap-filtered before fetching, as _crop_seam_halves does,
-                # but only for a split request. A lone window is left to GDAL,
-                # which warns and fills a miss with no-data rather than raising;
-                # filtering it too would turn that long-standing outcome into
-                # "neither half overlaps" for a bbox that never wrapped.
-                if len(windows) > 1 and not _window_overlaps(projwin, src):
-                    continue
-                try:
+            # Every projection first, before any raster exists. `_native_projwin`
+            # raises for a window that does not project to a finite native extent,
+            # and doing that here means no half can already be in hand when it
+            # does -- which is what a try around the fetch alone failed to cover.
+            projwins = [_native_projwin(window, crs, native_srs) for window in windows]
+            # Overlap-filtered before fetching, as _crop_seam_halves does, but only
+            # for a split request. A lone window is left to GDAL, which warns and
+            # fills a miss with no-data rather than raising; filtering it too would
+            # turn that long-standing outcome into "neither half overlaps" for a
+            # bbox that never wrapped.
+            if len(projwins) > 1:
+                projwins = [pw for pw in projwins if _window_overlaps(pw, src)]
+            try:
+                for projwin in projwins:
                     mems.append(_translate_window(src, projwin, coverage))
-                except BaseException:
-                    # A second window that fails must not strand the first. This
-                    # is the path the seam split introduced, and the rest of this
-                    # reader is explicit about ownership.
-                    for mem in mems:
-                        mem.Close()
-                    mems.clear()
-                    raise
+            except BaseException:
+                # A second window that fails must not strand the first. This is the
+                # path the seam split introduced, and the rest of this reader is
+                # explicit about ownership.
+                for mem in mems:
+                    mem.Close()
+                mems.clear()
+                raise
         finally:
             # Release the opened coverage handle on every path, error or not
             # (mirrors from_wmts / from_ogc_coverages); a raise from resolve /

--- a/src/pyramids/dataset/_wms.py
+++ b/src/pyramids/dataset/_wms.py
@@ -208,6 +208,10 @@ def _seam_windows(
         list[tuple[tuple[float, float, float, float], tuple[int, int]]]: One
             ``(bbox, size)`` request, or two in west-to-east order.
 
+    Raises:
+        ValueError: `bbox` wraps but `size` is under two pixels wide, which cannot
+            give each side of the seam a pixel of its own.
+
     Examples:
         - An ordinary bbox is one request, unchanged:
             ```python
@@ -244,10 +248,21 @@ def _seam_windows(
     else:
         west_half, east_half = halves
         _, miny, _, maxy = bbox
+        if width < 2:
+            raise ValueError(
+                f"a bbox crossing the antimeridian is rendered as two requests, so "
+                f"it needs at least 2 pixels of width; got {width}. Ask for a wider "
+                f"size, or a finer resolution."
+            )
         res = ((west_half[2] - west_half[0]) + (east_half[2] - east_half[0])) / width
-        # round(), not floor/ceil: the seam lands on whichever pixel boundary is
-        # nearest, which is what bounds the window shift at half a pixel.
-        west_columns = round((west_half[2] - west_half[0]) / res)
+        # Nearest pixel boundary, which is what bounds the window shift at half a
+        # pixel -- but rounded half *up* rather than through `round()`, whose
+        # banker's rounding sends an exactly-half-a-pixel half to zero and drops
+        # it. At (170, -10, -170, 10) and a width of 1 that discarded the entire
+        # western half and moved the request 10 degrees east of anything asked
+        # for. A half now collapses only when its span is strictly under half a
+        # pixel, which is the documented rule.
+        west_columns = int((west_half[2] - west_half[0]) / res + 0.5)
         east_columns = width - west_columns
         west_window = (
             (180.0 - west_columns * res, miny, 180.0, maxy),

--- a/src/pyramids/dataset/_wms.py
+++ b/src/pyramids/dataset/_wms.py
@@ -54,6 +54,7 @@ from pyramids.base._coverage import read_size as _read_size
 from pyramids.base._coverage import resolution_pair as _resolution_pair
 from pyramids.base._coverage import resolve_native_srs as _resolve_native_srs_neutral
 from pyramids.base._coverage import seam_halves as _seam_halves
+from pyramids.base._coverage import seam_offset as _seam_offset
 from pyramids.base._coverage import translate_to_mem as _translate_to_mem
 from pyramids.base._coverage import validate_bbox as _validate_bbox
 from pyramids.base._errors import CoverageError, WMSError
@@ -400,55 +401,6 @@ def _render_wms(src: gdal.Dataset, layers: str) -> gdal.Dataset:
     return _translate_to_mem(
         src, error=WMSError, action="WMS GetMap", subject=repr(layers)
     )
-
-
-def _seam_offset(
-    bbox: tuple[float, float, float, float],
-    crs: str,
-    native_srs: Any,
-) -> float:
-    """The x distance between the -180 and +180 meridians in the layer's own CRS.
-
-    What ``_merge_lon_halves`` needs to check that the east half really does
-    continue where the west one stops: 360 for a geographic layer, the full world
-    width (about 40 075 017 m) for a Web-Mercator one. Measured rather than
-    assumed, because a WMTS layer is cropped in *its* CRS, not in the request's.
-
-    Args:
-        bbox: The request bbox, used only for the latitude band the meridians are
-            measured across.
-        crs: The CRS ``bbox`` is expressed in.
-        native_srs: The layer's native spatial reference.
-
-    Returns:
-        float: The seam-to-seam x span in the native CRS's units.
-
-    Examples:
-        - A lon/lat layer measures the seam as the 360 degrees it is:
-            ```python
-            >>> from osgeo import osr
-            >>> from pyramids.dataset._wms import _seam_offset
-            >>> native = osr.SpatialReference()
-            >>> _ = native.ImportFromEPSG(4326)
-            >>> _seam_offset((170.0, -10.0, -170.0, 10.0), "EPSG:4326", native)
-            360.0
-
-            ```
-        - A Web Mercator layer measures the same seam in metres, so the check the
-          offset feeds is done in the units the halves are actually cropped in:
-            ```python
-            >>> from osgeo import osr
-            >>> from pyramids.dataset._wms import _seam_offset
-            >>> native = osr.SpatialReference()
-            >>> _ = native.ImportFromEPSG(3857)
-            >>> round(_seam_offset((170.0, -10.0, -170.0, 10.0), "EPSG:4326", native))
-            40075017
-
-            ```
-    """
-    _, miny, _, maxy = bbox
-    world = _native_projwin((-180.0, miny, 180.0, maxy), crs, native_srs)
-    return world[2] - world[0]
 
 
 def _check_halves_concatenable(

--- a/src/pyramids/dataset/_wms.py
+++ b/src/pyramids/dataset/_wms.py
@@ -46,6 +46,7 @@ from typing import TYPE_CHECKING, Any
 
 from osgeo import gdal
 
+from pyramids.base._coverage import MAX_PX
 from pyramids.base._coverage import check_seam_bbox as _check_seam_bbox
 from pyramids.base._coverage import native_projwin as _native_projwin
 from pyramids.base._coverage import native_resolution as _native_resolution
@@ -128,8 +129,9 @@ def _output_size(
         tuple[int, int]: The ``(width, height)`` to request, each at least 1 pixel.
 
     Raises:
-        ValueError: both or neither of ``size`` / ``resolution`` were given, or
-            ``size`` is not two positive integers.
+        ValueError: both or neither of ``size`` / ``resolution`` were given,
+            ``size`` is not two positive integers, or ``resolution`` over this
+            extent exceeds :data:`~pyramids.base._coverage.MAX_PX` on either axis.
 
     Examples:
         - A wrapping bbox is sized from the span it actually covers (20 degrees
@@ -157,9 +159,13 @@ def _output_size(
             )
         _, miny, _, maxy = bbox
         span_x = sum(half[2] - half[0] for half in _seam_halves(bbox))
-        # `max_px=None`: this is a local sizing decision, not the coverage
-        # readers' HTTP-fetch ceiling, so no cap applies here.
-        result = grid_size(span_x, maxy - miny, res, max_px=None)
+        # A GetMap is an HTTP fetch like any other, so it takes the same ceiling
+        # the coverage readers use. It matters more here than it used to: a
+        # transposed bbox is now read as a 359 degree wrap, and at a fine
+        # resolution that resolves to hundreds of thousands of columns -- two
+        # requests no server will serve, and half a gigabyte per half held in
+        # memory before the stitch copies both again.
+        result = grid_size(span_x, maxy - miny, res, max_px=MAX_PX)
     return result
 
 

--- a/src/pyramids/dataset/_wms.py
+++ b/src/pyramids/dataset/_wms.py
@@ -46,6 +46,7 @@ from typing import TYPE_CHECKING, Any
 
 from osgeo import gdal
 
+from pyramids.base._coverage import check_seam_bbox as _check_seam_bbox
 from pyramids.base._coverage import native_projwin as _native_projwin
 from pyramids.base._coverage import native_resolution as _native_resolution
 from pyramids.base._coverage import open_network_dataset as _open_network_dataset
@@ -59,7 +60,6 @@ from pyramids.base._errors import CoverageError, WMSError
 from pyramids.base._grid import grid_size
 from pyramids.base._ogc_api import gdal_http_config as _gdal_http_config
 from pyramids.base._ogc_api import not_advertised
-from pyramids.base.crs import sr_from_user_input
 from pyramids.dataset._subdataset import subdatasets_of
 
 if TYPE_CHECKING:
@@ -160,71 +160,6 @@ def _output_size(
         # readers' HTTP-fetch ceiling, so no cap applies here.
         result = grid_size(span_x, maxy - miny, res, max_px=None)
     return result
-
-
-def _check_seam_bbox(bbox: tuple[float, float, float, float], crs: str) -> None:
-    """Refuse a ``minx > maxx`` bbox this reader cannot read as an antimeridian wrap.
-
-    A no-op for an ordinary box. For a wrapping one it asserts the two things the
-    seam split silently assumes, so a transposed or projected-CRS bbox fails with a
-    message naming the problem instead of producing a raster stitched at a seam
-    that is not there.
-
-    Args:
-        bbox: The validated ``(minx, miny, maxx, maxy)``, possibly wrapping.
-        crs: The CRS ``bbox`` is expressed in (the WMS request CRS).
-
-    Raises:
-        ValueError: ``bbox`` wraps but ``crs`` is not geographic — the 180 degree
-            seam is a lon/lat feature, and in a projected CRS ``minx > maxx`` is
-            just an inverted box. Or it wraps but a corner lies outside
-            ``-180 .. 180``, where "west of the seam" and "east of it" stop
-            meaning anything.
-
-    Examples:
-        - An ordinary box passes in any CRS, projected included, because nothing
-          about it needs a seam:
-            ```python
-            >>> from pyramids.dataset._wms import _check_seam_bbox
-            >>> _check_seam_bbox((5.0, 51.0, 6.0, 52.0), "EPSG:3857") is None
-            True
-
-            ```
-        - A wrapping box in a projected CRS is refused rather than stitched at a
-          seam that CRS does not have:
-            ```python
-            >>> from pyramids.dataset._wms import _check_seam_bbox
-            >>> box = (170.0, -10.0, -170.0, 10.0)
-            >>> _check_seam_bbox(box, "EPSG:3857")  # doctest: +ELLIPSIS
-            Traceback (most recent call last):
-            ValueError: bbox (170.0, ...) has minx > maxx, ...it has no such seam...
-
-            ```
-        - So is a wrapping box reaching outside ``-180 .. 180``, where the two
-          sides of the seam stop being well defined:
-            ```python
-            >>> from pyramids.dataset._wms import _check_seam_bbox
-            >>> box = (190.0, -10.0, -170.0, 10.0)
-            >>> _check_seam_bbox(box, "EPSG:4326")  # doctest: +ELLIPSIS
-            Traceback (most recent call last):
-            ValueError: an antimeridian bbox must have both corners within -18...
-
-            ```
-    """
-    minx, _, maxx, _ = bbox
-    if minx > maxx:
-        if not sr_from_user_input(crs).IsGeographic():
-            raise ValueError(
-                f"bbox {bbox!r} has minx > maxx, which reads as a box crossing the "
-                f"180 degree seam - but crs={crs!r} is not a geographic (lon/lat) "
-                "CRS, so it has no such seam. Pass the bbox in a lon/lat CRS, or "
-                "give it as minx < maxx."
-            )
-        if minx > 180.0 or maxx < -180.0:
-            raise ValueError(
-                "an antimeridian bbox must have both corners within -180..180 "
-                f"degrees, got {bbox!r}"
-            )
 
 
 def _seam_windows(
@@ -799,7 +734,7 @@ def from_wms(
     Raises:
         ValueError: ``bbox`` is malformed, ``layers`` is empty, ``size`` /
             ``resolution`` was not given exactly once, or ``bbox`` wraps but
-            ``crs`` is projected (see :func:`_check_seam_bbox`).
+            ``crs`` is projected (see :func:`~pyramids.base._coverage.check_seam_bbox`).
         WMSError: the server could not be reached or returned a non-raster body.
     """
     minx, miny, maxx, maxy = _validate_bbox(bbox, allow_antimeridian=True)
@@ -829,7 +764,7 @@ def from_wms(
         return rendered
 
     with gdal.config_options(config):
-        # 360.0: the seam offset is in degrees because `_check_seam_bbox` has
+        # 360.0: the seam offset is in degrees because `check_seam_bbox` has
         # already established that a wrapping request CRS is geographic, and a WMS
         # renders in the request CRS itself (no native-CRS detour, unlike WMTS).
         mem = _collect_halves(fetch, windows, 360.0)
@@ -873,7 +808,7 @@ def from_wmts(
 
     Raises:
         ValueError: ``bbox`` is malformed, ``layer_crs`` cannot be interpreted, or
-            ``bbox`` wraps but ``crs`` is projected (see :func:`_check_seam_bbox`).
+            ``bbox`` wraps but ``crs`` is projected (see :func:`~pyramids.base._coverage.check_seam_bbox`).
         WMSError: the server could not be reached, the layer is unknown, or the
             tile read failed.
     """

--- a/src/pyramids/dataset/_wms.py
+++ b/src/pyramids/dataset/_wms.py
@@ -25,6 +25,14 @@ The two protocols map onto GDAL differently:
   (reprojecting the bbox into the layer's native CRS with ``pyproj``), exactly as
   the WCS reader windows a coverage.
 
+Both readers accept a bbox that **crosses the antimeridian** (``minx > maxx``,
+e.g. ``(170, -10, -170, 10)``), the same wrap :meth:`Dataset.crop` accepts: the
+request is split at the 180 degree seam, each half is fetched on its own, and the
+two are stitched back into one raster that keeps the west half's geotransform, so
+longitude runs on past the seam (``170 .. 180`` then ``180 .. 190``). See
+:func:`_seam_windows` for how a WMS request's *pixel* width is divided between
+the halves — the part that has no analogue in the other OGC readers.
+
 Scope boundary (see ``docs/SCOPE.md``): these readers take only generic OGC
 inputs. Provider specifics — endpoint / layer catalogs, agency auth (NASA GIBS,
 EUMETSAT), tile-matrix-set naming — live in the downstream consumer, which calls
@@ -44,12 +52,14 @@ from pyramids.base._coverage import open_network_dataset as _open_network_datase
 from pyramids.base._coverage import read_size as _read_size
 from pyramids.base._coverage import resolution_pair as _resolution_pair
 from pyramids.base._coverage import resolve_native_srs as _resolve_native_srs_neutral
+from pyramids.base._coverage import seam_halves as _seam_halves
 from pyramids.base._coverage import translate_to_mem as _translate_to_mem
 from pyramids.base._coverage import validate_bbox as _validate_bbox
 from pyramids.base._errors import CoverageError, WMSError
 from pyramids.base._grid import grid_size
 from pyramids.base._ogc_api import gdal_http_config as _gdal_http_config
 from pyramids.base._ogc_api import not_advertised
+from pyramids.base.crs import sr_from_user_input
 from pyramids.dataset._subdataset import subdatasets_of
 
 if TYPE_CHECKING:
@@ -101,9 +111,24 @@ def _output_size(
     ``resolution`` must be given: ``size`` is used verbatim; ``resolution`` (pixel
     size in the bbox CRS units) is divided into the bbox extent.
 
+    The extent is measured through :func:`~pyramids.base._coverage.seam_halves`, so
+    an antimeridian bbox (``minx > maxx``) is sized from the two halves it really
+    spans rather than from the negative ``maxx - minx`` that reading it as an
+    ordinary box would give.
+
     Raises:
         ValueError: both or neither of ``size`` / ``resolution`` were given, or
             ``size`` is not two positive integers.
+
+    Examples:
+        - A wrapping bbox is sized from the span it actually covers (20 degrees
+          across the seam, not the -340 the raw corners subtract to):
+            ```python
+            >>> from pyramids.dataset._wms import _output_size
+            >>> _output_size((170.0, -10.0, -170.0, 10.0), None, 0.05)
+            (400, 400)
+
+            ```
     """
     if size is not None and resolution is not None:
         raise ValueError("pass either size=(width, height) or resolution=, not both.")
@@ -119,10 +144,142 @@ def _output_size(
                 "from_wms needs the output size: pass size=(width, height) or "
                 "resolution=<pixel size in the bbox CRS units>."
             )
-        minx, miny, maxx, maxy = bbox
+        _, miny, _, maxy = bbox
+        span_x = sum(half[2] - half[0] for half in _seam_halves(bbox))
         # `max_px=None`: this is a local sizing decision, not the coverage
         # readers' HTTP-fetch ceiling, so no cap applies here.
-        result = grid_size(maxx - minx, maxy - miny, res, max_px=None)
+        result = grid_size(span_x, maxy - miny, res, max_px=None)
+    return result
+
+
+def _check_seam_bbox(bbox: tuple[float, float, float, float], crs: str) -> None:
+    """Refuse a ``minx > maxx`` bbox this reader cannot read as an antimeridian wrap.
+
+    A no-op for an ordinary box. For a wrapping one it asserts the two things the
+    seam split silently assumes, so a transposed or projected-CRS bbox fails with a
+    message naming the problem instead of producing a raster stitched at a seam
+    that is not there.
+
+    Args:
+        bbox: The validated ``(minx, miny, maxx, maxy)``, possibly wrapping.
+        crs: The CRS ``bbox`` is expressed in (the WMS request CRS).
+
+    Raises:
+        ValueError: ``bbox`` wraps but ``crs`` is not geographic — the 180 degree
+            seam is a lon/lat feature, and in a projected CRS ``minx > maxx`` is
+            just an inverted box. Or it wraps but a corner lies outside
+            ``-180 .. 180``, where "west of the seam" and "east of it" stop
+            meaning anything.
+    """
+    minx, _, maxx, _ = bbox
+    if minx > maxx:
+        if not sr_from_user_input(crs).IsGeographic():
+            raise ValueError(
+                f"bbox {bbox!r} has minx > maxx, which reads as a box crossing the "
+                f"180 degree seam - but crs={crs!r} is not a geographic (lon/lat) "
+                "CRS, so it has no such seam. Pass the bbox in a lon/lat CRS, or "
+                "give it as minx < maxx."
+            )
+        if minx > 180.0 or maxx < -180.0:
+            raise ValueError(
+                "an antimeridian bbox must have both corners within -180..180 "
+                f"degrees, got {bbox!r}"
+            )
+
+
+def _seam_windows(
+    bbox: tuple[float, float, float, float], size: tuple[int, int]
+) -> list[tuple[tuple[float, float, float, float], tuple[int, int]]]:
+    """The one or two ``GetMap`` requests that together render ``bbox`` at ``size``.
+
+    An ordinary bbox is one request, handed back untouched. A wrapping one must be
+    two, because ``GetMap`` cannot be asked for ``minx > maxx`` — and unlike the
+    other OGC readers a WMS request also carries an explicit **pixel** size, so the
+    requested ``width`` has to be divided between them. The rule:
+
+    1. The ground resolution is fixed first, at ``span / width`` over the *whole*
+       wrapping span — exactly the resolution a non-wrapping request of the same
+       span and width would get. Both halves are then asked for at that one
+       resolution, so it is uniform across the seam by construction.
+    2. The seam is snapped to the nearest whole pixel boundary:
+       ``west_columns = round(west_span / res)``, and the east half takes the
+       remaining ``width - west_columns``. The two counts sum to ``width`` by
+       definition, so the stitched raster is exactly as wide as was asked for.
+    3. Snapping moves the requested window by at most half a pixel, so the halves
+       are asked for over the *snapped* boxes (``180 - west_columns * res .. 180``
+       and ``-180 .. -180 + east_columns * res``) rather than the raw ones. The
+       alternative — keeping the raw corners and letting each half round its own
+       width — leaves one pixel straddling the seam, which no single ``GetMap``
+       can render, and gives the two halves subtly different resolutions.
+
+    When the snap puts every column on one side (a sliver under half a pixel wide
+    on the other), the result is that one request at the full ``width``: the sliver
+    was already unrenderable, and dropping it *is* the half-pixel snap rather than
+    a second exception to it.
+
+    Args:
+        bbox: The validated ``(minx, miny, maxx, maxy)``, possibly wrapping.
+        size: The requested output ``(width, height)`` in pixels.
+
+    Returns:
+        list[tuple[tuple[float, float, float, float], tuple[int, int]]]: One
+            ``(bbox, size)`` request, or two in west-to-east order.
+
+    Examples:
+        - An ordinary bbox is one request, unchanged:
+            ```python
+            >>> from pyramids.dataset._wms import _seam_windows
+            >>> _seam_windows((5.0, 51.0, 6.0, 52.0), (512, 256))
+            [((5.0, 51.0, 6.0, 52.0), (512, 256))]
+
+            ```
+        - A wrapping bbox becomes two requests whose widths sum to the requested
+          400, split in proportion to each half's share of the 20 degree span:
+            ```python
+            >>> from pyramids.dataset._wms import _seam_windows
+            >>> windows = _seam_windows((170.0, -10.0, -170.0, 10.0), (400, 200))
+            >>> [px for _, px in windows]
+            [(200, 200), (200, 200)]
+            >>> [tuple(round(v, 9) for v in box) for box, _ in windows]
+            [(170.0, -10.0, 180.0, 10.0), (-180.0, -10.0, -170.0, 10.0)]
+
+            ```
+        - An uneven split still sums to the requested width — the halves get 133
+          and 267 columns of one shared 0.0375 degree pixel, not 200 each:
+            ```python
+            >>> from pyramids.dataset._wms import _seam_windows
+            >>> windows = _seam_windows((175.0, -10.0, -170.0, 10.0), (400, 200))
+            >>> [px[0] for _, px in windows]
+            [133, 267]
+
+            ```
+    """
+    halves = _seam_halves(bbox)
+    width, height = size
+    if len(halves) == 1:
+        result = [(bbox, size)]
+    else:
+        west_half, east_half = halves
+        _, miny, _, maxy = bbox
+        res = ((west_half[2] - west_half[0]) + (east_half[2] - east_half[0])) / width
+        # round(), not floor/ceil: the seam lands on whichever pixel boundary is
+        # nearest, which is what bounds the window shift at half a pixel.
+        west_columns = round((west_half[2] - west_half[0]) / res)
+        east_columns = width - west_columns
+        west_window = (
+            (180.0 - west_columns * res, miny, 180.0, maxy),
+            (west_columns, height),
+        )
+        east_window = (
+            (-180.0, miny, -180.0 + east_columns * res, maxy),
+            (east_columns, height),
+        )
+        if west_columns == 0:
+            result = [east_window]
+        elif east_columns == 0:
+            result = [west_window]
+        else:
+            result = [west_window, east_window]
     return result
 
 
@@ -270,6 +427,169 @@ def _render_wms(src: gdal.Dataset, layers: str) -> gdal.Dataset:
     )
 
 
+def _seam_offset(
+    bbox: tuple[float, float, float, float],
+    crs: str,
+    native_srs: Any,
+) -> float:
+    """The x distance between the -180 and +180 meridians in the layer's own CRS.
+
+    What ``_merge_lon_halves`` needs to check that the east half really does
+    continue where the west one stops: 360 for a geographic layer, the full world
+    width (about 40 075 017 m) for a Web-Mercator one. Measured rather than
+    assumed, because a WMTS layer is cropped in *its* CRS, not in the request's.
+
+    Args:
+        bbox: The request bbox, used only for the latitude band the meridians are
+            measured across.
+        crs: The CRS ``bbox`` is expressed in.
+        native_srs: The layer's native spatial reference.
+
+    Returns:
+        float: The seam-to-seam x span in the native CRS's units.
+    """
+    _, miny, _, maxy = bbox
+    world = _native_projwin((-180.0, miny, 180.0, maxy), crs, native_srs)
+    return world[2] - world[0]
+
+
+def _check_halves_concatenable(
+    west: gdal.Dataset, east: gdal.Dataset, seam_offset: float
+) -> None:
+    """Assert that two seam-adjacent fetches really do tile one raster.
+
+    Both halves were asked for over the same latitude band, at the same pixel
+    size, meeting at the seam — this turns any violation of that into a clear
+    error rather than a silently shifted stitch. It mirrors
+    :func:`pyramids.dataset.engines.spatial._check_lon_halves_concatenable`, with
+    the 360 degree seam offset generalised to ``seam_offset`` so a WMTS layer in a
+    projected CRS is checked in its own units.
+
+    Args:
+        west: The pre-seam half.
+        east: The post-seam half.
+        seam_offset: The native-CRS distance from the -180 to the +180 meridian.
+
+    Raises:
+        ValueError: The halves differ in rows, band count, pixel size or top edge,
+            or they do not meet at the seam.
+    """
+    if west.RasterYSize != east.RasterYSize or west.RasterCount != east.RasterCount:
+        raise ValueError(
+            "antimeridian halves are not concatenable "
+            f"(rows {west.RasterYSize}/{east.RasterYSize}, "
+            f"bands {west.RasterCount}/{east.RasterCount})"
+        )
+    west_gt, east_gt = west.GetGeoTransform(), east.GetGeoTransform()
+    cell_x, cell_y = abs(west_gt[1]), abs(west_gt[5])
+    if abs(cell_x - abs(east_gt[1])) > 1e-6 * cell_x or abs(
+        cell_y - abs(east_gt[5])
+    ) > 1e-6 * abs(cell_y):
+        raise ValueError(
+            "antimeridian halves were rendered at different resolutions "
+            f"({west_gt[1]}, {west_gt[5]}) vs ({east_gt[1]}, {east_gt[5]}); "
+            "they cannot be stitched into one uniform grid"
+        )
+    if abs(west_gt[3] - east_gt[3]) > 0.5 * cell_y:
+        raise ValueError(
+            "antimeridian halves do not share a top edge "
+            f"({west_gt[3]} vs {east_gt[3]}), so they are not row-aligned"
+        )
+    gap = abs((west_gt[0] + west.RasterXSize * west_gt[1]) - (east_gt[0] + seam_offset))
+    if gap > 0.5 * cell_x:
+        raise ValueError(
+            f"antimeridian halves are {gap} apart at the seam (over half a "
+            f"{cell_x} pixel), so they do not tile a continuous raster"
+        )
+
+
+def _merge_lon_halves(
+    west: gdal.Dataset, east: gdal.Dataset, seam_offset: float
+) -> gdal.Dataset:
+    """Concatenate two seam-adjacent fetches into one ``MEM`` raster.
+
+    The merged raster keeps the **west** half's geotransform, so longitude runs on
+    past the seam (``170 .. 180`` then ``180 .. 190``) instead of jumping back to
+    -180 mid-raster — the same convention
+    :func:`pyramids.dataset.engines.spatial._stitch_lon_halves` gives a stitched
+    :meth:`Dataset.crop`. The pixels are copied as raw bytes so the band count,
+    data type, no-data value and colour interpretation of a rendered map survive
+    the stitch.
+
+    Args:
+        west: The pre-seam half.
+        east: The post-seam half, placed immediately to its right.
+        seam_offset: The native-CRS distance from the -180 to the +180 meridian,
+            for the alignment check.
+
+    Returns:
+        gdal.Dataset: The stitched raster, ``west.RasterXSize + east.RasterXSize``
+            columns wide.
+
+    Raises:
+        ValueError: The halves do not tile a continuous raster.
+    """
+    _check_halves_concatenable(west, east, seam_offset)
+    data_type = west.GetRasterBand(1).DataType
+    merged = gdal.GetDriverByName("MEM").Create(
+        "",
+        west.RasterXSize + east.RasterXSize,
+        west.RasterYSize,
+        west.RasterCount,
+        data_type,
+    )
+    merged.SetGeoTransform(west.GetGeoTransform())
+    merged.SetProjection(west.GetProjection())
+    for index in range(1, west.RasterCount + 1):
+        source, target = west.GetRasterBand(index), merged.GetRasterBand(index)
+        target.SetColorInterpretation(source.GetColorInterpretation())
+        no_data = source.GetNoDataValue()
+        if no_data is not None:
+            target.SetNoDataValue(no_data)
+    for part, x_offset in ((west, 0), (east, west.RasterXSize)):
+        merged.WriteRaster(
+            x_offset,
+            0,
+            part.RasterXSize,
+            part.RasterYSize,
+            part.ReadRaster(buf_type=data_type),
+            buf_type=data_type,
+        )
+    return merged
+
+
+def _collect_halves(fetch: Any, windows: list[Any], seam_offset: float) -> gdal.Dataset:
+    """Fetch each window and stitch the result, closing every part it does not return.
+
+    The ownership dance both readers need: one window is handed straight back (and
+    must therefore *not* be closed), two are merged into a third (and must be).
+    A failure part-way through closes whatever was already fetched.
+
+    Args:
+        fetch: Callable turning one window into a ``gdal.Dataset``.
+        windows: The one or two windows to fetch, in west-to-east order.
+        seam_offset: The native-CRS distance from the -180 to the +180 meridian.
+
+    Returns:
+        gdal.Dataset: The single fetch, or the stitched pair.
+
+    Raises:
+        ValueError: Two halves were fetched but do not tile a continuous raster.
+    """
+    parts: list[gdal.Dataset] = []
+    try:
+        for window in windows:
+            parts.append(fetch(window))
+        if len(parts) == 1:
+            result, parts = parts[0], []  # hand ownership to the caller
+        else:
+            result = _merge_lon_halves(parts[0], parts[1], seam_offset)
+    finally:
+        for part in parts:
+            part.Close()
+    return result
+
+
 def _reproject_tail(ds: Dataset, output_crs: str | None, resample: str) -> Dataset:
     """Reproject the result into ``output_crs`` when one was requested.
 
@@ -310,31 +630,54 @@ def from_wms(
     forwards resolved values here (so they are not restated on this signature) —
     see that method for the full parameter documentation.
 
+    Changed from the previous behaviour: a bbox crossing the antimeridian
+    (``minx > maxx``) used to be refused as inverted, the way every ``minx > maxx``
+    bbox was. It is now read as a wrap, matching :meth:`Dataset.crop` — two
+    ``GetMap`` requests either side of the 180 degree seam, stitched into one
+    raster that keeps the west half's geotransform (so its bbox reads e.g.
+    ``170 .. 190``). :func:`_seam_windows` documents how the requested pixel width
+    is divided; the stitched raster is exactly that wide, at one uniform
+    resolution, with the seam snapped to the nearest pixel boundary (a window shift
+    of at most half a pixel). An inverted bbox is therefore no longer caught here
+    — only ``miny >= maxy`` still is.
+
     Raises:
-        ValueError: ``bbox`` is malformed, ``layers`` is empty, or ``size`` /
-            ``resolution`` was not given exactly once.
+        ValueError: ``bbox`` is malformed, ``layers`` is empty, ``size`` /
+            ``resolution`` was not given exactly once, or ``bbox`` wraps but
+            ``crs`` is projected (see :func:`_check_seam_bbox`).
         WMSError: the server could not be reached or returned a non-raster body.
     """
-    minx, miny, maxx, maxy = _validate_bbox(bbox)
+    minx, miny, maxx, maxy = _validate_bbox(bbox, allow_antimeridian=True)
+    window = (minx, miny, maxx, maxy)
     layers_value = _layers_value(layers)
-    width, height = _output_size((minx, miny, maxx, maxy), size, resolution)
-    descriptor = _wms_descriptor(
-        endpoint,
-        layers_value,
-        crs,
-        image_format,
-        version,
-        (minx, miny, maxx, maxy),
-        (width, height),
-        bands,
-    )
+    _check_seam_bbox(window, crs)
+    windows = _seam_windows(window, _output_size(window, size, resolution))
     config = _gdal_http_config(auth, timeout)
-    with gdal.config_options(config):
+
+    def fetch(request: Any) -> gdal.Dataset:
+        """Render one ``(bbox, size)`` window through its own ``GetMap``."""
+        descriptor = _wms_descriptor(
+            endpoint,
+            layers_value,
+            crs,
+            image_format,
+            version,
+            request[0],
+            request[1],
+            bands,
+        )
         src = _open(descriptor, layers_value, "WMS")
         try:
-            mem = _render_wms(src, layers_value)
+            rendered = _render_wms(src, layers_value)
         finally:
             src = None
+        return rendered
+
+    with gdal.config_options(config):
+        # 360.0: the seam offset is in degrees because `_check_seam_bbox` has
+        # already established that a wrapping request CRS is geographic, and a WMS
+        # renders in the request CRS itself (no native-CRS detour, unlike WMTS).
+        mem = _collect_halves(fetch, windows, 360.0)
 
     ds = dataset_cls(mem, access="write")
     ds = _reproject_tail(ds, output_crs, resample)
@@ -365,13 +708,25 @@ def from_wmts(
     :meth:`pyramids.dataset.Dataset.from_wmts`, which forwards here and documents
     the parameters.
 
+    Changed from the previous behaviour: a bbox crossing the antimeridian
+    (``minx > maxx``) used to be refused as inverted. It is now read as a wrap,
+    matching :meth:`Dataset.crop` — the pyramid is windowed either side of the 180
+    degree seam and the two crops are stitched, keeping the west half's
+    geotransform. A wrapping read pins both halves to one resolution (the layer's
+    own when ``resolution`` is ``None``) so they land on a single grid; a
+    non-wrapping read is untouched.
+
     Raises:
-        ValueError: ``bbox`` is malformed, or ``layer_crs`` cannot be interpreted.
+        ValueError: ``bbox`` is malformed, ``layer_crs`` cannot be interpreted, or
+            ``bbox`` wraps but ``crs`` is projected (see :func:`_check_seam_bbox`).
         WMSError: the server could not be reached, the layer is unknown, or the
             tile read failed.
     """
-    minx, miny, maxx, maxy = _validate_bbox(bbox)
+    minx, miny, maxx, maxy = _validate_bbox(bbox, allow_antimeridian=True)
+    window = (minx, miny, maxx, maxy)
+    _check_seam_bbox(window, crs)
     res = _resolution_pair(resolution)
+    halves = _seam_halves(window)
     connection = _wmts_connection(endpoint, layer, tile_matrix_set)
     config = _gdal_http_config(auth, timeout)
     with gdal.config_options(config):
@@ -384,8 +739,23 @@ def from_wmts(
             raise
         try:
             native_srs = _resolve_native_srs(src, layer_crs)
-            projwin = _native_projwin((minx, miny, maxx, maxy), crs, native_srs)
-            mem = _translate_window(src, projwin, layer, res, resample)
+            # A split read pins both halves to one pixel size — left to itself each
+            # gdal.Translate would size its half from the source independently, and
+            # two grids that disagree cannot be stitched. A single-window read keeps
+            # the previous `resolution=None` meaning (finest level) untouched.
+            split = len(halves) > 1
+            half_res = (res or _native_resolution(src)) if split else res
+
+            def crop_half(half: Any) -> gdal.Dataset:
+                """Window one ``west < east`` half out of the pyramid."""
+                projwin = _native_projwin(half, crs, native_srs)
+                return _translate_window(src, projwin, layer, half_res, resample)
+
+            # The seam offset is only measured when there is a seam to check: the
+            # whole-world transform it needs is meaningless (and can be non-finite)
+            # for a layer whose CRS does not span both meridians.
+            offset = _seam_offset(window, crs, native_srs) if split else 0.0
+            mem = _collect_halves(crop_half, halves, offset)
         finally:
             src = None
 

--- a/src/pyramids/dataset/_wms.py
+++ b/src/pyramids/dataset/_wms.py
@@ -58,6 +58,7 @@ from pyramids.base._coverage import seam_halves as _seam_halves
 from pyramids.base._coverage import seam_offset as _seam_offset
 from pyramids.base._coverage import translate_to_mem as _translate_to_mem
 from pyramids.base._coverage import validate_bbox as _validate_bbox
+from pyramids.base._coverage import window_overlaps as _window_overlaps
 from pyramids.base._errors import CoverageError, WMSError
 from pyramids.base._grid import grid_size
 from pyramids.base._ogc_api import gdal_http_config as _gdal_http_config
@@ -496,9 +497,10 @@ def _merge_lon_halves(
     past the seam (``170 .. 180`` then ``180 .. 190``) instead of jumping back to
     -180 mid-raster — the same convention
     :func:`pyramids.dataset.engines.spatial._stitch_lon_halves` gives a stitched
-    :meth:`Dataset.crop`. The pixels are copied as raw bytes so the band count,
-    data type, no-data value and colour interpretation of a rendered map survive
-    the stitch.
+    :meth:`Dataset.crop`. The pixels are copied as raw bytes, and the west half's
+    band descriptions, metadata, units, no-data value, colour interpretation and
+    **colour table** are copied with them, so the same layer renders identically
+    whether or not the request happened to cross the seam.
 
     Args:
         west: The pre-seam half.
@@ -557,9 +559,22 @@ def _merge_lon_halves(
     )
     merged.SetGeoTransform(west.GetGeoTransform())
     merged.SetProjection(west.GetProjection())
+    merged.SetMetadata(west.GetMetadata())
     for index in range(1, west.RasterCount + 1):
         source, target = west.GetRasterBand(index), merged.GetRasterBand(index)
         target.SetColorInterpretation(source.GetColorInterpretation())
+        # The palette in particular: a WMS is the rendered-map reader, so a
+        # paletted image/png with bands=1 is an ordinary answer. Copying the
+        # interpretation without the table is worse than copying neither -- the
+        # band then declares itself GCI_PaletteIndex with nothing to look up.
+        color_table = source.GetRasterColorTable()
+        if color_table is not None:
+            target.SetRasterColorTable(color_table)
+        target.SetDescription(source.GetDescription())
+        target.SetMetadata(source.GetMetadata())
+        unit = source.GetUnitType()
+        if unit:
+            target.SetUnitType(unit)
         no_data = source.GetNoDataValue()
         if no_data is not None:
             target.SetNoDataValue(no_data)
@@ -591,7 +606,8 @@ def _collect_halves(fetch: Any, windows: list[Any], seam_offset: float) -> gdal.
         gdal.Dataset: The single fetch, or the stitched pair.
 
     Raises:
-        ValueError: Two halves were fetched but do not tile a continuous raster.
+        ValueError: `windows` is empty, or two halves were fetched but do not tile
+            a continuous raster.
 
     Examples:
         - One window is handed straight back, still open for the caller to use:
@@ -624,6 +640,8 @@ def _collect_halves(fetch: Any, windows: list[Any], seam_offset: float) -> gdal.
 
             ```
     """
+    if not windows:
+        raise ValueError("_collect_halves needs at least one window, got none")
     parts: list[gdal.Dataset] = []
     try:
         for window in windows:
@@ -803,6 +821,22 @@ def from_wmts(
             # whole-world transform it needs is meaningless (and can be non-finite)
             # for a layer whose CRS does not span both meridians.
             offset = _seam_offset(window, crs, native_srs) if split else 0.0
+            if split:
+                # Drop a half that misses the pyramid, as the WCS and OGC API
+                # Coverages readers do. A regional layer would otherwise return
+                # that half as a block of no-data and concatenate it in as though
+                # it were data. Only for a split read: a lone window keeps GDAL's
+                # own lenient behaviour, unchanged.
+                halves = [
+                    half
+                    for half in halves
+                    if _window_overlaps(_native_projwin(half, crs, native_srs), src)
+                ]
+                if not halves:
+                    raise ValueError(
+                        f"bbox {bbox!r} crosses the antimeridian but neither half "
+                        f"overlaps the extent of layer {layer!r}"
+                    )
             mem = _collect_halves(crop_half, halves, offset)
         finally:
             src = None

--- a/src/pyramids/dataset/_wms.py
+++ b/src/pyramids/dataset/_wms.py
@@ -116,6 +116,16 @@ def _output_size(
     spans rather than from the negative ``maxx - minx`` that reading it as an
     ordinary box would give.
 
+    Args:
+        bbox: The validated ``(minx, miny, maxx, maxy)``, possibly wrapping.
+        size: The caller's ``(width, height)`` in pixels, or ``None`` to derive it
+            from `resolution`.
+        resolution: Pixel size in the bbox CRS units -- a scalar for square pixels
+            or an ``(x_res, y_res)`` pair -- or ``None`` when `size` is given.
+
+    Returns:
+        tuple[int, int]: The ``(width, height)`` to request, each at least 1 pixel.
+
     Raises:
         ValueError: both or neither of ``size`` / ``resolution`` were given, or
             ``size`` is not two positive integers.
@@ -170,6 +180,36 @@ def _check_seam_bbox(bbox: tuple[float, float, float, float], crs: str) -> None:
             just an inverted box. Or it wraps but a corner lies outside
             ``-180 .. 180``, where "west of the seam" and "east of it" stop
             meaning anything.
+
+    Examples:
+        - An ordinary box passes in any CRS, projected included, because nothing
+          about it needs a seam:
+            ```python
+            >>> from pyramids.dataset._wms import _check_seam_bbox
+            >>> _check_seam_bbox((5.0, 51.0, 6.0, 52.0), "EPSG:3857") is None
+            True
+
+            ```
+        - A wrapping box in a projected CRS is refused rather than stitched at a
+          seam that CRS does not have:
+            ```python
+            >>> from pyramids.dataset._wms import _check_seam_bbox
+            >>> box = (170.0, -10.0, -170.0, 10.0)
+            >>> _check_seam_bbox(box, "EPSG:3857")  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+            ValueError: bbox (170.0, ...) has minx > maxx, ...it has no such seam...
+
+            ```
+        - So is a wrapping box reaching outside ``-180 .. 180``, where the two
+          sides of the seam stop being well defined:
+            ```python
+            >>> from pyramids.dataset._wms import _check_seam_bbox
+            >>> box = (190.0, -10.0, -170.0, 10.0)
+            >>> _check_seam_bbox(box, "EPSG:4326")  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+            ValueError: an antimeridian bbox must have both corners within -18...
+
+            ```
     """
     minx, _, maxx, _ = bbox
     if minx > maxx:
@@ -447,6 +487,29 @@ def _seam_offset(
 
     Returns:
         float: The seam-to-seam x span in the native CRS's units.
+
+    Examples:
+        - A lon/lat layer measures the seam as the 360 degrees it is:
+            ```python
+            >>> from osgeo import osr
+            >>> from pyramids.dataset._wms import _seam_offset
+            >>> native = osr.SpatialReference()
+            >>> _ = native.ImportFromEPSG(4326)
+            >>> _seam_offset((170.0, -10.0, -170.0, 10.0), "EPSG:4326", native)
+            360.0
+
+            ```
+        - A Web Mercator layer measures the same seam in metres, so the check the
+          offset feeds is done in the units the halves are actually cropped in:
+            ```python
+            >>> from osgeo import osr
+            >>> from pyramids.dataset._wms import _seam_offset
+            >>> native = osr.SpatialReference()
+            >>> _ = native.ImportFromEPSG(3857)
+            >>> round(_seam_offset((170.0, -10.0, -170.0, 10.0), "EPSG:4326", native))
+            40075017
+
+            ```
     """
     _, miny, _, maxy = bbox
     world = _native_projwin((-180.0, miny, 180.0, maxy), crs, native_srs)
@@ -473,6 +536,34 @@ def _check_halves_concatenable(
     Raises:
         ValueError: The halves differ in rows, band count, pixel size or top edge,
             or they do not meet at the seam.
+
+    Examples:
+        - Two halves that meet exactly at 180 pass, and the check returns nothing:
+            ```python
+            >>> from osgeo import gdal
+            >>> from pyramids.dataset._wms import _check_halves_concatenable
+            >>> west = gdal.GetDriverByName("MEM").Create("", 20, 40, 1)
+            >>> _ = west.SetGeoTransform((170.0, 0.5, 0.0, 10.0, 0.0, -0.5))
+            >>> east = gdal.GetDriverByName("MEM").Create("", 10, 40, 1)
+            >>> _ = east.SetGeoTransform((-180.0, 0.5, 0.0, 10.0, 0.0, -0.5))
+            >>> _check_halves_concatenable(west, east, 360.0) is None
+            True
+
+            ```
+        - A gap between them is caught rather than silently stitched, because the
+          east half no longer starts where the west one ends:
+            ```python
+            >>> from osgeo import gdal
+            >>> from pyramids.dataset._wms import _check_halves_concatenable
+            >>> west = gdal.GetDriverByName("MEM").Create("", 20, 40, 1)
+            >>> _ = west.SetGeoTransform((170.0, 0.5, 0.0, 10.0, 0.0, -0.5))
+            >>> east = gdal.GetDriverByName("MEM").Create("", 10, 40, 1)
+            >>> _ = east.SetGeoTransform((-179.0, 0.5, 0.0, 10.0, 0.0, -0.5))
+            >>> _check_halves_concatenable(west, east, 360.0)  # doctest: +ELLIPSIS
+            Traceback (most recent call last):
+            ValueError: antimeridian halves are 1.0 apart at the seam (over ha...
+
+            ```
     """
     if west.RasterYSize != east.RasterYSize or west.RasterCount != east.RasterCount:
         raise ValueError(
@@ -528,6 +619,39 @@ def _merge_lon_halves(
 
     Raises:
         ValueError: The halves do not tile a continuous raster.
+
+    Examples:
+        - The stitch is as wide as both halves together and keeps the west half's
+          origin, so longitude runs on past the seam instead of wrapping:
+            ```python
+            >>> from osgeo import gdal
+            >>> from pyramids.dataset._wms import _merge_lon_halves
+            >>> west = gdal.GetDriverByName("MEM").Create("", 20, 40, 1)
+            >>> _ = west.SetGeoTransform((170.0, 0.5, 0.0, 10.0, 0.0, -0.5))
+            >>> east = gdal.GetDriverByName("MEM").Create("", 10, 40, 1)
+            >>> _ = east.SetGeoTransform((-180.0, 0.5, 0.0, 10.0, 0.0, -0.5))
+            >>> merged = _merge_lon_halves(west, east, 360.0)
+            >>> merged.RasterXSize, merged.RasterYSize
+            (30, 40)
+            >>> merged.GetGeoTransform()[0]
+            170.0
+
+            ```
+        - The east edge of the result is therefore past 180, which is what makes it
+          one continuous raster rather than two:
+            ```python
+            >>> from osgeo import gdal
+            >>> from pyramids.dataset._wms import _merge_lon_halves
+            >>> west = gdal.GetDriverByName("MEM").Create("", 20, 40, 1)
+            >>> _ = west.SetGeoTransform((170.0, 0.5, 0.0, 10.0, 0.0, -0.5))
+            >>> east = gdal.GetDriverByName("MEM").Create("", 10, 40, 1)
+            >>> _ = east.SetGeoTransform((-180.0, 0.5, 0.0, 10.0, 0.0, -0.5))
+            >>> merged = _merge_lon_halves(west, east, 360.0)
+            >>> gt = merged.GetGeoTransform()
+            >>> gt[0] + merged.RasterXSize * gt[1]
+            185.0
+
+            ```
     """
     _check_halves_concatenable(west, east, seam_offset)
     data_type = west.GetRasterBand(1).DataType
@@ -575,6 +699,37 @@ def _collect_halves(fetch: Any, windows: list[Any], seam_offset: float) -> gdal.
 
     Raises:
         ValueError: Two halves were fetched but do not tile a continuous raster.
+
+    Examples:
+        - One window is handed straight back, still open for the caller to use:
+            ```python
+            >>> from osgeo import gdal
+            >>> from pyramids.dataset._wms import _collect_halves
+            >>> def fetch(window):
+            ...     part = gdal.GetDriverByName("MEM").Create("", 20, 40, 1)
+            ...     _ = part.SetGeoTransform((window, 0.5, 0.0, 10.0, 0.0, -0.5))
+            ...     return part
+            >>> only = _collect_halves(fetch, [170.0], 360.0)
+            >>> only.RasterXSize
+            20
+
+            ```
+        - Two windows come back as one stitched raster, twice as wide, on the west
+          half's origin:
+            ```python
+            >>> from osgeo import gdal
+            >>> from pyramids.dataset._wms import _collect_halves
+            >>> def fetch(window):
+            ...     part = gdal.GetDriverByName("MEM").Create("", 20, 40, 1)
+            ...     _ = part.SetGeoTransform((window, 0.5, 0.0, 10.0, 0.0, -0.5))
+            ...     return part
+            >>> merged = _collect_halves(fetch, [170.0, -180.0], 360.0)
+            >>> merged.RasterXSize
+            40
+            >>> merged.GetGeoTransform()[0]
+            170.0
+
+            ```
     """
     parts: list[gdal.Dataset] = []
     try:

--- a/src/pyramids/dataset/_wms.py
+++ b/src/pyramids/dataset/_wms.py
@@ -834,35 +834,22 @@ def from_wmts(
             raise
         try:
             native_srs = _resolve_native_srs(src, layer_crs)
-            # A split read pins both halves to one pixel size — left to itself each
-            # gdal.Translate would size its half from the source independently, and
-            # two grids that disagree cannot be stitched. A single-window read keeps
-            # the previous `resolution=None` meaning (finest level) untouched.
-            split = len(halves) > 1
-            half_res = (res or _native_resolution(src)) if split else res
-
-            def crop_half(half: Any) -> gdal.Dataset:
-                """Window one ``west < east`` half out of the pyramid."""
-                projwin = _native_projwin(half, crs, native_srs)
-                return _translate_window(src, projwin, layer, half_res, resample)
-
-            # The seam offset is only measured when there is a seam to check: the
-            # whole-world transform it needs is meaningless (and can be non-finite)
-            # for a layer whose CRS does not span both meridians.
-            offset = _seam_offset(window, crs, native_srs) if split else 0.0
-            if split:
+            # Project each half exactly once; the overlap filter and the fetch both
+            # need the window, and transforming twice is only a chance for the two
+            # to disagree.
+            windows = [
+                (half, _native_projwin(half, crs, native_srs)) for half in halves
+            ]
+            if len(windows) > 1:
                 # Drop a half that misses the pyramid, as the WCS and OGC API
                 # Coverages readers do. A regional layer would otherwise return
                 # that half as a block of no-data and concatenate it in as though
                 # it were data. Only for a split read: a lone window keeps GDAL's
                 # own lenient behaviour, unchanged.
-                projwins = [_native_projwin(half, crs, native_srs) for half in halves]
-                halves = [
-                    half
-                    for half, projwin in zip(halves, projwins, strict=True)
-                    if _window_overlaps(projwin, src)
-                ]
-                if not halves:
+                spans = [abs(pw[2] - pw[0]) for _, pw in windows]
+                first = windows[0][1]
+                windows = [(h, pw) for h, pw in windows if _window_overlaps(pw, src)]
+                if not windows:
                     raise ValueError(
                         f"bbox {bbox!r} crosses the antimeridian but neither half "
                         f"overlaps the extent of layer {layer!r}"
@@ -871,15 +858,27 @@ def from_wmts(
                 # `_translate_window` checks the ceiling per half, so without this
                 # a wrapping read is bounded at MAX_PX on *each* side -- twice the
                 # intended peak, and then a third copy to stitch them.
-                spans = [abs(pw[2] - pw[0]) for pw in projwins]
-                combined = [
-                    projwins[0][0],
-                    projwins[0][1],
-                    projwins[0][0] + sum(spans),
-                    projwins[0][3],
-                ]
-                _read_size(combined, half_res or _native_resolution(src))
-            mem = _collect_halves(crop_half, halves, offset)
+                combined = [first[0], first[1], first[0] + sum(spans), first[3]]
+                _read_size(combined, res or _native_resolution(src))
+            # `split` is decided by what survived the filter, not by what was asked
+            # for: a wrap where only one half overlaps is one request, and it should
+            # take the same path a non-wrapping request of that half would.
+            split = len(windows) > 1
+            # A split read pins both halves to one pixel size — left to itself each
+            # gdal.Translate would size its half from the source independently, and
+            # two grids that disagree cannot be stitched. A single-window read keeps
+            # the previous `resolution=None` meaning (finest level) untouched.
+            half_res = (res or _native_resolution(src)) if split else res
+
+            def crop_half(projwin: Any) -> gdal.Dataset:
+                """Window one already-projected half out of the pyramid."""
+                return _translate_window(src, projwin, layer, half_res, resample)
+
+            # The seam offset is only measured when there is a seam to check: the
+            # whole-world transform it needs is meaningless (and can be non-finite)
+            # for a layer whose CRS does not span both meridians.
+            offset = _seam_offset(window, crs, native_srs) if split else 0.0
+            mem = _collect_halves(crop_half, [pw for _, pw in windows], offset)
         finally:
             src = None
 

--- a/src/pyramids/dataset/_wms.py
+++ b/src/pyramids/dataset/_wms.py
@@ -564,6 +564,20 @@ def _merge_lon_halves(
             ```
     """
     _check_halves_concatenable(west, east, seam_offset)
+    band_types = {
+        west.GetRasterBand(i).DataType for i in range(1, west.RasterCount + 1)
+    }
+    if len(band_types) > 1:
+        # `Create` stamps one type on every band, and the raw copy below would
+        # then silently truncate the others -- a Float64 band written through a
+        # Byte buffer turns 3.25 into 3. GDAL's WMS and WMTS drivers make
+        # uniform-typed bands, so this is unreachable today; it is refused rather
+        # than left as a quiet numeric loss in a helper whose whole point is that
+        # a stitched raster matches an unstitched one.
+        raise ValueError(
+            f"antimeridian halves carry mixed band data types {sorted(band_types)}; "
+            "the stitch would truncate every band that is not the first"
+        )
     data_type = west.GetRasterBand(1).DataType
     merged = gdal.GetDriverByName("MEM").Create(
         "",
@@ -842,16 +856,29 @@ def from_wmts(
                 # that half as a block of no-data and concatenate it in as though
                 # it were data. Only for a split read: a lone window keeps GDAL's
                 # own lenient behaviour, unchanged.
+                projwins = [_native_projwin(half, crs, native_srs) for half in halves]
                 halves = [
                     half
-                    for half in halves
-                    if _window_overlaps(_native_projwin(half, crs, native_srs), src)
+                    for half, projwin in zip(halves, projwins, strict=True)
+                    if _window_overlaps(projwin, src)
                 ]
                 if not halves:
                     raise ValueError(
                         f"bbox {bbox!r} crosses the antimeridian but neither half "
                         f"overlaps the extent of layer {layer!r}"
                     )
+                # Budget the combined span once, as the coverage readers do.
+                # `_translate_window` checks the ceiling per half, so without this
+                # a wrapping read is bounded at MAX_PX on *each* side -- twice the
+                # intended peak, and then a third copy to stitch them.
+                spans = [abs(pw[2] - pw[0]) for pw in projwins]
+                combined = [
+                    projwins[0][0],
+                    projwins[0][1],
+                    projwins[0][0] + sum(spans),
+                    projwins[0][3],
+                ]
+                _read_size(combined, half_res or _native_resolution(src))
             mem = _collect_halves(crop_half, halves, offset)
         finally:
             src = None

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -3568,7 +3568,16 @@ class Dataset(RasterBase):
             layers: One layer name, or several to composite, as advertised by the
                 service ``GetCapabilities`` (joined with commas for the request).
             bbox: ``(minx, miny, maxx, maxy)`` in ``crs`` order (lon/lat for the
-                default ``"EPSG:4326"``).
+                default ``"EPSG:4326"``). ``minx > maxx`` reads as a window crossing
+                the antimeridian, the same wrap :meth:`crop` accepts:
+                ``(170, -10, -170, 10)`` is the 20 degrees around Fiji, not the 340
+                the corners subtract to. It is served as two ``GetMap`` requests
+                either side of the 180 degree seam and stitched into one raster whose
+                longitude runs on past it (``170 .. 180`` then ``180 .. 190``);
+                ``size`` is the width of the whole result, divided between the halves
+                at one shared resolution so the pixel size does not change across the
+                seam. Only a geographic ``crs`` has such a seam, so a wrapping bbox
+                with a projected one is refused rather than read as inverted.
             crs: CRS of ``bbox`` and of the rendered request. Defaults to
                 ``"EPSG:4326"`` (GDAL handles the WMS 1.3.0 lat/lon axis order).
             size: Output image size ``(width, height)`` in pixels. Mutually
@@ -3593,7 +3602,9 @@ class Dataset(RasterBase):
 
         Raises:
             ValueError: ``bbox`` is malformed, ``layers`` is empty, or ``size`` /
-                ``resolution`` was not given exactly once.
+                ``resolution`` was not given exactly once. A wrapping ``bbox`` is
+                malformed when ``crs`` is projected, or when a corner falls outside
+                ``-180 .. 180`` and "west of the seam" stops meaning anything.
             pyramids.errors.WMSError: The server could not be reached or returned a
                 non-raster body.
 
@@ -3663,7 +3674,13 @@ class Dataset(RasterBase):
             layer: The layer identifier as advertised by the capabilities document.
                 A value the service does not advertise raises :class:`ValueError`
                 (with the available layers listed).
-            bbox: ``(minx, miny, maxx, maxy)`` in ``crs`` order.
+            bbox: ``(minx, miny, maxx, maxy)`` in ``crs`` order. ``minx > maxx``
+                reads as a window crossing the antimeridian and is read as two crops
+                either side of the 180 degree seam, stitched into one raster whose
+                longitude continues past it. The seam offset is *measured* in the
+                layer's native CRS rather than assumed, so a layer tiled in Web
+                Mercator crosses as cleanly as a lon/lat one; a wrapping bbox in a
+                projected ``crs`` is still refused, since only lon/lat has the seam.
             crs: CRS of ``bbox``. Defaults to ``"EPSG:4326"``.
             tile_matrix_set: Optional tile-matrix-set id to pin. ``None`` lets GDAL
                 pick the layer's default.
@@ -3685,11 +3702,13 @@ class Dataset(RasterBase):
             Dataset: The cropped WMTS window.
 
         Raises:
-            ValueError: ``bbox`` is malformed, ``layer`` is not advertised,
-                ``layer_crs`` cannot be interpreted, or the requested window exceeds
-                the pixel ceiling (:data:`~pyramids.base._coverage.MAX_PX`; a
-                finest-level read over a wide ``bbox`` — pass a coarser ``resolution``
-                or a smaller ``bbox`` to bound it).
+            ValueError: ``bbox`` is malformed -- including a wrapping ``bbox`` with
+                a projected ``crs`` or a corner outside ``-180 .. 180`` -- ``layer``
+                is not advertised, ``layer_crs`` cannot be interpreted, or the
+                requested window exceeds the pixel ceiling
+                (:data:`~pyramids.base._coverage.MAX_PX`; a finest-level read over a
+                wide ``bbox`` — pass a coarser ``resolution`` or a smaller ``bbox``
+                to bound it).
             pyramids.errors.WMSError: The server could not be reached or the tile
                 read failed.
 

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -3593,7 +3593,10 @@ class Dataset(RasterBase):
                 exclusive with ``resolution``; exactly one is required.
             resolution: Output pixel size in ``crs`` units — a scalar (square) or
                 ``(x_res, y_res)`` pair — divided into the bbox extent to size the
-                image. Mutually exclusive with ``size``.
+                image. Mutually exclusive with ``size``. The derived size is capped
+                at :data:`~pyramids.base._coverage.MAX_PX` per axis; ``size``
+                itself is not, since a number the caller states cannot be amplified
+                by a mistake in ``bbox`` the way a derived one can.
             image_format: WMS ``FORMAT`` MIME type. Defaults to ``"image/png"``.
             version: WMS protocol version. Defaults to ``"1.3.0"``.
             bands: Number of bands to request (``3`` RGB, ``4`` RGBA). Defaults to
@@ -3610,10 +3613,13 @@ class Dataset(RasterBase):
             Dataset: The rendered map window.
 
         Raises:
-            ValueError: ``bbox`` is malformed, ``layers`` is empty, or ``size`` /
-                ``resolution`` was not given exactly once. A wrapping ``bbox`` is
-                malformed when ``crs`` is projected, or when a corner falls outside
-                ``-180 .. 180`` and "west of the seam" stops meaning anything.
+            ValueError: ``bbox`` is malformed, ``layers`` is empty, ``size`` /
+                ``resolution`` was not given exactly once, or ``resolution`` over
+                this ``bbox`` exceeds
+                :data:`~pyramids.base._coverage.MAX_PX` on either axis. A wrapping
+                ``bbox`` is malformed when ``crs`` is projected, or when a corner
+                falls outside ``-180 .. 180`` and "west of the seam" stops meaning
+                anything.
             pyramids.errors.WMSError: The server could not be reached or returned a
                 non-raster body.
 

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -3408,7 +3408,12 @@ class Dataset(RasterBase):
                 single open connection, so they come from the same source lattice
                 and stitch without resampling, and a half that misses the coverage
                 is skipped rather than requested. ``output_crs``, ``resolution`` and
-                ``output`` are applied once, to the merged raster.
+                ``output`` are applied once, to the merged raster. In ``direct``
+                mode there is no shared connection: the halves are two separate
+                ``GetCoverage`` requests, snapped to ``resolution`` so they land on
+                one lattice. Pass a ``resolution`` for a wrapping ``direct`` read —
+                without one nothing constrains the server to grid the two halves
+                alike, and a mismatch is refused rather than stitched.
             crs: CRS of ``bbox``. Defaults to ``"EPSG:4326"``.
             output_crs: Optional CRS to reproject the result into (any form
                 :meth:`to_crs` accepts). ``None`` (default) keeps the coverage's

--- a/src/pyramids/dataset/dataset.py
+++ b/src/pyramids/dataset/dataset.py
@@ -3400,7 +3400,15 @@ class Dataset(RasterBase):
                 ``GetCapabilities`` (e.g. ``"nitrogen_0-5cm_mean"``). A value the
                 server does not advertise raises :class:`ValueError`.
             bbox: ``(minx, miny, maxx, maxy)`` in ``crs`` order (lon/lat for the
-                default ``"EPSG:4326"``).
+                default ``"EPSG:4326"``). ``minx > maxx`` reads as a window crossing
+                the antimeridian, the same wrap :meth:`crop` accepts: it is fetched
+                as two ``GetCoverage`` requests either side of the 180 degree seam
+                and concatenated into one raster whose longitude runs on past it
+                (``170 .. 180`` then ``180 .. 190``). Both halves are read off a
+                single open connection, so they come from the same source lattice
+                and stitch without resampling, and a half that misses the coverage
+                is skipped rather than requested. ``output_crs``, ``resolution`` and
+                ``output`` are applied once, to the merged raster.
             crs: CRS of ``bbox``. Defaults to ``"EPSG:4326"``.
             output_crs: Optional CRS to reproject the result into (any form
                 :meth:`to_crs` accepts). ``None`` (default) keeps the coverage's
@@ -3456,9 +3464,10 @@ class Dataset(RasterBase):
             Dataset: The fetched coverage subset.
 
         Raises:
-            ValueError: ``bbox`` is malformed, ``coverage`` is not advertised
-                (discovery mode), ``coverage_crs`` cannot be interpreted, the
-                requested window exceeds the pixel ceiling
+            ValueError: ``bbox`` is malformed — an inverted *latitude* range still
+                counts, since there is no seam in latitude — ``coverage`` is not
+                advertised (discovery mode), ``coverage_crs`` cannot be interpreted,
+                the requested window exceeds the pixel ceiling
                 (:data:`~pyramids.base._coverage.MAX_PX`; a native-resolution read
                 over a wide ``bbox`` — pass a coarser ``resolution`` or a smaller
                 ``bbox`` to bound it), or (direct mode) the WCS version is
@@ -3794,6 +3803,13 @@ class Dataset(RasterBase):
                 **lon/lat (CRS84)**. It is projected into the coverage's native CRS
                 and read as a bounded, size-capped window; an unbounded full read is
                 not supported (the virtual raster spans the whole coverage).
+                ``minx > maxx`` reads as a subset crossing the antimeridian, as in
+                :meth:`from_wcs`, and is read as two windows either side of the 180
+                degree seam. With no ``resolution`` the two are sized *together* —
+                the combined span is capped once and the resulting pixel size
+                applied to both — because sizing each half against the cap on its
+                own gives them different pixel sizes and row counts, which cannot be
+                concatenated at all.
             output_crs: Optional CRS to reproject the result into (any form
                 :meth:`to_crs` accepts). ``None`` (default) keeps the coverage's
                 native CRS.
@@ -3828,8 +3844,9 @@ class Dataset(RasterBase):
             Dataset: The fetched coverage subset.
 
         Raises:
-            ValueError: ``bbox`` is malformed, ``coverage`` is not advertised, or
-                ``coverage_crs`` cannot be interpreted.
+            ValueError: ``bbox`` is malformed — an inverted *latitude* range
+                still counts, since there is no seam in latitude — ``coverage`` is
+                not advertised, or ``coverage_crs`` cannot be interpreted.
             pyramids.errors.OGCAPIError: The service could not be reached or
                 returned an error / a non-raster body.
 

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -17,6 +17,7 @@ from geopandas.geodataframe import GeoDataFrame
 from osgeo import gdal, osr
 from pyproj import Transformer
 
+from pyramids.base._bbox import split_antimeridian
 from pyramids.base._domain import is_no_data
 from pyramids.base._utils import DEFAULT_RESAMPLING, resolve_resampling
 from pyramids.base.crs import (
@@ -33,7 +34,6 @@ from pyramids.base.crs import (
 from pyramids.dataset.abstract_dataset import RasterBase
 from pyramids.feature import FeatureCollection
 from pyramids.feature import _ogr as _feature_ogr
-from pyramids.feature.bbox import split_antimeridian
 
 if TYPE_CHECKING:
     from pyramids.dataset.dataset import Dataset

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -92,22 +92,30 @@ def _resolve_resolution(
 
 
 def _check_lon_halves_concatenable(
-    west_part: RasterBase, east_part: RasterBase
+    west_part: RasterBase, east_part: RasterBase, seam_offset: float = 360.0
 ) -> None:
     """Assert the invariant that two longitude-adjacent crop halves are stitchable.
 
-    Both halves are cropped from the same source lattice, so equal row/band counts
-    and a shared cell boundary at the 180/360 seam are expected to hold — this is a
-    defensive guard that turns any future violation into a clear error instead of a
-    raw NumPy shape error or a silently shifted `np.concatenate` result.
+    Both halves are cropped from the same source lattice, so equal row/band counts,
+    one cell size and a shared cell boundary at the seam are expected to hold —
+    this is a defensive guard that turns any future violation into a clear error
+    instead of a raw NumPy shape error or a silently shifted `np.concatenate`
+    result.
 
     Args:
         west_part: Crop of the pre-seam half.
         east_part: Crop of the post-seam half (wrapped past the seam).
+        seam_offset: The distance from the west frame edge to the east one, in the
+            halves' own units. Defaults to `360.0`, which is right whenever the
+            halves are in degrees — every `Dataset.crop` and NetCDF path. A network
+            reader windows the source in the source's CRS, which may be projected,
+            and passes the measured value from
+            :func:`~pyramids.base._coverage.seam_offset` instead.
 
     Raises:
-        ValueError: The halves have mismatched row/band counts, or the grid has no
-            cell boundary at the seam so the halves are not seam-aligned.
+        ValueError: The halves have mismatched row/band counts, differ in cell
+            size, or the grid has no cell boundary at the seam so the halves are
+            not seam-aligned.
     """
     if west_part.rows != east_part.rows or west_part.band_count != east_part.band_count:
         raise ValueError(
@@ -115,14 +123,22 @@ def _check_lon_halves_concatenable(
             f"(rows {west_part.rows}/{east_part.rows}, "
             f"bands {west_part.band_count}/{east_part.band_count})"
         )
-    w_gt = west_part.geotransform
-    seam_gap = abs(
-        (w_gt[0] + west_part.columns * w_gt[1]) - (east_part.geotransform[0] + 360.0)
-    )
-    if seam_gap > 0.5 * abs(w_gt[1]):
+    w_gt, e_gt = west_part.geotransform, east_part.geotransform
+    cell_x = abs(w_gt[1])
+    # Cell size before seam gap: two halves rendered at different resolutions
+    # stitch into a raster whose geotransform describes only the west half's
+    # pixels, so the declared east edge drifts from where the data actually ends.
+    if abs(cell_x - abs(e_gt[1])) > 1e-6 * cell_x:
+        raise ValueError(
+            "antimeridian halves were produced at different resolutions "
+            f"({w_gt[1]} vs {e_gt[1]}); they cannot be stitched into one uniform "
+            "grid"
+        )
+    seam_gap = abs((w_gt[0] + west_part.columns * w_gt[1]) - (e_gt[0] + seam_offset))
+    if seam_gap > 0.5 * cell_x:
         raise ValueError(
             "antimeridian halves are not seam-aligned; the grid has no cell "
-            "boundary at the 180/360 seam, so the halves cannot be stitched"
+            "boundary at the seam, so the halves cannot be stitched"
         )
 
 
@@ -286,7 +302,9 @@ def _crop_seam_halves(
     return result
 
 
-def _stitch_lon_halves(ds: RasterBase, west_part: Any, east_part: Any) -> Dataset:
+def _stitch_lon_halves(
+    ds: RasterBase, west_part: Any, east_part: Any, seam_offset: float = 360.0
+) -> Dataset:
     """Concatenate two longitude-adjacent crops into one contiguous raster Dataset.
 
     `west_part` (pre-seam) sits to the left of `east_part` (wrapped past the seam);
@@ -299,6 +317,9 @@ def _stitch_lon_halves(ds: RasterBase, west_part: Any, east_part: Any) -> Datase
         ds: The dataset supplying the band names for the merged raster.
         west_part: Crop of the pre-seam half.
         east_part: Crop of the post-seam half.
+        seam_offset: The west-edge-to-east-edge distance in the halves' own units,
+            forwarded to :func:`_check_lon_halves_concatenable`. Defaults to
+            `360.0` for halves in degrees.
 
     Returns:
         Dataset: The concatenated raster.
@@ -308,7 +329,7 @@ def _stitch_lon_halves(ds: RasterBase, west_part: Any, east_part: Any) -> Datase
     # container).
     from pyramids.dataset.dataset import Dataset
 
-    _check_lon_halves_concatenable(west_part, east_part)
+    _check_lon_halves_concatenable(west_part, east_part, seam_offset)
     merged = np.concatenate([west_part.read_array(), east_part.read_array()], axis=-1)
     # epsg is None only for a no-EPSG CRS reported as such (a NetCDF
     # geostationary grid); from_array raises CRSError on None, so fall back to

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -116,6 +116,46 @@ def _check_lon_halves_concatenable(
         ValueError: The halves have mismatched row/band counts, differ in cell
             size, or the grid has no cell boundary at the seam so the halves are
             not seam-aligned.
+
+    Examples:
+        - Two halves in degrees meeting at 180 pass under the default offset:
+            ```python
+            >>> from osgeo import gdal
+            >>> from pyramids.dataset import Dataset
+            >>> from pyramids.dataset.engines.spatial import (
+            ...     _check_lon_halves_concatenable,
+            ... )
+            >>> def half(x, columns, cell):
+            ...     mem = gdal.GetDriverByName("MEM").Create("", columns, 4, 1)
+            ...     mem.SetGeoTransform((x, cell, 0.0, 10.0, 0.0, -cell))
+            ...     return Dataset(mem, access="write")
+            >>> west, east = half(170.0, 20, 0.5), half(-180.0, 10, 0.5)
+            >>> _check_lon_halves_concatenable(west, east) is None
+            True
+
+            ```
+        - The same pair in metres needs the offset measured in metres; leaving it
+          at 360 compares metres against degrees and rejects a well-formed pair:
+            ```python
+            >>> from osgeo import gdal
+            >>> from pyramids.dataset import Dataset
+            >>> from pyramids.dataset.engines.spatial import (
+            ...     _check_lon_halves_concatenable,
+            ... )
+            >>> def half(x, columns, cell):
+            ...     mem = gdal.GetDriverByName("MEM").Create("", columns, 4, 1)
+            ...     mem.SetGeoTransform((x, cell, 0.0, 10.0, 0.0, -cell))
+            ...     return Dataset(mem, access="write")
+            >>> world = 20037508.342789244
+            >>> west = half(world - 100000.0, 100, 1000.0)
+            >>> east = half(-world, 50, 1000.0)
+            >>> _check_lon_halves_concatenable(west, east, 2 * world) is None
+            True
+            >>> _check_lon_halves_concatenable(west, east)
+            Traceback (most recent call last):
+            ValueError: antimeridian halves are not seam-aligned...
+
+            ```
     """
     if west_part.rows != east_part.rows or west_part.band_count != east_part.band_count:
         raise ValueError(
@@ -323,6 +363,42 @@ def _stitch_lon_halves(
 
     Returns:
         Dataset: The concatenated raster.
+
+    Examples:
+        - The stitch is as wide as both halves and keeps the west half's origin, so
+          longitude runs past the seam instead of jumping back to -180:
+            ```python
+            >>> from osgeo import gdal
+            >>> from pyramids.dataset import Dataset
+            >>> from pyramids.dataset.engines.spatial import _stitch_lon_halves
+            >>> def half(x, columns):
+            ...     mem = gdal.GetDriverByName("MEM").Create("", columns, 4, 1)
+            ...     mem.SetGeoTransform((x, 0.5, 0.0, 10.0, 0.0, -0.5))
+            ...     return Dataset(mem, access="write")
+            >>> west, east = half(170.0, 20), half(-180.0, 10)
+            >>> merged = _stitch_lon_halves(west, west, east)
+            >>> merged.columns
+            30
+            >>> merged.geotransform[0]
+            170.0
+
+            ```
+        - So the east edge lands past 180, which is what makes the result one
+          continuous raster rather than two:
+            ```python
+            >>> from osgeo import gdal
+            >>> from pyramids.dataset import Dataset
+            >>> from pyramids.dataset.engines.spatial import _stitch_lon_halves
+            >>> def half(x, columns):
+            ...     mem = gdal.GetDriverByName("MEM").Create("", columns, 4, 1)
+            ...     mem.SetGeoTransform((x, 0.5, 0.0, 10.0, 0.0, -0.5))
+            ...     return Dataset(mem, access="write")
+            >>> merged = _stitch_lon_halves(half(170.0, 20), half(170.0, 20), half(-180.0, 10))
+            >>> gt = merged.geotransform
+            >>> gt[0] + merged.columns * gt[1]
+            185.0
+
+            ```
     """
     # Local import breaks the engines <-> Dataset cycle; the merged result must be a
     # plain raster Dataset (from_array on a variable view would build a NetCDF

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -419,7 +419,40 @@ def _stitch_lon_halves(
         no_data_value=west_part.no_data_value,
     )
     out.band_names = ds.band_names
+    _carry_band_metadata(west_part, out)
     return out
+
+
+def _carry_band_metadata(source: Any, target: Dataset) -> None:
+    """Copy the per-band description that survives a raw stitch but not a rebuild.
+
+    `_stitch_lon_halves` rebuilds through `Dataset.from_array`, which carries the
+    array, the geotransform and the no-data value and nothing else. Its WMS
+    counterpart copies the colour table, colour interpretation, units and metadata
+    explicitly, so a stitched map renders exactly like an unstitched one; this
+    brings the crop/coverage path to the same standard rather than leaving the two
+    stitchers disagreeing about what a seam read is allowed to lose.
+
+    Args:
+        source: The west half, whose band properties are authoritative.
+        target: The freshly built stitched raster, modified in place.
+
+    Returns:
+        None
+    """
+    src_raster, dst_raster = source.raster, target.raster
+    dst_raster.SetMetadata(src_raster.GetMetadata())
+    for index in range(1, min(src_raster.RasterCount, dst_raster.RasterCount) + 1):
+        src_band = src_raster.GetRasterBand(index)
+        dst_band = dst_raster.GetRasterBand(index)
+        dst_band.SetColorInterpretation(src_band.GetColorInterpretation())
+        color_table = src_band.GetRasterColorTable()
+        if color_table is not None:
+            dst_band.SetRasterColorTable(color_table)
+        unit = src_band.GetUnitType()
+        if unit:
+            dst_band.SetUnitType(unit)
+        dst_band.SetMetadata(src_band.GetMetadata())
 
 
 class Spatial(_Engine["Dataset"]):

--- a/src/pyramids/dataset/engines/spatial.py
+++ b/src/pyramids/dataset/engines/spatial.py
@@ -439,6 +439,52 @@ def _carry_band_metadata(source: Any, target: Dataset) -> None:
 
     Returns:
         None
+
+    Examples:
+        - A palette and a unit on the west half survive onto the stitched result,
+          so a seam-crossing crop renders like an ordinary one:
+            ```python
+            >>> from osgeo import gdal
+            >>> from pyramids.dataset import Dataset
+            >>> from pyramids.dataset.engines.spatial import _carry_band_metadata
+            >>> def raster(columns):
+            ...     mem = gdal.GetDriverByName("MEM").Create("", columns, 4, 1)
+            ...     mem.SetGeoTransform((0.0, 1.0, 0.0, 4.0, 0.0, -1.0))
+            ...     return Dataset(mem, access="write")
+            >>> west = raster(4)
+            >>> table = gdal.ColorTable()
+            >>> table.SetColorEntry(1, (10, 20, 30, 255))
+            >>> band = west.raster.GetRasterBand(1)
+            >>> band.SetRasterColorTable(table)
+            0
+            >>> band.SetUnitType("class")
+            0
+            >>> merged = raster(6)
+            >>> _carry_band_metadata(west, merged)
+            >>> merged.raster.GetRasterBand(1).GetUnitType()
+            'class'
+            >>> merged.raster.GetRasterBand(1).GetRasterColorTable().GetColorEntry(1)
+            (10, 20, 30, 255)
+
+            ```
+        - A half carrying nothing leaves the target as it was, so the copy is safe
+          for the ordinary case it runs on every crop:
+            ```python
+            >>> from osgeo import gdal
+            >>> from pyramids.dataset import Dataset
+            >>> from pyramids.dataset.engines.spatial import _carry_band_metadata
+            >>> def raster(columns):
+            ...     mem = gdal.GetDriverByName("MEM").Create("", columns, 4, 1)
+            ...     mem.SetGeoTransform((0.0, 1.0, 0.0, 4.0, 0.0, -1.0))
+            ...     return Dataset(mem, access="write")
+            >>> merged = raster(6)
+            >>> _carry_band_metadata(raster(4), merged)
+            >>> merged.raster.GetRasterBand(1).GetRasterColorTable() is None
+            True
+            >>> merged.raster.GetRasterBand(1).GetUnitType()
+            ''
+
+            ```
     """
     src_raster, dst_raster = source.raster, target.raster
     dst_raster.SetMetadata(src_raster.GetMetadata())

--- a/src/pyramids/feature/_ogc.py
+++ b/src/pyramids/feature/_ogc.py
@@ -39,7 +39,7 @@ import geopandas as gpd
 import pandas as pd
 from osgeo import gdal
 
-from pyramids.base._coverage import seam_halves, validate_bbox
+from pyramids.base._coverage import check_seam_bbox, seam_halves, validate_bbox
 from pyramids.base._ogc_api import gdal_http_config, not_advertised
 
 if TYPE_CHECKING:
@@ -206,7 +206,9 @@ def read_kwargs(
     Raises:
         ValueError: ``bbox`` is not a 4-tuple, holds a non-finite corner or is
             inverted (``minx >= maxx`` other than a wrap, or ``miny >= maxy``),
-            or ``max_features`` is less than 1.
+            or ``max_features`` is less than 1. A wrapping ``bbox`` reaching
+            outside ``-180 .. 180`` is refused too -- including one given in a
+            projected CRS, whose coordinates fall far outside that range.
 
     Examples:
         - An ordinary box becomes a single ``bbox`` filter:
@@ -236,6 +238,16 @@ def read_kwargs(
     kwargs: dict[str, Any] = {}
     if bbox is not None:
         kwargs["bbox"] = validate_bbox(bbox, allow_antimeridian=True)
+        # The same guard the raster readers apply, for the same reason and with
+        # more at stake here: an out-of-range wrap splits into an *inverted* first
+        # half, and an inverted rect handed to OGR is exactly the silent
+        # normalisation this module's split exists to prevent. `EPSG:4326` because
+        # OGC API - Features is CRS84 by contract; for WFS the layer's own CRS may
+        # be projected, and then its coordinates fall well outside -180..180, so
+        # the corner-range half of the check refuses the wrap anyway -- which is
+        # the right answer, since a projected CRS has no 180 degree seam to split
+        # at.
+        check_seam_bbox(kwargs["bbox"], "EPSG:4326")
     if where is not None:
         kwargs["where"] = where
     if max_features is not None:

--- a/src/pyramids/feature/_ogc.py
+++ b/src/pyramids/feature/_ogc.py
@@ -6,16 +6,40 @@ assembly (bbox / attribute filter / feature cap) is identical between them, so i
 lives here once instead of being copied into each reader. The GDAL HTTP config
 (auth + timeout) is shared more widely with the raster OGC readers and lives in
 :mod:`pyramids.base._ogc_api`.
+
+The antimeridian split lives here too, and it is a **network** split, not a local
+one. The `bbox` these readers take is not applied to a datasource pyramids holds:
+pyogrio turns it into `OGR_L_SetSpatialFilterRect`, and the `WFS` / `OAPIF`
+drivers turn *that* into a request parameter — a read filtered by
+``(170, -10, 180, 10)`` goes out as
+``GET /collections/<id>/items?limit=1000&bbox=170,-10,180,10``. Three
+consequences settle the design:
+
+* A wrapping ``west > east`` bbox therefore costs **two requests**, one per seam
+  half, whose results are concatenated here. There is no cheaper local option to
+  reach for; nothing is fetched that a caller did not ask for.
+* A multipart filter cannot be pushed into one request. Handing OGR a
+  two-part `MultiPolygon` through `mask=` sends the *envelope* —
+  ``bbox=-180,-10,180,10``, the whole globe in longitude — and filters exactly
+  on the client afterwards. The answer is right and the download is the entire
+  world, which is the opposite of what a bbox is for.
+* A wrapping rect handed straight to OGR is silently **inverted**:
+  ``SetSpatialFilterRect(170, -10, -170, 10)`` normalises its envelope and goes
+  out as ``bbox=-170,-10,170,10`` — the complement of what was asked for, with
+  no error. That is why :func:`read_kwargs` may record a wrapping bbox but
+  :func:`read_ogc_layer` must split it before it reaches the driver.
 """
 
 from __future__ import annotations
 
-from math import isfinite
+from itertools import repeat
 from typing import TYPE_CHECKING, Any
 
 import geopandas as gpd
+import pandas as pd
 from osgeo import gdal
 
+from pyramids.base._coverage import seam_halves, validate_bbox
 from pyramids.base._ogc_api import gdal_http_config, not_advertised
 
 if TYPE_CHECKING:
@@ -74,6 +98,19 @@ def read_ogc_layer(
     reproject. Only the connection string, discovery step, error class and
     failure-message wording differ between the two readers.
 
+    A ``west > east`` bbox in ``read_kwargs`` is split at the 180 degree meridian
+    by :func:`pyramids.base._coverage.seam_halves` and read as two requests, whose
+    features are unioned by :func:`merge_seam_halves`. This is a **behaviour
+    change** relative to ``origin/main``, where such a bbox was refused before any
+    request went out. A non-wrapping bbox still makes exactly one request with the
+    exact filters it was given, and a failure on either half raises the same
+    branded message a single failed read raises.
+
+    The split is at ±180, so it reads the bbox as lon/lat degrees — the convention
+    the OGC ``bbox`` parameter declares (CRS84 by default for OGC API – Features).
+    A service whose default CRS is projected has no seam at ±180, and a wrapping
+    bbox against one is a caller mistake this cannot detect.
+
     Args:
         fc_cls: The ``FeatureCollection`` class to construct.
         connection: The GDAL OGR connection string (``WFS:…`` / ``OAPIF:…``).
@@ -95,11 +132,28 @@ def read_ogc_layer(
             but the result carries no CRS.
     """
     config = gdal_http_config(auth, timeout)
+    bbox = read_kwargs.get("bbox")
+    # One window when the bbox does not wrap (or there is none), two when it does.
+    # `seam_halves` hands a non-wrapping box back untouched, so the common path
+    # stays a single request with the filters exactly as they were assembled.
+    windows: list[tuple[float, float, float, float] | None] = (
+        [None] if bbox is None else list(seam_halves(bbox))
+    )
+    frames: list[gpd.GeoDataFrame] = []
     with gdal.config_options(config):
-        try:
-            gdf = gpd.read_file(connection, layer=layer, **read_kwargs)
-        except Exception as exc:  # noqa: BLE001 — normalise any read failure to error_cls
-            raise error_cls(f"{read_fail_prefix} {layer!r}: {exc}") from exc
+        for window in windows:
+            per_window = dict(read_kwargs)
+            if window is not None:
+                per_window["bbox"] = window
+            try:
+                frames.append(gpd.read_file(connection, layer=layer, **per_window))
+            except Exception as exc:  # noqa: BLE001 — normalise any read failure to error_cls
+                raise error_cls(f"{read_fail_prefix} {layer!r}: {exc}") from exc
+    gdf = (
+        frames[0]
+        if len(frames) == 1
+        else merge_seam_halves(frames, read_kwargs.get("rows"))
+    )
     fc = fc_cls(gdf)
     if output_crs is not None:
         if fc.crs is None:
@@ -118,28 +172,70 @@ def read_kwargs(
 ) -> dict[str, Any]:
     """Assemble the pyogrio / GDAL read filters (bbox, attribute filter, count).
 
+    The bbox is validated by :func:`pyramids.base._coverage.validate_bbox`, the
+    same call the raster OGC readers make, rather than by a second copy of the
+    arity / finiteness / ordering block. The two copies were written out
+    separately with verbatim identical messages, which is why they were kept in
+    step by a test asserting the two sentences matched rather than by there
+    being one sentence.
+
+    ``allow_antimeridian=True`` is the one deliberate difference from what the
+    old copy did, and it is a **behaviour change** relative to ``origin/main``:
+    a ``west > east`` bbox used to be refused as inverted, and is now read as a
+    box crossing the 180 degree seam, exactly as :meth:`Dataset.crop` reads it.
+    The ordering rule on the Y axis is untouched — there is no seam in latitude,
+    so ``miny >= maxy`` is still an error — and so is ``minx == maxx``, a
+    zero-width box either way.
+
+    Note:
+        The returned dict is **not** splat-able into :func:`geopandas.read_file`
+        when the bbox wraps: ``kwargs["bbox"]`` then still carries the caller's
+        ``west > east`` box, and OGR would normalise that envelope into its
+        complement (see this module's docstring). :func:`read_ogc_layer` owns the
+        split, and both readers reach the driver only through it.
+
+    Args:
+        bbox: Optional ``(minx, miny, maxx, maxy)``, possibly wrapping.
+        where: Optional OGR SQL attribute filter.
+        max_features: Optional cap on the features returned.
+
+    Returns:
+        dict[str, Any]: The read filters, keyed as pyogrio names them
+            (``bbox`` / ``where`` / ``rows``).
+
     Raises:
         ValueError: ``bbox`` is not a 4-tuple, holds a non-finite corner or is
-            inverted, or ``max_features`` is less than 1.
+            inverted (``minx >= maxx`` other than a wrap, or ``miny >= maxy``),
+            or ``max_features`` is less than 1.
+
+    Examples:
+        - An ordinary box becomes a single ``bbox`` filter:
+            ```python
+            >>> from pyramids.feature._ogc import read_kwargs
+            >>> read_kwargs((1.0, 2.0, 3.0, 4.0), None, None)
+            {'bbox': (1.0, 2.0, 3.0, 4.0)}
+
+            ```
+        - A box crossing the seam is recorded as the caller wrote it; the split
+          happens in :func:`read_ogc_layer`, once, against the driver:
+            ```python
+            >>> from pyramids.feature._ogc import read_kwargs
+            >>> read_kwargs((170.0, -10.0, -170.0, 10.0), None, None)
+            {'bbox': (170.0, -10.0, -170.0, 10.0)}
+
+            ```
+        - An inverted latitude range stays an error — latitude has no seam:
+            ```python
+            >>> from pyramids.feature._ogc import read_kwargs
+            >>> read_kwargs((1.0, 4.0, 3.0, 2.0), None, None)
+            Traceback (most recent call last):
+            ValueError: bbox must have minx < maxx and miny < maxy, got (1.0, 4.0, 3.0, 2.0)
+
+            ```
     """
     kwargs: dict[str, Any] = {}
     if bbox is not None:
-        if len(bbox) != 4:
-            raise ValueError(f"bbox must be (minx, miny, maxx, maxy), got {bbox!r}")
-        minx, miny, maxx, maxy = (float(v) for v in bbox)
-        # Checked before the ordering test, exactly as `validate_bbox` does for
-        # the raster readers: every comparison against NaN is False, so
-        # `minx >= maxx` passes a NaN corner straight through, and an infinite
-        # one compares as a legitimately huge box. Both then reach the OGR
-        # driver as a spatial filter no feature can fall inside, where an empty
-        # result reads as "the service has nothing there".
-        if not all(isfinite(v) for v in (minx, miny, maxx, maxy)):
-            raise ValueError(f"bbox must be four finite numbers, got {bbox!r}")
-        if minx >= maxx or miny >= maxy:
-            raise ValueError(
-                f"bbox must have minx < maxx and miny < maxy, got {bbox!r}"
-            )
-        kwargs["bbox"] = (minx, miny, maxx, maxy)
+        kwargs["bbox"] = validate_bbox(bbox, allow_antimeridian=True)
     if where is not None:
         kwargs["where"] = where
     if max_features is not None:
@@ -149,3 +245,134 @@ def read_kwargs(
             raise ValueError(f"max_features must be >= 1 or None, got {max_features}")
         kwargs["rows"] = max_features
     return kwargs
+
+
+def content_keys(frame: gpd.GeoDataFrame) -> pd.Series:
+    """A hashable per-row identity: the geometry's WKB plus every attribute's repr.
+
+    Used only to spot the same feature coming back from both seam requests. The
+    geometry goes in as WKB so two rows match only when their coordinates match
+    exactly; the attributes go in as `repr` so a GeoJSON property that arrived as
+    a list or a dict — unhashable, and common enough in an OGC API response — does
+    not turn a de-duplication into a ``TypeError``.
+
+    Two rows the source genuinely holds twice, identical in geometry and in every
+    attribute, are indistinguishable to this and collapse to one. That is the
+    accepted cost of not trusting an FID: a WFS/OAPIF FID is assigned per request,
+    so the same integer means different features in the two halves, and keying on
+    it would drop real features rather than duplicate ones.
+
+    Args:
+        frame: A frame with an active geometry column.
+
+    Returns:
+        pandas.Series: One hashable key per row, aligned to `frame`'s index.
+
+    Examples:
+        - Two rows differing only in geometry get different keys:
+            ```python
+            >>> import geopandas as gpd
+            >>> from shapely.geometry import Point
+            >>> from pyramids.feature._ogc import content_keys
+            >>> frame = gpd.GeoDataFrame(
+            ...     {"name": ["a", "a"]}, geometry=[Point(0, 0), Point(1, 1)]
+            ... )
+            >>> content_keys(frame).duplicated().tolist()
+            [False, False]
+
+            ```
+        - An unhashable attribute value does not break the key:
+            ```python
+            >>> import geopandas as gpd
+            >>> from shapely.geometry import Point
+            >>> from pyramids.feature._ogc import content_keys
+            >>> frame = gpd.GeoDataFrame(
+            ...     {"tags": [["x"], ["x"]]}, geometry=[Point(0, 0), Point(0, 0)]
+            ... )
+            >>> content_keys(frame).duplicated().tolist()
+            [False, True]
+
+            ```
+    """
+    attributes = frame.drop(columns=[frame.geometry.name])
+    # `itertuples` on a frame with no columns yields nothing at all rather than
+    # one empty tuple per row, which would leave the keys shorter than the index.
+    attribute_rows = (
+        attributes.itertuples(index=False, name=None)
+        if attributes.shape[1]
+        else repeat((), len(frame))
+    )
+    keys = [
+        (blob, tuple(repr(value) for value in values))
+        for blob, values in zip(frame.geometry.to_wkb(), attribute_rows)
+    ]
+    return pd.Series(keys, index=frame.index, dtype=object)
+
+
+def merge_seam_halves(
+    frames: list[gpd.GeoDataFrame], cap: int | None
+) -> gpd.GeoDataFrame:
+    """Union the two seam halves' features into one frame.
+
+    Concatenating two feature sets is the whole of the "stitch" a vector read
+    needs — there is no grid to re-assemble, as there is for
+    :meth:`Dataset.crop`. What it does need is the two things a plain concat
+    gets wrong:
+
+    * **Duplicates.** The halves are disjoint boxes, but a feature that actually
+      straddles the seam intersects both and comes back from both requests. It is
+      dropped down to one occurrence by :func:`content_keys`.
+    * **The index.** Each request's frame is indexed from 0, so a concat that
+      kept them would hand back a frame with every label twice. The result is
+      re-indexed ``0..n-1``, which is what a single-box read returns anyway.
+
+    The ``max_features`` cap is applied to the *union*, not per half: each half is
+    read with the same cap (each may legitimately hold all of them), and the
+    concatenated result is then truncated, so the promise "at most this many
+    features" holds across the seam. West-half features therefore fill the cap
+    first when both halves are full.
+
+    Args:
+        frames: The per-half frames, west half first.
+        cap: The ``max_features`` cap, or ``None`` for no cap.
+
+    Returns:
+        geopandas.GeoDataFrame: The de-duplicated union, re-indexed from 0.
+
+    Examples:
+        - A feature returned by both halves appears once:
+            ```python
+            >>> import geopandas as gpd
+            >>> from shapely.geometry import Point
+            >>> from pyramids.feature._ogc import merge_seam_halves
+            >>> east = gpd.GeoDataFrame(
+            ...     {"name": ["a", "seam"]},
+            ...     geometry=[Point(172.0, 0.0), Point(180.0, 0.0)],
+            ...     crs="EPSG:4326",
+            ... )
+            >>> west = gpd.GeoDataFrame(
+            ...     {"name": ["seam", "b"]},
+            ...     geometry=[Point(180.0, 0.0), Point(-172.0, 0.0)],
+            ...     crs="EPSG:4326",
+            ... )
+            >>> merged = merge_seam_halves([east, west], None)
+            >>> list(merged["name"])
+            ['a', 'seam', 'b']
+            >>> list(merged.index)
+            [0, 1, 2]
+
+            ```
+        - The cap bounds the union rather than each half:
+            ```python
+            >>> from pyramids.feature._ogc import merge_seam_halves
+            >>> len(merge_seam_halves([east, west], 2))
+            2
+
+            ```
+    """
+    combined = pd.concat(frames, ignore_index=True)
+    if len(combined):
+        combined = combined[~content_keys(combined).duplicated()]
+    if cap is not None:
+        combined = combined.iloc[:cap]
+    return combined.reset_index(drop=True)

--- a/src/pyramids/feature/_ogc.py
+++ b/src/pyramids/feature/_ogc.py
@@ -321,7 +321,15 @@ def merge_seam_halves(
 
     * **Duplicates.** The halves are disjoint boxes, but a feature that actually
       straddles the seam intersects both and comes back from both requests. It is
-      dropped down to one occurrence by :func:`content_keys`.
+      dropped down to one occurrence by :func:`content_keys`. Note that the
+      de-duplication is over the whole concatenation, not over matched pairs, so a
+      row the *source* holds twice within a single half collapses too -- and only
+      when the bbox wraps, since a single-request read is passed through untouched.
+      Distinguishing the two would mean tagging each row with the half it came from
+      and dropping only cross-half matches; the simpler rule is kept because a
+      genuinely duplicated feature is far rarer than a seam-straddling one, and
+      because a caller who wants exact source multiplicity should not be asking
+      one request to span the antimeridian.
     * **The index.** Each request's frame is indexed from 0, so a concat that
       kept them would hand back a frame with every label twice. The result is
       re-indexed ``0..n-1``, which is what a single-box read returns anyway.

--- a/src/pyramids/feature/bbox.py
+++ b/src/pyramids/feature/bbox.py
@@ -37,7 +37,7 @@ from shapely.ops import unary_union
 # it is gone. The move also took `pyproj.Transformer` and `crs_from_user_input`
 # out of this module's namespace -- neither was ever advertised here (see
 # `__all__` below); their homes are `pyproj` and `pyramids.base.crs`.
-from pyramids.base._bbox import Bbox, transform
+from pyramids.base._bbox import Bbox, split_antimeridian, transform
 
 _CONVENTIONS = ("-180..180", "0..360")
 
@@ -71,51 +71,6 @@ __all__ = [
     "to_shapely",
     "transform",
 ]
-
-
-def split_antimeridian(bbox: Bbox) -> list[Bbox]:
-    """Split a bbox into one or two bboxes, severing the antimeridian.
-
-    Returns the input unchanged (as a single-element list) when `west <= east`.
-    When `west > east` the bbox is treated as crossing the 180 deg meridian
-    and is split into an eastern `(west, south, 180, north)` and a western
-    `(-180, south, east, north)` half.
-
-    Args:
-        bbox: A `(west, south, east, north)` tuple in degrees.
-
-    Returns:
-        A list of one bbox (no crossing) or two bboxes (crossing), each with
-        `west <= east`.
-
-    Examples:
-        - A bbox that does not cross the antimeridian is returned as-is:
-            ```python
-            >>> split_antimeridian((-10.0, -5.0, 10.0, 5.0))
-            [(-10.0, -5.0, 10.0, 5.0)]
-
-            ```
-        - A crossing bbox is split into an eastern and a western half:
-            ```python
-            >>> split_antimeridian((175.0, -22.0, -175.0, -12.0))
-            [(175.0, -22.0, 180.0, -12.0), (-180.0, -22.0, -175.0, -12.0)]
-
-            ```
-        - The two halves can be fed to separate spatial queries:
-            ```python
-            >>> halves = split_antimeridian((170.0, 0.0, -170.0, 10.0))
-            >>> [round(h[2] - h[0], 1) for h in halves]
-            [10.0, 10.0]
-
-            ```
-    """
-    west, south, east, north = bbox
-    if west <= east:
-        return [(west, south, east, north)]
-    return [
-        (west, south, 180.0, north),
-        (-180.0, south, east, north),
-    ]
 
 
 def normalise_longitude(bbox: Bbox, convention: str = "-180..180") -> Bbox:

--- a/src/pyramids/feature/collection.py
+++ b/src/pyramids/feature/collection.py
@@ -1520,7 +1520,13 @@ class FeatureCollection(GeoDataFrame):
             bbox: Optional ``(minx, miny, maxx, maxy)`` spatial filter, interpreted
                 in the feature type's **native CRS** (which WFS layers advertise;
                 usually ``EPSG:4326``, lon/lat). Only intersecting features are
-                returned. ``None`` (default) fetches all features.
+                returned. ``None`` (default) fetches all features. ``minx > maxx``
+                reads as a filter crossing the antimeridian: it costs two requests,
+                one per side of the 180 degree seam, whose features are merged and
+                de-duplicated. That split is what makes the filter mean what it says
+                -- handed to OGR whole, a wrapping rect raises nothing and is
+                silently normalised into its complement, so ``(170, -10, -170, 10)``
+                would quietly fetch the other 340 degrees.
             output_crs: Optional CRS to reproject the result into (any form
                 :meth:`to_crs` accepts). ``None`` (default) keeps the server's CRS.
             where: Optional OGR/SQL attribute filter (e.g. ``"PERSONS > 1000000"``)
@@ -1619,7 +1625,9 @@ class FeatureCollection(GeoDataFrame):
                 the layer in; that is CRS84 (lon/lat) because OGC API – Features
                 serves GeoJSON, so CRS84 coordinates are correct for the current
                 driver. Only intersecting features are returned. ``None`` (default)
-                fetches all features.
+                fetches all features. As in :meth:`from_wfs`, ``minx > maxx`` reads as
+                a filter crossing the antimeridian and is served as two requests
+                either side of the 180 degree seam, merged and de-duplicated.
             output_crs: Optional CRS to reproject the result into (any form
                 :meth:`to_crs` accepts). ``None`` (default) keeps the service's CRS.
             where: Optional OGR/SQL attribute filter (e.g. ``"scalerank <= 2"``)

--- a/src/pyramids/feature/tessellation.py
+++ b/src/pyramids/feature/tessellation.py
@@ -181,6 +181,37 @@ def fishnet_cells(
     slightly past ``bounds`` so every cell is a true square. The grid has ``ceil(width / cell_size)`` columns and
     ``ceil(height / cell_size)`` rows.
 
+    Note:
+        **A ``minx > maxx`` bounds is refused, deliberately, and this is settled — not an oversight.**
+        Elsewhere in pyramids a ``west > east`` box is read as crossing the 180 degree seam:
+        :meth:`Dataset.crop` splits and stitches it, and the OGC readers
+        (:func:`pyramids.feature._ogc.read_kwargs`) split it into two requests and union the features.
+        A fishnet is refused instead, for four reasons that do not apply to either of those:
+
+        1. ``bounds`` is **not a lon/lat box**. It is "the extent the grid covers, in the units of ``crs``",
+           and ``crs`` may be projected or ``None``. There is no seam at ±180 in metres, and no seam at all
+           in a CRS-less grid, so ``minx > maxx`` there is an inverted box and nothing else. Reading it as a
+           wrap would turn a caller's typo into a silent globe-spanning grid.
+        2. **The cell numbering has no coherent answer.** Columns are laid from ``minx`` and indexed
+           ``0..nx-1``. Two halves split at the seam start their columns at ``west`` and at ``-180``, and the
+           two runs only line up into one monotonic sequence when the wrap width is an exact multiple of
+           ``cell_size``. Otherwise the seam falls mid-cell and the ``col`` column either restarts or lies.
+        3. **The straddling cell is not a polygon.** A cell containing ±180 would have to be a MultiPolygon
+           in the ``-180..180`` convention, breaking the one-square-per-row/col contract the ``row`` / ``col``
+           columns index and the "every cell is a true square" invariant this function promises.
+        4. The OGC readers get away with it because there the wrap is only a *query filter*: two result sets
+           unioned, with no geometry of their own to keep coherent. A fishnet's output **is** the geometry.
+
+        A caller who wants a grid across the seam should build the two halves explicitly — pass each of
+        :func:`pyramids.base._coverage.seam_halves`' boxes to a separate call and concatenate — accepting
+        that ``col`` restarts at 0 in the second half, which is the honest description of what that grid is.
+
+        For the same reason this check is **not** collapsed onto
+        :func:`pyramids.base._coverage.validate_bbox` the way ``read_kwargs`` was. That validator is about a
+        lon/lat request bbox: it names the argument ``bbox``, coerces strings, and has an antimeridian mode.
+        This one is about a grid extent in arbitrary CRS units, and its refusal names ``fishnet`` and
+        ``bounds``. Same inequality, different rule.
+
     Args:
         bounds: ``(minx, miny, maxx, maxy)`` extent the grid covers.
         cell_size: Side length of each square cell, in the bounds' units.
@@ -190,8 +221,9 @@ def fishnet_cells(
         integer row / column indices.
 
     Raises:
-        ValueError: If ``cell_size`` is not positive, or ``bounds`` is degenerate (``minx >= maxx`` or
-            ``miny >= maxy``).
+        ValueError: If ``cell_size`` is not positive, or ``bounds`` is degenerate or inverted on either axis
+            (``minx >= maxx`` or ``miny >= maxy``). See the Note: ``minx > maxx`` is refused here rather than
+            read as an antimeridian crossing.
 
     Examples:
         - A 2x2 grid over the unit square:
@@ -202,6 +234,14 @@ def fishnet_cells(
             4
             >>> rows, cols
             ([0, 0, 1, 1], [0, 1, 0, 1])
+
+            ```
+        - A ``minx > maxx`` extent is refused rather than wrapped across the seam:
+            ```python
+            >>> from pyramids.feature.tessellation import fishnet_cells
+            >>> fishnet_cells((170.0, -10.0, -170.0, 10.0), 1.0)
+            Traceback (most recent call last):
+            ValueError: fishnet: bounds must satisfy minx < maxx and miny < maxy, got (170.0, -10.0, -170.0, 10.0)
 
             ```
     """

--- a/tests/base/test_bbox_validation_finite.py
+++ b/tests/base/test_bbox_validation_finite.py
@@ -10,9 +10,14 @@ Coercion is deliberately kept: a bbox read out of JSON arrives as strings often
 enough that accepting them is worth more than refusing them.
 
 The vector readers take the same `bbox=` argument through
-`pyramids.feature._ogc.read_kwargs`, which duplicates the arity and ordering block
-word for word, so the finiteness check has to be made in both places or the
-refusal depends on which reader the caller reached for.
+`pyramids.feature._ogc.read_kwargs`, which duplicated the arity and ordering block
+word for word, so the finiteness check had to be made in both places or the
+refusal depended on which reader the caller reached for. That copy is gone:
+`read_kwargs` now calls `validate_bbox` itself, with `allow_antimeridian=True`
+so a `west > east` bbox reaches the seam split instead of a refusal. The
+`TestTheVectorTwinRefusesItToo` cases below still run against `read_kwargs`,
+which is now the point — they pin that the vector reader really does reach the
+one validator.
 """
 
 from __future__ import annotations
@@ -136,10 +141,12 @@ class TestTheVectorTwinRefusesItToo:
 
     `validate_bbox` guards the raster readers (WCS, WMS/WMTS, OGC API –
     Coverages); `pyramids.feature._ogc.read_kwargs` guards the vector ones
-    (WFS, OGC API – Features) and duplicates the same arity and ordering block
-    with verbatim identical messages. A finite check on one of the two leaves
+    (WFS, OGC API – Features) and used to duplicate the same arity and ordering
+    block with verbatim identical messages. A finite check on one of the two left
     `from_wfs(bbox=(1, 2, nan, 4))` handing `nan` to the OGR driver, which is
-    the same failure one module over.
+    the same failure one module over. `read_kwargs` now delegates to
+    `validate_bbox`, so these assertions pin the delegation rather than the
+    agreement of two copies.
     """
 
     @pytest.mark.parametrize(
@@ -186,6 +193,14 @@ class TestTheVectorTwinRefusesItToo:
         }
 
     def test_the_ordering_check_still_fires(self):
-        """The finiteness check runs first, so ordering keeps its own message."""
+        """The finiteness check runs first, so ordering keeps its own message.
+
+        The box is inverted in *latitude* now. It used to be inverted in
+        longitude — `(3, 2, 1, 4)` — but `read_kwargs` calls the shared
+        `validate_bbox` with `allow_antimeridian=True`, so `minx > maxx` is read
+        as a box crossing the 180 degree seam and split into two requests rather
+        than refused. Latitude has no seam, so `miny >= maxy` still raises, and
+        it still raises this sentence.
+        """
         with pytest.raises(ValueError, match="minx < maxx"):
-            read_kwargs((3.0, 2.0, 1.0, 4.0), None, None)
+            read_kwargs((1.0, 4.0, 3.0, 2.0), None, None)

--- a/tests/dataset/remote/test_coverage_antimeridian.py
+++ b/tests/dataset/remote/test_coverage_antimeridian.py
@@ -67,9 +67,27 @@ class TestWindowOverlaps:
     """The overlap test that keeps a seam half that misses the coverage unfetched."""
 
     @staticmethod
-    def _src() -> gdal.Dataset:
+    def _src(
+        geotransform: tuple[float, float, float, float, float, float] = (
+            0.0,
+            1.0,
+            0.0,
+            10.0,
+            0.0,
+            -1.0,
+        ),
+    ) -> gdal.Dataset:
+        """A 10x10 MEM raster carrying `geotransform`.
+
+        Args:
+            geotransform: The GDAL geotransform to stamp. Defaults to the ordinary
+                north-up, east-positive one covering `0..10` on both axes.
+
+        Returns:
+            osgeo.gdal.Dataset: The in-memory raster.
+        """
         src = gdal.GetDriverByName("MEM").Create("", 10, 10, 1)
-        src.SetGeoTransform((0.0, 1.0, 0.0, 10.0, 0.0, -1.0))
+        src.SetGeoTransform(geotransform)
         return src
 
     def test_window_inside_overlaps(self):
@@ -93,6 +111,68 @@ class TestWindowOverlaps:
     def test_touching_edge_does_not_overlap(self):
         """A zero-area intersection has no pixels to read, so it is not an overlap."""
         assert not window_overlaps([10.0, 8.0, 20.0, 6.0], self._src())
+
+    def test_a_rotated_grid_is_measured_by_its_far_corner(self):
+        """A rotated geotransform reaches further east than its pixel width suggests.
+
+        Test scenario:
+            With a rotation term (`gt[2] = 0.5`) a 10-column raster spans `0 .. 15`
+            in x, not `0 .. 10`: the far corner is
+            `gt[0] + width*gt[1] + height*gt[2]`. A window at `11 .. 14` therefore
+            does overlap. Measuring the extent from `gt[1]` alone would place the
+            east edge at `10` and skip a half that genuinely has data.
+        """
+        rotated = self._src((0.0, 1.0, 0.5, 10.0, 0.5, -1.0))
+        result = window_overlaps([11.0, 9.0, 14.0, 6.0], rotated)
+        assert result, (
+            "a window inside the rotated footprint should overlap; measuring the "
+            "extent without the rotation terms would put the east edge at 10"
+        )
+
+    def test_a_rotated_grid_still_excludes_what_is_beyond_it(self):
+        """The far-corner extent bounds the raster rather than unbounding it.
+
+        Test scenario:
+            The same rotated raster reaches `15` in x, so a window at `16 .. 20` is
+            outside it. This is the companion to the previous case: widening the
+            extent to catch the rotation must not widen it without limit.
+        """
+        rotated = self._src((0.0, 1.0, 0.5, 10.0, 0.5, -1.0))
+        result = window_overlaps([16.0, 9.0, 20.0, 6.0], rotated)
+        assert not result, (
+            "a window east of the rotated footprint should not overlap, got True"
+        )
+
+    def test_a_south_up_grid_is_not_read_as_empty(self):
+        """A positive `gt[5]` puts the origin at the raster's south edge.
+
+        Test scenario:
+            With `gt[3] = 0` and `gt[5] = +1` the raster runs from `0` up to `10` in
+            y, so the origin is its *minimum*. Taking `gt[3]` as the maximum without
+            ordering the pair yields `miny > maxy`, which makes the intersection
+            test false for every window and would skip both halves of a seam read.
+        """
+        south_up = self._src((0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
+        result = window_overlaps([2.0, 8.0, 4.0, 6.0], south_up)
+        assert result, (
+            "a window inside a south-up raster should overlap; an unordered y "
+            "extent makes every window miss"
+        )
+
+    def test_a_west_positive_grid_is_not_read_as_empty(self):
+        """The same ordering problem on the x axis, with a negative `gt[1]`.
+
+        Test scenario:
+            `gt[0] = 10` with `gt[1] = -1` runs the columns westward, so the origin
+            is the raster's *maximum* x. A window at `2 .. 4` is inside it, and only
+            ordering the pair keeps that true.
+        """
+        west_positive = self._src((10.0, -1.0, 0.0, 10.0, 0.0, -1.0))
+        result = window_overlaps([2.0, 8.0, 4.0, 6.0], west_positive)
+        assert result, (
+            "a window inside a west-positive raster should overlap; an unordered x "
+            "extent makes every window miss"
+        )
 
 
 class TestWindowSizes:
@@ -254,6 +334,29 @@ class TestWcsDiscovery:
                     server.url, coverage="test_cov", bbox=WRAP, version="1.0.0"
                 )
 
+    def test_a_single_window_that_misses_is_left_to_gdal(self):
+        """The overlap filter must not change what a *non-wrapping* request does.
+
+        Test scenario:
+            An ordinary bbox nowhere near the coverage is one window, not two, so
+            the filter is skipped entirely and GDAL's own lenient behaviour
+            survives: it warns that the source window falls outside the raster and
+            fills the result with no-data rather than raising. Applying the filter
+            unconditionally would turn that long-standing outcome into
+            `neither half overlaps`, which is why the guard reads
+            `len(windows) > 1`.
+        """
+        with WcsMock(version="1.0.0") as server:
+            ds = Dataset.from_wcs(
+                server.url,
+                coverage="test_cov",
+                bbox=(50.0, 50.0, 52.0, 52.0),
+                version="1.0.0",
+            )
+        assert ds.shape == (1, 20, 20), (
+            f"a single off-coverage window should still return a raster, got {ds.shape}"
+        )
+
 
 @pytest.mark.skipif(
     gdal.GetDriverByName("OGCAPI") is None,
@@ -299,6 +402,23 @@ class TestOgcCoverages:
         with _serving((0.0, 0.0, 10.0, 8.0)) as url:
             with pytest.raises(ValueError, match="neither half overlaps"):
                 Dataset.from_ogc_coverages(url, coverage="demo", bbox=WRAP)
+
+    def test_a_single_window_that_misses_is_left_to_gdal(self):
+        """The same guard, on the reader that filters a whole list at once.
+
+        Test scenario:
+            `_fetch_windows` filters `projwins` only when there is more than one, so
+            an ordinary off-coverage bbox keeps GDAL's no-data fill instead of
+            gaining a refusal it never had. Without the length guard the list would
+            empty and `_window_sizes` would be handed nothing.
+        """
+        with _serving((0.0, 0.0, 10.0, 8.0)) as url:
+            ds = Dataset.from_ogc_coverages(
+                url, coverage="demo", bbox=(50.0, 50.0, 52.0, 52.0), resolution=0.1
+            )
+        assert ds.shape == (1, 20, 20), (
+            f"a single off-coverage window should still return a raster, got {ds.shape}"
+        )
 
     def test_output_crs_is_applied_once_to_the_merged_raster(self):
         with _serving(OGC_GLOBAL_BOUNDS) as url:

--- a/tests/dataset/remote/test_coverage_antimeridian.py
+++ b/tests/dataset/remote/test_coverage_antimeridian.py
@@ -118,10 +118,9 @@ class TestWindowOverlaps:
 
         Test scenario:
             With a rotation term (`gt[2] = 0.5`) a 10-column raster spans `0 .. 15`
-            in x, not `0 .. 10`: the far corner is
-            `gt[0] + width*gt[1] + height*gt[2]`. A window at `11 .. 14` therefore
-            does overlap. Measuring the extent from `gt[1]` alone would place the
-            east edge at `10` and skip a half that genuinely has data.
+            in x, not `0 .. 10`. A window at `11 .. 14` therefore does overlap.
+            Measuring the extent from `gt[1]` alone would place the east edge at
+            `10` and skip a half that genuinely has data.
         """
         rotated = self._src((0.0, 1.0, 0.5, 10.0, 0.5, -1.0))
         result = window_overlaps([11.0, 9.0, 14.0, 6.0], rotated)
@@ -142,6 +141,23 @@ class TestWindowOverlaps:
         result = window_overlaps([16.0, 9.0, 20.0, 6.0], rotated)
         assert not result, (
             "a window east of the rotated footprint should not overlap, got True"
+        )
+
+    def test_a_rotated_grid_is_bounded_on_the_axis_the_diagonal_misses(self):
+        """Two opposite corners do not bound a rotated grid; four do.
+
+        Test scenario:
+            The same rotated raster's true corners are `(0,10) (10,15) (5,0)
+            (15,5)`, so it spans `0 .. 15` in y. Taking only the origin and the
+            diagonally-opposite corner gives `5 .. 10` and misses a third of it: a
+            window at y `1 .. 2` holds real pixels and was reported as no overlap,
+            so a seam half over it was silently dropped.
+        """
+        rotated = self._src((0.0, 1.0, 0.5, 10.0, 0.5, -1.0))
+        result = window_overlaps([5.0, 2.0, 6.0, 1.0], rotated)
+        assert result, (
+            "a window inside the rotated footprint should overlap; the origin and "
+            "its diagonal alone bound y as 5..10 instead of 0..15"
         )
 
     def test_a_south_up_grid_is_not_read_as_empty(self):

--- a/tests/dataset/remote/test_coverage_antimeridian.py
+++ b/tests/dataset/remote/test_coverage_antimeridian.py
@@ -299,7 +299,18 @@ class TestWindowSizes:
         assert cells[0] == pytest.approx(cells[1], rel=1e-12), (
             f"the halves must share one cell size, got {cells}"
         )
-        assert sizes[0][1] == sizes[1][1], "the halves must share one row count"
+        # Sharing a cell size is what `_align_to_sizes` guarantees by construction,
+        # so on its own that assertion cannot see a wrong `_window_sizes`. What
+        # snapping *trades away* is fidelity to the requested corners, and that is
+        # the thing worth bounding: each snapped far edge must still land within
+        # half a cell of what was asked for.
+        for snapped_window, requested in zip(snapped, halves):
+            assert snapped_window[2] == pytest.approx(
+                requested[2], abs=0.5 * cells[0]
+            ), (
+                f"snapping may move a far edge by under half a cell, not from "
+                f"{requested[2]} to {snapped_window[2]}"
+            )
 
     def test_two_windows_share_one_resolution(self):
         """Both halves come back on one grid: equal height, widths summing to the cap."""

--- a/tests/dataset/remote/test_coverage_antimeridian.py
+++ b/tests/dataset/remote/test_coverage_antimeridian.py
@@ -225,6 +225,19 @@ class TestTheSeamGuardReachesEveryRasterReader:
         with pytest.raises(ValueError, match="within -180..180"):
             check_seam_bbox((190.0, -10.0, -170.0, 10.0), "EPSG:4326")
 
+    def test_a_geographic_crs_off_greenwich_is_refused(self):
+        """`IsGeographic()` alone does not put the seam at 180.
+
+        Test scenario:
+            EPSG:4807 (NTF, Paris) is geographic, but counts longitude from a
+            meridian 2.34 degrees east of Greenwich and expresses it in grads,
+            where the half-turn is 200. Splitting at 180 would cut such a bbox in
+            the wrong place and then measure the halves against a 360 that is not
+            the width of the world in those units.
+        """
+        with pytest.raises(ValueError, match="degrees from Greenwich"):
+            check_seam_bbox((170.0, -10.0, -170.0, 10.0), "EPSG:4807")
+
     def test_an_ordinary_bbox_passes_in_any_crs(self):
         """The guard is a no-op unless the box actually wraps."""
         assert check_seam_bbox((0.0, 0.0, 1e6, 1e6), "EPSG:3857") is None
@@ -398,6 +411,140 @@ class TestTheSeamOffsetIsMeasuredNotAssumed:
         east = self._half(-180.0, 50, 0.2, 4326)
         with pytest.raises(ValueError, match="different resolutions"):
             _stitch_lon_halves(west, west, east)
+
+
+class TestNothingIsStrandedWhenAHalfFails:
+    """A seam read fetches twice and adopts twice; either can raise part-way.
+
+    Before the split there was one window to fetch and one raster to adopt, so
+    neither loop could fail with something already in hand. Both can now, and the
+    rest of these readers is deliberately explicit about ownership -- a dedicated
+    finally in `_collect_halves`, `src = None` in three finally blocks, `parts`
+    closed in a finally. These two loops were the lapse.
+    """
+
+    @staticmethod
+    def _tracking_translate(monkeypatch, module, closed: list[int]):
+        """Replace the module's `_translate_window` with one that fails second.
+
+        Args:
+            monkeypatch: pytest's monkeypatch fixture.
+            module: The reader module to patch.
+            closed: Collects the id of every raster the reader closes.
+
+        Returns:
+            None
+        """
+        calls = {"n": 0}
+        real = module._translate_window
+
+        def fake(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] > 1:
+                raise RuntimeError("second half exploded")
+            mem = real(*args, **kwargs)
+            original_close = mem.Close
+
+            def close():
+                closed.append(id(mem))
+                original_close()
+
+            mem.Close = close
+            return mem
+
+        monkeypatch.setattr(module, "_translate_window", fake)
+
+    def test_wcs_closes_the_first_half_when_the_second_fetch_raises(self, monkeypatch):
+        """The first MEM raster must not be left to the garbage collector."""
+        closed: list[int] = []
+        self._tracking_translate(monkeypatch, _wcs, closed)
+        with WcsMock(version="1.0.0", bounds=GLOBAL_BOUNDS) as server:
+            with pytest.raises(RuntimeError, match="second half exploded"):
+                Dataset.from_wcs(
+                    server.url, coverage="test_cov", bbox=WRAP, version="1.0.0"
+                )
+        assert len(closed) == 1, (
+            f"the successfully fetched half should be closed on the way out, "
+            f"got {len(closed)} close(s)"
+        )
+
+    def test_wcs_closes_the_halves_it_could_not_adopt(self):
+        """A raise during adoption leaves the untouched tail wrapped by nothing.
+
+        Test scenario:
+            `parts` closes what it wrapped, but a raise part-way through means the
+            remaining `mems` entries were never wrapped, so nothing else would
+            close them. `from_wcs` takes `dataset_cls`, so a stub that fails on its
+            second construction reaches the path directly.
+        """
+        adopted_closed: list[int] = []
+        mem_closed: list[int] = []
+
+        class FailsOnSecond:
+            made = 0
+
+            def __init__(self, mem, access="read"):
+                FailsOnSecond.made += 1
+                # Track the raw handle's own Close, which is what the sweep must
+                # call for the half that was never wrapped.
+                original = mem.Close
+                mem.Close = lambda: (mem_closed.append(id(mem)), original())[1]
+                if FailsOnSecond.made > 1:
+                    raise RuntimeError("adoption exploded")
+                self._mem = mem
+
+            def close(self):
+                adopted_closed.append(id(self._mem))
+
+        with WcsMock(version="1.0.0", bounds=GLOBAL_BOUNDS) as server:
+            with pytest.raises(RuntimeError, match="adoption exploded"):
+                _wcs.from_wcs(
+                    FailsOnSecond,
+                    server.url,
+                    coverage="test_cov",
+                    bbox=WRAP,
+                    crs="EPSG:4326",
+                    version="1.0.0",
+                    output_crs=None,
+                    resolution=None,
+                    coverage_crs=None,
+                    wcs_format=None,
+                    output=None,
+                    resample="nearest",
+                    direct=False,
+                    subset_axes=None,
+                    auth=None,
+                    timeout=60.0,
+                    extra_params=None,
+                )
+        assert len(adopted_closed) == 1, (
+            f"the one part that was adopted is closed by `parts`, got "
+            f"{len(adopted_closed)}"
+        )
+        assert len(mem_closed) == 1, (
+            f"the half that was never wrapped has nothing else to close it, so "
+            f"the mems tail sweep must; got {len(mem_closed)} raw close(s)"
+        )
+
+    @pytest.mark.skipif(
+        gdal.GetDriverByName("OGCAPI") is None,
+        reason="GDAL build lacks the OGCAPI driver",
+    )
+    def test_coverages_closes_the_first_half_when_the_second_fetch_raises(
+        self, monkeypatch
+    ):
+        """The same guarantee on the reader that fetches a whole list at once."""
+        closed: list[int] = []
+        self._tracking_translate(monkeypatch, _ogc_coverages, closed)
+        with _serving(OGC_GLOBAL_BOUNDS) as url:
+            with pytest.raises(RuntimeError, match="second half exploded"):
+                Dataset.from_ogc_coverages(
+                    url, coverage="demo", bbox=WRAP, resolution=0.05
+                )
+        assert len(closed) == 1, (
+            f"the successfully fetched half should be closed on the way out, "
+            f"got {len(closed)} close(s)"
+        )
 
 
 class TestWcsDirect:

--- a/tests/dataset/remote/test_coverage_antimeridian.py
+++ b/tests/dataset/remote/test_coverage_antimeridian.py
@@ -24,7 +24,12 @@ import numpy as np
 import pytest
 from osgeo import gdal, osr
 
-from pyramids.base._coverage import check_seam_bbox, seam_offset, window_overlaps
+from pyramids.base._coverage import (
+    _is_lonlat_degrees_from_greenwich,
+    check_seam_bbox,
+    seam_offset,
+    window_overlaps,
+)
 from pyramids.dataset import Dataset, _ogc_coverages, _wcs
 from pyramids.dataset.engines.spatial import _stitch_lon_halves
 from tests.dataset.remote.test_ogc_coverages import GLOBAL_BOUNDS as OGC_GLOBAL_BOUNDS
@@ -237,6 +242,31 @@ class TestTheSeamGuardReachesEveryRasterReader:
         """
         with pytest.raises(ValueError, match="degrees from Greenwich"):
             check_seam_bbox((170.0, -10.0, -170.0, 10.0), "EPSG:4807")
+
+    def test_an_unreadable_prime_meridian_is_treated_as_not_greenwich(self):
+        """A PRIMEM value that will not parse must not be assumed to be zero.
+
+        Test scenario:
+            The offset comes from the WKT's PRIMEM node as a string. Valid WKT
+            always carries a number there, so this is a defensive branch -- but the
+            safe reading of an unparseable one is "not Greenwich", because assuming
+            zero would put the seam at 180 for a CRS whose meridian is unknown.
+        """
+
+        class OddSrs:
+            @staticmethod
+            def IsGeographic():
+                return True
+
+            @staticmethod
+            def GetAngularUnits():
+                return 0.017453292519943295
+
+            @staticmethod
+            def GetAttrValue(node, index):
+                return "not-a-number"
+
+        assert _is_lonlat_degrees_from_greenwich(OddSrs()) is False
 
     def test_an_ordinary_bbox_passes_in_any_crs(self):
         """The guard is a no-op unless the box actually wraps."""
@@ -459,6 +489,32 @@ class TestTheSeamOffsetIsMeasuredNotAssumed:
         with pytest.raises(ValueError, match="not seam-aligned"):
             _stitch_lon_halves(west, west, east)
 
+    def test_a_meridian_that_will_not_project_is_refused(self, monkeypatch):
+        """A non-finite offset must not be fed into the alignment check.
+
+        Test scenario:
+            The seam is measured by transforming +180 and -180 into the coverage's
+            CRS. `transform_bounds` clamps to a CRS's area of use rather than
+            returning infinity, so this is hard to reach with a real CRS -- but an
+            infinite offset would make the alignment check compare against `nan`
+            and reject everything with a message about the grid. It raises with the
+            real reason instead.
+        """
+
+        class Infinite:
+            @staticmethod
+            def transform(x, y):
+                return float("inf"), y
+
+        monkeypatch.setattr(
+            "pyramids.base._coverage.Transformer.from_crs",
+            staticmethod(lambda *a, **k: Infinite()),
+        )
+        native = osr.SpatialReference()
+        native.ImportFromEPSG(4326)
+        with pytest.raises(ValueError, match="does not project"):
+            seam_offset(WRAP, "EPSG:4326", native)
+
     def test_halves_at_different_resolutions_are_refused(self):
         """The check the shared guard was missing.
 
@@ -633,6 +689,46 @@ class TestNothingIsStrandedWhenAHalfFails:
         gdal.GetDriverByName("OGCAPI") is None,
         reason="GDAL build lacks the OGCAPI driver",
     )
+    def test_coverages_closes_the_halves_it_could_not_adopt(self):
+        """The adoption sweep on the reader that fetches a whole list at once.
+
+        Test scenario:
+            The twin of the WCS case. `parts` closes what it wrapped; a raise
+            part-way through leaves the remaining `mems` entries wrapped by
+            nothing, so only the tail sweep drops their GDAL handle.
+        """
+        adopted_closed: list[int] = []
+        mem_closed: list[int] = []
+
+        class FailsOnSecond:
+            made = 0
+
+            def __init__(self, mem, access="read"):
+                FailsOnSecond.made += 1
+                original = mem.Close
+                mem.Close = lambda: (mem_closed.append(id(mem)), original())[1]
+                if FailsOnSecond.made > 1:
+                    raise RuntimeError("adoption exploded")
+                self._mem = mem
+
+            def close(self):
+                adopted_closed.append(id(self._mem))
+
+        with _serving(OGC_GLOBAL_BOUNDS) as url:
+            with pytest.raises(RuntimeError, match="adoption exploded"):
+                _ogc_coverages.from_ogc_coverages(
+                    FailsOnSecond, url, coverage="demo", bbox=WRAP, resolution=0.05
+                )
+        assert len(adopted_closed) == 1
+        assert len(mem_closed) == 1, (
+            f"the half that was never wrapped needs the tail sweep to close it; "
+            f"got {len(mem_closed)} raw close(s)"
+        )
+
+    @pytest.mark.skipif(
+        gdal.GetDriverByName("OGCAPI") is None,
+        reason="GDAL build lacks the OGCAPI driver",
+    )
     def test_coverages_closes_the_first_half_when_the_second_fetch_raises(
         self, monkeypatch
     ):
@@ -678,6 +774,58 @@ class TestWcsDirect:
             )
         assert merged.shape == (1, 200, 150)
         _assert_is_concatenation(merged, west, east)
+
+    def test_the_halves_are_snapped_onto_one_lattice(self):
+        """Direct mode has no shared connection, so the two halves must be snapped.
+
+        Test scenario:
+            Discovery reads both halves off one open coverage and the WMS path
+            divides one pixel width between them; direct mode issues two
+            independent GetCoverage requests, so the west half's east edge lands on
+            180 only by luck. A west edge of 170.3 at 0.5 degree cells is 0.6 of a
+            pixel out. Snapping widens it to 170.0, which is a whole number of
+            cells from the seam, and leaves the east half alone since it already
+            was.
+        """
+        halves = [(170.3, -10.0, 180.0, 10.0), (-180.0, -10.0, -170.0, 10.0)]
+        west, east = _wcs._snap_direct_halves(halves, (0.5, 0.5))
+        assert west == (170.0, -10.0, 180.0, 10.0), (
+            f"the west edge must land on a cell boundary from the seam, got {west}"
+        )
+        assert east == (-180.0, -10.0, -170.0, 10.0)
+        assert (180.0 - west[0]) % 0.5 == pytest.approx(0.0)
+        assert (east[2] + 180.0) % 0.5 == pytest.approx(0.0)
+
+    def test_a_direct_wrap_with_a_resolution_reaches_the_snapper(self, monkeypatch):
+        """The snapping is wired in, not merely available.
+
+        Test scenario:
+            Records the windows handed to the direct fetch. With a resolution and a
+            wrapping bbox whose west edge is off-lattice, the request that goes out
+            must be the snapped one -- otherwise the alignment check refuses a pair
+            the caller cannot see anything wrong with.
+        """
+        seen: list[tuple[float, float, float, float]] = []
+        real = _wcs._from_wcs_direct
+
+        def recording(dataset_cls, endpoint, coverage, window, *args, **kwargs):
+            seen.append(window)
+            return real(dataset_cls, endpoint, coverage, window, *args, **kwargs)
+
+        monkeypatch.setattr(_wcs, "_from_wcs_direct", recording)
+        with WcsMock(version="1.0.0", bounds=GLOBAL_BOUNDS) as server:
+            Dataset.from_wcs(
+                server.url,
+                coverage="test_cov",
+                bbox=(170.3, -10.0, -175.0, 10.0),
+                version="1.0.0",
+                direct=True,
+                resolution=0.5,
+            )
+        assert seen[0][0] == pytest.approx(170.0), (
+            f"the west half should have been snapped from 170.3 to 170.0, "
+            f"but {seen[0][0]} was requested"
+        )
 
     def test_one_request_per_half_carrying_that_half_s_subset(self):
         """The URL built for each half asks for that half, not for the wrap."""

--- a/tests/dataset/remote/test_coverage_antimeridian.py
+++ b/tests/dataset/remote/test_coverage_antimeridian.py
@@ -22,10 +22,11 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
-from osgeo import gdal
+from osgeo import gdal, osr
 
-from pyramids.base._coverage import check_seam_bbox, window_overlaps
+from pyramids.base._coverage import check_seam_bbox, seam_offset, window_overlaps
 from pyramids.dataset import Dataset, _ogc_coverages, _wcs
+from pyramids.dataset.engines.spatial import _stitch_lon_halves
 from tests.dataset.remote.test_ogc_coverages import GLOBAL_BOUNDS as OGC_GLOBAL_BOUNDS
 from tests.dataset.remote.test_ogc_coverages import _serving
 from tests.dataset.remote.wcs_mock_server import GLOBAL_BOUNDS, WcsMock
@@ -249,6 +250,28 @@ class TestWindowSizes:
             (512, 1024)
         ]
 
+    def test_the_two_halves_land_on_exactly_one_cell_size(self):
+        """The halves must share a grid, not merely be sized from one.
+
+        Test scenario:
+            Rounding each half's width independently leaves them with cell sizes
+            differing in the sixth decimal -- measured at 0.01953125 against
+            0.019526627 before the fix, which puts the merged raster's declared
+            east edge about 87 m from where the data ends. The east width is now
+            the remainder of the combined width, and the windows are snapped to it.
+        """
+        halves = [[170.0, 10.0, 180.0, -10.0], [-180.0, 10.0, -176.7, -10.0]]
+        sizes = _ogc_coverages._window_sizes(halves, None)
+        snapped = _ogc_coverages._align_to_sizes(halves, sizes)
+        cells = [
+            (window[2] - window[0]) / width
+            for window, (width, _) in zip(snapped, sizes)
+        ]
+        assert cells[0] == pytest.approx(cells[1], rel=1e-12), (
+            f"the halves must share one cell size, got {cells}"
+        )
+        assert sizes[0][1] == sizes[1][1], "the halves must share one row count"
+
     def test_two_windows_share_one_resolution(self):
         """Both halves come back on one grid: equal height, widths summing to the cap."""
         west = [170.0, 10.0, 180.0, -10.0]
@@ -270,6 +293,95 @@ class TestWindowSizes:
             (100, 200),
             (50, 200),
         ]
+
+
+class TestTheSeamOffsetIsMeasuredNotAssumed:
+    """A coverage is windowed in its own CRS, which need not be degrees.
+
+    Both coverage readers window the source in the coverage's native CRS and then
+    stitch. The stitch guard used to hard-code a 360 seam offset, which is right
+    only for halves in degrees -- so for any coverage whose native CRS is projected
+    (Web Mercator, UTM, a national grid, polar stereographic) a seam read failed
+    every time, with a message blaming the caller's grid.
+    """
+
+    WORLD = 20037508.342789244
+
+    @staticmethod
+    def _half(origin_x: float, columns: int, cell: float, epsg: int) -> Dataset:
+        """A one-band raster whose geotransform is stamped before it is wrapped.
+
+        Args:
+            origin_x: The window's west edge in the CRS's own units.
+            columns: Pixel width.
+            cell: Pixel size in the CRS's own units.
+            epsg: The CRS to stamp.
+
+        Returns:
+            Dataset: The raster half.
+        """
+        mem = gdal.GetDriverByName("MEM").Create("", columns, 10, 1, gdal.GDT_Byte)
+        mem.SetGeoTransform((origin_x, cell, 0.0, 1_000_000.0, 0.0, -cell))
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(epsg)
+        mem.SetSpatialRef(srs)
+        return Dataset(mem, access="write")
+
+    def test_a_geographic_seam_measures_360_degrees(self):
+        """The default is still right for halves in degrees."""
+        native = osr.SpatialReference()
+        native.ImportFromEPSG(4326)
+        assert seam_offset(WRAP, "EPSG:4326", native) == pytest.approx(360.0)
+
+    def test_a_web_mercator_seam_measures_the_world_width(self):
+        """The same seam is about 40,075,017 m once the coverage is projected."""
+        native = osr.SpatialReference()
+        native.ImportFromEPSG(3857)
+        assert seam_offset(WRAP, "EPSG:4326", native) == pytest.approx(
+            2 * self.WORLD, rel=1e-6
+        )
+
+    def test_projected_halves_stitch_with_the_measured_offset(self):
+        """The case that failed for every projected coverage before the fix.
+
+        Test scenario:
+            Two halves in metres meeting exactly at the Web Mercator antimeridian.
+            With the measured offset they concatenate; the merged raster is as wide
+            as both and keeps the west half's origin.
+        """
+        west = self._half(self.WORLD - 100_000.0, 100, 1000.0, 3857)
+        east = self._half(-self.WORLD, 50, 1000.0, 3857)
+        merged = _stitch_lon_halves(west, west, east, 2 * self.WORLD)
+        assert merged.columns == 150, (
+            f"the stitch should be as wide as both halves, got {merged.columns}"
+        )
+        assert merged.geotransform[0] == pytest.approx(self.WORLD - 100_000.0)
+
+    def test_the_same_halves_are_refused_under_the_degree_default(self):
+        """Which is exactly what both readers used to do to every projected coverage.
+
+        Test scenario:
+            The companion to the previous case. Left at the 360 default the guard
+            compares metres against degrees, so a perfectly well-formed pair is
+            rejected -- the regression this finding was about.
+        """
+        west = self._half(self.WORLD - 100_000.0, 100, 1000.0, 3857)
+        east = self._half(-self.WORLD, 50, 1000.0, 3857)
+        with pytest.raises(ValueError, match="not seam-aligned"):
+            _stitch_lon_halves(west, west, east)
+
+    def test_halves_at_different_resolutions_are_refused(self):
+        """The check the shared guard was missing.
+
+        Test scenario:
+            Two halves whose cell sizes differ by more than a rounding wobble. The
+            stitch keeps the west geotransform, so accepting these would silently
+            misplace the east half's declared edge.
+        """
+        west = self._half(170.0, 100, 0.1, 4326)
+        east = self._half(-180.0, 50, 0.2, 4326)
+        with pytest.raises(ValueError, match="different resolutions"):
+            _stitch_lon_halves(west, west, east)
 
 
 class TestWcsDirect:

--- a/tests/dataset/remote/test_coverage_antimeridian.py
+++ b/tests/dataset/remote/test_coverage_antimeridian.py
@@ -315,6 +315,32 @@ class TestWindowSizes:
         # Same pixel size on both, which is what makes them stitchable.
         assert 10.0 / w_width == pytest.approx(5.0 / e_width)
 
+    def test_a_resolution_too_coarse_to_split_is_refused(self):
+        """Two windows cannot share one pixel, so the sizing must say so.
+
+        Test scenario:
+            A resolution coarse enough that the *combined* span sizes to a single
+            pixel left the east half with `total - west_width == 0` columns, and a
+            zero-width window reached `gdal.Translate` verbatim -- which failed
+            with "has negative width and/or height", naming neither the seam nor
+            the resolution. Worse than the refusal this branch replaced.
+        """
+        halves = [[170.0, 10.0, 180.0, -10.0], [-180.0, 10.0, -175.0, -10.0]]
+        with pytest.raises(ValueError, match="at least 2 pixels of width"):
+            _ogc_coverages._window_sizes(halves, (15.0, 15.0))
+
+    @pytest.mark.skipif(
+        gdal.GetDriverByName("OGCAPI") is None,
+        reason="GDAL build lacks the OGCAPI driver",
+    )
+    def test_the_coarse_refusal_reaches_the_public_reader(self):
+        """The same request through the public API, which is where it was found."""
+        with _serving(OGC_GLOBAL_BOUNDS) as url:
+            with pytest.raises(ValueError, match="at least 2 pixels of width"):
+                Dataset.from_ogc_coverages(
+                    url, coverage="demo", bbox=WRAP, resolution=15.0
+                )
+
     def test_explicit_resolution_is_used_for_both(self):
         west = [170.0, 10.0, 180.0, -10.0]
         east = [-180.0, 10.0, -175.0, -10.0]
@@ -466,6 +492,49 @@ class TestNothingIsStrandedWhenAHalfFails:
         assert len(closed) == 1, (
             f"the successfully fetched half should be closed on the way out, "
             f"got {len(closed)} close(s)"
+        )
+
+    def test_wcs_closes_the_first_half_when_the_second_will_not_project(
+        self, monkeypatch
+    ):
+        """Projection failure is a documented raise, and it happens before the fetch.
+
+        Test scenario:
+            `_native_projwin` raises for a window that does not project to a finite
+            native extent -- this reader's own Raises block says so. It used to sit
+            one line above the try that closes what was already fetched, so on the
+            second window the west half's MEM raster was orphaned. Every projection
+            now happens before any raster exists, so there is nothing to strand.
+        """
+        closed: list[int] = []
+        real_translate = _wcs._translate_window
+
+        def tracking(*args, **kwargs):
+            mem = real_translate(*args, **kwargs)
+            original = mem.Close
+            mem.Close = lambda: (closed.append(id(mem)), original())[1]
+            return mem
+
+        calls = {"n": 0}
+        real_projwin = _wcs._native_projwin
+
+        def failing_projwin(*args, **kwargs):
+            calls["n"] += 1
+            if calls["n"] > 1:
+                raise ValueError("second window does not project")
+            return real_projwin(*args, **kwargs)
+
+        monkeypatch.setattr(_wcs, "_translate_window", tracking)
+        monkeypatch.setattr(_wcs, "_native_projwin", failing_projwin)
+
+        with WcsMock(version="1.0.0", bounds=GLOBAL_BOUNDS) as server:
+            with pytest.raises(ValueError, match="does not project"):
+                Dataset.from_wcs(
+                    server.url, coverage="test_cov", bbox=WRAP, version="1.0.0"
+                )
+        assert closed == [], (
+            "projecting every window before fetching any means no raster exists "
+            f"when a projection fails; {len(closed)} were fetched and closed"
         )
 
     def test_wcs_closes_the_halves_it_could_not_adopt(self):

--- a/tests/dataset/remote/test_coverage_antimeridian.py
+++ b/tests/dataset/remote/test_coverage_antimeridian.py
@@ -396,6 +396,29 @@ class TestTheSeamOffsetIsMeasuredNotAssumed:
             2 * self.WORLD, rel=1e-6
         )
 
+    def test_a_utm_zone_on_the_seam_measures_no_offset_at_all(self):
+        """UTM 60N runs continuously through 180, so its halves need no offset.
+
+        Test scenario:
+            UTM zones 60N and 1N are the natural CRSs for a coverage that actually
+            straddles the antimeridian -- New Zealand, Fiji, the Aleutians. Their x
+            does not jump there: lon 179.9, 180 and -179.9 land at 822 836,
+            833 979 and 845 122 m, running straight on. Measuring across a
+            world-spanning box reported 29 238 222 m instead, so the alignment
+            check rejected halves that genuinely tile, blaming the data.
+        """
+        native = osr.SpatialReference()
+        native.ImportFromEPSG(32660)
+        assert seam_offset(WRAP, "EPSG:4326", native) == pytest.approx(0.0, abs=1.0)
+
+    def test_halves_of_a_utm_coverage_stitch_end_to_end(self):
+        """And with that offset the continuous halves concatenate."""
+        west = self._half(700_000.0, 100, 1000.0, 32660)
+        east = self._half(800_000.0, 50, 1000.0, 32660)
+        merged = _stitch_lon_halves(west, west, east, 0.0)
+        assert merged.columns == 150
+        assert merged.geotransform[0] == pytest.approx(700_000.0)
+
     def test_projected_halves_stitch_with_the_measured_offset(self):
         """The case that failed for every projected coverage before the fix.
 

--- a/tests/dataset/remote/test_coverage_antimeridian.py
+++ b/tests/dataset/remote/test_coverage_antimeridian.py
@@ -24,7 +24,7 @@ import numpy as np
 import pytest
 from osgeo import gdal
 
-from pyramids.base._coverage import window_overlaps
+from pyramids.base._coverage import check_seam_bbox, window_overlaps
 from pyramids.dataset import Dataset, _ogc_coverages, _wcs
 from tests.dataset.remote.test_ogc_coverages import GLOBAL_BOUNDS as OGC_GLOBAL_BOUNDS
 from tests.dataset.remote.test_ogc_coverages import _serving
@@ -173,6 +173,70 @@ class TestWindowOverlaps:
             "a window inside a west-positive raster should overlap; an unordered x "
             "extent makes every window miss"
         )
+
+
+class TestTheSeamGuardReachesEveryRasterReader:
+    """The refusals `from_wms` always had, now on the two coverage readers too.
+
+    A network reader has no grid to check a bbox against, so once a wrap is
+    accepted these two checks are the only thing standing between a transposed
+    bbox and a confidently wrong answer.
+    """
+
+    def test_wcs_refuses_a_wrapping_bbox_in_a_projected_crs(self):
+        """A projected CRS has no 180 degree meridian to split at.
+
+        Test scenario:
+            An ordinary transposed Web Mercator box. Split at +/-180 *metres* it
+            becomes two windows over central Europe -- nowhere near what was
+            asked for, and returned without an error. `from_wcs` takes an explicit
+            `crs`, so the caller can reach this.
+        """
+        box = (2_000_000.0, 6_000_000.0, 1_000_000.0, 6_100_000.0)
+        with pytest.raises(ValueError, match="not a geographic"):
+            check_seam_bbox(box, "EPSG:3857")
+
+    def test_a_wrapping_bbox_may_not_overhang_the_seam(self):
+        """A corner past 180 leaves "west of the seam" meaning nothing.
+
+        Test scenario:
+            `(190, -10, -170, 10)` splits into a `(190, ..., 180)` half whose
+            native projwin comes out inverted, which the overlap filter then
+            discards -- so 20 of the 30 requested degrees vanish silently. It is
+            refused instead.
+        """
+        with pytest.raises(ValueError, match="within -180..180"):
+            check_seam_bbox((190.0, -10.0, -170.0, 10.0), "EPSG:4326")
+
+    def test_an_ordinary_bbox_passes_in_any_crs(self):
+        """The guard is a no-op unless the box actually wraps."""
+        assert check_seam_bbox((0.0, 0.0, 1e6, 1e6), "EPSG:3857") is None
+        assert check_seam_bbox((5.0, 51.0, 6.0, 52.0), "EPSG:4326") is None
+
+    def test_the_wcs_reader_applies_it_before_any_request(self):
+        """The refusal happens client-side, so no request is issued.
+
+        Test scenario:
+            The mock server is never started -- an endpoint that cannot be reached
+            proves the guard fires before the network is touched.
+        """
+        with pytest.raises(ValueError, match="not a geographic"):
+            Dataset.from_wcs(
+                "http://127.0.0.1:1/wcs",
+                coverage="test_cov",
+                bbox=(2_000_000.0, 6_000_000.0, 1_000_000.0, 6_100_000.0),
+                crs="EPSG:3857",
+                version="1.0.0",
+            )
+
+    def test_the_coverages_reader_applies_the_range_check(self):
+        """Its bbox is contractually CRS84, so only the corner range can fire."""
+        with pytest.raises(ValueError, match="within -180..180"):
+            Dataset.from_ogc_coverages(
+                "http://127.0.0.1:1/ogcapi",
+                coverage="demo",
+                bbox=(190.0, -10.0, -170.0, 10.0),
+            )
 
 
 class TestWindowSizes:

--- a/tests/dataset/remote/test_coverage_antimeridian.py
+++ b/tests/dataset/remote/test_coverage_antimeridian.py
@@ -1,0 +1,308 @@
+"""Antimeridian (``minx > maxx``) bboxes through the WCS and OGC API coverage readers.
+
+Both readers used to refuse such a bbox outright — ``ValueError: bbox must have
+minx < maxx and miny < maxy`` — while ``Dataset.crop`` had served it for a long
+time by splitting at the seam and stitching. These tests pin the new behaviour
+(#1088): the request is split into a ``west..180`` and a ``-180..east`` half, each
+half is fetched through the reader's normal path, and the two are concatenated
+along longitude into one raster whose geotransform continues past the seam.
+
+Everything here is offline. The WCS side drives GDAL's real WCS driver against
+``wcs_mock_server``; the OGC API side drives GDAL's real ``OGCAPI`` driver against
+the in-process mock in ``test_ogc_coverages``. Both mocks can now advertise a
+coverage spanning the whole globe, which is what a seam-crossing request needs to
+have data either side of the split.
+
+The proof of a correct stitch is the same in every case: fetch the identical
+region as two *separate non-wrapping* requests and require the merged raster to be
+their concatenation, pixel for pixel, with the west half's geotransform.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from osgeo import gdal
+
+from pyramids.base._coverage import window_overlaps
+from pyramids.dataset import Dataset, _ogc_coverages, _wcs
+from tests.dataset.remote.test_ogc_coverages import GLOBAL_BOUNDS as OGC_GLOBAL_BOUNDS
+from tests.dataset.remote.test_ogc_coverages import _serving
+from tests.dataset.remote.wcs_mock_server import GLOBAL_BOUNDS, WcsMock
+
+# Deliberately asymmetric: 10 degrees west of the seam, 5 east of it. Equal halves
+# would let a swapped or offset stitch pass unnoticed.
+WRAP = (170.0, -10.0, -175.0, 10.0)
+WEST = (170.0, -10.0, 180.0, 10.0)
+EAST = (-180.0, -10.0, -175.0, 10.0)
+
+
+def _arr(ds: Dataset) -> np.ndarray:
+    """The dataset's single band as a 2-D array."""
+    return np.asarray(ds.read_array())
+
+
+def _assert_is_concatenation(merged: Dataset, west: Dataset, east: Dataset) -> None:
+    """The merged raster is exactly `west` then `east`, on the west geotransform.
+
+    This is the whole correctness claim in one place: the right width, the west
+    half's geotransform continued past the seam (so 170..180 runs on into
+    180..190 instead of jumping back to -180), and both halves' pixels where they
+    belong.
+    """
+    m, w, e = _arr(merged), _arr(west), _arr(east)
+    assert m.shape == (w.shape[0], w.shape[1] + e.shape[1])
+    assert merged.geotransform == pytest.approx(west.geotransform)
+    assert np.array_equal(m[:, : w.shape[1]], w)
+    assert np.array_equal(m[:, w.shape[1] :], e)
+    # The seam is where the west half ends; past it the geotransform keeps
+    # counting up rather than wrapping to -180.
+    gt = merged.geotransform
+    assert gt[0] + w.shape[1] * gt[1] == pytest.approx(180.0)
+    assert gt[0] + m.shape[1] * gt[1] > 180.0
+    assert merged.epsg == west.epsg
+
+
+class TestWindowOverlaps:
+    """The overlap test that keeps a seam half that misses the coverage unfetched."""
+
+    @staticmethod
+    def _src() -> gdal.Dataset:
+        src = gdal.GetDriverByName("MEM").Create("", 10, 10, 1)
+        src.SetGeoTransform((0.0, 1.0, 0.0, 10.0, 0.0, -1.0))
+        return src
+
+    def test_window_inside_overlaps(self):
+        assert window_overlaps([2.0, 8.0, 4.0, 6.0], self._src())
+
+    def test_window_partly_outside_overlaps(self):
+        assert window_overlaps([-5.0, 8.0, 4.0, 6.0], self._src())
+
+    @pytest.mark.parametrize(
+        "projwin",
+        [
+            [20.0, 8.0, 30.0, 6.0],  # east of the raster
+            [-30.0, 8.0, -20.0, 6.0],  # west of it
+            [2.0, 30.0, 4.0, 20.0],  # north of it
+            [2.0, -20.0, 4.0, -30.0],  # south of it
+        ],
+    )
+    def test_window_outside_does_not_overlap(self, projwin):
+        assert not window_overlaps(projwin, self._src())
+
+    def test_touching_edge_does_not_overlap(self):
+        """A zero-area intersection has no pixels to read, so it is not an overlap."""
+        assert not window_overlaps([10.0, 8.0, 20.0, 6.0], self._src())
+
+
+class TestWindowSizes:
+    """Sizing the halves of an OGC API coverage read onto one shared grid."""
+
+    def test_single_window_is_sized_as_before(self):
+        """One window keeps the plain read_size behaviour: cap the longer side."""
+        # 2 deg of longitude against 4 of latitude: the tall side takes the cap.
+        assert _ogc_coverages._window_sizes([[0.0, 10.0, 2.0, 6.0]], None) == [
+            (512, 1024)
+        ]
+
+    def test_two_windows_share_one_resolution(self):
+        """Both halves come back on one grid: equal height, widths summing to the cap."""
+        west = [170.0, 10.0, 180.0, -10.0]
+        east = [-180.0, 10.0, -175.0, -10.0]
+        (w_width, w_height), (e_width, e_height) = _ogc_coverages._window_sizes(
+            [west, east], None
+        )
+        assert w_height == e_height
+        # 15 deg of longitude against 20 of latitude: the tall side takes the cap.
+        assert w_height == 1024
+        assert (w_width, e_width) == (512, 256)
+        # Same pixel size on both, which is what makes them stitchable.
+        assert 10.0 / w_width == pytest.approx(5.0 / e_width)
+
+    def test_explicit_resolution_is_used_for_both(self):
+        west = [170.0, 10.0, 180.0, -10.0]
+        east = [-180.0, 10.0, -175.0, -10.0]
+        assert _ogc_coverages._window_sizes([west, east], (0.1, 0.1)) == [
+            (100, 200),
+            (50, 200),
+        ]
+
+
+class TestWcsDirect:
+    """Direct KVP GetCoverage: one request per half, then a stitch."""
+
+    def test_wrapping_bbox_is_the_concatenation_of_its_halves(self):
+        with WcsMock(version="2.0.1") as server:
+            merged = Dataset.from_wcs(
+                server.url,
+                coverage="test_cov",
+                bbox=WRAP,
+                version="2.0.1",
+                direct=True,
+            )
+            west = Dataset.from_wcs(
+                server.url,
+                coverage="test_cov",
+                bbox=WEST,
+                version="2.0.1",
+                direct=True,
+            )
+            east = Dataset.from_wcs(
+                server.url,
+                coverage="test_cov",
+                bbox=EAST,
+                version="2.0.1",
+                direct=True,
+            )
+        assert merged.shape == (1, 200, 150)
+        _assert_is_concatenation(merged, west, east)
+
+    def test_one_request_per_half_carrying_that_half_s_subset(self):
+        """The URL built for each half asks for that half, not for the wrap."""
+        with WcsMock(version="2.0.1") as server:
+            Dataset.from_wcs(
+                server.url,
+                coverage="test_cov",
+                bbox=WRAP,
+                version="2.0.1",
+                direct=True,
+            )
+            requests = server.getcoverage_requests()
+        assert len(requests) == 2
+        assert "SUBSET=Long(170.0,180.0)" in requests[0]
+        assert "SUBSET=Long(-180.0,-175.0)" in requests[1]
+        for request in requests:
+            assert "SUBSET=Lat(-10.0,10.0)" in request
+            # The wrapping bbox itself must never reach the wire.
+            assert "170.0,-175.0" not in request
+
+    def test_output_crs_is_applied_once_to_the_merged_raster(self):
+        with WcsMock(version="2.0.1") as server:
+            merged = Dataset.from_wcs(
+                server.url,
+                coverage="test_cov",
+                bbox=WRAP,
+                version="2.0.1",
+                direct=True,
+                output_crs="EPSG:3857",
+            )
+        assert merged.epsg == 3857
+
+    def test_output_writes_one_reopenable_stitched_file(self, tmp_path):
+        out = tmp_path / "wcs_seam.tif"
+        with WcsMock(version="2.0.1") as server:
+            Dataset.from_wcs(
+                server.url,
+                coverage="test_cov",
+                bbox=WRAP,
+                version="2.0.1",
+                direct=True,
+                output=out,
+            )
+        assert out.exists()
+        assert Dataset.read_file(str(out)).shape == (1, 200, 150)
+
+
+class TestWcsDiscovery:
+    """Full GetCapabilities → DescribeCoverage → GetCoverage cycle across the seam."""
+
+    @pytest.mark.parametrize("version", ["1.0.0", "2.0.1"])
+    def test_wrapping_bbox_is_the_concatenation_of_its_halves(self, version):
+        with WcsMock(version=version, bounds=GLOBAL_BOUNDS) as server:
+            merged = Dataset.from_wcs(
+                server.url, coverage="test_cov", bbox=WRAP, version=version
+            )
+            west = Dataset.from_wcs(
+                server.url, coverage="test_cov", bbox=WEST, version=version
+            )
+            east = Dataset.from_wcs(
+                server.url, coverage="test_cov", bbox=EAST, version=version
+            )
+        assert merged.shape == (1, 200, 150)
+        _assert_is_concatenation(merged, west, east)
+
+    def test_non_wrapping_bbox_is_unchanged(self):
+        """The ordinary request keeps the exact raster it had before the split."""
+        with WcsMock(version="1.0.0") as server:
+            ds = Dataset.from_wcs(
+                server.url,
+                coverage="test_cov",
+                bbox=(2.0, 2.0, 4.0, 4.0),
+                version="1.0.0",
+            )
+        assert ds.shape == (1, 20, 20)
+        assert ds.geotransform == pytest.approx((2.0, 0.1, 0.0, 4.0, 0.0, -0.1))
+
+    def test_half_that_misses_the_coverage_is_not_requested(self):
+        """A coverage reaching the seam from the west only returns just that half."""
+        with WcsMock(version="1.0.0", bounds=(170.0, -20.0, 180.0, 20.0)) as server:
+            merged = Dataset.from_wcs(
+                server.url, coverage="test_cov", bbox=WRAP, version="1.0.0"
+            )
+            west = Dataset.from_wcs(
+                server.url, coverage="test_cov", bbox=WEST, version="1.0.0"
+            )
+        assert merged.shape == west.shape == (1, 200, 100)
+        assert np.array_equal(_arr(merged), _arr(west))
+        assert merged.geotransform == pytest.approx(west.geotransform)
+
+    def test_no_overlapping_half_raises(self):
+        """A regional coverage nowhere near the seam gets a clear refusal."""
+        with WcsMock(version="1.0.0") as server:
+            with pytest.raises(ValueError, match="neither half overlaps"):
+                Dataset.from_wcs(
+                    server.url, coverage="test_cov", bbox=WRAP, version="1.0.0"
+                )
+
+
+@pytest.mark.skipif(
+    gdal.GetDriverByName("OGCAPI") is None,
+    reason="GDAL build lacks the OGCAPI driver; the real-driver path cannot run",
+)
+class TestOgcCoverages:
+    """The same behaviour through GDAL's real OGCAPI driver."""
+
+    def test_wrapping_bbox_is_the_concatenation_of_its_halves(self):
+        with _serving(OGC_GLOBAL_BOUNDS) as url:
+            merged = Dataset.from_ogc_coverages(url, coverage="demo", bbox=WRAP)
+            west = Dataset.from_ogc_coverages(url, coverage="demo", bbox=WEST)
+            east = Dataset.from_ogc_coverages(url, coverage="demo", bbox=EAST)
+        _assert_is_concatenation(merged, west, east)
+
+    def test_no_resolution_keeps_the_whole_seam_read_inside_one_pixel_budget(self):
+        """The cap is spent on the combined span, not twice over on each half."""
+        with _serving(OGC_GLOBAL_BOUNDS) as url:
+            merged = Dataset.from_ogc_coverages(url, coverage="demo", bbox=WRAP)
+        # 15 deg of longitude against 20 of latitude: the tall side takes the
+        # 1024 px cap and the width follows the aspect ratio, exactly as an
+        # unwrapped 15x20 deg window would.
+        assert merged.shape == (1, 1024, 768)
+
+    def test_explicit_resolution_grids_both_halves_the_same(self):
+        with _serving(OGC_GLOBAL_BOUNDS) as url:
+            merged = Dataset.from_ogc_coverages(
+                url, coverage="demo", bbox=WRAP, resolution=0.05
+            )
+        assert merged.shape == (1, 400, 300)
+        assert merged.geotransform == pytest.approx(
+            (170.0, 0.05, 0.0, 10.0, 0.0, -0.05)
+        )
+
+    def test_half_that_misses_the_coverage_is_not_requested(self):
+        with _serving((170.0, -20.0, 180.0, 20.0)) as url:
+            merged = Dataset.from_ogc_coverages(url, coverage="demo", bbox=WRAP)
+            west = Dataset.from_ogc_coverages(url, coverage="demo", bbox=WEST)
+        assert merged.shape == west.shape
+        assert np.array_equal(_arr(merged), _arr(west))
+
+    def test_no_overlapping_half_raises(self):
+        with _serving((0.0, 0.0, 10.0, 8.0)) as url:
+            with pytest.raises(ValueError, match="neither half overlaps"):
+                Dataset.from_ogc_coverages(url, coverage="demo", bbox=WRAP)
+
+    def test_output_crs_is_applied_once_to_the_merged_raster(self):
+        with _serving(OGC_GLOBAL_BOUNDS) as url:
+            merged = Dataset.from_ogc_coverages(
+                url, coverage="demo", bbox=WRAP, resolution=0.05, output_crs="EPSG:3857"
+            )
+        assert merged.epsg == 3857

--- a/tests/dataset/remote/test_ogc_coverages.py
+++ b/tests/dataset/remote/test_ogc_coverages.py
@@ -20,6 +20,7 @@ import json
 import os
 import re
 import threading
+from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 import numpy as np
@@ -209,15 +210,20 @@ class TestFromOgcCoveragesValidation:
             )
 
     def test_bad_bbox_raises_before_network(self, monkeypatch):
-        """An inverted bbox is rejected before any /collections or OpenEx call."""
+        """A bbox inverted in latitude is rejected before /collections or OpenEx.
+
+        Latitude only: a ``minx > maxx`` bbox is now read as crossing the
+        antimeridian rather than as inverted (#1088), so the X axis no longer
+        refuses. There is no seam in latitude, so ``miny >= maxy`` stays an error.
+        """
 
         def fail(*a, **k):  # pragma: no cover - must not be reached
             raise AssertionError("network must not be touched")
 
         monkeypatch.setattr(_ogc_coverages, "_get_collections", fail)
-        with pytest.raises(ValueError, match="minx < maxx"):
+        with pytest.raises(ValueError, match="miny < maxy"):
             Dataset.from_ogc_coverages(
-                "https://h/ogc", coverage="cov", bbox=(6.0, 51.0, 5.0, 52.0)
+                "https://h/ogc", coverage="cov", bbox=(5.0, 52.0, 6.0, 51.0)
             )
 
     def test_openex_none_raises_ogcapierror(self, monkeypatch):
@@ -348,89 +354,116 @@ _RES = 0.01
 _NX = int(round((_MAXX - _MINX) / _RES))  # 1000
 _NY = int(round((_MAXY - _MINY) / _RES))  # 800
 
-_COLLECTION = {
-    "id": "demo",
-    "title": "Demo coverage",
-    "extent": {
-        "spatial": {
-            "bbox": [[_MINX, _MINY, _MAXX, _MAXY]],
-            "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
-        }
-    },
-    "crs": ["http://www.opengis.net/def/crs/OGC/1.3/CRS84"],
-    "links": [
-        {
-            "rel": "self",
-            "type": "application/json",
-            "href": "http://HOST/collections/demo",
+# The extents the mock can advertise. DEFAULT_BOUNDS is the regional grid;
+# GLOBAL_BOUNDS reaches the 180 degree seam, which an antimeridian bbox needs —
+# a seam-crossing request only has data either side of the split if the coverage
+# spans the seam.
+DEFAULT_BOUNDS = (_MINX, _MINY, _MAXX, _MAXY)
+GLOBAL_BOUNDS = (-180.0, -80.0, 180.0, 80.0)
+
+
+def _collection(bounds):
+    """The ``/collections/demo`` document for a coverage over `bounds`."""
+    return {
+        "id": "demo",
+        "title": "Demo coverage",
+        "extent": {
+            "spatial": {
+                "bbox": [list(bounds)],
+                "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+            }
         },
-        {
-            "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage",
-            "type": "image/tiff; application=geotiff",
-            "href": "http://HOST/collections/demo/coverage",
-        },
-        {
-            "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage-domainset",
-            "type": "application/json",
-            "href": "http://HOST/collections/demo/coverage/domainset",
-        },
-        {
-            "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage-rangetype",
-            "type": "application/json",
-            "href": "http://HOST/collections/demo/coverage/rangetype",
-        },
-    ],
-}
-_DISCOVERY = {
-    "links": [
-        {"rel": "self", "type": "application/json", "href": "http://HOST/collections"}
-    ],
-    "collections": [_COLLECTION],
-}
-_DOMAINSET = {
-    "type": "DomainSet",
-    "generalGrid": {
-        "type": "GeneralGridCoverage",
-        "srsName": "http://www.opengis.net/def/crs/EPSG/0/4326",
-        "axisLabels": ["Lat", "Long"],
-        "axis": [
+        "crs": ["http://www.opengis.net/def/crs/OGC/1.3/CRS84"],
+        "links": [
             {
-                "type": "RegularAxis",
-                "axisLabel": "Lat",
-                "lowerBound": _MINY,
-                "upperBound": _MAXY,
-                "resolution": _RES,
-                "uomLabel": "deg",
+                "rel": "self",
+                "type": "application/json",
+                "href": "http://HOST/collections/demo",
             },
             {
-                "type": "RegularAxis",
-                "axisLabel": "Long",
-                "lowerBound": _MINX,
-                "upperBound": _MAXX,
-                "resolution": _RES,
-                "uomLabel": "deg",
+                "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage",
+                "type": "image/tiff; application=geotiff",
+                "href": "http://HOST/collections/demo/coverage",
+            },
+            {
+                "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage-domainset",
+                "type": "application/json",
+                "href": "http://HOST/collections/demo/coverage/domainset",
+            },
+            {
+                "rel": "http://www.opengis.net/def/rel/ogc/1.0/coverage-rangetype",
+                "type": "application/json",
+                "href": "http://HOST/collections/demo/coverage/rangetype",
             },
         ],
-        "gridLimits": {
-            "type": "GridLimits",
-            "axisLabels": ["i", "j"],
+    }
+
+
+def _discovery(bounds):
+    """The ``/collections`` document listing the single demo coverage."""
+    return {
+        "links": [
+            {
+                "rel": "self",
+                "type": "application/json",
+                "href": "http://HOST/collections",
+            }
+        ],
+        "collections": [_collection(bounds)],
+    }
+
+
+def _domainset(bounds):
+    """The coverage domain set: a regular ``_RES`` lattice over `bounds`."""
+    minx, miny, maxx, maxy = bounds
+    nx = int(round((maxx - minx) / _RES))
+    ny = int(round((maxy - miny) / _RES))
+    return {
+        "type": "DomainSet",
+        "generalGrid": {
+            "type": "GeneralGridCoverage",
+            "srsName": "http://www.opengis.net/def/crs/EPSG/0/4326",
+            "axisLabels": ["Lat", "Long"],
             "axis": [
                 {
-                    "type": "IndexAxis",
-                    "axisLabel": "i",
-                    "lowerBound": 0,
-                    "upperBound": _NY - 1,
+                    "type": "RegularAxis",
+                    "axisLabel": "Lat",
+                    "lowerBound": miny,
+                    "upperBound": maxy,
+                    "resolution": _RES,
+                    "uomLabel": "deg",
                 },
                 {
-                    "type": "IndexAxis",
-                    "axisLabel": "j",
-                    "lowerBound": 0,
-                    "upperBound": _NX - 1,
+                    "type": "RegularAxis",
+                    "axisLabel": "Long",
+                    "lowerBound": minx,
+                    "upperBound": maxx,
+                    "resolution": _RES,
+                    "uomLabel": "deg",
                 },
             ],
+            "gridLimits": {
+                "type": "GridLimits",
+                "axisLabels": ["i", "j"],
+                "axis": [
+                    {
+                        "type": "IndexAxis",
+                        "axisLabel": "i",
+                        "lowerBound": 0,
+                        "upperBound": ny - 1,
+                    },
+                    {
+                        "type": "IndexAxis",
+                        "axisLabel": "j",
+                        "lowerBound": 0,
+                        "upperBound": nx - 1,
+                    },
+                ],
+            },
         },
-    },
-}
+    }
+
+
 _RANGETYPE = {
     "type": "DataRecord",
     "field": [
@@ -488,13 +521,14 @@ class _CoverageHandler(BaseHTTPRequestHandler):
         self.wfile.write(body)
 
     def do_GET(self):
+        bounds = getattr(self.server, "bounds", DEFAULT_BOUNDS)
         path = self.path.split("?", 1)[0]
         if path == "/collections":
-            return self._json(_DISCOVERY)
+            return self._json(_discovery(bounds))
         if path in ("/collections/demo", "/collections/demo/"):
-            return self._json(_COLLECTION)
+            return self._json(_collection(bounds))
         if path == "/collections/demo/coverage/domainset":
-            return self._json(_DOMAINSET)
+            return self._json(_domainset(bounds))
         if path == "/collections/demo/coverage/rangetype":
             return self._json(_RANGETYPE)
         if path == "/collections/demo/coverage":
@@ -507,7 +541,9 @@ class _CoverageHandler(BaseHTTPRequestHandler):
                 y0, y1 = sorted(map(float, mlat.groups()))
                 w, h = int(msc.group(1)), int(msc.group(2))
             else:
-                x0, y0, x1, y1, w, h = _MINX, _MINY, _MAXX, _MAXY, _NX, _NY
+                x0, y0, x1, y1 = bounds
+                w = int(round((x1 - x0) / _RES))
+                h = int(round((y1 - y0) / _RES))
             tif = _make_geotiff(max(w, 1), max(h, 1), x0, y0, x1, y1)
             self.send_response(200)
             self.send_header("Content-Type", "image/tiff")
@@ -520,10 +556,11 @@ class _CoverageHandler(BaseHTTPRequestHandler):
         self.send_error(404, "unknown path")
 
 
-@pytest.fixture(scope="class")
-def coverage_server():
-    """A threaded in-process OGC API – Coverages mock; yields its base URL."""
+@contextmanager
+def _serving(bounds):
+    """Run the coverage mock over `bounds`; yields its base URL."""
     server = ThreadingHTTPServer(("127.0.0.1", 0), _CoverageHandler)
+    server.bounds = bounds
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
@@ -532,6 +569,20 @@ def coverage_server():
         server.shutdown()
         server.server_close()
         thread.join(timeout=5)
+
+
+@pytest.fixture(scope="class")
+def coverage_server():
+    """A threaded in-process OGC API – Coverages mock; yields its base URL."""
+    with _serving(DEFAULT_BOUNDS) as url:
+        yield url
+
+
+@pytest.fixture(scope="class")
+def global_coverage_server():
+    """The same mock advertising a coverage that spans the 180 degree seam."""
+    with _serving(GLOBAL_BOUNDS) as url:
+        yield url
 
 
 @pytest.mark.skipif(

--- a/tests/dataset/remote/test_wcs.py
+++ b/tests/dataset/remote/test_wcs.py
@@ -383,9 +383,15 @@ class TestFromWcsValidation:
             )
 
     def test_bad_bbox_raises_before_network(self):
-        with pytest.raises(ValueError, match="minx < maxx"):
+        """A bbox inverted in *latitude* is refused before any request goes out.
+
+        Latitude only: a ``minx > maxx`` bbox is now read as crossing the
+        antimeridian rather than as inverted (#1088), so the X axis no longer
+        refuses. There is no seam in latitude, so ``miny >= maxy`` stays an error.
+        """
+        with pytest.raises(ValueError, match="miny < maxy"):
             Dataset.from_wcs(
-                "http://127.0.0.1:1/wcs", coverage="cov", bbox=(6.0, 51.0, 5.0, 52.0)
+                "http://127.0.0.1:1/wcs", coverage="cov", bbox=(5.0, 52.0, 6.0, 51.0)
             )
 
     @staticmethod

--- a/tests/dataset/remote/test_wms.py
+++ b/tests/dataset/remote/test_wms.py
@@ -715,6 +715,28 @@ class TestMergeLonHalves:
         assert merged_band.GetMetadata() == {"legend": "corine"}
         assert merged.GetMetadata() == {"source": "wms"}
 
+    def test_refuses_halves_whose_bands_carry_different_types(self):
+        """One `Create` type for every band would truncate the others silently.
+
+        Test scenario:
+            `Create` stamps a single data type across all bands, and the raw
+            `ReadRaster`/`WriteRaster` copy then pushes every band through that
+            one buffer type -- a Float64 band written as Byte turns 3.25 into 3,
+            with no error. GDAL's WMS and WMTS drivers make uniform-typed bands so
+            this is unreachable through them, but the helper's whole purpose is
+            that a stitched raster matches an unstitched one.
+        """
+        west = gdal.GetDriverByName("MEM").Create("", 20, 40, 2, gdal.GDT_Byte)
+        west.SetGeoTransform((170.0, 0.5, 0.0, 10.0, 0.0, -0.5))
+        mixed = gdal.GetDriverByName("MEM").Create("", 20, 40, 1, gdal.GDT_Float64)
+        # A two-band raster whose bands differ in type has to be built by hand.
+        west.AddBand(gdal.GDT_Float64)
+        east = gdal.GetDriverByName("MEM").Create("", 10, 40, 3, gdal.GDT_Byte)
+        east.SetGeoTransform((-180.0, 0.5, 0.0, 10.0, 0.0, -0.5))
+        assert mixed is not None
+        with pytest.raises(ValueError, match="mixed band data types"):
+            _wms._merge_lon_halves(west, east, 360.0)
+
     def test_refuses_mismatched_rows_or_bands(self):
         with pytest.raises(ValueError, match="not concatenable"):
             _wms._merge_lon_halves(
@@ -854,6 +876,32 @@ class TestFromWmtsAntimeridian:
         assert ds.columns == 20, (
             f"only the western half overlaps, so the result should be 20 columns "
             f"wide, got {ds.columns}"
+        )
+
+    def test_the_pixel_budget_is_spent_on_the_combined_span(self, monkeypatch):
+        """A wrapping read must not get the whole ceiling twice.
+
+        Test scenario:
+            `_translate_window` checks the ceiling per half, so a split read was
+            bounded at MAX_PX on *each* side -- twice the intended peak, and then a
+            third copy to stitch them. Both coverage readers budget the combined
+            span once and say so. This asserts the combined check happens by
+            recording the extents `_read_size` is asked about: one of them must
+            span both halves.
+        """
+        seen: list[float] = []
+        real = _wms._read_size
+
+        def recording(projwin, res):
+            seen.append(abs(projwin[2] - projwin[0]))
+            return real(projwin, res)
+
+        monkeypatch.setattr(_wms, "_read_size", recording)
+        monkeypatch.setattr(_wms, "_open", lambda *_a: _global_pyramid())
+        Dataset.from_wmts("https://c.xml", layer="L", bbox=WRAP, resolution=0.5)
+        assert max(seen) == pytest.approx(20.0), (
+            f"the combined 20 degree span must be budgeted once; the widest extent "
+            f"checked was {max(seen)}"
         )
 
     def test_a_layer_nowhere_near_the_seam_is_refused(self, monkeypatch):

--- a/tests/dataset/remote/test_wms.py
+++ b/tests/dataset/remote/test_wms.py
@@ -476,6 +476,38 @@ class TestSeamWindows:
         assert west_box[2] == 180.0
         assert east_box[0] == -180.0
 
+    def test_a_wrap_needs_two_pixels_of_width(self):
+        """One pixel cannot straddle the seam, so asking for one is refused.
+
+        Test scenario:
+            At width 1 over a 20 degree wrap the resolution is 20 degrees and each
+            half is exactly half a pixel. `round()` sent the west half to zero
+            through banker's rounding, dropping 10 degrees that were requested and
+            adding 10 that were not -- the single window came back as
+            `-180 .. -160`. There is no honest one-pixel answer, so it raises.
+        """
+        with pytest.raises(ValueError, match="at least 2 pixels of width"):
+            _wms._seam_windows((170.0, -10.0, -170.0, 10.0), (1, 4))
+
+    def test_two_pixels_give_each_side_of_the_seam_one(self):
+        """The smallest width a wrap can be rendered at, split evenly."""
+        windows = _wms._seam_windows((170.0, -10.0, -170.0, 10.0), (2, 4))
+        assert [size for _, size in windows] == [(1, 4), (1, 4)]
+        assert [window[0] for window, _ in windows] == [170.0, -180.0]
+
+    def test_an_exact_half_pixel_half_is_kept_not_dropped(self):
+        """Rounding half up, so the boundary case keeps the half rather than losing it.
+
+        Test scenario:
+            A three-pixel wrap over equal spans puts each half at 1.5 pixels.
+            Banker's rounding would send one to 2 and leave the other at 1 by
+            accident of parity; rounding half up makes the west half the wider one
+            deterministically, and neither is dropped.
+        """
+        windows = _wms._seam_windows((170.0, -10.0, -170.0, 10.0), (3, 4))
+        assert [size[0] for _, size in windows] == [2, 1]
+        assert sum(size[0] for _, size in windows) == 3
+
     def test_sub_half_pixel_west_sliver_collapses_to_one_request(self):
         """A west side under half a pixel wide *is* the half-pixel snap: drop it."""
         windows = _wms._seam_windows((179.999, -10.0, -170.0, 10.0), (2000, 16))

--- a/tests/dataset/remote/test_wms.py
+++ b/tests/dataset/remote/test_wms.py
@@ -5,13 +5,24 @@ resolution, the ``<GDAL_WMS>`` descriptor, the ``WMTS:`` connection string, the
 layers normalisation, and the ``from_wms`` "needs a size" guard — are covered
 offline; a live end-to-end against public OSM-WMS and NASA GIBS WMTS runs only
 under ``-m live``.
+
+The antimeridian split is covered offline too, against a stand-in server whose
+pixels carry their own centre longitude (``_longitude_raster``). That is what
+makes the *geometry* checkable without a network: the stitched raster is compared
+column-for-column against the same two regions fetched as ordinary non-wrapping
+requests, and its pixel values must step by exactly one cell across the seam. What
+it cannot prove is how a real service renders the two ``GetMap`` calls — styling,
+label placement and tile-cache seams either side of 180 are a live-server
+question, covered only by ``-m live``.
 """
 
 from __future__ import annotations
 
+import re
+
 import numpy as np
 import pytest
-from osgeo import gdal
+from osgeo import gdal, osr
 
 from pyramids.base.georeference import GeoReference
 from pyramids.dataset import Dataset, _wms
@@ -20,6 +31,8 @@ from pyramids.errors import WMSError
 pytestmark = pytest.mark.core
 
 BBOX = (5.0, 51.0, 6.0, 52.0)
+WRAP = (170.0, -10.0, -170.0, 10.0)
+ENDPOINT = "https://host/wms?"
 
 
 def _tiny_dataset(epsg: int = 4326) -> Dataset:
@@ -29,6 +42,81 @@ def _tiny_dataset(epsg: int = 4326) -> Dataset:
         arr,
         geo_ref=GeoReference(top_left_corner=(0.0, 0.0), cell_size=0.1, epsg=epsg),
     )
+
+
+def _descriptor_values(descriptor: str) -> dict[str, str]:
+    """The simple text elements of a ``<GDAL_WMS>`` descriptor, by tag name."""
+    return dict(re.findall(r"<(\w+)>([^<]*)</\1>", descriptor))
+
+
+def _lonlat_srs() -> osr.SpatialReference:
+    """EPSG:4326 in lon/lat order, as the readers stamp it."""
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(4326)
+    srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+    return srs
+
+
+def _longitude_raster(
+    ulx: float,
+    uly: float,
+    x_res: float,
+    y_res: float,
+    size: tuple[int, int],
+    bands: int,
+) -> gdal.Dataset:
+    """A MEM raster whose every pixel carries its own centre longitude (folded to 0..360).
+
+    Encoding the geometry in the *pixel values* is what lets an offline test check a
+    stitch against the geometry it claims: a constant step between neighbouring
+    columns means one uniform ground resolution, and any jump at the seam means a
+    half landed in the wrong columns. Each band after the first is offset by a
+    further 1000, so a band mix-up cannot pass unnoticed either.
+    """
+    width, height = size
+    src = gdal.GetDriverByName("MEM").Create("", width, height, bands, gdal.GDT_Float64)
+    src.SetGeoTransform((ulx, x_res, 0.0, uly, 0.0, y_res))
+    src.SetSpatialRef(_lonlat_srs())
+    lon = np.mod(ulx + (np.arange(width) + 0.5) * x_res, 360.0)
+    for band in range(1, bands + 1):
+        src.GetRasterBand(band).WriteArray(
+            np.tile(lon, (height, 1)) + 1000.0 * (band - 1)
+        )
+    return src
+
+
+def _fake_wms_source(descriptor: str) -> gdal.Dataset:
+    """Render what a WMS would return for `descriptor`: the window it asked for."""
+    values = _descriptor_values(descriptor)
+    ulx, uly = float(values["UpperLeftX"]), float(values["UpperLeftY"])
+    lrx, lry = float(values["LowerRightX"]), float(values["LowerRightY"])
+    width, height = int(values["SizeX"]), int(values["SizeY"])
+    return _longitude_raster(
+        ulx,
+        uly,
+        (lrx - ulx) / width,
+        (lry - uly) / height,
+        (width, height),
+        int(values["BandsCount"]),
+    )
+
+
+@pytest.fixture
+def fake_wms(monkeypatch):
+    """Serve every ``GetMap`` offline, returning the list of descriptors requested."""
+    requests: list[str] = []
+
+    def _fake_open(descriptor, layer, hint):
+        requests.append(descriptor)
+        return _fake_wms_source(descriptor)
+
+    monkeypatch.setattr(_wms, "_open", _fake_open)
+    return requests
+
+
+def _bands_rows_columns(ds: Dataset) -> np.ndarray:
+    """`ds.read_array()` as ``(bands, rows, columns)`` whatever the band count."""
+    return np.asarray(ds.read_array()).reshape(-1, ds.rows, ds.columns)
 
 
 class TestOutputSize:
@@ -193,11 +281,16 @@ class TestFromWmsGuards:
             )
 
     def test_from_wms_rejects_malformed_bbox(self):
-        with pytest.raises(ValueError, match="minx < maxx"):
+        """An inverted *latitude* range is still refused.
+
+        Longitude no longer is: ``minx > maxx`` is now read as an antimeridian wrap
+        (see TestFromWmsAntimeridian), so only the y axis is still one-way.
+        """
+        with pytest.raises(ValueError, match="miny < maxy"):
             Dataset.from_wms(
                 "https://host/wms?",
                 layers="L",
-                bbox=(6.0, 51.0, 5.0, 52.0),
+                bbox=(5.0, 52.0, 6.0, 51.0),
                 size=(10, 10),
             )
 
@@ -276,6 +369,382 @@ class TestAvailableWmtsLayers:
         assert _wms._available_wmts_layers("https://x") == []
 
 
+class TestSeamBboxGuard:
+    """`_check_seam_bbox` refuses the wraps this reader cannot honestly serve."""
+
+    def test_ordinary_bbox_is_untouched_in_any_crs(self):
+        """A minx < maxx box is never a wrap, so the guard never looks at the CRS."""
+        assert _wms._check_seam_bbox((0.0, 0.0, 1e6, 1e6), "EPSG:3857") is None
+
+    def test_projected_crs_refuses_a_wrapping_bbox(self):
+        """There is no 180 degree seam in a projected CRS - minx > maxx is inverted."""
+        with pytest.raises(ValueError, match="not a geographic"):
+            Dataset.from_wms(
+                ENDPOINT, layers="L", bbox=WRAP, crs="EPSG:3857", size=(10, 10)
+            )
+
+    @pytest.mark.parametrize(
+        "bbox", [(200.0, -10.0, -170.0, 10.0), (170.0, -10.0, -200.0, 10.0)]
+    )
+    def test_corner_outside_the_lonlat_range_is_refused(self, bbox):
+        """A wrap needs both corners in -180..180; outside it, the split is guesswork."""
+        with pytest.raises(ValueError, match=r"-180\.\.180"):
+            Dataset.from_wms(ENDPOINT, layers="L", bbox=bbox, size=(10, 10))
+
+    def test_wmts_applies_the_same_guard(self):
+        with pytest.raises(ValueError, match="not a geographic"):
+            Dataset.from_wmts(
+                "https://c.xml", layer="L", bbox=WRAP, crs="EPSG:3857", resolution=0.5
+            )
+
+
+class TestSeamWindows:
+    """The pixel-width division rule (`_seam_windows`)."""
+
+    def test_ordinary_bbox_is_one_untouched_request(self):
+        assert _wms._seam_windows(BBOX, (512, 256)) == [(BBOX, (512, 256))]
+
+    @pytest.mark.parametrize("width", [400, 401, 333, 2, 4097])
+    def test_half_widths_always_sum_to_the_requested_width(self, width):
+        windows = _wms._seam_windows(WRAP, (width, 16))
+        assert sum(size[0] for _, size in windows) == width
+
+    @pytest.mark.parametrize(
+        "bbox, width",
+        [(WRAP, 400), ((175.0, -10.0, -170.0, 10.0), 400), (WRAP, 401)],
+    )
+    def test_every_half_is_rendered_at_the_one_shared_resolution(self, bbox, width):
+        """Each half's span / columns is the whole wrapping span / the whole width."""
+        expected = ((bbox[2] + 360.0) - bbox[0]) / width
+        for box, size in _wms._seam_windows(bbox, (width, 16)):
+            assert (box[2] - box[0]) / size[0] == pytest.approx(expected)
+
+    @pytest.mark.parametrize(
+        "bbox, width", [(WRAP, 400), ((175.0, -10.0, -170.0, 10.0), 400), (WRAP, 401)]
+    )
+    def test_snapping_moves_the_window_by_under_half_a_pixel(self, bbox, width):
+        """The seam is snapped to the nearest pixel edge, so nothing shifts further.
+
+        Half a pixel exactly is reachable — a seam landing on a column midpoint
+        (400 columns over 20 degrees split 10/10 at width 401) is the tie case.
+        """
+        res = ((bbox[2] + 360.0) - bbox[0]) / width
+        windows = _wms._seam_windows(bbox, (width, 16))
+        assert abs(windows[0][0][0] - bbox[0]) <= 0.5 * res + 1e-12
+
+    def test_uneven_halves_split_in_proportion_to_their_span(self):
+        """5 of 15 degrees is a third of the width, not half of it."""
+        windows = _wms._seam_windows((175.0, -10.0, -170.0, 10.0), (400, 16))
+        assert [size[0] for _, size in windows] == [133, 267]
+
+    def test_halves_meet_exactly_at_the_seam(self):
+        (west_box, _), (east_box, _) = _wms._seam_windows(WRAP, (401, 16))
+        assert west_box[2] == 180.0
+        assert east_box[0] == -180.0
+
+    def test_sub_half_pixel_west_sliver_collapses_to_one_request(self):
+        """A west side under half a pixel wide *is* the half-pixel snap: drop it."""
+        windows = _wms._seam_windows((179.999, -10.0, -170.0, 10.0), (2000, 16))
+        assert len(windows) == 1
+        assert windows[0][1][0] == 2000
+        assert windows[0][0][0] == -180.0
+
+    def test_sub_half_pixel_east_sliver_collapses_to_one_request(self):
+        windows = _wms._seam_windows((170.0, -10.0, -179.999, 10.0), (2000, 16))
+        assert len(windows) == 1
+        assert windows[0][1][0] == 2000
+        assert windows[0][0][2] == 180.0
+
+
+class TestFromWmsAntimeridian:
+    """`from_wms` splits, fetches and stitches a west > east bbox, like `crop`."""
+
+    def test_wrapping_bbox_is_no_longer_refused(self, fake_wms):
+        ds = Dataset.from_wms(ENDPOINT, layers="L", bbox=WRAP, size=(400, 200))
+        assert ds.shape == (3, 200, 400)
+
+    def test_two_getmap_requests_are_issued_either_side_of_the_seam(self, fake_wms):
+        Dataset.from_wms(ENDPOINT, layers="L", bbox=WRAP, size=(400, 200))
+        assert len(fake_wms) == 2
+        west, east = (_descriptor_values(d) for d in fake_wms)
+        assert float(west["UpperLeftX"]) == pytest.approx(170.0)
+        assert float(west["LowerRightX"]) == pytest.approx(180.0)
+        assert float(east["UpperLeftX"]) == pytest.approx(-180.0)
+        assert float(east["LowerRightX"]) == pytest.approx(-170.0)
+        assert (int(west["SizeX"]), int(east["SizeX"])) == (200, 200)
+        assert {west["SizeY"], east["SizeY"]} == {"200"}
+
+    @pytest.mark.parametrize("width", [400, 401, 333])
+    def test_output_width_is_exactly_what_was_requested(self, fake_wms, width):
+        ds = Dataset.from_wms(ENDPOINT, layers="L", bbox=WRAP, size=(width, 100))
+        assert ds.columns == width
+
+    def test_ground_resolution_is_uniform_across_the_seam(self, fake_wms):
+        """Neighbouring columns step by one cell everywhere, the seam column included."""
+        ds = Dataset.from_wms(ENDPOINT, layers="L", bbox=WRAP, size=(400, 200))
+        steps = np.diff(_bands_rows_columns(ds)[0, 0])
+        assert steps == pytest.approx(ds.geotransform[1])
+        assert steps[199] == pytest.approx(ds.geotransform[1])
+
+    def test_pixels_match_the_same_two_regions_fetched_separately(self, fake_wms):
+        """The stitched raster is the two non-wrapping requests, side by side."""
+        wrapped = _bands_rows_columns(
+            Dataset.from_wms(ENDPOINT, layers="L", bbox=WRAP, size=(400, 200))
+        )
+        west = _bands_rows_columns(
+            Dataset.from_wms(
+                ENDPOINT, layers="L", bbox=(170.0, -10.0, 180.0, 10.0), size=(200, 200)
+            )
+        )
+        east = _bands_rows_columns(
+            Dataset.from_wms(
+                ENDPOINT,
+                layers="L",
+                bbox=(-180.0, -10.0, -170.0, 10.0),
+                size=(200, 200),
+            )
+        )
+        assert wrapped[:, :, :200] == pytest.approx(west)
+        assert wrapped[:, :, 200:] == pytest.approx(east)
+
+    def test_longitude_continues_past_the_seam(self, fake_wms):
+        """The result keeps the west half's geotransform, as a stitched crop does."""
+        ds = Dataset.from_wms(ENDPOINT, layers="L", bbox=WRAP, size=(400, 200))
+        assert ds.geotransform[0] == pytest.approx(170.0)
+        assert ds.geotransform[1] == pytest.approx(0.05)
+        assert ds.bbox[0] == pytest.approx(170.0)
+        assert ds.bbox[2] == pytest.approx(190.0)
+
+    def test_uneven_split_keeps_one_resolution_and_the_full_width(self, fake_wms):
+        ds = Dataset.from_wms(
+            ENDPOINT, layers="L", bbox=(175.0, -10.0, -170.0, 10.0), size=(400, 200)
+        )
+        cell = 15.0 / 400
+        assert ds.columns == 400
+        assert ds.geotransform[1] == pytest.approx(cell)
+        assert [int(_descriptor_values(d)["SizeX"]) for d in fake_wms] == [133, 267]
+        assert abs(ds.geotransform[0] - 175.0) < 0.5 * cell
+        steps = np.diff(_bands_rows_columns(ds)[0, 0])
+        assert steps == pytest.approx(cell)
+
+    def test_resolution_sizes_the_wrapping_span(self, fake_wms):
+        """`resolution=` divides the 20 degree wrap, not the -340 the corners subtract to."""
+        ds = Dataset.from_wms(ENDPOINT, layers="L", bbox=WRAP, resolution=0.05)
+        assert ds.shape == (3, 400, 400)
+        assert ds.geotransform[1] == pytest.approx(0.05)
+
+    def test_sub_half_pixel_sliver_makes_one_request(self, fake_wms):
+        ds = Dataset.from_wms(
+            ENDPOINT, layers="L", bbox=(179.999, -10.0, -170.0, 10.0), size=(2000, 200)
+        )
+        assert len(fake_wms) == 1
+        assert ds.columns == 2000
+        assert abs(ds.geotransform[0] - (179.999 - 360.0)) < 0.5 * ds.geotransform[1]
+
+    def test_non_wrapping_bbox_still_makes_a_single_request(self, fake_wms):
+        ds = Dataset.from_wms(ENDPOINT, layers="L", bbox=BBOX, size=(512, 256))
+        assert len(fake_wms) == 1
+        assert ds.shape == (3, 256, 512)
+        assert ds.bbox == pytest.approx([5.0, 51.0, 6.0, 52.0])
+
+    def test_every_requested_band_survives_the_stitch(self, fake_wms):
+        """Band n of the fake source is offset by 1000n, so a mix-up cannot pass."""
+        ds = Dataset.from_wms(ENDPOINT, layers="L", bbox=WRAP, size=(400, 20), bands=4)
+        arr = _bands_rows_columns(ds)
+        assert arr.shape == (4, 20, 400)
+        for band in range(4):
+            assert arr[band, 0] - arr[0, 0] == pytest.approx(1000.0 * band)
+
+
+class TestSeamOffset:
+    def test_geographic_layer_spans_360_degrees(self):
+        assert _wms._seam_offset(WRAP, "EPSG:4326", _lonlat_srs()) == pytest.approx(
+            360.0
+        )
+
+    def test_web_mercator_layer_spans_the_world_width(self):
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(3857)
+        srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+        assert _wms._seam_offset(WRAP, "EPSG:4326", srs) == pytest.approx(
+            40075016.6856, rel=1e-9
+        )
+
+
+class TestMergeLonHalves:
+    """The stitch and the invariant it refuses to stitch without."""
+
+    @staticmethod
+    def _half(ulx, width, *, x_res=0.5, y_res=-0.5, uly=10.0, rows=4, bands=2):
+        src = gdal.GetDriverByName("MEM").Create("", width, rows, bands, gdal.GDT_Int16)
+        src.SetGeoTransform((ulx, x_res, 0.0, uly, 0.0, y_res))
+        for band in range(1, bands + 1):
+            src.GetRasterBand(band).WriteArray(
+                np.full((rows, width), band * 10, dtype="int16")
+            )
+        return src
+
+    def test_places_each_half_in_its_own_columns(self):
+        west, east = self._half(170.0, 20), self._half(-180.0, 12)
+        merged = _wms._merge_lon_halves(west, east, 360.0)
+        assert merged.RasterXSize == 32
+        assert merged.RasterYSize == 4
+        assert merged.RasterCount == 2
+        assert merged.GetGeoTransform() == west.GetGeoTransform()
+
+    def test_keeps_the_data_type_and_band_metadata(self):
+        west, east = self._half(170.0, 20), self._half(-180.0, 20)
+        west.GetRasterBand(1).SetNoDataValue(-999.0)
+        west.GetRasterBand(1).SetColorInterpretation(gdal.GCI_RedBand)
+        merged = _wms._merge_lon_halves(west, east, 360.0)
+        assert merged.GetRasterBand(1).DataType == gdal.GDT_Int16
+        assert merged.GetRasterBand(1).GetNoDataValue() == -999.0
+        assert merged.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_RedBand
+        assert merged.GetRasterBand(2).ReadAsArray().min() == 20
+
+    def test_refuses_mismatched_rows_or_bands(self):
+        with pytest.raises(ValueError, match="not concatenable"):
+            _wms._merge_lon_halves(
+                self._half(170.0, 20), self._half(-180.0, 20, rows=3), 360.0
+            )
+
+    def test_refuses_different_resolutions(self):
+        with pytest.raises(ValueError, match="different resolutions"):
+            _wms._merge_lon_halves(
+                self._half(170.0, 20), self._half(-180.0, 40, x_res=0.25), 360.0
+            )
+
+    def test_refuses_halves_that_do_not_share_a_top_edge(self):
+        with pytest.raises(ValueError, match="top edge"):
+            _wms._merge_lon_halves(
+                self._half(170.0, 20), self._half(-180.0, 20, uly=20.0), 360.0
+            )
+
+    def test_refuses_halves_that_do_not_meet_at_the_seam(self):
+        """A west half stopping a pixel short of 180 is not stitchable."""
+        with pytest.raises(ValueError, match="apart at the seam"):
+            _wms._merge_lon_halves(self._half(170.0, 18), self._half(-180.0, 18), 360.0)
+
+    def test_a_wrong_seam_offset_is_caught(self):
+        """A projected layer checked against 360 degrees fails rather than stitching."""
+        with pytest.raises(ValueError, match="apart at the seam"):
+            _wms._merge_lon_halves(self._half(170.0, 20), self._half(-180.0, 20), 1.0)
+
+
+class _Part:
+    """A stand-in for a fetched half that records whether it was closed."""
+
+    def __init__(self, name, closed):
+        self.name = name
+        self._closed = closed
+
+    def Close(self):  # noqa: N802 - mirrors gdal.Dataset.Close
+        self._closed.append(self.name)
+
+
+class TestCollectHalves:
+    """Ownership: what `_collect_halves` closes and what it hands back open."""
+
+    def test_a_single_window_is_handed_back_open(self):
+        closed: list[str] = []
+        part = _Part("only", closed)
+        assert _wms._collect_halves(lambda w: part, ["only"], 360.0) is part
+        assert closed == []
+
+    def test_both_halves_are_closed_once_merged(self, monkeypatch):
+        closed: list[str] = []
+        monkeypatch.setattr(_wms, "_merge_lon_halves", lambda w, e, off: "stitched")
+        result = _wms._collect_halves(
+            lambda w: _Part(w, closed), ["west", "east"], 360.0
+        )
+        assert result == "stitched"
+        assert closed == ["west", "east"]
+
+    def test_a_failed_second_fetch_closes_the_first(self):
+        closed: list[str] = []
+
+        def fetch(window):
+            if window == "east":
+                raise WMSError("GetMap failed")
+            return _Part(window, closed)
+
+        with pytest.raises(WMSError):
+            _wms._collect_halves(fetch, ["west", "east"], 360.0)
+        assert closed == ["west"]
+
+    def test_a_failed_merge_still_closes_both(self, monkeypatch):
+        closed: list[str] = []
+
+        def boom(*_a):
+            raise ValueError("not concatenable")
+
+        monkeypatch.setattr(_wms, "_merge_lon_halves", boom)
+        with pytest.raises(ValueError, match="not concatenable"):
+            _wms._collect_halves(lambda w: _Part(w, closed), ["west", "east"], 360.0)
+        assert closed == ["west", "east"]
+
+
+def _global_pyramid(res: float = 0.5) -> gdal.Dataset:
+    """A whole-world lon/lat raster standing in for an opened WMTS layer."""
+    return _longitude_raster(
+        -180.0, 90.0, res, -res, (int(360 / res), int(180 / res)), 1
+    )
+
+
+class TestFromWmtsAntimeridian:
+    """`from_wmts` windows the pyramid either side of the seam and stitches."""
+
+    @pytest.fixture
+    def fake_wmts(self, monkeypatch):
+        src = _global_pyramid()
+        monkeypatch.setattr(_wms, "_open", lambda *_a: src)
+        return src
+
+    def test_wrapping_bbox_is_stitched(self, fake_wmts):
+        ds = Dataset.from_wmts("https://c.xml", layer="L", bbox=WRAP, resolution=0.5)
+        assert ds.columns == 40
+        assert ds.geotransform[0] == pytest.approx(170.0)
+        assert ds.geotransform[1] == pytest.approx(0.5)
+        row = _bands_rows_columns(ds)[0, 0]
+        assert row == pytest.approx(170.0 + (np.arange(40) + 0.5) * 0.5)
+
+    def test_native_resolution_read_also_stitches(self, fake_wmts):
+        """`resolution=None` pins both halves to the layer's own grid before splitting."""
+        ds = Dataset.from_wmts("https://c.xml", layer="L", bbox=WRAP)
+        assert ds.columns == 40
+        assert ds.geotransform[1] == pytest.approx(0.5)
+
+    def test_non_wrapping_bbox_is_unchanged(self, fake_wmts):
+        ds = Dataset.from_wmts(
+            "https://c.xml", layer="L", bbox=(0.0, -10.0, 10.0, 10.0), resolution=0.5
+        )
+        assert ds.columns == 20
+        assert ds.geotransform[0] == pytest.approx(0.0)
+
+    def test_pixels_match_the_same_two_regions_fetched_separately(self, fake_wmts):
+        wrapped = _bands_rows_columns(
+            Dataset.from_wmts("https://c.xml", layer="L", bbox=WRAP, resolution=0.5)
+        )
+        west = _bands_rows_columns(
+            Dataset.from_wmts(
+                "https://c.xml",
+                layer="L",
+                bbox=(170.0, -10.0, 180.0, 10.0),
+                resolution=0.5,
+            )
+        )
+        east = _bands_rows_columns(
+            Dataset.from_wmts(
+                "https://c.xml",
+                layer="L",
+                bbox=(-180.0, -10.0, -170.0, 10.0),
+                resolution=0.5,
+            )
+        )
+        assert wrapped[:, :, :20] == pytest.approx(west)
+        assert wrapped[:, :, 20:] == pytest.approx(east)
+
+
 @pytest.mark.slow
 @pytest.mark.live
 class TestLiveWms:
@@ -316,3 +785,23 @@ class TestLiveWms:
                 bbox=BBOX,
                 resolution=0.1,
             )
+
+    # A real service is the only thing that can answer whether two GetMap calls
+    # either side of 180 come back consistently styled and cache-aligned - the
+    # offline suite proves the geometry, not the rendering.
+    FIJI = (179.0, -18.5, -179.0, -17.5)
+
+    def test_wms_across_the_antimeridian(self):
+        ds = Dataset.from_wms(
+            self.OSM, layers="OSM-WMS", bbox=self.FIJI, size=(512, 256)
+        )
+        assert ds.shape == (3, 256, 512)
+        assert ds.bbox[0] == pytest.approx(179.0, abs=0.01)
+        assert ds.bbox[2] == pytest.approx(181.0, abs=0.01)
+
+    def test_wmts_across_the_antimeridian(self):
+        ds = Dataset.from_wmts(
+            self.GIBS, layer=self.TRUECOLOR, bbox=self.FIJI, resolution=0.01
+        )
+        assert ds.shape[-2:] == (100, 200)
+        assert ds.bbox[0] == pytest.approx(179.0, abs=0.05)

--- a/tests/dataset/remote/test_wms.py
+++ b/tests/dataset/remote/test_wms.py
@@ -636,6 +636,46 @@ class TestMergeLonHalves:
         assert merged.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_RedBand
         assert merged.GetRasterBand(2).ReadAsArray().min() == 20
 
+    def test_keeps_the_colour_table_and_band_metadata(self):
+        """A paletted map must not lose its palette because the bbox crossed 180.
+
+        Test scenario:
+            WMS is the rendered-map reader, so a single-band paletted PNG is an
+            ordinary response. Copying `ColorInterpretation` without the table left
+            the merged band declaring `GCI_PaletteIndex` with nothing to look up --
+            worse than dropping both -- and the band description, units and
+            metadata went with it. A non-wrapping read kept all of it, so the same
+            layer rendered differently either side of the seam.
+        """
+        west = gdal.GetDriverByName("MEM").Create("", 20, 40, 1, gdal.GDT_Byte)
+        west.SetGeoTransform((170.0, 0.5, 0.0, 10.0, 0.0, -0.5))
+        table = gdal.ColorTable()
+        table.SetColorEntry(0, (10, 20, 30, 255))
+        table.SetColorEntry(1, (40, 50, 60, 255))
+        band = west.GetRasterBand(1)
+        band.SetRasterColorTable(table)
+        band.SetColorInterpretation(gdal.GCI_PaletteIndex)
+        band.SetDescription("landcover")
+        band.SetUnitType("class")
+        band.SetMetadata({"legend": "corine"})
+        west.SetMetadata({"source": "wms"})
+
+        east = gdal.GetDriverByName("MEM").Create("", 10, 40, 1, gdal.GDT_Byte)
+        east.SetGeoTransform((-180.0, 0.5, 0.0, 10.0, 0.0, -0.5))
+
+        merged = _wms._merge_lon_halves(west, east, 360.0)
+        merged_band = merged.GetRasterBand(1)
+
+        assert merged_band.GetRasterColorTable() is not None, (
+            "the palette must survive the stitch; without it the band declares "
+            "GCI_PaletteIndex with nothing to look up"
+        )
+        assert merged_band.GetRasterColorTable().GetColorEntry(1) == (40, 50, 60, 255)
+        assert merged_band.GetDescription() == "landcover"
+        assert merged_band.GetUnitType() == "class"
+        assert merged_band.GetMetadata() == {"legend": "corine"}
+        assert merged.GetMetadata() == {"source": "wms"}
+
     def test_refuses_mismatched_rows_or_bands(self):
         with pytest.raises(ValueError, match="not concatenable"):
             _wms._merge_lon_halves(
@@ -684,6 +724,18 @@ class TestCollectHalves:
         part = _Part("only", closed)
         assert _wms._collect_halves(lambda w: part, ["only"], 360.0) is part
         assert closed == []
+
+    def test_an_empty_window_list_is_refused_by_name(self):
+        """The invariant the callers rely on, stated rather than assumed.
+
+        Test scenario:
+            With no windows the loop never runs, the single-window branch is false
+            and the merge indexes an empty list -- an `IndexError` naming nothing.
+            Now that the WMTS reader filters halves by overlap, an empty list is
+            reachable, so it fails with a message instead.
+        """
+        with pytest.raises(ValueError, match="at least one window"):
+            _wms._collect_halves(lambda window: None, [], 360.0)
 
     def test_both_halves_are_closed_once_merged(self, monkeypatch):
         closed: list[str] = []
@@ -747,6 +799,36 @@ class TestFromWmtsAntimeridian:
         ds = Dataset.from_wmts("https://c.xml", layer="L", bbox=WRAP)
         assert ds.columns == 40
         assert ds.geotransform[1] == pytest.approx(0.5)
+
+    def test_a_half_that_misses_the_layer_is_not_requested(self, monkeypatch):
+        """A regional pyramid returns only the half it actually covers.
+
+        Test scenario:
+            A layer reaching the seam from the west only. Without the overlap
+            filter the eastern half comes back as a block of no-data and is
+            concatenated in as though it were data -- while the WCS and OGC API
+            Coverages readers drop it. All three now answer the same way.
+        """
+        regional = _longitude_raster(170.0, 10.0, 0.5, -0.5, (20, 40), 1)
+        monkeypatch.setattr(_wms, "_open", lambda *_a: regional)
+        ds = Dataset.from_wmts("https://c.xml", layer="L", bbox=WRAP, resolution=0.5)
+        assert ds.columns == 20, (
+            f"only the western half overlaps, so the result should be 20 columns "
+            f"wide, got {ds.columns}"
+        )
+
+    def test_a_layer_nowhere_near_the_seam_is_refused(self, monkeypatch):
+        """Neither half overlaps, so there is nothing honest to return.
+
+        Test scenario:
+            The same refusal `from_wcs` and `from_ogc_coverages` already give. A
+            European pyramid cannot serve a wrap; before the filter it returned two
+            no-data blocks stitched together.
+        """
+        regional = _longitude_raster(0.0, 10.0, 0.5, -0.5, (20, 40), 1)
+        monkeypatch.setattr(_wms, "_open", lambda *_a: regional)
+        with pytest.raises(ValueError, match="neither half overlaps"):
+            Dataset.from_wmts("https://c.xml", layer="L", bbox=WRAP, resolution=0.5)
 
     def test_non_wrapping_bbox_is_unchanged(self, fake_wmts):
         ds = Dataset.from_wmts(

--- a/tests/dataset/remote/test_wms.py
+++ b/tests/dataset/remote/test_wms.py
@@ -140,6 +140,40 @@ class TestOutputSize:
             _wms._output_size(BBOX, bad, None)
 
 
+class TestOutputSizeCeiling:
+    """A GetMap is bounded like every other network read.
+
+    Before a wrap was accepted, a `minx > maxx` bbox never reached the sizing path.
+    Now it does, and a transposed pair spans 359 degrees -- so without a ceiling an
+    ordinary typo becomes two requests of a few hundred thousand columns each.
+    """
+
+    def test_a_transposed_bbox_is_refused_rather_than_sized(self):
+        """The case the ceiling exists for.
+
+        Test scenario:
+            `(6, 51, 5, 52)` reads as a 359 degree wrap. At 0.001 degree pixels
+            that is 359,000 columns -- roughly half a gigabyte per half, and
+            another full copy to stitch them. It raises instead, and the message
+            names the way out.
+        """
+        with pytest.raises(
+            ValueError, match=r"exceeds the 25000 px limit: 359000x1000"
+        ):
+            _wms._output_size((6.0, 51.0, 5.0, 52.0), None, 0.001)
+
+    def test_an_ordinary_fine_read_is_still_allowed(self):
+        """The ceiling is generous enough not to bother a real request."""
+        assert _wms._output_size((5.0, 51.0, 6.0, 52.0), None, 0.001) == (1000, 1000)
+
+    def test_an_explicit_size_is_still_taken_verbatim(self):
+        """The cap applies to sizing from a resolution, not to a size the caller set."""
+        assert _wms._output_size((5.0, 51.0, 6.0, 52.0), (4096, 2048), None) == (
+            4096,
+            2048,
+        )
+
+
 class TestLayersValue:
     def test_string_passthrough(self):
         assert _wms._layers_value("OSM-WMS") == "OSM-WMS"

--- a/tests/dataset/remote/test_wms.py
+++ b/tests/dataset/remote/test_wms.py
@@ -495,18 +495,25 @@ class TestSeamWindows:
         assert [size for _, size in windows] == [(1, 4), (1, 4)]
         assert [window[0] for window, _ in windows] == [170.0, -180.0]
 
-    def test_an_exact_half_pixel_half_is_kept_not_dropped(self):
-        """Rounding half up, so the boundary case keeps the half rather than losing it.
+    def test_a_half_pixel_boundary_rounds_up_not_to_even(self):
+        """Banker's rounding is parity-dependent; the seam split must not be.
 
         Test scenario:
-            A three-pixel wrap over equal spans puts each half at 1.5 pixels.
-            Banker's rounding would send one to 2 and leave the other at 1 by
-            accident of parity; rounding half up makes the west half the wider one
-            deterministically, and neither is dropped.
+            Five pixels over two equal 10 degree halves puts each at exactly 2.5.
+            `round()` takes 2.5 to 2 -- to even -- giving the *east* half the extra
+            pixel, while 1.5 at three pixels goes to 2 and gives it to the west.
+            Which half grows would then depend on the requested width's parity.
+            Rounding half up always gives it to the west, and the widths still sum
+            to what was asked for.
         """
-        windows = _wms._seam_windows((170.0, -10.0, -170.0, 10.0), (3, 4))
-        assert [size[0] for _, size in windows] == [2, 1]
-        assert sum(size[0] for _, size in windows) == 3
+        five = _wms._seam_windows((170.0, -10.0, -170.0, 10.0), (5, 4))
+        assert [size[0] for _, size in five] == [3, 2], (
+            "half-up must give the extra pixel to the west half; banker's "
+            "rounding takes 2.5 to 2 and gives it to the east"
+        )
+        three = _wms._seam_windows((170.0, -10.0, -170.0, 10.0), (3, 4))
+        assert [size[0] for _, size in three] == [2, 1]
+        assert sum(size[0] for _, size in five) == 5
 
     def test_sub_half_pixel_west_sliver_collapses_to_one_request(self):
         """A west side under half a pixel wide *is* the half-pixel snap: drop it."""

--- a/tests/dataset/remote/test_wms.py
+++ b/tests/dataset/remote/test_wms.py
@@ -738,32 +738,31 @@ class TestMergeLonHalves:
             _wms._merge_lon_halves(west, east, 360.0)
 
     def test_refuses_mismatched_rows_or_bands(self):
+        west, east = self._half(170.0, 20), self._half(-180.0, 20, rows=3)
         with pytest.raises(ValueError, match="not concatenable"):
-            _wms._merge_lon_halves(
-                self._half(170.0, 20), self._half(-180.0, 20, rows=3), 360.0
-            )
+            _wms._merge_lon_halves(west, east, 360.0)
 
     def test_refuses_different_resolutions(self):
+        west, east = self._half(170.0, 20), self._half(-180.0, 40, x_res=0.25)
         with pytest.raises(ValueError, match="different resolutions"):
-            _wms._merge_lon_halves(
-                self._half(170.0, 20), self._half(-180.0, 40, x_res=0.25), 360.0
-            )
+            _wms._merge_lon_halves(west, east, 360.0)
 
     def test_refuses_halves_that_do_not_share_a_top_edge(self):
+        west, east = self._half(170.0, 20), self._half(-180.0, 20, uly=20.0)
         with pytest.raises(ValueError, match="top edge"):
-            _wms._merge_lon_halves(
-                self._half(170.0, 20), self._half(-180.0, 20, uly=20.0), 360.0
-            )
+            _wms._merge_lon_halves(west, east, 360.0)
 
     def test_refuses_halves_that_do_not_meet_at_the_seam(self):
         """A west half stopping a pixel short of 180 is not stitchable."""
+        west, east = self._half(170.0, 18), self._half(-180.0, 18)
         with pytest.raises(ValueError, match="apart at the seam"):
-            _wms._merge_lon_halves(self._half(170.0, 18), self._half(-180.0, 18), 360.0)
+            _wms._merge_lon_halves(west, east, 360.0)
 
     def test_a_wrong_seam_offset_is_caught(self):
         """A projected layer checked against 360 degrees fails rather than stitching."""
+        west, east = self._half(170.0, 20), self._half(-180.0, 20)
         with pytest.raises(ValueError, match="apart at the seam"):
-            _wms._merge_lon_halves(self._half(170.0, 20), self._half(-180.0, 20), 1.0)
+            _wms._merge_lon_halves(west, east, 1.0)
 
 
 class _Part:

--- a/tests/dataset/remote/wcs_mock_server.py
+++ b/tests/dataset/remote/wcs_mock_server.py
@@ -8,8 +8,12 @@ speaks both WCS dialects this matters for:
 * **1.0.0** — ``GetCoverage`` uses ``BBOX`` + ``WIDTH``/``HEIGHT``,
 * **2.0.1** — ``GetCoverage`` uses ``COVERAGEID`` + named-axis ``SUBSET``.
 
-The synthetic coverage ``test_cov`` is a 100×100 grid at 0.1° over lon/lat
-``[0, 10]`` (declared in CRS84 so GDAL builds a north-up geotransform). Each
+The synthetic coverage ``test_cov`` is a grid at 0.1° over a caller-chosen lon/lat
+extent (declared in CRS84 so GDAL builds a north-up geotransform), defaulting to
+``DEFAULT_BOUNDS`` — 100×100 over ``[0, 10]``. ``GLOBAL_BOUNDS`` gives instead a
+3600×1800 coverage over the whole globe, which is what an antimeridian request
+needs: a seam-crossing ``bbox`` splits into a ``170..180`` and a ``-180..-175``
+half, and only a coverage reaching the seam has data on both sides. Each
 ``GetCoverage`` is answered with a freshly generated GeoTIFF for the requested
 window, so the returned raster is real and openable.
 
@@ -30,7 +34,30 @@ from osgeo import gdal, osr
 COVERAGE = "test_cov"
 _RES = 0.1
 
-CAPS_100 = """<?xml version="1.0" encoding="UTF-8"?>
+# The lon/lat extents the mock can serve. DEFAULT_BOUNDS is the original small
+# regional grid; GLOBAL_BOUNDS reaches the 180 degree seam, which is what an
+# antimeridian request needs — a seam-crossing bbox only has data on both sides
+# of the split if the coverage spans the seam.
+DEFAULT_BOUNDS = (0.0, 0.0, 10.0, 10.0)
+GLOBAL_BOUNDS = (-180.0, -90.0, 180.0, 90.0)
+
+
+def _grid(bounds):
+    """``(columns, rows, origin_x, origin_y)`` of the coverage lattice at ``_RES``.
+
+    The origin is the *centre* of the top-left cell, which is what the
+    ``RectifiedGrid`` origin means in both WCS dialects.
+    """
+    minx, miny, maxx, maxy = bounds
+    nx = int(round((maxx - minx) / _RES))
+    ny = int(round((maxy - miny) / _RES))
+    return nx, ny, minx + _RES / 2, maxy - _RES / 2
+
+
+def caps_100(bounds):
+    """WCS 1.0.0 ``GetCapabilities`` advertising ``test_cov`` over `bounds`."""
+    minx, miny, maxx, maxy = bounds
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
 <WCS_Capabilities version="1.0.0" xmlns="http://www.opengis.net/wcs"
     xmlns:gml="http://www.opengis.net/gml" xmlns:xlink="http://www.w3.org/1999/xlink">
   <Service><name>mock</name><label>mock</label></Service>
@@ -40,42 +67,47 @@ CAPS_100 = """<?xml version="1.0" encoding="UTF-8"?>
       <name>test_cov</name>
       <label>Test Coverage</label>
       <lonLatEnvelope srsName="urn:ogc:def:crs:OGC:1.3:CRS84">
-        <gml:pos>0 0</gml:pos>
-        <gml:pos>10 10</gml:pos>
+        <gml:pos>{minx} {miny}</gml:pos>
+        <gml:pos>{maxx} {maxy}</gml:pos>
       </lonLatEnvelope>
     </CoverageOfferingBrief>
   </ContentMetadata>
 </WCS_Capabilities>
 """
 
-DESCRIBE_100 = """<?xml version="1.0" encoding="UTF-8"?>
+
+def describe_100(bounds):
+    """WCS 1.0.0 ``DescribeCoverage`` for ``test_cov`` over `bounds`."""
+    minx, miny, maxx, maxy = bounds
+    nx, ny, ox, oy = _grid(bounds)
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
 <CoverageDescription version="1.0.0" xmlns="http://www.opengis.net/wcs"
     xmlns:gml="http://www.opengis.net/gml" xmlns:xlink="http://www.w3.org/1999/xlink">
   <CoverageOffering>
     <name>test_cov</name>
     <label>Test Coverage</label>
     <lonLatEnvelope srsName="urn:ogc:def:crs:OGC:1.3:CRS84">
-      <gml:pos>0 0</gml:pos>
-      <gml:pos>10 10</gml:pos>
+      <gml:pos>{minx} {miny}</gml:pos>
+      <gml:pos>{maxx} {maxy}</gml:pos>
     </lonLatEnvelope>
     <domainSet>
       <spatialDomain>
         <gml:Envelope srsName="EPSG:4326">
-          <gml:pos>0 0</gml:pos>
-          <gml:pos>10 10</gml:pos>
+          <gml:pos>{minx} {miny}</gml:pos>
+          <gml:pos>{maxx} {maxy}</gml:pos>
         </gml:Envelope>
         <gml:RectifiedGrid dimension="2">
           <gml:limits>
             <gml:GridEnvelope>
               <gml:low>0 0</gml:low>
-              <gml:high>99 99</gml:high>
+              <gml:high>{nx - 1} {ny - 1}</gml:high>
             </gml:GridEnvelope>
           </gml:limits>
           <gml:axisName>x</gml:axisName>
           <gml:axisName>y</gml:axisName>
-          <gml:origin><gml:pos>0.05 9.95</gml:pos></gml:origin>
-          <gml:offsetVector>0.1 0</gml:offsetVector>
-          <gml:offsetVector>0 -0.1</gml:offsetVector>
+          <gml:origin><gml:pos>{ox} {oy}</gml:pos></gml:origin>
+          <gml:offsetVector>{_RES} 0</gml:offsetVector>
+          <gml:offsetVector>0 -{_RES}</gml:offsetVector>
         </gml:RectifiedGrid>
       </spatialDomain>
     </domainSet>
@@ -92,6 +124,7 @@ DESCRIBE_100 = """<?xml version="1.0" encoding="UTF-8"?>
   </CoverageOffering>
 </CoverageDescription>
 """
+
 
 CAPS_201 = """<?xml version="1.0" encoding="UTF-8"?>
 <wcs:Capabilities xmlns:wcs="http://www.opengis.net/wcs/2.0"
@@ -111,7 +144,12 @@ CAPS_201 = """<?xml version="1.0" encoding="UTF-8"?>
 </wcs:Capabilities>
 """
 
-DESCRIBE_201 = """<?xml version="1.0" encoding="UTF-8"?>
+
+def describe_201(bounds):
+    """WCS 2.0.1 ``DescribeCoverage`` for ``test_cov`` over `bounds`."""
+    minx, miny, maxx, maxy = bounds
+    nx, ny, ox, oy = _grid(bounds)
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
 <wcs:CoverageDescriptions xmlns:wcs="http://www.opengis.net/wcs/2.0"
     xmlns:gml="http://www.opengis.net/gml/3.2"
     xmlns:gmlcov="http://www.opengis.net/gmlcov/1.0"
@@ -120,8 +158,8 @@ DESCRIBE_201 = """<?xml version="1.0" encoding="UTF-8"?>
     <gml:boundedBy>
       <gml:Envelope srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"
           axisLabels="Long Lat" uomLabels="deg deg" srsDimension="2">
-        <gml:lowerCorner>0 0</gml:lowerCorner>
-        <gml:upperCorner>10 10</gml:upperCorner>
+        <gml:lowerCorner>{minx} {miny}</gml:lowerCorner>
+        <gml:upperCorner>{maxx} {maxy}</gml:upperCorner>
       </gml:Envelope>
     </gml:boundedBy>
     <wcs:CoverageId>test_cov</wcs:CoverageId>
@@ -130,17 +168,17 @@ DESCRIBE_201 = """<?xml version="1.0" encoding="UTF-8"?>
         <gml:limits>
           <gml:GridEnvelope>
             <gml:low>0 0</gml:low>
-            <gml:high>99 99</gml:high>
+            <gml:high>{nx - 1} {ny - 1}</gml:high>
           </gml:GridEnvelope>
         </gml:limits>
         <gml:axisLabels>Long Lat</gml:axisLabels>
         <gml:origin>
           <gml:Point gml:id="p_test_cov" srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84">
-            <gml:pos>0.05 9.95</gml:pos>
+            <gml:pos>{ox} {oy}</gml:pos>
           </gml:Point>
         </gml:origin>
-        <gml:offsetVector srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84">0.1 0</gml:offsetVector>
-        <gml:offsetVector srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84">0 -0.1</gml:offsetVector>
+        <gml:offsetVector srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84">{_RES} 0</gml:offsetVector>
+        <gml:offsetVector srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84">0 -{_RES}</gml:offsetVector>
       </gml:RectifiedGrid>
     </gml:domainSet>
     <gmlcov:rangeType>
@@ -163,6 +201,7 @@ DESCRIBE_201 = """<?xml version="1.0" encoding="UTF-8"?>
 </wcs:CoverageDescriptions>
 """
 
+
 EXCEPTION_REPORT = """<?xml version="1.0" encoding="UTF-8"?>
 <ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows/2.0" version="2.0.1">
   <ows:Exception exceptionCode="NoApplicableCode">
@@ -171,8 +210,8 @@ EXCEPTION_REPORT = """<?xml version="1.0" encoding="UTF-8"?>
 </ows:ExceptionReport>
 """
 
-_CAPS = {"1.0.0": CAPS_100, "2.0.1": CAPS_201}
-_DESCRIBE = {"1.0.0": DESCRIBE_100, "2.0.1": DESCRIBE_201}
+_CAPS = {"1.0.0": caps_100, "2.0.1": lambda bounds: CAPS_201}
+_DESCRIBE = {"1.0.0": describe_100, "2.0.1": describe_201}
 
 
 def _make_geotiff(width: int, height: int, minx: float, maxy: float) -> bytes:
@@ -223,11 +262,14 @@ def _window_from_bbox(qs: dict[str, str]) -> tuple[int, int, float, float]:
     return width, height, minx, maxy
 
 
-def make_handler(version: str, getcoverage_body: str | None):
+def make_handler(version: str, getcoverage_body: str | None, bounds=DEFAULT_BOUNDS):
     """Build a request handler class for `version`, recording every request path.
 
     When `getcoverage_body` is given, ``GetCoverage`` returns that XML body with
     HTTP 200 instead of a raster — used to test ``<ows:ExceptionReport>`` handling.
+    `bounds` is the lon/lat extent the coverage is advertised over; only the
+    discovery documents depend on it, since ``GetCoverage`` generates whatever
+    window it is asked for.
     """
 
     class Handler(http.server.BaseHTTPRequestHandler):
@@ -239,9 +281,9 @@ def make_handler(version: str, getcoverage_body: str | None):
             qs = {k.lower(): v[0] for k, v in parse_qs(query).items()}
             request = qs.get("request", "").lower()
             if request == "getcapabilities":
-                self._send(_CAPS[version])
+                self._send(_CAPS[version](bounds))
             elif request == "describecoverage":
-                self._send(_DESCRIBE[version])
+                self._send(_DESCRIBE[version](bounds))
             elif request == "getcoverage":
                 if getcoverage_body is not None:
                     self._send(getcoverage_body)
@@ -272,10 +314,20 @@ def make_handler(version: str, getcoverage_body: str | None):
 
 
 class WcsMock:
-    """A running mock WCS server. Use as a context manager; `url` is the endpoint."""
+    """A running mock WCS server. Use as a context manager; `url` is the endpoint.
 
-    def __init__(self, version: str = "2.0.1", getcoverage_body: str | None = None):
-        self._handler = make_handler(version, getcoverage_body)
+    `bounds` chooses the coverage extent: ``DEFAULT_BOUNDS`` (a regional grid over
+    ``[0, 10]``) or ``GLOBAL_BOUNDS`` (the whole globe, needed for an antimeridian
+    request to have data either side of the seam).
+    """
+
+    def __init__(
+        self,
+        version: str = "2.0.1",
+        getcoverage_body: str | None = None,
+        bounds=DEFAULT_BOUNDS,
+    ):
+        self._handler = make_handler(version, getcoverage_body, bounds)
         self._httpd = socketserver.ThreadingTCPServer(("127.0.0.1", 0), self._handler)
         port = self._httpd.server_address[1]
         self.url = f"http://127.0.0.1:{port}/wcs"

--- a/tests/dataset/spatial/test_bbox_crop_read_array.py
+++ b/tests/dataset/spatial/test_bbox_crop_read_array.py
@@ -8,6 +8,7 @@ import os
 import geopandas as gpd
 import numpy as np
 import pytest
+from osgeo import gdal
 from shapely.geometry import box
 
 from pyramids.base.georeference import GeoReference
@@ -15,6 +16,7 @@ from pyramids.dataset import Dataset, DatasetCollection
 from pyramids.dataset.engines.spatial import (
     _reaches_antimeridian_seam,
     _split_lon_bbox,
+    _stitch_lon_halves,
 )
 from pyramids.feature import FeatureCollection
 
@@ -1147,3 +1149,52 @@ class TestCutlineSegmentLength:
         )
         step = Spatial._cutline_segment_length(dataset, cutline)
         assert step is None or step > 0, f"a measured step must be positive, got {step}"
+
+
+class TestStitchKeepsBandFidelity:
+    """A seam-crossing crop must render like an ordinary one.
+
+    `_stitch_lon_halves` rebuilds through `Dataset.from_array`, which carries the
+    array, the geotransform and the no-data value -- and nothing else. Its WMS
+    counterpart copies the colour table, units and metadata explicitly, so the two
+    stitchers used to disagree about what a seam read is allowed to lose.
+    """
+
+    @staticmethod
+    def _half(origin_x: float, columns: int) -> Dataset:
+        """A one-band lon/lat raster at 0.5 degree cells.
+
+        Args:
+            origin_x: West edge in degrees.
+            columns: Pixel width.
+
+        Returns:
+            Dataset: The half.
+        """
+        mem = gdal.GetDriverByName("MEM").Create("", columns, 40, 1, gdal.GDT_Byte)
+        mem.SetGeoTransform((origin_x, 0.5, 0.0, 10.0, 0.0, -0.5))
+        return Dataset(mem, access="write")
+
+    def test_the_palette_units_and_metadata_survive(self):
+        """Everything the WMS stitcher keeps, this one keeps too."""
+        west = self._half(170.0, 20)
+        table = gdal.ColorTable()
+        table.SetColorEntry(1, (40, 50, 60, 255))
+        band = west.raster.GetRasterBand(1)
+        band.SetRasterColorTable(table)
+        band.SetColorInterpretation(gdal.GCI_PaletteIndex)
+        band.SetUnitType("class")
+        band.SetMetadata({"legend": "corine"})
+        west.raster.SetMetadata({"source": "crop"})
+
+        merged = _stitch_lon_halves(west, west, self._half(-180.0, 10))
+        merged_band = merged.raster.GetRasterBand(1)
+
+        assert merged_band.GetRasterColorTable() is not None, (
+            "the palette must survive a seam-crossing crop, as it does a "
+            "seam-crossing WMS read"
+        )
+        assert merged_band.GetRasterColorTable().GetColorEntry(1) == (40, 50, 60, 255)
+        assert merged_band.GetUnitType() == "class"
+        assert merged_band.GetMetadata() == {"legend": "corine"}
+        assert merged.raster.GetMetadata()["source"] == "crop"

--- a/tests/feature/test_antimeridian_bbox.py
+++ b/tests/feature/test_antimeridian_bbox.py
@@ -1,0 +1,687 @@
+"""A ``west > east`` bbox on the vector readers, and why ``fishnet`` still refuses one.
+
+`Dataset.crop` has read a `west > east` bbox as a box crossing the 180 degree seam
+for a while: it splits at the meridian, reads both sides and stitches them. The
+vector readers refused the same box, from a second, hand-written copy of the
+`minx < maxx` rule inside `pyramids.feature._ogc.read_kwargs`:
+
+    ValueError: bbox must have minx < maxx and miny < maxy, got (170.0, -10.0, -170.0, 10.0)
+
+The refusal fired before any request went out, so `from_wfs` / `from_ogc_features`
+could not be pointed at Fiji, the Aleutians, Chukotka or the Chatham Islands at all.
+
+What the split has to be is settled by where the filter goes. It is **not** applied
+to a datasource pyramids holds: pyogrio turns `bbox=` into
+`OGR_L_SetSpatialFilterRect`, and the `WFS` / `OAPIF` drivers turn that into a
+request parameter. `TestWhatTheFilterActuallyIs` drives the real OAPIF driver
+against a local recording stub to pin all three consequences:
+
+* the bbox leaves as `…/items?limit=1000&bbox=170,-10,180,10`, so a wrap is two
+  requests;
+* a two-part `MultiPolygon` mask is sent as its *envelope* — the whole globe in
+  longitude — so a multipart filter cannot be pushed into one request;
+* a wrapping rect handed straight to OGR is silently normalised into its
+  **complement**, which is the failure mode the old refusal was standing in front of.
+
+`fishnet` keeps its refusal; `TestFishnetRefusesTheWrapOnPurpose` pins the reasoning
+recorded in its docstring.
+"""
+
+from __future__ import annotations
+
+import http.server
+import json
+import socketserver
+import threading
+
+import geopandas as gpd
+import pytest
+from osgeo import gdal, ogr
+from shapely.geometry import LineString, Point, box
+
+from pyramids.base._coverage import seam_halves
+from pyramids.errors import OGCAPIError, WFSError
+from pyramids.feature import FeatureCollection, _oapif, _ogc, _wfs
+from pyramids.feature import tessellation as _tess
+
+WRAP = (170.0, -10.0, -170.0, 10.0)
+"""A ten-degree-wide box straddling the antimeridian — the Fiji / Chatham case."""
+
+EAST_HALF, WEST_HALF = seam_halves(WRAP)
+
+
+def _world() -> gpd.GeoDataFrame:
+    """Features either side of the seam, one of which straddles it.
+
+    ``crosses`` is the duplicate hazard: its planar envelope spans -179..179, so it
+    intersects both halves and comes back from both requests.
+    """
+    return gpd.GeoDataFrame(
+        {"name": ["east", "on-180", "just-west", "far-west", "elsewhere", "crosses"]},
+        geometry=[
+            Point(172.0, 0.0),
+            Point(180.0, 0.0),
+            Point(-179.0, 0.0),
+            Point(-172.0, 0.0),
+            Point(0.0, 0.0),
+            LineString([(179.0, 0.0), (-179.0, 0.0)]),
+        ],
+        crs="EPSG:4326",
+    )
+
+
+def _recording_reader(source: gpd.GeoDataFrame):
+    """A stand-in for ``gpd.read_file`` that filters like a service and records calls.
+
+    ``box(*bbox)`` on a wrapping bbox degenerates exactly the way OGR's envelope does,
+    so a caller that forgot to split gets the same wrong answer here as against a real
+    driver.
+    """
+    calls: list[dict] = []
+
+    def fake_read(connection, layer=None, bbox=None, where=None, rows=None):
+        calls.append(
+            {
+                "connection": connection,
+                "layer": layer,
+                "bbox": bbox,
+                "where": where,
+                "rows": rows,
+            }
+        )
+        result = source
+        if bbox is not None:
+            result = result[result.intersects(box(*bbox))]
+        if where is not None:
+            result = result[result["name"] != where]
+        if rows is not None:
+            result = result.iloc[:rows]
+        return result.reset_index(drop=True)
+
+    return fake_read, calls
+
+
+def _patch_oapif(monkeypatch, source: gpd.GeoDataFrame):
+    """Point ``from_ogc_features`` at the recording reader; return the call log."""
+    monkeypatch.setattr(_oapif, "_get_collections", lambda *a, **k: frozenset(["pts"]))
+    fake_read, calls = _recording_reader(source)
+    monkeypatch.setattr(_ogc.gpd, "read_file", fake_read)
+    return calls
+
+
+def _patch_wfs(monkeypatch, source: gpd.GeoDataFrame):
+    """Point ``from_wfs`` at the recording reader; return the call log."""
+    monkeypatch.setattr(
+        _wfs, "_get_capabilities", lambda *a, **k: ((), frozenset(["pts"]))
+    )
+    fake_read, calls = _recording_reader(source)
+    monkeypatch.setattr(_ogc.gpd, "read_file", fake_read)
+    return calls
+
+
+class TestTheWrapIsNoLongerRefused:
+    """`read_kwargs` records a wrapping box instead of raising on it."""
+
+    def test_it_records_the_box_the_caller_wrote(self):
+        """Test scenario: the split belongs to `read_ogc_layer`, so nothing is rewritten here."""
+        assert _ogc.read_kwargs(WRAP, None, None) == {"bbox": WRAP}
+
+    @pytest.mark.parametrize("reader", [_wfs, _oapif])
+    def test_both_readers_reach_the_same_assembler(self, reader):
+        """Args: reader: The reader module under test.
+
+        Test scenario:
+            The two readers import `read_kwargs` under a private alias each; a fix
+            applied to one and not the other would leave the refusal depending on
+            which reader the caller reached for.
+        """
+        assert reader._read_kwargs(WRAP, None, None) == {"bbox": WRAP}
+
+    def test_latitude_is_still_ordered(self):
+        """Test scenario: there is no seam in latitude, so `miny >= maxy` is still a mistake."""
+        with pytest.raises(ValueError, match="minx < maxx and miny < maxy"):
+            _ogc.read_kwargs((1.0, 4.0, 3.0, 2.0), None, None)
+
+    def test_a_zero_width_box_is_still_refused(self):
+        """Test scenario: `minx == maxx` is empty whichever way it is read, wrap or not."""
+        with pytest.raises(ValueError, match="minx < maxx"):
+            _ogc.read_kwargs((3.0, 2.0, 3.0, 4.0), None, None)
+
+    def test_a_non_finite_corner_is_still_refused(self):
+        """Test scenario: allowing the wrap must not reopen the hole finiteness closed."""
+        with pytest.raises(ValueError, match="four finite numbers"):
+            _ogc.read_kwargs((1.0, 2.0, float("nan"), 4.0), None, None)
+
+
+class TestTheReadIsSplitAtTheSeam:
+    """One request per half, and the union of what they return."""
+
+    def test_two_requests_are_made_one_per_half(self, monkeypatch):
+        """Test scenario: the filter is a request parameter, so the wrap costs two of them."""
+        calls = _patch_oapif(monkeypatch, _world())
+        FeatureCollection.from_ogc_features(
+            "https://h/api", collection="pts", bbox=WRAP
+        )
+        assert [call["bbox"] for call in calls] == [EAST_HALF, WEST_HALF]
+
+    def test_a_plain_bbox_still_makes_exactly_one(self, monkeypatch):
+        """Test scenario: the common path must not pay for the seam it does not cross."""
+        calls = _patch_oapif(monkeypatch, _world())
+        FeatureCollection.from_ogc_features(
+            "https://h/api", collection="pts", bbox=(1.0, 2.0, 3.0, 4.0)
+        )
+        assert [call["bbox"] for call in calls] == [(1.0, 2.0, 3.0, 4.0)]
+
+    def test_no_bbox_still_makes_exactly_one_unfiltered_read(self, monkeypatch):
+        """Test scenario: a reader with no bbox must not acquire a spatial filter."""
+        calls = _patch_oapif(monkeypatch, _world())
+        FeatureCollection.from_ogc_features("https://h/api", collection="pts")
+        assert len(calls) == 1 and calls[0]["bbox"] is None
+
+    def test_the_union_of_both_halves_is_returned(self, monkeypatch):
+        """Test scenario: everything inside the wrap, from either side of the seam."""
+        _patch_oapif(monkeypatch, _world())
+        fc = FeatureCollection.from_ogc_features(
+            "https://h/api", collection="pts", bbox=WRAP
+        )
+        assert sorted(fc["name"]) == [
+            "crosses",
+            "east",
+            "far-west",
+            "just-west",
+            "on-180",
+        ]
+
+    def test_nothing_outside_the_wrap_comes_back(self, monkeypatch):
+        """Test scenario: the split must not widen the box into the far hemisphere."""
+        _patch_oapif(monkeypatch, _world())
+        fc = FeatureCollection.from_ogc_features(
+            "https://h/api", collection="pts", bbox=WRAP
+        )
+        assert "elsewhere" not in list(fc["name"])
+
+    def test_a_feature_straddling_the_seam_is_not_duplicated(self, monkeypatch):
+        """Test scenario: `crosses` matches both halves; a plain concat would return it twice."""
+        _patch_oapif(monkeypatch, _world())
+        fc = FeatureCollection.from_ogc_features(
+            "https://h/api", collection="pts", bbox=WRAP
+        )
+        assert list(fc["name"]).count("crosses") == 1
+
+    def test_the_result_is_exactly_the_union_of_the_two_half_reads(self, monkeypatch):
+        """Test scenario: no losses either — compare against reading each half by hand."""
+        world = _world()
+        _patch_oapif(monkeypatch, world)
+        fc = FeatureCollection.from_ogc_features(
+            "https://h/api", collection="pts", bbox=WRAP
+        )
+        by_hand = set()
+        for half in (EAST_HALF, WEST_HALF):
+            by_hand |= set(world[world.intersects(box(*half))]["name"])
+        assert set(fc["name"]) == by_hand
+
+    def test_the_index_is_contiguous_from_zero(self, monkeypatch):
+        """Test scenario: both halves are indexed from 0, so a concat would repeat labels."""
+        _patch_oapif(monkeypatch, _world())
+        fc = FeatureCollection.from_ogc_features(
+            "https://h/api", collection="pts", bbox=WRAP
+        )
+        assert list(fc.index) == list(range(len(fc)))
+
+    def test_the_crs_survives_the_merge(self, monkeypatch):
+        """Test scenario: a concat that dropped the CRS would break `to_crs` downstream."""
+        _patch_oapif(monkeypatch, _world())
+        fc = FeatureCollection.from_ogc_features(
+            "https://h/api", collection="pts", bbox=WRAP
+        )
+        assert fc.crs.to_epsg() == 4326
+
+    def test_output_crs_reprojects_the_merged_result(self, monkeypatch):
+        """Test scenario: the reproject runs once, after the halves are unioned."""
+        _patch_oapif(monkeypatch, _world())
+        fc = FeatureCollection.from_ogc_features(
+            "https://h/api", collection="pts", bbox=WRAP, output_crs="EPSG:3857"
+        )
+        assert fc.crs.to_epsg() == 3857 and len(fc) == 5
+
+    def test_the_attribute_filter_is_applied_to_both_halves(self, monkeypatch):
+        """Test scenario: `where` is not a spatial filter, so both requests must carry it."""
+        calls = _patch_oapif(monkeypatch, _world())
+        fc = FeatureCollection.from_ogc_features(
+            "https://h/api", collection="pts", bbox=WRAP, where="crosses"
+        )
+        assert [call["where"] for call in calls] == ["crosses", "crosses"]
+        assert "crosses" not in list(fc["name"])
+
+    def test_max_features_caps_the_union_not_each_half(self, monkeypatch):
+        """Test scenario: a per-half cap of N would hand back up to 2N features."""
+        calls = _patch_oapif(monkeypatch, _world())
+        fc = FeatureCollection.from_ogc_features(
+            "https://h/api", collection="pts", bbox=WRAP, max_features=3
+        )
+        assert [call["rows"] for call in calls] == [3, 3], (
+            "each half needs the full cap"
+        )
+        assert len(fc) == 3, "but the promise is about the union"
+
+    @pytest.mark.parametrize(
+        ("failing_half", "label"), [(0, "the first"), (1, "the second")]
+    )
+    def test_a_failure_on_either_half_is_branded(
+        self, monkeypatch, failing_half, label
+    ):
+        """Args: failing_half: Which request fails. label: Which one, for the id.
+
+        Test scenario:
+            A wrapping read is two requests but still one call; either failing must
+            surface as the reader's own error, worded as a single failed read is.
+        """
+        monkeypatch.setattr(
+            _oapif, "_get_collections", lambda *a, **k: frozenset(["pts"])
+        )
+        seen: list[int] = []
+
+        def flaky(connection, **kwargs):
+            seen.append(1)
+            if len(seen) - 1 == failing_half:
+                raise RuntimeError("driver said no")
+            return _world()
+
+        monkeypatch.setattr(_ogc.gpd, "read_file", flaky)
+        with pytest.raises(OGCAPIError, match="items request failed for 'pts'"):
+            FeatureCollection.from_ogc_features(
+                "https://h/api", collection="pts", bbox=WRAP
+            )
+
+    def test_the_wfs_reader_splits_the_same_way(self, monkeypatch):
+        """Test scenario: both readers share `read_ogc_layer`; the fix must reach both."""
+        calls = _patch_wfs(monkeypatch, _world())
+        fc = FeatureCollection.from_wfs("https://h/ows", typename="pts", bbox=WRAP)
+        assert [call["bbox"] for call in calls] == [EAST_HALF, WEST_HALF]
+        assert sorted(fc["name"]) == [
+            "crosses",
+            "east",
+            "far-west",
+            "just-west",
+            "on-180",
+        ]
+
+    def test_the_wfs_reader_brands_a_half_failure_as_wfserror(self, monkeypatch):
+        """Test scenario: the per-reader error class must survive the split."""
+        monkeypatch.setattr(
+            _wfs, "_get_capabilities", lambda *a, **k: ((), frozenset(["pts"]))
+        )
+
+        def boom(*a, **k):
+            raise RuntimeError("driver said no")
+
+        monkeypatch.setattr(_ogc.gpd, "read_file", boom)
+        with pytest.raises(WFSError, match="GetFeature failed for 'pts'"):
+            FeatureCollection.from_wfs("https://h/ows", typename="pts", bbox=WRAP)
+
+
+class TestMergeSeamHalves:
+    """The union step on its own."""
+
+    def test_it_drops_a_row_both_halves_returned(self):
+        """Test scenario: identical geometry and attributes means one feature, seen twice."""
+        east = _world().iloc[[0, 5]].reset_index(drop=True)
+        west = _world().iloc[[5, 3]].reset_index(drop=True)
+        merged = _ogc.merge_seam_halves([east, west], None)
+        assert list(merged["name"]) == ["east", "crosses", "far-west"]
+
+    def test_it_keeps_rows_that_only_look_alike(self):
+        """Test scenario: same name, different geometry — two features, not one."""
+        east = gpd.GeoDataFrame(
+            {"name": ["twin"]}, geometry=[Point(172.0, 0.0)], crs="EPSG:4326"
+        )
+        west = gpd.GeoDataFrame(
+            {"name": ["twin"]}, geometry=[Point(-172.0, 0.0)], crs="EPSG:4326"
+        )
+        assert len(_ogc.merge_seam_halves([east, west], None)) == 2
+
+    def test_it_survives_an_unhashable_attribute(self):
+        """Test scenario: a GeoJSON property can be a list; keying on it must not raise."""
+        listy = gpd.GeoDataFrame(
+            {"tags": [["a", "b"]]}, geometry=[Point(179.0, 0.0)], crs="EPSG:4326"
+        )
+        merged = _ogc.merge_seam_halves([listy, listy], None)
+        assert len(merged) == 1
+
+    def test_it_handles_a_half_that_returned_nothing(self):
+        """Test scenario: a service with nothing east of the seam is normal, not an error."""
+        world = _world()
+        merged = _ogc.merge_seam_halves([world.iloc[0:0], world.iloc[[0]]], None)
+        assert list(merged["name"]) == ["east"] and merged.crs.to_epsg() == 4326
+
+    def test_it_handles_both_halves_empty(self):
+        """Test scenario: an empty result must stay an empty frame, not a crash."""
+        empty = _world().iloc[0:0]
+        assert len(_ogc.merge_seam_halves([empty, empty], None)) == 0
+
+    def test_it_reindexes_from_zero(self):
+        """Test scenario: both inputs are 0-indexed, so labels would otherwise repeat."""
+        world = _world()
+        merged = _ogc.merge_seam_halves([world.iloc[[0, 1]], world.iloc[[2, 3]]], None)
+        assert list(merged.index) == [0, 1, 2, 3]
+
+    def test_the_cap_is_applied_after_de_duplication(self):
+        """Test scenario: a duplicate must not eat a slot the cap could have given a feature."""
+        east = _world().iloc[[5, 0]].reset_index(drop=True)
+        west = _world().iloc[[5, 3]].reset_index(drop=True)
+        merged = _ogc.merge_seam_halves([east, west], 3)
+        assert list(merged["name"]) == ["crosses", "east", "far-west"]
+
+
+def _feature(fid: str, geometry: dict, name: str) -> dict:
+    """A single GeoJSON feature for the recording stub."""
+    return {
+        "type": "Feature",
+        "id": fid,
+        "geometry": geometry,
+        "properties": {"name": name},
+    }
+
+
+def _point(x: float, y: float) -> dict:
+    return {"type": "Point", "coordinates": [x, y]}
+
+
+STUB_FEATURES = [
+    (_feature("1", _point(172.0, 0.0), "east"), (172.0, 0.0, 172.0, 0.0)),
+    (_feature("2", _point(-172.0, 0.0), "far-west"), (-172.0, 0.0, -172.0, 0.0)),
+    (_feature("3", _point(0.0, 0.0), "elsewhere"), (0.0, 0.0, 0.0, 0.0)),
+    (
+        _feature(
+            "4",
+            {"type": "LineString", "coordinates": [[179.0, 0.0], [-179.0, 0.0]]},
+            "crosses",
+        ),
+        (-179.0, 0.0, 179.0, 0.0),
+    ),
+]
+"""The stub's features, each with the envelope it is filtered by."""
+
+REQUESTS: list[str] = []
+"""Every path the OAPIF driver asked the stub for, in order."""
+
+
+class _RecordingOapifHandler(http.server.BaseHTTPRequestHandler):
+    """A minimal OGC API – Features service that records paths and honours ``bbox``.
+
+    Faithful enough for GDAL's ``OAPIF`` driver to negotiate: landing page,
+    ``/conformance``, ``/collections``, the collection document and ``/items``.
+    ``/items`` filters by envelope intersection, which is what a ``bbox`` means.
+    """
+
+    def _json(self, doc: dict, content_type: str = "application/json"):
+        payload = json.dumps(doc).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def _items(self, base: str, query: str):
+        requested = None
+        for part in query.lstrip("?").split("&"):
+            if part.startswith("bbox="):
+                requested = [float(v) for v in part[len("bbox=") :].split(",")]
+        selected = [
+            feature
+            for feature, bounds in STUB_FEATURES
+            if requested is None
+            or (
+                bounds[0] <= requested[2]
+                and bounds[2] >= requested[0]
+                and bounds[1] <= requested[3]
+                and bounds[3] >= requested[1]
+            )
+        ]
+        self._json(
+            {
+                "type": "FeatureCollection",
+                "numberMatched": len(selected),
+                "numberReturned": len(selected),
+                "features": selected,
+                "links": [{"rel": "self", "href": f"{base}/collections/pts/items"}],
+            },
+            content_type="application/geo+json",
+        )
+
+    def do_GET(self):  # noqa: N802
+        REQUESTS.append(self.path)
+        base = f"http://{self.headers.get('Host')}"
+        path, _, query = self.path.partition("?")
+        items_link = {
+            "rel": "items",
+            "href": f"{base}/collections/pts/items",
+            "type": "application/geo+json",
+        }
+        extent = {"spatial": {"bbox": [[-180, -90, 180, 90]]}}
+        if path in ("", "/"):
+            self._json(
+                {
+                    "title": "Recording OAPIF stub",
+                    "links": [
+                        {"rel": "self", "href": f"{base}/", "type": "application/json"},
+                        {
+                            "rel": "conformance",
+                            "href": f"{base}/conformance",
+                            "type": "application/json",
+                        },
+                        {
+                            "rel": "data",
+                            "href": f"{base}/collections",
+                            "type": "application/json",
+                        },
+                    ],
+                }
+            )
+        elif path == "/conformance":
+            self._json(
+                {
+                    "conformsTo": [
+                        "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
+                        "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
+                    ]
+                }
+            )
+        elif path == "/collections":
+            self._json(
+                {
+                    "links": [{"rel": "self", "href": f"{base}/collections"}],
+                    "collections": [
+                        {
+                            "id": "pts",
+                            "title": "Points",
+                            "extent": extent,
+                            "links": [
+                                items_link,
+                                {"rel": "self", "href": f"{base}/collections/pts"},
+                            ],
+                        }
+                    ],
+                }
+            )
+        elif path == "/collections/pts":
+            self._json({"id": "pts", "extent": extent, "links": [items_link]})
+        elif path == "/collections/pts/items":
+            self._items(base, query)
+        else:
+            self.send_error(404)
+
+    def log_message(self, *args, **kwargs):  # noqa: N802
+        return
+
+
+class TestWhatTheFilterActuallyIs:
+    """Drive the real OAPIF driver against a recording stub.
+
+    This is the evidence behind the design: the vector `bbox` is not a local OGR
+    predicate pyramids can apply twice for free, it is a request parameter. The
+    driver is exercised directly through `gdal.OpenEx` because the bundled pyogrio
+    reader cannot reach a localhost mock reliably — the same reason
+    `test_oapif.py::TestOapifDriverPaging` does it this way.
+    """
+
+    @pytest.fixture
+    def service(self):
+        """Start the recording stub, clear the request log, yield its base URL."""
+        httpd = socketserver.ThreadingTCPServer(
+            ("127.0.0.1", 0), _RecordingOapifHandler
+        )
+        httpd.daemon_threads = True
+        threading.Thread(target=httpd.serve_forever, daemon=True).start()
+        REQUESTS.clear()
+        gdal.SetConfigOption("GDAL_HTTP_TIMEOUT", "15")
+        try:
+            yield f"http://127.0.0.1:{httpd.server_address[1]}"
+        finally:
+            gdal.SetConfigOption("GDAL_HTTP_TIMEOUT", None)
+            httpd.shutdown()
+            httpd.server_close()
+
+    @staticmethod
+    def _read(url: str, apply_filter=None) -> list[str]:
+        """Read the stub's layer through the OAPIF driver, optionally filtered."""
+        ds = gdal.OpenEx(f"OAPIF:{url}", gdal.OF_VECTOR)
+        layer = ds.GetLayerByName("pts")
+        if apply_filter is not None:
+            apply_filter(layer)
+        names = sorted(feature.GetField("name") for feature in layer)
+        layer = None
+        ds = None  # release the HTTP handle before the server tears down
+        return names
+
+    @staticmethod
+    def _item_requests() -> list[str]:
+        """The ``/items`` paths the driver issued, discovery noise dropped."""
+        return [path for path in REQUESTS if path.startswith("/collections/pts/items")]
+
+    def test_the_bbox_leaves_as_a_request_parameter(self, service):
+        """Test scenario: this is the whole reason a wrap costs two requests.
+
+        If the filter were local, both halves could be applied to one downloaded
+        result. It is not: the half box is in the URL, so the server decides.
+        """
+        names = self._read(
+            service, lambda layer: layer.SetSpatialFilterRect(*EAST_HALF)
+        )
+        assert any("bbox=170,-10,180,10" in path for path in self._item_requests()), (
+            f"the half box never reached the service: {self._item_requests()}"
+        )
+        assert names == ["crosses", "east"]
+
+    def test_a_multipart_mask_is_sent_as_its_envelope(self, service):
+        """Test scenario: the "one multipart query" option, measured rather than assumed.
+
+        OGR takes a `MultiPolygon` spatial filter, and the answer it computes is
+        right — it filters exactly on the client. What it *asks the server for* is
+        the geometry's envelope, which for two halves either side of the seam is
+        the entire globe in longitude. Correct, and a full download.
+        """
+        both = ogr.CreateGeometryFromWkt(
+            "MULTIPOLYGON(((170 -10, 180 -10, 180 10, 170 10, 170 -10)),"
+            "((-180 -10, -170 -10, -170 10, -180 10, -180 -10)))"
+        )
+        names = self._read(service, lambda layer: layer.SetSpatialFilter(both))
+        assert any("bbox=-180,-10,180,10" in path for path in self._item_requests()), (
+            f"expected the whole-globe envelope: {self._item_requests()}"
+        )
+        assert names == ["crosses", "east", "far-west"]
+
+    def test_a_wrapping_rect_handed_to_ogr_asks_for_the_complement(self, service):
+        """Test scenario: what "just pass the wrap through" would actually have done.
+
+        OGR normalises the envelope, so `(170, -10, -170, 10)` goes out as
+        `bbox=-170,-10,170,10` — everything *except* the requested strip — and it
+        raises nothing on the way. `east` and `far-west`, the two features actually
+        inside the requested box, are the ones missing from the answer. Splitting
+        before the driver is not a convenience.
+        """
+        names = self._read(service, lambda layer: layer.SetSpatialFilterRect(*WRAP))
+        assert any("bbox=-170,-10,170,10" in path for path in self._item_requests()), (
+            f"expected the inverted envelope: {self._item_requests()}"
+        )
+        assert "east" not in names and "far-west" not in names, (
+            f"the features inside the wrap were dropped, silently: {names}"
+        )
+        assert "elsewhere" in names, (
+            f"and a feature 170 degrees away was returned instead: {names}"
+        )
+
+    def test_the_two_halves_together_cover_the_wrap(self, service):
+        """Test scenario: end to end, the split is the right answer against a real driver."""
+        east = self._read(service, lambda layer: layer.SetSpatialFilterRect(*EAST_HALF))
+        west = self._read(service, lambda layer: layer.SetSpatialFilterRect(*WEST_HALF))
+        assert east == ["crosses", "east"]
+        assert west == ["crosses", "far-west"]
+        assert sorted(set(east) | set(west)) == ["crosses", "east", "far-west"]
+
+
+class TestFishnetRefusesTheWrapOnPurpose:
+    """A wrapping fishnet has no coherent answer; the refusal is the decision."""
+
+    def test_it_refuses_a_wrapping_extent(self):
+        """Test scenario: unlike the readers, `fishnet` does not read `minx > maxx` as a seam."""
+        with pytest.raises(
+            ValueError, match="fishnet: bounds must satisfy minx < maxx"
+        ):
+            _tess.fishnet_cells(WRAP, 1.0)
+
+    def test_the_public_classmethod_refuses_it_too(self):
+        """Test scenario: the refusal must be reachable where callers actually are."""
+        with pytest.raises(ValueError, match="fishnet: bounds must satisfy"):
+            FeatureCollection.fishnet(WRAP, 1.0, crs="EPSG:4326")
+
+    def test_it_refuses_regardless_of_crs(self):
+        """Test scenario: the reason it refuses — `bounds` is in the units of `crs`.
+
+        There is no 180 degree seam in metres and none at all in a CRS-less grid,
+        so `minx > maxx` cannot be read as a wrap without guessing what the numbers
+        mean. `crs` is not even passed to `fishnet_cells`, which settles it.
+        """
+        with pytest.raises(ValueError, match="fishnet: bounds must satisfy"):
+            FeatureCollection.fishnet((5e6, -1e6, -5e6, 1e6), 1e5, crs="EPSG:3857")
+        with pytest.raises(ValueError, match="fishnet: bounds must satisfy"):
+            FeatureCollection.fishnet((5.0, 0.0, 1.0, 1.0), 0.5)
+
+    def test_the_message_names_fishnet_and_bounds(self):
+        """Test scenario: the refusal is about a grid extent, not about a request bbox.
+
+        That is why this rule is not collapsed onto `validate_bbox` the way
+        `read_kwargs` was — the shared validator speaks about a lon/lat `bbox` and
+        has an antimeridian mode this one must not inherit.
+        """
+        with pytest.raises(ValueError) as excinfo:
+            _tess.fishnet_cells(WRAP, 1.0)
+        message = str(excinfo.value)
+        assert message.startswith("fishnet: bounds")
+        assert "bbox" not in message
+
+    def test_the_documented_workaround_produces_two_usable_grids(self):
+        """Test scenario: the docstring tells callers to grid each half; that has to work.
+
+        It also shows why one grid is not on offer: `col` restarts at 0 in the
+        second half, because each half's columns are laid from its own `minx`.
+        """
+        grids = [
+            FeatureCollection.fishnet(half, 5.0, crs="EPSG:4326")
+            for half in seam_halves(WRAP)
+        ]
+        assert [len(grid) for grid in grids] == [8, 8]
+        assert all(min(grid["col"]) == 0 for grid in grids), (
+            "each half numbers its own columns from zero — the reason a single "
+            "wrapping fishnet has no coherent numbering"
+        )
+        east_cells, west_cells = (
+            [geom.bounds for geom in grid.geometry] for grid in grids
+        )
+        assert max(bounds[2] for bounds in east_cells) == 180.0
+        assert min(bounds[0] for bounds in west_cells) == -180.0
+
+    def test_an_ordinary_extent_is_untouched(self):
+        """Test scenario: recording the refusal must not narrow what already worked."""
+        polygons, rows, cols = _tess.fishnet_cells((0.0, 0.0, 1.0, 1.0), 0.5)
+        assert len(polygons) == 4 and (rows, cols) == ([0, 0, 1, 1], [0, 1, 0, 1])

--- a/tests/feature/test_antimeridian_bbox.py
+++ b/tests/feature/test_antimeridian_bbox.py
@@ -204,7 +204,8 @@ class TestTheReadIsSplitAtTheSeam:
         """Test scenario: a reader with no bbox must not acquire a spatial filter."""
         calls = _patch_oapif(monkeypatch, _world())
         FeatureCollection.from_ogc_features("https://h/api", collection="pts")
-        assert len(calls) == 1 and calls[0]["bbox"] is None
+        assert len(calls) == 1
+        assert calls[0]["bbox"] is None
 
     def test_the_union_of_both_halves_is_returned(self, monkeypatch):
         """Test scenario: everything inside the wrap, from either side of the seam."""
@@ -270,7 +271,8 @@ class TestTheReadIsSplitAtTheSeam:
         fc = FeatureCollection.from_ogc_features(
             "https://h/api", collection="pts", bbox=WRAP, output_crs="EPSG:3857"
         )
-        assert fc.crs.to_epsg() == 3857 and len(fc) == 5
+        assert fc.crs.to_epsg() == 3857
+        assert len(fc) == 5
 
     def test_the_attribute_filter_is_applied_to_both_halves(self, monkeypatch):
         """Test scenario: `where` is not a spatial filter, so both requests must carry it."""
@@ -380,7 +382,8 @@ class TestMergeSeamHalves:
         """Test scenario: a service with nothing east of the seam is normal, not an error."""
         world = _world()
         merged = _ogc.merge_seam_halves([world.iloc[0:0], world.iloc[[0]]], None)
-        assert list(merged["name"]) == ["east"] and merged.crs.to_epsg() == 4326
+        assert list(merged["name"]) == ["east"]
+        assert merged.crs.to_epsg() == 4326
 
     def test_it_handles_both_halves_empty(self):
         """Test scenario: an empty result must stay an empty frame, not a crash."""
@@ -632,8 +635,11 @@ class TestWhatTheFilterActuallyIs:
         assert any("bbox=-170,-10,170,10" in path for path in self._item_requests()), (
             f"expected the inverted envelope: {self._item_requests()}"
         )
-        assert "east" not in names and "far-west" not in names, (
-            f"the features inside the wrap were dropped, silently: {names}"
+        assert "east" not in names, (
+            f"the feature east of the seam was dropped, silently: {names}"
+        )
+        assert "far-west" not in names, (
+            f"the feature west of the seam was dropped, silently: {names}"
         )
         assert "elsewhere" in names, (
             f"and a feature 170 degrees away was returned instead: {names}"
@@ -712,4 +718,5 @@ class TestFishnetRefusesTheWrapOnPurpose:
     def test_an_ordinary_extent_is_untouched(self):
         """Test scenario: recording the refusal must not narrow what already worked."""
         polygons, rows, cols = _tess.fishnet_cells((0.0, 0.0, 1.0, 1.0), 0.5)
-        assert len(polygons) == 4 and (rows, cols) == ([0, 0, 1, 1], [0, 1, 0, 1])
+        assert len(polygons) == 4
+        assert (rows, cols) == ([0, 0, 1, 1], [0, 1, 0, 1])

--- a/tests/feature/test_antimeridian_bbox.py
+++ b/tests/feature/test_antimeridian_bbox.py
@@ -142,6 +142,34 @@ class TestTheWrapIsNoLongerRefused:
         with pytest.raises(ValueError, match="minx < maxx and miny < maxy"):
             _ogc.read_kwargs((1.0, 4.0, 3.0, 2.0), None, None)
 
+    def test_a_wrap_reaching_past_the_seam_is_refused(self):
+        """An out-of-range wrap splits into an inverted rect, which OGR normalises.
+
+        Test scenario:
+            `(190, -10, -170, 10)` yields a first half of `(190, ..., 180)` --
+            west > east. Handing that to OGR is precisely the silent inversion the
+            split exists to prevent: the filter goes out as `180, -10, 190, 10`,
+            matches nothing on a CRS84 service, and the caller quietly receives
+            only the eastern half. The raster readers already refused it; there is
+            no reason for the two sides to disagree.
+        """
+        with pytest.raises(ValueError, match="within -180..180"):
+            _ogc.read_kwargs((190.0, -10.0, -170.0, 10.0), None, None)
+
+    def test_a_wrap_in_a_projected_crs_is_refused_by_its_coordinates(self):
+        """A projected bbox has no 180 degree seam, and its numbers say so.
+
+        Test scenario:
+            `read_kwargs` never learns the CRS, but it does not need to: a
+            wrapping bbox in metres carries coordinates far outside -180..180, so
+            the corner-range half of the guard refuses it -- which is the right
+            answer, since splitting it at 180 would be meaningless.
+        """
+        with pytest.raises(ValueError, match="within -180..180"):
+            _ogc.read_kwargs(
+                (2_000_000.0, 6_000_000.0, 1_000_000.0, 6_100_000.0), None, None
+            )
+
     def test_a_zero_width_box_is_still_refused(self):
         """Test scenario: `minx == maxx` is empty whichever way it is read, wrap or not."""
         with pytest.raises(ValueError, match="minx < maxx"):

--- a/tests/feature/test_oapif.py
+++ b/tests/feature/test_oapif.py
@@ -133,8 +133,21 @@ class TestPureHelpers:
             _oapif._read_kwargs((1.0, 2.0, 3.0), None, None)
 
     def test_read_kwargs_rejects_inverted_bbox(self):
+        """An inverted *latitude* range is still refused — latitude has no seam.
+
+        The x-axis half of this assertion used to live here too: `(3, 2, 1, 4)`
+        was refused as inverted. It is now read as a box wrapping the 180 degree
+        meridian, the same reading `Dataset.crop` gives it — see
+        `test_antimeridian_bbox.py` for what the readers do with it.
+        """
         with pytest.raises(ValueError, match="minx < maxx"):
-            _oapif._read_kwargs((3.0, 2.0, 1.0, 4.0), None, None)
+            _oapif._read_kwargs((1.0, 4.0, 3.0, 2.0), None, None)
+
+    def test_read_kwargs_accepts_a_wrapping_bbox(self):
+        """`minx > maxx` is recorded as the caller wrote it; `read_ogc_layer` splits it."""
+        assert _oapif._read_kwargs((170.0, -10.0, -170.0, 10.0), None, None) == {
+            "bbox": (170.0, -10.0, -170.0, 10.0)
+        }
 
     def test_collection_ids_prefers_id_then_name(self):
         doc = {"collections": [{"id": "a"}, {"name": "b"}, {"title": "no-id"}, "junk"]}

--- a/tests/feature/test_wfs.py
+++ b/tests/feature/test_wfs.py
@@ -139,8 +139,21 @@ class TestPureHelpers:
             _wfs._read_kwargs((1.0, 2.0, 3.0), None, None)
 
     def test_read_kwargs_rejects_inverted_bbox(self):
+        """An inverted *latitude* range is still refused — latitude has no seam.
+
+        The x-axis half of this assertion used to live here too: `(3, 2, 1, 4)`
+        was refused as inverted. It is now read as a box wrapping the 180 degree
+        meridian, the same reading `Dataset.crop` gives it — see
+        `test_antimeridian_bbox.py` for what the readers do with it.
+        """
         with pytest.raises(ValueError, match="minx < maxx"):
-            _wfs._read_kwargs((3.0, 2.0, 1.0, 4.0), None, None)
+            _wfs._read_kwargs((1.0, 4.0, 3.0, 2.0), None, None)
+
+    def test_read_kwargs_accepts_a_wrapping_bbox(self):
+        """`minx > maxx` is recorded as the caller wrote it; `read_ogc_layer` splits it."""
+        assert _wfs._read_kwargs((170.0, -10.0, -170.0, 10.0), None, None) == {
+            "bbox": (170.0, -10.0, -170.0, 10.0)
+        }
 
     def test_extract_typenames_only_under_featuretype(self):
         root = _wfs.ET.fromstring(


### PR DESCRIPTION
# Description

`Dataset.crop` has read a bbox that crosses the antimeridian for a long time: `minx > maxx` means a box wrapping
past 180, it is split at the seam, each half is read, and the two are stitched back into one raster. The six OGC
readers did not. They shared one validator, `base/_coverage.validate_bbox`, which called any `minx > maxx` box
inverted and raised before a request went out:

```
ValueError: bbox must have minx < maxx and miny < maxy, got (170.0, -10.0, -170.0, 10.0)
```

So the same box that crops a local raster fine was refused by every network reader — and on the vector side it was
worse than a refusal. A wrapping rect handed straight to OGR raises nothing; it is silently **normalised into its
complement**. Ask for the 20 degrees around Fiji, receive the other 340.

This teaches all four protocols the split `crop` already does. The shared contract in `base/_coverage.py` grows:
`validate_bbox(bbox, allow_antimeridian=True)` stops calling the wrap inverted, `seam_halves(bbox)` returns the one
or two `west < east` boxes to actually request, `check_seam_bbox` refuses the wraps no reader can honestly serve,
`seam_offset` measures how far apart the two halves' frames are, and `window_overlaps` drops a half that misses the
coverage before it costs a request. Each reader still owns its own merge, because that is exactly where the
protocols stop resembling each other.

**What each protocol needed that the others did not**

- **WFS / OGC API Features** — two requests, results merged with duplicates removed. De-duplication matches on the
  geometry's WKB plus the attribute values and **never on FID**: a WFS/OAPIF FID is assigned per request, so the
  same feature arrives under two different ids and keying on it would drop real features rather than duplicate
  ones.
- **WMS / WMTS** — the awkward one, because a `GetMap` carries an explicit output size in **pixels**. The
  resolution is fixed first at `whole_wrapping_span / requested_width` — what a non-wrapping request of the same
  span and width would get — and both halves are asked at that one resolution, so uniformity across the seam is by
  construction. The seam is then snapped to the nearest pixel boundary, rounding **half up** so an exactly-half-a-
  pixel half is never dropped by banker's rounding, and the two widths sum to the requested width by definition.
- **WCS** — both halves are read off **one** open handle, so they come off the same source lattice and stitch
  without resampling. `direct=True` has no shared connection, so its halves are snapped onto one lattice from the
  requested `resolution` instead.
- **OGC API Coverages** — the two halves are sized **together**: the combined span is capped once, the west width
  rounded and the east taken as the remainder, then both windows snapped to the whole number of pixels they will
  be read at. Sizing each half independently gives them cell sizes that differ in the sixth decimal, which the
  stitch cannot represent.

**Refused rather than approximated**

A wrapping bbox in a CRS that is not lon/lat **in degrees from Greenwich** (EPSG:4807 counts from Paris, in grads —
its antimeridian is not at 180); one reaching outside `-180 .. 180`; one under two pixels wide, since one pixel
cannot straddle the seam; and a resolution so coarse the combined span sizes to a single pixel.
`FeatureCollection.fishnet` keeps its existing refusal — its bounds are in the target `crs`, which may be
projected; there is no coherent column numbering across a wrap; and a cell containing ±180 would be a
`MultiPolygon`.

**Reuse over reimplementation**

The coverage merge is `_stitch_lon_halves` from the crop engine, not a third copy. Its guard is generalised rather
than duplicated: it took a hard-coded 360 seam offset, which is only right for halves in degrees, and both coverage
readers window in the coverage's **native** CRS. It now takes a measured offset (defaulting to 360, so `crop` and
the NetCDF selection engine are untouched) and also checks cell size, which it did not.
`split_antimeridian` moved from `feature/bbox.py` to `base/_bbox.py` so `base._coverage` could reach it without
`base` importing `feature`; `feature.bbox` re-exports it, and
`from pyramids.feature.bbox import split_antimeridian` returns the same object as before.

# Issues

- Closes #1088 — the OGC readers refuse an antimeridian bbox that `Dataset.crop` already splits

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**The breaking parts, stated plainly.** Both are recorded in `docs/migration.md`.

1. **A transposed longitude pair is no longer caught.** A network reader has no grid to measure a bbox against —
   it is fetching the grid — so with the wrap accepted, `(6, 51, 5, 52)` now reads as a 359 degree wrap instead of
   raising. Anyone leaning on that `ValueError` to catch swapped arguments must check the bbox themselves.
   Latitude is unaffected: `miny >= maxy` is still an error, because there is no seam in latitude.
2. **`from_wms(resolution=...)` is now capped at 25,000 px per axis**, on ordinary non-wrapping reads too. The cap
   exists because accepting a wrap lets a transposed bbox silently span 359 degrees, which at a fine resolution
   becomes two `GetMap` requests of a few hundred thousand columns. `size=(width, height)` is **not** capped: a
   size stated outright cannot be amplified by a mistake in `bbox` the way a derived one can.

Two further notes for subclassers and direct-mode users: a seam read through `from_wcs` / `from_ogc_coverages`
returns a plain `Dataset` (those two merge via `Dataset.from_array`), while `from_wms` / `from_wmts` keep the
subclass; and a wrapping `direct=True` WCS read should pass `resolution=`, since nothing else constrains the server
to grid the two halves alike.

# How Has This Been Tested?

Everything is offline — no live service is contacted. The mocks drive **GDAL's real drivers** (WCS on both the
`1.0.0` and `2.0.1` dialects, `OGCAPI`, WMS), not stand-ins for them.

- [x] **The stitch is proved, not asserted.** Every end-to-end case fetches the identical region as two *separate
  non-wrapping* requests and requires the merged raster to be their concatenation: right total width,
  `merged.geotransform == west.geotransform`, `merged[:, :w] == west` and `merged[:, w:] == east` pixel for pixel,
  the seam landing exactly where the west half ends, and longitude continuing past it rather than jumping to -180.
- [x] **The test bbox is deliberately asymmetric** — `(170, -10, -175, 10)`, 10 degrees west of the seam and 5
  east — because equal halves would let a swapped or offset stitch pass unnoticed.
- [x] **Fail-then-pass, verified by reverting only the source**, and **mutation-tested**: every fix from both review
  rounds was broken in turn and the intended test died for it. That pass caught four tests of mine that did *not*
  discriminate — an ownership test tracking the wrong `close()`, a rounding test at a width where both rounding
  rules agree, a missing non-Greenwich CRS case, and a snapping fix reachable only through doctests. All four were
  rewritten until the mutant died.
- [x] **Geometry over liveness for WMS.** The stand-in server returns a raster whose every pixel carries its own
  centre longitude, so the stitch is compared column-for-column against the two halves fetched separately, and the
  output width is asserted for 400, 401 and 333 — odd and even.
- [x] Wire-level assertions where the request is the behaviour: the two WCS `GetCoverage` URLs carry
  `SUBSET=Long(170.0,180.0)` and `SUBSET=Long(-180.0,-175.0)`, and the wrapping bbox never reaches the wire. On the
  vector side, a loopback server proves what OGR actually sends — including that a wrapping rect goes out as its
  complement.
- [x] Ownership is tested, not assumed: a second fetch that raises must close the first half, and a raise part-way
  through adoption must close the half that was never wrapped.
- [x] Coverage on the changed modules at HEAD: `base/_bbox.py`, `base/_coverage.py`, `dataset/_ogc_coverages.py`
  and `feature/_ogc.py` at **100 %** line+branch; `_wcs.py` 98 %, `_wms.py` 95 %, with every remaining uncovered
  line predating this branch.
- [x] Full suite green (**10,888 passed, 68 skipped**). `ruff format --check` under the pre-commit-pinned 0.15.22,
  `ruff check`, `mypy` and doctests clean on every changed file. SonarCloud: 0 open issues, quality gate OK.

# Checklist:

- [ ] updated version number in pyproject.toml.
- [ ] added changes to History.rst.
- [ ] updated the latest version in README file.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated.

The three unchecked boxes are release chores: versions are handled by commitizen through the release workflow, and
the change log is generated from the commits rather than edited by hand.
