### PR TITLE
fix(merge): name the source that could not be opened

### DIFF
--- a/src/pyramids/base/_coverage.py
+++ b/src/pyramids/base/_coverage.py
@@ -32,6 +32,7 @@ from pyramids.base._bbox import transform as bbox_transform
 from pyramids.base._errors import CoverageError, CRSError
 from pyramids.base._grid import grid_size
 from pyramids.base.crs import sr_from_user_input
+from pyramids.base.remote import redact_credentials
 
 
 def validate_bbox(
@@ -354,9 +355,11 @@ def open_network_dataset(
                 connection, gdal.OF_RASTER, open_options=list(open_options)
             )
     except RuntimeError as exc:
-        raise error(f"could not open {subject}: {exc}") from exc
+        # `subject` and GDAL's own text can both quote a signed URL, so scrub
+        # before the message escapes to a log handler or a traceback.
+        raise error(redact_credentials(f"could not open {subject}: {exc}")) from exc
     if src is None:
-        raise error(f"GDAL returned no dataset for {subject}")
+        raise error(redact_credentials(f"GDAL returned no dataset for {subject}"))
     return src
 
 

--- a/src/pyramids/base/_coverage.py
+++ b/src/pyramids/base/_coverage.py
@@ -380,6 +380,7 @@ def run_gdal_op(
     action: str,
     subject: str,
     hint: str | None = None,
+    outcome: str = "returned no raster",
 ) -> gdal.Dataset:
     """Run a GDAL dataset-producing call, re-branding both failure shapes as `error`.
 
@@ -391,22 +392,48 @@ def run_gdal_op(
     diagnostic text that can never be printed, and the raising path escapes with
     GDAL's own message, which for a remote source names nothing.
 
+    Build the options object and resolve the driver *before* the call and keep only
+    the GDAL call itself in `operation`: a bad keyword is the caller's mistake, and
+    re-branding it would blame the source for an argument error.
+
+    Every message is passed through
+    :func:`pyramids.base.remote.redact_credentials`, so a signed URL in `subject`
+    or in GDAL's own text keeps its path and loses its secret.
+
     Args:
-        operation: A zero-argument callable performing the GDAL call.
+        operation: A zero-argument callable performing the GDAL call. Prefer
+            :func:`functools.partial` over a lambda closing over a loop variable.
         error: The exception class to raise.
         action: What was being attempted, e.g. ``"building the source mosaic"``.
         subject: What it was attempted on, already quoted by the caller.
         hint: Optional trailing advice appended after a semicolon.
+        outcome: How to describe a ``None`` return. Defaults to
+            ``"returned no raster"``; a call that writes a file reads better with
+            something like ``"produced no output"``.
 
     Returns:
         osgeo.gdal.Dataset: The dataset the call produced.
 
     Raises:
-        Exception: An instance of `error` -- GDAL raised, or returned no dataset.
+        error: GDAL raised while running `operation`, or returned no dataset.
 
     Examples:
-        - GDAL raising is re-branded, naming the action and subject and keeping
-          GDAL's own text:
+        - A successful call is handed straight back:
+            ```python
+            >>> from osgeo import gdal
+            >>> from pyramids.base._coverage import run_gdal_op
+            >>> made = run_gdal_op(
+            ...     lambda: gdal.GetDriverByName("MEM").Create("", 4, 3, 1),
+            ...     error=RuntimeError,
+            ...     action="building the mosaic",
+            ...     subject="sources ['tile.tif']",
+            ... )
+            >>> (made.RasterXSize, made.RasterYSize)
+            (4, 3)
+
+            ```
+        - GDAL raising is re-branded, naming the action and subject, keeping GDAL's
+          own text and appending the hint:
             ```python
             >>> from pyramids.base._coverage import run_gdal_op
             >>> class DemoError(Exception):
@@ -418,16 +445,16 @@ def run_gdal_op(
             ...         boom,
             ...         error=DemoError,
             ...         action="building the mosaic",
-            ...         subject="sources ['tile.tif']",
+            ...         subject="sources ['t.tif']",
+            ...         hint="check the paths are readable",
             ...     )
             ... except DemoError as exc:
             ...     print(exc)
-            building the mosaic failed for sources ['tile.tif']: HTTP response code: 403
+            building the mosaic failed for sources ['t.tif']: HTTP response code: 403; check the paths are readable
 
             ```
-        - A `None` return (what GDAL does with exceptions off, and what
-          ``BuildVRT`` does for a source it skips) is branded the same way, with
-          the optional hint appended:
+        - A `None` return -- what GDAL does with exceptions off, and what
+          ``BuildVRT`` does when *no* source is usable -- is branded the same way:
             ```python
             >>> from pyramids.base._coverage import run_gdal_op
             >>> class DemoError(Exception):
@@ -436,28 +463,50 @@ def run_gdal_op(
             ...     run_gdal_op(
             ...         lambda: None,
             ...         error=DemoError,
-            ...         action="building the mosaic",
-            ...         subject="sources ['tile.tif']",
-            ...         hint="check the paths are readable rasters",
+            ...         action="writing the mosaic",
+            ...         subject="'out.tif'",
+            ...         outcome="produced no output",
             ...     )
             ... except DemoError as exc:
             ...     print(exc)
-            building the mosaic returned no raster for sources ['tile.tif']; check the paths are readable rasters
+            writing the mosaic produced no output for 'out.tif'
+
+            ```
+        - A credential in the subject is blanked, the path kept:
+            ```python
+            >>> from pyramids.base._coverage import run_gdal_op
+            >>> class DemoError(Exception):
+            ...     pass
+            >>> def boom():
+            ...     raise RuntimeError("HTTP response code: 403")
+            >>> try:
+            ...     run_gdal_op(
+            ...         boom,
+            ...         error=DemoError,
+            ...         action="opening",
+            ...         subject="source 'https://h/t.tif?sig=SECRET'",
+            ...     )
+            ... except DemoError as exc:
+            ...     print(exc)
+            opening failed for source 'https://h/t.tif?sig=<redacted>': HTTP response code: 403
 
             ```
     """
+
+    def _brand(message: str) -> str:
+        """Append the hint, scrub any credential, and hand back the final text."""
+        return redact_credentials(message if hint is None else f"{message}; {hint}")
+
     try:
         result = operation()
     except RuntimeError as exc:
-        message = f"{action} failed for {subject}: {exc}"
-        raise error(
-            redact_credentials(message if hint is None else f"{message}; {hint}")
-        ) from exc
+        raise error(_brand(f"{action} failed for {subject}: {exc}")) from exc
     if result is None:
-        message = f"{action} returned no raster for {subject}"
-        raise error(
-            redact_credentials(message if hint is None else f"{message}; {hint}")
-        )
+        # The None branch has no exception to chain, so GDAL's last error is the
+        # only diagnostic left; it is empty when the driver declined quietly.
+        last = gdal.GetLastErrorMsg()
+        detail = f"{action} {outcome} for {subject}"
+        raise error(_brand(detail if not last else f"{detail} ({last})"))
     return result
 
 

--- a/src/pyramids/base/_coverage.py
+++ b/src/pyramids/base/_coverage.py
@@ -22,7 +22,7 @@ that name the request, so the messages stay branded per protocol.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from math import isfinite
 from typing import Any, cast
 
@@ -361,6 +361,94 @@ def open_network_dataset(
     if src is None:
         raise error(redact_credentials(f"GDAL returned no dataset for {subject}"))
     return src
+
+
+def run_gdal_op(
+    operation: Callable[[], gdal.Dataset | None],
+    *,
+    error: type[Exception],
+    action: str,
+    subject: str,
+    hint: str | None = None,
+) -> gdal.Dataset:
+    """Run a GDAL dataset-producing call, re-branding both failure shapes as `error`.
+
+    The generalisation of :func:`open_network_dataset` beyond ``gdal.Open``: every
+    GDAL entry point that hands back a dataset -- ``BuildVRT``, ``Warp``,
+    ``Translate``, a driver's ``Create`` -- fails the same two ways. Under
+    ``gdal.UseExceptions()`` it raises ``RuntimeError``; with exceptions off it
+    returns ``None``. A bare call guarded only by ``if x is None`` therefore carries
+    diagnostic text that can never be printed, and the raising path escapes with
+    GDAL's own message, which for a remote source names nothing.
+
+    Args:
+        operation: A zero-argument callable performing the GDAL call.
+        error: The exception class to raise.
+        action: What was being attempted, e.g. ``"building the source mosaic"``.
+        subject: What it was attempted on, already quoted by the caller.
+        hint: Optional trailing advice appended after a semicolon.
+
+    Returns:
+        osgeo.gdal.Dataset: The dataset the call produced.
+
+    Raises:
+        Exception: An instance of `error` -- GDAL raised, or returned no dataset.
+
+    Examples:
+        - GDAL raising is re-branded, naming the action and subject and keeping
+          GDAL's own text:
+            ```python
+            >>> from pyramids.base._coverage import run_gdal_op
+            >>> class DemoError(Exception):
+            ...     pass
+            >>> def boom():
+            ...     raise RuntimeError("HTTP response code: 403")
+            >>> try:
+            ...     run_gdal_op(
+            ...         boom,
+            ...         error=DemoError,
+            ...         action="building the mosaic",
+            ...         subject="sources ['tile.tif']",
+            ...     )
+            ... except DemoError as exc:
+            ...     print(exc)
+            building the mosaic failed for sources ['tile.tif']: HTTP response code: 403
+
+            ```
+        - A `None` return (what GDAL does with exceptions off, and what
+          ``BuildVRT`` does for a source it skips) is branded the same way, with
+          the optional hint appended:
+            ```python
+            >>> from pyramids.base._coverage import run_gdal_op
+            >>> class DemoError(Exception):
+            ...     pass
+            >>> try:
+            ...     run_gdal_op(
+            ...         lambda: None,
+            ...         error=DemoError,
+            ...         action="building the mosaic",
+            ...         subject="sources ['tile.tif']",
+            ...         hint="check the paths are readable rasters",
+            ...     )
+            ... except DemoError as exc:
+            ...     print(exc)
+            building the mosaic returned no raster for sources ['tile.tif']; check the paths are readable rasters
+
+            ```
+    """
+    try:
+        result = operation()
+    except RuntimeError as exc:
+        message = f"{action} failed for {subject}: {exc}"
+        raise error(
+            redact_credentials(message if hint is None else f"{message}; {hint}")
+        ) from exc
+    if result is None:
+        message = f"{action} returned no raster for {subject}"
+        raise error(
+            redact_credentials(message if hint is None else f"{message}; {hint}")
+        )
+    return result
 
 
 def translate_to_mem(

--- a/src/pyramids/base/_coverage.py
+++ b/src/pyramids/base/_coverage.py
@@ -9,7 +9,7 @@ here once — neither reader reaches into the other's internals — and the CRS
 resolver raises the protocol-neutral :class:`~pyramids.base._errors.CoverageError`,
 which each reader re-wraps into its own branded error (WCSError / OGCAPIError).
 
-The two GDAL calls those readers wrap around live here too. Every network reader
+The GDAL calls those readers wrap around live here too. Every network reader
 — WCS, WMS / WMTS (:mod:`pyramids.dataset._wms`) and OGC API – Coverages — opens a
 connection string with GDAL and then materialises a window of it into a ``MEM``
 dataset, and each has to turn the same two failure shapes into its own branded
@@ -18,6 +18,14 @@ error: a ``RuntimeError`` (GDAL raises under ``gdal.UseExceptions()``) and a
 :func:`open_network_dataset` and :func:`translate_to_mem` own that sequence and
 that classification; the readers pass in their own exception class and the words
 that name the request, so the messages stay branded per protocol.
+
+:func:`run_gdal_op` is the protocol-neutral generalisation of that shape to **any**
+GDAL call that hands back a dataset — ``BuildVRT``, ``Warp``, ``Translate``, a
+driver's ``Create`` — and the other two are expressed in terms of it. It has no
+coverage or network flavour: :mod:`pyramids.dataset.merge` uses it to mosaic local
+GeoTIFFs. Every message all three build is passed through
+:func:`pyramids.base.remote.redact_credentials` first, so a signed source URL
+reaching an error keeps its path and loses its secret (#1107).
 """
 
 from __future__ import annotations
@@ -297,7 +305,9 @@ def open_network_dataset(
     leaks a raw GDAL message with no idea which coverage or layer it was about.
 
     Args:
-        connection: The GDAL connection string / service descriptor to open.
+        connection: What to hand :func:`gdal.Open` — a service descriptor
+            (``<WCS_GDAL>``, ``<GDAL_WMS>``, ``WMTS:``, ``OGCAPI:``) for the
+            network readers, or a plain raster path / URL for any other caller.
         error: The reader's branded exception class (``WCSError``, ``WMSError``,
             ``OGCAPIError``, ...), called with a single message argument.
         subject: What is being opened, already worded for the message — e.g.
@@ -551,10 +561,9 @@ def translate_to_mem(
     # re-branding it as a service error would blame the server for it. Only the
     # translate itself is guarded.
     translate_options = gdal.TranslateOptions(format="MEM", **options)
-    try:
-        mem = gdal.Translate("", src, options=translate_options)
-    except RuntimeError as exc:
-        raise error(f"{action} failed for {subject}: {exc}") from exc
-    if mem is None:
-        raise error(f"{action} returned no raster for {subject}")
-    return mem
+    return run_gdal_op(
+        lambda: gdal.Translate("", src, options=translate_options),
+        error=error,
+        action=action,
+        subject=subject,
+    )

--- a/src/pyramids/base/remote.py
+++ b/src/pyramids/base/remote.py
@@ -808,8 +808,16 @@ _CREDENTIAL_OPTION_NAMES = (
 )
 """Option names whose value is a credential, matched case-insensitively."""
 
+_AUTH_SCHEMES = ("Bearer", "Basic", "Digest", "Token", "AWS4-HMAC-SHA256")
+"""Auth schemes whose credential follows a space (`Authorization=Bearer <token>`)."""
+
+_CREDENTIAL_VALUE = (
+    r"(?:(?:" + "|".join(_AUTH_SCHEMES) + r")\s+[^&\s\"\']*|[^&\s\"\']*)"
+)
+"""One credential value: a scheme-plus-token pair, else text up to the delimiter."""
+
 _CREDENTIAL_OPTION_RE = re.compile(
-    r"(?i)(?<=[?&])(" + "|".join(_CREDENTIAL_OPTION_NAMES) + r")=([^&\s\"\']*)"
+    r"(?i)(?<=[?&])(" + "|".join(_CREDENTIAL_OPTION_NAMES) + r")=" + _CREDENTIAL_VALUE
 )
 """Matches a credential option inside a `/vsicurl?...` path or a URL query string.
 

--- a/src/pyramids/dataset/cog/write.py
+++ b/src/pyramids/dataset/cog/write.py
@@ -10,10 +10,12 @@ dataset's lifecycle.
 from __future__ import annotations
 
 import logging
+from functools import partial
 from pathlib import Path
 
 from osgeo import gdal
 
+from pyramids.base._coverage import run_gdal_op
 from pyramids.base._errors import DriverNotExistError, FailedToSaveError
 from pyramids.dataset.cog.options import (
     CreationOptions,
@@ -112,14 +114,12 @@ def translate_to_cog(
     logger.debug("translate_to_cog: %s -> %s", src.GetDescription(), dest)
     src.FlushCache()
 
-    dst: gdal.Dataset | None
-    try:
-        dst = driver.CreateCopy(dest, src, 0, options=gdal_opts)
-    except RuntimeError as exc:
-        raise FailedToSaveError(
-            f"GDAL COG CreateCopy failed for {path}: {exc}"
-        ) from exc
-
-    if dst is None:
-        raise FailedToSaveError(f"GDAL COG CreateCopy returned None for {path}")
-    return dst
+    # run_gdal_op owns both GDAL failure shapes and redacts the message, so a
+    # header-signed destination cannot put its token in the error (#1107).
+    return run_gdal_op(
+        partial(driver.CreateCopy, dest, src, 0, options=gdal_opts),
+        error=FailedToSaveError,
+        action="GDAL COG CreateCopy",
+        subject=f"{path}",
+        outcome="returned None",
+    )

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -353,12 +353,15 @@ def _source_bounds(
         # Name the source whichever way GDAL reports the failure: under
         # gdal.UseExceptions() (pyramids' default) Open raises instead of
         # returning None, and for a /vsicurl/ or /vsis3/ source GDAL's own
-        # message carries only the HTTP status -- not the URL (#1107).
+        # message carries only the HTTP status -- not the URL. The `is None`
+        # guard below is kept for a caller running with gdal.DontUseExceptions()
+        # (#1107).
+        source = str(path)
         try:
-            ds, opened = gdal.Open(str(path)), True
+            ds, opened = gdal.Open(source), True
         except RuntimeError as exc:
             raise RuntimeError(
-                redact_credentials(f"could not open merge source {path!r}: {exc}")
+                redact_credentials(f"could not open merge source {source!r}: {exc}")
             ) from exc
     if ds is None:
         raise RuntimeError(
@@ -795,10 +798,12 @@ def _prepare_sources(
     for index, path in enumerate(src_paths):
         # Name the source whichever way GDAL reports the failure. Under
         # gdal.UseExceptions() (pyramids' default) Open raises rather than
-        # returning None, so the `is None` guard below never runs; and for a
-        # /vsicurl/ or /vsis3/ source GDAL's message is just the HTTP status
-        # ("HTTP response code: 403"), naming no source at all. The index says
-        # how far the open got on a mosaic of many tiles (#1107).
+        # returning None; for a /vsicurl/ or /vsis3/ source GDAL's message is
+        # just the HTTP status ("HTTP response code: 403"), naming no source at
+        # all. The index says how far the open got on a mosaic of many tiles.
+        # The `is None` guard below is kept for a caller who has turned
+        # exceptions off -- gdal.UseExceptions() is process-global, so that is
+        # theirs to change, not ours to assume (#1107).
         try:
             dataset = gdal.Open(path)
         except RuntimeError as exc:

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -381,17 +382,11 @@ def _source_bounds(
     if isinstance(path, gdal.Dataset):
         ds, opened = path, False
     else:
-        # open_network_dataset owns both failure shapes (ARC-331): GDAL raises
-        # under gdal.UseExceptions() but returns None when exceptions are off,
-        # and for a /vsicurl/ or /vsis3/ source GDAL's own message carries only
-        # the HTTP status -- not the URL. Naming it here is what #1107 asks for.
         source = str(path)
         ds = open_network_dataset(
             source, error=RuntimeError, subject=f"merge source {source!r}"
         )
         opened = True
-    if ds is None:  # pragma: no cover - open_network_dataset never returns None
-        raise RuntimeError(f"GDAL returned no dataset for merge source {path!r}")
     bounds = GeoTransform(*ds.GetGeoTransform()).extent(ds.RasterXSize, ds.RasterYSize)
     if opened:
         # Close the handle we opened; a caller-supplied gdal.Dataset is theirs to own.
@@ -676,7 +671,7 @@ def merge_rasters(
             VRTNodata=str(init),
         )
         vrt_ds = run_gdal_op(
-            lambda: gdal.BuildVRT("", ordered, options=vrt_opts),
+            partial(gdal.BuildVRT, "", ordered, options=vrt_opts),
             error=RuntimeError,
             action="building the source mosaic",
             subject=f"sources {src_paths!r}",
@@ -734,10 +729,11 @@ def merge_rasters(
             projWin=proj_win,
         )
         out_ds = run_gdal_op(
-            lambda: gdal.Translate(str(dst), vrt_ds, options=translate_opts),
+            partial(gdal.Translate, str(dst), vrt_ds, options=translate_opts),
             error=RuntimeError,
             action="writing the mosaic",
-            subject=f"{str(dst)!r}",
+            subject=f"destination {str(dst)!r}",
+            outcome="produced no output",
         )
         out_ds.FlushCache()
         out_ds = None
@@ -828,10 +824,11 @@ def _prepare_sources(
     opened: list = []
     source_srs: list[osr.SpatialReference] = []
     for index, path in enumerate(src_paths):
-        # open_network_dataset owns both failure shapes (ARC-331). Naming the
-        # source is what #1107 asks for: for a /vsicurl/ or /vsis3/ source GDAL's
-        # own message is just the HTTP status ("HTTP response code: 403") and
-        # names nothing. The index says how far the open got on a big mosaic.
+        # open_network_dataset (PR #1084) owns both GDAL failure shapes, and
+        # redacts. Naming the source is what #1107 asks for: for a /vsicurl/ or
+        # /vsis3/ source GDAL's own message is just the HTTP status ("HTTP
+        # response code: 403") and names nothing. The index says how far the
+        # open got on a big mosaic.
         dataset = open_network_dataset(
             path,
             error=RuntimeError,
@@ -867,14 +864,14 @@ def _prepare_sources(
         if srs.IsSame(target_srs):
             sources.append(dataset)
             continue
+        # Built outside the thunk: a bad option is the caller's mistake, and
+        # re-branding it would blame the source for an argument error. `partial`
+        # rather than a lambda so nothing closes over the loop variable.
+        warp_opts = gdal.WarpOptions(
+            format="VRT", dstSRS=target_wkt, resampleAlg=resample_alg
+        )
         warped = run_gdal_op(
-            lambda: gdal.Warp(
-                "",
-                dataset,
-                options=gdal.WarpOptions(
-                    format="VRT", dstSRS=target_wkt, resampleAlg=resample_alg
-                ),
-            ),
+            partial(gdal.Warp, "", dataset, options=warp_opts),
             error=RuntimeError,
             action="reprojecting to the target CRS",
             subject=f"source {index + 1}/{len(src_paths)} {path!r}",
@@ -943,7 +940,7 @@ def _warp_onto_strip(
         dstNodata=float("nan"),
     )
     warped = run_gdal_op(
-        lambda: gdal.Warp("", source.handle, options=warp_opts),
+        partial(gdal.Warp, "", source.handle, options=warp_opts),
         error=RuntimeError,
         action="warping onto the union grid",
         subject=f"source {source.label}",
@@ -1073,7 +1070,7 @@ def _merge_reduce(
     """
     sources = [_Source.of(source) for source in src_paths]
     template = run_gdal_op(
-        lambda: gdal.BuildVRT("", [source.handle for source in sources]),
+        partial(gdal.BuildVRT, "", [source.handle for source in sources]),
         error=RuntimeError,
         action="building the union mosaic",
         subject="sources [" + ", ".join(source.label for source in sources) + "]",
@@ -1105,14 +1102,25 @@ def _merge_reduce(
     # GTiff-specific and is applied only there.
     out_driver = resolve_output_driver(dst)
     out_options = ["COMPRESS=LZW"] if out_driver == "GTiff" else []
+    # Resolved before the thunk: an unknown driver yields None here, and
+    # `.Create` on it would raise AttributeError -- which run_gdal_op does not
+    # catch, so the failure would escape un-branded.
+    driver = gdal.GetDriverByName(out_driver)
     out_ds = run_gdal_op(
-        lambda: gdal.GetDriverByName(out_driver).Create(
-            dst, x_size, y_size, band_count, gdal.GDT_Float64, options=out_options
+        partial(
+            driver.Create,
+            dst,
+            x_size,
+            y_size,
+            band_count,
+            gdal.GDT_Float64,
+            options=out_options,
         ),
         error=RuntimeError,
         action="writing the reduced mosaic",
-        subject=f"{dst!r}",
+        subject=f"destination {dst!r}",
         hint="check the output path is writable",
+        outcome="produced no output",
     )
     out_ds.SetGeoTransform(geotransform)
     out_ds.SetProjection(projection)

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -17,7 +17,7 @@ import numpy as np
 from osgeo import gdal, osr
 from pyproj.exceptions import ProjError
 
-from pyramids.base._coverage import open_network_dataset
+from pyramids.base._coverage import open_network_dataset, run_gdal_op
 from pyramids.base._utils import DEFAULT_RESAMPLING, resolve_resampling
 from pyramids.base.remote import redact_credentials, signer_cloud_config
 from pyramids.dataset._driver import resolve_output_driver
@@ -45,6 +45,11 @@ _GRID_SNAP_TOLERANCE = 1e-6
 # +inf loses every fmin, -inf loses every fmax, 0 is the additive identity. Cells that
 # never receive a sample keep this value and are replaced by the fill at the end.
 _REDUCE_IDENTITY = {"min": np.inf, "max": -np.inf, "sum": 0.0}
+
+
+_READABLE_RASTERS_HINT = (
+    "check that all paths are readable rasters with consistent band counts and CRS"
+)
 
 
 def _validated_bbox(bbox: Sequence[float]) -> tuple[float, float, float, float]:
@@ -639,13 +644,13 @@ def merge_rasters(
             srcNodata=str(n),
             VRTNodata=str(init),
         )
-        vrt_ds = gdal.BuildVRT("", ordered, options=vrt_opts)
-        if vrt_ds is None:
-            raise RuntimeError(
-                f"gdal.BuildVRT returned None for sources {src_paths!r}; "
-                "check that all paths are readable rasters with consistent "
-                "band counts and CRS."
-            )
+        vrt_ds = run_gdal_op(
+            lambda: gdal.BuildVRT("", ordered, options=vrt_opts),
+            error=RuntimeError,
+            action="building the source mosaic",
+            subject=f"sources {src_paths!r}",
+            hint=_READABLE_RASTERS_HINT,
+        )
         proj_win = None
         if bbox is not None:
             # Resolve the window here, in the mosaic's own CRS, and hand Translate a
@@ -697,11 +702,12 @@ def merge_rasters(
             noData=str(no_data_value),
             projWin=proj_win,
         )
-        out_ds = gdal.Translate(str(dst), vrt_ds, options=translate_opts)
-        if out_ds is None:
-            raise RuntimeError(
-                f"gdal.Translate returned None writing the mosaic to {str(dst)!r}."
-            )
+        out_ds = run_gdal_op(
+            lambda: gdal.Translate(str(dst), vrt_ds, options=translate_opts),
+            error=RuntimeError,
+            action="writing the mosaic",
+            subject=f"{str(dst)!r}",
+        )
         out_ds.FlushCache()
         out_ds = None
         vrt_ds = None
@@ -830,30 +836,18 @@ def _prepare_sources(
         if srs.IsSame(target_srs):
             sources.append(dataset)
             continue
-        # Same two failure shapes as the open above: gdal.UseExceptions() makes
-        # Warp raise, so name the source there too rather than letting the
-        # reproject half of this function fail anonymously (#1107).
-        try:
-            warped = gdal.Warp(
+        warped = run_gdal_op(
+            lambda: gdal.Warp(
                 "",
                 dataset,
                 options=gdal.WarpOptions(
                     format="VRT", dstSRS=target_wkt, resampleAlg=resample_alg
                 ),
-            )
-        except RuntimeError as exc:
-            raise RuntimeError(
-                redact_credentials(
-                    f"could not reproject source {path!r} to the target CRS: {exc}"
-                )
-            ) from exc
-        if warped is None:
-            raise RuntimeError(
-                redact_credentials(
-                    f"gdal.Warp returned None reprojecting source {path!r} to the "
-                    "target CRS."
-                )
-            )
+            ),
+            error=RuntimeError,
+            action="reprojecting to the target CRS",
+            subject=f"source {path!r}",
+        )
         sources.append(warped)
     return sources, sources
 
@@ -917,11 +911,12 @@ def _warp_onto_strip(
         srcNodata=src_nodata,
         dstNodata=float("nan"),
     )
-    warped = gdal.Warp("", path, options=warp_opts)
-    if warped is None:
-        raise RuntimeError(
-            f"gdal.Warp returned None warping source {path!r} onto the union grid."
-        )
+    warped = run_gdal_op(
+        lambda: gdal.Warp("", path, options=warp_opts),
+        error=RuntimeError,
+        action="warping onto the union grid",
+        subject=f"source {path!r}",
+    )
     # np.asarray pins the type: GDAL's ReadAsArray is untyped, so without it the
     # float64 cube is inferred as Any and leaks out of the annotated return.
     array = np.asarray(warped.ReadAsArray()).astype("float64")
@@ -1043,13 +1038,13 @@ def _merge_reduce(
     Raises:
         RuntimeError: GDAL failed to build the union mosaic or to warp a source.
     """
-    template = gdal.BuildVRT("", src_paths)
-    if template is None:
-        raise RuntimeError(
-            f"gdal.BuildVRT returned None for sources {src_paths!r}; "
-            "check that all paths are readable rasters with consistent "
-            "band counts and CRS."
-        )
+    template = run_gdal_op(
+        lambda: gdal.BuildVRT("", src_paths),
+        error=RuntimeError,
+        action="building the union mosaic",
+        subject=f"sources {src_paths!r}",
+        hint=_READABLE_RASTERS_HINT,
+    )
     geotransform = template.GetGeoTransform()
     projection = template.GetProjection()
     x_size, y_size = template.RasterXSize, template.RasterYSize
@@ -1076,14 +1071,15 @@ def _merge_reduce(
     # GTiff-specific and is applied only there.
     out_driver = resolve_output_driver(dst)
     out_options = ["COMPRESS=LZW"] if out_driver == "GTiff" else []
-    out_ds = gdal.GetDriverByName(out_driver).Create(
-        dst, x_size, y_size, band_count, gdal.GDT_Float64, options=out_options
+    out_ds = run_gdal_op(
+        lambda: gdal.GetDriverByName(out_driver).Create(
+            dst, x_size, y_size, band_count, gdal.GDT_Float64, options=out_options
+        ),
+        error=RuntimeError,
+        action="writing the reduced mosaic",
+        subject=f"{dst!r}",
+        hint="check the output path is writable",
     )
-    if out_ds is None:
-        raise RuntimeError(
-            f"gdal.Create returned None writing the reduced mosaic to {dst!r}; "
-            f"check the output path is writable ({gdal.GetLastErrorMsg()!r})."
-        )
     out_ds.SetGeoTransform(geotransform)
     out_ds.SetProjection(projection)
     for band_index in range(band_count):

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -539,7 +539,9 @@ def merge_rasters(
             reprojected, selects no whole pixel, does not overlap the mosaic, or
             cannot be projected into its CRS.
         RuntimeError: GDAL failed to open a source, reproject it, or build the
-            source mosaic.
+            source mosaic. When a source is at fault the message names it and
+            its position in `src`, and chains GDAL's own error; any credential
+            in a signed URL is redacted.
         DriverNotExistError: `dst` has no extension, or one the driver catalog
             does not know.
         FileFormatNotSupportedError: `dst`'s extension maps to a
@@ -779,9 +781,11 @@ def _prepare_sources(
         TypeError: ``resampling`` is not a string.
         ValueError: ``dst_crs`` (or ``resampling``) could not be parsed, or a
             source carries no CRS.
-        RuntimeError: A source could not be opened -- the message names the
-            source (and its position in ``src_paths``) and chains GDAL's own
-            error -- or a reprojecting :func:`gdal.Warp` failed.
+        RuntimeError: A source could not be opened, or a reprojecting
+            :func:`gdal.Warp` failed. Either way the message names the source
+            and redacts any credential in it; when GDAL raised (the usual case
+            under :func:`gdal.UseExceptions`) it also carries the source's
+            position in ``src_paths`` and chains GDAL's own error.
     """
     resample_alg = resolve_resampling(resampling)
 

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -348,7 +348,14 @@ def _source_bounds(
     if isinstance(path, gdal.Dataset):
         ds, opened = path, False
     else:
-        ds, opened = gdal.Open(str(path)), True
+        # Name the source whichever way GDAL reports the failure: under
+        # gdal.UseExceptions() (pyramids' default) Open raises instead of
+        # returning None, and for a /vsicurl/ or /vsis3/ source GDAL's own
+        # message carries only the HTTP status -- not the URL (#1107).
+        try:
+            ds, opened = gdal.Open(str(path)), True
+        except RuntimeError as exc:
+            raise RuntimeError(f"could not open merge source {path!r}: {exc}") from exc
     if ds is None:
         raise RuntimeError(f"gdal.Open returned None for merge source {path!r}.")
     bounds = GeoTransform(*ds.GetGeoTransform()).extent(ds.RasterXSize, ds.RasterYSize)
@@ -766,16 +773,28 @@ def _prepare_sources(
         TypeError: ``resampling`` is not a string.
         ValueError: ``dst_crs`` (or ``resampling``) could not be parsed, or a
             source carries no CRS.
-        RuntimeError: A source could not be opened, or a reprojecting
-            :func:`gdal.Warp` failed.
+        RuntimeError: A source could not be opened -- the message names the
+            source (and its position in ``src_paths``) and chains GDAL's own
+            error -- or a reprojecting :func:`gdal.Warp` failed.
     """
     resample_alg = resolve_resampling(resampling)
 
     # Open each source once; read its CRS from that same handle.
     opened: list = []
     source_srs: list[osr.SpatialReference] = []
-    for path in src_paths:
-        dataset = gdal.Open(path)
+    for index, path in enumerate(src_paths):
+        # Name the source whichever way GDAL reports the failure. Under
+        # gdal.UseExceptions() (pyramids' default) Open raises rather than
+        # returning None, so the `is None` guard below never runs; and for a
+        # /vsicurl/ or /vsis3/ source GDAL's message is just the HTTP status
+        # ("HTTP response code: 403"), naming no source at all. The index says
+        # how far the open got on a mosaic of many tiles (#1107).
+        try:
+            dataset = gdal.Open(path)
+        except RuntimeError as exc:
+            raise RuntimeError(
+                f"could not open source {index + 1}/{len(src_paths)} {path!r}: {exc}"
+            ) from exc
         if dataset is None:
             raise RuntimeError(f"gdal.Open returned None for source {path!r}.")
         wkt = dataset.GetProjection()

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -18,7 +18,7 @@ from osgeo import gdal, osr
 from pyproj.exceptions import ProjError
 
 from pyramids.base._utils import DEFAULT_RESAMPLING, resolve_resampling
-from pyramids.base.remote import signer_cloud_config
+from pyramids.base.remote import redact_credentials, signer_cloud_config
 from pyramids.dataset._driver import resolve_output_driver
 from pyramids.dataset.dataset import _INHERIT_NO_DATA, Dataset
 from pyramids.dataset.transform import GeoTransform
@@ -357,9 +357,13 @@ def _source_bounds(
         try:
             ds, opened = gdal.Open(str(path)), True
         except RuntimeError as exc:
-            raise RuntimeError(f"could not open merge source {path!r}: {exc}") from exc
+            raise RuntimeError(
+                redact_credentials(f"could not open merge source {path!r}: {exc}")
+            ) from exc
     if ds is None:
-        raise RuntimeError(f"gdal.Open returned None for merge source {path!r}.")
+        raise RuntimeError(
+            redact_credentials(f"gdal.Open returned None for merge source {path!r}.")
+        )
     bounds = GeoTransform(*ds.GetGeoTransform()).extent(ds.RasterXSize, ds.RasterYSize)
     if opened:
         # Close the handle we opened; a caller-supplied gdal.Dataset is theirs to own.
@@ -795,15 +799,21 @@ def _prepare_sources(
             dataset = gdal.Open(path)
         except RuntimeError as exc:
             raise RuntimeError(
-                f"could not open source {index + 1}/{len(src_paths)} {path!r}: {exc}"
+                redact_credentials(
+                    f"could not open source {index + 1}/{len(src_paths)} {path!r}: {exc}"
+                )
             ) from exc
         if dataset is None:
-            raise RuntimeError(f"gdal.Open returned None for source {path!r}.")
+            raise RuntimeError(
+                redact_credentials(f"gdal.Open returned None for source {path!r}.")
+            )
         wkt = dataset.GetProjection()
         if not wkt:
             raise ValueError(
-                f"source {path!r} has no CRS; every source must carry a CRS to "
-                "be merged/reprojected."
+                redact_credentials(
+                    f"source {path!r} has no CRS; every source must carry a CRS "
+                    "to be merged/reprojected."
+                )
             )
         srs = osr.SpatialReference()
         srs.ImportFromWkt(wkt)

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -10,6 +10,7 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -45,6 +46,30 @@ _GRID_SNAP_TOLERANCE = 1e-6
 # +inf loses every fmin, -inf loses every fmax, 0 is the additive identity. Cells that
 # never receive a sample keep this value and are replaced by the fill at the end.
 _REDUCE_IDENTITY = {"min": np.inf, "max": -np.inf, "sum": 0.0}
+
+
+@dataclass(frozen=True)
+class _Source:
+    """A merge source paired with the name to report it by when GDAL fails on it.
+
+    ``_prepare_sources`` hands the reduction path open :class:`gdal.Dataset`
+    handles, whose ``repr`` is a SWIG proxy address. Naming the source is the
+    whole point of #1107, so the label travels with the handle instead of being
+    recovered from it.
+
+    Attributes:
+        label: Display name, already quoted/positioned by the caller, e.g.
+            ``"1/2 'tile.tif'"``.
+        handle: The path string or open :class:`gdal.Dataset` GDAL is given.
+    """
+
+    label: str
+    handle: Any
+
+    @classmethod
+    def of(cls, source: Any) -> _Source:
+        """Return `source` as a `_Source`, labelling a bare path by its repr."""
+        return source if isinstance(source, cls) else cls(f"{source!r}", source)
 
 
 _READABLE_RASTERS_HINT = (
@@ -633,7 +658,13 @@ def merge_rasters(
         sources, _keepalive = _prepare_sources(src_paths, dst_crs, resampling)
 
         if method in _REDUCE_METHODS:
-            _merge_reduce(sources, str(dst), method, no_data_value, n, bbox, bbox_crs)
+            # Pair each handle with its path so a failure on the reduce path
+            # names the source, not a SWIG proxy address (#1107).
+            labelled = [
+                _Source(f"{index + 1}/{len(src_paths)} {path!r}", handle)
+                for index, (path, handle) in enumerate(zip(src_paths, sources))
+            ]
+            _merge_reduce(labelled, str(dst), method, no_data_value, n, bbox, bbox_crs)
             return
 
         # z-order: "last" keeps natural order (last source wins); "first"
@@ -832,7 +863,7 @@ def _prepare_sources(
     # path strings and dataset objects.
     target_wkt = target_srs.ExportToWkt()
     sources: list = []
-    for path, dataset, srs in zip(src_paths, opened, source_srs):
+    for index, (path, dataset, srs) in enumerate(zip(src_paths, opened, source_srs)):
         if srs.IsSame(target_srs):
             sources.append(dataset)
             continue
@@ -846,7 +877,7 @@ def _prepare_sources(
             ),
             error=RuntimeError,
             action="reprojecting to the target CRS",
-            subject=f"source {path!r}",
+            subject=f"source {index + 1}/{len(src_paths)} {path!r}",
         )
         sources.append(warped)
     return sources, sources
@@ -882,7 +913,7 @@ def _source_misses_strip(
 
 
 def _warp_onto_strip(
-    path: Any,
+    source: _Source,
     strip_bounds: Sequence[float],
     x_size: int,
     ysize: int,
@@ -891,7 +922,7 @@ def _warp_onto_strip(
     """Warp one source onto a strip's window and read it as a 3-D float64 cube.
 
     Args:
-        path: Source path or an already-open :class:`gdal.Dataset`.
+        source: The source to warp, paired with the label to report it by.
         strip_bounds: The strip's ``(west, south, east, north)`` window.
         x_size: Strip width in pixels.
         ysize: Strip height in pixels.
@@ -912,10 +943,10 @@ def _warp_onto_strip(
         dstNodata=float("nan"),
     )
     warped = run_gdal_op(
-        lambda: gdal.Warp("", path, options=warp_opts),
+        lambda: gdal.Warp("", source.handle, options=warp_opts),
         error=RuntimeError,
         action="warping onto the union grid",
-        subject=f"source {path!r}",
+        subject=f"source {source.label}",
     )
     # np.asarray pins the type: GDAL's ReadAsArray is untyped, so without it the
     # float64 cube is inferred as Any and leaks out of the annotated return.
@@ -965,7 +996,8 @@ def _reduce_strip(
     low.
 
     Args:
-        src_paths: Source rasters (paths or open datasets).
+        src_paths: Sources as :class:`_Source` pairs, or bare paths/open
+            datasets (labelled by their repr).
         src_bounds: Each source's ``(west, south, east, north)`` extent.
         strip_bounds: The strip's ``[west, south, east, north]`` output bounds.
         strip_lat: The strip's ``(south, north)`` latitude band for the overlap prune.
@@ -986,10 +1018,10 @@ def _reduce_strip(
     # count, only test presence below, so a bool cube (1 byte/px) replaces int64.
     covered = np.zeros(shape, dtype=bool)
 
-    for path, bounds in zip(src_paths, src_bounds):
+    for source, bounds in zip(src_paths, src_bounds):
         if _source_misses_strip(bounds, strip_lat, strip_bounds):
             continue
-        array = _warp_onto_strip(path, strip_bounds, x_size, ysize, src_nodata)
+        array = _warp_onto_strip(source, strip_bounds, x_size, ysize, src_nodata)
         valid = ~np.isnan(array)
         covered |= valid
         _fold_into(acc, array, valid, method)
@@ -1021,7 +1053,8 @@ def _merge_reduce(
     Pixels with no source coverage are written as ``no_data_value``.
 
     Args:
-        src_paths: Source rasters as path strings or already-open
+        src_paths: Sources as :class:`_Source` pairs (so a failure names the
+            source rather than a SWIG proxy), or bare path strings / already-open
             :class:`gdal.Dataset` objects (e.g. reprojected warped VRTs from
             :func:`_prepare_sources`).
         dst: Output raster path.
@@ -1038,11 +1071,12 @@ def _merge_reduce(
     Raises:
         RuntimeError: GDAL failed to build the union mosaic or to warp a source.
     """
+    sources = [_Source.of(source) for source in src_paths]
     template = run_gdal_op(
-        lambda: gdal.BuildVRT("", src_paths),
+        lambda: gdal.BuildVRT("", [source.handle for source in sources]),
         error=RuntimeError,
         action="building the union mosaic",
-        subject=f"sources {src_paths!r}",
+        subject="sources [" + ", ".join(source.label for source in sources) + "]",
         hint=_READABLE_RASTERS_HINT,
     )
     geotransform = template.GetGeoTransform()
@@ -1062,7 +1096,7 @@ def _merge_reduce(
     src_nodata = None if str(n).lower() == "nan" else float(n)
     fill = float(no_data_value)
     # Extent of every source, computed once, to skip sources a strip cannot touch.
-    src_bounds = [_source_bounds(path) for path in src_paths]
+    src_bounds = [_source_bounds(source.handle) for source in sources]
 
     # Resolve from the extension so that one `dst` does not yield two different
     # formats depending on an unrelated argument: this reduction path hardcoded
@@ -1096,7 +1130,7 @@ def _merge_reduce(
             strip_north,
         ]
         reduced = _reduce_strip(
-            src_paths,
+            sources,
             src_bounds,
             strip_bounds,
             (strip_south, strip_north),

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -17,6 +17,7 @@ import numpy as np
 from osgeo import gdal, osr
 from pyproj.exceptions import ProjError
 
+from pyramids.base._coverage import open_network_dataset
 from pyramids.base._utils import DEFAULT_RESAMPLING, resolve_resampling
 from pyramids.base.remote import redact_credentials, signer_cloud_config
 from pyramids.dataset._driver import resolve_output_driver
@@ -350,23 +351,17 @@ def _source_bounds(
     if isinstance(path, gdal.Dataset):
         ds, opened = path, False
     else:
-        # Name the source whichever way GDAL reports the failure: under
-        # gdal.UseExceptions() (pyramids' default) Open raises instead of
-        # returning None, and for a /vsicurl/ or /vsis3/ source GDAL's own
-        # message carries only the HTTP status -- not the URL. The `is None`
-        # guard below is kept for a caller running with gdal.DontUseExceptions()
-        # (#1107).
+        # open_network_dataset owns both failure shapes (ARC-331): GDAL raises
+        # under gdal.UseExceptions() but returns None when exceptions are off,
+        # and for a /vsicurl/ or /vsis3/ source GDAL's own message carries only
+        # the HTTP status -- not the URL. Naming it here is what #1107 asks for.
         source = str(path)
-        try:
-            ds, opened = gdal.Open(source), True
-        except RuntimeError as exc:
-            raise RuntimeError(
-                redact_credentials(f"could not open merge source {source!r}: {exc}")
-            ) from exc
-    if ds is None:
-        raise RuntimeError(
-            redact_credentials(f"gdal.Open returned None for merge source {path!r}.")
+        ds = open_network_dataset(
+            source, error=RuntimeError, subject=f"merge source {source!r}"
         )
+        opened = True
+    if ds is None:  # pragma: no cover - open_network_dataset never returns None
+        raise RuntimeError(f"GDAL returned no dataset for merge source {path!r}")
     bounds = GeoTransform(*ds.GetGeoTransform()).extent(ds.RasterXSize, ds.RasterYSize)
     if opened:
         # Close the handle we opened; a caller-supplied gdal.Dataset is theirs to own.
@@ -796,26 +791,15 @@ def _prepare_sources(
     opened: list = []
     source_srs: list[osr.SpatialReference] = []
     for index, path in enumerate(src_paths):
-        # Name the source whichever way GDAL reports the failure. Under
-        # gdal.UseExceptions() (pyramids' default) Open raises rather than
-        # returning None; for a /vsicurl/ or /vsis3/ source GDAL's message is
-        # just the HTTP status ("HTTP response code: 403"), naming no source at
-        # all. The index says how far the open got on a mosaic of many tiles.
-        # The `is None` guard below is kept for a caller who has turned
-        # exceptions off -- gdal.UseExceptions() is process-global, so that is
-        # theirs to change, not ours to assume (#1107).
-        try:
-            dataset = gdal.Open(path)
-        except RuntimeError as exc:
-            raise RuntimeError(
-                redact_credentials(
-                    f"could not open source {index + 1}/{len(src_paths)} {path!r}: {exc}"
-                )
-            ) from exc
-        if dataset is None:
-            raise RuntimeError(
-                redact_credentials(f"gdal.Open returned None for source {path!r}.")
-            )
+        # open_network_dataset owns both failure shapes (ARC-331). Naming the
+        # source is what #1107 asks for: for a /vsicurl/ or /vsis3/ source GDAL's
+        # own message is just the HTTP status ("HTTP response code: 403") and
+        # names nothing. The index says how far the open got on a big mosaic.
+        dataset = open_network_dataset(
+            path,
+            error=RuntimeError,
+            subject=f"source {index + 1}/{len(src_paths)} {path!r}",
+        )
         wkt = dataset.GetProjection()
         if not wkt:
             raise ValueError(

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -833,20 +833,33 @@ def _prepare_sources(
     # path strings and dataset objects.
     target_wkt = target_srs.ExportToWkt()
     sources: list = []
-    for dataset, srs in zip(opened, source_srs):
+    for path, dataset, srs in zip(src_paths, opened, source_srs):
         if srs.IsSame(target_srs):
             sources.append(dataset)
             continue
-        warped = gdal.Warp(
-            "",
-            dataset,
-            options=gdal.WarpOptions(
-                format="VRT", dstSRS=target_wkt, resampleAlg=resample_alg
-            ),
-        )
+        # Same two failure shapes as the open above: gdal.UseExceptions() makes
+        # Warp raise, so name the source there too rather than letting the
+        # reproject half of this function fail anonymously (#1107).
+        try:
+            warped = gdal.Warp(
+                "",
+                dataset,
+                options=gdal.WarpOptions(
+                    format="VRT", dstSRS=target_wkt, resampleAlg=resample_alg
+                ),
+            )
+        except RuntimeError as exc:
+            raise RuntimeError(
+                redact_credentials(
+                    f"could not reproject source {path!r} to the target CRS: {exc}"
+                )
+            ) from exc
         if warped is None:
             raise RuntimeError(
-                "gdal.Warp returned None reprojecting a source to the target CRS."
+                redact_credentials(
+                    f"gdal.Warp returned None reprojecting source {path!r} to the "
+                    "target CRS."
+                )
             )
         sources.append(warped)
     return sources, sources

--- a/src/pyramids/dataset/merge.py
+++ b/src/pyramids/dataset/merge.py
@@ -343,7 +343,9 @@ def _source_bounds(
         east, north)``.
 
     Raises:
-        RuntimeError: The path could not be opened.
+        RuntimeError: The path could not be opened -- the message names the
+            source and chains GDAL's own error, which for a ``/vsicurl/`` or
+            ``/vsis3/`` source carries only the HTTP status and no URL.
     """
     if isinstance(path, gdal.Dataset):
         ds, opened = path, False

--- a/src/pyramids/stac/_vrt.py
+++ b/src/pyramids/stac/_vrt.py
@@ -61,12 +61,14 @@ import warnings
 import weakref
 from collections.abc import Iterable
 from contextlib import AbstractContextManager
+from functools import partial
 from typing import Any
 from urllib.parse import quote
 
 from osgeo import gdal
 
 from pyramids.base._artifacts import register_vsimem, unregister_vsimem
+from pyramids.base._coverage import run_gdal_op
 from pyramids.base.remote import (
     CloudConfig,
     _to_vsi,
@@ -439,31 +441,47 @@ def _redacting_error_handler(err_class: int, err_num: int, err_msg: str) -> None
     logger.warning("GDAL[%s] %s", err_num, redact_credentials(str(err_msg)))
 
 
-def _build_vrt(vrt_path: str, vsi_paths: list[str], separate: bool) -> Any:
+def _build_vrt(vrt_path: str, vsi_paths: list[str], separate: bool, asset: str) -> Any:
     """Run `gdal.BuildVRT` with GDAL's own messages redacted.
 
     A source that fails to open makes GDAL print the full source path — token
     and all, for a header-signed build. The redacting handler is *pushed* for
     the duration of the call (see :func:`_redacting_error_handler` for why a
     process-wide one does not work), then popped, so the rest of the process
-    keeps whatever error handling it had.
+    keeps whatever error handling it had. That handler scrubs what GDAL writes
+    to its *log*; :func:`~pyramids.base._coverage.run_gdal_op` scrubs the
+    exception text and brands both GDAL failure shapes, so neither a raise nor
+    a `None` return escapes unnamed.
 
     Args:
         vrt_path: The `/vsimem` path to build into.
         vsi_paths: The source paths, in order.
         separate: Whether each source becomes its own band.
+        asset: The asset key, named in the error when the build fails.
 
     Returns:
-        The built `gdal.Dataset`, or `None` when GDAL could use no source.
+        The built `gdal.Dataset`.
+
+    Raises:
+        RuntimeError: GDAL raised, or could use no source.
     """
+    # Built outside the guarded call: a bad option is the caller's mistake.
+    vrt_options = gdal.BuildVRTOptions(separate=separate)
     gdal.PushErrorHandler(_redacting_error_handler)
     try:
-        vrt_ds = gdal.BuildVRT(
-            vrt_path, vsi_paths, options=gdal.BuildVRTOptions(separate=separate)
+        return run_gdal_op(
+            partial(gdal.BuildVRT, vrt_path, vsi_paths, options=vrt_options),
+            error=RuntimeError,
+            action="gdal.BuildVRT",
+            subject=f"asset {asset!r} over {len(vsi_paths)} item(s)",
+            hint=(
+                "check that every source is a readable raster with a consistent "
+                "band count and CRS"
+            ),
+            outcome="returned None",
         )
     finally:
         gdal.PopErrorHandler()
-    return vrt_ds
 
 
 def _check_dropped_sources(
@@ -619,13 +637,7 @@ def build_vrt_from_stac(
     # source's `.aux.xml` / world-file sidecars. Remoteness is decided on the
     # hrefs, not the rewritten paths, which `is_remote` does not classify.
     with _source_config(hrefs, gdal_env):
-        vrt_ds = _build_vrt(vrt_path, vsi_paths, separate)
-        if vrt_ds is None:
-            raise RuntimeError(
-                f"gdal.BuildVRT returned None for asset {asset!r} over "
-                f"{len(vsi_paths)} item(s); check that every source is a "
-                "readable raster with a consistent band count and CRS."
-            )
+        vrt_ds = _build_vrt(vrt_path, vsi_paths, separate, asset)
         # GDAL lists exactly the sources it kept, so the difference against what
         # was requested is what it silently skipped.
         dropped = _dropped_sources(sources, vrt_ds.GetFileList() or ())

--- a/tests/base/test_coverage_gdal_primitives.py
+++ b/tests/base/test_coverage_gdal_primitives.py
@@ -19,11 +19,24 @@ from __future__ import annotations
 import pytest
 from osgeo import gdal
 
-from pyramids.base._coverage import open_network_dataset, translate_to_mem
+from pyramids.base._coverage import (
+    open_network_dataset,
+    run_gdal_op,
+    translate_to_mem,
+)
 from pyramids.dataset import _ogc_coverages, _wcs, _wms
 from pyramids.errors import OGCAPIError, WCSError, WMSError
 
 pytestmark = pytest.mark.core
+
+
+def _raise_runtime_error(message: str):
+    """Return a zero-argument call that fails the way GDAL does."""
+
+    def _operation():
+        raise RuntimeError(message)
+
+    return _operation
 
 
 class _DemoError(Exception):
@@ -50,6 +63,126 @@ def _return_none(*_args, **_kwargs):
 def _refuse(*_args, **_kwargs):
     """Fail loudly if the wrong GDAL entry point is reached."""
     raise AssertionError("the wrong GDAL entry point was called")
+
+
+class TestRunGdalOp:
+    """The generalisation of the open/translate shape to any GDAL dataset call."""
+
+    def test_raising_call_is_branded_with_action_and_subject(self):
+        """A raising call keeps GDAL's text and names what was attempted on what."""
+        with pytest.raises(_DemoError) as excinfo:
+            run_gdal_op(
+                _raise_runtime_error("HTTP response code: 403"),
+                error=_DemoError,
+                action="building the mosaic",
+                subject="sources ['tile.tif']",
+            )
+        assert str(excinfo.value) == (
+            "building the mosaic failed for sources ['tile.tif']: "
+            "HTTP response code: 403"
+        ), f"unexpected message: {excinfo.value}"
+        assert isinstance(excinfo.value.__cause__, RuntimeError), (
+            "GDAL's error should be chained, not replaced"
+        )
+
+    def test_none_return_is_branded_too(self):
+        """A ``None`` return -- what GDAL does with exceptions off -- also raises."""
+        with pytest.raises(_DemoError) as excinfo:
+            run_gdal_op(
+                lambda: None,
+                error=_DemoError,
+                action="building the mosaic",
+                subject="sources ['tile.tif']",
+            )
+        assert str(excinfo.value) == (
+            "building the mosaic returned no raster for sources ['tile.tif']"
+        ), f"unexpected message: {excinfo.value}"
+
+    @pytest.mark.parametrize(
+        "operation", [_raise_runtime_error("boom"), lambda: None], ids=["raise", "none"]
+    )
+    def test_hint_is_appended_on_both_failure_shapes(self, operation):
+        """The optional hint reaches the message whichever way the call failed.
+
+        Args:
+            operation: A call that fails by raising, and one that returns None.
+
+        Test scenario:
+            The raise-plus-hint composition had no test at all, so a hint could
+            have been silently dropped on the branch that matters most.
+        """
+        with pytest.raises(_DemoError) as excinfo:
+            run_gdal_op(
+                operation,
+                error=_DemoError,
+                action="building the mosaic",
+                subject="sources ['tile.tif']",
+                hint="check the paths are readable rasters",
+            )
+        assert str(excinfo.value).endswith("; check the paths are readable rasters"), (
+            f"hint missing: {excinfo.value}"
+        )
+
+    def test_a_successful_call_is_returned_untouched(self):
+        """The helper is transparent when the call succeeds."""
+        dataset = gdal.GetDriverByName("MEM").Create("", 2, 3, 1)
+        result = run_gdal_op(
+            lambda: dataset,
+            error=_DemoError,
+            action="building the mosaic",
+            subject="sources ['tile.tif']",
+        )
+        assert (result.RasterXSize, result.RasterYSize) == (2, 3), (
+            "the helper must hand back the dataset the call produced"
+        )
+
+
+class TestSharedHelpersRedactCredentials:
+    """A signed URL must not reach a message either helper builds."""
+
+    def test_run_gdal_op_redacts_the_subject(self):
+        """A credential in the subject is blanked, the rest of the URL kept."""
+        signed = "'https://acct.blob.core.windows.net/c/t.tif?sig=SECRETTOKEN'"
+        with pytest.raises(_DemoError) as excinfo:
+            run_gdal_op(
+                _raise_runtime_error("HTTP response code: 403"),
+                error=_DemoError,
+                action="opening",
+                subject=f"source {signed}",
+            )
+        message = str(excinfo.value)
+        assert "SECRETTOKEN" not in message, f"credential leaked: {message}"
+        assert "<redacted>" in message, f"not redacted: {message}"
+        assert "t.tif" in message, f"the source should still be named: {message}"
+
+    def test_open_network_dataset_redacts_the_subject(self):
+        """The open helper redacts too (the readers rely on it)."""
+        signed = "'/vsicurl/https://acct.blob.core.windows.net/c/t.tif?sig=SECRETTOKEN'"
+        with pytest.raises(_DemoError) as excinfo:
+            open_network_dataset(
+                "/vsimem/definitely-absent.tif",
+                error=_DemoError,
+                subject=f"coverage {signed}",
+            )
+        message = str(excinfo.value)
+        assert "SECRETTOKEN" not in message, f"credential leaked: {message}"
+        assert "<redacted>" in message, f"not redacted: {message}"
+
+    def test_translate_to_mem_redacts_too(self):
+        """`translate_to_mem` shares the redaction, not just the wording."""
+        signed = "'https://acct.blob.core.windows.net/c/t.tif?sig=SECRETTOKEN'"
+        src = gdal.GetDriverByName("MEM").Create("", 8, 8, 1)
+        with pytest.raises(_DemoError) as excinfo:
+            translate_to_mem(
+                src,
+                error=_DemoError,
+                action="demo read",
+                subject=f"coverage {signed}",
+                bandList=[5],
+            )
+        message = str(excinfo.value)
+        assert "SECRETTOKEN" not in message, f"credential leaked: {message}"
+        assert "<redacted>" in message, f"not redacted: {message}"
 
 
 class TestOpenNetworkDataset:

--- a/tests/base/test_coverage_gdal_primitives.py
+++ b/tests/base/test_coverage_gdal_primitives.py
@@ -70,9 +70,10 @@ class TestRunGdalOp:
 
     def test_raising_call_is_branded_with_action_and_subject(self):
         """A raising call keeps GDAL's text and names what was attempted on what."""
+        operation = _raise_runtime_error("HTTP response code: 403")
         with pytest.raises(_DemoError) as excinfo:
             run_gdal_op(
-                _raise_runtime_error("HTTP response code: 403"),
+                operation,
                 error=_DemoError,
                 action="building the mosaic",
                 subject="sources ['tile.tif']",
@@ -143,9 +144,10 @@ class TestSharedHelpersRedactCredentials:
     def test_run_gdal_op_redacts_the_subject(self):
         """A credential in the subject is blanked, the rest of the URL kept."""
         signed = "'https://acct.blob.core.windows.net/c/t.tif?sig=SECRETTOKEN'"
+        operation = _raise_runtime_error("HTTP response code: 403")
         with pytest.raises(_DemoError) as excinfo:
             run_gdal_op(
-                _raise_runtime_error("HTTP response code: 403"),
+                operation,
                 error=_DemoError,
                 action="opening",
                 subject=f"source {signed}",

--- a/tests/base/test_remote.py
+++ b/tests/base/test_remote.py
@@ -870,6 +870,41 @@ class TestRedactCredentials:
         assert "SECRET" not in out, f"token survived: {out}"
         assert "header.Authorization=<redacted>" in out, out
 
+    def test_space_separated_scheme_and_token_is_blanked_whole(self):
+        """An unencoded `Bearer <token>` loses the token, not just the scheme.
+
+        Test scenario:
+            The value pattern stops at whitespace, which is right for a query
+            option but left the secret in an HTTP header value: `Bearer abc123`
+            redacted only the word `Bearer` and printed the token. A leading
+            auth scheme is now consumed together with what follows it.
+        """
+        text = "Can't open /vsicurl?header.Authorization=Bearer abc123SECRET"
+        out = redact_credentials(text)
+        assert "abc123SECRET" not in out, f"token survived: {out}"
+        assert "header.Authorization=<redacted>" in out, out
+
+    @pytest.mark.parametrize("scheme", ["Bearer", "Basic", "Digest", "Token"])
+    def test_every_auth_scheme_is_consumed_with_its_token(self, scheme):
+        """Each recognised scheme takes its credential with it.
+
+        Args:
+            scheme: An HTTP auth scheme that precedes the credential.
+        """
+        out = redact_credentials(
+            f"/vsicurl?header.Authorization={scheme} SUPERSECRET&url=https://h/a.tif"
+        )
+        assert "SUPERSECRET" not in out, f"{scheme} token survived: {out}"
+        assert "url=https://h/a.tif" in out, f"the rest was mangled: {out}"
+
+    def test_a_scheme_word_does_not_swallow_following_prose(self):
+        """Redaction stops at the next space, so a trailing sentence survives."""
+        out = redact_credentials(
+            "Can't open /vsicurl?header.Authorization=Bearer abc123. Skipping it"
+        )
+        assert "abc123" not in out, f"token survived: {out}"
+        assert out.endswith(" Skipping it"), f"prose was swallowed: {out}"
+
     def test_sas_query_parameter_is_blanked(self):
         """A SAS-style `sig=` parameter is caught as well."""
         out = redact_credentials("https://h/a.tif?sv=2021&sig=SECRET")

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -780,6 +780,36 @@ class TestSourceBounds:
 class TestPrepareSources:
     """Tests for the ``_prepare_sources`` reproject helper."""
 
+    def test_unopenable_signed_source_does_not_leak_its_credential(
+        self, shared_crs_pair, monkeypatch
+    ):
+        """The failure message keeps the URL but blanks the signed credential.
+
+        Test scenario:
+            ``merge_rasters`` signs every source before ``_prepare_sources`` sees
+            it, so ``src_paths`` can hold a live SAS/presigned URL. A failed open
+            must report the source -- that is the point of #1107 -- with the
+            secret replaced by ``<redacted>``, never the token itself.
+        """
+        pa, _pb = shared_crs_pair
+        signed = (
+            "/vsicurl/https://acct.blob.core.windows.net/c/tile.tif?sig=SECRETTOKEN"
+        )
+        real_open = merge_mod.gdal.Open
+
+        def _raise_for_signed(path, *args, **kwargs):
+            if str(path) == signed:
+                raise RuntimeError("HTTP response code: 403")
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(merge_mod.gdal, "Open", _raise_for_signed)
+        with pytest.raises(RuntimeError) as excinfo:
+            _prepare_sources([pa, signed], None)
+        message = str(excinfo.value)
+        assert "SECRETTOKEN" not in message, f"credential leaked: {message}"
+        assert "<redacted>" in message, f"credential not redacted: {message}"
+        assert "tile.tif" in message, f"source should still be named: {message}"
+
     def test_shared_crs_reuses_open_handles_no_reproject(self, shared_crs_pair):
         """A shared CRS with no ``dst_crs`` reuses the open handles (no reproject).
 

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -699,7 +699,7 @@ class TestMergeRastersDstCrs:
 
         pa, pb = shared_crs_pair
         monkeypatch.setattr(merge_mod.gdal, "Open", lambda *a, **k: None)
-        with pytest.raises(RuntimeError, match="gdal.Open returned None"):
+        with pytest.raises(RuntimeError, match="GDAL returned no dataset"):
             merge_rasters([pa, pb], tmp_path / "x.tif")
 
 
@@ -776,7 +776,7 @@ class TestSourceBounds:
         """
         monkeypatch.setattr(merge_mod.gdal, "Open", lambda *a, **k: None)
         with pytest.raises(
-            RuntimeError, match="gdal.Open returned None for merge source"
+            RuntimeError, match="GDAL returned no dataset for merge source"
         ):
             _source_bounds("/no/such/raster/does-not-exist.tif")
 

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -658,6 +658,37 @@ class TestMergeRastersDstCrs:
         with pytest.raises(RuntimeError, match="gdal.Open returned None"):
             merge_rasters([pa, pb], tmp_path / "x.tif")
 
+    def test_raising_open_names_the_source_and_its_position(
+        self, shared_crs_pair, monkeypatch
+    ):
+        """A raising ``gdal.Open`` names the failing source and how far the open got.
+
+        Test scenario:
+            The second of two sources is a remote tile whose open raises a bare
+            ``HTTP response code: 403`` -- GDAL names no source for a
+            ``/vsicurl/`` path. ``_prepare_sources`` must report the URL, its
+            ``2/2`` position in ``src_paths``, and chain GDAL's message (#1107).
+        """
+        pa, _pb = shared_crs_pair
+        remote = "/vsicurl/https://example.invalid/tile_B04_0042.tif"
+        real_open = merge_mod.gdal.Open
+
+        def _raise_for_remote(path, *args, **kwargs):
+            if str(path) == remote:
+                raise RuntimeError("HTTP response code: 403")
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(merge_mod.gdal, "Open", _raise_for_remote)
+        with pytest.raises(RuntimeError) as excinfo:
+            _prepare_sources([pa, remote], None)
+        message = str(excinfo.value)
+        assert "tile_B04_0042.tif" in message, f"source not named: {message}"
+        assert "2/2" in message, f"source position not reported: {message}"
+        assert "403" in message, f"GDAL's own message not preserved: {message}"
+        assert isinstance(excinfo.value.__cause__, RuntimeError), (
+            "GDAL's error should be chained as __cause__, not replaced"
+        )
+
 
 class TestSourceBounds:
     """Tests for the ``_source_bounds`` extent helper used by the strip reduction."""
@@ -695,6 +726,31 @@ class TestSourceBounds:
         """
         with pytest.raises(RuntimeError):
             _source_bounds("/no/such/raster/does-not-exist.tif")
+
+    def test_raising_open_names_the_source(self, monkeypatch):
+        """A raising ``gdal.Open`` still reports which source could not be opened.
+
+        Test scenario:
+            Under ``gdal.UseExceptions()`` (pyramids' default) ``gdal.Open``
+            raises instead of returning None, so the ``is None`` guard never
+            runs. For a remote source GDAL's message is a bare HTTP status that
+            names nothing, so ``_source_bounds`` must add the source itself and
+            chain GDAL's original message (#1107).
+        """
+        remote = "/vsicurl/https://example.invalid/tile_B04_0042.tif"
+
+        def _raise(*_args, **_kwargs):
+            raise RuntimeError("HTTP response code: 403")
+
+        monkeypatch.setattr(merge_mod.gdal, "Open", _raise)
+        with pytest.raises(RuntimeError) as excinfo:
+            _source_bounds(remote)
+        message = str(excinfo.value)
+        assert "tile_B04_0042.tif" in message, f"source not named: {message}"
+        assert "403" in message, f"GDAL's own message not preserved: {message}"
+        assert isinstance(excinfo.value.__cause__, RuntimeError), (
+            "GDAL's error should be chained as __cause__, not replaced"
+        )
 
 
 class TestPrepareSources:

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -702,47 +702,6 @@ class TestMergeRastersDstCrs:
         with pytest.raises(RuntimeError, match="gdal.Open returned None"):
             merge_rasters([pa, pb], tmp_path / "x.tif")
 
-    @pytest.mark.parametrize(
-        "failing_index, expected_position", [(0, "1/2"), (1, "2/2")]
-    )
-    def test_raising_open_names_the_source_and_its_position(
-        self, shared_crs_pair, monkeypatch, failing_index, expected_position
-    ):
-        """A raising ``gdal.Open`` names the failing source and how far the open got.
-
-        Args:
-            failing_index: Position of the unopenable remote source in ``src_paths``.
-            expected_position: The ``n/total`` marker the message must carry.
-
-        Test scenario:
-            One of two sources is a remote tile whose open raises a bare
-            ``HTTP response code: 403`` -- GDAL names no source for a
-            ``/vsicurl/`` path. ``_prepare_sources`` must report the URL, its
-            position in ``src_paths``, and chain GDAL's message (#1107). Both
-            positions are exercised so the reported index tracks the real one.
-        """
-        pa, _pb = shared_crs_pair
-        remote = "/vsicurl/https://example.invalid/tile_B04_0042.tif"
-        paths = [pa, pa]
-        paths[failing_index] = remote
-        real_open = merge_mod.gdal.Open
-
-        def _raise_for_remote(path, *args, **kwargs):
-            if str(path) == remote:
-                raise RuntimeError("HTTP response code: 403")
-            return real_open(path, *args, **kwargs)
-
-        monkeypatch.setattr(merge_mod.gdal, "Open", _raise_for_remote)
-        with pytest.raises(RuntimeError) as excinfo:
-            _prepare_sources(paths, None)
-        message = str(excinfo.value)
-        assert "tile_B04_0042.tif" in message, f"source not named: {message}"
-        assert expected_position in message, f"wrong position marker: {message}"
-        assert "403" in message, f"GDAL's own message not preserved: {message}"
-        assert isinstance(excinfo.value.__cause__, RuntimeError), (
-            "GDAL's error should be chained as __cause__, not replaced"
-        )
-
 
 class TestSourceBounds:
     """Tests for the ``_source_bounds`` extent helper used by the strip reduction."""
@@ -802,8 +761,9 @@ class TestSourceBounds:
         message = str(excinfo.value)
         assert "tile_B04_0042.tif" in message, f"source not named: {message}"
         assert "403" in message, f"GDAL's own message not preserved: {message}"
-        assert isinstance(excinfo.value.__cause__, RuntimeError), (
-            "GDAL's error should be chained as __cause__, not replaced"
+        cause = excinfo.value.__cause__
+        assert cause is not None and "403" in str(cause), (
+            f"GDAL's own error should be chained as __cause__, got {cause!r}"
         )
 
     def test_open_returning_none_raises(self, monkeypatch):
@@ -823,6 +783,48 @@ class TestSourceBounds:
 
 class TestPrepareSources:
     """Tests for the ``_prepare_sources`` reproject helper."""
+
+    @pytest.mark.parametrize(
+        "failing_index, expected_position", [(0, "1/2"), (1, "2/2")]
+    )
+    def test_raising_open_names_the_source_and_its_position(
+        self, shared_crs_pair, monkeypatch, failing_index, expected_position
+    ):
+        """A raising ``gdal.Open`` names the failing source and how far the open got.
+
+        Args:
+            failing_index: Position of the unopenable remote source in ``src_paths``.
+            expected_position: The ``n/total`` marker the message must carry.
+
+        Test scenario:
+            One of two sources is a remote tile whose open raises a bare
+            ``HTTP response code: 403`` -- GDAL names no source for a
+            ``/vsicurl/`` path. ``_prepare_sources`` must report the URL, its
+            position in ``src_paths``, and chain GDAL's message (#1107). Both
+            positions are exercised so the reported index tracks the real one.
+        """
+        pa, _pb = shared_crs_pair
+        remote = "/vsicurl/https://example.invalid/tile_B04_0042.tif"
+        paths = [pa, pa]
+        paths[failing_index] = remote
+        real_open = merge_mod.gdal.Open
+
+        def _raise_for_remote(path, *args, **kwargs):
+            if str(path) == remote:
+                raise RuntimeError("HTTP response code: 403")
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(merge_mod.gdal, "Open", _raise_for_remote)
+        with pytest.raises(RuntimeError) as excinfo:
+            _prepare_sources(paths, None)
+        message = str(excinfo.value)
+        assert "tile_B04_0042.tif" in message, f"source not named: {message}"
+        assert expected_position in message, f"wrong position marker: {message}"
+        assert "403" in message, f"GDAL's own message not preserved: {message}"
+        cause = excinfo.value.__cause__
+        assert cause is not None and "403" in str(cause), (
+            f"GDAL's own error should be chained as __cause__, got {cause!r}"
+        )
 
     def test_unopenable_signed_source_does_not_leak_its_credential(
         self, shared_crs_pair, monkeypatch

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -776,9 +776,8 @@ class TestSourceBounds:
         assert "tile_B04_0042.tif" in message, f"source not named: {message}"
         assert "403" in message, f"GDAL's own message not preserved: {message}"
         cause = excinfo.value.__cause__
-        assert cause is not None and "403" in str(cause), (
-            f"GDAL's own error should be chained as __cause__, got {cause!r}"
-        )
+        assert cause is not None, "GDAL's own error should be chained as __cause__"
+        assert "403" in str(cause), f"the chained cause lost GDAL's text: {cause!r}"
 
     def test_open_returning_none_raises(self, monkeypatch):
         """A ``None`` from ``gdal.Open`` is classified, not returned to the caller.
@@ -837,9 +836,8 @@ class TestPrepareSources:
         assert expected_position in message, f"wrong position marker: {message}"
         assert "403" in message, f"GDAL's own message not preserved: {message}"
         cause = excinfo.value.__cause__
-        assert cause is not None and "403" in str(cause), (
-            f"GDAL's own error should be chained as __cause__, got {cause!r}"
-        )
+        assert cause is not None, "GDAL's own error should be chained as __cause__"
+        assert "403" in str(cause), f"the chained cause lost GDAL's text: {cause!r}"
 
     def test_unopenable_signed_source_does_not_leak_its_credential(
         self, shared_crs_pair, monkeypatch

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -367,6 +367,27 @@ def disjoint_pair(tmp_path):
 class TestMergeRastersInputContracts:
     """Input/output contracts of ``merge_rasters`` beyond the overlap rule."""
 
+    def test_unopenable_source_is_named_end_to_end(self, tmp_path):
+        """A real failed open through ``merge_rasters`` names the source.
+
+        Test scenario:
+            No mocking -- real GDAL under ``gdal.UseExceptions()`` raises for a
+            missing source, and the wrapper must name it and its ``1/2``
+            position. This pins the catch type: if GDAL ever raised something
+            other than ``RuntimeError`` the wrapper would stop catching it and
+            this test would fail, which the monkeypatched tests cannot detect
+            (#1107).
+        """
+        good = write_raster(
+            tmp_path / "good.tif", np.ones((4, 4), dtype="float32"), (0, 4)
+        )
+        missing = str(tmp_path / "absent_tile.tif")
+        with pytest.raises(RuntimeError) as excinfo:
+            merge_rasters([missing, str(good)], tmp_path / "out.tif")
+        message = str(excinfo.value)
+        assert "absent_tile.tif" in message, f"source not named: {message}"
+        assert "1/2" in message, f"source position not reported: {message}"
+
     def test_zorder_init_fills_uncovered_pixels(self, disjoint_pair, tmp_path):
         """``init`` fills pixels no source covers on the z-order path.
 
@@ -734,7 +755,7 @@ class TestSourceBounds:
             A non-existent path cannot be opened, so the extent lookup fails loudly
             rather than returning a bogus extent.
         """
-        with pytest.raises(RuntimeError):
+        with pytest.raises(RuntimeError, match="could not open merge source"):
             _source_bounds("/no/such/raster/does-not-exist.tif")
 
     def test_raising_open_names_the_source(self, monkeypatch):

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -709,8 +709,12 @@ class TestMergeRastersDstCrs:
 
         pa, pb = shared_crs_pair
         monkeypatch.setattr(merge_mod.gdal, "Open", lambda *a, **k: None)
-        with pytest.raises(RuntimeError, match="GDAL returned no dataset"):
+        with pytest.raises(RuntimeError) as excinfo:
             merge_rasters([pa, pb], tmp_path / "x.tif")
+        message = str(excinfo.value)
+        assert "GDAL returned no dataset" in message, message
+        assert Path(pa).name in message, f"the failing source is not named: {message}"
+        assert "1/2" in message, f"the source position is missing: {message}"
 
 
 class TestSourceBounds:
@@ -777,12 +781,13 @@ class TestSourceBounds:
         )
 
     def test_open_returning_none_raises(self, monkeypatch):
-        """A ``None`` from ``gdal.Open`` still raises, for exceptions-disabled callers.
+        """A ``None`` from ``gdal.Open`` is classified, not returned to the caller.
 
         Test scenario:
             A caller running with ``gdal.DontUseExceptions()`` gets ``None`` from a
-            failed open rather than an exception, so the ``is None`` guard is the
-            branch that fires. It is kept alongside the raising path (#1107).
+            failed open rather than an exception. ``open_network_dataset`` brands
+            that shape too, so ``_source_bounds`` never has to guard for it -- this
+            pins that classification as seen from ``_source_bounds`` (#1107).
         """
         monkeypatch.setattr(merge_mod.gdal, "Open", lambda *a, **k: None)
         with pytest.raises(
@@ -1374,7 +1379,7 @@ class TestMergeNoneGuards:
         pa, pb = overlapping_pair
         monkeypatch.setattr(gdal, "Translate", lambda *a, **k: None)
         out = str(tmp_path / "o.tif")
-        with pytest.raises(RuntimeError, match="writing the mosaic returned no raster"):
+        with pytest.raises(RuntimeError, match="writing the mosaic produced no output"):
             merge_rasters([pa, pb], out, no_data_value=-1.0, method="last")
 
     def test_reduce_warp_none_raises(self, overlapping_pair, tmp_path, monkeypatch):

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -658,19 +658,29 @@ class TestMergeRastersDstCrs:
         with pytest.raises(RuntimeError, match="gdal.Open returned None"):
             merge_rasters([pa, pb], tmp_path / "x.tif")
 
+    @pytest.mark.parametrize(
+        "failing_index, expected_position", [(0, "1/2"), (1, "2/2")]
+    )
     def test_raising_open_names_the_source_and_its_position(
-        self, shared_crs_pair, monkeypatch
+        self, shared_crs_pair, monkeypatch, failing_index, expected_position
     ):
         """A raising ``gdal.Open`` names the failing source and how far the open got.
 
+        Args:
+            failing_index: Position of the unopenable remote source in ``src_paths``.
+            expected_position: The ``n/total`` marker the message must carry.
+
         Test scenario:
-            The second of two sources is a remote tile whose open raises a bare
+            One of two sources is a remote tile whose open raises a bare
             ``HTTP response code: 403`` -- GDAL names no source for a
             ``/vsicurl/`` path. ``_prepare_sources`` must report the URL, its
-            ``2/2`` position in ``src_paths``, and chain GDAL's message (#1107).
+            position in ``src_paths``, and chain GDAL's message (#1107). Both
+            positions are exercised so the reported index tracks the real one.
         """
         pa, _pb = shared_crs_pair
         remote = "/vsicurl/https://example.invalid/tile_B04_0042.tif"
+        paths = [pa, pa]
+        paths[failing_index] = remote
         real_open = merge_mod.gdal.Open
 
         def _raise_for_remote(path, *args, **kwargs):
@@ -680,10 +690,10 @@ class TestMergeRastersDstCrs:
 
         monkeypatch.setattr(merge_mod.gdal, "Open", _raise_for_remote)
         with pytest.raises(RuntimeError) as excinfo:
-            _prepare_sources([pa, remote], None)
+            _prepare_sources(paths, None)
         message = str(excinfo.value)
         assert "tile_B04_0042.tif" in message, f"source not named: {message}"
-        assert "2/2" in message, f"source position not reported: {message}"
+        assert expected_position in message, f"wrong position marker: {message}"
         assert "403" in message, f"GDAL's own message not preserved: {message}"
         assert isinstance(excinfo.value.__cause__, RuntimeError), (
             "GDAL's error should be chained as __cause__, not replaced"
@@ -751,6 +761,20 @@ class TestSourceBounds:
         assert isinstance(excinfo.value.__cause__, RuntimeError), (
             "GDAL's error should be chained as __cause__, not replaced"
         )
+
+    def test_open_returning_none_raises(self, monkeypatch):
+        """A ``None`` from ``gdal.Open`` still raises, for exceptions-disabled callers.
+
+        Test scenario:
+            A caller running with ``gdal.DontUseExceptions()`` gets ``None`` from a
+            failed open rather than an exception, so the ``is None`` guard is the
+            branch that fires. It is kept alongside the raising path (#1107).
+        """
+        monkeypatch.setattr(merge_mod.gdal, "Open", lambda *a, **k: None)
+        with pytest.raises(
+            RuntimeError, match="gdal.Open returned None for merge source"
+        ):
+            _source_bounds("/no/such/raster/does-not-exist.tif")
 
 
 class TestPrepareSources:

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -665,6 +665,29 @@ class TestMergeRastersDstCrs:
         with pytest.raises(RuntimeError, match="gdal.Warp returned None"):
             merge_rasters([pa, pb], tmp_path / "x.tif", dst_crs=3857)
 
+    def test_raising_warp_names_the_source(
+        self, shared_crs_pair, tmp_path, monkeypatch
+    ):
+        """A raising ``gdal.Warp`` names the source it could not reproject.
+
+        Test scenario:
+            Under ``gdal.UseExceptions()`` Warp raises rather than returning
+            None, so the reproject half of ``_prepare_sources`` must name the
+            source too -- the ``Raises:`` contract covers the whole function,
+            not just the open (#1107).
+        """
+        pa, pb = shared_crs_pair
+
+        def _raise(*_args, **_kwargs):
+            raise RuntimeError("Too many points failed to transform")
+
+        monkeypatch.setattr(merge_mod.gdal, "Warp", _raise)
+        with pytest.raises(RuntimeError) as excinfo:
+            merge_rasters([pa, pb], tmp_path / "x.tif", dst_crs=3857)
+        message = str(excinfo.value)
+        assert "could not reproject source" in message, f"unexpected message: {message}"
+        assert "failed to transform" in message, f"GDAL message not kept: {message}"
+
     def test_open_failure_raises(self, shared_crs_pair, tmp_path, monkeypatch):
         """A None from gdal.Open while reading source CRS raises RuntimeError.
 

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -344,10 +344,12 @@ class TestMergeMethod:
 
         pa, pb = overlapping_pair
         monkeypatch.setattr(merge_mod.gdal, "BuildVRT", lambda *a, **k: None)
-        with pytest.raises(
-            RuntimeError, match="building the union mosaic returned no raster"
-        ):
+        with pytest.raises(RuntimeError) as excinfo:
             merge_rasters([pa, pb], tmp_path / "x.tif", method="sum")
+        message = str(excinfo.value)
+        assert "building the union mosaic returned no raster" in message, message
+        assert Path(pa).name in message, f"sources are not named: {message}"
+        assert "Swig Object" not in message, f"a SWIG proxy leaked: {message}"
 
 
 @pytest.fixture(scope="function")
@@ -1380,10 +1382,37 @@ class TestMergeNoneGuards:
         pa, pb = overlapping_pair
         monkeypatch.setattr(gdal, "Warp", lambda *a, **k: None)
         out = str(tmp_path / "o.tif")
-        with pytest.raises(
-            RuntimeError, match="warping onto the union grid returned no raster"
-        ):
+        with pytest.raises(RuntimeError) as excinfo:
             _merge_reduce([pa, pb], out, "min", -1.0, "nan")
+        message = str(excinfo.value)
+        assert "warping onto the union grid returned no raster" in message, message
+        assert Path(pa).name in message, f"the failing source is not named: {message}"
+
+    def test_reduce_path_names_the_failing_source(
+        self, overlapping_pair, tmp_path, monkeypatch
+    ):
+        """The reduce methods name the source, like the z-order methods do.
+
+        Test scenario:
+            ``merge_rasters`` hands ``_merge_reduce`` open ``gdal.Dataset``
+            handles, whose repr is a SWIG proxy address. Before the labels were
+            threaded through, a failure on ``method="min"`` reported that proxy
+            instead of the file -- #1107's own complaint surviving on half the
+            public ``method`` surface. The message must name the file and carry
+            its ``1/2`` position, and must not leak a proxy repr.
+        """
+
+        def _raise(*_args, **_kwargs):
+            raise RuntimeError("Too many points failed to transform")
+
+        pa, pb = overlapping_pair
+        monkeypatch.setattr(merge_mod.gdal, "Warp", _raise)
+        with pytest.raises(RuntimeError) as excinfo:
+            merge_rasters([pa, pb], tmp_path / "o.tif", method="min")
+        message = str(excinfo.value)
+        assert Path(pa).name in message, f"the failing source is not named: {message}"
+        assert "1/2" in message, f"the source position is missing: {message}"
+        assert "Swig Object" not in message, f"a SWIG proxy leaked: {message}"
 
 
 class TestMergeRastersBbox:

--- a/tests/dataset/spatial/test_merge.py
+++ b/tests/dataset/spatial/test_merge.py
@@ -328,7 +328,9 @@ class TestMergeMethod:
 
         pa, pb = overlapping_pair
         monkeypatch.setattr(merge_mod.gdal, "BuildVRT", lambda *a, **k: None)
-        with pytest.raises(RuntimeError, match="gdal.BuildVRT returned None"):
+        with pytest.raises(
+            RuntimeError, match="building the source mosaic returned no raster"
+        ):
             merge_rasters([pa, pb], tmp_path / "x.tif", method="last")
 
     def test_failed_vrt_reduce_raises(self, overlapping_pair, tmp_path, monkeypatch):
@@ -342,7 +344,9 @@ class TestMergeMethod:
 
         pa, pb = overlapping_pair
         monkeypatch.setattr(merge_mod.gdal, "BuildVRT", lambda *a, **k: None)
-        with pytest.raises(RuntimeError, match="gdal.BuildVRT returned None"):
+        with pytest.raises(
+            RuntimeError, match="building the union mosaic returned no raster"
+        ):
             merge_rasters([pa, pb], tmp_path / "x.tif", method="sum")
 
 
@@ -662,7 +666,9 @@ class TestMergeRastersDstCrs:
 
         pa, pb = shared_crs_pair
         monkeypatch.setattr(merge_mod.gdal, "Warp", lambda *a, **k: None)
-        with pytest.raises(RuntimeError, match="gdal.Warp returned None"):
+        with pytest.raises(
+            RuntimeError, match="reprojecting to the target CRS returned no raster"
+        ):
             merge_rasters([pa, pb], tmp_path / "x.tif", dst_crs=3857)
 
     def test_raising_warp_names_the_source(
@@ -685,7 +691,9 @@ class TestMergeRastersDstCrs:
         with pytest.raises(RuntimeError) as excinfo:
             merge_rasters([pa, pb], tmp_path / "x.tif", dst_crs=3857)
         message = str(excinfo.value)
-        assert "could not reproject source" in message, f"unexpected message: {message}"
+        assert "reprojecting to the target CRS failed for source" in message, (
+            f"unexpected message: {message}"
+        )
         assert "failed to transform" in message, f"GDAL message not kept: {message}"
 
     def test_open_failure_raises(self, shared_crs_pair, tmp_path, monkeypatch):
@@ -1364,7 +1372,7 @@ class TestMergeNoneGuards:
         pa, pb = overlapping_pair
         monkeypatch.setattr(gdal, "Translate", lambda *a, **k: None)
         out = str(tmp_path / "o.tif")
-        with pytest.raises(RuntimeError, match="Translate returned None"):
+        with pytest.raises(RuntimeError, match="writing the mosaic returned no raster"):
             merge_rasters([pa, pb], out, no_data_value=-1.0, method="last")
 
     def test_reduce_warp_none_raises(self, overlapping_pair, tmp_path, monkeypatch):
@@ -1372,7 +1380,9 @@ class TestMergeNoneGuards:
         pa, pb = overlapping_pair
         monkeypatch.setattr(gdal, "Warp", lambda *a, **k: None)
         out = str(tmp_path / "o.tif")
-        with pytest.raises(RuntimeError, match="Warp returned None"):
+        with pytest.raises(
+            RuntimeError, match="warping onto the union grid returned no raster"
+        ):
             _merge_reduce([pa, pb], out, "min", -1.0, "nan")
 
 


### PR DESCRIPTION
# Description

`merge_rasters` already tried to name a source it could not open, but the guard was `if dataset is None` — and
pyramids enables `gdal.UseExceptions()` at import, so `gdal.Open` **raises** and that branch never runs. For a local
path GDAL's own message carries the path; for a `/vsicurl/` or `/vsis3/` source it is a bare HTTP status naming
nothing, so a mosaic over dozens of remote tiles gave the caller no way to tell which tile was unreadable:

```
before:  RuntimeError: HTTP response code: 403
after :  RuntimeError: could not open source 2/2 '/vsicurl/http://.../tile_B04_0042.tif': HTTP response code: 403
```

## What this changes

**Sources are named on every path.** `merge_rasters` hands the reduce methods (`min`/`max`/`sum`) the *open
`gdal.Dataset` handles* `_prepare_sources` returned, not the paths — so a failure there rendered a SWIG proxy address
(`<osgeo.gdal.Dataset; proxy of <Swig Object … at 0x…>>`), i.e. #1107's own complaint surviving on half the public
`method` surface. A `_Source` pair carries the label alongside the handle through `_merge_reduce` /
`_reduce_strip` / `_warp_onto_strip`, so the reduce methods now name the file and its `n/total` position like the
z-order ones already did. Bare paths still work, so the helpers can still be called directly.

**No GDAL call in `merge.py` classifies its own failure any more.** ARC-331 (PR #1084) had already consolidated
"open a GDAL source and brand both failure shapes" into `base/_coverage.open_network_dataset`; this generalises it to
`run_gdal_op`, which takes any dataset-producing call — `BuildVRT`, `Warp`, `Translate`, a driver's `Create` — and
brands both shapes. Every one of those calls in `merge.py` had a bare `if x is None` guard whose message could never
print under `UseExceptions()`; one even called an unreachable `gdal.GetLastErrorMsg()`, which reads like working
diagnostics. Options are built and drivers resolved *outside* the guarded call, so a bad argument is not re-branded
as a source failure, and each call is bound with `functools.partial` rather than a lambda over a loop variable.

**Credentials are redacted, in one place.** `merge_rasters` signs every source before opening it, so naming the
source would have published a live SAS/presigned URL to whatever consumes the exception. Redaction lives inside the
shared helpers, so it applies to merge, the WCS/WMS/OGC readers, COG writes and STAC VRT builds alike.
`redact_credentials` itself had a gap: its value pattern stopped at the first space, so
`header.Authorization=Bearer abc123` blanked the word `Bearer` and printed the token. An auth scheme is now consumed
together with its credential.

**Three other idioms folded in.** `cog/write.py` was a line-for-line duplicate of the helper's body that interpolated
its destination unredacted; `stac/_vrt.py` solved the same problem a third way and kept an unreachable `is None`
guard. Both now call the helper. `translate_to_mem` — the helper's own sibling — was hand-building the same two
messages and was the one that did *not* redact, while every reader calls it right after the one that does.

No new dependencies.

# Issues

- Closes #1107 — a remote source that cannot be opened is reported without its URL

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] **Mock-free, against real GDAL**: `merge_rasters` with a missing source asserts the message names it and its
  `1/2` position; the `_source_bounds` real-GDAL test matches the wrapper's message rather than only the exception
  type. These pin the catch type — the premise the fix rests on — which monkeypatched tests cannot.
- [x] **The reduce path**: a regression test asserts `method="min"` names the file, carries the position, and leaks
  no SWIG proxy. Verified to fail against `main`.
- [x] **Credential redaction**: a source signed `?sig=SECRETTOKEN` fails with `<redacted>` and no token, on all three
  shared helpers; `Bearer <token>`, `Basic <b64>`, `Digest` and `Token` schemes each redact whole, while query
  options still stop at `&` and an ordinary GDAL sentence is untouched.
- [x] **The helper itself**: both failure shapes, the hint on each, the success path, and the redaction — in
  `tests/base/test_coverage_gdal_primitives.py`, the file that declares itself their home.
- [x] Every new assertion was confirmed to **fail against `main`** and pass with the change.
- [x] Regression: 529 passed across `remote`, the shared primitives, merge and all three OGC readers; 751 across
  cog + STAC; doctests green; `ruff check` / `format --check` clean at the pinned `v0.15.22`; changed surface fully
  covered (`merge.py` 99%, `_coverage.py` 98%, both remaining misses pre-existing and outside the diff).

Reproduce:

```bash
pixi run -e dev pytest tests/dataset/spatial/test_merge.py tests/base/test_coverage_gdal_primitives.py \
  tests/base/test_remote.py tests/dataset/cog tests/stac -q
```

# Checklist:

- [ ] updated version number in pyproject.toml. (handled by commitizen in CI)
- [ ] added changes to History.rst. (commitizen-generated changelog)
- [ ] updated the latest version in README file. (n/a)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. (`merge_rasters`' public `Raises:` carries the naming + redaction contract; the
  `_coverage` module docstring names all three helpers, their redaction and `merge.py` as a consumer)
