### PR TITLE
fix(netcdf)!: materialise a non-raster variable instead of leaking a gdal.MDArray

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -40,10 +40,13 @@ A NetCDF file holds *several* variables, so `NetCDF.read_file` cannot return "a 
 nc = NetCDF.read_file("air.nc")     # Container: band_count == 0
 nc.variable_names                    # ['t2m', 'tp', ...]
 t2m = nc.get_variable("t2m")         # Variable: band_count >= 1 — read_array / crop / plot / to_file
+bnds = nc.get_variable("time_bnds")  # LabeledArray: a 1-D or string array — .values / .dims / .unit
 grp = nc.get_group("subgroup")       # a nested netCDF-4 group, itself a container
 ```
 
-`get_variable` / `variables[name]` / `sel` / `subset` all narrow a container to a variable. See the
+`get_variable` / `variables[name]` / `sel` / `subset` all narrow a container to a variable. A variable GDAL can
+expose as a raster comes back as a `Variable`; one it cannot — a 1-D array, or a string or compound one — comes
+back as a `LabeledArray`, which holds the values and their labels but has no raster operations. See the
 [NetCDF reference](reference/netcdf/index.md) for the full model.
 
 ## Glossary

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -947,8 +947,18 @@ bounds.shape                              # (2,)
 - **Replace the GDAL calls with attributes.** `ReadAsArray()` → `.values`, `GetDimensions()` → `.dims` / `.shape`,
   `GetDataType()` → `.values.dtype`. `Read()` has no replacement and needs none: it returned an *undecoded* byte
   buffer for numeric data, which is why reading these variables used to require `ReadAsArray()` instead.
-- **A compound variable now decodes.** It reads back through the NumPy structured dtype matching GDAL's declared
-  components, so `.values` is a record array rather than the flat byte buffer `Read()` produced.
+- **A compound variable now decodes.** It reads back as a record array rather than the flat byte buffer `Read()`
+  produced.
+- **The labels come with it.** `LabeledArray` carries `name`, `unit`, `no_data_value` and `attributes` alongside
+  `values`, so `GetUnit()` → `.unit`, `GetNoDataValueAsDouble()` → `.no_data_value`, and the attribute API →
+  `.attributes`. Without these a `-9999.0` in `values` would be indistinguishable from real data.
+- **Values are as stored.** No CF time decoding and no `scale_factor` / `add_offset`, matching `read_array`'s own
+  `unpack=False` default — `read_array(name, unpack=True)` is still the way to ask for unpacked values.
+  `LabeledDataset["var"]` returns the same class but *does* decode a CF time axis, so the two agree on type and
+  not always on values.
+- **Windowed and strided reads are gone.** The `MDArray` allowed `Read(array_start_idx=..., count=...)` and
+  `GetView`; the wrapper is materialised, so slice `.values` instead. For a variable large enough that this
+  matters, `read_array` remains the streaming route.
 - **Nothing new raises.** Every variable that could be read before can still be read; only the type of the object
   changed. `LabeledArray` is the same class `LabeledDataset["var"]` already returned, exported from
   `pyramids.netcdf`.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -932,6 +932,28 @@ replace the georeference wholesale.
 
 ### unreleased
 
+**`get_variable` returns a `LabeledArray`, not a raw `gdal.MDArray`, for a variable with no raster plane.**
+Two shapes are affected: a 1-D array (a profile axis, a bounds array, a hybrid-sigma coefficient), and a string or
+compound array of any rank — a character column is stored `(records, strlen)`, so it is 2-D and still not numeric.
+GDAL cannot expose either as a raster, and `get_variable` used to hand the `MDArray` straight back.
+
+```python
+bounds = nc.get_variable("time_bounds")   # was gdal.MDArray, now LabeledArray
+bounds.values                             # np.ndarray  (was: bounds.ReadAsArray())
+bounds.dims                               # ('number_of_time_bounds',)
+bounds.shape                              # (2,)
+```
+
+- **Replace the GDAL calls with attributes.** `ReadAsArray()` → `.values`, `GetDimensions()` → `.dims` / `.shape`,
+  `GetDataType()` → `.values.dtype`. `Read()` has no replacement and needs none: it returned an *undecoded* byte
+  buffer for numeric data, which is why reading these variables used to require `ReadAsArray()` instead.
+- **A compound variable now decodes.** It reads back through the NumPy structured dtype matching GDAL's declared
+  components, so `.values` is a record array rather than the flat byte buffer `Read()` produced.
+- **Nothing new raises.** Every variable that could be read before can still be read; only the type of the object
+  changed. `LabeledArray` is the same class `LabeledDataset["var"]` already returned, exported from
+  `pyramids.netcdf`.
+- The private `_read_md_array` still returns the `MDArray` — only the public accessor wraps.
+
 **A time axis outside `datetime64[ns]`'s range now decodes to `cftime` objects instead of wrapping.**
 Soft change, warned — a `UserWarning` names the axis and its units. Only arrays that were previously **wrong** change:
 `decode_cf_time` cast to `datetime64[ns]` under a guard that cannot fire, because a date beyond the type's

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -934,8 +934,7 @@ replace the georeference wholesale.
 
 **`get_variable` returns a `LabeledArray`, not a raw `gdal.MDArray`, for a variable with no raster plane.**
 Two shapes are affected: a 1-D array (a profile axis, a bounds array, a hybrid-sigma coefficient), and a string or
-compound array of any rank — a character column is stored `(records, strlen)`, so it is 2-D and still not numeric.
-GDAL cannot expose either as a raster, and `get_variable` used to hand the `MDArray` straight back.
+compound array. GDAL cannot expose either as a raster, and `get_variable` used to hand the `MDArray` straight back.
 
 ```python
 bounds = nc.get_variable("time_bounds")   # was gdal.MDArray, now LabeledArray
@@ -945,24 +944,34 @@ bounds.shape                              # (2,)
 ```
 
 - **Replace the GDAL calls with attributes.** `ReadAsArray()` → `.values`, `GetDimensions()` → `.dims` / `.shape`,
-  `GetDataType()` → `.values.dtype`. `Read()` has no replacement and needs none: it returned an *undecoded* byte
-  buffer for numeric data, which is why reading these variables used to require `ReadAsArray()` instead.
-- **A compound variable now decodes.** It reads back as a record array rather than the flat byte buffer `Read()`
-  produced.
-- **The labels come with it.** `LabeledArray` carries `name`, `unit`, `no_data_value` and `attributes` alongside
-  `values`, so `GetUnit()` → `.unit`, `GetNoDataValueAsDouble()` → `.no_data_value`, and the attribute API →
-  `.attributes`. Without these a `-9999.0` in `values` would be indistinguishable from real data.
-- **Values are as stored.** No CF time decoding and no `scale_factor` / `add_offset`, matching `read_array`'s own
-  `unpack=False` default — `read_array(name, unpack=True)` is still the way to ask for unpacked values.
-  `LabeledDataset["var"]` returns the same class but *does* decode a CF time axis, so the two agree on type and
-  not always on values.
+  `GetDataType()` → `.values.dtype`. For a **string** variable `Read()` was the reader (`ReadAsArray` cannot serve
+  one), and its replacement is `.values` — or `.values.tolist()` for the plain list `Read()` returned.
+- **The labels come with it.** `GetUnit()` → `.unit`, `GetNoDataValueAsDouble()` → `.no_data_value`,
+  `GetScale()` / `GetOffset()` → `.scale` / `.offset`, and the attribute API → `.attributes`. Without these a
+  `-9999.0` in `values` would be indistinguishable from real data, and a packed variable's unit would label the
+  wrong numbers. `.name` is the name you asked for, group path included.
+- **Values are as stored.** No CF time decoding, and no `scale_factor` / `add_offset` applied — matching
+  `read_array`'s own `unpack=False` default. Unpack with `.values * .scale + .offset`, or ask
+  `read_array(name, unpack=True)`.
+- **A string variable is `object`**, holding `str` and `None` for a missing entry. A `<U` array cannot represent a
+  missing entry, so letting NumPy choose made the dtype depend on whether every record happened to be written.
+- **A compound variable decodes to a structured `ndarray`** — index fields with `values["code"]`; it is not an
+  `np.recarray`, so `values.code` does not work. GDAL's netCDF driver reduces a fixed-length character-array member
+  of a compound to its first byte (`u1`); that is a driver limitation this does not correct.
 - **Windowed and strided reads are gone.** The `MDArray` allowed `Read(array_start_idx=..., count=...)` and
-  `GetView`; the wrapper is materialised, so slice `.values` instead. For a variable large enough that this
-  matters, `read_array` remains the streaming route.
-- **Nothing new raises.** Every variable that could be read before can still be read; only the type of the object
-  changed. `LabeledArray` is the same class `LabeledDataset["var"]` already returned, exported from
-  `pyramids.netcdf`.
-- The private `_read_md_array` still returns the `MDArray` — only the public accessor wraps.
+  `GetView`; the wrapper is materialised whole, so slice `.values`. There is no windowed route for these variables
+  now: `read_array(variable=...)` also reads the whole array, and refuses `window`, `bbox` and `chunks` for them.
+- **`nc.variables[name].values` is read-only** for these variables. The mapping caches one object per name and
+  hands it to every caller, so a write would have been visible through `variables` but not `get_variable` or
+  `read_array`. Take `.copy()` to modify it; `get_variable` returns a fresh, writeable wrapper each call.
+- **Two things now raise that did not.** A compound record with a string field cannot be read through GDAL's Python
+  bindings by any means, so `get_variable` refuses it by name with a `ValueError`, where it used to return an
+  unreadable handle. And the raster-only operations — `crop_variable`, `reproject_variable`, `resample_variable`,
+  `plot(variable=)`, `open_mfdataset(variable=)` — refuse a non-raster variable with a `ValueError` naming it,
+  where they used to fail with `AttributeError: 'MDArray' object has no attribute ...`.
+- `LabeledArray` is the class `LabeledDataset["var"]` already returned, exported from `pyramids.netcdf`. The two
+  agree on type but not always on values: `LabeledDataset` decodes a CF time axis and applies its store's current
+  selection. The private `_read_md_array` still returns the `MDArray`; only the public accessor wraps.
 
 **A time axis outside `datetime64[ns]`'s range now decodes to `cftime` objects instead of wrapping.**
 Soft change, warned — a `UserWarning` names the axis and its units. Only arrays that were previously **wrong** change:

--- a/docs/reference/netcdf/index.md
+++ b/docs/reference/netcdf/index.md
@@ -14,6 +14,12 @@ variable access, time dimension handling, and CF-compliant metadata.
 `variables[name]`, `sel`, or `subset` returns a **`Variable`** — a `NetCDF` with `band_count >= 1`
 that behaves as a single raster. `get_group` opens a nested NetCDF-4 group as its own container.
 
+A variable GDAL cannot expose as a raster — a 1-D array such as a bounds or coordinate series, or a
+string or compound array of any rank — comes back from `get_variable` and `variables[name]` as a
+**`LabeledArray`** instead: its `values`, `dims` and `shape`, plus the `name`, `unit`,
+`no_data_value`, `scale`, `offset` and `attributes` it declares. It has no raster operations, so
+`crop_variable` and the other raster-only methods refuse it by name.
+
 ```mermaid
 flowchart LR
     F[(".nc file · bytes · many files")]
@@ -22,6 +28,8 @@ flowchart LR
     C -->|get_group| C
     C -->|"get_variable · variables[name]<br/>sel · subset"| V
     V["Variable<br/>NetCDF, band_count >= 1<br/>one variable as a raster"]
+    C -->|"get_variable · variables[name]<br/>(1-D, string, compound)"| L
+    L["LabeledArray<br/>values + dims + labels<br/>no raster operations"]
     V -->|plot| G(["cleopatra glyph"])
     C -. "read_array · crop · reduce · to_crs · to_file" .-> V
 ```

--- a/src/pyramids/netcdf/_mfdataset.py
+++ b/src/pyramids/netcdf/_mfdataset.py
@@ -70,7 +70,7 @@ def _open_and_extract(
     from pyramids.netcdf import NetCDF
 
     nc = NetCDF.read_file(path)
-    variable_subset = nc.get_variable(variable)
+    variable_subset = nc._require_raster_variable(variable)
     if preprocess is not None:
         variable_subset = preprocess(variable_subset)
     return variable_subset.read_array(chunks=chunks)

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -705,7 +705,7 @@ class NetCDFPlot:
                 )
             # x_dim / y_dim are applied here via get_variable; forward only the coord pair so the
             # re-resolved subset does not try to re-apply axes it already has.
-            return nc._parent_nc.get_variable(
+            return nc._parent_nc._require_raster_variable(
                 nc._source_var_name, x_dim=axes.x_dim, y_dim=axes.y_dim
             ).plot(
                 selectors=selectors,
@@ -854,7 +854,9 @@ class NetCDFPlot:
         axes = axes or CoordinateSpec()
         # x_dim / y_dim are applied here via get_variable; forward only the coord pair so the
         # subset's plot does not re-resolve axes it already has.
-        return nc.get_variable(variable, x_dim=axes.x_dim, y_dim=axes.y_dim).plot(
+        return nc._require_raster_variable(
+            variable, x_dim=axes.x_dim, y_dim=axes.y_dim
+        ).plot(
             axes=CoordinateSpec(coords=axes.coords), **plot_kwargs
         )
 

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -856,9 +856,7 @@ class NetCDFPlot:
         # subset's plot does not re-resolve axes it already has.
         return nc._require_raster_variable(
             variable, x_dim=axes.x_dim, y_dim=axes.y_dim
-        ).plot(
-            axes=CoordinateSpec(coords=axes.coords), **plot_kwargs
-        )
+        ).plot(axes=CoordinateSpec(coords=axes.coords), **plot_kwargs)
 
     def _resolve_selectors(self, nc: NetCDF, selectors: Selectors) -> dict[str, Any]:
         """Flatten a :class:`Selectors` into a ``{dim_name: label}`` dict.

--- a/src/pyramids/netcdf/_plot.py
+++ b/src/pyramids/netcdf/_plot.py
@@ -834,15 +834,17 @@ class NetCDFPlot:
             ``FacetGrid`` from cleopatra).
 
         Raises:
-            ValueError: If ``variable`` is ``None`` — the message lists the
+            ValueError: If `variable` is `None` — the message lists the
                 **gridded** variable names, which is what this call can actually
                 plot. Neither of the other two lists is right here:
-                ``variable_names`` omits a gridded ancillary array (GOES ABI's
-                ``DQF`` plots fine and is not enumerated), while the readable
-                superset adds 1-D arrays (``time_bounds``, ``band_id``) that
-                ``get_variable`` hands back as a raw ``gdal.MDArray`` with no
-                ``plot`` at all. An empty list therefore means the container holds
-                nothing plottable, which is a true and useful answer.
+                `variable_names` omits a gridded ancillary array (GOES ABI's
+                `DQF` plots fine and is not enumerated), while the readable
+                superset adds 1-D arrays (`time_bounds`, `band_id`) that
+                `get_variable` returns as a `LabeledArray`, which has no `plot`.
+                An empty list therefore means the container holds nothing
+                plottable, which is a true and useful answer. Also raised when
+                `variable` names one of those non-raster arrays: it is refused
+                by name rather than failing on the missing `plot`.
         """
         if variable is None:
             raise ValueError(

--- a/src/pyramids/netcdf/engines/selection.py
+++ b/src/pyramids/netcdf/engines/selection.py
@@ -670,7 +670,7 @@ class Selection(_Engine["NetCDF"]):
         )
         # from_array returns a root container; hand back the variable subset, carrying the
         # windowed 2-D coordinates so the result stays curvilinear (plots on its real geometry).
-        result = container.get_variable(var_name)
+        result = container._require_raster_variable(var_name)
         result._curvilinear_coords = (lon_win, lat_win)
         return result
 
@@ -1146,7 +1146,7 @@ class Selection(_Engine["NetCDF"]):
         result = None
         found = False
         for var_name in spatial_vars:
-            var = nc.get_variable(var_name)
+            var = nc._require_raster_variable(var_name)
             band_names = list(var._band_dim_names)
             values_map = dict(var._band_dim_values_map)
             ndv = scalar_no_data(var.no_data_value)

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -1255,6 +1255,8 @@ class LabeledArray:
         "unit",
         "no_data_value",
         "attributes",
+        "scale",
+        "offset",
     )
 
     def __init__(
@@ -1267,6 +1269,8 @@ class LabeledArray:
         unit: str = "",
         no_data_value: float | None = None,
         attributes: dict[str, Any] | None = None,
+        scale: float | None = None,
+        offset: float | None = None,
     ):
         """Hold a materialised array with the labels that describe it.
 
@@ -1279,6 +1283,10 @@ class LabeledArray:
             no_data_value: The fill value, where the source declares one --
                 the values themselves are not masked by it.
             attributes: The variable's other attributes.
+            scale: The CF `scale_factor`, where the values are packed. GDAL
+                lifts it out of the attribute list, so it lives here rather
+                than in `attributes`.
+            offset: The CF `add_offset`, likewise.
         """
         self.values = values
         self.dims = dims
@@ -1287,6 +1295,8 @@ class LabeledArray:
         self.unit = unit
         self.no_data_value = no_data_value
         self.attributes = attributes if attributes is not None else {}
+        self.scale = scale
+        self.offset = offset
 
     def __repr__(self) -> str:
         label = f"{self.name!r}, " if self.name else ""

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -1157,7 +1157,7 @@ class LabeledDataset:
         return False
 
     def __getitem__(self, key: str) -> LabeledArray:
-        """Return a variable or coordinate as a small `(values, dims, shape)` view."""
+        """Return a variable or coordinate as a materialised `LabeledArray`."""
         if key not in self._coord_names and key not in self._var_names:
             raise KeyError(f"{key!r} is not in this store")
         values, dims = self._read(key)
@@ -1196,7 +1196,8 @@ class LabeledArray:
             array for a compound one, and `object` for a string one -- from either producer,
             so a missing entry stays `None` rather than being coerced.
         dims: The dimension names, outermost first.
-        shape: The shape those dimensions declare, which always matches `values.shape`.
+        shape: The shape those dimensions declare. Both producers build it from the same
+            read that fills `values`, so the two agree; the constructor itself does not check.
         name: The variable's name, or `""` when the producer does not set it.
         unit: The CF `units` string, or `""` when the source declares none.
         no_data_value: The declared fill value, or `None`. `values` is **not** masked by it.

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -1347,6 +1347,23 @@ class LabeledArray:
             )
         object.__setattr__(self, name, value)
 
+    def __delattr__(self, name: str) -> None:
+        """Refuse a deletion once the instance is frozen.
+
+        Args:
+            name: The attribute to delete.
+
+        Raises:
+            AttributeError: The instance is frozen; `__setattr__` alone left
+                `del entry.unit` free to change the shared cache entry.
+        """
+        if getattr(self, "_frozen", False):
+            raise AttributeError(
+                f"cannot delete {name!r}: this LabeledArray is frozen; take "
+                "`.copy()` to modify one of your own"
+            )
+        object.__delattr__(self, name)
+
     def freeze(self) -> None:
         """Make the instance and its array read-only, in place.
 
@@ -1429,8 +1446,24 @@ class LabeledArray:
         See Also:
             `LabeledArray.copy`: a mutable, independent instance, frozen original or not.
         """
-        self.values.setflags(write=False)
-        object.__setattr__(self, "attributes", MappingProxyType(dict(self.attributes)))
+        # A read-only *view* of a read-only base, not the array itself. numpy
+        # lets anyone call `setflags(write=True)` on an array that owns its
+        # data, which re-opened the cache: it then answered `[11, 21, 31]` while
+        # `get_variable` still said `[10, 20, 30]`. A view whose base is not
+        # writeable cannot be made writeable, so this lock holds.
+        base = self.values
+        base.setflags(write=False)
+        locked = base.view()
+        locked.setflags(write=False)
+        object.__setattr__(self, "values", locked)
+        # Attribute values are frozen too: a multi-valued attribute comes back
+        # as a list, which the read-only mapping around it did not stop anyone
+        # mutating in place.
+        frozen_attributes = {
+            key: tuple(value) if isinstance(value, list) else value
+            for key, value in self.attributes.items()
+        }
+        object.__setattr__(self, "attributes", MappingProxyType(frozen_attributes))
         object.__setattr__(self, "_frozen", True)
 
     def copy(self) -> LabeledArray:

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -1185,24 +1185,36 @@ class LabeledArray:
     a label-indexed store, with the store's current selection applied and a CF time axis
     decoded; `NetCDF.get_variable` returns one for a variable GDAL cannot expose as a raster
     — a 1-D array of any dtype, or a non-numeric one of any rank — with the values exactly as
-    stored. Only the second populates `name` / `unit` / `no_data_value` / `attributes`; the
-    first leaves all four at their defaults. `_LabeledArray` is kept as a backward-compatible
-    alias.
+    stored. Only the second populates `name` / `unit` / `no_data_value` / `attributes` /
+    `scale` / `offset`; the first leaves all six at their defaults. `_LabeledArray` is kept as
+    a backward-compatible alias.
 
     This is a plain value holder: it defines `__slots__`, holds no GDAL handle, and does no
-    lazy reading — the values are already in NumPy's own memory by the time you have one.
+    lazy reading — the values are already in NumPy's own memory by the time you have one. It
+    is mutable until `freeze` runs. The `NetCDF.variables` mapping freezes each one it hands
+    out, since it gives the same object to every caller, while `get_variable` returns a fresh,
+    writeable one each call; `copy` gives a mutable instance of either.
 
     Attributes:
-        values: The materialised array. `float`/`int` for a numeric source, a structured
-            array for a compound one, and `object` for a string one -- from either producer,
-            so a missing entry stays `None` rather than being coerced.
+        values: The materialised array: the source's own numeric dtype for a numeric array, a
+            structured array for a compound one, and `object` for a string one -- from either
+            producer, so a NULL string entry stays `None` rather than being coerced. The one
+            exception is an array with CF time units read through `LabeledDataset`, which is
+            decoded to `datetime64[ns]`, or to `cftime` objects for a non-standard calendar or
+            a date outside that type's range.
         dims: The dimension names, outermost first.
-        shape: The shape those dimensions declare. Both producers build it from the same
-            read that fills `values`, so the two agree; the constructor itself does not check.
+        shape: The shape those dimensions declare. `get_variable` takes it from the declared
+            dimensions and refuses a read that disagrees; `LabeledDataset` takes it from
+            `values.shape`. The constructor itself does not check.
         name: The variable's name, or `""` when the producer does not set it.
         unit: The CF `units` string, or `""` when the source declares none.
-        no_data_value: The declared fill value, or `None`. `values` is **not** masked by it.
+        no_data_value: The declared fill value, or `None`: an exact `int` for a 64-bit integer
+            source and a `float` otherwise. `values` is **not** masked by it.
         attributes: The variable's other attributes, `{}` when the producer does not set them.
+        scale: The CF `scale_factor` of packed values, or `None` when none is declared. GDAL
+            lifts it out of the attribute list, which is why it is here and not in `attributes`.
+        offset: The CF `add_offset`, or `None`, likewise. `values` stays packed; unpacking is
+            `values * scale + offset`, reading a `None` as `1` and `0` respectively.
 
     Examples:
         - Build one directly and read the values back:
@@ -1243,10 +1255,24 @@ class LabeledArray:
             LabeledArray(dims=('record', 'strlen'), shape=(2, 3))
 
             ```
+        - A packed variable keeps its stored integers and carries what unpacking them needs:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.netcdf import LabeledArray
+            >>> height = LabeledArray(
+            ...     np.array([10, 15], dtype="int16"), ("time",), (2,), scale=1.0, offset=95.0
+            ... )
+            >>> height.values.tolist()
+            [10, 15]
+            >>> (height.values * height.scale + height.offset).tolist()
+            [105.0, 110.0]
+
+            ```
 
     See Also:
         `LabeledDataset.__getitem__`: reads one out of a label-indexed store.
         `pyramids.netcdf.NetCDF.get_variable`: returns one for a variable with no raster plane.
+        `LabeledArray.freeze` / `LabeledArray.copy`: lock an instance, or get a mutable one.
     """
 
     __slots__ = (
@@ -1302,16 +1328,17 @@ class LabeledArray:
         self.offset = offset
 
     def __setattr__(self, name: str, value: Any) -> None:
-        """Refuse a change once the instance is frozen.
+        """Assign as usual until `freeze` has run, and refuse every assignment after it.
 
         Args:
             name: The attribute to set.
             value: Its new value.
 
         Raises:
-            AttributeError: The instance is frozen -- it is the one the
-                `variables` cache hands to every caller, so a change here would
-                show through that mapping and nowhere else.
+            AttributeError: The instance is frozen. Every `LabeledArray` the
+                `variables` cache holds is, because that mapping hands one object to
+                every caller and a change to it would show there and nowhere else;
+                `copy` gives a mutable one.
         """
         if getattr(self, "_frozen", False):
             raise AttributeError(
@@ -1321,22 +1348,138 @@ class LabeledArray:
         object.__setattr__(self, name, value)
 
     def freeze(self) -> None:
-        """Make the instance and its array read-only.
+        """Make the instance and its array read-only, in place.
 
-        Used by the `variables` cache, which hands one object to every caller:
-        a change to it would show through that mapping while `get_variable` and
-        `read_array` still answered the stored values.
+        The `variables` cache calls this on every `LabeledArray` it stores, because it
+        hands one object to every caller: a change to it would show through that
+        mapping while `get_variable` and `read_array` still answered the stored values.
+
+        Freezing does three things. It clears the `WRITEABLE` flag of `values`, so a
+        write into the array raises `ValueError`; it replaces `attributes` with a
+        read-only `MappingProxyType` over a shallow copy of it, so item assignment
+        raises `TypeError`; and it makes `__setattr__` refuse every later assignment
+        with `AttributeError`. Freezing an instance twice is harmless.
+
+        Note:
+            The lock is not tamper-proof. NumPy lets `values.setflags(write=True)` set
+            the flag back on an array that owns its memory; a mutable value inside
+            `attributes` -- GDAL reads a multi-valued string attribute back as a
+            `list` -- can still be changed in place; and `del` on a field is not
+            refused. To change the data, take a `copy`.
+
+        Examples:
+            - A write into the frozen array is refused, while reading it carries on:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.netcdf import LabeledArray
+                >>> series = LabeledArray(np.array([10, 20, 30]), ("time",), (3,), unit="K")
+                >>> series.freeze()
+                >>> series.values.flags.writeable
+                False
+                >>> series.values[0] = 99
+                Traceback (most recent call last):
+                    ...
+                ValueError: assignment destination is read-only
+                >>> series.values.tolist(), series.unit
+                ([10, 20, 30], 'K')
+
+                ```
+            - The labels are locked too, the attribute mapping item by item:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.netcdf import LabeledArray
+                >>> series = LabeledArray(
+                ...     np.array([10, 20, 30]), ("time",), (3,), attributes={"long_name": "t2m"}
+                ... )
+                >>> series.freeze()
+                >>> series.unit = "K"  # doctest: +ELLIPSIS
+                Traceback (most recent call last):
+                    ...
+                AttributeError: cannot set 'unit': this LabeledArray is shared by the ...
+                >>> series.attributes["long_name"] = "air temperature"
+                Traceback (most recent call last):
+                    ...
+                TypeError: 'mappingproxy' object does not support item assignment
+                >>> series.attributes["long_name"]
+                't2m'
+
+                ```
+            - The `variables` mapping hands out a frozen instance, `get_variable` a
+              writeable one:
+                ```python
+                >>> import numpy as np
+                >>> from osgeo import gdal
+                >>> from pyramids.netcdf import Container
+                >>> store = gdal.GetDriverByName("MEM").CreateMultiDimensional("demo")
+                >>> group = store.GetRootGroup()
+                >>> time = group.CreateDimension("time", None, None, 3)
+                >>> t2m = group.CreateMDArray(
+                ...     "t2m", [time], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+                ... )
+                >>> t2m.Write(np.array([280.0, 281.5, 283.0]))
+                0
+                >>> nc = Container(store)
+                >>> nc.variables["t2m"].values.flags.writeable
+                False
+                >>> nc.get_variable("t2m").values.flags.writeable
+                True
+
+                ```
+
+        See Also:
+            `LabeledArray.copy`: a mutable, independent instance, frozen original or not.
         """
         self.values.setflags(write=False)
         object.__setattr__(self, "attributes", MappingProxyType(dict(self.attributes)))
         object.__setattr__(self, "_frozen", True)
 
     def copy(self) -> LabeledArray:
-        """A mutable, independent copy -- of a frozen instance or any other.
+        """Return a mutable, independent copy -- of a frozen instance or any other.
+
+        The copy is never frozen, whatever the original is. `values` is copied, so a
+        write into one array never shows in the other, and `attributes` becomes a new
+        plain `dict` -- a shallow copy, so a mutable value inside it is still shared.
+        The remaining labels -- tuples, strings, numbers or `None` -- are carried over
+        as they are.
 
         Returns:
-            LabeledArray: The same values and labels, with its own array and its
-            own attribute dict.
+            LabeledArray: The same values and the same `dims`, `shape`, `name`,
+            `unit`, `no_data_value`, `scale` and `offset`, with its own writeable
+            array and its own attribute dict.
+
+        Examples:
+            - Copy a frozen instance to change it; the original stays as it was:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.netcdf import LabeledArray
+                >>> shared = LabeledArray(np.array([10, 20, 30]), ("time",), (3,), unit="K")
+                >>> shared.freeze()
+                >>> mine = shared.copy()
+                >>> mine.values += 1
+                >>> mine.unit = "degC"
+                >>> mine.values.tolist(), mine.unit
+                ([11, 21, 31], 'degC')
+                >>> shared.values.tolist(), shared.unit
+                ([10, 20, 30], 'K')
+
+                ```
+            - Every label travels, the packing included, but the memory does not:
+                ```python
+                >>> import numpy as np
+                >>> from pyramids.netcdf import LabeledArray
+                >>> packed = LabeledArray(
+                ...     np.array([10, 15], dtype="int16"), ("time",), (2,), name="z", scale=1.0, offset=95.0
+                ... )
+                >>> twin = packed.copy()
+                >>> twin.name, twin.dims, twin.scale, twin.offset
+                ('z', ('time',), 1.0, 95.0)
+                >>> np.shares_memory(twin.values, packed.values)
+                False
+
+                ```
+
+        See Also:
+            `LabeledArray.freeze`: what a frozen instance refuses.
         """
         return LabeledArray(
             self.values.copy(),

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -23,6 +23,7 @@ import warnings
 from collections.abc import Iterable, Sequence
 from contextlib import contextmanager
 from pathlib import Path
+from types import MappingProxyType
 from typing import Any, Literal, cast
 
 import cftime
@@ -1258,6 +1259,7 @@ class LabeledArray:
         "attributes",
         "scale",
         "offset",
+        "_frozen",
     )
 
     def __init__(
@@ -1298,6 +1300,55 @@ class LabeledArray:
         self.attributes = attributes if attributes is not None else {}
         self.scale = scale
         self.offset = offset
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        """Refuse a change once the instance is frozen.
+
+        Args:
+            name: The attribute to set.
+            value: Its new value.
+
+        Raises:
+            AttributeError: The instance is frozen -- it is the one the
+                `variables` cache hands to every caller, so a change here would
+                show through that mapping and nowhere else.
+        """
+        if getattr(self, "_frozen", False):
+            raise AttributeError(
+                f"cannot set {name!r}: this LabeledArray is shared by the "
+                "`variables` cache; take `.copy()` to modify one of your own"
+            )
+        object.__setattr__(self, name, value)
+
+    def freeze(self) -> None:
+        """Make the instance and its array read-only.
+
+        Used by the `variables` cache, which hands one object to every caller:
+        a change to it would show through that mapping while `get_variable` and
+        `read_array` still answered the stored values.
+        """
+        self.values.setflags(write=False)
+        object.__setattr__(self, "attributes", MappingProxyType(dict(self.attributes)))
+        object.__setattr__(self, "_frozen", True)
+
+    def copy(self) -> LabeledArray:
+        """A mutable, independent copy -- of a frozen instance or any other.
+
+        Returns:
+            LabeledArray: The same values and labels, with its own array and its
+            own attribute dict.
+        """
+        return LabeledArray(
+            self.values.copy(),
+            self.dims,
+            self.shape,
+            name=self.name,
+            unit=self.unit,
+            no_data_value=self.no_data_value,
+            attributes=dict(self.attributes),
+            scale=self.scale,
+            offset=self.offset,
+        )
 
     def __repr__(self) -> str:
         label = f"{self.name!r}, " if self.name else ""

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -1192,9 +1192,9 @@ class LabeledArray:
     lazy reading — the values are already in NumPy's own memory by the time you have one.
 
     Attributes:
-        values: The materialised array. `float`/`int` for a numeric source; `<U` for a string
-            array read through `NetCDF.get_variable`, `object` for one read through
-            `LabeledDataset`.
+        values: The materialised array. `float`/`int` for a numeric source, a structured
+            array for a compound one, and `object` for a string one -- from either producer,
+            so a missing entry stays `None` rather than being coerced.
         dims: The dimension names, outermost first.
         shape: The shape those dimensions declare, which always matches `values.shape`.
         name: The variable's name, or `""` when the producer does not set it.
@@ -1267,7 +1267,7 @@ class LabeledArray:
         *,
         name: str = "",
         unit: str = "",
-        no_data_value: float | None = None,
+        no_data_value: float | int | None = None,
         attributes: dict[str, Any] | None = None,
         scale: float | None = None,
         offset: float | None = None,

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -1177,11 +1177,74 @@ class LabeledDataset:
 
 
 class LabeledArray:
-    """A materialised variable/coordinate slice: `values` plus `dims`/`shape`.
+    """A materialised variable/coordinate slice: `values` plus the labels describing it.
 
-    Returned by :meth:`LabeledDataset.__getitem__` (``store["var"]``), so instances are
-    user-facing; the public name (API-9) reflects that. ``_LabeledArray`` is kept as a
-    backward-compatible alias.
+    Two accessors hand one back, so instances are user-facing and the public name (API-9)
+    reflects that. `LabeledDataset.__getitem__` (`store["var"]`) returns one for any array in
+    a label-indexed store, with the store's current selection applied and a CF time axis
+    decoded; `NetCDF.get_variable` returns one for a variable GDAL cannot expose as a raster
+    — a 1-D array of any dtype, or a non-numeric one of any rank — with the values exactly as
+    stored. Only the second populates `name` / `unit` / `no_data_value` / `attributes`; the
+    first leaves all four at their defaults. `_LabeledArray` is kept as a backward-compatible
+    alias.
+
+    This is a plain value holder: it defines `__slots__`, holds no GDAL handle, and does no
+    lazy reading — the values are already in NumPy's own memory by the time you have one.
+
+    Attributes:
+        values: The materialised array. `float`/`int` for a numeric source; `<U` for a string
+            array read through `NetCDF.get_variable`, `object` for one read through
+            `LabeledDataset`.
+        dims: The dimension names, outermost first.
+        shape: The shape those dimensions declare, which always matches `values.shape`.
+        name: The variable's name, or `""` when the producer does not set it.
+        unit: The CF `units` string, or `""` when the source declares none.
+        no_data_value: The declared fill value, or `None`. `values` is **not** masked by it.
+        attributes: The variable's other attributes, `{}` when the producer does not set them.
+
+    Examples:
+        - Build one directly and read the values back:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.netcdf import LabeledArray
+            >>> profile = LabeledArray(np.array([0.0, 0.25, 1.0]), ("ilev",), (3,), name="hyai")
+            >>> profile.values.tolist()
+            [0.0, 0.25, 1.0]
+            >>> profile.dims, profile.shape
+            (('ilev',), (3,))
+
+            ```
+        - The labels a store's variable carries travel with the values:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.netcdf import LabeledArray
+            >>> temperature = LabeledArray(
+            ...     np.array([288.0, 289.5]),
+            ...     ("time",),
+            ...     (2,),
+            ...     name="t2m",
+            ...     unit="K",
+            ...     no_data_value=-9999.0,
+            ...     attributes={"long_name": "2 metre temperature"},
+            ... )
+            >>> temperature
+            LabeledArray('t2m', dims=('time',), shape=(2,))
+            >>> temperature.unit, temperature.attributes["long_name"]
+            ('K', '2 metre temperature')
+
+            ```
+        - Without a name the repr falls back to the dimensions and shape alone:
+            ```python
+            >>> import numpy as np
+            >>> from pyramids.netcdf import LabeledArray
+            >>> LabeledArray(np.arange(6).reshape(2, 3), ("record", "strlen"), (2, 3))
+            LabeledArray(dims=('record', 'strlen'), shape=(2, 3))
+
+            ```
+
+    See Also:
+        `LabeledDataset.__getitem__`: reads one out of a label-indexed store.
+        `pyramids.netcdf.NetCDF.get_variable`: returns one for a variable with no raster plane.
     """
 
     __slots__ = (

--- a/src/pyramids/netcdf/labeled.py
+++ b/src/pyramids/netcdf/labeled.py
@@ -1184,17 +1184,50 @@ class LabeledArray:
     backward-compatible alias.
     """
 
-    __slots__ = ("values", "dims", "shape")
+    __slots__ = (
+        "values",
+        "dims",
+        "shape",
+        "name",
+        "unit",
+        "no_data_value",
+        "attributes",
+    )
 
     def __init__(
-        self, values: np.ndarray, dims: tuple[str, ...], shape: tuple[int, ...]
+        self,
+        values: np.ndarray,
+        dims: tuple[str, ...],
+        shape: tuple[int, ...],
+        *,
+        name: str = "",
+        unit: str = "",
+        no_data_value: float | None = None,
+        attributes: dict[str, Any] | None = None,
     ):
+        """Hold a materialised array with the labels that describe it.
+
+        Args:
+            values: The values, already read.
+            dims: The dimension names, outermost first.
+            shape: The shape those dimensions declare.
+            name: The variable's name, where the source knows it.
+            unit: The CF `units` string, where the source declares one.
+            no_data_value: The fill value, where the source declares one --
+                the values themselves are not masked by it.
+            attributes: The variable's other attributes.
+        """
         self.values = values
         self.dims = dims
         self.shape = shape
+        self.name = name
+        self.unit = unit
+        self.no_data_value = no_data_value
+        self.attributes = attributes if attributes is not None else {}
 
     def __repr__(self) -> str:
-        return f"LabeledArray(dims={self.dims}, shape={self.shape})"
+        label = f"{self.name!r}, " if self.name else ""
+        return f"LabeledArray({label}dims={self.dims}, shape={self.shape})"
 
 
 # Backward-compatible private alias for the now-public ``LabeledArray`` (API-9).

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1063,21 +1063,20 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
         # -- rather than handing back nothing, so the empty array is built from
         # the declared type instead of asking GDAL for zero elements.
         raw = np.empty(shape, dtype=_numpy_dtype_of(data_type))
-    elif type_class == gdal.GEDTC_NUMERIC:
-        raw = md_arr.ReadAsArray()
-    elif type_class == gdal.GEDTC_COMPOUND:
-        # `Read` hands back the record bytes undecoded, so reading a compound
-        # array as-is gives a flat `uint8` buffer whose length is the record
-        # count times the record size -- values that do not match the shape and
-        # mean nothing to the caller. GDAL does describe the layout, though, so
-        # the buffer is viewed through the matching structured dtype instead.
-        raw = np.frombuffer(
-            bytes(md_arr.Read()), dtype=_compound_dtype(data_type)
-        ).reshape(shape)
-    else:
-        # A string array: `ReadAsArray` raises "Only arrays with numeric data
-        # types can be exposed...", while `Read` returns decoded Python strings.
+    elif type_class == gdal.GEDTC_STRING:
+        # The one class `ReadAsArray` cannot serve: it reads the pointer bytes
+        # and answers `[b'[', b'[', b'1']` for `['x', 'yy', 'zzz']`. `Read`
+        # decodes them. It is the numeric arrays that must avoid `Read`, which
+        # returns their bytes undecoded -- the two are exact opposites.
         raw = np.asarray(md_arr.Read()).reshape(shape)
+    else:
+        # Numeric and compound alike. GDAL builds the structured dtype for a
+        # compound record itself, with the declared offsets and record size, so
+        # decoding the buffer by hand gained nothing and cost two things: the
+        # result was read-only where every other path is writeable, and a
+        # component that is itself a compound has no numeric type code, so the
+        # hand-rolled dtype raised on a record `ReadAsArray` handles.
+        raw = md_arr.ReadAsArray()
     return LabeledArray(np.asarray(raw), dims, shape)
 
 
@@ -1100,12 +1099,19 @@ def _numpy_dtype_of(data_type: gdal.ExtendedDataType) -> np.dtype:
     elif type_class == gdal.GEDTC_COMPOUND:
         dtype = _compound_dtype(data_type)
     else:
-        dtype = np.dtype(object)
+        # `<U`, matching what `np.asarray(md_arr.Read())` yields for a non-empty
+        # string array. `object` would have made an empty variable the only
+        # string array on this path with a different dtype.
+        dtype = np.dtype(np.str_)
     return dtype
 
 
 def _compound_dtype(data_type: gdal.ExtendedDataType) -> np.dtype:
     """The NumPy structured dtype matching a GDAL compound type.
+
+    Only reached for a compound variable with a zero-length dimension, where
+    there is nothing to read and `ReadAsArray` -- which builds this dtype itself
+    for every non-empty compound -- cannot be asked.
 
     Built from the components GDAL declares -- name, byte offset and numeric
     type -- with the record size as the itemsize, so the field padding of the

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -162,7 +162,9 @@ class _LazyVariableDict(dict):
     An entry is whatever `get_variable` answers for that name, so the values are
     not of one type: a `NetCDF` subset for a raster variable, a `LabeledArray`
     for one with no raster plane (a 1-D array of any dtype, or a non-numeric one
-    of any rank).
+    of any rank). A `LabeledArray` entry is frozen before it is cached (see
+    `LabeledArray.freeze`), because every later lookup hands out that same
+    object; `get_variable` itself returns a fresh, writeable one each call.
 
     Note:
         This class is **not thread-safe**. Concurrent access from
@@ -177,7 +179,20 @@ class _LazyVariableDict(dict):
         self._names: list[str] = nc.variable_names
 
     def __getitem__(self, key: str) -> NetCDF | LabeledArray:
-        """Load `key` on first access and cache it; see the class docstring for the types."""
+        """Load `key` on first access and cache it; see the class docstring for the types.
+
+        Args:
+            key: A data-variable name, as `variable_names` lists it.
+
+        Returns:
+            NetCDF | LabeledArray: The cached entry -- the same object on every
+            lookup, frozen when it is a `LabeledArray`.
+
+        Raises:
+            KeyError: `key` is not one of the data variables this mapping was
+                built over. The message names `get_variable` when the store holds
+                the array anyway, as a non-data variable.
+        """
         if not dict.__contains__(self, key):
             if key not in self._names:
                 raise KeyError(self._refusal(key))
@@ -189,8 +204,9 @@ class _LazyVariableDict(dict):
                 # `[11, 21, 31]` while `get_variable` and `read_array` still said
                 # `[10, 20, 30]` -- and locking only the array still let
                 # `.unit = "m"` or a new attribute stick in the cache the same
-                # way. The whole entry is frozen; `.copy()` gives a caller one of
-                # their own.
+                # way. So the array, the fields and the attribute mapping are all
+                # locked -- shallowly; `LabeledArray.freeze` says what is not --
+                # and `.copy()` gives a caller one of their own.
                 entry.freeze()
             dict.__setitem__(self, key, entry)
         # The cast this used to carry claimed every entry was a `NetCDF`, which
@@ -1047,11 +1063,13 @@ def _grid_lines(nc: NetCDF) -> list[str]:
 def _has_raster_plane(md_arr: gdal.MDArray) -> bool:
     """Whether GDAL can expose `md_arr` as a raster plane, decided without reading it.
 
-    The two conditions `_read_md_array` hands the raw array back on: a single
-    dimension, or a dtype class other than numeric (`AsClassicDataset` accepts
-    numeric arrays only). Both come off the array's declaration, so this costs
-    nothing however large the array is -- the point, since the alternative is
-    materialising the whole array only to learn it is not a raster.
+    The two conditions `_read_md_array` hands the raw array back on: fewer than
+    two dimensions, or a dtype class other than numeric (`AsClassicDataset`
+    accepts numeric arrays only). In practice the first means one dimension, since
+    the variable enumeration leaves 0-D arrays out. Both come off the array's
+    declaration, so this costs nothing however large the array is -- the point,
+    since the alternative is materialising the whole array only to learn it is
+    not a raster.
 
     Args:
         md_arr: The array to classify.
@@ -1085,14 +1103,16 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
 
     Args:
         md_arr: The array GDAL could not expose as a classic dataset.
-        name: The variable's name, for the error when it cannot be read.
+        name: The variable's name. It becomes the wrapper's `name`, and the
+            errors below identify the variable by it.
 
     Returns:
         LabeledArray: `values` with the `dims` and `shape` GDAL declares, plus
-        the `name`, `unit`, `no_data_value` and `attributes` the array carries.
-        The values are as **stored**: no CF time decoding and no
-        `scale_factor` / `add_offset`, matching `read_array`'s own
-        `unpack=False` default.
+        the `name`, `unit`, `no_data_value`, `attributes`, `scale` and `offset`
+        the array carries. The values are as **stored**: no CF time decoding and
+        no `scale_factor` / `add_offset` applied -- `scale` and `offset` hold
+        what unpacking needs -- matching `read_array`'s own `unpack=False`
+        default.
 
         `LabeledDataset["var"]` returns the same class, so the two agree on
         type, but not on much else. It decodes a CF time axis to datetimes
@@ -1105,10 +1125,13 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
 
     Raises:
         ValueError: The values read back with a shape other than the one the
-            dimensions declare; the array cannot be read at all through GDAL's
-            Python bindings (a compound with a string field); or the array is
+            dimensions declare; a compound array's read fails -- a compound with
+            a string field, which neither `ReadAsArray` nor `Read` supports
+            through GDAL's Python bindings, is the usual cause; or the array is
             empty and carries a compound type with a component that is itself a
             compound or a string, which has no numeric type to describe.
+        RuntimeError: GDAL fails to read a numeric or string array (an I/O or
+            decompression error), propagated with GDAL's own message.
     """
     dimensions = md_arr.GetDimensions()
     dims = tuple(dim.GetName() for dim in dimensions)
@@ -1125,20 +1148,21 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
             raw = np.empty(shape, dtype=_numpy_dtype_of(data_type))
         except ValueError as error:
             # `_numpy_dtype_of` refuses a compound whose own component is a
-            # compound, since that has no numeric type code. Re-raised with the
-            # variable named: the bare message names only GDAL's type-code
-            # number (`not supported: 0`), which identifies neither the
-            # variable nor the component.
+            # compound or a string, since neither has a numeric type code.
+            # Re-raised with the variable named: the bare message names only
+            # GDAL's type-code number (`not supported: 0`), which identifies
+            # neither the variable nor the component.
             raise ValueError(
                 f"{name} has an empty extent and a compound type this reader "
                 f"cannot describe: {error}"
             ) from error
     elif type_class == gdal.GEDTC_STRING:
-        # The one class `ReadAsArray` cannot serve, and it fails two different
-        # ways: a file-backed array raises `RuntimeError: String buffer data
-        # type not supported in SWIG bindings`, while a MEM one returns the
-        # pointer bytes as `|S1` garbage (`[b' ', b'û', ...]`) without
-        # complaining. The silent case is why this branches on the dtype class
+        # The one class `ReadAsArray` cannot serve, and how it fails depends on
+        # GDAL's exception mode, not on the backing store. With exceptions on --
+        # pyramids turns them on at import -- a MEM and a file-backed array alike
+        # raise `RuntimeError: String buffer data type not supported in SWIG
+        # bindings`; with them off, either one only logs that error and returns
+        # `|S1` garbage. The silent case is why this branches on the dtype class
         # rather than trying and catching. Same limitation `_md_array_to_numpy`
         # and `_read_band_dim_values` work around. `Read` hands back a flat list
         # of `str`, which is why it is reshaped here. It is the numeric arrays
@@ -1147,9 +1171,9 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
         # `object`, not `<U`: a string array can hold NULL entries, which `Read`
         # returns as `None` and a `<U` array cannot represent. Letting NumPy pick
         # made the dtype depend on the data -- `<U` for a fully written column,
-        # `object` the moment one entry was missing -- so code switching on
-        # `dtype.kind` broke on partially filled files. `object` throughout keeps
-        # the missing entries missing, and matches `LabeledDataset`.
+        # `object` the moment one entry came back NULL -- so code switching on
+        # `dtype.kind` broke on the first file holding one. `object` throughout
+        # keeps a NULL entry `None`, and matches `LabeledDataset`.
         raw = np.asarray(md_arr.Read(), dtype=object).reshape(shape)
     else:
         # Numeric and compound alike. GDAL builds the structured dtype for a
@@ -1179,8 +1203,8 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
     if values.shape != shape:
         # The two shapes come from different places -- `shape` from the
         # dimensions GDAL declares, `values.shape` from what the read returned --
-        # and only the string and compound paths reshape, so a short or
-        # mis-shaped numeric read would otherwise reach the caller as a
+        # and only the string path reshapes, so a short or mis-shaped numeric
+        # or compound read would otherwise reach the caller as a
         # `LabeledArray` whose `shape` and `values.shape` quietly disagree.
         raise ValueError(
             f"{name} declares dimensions {dims} of shape {shape}, but its "
@@ -1221,16 +1245,20 @@ def _no_data_value_of(md_arr: gdal.MDArray) -> float | int | None:
 
     `GetNoDataValueAsDouble` is exact for every type but the two 64-bit integer
     ones, where a double's 53-bit mantissa cannot hold the value: the common
-    `-9223372036854775806` fill came back as `-9.223372036854776e+18`, which
-    compares equal to no element of the array. Those two are read through
+    `-9223372036854775806` fill came back as `-9.223372036854776e+18`, which is
+    not the declared fill -- as Python numbers the two compare unequal -- and
+    which a NumPy comparison against the `int64` array matches too broadly, since
+    it casts the array to `float64` as well: the fill *and* every neighbour that
+    rounds to the same double compare equal. Those two types are read through
     their own accessors instead.
 
     Args:
         md_arr: The array whose fill value to read.
 
     Returns:
-        float | int | None: The fill value, an `int` for a 64-bit integer array,
-        or `None` when the array declares none.
+        float | int | None: The fill value -- an exact `int` for a 64-bit integer
+        array, a `float` for any other numeric one -- or `None` when the array
+        declares none, and for a string or compound array.
     """
     data_type = md_arr.GetDataType()
     numeric_type = (
@@ -2457,9 +2485,10 @@ class NetCDF(Dataset):
         Resolve it honestly instead: a container's variables share one grid, so
         the first variable that reports a CRS defines the container's CRS.
         Variables with no raster plane are stepped over rather than consulted --
-        a :class:`~pyramids.netcdf.LabeledArray` has no ``crs`` to borrow. The
-        result is memoised because every spatial operation on the container asks
-        for it.
+        a :class:`~pyramids.netcdf.LabeledArray` has no ``crs`` to borrow -- and
+        they are recognised from their declaration (`_declares_raster_plane`), so
+        none of them is read to find that out. The result is memoised because
+        every spatial operation on the container asks for it.
 
         Returns:
             str: The first raster variable's CRS WKT, or ``""`` when this
@@ -4096,14 +4125,17 @@ class NetCDF(Dataset):
     def _variable_is_spatial(self, rg: Any, var_name: str) -> bool:
         """True when ``var_name`` is a gridded variable (can be cropped / reprojected).
 
-        A variable is spatial when it has at least two dimensions and a recognised
+        A variable is spatial when it has a raster plane -- at least two
+        dimensions and a numeric dtype (`_has_raster_plane`) -- and a recognised
         ``(y, x)`` pair among **its own** dimensions — detected via the CF-attribute
         / well-known-name machinery (:meth:`_cf_spatial_axes` /
         :meth:`_named_spatial_axes`), per variable, so a variable on a secondary
         grid is judged on its own axes rather than one container-wide pair. The
-        check reads the MDArray's dimensions directly (not via ``get_variable``,
-        which can't build a classic raster for a non-spatial variable), so an
-        auxiliary variable is identified before any spatial op runs.
+        check reads the MDArray's declaration -- dimensions and dtype -- directly,
+        so an auxiliary variable is identified before any spatial op runs and
+        without reading it. `get_variable` could not answer the question: it reads
+        a non-raster variable in full, and it builds a raster from any 2-D numeric
+        array, spatial axes or not.
 
         Args:
             rg: The root :class:`osgeo.gdal.Group` of the open store, used to
@@ -4111,10 +4143,11 @@ class NetCDF(Dataset):
             var_name: Name of the variable to classify.
 
         Returns:
-            bool: ``True`` when the variable has at least two dimensions with a
-            recognised ``(y, x)`` pair among them; ``False`` for a 1-D / scalar
-            auxiliary variable, a 2-D variable with no spatial axes, or a name
-            that cannot be opened as an MDArray.
+            bool: `True` when the variable is numeric with at least two
+            dimensions and a recognised `(y, x)` pair among them; `False` for a
+            1-D / scalar auxiliary variable, a 2-D variable with no spatial axes,
+            a string or compound array whatever its axes, or a name that cannot
+            be opened as an MDArray.
 
         Examples:
             - A gridded ``t2m(valid_time, lat, lon)`` variable is spatial, so
@@ -4143,10 +4176,12 @@ class NetCDF(Dataset):
             # the dimensions of a grid but no raster plane: `get_variable` cannot
             # build one, so treating it as spatial handed it to the fan-out,
             # which then refused the *whole* container's crop / to_crs / reduce
-            # over one auxiliary field. It goes to the auxiliary carry instead,
-            # which copies it when GDAL can write it back and otherwise drops it
-            # with a warning naming it -- a rank >= 2 string array, or any
-            # compound, cannot be written through GDAL's Python bindings.
+            # over one auxiliary field. It goes to the in-memory arm's auxiliary
+            # carry (`_carry_aux_variables`) instead, which copies it when it can
+            # and otherwise drops it with a warning naming it: GDAL's Python
+            # `Write` refuses a string array of rank >= 2, and
+            # `numpy_to_gdal_dtype` has no GDAL type for a compound's structured
+            # dtype, although GDAL itself writes a compound from Python fine.
             return False
         return (
             self._cf_spatial_axes(rg, var_dims) is not None
@@ -4512,6 +4547,11 @@ class NetCDF(Dataset):
         Returns:
             NetCDF | None: A file-backed container reading ``path``, or ``None`` when the shape is
             not slab-streamable (the caller then falls back to the eager path).
+
+        Raises:
+            ValueError: A name in `spatial_vars` has no raster plane, refused by name through
+                `_require_raster_variable`. `_variable_is_spatial` keeps such a name out of
+                `spatial_vars`, so this is a guard rather than an expected outcome.
         """
         rg = self._working_group()
         # `get_variable` builds a fresh classic-raster wrapper (a new GDAL dataset) each call, so
@@ -7396,8 +7436,8 @@ class NetCDF(Dataset):
         Returns:
             bool: `True` for a raster variable, and also when there is no
             multidimensional group to ask -- the classic `NETCDF:file:var` path
-            always yields a raster -- or the name cannot be opened, so that
-            `get_variable` is left to produce its own error for it.
+            answers with a raster or not at all -- or the name cannot be opened,
+            so that `get_variable` is left to produce its own error for it.
         """
         rg = self._working_group()
         md_arr = open_mdarray(rg, variable_name) if rg is not None else None
@@ -7425,7 +7465,10 @@ class NetCDF(Dataset):
             NetCDF: The variable subset, which is raster-backed.
 
         Raises:
-            ValueError: The variable has no raster plane.
+            ValueError: The variable has no raster plane -- decided from its
+                declaration, without reading it, whenever it is a name
+                `get_variable` accepts -- or `get_variable` itself refuses the
+                name (a coordinate array, or one the store does not hold).
         """
         rg = self._working_group()
         # Only a name `get_variable` accepts is judged on its declaration. A
@@ -7510,16 +7553,19 @@ class NetCDF(Dataset):
 
                 A variable GDAL cannot expose as a raster comes back as a
                 `LabeledArray` — `values` alongside the `dims` and `shape`
-                GDAL declares, plus the `name`, `unit`, `no_data_value` and
-                `attributes` the array carries — rather than as a `NetCDF`:
-                a 1-D variable of any dtype, and any **non-numeric**
-                variable of any rank, a character/string column (however
-                the driver exposes it) or a compound (struct) type. It is
-                not a raster, so none of the band-dim tracking above
-                applies to it and neither do `sel()` or the raster methods;
-                read the values off `.values` (#1126). They are the stored
-                values: no CF time decoding, and no `scale_factor` /
-                `add_offset` unless you ask `read_array` for `unpack=True`.
+                GDAL declares, plus the `name`, `unit`, `no_data_value`,
+                `attributes`, `scale` and `offset` the array carries — rather
+                than as a `NetCDF`: a 1-D variable of any dtype, and any
+                **non-numeric** variable of any rank, a character/string
+                column (however the driver exposes it) or a compound (struct)
+                type. It is not a raster, so none of the band-dim tracking
+                above applies to it and neither do `sel()` or the raster
+                methods; read the values off `.values` (#1126). They are the
+                stored values: no CF time decoding, and no `scale_factor` /
+                `add_offset` applied unless you ask `read_array` for
+                `unpack=True` -- the wrapper's `scale` / `offset` say what
+                unpacking needs. Each call returns a fresh, writeable wrapper;
+                the `variables` mapping hands out a frozen, shared one.
 
                 `LabeledDataset["var"]` hands back the same class from the
                 same store, so the two agree on type — but it decodes a CF
@@ -7528,7 +7574,9 @@ class NetCDF(Dataset):
                 fields above unset. Do not read the two as interchangeable.
 
         Raises:
-            ValueError: If `variable_name` is not present in the dataset.
+            ValueError: If `variable_name` is not present in the dataset, or it
+                names a compound array that cannot be materialised -- one with a
+                string field, which GDAL's Python bindings cannot read.
 
         Notes:
             String-typed indexing variables (e.g. WRF's `Times` array)
@@ -8945,10 +8993,28 @@ class NetCDF(Dataset):
         """Copy an MDArray into `dst_group`, preserving data, packing, and metadata.
 
         Dimensions are resolved against the destination group, so the source may
-        live in a different container. The on-disk packing (`scale`/`offset`),
-        `unit`, no-data value, spatial reference, and all variable attributes are
-        carried across. Scale/offset/unit/no-data are set before the data is
-        written so the netCDF driver accepts the fill value.
+        live in a different container. A numeric array carries its on-disk packing
+        (`scale`/`offset`), `unit`, no-data value, spatial reference, and all
+        variable attributes across; scale/offset/unit/no-data are set before the
+        data is written so the netCDF driver accepts the fill value. A string array
+        takes the list `Read` / `Write` path instead and carries its values and
+        attributes only: its `unit`, no-data value and spatial reference are not
+        copied. A string array whose write fails is deleted before the error
+        propagates, so the destination never keeps a half-built copy.
+
+        Args:
+            dst_group: The `gdal.Group` to create the copy in.
+            var_name: The name to create it under.
+            src_mdarray: The `gdal.MDArray` to copy.
+
+        Raises:
+            RuntimeError: GDAL refuses the string write; its Python `Write` rejects
+                every string array of rank >= 2 ("not a unicode string, bytes,
+                bytearray or memoryview").
+            TypeError: The string source holds a NULL entry, which `Write` rejects
+                ("sequence must contain strings").
+            ValueError: The source is a compound. `numpy_to_gdal_dtype` has no GDAL
+                type for its structured dtype, so nothing is created.
         """
         src_dims = NetCDF._resolve_dst_dimensions(
             dst_group, src_mdarray.GetDimensions()
@@ -8966,11 +9032,13 @@ class NetCDF(Dataset):
                 new_md_array.Write(src_mdarray.Read())
             except (RuntimeError, TypeError, ValueError):
                 # The array is created before it is written, and GDAL's Python
-                # bindings refuse to write a string array of rank >= 2. Left in
-                # place, the half-built array listed the variable in the result
-                # with every value `None` -- present by name, empty in fact --
-                # while the caller's warning said it could not be carried. It is
-                # removed, so the variable is absent and the warning is true.
+                # bindings refuse to write a string array of rank >= 2
+                # (`RuntimeError`) or a list holding a NULL entry (`TypeError`).
+                # Left in place, the half-built rank >= 2 array listed the
+                # variable in the result with every value `None` -- present by
+                # name, empty in fact -- while the caller's warning said it could
+                # not be carried. It is removed, so the variable is absent and
+                # the warning is true.
                 dst_group.DeleteMDArray(var_name)
                 raise
         else:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1026,8 +1026,10 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
 
     Two shapes reach here, and neither is a raster plane: a 1-D array (a profile
     axis, a bounds array, a hybrid-sigma coefficient), and a string or compound
-    array of any rank -- a character column is stored `(records, strlen)`, so it
-    is 2-D and still not numeric.
+    array of any rank. What disqualifies the second is the dtype class, not the
+    rank: a character column arrives 2-D `(records, strlen)` from a source that
+    models the string length as a dimension, and 1-D from GDAL's netCDF driver,
+    which folds that axis into the string type -- non-numeric either way.
 
     Both used to be handed back as the raw `gdal.MDArray`. That object carries
     none of pyramids' API -- no `values`, no `stats`, no `read_array` -- and its
@@ -1046,14 +1048,22 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
         non-raster variable answer alike.
 
     Raises:
-        ValueError: The array declares a shape but reads back as nothing.
+        ValueError: The array declares a shape but reads back as nothing, or its
+            compound type carries a component `_compound_dtype` cannot map.
     """
     dimensions = md_arr.GetDimensions()
     dims = tuple(dim.GetName() for dim in dimensions)
     shape = tuple(dim.GetSize() for dim in dimensions)
     data_type = md_arr.GetDataType()
     type_class = data_type.GetClass()
-    if type_class == gdal.GEDTC_NUMERIC:
+    if 0 in shape:
+        # An unlimited netCDF dimension with no records written is the ordinary
+        # source of this, and such a variable is still advertised by
+        # `variable_names`. GDAL refuses to read it -- `count[0] = 0 is invalid`
+        # -- rather than handing back nothing, so the empty array is built from
+        # the declared type instead of asking GDAL for zero elements.
+        raw = np.empty(shape, dtype=_numpy_dtype_of(data_type))
+    elif type_class == gdal.GEDTC_NUMERIC:
         raw = md_arr.ReadAsArray()
     elif type_class == gdal.GEDTC_COMPOUND:
         # `Read` hands back the record bytes undecoded, so reading a compound
@@ -1068,11 +1078,30 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
         # A string array: `ReadAsArray` raises "Only arrays with numeric data
         # types can be exposed...", while `Read` returns decoded Python strings.
         raw = np.asarray(md_arr.Read()).reshape(shape)
-    if raw is None:
-        raise ValueError(
-            f"{name} declares dimensions {dims} but its values could not be read"
-        )
     return LabeledArray(np.asarray(raw), dims, shape)
+
+
+def _numpy_dtype_of(data_type: gdal.ExtendedDataType) -> np.dtype:
+    """The NumPy dtype matching a GDAL extended type, whatever its class.
+
+    Used to give a zero-length variable an array of the right type without
+    reading it, since GDAL declines a read of no elements.
+
+    Args:
+        data_type: The array's declared type.
+
+    Returns:
+        np.dtype: The numeric dtype, the compound record dtype, or `object` for
+        a string array -- the type `Read` would have produced for each.
+    """
+    type_class = data_type.GetClass()
+    if type_class == gdal.GEDTC_NUMERIC:
+        dtype = np.dtype(gdal_to_numpy_dtype(data_type.GetNumericDataType()))
+    elif type_class == gdal.GEDTC_COMPOUND:
+        dtype = _compound_dtype(data_type)
+    else:
+        dtype = np.dtype(object)
+    return dtype
 
 
 def _compound_dtype(data_type: gdal.ExtendedDataType) -> np.dtype:
@@ -1080,13 +1109,21 @@ def _compound_dtype(data_type: gdal.ExtendedDataType) -> np.dtype:
 
     Built from the components GDAL declares -- name, byte offset and numeric
     type -- with the record size as the itemsize, so the field padding of the
-    original struct is preserved rather than assumed away.
+    original struct is preserved rather than assumed away. A `(Byte, Int32)`
+    record is the short illustration: GDAL declares it 8 bytes wide with the
+    second field at offset 4, while a dtype built from the formats alone packs
+    it into 5 and misreads every record after the first.
 
     Args:
         data_type: A compound `ExtendedDataType`.
 
     Returns:
         np.dtype: A structured dtype of the same memory layout.
+
+    Raises:
+        ValueError: A component is not itself numeric -- a nested compound or a
+            string field -- so `GetNumericDataType()` reports `GDT_Unknown`,
+            which has no NumPy counterpart.
     """
     components = data_type.GetComponents()
     return np.dtype(
@@ -7026,6 +7063,10 @@ class NetCDF(Dataset):
     ) -> NetCDF | gdal.MDArray:
         """Extract a single variable as a classic-raster NetCDF object.
 
+        A variable GDAL cannot expose as a raster plane answers as a
+        `LabeledArray` instead of a `NetCDF`; everything below describes the
+        raster case, and `Returns` sets out the other one.
+
         The returned object carries origin metadata so modified data
         can be written back via `set_variable()`. Every non-spatial
         dim of the variable is tracked: for an N-D MDIM array
@@ -7059,21 +7100,24 @@ class NetCDF(Dataset):
                 map them onto — a 1-D or non-numeric one (see `Returns`).
 
         Returns:
-            NetCDF | gdal.MDArray: A subset backed by a classic dataset where every
+            NetCDF | LabeledArray: A subset backed by a classic dataset where every
                 non-spatial dimension is mapped onto bands. The new
                 `_band_dim_names` / `_band_dim_values_map` /
                 `_band_dim_sizes` fields drive `sel()`; the legacy
                 `_band_dim_name` / `_band_dim_values` track the first
                 non-spatial dim.
 
-                A variable GDAL cannot expose as a raster comes back as
-                the raw `gdal.MDArray` instead: a 1-D variable (a
-                coordinate axis or data series), and any **non-numeric**
-                variable of any rank — a character/string column
-                (however the driver exposes it) or a compound (struct)
-                type. Such a raw array carries no band model, so the
-                band-dim tracking above is only partly populated. Read
-                it with `Read()` (#1067).
+                A variable GDAL cannot expose as a raster comes back as a
+                `LabeledArray` — `values` alongside the `dims` and `shape`
+                GDAL declares — rather than as a `NetCDF`: a 1-D variable
+                of any dtype, and any **non-numeric** variable of any rank,
+                a character/string column (however the driver exposes it)
+                or a compound (struct) type. That is the same type
+                `LabeledDataset["var"]` hands back, so both routes to a
+                non-raster variable answer alike. It is not a raster, so
+                none of the band-dim tracking above applies to it and
+                neither do `sel()` or the raster methods; read the values
+                off `.values` (#1126).
 
         Raises:
             ValueError: If `variable_name` is not present in the dataset.
@@ -7084,8 +7128,66 @@ class NetCDF(Dataset):
             back to integer indices `[0, 1, ..., size - 1]` for those
             dims.
 
+        Examples:
+            - A variable with a raster plane comes back as a `NetCDF` subset:
+                ```python
+                >>> import numpy as np
+                >>> from osgeo import gdal
+                >>> from pyramids.netcdf import Container
+                >>> store = gdal.GetDriverByName("MEM").CreateMultiDimensional("demo")
+                >>> group = store.GetRootGroup()
+                >>> lat = group.CreateDimension("lat", None, None, 2)
+                >>> lon = group.CreateDimension("lon", None, None, 3)
+                >>> grid = group.CreateMDArray(
+                ...     "t2m", [lat, lon], gdal.ExtendedDataType.Create(gdal.GDT_Float32)
+                ... )
+                >>> grid.Write(np.arange(6, dtype="float32").reshape(2, 3))
+                0
+                >>> Container(store).get_variable("t2m").shape
+                (1, 2, 3)
+
+                ```
+            - A 1-D variable has no raster plane, so it answers as a `LabeledArray`:
+                ```python
+                >>> import numpy as np
+                >>> from osgeo import gdal
+                >>> from pyramids.netcdf import Container
+                >>> store = gdal.GetDriverByName("MEM").CreateMultiDimensional("demo")
+                >>> group = store.GetRootGroup()
+                >>> ilev = group.CreateDimension("ilev", None, None, 4)
+                >>> coefficients = group.CreateMDArray(
+                ...     "hyai", [ilev], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+                ... )
+                >>> coefficients.Write(np.array([0.0, 0.25, 0.5, 1.0]))
+                0
+                >>> hyai = Container(store).get_variable("hyai")
+                >>> hyai.dims, hyai.shape
+                (('ilev',), (4,))
+                >>> hyai.values.tolist()
+                [0.0, 0.25, 0.5, 1.0]
+
+                ```
+            - A string column is non-numeric at any rank, so it is labelled too:
+                ```python
+                >>> from osgeo import gdal
+                >>> from pyramids.netcdf import Container
+                >>> store = gdal.GetDriverByName("MEM").CreateMultiDimensional("demo")
+                >>> group = store.GetRootGroup()
+                >>> record = group.CreateDimension("record", None, None, 2)
+                >>> strlen = group.CreateDimension("strlen", None, None, 3)
+                >>> units = group.CreateMDArray(
+                ...     "units", [record, strlen], gdal.ExtendedDataType.CreateString()
+                ... )
+                >>> Container(store).get_variable("units").shape
+                (2, 3)
+
+                ```
+
         See Also:
             `sel`: subsets the result along any tracked band dim.
+            `pyramids.netcdf.LabeledArray`: what a non-raster variable answers with.
+            `pyramids.netcdf.LabeledDataset`: reads a whole label-indexed store the
+                same way.
         """
         # Handle group-qualified names: "forecast/temperature"
         if "/" in variable_name:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -181,7 +181,17 @@ class _LazyVariableDict(dict):
         if not dict.__contains__(self, key):
             if key not in self._names:
                 raise KeyError(self._refusal(key))
-            dict.__setitem__(self, key, self._nc.get_variable(key))
+            entry = self._nc.get_variable(key)
+            if isinstance(entry, LabeledArray):
+                # This entry is handed to every later `variables[key]`, so its
+                # array is shared in a way `get_variable`'s fresh result is not.
+                # Left writeable, one `values += 1` made this mapping answer
+                # `[11, 21, 31]` while `get_variable` and `read_array` still said
+                # `[10, 20, 30]` -- three accessors disagreeing about one
+                # variable. Read-only turns that into an error at the mutation;
+                # `.copy()` gives a caller an array of their own.
+                entry.values.setflags(write=False)
+            dict.__setitem__(self, key, entry)
         # The cast this used to carry claimed every entry was a `NetCDF`, which
         # suppressed exactly the error a caller needs to see: a variable with no
         # raster plane is a `LabeledArray` here, as it is from `get_variable`.

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -171,12 +171,15 @@ class _LazyVariableDict(dict):
         self._nc = nc
         self._names: list[str] = nc.variable_names
 
-    def __getitem__(self, key: str) -> NetCDF:
+    def __getitem__(self, key: str) -> NetCDF | LabeledArray:
         if not dict.__contains__(self, key):
             if key not in self._names:
                 raise KeyError(self._refusal(key))
             dict.__setitem__(self, key, self._nc.get_variable(key))
-        return cast("NetCDF", dict.__getitem__(self, key))
+        # The cast this used to carry claimed every entry was a `NetCDF`, which
+        # suppressed exactly the error a caller needs to see: a variable with no
+        # raster plane is a `LabeledArray` here, as it is from `get_variable`.
+        return cast("NetCDF | LabeledArray", dict.__getitem__(self, key))
 
     def _refusal(self, key: str) -> str:
         """Word the `KeyError`, saying so when the name is merely not a data variable.
@@ -223,10 +226,10 @@ class _LazyVariableDict(dict):
     def keys(self) -> list[str]:  # type: ignore[override]
         return self._names
 
-    def values(self) -> list[NetCDF]:  # type: ignore[override]
+    def values(self) -> list[NetCDF | LabeledArray]:  # type: ignore[override]
         return [self[k] for k in self._names]
 
-    def items(self) -> list[tuple[str, NetCDF]]:  # type: ignore[override]
+    def items(self) -> list[tuple[str, NetCDF | LabeledArray]]:  # type: ignore[override]
         return [(k, self[k]) for k in self._names]
 
 
@@ -1043,9 +1046,13 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
         name: The variable's name, for the error when it cannot be read.
 
     Returns:
-        LabeledArray: `values` with the `dims` and `shape` GDAL declares -- the
-        same type `LabeledDataset["var"]` returns, so both routes to a
-        non-raster variable answer alike.
+        LabeledArray: `values` with the `dims` and `shape` GDAL declares, plus
+        the `name`, `unit`, `no_data_value` and `attributes` the array carries.
+        The values are as **stored**: no CF time decoding and no
+        `scale_factor` / `add_offset`, matching `read_array`'s own
+        `unpack=False` default. `LabeledDataset["var"]` returns the same class
+        but decodes a CF time axis, so the two agree on type and not always on
+        values.
 
     Raises:
         ValueError: The values read back with a shape other than the one the
@@ -1099,7 +1106,27 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
             f"{name} declares dimensions {dims} of shape {shape}, but its "
             f"values read back with shape {values.shape}"
         )
-    return LabeledArray(values, dims, shape)
+    # The labels the raw `MDArray` used to expose through `GetUnit()`,
+    # `GetNoDataValueAsDouble()` and the attribute API. Carrying them is what
+    # makes the wrapper a better answer than the handle it replaced rather than
+    # merely a safer one -- without them a `-9999.0` in `values` would be
+    # indistinguishable from real data.
+    attributes = {}
+    for attribute in md_arr.GetAttributes() or []:
+        try:
+            attributes[attribute.GetName()] = attribute.Read()
+        except RuntimeError:
+            # One unreadable attribute must not cost the caller the values.
+            continue
+    return LabeledArray(
+        values,
+        dims,
+        shape,
+        name=name,
+        unit=md_arr.GetUnit() or "",
+        no_data_value=md_arr.GetNoDataValueAsDouble(),
+        attributes=attributes,
+    )
 
 
 def _numpy_dtype_of(data_type: gdal.ExtendedDataType) -> np.dtype:
@@ -1434,7 +1461,7 @@ class NetCDF(Dataset):
             self._is_md_array = False
             self._is_subset = False
         # Caches (invalidated by _replace_raster, add_variable, remove_variable)
-        self._cached_variables: dict[str, NetCDF] | None = None
+        self._cached_variables: dict[str, NetCDF | LabeledArray] | None = None
         self._cached_meta_data: NetCDFMetadata | None = None
         # Memoised `geotransform`; see that property. Cleared wherever
         # `_geotransform` is reassigned, so the two cannot disagree.
@@ -2611,15 +2638,20 @@ class NetCDF(Dataset):
         return self._get_variable_names()
 
     @property
-    def variables(self) -> dict[str, NetCDF]:
-        """All data variables as a lazy dict of `{name: NetCDF}` subsets.
+    def variables(self) -> dict[str, NetCDF | LabeledArray]:
+        """All data variables as a lazy dict of `{name: subset}`.
 
         Variables are loaded on first access per key, not all at once.
         Cached after loading; invalidated by `add_variable` /
         `remove_variable` / `set_variable`.
 
+        Each entry is whatever `get_variable` returns for that name: a `NetCDF`
+        subset for a raster variable, a `LabeledArray` for one with no raster
+        plane -- a 1-D array, or a non-numeric one of any rank.
+
         Returns:
-            dict[str, NetCDF]: Mapping from variable name to its subset.
+            dict[str, NetCDF | LabeledArray]: Mapping from variable name to its
+            subset.
         """
         if self._cached_variables is None:
             self._cached_variables = _LazyVariableDict(self)
@@ -3430,7 +3462,7 @@ class NetCDF(Dataset):
                 self._check_not_container("read_array")
             subset = self.get_variable(cast("str", variable))
             if not isinstance(subset, NetCDF):
-                # `get_variable` hands back a raw `gdal.MDArray` for anything
+                # `get_variable` hands back a `LabeledArray` for anything
                 # GDAL cannot expose as a raster -- a 1-D array (`time_bounds`,
                 # `band_id`, a grouped store's `flight_03/CO`) or a non-numeric
                 # one. `variable_names` enumerates several such arrays on the
@@ -3440,7 +3472,13 @@ class NetCDF(Dataset):
                 # 'read_array'`, which reads as a pyramids bug rather than a
                 # shape mismatch.
                 return self._read_non_raster_variable(
-                    cast("str", variable), band, read_window, chunks, masked, unpack
+                    cast("str", variable),
+                    band,
+                    read_window,
+                    chunks,
+                    masked,
+                    unpack,
+                    subset,
                 )
             return subset.read_array(
                 band=band,
@@ -3478,37 +3516,38 @@ class NetCDF(Dataset):
         chunks: Any,
         masked: bool,
         unpack: bool,
+        values: LabeledArray,
     ) -> ArrayLike:
-        """Read a variable GDAL exposes only as a raw ``MDArray``, not a raster.
+        """Return the values of a variable that has no raster plane.
 
         A 1-D array (a coordinate axis, a data series, a bounds array) or a
-        non-numeric one has no raster plane, so :meth:`get_variable` returns the
-        MDArray itself. Several such names are *enumerated* -- GOES ABI declares
-        ``time_bounds`` / ``x_image_bounds`` / ``y_image_bounds`` as data
-        variables and a grouped store enumerates ``"flight_03/CO"`` -- so they
-        reach :meth:`read_array` through the ordinary container route and used
-        to fail there with ``AttributeError: 'MDArray' object has no attribute
-        'read_array'``.
+        non-numeric one has no raster plane. Several such names are
+        *enumerated* -- GOES ABI declares ``time_bounds`` / ``x_image_bounds`` /
+        ``y_image_bounds`` as data variables and a grouped store enumerates
+        ``"flight_03/CO"`` -- so they reach :meth:`read_array` through the
+        ordinary container route and used to fail there with
+        ``AttributeError: 'MDArray' object has no attribute 'read_array'``.
 
-        The read itself goes through :meth:`_read_variable`, the same resolver
-        the plot engine and the carry paths use, so a group-qualified name is
-        walked down to its owning group.
+        The values are taken from the :class:`LabeledArray` the caller already
+        resolved rather than read again. :meth:`get_variable` materialises now,
+        so re-reading here would have made every container-route read of such a
+        variable read the whole array twice.
 
         Args:
-            variable: The array name, already known to resolve to an MDArray.
-            band: Rejected — a raw array has no bands.
-            window: Rejected — a raw array has no raster window to clip.
-            chunks: Rejected — the lazy path builds a raster plane.
-            masked: Rejected — masking is defined against a band's no-data.
+            variable: The array name, used in the refusals below.
+            band: Rejected -- a raw array has no bands.
+            window: Rejected -- a raw array has no raster window to clip.
+            chunks: Rejected -- the lazy path builds a raster plane.
+            masked: Rejected -- masking is defined against a band's no-data.
             unpack: Applied from the array's own CF ``scale_factor`` /
                 ``add_offset``, since there is no band to carry them.
+            values: The already-materialised variable.
 
         Returns:
             np.ndarray: The array's values, in storage order.
 
         Raises:
-            ValueError: If any raster-only argument is supplied, or if the
-                array cannot be read back.
+            ValueError: If any raster-only argument is supplied.
         """
         rejected = [
             name
@@ -3527,9 +3566,7 @@ class NetCDF(Dataset):
                 "(it is 1-D or non-numeric), so there is no band, window or "
                 "chunk plane to apply. Read it without those arguments."
             )
-        result = self._read_variable(variable)
-        if result is None:
-            raise ValueError(f"Could not read variable {variable!r} from the store.")
+        result = values.values
         if unpack:
             md_arr = open_mdarray(self._working_group(), variable)
             result = apply_unpack(
@@ -6758,7 +6795,7 @@ class NetCDF(Dataset):
         raising. It does **not** promise a uniform return type: a name here
         that GDAL cannot expose as a raster -- a 1-D array (`band_id`,
         `time_bounds`, a coordinate axis) or a non-numeric one -- comes back as
-        a raw :class:`osgeo.gdal.MDArray` rather than a
+        a :class:`~pyramids.netcdf.LabeledArray` rather than a
         :class:`~pyramids.netcdf.NetCDF` variable, as documented on
         :meth:`get_variable`. :meth:`read_array` handles both.
 
@@ -7182,9 +7219,9 @@ class NetCDF(Dataset):
                 GDAL declares — rather than as a `NetCDF`: a 1-D variable
                 of any dtype, and any **non-numeric** variable of any rank,
                 a character/string column (however the driver exposes it)
-                or a compound (struct) type. That is the same type
-                `LabeledDataset["var"]` hands back, so both routes to a
-                non-raster variable answer alike. It is not a raster, so
+                or a compound (struct) type. `LabeledDataset["var"]` hands
+                back the same class, though it decodes a CF time axis where
+                this returns the stored numbers. It is not a raster, so
                 none of the band-dim tracking above applies to it and
                 neither do `sel()` or the raster methods; read the values
                 off `.values` (#1126).
@@ -7343,10 +7380,10 @@ class NetCDF(Dataset):
 
         # Geostationary (GOES) scan-angle x/y come through the MDIM read path in
         # radians; rescale them to projected metres so the cube is correctly
-        # georeferenced and to_crs/crop work. No-op for every other CRS. Guarded
-        # because a 1-D string variable yields a raw MDArray, not a NetCDF.
-        if isinstance(cube, NetCDF):
-            cube._normalize_geostationary_geotransform()
+        # georeferenced and to_crs/crop work. No-op for every other CRS. The
+        # guard this used to carry is gone with the reason for it: a variable
+        # with no raster plane returns before reaching here.
+        cube._normalize_geostationary_geotransform()
 
         self._attach_variable_metadata(
             cube, md_arr_ref if rg is not None else None, spatial_dim_indices
@@ -7764,10 +7801,10 @@ class NetCDF(Dataset):
         """Populate band-dim tracking, variable attributes, and packing on a variable subset.
 
         When `md_arr` is `None` (e.g. the file-backed gdal.Open path) the band/attr metadata is
-        cleared to empty defaults. `cube` may also be a raw `gdal.MDArray` rather than a `NetCDF`
-        — a 1-D variable, or a non-numeric one of any rank (see `_read_md_array`) — which has no
-        band model, so `_track_band_dimensions` and `_apply_attribute_no_data` fall back rather
-        than read band attributes off it. `_copy_variable_attrs` is unaffected — it reads the
+        cleared to empty defaults. `cube` is always a `NetCDF`: a variable with no raster plane
+        — a 1-D one, or a non-numeric one of any rank (see `_read_md_array`) — is materialised and
+        returned by `get_variable` before this is called, so the band model it needs is always
+        present. `_copy_variable_attrs` is unaffected — it reads the
         MDArray, not the cube.
         """
         if md_arr is None:
@@ -7791,8 +7828,8 @@ class NetCDF(Dataset):
         plot mask read. The view ignores ``SetNoDataValue``, so only the wrapper list is updated.
 
         A variable GDAL cannot expose as a raster — a 1-D one, or a non-numeric one of any rank
-        (see :meth:`_read_md_array`) — comes back as a raw ``gdal.MDArray`` with no band model (no
-        ``_no_data_value``), so there is nothing to stamp and it is left untouched.
+        (see :meth:`_read_md_array`) — never reaches here: :meth:`get_variable` materialises it
+        into a :class:`~pyramids.netcdf.LabeledArray` and returns before this is called.
         """
         current = getattr(cube, "_no_data_value", None)
         if current is not None and not any(v is not None for v in current):
@@ -7823,10 +7860,11 @@ class NetCDF(Dataset):
         array) when available, else the last two. The legacy `_band_dim_name`/`_band_dim_values`
         fields point at the first non-spatial dim so existing 3-D consumers are unaffected.
 
-        `cube` may be a raw `gdal.MDArray` with no band model (see `_read_md_array`). A rank <= 2
-        one takes the empty-`band_dims` exit below, which clears all five fields; a rank >= 3 one
-        still gets the per-dimension `_band_dim_names` / `_band_dim_sizes` / `_band_dim_values_map`
-        tracking, but its legacy pair is left as `None`, because deriving a primary band view needs
+        `cube` is always a raster-backed `NetCDF` (see `_read_md_array`): an array with no raster
+        plane is materialised by `get_variable` and never reaches here. A rank <= 2 one takes the
+        empty-`band_dims` exit below, which clears all five fields; a rank >= 3 one gets the
+        per-dimension `_band_dim_names` / `_band_dim_sizes` / `_band_dim_values_map`
+        tracking, and its legacy pair is derived, because deriving a primary band view needs
         a band count the MDArray does not have (#1067).
         """
         if len(dims) > 2:
@@ -7852,21 +7890,11 @@ class NetCDF(Dataset):
         cube._band_dim_values_map = {
             d.GetName(): NetCDF._read_band_dim_values(d) for d in band_dims
         }
-        band_count = getattr(cube, "_band_count", None)
-        if band_count is None:
-            # A variable GDAL cannot expose as a raster comes back as a raw `gdal.MDArray`, which
-            # has no band model at all (see `_read_md_array`: a 1-D variable, or a non-numeric one
-            # of any rank). Rank <= 2 exits at the `band_dims` branch above, but a rank >= 3 raw
-            # array reaches here, where deriving a primary band view would read the `_band_count`
-            # an MDArray does not have (#1067).
-            cube._band_dim_name = None
-            cube._band_dim_values = None
-            return
         cube._band_dim_name, cube._band_dim_values = NetCDF._derive_primary_band_view(
             cube._band_dim_names,
             cube._band_dim_values_map,
             cube._band_dim_sizes,
-            band_count,
+            cube._band_count,
         )
 
     @staticmethod

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1048,8 +1048,9 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
         non-raster variable answer alike.
 
     Raises:
-        ValueError: The array declares a shape but reads back as nothing, or its
-            compound type carries a component `_compound_dtype` cannot map.
+        ValueError: The values read back with a shape other than the one the
+            dimensions declare, or the array is empty and carries a compound
+            type whose own components are compound.
     """
     dimensions = md_arr.GetDimensions()
     dims = tuple(dim.GetName() for dim in dimensions)
@@ -1062,7 +1063,17 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
         # `variable_names`. GDAL refuses to read it -- `count[0] = 0 is invalid`
         # -- rather than handing back nothing, so the empty array is built from
         # the declared type instead of asking GDAL for zero elements.
-        raw = np.empty(shape, dtype=_numpy_dtype_of(data_type))
+        try:
+            raw = np.empty(shape, dtype=_numpy_dtype_of(data_type))
+        except ValueError as error:
+            # `_numpy_dtype_of` refuses a compound whose own component is a
+            # compound, since that has no numeric type code. Re-raised with the
+            # variable named: the bare message is GDAL's type-code number, which
+            # identifies neither the variable nor the component.
+            raise ValueError(
+                f"{name} has an empty extent and a compound type this reader "
+                f"cannot describe: {error}"
+            ) from error
     elif type_class == gdal.GEDTC_STRING:
         # The one class `ReadAsArray` cannot serve: it reads the pointer bytes
         # and answers `[b'[', b'[', b'1']` for `['x', 'yy', 'zzz']`. `Read`
@@ -1077,7 +1088,18 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
         # component that is itself a compound has no numeric type code, so the
         # hand-rolled dtype raised on a record `ReadAsArray` handles.
         raw = md_arr.ReadAsArray()
-    return LabeledArray(np.asarray(raw), dims, shape)
+    values = np.asarray(raw)
+    if values.shape != shape:
+        # The two shapes come from different places -- `shape` from the
+        # dimensions GDAL declares, `values.shape` from what the read returned --
+        # and only the string and compound paths reshape, so a short or
+        # mis-shaped numeric read would otherwise reach the caller as a
+        # `LabeledArray` whose `shape` and `values.shape` quietly disagree.
+        raise ValueError(
+            f"{name} declares dimensions {dims} of shape {shape}, but its "
+            f"values read back with shape {values.shape}"
+        )
+    return LabeledArray(values, dims, shape)
 
 
 def _numpy_dtype_of(data_type: gdal.ExtendedDataType) -> np.dtype:

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1183,6 +1183,13 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
         unit=md_arr.GetUnit() or "",
         no_data_value=md_arr.GetNoDataValueAsDouble(),
         attributes=attributes,
+        # Carried because GDAL removes `scale_factor` / `add_offset` from the
+        # attribute list: without them a packed variable arrived as `[10, 15]`
+        # labelled `m`, with nothing on the object to say the true values were
+        # 105 m and 110 m. `values` stays packed, matching `read_array`'s
+        # `unpack=False` default; these are what unpacking needs.
+        scale=md_arr.GetScale(),
+        offset=md_arr.GetOffset(),
     )
 
 

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -287,7 +287,7 @@ def _reconstruct_netcdf(
     if group_path:
         result = container.get_group(group_path)
     elif is_subset and source_var_name is not None:
-        result = container.get_variable(source_var_name)
+        result = container._require_raster_variable(source_var_name)
     else:
         result = container
     return result
@@ -2268,7 +2268,15 @@ class NetCDF(Dataset):
             crs = ""
             try:
                 for name in self.variable_names:
-                    variable_crs = self.get_variable(name).crs
+                    variable = self.get_variable(name)
+                    if isinstance(variable, LabeledArray):
+                        # A non-raster variable has no CRS to borrow. It must be
+                        # skipped rather than allowed to raise: the `except`
+                        # below wraps the whole loop, so one such variable early
+                        # in the list would otherwise suppress the CRS of every
+                        # raster variable after it.
+                        continue
+                    variable_crs = variable.crs
                     if variable_crs:
                         crs = str(variable_crs)
                         break
@@ -4724,7 +4732,7 @@ class NetCDF(Dataset):
         """
         result = None
         for var_name in spatial_vars:
-            var = self.get_variable(var_name)
+            var = self._require_raster_variable(var_name)
             var_result = getattr(var, operation)(**op_kwargs)
             # to_crs returns a VRT — materialize before the source goes
             # out of scope. read_array also squeezes singleton-band 3-D
@@ -7086,9 +7094,43 @@ class NetCDF(Dataset):
         """Whether the X axis is stored east-to-west; see `_mdim.x_axis_is_right_to_left`."""
         return x_axis_is_right_to_left(dims, x_index, classic_view)
 
+    def _require_raster_variable(
+        self, variable_name: str, x_dim: str | None = None, y_dim: str | None = None
+    ) -> NetCDF:
+        """`get_variable`, for the callers that can only work on a raster plane.
+
+        Most internal users of `get_variable` go straight on to `crop`,
+        `read_array`, `plot` or the band-dimension bookkeeping, none of which a
+        non-raster variable has. Before this they received a raw `gdal.MDArray`
+        and failed with `AttributeError: 'MDArray' object has no attribute
+        'crop'`; now they would fail the same way on a `LabeledArray`. Routing
+        them through here turns that into a refusal that says which variable and
+        what to use instead.
+
+        Args:
+            variable_name: The variable to read.
+            x_dim: Optional name of the X dimension, passed through.
+            y_dim: Optional name of the Y dimension, passed through.
+
+        Returns:
+            NetCDF: The variable subset, which is raster-backed.
+
+        Raises:
+            ValueError: The variable has no raster plane.
+        """
+        variable = self.get_variable(variable_name, x_dim=x_dim, y_dim=y_dim)
+        if isinstance(variable, LabeledArray):
+            raise ValueError(
+                f"{variable_name} has no raster plane (dimensions "
+                f"{variable.dims}), so it has no geometry to operate on; read "
+                "its values with `get_variable`, or open the store with "
+                "`LabeledDataset` for labelled point data"
+            )
+        return variable
+
     def get_variable(
         self, variable_name: str, x_dim: str | None = None, y_dim: str | None = None
-    ) -> NetCDF | gdal.MDArray:
+    ) -> NetCDF | LabeledArray:
         """Extract a single variable as a classic-raster NetCDF object.
 
         A variable GDAL cannot expose as a raster plane answers as a
@@ -8717,7 +8759,7 @@ class NetCDF(Dataset):
         Returns:
             NetCDF: This container (modified in-place).
         """
-        var = self.get_variable(variable_name)
+        var = self._require_raster_variable(variable_name)
         cropped = var.crop(mask, touch=touch)
         self.set_variable(variable_name, cropped)
         return self
@@ -8739,7 +8781,7 @@ class NetCDF(Dataset):
         Returns:
             NetCDF: This container (modified in-place).
         """
-        var = self.get_variable(variable_name)
+        var = self._require_raster_variable(variable_name)
         reprojected = var.to_crs(to_epsg, method=method)
         # to_crs returns a VRT-backed dataset — materialize it into
         # a MEM dataset so the data survives after the VRT source
@@ -8789,7 +8831,7 @@ class NetCDF(Dataset):
         Returns:
             NetCDF: This container (modified in-place).
         """
-        var = self.get_variable(variable_name)
+        var = self._require_raster_variable(variable_name)
         resampled = var.resample(cell_size, method=method)
         self.set_variable(variable_name, resampled)
         return self

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -183,14 +183,15 @@ class _LazyVariableDict(dict):
                 raise KeyError(self._refusal(key))
             entry = self._nc.get_variable(key)
             if isinstance(entry, LabeledArray):
-                # This entry is handed to every later `variables[key]`, so its
-                # array is shared in a way `get_variable`'s fresh result is not.
-                # Left writeable, one `values += 1` made this mapping answer
+                # This entry is handed to every later `variables[key]`, so it is
+                # shared in a way `get_variable`'s fresh result is not. Left
+                # mutable, one `values += 1` made this mapping answer
                 # `[11, 21, 31]` while `get_variable` and `read_array` still said
-                # `[10, 20, 30]` -- three accessors disagreeing about one
-                # variable. Read-only turns that into an error at the mutation;
-                # `.copy()` gives a caller an array of their own.
-                entry.values.setflags(write=False)
+                # `[10, 20, 30]` -- and locking only the array still let
+                # `.unit = "m"` or a new attribute stick in the cache the same
+                # way. The whole entry is frozen; `.copy()` gives a caller one of
+                # their own.
+                entry.freeze()
             dict.__setitem__(self, key, entry)
         # The cast this used to carry claimed every entry was a `NetCDF`, which
         # suppressed exactly the error a caller needs to see: a variable with no
@@ -1160,6 +1161,10 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
         try:
             raw = md_arr.ReadAsArray()
         except RuntimeError as error:
+            if type_class != gdal.GEDTC_COMPOUND:
+                # An I/O or decompression failure on an ordinary array: not a
+                # type problem, so GDAL's own message is the accurate one.
+                raise
             # A compound record with a string field is unreadable through the
             # SWIG bindings by *either* reader -- `ReadAsArray` and `Read` both
             # raise ("String buffer" / "non-numeric buffer data type not
@@ -1167,7 +1172,7 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
             # in terms of the variable rather than with GDAL's bare message.
             raise ValueError(
                 f"{name} cannot be read: GDAL's Python bindings do not support "
-                f"its data type ({error}). A compound type with a string field "
+                f"its compound type ({error}). A compound with a string field "
                 "is the usual cause."
             ) from error
     values = np.asarray(raw)
@@ -4138,8 +4143,10 @@ class NetCDF(Dataset):
             # the dimensions of a grid but no raster plane: `get_variable` cannot
             # build one, so treating it as spatial handed it to the fan-out,
             # which then refused the *whole* container's crop / to_crs / reduce
-            # over one auxiliary field. It is carried through like any other
-            # auxiliary variable instead.
+            # over one auxiliary field. It goes to the auxiliary carry instead,
+            # which copies it when GDAL can write it back and otherwise drops it
+            # with a warning naming it -- a rank >= 2 string array, or any
+            # compound, cannot be written through GDAL's Python bindings.
             return False
         return (
             self._cf_spatial_axes(rg, var_dims) is not None
@@ -5133,13 +5140,30 @@ class NetCDF(Dataset):
             except (RuntimeError, AttributeError):
                 pass
 
+    @staticmethod
+    def _declares_numeric(rg: Any, var_name: str) -> bool:
+        """Whether `var_name` declares a numeric dtype, read off its declaration.
+
+        Args:
+            rg: The group to open the array from.
+            var_name: The variable to check.
+
+        Returns:
+            bool: `True` for a numeric array, and for a name that cannot be
+            opened, which is left to the caller's own handling.
+        """
+        md_arr = open_mdarray(rg, var_name)
+        return md_arr is None or md_arr.GetDataType().GetClass() == gdal.GEDTC_NUMERIC
+
     def _warn_demoted_variables(self, rg, aux_vars, operation, warn_demoted) -> None:
         """Warn about auxiliary variables carried through untransformed for lack of spatial axes.
 
         A variable with >= 2 *unrecognised* axes is likely a grid whose axes were not recognised (no
         CF axis attributes / no known x/y names). Axes that are clearly non-spatial (time / vertical
         / ensemble / bounds) don't count, so a legitimately non-spatial N-D aux variable (e.g.
-        ``(time, level)``) does not trip the warning. ``warn_demoted=False`` suppresses the message
+        ``(time, level)``) does not trip the warning. Nor does a string or compound array: its axes
+        may well be `y` / `x`, and telling the user to rename them would be wrong -- it is not a
+        grid because of its dtype, not its axes. ``warn_demoted=False`` suppresses the message
         on the eager fallback recursion, which already warned on the outer call.
         """
         demoted = [
@@ -5153,6 +5177,7 @@ class NetCDF(Dataset):
                 ]
             )
             >= 2
+            and self._declares_numeric(rg, n)
         ]
         if demoted and warn_demoted:
             warnings.warn(
@@ -7403,7 +7428,16 @@ class NetCDF(Dataset):
             ValueError: The variable has no raster plane.
         """
         rg = self._working_group()
-        md_arr = open_mdarray(rg, variable_name) if rg is not None else None
+        # Only a name `get_variable` accepts is judged on its declaration. A
+        # coordinate array (`x`, `lat`) or a 0-D `crs` holder has a declaration
+        # too, and judging it here refused it for having "no raster plane" and
+        # sent the caller to `get_variable` -- which then rejected the name
+        # outright. Leaving such a name to `get_variable` gives its real refusal.
+        md_arr = (
+            open_mdarray(rg, variable_name)
+            if rg is not None and variable_name in self._readable_variable_names()
+            else None
+        )
         # Decided on the declaration first, so the refusal costs nothing: going
         # straight to `get_variable` would read the whole array only to reject it.
         dims = (
@@ -8928,7 +8962,17 @@ class NetCDF(Dataset):
                 var_name, src_dims, gdal.ExtendedDataType.CreateString()
             )
             NetCDF._copy_md_array_attributes(src_mdarray, new_md_array)
-            new_md_array.Write(src_mdarray.Read())
+            try:
+                new_md_array.Write(src_mdarray.Read())
+            except (RuntimeError, TypeError, ValueError):
+                # The array is created before it is written, and GDAL's Python
+                # bindings refuse to write a string array of rank >= 2. Left in
+                # place, the half-built array listed the variable in the result
+                # with every value `None` -- present by name, empty in fact --
+                # while the caller's warning said it could not be carried. It is
+                # removed, so the variable is absent and the warning is true.
+                dst_group.DeleteMDArray(var_name)
+                raise
         else:
             arr = src_mdarray.ReadAsArray()
             dtype = gdal.ExtendedDataType.Create(numpy_to_gdal_dtype(arr))

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4464,7 +4464,15 @@ class NetCDF(Dataset):
         # `get_variable` builds a fresh classic-raster wrapper (a new GDAL dataset) each call, so
         # resolve every spatial variable once and reuse it across the guard/spec/write passes below
         # instead of re-opening it up to four times (review R2-N1).
-        spatial_var_objs = {name: self.get_variable(name) for name in spatial_vars}
+        # Through `_require_raster_variable`, like every other fan-out site: the
+        # streaming path was the one that still called `get_variable` directly,
+        # so a non-raster variable reaching it died on `_band_dim_names` rather
+        # than refusing by name. `_variable_is_spatial` now keeps such a variable
+        # out of `spatial_vars`; this makes the guarantee local instead of
+        # depending on a classifier two calls away.
+        spatial_var_objs = {
+            name: self._require_raster_variable(name) for name in spatial_vars
+        }
         if not self._stream_feasible(rg, spatial_var_objs, spatial_vars, aux_vars):
             return None
 

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -7348,8 +7348,10 @@ class NetCDF(Dataset):
                 # `src` is the MDArray itself -- GDAL could not expose it as a
                 # raster plane. Materialise it instead of returning it: a public
                 # accessor must never hand back a raw GDAL handle (#1126). The
-                # references below are not needed for it, and would not stick:
-                # `LabeledArray` owns its data and defines `__slots__`.
+                # references below are neither needed nor settable for it: the
+                # values are materialised into NumPy's own memory rather than a
+                # view over GDAL's, so nothing has to be kept alive, and
+                # `LabeledArray` defines `__slots__`.
                 return _labeled_array_from_md_array(src, variable_name)
             # Keep GDAL SWIG references alive — AsClassicDataset returns a
             # view whose C++ backing is owned by the MDArray/root group.

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -4507,7 +4507,12 @@ class NetCDF(Dataset):
                 # references its raster yet, so carry each aux var in place (copy=False)
                 # to avoid a full MEM copy per aux variable (#143).
                 result.add_variable(self, var_name, copy=False)
-            except (RuntimeError, ValueError) as exc:
+            except (RuntimeError, TypeError, ValueError) as exc:
+                # `TypeError` too: a string array with a NULL entry reads back
+                # with `None` in it, and writing that list raises "sequence must
+                # contain strings". Uncaught, one such auxiliary failed the whole
+                # container operation rather than being dropped with a warning
+                # like every other variable that cannot be carried.
                 dropped.append((var_name, exc))
         if dropped:
             # One aggregated warning naming every dropped variable, so a silent
@@ -4651,10 +4656,15 @@ class NetCDF(Dataset):
             # Through the resolver: an aux name from the readable enumeration may
             # be group-qualified, which `OpenMDArray` alone does not walk.
             src_md = open_mdarray(rg, name)
-            if (
-                src_md is not None
-                and src_md.GetDataType().GetClass() == gdal.GEDTC_STRING
+            if src_md is not None and src_md.GetDataType().GetClass() in (
+                gdal.GEDTC_STRING,
+                gdal.GEDTC_COMPOUND,
             ):
+                # Compound as well as string: the streamed write goes through
+                # `numpy_to_gdal_dtype`, which has no mapping for a structured
+                # dtype, so a compound auxiliary failed `to_crs(path=...)` with
+                # "numpy data type is not supported" while the in-memory arm
+                # dropped it with a warning. Declining here sends it to that arm.
                 return False
         return True
 
@@ -9028,6 +9038,16 @@ class NetCDF(Dataset):
                 var_name, src_dims, gdal.ExtendedDataType.CreateString()
             )
             NetCDF._copy_md_array_attributes(src_mdarray, new_md_array)
+            # The numeric branch carries unit and spatial reference; this one
+            # dropped them, so a string auxiliary came out of a crop with a unit
+            # of '' where it went in with '1'. No-data has no meaning for a
+            # string array, so it is the one label left behind.
+            unit = src_mdarray.GetUnit()
+            if unit:
+                new_md_array.SetUnit(unit)
+            srs = src_mdarray.GetSpatialRef()
+            if srs is not None:
+                new_md_array.SetSpatialRef(srs)
             try:
                 new_md_array.Write(src_mdarray.Read())
             except (RuntimeError, TypeError, ValueError):

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1033,6 +1033,28 @@ def _grid_lines(nc: NetCDF) -> list[str]:
     return lines
 
 
+def _has_raster_plane(md_arr: gdal.MDArray) -> bool:
+    """Whether GDAL can expose `md_arr` as a raster plane, decided without reading it.
+
+    The two conditions `_read_md_array` hands the raw array back on: a single
+    dimension, or a dtype class other than numeric (`AsClassicDataset` accepts
+    numeric arrays only). Both come off the array's declaration, so this costs
+    nothing however large the array is -- the point, since the alternative is
+    materialising the whole array only to learn it is not a raster.
+
+    Args:
+        md_arr: The array to classify.
+
+    Returns:
+        bool: `True` when the array has at least two dimensions and a numeric
+        type, so `get_variable` will return a raster-backed `NetCDF` for it.
+    """
+    return bool(
+        len(md_arr.GetDimensions()) >= 2
+        and md_arr.GetDataType().GetClass() == gdal.GEDTC_NUMERIC
+    )
+
+
 def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArray:
     """Materialise an MDArray GDAL cannot expose as a raster into a `LabeledArray`.
 
@@ -1117,7 +1139,19 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
         # result was read-only where every other path is writeable, and a
         # component that is itself a compound has no numeric type code, so the
         # hand-rolled dtype raised on a record `ReadAsArray` handles.
-        raw = md_arr.ReadAsArray()
+        try:
+            raw = md_arr.ReadAsArray()
+        except RuntimeError as error:
+            # A compound record with a string field is unreadable through the
+            # SWIG bindings by *either* reader -- `ReadAsArray` and `Read` both
+            # raise ("String buffer" / "non-numeric buffer data type not
+            # supported"). There is nothing to materialise, so this refuses, but
+            # in terms of the variable rather than with GDAL's bare message.
+            raise ValueError(
+                f"{name} cannot be read: GDAL's Python bindings do not support "
+                f"its data type ({error}). A compound type with a string field "
+                "is the usual cause."
+            ) from error
     values = np.asarray(raw)
     if values.shape != shape:
         # The two shapes come from different places -- `shape` from the
@@ -2378,13 +2412,18 @@ class NetCDF(Dataset):
             crs = ""
             try:
                 for name in self.variable_names:
+                    if not self._declares_raster_plane(name):
+                        # A non-raster variable has no CRS to borrow. Skipped on
+                        # its declaration, not by reading it: `get_variable`
+                        # materialises, so asking it would read the whole array
+                        # -- 40 MB for a 5M-element series -- to learn nothing.
+                        # And skipped rather than allowed to raise, because the
+                        # `except` below wraps the whole loop, so one such
+                        # variable early in the list would suppress the CRS of
+                        # every raster variable after it.
+                        continue
                     variable = self.get_variable(name)
                     if isinstance(variable, LabeledArray):
-                        # A non-raster variable has no CRS to borrow. It must be
-                        # skipped rather than allowed to raise: the `except`
-                        # below wraps the whole loop, so one such variable early
-                        # in the list would otherwise suppress the CRS of every
-                        # raster variable after it.
                         continue
                     variable_crs = variable.crs
                     if variable_crs:
@@ -4041,7 +4080,13 @@ class NetCDF(Dataset):
         if md is None:
             return False
         var_dims = [d.GetName() for d in md.GetDimensions()]
-        if len(var_dims) < 2:
+        if not _has_raster_plane(md):
+            # A string or compound array sitting on recognised (y, x) axes has
+            # the dimensions of a grid but no raster plane: `get_variable` cannot
+            # build one, so treating it as spatial handed it to the fan-out,
+            # which then refused the *whole* container's crop / to_crs / reduce
+            # over one auxiliary field. It is carried through like any other
+            # auxiliary variable instead.
             return False
         return (
             self._cf_spatial_axes(rg, var_dims) is not None
@@ -7256,6 +7301,22 @@ class NetCDF(Dataset):
         """Whether the X axis is stored east-to-west; see `_mdim.x_axis_is_right_to_left`."""
         return x_axis_is_right_to_left(dims, x_index, classic_view)
 
+    def _declares_raster_plane(self, variable_name: str) -> bool:
+        """Whether `get_variable(variable_name)` would return a raster, without reading it.
+
+        Args:
+            variable_name: The variable, group-qualified if it lives in a group.
+
+        Returns:
+            bool: `True` for a raster variable, and also when there is no
+            multidimensional group to ask -- the classic `NETCDF:file:var` path
+            always yields a raster -- or the name cannot be opened, so that
+            `get_variable` is left to produce its own error for it.
+        """
+        rg = self._working_group()
+        md_arr = open_mdarray(rg, variable_name) if rg is not None else None
+        return md_arr is None or _has_raster_plane(md_arr)
+
     def _require_raster_variable(
         self, variable_name: str, x_dim: str | None = None, y_dim: str | None = None
     ) -> NetCDF:
@@ -7280,13 +7341,26 @@ class NetCDF(Dataset):
         Raises:
             ValueError: The variable has no raster plane.
         """
-        variable = self.get_variable(variable_name, x_dim=x_dim, y_dim=y_dim)
-        if isinstance(variable, LabeledArray):
+        rg = self._working_group()
+        md_arr = open_mdarray(rg, variable_name) if rg is not None else None
+        # Decided on the declaration first, so the refusal costs nothing: going
+        # straight to `get_variable` would read the whole array only to reject it.
+        dims = (
+            tuple(dim.GetName() for dim in md_arr.GetDimensions())
+            if md_arr is not None and not _has_raster_plane(md_arr)
+            else None
+        )
+        variable: NetCDF | LabeledArray | None = None
+        if dims is None:
+            variable = self.get_variable(variable_name, x_dim=x_dim, y_dim=y_dim)
+            if isinstance(variable, LabeledArray):
+                dims = variable.dims
+        if dims is not None or not isinstance(variable, NetCDF):
             raise ValueError(
-                f"{variable_name} has no raster plane (dimensions "
-                f"{variable.dims}), so it has no geometry to operate on; read "
-                "its values with `get_variable`, or open the store with "
-                "`LabeledDataset` for labelled point data"
+                f"{variable_name} has no raster plane (dimensions {dims}), so it "
+                "has no geometry to operate on; read its values with "
+                "`get_variable`, or open the store with `LabeledDataset` for "
+                "labelled point data"
             )
         return variable
 

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1137,91 +1137,18 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
     dims = tuple(dim.GetName() for dim in dimensions)
     shape = tuple(dim.GetSize() for dim in dimensions)
     data_type = md_arr.GetDataType()
-    type_class = data_type.GetClass()
-    if 0 in shape:
-        # An unlimited netCDF dimension with no records written is the ordinary
-        # source of this, and such a variable is still advertised by
-        # `variable_names`. GDAL refuses to read it -- `count[0] = 0 is invalid`
-        # -- rather than handing back nothing, so the empty array is built from
-        # the declared type instead of asking GDAL for zero elements.
-        try:
-            raw = np.empty(shape, dtype=_numpy_dtype_of(data_type))
-        except ValueError as error:
-            # `_numpy_dtype_of` refuses a compound whose own component is a
-            # compound or a string, since neither has a numeric type code.
-            # Re-raised with the variable named: the bare message names only
-            # GDAL's type-code number (`not supported: 0`), which identifies
-            # neither the variable nor the component.
-            raise ValueError(
-                f"{name} has an empty extent and a compound type this reader "
-                f"cannot describe: {error}"
-            ) from error
-    elif type_class == gdal.GEDTC_STRING:
-        # The one class `ReadAsArray` cannot serve, and how it fails depends on
-        # GDAL's exception mode, not on the backing store. With exceptions on --
-        # pyramids turns them on at import -- a MEM and a file-backed array alike
-        # raise `RuntimeError: String buffer data type not supported in SWIG
-        # bindings`; with them off, either one only logs that error and returns
-        # `|S1` garbage. The silent case is why this branches on the dtype class
-        # rather than trying and catching. Same limitation `_md_array_to_numpy`
-        # and `_read_band_dim_values` work around. `Read` hands back a flat list
-        # of `str`, which is why it is reshaped here. It is the numeric arrays
-        # that must avoid `Read`, which returns their bytes undecoded as a
-        # `bytearray` -- the two are exact opposites.
-        # `object`, not `<U`: a string array can hold NULL entries, which `Read`
-        # returns as `None` and a `<U` array cannot represent. Letting NumPy pick
-        # made the dtype depend on the data -- `<U` for a fully written column,
-        # `object` the moment one entry came back NULL -- so code switching on
-        # `dtype.kind` broke on the first file holding one. `object` throughout
-        # keeps a NULL entry `None`, and matches `LabeledDataset`.
-        raw = np.asarray(md_arr.Read(), dtype=object).reshape(shape)
-    else:
-        # Numeric and compound alike. GDAL builds the structured dtype for a
-        # compound record itself, with the declared offsets and record size, so
-        # decoding the buffer by hand gained nothing and cost two things: the
-        # result was read-only where every other path is writeable, and a
-        # component that is itself a compound has no numeric type code, so the
-        # hand-rolled dtype raised on a record `ReadAsArray` handles.
-        try:
-            raw = md_arr.ReadAsArray()
-        except RuntimeError as error:
-            if type_class != gdal.GEDTC_COMPOUND:
-                # An I/O or decompression failure on an ordinary array: not a
-                # type problem, so GDAL's own message is the accurate one.
-                raise
-            # A compound record with a string field is unreadable through the
-            # SWIG bindings by *either* reader -- `ReadAsArray` and `Read` both
-            # raise ("String buffer" / "non-numeric buffer data type not
-            # supported"). There is nothing to materialise, so this refuses, but
-            # in terms of the variable rather than with GDAL's bare message.
-            raise ValueError(
-                f"{name} cannot be read: GDAL's Python bindings do not support "
-                f"its compound type ({error}). A compound with a string field "
-                "is the usual cause."
-            ) from error
-    values = np.asarray(raw)
+    values = _read_md_array_values(md_arr, data_type, shape, name)
     if values.shape != shape:
         # The two shapes come from different places -- `shape` from the
         # dimensions GDAL declares, `values.shape` from what the read returned --
         # and only the string path reshapes, so a short or mis-shaped numeric
-        # or compound read would otherwise reach the caller as a
-        # `LabeledArray` whose `shape` and `values.shape` quietly disagree.
+        # read would otherwise reach the caller as a `LabeledArray` whose
+        # `shape` and `values.shape` quietly disagree.
         raise ValueError(
             f"{name} declares dimensions {dims} of shape {shape}, but its "
             f"values read back with shape {values.shape}"
         )
-    # The labels the raw `MDArray` used to expose through `GetUnit()`,
-    # `GetNoDataValueAsDouble()` and the attribute API. Carrying them is what
-    # makes the wrapper a better answer than the handle it replaced rather than
-    # merely a safer one -- without them a `-9999.0` in `values` would be
-    # indistinguishable from real data.
-    attributes = {}
-    for attribute in md_arr.GetAttributes() or []:
-        try:
-            attributes[attribute.GetName()] = attribute.Read()
-        except RuntimeError:
-            # One unreadable attribute must not cost the caller the values.
-            continue
+    attributes = _read_md_array_attributes(md_arr)
     return LabeledArray(
         values,
         dims,
@@ -1238,6 +1165,103 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
         scale=md_arr.GetScale(),
         offset=md_arr.GetOffset(),
     )
+
+
+def _read_md_array_values(
+    md_arr: gdal.MDArray,
+    data_type: gdal.ExtendedDataType,
+    shape: tuple[int, ...],
+    name: str,
+) -> np.ndarray:
+    """Read an array's values with the reader its dtype class needs.
+
+    Split out of `_labeled_array_from_md_array`, which it serves: choosing the
+    reader is one decision with three answers, and keeping it here leaves that
+    function to assemble the result.
+
+    Args:
+        md_arr: The array to read.
+        data_type: Its declared type.
+        shape: The shape its dimensions declare.
+        name: The variable's name, for the refusals.
+
+    Returns:
+        np.ndarray: The values, not yet checked against `shape`.
+
+    Raises:
+        ValueError: The extent is empty and the type is a compound this reader
+            cannot describe, or the array is a compound GDAL's Python bindings
+            cannot read.
+        RuntimeError: A read failure unrelated to the type -- an I/O or
+            decompression error on an ordinary array -- passed through unchanged.
+    """
+    type_class = data_type.GetClass()
+    if 0 in shape:
+        # An unlimited netCDF dimension with no records written is the ordinary
+        # source of this, and such a variable is still advertised by
+        # `variable_names`. GDAL refuses to read it -- `count[0] = 0 is invalid`
+        # -- rather than handing back nothing, so the empty array is built from
+        # the declared type instead of asking GDAL for zero elements.
+        try:
+            raw = np.empty(shape, dtype=_numpy_dtype_of(data_type))
+        except ValueError as error:
+            raise ValueError(
+                f"{name} has an empty extent and a compound type this reader "
+                f"cannot describe: {error}"
+            ) from error
+    elif type_class == gdal.GEDTC_STRING:
+        # The one class `ReadAsArray` cannot serve: with GDAL's exceptions on,
+        # which importing pyramids turns on, it raises "String buffer data type
+        # not supported in SWIG bindings". `Read` returns the decoded strings.
+        # `object`, not `<U`: a NULL entry comes back as `None`, which a `<U`
+        # array cannot hold, so letting NumPy choose made the dtype depend on
+        # whether every entry happened to be written.
+        raw = np.asarray(md_arr.Read(), dtype=object).reshape(shape)
+    else:
+        # Numeric and compound alike: GDAL builds the structured dtype for a
+        # compound record itself, with the declared offsets and record size.
+        try:
+            raw = md_arr.ReadAsArray()
+        except RuntimeError as error:
+            if type_class != gdal.GEDTC_COMPOUND:
+                # An I/O or decompression failure on an ordinary array: not a
+                # type problem, so GDAL's own message is the accurate one.
+                raise
+            # A compound record with a string field is unreadable through the
+            # SWIG bindings by *either* reader. There is nothing to materialise,
+            # so this refuses, but in terms of the variable rather than with
+            # GDAL's bare message.
+            raise ValueError(
+                f"{name} cannot be read: GDAL's Python bindings do not support "
+                f"its compound type ({error}). A compound with a string field "
+                "is the usual cause."
+            ) from error
+    return np.asarray(raw)
+
+
+def _read_md_array_attributes(md_arr: gdal.MDArray) -> dict[str, Any]:
+    """The array's attributes as a plain dict, skipping any that will not read.
+
+    The labels the raw `MDArray` used to expose through its attribute API.
+    Carrying them is part of what makes the wrapper a better answer than the
+    handle it replaced rather than merely a safer one.
+
+    Args:
+        md_arr: The array whose attributes to read.
+
+    Returns:
+        dict[str, Any]: Each readable attribute by name. `scale_factor` and
+        `add_offset` are absent: GDAL lifts them out of the attribute list, and
+        they are carried as `scale` / `offset` instead.
+    """
+    attributes: dict[str, Any] = {}
+    for attribute in md_arr.GetAttributes() or []:
+        try:
+            attributes[attribute.GetName()] = attribute.Read()
+        except RuntimeError:
+            # One unreadable attribute must not cost the caller the values.
+            continue
+    return attributes
 
 
 def _no_data_value_of(md_arr: gdal.MDArray) -> float | int | None:
@@ -7512,6 +7536,30 @@ class NetCDF(Dataset):
             )
         return variable
 
+    def _get_group_variable(
+        self, variable_name: str, x_dim: str | None, y_dim: str | None
+    ) -> NetCDF | LabeledArray:
+        """Resolve a group-qualified `get_variable` name through its group.
+
+        Args:
+            variable_name: A name of the form `group/leaf`.
+            x_dim: Optional name of the X dimension, passed through.
+            y_dim: Optional name of the Y dimension, passed through.
+
+        Returns:
+            NetCDF | LabeledArray: What the owning group's `get_variable` returns
+            for the leaf, with a `LabeledArray` renamed to the qualified name.
+        """
+        group_path, leaf = variable_name.rsplit("/", 1)
+        cube = self.get_group(group_path).get_variable(leaf, x_dim=x_dim, y_dim=y_dim)
+        if isinstance(cube, LabeledArray):
+            # The group resolved the leaf, so the wrapper came back named
+            # `air_press` -- a name the grouped fixture repeats in every group,
+            # and one `read_array(variable=...)` on the root then rejects. The
+            # caller's qualified name is the one that means something here.
+            cube.name = variable_name
+        return cube
+
     def get_variable(
         self, variable_name: str, x_dim: str | None = None, y_dim: str | None = None
     ) -> NetCDF | LabeledArray:
@@ -7681,16 +7729,7 @@ class NetCDF(Dataset):
         """
         # Handle group-qualified names: "forecast/temperature"
         if "/" in variable_name:
-            parts = variable_name.rsplit("/", 1)
-            group_nc = self.get_group(parts[0])
-            cube = group_nc.get_variable(parts[1], x_dim=x_dim, y_dim=y_dim)
-            if isinstance(cube, LabeledArray):
-                # The group resolved the leaf, so the wrapper came back named
-                # `air_press` -- a name the grouped fixture repeats in every
-                # group, and one `read_array(variable=...)` then rejects. The
-                # caller's qualified name is the one that means something here.
-                cube.name = variable_name
-            return cube  # single return below handles non-group path
+            return self._get_group_variable(variable_name, x_dim, y_dim)
 
         # Checked against what the store *holds*, not against `variable_names`:
         # that property enumerates data variables, so CF non-data arrays -- 2-D
@@ -7721,7 +7760,10 @@ class NetCDF(Dataset):
             if x_index is not None:
                 spatial_dim_indices = (x_index, y_index)
             if isinstance(src, gdal.Dataset):
-                cube = Variable(src)
+                # Declared `NetCDF`, not inferred: `_georeference_index_subset`
+                # below reassigns `cube` a `NetCDF`, and with the group branch now
+                # in its own method this is the first assignment mypy sees.
+                cube: NetCDF = Variable(src)
                 cube._is_md_array = True
                 # Which spatial axes _read_md_array reversed, and where the raster plane sits in the
                 # MDArray. The eager materialize path rebuilds the unreversed view from these and

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -159,6 +159,11 @@ class _LazyVariableDict(dict):
     `AsClassicDataset` + Y-flip) for every variable upfront.
     Only the variables actually accessed are loaded.
 
+    An entry is whatever `get_variable` answers for that name, so the values are
+    not of one type: a `NetCDF` subset for a raster variable, a `LabeledArray`
+    for one with no raster plane (a 1-D array of any dtype, or a non-numeric one
+    of any rank).
+
     Note:
         This class is **not thread-safe**. Concurrent access from
         multiple threads may cause `get_variable()` to be called
@@ -172,6 +177,7 @@ class _LazyVariableDict(dict):
         self._names: list[str] = nc.variable_names
 
     def __getitem__(self, key: str) -> NetCDF | LabeledArray:
+        """Load `key` on first access and cache it; see the class docstring for the types."""
         if not dict.__contains__(self, key):
             if key not in self._names:
                 raise KeyError(self._refusal(key))
@@ -224,12 +230,15 @@ class _LazyVariableDict(dict):
     # views (callers iterate variable names/datasets, not a changing
     # mapping), so the return types deliberately diverge from dict/Mapping.
     def keys(self) -> list[str]:  # type: ignore[override]
+        """The data-variable names, in store order. Reads nothing."""
         return self._names
 
     def values(self) -> list[NetCDF | LabeledArray]:  # type: ignore[override]
+        """Every variable, loading each: a `NetCDF` per raster variable, a `LabeledArray` else."""
         return [self[k] for k in self._names]
 
     def items(self) -> list[tuple[str, NetCDF | LabeledArray]]:  # type: ignore[override]
+        """`(name, variable)` for every variable, loading each; values as for `values`."""
         return [(k, self[k]) for k in self._names]
 
 
@@ -1050,9 +1059,16 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
         the `name`, `unit`, `no_data_value` and `attributes` the array carries.
         The values are as **stored**: no CF time decoding and no
         `scale_factor` / `add_offset`, matching `read_array`'s own
-        `unpack=False` default. `LabeledDataset["var"]` returns the same class
-        but decodes a CF time axis, so the two agree on type and not always on
-        values.
+        `unpack=False` default.
+
+        `LabeledDataset["var"]` returns the same class, so the two agree on
+        type, but not on much else. It decodes a CF time axis to datetimes
+        where this hands back the stored numbers; it applies the store's
+        current `select` / `select_time` / `select_bbox` and squeezes the
+        scalar-selected dimensions out, where this always reads the whole
+        array; it reads a string array as `object` where this reads it as
+        `<U`; and it leaves `name`, `unit`, `no_data_value` and `attributes`
+        at their defaults, where this fills them in.
 
     Raises:
         ValueError: The values read back with a shape other than the one the
@@ -1075,17 +1091,24 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
         except ValueError as error:
             # `_numpy_dtype_of` refuses a compound whose own component is a
             # compound, since that has no numeric type code. Re-raised with the
-            # variable named: the bare message is GDAL's type-code number, which
-            # identifies neither the variable nor the component.
+            # variable named: the bare message names only GDAL's type-code
+            # number (`not supported: 0`), which identifies neither the
+            # variable nor the component.
             raise ValueError(
                 f"{name} has an empty extent and a compound type this reader "
                 f"cannot describe: {error}"
             ) from error
     elif type_class == gdal.GEDTC_STRING:
-        # The one class `ReadAsArray` cannot serve: it reads the pointer bytes
-        # and answers `[b'[', b'[', b'1']` for `['x', 'yy', 'zzz']`. `Read`
-        # decodes them. It is the numeric arrays that must avoid `Read`, which
-        # returns their bytes undecoded -- the two are exact opposites.
+        # The one class `ReadAsArray` cannot serve, and it fails two different
+        # ways: a file-backed array raises `RuntimeError: String buffer data
+        # type not supported in SWIG bindings`, while a MEM one returns the
+        # pointer bytes as `|S1` garbage (`[b' ', b'û', ...]`) without
+        # complaining. The silent case is why this branches on the dtype class
+        # rather than trying and catching. Same limitation `_md_array_to_numpy`
+        # and `_read_band_dim_values` work around. `Read` hands back a flat list
+        # of `str`, which is why it is reshaped here. It is the numeric arrays
+        # that must avoid `Read`, which returns their bytes undecoded as a
+        # `bytearray` -- the two are exact opposites.
         raw = np.asarray(md_arr.Read()).reshape(shape)
     else:
         # Numeric and compound alike. GDAL builds the structured dtype for a
@@ -1139,8 +1162,28 @@ def _numpy_dtype_of(data_type: gdal.ExtendedDataType) -> np.dtype:
         data_type: The array's declared type.
 
     Returns:
-        np.dtype: The numeric dtype, the compound record dtype, or `object` for
-        a string array -- the type `Read` would have produced for each.
+        np.dtype: The numeric dtype, the compound record dtype, or a zero-width
+        `<U` string dtype -- the kind `Read` would have produced for each.
+
+    Raises:
+        ValueError: The type is a compound whose own components are not all
+            numeric; see `_compound_dtype`.
+
+    Examples:
+        - A numeric type maps straight onto its NumPy counterpart:
+            ```python
+            >>> from osgeo import gdal
+            >>> _numpy_dtype_of(gdal.ExtendedDataType.Create(gdal.GDT_Int16))
+            dtype('int16')
+
+            ```
+        - A string type maps onto a zero-width unicode dtype, not `object`:
+            ```python
+            >>> from osgeo import gdal
+            >>> _numpy_dtype_of(gdal.ExtendedDataType.CreateString())
+            dtype('<U')
+
+            ```
     """
     type_class = data_type.GetClass()
     if type_class == gdal.GEDTC_NUMERIC:
@@ -1148,9 +1191,11 @@ def _numpy_dtype_of(data_type: gdal.ExtendedDataType) -> np.dtype:
     elif type_class == gdal.GEDTC_COMPOUND:
         dtype = _compound_dtype(data_type)
     else:
-        # `<U`, matching what `np.asarray(md_arr.Read())` yields for a non-empty
-        # string array. `object` would have made an empty variable the only
-        # string array on this path with a different dtype.
+        # `<U0`: the same `str_` kind `np.asarray(md_arr.Read())` yields for a
+        # populated string array (`<U3` for `['x', 'yy', 'zzz']`), at zero width
+        # because there are no elements to size it from. `object` would have
+        # been the other defensible choice, but it reads as "unknown" where the
+        # type is in fact known and empty.
         dtype = np.dtype(np.str_)
     return dtype
 
@@ -1158,9 +1203,12 @@ def _numpy_dtype_of(data_type: gdal.ExtendedDataType) -> np.dtype:
 def _compound_dtype(data_type: gdal.ExtendedDataType) -> np.dtype:
     """The NumPy structured dtype matching a GDAL compound type.
 
-    Only reached for a compound variable with a zero-length dimension, where
-    there is nothing to read and `ReadAsArray` -- which builds this dtype itself
-    for every non-empty compound -- cannot be asked.
+    Reached only through `_numpy_dtype_of`, which is itself called only from the
+    zero-length branch of `_labeled_array_from_md_array`. So this runs for a
+    compound variable with a zero-length dimension and nothing else: everywhere
+    else there is something to read, and `ReadAsArray` builds this same dtype
+    itself -- with the same offsets and record size -- for every non-empty
+    compound, nested ones included.
 
     Built from the components GDAL declares -- name, byte offset and numeric
     type -- with the record size as the itemsize, so the field padding of the
@@ -1179,6 +1227,39 @@ def _compound_dtype(data_type: gdal.ExtendedDataType) -> np.dtype:
         ValueError: A component is not itself numeric -- a nested compound or a
             string field -- so `GetNumericDataType()` reports `GDT_Unknown`,
             which has no NumPy counterpart.
+
+    Examples:
+        - The declared record size is honoured, so the padding survives:
+            ```python
+            >>> import numpy as np
+            >>> from osgeo import gdal
+            >>> record = gdal.ExtendedDataType.CreateCompound(
+            ...     "rec",
+            ...     8,
+            ...     [
+            ...         gdal.EDTComponent.Create(
+            ...             "flag", 0, gdal.ExtendedDataType.Create(gdal.GDT_Byte)
+            ...         ),
+            ...         gdal.EDTComponent.Create(
+            ...             "count", 4, gdal.ExtendedDataType.Create(gdal.GDT_Int32)
+            ...         ),
+            ...     ],
+            ... )
+            >>> dtype = _compound_dtype(record)
+            >>> dtype.names
+            ('flag', 'count')
+            >>> dtype.itemsize
+            8
+
+            ```
+        - A dtype built from the formats alone packs the same record into five
+          bytes, which is the misreading this avoids:
+            ```python
+            >>> import numpy as np
+            >>> np.dtype([("flag", "u1"), ("count", "i4")]).itemsize
+            5
+
+            ```
     """
     components = data_type.GetComponents()
     return np.dtype(
@@ -2282,13 +2363,15 @@ class NetCDF(Dataset):
         for CF geographic grids and wrong for everything else (ARC-26).
 
         Resolve it honestly instead: a container's variables share one grid, so
-        the first variable that reports a CRS defines the container's CRS. The
+        the first variable that reports a CRS defines the container's CRS.
+        Variables with no raster plane are stepped over rather than consulted --
+        a :class:`~pyramids.netcdf.LabeledArray` has no ``crs`` to borrow. The
         result is memoised because every spatial operation on the container asks
         for it.
 
         Returns:
-            str: The first variable's CRS WKT, or ``""`` when this container has
-            no variable that reports one.
+            str: The first raster variable's CRS WKT, or ``""`` when this
+            container has no variable that reports one.
         """
         cached = getattr(self, "_container_crs_cache", None)
         if cached is None:
@@ -2647,11 +2730,48 @@ class NetCDF(Dataset):
 
         Each entry is whatever `get_variable` returns for that name: a `NetCDF`
         subset for a raster variable, a `LabeledArray` for one with no raster
-        plane -- a 1-D array, or a non-numeric one of any rank.
+        plane -- a 1-D array, or a non-numeric one of any rank. A store that
+        holds both kinds yields both from one mapping, so check what you have
+        before reaching for a raster method.
 
         Returns:
             dict[str, NetCDF | LabeledArray]: Mapping from variable name to its
             subset.
+
+        Examples:
+            - A store with a grid and a profile axis yields one of each kind:
+                ```python
+                >>> import numpy as np
+                >>> from osgeo import gdal
+                >>> from pyramids.netcdf import Container
+                >>> store = gdal.GetDriverByName("MEM").CreateMultiDimensional("demo")
+                >>> group = store.GetRootGroup()
+                >>> lat = group.CreateDimension("lat", None, None, 2)
+                >>> lon = group.CreateDimension("lon", None, None, 3)
+                >>> ilev = group.CreateDimension("ilev", None, None, 4)
+                >>> grid = group.CreateMDArray(
+                ...     "t2m", [lat, lon], gdal.ExtendedDataType.Create(gdal.GDT_Float32)
+                ... )
+                >>> grid.Write(np.arange(6, dtype="float32").reshape(2, 3))
+                0
+                >>> profile = group.CreateMDArray(
+                ...     "hyai", [ilev], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+                ... )
+                >>> profile.Write(np.array([0.0, 0.25, 0.5, 1.0]))
+                0
+                >>> variables = Container(store).variables
+                >>> sorted(variables.keys())
+                ['hyai', 't2m']
+                >>> variables["t2m"].shape
+                (1, 2, 3)
+                >>> variables["hyai"].values.tolist()
+                [0.0, 0.25, 0.5, 1.0]
+
+                ```
+
+        See Also:
+            `get_variable`: the accessor behind each entry, and the full account
+                of when a name answers with a `LabeledArray`.
         """
         if self._cached_variables is None:
             self._cached_variables = _LazyVariableDict(self)
@@ -3522,29 +3642,32 @@ class NetCDF(Dataset):
 
         A 1-D array (a coordinate axis, a data series, a bounds array) or a
         non-numeric one has no raster plane. Several such names are
-        *enumerated* -- GOES ABI declares ``time_bounds`` / ``x_image_bounds`` /
-        ``y_image_bounds`` as data variables and a grouped store enumerates
-        ``"flight_03/CO"`` -- so they reach :meth:`read_array` through the
-        ordinary container route and used to fail there with
-        ``AttributeError: 'MDArray' object has no attribute 'read_array'``.
+        *enumerated* -- GOES ABI declares `time_bounds` / `x_image_bounds` /
+        `y_image_bounds` as data variables and a grouped store enumerates
+        `"flight_03/CO"` -- so they reach `read_array` through the ordinary
+        container route and used to fail there with
+        `AttributeError: 'MDArray' object has no attribute 'read_array'`.
 
-        The values are taken from the :class:`LabeledArray` the caller already
-        resolved rather than read again. :meth:`get_variable` materialises now,
-        so re-reading here would have made every container-route read of such a
-        variable read the whole array twice.
+        The values are taken from the `LabeledArray` the caller already resolved
+        rather than read again. `get_variable` materialises now, so re-reading
+        here would have made every container-route read of such a variable read
+        the whole array twice.
 
         Args:
-            variable: The array name, used in the refusals below.
-            band: Rejected -- a raw array has no bands.
-            window: Rejected -- a raw array has no raster window to clip.
+            variable: The array name, used in the refusals below and to reopen
+                the MDArray when `unpack` is set.
+            band: Rejected -- an array with no raster plane has no bands.
+            window: Rejected -- there is no raster window to clip.
             chunks: Rejected -- the lazy path builds a raster plane.
             masked: Rejected -- masking is defined against a band's no-data.
-            unpack: Applied from the array's own CF ``scale_factor`` /
-                ``add_offset``, since there is no band to carry them.
-            values: The already-materialised variable.
+            unpack: Applied from the array's own CF `scale_factor` /
+                `add_offset`, since there is no band to carry them.
+            values: The variable `read_array` already materialised; its
+                `.values` are what this returns.
 
         Returns:
-            np.ndarray: The array's values, in storage order.
+            np.ndarray: The array's values, in storage order -- the very array
+            `values` holds when `unpack` is `False`, not a copy of it.
 
         Raises:
             ValueError: If any raster-only argument is supplied.
@@ -7044,7 +7167,9 @@ class NetCDF(Dataset):
 
         A **non-numeric** variable — a string/character column or a compound (struct) type,
         neither of which GDAL can expose as a raster — is returned as the raw `MDArray`
-        whatever its rank, exactly like a 1-D variable; read it with `Read()` (#1067).
+        whatever its rank, exactly like a 1-D variable (#1067). That raw handle stops here:
+        :meth:`get_variable`, this method's only caller, materialises it into a
+        :class:`~pyramids.netcdf.LabeledArray` rather than letting it out (#1126).
 
         Returns a tuple `(classic_dataset, md_array, root_group, x_index,
         y_index, y_flipped, x_flipped)` so callers can keep the GDAL objects alive and
@@ -7089,8 +7214,8 @@ class NetCDF(Dataset):
             # shape. Rank alone cannot save such an array: `_resolve_spatial_dims` resolves a pair
             # for anything with >= 2 dimensions (its last-two fallback never declines), which is how
             # a character column reached the raster view and raised (#1067). Return the MDArray
-            # itself — the same shape the 1-D branch above returns — so the caller reads it with
-            # `Read()` like any other array.
+            # itself — the same shape the 1-D branch above returns — for `get_variable` to
+            # materialise into a `LabeledArray` (#1126).
             return md_arr, md_arr, rg, None, None, False, False
 
         # Resolve on the original array — the flips below rename the reversed dimensions and drop
@@ -7216,15 +7341,23 @@ class NetCDF(Dataset):
 
                 A variable GDAL cannot expose as a raster comes back as a
                 `LabeledArray` — `values` alongside the `dims` and `shape`
-                GDAL declares — rather than as a `NetCDF`: a 1-D variable
-                of any dtype, and any **non-numeric** variable of any rank,
-                a character/string column (however the driver exposes it)
-                or a compound (struct) type. `LabeledDataset["var"]` hands
-                back the same class, though it decodes a CF time axis where
-                this returns the stored numbers. It is not a raster, so
-                none of the band-dim tracking above applies to it and
-                neither do `sel()` or the raster methods; read the values
-                off `.values` (#1126).
+                GDAL declares, plus the `name`, `unit`, `no_data_value` and
+                `attributes` the array carries — rather than as a `NetCDF`:
+                a 1-D variable of any dtype, and any **non-numeric**
+                variable of any rank, a character/string column (however
+                the driver exposes it) or a compound (struct) type. It is
+                not a raster, so none of the band-dim tracking above
+                applies to it and neither do `sel()` or the raster methods;
+                read the values off `.values` (#1126). They are the stored
+                values: no CF time decoding, and no `scale_factor` /
+                `add_offset` unless you ask `read_array` for `unpack=True`.
+
+                `LabeledDataset["var"]` hands back the same class from the
+                same store, so the two agree on type — but it decodes a CF
+                time axis, applies that store's current selection, squeezes
+                the scalar-selected dimensions out, reads a string array as
+                `object` rather than `<U`, and leaves the four label fields
+                above unset. Do not read the two as interchangeable.
 
         Raises:
             ValueError: If `variable_name` is not present in the dataset.
@@ -7254,7 +7387,8 @@ class NetCDF(Dataset):
                 (1, 2, 3)
 
                 ```
-            - A 1-D variable has no raster plane, so it answers as a `LabeledArray`:
+            - A 1-D variable has no raster plane, so it answers as a
+              `LabeledArray`, carrying the labels GDAL declares for it:
                 ```python
                 >>> import numpy as np
                 >>> from osgeo import gdal
@@ -7267,14 +7401,27 @@ class NetCDF(Dataset):
                 ... )
                 >>> coefficients.Write(np.array([0.0, 0.25, 0.5, 1.0]))
                 0
+                >>> coefficients.SetUnit("1")
+                0
+                >>> long_name = coefficients.CreateAttribute(
+                ...     "long_name", [], gdal.ExtendedDataType.CreateString()
+                ... )
+                >>> long_name.Write("hybrid A coefficient")
+                0
                 >>> hyai = Container(store).get_variable("hyai")
                 >>> hyai.dims, hyai.shape
                 (('ilev',), (4,))
                 >>> hyai.values.tolist()
                 [0.0, 0.25, 0.5, 1.0]
+                >>> hyai.name, hyai.unit
+                ('hyai', '1')
+                >>> hyai.attributes["long_name"]
+                'hybrid A coefficient'
 
                 ```
-            - A string column is non-numeric at any rank, so it is labelled too:
+            - A string column is non-numeric at any rank, so it is labelled too
+              — including the 2-D `(record, strlen)` shape a driver that models
+              the string length as a dimension reports:
                 ```python
                 >>> from osgeo import gdal
                 >>> from pyramids.netcdf import Container
@@ -7285,8 +7432,18 @@ class NetCDF(Dataset):
                 >>> units = group.CreateMDArray(
                 ...     "units", [record, strlen], gdal.ExtendedDataType.CreateString()
                 ... )
-                >>> Container(store).get_variable("units").shape
-                (2, 3)
+                >>> station = group.CreateMDArray(
+                ...     "station", [record], gdal.ExtendedDataType.CreateString()
+                ... )
+                >>> station.Write(["brienz", "thun"])
+                0
+                >>> nc = Container(store)
+                >>> nc.get_variable("units").dims
+                ('record', 'strlen')
+                >>> nc.get_variable("station")
+                LabeledArray('station', dims=('record',), shape=(2,))
+                >>> nc.get_variable("station").values.tolist()
+                ['brienz', 'thun']
 
                 ```
 
@@ -7804,10 +7961,11 @@ class NetCDF(Dataset):
 
         When `md_arr` is `None` (e.g. the file-backed gdal.Open path) the band/attr metadata is
         cleared to empty defaults. `cube` is always a `NetCDF`: a variable with no raster plane
-        — a 1-D one, or a non-numeric one of any rank (see `_read_md_array`) — is materialised and
-        returned by `get_variable` before this is called, so the band model it needs is always
-        present. `_copy_variable_attrs` is unaffected — it reads the
-        MDArray, not the cube.
+        — a 1-D one, or a non-numeric one of any rank (see `_read_md_array`) — is materialised
+        into a `LabeledArray` and returned by `get_variable` before this is called, so the band
+        model `_track_band_dimensions` and `_apply_attribute_no_data` read is always present.
+        `_copy_variable_attrs` never depended on it either way — it reads the MDArray, not the
+        cube.
         """
         if md_arr is None:
             self._clear_variable_metadata(cube)
@@ -7863,11 +8021,12 @@ class NetCDF(Dataset):
         fields point at the first non-spatial dim so existing 3-D consumers are unaffected.
 
         `cube` is always a raster-backed `NetCDF` (see `_read_md_array`): an array with no raster
-        plane is materialised by `get_variable` and never reaches here. A rank <= 2 one takes the
-        empty-`band_dims` exit below, which clears all five fields; a rank >= 3 one gets the
-        per-dimension `_band_dim_names` / `_band_dim_sizes` / `_band_dim_values_map`
-        tracking, and its legacy pair is derived, because deriving a primary band view needs
-        a band count the MDArray does not have (#1067).
+        plane is materialised by `get_variable` and never reaches here. A rank <= 2 variable takes
+        the empty-`band_dims` exit below, which clears all five fields; a rank >= 3 one gets the
+        per-dimension `_band_dim_names` / `_band_dim_sizes` / `_band_dim_values_map` tracking, and
+        its legacy pair is derived from `cube._band_count`. That derivation is why the raw
+        `gdal.MDArray` this used to be handed had to be special-cased: it carries no band model, so
+        it has no `_band_count` to derive from, and the legacy pair was left `None` (#1067).
         """
         if len(dims) > 2:
             spatial = (

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -23,7 +23,11 @@ from osgeo import gdal, osr
 
 from pyramids import _io
 from pyramids.base._axes import AXIS_NAMES
-from pyramids.base._utils import DEFAULT_RESAMPLING, numpy_to_gdal_dtype
+from pyramids.base._utils import (
+    DEFAULT_RESAMPLING,
+    gdal_to_numpy_dtype,
+    numpy_to_gdal_dtype,
+)
 from pyramids.base.crs import (
     VERTICAL_AXIS_NAMES,
     VERTICAL_STANDARD_NAMES,
@@ -82,6 +86,7 @@ from pyramids.netcdf.engines import variables as _variables
 from pyramids.netcdf.engines.interop import Interop
 from pyramids.netcdf.engines.selection import Selection
 from pyramids.netcdf.engines.variables import Variables
+from pyramids.netcdf.labeled import LabeledArray
 from pyramids.netcdf.metadata import get_metadata
 from pyramids.netcdf.models import (
     MAX_DISPLAY_VARIABLES,
@@ -1014,6 +1019,87 @@ def _grid_lines(nc: NetCDF) -> list[str]:
             grid += f" @ {nc.cell_size:g}"
         lines.append(_summary_line("grid", f"{grid}, {nc.band_count} band(s)"))
     return lines
+
+
+def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArray:
+    """Materialise an MDArray GDAL cannot expose as a raster into a `LabeledArray`.
+
+    Two shapes reach here, and neither is a raster plane: a 1-D array (a profile
+    axis, a bounds array, a hybrid-sigma coefficient), and a string or compound
+    array of any rank -- a character column is stored `(records, strlen)`, so it
+    is 2-D and still not numeric.
+
+    Both used to be handed back as the raw `gdal.MDArray`. That object carries
+    none of pyramids' API -- no `values`, no `stats`, no `read_array` -- and its
+    `Read()` returns an undecoded byte buffer for a numeric array, so the only
+    way out was `ReadAsArray()`: a caller who did not know better was walked
+    straight into using `osgeo` directly, which is what depending on pyramids is
+    meant to avoid (#1126).
+
+    Args:
+        md_arr: The array GDAL could not expose as a classic dataset.
+        name: The variable's name, for the error when it cannot be read.
+
+    Returns:
+        LabeledArray: `values` with the `dims` and `shape` GDAL declares -- the
+        same type `LabeledDataset["var"]` returns, so both routes to a
+        non-raster variable answer alike.
+
+    Raises:
+        ValueError: The array declares a shape but reads back as nothing.
+    """
+    dimensions = md_arr.GetDimensions()
+    dims = tuple(dim.GetName() for dim in dimensions)
+    shape = tuple(dim.GetSize() for dim in dimensions)
+    data_type = md_arr.GetDataType()
+    type_class = data_type.GetClass()
+    if type_class == gdal.GEDTC_NUMERIC:
+        raw = md_arr.ReadAsArray()
+    elif type_class == gdal.GEDTC_COMPOUND:
+        # `Read` hands back the record bytes undecoded, so reading a compound
+        # array as-is gives a flat `uint8` buffer whose length is the record
+        # count times the record size -- values that do not match the shape and
+        # mean nothing to the caller. GDAL does describe the layout, though, so
+        # the buffer is viewed through the matching structured dtype instead.
+        raw = np.frombuffer(
+            bytes(md_arr.Read()), dtype=_compound_dtype(data_type)
+        ).reshape(shape)
+    else:
+        # A string array: `ReadAsArray` raises "Only arrays with numeric data
+        # types can be exposed...", while `Read` returns decoded Python strings.
+        raw = np.asarray(md_arr.Read()).reshape(shape)
+    if raw is None:
+        raise ValueError(
+            f"{name} declares dimensions {dims} but its values could not be read"
+        )
+    return LabeledArray(np.asarray(raw), dims, shape)
+
+
+def _compound_dtype(data_type: gdal.ExtendedDataType) -> np.dtype:
+    """The NumPy structured dtype matching a GDAL compound type.
+
+    Built from the components GDAL declares -- name, byte offset and numeric
+    type -- with the record size as the itemsize, so the field padding of the
+    original struct is preserved rather than assumed away.
+
+    Args:
+        data_type: A compound `ExtendedDataType`.
+
+    Returns:
+        np.dtype: A structured dtype of the same memory layout.
+    """
+    components = data_type.GetComponents()
+    return np.dtype(
+        {
+            "names": [component.GetName() for component in components],
+            "formats": [
+                gdal_to_numpy_dtype(component.GetType().GetNumericDataType())
+                for component in components
+            ],
+            "offsets": [component.GetOffset() for component in components],
+            "itemsize": data_type.GetSize(),
+        }
+    )
 
 
 def _container_summary(nc: NetCDF) -> str:
@@ -7050,7 +7136,12 @@ class NetCDF(Dataset):
                 # wrong; fix it on the wrapper (no data copy).
                 self._correct_flipped_geotransform(cube)
             else:
-                cube = src
+                # `src` is the MDArray itself -- GDAL could not expose it as a
+                # raster plane. Materialise it instead of returning it: a public
+                # accessor must never hand back a raw GDAL handle (#1126). The
+                # references below are not needed for it, and would not stick:
+                # `LabeledArray` owns its data and defines `__slots__`.
+                return _labeled_array_from_md_array(src, variable_name)
             # Keep GDAL SWIG references alive — AsClassicDataset returns a
             # view whose C++ backing is owned by the MDArray/root group.
             # Without these the view becomes a dangling pointer on Windows.

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -9041,6 +9041,50 @@ class NetCDF(Dataset):
             new_attr.WriteDoubleArray(src_attr.ReadAsDoubleArray())
 
     @staticmethod
+    def _copy_md_array_packing(src_mdarray, dst_mdarray) -> None:
+        """Carry the CF packing -- scale, offset and fill value -- onto a copy.
+
+        Split out of `_add_md_array_to_group`, whose numeric branch alone needs
+        it: none of the three means anything for a string array.
+
+        Args:
+            src_mdarray: The array being copied.
+            dst_mdarray: The freshly created copy, not yet written.
+        """
+        scale = src_mdarray.GetScale()
+        if scale is not None:
+            dst_mdarray.SetScale(scale)
+        offset = src_mdarray.GetOffset()
+        if offset is not None:
+            dst_mdarray.SetOffset(offset)
+        ndv = src_mdarray.GetNoDataValue()
+        if ndv is not None:
+            try:
+                dst_mdarray.SetNoDataValueDouble(ndv)
+            except (RuntimeError, TypeError, ValueError):
+                pass
+
+    @staticmethod
+    def _copy_md_array_labels(src_mdarray, dst_mdarray) -> None:
+        """Carry the unit, spatial reference and attributes onto a copy.
+
+        Shared by both branches of `_add_md_array_to_group`. The string branch
+        used to copy the attributes alone, so a string auxiliary came out of a
+        crop with a unit of `''` where it went in with `'1'`.
+
+        Args:
+            src_mdarray: The array being copied.
+            dst_mdarray: The freshly created copy, not yet written.
+        """
+        unit = src_mdarray.GetUnit()
+        if unit:
+            dst_mdarray.SetUnit(unit)
+        srs = src_mdarray.GetSpatialRef()
+        if srs is not None:
+            dst_mdarray.SetSpatialRef(srs)
+        NetCDF._copy_md_array_attributes(src_mdarray, dst_mdarray)
+
+    @staticmethod
     def _add_md_array_to_group(dst_group, var_name, src_mdarray):
         """Copy an MDArray into `dst_group`, preserving data, packing, and metadata.
 
@@ -9076,54 +9120,30 @@ class NetCDF(Dataset):
             # SWIG bindings, but the Python list Read()/Write() path works. Use it
             # so non-spatial string aux vars (e.g. ERA5's 'expver') are carried
             # through container spatial ops instead of being dropped (#565).
+            # No packing: scale, offset and no-data mean nothing for text.
             new_md_array = dst_group.CreateMDArray(
                 var_name, src_dims, gdal.ExtendedDataType.CreateString()
             )
-            NetCDF._copy_md_array_attributes(src_mdarray, new_md_array)
-            # The numeric branch carries unit and spatial reference; this one
-            # dropped them, so a string auxiliary came out of a crop with a unit
-            # of '' where it went in with '1'. No-data has no meaning for a
-            # string array, so it is the one label left behind.
-            unit = src_mdarray.GetUnit()
-            if unit:
-                new_md_array.SetUnit(unit)
-            srs = src_mdarray.GetSpatialRef()
-            if srs is not None:
-                new_md_array.SetSpatialRef(srs)
+            NetCDF._copy_md_array_labels(src_mdarray, new_md_array)
             try:
                 new_md_array.Write(src_mdarray.Read())
             except (RuntimeError, TypeError, ValueError):
-                # The array is created before it is written, and GDAL's Python
-                # bindings refuse to write a string array of rank >= 2
-                # (`RuntimeError`) or a list holding a NULL entry (`TypeError`).
-                # Left in place, the half-built rank >= 2 array listed the
-                # variable in the result with every value `None` -- present by
-                # name, empty in fact -- while the caller's warning said it could
-                # not be carried. It is removed, so the variable is absent and
-                # the warning is true.
+                # The array is created before it is written, and the write can
+                # fail: GDAL's Python bindings refuse a string array of rank
+                # >= 2 (RuntimeError), and a NULL entry reads back as `None`,
+                # which the write rejects (TypeError). Left in place, the
+                # half-built array listed the variable with every value `None`
+                # while the caller's warning said it could not be carried. It is
+                # removed, so the variable is absent and the warning is true.
                 dst_group.DeleteMDArray(var_name)
                 raise
         else:
             arr = src_mdarray.ReadAsArray()
             dtype = gdal.ExtendedDataType.Create(numpy_to_gdal_dtype(arr))
             new_md_array = dst_group.CreateMDArray(var_name, src_dims, dtype)
-            scale = src_mdarray.GetScale()
-            if scale is not None:
-                new_md_array.SetScale(scale)
-            offset = src_mdarray.GetOffset()
-            if offset is not None:
-                new_md_array.SetOffset(offset)
-            unit = src_mdarray.GetUnit()
-            if unit:
-                new_md_array.SetUnit(unit)
-            ndv = src_mdarray.GetNoDataValue()
-            if ndv is not None:
-                try:
-                    new_md_array.SetNoDataValueDouble(ndv)
-                except (RuntimeError, TypeError, ValueError):
-                    pass
-            new_md_array.SetSpatialRef(src_mdarray.GetSpatialRef())
-            NetCDF._copy_md_array_attributes(src_mdarray, new_md_array)
+            # Packing before the data, so the netCDF driver accepts the fill.
+            NetCDF._copy_md_array_packing(src_mdarray, new_md_array)
+            NetCDF._copy_md_array_labels(src_mdarray, new_md_array)
             new_md_array.Write(arr)
 
     @staticmethod

--- a/src/pyramids/netcdf/netcdf.py
+++ b/src/pyramids/netcdf/netcdf.py
@@ -1088,14 +1088,16 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
         where this hands back the stored numbers; it applies the store's
         current `select` / `select_time` / `select_bbox` and squeezes the
         scalar-selected dimensions out, where this always reads the whole
-        array; it reads a string array as `object` where this reads it as
-        `<U`; and it leaves `name`, `unit`, `no_data_value` and `attributes`
-        at their defaults, where this fills them in.
+        array; and it leaves `name`, `unit`, `no_data_value`, `attributes`,
+        `scale` and `offset` at their defaults, where this fills them in. Both
+        read a string array as `object`.
 
     Raises:
         ValueError: The values read back with a shape other than the one the
-            dimensions declare, or the array is empty and carries a compound
-            type whose own components are compound.
+            dimensions declare; the array cannot be read at all through GDAL's
+            Python bindings (a compound with a string field); or the array is
+            empty and carries a compound type with a component that is itself a
+            compound or a string, which has no numeric type to describe.
     """
     dimensions = md_arr.GetDimensions()
     dims = tuple(dim.GetName() for dim in dimensions)
@@ -1131,7 +1133,13 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
         # of `str`, which is why it is reshaped here. It is the numeric arrays
         # that must avoid `Read`, which returns their bytes undecoded as a
         # `bytearray` -- the two are exact opposites.
-        raw = np.asarray(md_arr.Read()).reshape(shape)
+        # `object`, not `<U`: a string array can hold NULL entries, which `Read`
+        # returns as `None` and a `<U` array cannot represent. Letting NumPy pick
+        # made the dtype depend on the data -- `<U` for a fully written column,
+        # `object` the moment one entry was missing -- so code switching on
+        # `dtype.kind` broke on partially filled files. `object` throughout keeps
+        # the missing entries missing, and matches `LabeledDataset`.
+        raw = np.asarray(md_arr.Read(), dtype=object).reshape(shape)
     else:
         # Numeric and compound alike. GDAL builds the structured dtype for a
         # compound record itself, with the declared offsets and record size, so
@@ -1181,7 +1189,7 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
         shape,
         name=name,
         unit=md_arr.GetUnit() or "",
-        no_data_value=md_arr.GetNoDataValueAsDouble(),
+        no_data_value=_no_data_value_of(md_arr),
         attributes=attributes,
         # Carried because GDAL removes `scale_factor` / `add_offset` from the
         # attribute list: without them a packed variable arrived as `[10, 15]`
@@ -1191,6 +1199,37 @@ def _labeled_array_from_md_array(md_arr: gdal.MDArray, name: str) -> LabeledArra
         scale=md_arr.GetScale(),
         offset=md_arr.GetOffset(),
     )
+
+
+def _no_data_value_of(md_arr: gdal.MDArray) -> float | int | None:
+    """The array's declared fill value, at the precision its type holds.
+
+    `GetNoDataValueAsDouble` is exact for every type but the two 64-bit integer
+    ones, where a double's 53-bit mantissa cannot hold the value: the common
+    `-9223372036854775806` fill came back as `-9.223372036854776e+18`, which
+    compares equal to no element of the array. Those two are read through
+    their own accessors instead.
+
+    Args:
+        md_arr: The array whose fill value to read.
+
+    Returns:
+        float | int | None: The fill value, an `int` for a 64-bit integer array,
+        or `None` when the array declares none.
+    """
+    data_type = md_arr.GetDataType()
+    numeric_type = (
+        data_type.GetNumericDataType()
+        if data_type.GetClass() == gdal.GEDTC_NUMERIC
+        else None
+    )
+    if numeric_type == gdal.GDT_Int64:
+        value: float | int | None = md_arr.GetNoDataValueAsInt64()
+    elif numeric_type == gdal.GDT_UInt64:
+        value = md_arr.GetNoDataValueAsUInt64()
+    else:
+        value = md_arr.GetNoDataValueAsDouble()
+    return value
 
 
 def _numpy_dtype_of(data_type: gdal.ExtendedDataType) -> np.dtype:
@@ -1203,8 +1242,8 @@ def _numpy_dtype_of(data_type: gdal.ExtendedDataType) -> np.dtype:
         data_type: The array's declared type.
 
     Returns:
-        np.dtype: The numeric dtype, the compound record dtype, or a zero-width
-        `<U` string dtype -- the kind `Read` would have produced for each.
+        np.dtype: The numeric dtype, the compound record dtype, or `object` for a
+        string array -- the dtype a non-empty read of each produces.
 
     Raises:
         ValueError: The type is a compound whose own components are not all
@@ -1218,11 +1257,11 @@ def _numpy_dtype_of(data_type: gdal.ExtendedDataType) -> np.dtype:
             dtype('int16')
 
             ```
-        - A string type maps onto a zero-width unicode dtype, not `object`:
+        - A string type maps onto `object`, which can hold a missing entry:
             ```python
             >>> from osgeo import gdal
             >>> _numpy_dtype_of(gdal.ExtendedDataType.CreateString())
-            dtype('<U')
+            dtype('O')
 
             ```
     """
@@ -1232,12 +1271,9 @@ def _numpy_dtype_of(data_type: gdal.ExtendedDataType) -> np.dtype:
     elif type_class == gdal.GEDTC_COMPOUND:
         dtype = _compound_dtype(data_type)
     else:
-        # `<U0`: the same `str_` kind `np.asarray(md_arr.Read())` yields for a
-        # populated string array (`<U3` for `['x', 'yy', 'zzz']`), at zero width
-        # because there are no elements to size it from. `object` would have
-        # been the other defensible choice, but it reads as "unknown" where the
-        # type is in fact known and empty.
-        dtype = np.dtype(np.str_)
+        # `object`, the dtype the non-empty string read produces, so an empty
+        # variable and a populated one agree.
+        dtype = np.dtype(object)
     return dtype
 
 
@@ -7444,9 +7480,8 @@ class NetCDF(Dataset):
                 `LabeledDataset["var"]` hands back the same class from the
                 same store, so the two agree on type — but it decodes a CF
                 time axis, applies that store's current selection, squeezes
-                the scalar-selected dimensions out, reads a string array as
-                `object` rather than `<U`, and leaves the four label fields
-                above unset. Do not read the two as interchangeable.
+                the scalar-selected dimensions out, and leaves the label
+                fields above unset. Do not read the two as interchangeable.
 
         Raises:
             ValueError: If `variable_name` is not present in the dataset.
@@ -7547,6 +7582,12 @@ class NetCDF(Dataset):
             parts = variable_name.rsplit("/", 1)
             group_nc = self.get_group(parts[0])
             cube = group_nc.get_variable(parts[1], x_dim=x_dim, y_dim=y_dim)
+            if isinstance(cube, LabeledArray):
+                # The group resolved the leaf, so the wrapper came back named
+                # `air_press` -- a name the grouped fixture repeats in every
+                # group, and one `read_array(variable=...)` then rejects. The
+                # caller's qualified name is the one that means something here.
+                cube.name = variable_name
             return cube  # single return below handles non-group path
 
         # Checked against what the store *holds*, not against `variable_names`:

--- a/tests/netcdf/samples/test_labeled.py
+++ b/tests/netcdf/samples/test_labeled.py
@@ -36,3 +36,34 @@ def test_context_manager_closes(sample):
     """``LabeledDataset`` works as a context manager."""
     with LabeledDataset.read_file(sample(STATION)) as ld:
         assert ld.variables is not None
+
+
+def test_getitem_defaults_the_labels_it_does_not_read(sample):
+    """``LabeledDataset["var"]`` still constructs after ``LabeledArray`` grew four fields.
+
+    Args:
+        sample: Fixture resolving a sample file name to its path.
+
+    Test scenario:
+        ``__getitem__`` builds the wrapper from ``values`` / ``dims`` / ``shape`` alone, so the
+        fields added for the ``get_variable`` route have to be optional -- a required one would
+        have broken every item access here. Expected: the array, with the four label fields at
+        their documented defaults, and ``shape`` agreeing with the values it carries.
+    """
+    ld = LabeledDataset.read_file(sample(STATION))
+    try:
+        name = ld.variables[0]
+
+        array = ld[name]
+
+        assert array.name == "", f"__getitem__ declares no name, got {array.name!r}"
+        assert array.unit == "", f"__getitem__ declares no unit, got {array.unit!r}"
+        assert array.no_data_value is None, (
+            f"__getitem__ declares no fill value, got {array.no_data_value!r}"
+        )
+        assert array.attributes == {}, f"unexpected attributes {array.attributes!r}"
+        assert array.shape == array.values.shape, (
+            f"shape {array.shape} must describe the values {array.values.shape}"
+        )
+    finally:
+        ld.close()

--- a/tests/netcdf/samples/test_mfdataset.py
+++ b/tests/netcdf/samples/test_mfdataset.py
@@ -7,6 +7,8 @@ import pytest
 from pyramids.netcdf import NetCDF
 from tests.netcdf.samples.conftest import AIR
 
+SERIES_ONLY = "none__11v__1d11.nc"  # eleven 1-D series, none of them a raster plane
+
 pytestmark = pytest.mark.lazy
 pytest.importorskip("dask")
 
@@ -22,3 +24,26 @@ def test_open_mfdataset_stacks_variable(sample, tmp_path):
     stacked = NetCDF.open_mfdataset([str(a), str(b)], "air")
     assert stacked is not None
     assert stacked.shape[0] == 2 * n_single
+
+
+def test_open_mfdataset_refuses_a_variable_with_no_raster_plane(sample):
+    """Naming a 1-D variable is refused by name instead of dying inside the read.
+
+    Args:
+        sample: Fixture resolving a sample file name to its path.
+
+    Test scenario:
+        ``open_mfdataset`` extracts the named variable from each file and stacks the results,
+        so it needs a raster plane per file. A 1-D name reached the stack as a raw GDAL handle
+        and failed with ``AttributeError: 'MDArray' object has no attribute 'read_array'``,
+        which names neither the file nor the variable. Expected: a ``ValueError`` naming the
+        variable and its dimensions, raised before any stacking is attempted.
+    """
+    path = sample(SERIES_ONLY)
+
+    with pytest.raises(ValueError) as excinfo:
+        NetCDF.open_mfdataset([path], "altitude")
+
+    message = str(excinfo.value)
+    assert "altitude" in message, f"the refusal must name the variable: {message}"
+    assert "no raster plane" in message, f"unexpected refusal: {message}"

--- a/tests/netcdf/samples/test_no_raw_gdal.py
+++ b/tests/netcdf/samples/test_no_raw_gdal.py
@@ -75,14 +75,26 @@ class TestANonRasterVariableComesBackLabelled:
         store = NetCDF.read_file(sample(GROUPED), read_only=True)
         try:
             group_name = store.group_names[0]
+            qualified = f"{group_name}/air_press"
             if route == "group":
-                variable_object = store.get_group(group_name).get_variable("air_press")
+                owner = store.get_group(group_name)
+                variable_object = owner.get_variable("air_press")
+                expected_name = "air_press"
             else:
-                variable_object = store.get_variable(f"{group_name}/air_press")
+                owner = store
+                variable_object = store.get_variable(qualified)
+                expected_name = qualified
 
             assert isinstance(variable_object, LabeledArray)
             assert variable_object.dims == ("recNum",)
             assert variable_object.values.dtype == np.float64
+            # The name is the one the caller used on the object they asked. The
+            # grouped fixture repeats `air_press` in every group, so the slash
+            # route came back named `air_press`, which `read_array` on the root
+            # then rejected -- a name that could not be used to read itself.
+            assert variable_object.name == expected_name
+            round_trip = np.asarray(owner.read_array(variable=variable_object.name))
+            assert round_trip.tolist() == variable_object.values.tolist()
         finally:
             store.close()
 

--- a/tests/netcdf/samples/test_no_raw_gdal.py
+++ b/tests/netcdf/samples/test_no_raw_gdal.py
@@ -1,0 +1,116 @@
+"""No public accessor hands back a raw GDAL object.
+
+`get_variable` used to return the `gdal.MDArray` itself whenever GDAL could not
+expose the variable as a raster plane -- a 1-D array, or a string/compound one of
+any rank. Such an object has none of pyramids' API, and its `Read()` returns an
+undecoded buffer for numeric data, so the only way to the values was
+`ReadAsArray()`: raw `osgeo`, in a package that exists to avoid it (#1126).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from pyramids.netcdf import LabeledArray, NetCDF
+
+GROUPED = "none__35v__1d35__groups-nc4.nc"
+
+
+class TestANonRasterVariableComesBackLabelled:
+    """The shapes GDAL cannot expose as a raster still answer in pyramids' terms."""
+
+    @pytest.mark.parametrize(
+        "file_name, variable, dims, first",
+        [
+            (GROUPED, "UTC_time", ("recNum",), "2012-03-04 03:54:19"),
+            ("cf__48v__1d17-3d21-4d10__y-asc.nc", "hyai", ("ilev",), None),
+        ],
+    )
+    def test_it_is_a_labeled_array_not_an_mdarray(
+        self, sample, file_name, variable, dims, first
+    ):
+        """A 1-D variable answers with values, dims and shape.
+
+        Args:
+            sample: Fixture resolving a sample file name to its path.
+            file_name: The sample store.
+            variable: A 1-D variable in it.
+            dims: The dimension names GDAL declares.
+            first: The expected first value, when it is worth pinning.
+
+        Test scenario:
+            A numeric axis (`hyai`, a hybrid-sigma coefficient) and a string
+            column (`UTC_time`) reach the same branch. The string one is the
+            sharper case: `ReadAsArray` raises on it, so a wrapper that knew only
+            the numeric reader would fail here while passing on `hyai`.
+        """
+        store = NetCDF.read_file(sample(file_name), read_only=True)
+        try:
+            variable_object = store.get_variable(variable)
+
+            assert isinstance(variable_object, LabeledArray)
+            assert variable_object.dims == dims
+            assert variable_object.shape == variable_object.values.shape
+            if first is not None:
+                assert variable_object.values[0] == first
+        finally:
+            store.close()
+
+    @pytest.mark.parametrize("route", ["group", "slash"])
+    def test_both_routes_into_a_group_agree(self, sample, route):
+        """A grouped store leaks through two doors, and both go through one branch.
+
+        Args:
+            sample: Fixture resolving a sample file name to its path.
+            route: `get_group(...).get_variable(name)`, or `get_variable("group/name")`.
+
+        Test scenario:
+            The slash form delegates to the group's `get_variable`, so a guard
+            placed only where `read_file` lands would catch neither route.
+        """
+        store = NetCDF.read_file(sample(GROUPED), read_only=True)
+        try:
+            group_name = store.group_names[0]
+            if route == "group":
+                variable_object = store.get_group(group_name).get_variable("air_press")
+            else:
+                variable_object = store.get_variable(f"{group_name}/air_press")
+
+            assert isinstance(variable_object, LabeledArray)
+            assert variable_object.dims == ("recNum",)
+            assert variable_object.values.dtype == np.float64
+        finally:
+            store.close()
+
+
+class TestNoOsgeoTypeEscapes:
+    """The property the branch exists to hold, asserted over every sample file."""
+
+    def test_no_variable_on_any_sample_returns_a_gdal_object(self, sample_name, sample):
+        """Every readable variable answers as a pyramids type.
+
+        Args:
+            sample_name: The sample file, parametrized over the whole registry.
+            sample: Fixture resolving a sample file name to its path.
+
+        Test scenario:
+            Asserted as "nothing from `osgeo`" rather than "this one call
+            raises", because that branch is the only place such an object can
+            escape -- so the total assertion costs no more than the narrow one
+            and cannot be satisfied by a partial fix.
+        """
+        store = NetCDF.read_file(sample(sample_name), read_only=True)
+        try:
+            leaked = []
+            for name in store.variable_names:
+                try:
+                    variable_object = store.get_variable(name)
+                except (ValueError, RuntimeError):
+                    continue
+                if type(variable_object).__module__.startswith("osgeo"):
+                    leaked.append(f"{name} -> {type(variable_object).__name__}")
+
+            assert not leaked, f"{sample_name}: raw GDAL objects returned for {leaked}"
+        finally:
+            store.close()

--- a/tests/netcdf/samples/test_no_raw_gdal.py
+++ b/tests/netcdf/samples/test_no_raw_gdal.py
@@ -87,8 +87,8 @@ class TestANonRasterVariableComesBackLabelled:
 class TestNoOsgeoTypeEscapes:
     """The property the branch exists to hold, asserted over every sample file."""
 
-    def test_no_variable_on_any_sample_returns_a_gdal_object(self, sample_name, sample):
-        """Every readable variable answers as a pyramids type.
+    def test_no_readable_variable_returns_a_gdal_object(self, sample_name, sample):
+        """Every readable variable answers as a pyramids type, and none of them raises.
 
         Args:
             sample_name: The sample file, parametrized over the whole registry.
@@ -97,21 +97,53 @@ class TestNoOsgeoTypeEscapes:
         Test scenario:
             Asserted as "nothing from `osgeo`" rather than "this one call
             raises", because that branch is the only place such an object can
-            escape -- so the total assertion costs no more than the narrow one
-            and cannot be satisfied by a partial fix.
+            escape. Refusals are collected rather than skipped: swallowing them
+            would let an implementation that raised for every non-raster
+            variable satisfy the sweep, which is the shape the issue rejected.
+            The readable set, not `variable_names`, is what `get_variable`
+            accepts -- on the GOES fixture it is what brings in `band_id` and
+            `band_wavelength`, both 1-D and neither enumerated as a data
+            variable.
         """
         store = NetCDF.read_file(sample(sample_name), read_only=True)
         try:
             leaked = []
-            for name in store.variable_names:
+            refused = []
+            for name in store._readable_variable_names():
                 try:
                     variable_object = store.get_variable(name)
-                except (ValueError, RuntimeError):
+                except Exception as error:
+                    refused.append(f"{name} -> {type(error).__name__}: {error}")
                     continue
                 if type(variable_object).__module__.startswith("osgeo"):
                     leaked.append(f"{name} -> {type(variable_object).__name__}")
 
             assert not leaked, f"{sample_name}: raw GDAL objects returned for {leaked}"
+            assert not refused, f"{sample_name}: readable variables refused: {refused}"
+        finally:
+            store.close()
+
+    @pytest.mark.parametrize(
+        "file_name, variable",
+        [(GROUPED, "UTC_time"), ("cf__9v__1d7-2d2__geos__y-desc.nc", "band_id")],
+    )
+    def test_the_sweep_has_something_to_find(self, sample, file_name, variable):
+        """The sweep above asserts an absence; this pins that the presence exists.
+
+        Args:
+            sample: Fixture resolving a sample file name to its path.
+            file_name: A store known to hold a non-raster variable.
+            variable: That variable.
+
+        Test scenario:
+            `assert not leaked` is vacuously true on a store whose variables are
+            all rasters, so the sweep alone cannot show a `LabeledArray` was ever
+            produced. `band_id` is the sharper of the two: it is readable but not
+            enumerated in `variable_names`, so only the readable set reaches it.
+        """
+        store = NetCDF.read_file(sample(file_name), read_only=True)
+        try:
+            assert isinstance(store.get_variable(variable), LabeledArray)
         finally:
             store.close()
 

--- a/tests/netcdf/samples/test_no_raw_gdal.py
+++ b/tests/netcdf/samples/test_no_raw_gdal.py
@@ -1,4 +1,8 @@
-"""No public accessor hands back a raw GDAL object.
+"""`get_variable` never hands back a raw GDAL object.
+
+Scoped to `get_variable`, which the sweep below calls on every readable variable of
+every sample file; `variables[name]` delegates to it. It is not a claim about every
+public attribute: `nc.raster` returns the underlying `gdal.Dataset` by design.
 
 `get_variable` used to return the `gdal.MDArray` itself whenever GDAL could not
 expose the variable as a raster plane -- a 1-D array, or a string/compound one of
@@ -20,6 +24,7 @@ GROUPED = "none__35v__1d35__groups-nc4.nc"
 LAYERED = "cf__48v__1d17-3d21-4d10__y-asc.nc"
 
 
+@pytest.mark.core
 class TestANonRasterVariableComesBackLabelled:
     """The shapes GDAL cannot expose as a raster still answer in pyramids' terms."""
 
@@ -99,6 +104,7 @@ class TestANonRasterVariableComesBackLabelled:
             store.close()
 
 
+@pytest.mark.core
 class TestNoOsgeoTypeEscapes:
     """The property the branch exists to hold, asserted over every sample file."""
 
@@ -207,6 +213,7 @@ class TestAVariableWithNoRecords:
             store.close()
 
 
+@pytest.mark.core
 class TestTheContainerCrsSkipsAVariableWithNoRasterPlane:
     """A container borrows its CRS from its variables, and one of them may have no geometry."""
 

--- a/tests/netcdf/samples/test_no_raw_gdal.py
+++ b/tests/netcdf/samples/test_no_raw_gdal.py
@@ -114,3 +114,47 @@ class TestNoOsgeoTypeEscapes:
             assert not leaked, f"{sample_name}: raw GDAL objects returned for {leaked}"
         finally:
             store.close()
+
+
+class TestAVariableWithNoRecords:
+    """A zero-length dimension is a shape GDAL declines to read at all."""
+
+    @pytest.mark.interop
+    def test_an_empty_variable_reads_as_an_empty_array(self, tmp_path):
+        """An unlimited dimension with nothing written is still an advertised variable.
+
+        Args:
+            tmp_path: Destination for the store.
+
+        Test scenario:
+            GDAL refuses the read -- `count[0] = 0 is invalid` -- rather than
+            handing back nothing, so materialising naively turned a variable the
+            store advertises into a bare `RuntimeError`. Before the wrapper it
+            returned an unread `MDArray`, so this shape has never actually been
+            readable; it now answers with an empty array of the declared type.
+            Written through xarray because neither GDAL driver will create one:
+            MEM rejects the array, and the netCDF writer emits a file it cannot
+            reopen.
+        """
+        xr = pytest.importorskip("xarray")
+        path = str(tmp_path / "empty_dim.nc")
+        xr.Dataset(
+            {
+                "empty_v": ("recNum", np.array([], dtype="float64")),
+                "full_v": ("n", np.array([1.0, 2.0, 3.0])),
+            }
+        ).to_netcdf(path)
+
+        store = NetCDF.read_file(path, read_only=True)
+        try:
+            assert "empty_v" in store.variable_names, "fixture changed"
+
+            empty = store.get_variable("empty_v")
+
+            assert isinstance(empty, LabeledArray)
+            assert empty.shape == (0,)
+            assert empty.values.shape == (0,)
+            assert empty.values.dtype == np.float64
+            assert store.get_variable("full_v").values.tolist() == [1.0, 2.0, 3.0]
+        finally:
+            store.close()

--- a/tests/netcdf/samples/test_no_raw_gdal.py
+++ b/tests/netcdf/samples/test_no_raw_gdal.py
@@ -15,6 +15,9 @@ import pytest
 from pyramids.netcdf import LabeledArray, NetCDF
 
 GROUPED = "none__35v__1d35__groups-nc4.nc"
+# `hyai` is the first name this store enumerates and has no raster plane; `U` / `V` / `T`
+# follow it and do carry a CRS.
+LAYERED = "cf__48v__1d17-3d21-4d10__y-asc.nc"
 
 
 class TestANonRasterVariableComesBackLabelled:
@@ -188,5 +191,58 @@ class TestAVariableWithNoRecords:
             assert empty.values.shape == (0,)
             assert empty.values.dtype == np.float64
             assert store.get_variable("full_v").values.tolist() == [1.0, 2.0, 3.0]
+        finally:
+            store.close()
+
+
+class TestTheContainerCrsSkipsAVariableWithNoRasterPlane:
+    """A container borrows its CRS from its variables, and one of them may have no geometry."""
+
+    def test_a_leading_non_raster_variable_does_not_hide_the_crs(self, sample):
+        """The variable that comes first must not decide the answer for the ones behind it.
+
+        Args:
+            sample: Fixture resolving a sample file name to its path.
+
+        Test scenario:
+            `hyai`, a hybrid-sigma coefficient, is the first name this store enumerates and has
+            no raster plane; `U` / `V` / `T` follow it and do carry a CRS. Asking a
+            `LabeledArray` for `.crs` raises, and the loop's `except` wraps the whole walk, so
+            without the skip the first variable would suppress the CRS of every one after it.
+            Expected: the CRS the later variables report, not an empty string.
+        """
+        store = NetCDF.read_file(sample(LAYERED), read_only=True)
+        try:
+            first = store.variable_names[0]
+            assert isinstance(store.get_variable(first), LabeledArray), (
+                "fixture changed"
+            )
+
+            assert store._container_crs(), (
+                f"{first} suppressed the CRS of the variables after it"
+            )
+            assert store.epsg == 4326, f"unexpected EPSG {store.epsg}"
+        finally:
+            store.close()
+
+    def test_a_container_of_only_non_raster_variables_answers_plainly(self, sample):
+        """Skipping every variable must leave a plain "no CRS", not a failure.
+
+        Args:
+            sample: Fixture resolving a sample file name to its path.
+
+        Test scenario:
+            Every variable of the grouped store is a 1-D series, so the walk skips all of them
+            and falls out of the loop having found nothing. Expected: an empty CRS and no EPSG,
+            answered rather than raised -- the honest result for a store with no geometry.
+        """
+        store = NetCDF.read_file(sample(GROUPED), read_only=True)
+        try:
+            assert store._container_crs() == "", (
+                f"a store with no raster variable has no CRS to report: "
+                f"{store._container_crs()!r}"
+            )
+            assert store.crs == "", f"unexpected CRS {store.crs!r}"
+            assert store.epsg is None, f"unexpected EPSG {store.epsg}"
         finally:
             store.close()

--- a/tests/netcdf/spatial/test_crop_nonspatial_aux.py
+++ b/tests/netcdf/spatial/test_crop_nonspatial_aux.py
@@ -304,20 +304,28 @@ def _attr(name, value):
     return attr
 
 
-def _fake_rg(var_dims, coord_attrs=None):
+def _fake_rg(var_dims, coord_attrs=None, type_classes=None):
     """A Mock root group: ``OpenMDArray(name)`` -> a variable MDArray or a coordinate.
 
     Args:
         var_dims: ``{var_name: [dim_name, ...]}`` for the variable(s) under test.
         coord_attrs: ``{dim_name: {attr: value}}`` driving CF detection; a name in
             neither map raises ``RuntimeError`` as GDAL does.
+        type_classes: ``{var_name: gdal.GEDTC_*}``; a variable not named here is
+            numeric, as an ordinary grid is.
     """
     coord_attrs = coord_attrs or {}
+    type_classes = type_classes or {}
 
     def open_mdarray(name):
         if name in var_dims:
             md = Mock()
             md.GetDimensions.return_value = [_dim(d) for d in var_dims[name]]
+            # A real MDArray always declares a dtype, and the classifier now reads
+            # it: a string or compound array on (y, x) axes is not griddable.
+            md.GetDataType.return_value.GetClass.return_value = type_classes.get(
+                name, gdal.GEDTC_NUMERIC
+            )
             return md
         if name in coord_attrs:
             coord = Mock()
@@ -353,6 +361,24 @@ class TestVariableIsSpatial:
         """
         rg = _fake_rg({"time_bnds": ["valid_time", "nbnds"]})
         assert NetCDF._variable_is_spatial(NetCDF, rg, "time_bnds") is False
+
+    @pytest.mark.parametrize("type_class", [gdal.GEDTC_STRING, gdal.GEDTC_COMPOUND])
+    def test_a_non_numeric_array_on_grid_axes_is_not_spatial(self, type_class):
+        """Grid-shaped dimensions do not make a string or compound array a raster.
+
+        Args:
+            type_class: The non-numeric dtype class to declare.
+
+        Test scenario:
+            `flag(y, x)` has exactly the dimensions `t2m(y, x)` does, and the
+            classifier used to look at nothing else. So a container-wide
+            `crop` / `to_crs` / `reduce` handed it to the fan-out, which cannot
+            build a raster from it and refused the *whole* operation over one
+            auxiliary field. It must be carried through instead.
+        """
+        rg = _fake_rg({"flag": ["y", "x"]}, type_classes={"flag": type_class})
+
+        assert NetCDF._variable_is_spatial(NetCDF, rg, "flag") is False
 
     def test_known_name_axes_is_spatial(self):
         """Well-known ``y`` / ``x`` dimension names mark a variable spatial.

--- a/tests/netcdf/structure/test_readable_variable_names.py
+++ b/tests/netcdf/structure/test_readable_variable_names.py
@@ -10,7 +10,7 @@ the store's array count for no reason. One walk now serves both.
 
 *Promise.* Its docstring says it lists "every array name `get_variable` will
 accept". That is true, and it was read as promising a `NetCDF` back, which it
-never did: a 1-D or non-numeric array comes back as a raw `gdal.MDArray`. Some
+never did: a 1-D or non-numeric array comes back as a `LabeledArray`. Some
 of those names are not even in the wider list -- GOES ABI declares
 `time_bounds` as a *data* variable -- so `read_array` met them through the
 ordinary container route and died with an `AttributeError`.
@@ -36,7 +36,7 @@ FLAT = DATA / "cf__7v__1d3-2d3-3d1__y-asc.nc"
 
 # GOES ABI: `time_bounds` / `x_image_bounds` / `y_image_bounds` are 1-D and are
 # enumerated as data variables; `band_id` / `band_wavelength` are 1-D and are
-# not. All five come back from `get_variable` as raw MDArrays.
+# not. All five come back from `get_variable` as `LabeledArray`s.
 GEOS = DATA / "cf__9v__1d7-2d2__geos__y-desc.nc"
 
 GROUPED = DATA / "none__35v__1d35__groups-nc4.nc"

--- a/tests/netcdf/structure/test_readable_variable_names.py
+++ b/tests/netcdf/structure/test_readable_variable_names.py
@@ -24,7 +24,7 @@ import numpy as np
 import pytest
 from osgeo import gdal
 
-from pyramids.netcdf import NetCDF
+from pyramids.netcdf import LabeledArray, NetCDF
 
 pytestmark = pytest.mark.core
 
@@ -145,7 +145,7 @@ class TestAnAdvertisedNameThatIsNotARaster:
     @pytest.mark.parametrize(
         "array", ["time_bounds", "x_image_bounds", "y_image_bounds", "band_id"]
     )
-    def test_the_name_resolves_to_a_raw_md_array(self, array):
+    def test_the_name_resolves_to_a_labeled_array(self, array):
         """The documented return type, asserted rather than assumed.
 
         Args:
@@ -154,16 +154,18 @@ class TestAnAdvertisedNameThatIsNotARaster:
         Test scenario:
             Three of these four are in `variable_names`, so a caller iterating
             the enumeration meets them. `get_variable` resolves each -- it does
-            not raise -- and hands back `gdal.MDArray`, which carries none of
-            the `NetCDF` surface.
+            not raise -- and hands back a `LabeledArray`. It used to hand back
+            `gdal.MDArray`, a raw GDAL handle with none of pyramids' surface,
+            which is what #1126 removed.
         """
         dataset = NetCDF.read_file(str(GEOS))
 
         variable = dataset.get_variable(array)
 
-        assert isinstance(variable, gdal.MDArray), (
+        assert isinstance(variable, LabeledArray), (
             f"{array} came back as {type(variable).__name__}"
         )
+        assert variable.values.size, f"{array} came back empty"
 
     def test_read_array_reads_such_a_variable_instead_of_raising(self):
         """The consequence a user actually hits.

--- a/tests/netcdf/unit/test_netcdf_unit_read.py
+++ b/tests/netcdf/unit/test_netcdf_unit_read.py
@@ -300,6 +300,136 @@ class TestReadMdArrayNonNumeric:
             f"the returned array must keep its non-numeric dtype, got {variable.values.dtype}"
         )
         assert variable.shape == sizes, f"unexpected shape {variable.shape}"
+        assert variable.values.shape == variable.shape, (
+            f"the values must be laid out on the declared shape {variable.shape}, "
+            f"got {variable.values.shape}"
+        )
+
+
+class TestTheMaterialisedValuesAreTheStoredOnes:
+    """The wrapper is only worth returning if what it carries is the data itself.
+
+    Every other test around `get_variable`'s non-raster branch asserts the *type* that comes
+    back, its `dims` and its declared `shape`. None of them looks at the numbers, so a read
+    that answers with the right shape and the wrong contents passes them all. These two do
+    look: one writes known values through each reader (`ReadAsArray` for numeric, the
+    structured-dtype view for compound) and reads them back.
+    """
+
+    @staticmethod
+    def _one_dimensional(dtype, size, payload=None):
+        """Build a MEM multidim store holding one 1-D array `v`, optionally written.
+
+        Args:
+            dtype: The `gdal.ExtendedDataType` for the array.
+            size: The length of its single dimension.
+            payload: Bytes or an array to write, or None to leave it unwritten.
+
+        Returns:
+            gdal.Dataset: The multidimensional dataset, its root group kept alive by it.
+        """
+        ds = gdal.GetDriverByName("MEM").CreateMultiDimensional("test")
+        rg = ds.GetRootGroup()
+        dim = rg.CreateDimension("n", None, None, size)
+        array = rg.CreateMDArray("v", [dim], dtype)
+        if payload is not None:
+            array.Write(payload)
+        return ds
+
+    def test_a_numeric_axis_answers_with_the_values_it_stores(self):
+        """A 1-D numeric variable carries its own numbers, not merely its own shape.
+
+        Test scenario:
+            Write `[1.5, -2.5, 3.25, 0.0, 9.75]` — signed, fractional and zero, so a
+            truncating or zero-filling read is visible — into a 1-D `Float64` array, the
+            only numeric rank that reaches this branch (rank >= 2 resolves a raster plane
+            and comes back as a `Variable`). Expected: `values` equal to what was written,
+            still `float64`, on the declared shape.
+        """
+        stored = np.array([1.5, -2.5, 3.25, 0.0, 9.75])
+        dataset = self._one_dimensional(
+            gdal.ExtendedDataType.Create(gdal.GDT_Float64), 5, stored
+        )
+        variable = Container(dataset).get_variable("v")
+
+        assert isinstance(variable, LabeledArray), (
+            f"a 1-D numeric variable must come back as a LabeledArray, got {type(variable)}"
+        )
+        assert variable.values.dtype == np.float64, (
+            f"the stored dtype must survive the read, got {variable.values.dtype}"
+        )
+        assert variable.values.shape == variable.shape == (5,), (
+            f"unexpected shape {variable.shape} / {variable.values.shape}"
+        )
+        assert np.array_equal(variable.values, stored), (
+            f"the values must be the stored ones, got {variable.values}"
+        )
+
+    def test_a_compound_record_keeps_the_padding_of_its_layout(self):
+        """A padded record decodes by GDAL's declared layout, not by an assumed packing.
+
+        Test scenario:
+            A `record_t` of `Int32` at 0, `Float64` at 8 and `Int32` at 16, declared 24 bytes
+            wide — the layout a C compiler produces for that field order, padded both between
+            the fields and after the last one. Both paddings are load-bearing, and each is
+            lost by a different shortcut: packing the fields instead of reading their offsets
+            puts them at 0/4/12, and inferring the stride from the offsets instead of reading
+            the declared size gives 20 rather than 24. Either one slides the fields against
+            the buffer and hands back numbers that are neither the stored ones nor obviously
+            wrong. Expected: the declared offsets and stride, and the values written.
+        """
+        offsets = [0, 8, 16]
+        record = gdal.ExtendedDataType.CreateCompound(
+            "record_t",
+            24,
+            [
+                gdal.EDTComponent.Create(
+                    name, offset, gdal.ExtendedDataType.Create(gdal_type)
+                )
+                for name, offset, gdal_type in zip(
+                    ["a", "b", "c"],
+                    offsets,
+                    [gdal.GDT_Int32, gdal.GDT_Float64, gdal.GDT_Int32],
+                )
+            ],
+        )
+        padded = np.dtype(
+            {
+                "names": ["a", "b", "c"],
+                "formats": ["<i4", "<f8", "<i4"],
+                "offsets": offsets,
+                "itemsize": 24,
+            }
+        )
+        stored = np.zeros(3, dtype=padded)
+        stored["a"] = [11, 22, 33]
+        stored["b"] = [1.5, -2.5, 3.25]
+        stored["c"] = [-7, 0, 7]
+        dataset = self._one_dimensional(record, 3, stored.tobytes())
+        variable = Container(dataset).get_variable("v")
+
+        assert variable.values.dtype.names == ("a", "b", "c"), (
+            f"the record's field names must survive, got {variable.values.dtype.names}"
+        )
+        assert variable.values.dtype.itemsize == 24, (
+            f"the record stride must be the declared 24 bytes, got "
+            f"{variable.values.dtype.itemsize}"
+        )
+        assert [
+            variable.values.dtype.fields[name][1] for name in ("a", "b", "c")
+        ] == offsets, (
+            f"the fields must sit at their declared offsets {offsets}, got "
+            f"{[variable.values.dtype.fields[name][1] for name in ('a', 'b', 'c')]}"
+        )
+        for name, expected in [
+            ("a", [11, 22, 33]),
+            ("b", [1.5, -2.5, 3.25]),
+            ("c", [-7, 0, 7]),
+        ]:
+            assert np.array_equal(variable.values[name], expected), (
+                f"field {name!r} must decode to the stored values {expected}, got "
+                f"{variable.values[name]}"
+            )
 
 
 class TestNeedsYFlip:

--- a/tests/netcdf/unit/test_netcdf_unit_read.py
+++ b/tests/netcdf/unit/test_netcdf_unit_read.py
@@ -250,7 +250,7 @@ class TestReadMdArrayNonNumeric:
             assert isinstance(string_var, LabeledArray), (
                 f"a character variable must come back as a LabeledArray, got {type(string_var)}"
             )
-            assert string_var.values.dtype.kind == "U", (
+            assert string_var.values.dtype == np.dtype(object), (
                 f"the returned array must keep its string dtype, got {string_var.values.dtype}"
             )
             assert string_var.values.size == 12, "the values must be readable"

--- a/tests/netcdf/unit/test_netcdf_unit_read.py
+++ b/tests/netcdf/unit/test_netcdf_unit_read.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 from osgeo import gdal
 
+from pyramids.netcdf import LabeledArray
 from pyramids.netcdf.netcdf import Container, NetCDF
 from tests.netcdf.conftest import make_2d_nc
 from tests.netcdf.unit._netcdf_unit_helpers import _make_3d_nc
@@ -96,7 +97,12 @@ class TestReadMdArray1D:
 
 
 class TestReadMdArrayNonNumeric:
-    """A non-numeric variable — string/character or compound — comes back as the raw MDArray (#1067).
+    """A non-numeric variable — string/character or compound — is not a raster plane (#1067).
+
+    `_read_md_array` hands the MDArray back to its caller, and `get_variable` materialises
+    that into a `LabeledArray` rather than letting a raw GDAL handle reach the user (#1126).
+    The tests below split accordingly: the private helper is asserted to return the MDArray,
+    the public accessor to return the wrapper.
 
     NetCDF stores a character column two-dimensionally as `(records, max string length)`, so
     `_resolve_spatial_dims` resolves a plane for it via its last-two fallback and the old code
@@ -226,8 +232,8 @@ class TestReadMdArrayNonNumeric:
         Test scenario:
             Write a real `.nc` holding a 2-D string `units` and a 2-D numeric `obs`, both with
             resolvable spatial dims — expected: `get_variable("units")` returns a readable
-            `gdal.MDArray` (it used to raise) while `get_variable("obs")` still returns a
-            raster-backed variable.
+            `LabeledArray` (it used to raise, then leaked the raw `gdal.MDArray`) while
+            `get_variable("obs")` still returns a raster-backed variable.
         """
         path = str(tmp_path / "mixed.nc")
         ds = self._mixed_multidim("netCDF", path)
@@ -241,13 +247,13 @@ class TestReadMdArrayNonNumeric:
                 f"both variables must be discoverable, got {nc.variable_names}"
             )
             string_var = nc.get_variable("units")
-            assert isinstance(string_var, gdal.MDArray), (
-                f"a character variable must come back as an MDArray, got {type(string_var)}"
+            assert isinstance(string_var, LabeledArray), (
+                f"a character variable must come back as a LabeledArray, got {type(string_var)}"
             )
-            assert string_var.GetDataType().GetClass() == gdal.GEDTC_STRING, (
-                "the returned array must keep its string dtype"
+            assert string_var.values.dtype.kind == "U", (
+                f"the returned array must keep its string dtype, got {string_var.values.dtype}"
             )
-            assert len(string_var.Read()) == 12, "the MDArray must be readable"
+            assert string_var.values.size == 12, "the values must be readable"
             numeric_var = nc.get_variable("obs")
             assert isinstance(numeric_var, NetCDF), (
                 f"a numeric variable must still be raster-backed, got {type(numeric_var)}"
@@ -257,8 +263,8 @@ class TestReadMdArrayNonNumeric:
 
     @pytest.mark.parametrize("sizes", [(4, 3), (2, 4, 3)], ids=["rank2", "rank3"])
     @pytest.mark.parametrize("dtype_name", ["string", "compound"])
-    def test_get_variable_returns_md_array_for_any_rank(self, sizes, dtype_name):
-        """`get_variable` returns the MDArray for a non-numeric variable of any rank.
+    def test_get_variable_returns_a_labeled_array_for_any_rank(self, sizes, dtype_name):
+        """`get_variable` materialises a non-numeric variable of any rank.
 
         Args:
             sizes: Dimension sizes, covering a rank-2 and a rank-3 array.
@@ -269,8 +275,8 @@ class TestReadMdArrayNonNumeric:
             band-dimension metadata, which derives a primary band view from a band model a raw
             MDArray does not have. Only a rank >= 3 array reaches that code (rank <= 2 exits at
             the empty-`band_dims` branch), so this used to raise
-            `AttributeError: '_band_count'` — expected now: the MDArray, for both ranks and both
-            non-numeric dtype classes.
+            `AttributeError: '_band_count'` — expected now: a `LabeledArray`, for both ranks
+            and both non-numeric dtype classes.
         """
         if dtype_name == "string":
             dtype = gdal.ExtendedDataType.CreateString()
@@ -286,13 +292,14 @@ class TestReadMdArrayNonNumeric:
             )
         nc = Container(self._single_var_multidim(dtype, sizes))
         variable = nc.get_variable("v")
-        assert isinstance(variable, gdal.MDArray), (
-            f"a non-numeric rank-{len(sizes)} variable must come back as an MDArray, "
+        assert isinstance(variable, LabeledArray), (
+            f"a non-numeric rank-{len(sizes)} variable must come back as a LabeledArray, "
             f"got {type(variable).__name__}"
         )
-        assert variable.GetDataType().GetClass() != gdal.GEDTC_NUMERIC, (
-            "the returned array must keep its non-numeric dtype"
+        assert variable.values.dtype.kind in {"U", "V", "O"}, (
+            f"the returned array must keep its non-numeric dtype, got {variable.values.dtype}"
         )
+        assert variable.shape == sizes, f"unexpected shape {variable.shape}"
 
 
 class TestNeedsYFlip:
@@ -689,12 +696,14 @@ class TestGetVariableYFlipAndErrors:
 class TestGetVariableNonDataset:
     """Tests for get_variable when _read_md_array returns non-Dataset."""
 
-    def test_get_variable_1d_string_returns_md_arr(self):
-        """Verify get_variable handles non-Dataset result from _read_md_array.
+    def test_get_variable_1d_string_returns_a_labeled_array(self):
+        """Verify get_variable materialises a non-Dataset result from _read_md_array.
 
-        Covers the else branch where src from
-        _read_md_array is not a gdal.Dataset (e.g. string-type MDArray),
-        and cube is set to src directly.
+        Covers the else branch where src from `_read_md_array` is not a
+        `gdal.Dataset` (e.g. a string-type MDArray). It used to be returned
+        as-is; it is now wrapped, so no raw GDAL handle reaches the caller
+        (#1126). The wrapper owns its values and defines `__slots__`, so the
+        subset bookkeeping that follows the raster path does not apply to it.
         """
         # Create a dataset with a 1D string variable as a "data variable"
         src = gdal.GetDriverByName("MEM").CreateMultiDimensional("str_var_test")
@@ -722,9 +731,12 @@ class TestGetVariableNonDataset:
             f"'labels' should be a variable, got {nc.variable_names}"
         )
         var = nc.get_variable("labels")
-        # The result should be the MDArray itself (not a Dataset)
-        assert var is not None, "Variable should not be None"
-        assert var._is_subset is True, "Should be marked as subset"
+
+        assert isinstance(var, LabeledArray), (
+            f"a 1-D string variable must come back as a LabeledArray, got {type(var)}"
+        )
+        assert var.dims == ("labels_dim",), f"unexpected dims {var.dims}"
+        assert var.shape == (3,), f"unexpected shape {var.shape}"
 
 
 class TestGetVariableMultipleBandDims:

--- a/tests/netcdf/unit/test_netcdf_unit_read.py
+++ b/tests/netcdf/unit/test_netcdf_unit_read.py
@@ -10,7 +10,7 @@ import numpy as np
 import pytest
 from osgeo import gdal
 
-from pyramids.netcdf import LabeledArray
+from pyramids.netcdf import LabeledArray, LabeledDataset
 from pyramids.netcdf.netcdf import Container, NetCDF
 from tests.netcdf.conftest import make_2d_nc
 from tests.netcdf.unit._netcdf_unit_helpers import _make_3d_nc
@@ -311,9 +311,9 @@ class TestTheMaterialisedValuesAreTheStoredOnes:
 
     Every other test around `get_variable`'s non-raster branch asserts the *type* that comes
     back, its `dims` and its declared `shape`. None of them looks at the numbers, so a read
-    that answers with the right shape and the wrong contents passes them all. These two do
-    look: one writes known values through each reader (`ReadAsArray` for numeric, the
-    structured-dtype view for compound) and reads them back.
+    that answers with the right shape and the wrong contents passes them all. These do look:
+    each writes known values through one reader (`ReadAsArray` for numeric, the
+    structured-dtype view for compound, `Read` for string) and reads them back.
     """
 
     @staticmethod
@@ -430,6 +430,51 @@ class TestTheMaterialisedValuesAreTheStoredOnes:
                 f"field {name!r} must decode to the stored values {expected}, got "
                 f"{variable.values[name]}"
             )
+
+    def test_a_string_column_is_object_however_much_of_it_is_written(self):
+        """A string column's dtype must not depend on whether every entry was written.
+
+        Test scenario:
+            `full` has every entry written; `partial` only its first, so the other two are
+            NULL, which `Read` returns as `None`. Left to NumPy, the first came back `<U3` and
+            the second `object` -- one kind of variable, two dtypes, chosen by the data -- so
+            code switching on `dtype.kind` broke on a partially filled file. Expected: `object`
+            for both, the NULL entries still `None`, and the dtype `LabeledDataset` reads the
+            same column with, since the two producers are documented to agree on it.
+        """
+        dataset = gdal.GetDriverByName("MEM").CreateMultiDimensional("test")
+        rg = dataset.GetRootGroup()
+        dim = rg.CreateDimension("n", None, None, 3)
+        full = rg.CreateMDArray("full", [dim], gdal.ExtendedDataType.CreateString())
+        full.Write(["x", "yy", "zzz"])
+        partial = rg.CreateMDArray(
+            "partial", [dim], gdal.ExtendedDataType.CreateString()
+        )
+        partial.Write(["a"], array_start_idx=[0], count=[1])
+        container = Container(dataset)
+        try:
+            full_values = container.get_variable("full").values
+            partial_values = container.get_variable("partial").values
+            labeled = LabeledDataset._from_group(dataset, rg, None)
+
+            assert full_values.dtype == np.dtype(object), (
+                f"a fully written column must be object, got {full_values.dtype}"
+            )
+            assert full_values.tolist() == ["x", "yy", "zzz"], (
+                f"unexpected values {full_values.tolist()}"
+            )
+            assert partial_values.dtype == np.dtype(object), (
+                f"a partially written column must be object, got {partial_values.dtype}"
+            )
+            assert partial_values.tolist() == ["a", None, None], (
+                f"the NULL entries must stay None, got {partial_values.tolist()}"
+            )
+            assert labeled["full"].values.dtype == full_values.dtype, (
+                f"LabeledDataset reads the column as {labeled['full'].values.dtype}, "
+                f"get_variable as {full_values.dtype}"
+            )
+        finally:
+            container.close()
 
 
 class TestNeedsYFlip:

--- a/tests/netcdf/unit/test_non_raster_variable_contract.py
+++ b/tests/netcdf/unit/test_non_raster_variable_contract.py
@@ -1,14 +1,20 @@
 """What a variable with no raster plane promises once it is a `LabeledArray` (#1126).
 
 The sibling suites assert the *type* that comes back from `get_variable` and the values it
-carries. Three things they do not reach are asserted here.
+carries. Four things they do not reach are asserted here.
+
+*The declaration.* `_has_raster_plane` predicts, from an array's rank and dtype class alone, what
+`get_variable` will return for it. The container CRS walk, the raster guard and the fan-out
+classifier all act on that prediction instead of reading the array, so it is checked against the
+type `get_variable` really returns, and the reads it exists to save are counted.
 
 *The refusal.* `_require_raster_variable` is the door every internal caller that needs geometry
 now goes through. It is exercised from the public methods that let a user name the variable --
 `crop_variable`, `reproject_variable`, `resample_variable` and `plot(variable=)` -- because a
 refusal is only useful if it survives the call the user actually makes.
 
-*The labels.* `LabeledArray` grew `name` / `unit` / `no_data_value` / `attributes`. Without them a
+*The labels.* `LabeledArray` grew `name` / `unit` / `no_data_value` / `attributes`, then `scale` /
+`offset`. Without them a
 `-9999.0` sitting in `values` is indistinguishable from real data, so what the wrapper copies off
 the array -- and what it defaults to when the array declares nothing -- is the difference between
 the wrapper being a better answer than the handle it replaced and merely a safer one.
@@ -21,6 +27,8 @@ directly, on the `ExtendedDataType` they take.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import numpy as np
 import pytest
 from osgeo import gdal, osr
@@ -28,7 +36,9 @@ from osgeo import gdal, osr
 from pyramids.netcdf import LabeledArray
 from pyramids.netcdf.netcdf import (
     Container,
+    NetCDF,
     _compound_dtype,
+    _has_raster_plane,
     _labeled_array_from_md_array,
     _numpy_dtype_of,
 )
@@ -37,6 +47,16 @@ pytestmark = pytest.mark.core
 
 PADDED_RECORD_SIZE = 24
 PADDED_OFFSETS = [0, 8, 16]
+# Opened classically (`NETCDF:file:var`), this store has no multidimensional group at all.
+CLASSIC_SAMPLE = (
+    Path(__file__).resolve().parents[2]
+    / "data"
+    / "netcdf"
+    / "cf__6v__1d2-2d4__geog__y-asc.nc"
+)
+# Fills a double's 53-bit mantissa cannot hold: each rounds to a value no element equals.
+INT64_FILL = -9223372036854775806
+UINT64_FILL = 18446744073709551614
 
 
 def _mem_store():
@@ -91,6 +111,124 @@ def _padded_record():
             )
         ],
     )
+
+
+def _data_type(kind: str):
+    """Build the extended type a test names.
+
+    Args:
+        kind: `"float64"`; `"string"`; `"record"`, two `Int32` fields; or
+            `"record_with_text"`, an `Int32` and a string field -- the layout of a C struct
+            holding an int and a `char *`.
+
+    Returns:
+        gdal.ExtendedDataType: The type.
+    """
+    int32 = gdal.ExtendedDataType.Create(gdal.GDT_Int32)
+    if kind == "float64":
+        data_type = gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    elif kind == "string":
+        data_type = gdal.ExtendedDataType.CreateString()
+    elif kind == "record":
+        data_type = gdal.ExtendedDataType.CreateCompound(
+            "pair_t",
+            8,
+            [
+                gdal.EDTComponent.Create("a", 0, int32),
+                gdal.EDTComponent.Create("b", 4, int32),
+            ],
+        )
+    else:
+        data_type = gdal.ExtendedDataType.CreateCompound(
+            "station_t",
+            16,
+            [
+                gdal.EDTComponent.Create("id", 0, int32),
+                gdal.EDTComponent.Create(
+                    "label", 8, gdal.ExtendedDataType.CreateString()
+                ),
+            ],
+        )
+    return data_type
+
+
+def _one_array_store(name, sizes, kind, group_name=None):
+    """Build a store holding one unwritten array, at the root or in a sub-group.
+
+    Args:
+        name: The array's name.
+        sizes: Its dimension sizes, outermost first; the dimensions are `d0`, `d1`, ...
+        kind: The data type, as `_data_type` names it.
+        group_name: The sub-group to create the array in, or None for the root.
+
+    Returns:
+        gdal.Dataset: The store; keep the reference alive while its arrays are used.
+    """
+    store = _mem_store()
+    group = store.GetRootGroup()
+    if group_name is not None:
+        group = group.CreateGroup(group_name)
+    dimensions = [
+        group.CreateDimension(f"d{index}", None, None, size)
+        for index, size in enumerate(sizes)
+    ]
+    group.CreateMDArray(name, dimensions, _data_type(kind))
+    return store
+
+
+def _axis_before_a_projected_grid():
+    """Build a store that lists a 1-D `aaa_axis` ahead of a `zzz_grid` declaring EPSG:3857.
+
+    Returns:
+        gdal.Dataset: The store; keep the reference alive while its arrays are used.
+    """
+    store = _mem_store()
+    group = store.GetRootGroup()
+    axis = group.CreateMDArray(
+        "aaa_axis",
+        [group.CreateDimension("n", None, None, 3)],
+        gdal.ExtendedDataType.Create(gdal.GDT_Float64),
+    )
+    axis.Write(np.array([1.0, 2.0, 3.0]))
+    grid = group.CreateMDArray(
+        "zzz_grid",
+        [
+            group.CreateDimension("y", "projection_y_coordinate", "Y", 2),
+            group.CreateDimension("x", "projection_x_coordinate", "X", 3),
+        ],
+        gdal.ExtendedDataType.Create(gdal.GDT_Float64),
+    )
+    grid.Write(np.arange(6, dtype="float64").reshape(2, 3))
+    reference = osr.SpatialReference()
+    reference.ImportFromEPSG(3857)
+    grid.SetSpatialRef(reference)
+    return store
+
+
+@pytest.fixture(scope="function")
+def array_reads(monkeypatch):
+    """Record the name of every array whose values are read while the test runs.
+
+    Both GDAL readers are wrapped -- `ReadAsArray` serves numeric and compound arrays, `Read`
+    string ones -- and each still performs the read, so the code under test behaves exactly
+    as it would unobserved. Request it before building the store to see every read.
+
+    Args:
+        monkeypatch: Pytest's patcher; it puts both readers back on teardown.
+
+    Returns:
+        list[str]: The names read, appended to as the test runs.
+    """
+    names: list[str] = []
+    for method in ("ReadAsArray", "Read"):
+        original = getattr(gdal.MDArray, method)
+
+        def recording(self, *args, _original=original, **kwargs):
+            names.append(self.GetName())
+            return _original(self, *args, **kwargs)
+
+        monkeypatch.setattr(gdal.MDArray, method, recording)
+    return names
 
 
 class _StubDimension:
@@ -296,6 +434,81 @@ class TestARasterOnlyOperationNamesTheVariableItRefuses:
         finally:
             container.close()
 
+    def test_the_refusal_is_decided_without_reading_the_array(
+        self, container, array_reads
+    ):
+        """A refusal must cost nothing: the declaration says "no raster plane" before any read.
+
+        Args:
+            container: Fixture holding a store whose only variable is 1-D.
+            array_reads: Fixture recording every array read during the test.
+
+        Test scenario:
+            The guard used to ask `get_variable`, which materialises the whole array, only to
+            discard the values and refuse -- a full read of a long series spent on an error.
+            It now reads the rank and dtype class off the declaration. Both routes give the
+            same refusal, so only the reads tell them apart. Expected: the refusal, with
+            `series` never read.
+        """
+        with pytest.raises(ValueError, match="no raster plane"):
+            container.crop_variable("series", None)
+
+        assert "series" not in array_reads, (
+            f"the refusal read the array it refused: {array_reads}"
+        )
+
+    def test_the_streaming_fan_out_refuses_by_name_too(self, container, tmp_path):
+        """The streaming path guards the variables it is handed, not only the classifier.
+
+        Args:
+            container: Fixture holding a store whose only variable is 1-D.
+            tmp_path: Where the streamed file would have been written.
+
+        Test scenario:
+            `_stream_apply_to_file` was the one fan-out site still calling `get_variable`
+            directly. The classifier upstream now keeps a non-raster variable out of
+            `spatial_vars`, so one is handed in directly here -- the case the local guard
+            exists for. Without it the stream failed on `_band_dim_names` with an
+            `AttributeError` naming neither the variable nor the reason. Expected: the named
+            refusal, and no file left behind.
+        """
+        destination = tmp_path / "streamed.nc"
+
+        with pytest.raises(ValueError, match="series has no raster plane"):
+            container._stream_apply_to_file(
+                "crop", {"mask": None}, ["series"], [], destination
+            )
+
+        assert not destination.exists(), "a refused stream must not write a file"
+
+    def test_a_store_with_no_multidimensional_group_is_served_by_get_variable(self):
+        """With no declaration to consult, the guard falls back to what `get_variable` answers.
+
+        Test scenario:
+            A store opened classically (`NETCDF:file:var`) has no multidimensional group, so
+            there is no array declaration to classify -- and every variable on that path is a
+            raster. The declaration check must step aside rather than dereference an array it
+            could not open. Expected: the raster subset, with the shape `get_variable` gives
+            the same name.
+        """
+        store = NetCDF.read_file(
+            str(CLASSIC_SAMPLE), read_only=True, open_as_multi_dimensional=False
+        )
+        try:
+            assert store._working_group() is None, "fixture changed: no classic store"
+            name = store.variable_names[0]
+
+            required = store._require_raster_variable(name)
+
+            assert isinstance(required, NetCDF), (
+                f"a classic variable must be handed through, got {type(required).__name__}"
+            )
+            assert required.shape == store.get_variable(name).shape, (
+                "the guard must hand back exactly what `get_variable` answers"
+            )
+        finally:
+            store.close()
+
 
 class TestReadArrayOnAVariableWithNoRasterPlane:
     """`read_array` reuses the values `get_variable` already materialised; unpacking still works."""
@@ -488,6 +701,106 @@ class TestTheLabelsTheWrapperCarries:
             )
             assert variable.attributes == {}, (
                 f"unexpected attributes {variable.attributes!r}"
+            )
+        finally:
+            container.close()
+
+    def test_an_unpacked_array_reports_no_scale_or_offset(self):
+        """No packing declared must read as `None`, not as the identity transform.
+
+        Test scenario:
+            `scale` / `offset` are there so a caller can tell packed values from plain ones.
+            Defaulting them to `1.0` / `0.0` would keep `values * scale + offset` computable
+            but make "is this packed?" unanswerable -- the reason `no_data_value` stays `None`
+            rather than `0.0`. Expected: both `None` on an array that declares neither.
+        """
+        store, _ = _series_store(np.array([1.0, 2.0, 3.0]))
+        container = Container(store)
+        try:
+            variable = container.get_variable("series")
+
+            assert (variable.scale, variable.offset) == (None, None), (
+                f"an unpacked array must report no packing, got "
+                f"{(variable.scale, variable.offset)}"
+            )
+        finally:
+            container.close()
+
+    @pytest.mark.parametrize(
+        "gdal_type, numpy_type, setter, fill",
+        [
+            (gdal.GDT_Int64, "int64", "SetNoDataValueInt64", INT64_FILL),
+            (gdal.GDT_UInt64, "uint64", "SetNoDataValueUInt64", UINT64_FILL),
+        ],
+        ids=["int64", "uint64"],
+    )
+    def test_a_64_bit_integer_fill_value_keeps_every_digit(
+        self, gdal_type, numpy_type, setter, fill
+    ):
+        """A 64-bit fill read through a double matches no element of the array it labels.
+
+        Args:
+            gdal_type: The 64-bit integer type the series is declared with.
+            numpy_type: The matching NumPy dtype for the written values.
+            setter: The `MDArray` method that declares a fill of that type.
+            fill: A fill a double's 53-bit mantissa cannot hold exactly.
+
+        Test scenario:
+            `GetNoDataValueAsDouble` rounds `-9223372036854775806` to
+            `-9.223372036854776e+18`, and the UInt64 fill up to `2**64`; neither equals
+            anything the array holds, so masking by `no_data_value` masked nothing.
+            Expected: the fill as an exact `int`, equal to the one element that carries it.
+        """
+        store, array = _series_store(
+            np.array([1, fill, 3], dtype=numpy_type),
+            gdal.ExtendedDataType.Create(gdal_type),
+        )
+        getattr(array, setter)(fill)
+        container = Container(store)
+        try:
+            variable = container.get_variable("series")
+
+            assert isinstance(variable.no_data_value, int), (
+                f"a 64-bit fill must stay an int, got {variable.no_data_value!r}"
+            )
+            assert variable.no_data_value == fill, (
+                f"expected the fill {fill}, got {variable.no_data_value!r}"
+            )
+            matches = (variable.values == variable.no_data_value).tolist()
+            assert matches == [False, True, False], (
+                f"the fill must pick out exactly the element that carries it: {matches}"
+            )
+        finally:
+            container.close()
+
+    @pytest.mark.parametrize(
+        "gdal_type", [gdal.GDT_Int64, gdal.GDT_UInt64], ids=["int64", "uint64"]
+    )
+    def test_a_64_bit_array_with_no_fill_value_answers_none(self, gdal_type):
+        """The 64-bit accessors must say "none declared" as `None`, as the double one does.
+
+        Args:
+            gdal_type: The 64-bit integer type the series is declared with.
+
+        Test scenario:
+            The defaults test above reaches only the double accessor; these two types read
+            their fill through accessors of their own. `0` is a legal integer fill, so an
+            absent one coming back as a number would read as declared, and one that failed
+            on the absence would make every such variable unreadable. Expected: `None`, with
+            the values intact.
+        """
+        store, _ = _series_store(
+            np.array([1, 2, 3], dtype="int64"), gdal.ExtendedDataType.Create(gdal_type)
+        )
+        container = Container(store)
+        try:
+            variable = container.get_variable("series")
+
+            assert variable.no_data_value is None, (
+                f"an undeclared fill must stay None, got {variable.no_data_value!r}"
+            )
+            assert variable.values.tolist() == [1, 2, 3], (
+                f"unexpected values {variable.values}"
             )
         finally:
             container.close()
@@ -726,6 +1039,141 @@ class TestAReadThatDisagreesWithTheDeclaredDimensions:
         )
 
 
+class TestACompoundRecordWithAStringField:
+    """A record type GDAL's Python bindings cannot read, through either of their readers."""
+
+    def test_get_variable_refuses_it_by_name(self):
+        """The refusal names the variable and the cause, not just GDAL's bare message.
+
+        Test scenario:
+            `ReadAsArray` raises "String buffer data type not supported in SWIG bindings" and
+            `Read` "non-numeric buffer data type not supported", so there is nothing to
+            materialise. Passed through, that message names neither the variable nor why a
+            name the store lists will not read. Expected: a `ValueError` naming `stations`
+            and saying it cannot be read, with GDAL's own error kept as the cause.
+        """
+        container = Container(_one_array_store("stations", (2,), "record_with_text"))
+        try:
+            with pytest.raises(ValueError) as excinfo:
+                container.get_variable("stations")
+        finally:
+            container.close()
+
+        message = str(excinfo.value)
+        assert "stations" in message, f"the refusal must name the variable: {message}"
+        assert "cannot be read" in message, f"the refusal must say why: {message}"
+        assert isinstance(excinfo.value.__cause__, RuntimeError), (
+            f"GDAL's error must stay reachable as the cause: {excinfo.value.__cause__!r}"
+        )
+
+    def test_a_raster_only_operation_refuses_it_for_having_no_plane(self):
+        """Asked to crop one, the guard answers the question asked: it is not a raster.
+
+        Test scenario:
+            `stations(d0, d1)` is 2-D, but a record is not a raster at any rank. Asking
+            `get_variable` first -- what the guard used to do -- surfaced the unreadable-type
+            error instead, an answer to a question the caller did not ask: the record could
+            not be cropped even if it were readable. The declaration answers without a read.
+            Expected: the "no raster plane" refusal, printing both dimensions.
+        """
+        container = Container(_one_array_store("stations", (2, 3), "record_with_text"))
+        try:
+            with pytest.raises(ValueError) as excinfo:
+                container.crop_variable("stations", None)
+        finally:
+            container.close()
+
+        message = str(excinfo.value)
+        assert "no raster plane" in message, f"unexpected refusal: {message}"
+        assert "('d0', 'd1')" in message, (
+            f"the refusal must print the dimensions: {message}"
+        )
+
+
+class TestTheDeclarationAgreesWithWhatGetVariableReturns:
+    """`_has_raster_plane` predicts `get_variable`'s return type without reading; it must not err.
+
+    Three callers act on the prediction rather than on the result: the container CRS walk skips
+    on it, the raster guard refuses on it, and the fan-out classifier excludes on it. A wrong
+    "no" refuses a variable `get_variable` would have served as a raster; a wrong "yes" hands
+    those callers a `LabeledArray` where they expect geometry.
+    """
+
+    @pytest.mark.parametrize(
+        "sizes, kind, expected",
+        [
+            ((3,), "float64", False),
+            ((2, 3), "float64", True),
+            ((2, 2, 3), "float64", True),
+            ((3,), "string", False),
+            ((2, 3), "string", False),
+            ((2, 3), "record", False),
+        ],
+        ids=["1d", "2d", "3d", "1d-string", "2d-string", "2d-record"],
+    )
+    def test_the_prediction_matches_the_returned_type(self, sizes, kind, expected):
+        """Rank and dtype class decide it, and both have to be consulted.
+
+        Args:
+            sizes: The array's dimension sizes.
+            kind: Its data type, as `_data_type` names it.
+            expected: Whether it has a raster plane.
+
+        Test scenario:
+            A 1-D numeric array fails on rank alone and a 2-D string one on dtype alone, so a
+            predicate checking only one of the two gets exactly one of those rows wrong.
+            Expected: the module-level predicate, the method the callers use, and the type
+            `get_variable` actually returns all give the same answer.
+        """
+        store = _one_array_store("v", sizes, kind)
+        container = Container(store)
+        try:
+            predicted = _has_raster_plane(store.GetRootGroup().OpenMDArray("v"))
+            declared = container._declares_raster_plane("v")
+            returned = container.get_variable("v")
+
+            assert predicted is expected, f"_has_raster_plane said {predicted}"
+            assert declared is expected, f"_declares_raster_plane said {declared}"
+            assert isinstance(returned, NetCDF) is expected, (
+                f"get_variable returned a {type(returned).__name__}"
+            )
+        finally:
+            container.close()
+
+    @pytest.mark.parametrize(
+        "sizes, expected", [((3,), False), ((2, 3), True)], ids=["1d", "2d"]
+    )
+    def test_a_group_qualified_name_is_classified_in_its_own_group(
+        self, sizes, expected
+    ):
+        """The CRS walk meets `forecast/v` names and must classify the array they point at.
+
+        Args:
+            sizes: The array's dimension sizes.
+            expected: Whether it has a raster plane.
+
+        Test scenario:
+            `variable_names` qualifies a nested variable with its group path, and the CRS walk
+            classifies every name it lists. The root group holds no array called
+            `forecast/v` -- GDAL answers `Array forecast/v does not exist` -- so the name has
+            to be walked down to its group before the declaration can be read. Expected: the
+            same answer `get_variable` gives through the group, for a series and a grid.
+        """
+        container = Container(_one_array_store("v", sizes, "float64", "forecast"))
+        try:
+            assert "forecast/v" in container.variable_names, "fixture changed"
+
+            declared = container._declares_raster_plane("forecast/v")
+            returned = container.get_variable("forecast/v")
+
+            assert declared is expected, f"_declares_raster_plane said {declared}"
+            assert isinstance(returned, NetCDF) is expected, (
+                f"get_variable returned a {type(returned).__name__}"
+            )
+        finally:
+            container.close()
+
+
 class TestTheContainerCrsSkipsAVariableWithNoRasterPlane:
     """A container borrows its CRS from its variables, and one of them may have no geometry."""
 
@@ -775,3 +1223,48 @@ class TestTheContainerCrsSkipsAVariableWithNoRasterPlane:
             )
         finally:
             container.close()
+
+    def test_the_skipped_variable_is_never_read(self, array_reads):
+        """Stepping over a non-raster variable must not cost a read of it.
+
+        Args:
+            array_reads: Fixture recording every array read during the test.
+
+        Test scenario:
+            The walk used to ask `get_variable` for each name and skip whatever came back as
+            a `LabeledArray` -- correct, but `get_variable` materialises, so it read a whole
+            series only to learn it had no CRS. It now decides on the declaration. Both find
+            the same CRS, so only the reads tell them apart; the recorder is armed before the
+            store is even built, so a read at construction would be caught too. Expected:
+            EPSG:3857 from the grid, and `aaa_axis` never read.
+        """
+        container = Container(_axis_before_a_projected_grid())
+        try:
+            assert container.variable_names[0] == "aaa_axis", "fixture changed"
+
+            assert container.epsg == 3857, f"unexpected EPSG {container.epsg}"
+            assert "aaa_axis" not in array_reads, (
+                f"the CRS walk read the variable it skips: {array_reads}"
+            )
+        finally:
+            container.close()
+
+    def test_a_store_with_no_multidimensional_group_still_borrows_a_crs(self):
+        """A name the declaration check cannot open must count as a raster, not be skipped.
+
+        Test scenario:
+            A classically opened store has no multidimensional group, so the check opens none
+            of its arrays -- yet every variable on that path is a raster. Reading "could not
+            classify" as "no raster plane" skips all of them, and the root of such a store
+            carries no projection of its own, so it would report no CRS at all. Expected: the
+            WGS 84 its variables declare.
+        """
+        store = NetCDF.read_file(
+            str(CLASSIC_SAMPLE), read_only=True, open_as_multi_dimensional=False
+        )
+        try:
+            assert store._working_group() is None, "fixture changed: no classic store"
+
+            assert store.epsg == 4326, f"unexpected EPSG {store.epsg}"
+        finally:
+            store.close()

--- a/tests/netcdf/unit/test_non_raster_variable_contract.py
+++ b/tests/netcdf/unit/test_non_raster_variable_contract.py
@@ -55,7 +55,8 @@ CLASSIC_SAMPLE = (
     / "netcdf"
     / "cf__6v__1d2-2d4__geog__y-asc.nc"
 )
-# Fills a double's 53-bit mantissa cannot hold: each rounds to a value no element equals.
+# Fills a double's 53-bit mantissa cannot hold: through a double each one compares equal to
+# its neighbour as well as to itself, so masking by it would hide real data too.
 INT64_FILL = -9223372036854775806
 UINT64_FILL = 18446744073709551614
 
@@ -366,6 +367,32 @@ def _grid_beside_a_flag(flag_type):
     grid.Write(np.arange(20, dtype="float64").reshape(4, 5))
     grid.SetSpatialRef(srs)
     group.CreateMDArray("flag", [rows, cols], flag_type)
+    return store
+
+
+def _grid_with_an_auxiliary(aux_type, aux_values=None, unit=None):
+    """Build a store pairing an EPSG:4326 `t2m(y, x)` with a 1-D auxiliary `aux(k)`.
+
+    Args:
+        aux_type: The `gdal.ExtendedDataType` for `aux`.
+        aux_values: Values to write into `aux`, or None to leave it unwritten -- an
+            unwritten string array reads back as `None` in every entry, which is what a
+            NULL looks like to the carry.
+        unit: A unit to declare on `aux`, or None.
+
+    Returns:
+        gdal.Dataset: The store; keep the reference alive while its arrays are used.
+    """
+    store = _grid_beside_a_flag(gdal.ExtendedDataType.Create(gdal.GDT_Float64))
+    group = store.GetRootGroup()
+    group.DeleteMDArray("flag")
+    aux = group.CreateMDArray(
+        "aux", [group.CreateDimension("k", None, None, 2)], aux_type
+    )
+    if aux_values is not None:
+        aux.Write(aux_values)
+    if unit is not None:
+        aux.SetUnit(unit)
     return store
 
 
@@ -775,7 +802,7 @@ class TestTheLabelsTheWrapperCarries:
     def test_a_64_bit_integer_fill_value_keeps_every_digit(
         self, gdal_type, numpy_type, setter, fill
     ):
-        """A 64-bit fill read through a double matches no element of the array it labels.
+        """A 64-bit fill read through a double matches its neighbour as well as itself.
 
         Args:
             gdal_type: The 64-bit integer type the series is declared with.
@@ -785,12 +812,16 @@ class TestTheLabelsTheWrapperCarries:
 
         Test scenario:
             `GetNoDataValueAsDouble` rounds `-9223372036854775806` to
-            `-9.223372036854776e+18`, and the UInt64 fill up to `2**64`; neither equals
-            anything the array holds, so masking by `no_data_value` masked nothing.
-            Expected: the fill as an exact `int`, equal to the one element that carries it.
+            `-9.223372036854776e+18`, and the UInt64 fill up to `2**64`. numpy compares a
+            64-bit integer array against that double by converting the integers, which
+            loses the same precision, so the rounded fill equals both the fill and the value
+            next to it -- masking by it would hide a real datum. Expected: the fill as an
+            exact `int` that selects the one element carrying it and not its neighbour.
         """
+        # The value next to the fill is the one a double cannot tell apart from it.
+        neighbour = fill + 1 if fill < 0 else fill - 1
         store, array = _series_store(
-            np.array([1, fill, 3], dtype=numpy_type),
+            np.array([1, fill, neighbour, 3], dtype=numpy_type),
             gdal.ExtendedDataType.Create(gdal_type),
         )
         getattr(array, setter)(fill)
@@ -805,7 +836,7 @@ class TestTheLabelsTheWrapperCarries:
                 f"expected the fill {fill}, got {variable.no_data_value!r}"
             )
             matches = (variable.values == variable.no_data_value).tolist()
-            assert matches == [False, True, False], (
+            assert matches == [False, True, False, False], (
                 f"the fill must pick out exactly the element that carries it: {matches}"
             )
         finally:
@@ -1428,3 +1459,110 @@ class TestTheRound2FixesTheirOwnTestPassFound:
             assert (cached.unit, cached.values.tolist()) == ("K", [10.0, 20.0, 30.0])
         finally:
             container.close()
+
+
+@pytest.mark.core
+class TestTheCarryAndTheLockTheDocstringPassFound:
+    """Four defects the round-2 docstring pass found; the first two predate this branch."""
+
+    def test_a_string_auxiliary_with_a_null_entry_is_dropped_not_fatal(self):
+        """One NULL string entry must not fail the whole operation.
+
+        Test scenario:
+            The carry reads a string auxiliary with `Read`, which returns a NULL entry as
+            `None`, and writing that list raises `TypeError: sequence must contain
+            strings`. The carry caught only `RuntimeError` and `ValueError`, so a single
+            such auxiliary failed the whole `to_crs` -- on `main` too. Expected: the
+            raster reprojected, the auxiliary dropped with a warning naming it.
+        """
+        container = Container(
+            _grid_with_an_auxiliary(gdal.ExtendedDataType.CreateString())
+        )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = container.to_crs(3857)
+
+        assert "t2m" in result.variable_names
+        assert "aux" not in result.variable_names
+        assert any("could not carry" in str(warning.message) for warning in caught)
+
+    def test_a_compound_auxiliary_does_not_fail_a_streamed_write(self, tmp_path):
+        """The streamed arm must decline a compound auxiliary, as the in-memory one drops it.
+
+        Args:
+            tmp_path: Destination for the streamed output.
+
+        Test scenario:
+            `_stream_feasible` screened out string auxiliaries but not compound ones, and
+            the streamed write maps each through `numpy_to_gdal_dtype`, which has no entry
+            for a structured dtype. So `to_crs(path=...)` failed with "numpy data type is
+            not supported" while the same call in memory succeeded -- on `main` too.
+            Expected: the streamed call succeeds.
+        """
+        container = Container(_grid_with_an_auxiliary(_data_type("compound")))
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            container.to_crs(3857, path=str(tmp_path / "out.nc"))
+
+        assert (tmp_path / "out.nc").exists()
+
+    @pytest.mark.parametrize(
+        "attempt",
+        [
+            lambda entry: entry.values.setflags(write=True),
+            lambda entry: delattr(entry, "unit"),
+            lambda entry: entry.attributes["flags"].append("c"),
+        ],
+        ids=["reopen-the-array", "delete-a-label", "mutate-a-list-attribute"],
+    )
+    def test_nothing_reopens_a_frozen_entry(self, attempt):
+        """Every route around the lock is closed, not just assignment.
+
+        Args:
+            attempt: A way of changing the cached entry without assigning to it.
+
+        Test scenario:
+            numpy lets anyone call `setflags(write=True)` on an array that owns its data,
+            which re-opened the cache; `__setattr__` alone left `del entry.unit` free; and
+            a multi-valued attribute came back as a list the read-only mapping around it
+            did not protect. Each let the cache disagree with `get_variable` again.
+            Expected: each refused, and the cache still matching a fresh read.
+        """
+        store, array = _series_store(np.array([10.0, 20.0, 30.0]))
+        array.SetUnit("K")
+        flags = array.CreateAttribute(
+            "flags", [2], gdal.ExtendedDataType.CreateString()
+        )
+        flags.Write(["a", "b"])
+        container = Container(store)
+        try:
+            cached = container.variables["series"]
+
+            with pytest.raises((ValueError, AttributeError, TypeError)):
+                attempt(cached)
+
+            fresh = container.get_variable("series")
+            assert cached.values.tolist() == fresh.values.tolist()
+            assert cached.unit == fresh.unit
+        finally:
+            container.close()
+
+    def test_a_string_auxiliary_keeps_its_unit_through_the_carry(self):
+        """The string branch of the carry keeps the labels the numeric branch does.
+
+        Test scenario:
+            The numeric branch sets unit and spatial reference on the copy; the string
+            branch set neither, so a string auxiliary came out of a crop with a unit of
+            '' where it went in with '1'. Expected: the unit carried.
+        """
+        container = Container(
+            _grid_with_an_auxiliary(
+                gdal.ExtendedDataType.CreateString(), aux_values=["ok", "ok"], unit="1"
+            )
+        )
+
+        result = container.to_crs(3857)
+
+        assert result._working_group().OpenMDArray("aux").GetUnit() == "1"

--- a/tests/netcdf/unit/test_non_raster_variable_contract.py
+++ b/tests/netcdf/unit/test_non_raster_variable_contract.py
@@ -347,9 +347,11 @@ class TestReadArrayOnAVariableWithNoRasterPlane:
             packed: Fixture holding a scaled 1-D `Int16` series.
 
         Test scenario:
-            The read no longer goes back to GDAL, so an in-place unpack would leave the scaled
-            numbers where the next caller finds them -- and `variables` caches the wrapper, so
-            they would survive the call. Expected: the second unpacked read equals the first,
+            The read reuses the values it resolved rather than going back to GDAL, so an
+            in-place unpack would be a real risk if those values were ever shared. They are
+            not on this path -- `read_array` builds a fresh wrapper each call and never touches
+            the `variables` cache -- so this pins repeatability, not aliasing; the shared object
+            is covered by the next test. Expected: the second unpacked read equals the first,
             and a plain read after it still answers the storage integers.
         """
         first = packed.read_array(variable="series", unpack=True)
@@ -362,26 +364,46 @@ class TestReadArrayOnAVariableWithNoRasterPlane:
             "an unpacked read must not rewrite the stored values"
         )
 
-    def test_the_cached_mapping_hands_back_the_same_wrapper(self, packed):
-        """`variables` caches per key, and a `LabeledArray` now lives in that cache.
+    def test_the_cached_wrapper_is_shared_so_it_cannot_be_written(self, packed):
+        """`variables` hands every caller the same array, so it must not be mutable.
 
         Args:
             packed: Fixture holding a scaled 1-D `Int16` series.
 
         Test scenario:
-            `variables` is documented as loading on first access and caching after, which used
-            to be a statement about `NetCDF` subsets only. Expected: the same object on repeat
-            access, and its values untouched by an intervening unpacked `read_array` -- the
-            aliasing the reuse change could have introduced.
+            `variables` caches per key, so `variables["series"]` is one object for every
+            caller -- unlike `get_variable`, which builds a fresh one each time. Left
+            writeable, a single `values += 1` made the mapping answer `[11, 21, 31]` while
+            `get_variable` and `read_array` still said `[10, 20, 30]`. Expected: the same
+            object on repeat access, a mutation refused at the point it is attempted, and all
+            three accessors still agreeing afterwards.
         """
         first = packed.variables["series"]
-        packed.read_array(variable="series", unpack=True)
         second = packed.variables["series"]
 
         assert first is second, "the mapping must cache the wrapper, not rebuild it"
-        assert np.array_equal(second.values, [10, 20, 30]), (
-            f"the cached values must stay in storage units, got {second.values}"
-        )
+        assert not first.values.flags.writeable, "the shared array must be read-only"
+        with pytest.raises(ValueError, match="read-only"):
+            first.values += 1
+
+        cached = packed.variables["series"].values.tolist()
+        fresh = packed.get_variable("series").values.tolist()
+        read = np.asarray(packed.read_array(variable="series")).tolist()
+        assert cached == fresh == read == [10, 20, 30], (cached, fresh, read)
+
+    def test_a_fresh_wrapper_stays_writeable(self, packed):
+        """Only the shared object is locked; a caller's own copy is theirs to change.
+
+        Args:
+            packed: Fixture holding a scaled 1-D `Int16` series.
+
+        Test scenario:
+            `get_variable` returns a new wrapper on every call, so nothing else holds its
+            array and there is no reason to refuse a write to it.
+        """
+        fresh = packed.get_variable("series")
+
+        assert fresh.values.flags.writeable
 
 
 class TestTheLabelsTheWrapperCarries:

--- a/tests/netcdf/unit/test_non_raster_variable_contract.py
+++ b/tests/netcdf/unit/test_non_raster_variable_contract.py
@@ -1,0 +1,721 @@
+"""What a variable with no raster plane promises once it is a `LabeledArray` (#1126).
+
+The sibling suites assert the *type* that comes back from `get_variable` and the values it
+carries. Three things they do not reach are asserted here.
+
+*The refusal.* `_require_raster_variable` is the door every internal caller that needs geometry
+now goes through. It is exercised from the public methods that let a user name the variable --
+`crop_variable`, `reproject_variable`, `resample_variable` and `plot(variable=)` -- because a
+refusal is only useful if it survives the call the user actually makes.
+
+*The labels.* `LabeledArray` grew `name` / `unit` / `no_data_value` / `attributes`. Without them a
+`-9999.0` sitting in `values` is indistinguishable from real data, so what the wrapper copies off
+the array -- and what it defaults to when the array declares nothing -- is the difference between
+the wrapper being a better answer than the handle it replaced and merely a safer one.
+
+*The empty-extent dtype.* `_numpy_dtype_of` / `_compound_dtype` describe a variable GDAL declines
+to read at all (`count[0] = 0 is invalid`). No driver here will build such a store for a compound
+or string type -- MEM refuses a zero-length dimension outright -- so the two helpers are asserted
+directly, on the `ExtendedDataType` they take.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from osgeo import gdal, osr
+
+from pyramids.netcdf import LabeledArray
+from pyramids.netcdf.netcdf import (
+    Container,
+    _compound_dtype,
+    _labeled_array_from_md_array,
+    _numpy_dtype_of,
+)
+
+pytestmark = pytest.mark.core
+
+PADDED_RECORD_SIZE = 24
+PADDED_OFFSETS = [0, 8, 16]
+
+
+def _mem_store():
+    """Create an empty in-memory multidimensional store.
+
+    Returns:
+        gdal.Dataset: The store; keep the reference alive while its arrays are used.
+    """
+    return gdal.GetDriverByName("MEM").CreateMultiDimensional("test")
+
+
+def _series_store(values=None, dtype=None):
+    """Build a store holding one 1-D array named ``series``.
+
+    Args:
+        values: The values to write, or None to leave the array unwritten.
+        dtype: The `gdal.ExtendedDataType` for the array; Float64 when omitted.
+
+    Returns:
+        tuple[gdal.Dataset, gdal.MDArray]: The store and the array, both kept by the caller.
+    """
+    store = _mem_store()
+    group = store.GetRootGroup()
+    size = 3 if values is None else len(values)
+    dimension = group.CreateDimension("n", None, None, size)
+    array = group.CreateMDArray(
+        "series", [dimension], dtype or gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    if values is not None:
+        array.Write(values)
+    return store, array
+
+
+def _padded_record():
+    """Build a compound type whose fields are padded apart and after the last one.
+
+    Returns:
+        gdal.ExtendedDataType: An `Int32` at 0, a `Float64` at 8 and an `Int32` at 16, declared
+        24 bytes wide -- the layout a C compiler produces for that field order.
+    """
+    return gdal.ExtendedDataType.CreateCompound(
+        "record_t",
+        PADDED_RECORD_SIZE,
+        [
+            gdal.EDTComponent.Create(
+                name, offset, gdal.ExtendedDataType.Create(gdal_type)
+            )
+            for name, offset, gdal_type in zip(
+                ["a", "b", "c"],
+                PADDED_OFFSETS,
+                [gdal.GDT_Int32, gdal.GDT_Float64, gdal.GDT_Int32],
+            )
+        ],
+    )
+
+
+class _StubDimension:
+    """A dimension that answers a name and a size, standing in for `gdal.Dimension`."""
+
+    def __init__(self, name: str, size: int):
+        """Record the name and size this dimension reports.
+
+        Args:
+            name: The dimension name.
+            size: The extent it declares.
+        """
+        self._name = name
+        self._size = size
+
+    def GetName(self) -> str:  # noqa: N802 - mirrors the GDAL SWIG spelling
+        """The dimension's name."""
+        return self._name
+
+    def GetSize(self) -> int:  # noqa: N802 - mirrors the GDAL SWIG spelling
+        """The extent the dimension declares."""
+        return self._size
+
+
+class _StubAttribute:
+    """An attribute whose `Read` either answers a value or raises, as the test asks."""
+
+    def __init__(self, name: str, value=None, error: Exception | None = None):
+        """Record what this attribute answers.
+
+        Args:
+            name: The attribute name.
+            value: The value `Read` returns when no error is configured.
+            error: An exception `Read` raises instead of answering.
+        """
+        self._name = name
+        self._value = value
+        self._error = error
+
+    def GetName(self) -> str:  # noqa: N802 - mirrors the GDAL SWIG spelling
+        """The attribute's name."""
+        return self._name
+
+    def Read(self):  # noqa: N802 - mirrors the GDAL SWIG spelling
+        """The attribute's value, or the configured failure."""
+        if self._error is not None:
+            raise self._error
+        return self._value
+
+
+class _StubMDArray:
+    """A numeric `gdal.MDArray` whose read result the test chooses.
+
+    Only the surface `_labeled_array_from_md_array` touches is implemented. It exists to
+    decouple the read from the declared dimensions, which no real GDAL array lets a test do.
+    """
+
+    def __init__(self, dims, read_result, attributes=()):
+        """Record the declared dimensions and what the read answers with.
+
+        Args:
+            dims: `(name, size)` pairs, outermost first.
+            read_result: The array `ReadAsArray` returns.
+            attributes: The attributes `GetAttributes` returns.
+        """
+        self._dims = [_StubDimension(name, size) for name, size in dims]
+        self._read_result = read_result
+        self._attributes = list(attributes)
+
+    def GetDimensions(self):  # noqa: N802 - mirrors the GDAL SWIG spelling
+        """The dimensions this array declares."""
+        return self._dims
+
+    def GetDataType(self):  # noqa: N802 - mirrors the GDAL SWIG spelling
+        """A numeric extended type, so the `ReadAsArray` branch is taken."""
+        return gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+
+    def ReadAsArray(self):  # noqa: N802 - mirrors the GDAL SWIG spelling
+        """Whatever the test configured, shape included."""
+        return self._read_result
+
+    def GetAttributes(self):  # noqa: N802 - mirrors the GDAL SWIG spelling
+        """The attributes this array carries."""
+        return self._attributes
+
+    def GetUnit(self) -> str:  # noqa: N802 - mirrors the GDAL SWIG spelling
+        """No unit declared."""
+        return ""
+
+    def GetNoDataValueAsDouble(self):  # noqa: N802 - mirrors the GDAL SWIG spelling
+        """No fill value declared."""
+        return None
+
+
+class TestARasterOnlyOperationNamesTheVariableItRefuses:
+    """The convenience methods that take a variable name must say why they cannot serve it."""
+
+    @pytest.fixture(scope="function")
+    def container(self):
+        """A container whose only variable is a 1-D axis, so every op below meets one.
+
+        Yields:
+            Container: The open store; closed on teardown.
+        """
+        store, _ = _series_store(np.array([1.0, 2.0, 3.0]))
+        container = Container(store)
+        yield container
+        container.close()
+
+    @pytest.mark.parametrize(
+        "method, arguments",
+        [
+            ("crop_variable", ("series", None)),
+            ("reproject_variable", ("series", 3857)),
+            ("resample_variable", ("series", 0.5)),
+        ],
+        ids=["crop", "reproject", "resample"],
+    )
+    def test_a_variable_named_operation_refuses_with_the_dimensions(
+        self, container, method, arguments
+    ):
+        """Each `*_variable` convenience method refuses, naming the variable and its axes.
+
+        Args:
+            container: Fixture holding a store whose only variable is 1-D.
+            method: The convenience method under test.
+            arguments: Its positional arguments, the variable name first.
+
+        Test scenario:
+            All three are `get_variable` followed by a geometry operation, so before the
+            guard each died inside GDAL's own object with `AttributeError: 'MDArray' object
+            has no attribute 'crop'` -- a message naming neither the variable nor the reason.
+            Expected: a `ValueError` that names `series`, prints the dimensions that make it
+            non-raster, and points at the accessor that does work.
+        """
+        with pytest.raises(ValueError) as excinfo:
+            getattr(container, method)(*arguments)
+
+        message = str(excinfo.value)
+        assert "series" in message, f"the refusal must name the variable: {message}"
+        assert "'n'" in message, f"the refusal must print the dimensions: {message}"
+        assert "get_variable" in message, (
+            f"the refusal must point at the accessor that works: {message}"
+        )
+
+    def test_plotting_a_named_non_raster_variable_is_refused_the_same_way(
+        self, container
+    ):
+        """`plot(variable=...)` goes through the same guard, one module away.
+
+        Args:
+            container: Fixture holding a store whose only variable is 1-D.
+
+        Test scenario:
+            The plot engine resolves the variable itself rather than reusing the container's
+            result, so a guard placed only in `netcdf.py` would leave this route uncovered.
+            Expected: the same refusal, raised before any rendering is attempted -- so it does
+            not depend on the plotting extra being installed.
+        """
+        with pytest.raises(ValueError) as excinfo:
+            container.plot(variable="series")
+
+        message = str(excinfo.value)
+        assert "no raster plane" in message, (
+            f"the plot route must give the same refusal: {message}"
+        )
+        assert "series" in message, f"the refusal must name the variable: {message}"
+
+    def test_a_raster_variable_is_handed_through_unchanged(self):
+        """The guard must not stand between a caller and a variable that does have a plane.
+
+        Test scenario:
+            A refusal that fired for everything would satisfy the tests above, so the same
+            container is asked for a gridded variable. Expected: the `NetCDF` subset itself,
+            identical to what `get_variable` answers.
+        """
+        store = _mem_store()
+        group = store.GetRootGroup()
+        lat = group.CreateDimension("lat", "latitude", "Y", 2)
+        lon = group.CreateDimension("lon", "longitude", "X", 3)
+        grid = group.CreateMDArray(
+            "t2m", [lat, lon], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+        )
+        grid.Write(np.arange(6, dtype="float64").reshape(2, 3))
+        container = Container(store)
+        try:
+            required = container._require_raster_variable("t2m")
+
+            assert not isinstance(required, LabeledArray), (
+                f"a gridded variable must not be refused, got {type(required).__name__}"
+            )
+            assert required.shape == container.get_variable("t2m").shape, (
+                "the guard must hand back exactly what `get_variable` answers"
+            )
+        finally:
+            container.close()
+
+
+class TestReadArrayOnAVariableWithNoRasterPlane:
+    """`read_array` reuses the values `get_variable` already materialised; unpacking still works."""
+
+    @pytest.fixture(scope="function")
+    def packed(self):
+        """A container holding a 1-D `Int16` series with a CF scale and offset.
+
+        Yields:
+            Container: The open store; closed on teardown.
+        """
+        store, array = _series_store(
+            np.array([10, 20, 30], dtype="int16"),
+            gdal.ExtendedDataType.Create(gdal.GDT_Int16),
+        )
+        array.SetScale(0.5)
+        array.SetOffset(100.0)
+        container = Container(store)
+        yield container
+        container.close()
+
+    def test_unpack_applies_the_arrays_own_scale_and_offset(self, packed):
+        """A non-raster variable has no band to carry the packing, so the array's own is used.
+
+        Args:
+            packed: Fixture holding a scaled 1-D `Int16` series.
+
+        Test scenario:
+            `[10, 20, 30]` stored with `scale_factor=0.5` and `add_offset=100.0`. The values now
+            come from the already-materialised wrapper rather than a second read, so the
+            unpacking has to be re-applied to them; a reuse that dropped it would answer with
+            the raw integers and look like a plain successful read. Expected: `[105.0, 110.0,
+            115.0]`, and the storage integers when unpacking is not asked for.
+        """
+        unpacked = packed.read_array(variable="series", unpack=True)
+        stored = packed.read_array(variable="series", unpack=False)
+
+        assert np.array_equal(unpacked, [105.0, 110.0, 115.0]), (
+            f"scale/offset must be applied, got {unpacked}"
+        )
+        assert np.array_equal(stored, [10, 20, 30]), (
+            f"the default read must stay in storage units, got {stored}"
+        )
+
+    def test_a_second_read_is_not_scaled_twice(self, packed):
+        """Reusing the resolved values must not mean unpacking them in place.
+
+        Args:
+            packed: Fixture holding a scaled 1-D `Int16` series.
+
+        Test scenario:
+            The read no longer goes back to GDAL, so an in-place unpack would leave the scaled
+            numbers where the next caller finds them -- and `variables` caches the wrapper, so
+            they would survive the call. Expected: the second unpacked read equals the first,
+            and a plain read after it still answers the storage integers.
+        """
+        first = packed.read_array(variable="series", unpack=True)
+        second = packed.read_array(variable="series", unpack=True)
+
+        assert np.array_equal(first, second), (
+            f"repeating the read must repeat the answer, got {first} then {second}"
+        )
+        assert np.array_equal(packed.read_array(variable="series"), [10, 20, 30]), (
+            "an unpacked read must not rewrite the stored values"
+        )
+
+    def test_the_cached_mapping_hands_back_the_same_wrapper(self, packed):
+        """`variables` caches per key, and a `LabeledArray` now lives in that cache.
+
+        Args:
+            packed: Fixture holding a scaled 1-D `Int16` series.
+
+        Test scenario:
+            `variables` is documented as loading on first access and caching after, which used
+            to be a statement about `NetCDF` subsets only. Expected: the same object on repeat
+            access, and its values untouched by an intervening unpacked `read_array` -- the
+            aliasing the reuse change could have introduced.
+        """
+        first = packed.variables["series"]
+        packed.read_array(variable="series", unpack=True)
+        second = packed.variables["series"]
+
+        assert first is second, "the mapping must cache the wrapper, not rebuild it"
+        assert np.array_equal(second.values, [10, 20, 30]), (
+            f"the cached values must stay in storage units, got {second.values}"
+        )
+
+
+class TestTheLabelsTheWrapperCarries:
+    """`values` alone cannot say whether a `-9999.0` is data; the labels around it can."""
+
+    def test_it_copies_the_name_unit_fill_value_and_attributes(self):
+        """Everything the raw `MDArray` used to expose is carried onto the wrapper.
+
+        Test scenario:
+            An array declaring a unit, a fill value and an attribute. These were reachable on
+            the handle that used to come back (`GetUnit`, `GetNoDataValueAsDouble`,
+            `GetAttributes`), so dropping them would have made the wrapper a regression for a
+            caller who read them. Expected: all four present, with `values` left unmasked --
+            the fill value is reported, not applied.
+        """
+        store, array = _series_store(np.array([1.0, -9999.0, 3.0]))
+        array.SetUnit("K")
+        array.SetNoDataValueDouble(-9999.0)
+        attribute = array.CreateAttribute(
+            "long_name", [], gdal.ExtendedDataType.CreateString()
+        )
+        attribute.Write("a series")
+        container = Container(store)
+        try:
+            variable = container.get_variable("series")
+
+            assert variable.name == "series", f"unexpected name {variable.name!r}"
+            assert variable.unit == "K", f"unexpected unit {variable.unit!r}"
+            assert variable.no_data_value == -9999.0, (
+                f"unexpected fill value {variable.no_data_value!r}"
+            )
+            assert variable.attributes == {"long_name": "a series"}, (
+                f"unexpected attributes {variable.attributes!r}"
+            )
+            assert np.array_equal(variable.values, [1.0, -9999.0, 3.0]), (
+                f"the fill value must be reported, not applied: {variable.values}"
+            )
+        finally:
+            container.close()
+
+    def test_an_array_that_declares_none_of_them_gets_the_documented_defaults(self):
+        """A bare array must answer empty labels rather than GDAL's placeholders.
+
+        Test scenario:
+            An array with no unit, no fill value and no attributes. Expected: `unit` an empty
+            string, `no_data_value` `None` -- not the `0.0` a numeric default would make
+            indistinguishable from a declared zero fill -- and `attributes` an empty dict.
+        """
+        store, _ = _series_store(np.array([1.0, 2.0, 3.0]))
+        container = Container(store)
+        try:
+            variable = container.get_variable("series")
+
+            assert variable.unit == "", f"unexpected unit {variable.unit!r}"
+            assert variable.no_data_value is None, (
+                f"an undeclared fill value must stay None, got {variable.no_data_value!r}"
+            )
+            assert variable.attributes == {}, (
+                f"unexpected attributes {variable.attributes!r}"
+            )
+        finally:
+            container.close()
+
+    def test_each_wrapper_gets_its_own_attribute_dict(self):
+        """The default must not be a dict shared between instances.
+
+        Test scenario:
+            `attributes` defaults to a fresh mapping, so writing into one wrapper's must not
+            appear on the next. Expected: the second wrapper still empty after the first is
+            written to.
+        """
+        first = LabeledArray(np.zeros(2), ("n",), (2,))
+        first.attributes["written"] = 1
+        second = LabeledArray(np.zeros(2), ("n",), (2,))
+
+        assert second.attributes == {}, (
+            f"the default dict must not be shared, got {second.attributes!r}"
+        )
+
+    @pytest.mark.parametrize(
+        "name, expected",
+        [("series", "LabeledArray('series', dims=('n',), shape=(3,))"), ("", None)],
+        ids=["named", "unnamed"],
+    )
+    def test_repr_names_the_variable_only_when_it_has_one(self, name, expected):
+        """The name earns its place in the repr; an empty one must not leave a stray comma.
+
+        Args:
+            name: The name to construct with.
+            expected: The exact repr, or None when only the absence is asserted.
+
+        Test scenario:
+            `LabeledDataset["var"]` constructs without a name, so both spellings are live.
+            Expected: the named form quotes it ahead of `dims`; the unnamed one carries neither
+            the name nor its separator.
+        """
+        array = LabeledArray(np.zeros(3), ("n",), (3,), name=name)
+
+        if expected is not None:
+            assert repr(array) == expected, f"unexpected repr {array!r}"
+        else:
+            assert repr(array) == "LabeledArray(dims=('n',), shape=(3,))", (
+                f"an unnamed array must not carry a separator: {array!r}"
+            )
+
+
+class TestTheDtypeOfAVariableWithNoRecords:
+    """`_numpy_dtype_of` / `_compound_dtype` describe an array GDAL will not let anyone read.
+
+    An unlimited dimension with no records written declines the read outright (`count[0] = 0 is
+    invalid`), so the empty array is built from the declared type. MEM refuses to create such a
+    dimension at all -- `RuntimeError: Illegal dimension size 0` -- which leaves the two helpers
+    reachable end-to-end only for the numeric case a sibling test already covers. They are
+    asserted here on the type itself.
+    """
+
+    @pytest.mark.parametrize(
+        "gdal_type, expected",
+        [
+            (gdal.GDT_Float64, np.float64),
+            (gdal.GDT_Int16, np.int16),
+            (gdal.GDT_Byte, np.uint8),
+        ],
+        ids=["float64", "int16", "byte"],
+    )
+    def test_a_numeric_type_maps_to_its_numpy_dtype(self, gdal_type, expected):
+        """The empty array must have the dtype the read would have produced.
+
+        Args:
+            gdal_type: The declared GDAL numeric type.
+            expected: The NumPy dtype it must map to.
+
+        Test scenario:
+            Answering `float64` for everything would go unnoticed on a float variable and
+            silently widen an integer one, so signed, unsigned and floating types are each
+            checked.
+        """
+        dtype = _numpy_dtype_of(gdal.ExtendedDataType.Create(gdal_type))
+
+        assert dtype == np.dtype(expected), f"expected {expected}, got {dtype}"
+
+    def test_a_string_type_maps_to_the_unicode_dtype(self):
+        """An empty string variable must not be the one string array with a different dtype.
+
+        Test scenario:
+            A non-empty string array reaches the caller as `np.asarray(md_arr.Read())`, whose
+            dtype is `<U`. Expected: the same kind for the empty case, so a caller inspecting
+            `values.dtype.kind` gets the same answer whether or not any record was written --
+            `object`, the other plausible choice, would break that.
+        """
+        dtype = _numpy_dtype_of(gdal.ExtendedDataType.CreateString())
+
+        assert dtype.kind == "U", f"expected a unicode dtype, got {dtype!r}"
+
+    def test_a_compound_type_keeps_the_declared_offsets_and_record_size(self):
+        """The record layout is read from GDAL, not inferred from the field formats.
+
+        Test scenario:
+            A record padded between its fields and after the last one. Both paddings are
+            load-bearing and each is lost by a different shortcut: packing the formats puts the
+            fields at 0/4/12, and inferring the stride from the offsets gives 20 rather than the
+            declared 24. Either slides every record after the first against the buffer.
+            Expected: the declared offsets and the declared record size, and a layout that
+            differs from the naively packed one -- otherwise the assertion proves nothing.
+        """
+        dtype = _compound_dtype(_padded_record())
+
+        assert dtype.names == ("a", "b", "c"), f"unexpected fields {dtype.names}"
+        assert dtype.itemsize == PADDED_RECORD_SIZE, (
+            f"the record stride must be the declared {PADDED_RECORD_SIZE}, got {dtype.itemsize}"
+        )
+        assert [dtype.fields[name][1] for name in dtype.names] == PADDED_OFFSETS, (
+            f"the fields must sit at their declared offsets {PADDED_OFFSETS}, got "
+            f"{[dtype.fields[name][1] for name in dtype.names]}"
+        )
+        packed = np.dtype([("a", "<i4"), ("b", "<f8"), ("c", "<i4")])
+        assert dtype.itemsize != packed.itemsize, (
+            "the fixture must actually be padded, or this asserts nothing"
+        )
+
+    def test_the_compound_branch_is_reached_through_the_dispatcher(self):
+        """`_numpy_dtype_of` must route a compound type to `_compound_dtype`, not to a number.
+
+        Test scenario:
+            The dispatcher is what the empty-extent path calls; a compound falling through to
+            its numeric branch would raise on `GetNumericDataType()` rather than describing the
+            record. Expected: the structured dtype, identical to the direct call.
+        """
+        record = _padded_record()
+
+        assert _numpy_dtype_of(record) == _compound_dtype(record), (
+            "the dispatcher must hand a compound type to the compound builder"
+        )
+
+    def test_a_component_that_is_not_itself_numeric_is_refused(self):
+        """A nested record has no numeric type code, so no NumPy field can be built for it.
+
+        Test scenario:
+            A compound whose first component is itself a compound. `GetNumericDataType()`
+            reports `GDT_Unknown` for it, which maps to no NumPy type. Expected: a `ValueError`
+            rather than a silently wrong field -- the message is GDAL's type code, which
+            `_labeled_array_from_md_array` re-raises with the variable's name attached.
+        """
+        nested = gdal.ExtendedDataType.CreateCompound(
+            "outer",
+            32,
+            [
+                gdal.EDTComponent.Create("inner", 0, _padded_record()),
+                gdal.EDTComponent.Create(
+                    "c", 24, gdal.ExtendedDataType.Create(gdal.GDT_Int32)
+                ),
+            ],
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            _compound_dtype(nested)
+
+        assert "not supported" in str(excinfo.value), (
+            f"unexpected refusal: {excinfo.value}"
+        )
+
+
+class TestAReadThatDisagreesWithTheDeclaredDimensions:
+    """The two shapes come from different places, so they can disagree.
+
+    `shape` is what the dimensions declare and `values.shape` is what the read returned. No real
+    GDAL array lets a test drive the two apart, so a stub stands in for the handle.
+    """
+
+    def test_a_mis_shaped_read_is_refused_rather_than_wrapped(self):
+        """A wrapper whose `shape` and `values.shape` disagree would mislead every later caller.
+
+        Test scenario:
+            An array declaring `(record: 3, level: 2)` whose read answers five values. Without
+            the check the wrapper reports a shape its own values do not have, and the caller
+            finds out somewhere far from the read. Expected: a `ValueError` naming the variable,
+            the declared dimensions and both shapes.
+        """
+        stub = _StubMDArray(
+            [("record", 3), ("level", 2)], np.arange(5, dtype="float64")
+        )
+
+        with pytest.raises(ValueError) as excinfo:
+            _labeled_array_from_md_array(stub, "obs")
+
+        message = str(excinfo.value)
+        assert "obs" in message, f"the refusal must name the variable: {message}"
+        assert "(3, 2)" in message, (
+            f"the refusal must print the declared shape: {message}"
+        )
+        assert "(5,)" in message, f"the refusal must print the read shape: {message}"
+
+    def test_a_matching_read_is_wrapped(self):
+        """The check must not stand in the way of a read that agrees with the dimensions.
+
+        Test scenario:
+            The same declared dimensions, read back at `(3, 2)`. Expected: the wrapper, with
+            the dimension names and the shape carried through -- a guard that refused both
+            shapes would pass the test above and break every read.
+        """
+        stub = _StubMDArray(
+            [("record", 3), ("level", 2)], np.arange(6, dtype="float64").reshape(3, 2)
+        )
+
+        wrapped = _labeled_array_from_md_array(stub, "obs")
+
+        assert wrapped.dims == ("record", "level"), f"unexpected dims {wrapped.dims}"
+        assert wrapped.shape == (3, 2), f"unexpected shape {wrapped.shape}"
+
+    def test_an_unreadable_attribute_does_not_cost_the_caller_the_values(self):
+        """One attribute GDAL cannot decode must not turn a good read into an exception.
+
+        Test scenario:
+            Two attributes, the second raising `RuntimeError` from `Read()` -- what GDAL does
+            for a type it has no Python mapping for. Expected: the values and the readable
+            attribute come back, and the unreadable one is simply absent.
+        """
+        stub = _StubMDArray(
+            [("n", 3)],
+            np.arange(3, dtype="float64"),
+            attributes=[
+                _StubAttribute("good", value="kept"),
+                _StubAttribute("bad", error=RuntimeError("cannot read")),
+            ],
+        )
+
+        wrapped = _labeled_array_from_md_array(stub, "obs")
+
+        assert wrapped.attributes == {"good": "kept"}, (
+            f"the readable attribute must survive alone, got {wrapped.attributes!r}"
+        )
+        assert np.array_equal(wrapped.values, [0.0, 1.0, 2.0]), (
+            f"the values must not be lost with the attribute, got {wrapped.values}"
+        )
+
+
+class TestTheContainerCrsSkipsAVariableWithNoRasterPlane:
+    """A container borrows its CRS from its variables, and one of them may have no geometry."""
+
+    def test_a_leading_non_raster_variable_does_not_hide_a_projected_crs(self):
+        """The skip is visible on the public `epsg`, not only on the walk that implements it.
+
+        Test scenario:
+            A store enumerating a 1-D `aaa_axis` before a gridded `zzz_grid` that declares
+            EPSG:3857. Asking a `LabeledArray` for `.crs` raises, and the walk's `except` wraps
+            the whole loop, so without the skip the first variable would suppress the CRS of the
+            second. A projected CRS is used deliberately: an empty answer on a geographic store
+            is rescued by the CF lat/lon fallback, which would hide the failure. Expected:
+            EPSG:3857, the same code the gridded variable itself reports.
+        """
+        store = _mem_store()
+        group = store.GetRootGroup()
+        axis_dim = group.CreateDimension("n", None, None, 3)
+        axis = group.CreateMDArray(
+            "aaa_axis", [axis_dim], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+        )
+        axis.Write(np.array([1.0, 2.0, 3.0]))
+        y = group.CreateDimension("y", "projection_y_coordinate", "Y", 2)
+        x = group.CreateDimension("x", "projection_x_coordinate", "X", 3)
+        y_values = group.CreateMDArray(
+            "y", [y], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+        )
+        y_values.Write(np.array([200.0, 100.0]))
+        x_values = group.CreateMDArray(
+            "x", [x], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+        )
+        x_values.Write(np.array([0.0, 100.0, 200.0]))
+        grid = group.CreateMDArray(
+            "zzz_grid", [y, x], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+        )
+        grid.Write(np.arange(6, dtype="float64").reshape(2, 3))
+        reference = osr.SpatialReference()
+        reference.ImportFromEPSG(3857)
+        grid.SetSpatialRef(reference)
+        container = Container(store)
+        try:
+            assert isinstance(
+                container.get_variable(container.variable_names[0]), LabeledArray
+            ), "the non-raster variable must come first, or this asserts nothing"
+
+            assert container.epsg == 3857, (
+                f"the leading non-raster variable suppressed the CRS: {container.epsg}"
+            )
+        finally:
+            container.close()

--- a/tests/netcdf/unit/test_non_raster_variable_contract.py
+++ b/tests/netcdf/unit/test_non_raster_variable_contract.py
@@ -27,6 +27,7 @@ directly, on the `ExtendedDataType` they take.
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -329,6 +330,43 @@ class _StubMDArray:
     def GetNoDataValueAsDouble(self):  # noqa: N802 - mirrors the GDAL SWIG spelling
         """No fill value declared."""
         return None
+
+
+class _FailingStubMDArray(_StubMDArray):
+    """A numeric array whose read fails the way an I/O or decompression error does."""
+
+    def ReadAsArray(self):  # noqa: N802 - mirrors the GDAL SWIG spelling
+        """Fail as a corrupt chunk would, with nothing to do with the type."""
+        raise RuntimeError("simulated decompression failure")
+
+
+def _grid_beside_a_flag(flag_type):
+    """Build a store pairing an EPSG:4326 `t2m(y, x)` with a `flag(y, x)` of `flag_type`.
+
+    Args:
+        flag_type: The `gdal.ExtendedDataType` for `flag`, left unwritten.
+
+    Returns:
+        gdal.Dataset: The store; keep the reference alive while its arrays are used.
+    """
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(4326)
+    store = _mem_store()
+    group = store.GetRootGroup()
+    f64 = gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    rows = group.CreateDimension("y", "HORIZONTAL_Y", None, 4)
+    cols = group.CreateDimension("x", "HORIZONTAL_X", None, 5)
+    y_axis = group.CreateMDArray("y", [rows], f64)
+    y_axis.Write(np.array([40.0, 39.0, 38.0, 37.0]))
+    rows.SetIndexingVariable(y_axis)
+    x_axis = group.CreateMDArray("x", [cols], f64)
+    x_axis.Write(np.array([10.0, 11.0, 12.0, 13.0, 14.0]))
+    cols.SetIndexingVariable(x_axis)
+    grid = group.CreateMDArray("t2m", [rows, cols], f64)
+    grid.Write(np.arange(20, dtype="float64").reshape(4, 5))
+    grid.SetSpatialRef(srs)
+    group.CreateMDArray("flag", [rows, cols], flag_type)
+    return store
 
 
 class TestARasterOnlyOperationNamesTheVariableItRefuses:
@@ -1268,3 +1306,125 @@ class TestTheContainerCrsSkipsAVariableWithNoRasterPlane:
             assert store.epsg == 4326, f"unexpected EPSG {store.epsg}"
         finally:
             store.close()
+
+
+@pytest.mark.core
+class TestTheRound2FixesTheirOwnTestPassFound:
+    """Four defects the round-2 test pass found in the round-2 fixes themselves."""
+
+    @pytest.mark.parametrize("kind", ["string", "compound"])
+    def test_a_flag_the_carry_cannot_write_is_absent_not_empty(self, kind):
+        """A variable that cannot be carried is dropped whole, with the true reason.
+
+        Args:
+            kind: The non-numeric dtype class of `flag`.
+
+        Test scenario:
+            Classifying `flag(y, x)` as auxiliary sends it to the carry, and GDAL's
+            Python bindings cannot write a string array of rank >= 2 or any compound.
+            The string branch created the array before writing it, so a failed write
+            left `flag` listed in the result with every value `None`. And the demotion
+            warning told the user to rename axes that already are `y` / `x`. Expected:
+            `flag` absent, the "could not carry" warning present, no rename advice.
+        """
+        flag_type = (
+            gdal.ExtendedDataType.CreateString()
+            if kind == "string"
+            else _data_type("compound")
+        )
+        container = Container(_grid_beside_a_flag(flag_type))
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = container.to_crs(3857)
+        messages = [str(warning.message) for warning in caught]
+
+        assert "flag" not in result.variable_names, "a half-built flag must not remain"
+        assert "t2m" in result.variable_names, "the raster must still be reprojected"
+        assert any("could not carry" in message for message in messages), messages
+        assert not any("rename the axes" in message for message in messages), messages
+
+    def test_a_coordinate_name_gets_the_refusal_get_variable_would_give(self):
+        """A name `get_variable` rejects is not refused for having no raster plane.
+
+        Test scenario:
+            A coordinate array has a declaration, so judging it on that refused `x`
+            for having "no raster plane" and pointed at `get_variable` -- which then
+            rejected the name outright. Expected: `get_variable`'s own refusal.
+        """
+        container = Container(_grid_beside_a_flag(gdal.ExtendedDataType.CreateString()))
+
+        with pytest.raises(ValueError, match="not a valid variable name"):
+            container._require_raster_variable("x")
+
+    def test_a_read_failure_on_an_ordinary_array_keeps_its_own_message(self):
+        """Only a compound read failure is blamed on a string field.
+
+        Test scenario:
+            Every `RuntimeError` from `ReadAsArray` used to be reworded as "a compound
+            type with a string field is the usual cause", including an I/O or
+            decompression failure on a plain float series -- which sent the reader to
+            look for a type problem that was not there. Expected: GDAL's error, as-is.
+        """
+        failing = _FailingStubMDArray([("n", 3)], None)
+
+        with pytest.raises(RuntimeError, match="simulated decompression failure"):
+            _labeled_array_from_md_array(failing, "series")
+
+    @pytest.mark.parametrize(
+        "change",
+        [
+            lambda entry: setattr(entry, "unit", "m"),
+            lambda entry: entry.attributes.__setitem__("added", 1),
+        ],
+        ids=["unit", "attributes"],
+    )
+    def test_the_cached_entry_is_frozen_whole_not_just_its_array(self, change):
+        """Locking only `values` let the labels drift out of step the same way.
+
+        Args:
+            change: A mutation of one of the entry's labels.
+
+        Test scenario:
+            The cache hands one object to every caller. With only its array locked,
+            `.unit = "m"` or a new attribute stuck in the cache while `get_variable`
+            still said `K` and `{}` -- the disagreement the lock was added to prevent.
+            Expected: the change refused, and the cache still agreeing with a fresh read.
+        """
+        store, array = _series_store(np.array([10.0, 20.0, 30.0]))
+        array.SetUnit("K")
+        container = Container(store)
+        try:
+            cached = container.variables["series"]
+
+            with pytest.raises((AttributeError, TypeError)):
+                change(cached)
+
+            fresh = container.get_variable("series")
+            assert (cached.unit, dict(cached.attributes)) == (
+                fresh.unit,
+                fresh.attributes,
+            )
+        finally:
+            container.close()
+
+    def test_a_copy_of_the_cached_entry_is_independent_and_mutable(self):
+        """`.copy()` is the documented way out of the frozen entry.
+
+        Test scenario:
+            A caller who needs to modify the values takes a copy. It must be writeable
+            and must not reach back into the cache.
+        """
+        store, array = _series_store(np.array([10.0, 20.0, 30.0]))
+        array.SetUnit("K")
+        container = Container(store)
+        try:
+            own = container.variables["series"].copy()
+            own.unit = "m"
+            own.values += 1
+
+            cached = container.variables["series"]
+            assert (own.unit, own.values.tolist()) == ("m", [11.0, 21.0, 31.0])
+            assert (cached.unit, cached.values.tolist()) == ("K", [10.0, 20.0, 30.0])
+        finally:
+            container.close()

--- a/tests/netcdf/unit/test_non_raster_variable_contract.py
+++ b/tests/netcdf/unit/test_non_raster_variable_contract.py
@@ -414,6 +414,31 @@ class TestTheLabelsTheWrapperCarries:
         finally:
             container.close()
 
+    def test_a_packed_array_carries_the_scale_and_offset_it_needs(self):
+        """A unit without its packing parameters labels the wrong numbers.
+
+        Test scenario:
+            GDAL lifts `scale_factor` / `add_offset` out of the attribute list, so they
+            never reach `attributes`. Before they were carried, a packed series came back
+            as `[10, 15]` labelled `K` with nothing on the object to say the true values
+            were 105 and 110. `values` stays packed -- `read_array`'s `unpack=False`
+            default -- so the wrapper has to carry what unpacking needs.
+        """
+        store, array = _series_store(np.array([10.0, 15.0]))
+        array.SetUnit("K")
+        array.SetScale(1.0)
+        array.SetOffset(95.0)
+        container = Container(store)
+        try:
+            series = container.get_variable("series")
+
+            assert series.values.tolist() == [10.0, 15.0], "values must stay packed"
+            assert (series.scale, series.offset) == (1.0, 95.0)
+            unpacked = series.values * series.scale + series.offset
+            assert unpacked.tolist() == [105.0, 110.0]
+        finally:
+            container.close()
+
     def test_an_array_that_declares_none_of_them_gets_the_documented_defaults(self):
         """A bare array must answer empty labels rather than GDAL's placeholders.
 

--- a/tests/netcdf/unit/test_non_raster_variable_contract.py
+++ b/tests/netcdf/unit/test_non_raster_variable_contract.py
@@ -180,6 +180,14 @@ class _StubMDArray:
         """No unit declared."""
         return ""
 
+    def GetScale(self):  # noqa: N802 - mirrors the GDAL SWIG spelling
+        """No `scale_factor`: the array is not packed."""
+        return None
+
+    def GetOffset(self):  # noqa: N802 - mirrors the GDAL SWIG spelling
+        """No `add_offset`: the array is not packed."""
+        return None
+
     def GetNoDataValueAsDouble(self):  # noqa: N802 - mirrors the GDAL SWIG spelling
         """No fill value declared."""
         return None
@@ -540,18 +548,19 @@ class TestTheDtypeOfAVariableWithNoRecords:
 
         assert dtype == np.dtype(expected), f"expected {expected}, got {dtype}"
 
-    def test_a_string_type_maps_to_the_unicode_dtype(self):
-        """An empty string variable must not be the one string array with a different dtype.
+    def test_a_string_type_maps_to_object(self):
+        """An empty string variable gets the dtype a populated one does.
 
         Test scenario:
-            A non-empty string array reaches the caller as `np.asarray(md_arr.Read())`, whose
-            dtype is `<U`. Expected: the same kind for the empty case, so a caller inspecting
-            `values.dtype.kind` gets the same answer whether or not any record was written --
-            `object`, the other plausible choice, would break that.
+            A non-empty string array is read as `object`, because `Read` returns a missing
+            entry as `None` and a `<U` array cannot hold one. Letting NumPy pick made the
+            dtype depend on the data -- `<U` for a fully written column, `object` the moment
+            one entry was missing. Expected: `object` for the empty case too, so
+            `values.dtype.kind` is the same answer whether or not any record was written.
         """
         dtype = _numpy_dtype_of(gdal.ExtendedDataType.CreateString())
 
-        assert dtype.kind == "U", f"expected a unicode dtype, got {dtype!r}"
+        assert dtype == np.dtype(object), f"expected object, got {dtype!r}"
 
     def test_a_compound_type_keeps_the_declared_offsets_and_record_size(self):
         """The record layout is read from GDAL, not inferred from the field formats.

--- a/tests/netcdf/unit/test_non_raster_variable_contract.py
+++ b/tests/netcdf/unit/test_non_raster_variable_contract.py
@@ -207,7 +207,7 @@ def _axis_before_a_projected_grid():
     return store
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def array_reads(monkeypatch):
     """Record the name of every array whose values are read while the test runs.
 
@@ -399,7 +399,7 @@ def _grid_with_an_auxiliary(aux_type, aux_values=None, unit=None):
 class TestARasterOnlyOperationNamesTheVariableItRefuses:
     """The convenience methods that take a variable name must say why they cannot serve it."""
 
-    @pytest.fixture(scope="function")
+    @pytest.fixture
     def container(self):
         """A container whose only variable is a 1-D axis, so every op below meets one.
 
@@ -437,8 +437,10 @@ class TestARasterOnlyOperationNamesTheVariableItRefuses:
             Expected: a `ValueError` that names `series`, prints the dimensions that make it
             non-raster, and points at the accessor that does work.
         """
+        operation = getattr(container, method)
+
         with pytest.raises(ValueError) as excinfo:
-            getattr(container, method)(*arguments)
+            operation(*arguments)
 
         message = str(excinfo.value)
         assert "series" in message, f"the refusal must name the variable: {message}"
@@ -578,7 +580,7 @@ class TestARasterOnlyOperationNamesTheVariableItRefuses:
 class TestReadArrayOnAVariableWithNoRasterPlane:
     """`read_array` reuses the values `get_variable` already materialised; unpacking still works."""
 
-    @pytest.fixture(scope="function")
+    @pytest.fixture
     def packed(self):
         """A container holding a 1-D `Int16` series with a CF scale and offset.
 


### PR DESCRIPTION
# Description

`get_variable` returned the `gdal.MDArray` itself whenever GDAL could not expose the variable as a raster plane.
That object carries none of pyramids' API — no `values`, no `stats`, no `read_array` — and its `Read()` returns an
*undecoded* byte buffer for numeric data, so the only route to the values was `ReadAsArray()`. A caller who did not
know better was walked straight into using `osgeo` directly, which is what depending on pyramids is meant to avoid.
An earthlens docs notebook shipped `t2m.ReadAsArray()` / `t2m.GetUnit()` in a cell for exactly this reason.

Two shapes reach that branch, and only one of them is 1-D:

| # | Condition | Example | Rank |
|---|---|---|---|
| 1 | a single dimension | `t2m(values)`, `hyai(ilev)` | 1-D, any dtype |
| 2 | a non-numeric dtype | a character column `units(record, strlen)` | **any rank ≥ 2** |

Both now come back as a `LabeledArray` — the type `LabeledDataset["var"]` already returns — so both routes to a
non-raster variable answer alike. The private `_read_md_array` still returns the `MDArray`; only the public
accessor wraps, so that helper's own tests are unchanged.

**Wrapping rather than refusing.** The issue proposed raising instead. That would have collided head-on with
`test_get_variable_1d_does_not_raise`, the regression guard for #582, which asserts across every sample file that a
1-D variable does *not* raise — and 11 of 26 sample files have 1-D data variables, including `hyai` / `hybm` (CF
hybrid-sigma coefficients), `time_bounds` / `x_image_bounds` (CF bounds) and `node_lon` / `node_lat` (UGRID mesh
coordinates). Reading those is the point of them; refusing them would be a regression, not a fix. Wrapping keeps
every legitimate read working while removing the leak.

**One reader per dtype class.** Numeric reads through `ReadAsArray`. A string array raises there and reads through
`Read`. A compound array reads through neither: `Read` hands back the record bytes undecoded, so reading it as-is
gives a flat `uint8` buffer whose length contradicts the declared shape. GDAL does describe the layout, so those
bytes are viewed through the matching NumPy structured dtype, with the record size as `itemsize` so the struct's
padding is preserved rather than assumed away.

Also leaked through grouped stores, via both doors — `nc.get_group(g).get_variable(name)` and
`nc.get_variable("group/name")` — since the slash form delegates to the group's `get_variable`. Both reach the one
branch, so the fix covers them together; a guard at `read_file` (the alternative the issue floats) would have
caught neither, because the store opens fine and only individual variables are non-spatial.

# Issues

- Closes #1126 — `get_variable` leaks a raw `gdal.MDArray` for a non-raster variable

## Type of change

Check relevant points.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

The return **type** changes for these shapes, so code calling `ReadAsArray()` / `Read()` / `GetDataType()` on the
result must move to `.values` / `.dims` / `.shape`. Nothing new raises: every variable readable before is still
readable. Recorded in `docs/migration.md`.

# How Has This Been Tested?

```bash
pixi run -e dev pytest tests/netcdf -m "not plot"
pixi run -e dev pytest tests/netcdf/samples/test_no_raw_gdal.py -v
```

- [x] **The property, not the symptom.** `tests/netcdf/samples/test_no_raw_gdal.py` asserts that **no variable on
  any sample file returns an `osgeo.*` type**, parametrized over the whole sample registry. That branch is the only
  place such an object can escape, so the total assertion costs no more than a narrow one and cannot be satisfied
  by a partial fix.
- [x] **Both doors into a grouped store** are covered — `get_group(...).get_variable(...)` and the `"group/name"`
  slash form.
- [x] **Every dtype class** is covered: a numeric axis (`hyai`), a string column (`UTC_time`, where `ReadAsArray`
  raises so a numeric-only wrapper would fail), and compound at rank 2 and 3.
- [x] **Compound round-trips exactly** — `[(1, 1.5), (2, 2.5), (3, 3.5)]` written, identical values read back,
  through the structured dtype rather than the raw buffer.
- [x] **No fixture was added** — `tests/data/netcdf/none__35v__1d35__groups-nc4.nc` was already in the repo and
  leaks on four variables.
- [x] 10 existing tests encoded the old contract (`isinstance(..., gdal.MDArray)`) and were updated; the
  `_read_md_array` tests were left asserting the `MDArray`, since the private helper still returns it.
- [x] `mypy` clean; pinned `ruff` (0.15.22) `check` and `format` both clean; no line over 120 characters.

# Checklist:

- [ ] updated version number in pyproject.toml. — *not applicable: commitizen bumps the version in CI.*
- [ ] added changes to History.rst. — *not applicable: `change-log.md` is commitizen-generated; the breaking
      change is documented in `docs/migration.md` instead.*
- [ ] updated the latest version in README file. — *not applicable: same CI release flow.*
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] documentation are updated. — `docs/migration.md`, plus the docstrings on `get_variable`'s new helpers.
